### PR TITLE
chore: prepare npm packages for publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -131,11 +131,10 @@ jobs:
 
   publish-node:
     name: Publish to npm
-    needs: build-node
+    needs: [build-node, publish]
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
-      id-token: write # npm provenance
     defaults:
       run:
         working-directory: crates/gf-bindings-node
@@ -169,25 +168,26 @@ jobs:
           python3 ../../../scripts/ci/validate-napi-artifacts.py \
             --npm-dir npm --manifest package.json
 
-      - name: Publish platform packages + main package
-        # prepublish publishes the npm/<platform> packages and wires the main
-        # package's optionalDependencies; `npm publish` then ships the main one.
-        run: |
-          pnpm exec napi prepublish -t npm --skip-gh-release
-          npm publish --access public --provenance
+      - name: Verify npm publishing identity
+        run: npm whoami
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish platform packages and main package
+        # npm invokes prepublishOnly exactly once. napi then publishes each
+        # generated public platform package and wires those exact versions into
+        # the main package before npm publishes it.
+        run: npm publish --access public
+        env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   # ---- NPX agent skills (@graphforge/agent-skills) ----
   publish-agent-skills:
     name: Publish agent-skills to npm
-    needs: license-compliance
+    needs: publish-node
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
-      id-token: write # npm provenance
     defaults:
       run:
         working-directory: packages/agent-skills
@@ -209,8 +209,13 @@ jobs:
         run: pnpm --filter @graphforge/agent-skills test:offline
         working-directory: .
 
+      - name: Verify npm publishing identity
+        run: npm whoami
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Publish @graphforge/agent-skills
-        run: npm publish --access public --provenance
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,4 +1,4 @@
-name: Publish
+name: Publish to PyPI and npm
 
 on:
   release:

