### PR TITLE
ci: eliminate redundant post-merge test runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: Test Suite
 
 on:
-  push:
-    branches: ["main", "develop"]
   pull_request:
     branches: ["main"]
 
@@ -34,7 +32,7 @@ jobs:
         shell: bash
         run: |
           scripts/ci/classify-changes.sh \
-            "${{ github.event.pull_request.base.sha || github.event.before }}" \
+            "${{ github.event.pull_request.base.sha }}" \
             "${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
   policy:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,22 +56,20 @@ Merge only when:
 - `closingIssuesReferences` contains exactly the intended issue;
 - the diff contains no unrelated changes.
 
-Squash merge, delete the branch, verify issue closure, then verify post-merge `main` CI at the exact merge SHA.
+Squash merge, delete the branch, then verify the merge and issue closure. Do not
+rerun an unchanged tree solely to attach duplicate CI results to the squash
+commit; exact-head PR CI is the merge gate.
 
 ## Issue close
 
-Close an issue when its acceptance criteria **outcomes** are met: merged work (or an explicit documented non-code disposition), tests or other deterministic evidence for the stated criteria, and green checks for the *changed surface* on the merge commit.
+Close an issue when its acceptance criteria **outcomes** are met: merged work (or an explicit documented non-code disposition), tests or other deterministic evidence for the stated criteria, and green checks for the changed surface before merge.
 
 Do **not** require any of the following to close ordinary implementation, construction, infrastructure, or gate-tracker issues:
 
 - a multi-workflow “release gate cascade” (for example Rust surface → Binding RC → release aggregate);
-- citing an exact 40-character SHA or a SHA-bound downloadable artifact as the close criterion;
-- treating `workflow_dispatch` input hygiene (run IDs, stale-SHA rejection, artifact pairing) as existential for issue closure;
 - waiting on release-only certification workflows that are unrelated to the issue’s changed surface.
 
-Manual SHA-bound workflows remain valid for **publication / human release close** (the v0.5.0 publication close-out issue and `publish.yaml` readiness). Their success is release-certification evidence, not a close blocker for child implementation or construction issues. Keep real evidence: do not lie, skip tests, weaken assertions, or claim green without running the relevant checks.
-
-Write issue acceptance criteria as outcomes (what must be true), not as a serial dispatch script. Exact-SHA / same-SHA artifact language belongs in the release process for publication, not in child issue close gates.
+Manual SHA-bound workflows remain valid only for **publication / human release close** (the v0.5.0 publication close-out issue and `publish.yaml` readiness). Keep real evidence: do not lie, skip tests, weaken assertions, or claim green without running the relevant checks.
 
 ## Failure handling
 
@@ -97,6 +95,6 @@ Claims require authoritative evidence appropriate to the claim:
 - exact command and result for local or CI verification;
 - real Rust-facade or binding execution where the issue requires it;
 - reopen/recovery evidence for persistence claims;
-- for **release publication** claims only: exact SHA, exact CI run, and same-SHA artifacts as required by the release process.
+- for release publication claims, the SHA-bound evidence required by the release process.
 
 Do not invent SHA-citation rituals for ordinary issue close. Explicit maintainer instructions override this file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Post-v0.5.0 work lands here. The v0.5.0 publication cut is under `[0.5.0]` below.
 
