### PR TITLE
feat(bindings): expose embedded write modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,10 @@ the authoritative runnable corpus enforced by the BDD gate.
   `optimistic_multi_writer` embedded modes. Optimistic composite transactions
   rebase compatible creates, immutable-ledger rows, and disjoint property
   changes while returning stable conflict and exhausted-retry errors (#213).
+- Expose the three embedded write modes through equivalent validated Python and
+  Node constructor options, thread explicit selections through agent workflows,
+  and verify compatible multi-agent publication, reopen, identity preservation,
+  and conflict atomicity across the native concurrency matrix (#214).
 
 - Add transaction-addressed optimistic project staging with OS-backed attempt
   leases, exact-base commit comparison, atomic generation promotion, and

--- a/crates/gf-api/src/composite_publish.rs
+++ b/crates/gf-api/src/composite_publish.rs
@@ -224,12 +224,7 @@ impl GraphForge {
                         |_| Ok(()),
                         |actual_parent, _| {
                             if actual_parent.generation_uuid() != expected_parent {
-                                return Err(GfError::Project {
-                                    code: ProjectErrorCode::TransactionConflict,
-                                    message:
-                                        "project generation changed before composite publication"
-                                            .into(),
-                                });
+                                return Err(publication_parent_changed(optimistic));
                             }
                             Ok(())
                         },
@@ -544,6 +539,15 @@ fn write_conflict(message: impl Into<String>) -> GfError {
     GfError::Project {
         code: ProjectErrorCode::WriteConflict,
         message: message.into(),
+    }
+}
+
+fn publication_parent_changed(optimistic: bool) -> GfError {
+    let message = "project generation changed before composite publication";
+    if optimistic {
+        write_conflict(message)
+    } else {
+        idempotency_conflict(message)
     }
 }
 
@@ -1413,6 +1417,15 @@ mod tests {
             max_rebase_attempts,
             ..GraphForgeOptions::default()
         }
+    }
+
+    #[test]
+    fn publication_parent_drift_is_retriable_only_in_optimistic_mode() {
+        assert_eq!(publication_parent_changed(true).code(), "GF_WRITE_CONFLICT");
+        assert_eq!(
+            publication_parent_changed(false).code(),
+            "GF_IDEMPOTENCY_CONFLICT"
+        );
     }
 
     fn publish_concurrently(

--- a/crates/gf-bindings-node/README.md
+++ b/crates/gf-bindings-node/README.md
@@ -39,6 +39,21 @@ surfaces. Decode them with `apache-arrow` as shown above.
 For persistent projects, create the project directory before passing its path
 to `new GraphForge(path)`.
 
+Choose an embedded write mode with the optional second constructor argument:
+
+```js
+const forge = new GraphForge(path, {
+  writeMode: "optimistic_multi_writer",
+  writeQueueCapacity: 64,
+  maxRebaseAttempts: 3,
+});
+```
+
+The stable mode names are `single_writer` (default), `queued_writer`, and
+`optimistic_multi_writer`. Queue capacity is bounded to 1–65,536 and rebase
+attempts to 0–32. Optimistic replay applies only to composite transactions.
+GraphForge remains embedded; remote transports are separate extensions.
+
 ## Documentation and support
 
 - [Documentation](https://curatelabs.github.io/graphforge-legecy/)

--- a/crates/gf-bindings-node/src/lib.rs
+++ b/crates/gf-bindings-node/src/lib.rs
@@ -6885,7 +6885,7 @@ mod tests {
 
     #[test]
     fn node_engine_lock_allows_shared_reads_and_blocks_exclusive_replacement() {
-        let graph = Arc::new(GraphForge::new(None).unwrap());
+        let graph = Arc::new(GraphForge::new(None, None).unwrap());
 
         let read_guard = graph.open_guard().unwrap();
         let reader = Arc::clone(&graph);
@@ -6975,7 +6975,7 @@ mod tests {
 
     #[test]
     fn source_free_minimum_steiner_reaches_active_rust_handler() {
-        let graph = GraphForge::new(None).unwrap();
+        let graph = GraphForge::new(None, None).unwrap();
         let first = graph.add_node("Person".into(), None).unwrap();
         let second = graph.add_node("Person".into(), None).unwrap();
 
@@ -7009,7 +7009,7 @@ mod tests {
 
     #[test]
     fn capability_tasks_return_rust_owned_arrow_ipc() {
-        let graph = GraphForge::new(None).unwrap();
+        let graph = GraphForge::new(None, None).unwrap();
         let mut inspect = ProjectCapabilitiesTask {
             engine: Arc::clone(&graph.inner),
         };

--- a/crates/gf-bindings-node/src/lib.rs
+++ b/crates/gf-bindings-node/src/lib.rs
@@ -25,12 +25,12 @@ use gf_api::{
     EmbeddingRefreshWorkerState, EmbeddingSpaceFreshnessInspection, EmbeddingSpaceFreshnessState,
     EmbeddingSpaceInfo, EmbeddingSpaceProducer, EmbeddingSpaceReadDecision,
     EmbeddingTokenCountClass, ExecutionResult, FastRpOptions, FindDiagnostic, FindExecutionOptions,
-    FindOptions, FindRerankOptions, GfError, GraphObjectKind, GraphSageAggregator,
-    GraphSageOptions, HashGnnOptions, InvocationDescriptor, InvocationError, IrLiteral,
-    M18EmbeddingDistance, M18EmbeddingNormalization, M18EmbeddingPublicationRequest,
+    FindOptions, FindRerankOptions, GfError, GraphForgeOptions, GraphObjectKind,
+    GraphSageAggregator, GraphSageOptions, HashGnnOptions, InvocationDescriptor, InvocationError,
+    IrLiteral, M18EmbeddingDistance, M18EmbeddingNormalization, M18EmbeddingPublicationRequest,
     Node2VecOptions, NodeSelector, OpenRouterProviderSession, OpenRouterProviderSessionConfig,
-    OpenRouterWireLimits, OperationId, PathsOptions, PropValue, ProviderBatchLimits,
-    ProviderCapabilities, ProviderCapability, ProviderEmbeddingDistance,
+    OpenRouterWireLimits, OperationId, PathsOptions, ProjectWriteMode, PropValue,
+    ProviderBatchLimits, ProviderCapabilities, ProviderCapability, ProviderEmbeddingDistance,
     ProviderEmbeddingNormalization, ProviderEmbeddingPlanInspection, ProviderEmbeddingPlanRequest,
     ProviderExecutionLimits, ProviderRequestLimits, RerankAdvisoryPolicy, RerankFailurePolicy,
     ResolveBeliefProjectionRequest, ResolveBeliefSubjectRequest, ResolvedAttachmentOutcome,
@@ -55,6 +55,28 @@ pub(crate) type Result<T> = std::result::Result<T, NodeError>;
 
 pub(crate) fn napi_validation(message: &'static str) -> NodeError {
     to_napi_err(&GfError::Validation(message.into()))
+}
+
+fn project_write_mode(value: &str) -> Result<ProjectWriteMode> {
+    match value {
+        "single_writer" => Ok(ProjectWriteMode::SingleWriter),
+        "queued_writer" => Ok(ProjectWriteMode::QueuedWriter),
+        "optimistic_multi_writer" => Ok(ProjectWriteMode::OptimisticMultiWriter),
+        _ => Err(napi_validation(
+            "writeMode must be single_writer, queued_writer, or optimistic_multi_writer",
+        )),
+    }
+}
+
+#[napi(object)]
+/// Embedded project-write construction options.
+pub struct GraphForgeOptionsInput {
+    /// Write coordination policy name.
+    pub write_mode: Option<String>,
+    /// Maximum number of queued same-instance writers.
+    pub write_queue_capacity: Option<i32>,
+    /// Maximum optimistic rebase attempts after initial staging.
+    pub max_rebase_attempts: Option<i32>,
 }
 
 fn to_napi_invocation_err(error: &InvocationError) -> NodeError {
@@ -2743,8 +2765,44 @@ impl GraphForge {
 impl GraphForge {
     /// Open an in-memory (`path` omitted) or Parquet-backed (`path` = dir) instance.
     #[napi(constructor)]
-    pub fn new(path: Option<String>) -> Result<Self> {
-        let inner = gf_api::GraphForge::new(path.as_deref()).map_err(|e| to_napi_err(&e))?;
+    pub fn new(path: Option<String>, options: Option<GraphForgeOptionsInput>) -> Result<Self> {
+        let defaults = GraphForgeOptions::default();
+        let options = options.unwrap_or(GraphForgeOptionsInput {
+            write_mode: None,
+            write_queue_capacity: None,
+            max_rebase_attempts: None,
+        });
+        let options = GraphForgeOptions {
+            write_mode: match options.write_mode {
+                Some(value) => project_write_mode(&value)?,
+                None => defaults.write_mode,
+            },
+            write_queue_capacity: match options.write_queue_capacity {
+                Some(value) if (1..=65_536).contains(&value) => {
+                    usize::try_from(value).map_err(|_| {
+                        napi_validation("writeQueueCapacity must be between 1 and 65536")
+                    })?
+                }
+                Some(_) => {
+                    return Err(napi_validation(
+                        "writeQueueCapacity must be between 1 and 65536",
+                    ));
+                }
+                None => defaults.write_queue_capacity,
+            },
+            max_rebase_attempts: match options.max_rebase_attempts {
+                Some(value) if (0..=32).contains(&value) => u32::try_from(value)
+                    .map_err(|_| napi_validation("maxRebaseAttempts must be between 0 and 32"))?,
+                Some(_) => {
+                    return Err(napi_validation(
+                        "maxRebaseAttempts must be between 0 and 32",
+                    ));
+                }
+                None => defaults.max_rebase_attempts,
+            },
+        };
+        let inner = gf_api::GraphForge::new_with_options(path.as_deref(), options)
+            .map_err(|e| to_napi_err(&e))?;
         Ok(Self {
             inner: OwnedEngine::new(inner),
             provider: None,

--- a/crates/gf-bindings-node/tests/concurrency-parity.test.mjs
+++ b/crates/gf-bindings-node/tests/concurrency-parity.test.mjs
@@ -5,6 +5,7 @@ import { existsSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
+import { Worker } from "node:worker_threads";
 import { tableFromIPC } from "apache-arrow";
 import {
   GraphForge,
@@ -33,6 +34,15 @@ function names(forge) {
   return [...tableFromIPC(forge.execute(QUERY)).getChild("name").toArray()];
 }
 
+function reopenedNames(path) {
+  const forge = new GraphForge(path);
+  try {
+    return names(forge);
+  } finally {
+    forge.close();
+  }
+}
+
 async function namesAsync(forge) {
   const ipc = await forge.plan(QUERY).collectIpc();
   return [...tableFromIPC(ipc).getChild("name").toArray()];
@@ -45,6 +55,128 @@ function transactionNames(root) {
   }
   return readdirSync(directory).sort();
 }
+
+function optimisticWorker(project, operationUuid, nodeUuid, name) {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(
+      new URL("./fixtures/write-mode-worker.mjs", import.meta.url),
+      { workerData: { name, nodeUuid, operationUuid, project } },
+    );
+    let settled = false;
+    const deadline = AbortSignal.timeout(DEADLINE_MS);
+    const finish = (complete, value) => {
+      if (settled) return;
+      settled = true;
+      deadline.removeEventListener("abort", onTimeout);
+      void worker.terminate();
+      complete(value);
+    };
+    const onTimeout = () =>
+      finish(reject, new Error("optimistic worker timed out"));
+    deadline.addEventListener("abort", onTimeout, { once: true });
+    worker.once("message", (message) => {
+      if (message.ok) finish(resolve, message);
+      else finish(reject, Object.assign(new Error(message.message), message));
+    });
+    worker.once("error", (error) => finish(reject, error));
+    worker.once("exit", (code) => {
+      if (!settled) {
+        finish(
+          reject,
+          new Error(`optimistic worker exited ${code} before responding`),
+        );
+      }
+    });
+  });
+}
+
+test("write-mode options validate and optimistic agents publish exactly once", async () => {
+  for (const writeMode of [
+    "single_writer",
+    "queued_writer",
+    "optimistic_multi_writer",
+  ]) {
+    const root = mkdtempSync(join(tmpdir(), "gf-node-write-mode-"));
+    try {
+      const forge = new GraphForge(root, {
+        maxRebaseAttempts: 4,
+        writeMode,
+        writeQueueCapacity: 8,
+      });
+      forge.execute("CREATE (:Person {name:'mode'})");
+      forge.close();
+      assert.deepEqual(reopenedNames(root), ["mode"]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+
+  for (const options of [
+    { writeMode: "server" },
+    { writeQueueCapacity: 0 },
+    { writeQueueCapacity: -1 },
+    { maxRebaseAttempts: -1 },
+    { maxRebaseAttempts: 33 },
+  ]) {
+    assert.throws(
+      () => new GraphForge(undefined, options),
+      (error) => error.code === "ValidationError",
+    );
+  }
+
+  const root = mkdtempSync(join(tmpdir(), "gf-node-optimistic-agents-"));
+  const operations = [
+    "018f0f4e-7b8c-7000-8000-000000002146",
+    "018f0f4e-7b8c-7000-8000-000000002147",
+  ];
+  try {
+    new GraphForge(root).close();
+    const results = await Promise.all([
+      optimisticWorker(
+        root,
+        operations[0],
+        "018f0f4e-7b8c-7000-8000-000000002148",
+        "agent-0",
+      ),
+      optimisticWorker(
+        root,
+        operations[1],
+        "018f0f4e-7b8c-7000-8000-000000002149",
+        "agent-1",
+      ),
+    ]);
+    assert.deepEqual(
+      results.map(({ operationUuid }) => operationUuid).sort(),
+      [...operations].sort(),
+    );
+    assert.deepEqual(reopenedNames(root), ["agent-0", "agent-1"]);
+
+    const before = reopenedNames(root);
+    const conflicting = new GraphForge(root, {
+      writeMode: "optimistic_multi_writer",
+    });
+    assert.throws(
+      () =>
+        conflicting.publishCompositeTransaction({
+          contractVersion: 1,
+          operationUuid: operations[0],
+          graphMutations: [
+            {
+              kind: "create_node",
+              label: "Person",
+              nodeUuid: "018f0f4e-7b8c-7000-8000-000000002150",
+              properties: { name: "conflict" },
+            },
+          ],
+        }),
+      (error) => error.code === "GF_IDEMPOTENCY_CONFLICT",
+    );
+    conflicting.close();
+    assert.deepEqual(reopenedNames(root), before);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
 
 test(
   "independent and same-instance concurrent reads are ordered and equal",

--- a/crates/gf-bindings-node/tests/fixtures/write-mode-worker.mjs
+++ b/crates/gf-bindings-node/tests/fixtures/write-mode-worker.mjs
@@ -1,0 +1,35 @@
+import { parentPort, workerData } from "node:worker_threads";
+
+import { GraphForge } from "../../index.js";
+
+try {
+  const forge = new GraphForge(workerData.project, {
+    maxRebaseAttempts: 8,
+    writeMode: "optimistic_multi_writer",
+    writeQueueCapacity: 8,
+  });
+  const receipt = forge.publishCompositeTransaction({
+    contractVersion: 1,
+    operationUuid: workerData.operationUuid,
+    graphMutations: [
+      {
+        kind: "create_node",
+        label: "Person",
+        nodeUuid: workerData.nodeUuid,
+        properties: { name: workerData.name },
+      },
+    ],
+  });
+  forge.close();
+  parentPort.postMessage({
+    ok: receipt.byteLength > 0,
+    operationUuid: workerData.operationUuid,
+  });
+} catch (error) {
+  parentPort.postMessage({
+    code: error?.code,
+    message: error instanceof Error ? error.message : String(error),
+    ok: false,
+    stack: error instanceof Error ? error.stack : undefined,
+  });
+}

--- a/crates/gf-bindings-py/python/graphforge/_graphforge_rs.pyi
+++ b/crates/gf-bindings-py/python/graphforge/_graphforge_rs.pyi
@@ -160,7 +160,16 @@ class ResolvedBeliefProjection:
     ) -> InvocationDescriptor: ...
 
 class GraphForge:
-    def __init__(self, path: str | None = None) -> None: ...
+    def __init__(
+        self,
+        path: str | None = None,
+        *,
+        write_mode: Literal[
+            "single_writer", "queued_writer", "optimistic_multi_writer"
+        ] = "single_writer",
+        write_queue_capacity: int = 64,
+        max_rebase_attempts: int = 3,
+    ) -> None: ...
     def project_capabilities(self) -> pyarrow.Table: ...
     def checkpoint(
         self,

--- a/crates/gf-bindings-py/src/lib.rs
+++ b/crates/gf-bindings-py/src/lib.rs
@@ -23,16 +23,16 @@ use gf_api::{
     EmbeddingRefreshSpacePolicy, EmbeddingRefreshWorkerState, EmbeddingSpaceFreshnessInspection,
     EmbeddingSpaceFreshnessState, EmbeddingSpaceInfo, EmbeddingSpaceProducer,
     EmbeddingSpaceReadDecision, EmbeddingTokenCountClass, ExecutionResult, FastRpOptions,
-    FindDiagnostic, FindExecutionOptions, FindRerankOptions, GfError, GraphSageAggregator,
-    GraphSageOptions, HashGnnOptions, InvocationDescriptor, InvocationError, IrLiteral,
-    M18EmbeddingDistance, M18EmbeddingNormalization, M18EmbeddingPublicationRequest,
+    FindDiagnostic, FindExecutionOptions, FindRerankOptions, GfError, GraphForgeOptions,
+    GraphSageAggregator, GraphSageOptions, HashGnnOptions, InvocationDescriptor, InvocationError,
+    IrLiteral, M18EmbeddingDistance, M18EmbeddingNormalization, M18EmbeddingPublicationRequest,
     Node2VecOptions, NodeSelector, OpenRouterProviderSession, OpenRouterProviderSessionConfig,
-    OpenRouterWireLimits, OperationId, PropValue, ProviderBatchLimits, ProviderCapabilities,
-    ProviderCapability, ProviderEmbeddingDistance, ProviderEmbeddingNormalization,
-    ProviderEmbeddingPlanInspection, ProviderEmbeddingPlanRequest, ProviderExecutionLimits,
-    ProviderRequestLimits, RerankAdvisoryPolicy, RerankFailurePolicy, RuntimeGuard,
-    SearchIndexOptions, SendableRecordBatchStream, TextIndexInspection, TokenCountClass,
-    WriteContext, validate_embedding_options,
+    OpenRouterWireLimits, OperationId, ProjectWriteMode, PropValue, ProviderBatchLimits,
+    ProviderCapabilities, ProviderCapability, ProviderEmbeddingDistance,
+    ProviderEmbeddingNormalization, ProviderEmbeddingPlanInspection, ProviderEmbeddingPlanRequest,
+    ProviderExecutionLimits, ProviderRequestLimits, RerankAdvisoryPolicy, RerankFailurePolicy,
+    RuntimeGuard, SearchIndexOptions, SendableRecordBatchStream, TextIndexInspection,
+    TokenCountClass, WriteContext, validate_embedding_options,
 };
 use pyo3::create_exception;
 use pyo3::exceptions::{
@@ -2293,15 +2293,47 @@ impl GraphForge {
     }
 }
 
+fn project_write_mode(value: &str) -> Result<ProjectWriteMode, GfError> {
+    match value {
+        "single_writer" => Ok(ProjectWriteMode::SingleWriter),
+        "queued_writer" => Ok(ProjectWriteMode::QueuedWriter),
+        "optimistic_multi_writer" => Ok(ProjectWriteMode::OptimisticMultiWriter),
+        _ => Err(GfError::Validation(
+            "write_mode must be single_writer, queued_writer, or optimistic_multi_writer".into(),
+        )),
+    }
+}
+
 #[pymethods]
 impl GraphForge {
     /// Open an in-memory (`path=None`) or Parquet-backed (`path=<dir>`) instance.
     #[new]
-    #[pyo3(signature = (path=None))]
-    fn new(py: Python<'_>, path: Option<&str>) -> PyResult<Self> {
+    #[pyo3(signature = (path=None, *, write_mode="single_writer", write_queue_capacity=64, max_rebase_attempts=3))]
+    fn new(
+        py: Python<'_>,
+        path: Option<&str>,
+        write_mode: &str,
+        write_queue_capacity: i64,
+        max_rebase_attempts: i64,
+    ) -> PyResult<Self> {
         let path = path.map(str::to_owned);
+        let options = GraphForgeOptions {
+            write_mode: project_write_mode(write_mode).map_err(|error| to_pyerr(py, &error))?,
+            write_queue_capacity: usize::try_from(write_queue_capacity).map_err(|_| {
+                to_pyerr(
+                    py,
+                    &GfError::Validation("write_queue_capacity must be between 1 and 65536".into()),
+                )
+            })?,
+            max_rebase_attempts: u32::try_from(max_rebase_attempts).map_err(|_| {
+                to_pyerr(
+                    py,
+                    &GfError::Validation("max_rebase_attempts must not exceed 32".into()),
+                )
+            })?,
+        };
         let inner = py
-            .detach(|| gf_api::GraphForge::new(path.as_deref()))
+            .detach(|| gf_api::GraphForge::new_with_options(path.as_deref(), options))
             .map_err(|e| to_pyerr(py, &e))?;
         Ok(Self {
             inner,

--- a/crates/gf-bindings-py/tests/concurrency_parity.py
+++ b/crates/gf-bindings-py/tests/concurrency_parity.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import tempfile
 import threading
 import time
+from uuid import UUID
 
 import gil_release
 
@@ -45,6 +46,15 @@ def _join(phase: str, worker: threading.Thread, deadline: float) -> None:
     worker.join(timeout=_remaining(deadline))
     if worker.is_alive():
         raise AssertionError(f"phase={phase} timeout={DEADLINE_SECONDS}s worker hung")
+
+
+def _expect_constructor_validation(kwargs: dict[str, object]) -> None:
+    try:
+        g.GraphForge(**kwargs)
+    except g.GraphForgeError as error:
+        assert error.code == "GF_VALIDATION", error.code
+    else:
+        raise AssertionError(f"constructor accepted invalid options: {kwargs}")
 
 
 def check_gil_release_native_boundary() -> None:
@@ -249,12 +259,101 @@ def check_shared_directory_writer_busy_and_reopen() -> None:
         assert _names(reopened) == ["Alice", "Bob", "Carol", "Delta"]
 
 
+def check_write_mode_options_and_optimistic_agents() -> None:
+    for mode in ("single_writer", "queued_writer", "optimistic_multi_writer"):
+        with tempfile.TemporaryDirectory() as directory:
+            forge = g.GraphForge(
+                directory,
+                write_mode=mode,
+                write_queue_capacity=8,
+                max_rebase_attempts=4,
+            )
+            forge.execute("CREATE (:Person {name:'mode'})")
+            forge.close()
+            assert _names(g.GraphForge(directory)) == ["mode"]
+
+    for kwargs in (
+        {"write_mode": "server"},
+        {"write_queue_capacity": 0},
+        {"write_queue_capacity": -1},
+        {"max_rebase_attempts": -1},
+        {"max_rebase_attempts": 33},
+    ):
+        _expect_constructor_validation(kwargs)
+
+    deadline = _deadline()
+    with tempfile.TemporaryDirectory() as directory:
+        agents = [
+            g.GraphForge(directory, write_mode="optimistic_multi_writer"),
+            g.GraphForge(directory, write_mode="optimistic_multi_writer"),
+        ]
+        operations = [
+            "018f0f4e-7b8c-7000-8000-000000002141",
+            "018f0f4e-7b8c-7000-8000-000000002142",
+        ]
+        nodes = [
+            "018f0f4e-7b8c-7000-8000-000000002143",
+            "018f0f4e-7b8c-7000-8000-000000002144",
+        ]
+        barrier = threading.Barrier(2)
+        outcomes: list[object | None] = [None, None]
+
+        def publish(index: int) -> None:
+            try:
+                barrier.wait(timeout=_remaining(deadline))
+                outcomes[index] = agents[index].publish_composite_transaction(
+                    operation_uuid=operations[index],
+                    graph_mutations=[
+                        {
+                            "kind": "create_node",
+                            "node_uuid": nodes[index],
+                            "label": "Person",
+                            "properties": {"name": f"agent-{index}"},
+                        }
+                    ],
+                )
+            except BaseException as error:
+                outcomes[index] = error
+
+        workers = [threading.Thread(target=publish, args=(index,)) for index in range(2)]
+        for worker in workers:
+            worker.start()
+        for worker in workers:
+            _join("optimistic-agents", worker, deadline)
+        for index, outcome in enumerate(outcomes):
+            if isinstance(outcome, BaseException):
+                raise AssertionError(f"optimistic agent {index} failed") from outcome
+            assert outcome.column("request_identity").to_pylist() == [UUID(operations[index]).bytes]
+
+        reopened = g.GraphForge(directory)
+        assert _names(reopened) == ["agent-0", "agent-1"]
+        before = _names(reopened)
+        try:
+            agents[0].publish_composite_transaction(
+                operation_uuid=operations[0],
+                graph_mutations=[
+                    {
+                        "kind": "create_node",
+                        "node_uuid": "018f0f4e-7b8c-7000-8000-000000002145",
+                        "label": "Person",
+                        "properties": {"name": "conflict"},
+                    }
+                ],
+            )
+        except g.GraphForgeError as error:
+            assert error.code == "GF_IDEMPOTENCY_CONFLICT", error.code
+        else:
+            raise AssertionError("conflicting agent operation was accepted")
+        assert _names(g.GraphForge(directory)) == before
+
+
 def main() -> None:
     check_gil_release_native_boundary()
     check_independent_and_same_instance_reads()
     check_cancellation_isolation()
     check_stream_early_drop_isolation()
     check_shared_directory_writer_busy_and_reopen()
+    check_write_mode_options_and_optimistic_agents()
     print("python concurrency parity passed")
 
 

--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -8,6 +8,13 @@ mutation, opens them only through `@graphforge/node`, decodes native Arrow IPC
 through `apache-arrow`, checks exact capability versions, and normalizes errors
 for agents. It contains no alternate backend or runtime fallback.
 
+Every adapter and workflow open selects native embedded-write options. The
+validated choices are `single_writer` (default), `queued_writer`, and
+`optimistic_multi_writer`, with bounded queue capacity and rebase attempts.
+These options are forwarded unchanged to `@graphforge/node`; the package does
+not infer operation, actor, provenance, graph, or knowledge identities and does
+not provide MCP, HTTP, or any other server transport.
+
 The adapter's deterministic interchange rules are lowercase hyphenated UUIDs,
 Arrow schema-order rows, decimal strings for 64-bit integers, recursively
 key-sorted JSON objects, and one trailing LF. Unsupported or future capability

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -36,12 +36,26 @@ valid-time, resolved-projection, and attachment behavior is normative in
 ```python
 forge = GraphForge()            # in-memory, ephemeral
 forge = GraphForge("path/")     # Parquet-backed, persistent
+forge = GraphForge(
+    "path/",
+    write_mode="optimistic_multi_writer",
+    write_queue_capacity=64,
+    max_rebase_attempts=3,
+)
 ```
 
 The persistent form opens a project root that must already exist. GraphForge initializes
 project files inside an existing directory; it never creates the directory itself. A missing
 path fails with `StorageError: path does not exist`, and a foreign non-project directory fails
 with `GF_UNSUPPORTED_PROJECT_FORMAT`, both before any mutation.
+
+Python and Node expose the same three embedded modes: `single_writer` (the
+default), `queued_writer`, and `optimistic_multi_writer`. Node passes them as a
+second options object using `writeMode`, `writeQueueCapacity`, and
+`maxRebaseAttempts`. Queue capacity is bounded to 1–65,536 and optimistic
+rebase attempts to 0–32. Only composite transactions use optimistic replay;
+other mutation APIs retain their single-writer behavior. See
+[ADR 0015](../adr/0015-embedded-write-modes.md).
 
 ---
 

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -91,6 +91,10 @@ the authoritative runnable corpus enforced by the BDD gate.
   `optimistic_multi_writer` embedded modes. Optimistic composite transactions
   rebase compatible creates, immutable-ledger rows, and disjoint property
   changes while returning stable conflict and exhausted-retry errors (#213).
+- Expose the three embedded write modes through equivalent validated Python and
+  Node constructor options, thread explicit selections through agent workflows,
+  and verify compatible multi-agent publication, reopen, identity preservation,
+  and conflict atomicity across the native concurrency matrix (#214).
 
 - Add `scripts/record_release_artifacts.py` and
   `docs/development/release-artifact-record.md` for RC checksum/SBOM/contents

--- a/packages/agent-skills/README.md
+++ b/packages/agent-skills/README.md
@@ -23,6 +23,11 @@ const opened = await openProject({
   path: "/absolute/path/to/project",
   requiredCapabilities: { graph: 1, workspace: 1 },
   tableFromIPC,
+  writeOptions: {
+    writeMode: "optimistic_multi_writer",
+    writeQueueCapacity: 64,
+    maxRebaseAttempts: 3,
+  },
 });
 ```
 
@@ -30,6 +35,12 @@ Discovery accepts only an existing, real directory with the exact v0.5
 `FORMAT` marker. Missing, ambiguous, symlinked, malformed, and future-format
 inputs fail before the native constructor is called. Capability checks require
 exact versions and reject `unsupported_future` rows.
+
+Every adapter/workflow open passes an explicit validated embedded-write options
+object to the native binding. Callers may select `single_writer` (the default),
+`queued_writer`, or `optimistic_multi_writer`; invalid names, unbounded queues,
+and unbounded retry counts fail before native construction. The adapter does not
+add coordination semantics, identity inference, a server, or a transport.
 
 The adapter contract version is `1`. `uuidToString` emits lowercase hyphenated
 UUIDs, `tableToJson` preserves Arrow schema column order while representing

--- a/packages/agent-skills/adapter/index.js
+++ b/packages/agent-skills/adapter/index.js
@@ -190,7 +190,48 @@ async function containsSymlink(candidate) {
   return false;
 }
 
-export async function openProject({ path, GraphForge, tableFromIPC, requiredCapabilities = {} }) {
+const WRITE_MODES = new Set(["single_writer", "queued_writer", "optimistic_multi_writer"]);
+
+export function normalizeWriteOptions(options = {}) {
+  if (options === null || typeof options !== "object" || Array.isArray(options)) {
+    throw new AgentAdapterError(
+      "GF_AGENT_ADAPTER_CONFIGURATION",
+      "write options must be an object",
+    );
+  }
+  const { writeMode = "single_writer", writeQueueCapacity = 64, maxRebaseAttempts = 3 } = options;
+  if (!WRITE_MODES.has(writeMode)) {
+    throw new AgentAdapterError(
+      "GF_AGENT_ADAPTER_CONFIGURATION",
+      "write mode must be single_writer, queued_writer, or optimistic_multi_writer",
+    );
+  }
+  if (
+    !Number.isInteger(writeQueueCapacity) ||
+    writeQueueCapacity < 1 ||
+    writeQueueCapacity > 65_536
+  ) {
+    throw new AgentAdapterError(
+      "GF_AGENT_ADAPTER_CONFIGURATION",
+      "write queue capacity must be an integer between 1 and 65536",
+    );
+  }
+  if (!Number.isInteger(maxRebaseAttempts) || maxRebaseAttempts < 0 || maxRebaseAttempts > 32) {
+    throw new AgentAdapterError(
+      "GF_AGENT_ADAPTER_CONFIGURATION",
+      "max rebase attempts must be an integer between 0 and 32",
+    );
+  }
+  return { maxRebaseAttempts, writeMode, writeQueueCapacity };
+}
+
+export async function openProject({
+  path,
+  GraphForge,
+  tableFromIPC,
+  requiredCapabilities = {},
+  writeOptions,
+}) {
   if (typeof GraphForge !== "function" || typeof tableFromIPC !== "function") {
     throw new AgentAdapterError(
       "GF_AGENT_ADAPTER_CONFIGURATION",
@@ -198,10 +239,11 @@ export async function openProject({ path, GraphForge, tableFromIPC, requiredCapa
     );
   }
   const projectPath = await discoverProject({ candidates: [path] });
+  const normalizedWriteOptions = normalizeWriteOptions(writeOptions);
   let graph;
   try {
     await validateProjectPath({ path: projectPath });
-    graph = new GraphForge(projectPath);
+    graph = new GraphForge(projectPath, normalizedWriteOptions);
     const capabilities = capabilitiesFromTable(tableFromIPC(await graph.projectCapabilities()));
     requireCapabilities(capabilities, requiredCapabilities);
     return { capabilities, graph, path: projectPath };

--- a/packages/agent-skills/tests/adapter.test.mjs
+++ b/packages/agent-skills/tests/adapter.test.mjs
@@ -16,6 +16,7 @@ import {
   capabilitiesFromTable,
   discoverProject,
   normalizeGraphForgeError,
+  normalizeWriteOptions,
   openProject,
   requestSubprocess,
   requireCapabilities,
@@ -117,8 +118,9 @@ test("opens only through shipped surfaces and checks exact capabilities", async 
     status: ["supported", "supported"],
   });
   class GraphForge {
-    constructor(opened) {
+    constructor(opened, options) {
       this.opened = opened;
+      this.options = options;
     }
     async projectCapabilities() {
       return Buffer.from("ipc");
@@ -131,10 +133,43 @@ test("opens only through shipped surfaces and checks exact capabilities", async 
     tableFromIPC: () => capabilityTable,
   });
   assert.equal(opened.graph.opened, path);
+  assert.deepEqual(opened.graph.options, {
+    maxRebaseAttempts: 3,
+    writeMode: "single_writer",
+    writeQueueCapacity: 64,
+  });
   assert.deepEqual(opened.capabilities, {
     graph: { status: "supported", version: 1 },
     workspace: { status: "supported", version: 1 },
   });
+});
+
+test("validates and forwards explicit embedded write modes", async () => {
+  assert.deepEqual(
+    normalizeWriteOptions({
+      maxRebaseAttempts: 7,
+      writeMode: "optimistic_multi_writer",
+      writeQueueCapacity: 8,
+    }),
+    {
+      maxRebaseAttempts: 7,
+      writeMode: "optimistic_multi_writer",
+      writeQueueCapacity: 8,
+    },
+  );
+  for (const options of [
+    { writeMode: "server" },
+    { writeQueueCapacity: 0 },
+    { writeQueueCapacity: -1 },
+    { maxRebaseAttempts: -1 },
+    { maxRebaseAttempts: 33 },
+    null,
+  ]) {
+    assert.throws(
+      () => normalizeWriteOptions(options),
+      ({ code }) => code === "GF_AGENT_ADAPTER_CONFIGURATION",
+    );
+  }
 });
 
 test("does not construct GraphForge for unsupported project formats", async () => {

--- a/packages/agent-skills/tests/workflows.test.mjs
+++ b/packages/agent-skills/tests/workflows.test.mjs
@@ -24,7 +24,7 @@ const uuids = Array.from(
 );
 
 class GraphForge {
-  constructor(path) {
+  constructor(path, writeOptions) {
     this.openedPath = path;
     if (!projects.has(path)) {
       mkdirSync(path, { recursive: true });
@@ -38,10 +38,12 @@ class GraphForge {
         edges: [],
         marker: undefined,
         nodes: [],
+        openOptions: [],
         ontologyMode: "exploratory",
       });
     }
     this.state = projects.get(path);
+    this.state.openOptions.push(writeOptions);
     this.ontologyMode = this.state.ontologyMode;
   }
 
@@ -299,11 +301,18 @@ test("build knowledge preserves domain confidence and leaves M20 statusless", as
   const root = await realpath(await mkdtemp(join(tmpdir(), "gf-agent-build-")));
   const path = join(root, "project");
   await bootstrapProject({ GraphForge, path, tableFromIPC });
+  const input = buildInput();
+  const writeOptions = {
+    maxRebaseAttempts: 5,
+    writeMode: "optimistic_multi_writer",
+    writeQueueCapacity: 12,
+  };
   const result = await buildKnowledge({
     GraphForge,
-    input: buildInput(),
+    input,
     path,
     tableFromIPC,
+    writeOptions,
   });
   const state = projects.get(path);
 
@@ -329,6 +338,28 @@ test("build knowledge preserves domain confidence and leaves M20 statusless", as
     state.calls.filter(([name]) => name === "assertion_with_evidence").length,
     1,
   );
+  assert.deepEqual(state.openOptions.at(-1), writeOptions);
+  for (const [, request] of state.calls.filter(([name]) => name === "enable")) {
+    assert.equal(request.actorUuid, input.actor_uuid);
+    assert.equal(
+      request.operationUuid,
+      input.capability_operation_uuids[request.capabilityId],
+    );
+  }
+  const assertion = state.calls.find(
+    ([name]) => name === "assertion_with_evidence",
+  )[1];
+  assert.equal(assertion.actorUuid, input.actor_uuid);
+  assert.equal(assertion.assertionUuid, input.assertion.assertion_uuid);
+  assert.equal(assertion.operationUuid, input.assertion.operation_uuid);
+  assert.equal(
+    assertion.evidence[0].evidenceUuid,
+    input.evidence[0].evidence_uuid,
+  );
+  const confidence = state.calls.find(([name]) => name === "confidence")[1];
+  assert.equal(confidence.actorUuid, input.actor_uuid);
+  assert.equal(confidence.confidenceUuid, input.confidence.confidence_uuid);
+  assert.equal(confidence.operationUuid, input.confidence.operation_uuid);
 });
 
 test("build knowledge rejects missing baseline M20 records", async () => {

--- a/packages/agent-skills/workflows/index.js
+++ b/packages/agent-skills/workflows/index.js
@@ -8,6 +8,7 @@ import {
   tableToJson,
   uuidToString,
   validateProjectPath,
+  normalizeWriteOptions,
 } from "../adapter/index.js";
 
 const BOOTSTRAP_QUERY =
@@ -20,6 +21,7 @@ export async function bootstrapProject({
   cwd,
   ontologyMode = "exploratory",
   ontologyPath,
+  writeOptions,
 }) {
   configuredSurfaces(GraphForge, tableFromIPC);
   if (!["exploratory", "advisory", "strict"].includes(ontologyMode)) {
@@ -35,7 +37,8 @@ export async function bootstrapProject({
       if (error?.code !== "EEXIST") throw error;
     });
     await validateProjectPath({ path: projectPath });
-    graph = new GraphForge(projectPath);
+    const normalizedWriteOptions = normalizeWriteOptions(writeOptions);
+    graph = new GraphForge(projectPath, normalizedWriteOptions);
     if (ontologyMode === "advisory" && graph.ontologyMode === "exploratory") {
       if (typeof ontologyPath !== "string" || ontologyPath.length === 0) {
         throw new AgentAdapterError(
@@ -77,6 +80,7 @@ export async function bootstrapProject({
       path: projectPath,
       requiredCapabilities: { graph: 1 },
       tableFromIPC,
+      writeOptions: normalizedWriteOptions,
     });
     graph = reopened.graph;
     const verified = decode(tableFromIPC, await graph.execute(BOOTSTRAP_QUERY));
@@ -100,7 +104,7 @@ export async function bootstrapProject({
   }
 }
 
-export async function buildKnowledge({ GraphForge, tableFromIPC, path, input }) {
+export async function buildKnowledge({ GraphForge, tableFromIPC, path, input, writeOptions }) {
   configuredSurfaces(GraphForge, tableFromIPC);
   validateBuildInput(input);
   let graph;
@@ -110,6 +114,7 @@ export async function buildKnowledge({ GraphForge, tableFromIPC, path, input }) 
       path,
       requiredCapabilities: { graph: 1 },
       tableFromIPC,
+      writeOptions,
     });
     graph = opened.graph;
     for (const capabilityId of requiredCapabilitiesFor(input)) {
@@ -236,7 +241,13 @@ export async function buildKnowledge({ GraphForge, tableFromIPC, path, input }) 
  * workflow only decodes the canonical native evidence and exposes the opaque
  * projection for a later recorded invocation.
  */
-export async function resolveBeliefSubject({ GraphForge, tableFromIPC, path, input }) {
+export async function resolveBeliefSubject({
+  GraphForge,
+  tableFromIPC,
+  path,
+  input,
+  writeOptions,
+}) {
   configuredSurfaces(GraphForge, tableFromIPC);
   const request = validateBeliefSubjectInput(input);
   let graph;
@@ -246,6 +257,7 @@ export async function resolveBeliefSubject({ GraphForge, tableFromIPC, path, inp
       path,
       requiredCapabilities: { epistemic: 1, graph: 1, knowledge: 1 },
       tableFromIPC,
+      writeOptions,
     });
     graph = opened.graph;
     const resolved = await graph.resolveBeliefSubject({
@@ -321,9 +333,21 @@ const NEXT_PAGE_TOKEN_KEY = "graphforge.next_page_token";
  * fails closed when the caller budget is exhausted, and returns UUID-addressed
  * descriptors for broader project-level collections instead of truncating them.
  */
-export async function narrateBeliefRecords({ GraphForge, tableFromIPC, path, input }) {
+export async function narrateBeliefRecords({
+  GraphForge,
+  tableFromIPC,
+  path,
+  input,
+  writeOptions,
+}) {
   configuredSurfaces(GraphForge, tableFromIPC);
-  const resolved = await resolveBeliefSubject({ GraphForge, tableFromIPC, path, input });
+  const resolved = await resolveBeliefSubject({
+    GraphForge,
+    tableFromIPC,
+    path,
+    input,
+    writeOptions,
+  });
   const budget = narrationBudget(input?.record_budget);
   const pageLimit = narrationPageLimit(input?.page_limit);
   const counter = { budget, remaining: budget };
@@ -334,6 +358,7 @@ export async function narrateBeliefRecords({ GraphForge, tableFromIPC, path, inp
       path,
       requiredCapabilities: { epistemic: 1, graph: 1, knowledge: 1 },
       tableFromIPC,
+      writeOptions,
     });
     graph = opened.graph;
     const assertionUuids = resolved.assertions.map((row) => row.assertion_uuid);
@@ -520,7 +545,13 @@ export async function narrateBeliefRecords({ GraphForge, tableFromIPC, path, inp
  * Optionally dispatch one caller-prepared neutral M18 analysis on a resolved
  * belief projection, preserving completed M20 runs when M21 attachment fails.
  */
-export async function dispatchRecordedNeutralAnalysis({ GraphForge, tableFromIPC, path, input }) {
+export async function dispatchRecordedNeutralAnalysis({
+  GraphForge,
+  tableFromIPC,
+  path,
+  input,
+  writeOptions,
+}) {
   configuredSurfaces(GraphForge, tableFromIPC);
   const request = validateRecordedAnalysisInput(input);
   let graph;
@@ -530,6 +561,7 @@ export async function dispatchRecordedNeutralAnalysis({ GraphForge, tableFromIPC
       path,
       requiredCapabilities: { epistemic: 1, graph: 1, knowledge: 1 },
       tableFromIPC,
+      writeOptions,
     });
     graph = opened.graph;
     const recorded = await graph.invokeResolvedRecorded(request.projection, {
@@ -575,7 +607,7 @@ const MAX_EXPLORE_DEPTH = 10_000;
  * finite agent bounds, dispatches the selected public paths algorithm, and
  * returns UUID-addressed summaries with complete Arrow/JSON linkage.
  */
-export async function exploreGraph({ GraphForge, tableFromIPC, path, input }) {
+export async function exploreGraph({ GraphForge, tableFromIPC, path, input, writeOptions }) {
   configuredSurfaces(GraphForge, tableFromIPC);
   const request = validateExploreInput(input);
   let graph;
@@ -585,6 +617,7 @@ export async function exploreGraph({ GraphForge, tableFromIPC, path, input }) {
       path,
       requiredCapabilities: { graph: 1 },
       tableFromIPC,
+      writeOptions,
     });
     graph = opened.graph;
     if (request.signal?.aborted) {
@@ -783,7 +816,7 @@ const MAX_RETRIEVE_RESULT_LIMIT = 10_000;
  * algorithm/search semantics; this workflow only enforces finite bounds and
  * agent-legible truncation while opening the graph capability alone.
  */
-export async function retrieveAnalyze({ GraphForge, tableFromIPC, path, input }) {
+export async function retrieveAnalyze({ GraphForge, tableFromIPC, path, input, writeOptions }) {
   configuredSurfaces(GraphForge, tableFromIPC);
   const request = validateRetrieveInput(input);
   let graph;
@@ -793,6 +826,7 @@ export async function retrieveAnalyze({ GraphForge, tableFromIPC, path, input })
       path,
       requiredCapabilities: { graph: 1 },
       tableFromIPC,
+      writeOptions,
     });
     graph = opened.graph;
     if (request.signal?.aborted) {

--- a/tests/contracts/concurrency-short-matrix.json
+++ b/tests/contracts/concurrency-short-matrix.json
@@ -146,6 +146,62 @@
       ]
     },
     {
+      "id": "rust-write-mode-defaults",
+      "surface": "rust",
+      "argv": [
+        "cargo",
+        "test",
+        "-p",
+        "gf-api",
+        "--lib",
+        "write_modes::tests::defaults_and_bounds_are_stable",
+        "--",
+        "--exact"
+      ]
+    },
+    {
+      "id": "rust-queued-writer-order",
+      "surface": "rust",
+      "argv": [
+        "cargo",
+        "test",
+        "-p",
+        "gf-api",
+        "--lib",
+        "write_modes::tests::queued_writes_start_in_admission_order",
+        "--",
+        "--exact"
+      ]
+    },
+    {
+      "id": "rust-optimistic-compatible",
+      "surface": "rust",
+      "argv": [
+        "cargo",
+        "test",
+        "-p",
+        "gf-api",
+        "--lib",
+        "composite_publish::tests::optimistic_distinct_creates_rebase_and_both_publish",
+        "--",
+        "--exact"
+      ]
+    },
+    {
+      "id": "rust-optimistic-conflict",
+      "surface": "rust",
+      "argv": [
+        "cargo",
+        "test",
+        "-p",
+        "gf-api",
+        "--lib",
+        "composite_publish::tests::optimistic_same_property_change_is_a_write_conflict",
+        "--",
+        "--exact"
+      ]
+    },
+    {
       "id": "python-concurrency-parity",
       "surface": "python",
       "argv": ["python", "crates/gf-bindings-py/tests/concurrency_parity.py"]


### PR DESCRIPTION
Closes #214

## Summary
- expose single_writer, queued_writer, and optimistic_multi_writer through validated Python and Node constructor options
- forward explicit embedded write options through every agent adapter/workflow open without adding transport semantics or changing caller-owned identities
- extend the required Rust/Python/Node concurrency matrix with mode-specific, reopen, exactly-once, and conflict-atomicity coverage
- document the embedded-only boundary and v0.5.0 contracts

## Validation
- cargo check -p gf-bindings-py
- cargo check -p gf-bindings-node
- Python native binding contract suite
- Node native suite: 215 passed
- Python and Node concurrency parity tests
- four exact Rust write-mode tests
- agent-skills tests: 53 passed
- concurrency matrix validation and mutation tests
- changed-path classifier tests
- cargo fmt, mypy, Prettier, diff checks
- CodeRabbit CLI: zero findings on final diff

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788025543&installation_model_id=20486&pr_number=220&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F220&signature=f0297d87e2e92758d2b9aebb15ff7bb07699f011f669601659d22cb2de4cd891"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable write behavior for GraphForge in Python and Node.js, including write modes, queue capacity, and retry limits.
  * Added validation with clear errors for unsupported modes and out-of-range values.
  * Propagated write settings through agent workflows and project opening.
  * Added support for concurrent optimistic writers, including conflict detection and idempotency handling.
* **Tests**
  * Expanded concurrency and cross-language coverage for write configuration and optimistic publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose embedded write modes in Python and Node `GraphForge` constructors
> - Adds `write_mode`, `write_queue_capacity`, and `max_rebase_attempts` options to the Python and Node `GraphForge` constructors, with bounds validation (capacity 1–65536, rebase attempts 0–32) that fails fast with a validation error.
> - Propagates `writeOptions` through all agent-skills workflow entry points (`buildKnowledge`, `exploreGraph`, `retrieveAnalyze`, etc.) down to `openProject` and the native constructor.
> - Fixes composite publication to return `GF_WRITE_CONFLICT` on parent-generation drift in optimistic mode and `GF_IDEMPOTENCY_CONFLICT` in non-optimistic modes, replacing a generic `Project TransactionConflict` code.
> - Adds concurrency parity tests in both Python and Node verifying optimistic multi-agent publish and idempotency conflict behavior.
> - Behavioral Change: `GraphForge` construction in Python and Node now accepts a second options argument; existing call sites using positional args are unaffected, but invalid option values now raise `GF_VALIDATION` errors at construction time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c727fc8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->