### PR TITLE
docs: publish Pages at docs.graphforge.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Post-v0.5.0 work lands here. The v0.5.0 publication cut is under `[0.5.0]` below.
 
+- Publish the GitHub Pages documentation at `https://docs.graphforge.sh`, with
+  root-relative site URLs and current `CurateLabs/graphforge` source links (#223).
+
 - Stop rerunning the full Test Suite after an already-green pull request is
   squash-merged; exact-head pull-request CI remains the required merge gate
   ([#209](https://github.com/CurateLabs/graphforge/issues/209)).

--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ clean:  ## Clean up cache files
 	rm -f test-results*.xml coverage.xml .coverage 2>/dev/null || true
 	rm -rf htmlcov/ build/coverage-rust/ crates/gf-bindings-node/coverage/ 2>/dev/null || true
 
-docs-serve:  ## Serve Starlight docs locally (http://localhost:4321/graphforge-legecy/)
+docs-serve:  ## Serve Starlight docs locally (http://localhost:4321/)
 	pnpm docs:dev
 
 docs-build:  ## Build Starlight docs site to docs-site/dist/

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
   <a href="https://github.com/CurateLabs/graphforge-x/tree/main/crates/gf-bindings-node"><img src="https://img.shields.io/badge/Node.js-20%2B-5FA04E.svg?logo=nodedotjs&logoColor=white" alt="Node.js 20 or newer" /></a>
   <a href="https://github.com/CurateLabs/graphforge-x/blob/main/rust-toolchain.toml"><img src="https://img.shields.io/badge/Rust-1.96-000000.svg?logo=rust&logoColor=white" alt="Rust 1.96" /></a>
   <a href="https://github.com/CurateLabs/graphforge-x/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/CurateLabs/graphforge-x/test.yml?branch=main&label=CI&logo=github" alt="Test Suite status" /></a>
-  <a href="https://curatelabs.github.io/graphforge-legecy/"><img src="https://img.shields.io/badge/docs-online-0A66C2.svg" alt="Documentation" /></a>
-  <a href="https://curatelabs.github.io/graphforge-legecy/reference/tck-compliance/"><img src="https://img.shields.io/badge/openCypher%20TCK-3897%2F3897-brightgreen.svg" alt="openCypher TCK" /></a>
+  <a href="https://docs.graphforge.sh/"><img src="https://img.shields.io/badge/docs-online-0A66C2.svg" alt="Documentation" /></a>
+  <a href="https://docs.graphforge.sh/reference/tck-compliance/"><img src="https://img.shields.io/badge/openCypher%20TCK-3897%2F3897-brightgreen.svg" alt="openCypher TCK" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="Apache License 2.0" /></a>
 </p>
 
@@ -272,7 +272,7 @@ into the Starlight content collection at build time.
 ```bash
 # Docs site (local) — see also docs/README.md and docs-site/README.md
 pnpm install
-pnpm docs:dev          # http://localhost:4321/graphforge-legecy/
+pnpm docs:dev          # http://localhost:4321/
 pnpm docs:build        # output: docs-site/dist/
 pnpm docs:preview      # serve docs-site/dist/
 # or: make docs-serve / make docs-build / make docs-clean

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -9,7 +9,7 @@ From the **repository root** (not this directory):
 
 ```bash
 pnpm install
-pnpm docs:dev          # http://localhost:4321/graphforge-legecy/
+pnpm docs:dev          # http://localhost:4321/
 pnpm docs:build        # output: docs-site/dist/
 pnpm docs:check-links  # after build: zero broken same-site hrefs
 pnpm docs:preview

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -4,8 +4,7 @@ import starlight from '@astrojs/starlight';
 
 /** @type {import('astro').AstroUserConfig} */
 export default defineConfig({
-  site: 'https://curatelabs.github.io',
-  base: '/graphforge-legecy',
+  site: 'https://docs.graphforge.sh',
   outDir: 'dist',
   integrations: [
     starlight({
@@ -16,11 +15,11 @@ export default defineConfig({
         {
           icon: 'github',
           label: 'GitHub',
-          href: 'https://github.com/CurateLabs/graphforge-legecy',
+          href: 'https://github.com/CurateLabs/graphforge',
         },
       ],
       editLink: {
-        baseUrl: 'https://github.com/CurateLabs/graphforge-legecy/edit/main/docs/',
+        baseUrl: 'https://github.com/CurateLabs/graphforge/edit/main/docs/',
       },
       customCss: ['./src/styles/custom.css'],
       // Published nav is reader-journey ordered (Diátaxis). On-disk trees remain

--- a/docs-site/scripts/check-links.mjs
+++ b/docs-site/scripts/check-links.mjs
@@ -13,7 +13,8 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const siteRoot = path.resolve(__dirname, '..');
 const dist = path.join(siteRoot, 'dist');
-const SITE_BASE = '/graphforge-legecy';
+const SITE_ORIGIN = 'https://docs.graphforge.sh';
+const SITE_BASE = '';
 
 if (!fs.existsSync(dist)) {
   console.error('Missing docs-site/dist — run `pnpm build` first.');
@@ -85,29 +86,29 @@ function consider(pageUrl, href, { assetsOnly = false } = {}) {
   ) {
     stale.push({ page: pageUrl, href, reason: 'DecisionNerd leftover' });
   }
-  if (href === '/graphforge' || href.startsWith('/graphforge/') || href.includes('://decisionnerd.github.io/graphforge')) {
-    stale.push({ page: pageUrl, href, reason: 'stale /graphforge base' });
+  if (
+    href === '/graphforge' ||
+    href.startsWith('/graphforge/') ||
+    href === '/graphforge-legecy' ||
+    href.startsWith('/graphforge-legecy/') ||
+    href.includes('://decisionnerd.github.io/graphforge') ||
+    href.includes('://curatelabs.github.io/graphforge-legecy')
+  ) {
+    stale.push({ page: pageUrl, href, reason: 'stale GitHub Pages project base' });
   }
 
   let pathname;
   if (/^https?:\/\//i.test(href)) {
     if (
-      href.startsWith(`https://curatelabs.github.io${SITE_BASE}`) ||
+      href.startsWith(SITE_ORIGIN) ||
       href.startsWith(`http://localhost:4321${SITE_BASE}`)
     ) {
       pathname = new URL(href).pathname;
     } else {
       return;
     }
-  } else if (href.startsWith(SITE_BASE) || href.startsWith(`${SITE_BASE}/`)) {
-    pathname = href.split('#')[0].split('?')[0];
   } else if (href.startsWith('/')) {
     pathname = href.split('#')[0].split('?')[0];
-    if (!pathname.startsWith(SITE_BASE)) {
-      broken.push({ page: pageUrl, href, reason: 'root path outside site base' });
-      checked += 1;
-      return;
-    }
   } else {
     try {
       pathname = new URL(href, `https://example.com${pageUrl}`).pathname;
@@ -155,7 +156,7 @@ console.log(
 
 if (uniqBroken.length || uniqStale.length) {
   console.error(
-    `\nlink check failed: ${uniqBroken.length} broken, ${uniqStale.length} stale DecisionNerd//graphforge hrefs`,
+    `\nlink check failed: ${uniqBroken.length} broken, ${uniqStale.length} stale repository/site hrefs`,
   );
   process.exit(1);
 }

--- a/docs-site/scripts/check-links.mjs
+++ b/docs-site/scripts/check-links.mjs
@@ -92,6 +92,7 @@ function consider(pageUrl, href, { assetsOnly = false } = {}) {
     href === '/graphforge-legecy' ||
     href.startsWith('/graphforge-legecy/') ||
     href.includes('://decisionnerd.github.io/graphforge') ||
+    /https?:\/\/curatelabs\.github\.io\/graphforge(?:[/?#]|$)/i.test(href) ||
     href.includes('://curatelabs.github.io/graphforge-legecy')
   ) {
     stale.push({ page: pageUrl, href, reason: 'stale GitHub Pages project base' });
@@ -99,11 +100,9 @@ function consider(pageUrl, href, { assetsOnly = false } = {}) {
 
   let pathname;
   if (/^https?:\/\//i.test(href)) {
-    if (
-      href.startsWith(SITE_ORIGIN) ||
-      href.startsWith(`http://localhost:4321${SITE_BASE}`)
-    ) {
-      pathname = new URL(href).pathname;
+    const url = new URL(href);
+    if (url.origin === SITE_ORIGIN || url.origin === 'http://localhost:4321') {
+      pathname = url.pathname;
     } else {
       return;
     }

--- a/docs-site/scripts/sync-content.mjs
+++ b/docs-site/scripts/sync-content.mjs
@@ -10,10 +10,9 @@ const repoRoot = path.resolve(siteRoot, '..');
 const contentRoot = path.join(siteRoot, 'src/content/docs');
 const docsRoot = path.join(repoRoot, 'docs');
 
-/** Must match `base` in astro.config.mjs (CurateLabs GH Pages project site). */
-const GH_DOCS_BLOB = 'https://github.com/CurateLabs/graphforge-legecy/blob/main/docs';
-const GH_REPO_BLOB = 'https://github.com/CurateLabs/graphforge-legecy/blob/main';
-const GH_DOCS_TREE = 'https://github.com/CurateLabs/graphforge-legecy/tree/main/docs';
+const GH_DOCS_BLOB = 'https://github.com/CurateLabs/graphforge/blob/main/docs';
+const GH_REPO_BLOB = 'https://github.com/CurateLabs/graphforge/blob/main';
+const GH_DOCS_TREE = 'https://github.com/CurateLabs/graphforge/tree/main/docs';
 
 /** Directory hrefs with no published index → concrete allowlisted page (docs-relative). */
 const DIRECTORY_DEFAULTS = {

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ From the repository root (requires Node ≥ 22.12 and the repo `pnpm` workspace)
 
 ```bash
 pnpm install
-pnpm docs:dev          # http://localhost:4321/graphforge-legecy/
+pnpm docs:dev          # http://localhost:4321/
 pnpm docs:build        # output: docs-site/dist/
 pnpm docs:check-links  # after build: zero broken same-site hrefs
 pnpm docs:preview      # serve the build output

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 
 [![PyPI](https://img.shields.io/pypi/v/graphforge.svg)](https://pypi.org/project/graphforge/)
 [![Python](https://img.shields.io/pypi/pyversions/graphforge.svg)](https://pypi.org/project/graphforge/)
-[![Docs](https://img.shields.io/badge/docs-online-0A66C2.svg)](https://curatelabs.github.io/graphforge-legecy/)
+[![Docs](https://img.shields.io/badge/docs-online-0A66C2.svg)](https://docs.graphforge.sh/)
 [![openCypher TCK](https://img.shields.io/badge/openCypher%20TCK-3897%2F3897-brightgreen.svg)](reference/tck-compliance.md)
 [![Apache License 2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](../LICENSE)
 


### PR DESCRIPTION
## Summary

- publish Astro/Starlight with `https://docs.graphforge.sh` as the root origin
- replace the legacy GitHub Pages project base and repository links
- update documentation badges and local serve URLs
- validate root-relative links and reject stale project-site URLs

## Validation

- `pnpm docs:build` (88 pages)
- `pnpm docs:check-links` (9,176 links; 0 broken, 0 stale)
- authoritative/public DNS: `docs.graphforge.sh CNAME curatelabs.github.io`

Closes #223

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788043803&installation_model_id=20486&pr_number=224&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F224&signature=23b39c3ac11caa60e153fa938f621cacfec9fbb9adf00750dbb71429298ca4ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish documentation site at docs.graphforge.sh with root-relative URLs
> - Updates [astro.config.mjs](https://github.com/CurateLabs/graphforge/pull/224/files#diff-1b0fab06a6fe0187282dccecefbe949a4ba8345b84e5e0d32321e28ccf910329) to target `https://docs.graphforge.sh` as the site URL and removes the `/graphforge-legecy` base path, making all URLs root-relative.
> - Updates navbar GitHub and "Edit this page" links to point to `CurateLabs/graphforge` instead of the legacy repository.
> - Updates the link checker in [check-links.mjs](https://github.com/CurateLabs/graphforge/pull/224/files#diff-d8516ad741e1d7b8226016565edd36a8f9ea1d47882f6b780e90668b54d5dac6) to validate against the new origin and flag stale `curatelabs.github.io/graphforge-legecy` URLs.
> - Updates [sync-content.mjs](https://github.com/CurateLabs/graphforge/pull/224/files#diff-b4da7c53b10fb11f04eb4de3ed5e79542073063277526d5acce402dcffb53f86) repository constants to reference `CurateLabs/graphforge`.
> - Updates README files and badges across the repo to replace old GitHub Pages URLs with `https://docs.graphforge.sh`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6230639.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links to use the new `https://docs.graphforge.sh` site.
  * Corrected repository and edit-link references.
  * Improved link validation to detect outdated site and repository URLs.
  * Fixed the documentation server help URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->