+- Stop rerunning the full Test Suite after an already-green pull request is
+  squash-merged; exact-head pull-request CI remains the required merge gate
+  ([#209](https://github.com/CurateLabs/graphforge/issues/209)).
+
 - Minimize Blacksmith CI storage by removing speculative caches from infrequent
   gates, sharing dependency caches by lockfile identity, and deleting the
   one-run M22 build disk after certification (#207).

--- a/scripts/ci/test-ci-storage-policy.py
+++ b/scripts/ci/test-ci-storage-policy.py
@@ -193,8 +193,20 @@ def validate_maturin_storage(text: str) -> None:
         )
 
 
+def validate_test_suite_trigger(text: str) -> None:
+    trigger, found, _ = text.partition("\npermissions:\n")
+    assert found, "Test Suite workflow is missing its permissions boundary"
+    assert '  pull_request:\n    branches: ["main"]' in trigger, (
+        "Test Suite must gate pull requests to main"
+    )
+    assert "  push:" not in trigger, (
+        "Test Suite must not duplicate exact-head PR validation after merge"
+    )
+
+
 def main() -> None:
     texts = {path: path.read_text(encoding="utf-8") for path in sorted(WORKFLOWS.glob("*.y*ml"))}
+    validate_test_suite_trigger(texts[WORKFLOWS / "test.yml"])
     for path, text in texts.items():
         for forbidden in FORBIDDEN:
             assert forbidden not in text, f"{path.relative_to(ROOT)} uses {forbidden}"

--- a/scripts/ci/test-classify-changes.sh
+++ b/scripts/ci/test-classify-changes.sh
@@ -109,23 +109,9 @@ missing=$(
   exit 1
 }
 
-# A push receives `github.event.before`, so a docs-only merge remains scoped.
-printf 'docs\n' >"$fixture/docs.md"
-git -C "$fixture" add docs.md
-git -C "$fixture" commit -qm "docs-only push"
-push=$(
-  cd "$fixture"
-  "$classifier" "$base" HEAD
-)
-[[ "$push" == "$none" ]] || {
-  printf 'docs-only push classification must remain scoped, got:\n%s\n' "$push" >&2
-  exit 1
-}
-git -C "$fixture" reset --hard -q "$base"
-
-# The workflow must select the PR base when present and the push `before` SHA
-# otherwise. An absent or unusable base still fails closed in the classifier.
-grep -Fq '"${{ github.event.pull_request.base.sha || github.event.before }}"' "$workflow"
+# The PR-only workflow must classify against the pull request base. An absent
+# or unusable base still fails closed in the classifier.
+grep -Fq '"${{ github.event.pull_request.base.sha }}"' "$workflow"
 empty=$(
   cd "$fixture"
   "$classifier" "" HEAD


### PR DESCRIPTION
## Summary

- run the required full Test Suite only for pull requests to `main`
- retain the documentation push workflow because it publishes GitHub Pages
- make exact-head PR CI authoritative and remove duplicate merge-SHA instructions
- enforce the PR-only Test Suite trigger in repository policy

## Validation

- `python3 scripts/ci/test-ci-storage-policy.py`
- `scripts/check-workflows.sh`
- `uv run ruff check scripts/ci/test-ci-storage-policy.py`
- `uv run ruff format --check scripts/ci/test-ci-storage-policy.py`
- `git diff --check`

Closes #209

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787975241&installation_model_id=20486&pr_number=210&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F210&signature=f5e6bc2331d75c7e0855ef8d5f4271f76a1efb4500701d04d026b9682975d129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove push trigger from Test Suite workflow to eliminate redundant post-merge runs
> - Removes the `push` trigger (branches: `main`, `develop`) from [test.yml](https://github.com/CurateLabs/graphforge/pull/210/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88) so the workflow only runs on pull requests targeting `main`.
> - Updates the classify-changes step to use only `${{ github.event.pull_request.base.sha }}`, dropping the `github.event.before` fallback.
> - Adds a `validate_test_suite_trigger` check in [test-ci-storage-policy.py](https://github.com/CurateLabs/graphforge/pull/210/files#diff-855ed98597547ac200b4015777e47aa99dda2b0ac141e95ffab9c0d96e87c1a0) that enforces the push trigger is absent and the PR trigger targets `main`.
> - Updates [test-classify-changes.sh](https://github.com/CurateLabs/graphforge/pull/210/files#diff-b0cf9ea62c36d41efe27b93e7d80500212baff24baf9ff35652d79e540ee6c61) to remove the push-path test and assert only PR-base classification.
> - Behavioral Change: CI no longer runs after squash merges to `main`; the green PR head is the sole merge gate.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 63a94f7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->