### PR TITLE
feat(api): add embedded write modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,11 @@ the authoritative runnable corpus enforced by the BDD gate.
 
 ### Added
 
+- Add explicit `single_writer`, bounded FIFO `queued_writer`, and
+  `optimistic_multi_writer` embedded modes. Optimistic composite transactions
+  rebase compatible creates, immutable-ledger rows, and disjoint property
+  changes while returning stable conflict and exhausted-retry errors (#213).
+
 - Add transaction-addressed optimistic project staging with OS-backed attempt
   leases, exact-base commit comparison, atomic generation promotion, and
   recovery that preserves live attempts while removing abandoned ones (#212).

--- a/crates/gf-api/src/belief_projection.rs
+++ b/crates/gf-api/src/belief_projection.rs
@@ -338,10 +338,7 @@ impl GraphForge {
         &self,
         request: ResolveBeliefProjectionRequest,
     ) -> Result<ResolvedBeliefProjection, GfError> {
-        let _visibility = self
-            .graph_visibility
-            .lock()
-            .expect("graph visibility lock poisoned");
+        let _visibility = self.graph_visibility.read()?;
         self.resolve_belief_projection_locked(&request, None)
             .map(|(projection, _)| projection)
     }
@@ -351,10 +348,7 @@ impl GraphForge {
         &self,
         request: &ResolveBeliefSubjectRequest,
     ) -> Result<ResolvedBeliefSubject, GfError> {
-        let _visibility = self
-            .graph_visibility
-            .lock()
-            .expect("graph visibility lock poisoned");
+        let _visibility = self.graph_visibility.read()?;
         let (projection, evidence) =
             self.resolve_belief_projection_locked(&request.projection, Some(&request.subject))?;
         let evidence = subject_evidence_envelope(
@@ -505,7 +499,7 @@ impl GraphForge {
     ) -> Result<gf_exec::ExecutionResult, GfError> {
         validate_attachment_request(&request)?;
         fail_attachment_for_test()?;
-        let _visibility = crate::knowledge::lock_graph_visibility(self);
+        let _visibility = crate::knowledge::lock_graph_visibility(self)?;
         let parent =
             gf_storage::resolve_project_generation(self.resolved_generation.container_root())?;
         parent.validate_complete_participant_inventory()?;

--- a/crates/gf-api/src/bulk_construction.rs
+++ b/crates/gf-api/src/bulk_construction.rs
@@ -337,10 +337,13 @@ impl GraphForge {
         operation_uuid: OperationId,
         batches: &[RecordBatch],
     ) -> Result<ValidatedBulkNodes, BulkValidationError> {
-        let _visibility = self
-            .graph_visibility
-            .lock()
-            .expect("graph visibility lock poisoned");
+        let _visibility = self.graph_visibility.read().map_err(|error| {
+            contract_error(
+                BulkInputKind::Node,
+                BulkValidationReason::ProjectState,
+                &error.to_string(),
+            )
+        })?;
         self.normalize_bulk_nodes(operation_uuid, batches, true)
     }
 
@@ -442,10 +445,7 @@ impl GraphForge {
         operation_uuid: OperationId,
         batches: &[RecordBatch],
     ) -> Result<RecordBatch, BulkNodePublicationError> {
-        let _visibility = self
-            .graph_visibility
-            .lock()
-            .expect("graph visibility lock poisoned");
+        let _visibility = self.graph_visibility.lock()?;
         let normalized = self.normalize_bulk_nodes(operation_uuid, batches, false)?;
         if normalized.rows.is_empty() {
             return Ok(node_receipt(&normalized.rows, operation_uuid, Uuid::nil())?);
@@ -584,10 +584,13 @@ impl GraphForge {
         batches: &[RecordBatch],
         same_request_nodes: &ValidatedBulkNodes,
     ) -> Result<ValidatedBulkEdges, BulkValidationError> {
-        let _visibility = self
-            .graph_visibility
-            .lock()
-            .expect("graph visibility lock poisoned");
+        let _visibility = self.graph_visibility.read().map_err(|error| {
+            contract_error(
+                BulkInputKind::Edge,
+                BulkValidationReason::ProjectState,
+                &error.to_string(),
+            )
+        })?;
         self.normalize_bulk_edges(operation_uuid, batches, same_request_nodes, true)
     }
 
@@ -707,10 +710,7 @@ impl GraphForge {
         operation_uuid: OperationId,
         batches: &[RecordBatch],
     ) -> Result<RecordBatch, BulkEdgePublicationError> {
-        let _visibility = self
-            .graph_visibility
-            .lock()
-            .expect("graph visibility lock poisoned");
+        let _visibility = self.graph_visibility.lock()?;
         let empty_nodes = ValidatedBulkNodes {
             rows: Vec::new(),
             operation_uuid,

--- a/crates/gf-api/src/checkpoints.rs
+++ b/crates/gf-api/src/checkpoints.rs
@@ -683,6 +683,7 @@ impl GraphForge {
         }
         let container_root = self.resolved_generation.container_root().to_path_buf();
         let clock = self.clock.lock().expect("clock lock poisoned").clone();
+        let write_options = self.write_options;
         let select_clock = Arc::clone(&clock);
         let prepared = std::cell::RefCell::new(None);
         let (receipt, resolved) = gf_storage::revert_checkpoint(
@@ -696,10 +697,11 @@ impl GraphForge {
             move || select_clock(),
             |generation| {
                 validate_revert_source(generation)?;
-                prepared.replace(Some(GraphForge::open_resolved_with_mode(
+                prepared.replace(Some(GraphForge::open_resolved_with_options(
                     container_root.clone(),
                     generation.clone(),
                     true,
+                    write_options,
                 )?));
                 Ok(())
             },
@@ -2084,7 +2086,14 @@ mod tests {
     #[test]
     fn revert_is_visible_on_the_same_graphforge_instance() {
         let directory = tempdir().unwrap();
-        let mut graph = GraphForge::new(Some(directory.path().to_str().unwrap())).unwrap();
+        let write_options = crate::GraphForgeOptions {
+            write_mode: crate::ProjectWriteMode::QueuedWriter,
+            write_queue_capacity: 7,
+            max_rebase_attempts: 2,
+        };
+        let mut graph =
+            GraphForge::new_with_options(Some(directory.path().to_str().unwrap()), write_options)
+                .unwrap();
         graph.execute("CREATE (:Person {name: 'before'})").unwrap();
         graph
             .checkpoint(CheckpointRequest {
@@ -2094,6 +2103,7 @@ mod tests {
                 actor_uuid: None,
             })
             .unwrap();
+        assert_eq!(graph.write_options, write_options);
         graph.execute("CREATE (:Person {name: 'after'})").unwrap();
         let post_checkpoint_handle = graph.add_node("Transient", &HashMap::new()).unwrap();
 

--- a/crates/gf-api/src/composite_publish.rs
+++ b/crates/gf-api/src/composite_publish.rs
@@ -1268,8 +1268,8 @@ mod tests {
         COMPOSITE_TRANSACTION_CONTRACT_VERSION, CompositeKnowledgeParticipants,
     };
     use crate::{
-        CapabilityId, EnableCapabilityRequest, GraphForgeOptions, OperationId, ProjectWriteMode,
-        PropValue, WriteContext,
+        CancellationToken, CapabilityId, EnableCapabilityRequest, GraphForgeOptions, OperationId,
+        ProjectWriteMode, PropValue, WriteContext,
     };
     use gf_knowledge::{
         Assertion, AssertionGraphRef, AssertionGraphRole, AssertionStatus, AssertionStatusEvent,
@@ -1489,6 +1489,46 @@ mod tests {
                 .lock()
                 .expect("generation UUID lock poisoned"),
             after
+        );
+    }
+
+    #[test]
+    fn cancelled_public_composite_publish_never_mutates() {
+        let directory = TempDir::new().unwrap();
+        let graph = GraphForge::new_with_options(
+            directory.path().to_str(),
+            GraphForgeOptions {
+                write_mode: ProjectWriteMode::QueuedWriter,
+                ..GraphForgeOptions::default()
+            },
+        )
+        .unwrap();
+        let before = *graph
+            .current_generation_uuid
+            .lock()
+            .expect("generation UUID lock poisoned");
+        let cancellation = CancellationToken::new();
+        cancellation.cancel();
+
+        let error = graph
+            .publish_composite_transaction_with_cancellation(
+                graph_request(71, 72, "cancelled"),
+                Some(cancellation),
+            )
+            .unwrap_err();
+
+        assert_eq!(error.code(), "GF_CANCELLED");
+        assert_eq!(
+            *graph
+                .current_generation_uuid
+                .lock()
+                .expect("generation UUID lock poisoned"),
+            before
+        );
+        assert!(
+            gf_storage::published_project_transaction(directory.path(), uuid7(71))
+                .unwrap()
+                .is_none()
         );
     }
 

--- a/crates/gf-api/src/composite_publish.rs
+++ b/crates/gf-api/src/composite_publish.rs
@@ -88,6 +88,7 @@ impl GraphForge {
         loop {
             let parent = gf_storage::resolve_project_generation(root)?;
             parent.validate_complete_participant_inventory()?;
+            let mut reconciled = false;
             let expected_parent = *self
                 .current_generation_uuid
                 .lock()
@@ -106,19 +107,16 @@ impl GraphForge {
                     ));
                 }
                 reconcile_workspace_to(self, &parent)?;
+                reconciled = true;
             }
 
-            if baseline.is_none() {
+            if optimistic && baseline.is_none() {
                 baseline = Some(capture_rebase_baseline(self, &request, &parent)?);
             }
-            let baseline = baseline
-                .as_ref()
-                .expect("rebase baseline initialized before publication")
-                .clone();
             let snapshot = build_validation_snapshot(self, &parent)?;
             let receipt =
                 authorize_composite_transaction(&request, &snapshot, None).map_err(|error| {
-                    if rebases > 0 && error.code() == "GF_IDENTITY_CONFLICT" {
+                    if (reconciled || rebases > 0) && error.code() == "GF_IDENTITY_CONFLICT" {
                         write_conflict("concurrent operation occupied a requested identity")
                     } else {
                         error
@@ -136,6 +134,9 @@ impl GraphForge {
             ) {
                 Ok(batch) => return Ok(batch),
                 Err(error) if optimistic && error.code() == "GF_WRITE_CONFLICT" => {
+                    let baseline = baseline
+                        .as_ref()
+                        .expect("optimistic publication initializes its rebase baseline");
                     if baseline.non_mergeable {
                         return Err(write_conflict(
                             "concurrent change conflicts with delete or administrative graph work",
@@ -153,7 +154,7 @@ impl GraphForge {
                     }
                     let latest = gf_storage::resolve_project_generation(root)?;
                     reconcile_workspace_to(self, &latest)?;
-                    ensure_rebase_compatible(self, &request, &latest, &baseline)?;
+                    ensure_rebase_compatible(self, &request, &latest, baseline)?;
                     rebases += 1;
                 }
                 Err(error) => return Err(error),
@@ -259,15 +260,21 @@ impl GraphForge {
                 Ok(batch)
             }
             Err(error) => {
-                let durable = gf_storage::resolve_project_generation(root)?;
-                if durable.generation_uuid() == expected_parent {
-                    crate::graph_snapshot::restore(&prior_snapshot.bytes, &self.dir)?;
-                    *self
-                        .runtime_catalog
-                        .lock()
-                        .expect("runtime catalog poisoned") = prior_catalog;
-                } else {
-                    reconcile_workspace_to(self, &durable)?;
+                // Preserve the stable publication error. Recovery is best-effort:
+                // callers must not receive an unrelated storage code instead of
+                // the validation or conflict that caused publication to abort.
+                if let Ok(durable) = gf_storage::resolve_project_generation(root) {
+                    if durable.generation_uuid() == expected_parent {
+                        if crate::graph_snapshot::restore(&prior_snapshot.bytes, &self.dir).is_ok()
+                        {
+                            *self
+                                .runtime_catalog
+                                .lock()
+                                .expect("runtime catalog poisoned") = prior_catalog;
+                        }
+                    } else {
+                        let _ = reconcile_workspace_to(self, &durable);
+                    }
                 }
                 Err(error)
             }
@@ -1641,6 +1648,24 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[test]
+    fn optimistic_first_reconciliation_remaps_identity_collision() {
+        let directory = TempDir::new().unwrap();
+        GraphForge::new(directory.path().to_str()).unwrap();
+        let options = optimistic_options(1);
+        let stale = GraphForge::new_with_options(directory.path().to_str(), options).unwrap();
+        let concurrent = GraphForge::new_with_options(directory.path().to_str(), options).unwrap();
+        concurrent
+            .publish_composite_transaction(graph_request(151, 152, "concurrent"))
+            .unwrap();
+
+        let error = stale
+            .publish_composite_transaction(graph_request(153, 152, "stale"))
+            .unwrap_err();
+
+        assert_eq!(error.code(), "GF_WRITE_CONFLICT");
     }
 
     #[test]

--- a/crates/gf-api/src/composite_publish.rs
+++ b/crates/gf-api/src/composite_publish.rs
@@ -1,6 +1,6 @@
 //! Atomic publication of a composite graph + M20/M21 transaction.
 
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::Path;
 
 use arrow::array::{Array, FixedSizeBinaryArray, UInt64Array};
@@ -42,22 +42,26 @@ impl GraphForge {
         &self,
         request: CompositeTransactionRequest,
     ) -> Result<RecordBatch, GfError> {
-        let _visibility = crate::knowledge::lock_graph_visibility(self);
-        let root = self.resolved_generation.container_root();
-        let parent = gf_storage::resolve_project_generation(root)?;
-        parent.validate_complete_participant_inventory()?;
-        let expected_parent = *self
-            .current_generation_uuid
-            .lock()
-            .expect("generation UUID lock poisoned");
-        if parent.generation_uuid() != expected_parent {
-            return Err(GfError::Project {
-                code: ProjectErrorCode::TransactionConflict,
-                message: "project generation changed before composite publication".into(),
-            });
-        }
+        self.publish_composite_transaction_with_cancellation(request, None)
+    }
 
-        let snapshot = build_validation_snapshot(self, &parent)?;
+    /// Publish a composite transaction with cooperative queued-write cancellation.
+    ///
+    /// Cancellation is observed only before this operation starts mutating its
+    /// private workspace. Once admitted, the operation runs to a deterministic
+    /// publication or rollback boundary.
+    ///
+    /// # Errors
+    /// Returns `GF_CANCELLED` only while queued, plus the errors documented by
+    /// [`Self::publish_composite_transaction`].
+    #[allow(clippy::too_many_lines, clippy::needless_pass_by_value)]
+    pub fn publish_composite_transaction_with_cancellation(
+        &self,
+        request: CompositeTransactionRequest,
+        cancellation: Option<crate::CancellationToken>,
+    ) -> Result<RecordBatch, GfError> {
+        let _visibility = self.graph_visibility.acquire(cancellation.as_ref())?;
+        let root = self.resolved_generation.container_root();
         let content_fingerprint = request.canonical_fingerprint()?;
         let generation_uuid =
             composite_generation_uuid(request.context.operation_uuid.0, content_fingerprint);
@@ -77,8 +81,99 @@ impl GraphForge {
             return crate::composite_receipt::build_composite_receipt(&request);
         }
 
-        let receipt = authorize_composite_transaction(&request, &snapshot, None)?;
-        require_capabilities(&parent, &request)?;
+        let optimistic =
+            self.write_options.write_mode == crate::ProjectWriteMode::OptimisticMultiWriter;
+        let mut rebases = 0_u32;
+        let mut baseline = None;
+        loop {
+            let parent = gf_storage::resolve_project_generation(root)?;
+            parent.validate_complete_participant_inventory()?;
+            let expected_parent = *self
+                .current_generation_uuid
+                .lock()
+                .expect("generation UUID lock poisoned");
+            if parent.generation_uuid() != expected_parent {
+                if !optimistic {
+                    return Err(idempotency_conflict(
+                        "project generation changed before composite publication",
+                    ));
+                }
+                if administrative_contract(&parent)?
+                    != administrative_contract(&self.resolved_generation)?
+                {
+                    return Err(write_conflict(
+                        "project capabilities or workspace configuration changed since open",
+                    ));
+                }
+                reconcile_workspace_to(self, &parent)?;
+            }
+
+            if baseline.is_none() {
+                baseline = Some(capture_rebase_baseline(self, &request, &parent)?);
+            }
+            let baseline = baseline
+                .as_ref()
+                .expect("rebase baseline initialized before publication")
+                .clone();
+            let snapshot = build_validation_snapshot(self, &parent)?;
+            let receipt =
+                authorize_composite_transaction(&request, &snapshot, None).map_err(|error| {
+                    if rebases > 0 && error.code() == "GF_IDENTITY_CONFLICT" {
+                        write_conflict("concurrent operation occupied a requested identity")
+                    } else {
+                        error
+                    }
+                })?;
+            require_capabilities(&parent, &request)?;
+
+            match self.publish_composite_attempt(
+                &request,
+                &parent,
+                receipt,
+                content_fingerprint,
+                generation_uuid,
+                optimistic,
+            ) {
+                Ok(batch) => return Ok(batch),
+                Err(error) if optimistic && error.code() == "GF_WRITE_CONFLICT" => {
+                    if baseline.non_mergeable {
+                        return Err(write_conflict(
+                            "concurrent change conflicts with delete or administrative graph work",
+                        ));
+                    }
+                    if rebases >= self.write_options.max_rebase_attempts {
+                        return Err(GfError::Project {
+                            code: ProjectErrorCode::RebaseExhausted,
+                            message: format!(
+                                "operation_uuid={} attempts={} cause=optimistic_contention",
+                                transaction_uuid.hyphenated(),
+                                rebases + 1
+                            ),
+                        });
+                    }
+                    let latest = gf_storage::resolve_project_generation(root)?;
+                    reconcile_workspace_to(self, &latest)?;
+                    ensure_rebase_compatible(self, &request, &latest, &baseline)?;
+                    rebases += 1;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+    fn publish_composite_attempt(
+        &self,
+        request: &CompositeTransactionRequest,
+        parent: &ResolvedProjectGeneration,
+        receipt: RecordBatch,
+        content_fingerprint: [u8; 32],
+        generation_uuid: Uuid,
+        optimistic: bool,
+    ) -> Result<RecordBatch, GfError> {
+        let root = self.resolved_generation.container_root();
+        let expected_parent = parent.generation_uuid();
+        let transaction_uuid = request.context.operation_uuid.0;
 
         let prior_snapshot = crate::graph_snapshot::capture(&self.dir)?;
         let prior_catalog = self
@@ -90,12 +185,12 @@ impl GraphForge {
         let recorded_at = (self.clock.lock().expect("clock lock poisoned"))()?;
 
         let publication = (|| -> Result<RecordBatch, GfError> {
-            apply_graph_mutations(self, &request, &mut next_catalog, recorded_at)?;
+            apply_graph_mutations(self, request, &mut next_catalog, recorded_at)?;
             if self.path.is_some() {
                 crate::persist_runtime_catalog(&self.dir, &next_catalog)?;
             }
             let graph = crate::graph_snapshot::capture(&self.dir)?;
-            let participants = assemble_composite_participants(self, &parent, &request, graph)?;
+            let participants = assemble_composite_participants(self, parent, request, graph)?;
             let capabilities = parent
                 .capabilities()
                 .into_iter()
@@ -110,7 +205,18 @@ impl GraphForge {
                 capabilities,
                 participants,
             };
-            let outcome = match gf_storage::stage_project_generation(root, &publication)? {
+            let staged = if optimistic {
+                gf_storage::stage_project_generation_optimistic(
+                    root,
+                    &publication,
+                    content_fingerprint,
+                )?
+            } else {
+                gf_storage::stage_project_generation(root, &publication)?
+            };
+            #[cfg(test)]
+            optimistic_publish_barrier_for_test(optimistic);
+            let outcome = match staged {
                 ProjectStageOutcome::AlreadyPublished(published) => published,
                 ProjectStageOutcome::Staged(staged) => staged
                     .validate(
@@ -153,27 +259,284 @@ impl GraphForge {
                 Ok(batch)
             }
             Err(error) => {
-                let still_prior = *self
-                    .current_generation_uuid
-                    .lock()
-                    .expect("generation UUID lock poisoned")
-                    == expected_parent;
-                if still_prior {
+                let durable = gf_storage::resolve_project_generation(root)?;
+                if durable.generation_uuid() == expected_parent {
                     crate::graph_snapshot::restore(&prior_snapshot.bytes, &self.dir)?;
                     *self
                         .runtime_catalog
                         .lock()
                         .expect("runtime catalog poisoned") = prior_catalog;
                 } else {
-                    *self
-                        .runtime_catalog
-                        .lock()
-                        .expect("runtime catalog poisoned") = next_catalog;
-                    self.adjacency_provider.invalidate();
+                    reconcile_workspace_to(self, &durable)?;
                 }
                 Err(error)
             }
         }
+    }
+}
+
+#[cfg(test)]
+fn optimistic_publish_barrier_for_test(optimistic: bool) {
+    if !optimistic {
+        return;
+    }
+    let barrier = OPTIMISTIC_PUBLISH_BARRIER
+        .get_or_init(|| std::sync::Mutex::new(None))
+        .lock()
+        .expect("optimistic publish test barrier poisoned")
+        .clone();
+    if let Some(barrier) = barrier {
+        let (state, changed) = barrier.as_ref();
+        let mut state = state
+            .lock()
+            .expect("optimistic publish test barrier poisoned");
+        state.arrived += 1;
+        if state.arrived == 2 {
+            state.released = true;
+            changed.notify_all();
+        } else {
+            let (next, timeout) = changed
+                .wait_timeout_while(state, std::time::Duration::from_secs(5), |state| {
+                    !state.released
+                })
+                .expect("optimistic publish test barrier poisoned");
+            assert!(
+                !timeout.timed_out(),
+                "optimistic publish test barrier timed out waiting for a second writer"
+            );
+            state = next;
+        }
+        drop(state);
+        *OPTIMISTIC_PUBLISH_BARRIER
+            .get()
+            .expect("optimistic publish test barrier initialized")
+            .lock()
+            .expect("optimistic publish test barrier poisoned") = None;
+    }
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct OptimisticPublishBarrierState {
+    arrived: usize,
+    released: bool,
+}
+
+#[cfg(test)]
+type OptimisticPublishBarrier = std::sync::Arc<(
+    std::sync::Mutex<OptimisticPublishBarrierState>,
+    std::sync::Condvar,
+)>;
+
+#[cfg(test)]
+static OPTIMISTIC_PUBLISH_BARRIER: std::sync::OnceLock<
+    std::sync::Mutex<Option<OptimisticPublishBarrier>>,
+> = std::sync::OnceLock::new();
+
+#[cfg(test)]
+static OPTIMISTIC_PUBLISH_SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum RebaseEntity {
+    Node(Uuid),
+    Edge(Uuid),
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct RebaseField {
+    entity: RebaseEntity,
+    property: String,
+}
+
+type AdministrativeContract = Vec<(String, String, u32, [u8; 32])>;
+
+#[derive(Clone, Debug, Default, PartialEq)]
+struct RebaseBaseline {
+    fields: BTreeMap<RebaseField, Option<IrLiteral>>,
+    node_targets: BTreeSet<Uuid>,
+    edge_targets: BTreeSet<Uuid>,
+    administrative_contract: AdministrativeContract,
+    non_mergeable: bool,
+}
+
+fn capture_rebase_baseline(
+    graph: &GraphForge,
+    request: &CompositeTransactionRequest,
+    generation: &ResolvedProjectGeneration,
+) -> Result<RebaseBaseline, GfError> {
+    let created_nodes = request
+        .graph_mutations
+        .iter()
+        .filter_map(|mutation| match mutation {
+            CompositeGraphMutation::CreateNode { node_uuid, .. } => Some(*node_uuid),
+            _ => None,
+        })
+        .collect::<BTreeSet<_>>();
+    let created_edges = request
+        .graph_mutations
+        .iter()
+        .filter_map(|mutation| match mutation {
+            CompositeGraphMutation::CreateEdge { edge_uuid, .. } => Some(*edge_uuid),
+            _ => None,
+        })
+        .collect::<BTreeSet<_>>();
+    let mut baseline = RebaseBaseline {
+        administrative_contract: administrative_contract(generation)?,
+        ..RebaseBaseline::default()
+    };
+    for mutation in &request.graph_mutations {
+        match mutation {
+            CompositeGraphMutation::SetNodeProperty {
+                node_uuid,
+                property,
+                ..
+            }
+            | CompositeGraphMutation::RemoveNodeProperty {
+                node_uuid,
+                property,
+            } if !created_nodes.contains(node_uuid) => {
+                baseline.node_targets.insert(*node_uuid);
+                capture_rebase_field(graph, &mut baseline, *node_uuid, property, false)?;
+            }
+            CompositeGraphMutation::SetEdgeProperty {
+                edge_uuid,
+                property,
+                ..
+            }
+            | CompositeGraphMutation::RemoveEdgeProperty {
+                edge_uuid,
+                property,
+            } if !created_edges.contains(edge_uuid) => {
+                baseline.edge_targets.insert(*edge_uuid);
+                capture_rebase_field(graph, &mut baseline, *edge_uuid, property, true)?;
+            }
+            CompositeGraphMutation::DeleteNode { .. }
+            | CompositeGraphMutation::DeleteEdge { .. } => baseline.non_mergeable = true,
+            _ => {}
+        }
+    }
+    Ok(baseline)
+}
+
+fn capture_rebase_field(
+    graph: &GraphForge,
+    baseline: &mut RebaseBaseline,
+    uuid: Uuid,
+    property: &str,
+    is_edge: bool,
+) -> Result<(), GfError> {
+    let properties =
+        gf_storage::read_entity_properties(&graph.dir, "_untyped", &uuid.into_bytes(), is_edge)?;
+    let entity = if is_edge {
+        RebaseEntity::Edge(uuid)
+    } else {
+        RebaseEntity::Node(uuid)
+    };
+    baseline.fields.insert(
+        RebaseField {
+            entity,
+            property: property.to_owned(),
+        },
+        properties.get(property).cloned(),
+    );
+    Ok(())
+}
+
+fn ensure_rebase_compatible(
+    graph: &GraphForge,
+    request: &CompositeTransactionRequest,
+    latest: &ResolvedProjectGeneration,
+    baseline: &RebaseBaseline,
+) -> Result<(), GfError> {
+    if administrative_contract(latest)? != baseline.administrative_contract {
+        return Err(write_conflict(
+            "concurrent operation changed project capabilities or workspace configuration",
+        ));
+    }
+    let snapshot = build_validation_snapshot(graph, latest)?;
+    if !baseline.node_targets.is_subset(&snapshot.nodes)
+        || !baseline.edge_targets.is_subset(&snapshot.edges)
+    {
+        return Err(write_conflict(
+            "concurrent operation removed a graph mutation target",
+        ));
+    }
+    let current = capture_rebase_baseline(graph, request, latest)?;
+    if current.fields != baseline.fields {
+        return Err(write_conflict(
+            "concurrent operation changed a requested graph property",
+        ));
+    }
+    Ok(())
+}
+
+fn administrative_contract(
+    generation: &ResolvedProjectGeneration,
+) -> Result<AdministrativeContract, GfError> {
+    let mut contract = generation
+        .participant_descriptors()?
+        .into_iter()
+        .filter(|descriptor| descriptor.capability_id == "workspace")
+        .map(|descriptor| {
+            (
+                descriptor.capability_id,
+                descriptor.record_family_id,
+                descriptor.capability_version,
+                descriptor.content_sha256,
+            )
+        })
+        .collect::<Vec<_>>();
+    contract.extend(generation.capabilities().into_iter().map(|capability| {
+        (
+            capability.capability_id,
+            String::new(),
+            capability.capability_version,
+            [0; 32],
+        )
+    }));
+    contract.sort();
+    Ok(contract)
+}
+
+fn reconcile_workspace_to(
+    graph: &GraphForge,
+    generation: &ResolvedProjectGeneration,
+) -> Result<(), GfError> {
+    let snapshot = generation
+        .participant_snapshot("graph", "snapshot")?
+        .ok_or_else(|| GfError::Validation("generation is missing graph snapshot".into()))?;
+    if snapshot.capability_version != 1
+        || snapshot.record_version != 1
+        || snapshot.encoding != "arrow"
+    {
+        return Err(GfError::Validation(
+            "unsupported graph snapshot participant contract".into(),
+        ));
+    }
+    crate::graph_snapshot::restore(&snapshot.bytes, &graph.dir)?;
+    *graph
+        .runtime_catalog
+        .lock()
+        .expect("runtime catalog poisoned") = crate::load_runtime_catalog(&graph.dir);
+    *graph
+        .current_generation_uuid
+        .lock()
+        .expect("generation UUID lock poisoned") = generation.generation_uuid();
+    graph.adjacency_provider.invalidate();
+    Ok(())
+}
+
+fn idempotency_conflict(message: impl Into<String>) -> GfError {
+    GfError::Project {
+        code: ProjectErrorCode::TransactionConflict,
+        message: message.into(),
+    }
+}
+
+fn write_conflict(message: impl Into<String>) -> GfError {
+    GfError::Project {
+        code: ProjectErrorCode::WriteConflict,
+        message: message.into(),
     }
 }
 
@@ -904,13 +1267,18 @@ mod tests {
     use crate::composite_transaction::{
         COMPOSITE_TRANSACTION_CONTRACT_VERSION, CompositeKnowledgeParticipants,
     };
-    use crate::{CapabilityId, EnableCapabilityRequest, OperationId, PropValue, WriteContext};
+    use crate::{
+        CapabilityId, EnableCapabilityRequest, GraphForgeOptions, OperationId, ProjectWriteMode,
+        PropValue, WriteContext,
+    };
     use gf_knowledge::{
         Assertion, AssertionGraphRef, AssertionGraphRole, AssertionStatus, AssertionStatusEvent,
         GraphObjectKind,
     };
     use gf_provenance::{EventKind, LineageRecord, LineageRole, ProvenanceEvent, SubjectKind};
     use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::thread;
     use tempfile::TempDir;
 
     fn uuid7(seed: u8) -> Uuid {
@@ -993,6 +1361,73 @@ mod tests {
                 ..CompositeKnowledgeParticipants::default()
             },
         }
+    }
+
+    fn graph_request(operation_seed: u8, node_seed: u8, name: &str) -> CompositeTransactionRequest {
+        CompositeTransactionRequest {
+            contract_version: COMPOSITE_TRANSACTION_CONTRACT_VERSION,
+            context: WriteContext {
+                operation_uuid: OperationId(uuid7(operation_seed)),
+                actor_uuid: None,
+            },
+            graph_mutations: vec![CompositeGraphMutation::CreateNode {
+                node_uuid: uuid7(node_seed),
+                label: "Person".into(),
+                properties: HashMap::from([("name".into(), PropValue::Str(name.into()))]),
+            }],
+            knowledge: CompositeKnowledgeParticipants::default(),
+        }
+    }
+
+    fn property_request(
+        operation_seed: u8,
+        node_seed: u8,
+        property: &str,
+        value: &str,
+    ) -> CompositeTransactionRequest {
+        CompositeTransactionRequest {
+            contract_version: COMPOSITE_TRANSACTION_CONTRACT_VERSION,
+            context: WriteContext {
+                operation_uuid: OperationId(uuid7(operation_seed)),
+                actor_uuid: None,
+            },
+            graph_mutations: vec![CompositeGraphMutation::SetNodeProperty {
+                node_uuid: uuid7(node_seed),
+                property: property.into(),
+                value: PropValue::Str(value.into()),
+            }],
+            knowledge: CompositeKnowledgeParticipants::default(),
+        }
+    }
+
+    fn optimistic_options(max_rebase_attempts: u32) -> GraphForgeOptions {
+        GraphForgeOptions {
+            write_mode: ProjectWriteMode::OptimisticMultiWriter,
+            max_rebase_attempts,
+            ..GraphForgeOptions::default()
+        }
+    }
+
+    fn publish_concurrently(
+        directory: &TempDir,
+        options: GraphForgeOptions,
+        left: CompositeTransactionRequest,
+        right: CompositeTransactionRequest,
+    ) -> [Result<RecordBatch, GfError>; 2] {
+        let left_graph =
+            Arc::new(GraphForge::new_with_options(directory.path().to_str(), options).unwrap());
+        let right_graph =
+            Arc::new(GraphForge::new_with_options(directory.path().to_str(), options).unwrap());
+        *OPTIMISTIC_PUBLISH_BARRIER
+            .get_or_init(|| std::sync::Mutex::new(None))
+            .lock()
+            .unwrap() = Some(Arc::new((
+            std::sync::Mutex::new(OptimisticPublishBarrierState::default()),
+            std::sync::Condvar::new(),
+        )));
+        let left_worker = thread::spawn(move || left_graph.publish_composite_transaction(left));
+        let right_worker = thread::spawn(move || right_graph.publish_composite_transaction(right));
+        [left_worker.join().unwrap(), right_worker.join().unwrap()]
     }
 
     #[test]
@@ -1115,5 +1550,81 @@ mod tests {
                 replay.column(index).as_ref()
             );
         }
+    }
+
+    #[test]
+    fn optimistic_distinct_creates_rebase_and_both_publish() {
+        let _serial = OPTIMISTIC_PUBLISH_SERIAL.lock().unwrap();
+        let directory = TempDir::new().unwrap();
+        GraphForge::new(directory.path().to_str()).unwrap();
+        let results = publish_concurrently(
+            &directory,
+            optimistic_options(1),
+            graph_request(131, 132, "Ada"),
+            graph_request(133, 134, "Grace"),
+        );
+        assert!(
+            results.iter().all(Result::is_ok),
+            "concurrent results: {results:?}"
+        );
+        let reopened = GraphForge::new(directory.path().to_str()).unwrap();
+        let rows = reopened
+            .execute("MATCH (n:Person) RETURN n.node_uuid AS id")
+            .unwrap();
+        assert_eq!(rows.batches[0].num_rows(), 2);
+    }
+
+    #[test]
+    fn optimistic_same_property_change_is_a_write_conflict() {
+        let _serial = OPTIMISTIC_PUBLISH_SERIAL.lock().unwrap();
+        let directory = TempDir::new().unwrap();
+        let bootstrap = GraphForge::new(directory.path().to_str()).unwrap();
+        bootstrap
+            .publish_composite_transaction(graph_request(135, 136, "Initial"))
+            .unwrap();
+        drop(bootstrap);
+        let results = publish_concurrently(
+            &directory,
+            optimistic_options(1),
+            property_request(137, 136, "nickname", "left"),
+            property_request(138, 136, "nickname", "right"),
+        );
+        let codes = results
+            .iter()
+            .map(|result| result.as_ref().err().map(GfError::code))
+            .collect::<Vec<_>>();
+        assert_eq!(codes.iter().filter(|code| code.is_none()).count(), 1);
+        assert_eq!(
+            codes
+                .iter()
+                .filter(|code| **code == Some("GF_WRITE_CONFLICT"))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn optimistic_retry_budget_is_bounded() {
+        let _serial = OPTIMISTIC_PUBLISH_SERIAL.lock().unwrap();
+        let directory = TempDir::new().unwrap();
+        GraphForge::new(directory.path().to_str()).unwrap();
+        let results = publish_concurrently(
+            &directory,
+            optimistic_options(0),
+            graph_request(139, 140, "Ada"),
+            graph_request(141, 142, "Grace"),
+        );
+        let codes = results
+            .iter()
+            .map(|result| result.as_ref().err().map(GfError::code))
+            .collect::<Vec<_>>();
+        assert_eq!(codes.iter().filter(|code| code.is_none()).count(), 1);
+        assert_eq!(
+            codes
+                .iter()
+                .filter(|code| **code == Some("GF_REBASE_EXHAUSTED"))
+                .count(),
+            1
+        );
     }
 }

--- a/crates/gf-api/src/embedding_refresh.rs
+++ b/crates/gf-api/src/embedding_refresh.rs
@@ -269,6 +269,7 @@ impl GraphForge {
             embedding_refresh_epoch: self.embedding_refresh_epoch,
             embedding_refresh_visibility: Arc::clone(&self.embedding_refresh_visibility),
             graph_visibility: Arc::clone(&self.graph_visibility),
+            write_options: self.write_options,
             provider_refresh_driver_active: Arc::clone(&self.provider_refresh_driver_active),
             provider_refresh_runtimes: Arc::clone(&self.provider_refresh_runtimes),
             provider_find_runtimes: Arc::clone(&self.provider_find_runtimes),

--- a/crates/gf-api/src/hypotheses.rs
+++ b/crates/gf-api/src/hypotheses.rs
@@ -522,7 +522,7 @@ impl GraphForge {
     where
         F: FnOnce(&HypothesisLedger, i64) -> Result<Change, GfError>,
     {
-        let _visibility = crate::knowledge::lock_graph_visibility(self);
+        let _visibility = crate::knowledge::lock_graph_visibility(self)?;
         let parent = resolve_for_write(self)?;
         parent.validate_complete_participant_inventory()?;
         parent.require_capability("epistemic", EPISTEMIC_CAPABILITY_VERSION)?;

--- a/crates/gf-api/src/knowledge.rs
+++ b/crates/gf-api/src/knowledge.rs
@@ -274,7 +274,7 @@ impl GraphForge {
         request: CreateAssertionRequest,
     ) -> Result<gf_exec::ExecutionResult, GfError> {
         request.validate_context()?;
-        let _graph_visibility = lock_graph_visibility(self);
+        let _graph_visibility = lock_graph_visibility(self)?;
         validate_graph_refs(self, &request.graph_refs)?;
         let root = self.resolved_generation.container_root();
         let parent = gf_storage::resolve_project_generation(root)?;
@@ -392,7 +392,7 @@ impl GraphForge {
                 "superseded status requires the atomic supersession API".into(),
             ));
         }
-        let _graph_visibility = lock_graph_visibility(self);
+        let _graph_visibility = lock_graph_visibility(self)?;
         validate_graph_refs(self, &request.assertion.graph_refs)?;
         let root = self.resolved_generation.container_root();
         let parent = gf_storage::resolve_project_generation(root)?;
@@ -610,7 +610,7 @@ impl GraphForge {
         validate_write_context(&request.context)?;
         require_uuid(request.confidence_uuid, "confidence_uuid")?;
         require_uuid(request.assertion_uuid, "assertion_uuid")?;
-        let _graph_visibility = lock_graph_visibility(self);
+        let _graph_visibility = lock_graph_visibility(self)?;
         let root = self.resolved_generation.container_root();
         let parent = gf_storage::resolve_project_generation(root)?;
         parent.validate_complete_participant_inventory()?;
@@ -825,7 +825,7 @@ impl GraphForge {
                 "assertion evidence bundle must not be empty".into(),
             ));
         }
-        let _graph_visibility = lock_graph_visibility(self);
+        let _graph_visibility = lock_graph_visibility(self)?;
         validate_graph_refs(self, &request.assertion.graph_refs)?;
         for input in &request.evidence {
             require_uuid(input.evidence_uuid, "evidence_uuid")?;
@@ -922,7 +922,7 @@ impl GraphForge {
         require_uuid(request.evidence_uuid, "evidence_uuid")?;
         require_uuid(request.assertion_uuid, "assertion_uuid")?;
         require_uuid(request.source_uuid, "source_uuid")?;
-        let _graph_visibility = lock_graph_visibility(self);
+        let _graph_visibility = lock_graph_visibility(self)?;
         validate_evidence_source(self, request.source_uuid, request.source_kind)?;
         let root = self.resolved_generation.container_root();
         let parent = gf_storage::resolve_project_generation(root)?;
@@ -1090,7 +1090,7 @@ impl GraphForge {
         if let Some(previous) = request.supersedes_reasoning_uuid {
             require_uuid(previous, "supersedes_reasoning_uuid")?;
         }
-        let _graph_visibility = lock_graph_visibility(self);
+        let _graph_visibility = lock_graph_visibility(self)?;
         let root = self.resolved_generation.container_root();
         let parent = gf_storage::resolve_project_generation(root)?;
         parent.validate_complete_participant_inventory()?;
@@ -1241,7 +1241,7 @@ impl GraphForge {
                 "superseded status requires the atomic supersession API".into(),
             ));
         }
-        let _graph_visibility = lock_graph_visibility(self);
+        let _graph_visibility = lock_graph_visibility(self)?;
         let root = self.resolved_generation.container_root();
         let parent = gf_storage::resolve_project_generation(root)?;
         parent.validate_complete_participant_inventory()?;
@@ -1396,7 +1396,7 @@ impl GraphForge {
         ] {
             require_uuid(uuid, name)?;
         }
-        let _graph_visibility = lock_graph_visibility(self);
+        let _graph_visibility = lock_graph_visibility(self)?;
         let root = self.resolved_generation.container_root();
         let parent = gf_storage::resolve_project_generation(root)?;
         parent.validate_complete_participant_inventory()?;
@@ -2852,11 +2852,10 @@ fn validate_evidence_source(
     }
 }
 
-pub(crate) fn lock_graph_visibility(graph: &GraphForge) -> std::sync::MutexGuard<'_, ()> {
-    graph
-        .graph_visibility
-        .lock()
-        .expect("graph visibility lock poisoned")
+pub(crate) fn lock_graph_visibility(
+    graph: &GraphForge,
+) -> Result<crate::write_modes::WritePermit<'_>, GfError> {
+    graph.graph_visibility.lock()
 }
 
 fn match_requested_node_uuids(

--- a/crates/gf-api/src/lib.rs
+++ b/crates/gf-api/src/lib.rs
@@ -89,6 +89,7 @@ mod shared_directory_semantics_tests;
 mod stream_cancellation_isolation_tests;
 mod valid_time;
 mod workspace_ontology;
+mod write_modes;
 
 // Re-export the foundational types callers need alongside the facade, so a
 // single `use gf_api::...` reaches the common surface.
@@ -219,6 +220,7 @@ pub use valid_time::{
     VALID_TIME_POLICY_VERSION,
 };
 pub use workspace_ontology::{AdoptOntologyRequest, ClearOntologyRequest};
+pub use write_modes::{GraphForgeOptions, ProjectWriteMode};
 
 fn insert_usize(
     parameters: &mut std::collections::BTreeMap<String, InvocationParameter>,
@@ -341,7 +343,9 @@ pub struct GraphForge {
     /// Cross-publication stability comes from `resolved_generation`; this lock
     /// closes the remaining window for mutation APIs that still operate through
     /// this exact facade instance.
-    graph_visibility: Arc<Mutex<()>>,
+    graph_visibility: Arc<write_modes::WriteCoordinator>,
+    /// Validated embedded write behavior for this facade.
+    write_options: GraphForgeOptions,
     /// Ensures mutation bursts share one bounded process-local driver thread.
     provider_refresh_driver_active: Arc<AtomicBool>,
     /// Runtime-only provider recipes capable of refreshing exact lineages.
@@ -373,6 +377,7 @@ impl std::fmt::Debug for GraphForge {
             )
             .field("dir", &self.dir)
             .field("ontology_mode", &self.ontology_mode)
+            .field("write_options", &self.write_options)
             .field("has_ontology", &self.ontology.is_some())
             .finish_non_exhaustive()
     }
@@ -398,8 +403,21 @@ impl GraphForge {
     /// provenance, or publication errors while reconciling an interrupted
     /// recorded algorithm run.
     pub fn new(path: Option<&str>) -> Result<Self, GfError> {
+        Self::new_with_options(path, GraphForgeOptions::default())
+    }
+
+    /// Create a facade with an explicit embedded project-write policy.
+    ///
+    /// # Errors
+    /// Returns the same open errors as [`Self::new`] and rejects unbounded or
+    /// otherwise invalid write-coordination limits.
+    pub fn new_with_options(
+        path: Option<&str>,
+        options: GraphForgeOptions,
+    ) -> Result<Self, GfError> {
+        let options = options.validate()?;
         if let Some(p) = path {
-            return Self::open_dir(PathBuf::from(p));
+            return Self::open_dir_with_options(PathBuf::from(p), options);
         }
         // In-memory: exploratory, backed by a temp directory kept alive for the
         // engine's lifetime.
@@ -427,7 +445,8 @@ impl GraphForge {
             )),
             embedding_refresh_epoch: Instant::now(),
             embedding_refresh_visibility: Arc::new(Mutex::new(())),
-            graph_visibility: Arc::new(Mutex::new(())),
+            graph_visibility: Arc::new(write_modes::WriteCoordinator::new(options)),
+            write_options: options,
             provider_refresh_driver_active: Arc::new(AtomicBool::new(false)),
             provider_refresh_runtimes: Arc::new(Mutex::new(Vec::new())),
             provider_find_runtimes: Arc::new(Mutex::new(Vec::new())),
@@ -447,9 +466,7 @@ impl GraphForge {
         *self.clock.lock().expect("clock lock poisoned") = Arc::new(clock);
     }
 
-    /// Open a Parquet-backed project directory: load manifest + ontology +
-    /// runtime catalog and resolve the effective ontology mode.
-    fn open_dir(dir: PathBuf) -> Result<Self, GfError> {
+    fn open_dir_with_options(dir: PathBuf, options: GraphForgeOptions) -> Result<Self, GfError> {
         if !dir.exists() {
             return Err(GfError::Storage(format!(
                 "path does not exist: {}",
@@ -458,20 +475,27 @@ impl GraphForge {
         }
 
         let resolved_generation = gf_storage::open_or_initialize_project(&dir)?;
-        Self::open_resolved(dir, resolved_generation)
-    }
-
-    fn open_resolved(
-        container_dir: PathBuf,
-        resolved_generation: ResolvedProjectGeneration,
-    ) -> Result<Self, GfError> {
-        Self::open_resolved_with_mode(container_dir, resolved_generation, false)
+        Self::open_resolved_with_options(dir, resolved_generation, false, options)
     }
 
     fn open_resolved_with_mode(
         container_dir: PathBuf,
         resolved_generation: ResolvedProjectGeneration,
         read_only: bool,
+    ) -> Result<Self, GfError> {
+        Self::open_resolved_with_options(
+            container_dir,
+            resolved_generation,
+            read_only,
+            GraphForgeOptions::default(),
+        )
+    }
+
+    fn open_resolved_with_options(
+        container_dir: PathBuf,
+        resolved_generation: ResolvedProjectGeneration,
+        read_only: bool,
+        write_options: GraphForgeOptions,
     ) -> Result<Self, GfError> {
         let generation_uuid = resolved_generation.generation_uuid();
         let (ontology_mode, ontology) = load_workspace_ontology(&resolved_generation)?;
@@ -497,7 +521,8 @@ impl GraphForge {
             )),
             embedding_refresh_epoch: Instant::now(),
             embedding_refresh_visibility: Arc::new(Mutex::new(())),
-            graph_visibility: Arc::new(Mutex::new(())),
+            graph_visibility: Arc::new(write_modes::WriteCoordinator::new(write_options)),
+            write_options,
             provider_refresh_driver_active: Arc::new(AtomicBool::new(false)),
             provider_refresh_runtimes: Arc::new(Mutex::new(Vec::new())),
             provider_find_runtimes: Arc::new(Mutex::new(Vec::new())),
@@ -631,10 +656,6 @@ impl GraphForge {
         cypher: &str,
         params: &HashMap<String, IrLiteral>,
     ) -> Result<ExecutionResult, GfError> {
-        let _graph_visibility = self
-            .graph_visibility
-            .lock()
-            .expect("graph visibility lock poisoned");
         if cypher.trim().is_empty() {
             return Err(GfError::Validation("empty query".into()));
         }
@@ -707,6 +728,10 @@ impl GraphForge {
             })
             .count();
         let is_write = write_ops > 0;
+        let _write_visibility = is_write.then(|| self.graph_visibility.lock()).transpose()?;
+        let _read_visibility = (!is_write)
+            .then(|| self.graph_visibility.read())
+            .transpose()?;
         let expected_generation_before_write = *self
             .current_generation_uuid
             .lock()
@@ -1133,10 +1158,7 @@ impl GraphForge {
     /// Returns [`GfError::Storage`] for persistent projects or if the in-memory
     /// project cannot be reset.
     pub fn clear(&self) -> Result<(), GfError> {
-        let _graph_visibility = self
-            .graph_visibility
-            .lock()
-            .expect("graph visibility lock poisoned");
+        let _graph_visibility = self.graph_visibility.lock()?;
         if self.path.is_some() {
             return Err(GfError::Storage(
                 "clear is supported only for in-memory GraphForge instances".to_owned(),
@@ -1285,10 +1307,7 @@ impl GraphForge {
         &self,
         descriptor: &InvocationDescriptor,
     ) -> Result<arrow::record_batch::RecordBatch, InvocationError> {
-        let _graph_visibility = self
-            .graph_visibility
-            .lock()
-            .expect("graph visibility lock poisoned");
+        let _graph_visibility = self.graph_visibility.lock()?;
         let Algorithm::Rank(by) = descriptor.algorithm() else {
             return Err(InvocationDescriptorError::Invalid(
                 "rank dispatch requires a rank descriptor".into(),
@@ -1379,10 +1398,7 @@ impl GraphForge {
         &self,
         descriptor: &InvocationDescriptor,
     ) -> Result<arrow::record_batch::RecordBatch, InvocationError> {
-        let _graph_visibility = self
-            .graph_visibility
-            .lock()
-            .expect("graph visibility lock poisoned");
+        let _graph_visibility = self.graph_visibility.lock()?;
         let Algorithm::Cluster(by) = descriptor.algorithm() else {
             return Err(InvocationDescriptorError::Invalid(
                 "cluster dispatch requires a cluster descriptor".into(),
@@ -1471,10 +1487,7 @@ impl GraphForge {
         &self,
         descriptor: &InvocationDescriptor,
     ) -> Result<arrow::record_batch::RecordBatch, InvocationError> {
-        let _graph_visibility = self
-            .graph_visibility
-            .lock()
-            .expect("graph visibility lock poisoned");
+        let _graph_visibility = self.graph_visibility.lock()?;
         let Algorithm::Similar(by) = descriptor.algorithm() else {
             return Err(InvocationDescriptorError::Invalid(
                 "similar dispatch requires a similarity descriptor".into(),
@@ -1664,10 +1677,7 @@ impl GraphForge {
         &self,
         descriptor: &InvocationDescriptor,
     ) -> Result<arrow::record_batch::RecordBatch, InvocationError> {
-        let _graph_visibility = self
-            .graph_visibility
-            .lock()
-            .expect("graph visibility lock poisoned");
+        let _graph_visibility = self.graph_visibility.lock()?;
         let Algorithm::Analyze(by) = descriptor.algorithm() else {
             return Err(InvocationDescriptorError::Invalid(
                 "embedding dispatch requires an analyze descriptor".into(),
@@ -1874,10 +1884,7 @@ impl GraphForge {
         &self,
         descriptor: &InvocationDescriptor,
     ) -> Result<arrow::record_batch::RecordBatch, InvocationError> {
-        let _graph_visibility = self
-            .graph_visibility
-            .lock()
-            .expect("graph visibility lock poisoned");
+        let _graph_visibility = self.graph_visibility.lock()?;
         let Algorithm::Analyze(by) = descriptor.algorithm() else {
             return Err(InvocationDescriptorError::Invalid(
                 "analyze dispatch requires an analyze descriptor".into(),
@@ -2026,10 +2033,7 @@ impl GraphForge {
         &self,
         descriptor: &InvocationDescriptor,
     ) -> Result<arrow::record_batch::RecordBatch, InvocationError> {
-        let _graph_visibility = self
-            .graph_visibility
-            .lock()
-            .expect("graph visibility lock poisoned");
+        let _graph_visibility = self.graph_visibility.lock()?;
         let Algorithm::Paths(by) = descriptor.algorithm() else {
             return Err(InvocationDescriptorError::Invalid(
                 "paths dispatch requires a paths descriptor".into(),
@@ -2147,11 +2151,10 @@ impl GraphForge {
             directed,
             write_property: None,
         };
-        let _graph_visibility = write_property.as_ref().map(|_| {
-            self.graph_visibility
-                .lock()
-                .expect("graph visibility lock poisoned")
-        });
+        let _graph_visibility = write_property
+            .as_ref()
+            .map(|_| self.graph_visibility.lock())
+            .transpose()?;
         let (label_id, stem) = self.algorithm_label(label, "rank")?;
         let _adjacency_visibility = self
             .adjacency_visibility
@@ -2202,11 +2205,10 @@ impl GraphForge {
             directed,
             write_property: None,
         };
-        let _graph_visibility = write_property.as_ref().map(|_| {
-            self.graph_visibility
-                .lock()
-                .expect("graph visibility lock poisoned")
-        });
+        let _graph_visibility = write_property
+            .as_ref()
+            .map(|_| self.graph_visibility.lock())
+            .transpose()?;
         let (label_id, stem) = self.algorithm_label(label, "cluster")?;
         let _adjacency_visibility = self
             .adjacency_visibility

--- a/crates/gf-api/src/search_index.rs
+++ b/crates/gf-api/src/search_index.rs
@@ -234,10 +234,7 @@ impl GraphForge {
         &self,
         cancellation: Option<CancellationToken>,
     ) -> Result<AdjacencyInspection, GfError> {
-        let visibility = self
-            .graph_visibility
-            .lock()
-            .expect("graph visibility lock poisoned");
+        let visibility = self.graph_visibility.lock()?;
         let adjacency_visibility = self
             .adjacency_visibility
             .write()
@@ -343,10 +340,7 @@ impl GraphForge {
     /// # Errors
     /// Returns [`GfError::Storage`] when canonical topology cannot be read.
     pub fn inspect_adjacency(&self) -> Result<AdjacencyInspection, GfError> {
-        let _visibility = self
-            .graph_visibility
-            .lock()
-            .expect("graph visibility lock poisoned");
+        let _visibility = self.graph_visibility.read()?;
         let _adjacency_visibility = self
             .adjacency_visibility
             .read()

--- a/crates/gf-api/src/valid_time.rs
+++ b/crates/gf-api/src/valid_time.rs
@@ -81,7 +81,7 @@ impl GraphForge {
         if let Some(uuid) = request.reasoning_uuid {
             require_uuid(uuid, "reasoning_uuid")?;
         }
-        let _visibility = crate::knowledge::lock_graph_visibility(self);
+        let _visibility = crate::knowledge::lock_graph_visibility(self)?;
         let parent = resolve(self)?;
         parent.validate_complete_participant_inventory()?;
         parent.require_capability("valid_time", 1)?;

--- a/crates/gf-api/src/write_modes.rs
+++ b/crates/gf-api/src/write_modes.rs
@@ -1,0 +1,355 @@
+use std::collections::VecDeque;
+use std::sync::{Condvar, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+use gf_core::{ApiErrorCode, GfError};
+
+use crate::CancellationToken;
+
+/// Embedded project-write coordination policy.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ProjectWriteMode {
+    /// Preserve the existing non-blocking cross-process single-writer protocol.
+    #[default]
+    SingleWriter,
+    /// Admit same-instance writes through a bounded first-in, first-out queue.
+    QueuedWriter,
+    /// Stage compatible composite transactions concurrently and rebase them
+    /// before commit; other mutation APIs remain serialized.
+    OptimisticMultiWriter,
+}
+
+/// Validated construction options for an embedded [`crate::GraphForge`] facade.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GraphForgeOptions {
+    /// Project write policy. Defaults to [`ProjectWriteMode::SingleWriter`].
+    pub write_mode: ProjectWriteMode,
+    /// Maximum number of not-yet-started operations retained by queued mode.
+    pub write_queue_capacity: usize,
+    /// Maximum optimistic rebase attempts after the initial staging attempt.
+    pub max_rebase_attempts: u32,
+}
+
+impl Default for GraphForgeOptions {
+    fn default() -> Self {
+        Self {
+            write_mode: ProjectWriteMode::SingleWriter,
+            write_queue_capacity: 64,
+            max_rebase_attempts: 3,
+        }
+    }
+}
+
+impl GraphForgeOptions {
+    pub(crate) fn validate(self) -> Result<Self, GfError> {
+        if !(1..=65_536).contains(&self.write_queue_capacity) {
+            return Err(validation(
+                "write_queue_capacity must be between 1 and 65536",
+            ));
+        }
+        if self.max_rebase_attempts > 32 {
+            return Err(validation("max_rebase_attempts must not exceed 32"));
+        }
+        Ok(self)
+    }
+}
+
+pub(crate) struct WriteCoordinator {
+    mode: ProjectWriteMode,
+    visibility: RwLock<()>,
+    queued: Mutex<QueuedState>,
+    changed: Condvar,
+    capacity: usize,
+}
+
+#[derive(Default)]
+struct QueuedState {
+    next_ticket: u64,
+    waiting: VecDeque<u64>,
+    active: bool,
+}
+
+pub(crate) enum WritePermit<'a> {
+    Direct {
+        _guard: RwLockWriteGuard<'a, ()>,
+    },
+    Queued {
+        coordinator: &'a WriteCoordinator,
+        _guard: RwLockWriteGuard<'a, ()>,
+    },
+}
+
+impl WriteCoordinator {
+    pub(crate) fn new(options: GraphForgeOptions) -> Self {
+        Self {
+            mode: options.write_mode,
+            visibility: RwLock::new(()),
+            queued: Mutex::new(QueuedState::default()),
+            changed: Condvar::new(),
+            capacity: options.write_queue_capacity,
+        }
+    }
+
+    pub(crate) fn acquire(
+        &self,
+        cancellation: Option<&CancellationToken>,
+    ) -> Result<WritePermit<'_>, GfError> {
+        if self.mode != ProjectWriteMode::QueuedWriter {
+            return self
+                .visibility
+                .write()
+                .map(|guard| WritePermit::Direct { _guard: guard })
+                .map_err(|_| validation("write coordinator lock poisoned"));
+        }
+        if cancellation.is_some_and(CancellationToken::is_cancelled) {
+            return Err(cancelled());
+        }
+        let mut state = self
+            .queued
+            .lock()
+            .map_err(|_| validation("write queue lock poisoned"))?;
+        if state.waiting.len() >= self.capacity {
+            return Err(resource_limit("write queue capacity exceeded"));
+        }
+        let ticket = state.next_ticket;
+        state.next_ticket = state
+            .next_ticket
+            .checked_add(1)
+            .ok_or_else(|| resource_limit("write queue ticket space exhausted"))?;
+        state.waiting.push_back(ticket);
+        loop {
+            if cancellation.is_some_and(CancellationToken::is_cancelled) {
+                state.waiting.retain(|candidate| *candidate != ticket);
+                self.changed.notify_all();
+                return Err(cancelled());
+            }
+            if !state.active && state.waiting.front() == Some(&ticket) {
+                state.waiting.pop_front();
+                state.active = true;
+                drop(state);
+                let Ok(guard) = self.visibility.write() else {
+                    let mut state = self
+                        .queued
+                        .lock()
+                        .map_err(|_| validation("write queue lock poisoned"))?;
+                    state.active = false;
+                    self.changed.notify_all();
+                    return Err(validation("write coordinator lock poisoned"));
+                };
+                return Ok(WritePermit::Queued {
+                    coordinator: self,
+                    _guard: guard,
+                });
+            }
+            state = self
+                .changed
+                .wait(state)
+                .map_err(|_| validation("write queue lock poisoned"))?;
+        }
+    }
+
+    pub(crate) fn lock(&self) -> Result<WritePermit<'_>, GfError> {
+        self.acquire(None)
+    }
+
+    pub(crate) fn read(&self) -> Result<RwLockReadGuard<'_, ()>, GfError> {
+        if self.mode == ProjectWriteMode::QueuedWriter {
+            let mut state = self
+                .queued
+                .lock()
+                .map_err(|_| validation("write queue lock poisoned"))?;
+            while state.active || !state.waiting.is_empty() {
+                state = self
+                    .changed
+                    .wait(state)
+                    .map_err(|_| validation("write queue lock poisoned"))?;
+            }
+        }
+        self.visibility
+            .read()
+            .map_err(|_| validation("write coordinator lock poisoned"))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn try_lock(&self) -> Result<WritePermit<'_>, ()> {
+        if self.mode != ProjectWriteMode::QueuedWriter {
+            return match self.visibility.try_write() {
+                Ok(guard) => Ok(WritePermit::Direct { _guard: guard }),
+                Err(std::sync::TryLockError::Poisoned(_) | std::sync::TryLockError::WouldBlock) => {
+                    Err(())
+                }
+            };
+        }
+        let mut state = self.queued.try_lock().map_err(|_| ())?;
+        if state.active || !state.waiting.is_empty() {
+            return Err(());
+        }
+        let guard = self.visibility.try_write().map_err(|_| ())?;
+        state.active = true;
+        drop(state);
+        Ok(WritePermit::Queued {
+            coordinator: self,
+            _guard: guard,
+        })
+    }
+}
+
+impl Drop for WritePermit<'_> {
+    fn drop(&mut self) {
+        if let Self::Queued { coordinator, .. } = self
+            && let Ok(mut state) = coordinator.queued.lock()
+        {
+            state.active = false;
+            coordinator.changed.notify_all();
+        }
+    }
+}
+
+fn validation(message: impl Into<String>) -> GfError {
+    GfError::Validation(message.into())
+}
+
+fn cancelled() -> GfError {
+    GfError::Api {
+        code: ApiErrorCode::Cancelled,
+        message: "queued write was cancelled before execution".into(),
+    }
+}
+
+fn resource_limit(message: impl Into<String>) -> GfError {
+    GfError::Api {
+        code: ApiErrorCode::ResourceLimit,
+        message: message.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::mpsc;
+    use std::thread;
+
+    use super::*;
+
+    fn queued(capacity: usize) -> Arc<WriteCoordinator> {
+        Arc::new(WriteCoordinator::new(GraphForgeOptions {
+            write_mode: ProjectWriteMode::QueuedWriter,
+            write_queue_capacity: capacity,
+            ..GraphForgeOptions::default()
+        }))
+    }
+
+    #[test]
+    fn queued_writes_start_in_admission_order() {
+        let coordinator = queued(2);
+        let active = coordinator.acquire(None).unwrap();
+        let (ready_tx, ready_rx) = mpsc::channel();
+        let (order_tx, order_rx) = mpsc::channel();
+        let mut workers = Vec::new();
+        for id in [1, 2] {
+            let worker_coordinator = Arc::clone(&coordinator);
+            let ready_tx = ready_tx.clone();
+            let order_tx = order_tx.clone();
+            workers.push(thread::spawn(move || {
+                ready_tx.send(id).unwrap();
+                let _permit = worker_coordinator.acquire(None).unwrap();
+                order_tx.send(id).unwrap();
+            }));
+            assert_eq!(ready_rx.recv().unwrap(), id);
+            while coordinator.queued.lock().unwrap().waiting.len() != id {
+                thread::yield_now();
+            }
+        }
+        drop(active);
+        assert_eq!(order_rx.recv().unwrap(), 1);
+        assert_eq!(order_rx.recv().unwrap(), 2);
+        for worker in workers {
+            worker.join().unwrap();
+        }
+    }
+
+    #[test]
+    fn queue_is_bounded_and_cancellation_never_starts_work() {
+        let coordinator = queued(1);
+        let active = coordinator.acquire(None).unwrap();
+        let cancellation = CancellationToken::new();
+        let worker_coordinator = Arc::clone(&coordinator);
+        let worker_token = cancellation.clone();
+        let worker = thread::spawn(move || worker_coordinator.acquire(Some(&worker_token)).err());
+        while coordinator.queued.lock().unwrap().waiting.is_empty() {
+            thread::yield_now();
+        }
+        let overflow = coordinator.acquire(None).err().unwrap();
+        assert_eq!(overflow.code(), "GF_RESOURCE_LIMIT");
+        cancellation.cancel();
+        drop(active);
+        let cancelled = worker.join().unwrap().unwrap();
+        assert_eq!(cancelled.code(), "GF_CANCELLED");
+        assert!(coordinator.try_lock().is_ok());
+    }
+
+    #[test]
+    fn snapshot_reads_are_concurrent_and_do_not_consume_queue_capacity() {
+        let coordinator = queued(1);
+        let first = coordinator.read().unwrap();
+        let second = coordinator.read().unwrap();
+        assert!(coordinator.queued.lock().unwrap().waiting.is_empty());
+        drop(second);
+        drop(first);
+        assert!(coordinator.try_lock().is_ok());
+    }
+
+    #[test]
+    fn admitted_writer_precedes_new_snapshot_reader() {
+        let coordinator = queued(1);
+        let existing_reader = coordinator.read().unwrap();
+        let (writer_started_tx, writer_started_rx) = mpsc::channel();
+        let (release_writer_tx, release_writer_rx) = mpsc::channel();
+        let writer_coordinator = Arc::clone(&coordinator);
+        let writer = thread::spawn(move || {
+            let _permit = writer_coordinator.acquire(None).unwrap();
+            writer_started_tx.send(()).unwrap();
+            release_writer_rx.recv().unwrap();
+        });
+        while !coordinator.queued.lock().unwrap().active {
+            thread::yield_now();
+        }
+
+        let (reader_started_tx, reader_started_rx) = mpsc::channel();
+        let reader_coordinator = Arc::clone(&coordinator);
+        let reader = thread::spawn(move || {
+            let _permit = reader_coordinator.read().unwrap();
+            reader_started_tx.send(()).unwrap();
+        });
+        drop(existing_reader);
+        writer_started_rx.recv().unwrap();
+        assert!(reader_started_rx.try_recv().is_err());
+        release_writer_tx.send(()).unwrap();
+        writer.join().unwrap();
+        reader_started_rx.recv().unwrap();
+        reader.join().unwrap();
+    }
+
+    #[test]
+    fn defaults_and_bounds_are_stable() {
+        let defaults = GraphForgeOptions::default();
+        assert_eq!(defaults.write_mode, ProjectWriteMode::SingleWriter);
+        assert!(defaults.validate().is_ok());
+        assert!(
+            GraphForgeOptions {
+                write_queue_capacity: 0,
+                ..defaults
+            }
+            .validate()
+            .is_err()
+        );
+        assert!(
+            GraphForgeOptions {
+                max_rebase_attempts: 33,
+                ..defaults
+            }
+            .validate()
+            .is_err()
+        );
+    }
+}

--- a/crates/gf-api/src/write_modes.rs
+++ b/crates/gf-api/src/write_modes.rs
@@ -136,6 +136,16 @@ impl WriteCoordinator {
                     self.changed.notify_all();
                     return Err(validation("write coordinator lock poisoned"));
                 };
+                if cancellation.is_some_and(CancellationToken::is_cancelled) {
+                    drop(guard);
+                    let mut state = self
+                        .queued
+                        .lock()
+                        .map_err(|_| validation("write queue lock poisoned"))?;
+                    state.active = false;
+                    self.changed.notify_all();
+                    return Err(cancelled());
+                }
                 return Ok(WritePermit::Queued {
                     coordinator: self,
                     _guard: guard,
@@ -143,7 +153,8 @@ impl WriteCoordinator {
             }
             state = self
                 .changed
-                .wait(state)
+                .wait_timeout(state, std::time::Duration::from_millis(50))
+                .map(|(guard, _)| guard)
                 .map_err(|_| validation("write queue lock poisoned"))?;
         }
     }
@@ -275,15 +286,24 @@ mod tests {
         let cancellation = CancellationToken::new();
         let worker_coordinator = Arc::clone(&coordinator);
         let worker_token = cancellation.clone();
-        let worker = thread::spawn(move || worker_coordinator.acquire(Some(&worker_token)).err());
+        let (cancelled_tx, cancelled_rx) = mpsc::channel();
+        let worker = thread::spawn(move || {
+            cancelled_tx
+                .send(worker_coordinator.acquire(Some(&worker_token)).err())
+                .unwrap();
+        });
         while coordinator.queued.lock().unwrap().waiting.is_empty() {
             thread::yield_now();
         }
         let overflow = coordinator.acquire(None).err().unwrap();
         assert_eq!(overflow.code(), "GF_RESOURCE_LIMIT");
         cancellation.cancel();
+        let cancelled = cancelled_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("queued cancellation must not wait for the active writer")
+            .unwrap();
         drop(active);
-        let cancelled = worker.join().unwrap().unwrap();
+        worker.join().unwrap();
         assert_eq!(cancelled.code(), "GF_CANCELLED");
         assert!(coordinator.try_lock().is_ok());
     }
@@ -296,6 +316,36 @@ mod tests {
         assert!(coordinator.queued.lock().unwrap().waiting.is_empty());
         drop(second);
         drop(first);
+        assert!(coordinator.try_lock().is_ok());
+    }
+
+    #[test]
+    fn cancellation_after_admission_never_returns_a_write_permit() {
+        let coordinator = queued(1);
+        let reader = coordinator.read().unwrap();
+        let cancellation = CancellationToken::new();
+        let worker_coordinator = Arc::clone(&coordinator);
+        let worker_token = cancellation.clone();
+        let (result_tx, result_rx) = mpsc::channel();
+        let worker = thread::spawn(move || {
+            result_tx
+                .send(worker_coordinator.acquire(Some(&worker_token)).err())
+                .unwrap();
+        });
+        while !coordinator.queued.lock().unwrap().active {
+            thread::yield_now();
+        }
+
+        cancellation.cancel();
+        drop(reader);
+        let error = result_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("admitted cancellation must finish after the reader releases")
+            .expect("cancellation must not return a write permit");
+        worker.join().unwrap();
+
+        assert_eq!(error.code(), "GF_CANCELLED");
+        assert!(!coordinator.queued.lock().unwrap().active);
         assert!(coordinator.try_lock().is_ok());
     }
 

--- a/crates/gf-bindings-node/tests/non-cypher-parity-policy.json
+++ b/crates/gf-bindings-node/tests/non-cypher-parity-policy.json
@@ -1,8 +1,8 @@
 {
   "contractVersion": 1,
   "rustManifest": "../../../tests/contracts/non-cypher-rust-surface.json",
-  "releaseSurfaceCount": 179,
-  "releaseSurfaceDigest": "00838ed9c9cb72ed5d097128adb801bef1a7cdd8cc28ab8c998d6fdf0677b9bd",
+  "releaseSurfaceCount": 180,
+  "releaseSurfaceDigest": "ca1d54b28ed0cb6b2e57b081020494c35c5c8842a37c6bc349bfa6936cf067a8",
   "rustEvidenceGroupMap": {
     "lifecycle-construction": "lifecycleConstruction",
     "checkpoint-view": "checkpointView",

--- a/crates/gf-bindings-py/tests/non_cypher_release.py
+++ b/crates/gf-bindings-py/tests/non_cypher_release.py
@@ -23,8 +23,8 @@ ROOT = Path(__file__).resolve().parents[3]
 RUST_MANIFEST = ROOT / "tests/contracts/non-cypher-rust-surface.json"
 RUST_GATE = ROOT / "scripts/ci/non-cypher-surface-gate.py"
 PYO3_SOURCE = ROOT / "crates/gf-bindings-py/src/lib.rs"
-EXPECTED_RUST_DIGEST = "d9eb63063042d381288599f48b909f52b1701a74027595a0c630a17fffae82db"
-EXPECTED_RELEASE_DIGEST = "00838ed9c9cb72ed5d097128adb801bef1a7cdd8cc28ab8c998d6fdf0677b9bd"
+EXPECTED_RUST_DIGEST = "c2d337db7483484d35da304dbc3d1c996100e93c01c8e2ded49551a5ac83122f"
+EXPECTED_RELEASE_DIGEST = "ca1d54b28ed0cb6b2e57b081020494c35c5c8842a37c6bc349bfa6936cf067a8"
 
 EVIDENCE = {
     "lifecycle-construction": {
@@ -179,7 +179,7 @@ def _classification_report() -> dict[str, object]:
         for group in manifest["method_evidence_groups"].values()
         for method_id in group["ids"]
     }
-    assert len(release_methods) == 179
+    assert len(release_methods) == 180
     assert _digest(release_methods) == EXPECTED_RELEASE_DIGEST
     assert set(EVIDENCE) == set(manifest["method_evidence_groups"])
 

--- a/crates/gf-storage/src/project_publication.rs
+++ b/crates/gf-storage/src/project_publication.rs
@@ -412,6 +412,14 @@ fn acquire_writer_lock_for_parts(
     Ok(writer_lock)
 }
 
+fn wait_for_writer_lock(root: &Path) -> Result<File, GfError> {
+    let lock_dir = ensure_machine_directory(root, Path::new(LOCKS_DIR))?;
+    sync_directory(root)?;
+    let writer_lock = open_regular_lock(&lock_dir.join(WRITER_LOCK_FILE))?;
+    FileExt::lock_exclusive(&writer_lock).map_err(publication_io)?;
+    Ok(writer_lock)
+}
+
 fn acquire_transaction_lock(
     root: &Path,
     request: &ProjectGenerationRequest,
@@ -829,11 +837,7 @@ impl ValidatedProjectGeneration {
             return Ok(None);
         }
         let staged = &self.0;
-        let writer_lock = acquire_writer_lock_for_parts(
-            &staged.root,
-            staged.transaction_uuid,
-            staged.generation_uuid,
-        )?;
+        let writer_lock = wait_for_writer_lock(&staged.root)?;
         project_failpoint::hit(
             "project.after_optimistic_commit_lock",
             Some(staged.transaction_uuid),
@@ -1528,12 +1532,26 @@ pub(crate) fn ensure_machine_directory(root: &Path, relative: &Path) -> Result<P
                 ));
             }
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                std::fs::create_dir(&current).map_err(publication_io)?;
-                sync_directory(
-                    current
-                        .parent()
-                        .expect("machine directory beneath project has a parent"),
-                )?;
+                match std::fs::create_dir(&current) {
+                    Ok(()) => {
+                        sync_directory(
+                            current
+                                .parent()
+                                .expect("machine directory beneath project has a parent"),
+                        )?;
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                        let metadata =
+                            std::fs::symlink_metadata(&current).map_err(publication_io)?;
+                        if !metadata.is_dir() || metadata.file_type().is_symlink() {
+                            return Err(project_error(
+                                ProjectErrorCode::ProjectCorrupt,
+                                "concurrently created machine path is linked or not a directory",
+                            ));
+                        }
+                    }
+                    Err(error) => return Err(publication_io(error)),
+                }
             }
             Err(error) => return Err(publication_io(error)),
         }

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -215,6 +215,10 @@ export default defineConfig({
                   label: '0014 — Workspace Checkpoints',
                   slug: 'adr/0014-workspace-checkpoints',
                 },
+                {
+                  label: '0015 — Embedded Write Modes',
+                  slug: 'adr/0015-embedded-write-modes',
+                },
               ],
             },
           ],

--- a/docs-site/scripts/sync-content.mjs
+++ b/docs-site/scripts/sync-content.mjs
@@ -123,6 +123,7 @@ const PAGES = [
   'adr/0012-m20-domain-ownership.md',
   'adr/0013-project-generation-protocol.md',
   'adr/0014-workspace-checkpoints.md',
+  'adr/0015-embedded-write-modes.md',
   'releases/roadmap.md',
   'legal/licensing.md',
   'community/security.md',

--- a/docs/adr/0013-project-generation-protocol.md
+++ b/docs/adr/0013-project-generation-protocol.md
@@ -181,7 +181,10 @@ The default writer-lock acquisition is non-blocking and returns
 `GF_WRITER_BUSY`.
 Callers may supply a finite timeout measured by a monotonic clock; expiry
 returns the same code without mutation. Infinite waits are not exposed by a
-public API.
+public API. A validated optimistic attempt is the exception inside the storage
+protocol: it waits for the short commit lock, compares its pinned parent with
+`CURRENT`, and returns `GF_WRITE_CONFLICT` when another commit won. This wait is
+not a caller-configurable lock API and cannot expose partial state.
 
 Each generation has `lease.lock`. A reader:
 

--- a/docs/adr/0015-embedded-write-modes.md
+++ b/docs/adr/0015-embedded-write-modes.md
@@ -1,0 +1,56 @@
+# ADR 0015: Three embedded project-write modes
+
+**Status:** Accepted for v0.5.0
+
+## Context
+
+GraphForge is an embedded engine, but one project may be opened by multiple
+threads, processes, or agent clients. The durable generation protocol already
+provides immutable snapshots, transaction-addressed attempts, and an atomic
+`CURRENT` boundary. Callers need explicit coordination choices without making
+the storage engine a distributed database or adding a network server to core.
+
+## Decision
+
+`GraphForgeOptions` selects exactly one `ProjectWriteMode`:
+
+- `SingleWriter` is the compatibility default. A competing cross-process writer
+  receives `GF_WRITER_BUSY` before staging.
+- `QueuedWriter` admits mutations through a bounded FIFO queue owned by one
+  facade. Queue capacity is explicit. Snapshot reads bypass the admission queue,
+  and cancellation removes only a request that has not started.
+- `OptimisticMultiWriter` allows different composite transaction identities to
+  stage in parallel. Committers wait for the short writer-lock promotion
+  boundary, compare their pinned parent with durable `CURRENT`, and either
+  publish or rebase within the configured finite retry budget.
+
+The optimistic conflict matrix is closed:
+
+| Concurrent work | Outcome |
+| --- | --- |
+| Distinct graph creates | Rebase and merge |
+| Distinct immutable-ledger identities | Rebase and merge |
+| Different properties on one object | Rebase and merge |
+| Same property or removed target | `GF_WRITE_CONFLICT` |
+| Delete or administrative work | `GF_WRITE_CONFLICT` |
+| Retry budget consumed | `GF_REBASE_EXHAUSTED` |
+| Same operation and same content | Exact idempotent replay |
+| Same operation and changed content | `GF_IDEMPOTENCY_CONFLICT` |
+
+Only `publish_composite_transaction` has optimistic replay semantics in
+v0.5.0. Arbitrary write Cypher, bulk construction, index administration, and
+other mutation APIs remain serialized. After any attempted publication, the
+facade workspace, runtime catalog, and generation UUID reconcile to durable
+`CURRENT`; a committed generation is never reported as rolled back.
+
+The modes are local embedded capabilities, not transport protocols. MCP and
+HTTP remain outside core. An optional extension can expose one authenticated
+authority over these APIs without changing the on-disk protocol.
+
+## Consequences
+
+Applications keep a zero-configuration safe default and may opt into bounded
+backpressure or compatible multi-writer throughput. Queue memory cannot grow
+without limit, retries cannot continue without limit, and conflict outcomes are
+machine-readable. Remote fleets require an extension or application-owned
+authority rather than a server dependency in the engine.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,6 +20,7 @@ are not retained in this tree.
 | 0012 | [Knowledge and epistemic domain ownership and schema evolution](0012-m20-domain-ownership.md) | `0012-m20-domain-ownership.md` |
 | 0013 | [Durable v0.5 project-generation protocol](0013-project-generation-protocol.md) | `0013-project-generation-protocol.md` |
 | 0014 | [Complete-workspace checkpoints and generation-preserving revert](0014-workspace-checkpoints.md) | `0014-workspace-checkpoints.md` |
+| 0015 | [Three embedded project-write modes](0015-embedded-write-modes.md) | `0015-embedded-write-modes.md` |
 
 ## Numbering
 

--- a/docs/book/architecture/concurrency-recovery.md
+++ b/docs/book/architecture/concurrency-recovery.md
@@ -10,10 +10,29 @@ Dropping a stream or cancelling one request affects only that operation. A peer
 continues to a complete result, while cooperative cancellation reports
 `GF_CANCELLED`.
 
-Project mutation is single-writer. A competing writer is rejected with
-`GF_WRITER_BUSY` before it creates staging or publication state. Multi-writer
-merge semantics and throughput guarantees are unsupported. Cross-process
-publication exposes one complete generation, never a partially staged one.
+Project mutation has three explicit embedded modes. `single_writer` is the
+default and rejects a competing writer with `GF_WRITER_BUSY` before it creates
+staging or publication state. `queued_writer` adds a bounded, first-in-first-out
+queue per facade; snapshot reads do not enter that queue, and cancellation can
+remove only work that has not started. `optimistic_multi_writer` lets distinct
+composite transaction identities stage concurrently, serializes only the
+`CURRENT` commit point, and rebases compatible work against the winning
+generation. Cross-process publication always exposes one complete generation,
+never a partially staged one.
+
+Optimistic merge rules are deliberately finite. Distinct creates and immutable
+ledger identities merge. Changes to different properties of the same graph
+object merge. Reusing an identity with changed content, changing the same
+property, losing a mutation target, and delete or administrative work do not
+merge. Stable outcomes are `GF_IDEMPOTENCY_CONFLICT`, `GF_WRITE_CONFLICT`, or
+`GF_REBASE_EXHAUSTED`. Only the composite publication API is replayed
+optimistically in v0.5.0; other mutation APIs keep their established
+single-writer behavior even when the facade selects optimistic mode.
+
+These modes coordinate embedded callers directly against the project directory.
+GraphForge core does not include an MCP or HTTP server. A separately packaged
+extension may expose one authenticated remote authority without changing the
+storage engine into a distributed database.
 
 Recovery after a writer is killed selects either the previous complete
 generation or the newly published complete generation according to the durable

--- a/docs/book/architecture/overview.md
+++ b/docs/book/architecture/overview.md
@@ -253,7 +253,7 @@ Shipped v0.5.0 expects these surfaces to stay green on `main`:
 - [Algorithm Verbs](algorithms.md) — full algorithm catalog across rank/cluster/paths/analyze/similar
 - [Execution Model](execution-model.md) — DataFusion integration, custom graph operators, Arrow result streams
 - [Storage](storage.md) — StorageProvider trait, Parquet provider
-- [ADR Index](../../adr/README.md) — contiguous v0.5.0 decision log (`0001`–`0014`)
+- [ADR Index](../../adr/README.md) — contiguous v0.5.0 decision log (`0001`–`0015`)
 - [ADR 0001: Rust Core](../../adr/0001-rust-core.md) — Rust core and binding strategy
 - [ADR 0002: RD+Pratt Parser](../../adr/0002-lr1-grammar.md) — Parser algorithm decision
 - [ADR 0003: Progressive Ontology](../../adr/0003-progressive-ontology.md) — exploration-first ontology modes
@@ -265,4 +265,5 @@ Shipped v0.5.0 expects these surfaces to stay green on `main`:
   cross-domain validation
 - [ADR 0013: Project Generations](../../adr/0013-project-generation-protocol.md) — durable project-generation protocol
 - [ADR 0014: Workspace Checkpoints](../../adr/0014-workspace-checkpoints.md) — complete-workspace checkpoints and revert
+- [ADR 0015: Embedded Write Modes](../../adr/0015-embedded-write-modes.md) — single, queued, and optimistic project writes
 - [Roadmap](../../releases/roadmap.md) — Milestones and timeline

--- a/docs/engineering/ARCHITECTURE.md
+++ b/docs/engineering/ARCHITECTURE.md
@@ -118,6 +118,7 @@ The DocSlime index is [`adrs/README.md`](adrs/README.md) (links only; does not r
 | [0012](../adr/0012-m20-domain-ownership.md) | Knowledge and epistemic domain ownership and schema evolution |
 | [0013](../adr/0013-project-generation-protocol.md) | Durable project-generation protocol |
 | [0014](../adr/0014-workspace-checkpoints.md) | Complete-workspace checkpoints |
+| [0015](../adr/0015-embedded-write-modes.md) | Three embedded project-write modes |
 
 ## Risks & trade-offs
 

--- a/docs/engineering/adrs/README.md
+++ b/docs/engineering/adrs/README.md
@@ -51,3 +51,4 @@ Keeper set after #2730 (mirrors [`../../adr/README.md`](../../adr/README.md)):
 | 0012 | Knowledge and epistemic domain ownership and schema evolution | Accepted | [`../../adr/0012-m20-domain-ownership.md`](../../adr/0012-m20-domain-ownership.md) |
 | 0013 | Durable v0.5 project-generation protocol | Accepted | [`../../adr/0013-project-generation-protocol.md`](../../adr/0013-project-generation-protocol.md) |
 | 0014 | Complete-workspace checkpoints | Accepted | [`../../adr/0014-workspace-checkpoints.md`](../../adr/0014-workspace-checkpoints.md) |
+| 0015 | Three embedded project-write modes | Accepted | [`../../adr/0015-embedded-write-modes.md`](../../adr/0015-embedded-write-modes.md) |

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -86,6 +86,12 @@ the authoritative runnable corpus enforced by the BDD gate.
   not planned.
 
 ### Added
+
+- Add explicit `single_writer`, bounded FIFO `queued_writer`, and
+  `optimistic_multi_writer` embedded modes. Optimistic composite transactions
+  rebase compatible creates, immutable-ledger rows, and disjoint property
+  changes while returning stable conflict and exhausted-retry errors (#213).
+
 - Add `scripts/record_release_artifacts.py` and
   `docs/development/release-artifact-record.md` for RC checksum/SBOM/contents
   inventories usable by GitHub Release and §7 clean-env checks (#2798).

--- a/scripts/ci/test-non-cypher-surface-gate.py
+++ b/scripts/ci/test-non-cypher-surface-gate.py
@@ -29,7 +29,7 @@ class SurfaceGateTests(unittest.TestCase):
 
     def test_checked_in_inventory_is_complete(self) -> None:
         self.assertEqual(GATE.validate(), [])
-        self.assertEqual(len(GATE.public_methods()), 250)
+        self.assertEqual(len(GATE.public_methods()), 252)
         self.assertEqual(len(GATE.m18_registry()), 94)
 
     def test_new_or_removed_public_method_fails_frozen_digest(self) -> None:

--- a/tests/contracts/non-cypher-rust-surface.json
+++ b/tests/contracts/non-cypher-rust-surface.json
@@ -1,7 +1,7 @@
 {
   "contract_version": 1,
   "scope": "Rust non-Cypher public release surface",
-  "public_method_digest": "d9eb63063042d381288599f48b909f52b1701a74027595a0c630a17fffae82db",
+  "public_method_digest": "c2d337db7483484d35da304dbc3d1c996100e93c01c8e2ded49551a5ac83122f",
   "method_policy": {
     "receiver_defaults": {
       "GraphForge": "release-tested",
@@ -41,6 +41,7 @@
       "crate.composite_receipt_schema": "introspection",
       "crate.hold_writer": "internal-helper",
       "GraphForge.new": "introspection",
+      "GraphForge.new_with_options": "introspection",
       "GraphForge.path": "introspection",
       "CheckpointView.checkpoint_uuid": "introspection",
       "CheckpointView.generation_uuid": "introspection",
@@ -191,7 +192,7 @@
       "ids": [
         "GraphForge.assertion", "GraphForge.assertion_graph_refs", "GraphForge.assertion_status", "GraphForge.assess_confidence",
         "GraphForge.attach_evidence", "GraphForge.confidence_assessment", "GraphForge.confidence_inputs", "GraphForge.create_assertion",
-        "GraphForge.create_assertion_with_evidence", "GraphForge.create_assertion_with_status", "GraphForge.enable_capability", "GraphForge.publish_composite_transaction",
+        "GraphForge.create_assertion_with_evidence", "GraphForge.create_assertion_with_status", "GraphForge.enable_capability", "GraphForge.publish_composite_transaction", "GraphForge.publish_composite_transaction_with_cancellation",
         "GraphForge.evidence_link", "GraphForge.list_assertion_status", "GraphForge.list_assertion_supersessions",
         "GraphForge.list_assertion_validity", "GraphForge.list_assertions", "GraphForge.list_confidence_assessments",
         "GraphForge.list_evidence_links", "GraphForge.list_provenance_history", "GraphForge.list_reasoning",
@@ -212,6 +213,7 @@
         {"path": "crates/gf-api/src/belief_projection.rs", "symbol": "statusless_include_materializes_the_same_neutral_rank_projection"},
         {"path": "crates/gf-api/src/knowledge.rs", "symbol": "assertion_with_evidence_is_one_atomic_idempotent_generation"},
         {"path": "crates/gf-api/src/composite_publish.rs", "symbol": "publish_composite_is_one_generation_with_canonical_receipt"},
+        {"path": "crates/gf-api/src/composite_publish.rs", "symbol": "cancelled_public_composite_publish_never_mutates"},
         {"path": "crates/gf-api/src/composite_publish.rs", "symbol": "invalid_composite_request_does_not_mutate"},
         {"path": "crates/gf-api/src/knowledge.rs", "symbol": "supersession_is_atomic_branch_preserving_idempotent_and_reopenable"}
       ]


### PR DESCRIPTION
Closes #213

## Summary
- expose explicit single-writer, bounded FIFO queued-writer, and optimistic multi-writer Rust options
- rebase compatible composite transactions with stable conflict outcomes and durable CURRENT reconciliation
- document the closed conflict matrix and keep MCP/HTTP outside core

## Verification
- cargo test -p gf-api --lib (418 passed)
- cargo test -p gf-storage project_publication::tests (14 passed)
- cargo clippy --workspace -- -D warnings
- pnpm --dir docs-site run build
- CodeRabbit CLI follow-up review: 0 findings
- make pre-push completed fast checks and all Rust/BDD test results; the existing BDD binary remained alive after its 123 passed / 8 skipped summary, so the coverage wrapper was interrupted after completion output

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788019973&installation_model_id=20486&pr_number=217&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F217&signature=77e3db8fdfee8537b9dbb9588f9000a8b325be699bddcfd0bd09bfd4d1099da8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add embedded write modes (`SingleWriter`, `QueuedWriter`, `OptimisticMultiWriter`) to `GraphForge`
> - Introduces `ProjectWriteMode` enum and `GraphForgeOptions` struct, configurable via a new `GraphForge::new_with_options` constructor; defaults to `SingleWriter` with queue capacity 64 and 3 rebase attempts.
> - Adds `WriteCoordinator` in [write_modes.rs](https://github.com/CurateLabs/graphforge/pull/217/files#diff-97bd70e9ed3a78c6312751dd8875b0586b3260c14815614f10b5d189ee08d1ef) to manage per-mode write permits: `SingleWriter` takes an exclusive lock directly, `QueuedWriter` admits writers FIFO up to a bounded capacity with cancellation support, and `OptimisticMultiWriter` allows parallel staging with a short commit lock and compare-against-CURRENT conflict detection.
> - Adds `publish_composite_transaction_with_cancellation` in [composite_publish.rs](https://github.com/CurateLabs/graphforge/pull/217/files#diff-dcc626167e24aa94d6761303e4f0da4075acfb3457bbec46c6813e34a16ca0a3) supporting optimistic rebases up to `max_rebase_attempts`, returning `GF_WRITE_CONFLICT` on incompatible concurrent changes or `GF_REBASE_EXHAUSTED` when the retry budget is spent.
> - Converts all mutation methods across `knowledge.rs`, `bulk_construction.rs`, `belief_projection.rs`, `search_index.rs`, and others from panicking `expect()` mutex calls to `Result`-returning write/read permits via `WriteCoordinator`.
> - Read-only queries and adjacency inspection now acquire a read permit instead of an exclusive write lock, allowing concurrent readers.
> - Risk: all write-path methods now return a new `GfError` variant on permit acquisition failure instead of panicking; callers must handle these new error cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ac8427.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable write modes for improved concurrency, including queued and optimistic multi-writer options.
  * Added cancellation support for composite transactions.
  * Added a constructor for configuring GraphForge write behavior.

* **Bug Fixes**
  * Preserved write settings when reverting to checkpoints.
  * Improved concurrent publishing and directory creation reliability.
  * Lock failures now return errors instead of causing panics.

* **Documentation**
  * Added documentation navigation for embedded write modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->