### PR TITLE
ci: minimize Blacksmith cache storage

### DIFF
--- a/.github/workflows/binding-release-candidate.yml
+++ b/.github/workflows/binding-release-candidate.yml
@@ -78,7 +78,7 @@ jobs:
           command: build
           args: --release --manifest-path crates/gf-bindings-py/Cargo.toml --out dist
           manylinux: auto
-          sccache: "true"
+          sccache: "false"
 
       # The maturin action owns its build wrapper. Later Python contracts may
       # launch Cargo after that wrapper has left PATH, especially on containerized
@@ -233,16 +233,6 @@ jobs:
         with:
           toolchain: "1.96.0"
           targets: ${{ matrix.target }}
-
-      - name: Restore Windows Node Cargo build state
-        if: matrix.target == 'x86_64-pc-windows-msvc'
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git/db
-            target
-          key: ${{ runner.os }}-cargo-x86_64-pc-windows-msvc-release-rust-1.96.0-${{ hashFiles('Cargo.lock') }}
 
       - name: Install workspace dependencies
         run: pnpm install

--- a/.github/workflows/checkpoint-recovery-gate.yml
+++ b/.github/workflows/checkpoint-recovery-gate.yml
@@ -22,13 +22,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.96.0"
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-checkpoint-rust-v1-${{ hashFiles('Cargo.lock', 'crates/**/*.rs') }}
       - name: Validate frozen acceptance ledger
         run: python3 scripts/ci/checkpoint-recovery-gate.py
       - name: Execute Rust and CLI matrix
@@ -86,13 +79,6 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-checkpoint-python-v1-${{ hashFiles('Cargo.lock', 'crates/**/*.rs') }}
       - name: Build and prove isolated same-SHA wheel
         run: |
           uv run --with maturin maturin build --manifest-path crates/gf-bindings-py/Cargo.toml --out dist
@@ -135,13 +121,6 @@ jobs:
         with:
           node-version: "20"
       - uses: pnpm/action-setup@v4
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-checkpoint-node-v1-${{ hashFiles('Cargo.lock', 'crates/**/*.rs', 'pnpm-lock.yaml') }}
       - name: Build and prove same-SHA Node package
         run: |
           pnpm install --frozen-lockfile

--- a/.github/workflows/concurrency-stress-gate.yml
+++ b/.github/workflows/concurrency-stress-gate.yml
@@ -44,14 +44,6 @@ jobs:
         with:
           python-version: "3.13"
 
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-concurrency-stress-v1-${{ hashFiles('Cargo.lock', 'crates/**/*.rs') }}
-
       - name: Validate stress configuration
         run: |
           python3 scripts/ci/concurrency-stress-gate.py validate

--- a/.github/workflows/m20-contract-gate.yml
+++ b/.github/workflows/m20-contract-gate.yml
@@ -19,13 +19,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.96.0"
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-m20-rust-v1-${{ hashFiles('Cargo.lock', 'crates/**/*.rs') }}
       - name: Execute Rust matrix group
         run: python3 scripts/ci/m20-contract-gate.py run-group --group rust --output gate-fragments
       - name: Save Rust evidence for report job
@@ -72,13 +65,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.96.0"
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-m20-node-v1-${{ hashFiles('Cargo.lock', 'crates/**/*.rs', 'pnpm-lock.yaml') }}
       - name: Execute Node matrix group
         run: python3 scripts/ci/m20-contract-gate.py run-group --group node --output gate-fragments
       - name: Save Node evidence for report job

--- a/.github/workflows/m21-contract-gate.yml
+++ b/.github/workflows/m21-contract-gate.yml
@@ -19,13 +19,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.96.0"
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-m21-rust-v1-${{ hashFiles('Cargo.lock', 'crates/**/*.rs') }}
       - name: Execute Rust matrix group
         run: python3 scripts/ci/m21-contract-gate.py run-group --group rust --output gate-fragments
       - name: Save Rust evidence for report job
