### PR TITLE
feat(storage): stage concurrent attempts and commit by base comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,11 @@ the authoritative runnable corpus enforced by the BDD gate.
   not planned.
 
 ### Added
+
+- Add transaction-addressed optimistic project staging with OS-backed attempt
+  leases, exact-base commit comparison, atomic generation promotion, and
+  recovery that preserves live attempts while removing abandoned ones (#212).
+
 - Add `scripts/record_release_artifacts.py` and
   `docs/development/release-artifact-record.md` for RC checksum/SBOM/contents
   inventories usable by GitHub Release and §7 clean-env checks (#2798).

--- a/crates/gf-core/src/lib.rs
+++ b/crates/gf-core/src/lib.rs
@@ -266,6 +266,10 @@ pub enum ProjectErrorCode {
     UnsupportedFilesystem,
     /// Another process currently owns the project writer lock.
     WriterBusy,
+    /// A staged write cannot be applied to the latest committed generation.
+    WriteConflict,
+    /// Compatible contention exceeded the caller's bounded rebase attempts.
+    RebaseExhausted,
     /// A transaction UUID was reused with different immutable inputs.
     TransactionConflict,
     /// A generation failed before or after its commit point.
@@ -298,6 +302,8 @@ impl ProjectErrorCode {
             Self::ProjectCorrupt => "GF_PROJECT_CORRUPT",
             Self::UnsupportedFilesystem => "GF_UNSUPPORTED_FILESYSTEM",
             Self::WriterBusy => "GF_WRITER_BUSY",
+            Self::WriteConflict => "GF_WRITE_CONFLICT",
+            Self::RebaseExhausted => "GF_REBASE_EXHAUSTED",
             Self::TransactionConflict => "GF_IDEMPOTENCY_CONFLICT",
             Self::PublicationFailed => "GF_PUBLICATION_FAILED",
             Self::UnsupportedCapabilityVersion => "GF_UNSUPPORTED_CAPABILITY_VERSION",

--- a/crates/gf-storage/src/lib.rs
+++ b/crates/gf-storage/src/lib.rs
@@ -44,6 +44,7 @@ pub use project_publication::{
     ProjectCapability, ProjectGenerationRequest, ProjectParticipant, ProjectParticipantEncoding,
     ProjectPublicationReceipt, ProjectStageOutcome, StagedParticipant, StagedProjectGeneration,
     ValidatedProjectGeneration, published_project_transaction, stage_project_generation,
+    stage_project_generation_optimistic,
 };
 
 pub mod project_recovery;

--- a/crates/gf-storage/src/project_publication.rs
+++ b/crates/gf-storage/src/project_publication.rs
@@ -22,7 +22,9 @@ use crate::project_generation::{
 
 pub(crate) const LOCKS_DIR: &str = "locks";
 pub(crate) const WRITER_LOCK_FILE: &str = "writer.lock";
+pub(crate) const TRANSACTION_LOCKS_DIR: &str = "transactions";
 pub(crate) const TRANSACTIONS_DIR: &str = "transactions";
+pub(crate) const ATTEMPTS_DIR: &str = "attempts";
 pub(crate) const GENERATIONS_DIR: &str = "generations";
 const PARTICIPANTS_DIR: &str = "participants";
 const LEASE_FILE: &str = "lease.lock";
@@ -138,7 +140,7 @@ pub struct ProjectPublicationReceipt {
 
 /// Result of the stage operation.
 pub enum ProjectStageOutcome {
-    /// New private generation staged under the writer lock.
+    /// New private generation staged under its required publication locks.
     Staged(Box<StagedProjectGeneration>),
     /// The transaction and identical immutable inputs were already published.
     AlreadyPublished(ProjectPublicationReceipt),
@@ -147,15 +149,22 @@ pub enum ProjectStageOutcome {
 /// A staged generation that still requires domain and composite validation.
 pub struct StagedProjectGeneration {
     root: PathBuf,
-    writer_lock: File,
+    publication_lock: PublicationLock,
     parent: ResolvedProjectGeneration,
     transaction_uuid: Uuid,
     generation_uuid: Uuid,
     generation_root: PathBuf,
+    requires_promotion: bool,
     request_fingerprint: String,
+    operation_fingerprint: String,
     capabilities: Vec<ProjectCapability>,
     participants: Vec<StagedParticipant>,
     revert: Option<RevertJournalExtension>,
+}
+
+enum PublicationLock {
+    Exclusive(File),
+    Optimistic(File),
 }
 
 /// Canonical revert metadata persisted in every ADR 0015 journal phase.
@@ -198,6 +207,33 @@ pub fn stage_project_generation(
     })
 }
 
+/// Stage a complete private generation while allowing other transaction
+/// identities to stage against the same committed parent.
+///
+/// A transaction-scoped kernel lock prevents two live attempts for the same
+/// logical operation. Publication later acquires the global writer lock and
+/// compares the pinned parent with `CURRENT`. `operation_fingerprint` is stable
+/// across rebase attempts even though carried-forward parent participant bytes
+/// may change.
+///
+/// # Errors
+/// Returns a stable busy, idempotency, validation, corruption, or storage error.
+pub fn stage_project_generation_optimistic(
+    container_root: impl AsRef<Path>,
+    request: &ProjectGenerationRequest,
+    operation_fingerprint: [u8; 32],
+) -> Result<ProjectStageOutcome, GfError> {
+    stage_project_generation_optimistic_inner(
+        container_root.as_ref(),
+        request,
+        operation_fingerprint,
+    )
+    .map_err(|error| match error {
+        GfError::Storage(message) => publication_error(request, "STAGE", false, &message),
+        other => other,
+    })
+}
+
 fn stage_project_generation_inner(
     container_root: &Path,
     request: &ProjectGenerationRequest,
@@ -215,6 +251,24 @@ fn stage_project_generation_inner(
     stage_project_generation_with_lock(root, writer_lock, parent, request, None)
 }
 
+fn stage_project_generation_optimistic_inner(
+    container_root: &Path,
+    request: &ProjectGenerationRequest,
+    operation_fingerprint: [u8; 32],
+) -> Result<ProjectStageOutcome, GfError> {
+    let root = canonical_supported_root(container_root)?;
+    let transaction_lock = acquire_transaction_lock(&root, request)?;
+    let parent = resolve_project_generation(&root)?;
+    stage_project_generation_inner_with_locks(
+        root,
+        PublicationLock::Optimistic(transaction_lock),
+        parent,
+        request,
+        None,
+        Some(operation_fingerprint),
+    )
+}
+
 /// Stage a generation using a writer lock and parent resolved by a composed
 /// storage operation such as complete-workspace checkpoint revert.
 pub(crate) fn stage_project_generation_with_lock(
@@ -224,8 +278,28 @@ pub(crate) fn stage_project_generation_with_lock(
     request: &ProjectGenerationRequest,
     revert: Option<RevertJournalExtension>,
 ) -> Result<ProjectStageOutcome, GfError> {
+    stage_project_generation_inner_with_locks(
+        root,
+        PublicationLock::Exclusive(writer_lock),
+        parent,
+        request,
+        revert,
+        None,
+    )
+}
+
+fn stage_project_generation_inner_with_locks(
+    root: PathBuf,
+    publication_lock: PublicationLock,
+    parent: ResolvedProjectGeneration,
+    request: &ProjectGenerationRequest,
+    revert: Option<RevertJournalExtension>,
+    operation_fingerprint: Option<[u8; 32]>,
+) -> Result<ProjectStageOutcome, GfError> {
     validate_request(request)?;
     let (capabilities, participants, request_fingerprint) = request_metadata(request)?;
+    let operation_fingerprint =
+        operation_fingerprint.map_or_else(|| request_fingerprint.clone(), hex_digest);
     let transactions_dir = ensure_machine_directory(&root, Path::new(TRANSACTIONS_DIR))?;
     sync_directory(&root)?;
     let journal_path =
@@ -235,6 +309,7 @@ pub(crate) fn stage_project_generation_with_lock(
             &root,
             request,
             &request_fingerprint,
+            &operation_fingerprint,
             revert.as_ref(),
             &journal_path,
         )?
@@ -242,14 +317,16 @@ pub(crate) fn stage_project_generation_with_lock(
         return Ok(outcome);
     }
 
-    let generation_root = prepare_generation_directory(&root, request)?;
+    let requires_promotion = matches!(publication_lock, PublicationLock::Optimistic(_));
+    let generation_root =
+        prepare_generation_directory(&root, request, &request_fingerprint, requires_promotion)?;
     write_journal(
         &journal_path,
         &JournalRecord::new(
             request,
             Some(parent.generation_uuid()),
             JournalPhase::Preparing,
-            request_fingerprint.clone(),
+            (request_fingerprint.clone(), operation_fingerprint.clone()),
             &participants,
             None,
             revert.clone(),
@@ -278,7 +355,7 @@ pub(crate) fn stage_project_generation_with_lock(
             request,
             Some(parent.generation_uuid()),
             JournalPhase::Staged,
-            request_fingerprint.clone(),
+            (request_fingerprint.clone(), operation_fingerprint.clone()),
             &participants,
             None,
             revert.clone(),
@@ -295,12 +372,14 @@ pub(crate) fn stage_project_generation_with_lock(
     Ok(ProjectStageOutcome::Staged(Box::new(
         StagedProjectGeneration {
             root,
-            writer_lock,
+            publication_lock,
             parent,
             transaction_uuid: request.transaction_uuid,
             generation_uuid: request.generation_uuid,
             generation_root,
+            requires_promotion,
             request_fingerprint,
+            operation_fingerprint,
             capabilities,
             participants,
             revert,
@@ -309,6 +388,14 @@ pub(crate) fn stage_project_generation_with_lock(
 }
 
 fn acquire_writer_lock(root: &Path, request: &ProjectGenerationRequest) -> Result<File, GfError> {
+    acquire_writer_lock_for_parts(root, request.transaction_uuid, request.generation_uuid)
+}
+
+fn acquire_writer_lock_for_parts(
+    root: &Path,
+    transaction_uuid: Uuid,
+    generation_uuid: Uuid,
+) -> Result<File, GfError> {
     let lock_dir = ensure_machine_directory(root, Path::new(LOCKS_DIR))?;
     sync_directory(root)?;
     let writer_lock = open_regular_lock(&lock_dir.join(WRITER_LOCK_FILE))?;
@@ -317,23 +404,48 @@ fn acquire_writer_lock(root: &Path, request: &ProjectGenerationRequest) -> Resul
             ProjectErrorCode::WriterBusy,
             format!(
                 "transaction_uuid={} generation_uuid={} phase=WRITER_LOCK committed=false cause=busy",
-                request.transaction_uuid.hyphenated(),
-                request.generation_uuid.hyphenated()
+                transaction_uuid.hyphenated(),
+                generation_uuid.hyphenated()
             ),
         ));
     }
     Ok(writer_lock)
 }
 
+fn acquire_transaction_lock(
+    root: &Path,
+    request: &ProjectGenerationRequest,
+) -> Result<File, GfError> {
+    let lock = open_transaction_lock(root, request.transaction_uuid)?;
+    if !FileExt::try_lock_exclusive(&lock).map_err(publication_io)? {
+        return Err(project_error(
+            ProjectErrorCode::WriterBusy,
+            format!(
+                "transaction_uuid={} generation_uuid={} phase=TRANSACTION_LOCK committed=false cause=busy",
+                request.transaction_uuid.hyphenated(),
+                request.generation_uuid.hyphenated()
+            ),
+        ));
+    }
+    Ok(lock)
+}
+
+pub(crate) fn open_transaction_lock(root: &Path, transaction_uuid: Uuid) -> Result<File, GfError> {
+    let lock_dir =
+        ensure_machine_directory(root, &Path::new(LOCKS_DIR).join(TRANSACTION_LOCKS_DIR))?;
+    open_regular_lock(&lock_dir.join(format!("{}.lock", transaction_uuid.hyphenated())))
+}
+
 fn handle_existing_journal(
     root: &Path,
     request: &ProjectGenerationRequest,
     request_fingerprint: &str,
+    operation_fingerprint: &str,
     expected_revert: Option<&RevertJournalExtension>,
     journal_path: &Path,
 ) -> Result<Option<ProjectStageOutcome>, GfError> {
     let journal = read_journal(journal_path)?;
-    if journal.request_fingerprint != request_fingerprint
+    if journal.operation_fingerprint() != operation_fingerprint
         || journal.generation_uuid != request.generation_uuid.hyphenated().to_string()
         || journal.revert.as_ref() != expected_revert
     {
@@ -351,7 +463,13 @@ fn handle_existing_journal(
                 "aborted transaction cleanup is incomplete; run recovery again",
             ));
         }
+        cleanup_aborted_attempts(root, request.transaction_uuid)?;
         return Ok(None);
+    }
+    if journal.request_fingerprint != request_fingerprint
+        && journal.phase != JournalPhase::Published
+    {
+        return Err(transaction_conflict(request));
     }
     if journal.phase != JournalPhase::Published {
         return Err(publication_error(
@@ -391,6 +509,24 @@ fn handle_existing_journal(
             idempotent_replay: true,
         },
     )))
+}
+
+fn cleanup_aborted_attempts(root: &Path, transaction_uuid: Uuid) -> Result<(), GfError> {
+    let attempts_root = root.join(ATTEMPTS_DIR);
+    let transaction_root = attempts_root.join(transaction_uuid.hyphenated().to_string());
+    let metadata = match std::fs::symlink_metadata(&transaction_root) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(publication_io(error)),
+    };
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Err(project_error(
+            ProjectErrorCode::ProjectCorrupt,
+            "aborted transaction attempt path is linked or not a directory",
+        ));
+    }
+    std::fs::remove_dir_all(&transaction_root).map_err(publication_io)?;
+    sync_directory(&attempts_root)
 }
 
 /// Load the canonical revert extension for direct idempotent replay lookup.
@@ -509,19 +645,21 @@ pub fn published_project_transaction(
 fn prepare_generation_directory(
     root: &Path,
     request: &ProjectGenerationRequest,
+    request_fingerprint: &str,
+    requires_promotion: bool,
 ) -> Result<PathBuf, GfError> {
-    let generation_root = root
-        .join(GENERATIONS_DIR)
-        .join(request.generation_uuid.hyphenated().to_string());
+    let relative_root = if requires_promotion {
+        Path::new(ATTEMPTS_DIR)
+            .join(request.transaction_uuid.hyphenated().to_string())
+            .join(request_fingerprint)
+    } else {
+        Path::new(GENERATIONS_DIR).join(request.generation_uuid.hyphenated().to_string())
+    };
+    let generation_root = root.join(&relative_root);
     if generation_root.exists() {
         return Err(transaction_conflict(request));
     }
-    ensure_machine_directory(
-        root,
-        &Path::new(GENERATIONS_DIR)
-            .join(request.generation_uuid.hyphenated().to_string())
-            .join(PARTICIPANTS_DIR),
-    )?;
+    ensure_machine_directory(root, &relative_root.join(PARTICIPANTS_DIR))?;
     Ok(generation_root)
 }
 
@@ -649,6 +787,7 @@ impl StagedProjectGeneration {
             parent_generation_uuid: Some(self.parent.generation_uuid().hyphenated().to_string()),
             phase,
             request_fingerprint: self.request_fingerprint.clone(),
+            operation_fingerprint: Some(self.operation_fingerprint.clone()),
             participant_paths: self
                 .participants
                 .iter()
@@ -667,7 +806,8 @@ impl ValidatedProjectGeneration {
     /// Returns a stable publication error whose diagnostic states whether the
     /// commit point was crossed.
     pub fn publish(self) -> Result<ProjectPublicationReceipt, GfError> {
-        self.publish_inner().map_err(|error| {
+        let commit_lock = self.prepare_commit_lock()?;
+        let result = self.publish_inner().map_err(|error| {
             if matches!(error, GfError::Project { .. }) {
                 error
             } else {
@@ -679,7 +819,43 @@ impl ValidatedProjectGeneration {
                     &error.to_string(),
                 )
             }
-        })
+        });
+        drop(commit_lock);
+        result
+    }
+
+    fn prepare_commit_lock(&self) -> Result<Option<File>, GfError> {
+        if matches!(self.0.publication_lock, PublicationLock::Exclusive(_)) {
+            return Ok(None);
+        }
+        let staged = &self.0;
+        let writer_lock = acquire_writer_lock_for_parts(
+            &staged.root,
+            staged.transaction_uuid,
+            staged.generation_uuid,
+        )?;
+        project_failpoint::hit(
+            "project.after_optimistic_commit_lock",
+            Some(staged.transaction_uuid),
+            Some(staged.generation_uuid),
+            "COMMIT_LOCK",
+            false,
+        )?;
+        let current = resolve_project_generation(&staged.root)?;
+        if current.generation_uuid() != staged.parent.generation_uuid() {
+            abort_stale_generation(staged)?;
+            return Err(project_error(
+                ProjectErrorCode::WriteConflict,
+                format!(
+                    "transaction_uuid={} generation_uuid={} phase=COMMIT_LOCK committed=false cause=stale_parent expected_parent={} actual_parent={}",
+                    staged.transaction_uuid.hyphenated(),
+                    staged.generation_uuid.hyphenated(),
+                    staged.parent.generation_uuid().hyphenated(),
+                    current.generation_uuid().hyphenated()
+                ),
+            ));
+        }
+        Ok(Some(writer_lock))
     }
 
     fn publish_inner(&self) -> Result<ProjectPublicationReceipt, GfError> {
@@ -694,6 +870,23 @@ impl ValidatedProjectGeneration {
             idempotent_replay: false,
         })
     }
+}
+
+fn abort_stale_generation(staged: &StagedProjectGeneration) -> Result<(), GfError> {
+    write_journal(
+        &staged.journal_path(),
+        &staged.journal(JournalPhase::Aborted, None),
+    )?;
+    if staged.generation_root.exists() {
+        std::fs::remove_dir_all(&staged.generation_root).map_err(publication_io)?;
+        sync_directory(
+            staged
+                .generation_root
+                .parent()
+                .expect("machine attempt path has a parent"),
+        )?;
+    }
+    Ok(())
 }
 
 fn make_generation_durable(staged: &StagedProjectGeneration) -> Result<[u8; 32], GfError> {
@@ -762,7 +955,11 @@ fn make_generation_durable(staged: &StagedProjectGeneration) -> Result<[u8; 32],
         "DURABLE",
         false,
     )?;
-    sync_directory(&staged.root.join(GENERATIONS_DIR))?;
+    if staged.requires_promotion {
+        promote_optimistic_generation(staged)?;
+    } else {
+        sync_directory(&staged.root.join(GENERATIONS_DIR))?;
+    }
     write_journal(
         &staged.journal_path(),
         &staged.journal(JournalPhase::Durable, Some(hex_digest(manifest_sha256))),
@@ -775,6 +972,37 @@ fn make_generation_durable(staged: &StagedProjectGeneration) -> Result<[u8; 32],
         false,
     )?;
     Ok(manifest_sha256)
+}
+
+fn promote_optimistic_generation(staged: &StagedProjectGeneration) -> Result<(), GfError> {
+    let generations_root = staged.root.join(GENERATIONS_DIR);
+    let destination = generations_root.join(staged.generation_uuid.hyphenated().to_string());
+    if destination.exists() {
+        return Err(project_error(
+            ProjectErrorCode::TransactionConflict,
+            format!(
+                "transaction_uuid={} generation_uuid={} phase=PROMOTE committed=false cause=generation_exists",
+                staged.transaction_uuid.hyphenated(),
+                staged.generation_uuid.hyphenated()
+            ),
+        ));
+    }
+    std::fs::rename(&staged.generation_root, &destination).map_err(publication_io)?;
+    let transaction_attempt_root = staged
+        .generation_root
+        .parent()
+        .expect("machine attempt path has a parent");
+    sync_directory(transaction_attempt_root)?;
+    std::fs::remove_dir(transaction_attempt_root).map_err(publication_io)?;
+    sync_directory(&staged.root.join(ATTEMPTS_DIR))?;
+    sync_directory(&generations_root)?;
+    project_failpoint::hit(
+        "project.after_optimistic_promotion",
+        Some(staged.transaction_uuid),
+        Some(staged.generation_uuid),
+        "DURABLE",
+        false,
+    )
 }
 
 fn replace_current(
@@ -901,7 +1129,11 @@ fn finish_published_generation(
 
 impl Drop for StagedProjectGeneration {
     fn drop(&mut self) {
-        let _ = FileExt::unlock(&self.writer_lock);
+        match &self.publication_lock {
+            PublicationLock::Exclusive(lock) | PublicationLock::Optimistic(lock) => {
+                let _ = FileExt::unlock(lock);
+            }
+        }
     }
 }
 
@@ -926,6 +1158,8 @@ pub(crate) struct JournalRecord {
     pub(crate) parent_generation_uuid: Option<String>,
     pub(crate) phase: JournalPhase,
     pub(crate) request_fingerprint: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) operation_fingerprint: Option<String>,
     pub(crate) participant_paths: Vec<String>,
     pub(crate) generation_manifest_sha256: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -937,11 +1171,12 @@ impl JournalRecord {
         request: &ProjectGenerationRequest,
         parent: Option<Uuid>,
         phase: JournalPhase,
-        request_fingerprint: String,
+        fingerprints: (String, String),
         participants: &[StagedParticipant],
         generation_manifest_sha256: Option<String>,
         revert: Option<RevertJournalExtension>,
     ) -> Self {
+        let (request_fingerprint, operation_fingerprint) = fingerprints;
         Self {
             format: "graphforge-transaction".into(),
             format_version: 1,
@@ -950,6 +1185,7 @@ impl JournalRecord {
             parent_generation_uuid: parent.map(|uuid| uuid.hyphenated().to_string()),
             phase,
             request_fingerprint,
+            operation_fingerprint: Some(operation_fingerprint),
             participant_paths: participants
                 .iter()
                 .map(|participant| participant.relative_path.clone())
@@ -957,6 +1193,12 @@ impl JournalRecord {
             generation_manifest_sha256,
             revert,
         }
+    }
+
+    pub(crate) fn operation_fingerprint(&self) -> &str {
+        self.operation_fingerprint
+            .as_deref()
+            .unwrap_or(&self.request_fingerprint)
     }
 }
 
@@ -1381,6 +1623,11 @@ pub(crate) fn read_journal(path: &Path) -> Result<JournalRecord, GfError> {
     if canonical_line(&journal)? != bytes
         || journal.format != "graphforge-transaction"
         || journal.format_version != 1
+        || parse_digest(&journal.request_fingerprint).is_none()
+        || journal
+            .operation_fingerprint
+            .as_deref()
+            .is_some_and(|fingerprint| parse_digest(fingerprint).is_none())
     {
         return Err(project_error(
             ProjectErrorCode::ProjectCorrupt,
@@ -1881,6 +2128,99 @@ mod tests {
             child
         );
         assert!(parent.generation_root().exists());
+    }
+
+    #[test]
+    fn optimistic_attempts_stage_concurrently_and_compare_parent_at_commit() {
+        let root = project();
+        let first = request(vec![participant("graph", "nodes", b"first")]);
+        let second = request(vec![participant("graph", "nodes", b"second")]);
+        let first_operation: [u8; 32] = Sha256::digest(b"logical-first").into();
+        let second_operation: [u8; 32] = Sha256::digest(b"logical-second").into();
+
+        let ProjectStageOutcome::Staged(first_staged) =
+            stage_project_generation_optimistic(root.path(), &first, first_operation).unwrap()
+        else {
+            panic!("first optimistic operation replayed unexpectedly");
+        };
+        let ProjectStageOutcome::Staged(second_staged) =
+            stage_project_generation_optimistic(root.path(), &second, second_operation).unwrap()
+        else {
+            panic!("second optimistic operation replayed unexpectedly");
+        };
+
+        let first_validated = first_staged.validate(|_| Ok(()), |_, _| Ok(())).unwrap();
+        let second_validated = second_staged.validate(|_| Ok(()), |_, _| Ok(())).unwrap();
+        first_validated.publish().unwrap();
+        let error = second_validated
+            .publish()
+            .expect_err("stale optimistic parent must not publish");
+        assert_eq!(error.code(), "GF_WRITE_CONFLICT");
+        assert!(
+            !root
+                .path()
+                .join(GENERATIONS_DIR)
+                .join(second.generation_uuid.hyphenated().to_string())
+                .exists()
+        );
+
+        let mut rebased = second.clone();
+        rebased.participants[0].bytes = b"second-rebased".to_vec();
+        let ProjectStageOutcome::Staged(rebased) =
+            stage_project_generation_optimistic(root.path(), &rebased, second_operation).unwrap()
+        else {
+            panic!("aborted optimistic operation did not permit a rebase attempt");
+        };
+        rebased
+            .validate(|_| Ok(()), |_, _| Ok(()))
+            .unwrap()
+            .publish()
+            .unwrap();
+        assert_eq!(
+            resolve_project_generation(root.path())
+                .unwrap()
+                .generation_uuid(),
+            second.generation_uuid
+        );
+    }
+
+    #[test]
+    fn optimistic_transaction_identity_has_one_live_attempt() {
+        let root = project();
+        let request = request(vec![participant("graph", "nodes", b"attempt")]);
+        let operation: [u8; 32] = Sha256::digest(b"logical-attempt").into();
+        let first = stage_project_generation_optimistic(root.path(), &request, operation).unwrap();
+
+        let error = stage_project_generation_optimistic(root.path(), &request, operation)
+            .err()
+            .expect("duplicate live attempt must be rejected");
+        assert_eq!(error.code(), "GF_WRITER_BUSY");
+        drop(first);
+    }
+
+    #[test]
+    fn recovery_preserves_live_optimistic_attempt_then_cleans_it_after_release() {
+        let root = project();
+        let request = request(vec![participant("graph", "nodes", b"live")]);
+        let operation: [u8; 32] = Sha256::digest(b"logical-live").into();
+        let (_, _, request_fingerprint) = request_metadata(&request).unwrap();
+        let generation_path = root
+            .path()
+            .join(ATTEMPTS_DIR)
+            .join(request.transaction_uuid.hyphenated().to_string())
+            .join(request_fingerprint);
+        let staged = stage_project_generation_optimistic(root.path(), &request, operation).unwrap();
+
+        let live_report = crate::recover_project_transactions(root.path()).unwrap();
+        assert_eq!(live_report.aborted_journals, 0);
+        assert_eq!(live_report.removed_generations, 0);
+        assert!(generation_path.exists());
+
+        drop(staged);
+        let abandoned_report = crate::recover_project_transactions(root.path()).unwrap();
+        assert_eq!(abandoned_report.aborted_journals, 1);
+        assert_eq!(abandoned_report.removed_generations, 1);
+        assert!(!generation_path.exists());
     }
 
     #[test]

--- a/crates/gf-storage/src/project_recovery.rs
+++ b/crates/gf-storage/src/project_recovery.rs
@@ -18,8 +18,9 @@ use crate::project_generation::{
     resolve_project_generation, validated_generation_manifest_sha256, validated_generation_parent,
 };
 use crate::project_publication::{
-    GENERATIONS_DIR, JournalPhase, LOCKS_DIR, TRANSACTIONS_DIR, WRITER_LOCK_FILE,
-    ensure_machine_directory, open_regular_lock, read_journal, sync_directory, write_journal,
+    ATTEMPTS_DIR, GENERATIONS_DIR, JournalPhase, LOCKS_DIR, TRANSACTIONS_DIR, WRITER_LOCK_FILE,
+    ensure_machine_directory, open_regular_lock, open_transaction_lock, read_journal,
+    sync_directory, write_journal,
 };
 
 const TRASH_DIR: &str = "trash";
@@ -112,6 +113,13 @@ fn recover_journals(
                 "transaction directory contains a noncanonical journal entry",
             ));
         };
+        let transaction_lock = open_transaction_lock(root, transaction_uuid)?;
+        if !FileExt::try_lock_exclusive(&transaction_lock).map_err(storage_io)? {
+            // A live optimistic writer owns this exact attempt. The global
+            // commit lock prevents it from publishing during this recovery
+            // pass, while its transaction lease prevents false abandonment.
+            continue;
+        }
         let mut journal = read_journal(&journal_path)
             .map_err(|_| recovery_corrupt("transaction journal is torn, invalid, or ambiguous"))?;
         if parse_canonical_uuid(&journal.transaction_uuid) != Some(transaction_uuid) {
@@ -142,8 +150,13 @@ fn recover_journals(
                 write_journal(&journal_path, &journal)?;
                 report.aborted_journals += 1;
             }
-            report.removed_generations +=
-                cleanup_abandoned_generation(root, transaction_uuid, generation_uuid, retained)?;
+            report.removed_generations += cleanup_abandoned_generation(
+                root,
+                transaction_uuid,
+                generation_uuid,
+                &journal.request_fingerprint,
+                retained,
+            )?;
         }
     }
     Ok(())
@@ -202,6 +215,7 @@ fn cleanup_abandoned_generation(
     root: &Path,
     transaction_uuid: Uuid,
     generation_uuid: Uuid,
+    request_fingerprint: &str,
     retained: &BTreeSet<Uuid>,
 ) -> Result<u64, GfError> {
     if retained.contains(&generation_uuid) {
@@ -209,6 +223,29 @@ fn cleanup_abandoned_generation(
     }
     let generation_name = generation_uuid.hyphenated().to_string();
     let generation_path = root.join(GENERATIONS_DIR).join(&generation_name);
+    let attempt_path = root
+        .join(ATTEMPTS_DIR)
+        .join(transaction_uuid.hyphenated().to_string())
+        .join(request_fingerprint);
+    let mut removed = 0;
+    if attempt_path.exists() {
+        reject_real_directory(&attempt_path)?;
+        std::fs::remove_dir_all(&attempt_path).map_err(storage_io)?;
+        sync_directory(
+            attempt_path
+                .parent()
+                .expect("machine attempt path has a parent"),
+        )?;
+        let transaction_attempt_root = attempt_path
+            .parent()
+            .expect("machine attempt path has a parent");
+        match std::fs::remove_dir(transaction_attempt_root) {
+            Ok(()) => sync_directory(&root.join(ATTEMPTS_DIR))?,
+            Err(error) if error.kind() == std::io::ErrorKind::DirectoryNotEmpty => {}
+            Err(error) => return Err(storage_io(error)),
+        }
+        removed = 1;
+    }
     let trash_root = ensure_machine_directory(root, Path::new(TRASH_DIR))?;
     let trash_path = trash_root.join(&generation_name);
 
@@ -223,7 +260,7 @@ fn cleanup_abandoned_generation(
         return Ok(1);
     }
     if !generation_path.exists() {
-        return Ok(0);
+        return Ok(removed);
     }
     reject_real_directory(&generation_path)?;
     let lease_path = generation_path.join("lease.lock");
@@ -400,7 +437,7 @@ mod tests {
     use crate::{
         ProjectCapability, ProjectGenerationRequest, ProjectParticipant,
         ProjectParticipantEncoding, ProjectStageOutcome, open_or_initialize_project,
-        stage_project_generation,
+        stage_project_generation, stage_project_generation_optimistic,
     };
 
     const ENABLE_COOKIE: &str = "graphforge-internal-subprocess-v1";
@@ -529,6 +566,33 @@ mod tests {
             .unwrap()
     }
 
+    fn spawn_optimistic_writer(
+        root: &Path,
+        transaction_uuid: Uuid,
+        generation_uuid: Uuid,
+        failpoint: &str,
+    ) -> std::process::ExitStatus {
+        Command::new(std::env::current_exe().unwrap())
+            .arg("--exact")
+            .arg(WRITER_HELPER)
+            .arg("--nocapture")
+            .env("GRAPHFORGE_TEST_PROJECT_ROOT", root)
+            .env(
+                "GRAPHFORGE_TEST_TRANSACTION_UUID",
+                transaction_uuid.hyphenated().to_string(),
+            )
+            .env(
+                "GRAPHFORGE_TEST_GENERATION_UUID",
+                generation_uuid.hyphenated().to_string(),
+            )
+            .env("GRAPHFORGE_TEST_PARTICIPANT_SET", "graph")
+            .env("GRAPHFORGE_TEST_OPTIMISTIC", "1")
+            .env("GRAPHFORGE_PROJECT_FAILPOINTS", ENABLE_COOKIE)
+            .env("GRAPHFORGE_PROJECT_FAILPOINT", failpoint)
+            .status()
+            .unwrap()
+    }
+
     fn assert_reopen(root: &Path, expected: Uuid, set: &str, expect_child: bool) {
         let before_recovery = resolve_project_generation(root).unwrap();
         assert_eq!(before_recovery.generation_uuid(), expected);
@@ -604,6 +668,23 @@ mod tests {
                 "graph",
                 committed,
             );
+        }
+    }
+
+    #[test]
+    fn optimistic_commit_failpoints_never_expose_a_partial_generation() {
+        for failpoint in [
+            "project.after_optimistic_commit_lock",
+            "project.after_optimistic_promotion",
+        ] {
+            let root = tempfile::tempdir().unwrap();
+            let parent = open_or_initialize_project(root.path())
+                .unwrap()
+                .generation_uuid();
+            let status =
+                spawn_optimistic_writer(root.path(), Uuid::now_v7(), Uuid::now_v7(), failpoint);
+            assert_eq!(status.code(), Some(crate::project_failpoint::exit_code()));
+            assert_reopen(root.path(), parent, "graph", false);
         }
     }
 
@@ -1026,8 +1107,16 @@ mod tests {
             participants: participants(&set),
         };
         let result = (|| {
-            let ProjectStageOutcome::Staged(staged) = stage_project_generation(&root, &request)?
-            else {
+            let outcome = if std::env::var("GRAPHFORGE_TEST_OPTIMISTIC").is_ok() {
+                stage_project_generation_optimistic(
+                    &root,
+                    &request,
+                    Sha256::digest(b"optimistic-subprocess-operation").into(),
+                )?
+            } else {
+                stage_project_generation(&root, &request)?
+            };
+            let ProjectStageOutcome::Staged(staged) = outcome else {
                 panic!("new transaction replayed");
             };
             staged.validate(|_| Ok(()), |_, _| Ok(()))?.publish()

--- a/docs/adr/0013-project-generation-protocol.md
+++ b/docs/adr/0013-project-generation-protocol.md
@@ -22,8 +22,9 @@ any earlier development layout.
 
 ### Scope and filesystem support
 
-The protocol is for a local filesystem, one writer, and any number of readers.
-The implementation must preflight these primitives before creating or mutating
+The protocol is for a local filesystem, one commit writer, any number of
+readers, and optionally multiple private optimistic staging attempts. The
+implementation must preflight these primitives before creating or mutating
 a project:
 
 1. exclusive and shared advisory file locks released by the operating system
@@ -60,9 +61,14 @@ project/
 ├── FORMAT
 ├── CURRENT
 ├── locks/
-│   └── writer.lock
+│   ├── writer.lock
+│   └── transactions/
+│       └── <transaction-uuid>.lock
 ├── transactions/
 │   └── <transaction-uuid>.json
+├── attempts/
+│   └── <transaction-uuid>/<request-sha256>/
+│       └── participants/
 ├── generations/
 │   └── <generation-uuid>/
 │       ├── lease.lock
@@ -154,15 +160,25 @@ version returns the same code.
 
 ### Locks and ownership
 
-`locks/writer.lock` is held exclusively for the complete transaction,
-including cleanup after publication. The kernel lock is authoritative.
+`locks/writer.lock` is held exclusively for the complete transaction in the
+default single-writer protocol, including cleanup after publication. An
+optimistic attempt instead holds its transaction-scoped kernel lock while it
+prepares and validates in `attempts/`; it acquires `writer.lock` only for base
+comparison, promotion, publication, and cleanup. The kernel locks are
+authoritative.
 Metadata written after acquisition may contain an owner UUID, process ID,
 hostname hash, operation, and acquisition time for diagnostics only. PID,
 hostname, file age, heartbeat age, or wall-clock time never permits lock
 stealing. A dead process is proved only when the operating system releases its
 lock.
 
-The default acquisition is non-blocking and returns `GF_WRITER_BUSY`.
+Only one live attempt may own a transaction UUID. Different transaction UUIDs
+may stage concurrently. Transaction lock files carry no authority once their
+OS lock is released and are never reclaimed using PID, age, or heartbeat
+heuristics.
+
+The default writer-lock acquisition is non-blocking and returns
+`GF_WRITER_BUSY`.
 Callers may supply a finite timeout measured by a monotonic clock; expiry
 returns the same code without mutation. Infinite waits are not exposed by a
 public API.
@@ -200,11 +216,14 @@ Journal replacement itself uses write, file flush, atomic replace, and
 directory flush. Its failure can leave an earlier valid journal state without
 changing commit authority.
 
-The writer performs these ordered operations while holding `writer.lock`:
+The default writer performs these ordered operations while holding
+`writer.lock`. An optimistic writer performs steps 1 through 4 under its
+transaction lock, then acquires `writer.lock`, resolves `CURRENT` again, and
+continues only when it still names the pinned parent:
 
 1. **Resolve parent.** Pin and fully validate `CURRENT`, if present. An absent
    `CURRENT` is allowed only for an uninitialized v1 container.
-2. **PREPARING.** Create a transaction UUID and a private generation directory;
+2. **PREPARING.** Create a transaction UUID and a private attempt directory;
    persist a `PREPARING` journal containing only IDs, phases, and relative
    participant names.
 3. **STAGED.** Write every participant to its final path in the private
@@ -216,7 +235,9 @@ The writer performs these ordered operations while holding `writer.lock`:
 5. **DURABLE.** Write and flush `lease.lock`, write and flush
    `manifest.json`, reread and verify every participant and the manifest, flush
    `participants/` directories from leaves upward, flush the generation
-   directory, flush `generations/`, then persist the `DURABLE` journal.
+   directory, promote an optimistic attempt by atomic rename into
+   `generations/<generation-uuid>/`, flush both changed parent directories and
+   `generations/`, then persist the `DURABLE` journal.
 6. **Publish.** Write the exact new `CURRENT` bytes to a sibling private file,
    flush it, atomically replace `CURRENT` (or atomically create it for the first
    generation), and flush the project root.
@@ -228,6 +249,11 @@ The successful atomic replacement/creation of `CURRENT` in step 6 is the sole
 linearization point. Before it, every reader resolves the parent. After it,
 every new reader resolves the new generation. A journal state, directory scan,
 newer UUID, timestamp, or highest counter can never override `CURRENT`.
+
+If the optimistic base comparison finds a different committed parent, the
+attempt is marked `ABORTED`, its private directory is removed, and
+`GF_WRITE_CONFLICT` is returned without promoting a generation. Domain-level
+rebase policy belongs above this storage protocol.
 
 The root directory flush is required to make the pointer replacement durable
 against power loss. If the process stops between pointer replacement and root
@@ -270,6 +296,12 @@ Open always resolves authority first:
 4. verify the manifest digest and only the capabilities requested by the API.
 
 With the writer lock held, recovery classifies journals mechanically:
+
+Before classifying a journal, recovery also acquires its transaction lock
+without waiting. A busy transaction lock proves that the private attempt is
+live, so recovery leaves that journal and attempt untouched. Because recovery
+already owns `writer.lock`, that attempt cannot cross the commit boundary
+during classification.
 
 | Observed state | Classification | Action |
 |---|---|---|
@@ -326,6 +358,8 @@ The names are public test vocabulary:
 | `project.after_manifest_write` | parent / uninitialized |
 | `project.after_manifest_fsync` | parent / uninitialized |
 | `project.after_generation_dir_fsync` | parent / uninitialized |
+| `project.after_optimistic_commit_lock` | parent / uninitialized |
+| `project.after_optimistic_promotion` | parent / uninitialized |
 | `project.after_journal_durable` | parent / uninitialized |
 | `project.after_current_temp_write` | parent / uninitialized |
 | `project.after_current_temp_fsync` | parent / uninitialized |
@@ -341,7 +375,7 @@ the stable base name and outcome do not change. Each pre-publication failpoint
 also has an `.error` variant that makes that operation return its platform
 error instead of terminating; it must return `committed: false`. The
 `project.after_current_replace.error` variant must return `committed: true`.
- must exercise every row and every error variant for first publication and
+Tests must exercise every row and every error variant for first publication and
 replacement publication on each supported operating system. Tests assert
 selected UUID, manifest digest, participant checksums, and row visibility; they
 do not accept log inspection or timing as evidence.


### PR DESCRIPTION
## Summary

- stage optimistic writes in transaction-addressed private attempt directories under OS-backed transaction locks
- compare the pinned parent under the global writer lock before atomic promotion and CURRENT replacement
- preserve live attempts during recovery and remove only proven-abandoned attempts
- retain the default single-writer protocol unchanged

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p gf-storage -p gf-core`
- `cargo test -p gf-storage` (328 passed, 1 existing ignored subprocess helper)
- focused optimistic contention, live-attempt recovery, and crash-boundary tests

Closes #212

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788016954&installation_model_id=20486&pr_number=216&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F216&signature=724660a14167d2e2b28b7e0ba9d53fd98b6e806d6e5c033e58b5c97cf3148958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add optimistic concurrent project staging with exact-base commit comparison
> - Introduces `stage_project_generation_optimistic` in [project_publication.rs](https://github.com/CurateLabs/graphforge/pull/216/files#diff-2251b90e0879846b0169bbadcb1d96eba3d8626a73302c7a484349f919acb4df), allowing multiple transactions to stage concurrently by writing artifacts to `attempts/<tx>/<request>/` instead of `generations/<gen>/`.
> - Enforces one live attempt per transaction UUID via a transaction-scoped kernel lock under `locks/transactions/<tx>.lock`; duplicate attempts return `GF_WRITER_BUSY`.
> - At commit time, re-resolves `CURRENT` and compares it to the pinned parent; stale attempts are aborted and return the new `GF_WRITE_CONFLICT` error code. Successful attempts are atomically renamed into `generations/<gen>/` before publishing.
> - Extends recovery in [project_recovery.rs](https://github.com/CurateLabs/graphforge/pull/216/files#diff-c8cec40ca4f20a5cb8c0df295366b7b0e8259d5f7e616aebbc2fc43f88e2ee83) to skip live optimistic attempts (identified by held transaction locks) and clean abandoned `attempts/` directories.
> - Risk: Behavioral change — callers must now handle two new error codes (`GF_WRITE_CONFLICT`, `GF_REBASE_EXHAUSTED`) and journal records include an additional `operation_fingerprint` field, which affects idempotency checks for retried operations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 51cdde4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->