--- a/crates/gf-bindings-node/README.md
+++ b/crates/gf-bindings-node/README.md
@@ -1,0 +1,51 @@
+# `@graphforge/node`
+
+Native Node.js bindings for the GraphForge embedded graph engine. The package
+loads the Rust implementation for the current platform; it does not include a
+JavaScript fallback engine.
+
+## Install
+
+```bash
+npm install @graphforge/node apache-arrow
+```
+
+Node.js 20 or newer is required. Prebuilt packages are published for:
+
+- macOS: Apple silicon and Intel
+- Linux glibc: ARM64 and x64
+- Windows: x64
+
+## Quick start
+
+```js
+import { tableFromIPC } from "apache-arrow";
+import { GraphForge } from "@graphforge/node";
+
+const forge = new GraphForge();
+forge.execute("CREATE (:Person {name: 'Alice', age: 30})");
+
+const result = forge.execute(
+  "MATCH (p:Person) RETURN p.name AS name, p.age AS age",
+);
+const table = tableFromIPC(result);
+
+console.log(table.toArray());
+```
+
+GraphForge returns Arrow IPC buffers from query and analyst-verb result
+surfaces. Decode them with `apache-arrow` as shown above.
+
+For persistent projects, create the project directory before passing its path
+to `new GraphForge(path)`.
+
+## Documentation and support
+
+- [Documentation](https://curatelabs.github.io/graphforge-legecy/)
+- [Issue tracker](https://github.com/CurateLabs/graphforge-x/issues)
+- [Source](https://github.com/CurateLabs/graphforge-x/tree/main/crates/gf-bindings-node)
+
+## License
+
+GraphForge is source-available under the Business Source License 1.1. See the
+included `LICENSE` and `NOTICE` files for terms and attribution.

--- a/crates/gf-bindings-node/package.json
+++ b/crates/gf-bindings-node/package.json
@@ -1,29 +1,40 @@
 {
   "name": "@graphforge/node",
   "version": "0.5.0-dev.0",
+  "description": "Native Node.js bindings for the GraphForge embedded graph engine",
   "license": "BUSL-1.1",
   "homepage": "https://curatelabs.github.io/graphforge-legecy/",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/CurateLabs/graphforge-legecy.git",
+    "url": "git+https://github.com/CurateLabs/graphforge-x.git",
     "directory": "crates/gf-bindings-node"
   },
   "bugs": {
-    "url": "https://github.com/CurateLabs/graphforge-legecy/issues"
+    "url": "https://github.com/CurateLabs/graphforge-x/issues"
   },
+  "keywords": [
+    "graph",
+    "cypher",
+    "opencypher",
+    "arrow",
+    "parquet",
+    "knowledge-graph",
+    "native-addon"
+  ],
   "main": "index.js",
   "types": "index.d.ts",
   "files": [
     "index.js",
     "index.d.ts",
     "lib/",
+    "README.md",
     "LICENSE",
     "NOTICE",
     "THIRD_PARTY_NOTICES.md",
     "*.node"
   ],
   "napi": {
-    "name": "graphforge",
+    "binaryName": "graphforge",
     "targets": [
       "aarch64-apple-darwin",
       "x86_64-apple-darwin",
@@ -40,6 +51,13 @@
     "test:smoke": "node --test tests/smoke.test.mjs",
     "test:coverage": "c8 --include=\"lib/**/*.mjs\" --exclude=\"tests/**\" --exclude=\"node_modules/**\" --reporter=text --reporter=lcov --reporter=json-summary --reports-dir=coverage node --test",
     "format:check": "prettier --check package.json \"lib/**/*.mjs\" \"tests/*.mjs\""
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.6.0",

--- a/docs/development/publication-order.md
+++ b/docs/development/publication-order.md
@@ -141,7 +141,14 @@ final `#742` close.
 ## Human blockers (checklist)
 
 - [ ] Version freeze PR merged on the RC commit (#2796)
-- [ ] `NPM_TOKEN` (or npm trusted publishing) available to `publish.yaml`
+- [ ] `@graphforge` npm organization exists and the publishing maintainer can
+      create public organization-scoped packages
+- [ ] `NPM_TOKEN` is a granular token authorized for the `@graphforge` scope,
+      can bypass 2FA for CI publishing, and is available to `publish.yaml`
+- [ ] After the first publish, configure trusted publishing for each npm package
+      before removing the token path; npm requires an existing package and a
+      supported GitHub-hosted runner (the repository is currently private, so
+      npm provenance is not available)
 - [ ] PyPI trusted publishing OIDC configured for this repo / environment
 - [ ] `CARGO_REGISTRY_TOKEN` (or crates.io trusted publishing) once crates.io
       names are resolved

--- a/packages/agent-skills/package.json
+++ b/packages/agent-skills/package.json
@@ -1,17 +1,24 @@
 {
   "name": "@graphforge/agent-skills",
   "version": "0.5.0-dev.0",
-  "description": "Agent skill package shell for GraphForge",
+  "description": "NPX-distributed agent skills and adapters for GraphForge",
   "license": "BUSL-1.1",
   "homepage": "https://curatelabs.github.io/graphforge-legecy/",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/CurateLabs/graphforge-legecy.git",
+    "url": "git+https://github.com/CurateLabs/graphforge-x.git",
     "directory": "packages/agent-skills"
   },
   "bugs": {
-    "url": "https://github.com/CurateLabs/graphforge-legecy/issues"
+    "url": "https://github.com/CurateLabs/graphforge-x/issues"
   },
+  "keywords": [
+    "graphforge",
+    "agent-skills",
+    "knowledge-graph",
+    "ai-agents",
+    "npx"
+  ],
   "type": "module",
   "bin": {
     "graphforge-agent-skills": "bin/graphforge-agent-skills.js"
@@ -54,6 +61,7 @@
     "format:check": "prettier --check package.json compatibility.json README.md adapter bin tests schemas skills workflows rc examples scripts"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }


### PR DESCRIPTION
## Summary

- add publish-ready metadata and a package README for `@graphforge/node`
- make generated napi platform packages public and avoid duplicate lifecycle publication
- enforce PyPI -> Node -> agent-skills registry order with npm identity preflight
- document first-publish npm organization/token requirements and private-repo provenance limits

## Validation

- `make workflow-lint`
- `python3 scripts/license_policy.py check --report /tmp/graphforge-license-report.json`
- generated and validated all five napi platform manifests
- isolated `pnpm --filter @graphforge/node build`
- `pnpm --filter @graphforge/node test:smoke` (7 passed)
- dry-run tarball inspection for `@graphforge/node` and `@graphforge/agent-skills`
- `pnpm --filter @graphforge/agent-skills format:check`
- `pnpm --filter @graphforge/agent-skills test:offline`
- `git diff --check`

Refs #198
Related: #191

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge-x/pr/204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787889548&installation_model_id=20486&pr_number=204&repository=CurateLabs%2Fgraphforge-x&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge-x%2Fpull%2F204&signature=c21308efda3c0cb35db5a3eae6129c054b32d23db773bad99272ec631295d076"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer package descriptions, keywords, repository links, and issue-reporting links for improved discoverability.
  - Enabled public npm publishing with explicit registry configuration.
  - Included the package README in published contents.
  - Updated the native package configuration with the `graphforge` binary name.
  - Declared Node.js 20 or newer as a runtime requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prepare npm packages for publishing to the public npm registry
> - Updates [publish.yaml](.github/workflows/publish.yaml) to add an `npm whoami` identity check, remove provenance flags, and sequence jobs so `publish-node` waits on both `build-node` and `publish`, and `publish-agent-skills` waits on `publish-node`.
> - Updates [gf-bindings-node/package.json](crates/gf-bindings-node/package.json) to set `publishConfig` targeting the public npm registry, add `engines: {node: '>=20'}`, rename the N-API `name` field to `binaryName`, and include `README.md` in the published files.
> - Updates [agent-skills/package.json](packages/agent-skills/package.json) to point `publishConfig` at the public npm registry and adds keywords and corrected repository URLs.
> - Adds a [publication-order.md](docs/development/publication-order.md) checklist for npm org setup, token scoping, and post-first-publish provenance configuration.
> - Behavioral Change: provenance attestation is removed from both npm publish steps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31a2fe1.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->