@@ -72,13 +65,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.96.0"
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-m21-node-v1-${{ hashFiles('Cargo.lock', 'crates/**/*.rs', 'pnpm-lock.yaml') }}
       - name: Execute Node matrix group
         run: python3 scripts/ci/m21-contract-gate.py run-group --group node --output gate-fragments
       - name: Save Node evidence for report job

--- a/.github/workflows/m22-non-cypher-surface-gate.yml
+++ b/.github/workflows/m22-non-cypher-surface-gate.yml
@@ -128,8 +128,8 @@ jobs:
       - name: Mount Cargo build disk
         uses: useblacksmith/stickydisk@v1
         with:
-          # v2: discard volumes that may retain root-owned maturin leftovers.
-          key: ${{ github.repository }}-m22-load-${{ hashFiles('Cargo.lock') }}-target-v2
+          # Per-certification workspace; cleanup_load_disk deletes it after load.
+          key: ${{ github.repository }}-m22-load-${{ inputs.commit_sha }}-target-v3
           path: target
       - name: Install workspace dependencies
         run: pnpm install
@@ -139,7 +139,7 @@ jobs:
           command: build
           args: --release --manifest-path crates/gf-bindings-py/Cargo.toml --out dist
           manylinux: auto
-          sccache: "true"
+          sccache: "false"
       # manylinux maturin writes into CARGO_TARGET_DIR as root; host cargo then
       # cannot open .cargo-build-lock (EACCES) without reclaiming ownership.
       - name: Reclaim sticky-disk ownership after maturin
@@ -205,10 +205,21 @@ jobs:
           path: m22-load-evidence
           key: m22-load-${{ github.run_id }}
 
+  cleanup_load_disk:
+    name: Delete one-run M22 build disk
+    if: always()
+    needs: load
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Delete M22 build disk
+        uses: useblacksmith/stickydisk-delete@v1
+        with:
+          delete-key: ${{ github.repository }}-m22-load-${{ inputs.commit_sha }}-target-v3
+
   aggregate:
     name: Aggregate final M22 non-Cypher evidence
     if: always() && needs.validate_source.result == 'success'
-    needs: [validate_source, load]
+    needs: [validate_source, load, cleanup_load_disk]
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/non-cypher-surface-gate.yml
+++ b/.github/workflows/non-cypher-surface-gate.yml
@@ -26,11 +26,6 @@ jobs:
         with:
           toolchain: stable
 
-      - uses: actions/cache@v5
-        with:
-          path: target
-          key: ${{ runner.os }}-non-cypher-rust-v1-${{ hashFiles('Cargo.lock', 'crates/**/*.rs') }}
-
       - name: Validate exhaustive inventory
         env:
           GITHUB_SHA: ${{ env.EVIDENCE_SHA }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -36,7 +36,7 @@ jobs:
           command: build
           args: --release --manifest-path crates/gf-bindings-py/Cargo.toml --out dist
           manylinux: auto # builds the Linux wheel in a manylinux container
-          sccache: "true"
+          sccache: "false"
 
       - name: Save wheel for publish job
         uses: actions/cache/save@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -355,10 +355,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: >-
-            ${{ runner.os }}-python-binding-v1-${{
-            hashFiles('Cargo.lock', 'Cargo.toml', 'crates/**/Cargo.toml',
-            'crates/**/*.rs', 'crates/gf-bindings-py/pyproject.toml') }}
+          key: ${{ runner.os }}-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
 
       - name: Build same-SHA wheel
         shell: bash
@@ -478,10 +475,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: >-
-            ${{ runner.os }}-node-binding-v2-${{
-            hashFiles('Cargo.lock', 'Cargo.toml', 'crates/**/Cargo.toml',
-            'crates/**/*.rs', 'package.json', 'pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
 
       - name: Install workspace dependencies
         run: pnpm install
@@ -577,10 +571,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: >-
-            ${{ runner.os }}-concurrency-matrix-v1-${{
-            hashFiles('Cargo.lock', 'Cargo.toml', 'crates/**/Cargo.toml',
-            'crates/**/*.rs', 'pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
 
       - name: Build Python wheel and Node addon
         shell: bash
@@ -627,9 +618,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: >-
-            ${{ runner.os }}-gf-storage-locks-v1-${{
-            hashFiles('Cargo.lock', 'crates/gf-storage/**') }}
+          key: ${{ runner.os }}-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
 
       - name: Run Windows project-root lock unit tests
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Post-v0.5.0 work lands here. The v0.5.0 publication cut is under `[0.5.0]` below.
 
+- Minimize Blacksmith CI storage by removing speculative caches from infrequent
+  gates, sharing dependency caches by lockfile identity, and deleting the
+  one-run M22 build disk after certification (#207).
 - Remove unconsumed CI artifacts and move required cross-job transfers to
   Blacksmith-backed cache storage, eliminating GitHub artifact-quota failures
   from the required CI Gate (#205).

--- a/scripts/ci/test-binding-release-candidate.py
+++ b/scripts/ci/test-binding-release-candidate.py
@@ -229,27 +229,18 @@ def validate_windows_node_cold_start_policy(workflow_text: str) -> None:
     )
     assert_active_lines(node_job, "timeout-minutes: ${{ matrix.timeout_minutes || 60 }}")
 
-    cache_name = "Restore Windows Node Cargo build state"
-    assert node_job.count(cache_name) == 1
-    cache = required_section(
-        node_job, f"- name: {cache_name}", "- name: Install workspace dependencies"
-    )
+    assert "actions/cache@v5" not in node_job
+    assert "actions/cache/restore@v5" not in node_job
+    assert node_job.count("actions/cache/save@v5") == 1
     assert_active_lines(
-        cache,
-        "if: matrix.target == 'x86_64-pc-windows-msvc'",
-        "uses: actions/cache@v5",
-        "~/.cargo/registry",
-        "~/.cargo/git/db",
-        "target",
-        "key: ${{ runner.os }}-cargo-x86_64-pc-windows-msvc-release-rust-1.96.0-"
-        "${{ hashFiles('Cargo.lock') }}",
+        node_job,
+        "path: binding-rc-reports",
+        "key: binding-rc-transfer-${{ github.run_id }}-${{ matrix.report_target }}",
     )
-    assert all(
-        forbidden not in cache
-        for forbidden in ("inputs.commit_sha", "EVIDENCE_SHA", "github.sha", "restore-keys")
+    assert "Restore Windows Node Cargo build state" not in node_job
+    assert node_job.index("uses: dtolnay/rust-toolchain@master") < node_job.index(
+        "Build declared publish target"
     )
-    assert node_job.index("uses: dtolnay/rust-toolchain@master") < node_job.index(cache_name)
-    assert node_job.index(cache_name) < node_job.index("Build declared publish target")
 
     assert_active_lines(
         node_job,
@@ -373,25 +364,21 @@ def main() -> None:
         rc_workflow_text.replace(windows_entry, windows_entry + windows_entry, 1),
         "duplicate Windows matrix entry",
     )
+    install_marker = "      - name: Install workspace dependencies"
+    for cache_action in ("actions/cache/restore@v5", "actions/cache/save@v5"):
+        injected = (
+            "      - name: Unapproved Windows cache transfer\n"
+            f"        uses: {cache_action}\n"
+            "        with:\n"
+            "          path: target\n"
+            "          key: unapproved-windows-build-cache\n"
+        )
+        rejected_windows_node_cold_start_policy(
+            rc_workflow_text.replace(install_marker, injected + install_marker, 1),
+            cache_action,
+        )
     for original, invalid in (
         ("timeout_minutes: 90", "timeout_minutes: 60"),
-        (
-            "${{ runner.os }}-cargo-x86_64-pc-windows-msvc-release-rust-1.96.0-"
-            "${{ hashFiles('Cargo.lock') }}",
-            "${{ github.sha }}-cargo-x86_64-pc-windows-msvc-release-rust-1.96.0",
-        ),
-        ("${{ runner.os }}-cargo-", "cargo-"),
-        ("x86_64-pc-windows-msvc-release", "windows-release"),
-        ("-release-rust-", "-rust-"),
-        ("rust-1.96.0-", "rust-unpinned-"),
-        ("${{ hashFiles('Cargo.lock') }}", "no-lockfile"),
-        (
-            "if: matrix.target == 'x86_64-pc-windows-msvc'",
-            "if: matrix.execution_mode == 'native'",
-        ),
-        ("~/.cargo/registry", "~/.cargo/registry-disabled"),
-        ("~/.cargo/git/db", "~/.cargo/git-disabled"),
-        ("            target\n", "            target-disabled\n"),
         ("--platform --release", "--platform --debug"),
         ("pnpm --filter @graphforge/node test:smoke", "sleep 1"),
         ("pnpm --filter @graphforge/node test:smoke", "retry native-smoke"),

--- a/scripts/ci/test-ci-storage-policy.py
+++ b/scripts/ci/test-ci-storage-policy.py
@@ -9,6 +9,25 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOWS = ROOT / ".github" / "workflows"
 FORBIDDEN = ("actions/upload-artifact@", "actions/download-artifact@", "retention-days:")
+EXPECTED_DEPENDENCY_KEYS = Counter(
+    {
+        "${{ runner.os }}-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}": 7,
+        "${{ runner.os }}-fuzz-${{ hashFiles('fuzz/Cargo.toml', '**/Cargo.lock') }}": 1,
+    }
+)
+EXPECTED_STICKY_KEYS = Counter(
+    {
+        "${{ github.repository }}-${{ github.job }}-${{ hashFiles('Cargo.lock') }}-target-v1": 5,
+        (
+            "${{ github.repository }}-daily-fuzz-"
+            "${{ hashFiles('fuzz/Cargo.toml', '**/Cargo.lock') }}-target-v1"
+        ): 1,
+        "${{ github.repository }}-m22-load-${{ inputs.commit_sha }}-target-v3": 1,
+    }
+)
+EXPECTED_STICKY_DELETES = Counter(
+    {"${{ github.repository }}-m22-load-${{ inputs.commit_sha }}-target-v3": 1}
+)
 EXPECTED_SAVES = Counter(
     {
         "binding-rc-transfer-${{ github.run_id }}-${{ matrix.target }}": 1,
@@ -65,13 +84,13 @@ EXPECTED_RESTORES = Counter(
 )
 
 
-def cache_steps(text: str) -> list[list[str]]:
-    """Return cache action steps without accepting matches from later steps."""
+def action_steps(text: str, action_prefix: str) -> list[list[str]]:
+    """Return matching action steps without accepting fields from later steps."""
     lines = text.splitlines()
     steps: list[list[str]] = []
     for index, line in enumerate(lines):
         normalized = line.strip().removeprefix("- ").removeprefix("uses:").strip().strip("'\"")
-        if not normalized.startswith("actions/cache/"):
+        if not normalized.startswith(action_prefix):
             continue
         uses_indent = len(line) - len(line.lstrip())
         start = index
@@ -96,6 +115,10 @@ def cache_steps(text: str) -> list[list[str]]:
             end += 1
         steps.append(lines[start:end])
     return steps
+
+
+def cache_steps(text: str) -> list[list[str]]:
+    return action_steps(text, "actions/cache/")
 
 
 def field(step: list[str], name: str) -> str | None:
@@ -126,6 +149,50 @@ def cache_contracts(text: str) -> tuple[list[str], list[str]]:
     return saved, restored
 
 
+def dependency_contracts(text: str) -> list[str]:
+    keys: list[str] = []
+    for step in action_steps(text, "actions/cache@"):
+        assert field(step, "uses") == "actions/cache@v5", (
+            "dependency cache must use actions/cache@v5"
+        )
+        key = field(step, "key")
+        assert key is not None, "dependency cache has no exact key"
+        rendered = "\n".join(step)
+        assert "target" not in rendered, f"large build tree stored in actions/cache: {key}"
+        assert "crates/**/*.rs" not in key and "crates/**" not in key, (
+            f"dependency cache is keyed by source files: {key}"
+        )
+        keys.append(key)
+    return keys
+
+
+def sticky_contracts(text: str) -> tuple[list[str], list[str]]:
+    mounted: list[str] = []
+    deleted: list[str] = []
+    for step in action_steps(text, "useblacksmith/stickydisk"):
+        uses = field(step, "uses")
+        if uses == "useblacksmith/stickydisk@v1":
+            key = field(step, "key")
+            assert key is not None, "sticky disk has no exact key"
+            mounted.append(key)
+        elif uses == "useblacksmith/stickydisk-delete@v1":
+            key = field(step, "delete-key")
+            assert key is not None, "sticky disk deletion has no exact key"
+            deleted.append(key)
+        else:
+            raise AssertionError(f"unapproved sticky-disk action: {uses}")
+    return mounted, deleted
+
+
+def validate_maturin_storage(text: str) -> None:
+    for step in action_steps(text, "PyO3/maturin-action@"):
+        assert field(step, "uses") == "PyO3/maturin-action@v1", "unapproved Maturin action"
+        sccache = field(step, "sccache")
+        assert sccache is None or sccache.lower() == "false", (
+            f"Maturin sccache uses GitHub storage: {sccache}"
+        )
+
+
 def main() -> None:
     texts = {path: path.read_text(encoding="utf-8") for path in sorted(WORKFLOWS.glob("*.y*ml"))}
     for path, text in texts.items():
@@ -134,14 +201,26 @@ def main() -> None:
 
     saved: list[str] = []
     restored: list[str] = []
+    dependency_keys: list[str] = []
+    sticky_keys: list[str] = []
+    sticky_deletes: list[str] = []
     for text in texts.values():
         file_saves, file_restores = cache_contracts(text)
         saved.extend(file_saves)
         restored.extend(file_restores)
+        dependency_keys.extend(dependency_contracts(text))
+        file_sticky, file_deletes = sticky_contracts(text)
+        sticky_keys.extend(file_sticky)
+        sticky_deletes.extend(file_deletes)
+        validate_maturin_storage(text)
     assert Counter(saved) == EXPECTED_SAVES, "CI transfer producer contract drift"
     assert Counter(restored) == EXPECTED_RESTORES, "CI transfer consumer contract drift"
+    assert Counter(dependency_keys) == EXPECTED_DEPENDENCY_KEYS, "dependency cache contract drift"
+    assert Counter(sticky_keys) == EXPECTED_STICKY_KEYS, "sticky-disk contract drift"
+    assert Counter(sticky_deletes) == EXPECTED_STICKY_DELETES, "sticky-disk cleanup contract drift"
     print(
-        f"CI storage policy passed: {len(saved)} producers, {len(restored)} consumers, "
+        f"CI storage policy passed: {len(saved)} transfer producers, {len(restored)} consumers, "
+        f"{len(dependency_keys)} dependency caches, {len(sticky_keys)} bounded sticky disks, "
         "zero retained GitHub artifacts"
     )
 

--- a/scripts/ci/test-m22-non-cypher-surface-gate.py
+++ b/scripts/ci/test-m22-non-cypher-surface-gate.py
@@ -115,9 +115,11 @@ class M22SurfaceGateTests(unittest.TestCase):
         self.assertIn("release-load-matrix.py run", load_job)
         self.assertIn("useblacksmith/stickydisk@v1", load_job)
         self.assertIn(
-            "${{ github.repository }}-m22-load-${{ hashFiles('Cargo.lock') }}-target-v2",
+            "${{ github.repository }}-m22-load-${{ inputs.commit_sha }}-target-v3",
             load_job,
         )
+        self.assertIn("useblacksmith/stickydisk-delete@v1", load_job)
+        self.assertIn("needs: load", load_job)
         self.assertIn("CARGO_TARGET_DIR: ${{ github.workspace }}/target", load_job)
         self.assertIn("Reclaim sticky-disk ownership after maturin", load_job)
         self.assertIn(


### PR DESCRIPTION
## Summary

- remove speculative build caches from infrequent manual, checkpoint, milestone, stress, and release-certification gates
- share Test Suite Cargo dependency caches by OS and Cargo.lock identity instead of source hashes
- keep large mutable target trees only on frequently reused Blacksmith sticky disks
- make the capacity-only M22 sticky disk per-certification and delete it after the load job
- disable Maturin sccache because Blacksmith documents that Rust sccache still uses GitHub's cache backend
- enforce the complete dependency-cache, transfer-cache, sticky-disk, and cleanup ledger in repository policy

## Storage contract

- 17 exact transfer producers / 29 fail-closed consumers
- 8 dependency cache declarations
- 7 bounded sticky disks, including one M22 disk with mandatory deletion
- zero ordinary GitHub artifact storage
- zero source-keyed dependency caches
- zero target directories in actions/cache
- zero GitHub-backed Maturin sccache uses

## Validation

- `python3 scripts/ci/test-ci-storage-policy.py`
- `scripts/check-workflows.sh`
- `python3 scripts/ci/test-binding-release-candidate.py`
- `python3 scripts/ci/test-m20-contract-gate.py`
- `python3 scripts/ci/test-m21-contract-gate.py`
- `python3 scripts/ci/test-m22-non-cypher-surface-gate.py`
- `python3 scripts/ci/test-concurrency-stress-gate.py`
- `python3 scripts/ci/test-checkpoint-recovery-gate.py`
- `uv run ruff check ...`
- `uv run ruff format --check ...`

Closes #207

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787974100&installation_model_id=20486&pr_number=208&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F208&signature=8caa0e53983a4cb29c860bb39737a3715495dcfeea3681ce0b46c2b2a98d88ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Minimize Blacksmith cache storage across CI workflows
> - Removes speculative Cargo registry/target caches from infrequent gate workflows (`checkpoint-recovery-gate`, `concurrency-stress-gate`, `m20/m21-contract-gate`, `non-cypher-surface-gate`).
> - Disables `sccache` in maturin builds across `binding-release-candidate`, `publish`, and `m22-non-cypher-surface-gate`.
> - Normalizes remaining dependency cache keys in [test.yml](.github/workflows/test.yml) to a single `runner.os-cargo-registry-v1-{Cargo.lock hash}` format.
> - Switches the M22 stickydisk key from a `Cargo.lock`-hash-based key to a per-run commit-SHA key (`-target-v3`) and adds a `cleanup_load_disk` job that always deletes it after the load job.
> - Extends [test-ci-storage-policy.py](https://github.com/CurateLabs/graphforge/pull/208/files#diff-855ed98597547ac200b4015777e47aa99dda2b0ac141e95ffab9c0d96e87c1a0) to enforce contracts on dependency cache keys, stickydisk lifecycle, and maturin sccache usage.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 481bc0d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Strengthened CI validation for dependency caches, persistent storage, and cleanup workflows.
  - Added checks to prevent unintended use of GitHub-hosted storage for compiler caching.
  - Updated Windows release-candidate checks to enforce cache-free cold starts and correct build-step ordering.
  - Updated non-Cypher workflow validation for the latest target storage configuration.

- **Chores**
  - Refined workflow policy checks to reflect current CI behavior and storage contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->