### PR TITLE
feat: add portable project interchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add deterministic portable export of the current generation or a named
+  checkpoint and validate-before-mutation atomic import into new or empty
+  projects, excluding live pointers, locks, journals, caches, and trash (#229).
 - Add Rust-owned repository lifecycle commands and APIs for safe `.graphforge/`
   initialization, deterministic configuration resolution, declared-input sync,
   Git provenance, and guarded state-only removal (#228).

--- a/crates/gf-api/src/lib.rs
+++ b/crates/gf-api/src/lib.rs
@@ -70,6 +70,7 @@ mod m18_embedding_publication;
 mod multi_process_publication_tests;
 mod node_selector;
 mod paging;
+mod portable;
 mod provenance;
 mod provider_embedding;
 mod provider_embedding_execution;
@@ -92,6 +93,10 @@ mod valid_time;
 mod workspace_ontology;
 mod write_modes;
 
+pub use portable::{
+    PortableExportRequest, PortableExportResult, PortableImportRequest, PortableImportResult,
+    PortableSelection,
+};
 pub use repository::{
     GitProvenance, ProjectConfig, RepositoryContext, RepositoryInitReceipt,
     RepositoryRemoveReceipt, RepositorySyncReceipt,

--- a/crates/gf-api/src/portable.rs
+++ b/crates/gf-api/src/portable.rs
@@ -1,0 +1,242 @@
+//! Portable project interchange orchestration.
+
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use gf_core::GfError;
+use gf_storage::{PortableProjectLimits, ProjectCapability};
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::{GraphForge, OperationId};
+
+/// Immutable generation selected for portable export.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PortableSelection {
+    /// Resolve the committed generation at call time.
+    Current,
+    /// Resolve an active named checkpoint.
+    Checkpoint(String),
+}
+
+/// Portable export request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PortableExportRequest {
+    /// Current or named-checkpoint selection.
+    pub selection: PortableSelection,
+    /// Destination file. Existing paths are rejected.
+    pub output: PathBuf,
+}
+
+/// Portable import request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PortableImportRequest {
+    /// Bounded regular envelope file.
+    pub input: PathBuf,
+    /// Caller-owned idempotency identity.
+    pub operation_id: OperationId,
+}
+
+/// Stable export result.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct PortableExportResult {
+    /// Contract name.
+    pub contract: &'static str,
+    /// Source selector kind.
+    pub source: &'static str,
+    /// Named checkpoint, when selected.
+    pub checkpoint: Option<String>,
+    /// Exported generation UUID.
+    pub generation_uuid: Uuid,
+    /// Complete envelope SHA-256.
+    pub envelope_sha256: String,
+    /// Complete envelope bytes.
+    pub byte_length: u64,
+    /// Participant count.
+    pub participant_count: usize,
+    /// Caller-selected output path.
+    pub output: PathBuf,
+}
+
+/// Stable import result.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct PortableImportResult {
+    /// Contract name.
+    pub contract: &'static str,
+    /// Original exported generation UUID.
+    pub source_generation_uuid: Uuid,
+    /// Newly published local generation UUID.
+    pub generation_uuid: Uuid,
+    /// Complete envelope SHA-256.
+    pub envelope_sha256: String,
+    /// Whether an identical operation was replayed.
+    pub idempotent_replay: bool,
+}
+
+impl GraphForge {
+    /// Export one pinned current/checkpoint generation without copying live layout metadata.
+    pub fn export_portable(
+        &self,
+        request: PortableExportRequest,
+    ) -> Result<PortableExportResult, GfError> {
+        let root = self.resolved_generation.container_root();
+        let (generation, source, checkpoint) = match request.selection {
+            PortableSelection::Current => (
+                gf_storage::resolve_project_generation(root)?,
+                "current",
+                None,
+            ),
+            PortableSelection::Checkpoint(name) => {
+                let (_, generation) = gf_storage::open_checkpoint_generation(root, &name)?;
+                (generation, "checkpoint", Some(name))
+            }
+        };
+        let receipt = gf_storage::export_portable_project(
+            &generation,
+            &request.output,
+            PortableProjectLimits::default(),
+        )?;
+        Ok(PortableExportResult {
+            contract: "graphforge-portable-export/1",
+            source,
+            checkpoint,
+            generation_uuid: receipt.generation_uuid,
+            envelope_sha256: hex(receipt.envelope_sha256),
+            byte_length: receipt.byte_length,
+            participant_count: receipt.participant_count,
+            output: request.output,
+        })
+    }
+
+    /// Validate and import into a new, empty, or pristine initialized project.
+    pub fn import_portable(
+        project_root: &Path,
+        request: &PortableImportRequest,
+    ) -> Result<PortableImportResult, GfError> {
+        let generation_uuid = Uuid::new_v5(
+            &request.operation_id.0,
+            b"graphforge-portable-import-generation/1",
+        );
+        let receipt = gf_storage::import_portable_project_file(
+            &request.input,
+            project_root,
+            request.operation_id.0,
+            generation_uuid,
+            &supported_capabilities(),
+            PortableProjectLimits::default(),
+        )?;
+        // Reopen through the public facade so success also proves normal runtime readability.
+        let root = project_root
+            .to_str()
+            .ok_or_else(|| GfError::Validation("project path must be valid UTF-8".into()))?;
+        let reopened = Self::new(Some(root))?;
+        if reopened.resolved_generation.generation_uuid() != receipt.publication.generation_uuid {
+            return Err(GfError::Lifecycle(
+                "imported generation did not reopen as CURRENT".into(),
+            ));
+        }
+        Ok(PortableImportResult {
+            contract: "graphforge-portable-import/1",
+            source_generation_uuid: receipt.source_generation_uuid,
+            generation_uuid: receipt.publication.generation_uuid,
+            envelope_sha256: hex(receipt.envelope_sha256),
+            idempotent_replay: receipt.publication.idempotent_replay,
+        })
+    }
+}
+
+fn supported_capabilities() -> Vec<ProjectCapability> {
+    [
+        "epistemic",
+        "graph",
+        "knowledge",
+        "provenance",
+        "valid_time",
+        "workspace",
+    ]
+    .into_iter()
+    .map(|capability_id| ProjectCapability {
+        capability_id: capability_id.into(),
+        capability_version: 1,
+    })
+    .collect()
+}
+
+fn hex(digest: [u8; 32]) -> String {
+    let mut encoded = String::with_capacity(64);
+    for byte in digest {
+        write!(encoded, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn public_facade_round_trips_current_generation_and_reopens_import() {
+        let source = tempfile::tempdir().unwrap();
+        let source_path = source.path().join("source");
+        std::fs::create_dir(&source_path).unwrap();
+        let graph = GraphForge::new(source_path.to_str()).unwrap();
+        let envelope = source.path().join("portable.gfportable");
+
+        let exported = graph
+            .export_portable(PortableExportRequest {
+                selection: PortableSelection::Current,
+                output: envelope.clone(),
+            })
+            .unwrap();
+        assert_eq!(exported.contract, "graphforge-portable-export/1");
+        assert_eq!(exported.source, "current");
+        assert_eq!(exported.checkpoint, None);
+        assert_eq!(exported.output, envelope);
+
+        let target = source.path().join("imported");
+        let imported = GraphForge::import_portable(
+            &target,
+            &PortableImportRequest {
+                input: exported.output,
+                operation_id: OperationId(Uuid::new_v4()),
+            },
+        )
+        .unwrap();
+        assert_eq!(imported.contract, "graphforge-portable-import/1");
+        assert_eq!(imported.source_generation_uuid, exported.generation_uuid);
+        assert_eq!(imported.envelope_sha256, exported.envelope_sha256);
+
+        GraphForge::new(target.to_str()).expect("imported CURRENT must reopen");
+    }
+
+    #[test]
+    fn import_rejects_nonempty_target_without_changing_it() {
+        let source = tempfile::tempdir().unwrap();
+        let source_path = source.path().join("source");
+        std::fs::create_dir(&source_path).unwrap();
+        let graph = GraphForge::new(source_path.to_str()).unwrap();
+        let envelope = source.path().join("portable.gfportable");
+        graph
+            .export_portable(PortableExportRequest {
+                selection: PortableSelection::Current,
+                output: envelope.clone(),
+            })
+            .unwrap();
+
+        let target = source.path().join("occupied");
+        std::fs::create_dir(&target).unwrap();
+        let sentinel = target.join("keep.txt");
+        std::fs::write(&sentinel, b"preserve me").unwrap();
+        let error = GraphForge::import_portable(
+            &target,
+            &PortableImportRequest {
+                input: envelope,
+                operation_id: OperationId(Uuid::new_v4()),
+            },
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("must be empty"));
+        assert_eq!(std::fs::read(sentinel).unwrap(), b"preserve me");
+    }
+}

--- a/crates/gf-bindings-py/tests/non_cypher_release.py
+++ b/crates/gf-bindings-py/tests/non_cypher_release.py
@@ -23,7 +23,7 @@ ROOT = Path(__file__).resolve().parents[3]
 RUST_MANIFEST = ROOT / "tests/contracts/non-cypher-rust-surface.json"
 RUST_GATE = ROOT / "scripts/ci/non-cypher-surface-gate.py"
 PYO3_SOURCE = ROOT / "crates/gf-bindings-py/src/lib.rs"
-EXPECTED_RUST_DIGEST = "65d91b9fa187393a27796eb34bb2989f49a89c1e5f449aab4106dba432d0003d"
+EXPECTED_RUST_DIGEST = "01a8d14b3c5a4a76ce5f02ad4a3b65c53e5b53b1557c1cbc8ba2779c9cf79360"
 EXPECTED_RELEASE_DIGEST = "ca1d54b28ed0cb6b2e57b081020494c35c5c8842a37c6bc349bfa6936cf067a8"
 
 EVIDENCE = {

--- a/crates/gf-cli/src/main.rs
+++ b/crates/gf-cli/src/main.rs
@@ -2,15 +2,16 @@
 #![forbid(unsafe_code)]
 
 use std::io::{self, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use arrow::ipc::writer::StreamWriter;
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use gf_api::{
     CheckpointDiffDetail, CheckpointDiffScope, CheckpointRequest, CheckpointSelector,
     DeleteCheckpointRequest, DiffCheckpointsRequest, ExecutionResult, GraphForge,
-    ListCheckpointsRequest, OperationId, PageRequest, PageToken, RepositoryContext,
-    RevertCheckpointRequest,
+    ListCheckpointsRequest, OperationId, PageRequest, PageToken, PortableExportRequest,
+    PortableExportResult, PortableImportRequest, PortableImportResult, PortableSelection,
+    RepositoryContext, RevertCheckpointRequest,
 };
 use uuid::Uuid;
 
@@ -53,6 +54,10 @@ enum Command {
     },
     /// Restore the complete workspace from a checkpoint.
     Revert(RevertArgs),
+    /// Export one immutable generation as a portable envelope.
+    Export(ExportArgs),
+    /// Import a portable envelope into a new or empty project.
+    Import(ImportArgs),
     /// Manage immutable named workspace checkpoints.
     Checkpoint {
         #[command(subcommand)]
@@ -181,6 +186,33 @@ struct RevertArgs {
     actor_uuid: Option<String>,
 }
 
+#[derive(Args)]
+struct ExportArgs {
+    /// Export the generation committed as CURRENT when the command starts.
+    #[arg(
+        long,
+        required_unless_present = "checkpoint",
+        conflicts_with = "checkpoint"
+    )]
+    current: bool,
+    /// Export the generation pinned by this active checkpoint.
+    #[arg(long, required_unless_present = "current", conflicts_with = "current")]
+    checkpoint: Option<String>,
+    /// Portable envelope destination.
+    #[arg(long)]
+    output: PathBuf,
+}
+
+#[derive(Args)]
+struct ImportArgs {
+    /// Portable envelope source.
+    #[arg(long)]
+    input: PathBuf,
+    /// Required canonical UUID used for idempotent replay.
+    #[arg(long)]
+    idempotency_key: String,
+}
+
 fn canonical_uuid(value: &str) -> Result<Uuid, gf_api::GfError> {
     let parsed = Uuid::parse_str(value)
         .map_err(|_| gf_api::GfError::Validation("expected canonical UUID".into()))?;
@@ -236,6 +268,72 @@ fn write_result(result: &ExecutionResult) -> Result<(), gf_api::GfError> {
     output
         .flush()
         .map_err(|error| gf_api::GfError::Execution(error.to_string()))
+}
+
+fn write_export_result(result: &PortableExportResult, json: bool) -> Result<(), gf_api::GfError> {
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string(result)
+                .map_err(|error| gf_api::GfError::Execution(error.to_string()))?
+        );
+    } else {
+        println!(
+            "exported {} generation {} to {} (sha256 {}, {} bytes, {} participants)",
+            result.source,
+            result.generation_uuid,
+            result.output.display(),
+            result.envelope_sha256,
+            result.byte_length,
+            result.participant_count
+        );
+    }
+    Ok(())
+}
+
+fn write_import_result(result: &PortableImportResult, json: bool) -> Result<(), gf_api::GfError> {
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string(result)
+                .map_err(|error| gf_api::GfError::Execution(error.to_string()))?
+        );
+    } else {
+        let outcome = if result.idempotent_replay {
+            "replayed"
+        } else {
+            "imported"
+        };
+        println!(
+            "{outcome} source generation {} as {} (sha256 {})",
+            result.source_generation_uuid, result.generation_uuid, result.envelope_sha256
+        );
+    }
+    Ok(())
+}
+
+fn run_import(args: ImportArgs, path: &Path, json: bool) -> Result<(), gf_api::GfError> {
+    let result = GraphForge::import_portable(
+        path,
+        &PortableImportRequest {
+            input: args.input,
+            operation_id: OperationId(canonical_uuid(&args.idempotency_key)?),
+        },
+    )?;
+    write_import_result(&result, json)
+}
+
+fn run_export(graph: &GraphForge, args: ExportArgs, json: bool) -> Result<(), gf_api::GfError> {
+    let selection = match args.checkpoint {
+        Some(name) => PortableSelection::Checkpoint(name),
+        None if args.current => PortableSelection::Current,
+        None => unreachable!("clap requires exactly one export selector"),
+    };
+    let result = graph.export_portable(PortableExportRequest {
+        selection,
+        output: args.output,
+    })?;
+    write_export_result(&result, json)
 }
 
 fn run_repository(
@@ -308,10 +406,18 @@ fn run(cli: Cli) -> Result<(), gf_api::GfError> {
             .state_path
         }
     };
+    let command = match command {
+        Command::Import(args) => return run_import(args, &path, cli.json),
+        command => command,
+    };
     let path = path
         .to_str()
         .ok_or_else(|| gf_api::GfError::Validation("--project must be valid UTF-8".into()))?;
     let mut graph = GraphForge::new(Some(path))?;
+    let command = match command {
+        Command::Export(args) => return run_export(&graph, args, cli.json),
+        command => command,
+    };
     let result = match command {
         Command::Revert(args) => graph.revert_to_checkpoint(RevertCheckpointRequest {
             name: args.name,
@@ -499,5 +605,41 @@ mod tests {
             cli.command,
             Some(Command::Remove(RemoveArgs { yes: false }))
         ));
+    }
+
+    #[test]
+    fn export_requires_exactly_one_generation_selector() {
+        let base = ["gf", "--project", "/tmp/project", "export"];
+        assert!(
+            Cli::try_parse_from(base.into_iter().chain(["--output", "/tmp/out.gfportable"]))
+                .is_err()
+        );
+        assert!(
+            Cli::try_parse_from(base.into_iter().chain([
+                "--current",
+                "--checkpoint",
+                "before-change",
+                "--output",
+                "/tmp/out.gfportable",
+            ]))
+            .is_err()
+        );
+        assert!(
+            Cli::try_parse_from(base.into_iter().chain([
+                "--current",
+                "--output",
+                "/tmp/out.gfportable",
+            ]))
+            .is_ok()
+        );
+        assert!(
+            Cli::try_parse_from(base.into_iter().chain([
+                "--checkpoint",
+                "before-change",
+                "--output",
+                "/tmp/out.gfportable",
+            ]))
+            .is_ok()
+        );
     }
 }

--- a/crates/gf-cli/tests/portable.rs
+++ b/crates/gf-cli/tests/portable.rs
@@ -1,0 +1,188 @@
+//! Same-binary integration coverage for portable project interchange.
+
+use std::fs;
+use std::process::{Command, Output};
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn gf(project: &std::path::Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_gf"))
+        .arg("--project")
+        .arg(project)
+        .args(args)
+        .output()
+        .expect("run same-build gf binary")
+}
+
+fn gf_repo(repository: &std::path::Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_gf"))
+        .arg("--project-dir")
+        .arg(repository)
+        .args(args)
+        .output()
+        .expect("run same-build gf binary")
+}
+
+fn json(output: &Output) -> Value {
+    assert!(
+        output.status.success(),
+        "gf failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("stable JSON result")
+}
+
+#[test]
+fn current_export_and_import_round_trip_with_stable_json() {
+    let source = TempDir::new().expect("source project parent");
+    let source_project = source.path().join("source");
+    fs::create_dir(&source_project).expect("source project directory");
+    let envelope = source.path().join("project.gfportable");
+
+    let exported = json(&gf(
+        &source_project,
+        &[
+            "--json",
+            "export",
+            "--current",
+            "--output",
+            envelope.to_str().unwrap(),
+        ],
+    ));
+    assert_eq!(exported["contract"], "graphforge-portable-export/1");
+    assert_eq!(exported["source"], "current");
+    assert!(exported["checkpoint"].is_null());
+    assert_eq!(exported["output"], envelope.to_str().unwrap());
+    assert_eq!(exported["envelope_sha256"].as_str().unwrap().len(), 64);
+    assert!(exported["participant_count"].as_u64().unwrap() > 0);
+
+    let destination_project = source.path().join("destination");
+    let imported = json(&gf(
+        &destination_project,
+        &[
+            "--json",
+            "import",
+            "--input",
+            envelope.to_str().unwrap(),
+            "--idempotency-key",
+            "00000000-0000-0000-0000-000000000229",
+        ],
+    ));
+    assert_eq!(imported["contract"], "graphforge-portable-import/1");
+    assert_eq!(
+        imported["source_generation_uuid"],
+        exported["generation_uuid"]
+    );
+    assert_eq!(imported["envelope_sha256"], exported["envelope_sha256"]);
+    assert_eq!(imported["idempotent_replay"], false);
+
+    // Normal runtime access after import proves the published CURRENT is readable.
+    let listed = gf(&destination_project, &["checkpoint", "list"]);
+    assert!(
+        listed.status.success(),
+        "reopen failed: {}",
+        String::from_utf8_lossy(&listed.stderr)
+    );
+}
+
+#[test]
+fn checkpoint_export_reports_the_selected_checkpoint() {
+    let project = TempDir::new().expect("project parent");
+    let source_project = project.path().join("source");
+    fs::create_dir(&source_project).expect("source project directory");
+    let created = gf(
+        &source_project,
+        &[
+            "checkpoint",
+            "create",
+            "before-change",
+            "--idempotency-key",
+            "00000000-0000-0000-0000-000000000001",
+        ],
+    );
+    assert!(created.status.success());
+
+    let envelope = project.path().join("checkpoint.gfportable");
+    let exported = json(&gf(
+        &source_project,
+        &[
+            "--json",
+            "export",
+            "--checkpoint",
+            "before-change",
+            "--output",
+            envelope.to_str().unwrap(),
+        ],
+    ));
+    assert_eq!(exported["source"], "checkpoint");
+    assert_eq!(exported["checkpoint"], "before-change");
+}
+
+#[test]
+fn import_rejects_noncanonical_idempotency_key_as_stable_json() {
+    let project = TempDir::new().expect("project parent");
+    let output = gf(
+        &project.path().join("destination"),
+        &[
+            "--json",
+            "import",
+            "--input",
+            project.path().join("missing.gfportable").to_str().unwrap(),
+            "--idempotency-key",
+            "NOT-A-UUID",
+        ],
+    );
+    assert_eq!(output.status.code(), Some(2));
+    let value: Value = serde_json::from_slice(&output.stderr).expect("JSON error");
+    assert_eq!(value["error"]["code"], "GF_VALIDATION");
+    assert_eq!(
+        value["error"]["message"],
+        "validation error: expected canonical UUID"
+    );
+}
+
+#[test]
+fn initialized_repository_can_import_into_its_pristine_state() {
+    let repository = TempDir::new().expect("repository");
+    let initialized_git = Command::new("git")
+        .args(["init", "--quiet"])
+        .current_dir(repository.path())
+        .status()
+        .expect("initialize Git fixture");
+    assert!(initialized_git.success());
+    let initialized = gf_repo(repository.path(), &["init"]);
+    assert!(
+        initialized.status.success(),
+        "init failed: {}",
+        String::from_utf8_lossy(&initialized.stderr)
+    );
+    let envelope = repository
+        .path()
+        .join(".graphforge/exports/pristine.gfportable");
+    let exported = gf_repo(
+        repository.path(),
+        &[
+            "export",
+            "--current",
+            "--output",
+            envelope.to_str().unwrap(),
+        ],
+    );
+    assert!(exported.status.success());
+    let imported = gf_repo(
+        repository.path(),
+        &[
+            "import",
+            "--input",
+            envelope.to_str().unwrap(),
+            "--idempotency-key",
+            "00000000-0000-0000-0000-000000000230",
+        ],
+    );
+    assert!(
+        imported.status.success(),
+        "import failed: {}",
+        String::from_utf8_lossy(&imported.stderr)
+    );
+}

--- a/crates/gf-storage/src/lib.rs
+++ b/crates/gf-storage/src/lib.rs
@@ -50,6 +50,12 @@ pub use project_publication::{
 pub mod project_recovery;
 pub use project_recovery::{ProjectRecoveryReport, recover_project_transactions};
 
+pub mod project_portable;
+pub use project_portable::{
+    PortableExportReceipt, PortableImportReceipt, PortableProjectLimits, encode_portable_project,
+    export_portable_project, import_portable_project, import_portable_project_file,
+};
+
 pub mod workspace_participants;
 pub use workspace_participants::{
     WORKSPACE_CAPABILITY_ID, WORKSPACE_CAPABILITY_VERSION, WORKSPACE_CONFIGURATION_FAMILY,

--- a/crates/gf-storage/src/project_portable.rs
+++ b/crates/gf-storage/src/project_portable.rs
@@ -1,0 +1,1197 @@
+//! Deterministic, bounded portable project-generation envelopes.
+//!
+//! The envelope is intentionally not an archive of the live project layout.
+//! It contains one resolved immutable generation, its canonical capability and
+//! participant inventory, and participant bytes. Locks, journals, attempts,
+//! trash, caches, leases, manifests, and `CURRENT` are never enumerated.
+
+use std::collections::BTreeSet;
+use std::io::{Read, Write};
+use std::path::Path;
+
+use atomicwrites::{AtomicFile, DisallowOverwrite};
+use gf_core::{GfError, ProjectErrorCode};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::{
+    ProjectCapability, ProjectGenerationRequest, ProjectParticipant, ProjectParticipantEncoding,
+    ProjectPublicationReceipt, ProjectStageOutcome, ResolvedProjectGeneration,
+    open_or_initialize_project, resolve_project_generation, stage_project_generation,
+};
+
+const MAGIC: &[u8; 16] = b"graphforge-exp\0\n";
+const FORMAT: &str = "graphforge-portable-export";
+const FORMAT_VERSION: u32 = 1;
+const HEADER_LENGTH_BYTES: usize = 8;
+
+/// Default resource bounds for portable envelope decoding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PortableProjectLimits {
+    /// Maximum complete envelope size.
+    pub max_envelope_bytes: u64,
+    /// Maximum canonical JSON header size.
+    pub max_header_bytes: u64,
+    /// Maximum participant count.
+    pub max_participants: usize,
+    /// Maximum size of one participant.
+    pub max_participant_bytes: u64,
+}
+
+impl Default for PortableProjectLimits {
+    fn default() -> Self {
+        Self {
+            max_envelope_bytes: 16 * 1024 * 1024 * 1024,
+            max_header_bytes: 4 * 1024 * 1024,
+            max_participants: 100_000,
+            max_participant_bytes: 8 * 1024 * 1024 * 1024,
+        }
+    }
+}
+
+/// Deterministic export result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PortableExportReceipt {
+    /// Exported immutable generation.
+    pub generation_uuid: Uuid,
+    /// SHA-256 of the complete envelope.
+    pub envelope_sha256: [u8; 32],
+    /// Complete envelope byte length.
+    pub byte_length: u64,
+    /// Number of participants in the envelope.
+    pub participant_count: usize,
+}
+
+/// Import result after atomic generation publication.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PortableImportReceipt {
+    /// Integrity digest of the imported envelope.
+    pub envelope_sha256: [u8; 32],
+    /// Original exported generation identity recorded by the envelope.
+    pub source_generation_uuid: Uuid,
+    /// Receipt for the newly published local generation.
+    pub publication: ProjectPublicationReceipt,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EnvelopeHeader {
+    format: String,
+    format_version: u32,
+    source_generation_uuid: String,
+    capabilities: Vec<EnvelopeCapability>,
+    participants: Vec<EnvelopeParticipant>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EnvelopeCapability {
+    capability_id: String,
+    capability_version: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EnvelopeParticipant {
+    capability_id: String,
+    capability_version: u32,
+    record_family_id: String,
+    record_version: u32,
+    encoding: String,
+    schema_fingerprint: String,
+    row_count: u64,
+    byte_length: u64,
+    content_sha256: String,
+}
+
+struct ValidatedEnvelope {
+    source_generation_uuid: Uuid,
+    envelope_sha256: [u8; 32],
+    capabilities: Vec<ProjectCapability>,
+    participants: Vec<ProjectParticipant>,
+}
+
+/// Encode one already-resolved generation into deterministic portable bytes.
+///
+/// The caller may resolve either `CURRENT` or a checkpoint before calling this
+/// function. Resolution pins the generation; this function never follows live
+/// pointers or enumerates the project container.
+pub fn encode_portable_project(
+    generation: &ResolvedProjectGeneration,
+    limits: PortableProjectLimits,
+) -> Result<(Vec<u8>, PortableExportReceipt), GfError> {
+    let snapshots = generation.participant_snapshots()?;
+    enforce_count(snapshots.len(), limits.max_participants)?;
+    let capabilities = generation
+        .capabilities()
+        .into_iter()
+        .map(|item| EnvelopeCapability {
+            capability_id: item.capability_id,
+            capability_version: item.capability_version,
+        })
+        .collect();
+    let mut participants = Vec::with_capacity(snapshots.len());
+    let mut body_length = 0_u64;
+    for snapshot in &snapshots {
+        let byte_length = u64::try_from(snapshot.bytes.len())
+            .map_err(|_| resource("portable participant byte length exceeds u64"))?;
+        enforce_size(
+            byte_length,
+            limits.max_participant_bytes,
+            "portable participant",
+        )?;
+        body_length = body_length
+            .checked_add(byte_length)
+            .ok_or_else(|| resource("portable envelope size overflow"))?;
+        participants.push(EnvelopeParticipant {
+            capability_id: snapshot.capability_id.clone(),
+            capability_version: snapshot.capability_version,
+            record_family_id: snapshot.record_family_id.clone(),
+            record_version: snapshot.record_version,
+            encoding: snapshot.encoding.clone(),
+            schema_fingerprint: hex(snapshot.schema_fingerprint),
+            row_count: snapshot.row_count,
+            byte_length,
+            content_sha256: hex(Sha256::digest(&snapshot.bytes).into()),
+        });
+    }
+    let header = EnvelopeHeader {
+        format: FORMAT.into(),
+        format_version: FORMAT_VERSION,
+        source_generation_uuid: generation.generation_uuid().hyphenated().to_string(),
+        capabilities,
+        participants,
+    };
+    let mut header_bytes = serde_json::to_vec(&header)
+        .map_err(|error| GfError::Storage(format!("failed to encode portable header: {error}")))?;
+    header_bytes.push(b'\n');
+    let header_length = u64::try_from(header_bytes.len())
+        .map_err(|_| resource("portable header byte length exceeds u64"))?;
+    enforce_size(header_length, limits.max_header_bytes, "portable header")?;
+    let total = u64::try_from(MAGIC.len() + HEADER_LENGTH_BYTES)
+        .expect("fixed prefix fits u64")
+        .checked_add(header_length)
+        .and_then(|value| value.checked_add(body_length))
+        .ok_or_else(|| resource("portable envelope size overflow"))?;
+    enforce_size(total, limits.max_envelope_bytes, "portable envelope")?;
+    let capacity = usize::try_from(total)
+        .map_err(|_| resource("portable envelope does not fit address space"))?;
+    let mut envelope = Vec::with_capacity(capacity);
+    envelope.extend_from_slice(MAGIC);
+    envelope.extend_from_slice(&header_length.to_be_bytes());
+    envelope.extend_from_slice(&header_bytes);
+    for snapshot in snapshots {
+        envelope.extend_from_slice(&snapshot.bytes);
+    }
+    let envelope_sha256 = Sha256::digest(&envelope).into();
+    Ok((
+        envelope,
+        PortableExportReceipt {
+            generation_uuid: generation.generation_uuid(),
+            envelope_sha256,
+            byte_length: total,
+            participant_count: header.participants.len(),
+        },
+    ))
+}
+
+/// Atomically write a deterministic portable envelope to a regular file.
+pub fn export_portable_project(
+    generation: &ResolvedProjectGeneration,
+    destination: impl AsRef<Path>,
+    limits: PortableProjectLimits,
+) -> Result<PortableExportReceipt, GfError> {
+    let destination = destination.as_ref();
+    reject_export_destination(destination)?;
+    let (bytes, receipt) = encode_portable_project(generation, limits)?;
+    AtomicFile::new(destination, DisallowOverwrite)
+        .write(|file| {
+            file.write_all(&bytes)?;
+            file.sync_all()
+        })
+        .map_err(|error| GfError::Storage(format!("failed to write portable export: {error}")))?;
+    Ok(receipt)
+}
+
+/// Validate a complete envelope before initializing and atomically publishing
+/// it into a new, empty, or pristine initialized project directory.
+///
+/// `supported_capabilities` is the exact `(id, version)` inventory implemented
+/// by the calling binary. Unknown or version-mismatched capabilities fail
+/// before target mutation.
+pub fn import_portable_project(
+    envelope: &[u8],
+    target: impl AsRef<Path>,
+    transaction_uuid: Uuid,
+    generation_uuid: Uuid,
+    supported_capabilities: &[ProjectCapability],
+    limits: PortableProjectLimits,
+) -> Result<PortableImportReceipt, GfError> {
+    let validated = validate_envelope(envelope, supported_capabilities, limits)?;
+    let target = target.as_ref();
+    let existing_parent = prepare_import_target(target)?;
+    let initialized_parent;
+    let _parent = if let Some(parent) = existing_parent {
+        parent
+    } else {
+        initialized_parent = open_or_initialize_project(target)?;
+        initialized_parent
+    };
+    let request = ProjectGenerationRequest {
+        transaction_uuid,
+        generation_uuid,
+        capabilities: validated.capabilities,
+        participants: validated.participants,
+    };
+    let publication = match stage_project_generation(target, &request)? {
+        ProjectStageOutcome::AlreadyPublished(receipt) => receipt,
+        ProjectStageOutcome::Staged(staged) => {
+            staged.validate(|_| Ok(()), |_, _| Ok(()))?.publish()?
+        }
+    };
+    Ok(PortableImportReceipt {
+        envelope_sha256: validated.envelope_sha256,
+        source_generation_uuid: validated.source_generation_uuid,
+        publication,
+    })
+}
+
+/// Read a bounded regular envelope file and import it.
+///
+/// The source and every caller-controlled existing path component must not be
+/// symbolic links. The size bound is checked from metadata and again while
+/// reading, so replacement or growth races cannot cause an unbounded allocation.
+pub fn import_portable_project_file(
+    source: impl AsRef<Path>,
+    target: impl AsRef<Path>,
+    transaction_uuid: Uuid,
+    generation_uuid: Uuid,
+    supported_capabilities: &[ProjectCapability],
+    limits: PortableProjectLimits,
+) -> Result<PortableImportReceipt, GfError> {
+    let source = source.as_ref();
+    reject_symlink_components(source, "portable import source")?;
+    let metadata = std::fs::symlink_metadata(source).map_err(|error| {
+        GfError::Storage(format!("failed to inspect portable import source: {error}"))
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(project_error(
+            ProjectErrorCode::UnsupportedFilesystem,
+            "portable import source is linked or not a regular file",
+        ));
+    }
+    enforce_size(
+        metadata.len(),
+        limits.max_envelope_bytes,
+        "portable envelope",
+    )?;
+    let bounded_capacity = usize::try_from(metadata.len())
+        .map_err(|_| resource("portable envelope does not fit address space"))?;
+    let mut bytes = Vec::with_capacity(bounded_capacity);
+    let mut file = open_regular_nofollow(source).map_err(|error| {
+        GfError::Storage(format!("failed to open portable import source: {error}"))
+    })?;
+    let opened_metadata = file.metadata().map_err(|error| {
+        GfError::Storage(format!(
+            "failed to inspect opened portable import source: {error}"
+        ))
+    })?;
+    if !opened_metadata.is_file() || !same_file_identity(&metadata, &opened_metadata) {
+        return Err(project_error(
+            ProjectErrorCode::UnsupportedFilesystem,
+            "portable import source changed while it was being opened",
+        ));
+    }
+    reject_symlink_components(source, "portable import source")?;
+    Read::by_ref(&mut file)
+        .take(limits.max_envelope_bytes.saturating_add(1))
+        .read_to_end(&mut bytes)
+        .map_err(|error| {
+            GfError::Storage(format!("failed to read portable import source: {error}"))
+        })?;
+    if u64::try_from(bytes.len()).unwrap_or(u64::MAX) > limits.max_envelope_bytes {
+        return Err(resource("portable envelope exceeds limit"));
+    }
+    import_portable_project(
+        &bytes,
+        target,
+        transaction_uuid,
+        generation_uuid,
+        supported_capabilities,
+        limits,
+    )
+}
+
+fn validate_envelope(
+    envelope: &[u8],
+    supported_capabilities: &[ProjectCapability],
+    limits: PortableProjectLimits,
+) -> Result<ValidatedEnvelope, GfError> {
+    let envelope_length = u64::try_from(envelope.len())
+        .map_err(|_| resource("portable envelope byte length exceeds u64"))?;
+    enforce_size(
+        envelope_length,
+        limits.max_envelope_bytes,
+        "portable envelope",
+    )?;
+    let prefix = MAGIC.len() + HEADER_LENGTH_BYTES;
+    if envelope.len() < prefix || &envelope[..MAGIC.len()] != MAGIC {
+        return Err(corrupt("portable envelope magic is invalid"));
+    }
+    let header_length = u64::from_be_bytes(
+        envelope[MAGIC.len()..prefix]
+            .try_into()
+            .expect("fixed header length slice"),
+    );
+    enforce_size(header_length, limits.max_header_bytes, "portable header")?;
+    let header_length = usize::try_from(header_length)
+        .map_err(|_| resource("portable header does not fit address space"))?;
+    let header_end = prefix
+        .checked_add(header_length)
+        .ok_or_else(|| corrupt("portable header length overflows"))?;
+    let header_bytes = envelope
+        .get(prefix..header_end)
+        .ok_or_else(|| corrupt("portable envelope header is truncated"))?;
+    let header: EnvelopeHeader = serde_json::from_slice(header_bytes)
+        .map_err(|_| corrupt("portable envelope header is not valid canonical JSON"))?;
+    let canonical = {
+        let mut bytes = serde_json::to_vec(&header).map_err(|error| {
+            GfError::Storage(format!("failed to canonicalize portable header: {error}"))
+        })?;
+        bytes.push(b'\n');
+        bytes
+    };
+    if canonical != header_bytes {
+        return Err(corrupt("portable envelope header is not canonical"));
+    }
+    if header.format != FORMAT || header.format_version != FORMAT_VERSION {
+        return Err(project_error(
+            ProjectErrorCode::UnsupportedProjectFormat,
+            "portable envelope format or version is unsupported",
+        ));
+    }
+    let source_generation_uuid = parse_canonical_uuid(&header.source_generation_uuid)?;
+    enforce_count(header.participants.len(), limits.max_participants)?;
+    validate_capabilities(&header.capabilities, supported_capabilities)?;
+    let participants = validate_participants(&header, envelope, header_end, limits)?;
+    let capabilities = header
+        .capabilities
+        .into_iter()
+        .map(|item| ProjectCapability {
+            capability_id: item.capability_id,
+            capability_version: item.capability_version,
+        })
+        .collect();
+    Ok(ValidatedEnvelope {
+        source_generation_uuid,
+        envelope_sha256: Sha256::digest(envelope).into(),
+        capabilities,
+        participants,
+    })
+}
+
+fn validate_participants(
+    header: &EnvelopeHeader,
+    envelope: &[u8],
+    header_end: usize,
+    limits: PortableProjectLimits,
+) -> Result<Vec<ProjectParticipant>, GfError> {
+    let mut cursor = header_end;
+    let mut identities = BTreeSet::new();
+    let mut prior_identity: Option<(&str, &str)> = None;
+    let mut participants = Vec::with_capacity(header.participants.len());
+    for item in &header.participants {
+        validate_machine_id(&item.capability_id)?;
+        validate_machine_id(&item.record_family_id)?;
+        let identity = (item.capability_id.as_str(), item.record_family_id.as_str());
+        if prior_identity.is_some_and(|prior| prior >= identity) {
+            return Err(corrupt("portable participant inventory is not canonical"));
+        }
+        prior_identity = Some(identity);
+        if !identities.insert((&item.capability_id, &item.record_family_id)) {
+            return Err(corrupt(
+                "portable envelope has duplicate participant identity",
+            ));
+        }
+        enforce_size(
+            item.byte_length,
+            limits.max_participant_bytes,
+            "portable participant",
+        )?;
+        let length = usize::try_from(item.byte_length)
+            .map_err(|_| resource("portable participant does not fit address space"))?;
+        let end = cursor
+            .checked_add(length)
+            .ok_or_else(|| corrupt("portable participant length overflows"))?;
+        let bytes = envelope
+            .get(cursor..end)
+            .ok_or_else(|| corrupt("portable participant is truncated"))?;
+        if Sha256::digest(bytes).as_slice() != parse_digest(&item.content_sha256)? {
+            return Err(corrupt(
+                "portable participant content digest does not match",
+            ));
+        }
+        let encoding = match item.encoding.as_str() {
+            "parquet" => ProjectParticipantEncoding::Parquet,
+            "arrow" => ProjectParticipantEncoding::Arrow,
+            "json" => ProjectParticipantEncoding::Json,
+            _ => return Err(corrupt("portable participant encoding is unsupported")),
+        };
+        if !header.capabilities.iter().any(|capability| {
+            capability.capability_id == item.capability_id
+                && capability.capability_version == item.capability_version
+        }) {
+            return Err(corrupt("portable participant capability is not declared"));
+        }
+        participants.push(ProjectParticipant {
+            capability_id: item.capability_id.clone(),
+            capability_version: item.capability_version,
+            record_family_id: item.record_family_id.clone(),
+            record_version: item.record_version,
+            encoding,
+            schema_fingerprint: parse_digest(&item.schema_fingerprint)?,
+            row_count: item.row_count,
+            bytes: bytes.to_vec(),
+        });
+        cursor = end;
+    }
+    if cursor != envelope.len() {
+        return Err(corrupt("portable envelope has trailing bytes"));
+    }
+    Ok(participants)
+}
+
+fn validate_capabilities(
+    capabilities: &[EnvelopeCapability],
+    supported: &[ProjectCapability],
+) -> Result<(), GfError> {
+    let mut prior: Option<&str> = None;
+    for item in capabilities {
+        validate_machine_id(&item.capability_id)?;
+        if item.capability_version == 0
+            || prior.is_some_and(|value| value >= item.capability_id.as_str())
+        {
+            return Err(corrupt("portable capability inventory is not canonical"));
+        }
+        prior = Some(&item.capability_id);
+        if !supported.iter().any(|candidate| {
+            candidate.capability_id == item.capability_id
+                && candidate.capability_version == item.capability_version
+        }) {
+            return Err(project_error(
+                ProjectErrorCode::UnsupportedCapabilityVersion,
+                format!(
+                    "portable capability {}@{} is unsupported",
+                    item.capability_id, item.capability_version
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn prepare_import_target(target: &Path) -> Result<Option<ResolvedProjectGeneration>, GfError> {
+    reject_symlink_components(target, "portable import target")?;
+    match std::fs::symlink_metadata(target) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            Err(project_error(
+                ProjectErrorCode::UnsupportedProjectFormat,
+                "portable import target is linked or not a directory",
+            ))
+        }
+        Ok(_) => {
+            let is_empty = std::fs::read_dir(target)
+                .map_err(|error| {
+                    GfError::Storage(format!("failed to inspect portable import target: {error}"))
+                })?
+                .next()
+                .is_none();
+            if is_empty {
+                Ok(None)
+            } else if is_pristine_initialized_target(target)? {
+                resolve_project_generation(target).map(Some)
+            } else {
+                Err(project_error(
+                    ProjectErrorCode::UnsupportedProjectFormat,
+                    "portable import target must be empty or pristine",
+                ))
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            std::fs::create_dir(target).map_err(|error| {
+                GfError::Storage(format!("failed to create portable import target: {error}"))
+            })?;
+            Ok(None)
+        }
+        Err(error) => Err(GfError::Storage(format!(
+            "failed to inspect portable import target: {error}"
+        ))),
+    }
+}
+
+fn is_pristine_initialized_target(target: &Path) -> Result<bool, GfError> {
+    let Ok(resolved) = resolve_project_generation(target) else {
+        return Ok(false);
+    };
+    let capabilities = resolved.capabilities();
+    if capabilities.len() != 2
+        || capabilities[0].capability_id != "graph"
+        || capabilities[0].capability_version != 1
+        || capabilities[1].capability_id != "workspace"
+        || capabilities[1].capability_version != 1
+    {
+        return Ok(false);
+    }
+    let actual = resolved.participant_snapshots()?;
+    let expected = crate::workspace_participants::empty_workspace_participants()?;
+    if actual.len() != expected.len()
+        || !actual.iter().zip(&expected).all(|(actual, expected)| {
+            actual.capability_id == expected.capability_id
+                && actual.capability_version == expected.capability_version
+                && actual.record_family_id == expected.record_family_id
+                && actual.record_version == expected.record_version
+                && actual.encoding
+                    == match expected.encoding {
+                        ProjectParticipantEncoding::Parquet => "parquet",
+                        ProjectParticipantEncoding::Arrow => "arrow",
+                        ProjectParticipantEncoding::Json => "json",
+                    }
+                && actual.schema_fingerprint == expected.schema_fingerprint
+                && actual.row_count == expected.row_count
+                && actual.bytes == expected.bytes
+        })
+    {
+        return Ok(false);
+    }
+    has_exact_pristine_layout(target, resolved.generation_uuid())
+}
+
+fn has_exact_pristine_layout(target: &Path, generation_uuid: Uuid) -> Result<bool, GfError> {
+    let root_names = directory_names(target)?;
+    if root_names != ["CURRENT", "FORMAT", "generations"] {
+        return Ok(false);
+    }
+    let generations = target.join("generations");
+    if directory_names(&generations)? != [generation_uuid.hyphenated().to_string()] {
+        return Ok(false);
+    }
+    let generation = generations.join(generation_uuid.hyphenated().to_string());
+    if directory_names(&generation)? != ["lease.lock", "manifest.json", "participants"] {
+        return Ok(false);
+    }
+    let participants = generation.join("participants");
+    if directory_names(&participants)? != ["workspace"] {
+        return Ok(false);
+    }
+    Ok(
+        directory_names(&participants.join("workspace"))?
+            == ["configuration.json", "ontology.json"],
+    )
+}
+
+fn directory_names(path: &Path) -> Result<Vec<String>, GfError> {
+    let mut names = std::fs::read_dir(path)
+        .map_err(|error| {
+            GfError::Storage(format!("failed to inspect portable import target: {error}"))
+        })?
+        .map(|entry| {
+            entry
+                .map_err(|error| {
+                    GfError::Storage(format!("failed to inspect portable import target: {error}"))
+                })?
+                .file_name()
+                .into_string()
+                .map_err(|_| {
+                    project_error(
+                        ProjectErrorCode::UnsupportedProjectFormat,
+                        "portable import target contains a non-UTF-8 entry",
+                    )
+                })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    names.sort();
+    Ok(names)
+}
+
+fn reject_export_destination(path: &Path) -> Result<(), GfError> {
+    reject_symlink_components(path, "portable export destination")?;
+    if std::fs::symlink_metadata(path).is_ok() {
+        return Err(project_error(
+            ProjectErrorCode::UnsupportedProjectFormat,
+            "portable export destination already exists",
+        ));
+    }
+    let parent = path.parent().ok_or_else(|| {
+        project_error(
+            ProjectErrorCode::UnsupportedFilesystem,
+            "portable export destination has no parent",
+        )
+    })?;
+    let metadata = std::fs::symlink_metadata(parent).map_err(|error| {
+        GfError::Storage(format!("failed to inspect portable export parent: {error}"))
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(project_error(
+            ProjectErrorCode::UnsupportedFilesystem,
+            "portable export parent is linked or not a directory",
+        ));
+    }
+    Ok(())
+}
+
+fn reject_symlink_components(path: &Path, name: &str) -> Result<(), GfError> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|error| {
+                GfError::Storage(format!("failed to resolve current directory: {error}"))
+            })?
+            .join(path)
+    };
+    for component in absolute.ancestors() {
+        match std::fs::symlink_metadata(component) {
+            Ok(metadata)
+                if metadata.file_type().is_symlink() && !trusted_platform_symlink(&metadata) =>
+            {
+                return Err(project_error(
+                    ProjectErrorCode::UnsupportedFilesystem,
+                    format!("{name} has a symbolic-link path component"),
+                ));
+            }
+            Ok(metadata)
+                if component != absolute
+                    && !metadata.is_dir()
+                    && !metadata.file_type().is_symlink() =>
+            {
+                return Err(project_error(
+                    ProjectErrorCode::UnsupportedFilesystem,
+                    format!("{name} has a non-directory ancestor"),
+                ));
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(GfError::Storage(format!(
+                    "failed to inspect {name} path components: {error}"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+// macOS exposes stable system prefixes such as `/var` through root-owned
+// links. Those are outside a caller's control; project-local links are not.
+#[cfg(unix)]
+fn trusted_platform_symlink(metadata: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    metadata.uid() == 0
+}
+
+#[cfg(not(unix))]
+fn trusted_platform_symlink(_metadata: &std::fs::Metadata) -> bool {
+    false
+}
+
+#[cfg(unix)]
+fn open_regular_nofollow(path: &Path) -> std::io::Result<std::fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+}
+
+#[cfg(not(unix))]
+fn open_regular_nofollow(path: &Path) -> std::io::Result<std::fs::File> {
+    std::fs::File::open(path)
+}
+
+#[cfg(unix)]
+fn same_file_identity(before: &std::fs::Metadata, after: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    before.dev() == after.dev() && before.ino() == after.ino()
+}
+
+#[cfg(not(unix))]
+fn same_file_identity(before: &std::fs::Metadata, after: &std::fs::Metadata) -> bool {
+    before.len() == after.len()
+        && before.modified().ok() == after.modified().ok()
+        && before.created().ok() == after.created().ok()
+}
+
+fn validate_machine_id(value: &str) -> Result<(), GfError> {
+    if value.is_empty()
+        || value.len() > 128
+        || !value.bytes().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-' || byte == b'_'
+        })
+    {
+        return Err(corrupt(
+            "portable envelope contains an invalid machine identifier",
+        ));
+    }
+    Ok(())
+}
+
+fn parse_canonical_uuid(value: &str) -> Result<Uuid, GfError> {
+    let parsed = Uuid::parse_str(value)
+        .map_err(|_| corrupt("portable envelope generation UUID is invalid"))?;
+    if parsed.hyphenated().to_string() != value {
+        return Err(corrupt(
+            "portable envelope generation UUID is not canonical",
+        ));
+    }
+    Ok(parsed)
+}
+
+fn parse_digest(value: &str) -> Result<[u8; 32], GfError> {
+    if value.len() != 64
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(corrupt("portable envelope digest is invalid"));
+    }
+    let mut digest = [0_u8; 32];
+    for (index, chunk) in value.as_bytes().chunks_exact(2).enumerate() {
+        digest[index] = (hex_nibble(chunk[0]) << 4) | hex_nibble(chunk[1]);
+    }
+    Ok(digest)
+}
+
+fn hex_nibble(byte: u8) -> u8 {
+    if byte <= b'9' {
+        byte - b'0'
+    } else {
+        byte - b'a' + 10
+    }
+}
+
+fn hex(digest: [u8; 32]) -> String {
+    const DIGITS: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(64);
+    for byte in digest {
+        output.push(DIGITS[usize::from(byte >> 4)] as char);
+        output.push(DIGITS[usize::from(byte & 0xf)] as char);
+    }
+    output
+}
+
+fn enforce_count(actual: usize, limit: usize) -> Result<(), GfError> {
+    if actual > limit {
+        Err(resource("portable participant count exceeds limit"))
+    } else {
+        Ok(())
+    }
+}
+
+fn enforce_size(actual: u64, limit: u64, name: &str) -> Result<(), GfError> {
+    if actual > limit {
+        Err(resource(format!("{name} exceeds limit")))
+    } else {
+        Ok(())
+    }
+}
+
+fn corrupt(message: impl Into<String>) -> GfError {
+    project_error(ProjectErrorCode::ProjectCorrupt, message)
+}
+fn resource(message: impl Into<String>) -> GfError {
+    project_error(ProjectErrorCode::ResourceLimit, message)
+}
+fn project_error(code: ProjectErrorCode, message: impl Into<String>) -> GfError {
+    GfError::Project {
+        code,
+        message: message.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+
+    use super::*;
+
+    const ENABLE_COOKIE: &str = "graphforge-internal-subprocess-v1";
+    const IMPORT_HELPER: &str = "project_portable::tests::subprocess_portable_import_writer";
+
+    fn supported(generation: &ResolvedProjectGeneration) -> Vec<ProjectCapability> {
+        generation
+            .capabilities()
+            .into_iter()
+            .map(|item| ProjectCapability {
+                capability_id: item.capability_id,
+                capability_version: item.capability_version,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn subprocess_portable_import_writer() {
+        let Ok(target) = std::env::var("GRAPHFORGE_TEST_PROJECT_ROOT") else {
+            return;
+        };
+        let envelope =
+            std::fs::read(std::env::var("GRAPHFORGE_TEST_PORTABLE_ENVELOPE").unwrap()).unwrap();
+        import_portable_project(
+            &envelope,
+            target,
+            Uuid::parse_str(&std::env::var("GRAPHFORGE_TEST_TRANSACTION_UUID").unwrap()).unwrap(),
+            Uuid::parse_str(&std::env::var("GRAPHFORGE_TEST_GENERATION_UUID").unwrap()).unwrap(),
+            &[
+                ProjectCapability {
+                    capability_id: "graph".into(),
+                    capability_version: 1,
+                },
+                ProjectCapability {
+                    capability_id: "workspace".into(),
+                    capability_version: 1,
+                },
+            ],
+            PortableProjectLimits::default(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn prepublication_failure_keeps_pristine_current_authoritative() {
+        let source = tempfile::tempdir().unwrap();
+        let source_generation = open_or_initialize_project(source.path()).unwrap();
+        let (envelope, _) =
+            encode_portable_project(&source_generation, PortableProjectLimits::default()).unwrap();
+        let envelope_path = source.path().join("portable.gfportable");
+        std::fs::write(&envelope_path, envelope).unwrap();
+
+        let target = tempfile::tempdir().unwrap();
+        let parent = open_or_initialize_project(target.path())
+            .unwrap()
+            .generation_uuid();
+        let status = Command::new(std::env::current_exe().unwrap())
+            .arg("--exact")
+            .arg(IMPORT_HELPER)
+            .arg("--nocapture")
+            .env("GRAPHFORGE_TEST_PROJECT_ROOT", target.path())
+            .env("GRAPHFORGE_TEST_PORTABLE_ENVELOPE", &envelope_path)
+            .env(
+                "GRAPHFORGE_TEST_TRANSACTION_UUID",
+                Uuid::new_v4().to_string(),
+            )
+            .env(
+                "GRAPHFORGE_TEST_GENERATION_UUID",
+                Uuid::new_v4().to_string(),
+            )
+            .env("GRAPHFORGE_PROJECT_FAILPOINTS", ENABLE_COOKIE)
+            .env(
+                "GRAPHFORGE_PROJECT_FAILPOINT",
+                "project.before_current_replace",
+            )
+            .status()
+            .unwrap();
+        assert_eq!(status.code(), Some(crate::project_failpoint::exit_code()));
+        assert_eq!(
+            resolve_project_generation(target.path())
+                .unwrap()
+                .generation_uuid(),
+            parent
+        );
+    }
+
+    #[test]
+    fn deterministic_round_trip_publishes_complete_new_generation() {
+        let source = tempfile::tempdir().unwrap();
+        let source_generation = open_or_initialize_project(source.path()).unwrap();
+        let expected = source_generation.participant_snapshots().unwrap();
+        let limits = PortableProjectLimits::default();
+        let (first, first_receipt) = encode_portable_project(&source_generation, limits).unwrap();
+        let (second, second_receipt) = encode_portable_project(&source_generation, limits).unwrap();
+        assert_eq!(first, second);
+        assert_eq!(first_receipt, second_receipt);
+
+        let parent = tempfile::tempdir().unwrap();
+        let target = parent.path().join("imported project");
+        let imported = import_portable_project(
+            &first,
+            &target,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            &supported(&source_generation),
+            limits,
+        )
+        .unwrap();
+        assert_eq!(
+            imported.source_generation_uuid,
+            source_generation.generation_uuid()
+        );
+        assert_eq!(imported.envelope_sha256, first_receipt.envelope_sha256);
+        let reopened = resolve_project_generation(&target).unwrap();
+        assert_eq!(
+            reopened.generation_uuid(),
+            imported.publication.generation_uuid
+        );
+        assert_eq!(reopened.participant_snapshots().unwrap(), expected);
+        assert!(!target.join("trash").exists());
+        assert!(!target.join("cache").exists());
+    }
+
+    #[test]
+    fn pristine_initialized_target_is_importable() {
+        let source = tempfile::tempdir().unwrap();
+        let generation = open_or_initialize_project(source.path()).unwrap();
+        let limits = PortableProjectLimits::default();
+        let (envelope, _) = encode_portable_project(&generation, limits).unwrap();
+        let target = tempfile::tempdir().unwrap();
+        let prior = open_or_initialize_project(target.path()).unwrap();
+        let prior_uuid = prior.generation_uuid();
+        drop(prior);
+
+        let imported = import_portable_project(
+            &envelope,
+            target.path(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            &supported(&generation),
+            limits,
+        )
+        .unwrap();
+        assert_ne!(imported.publication.generation_uuid, prior_uuid);
+        assert_eq!(
+            resolve_project_generation(target.path())
+                .unwrap()
+                .generation_uuid(),
+            imported.publication.generation_uuid
+        );
+    }
+
+    #[test]
+    fn validation_failure_preserves_pristine_target_current() {
+        let source = tempfile::tempdir().unwrap();
+        let generation = open_or_initialize_project(source.path()).unwrap();
+        let limits = PortableProjectLimits::default();
+        let (envelope, _) = encode_portable_project(&generation, limits).unwrap();
+        let target = tempfile::tempdir().unwrap();
+        let prior = open_or_initialize_project(target.path()).unwrap();
+        let prior_uuid = prior.generation_uuid();
+        drop(prior);
+
+        let error = import_portable_project(
+            &envelope,
+            target.path(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            &[],
+            limits,
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), "GF_UNSUPPORTED_CAPABILITY_VERSION");
+        assert_eq!(
+            resolve_project_generation(target.path())
+                .unwrap()
+                .generation_uuid(),
+            prior_uuid
+        );
+    }
+
+    #[test]
+    fn export_refuses_to_overwrite_existing_destination() {
+        let source = tempfile::tempdir().unwrap();
+        let generation = open_or_initialize_project(source.path()).unwrap();
+        let destination = source.path().join("existing.gfx");
+        std::fs::write(&destination, b"keep").unwrap();
+
+        let error =
+            export_portable_project(&generation, &destination, PortableProjectLimits::default())
+                .unwrap_err();
+        assert_eq!(error.code(), "GF_UNSUPPORTED_PROJECT_FORMAT");
+        assert_eq!(std::fs::read(destination).unwrap(), b"keep");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn linked_ancestor_is_rejected_for_source_export_and_target() {
+        use std::os::unix::fs::symlink;
+
+        let source_project = tempfile::tempdir().unwrap();
+        let generation = open_or_initialize_project(source_project.path()).unwrap();
+        let limits = PortableProjectLimits::default();
+        let (envelope, _) = encode_portable_project(&generation, limits).unwrap();
+        let real = tempfile::tempdir().unwrap();
+        let links = tempfile::tempdir().unwrap();
+        let linked = links.path().join("linked");
+        symlink(real.path(), &linked).unwrap();
+
+        let export_error =
+            export_portable_project(&generation, linked.join("out.gfx"), limits).unwrap_err();
+        assert_eq!(export_error.code(), "GF_UNSUPPORTED_FILESYSTEM");
+        assert!(!real.path().join("out.gfx").exists());
+
+        std::fs::write(real.path().join("in.gfx"), &envelope).unwrap();
+        let source_error = import_portable_project_file(
+            linked.join("in.gfx"),
+            real.path().join("unused-target"),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            &supported(&generation),
+            limits,
+        )
+        .unwrap_err();
+        assert_eq!(source_error.code(), "GF_UNSUPPORTED_FILESYSTEM");
+        assert!(!real.path().join("unused-target").exists());
+
+        let input = links.path().join("input.gfx");
+        std::fs::write(&input, envelope).unwrap();
+        let target_error = import_portable_project_file(
+            input,
+            linked.join("target"),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            &supported(&generation),
+            limits,
+        )
+        .unwrap_err();
+        assert_eq!(target_error.code(), "GF_UNSUPPORTED_FILESYSTEM");
+        assert!(!real.path().join("target").exists());
+    }
+
+    #[test]
+    fn corruption_and_trailing_bytes_fail_before_target_creation() {
+        let source = tempfile::tempdir().unwrap();
+        let generation = open_or_initialize_project(source.path()).unwrap();
+        let limits = PortableProjectLimits::default();
+        let (mut envelope, _) = encode_portable_project(&generation, limits).unwrap();
+        *envelope.last_mut().unwrap() ^= 1;
+        let parent = tempfile::tempdir().unwrap();
+        let corrupt_target = parent.path().join("corrupt");
+        let error = import_portable_project(
+            &envelope,
+            &corrupt_target,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            &supported(&generation),
+            limits,
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), "GF_PROJECT_CORRUPT");
+        assert!(!corrupt_target.exists());
+
+        let (mut envelope, _) = encode_portable_project(&generation, limits).unwrap();
+        envelope.push(0);
+        let trailing_target = parent.path().join("trailing");
+        let error = import_portable_project(
+            &envelope,
+            &trailing_target,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            &supported(&generation),
+            limits,
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), "GF_PROJECT_CORRUPT");
+        assert!(!trailing_target.exists());
+    }
+
+    #[test]
+    fn resource_and_capability_checks_precede_mutation() {
+        let source = tempfile::tempdir().unwrap();
+        let generation = open_or_initialize_project(source.path()).unwrap();
+        let limits = PortableProjectLimits::default();
+        let (envelope, _) = encode_portable_project(&generation, limits).unwrap();
+        let parent = tempfile::tempdir().unwrap();
+
+        let bounded_target = parent.path().join("bounded");
+        let tiny = PortableProjectLimits {
+            max_envelope_bytes: u64::try_from(envelope.len() - 1).unwrap(),
+            ..limits
+        };
+        let error = import_portable_project(
+            &envelope,
+            &bounded_target,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            &supported(&generation),
+            tiny,
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), "GF_RESOURCE_LIMIT");
+        assert!(!bounded_target.exists());
+
+        let capability_target = parent.path().join("unsupported");
+        let error = import_portable_project(
+            &envelope,
+            &capability_target,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            &[],
+            limits,
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), "GF_UNSUPPORTED_CAPABILITY_VERSION");
+        assert!(!capability_target.exists());
+    }
+
+    #[test]
+    fn nonempty_target_is_never_modified() {
+        let source = tempfile::tempdir().unwrap();
+        let generation = open_or_initialize_project(source.path()).unwrap();
+        let limits = PortableProjectLimits::default();
+        let (envelope, _) = encode_portable_project(&generation, limits).unwrap();
+        let target = tempfile::tempdir().unwrap();
+        std::fs::write(target.path().join("keep.txt"), b"keep").unwrap();
+        let error = import_portable_project(
+            &envelope,
+            target.path(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            &supported(&generation),
+            limits,
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), "GF_UNSUPPORTED_PROJECT_FORMAT");
+        assert_eq!(
+            std::fs::read(target.path().join("keep.txt")).unwrap(),
+            b"keep"
+        );
+        assert!(!target.path().join("CURRENT").exists());
+    }
+
+    #[test]
+    fn traversal_identity_is_rejected_before_target_creation() {
+        let source = tempfile::tempdir().unwrap();
+        let generation = open_or_initialize_project(source.path()).unwrap();
+        let limits = PortableProjectLimits::default();
+        let (envelope, _) = encode_portable_project(&generation, limits).unwrap();
+        let prefix = MAGIC.len() + HEADER_LENGTH_BYTES;
+        let header_length =
+            u64::from_be_bytes(envelope[MAGIC.len()..prefix].try_into().unwrap()) as usize;
+        let header_end = prefix + header_length;
+        let mut header: EnvelopeHeader =
+            serde_json::from_slice(&envelope[prefix..header_end]).unwrap();
+        header.participants[0].record_family_id = "../escape".into();
+        let mut header_bytes = serde_json::to_vec(&header).unwrap();
+        header_bytes.push(b'\n');
+        let mut malicious = Vec::new();
+        malicious.extend_from_slice(MAGIC);
+        malicious.extend_from_slice(&u64::try_from(header_bytes.len()).unwrap().to_be_bytes());
+        malicious.extend_from_slice(&header_bytes);
+        malicious.extend_from_slice(&envelope[header_end..]);
+
+        let parent = tempfile::tempdir().unwrap();
+        let target = parent.path().join("traversal");
+        let error = import_portable_project(
+            &malicious,
+            &target,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            &supported(&generation),
+            limits,
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), "GF_PROJECT_CORRUPT");
+        assert!(!target.exists());
+    }
+}

--- a/docs/guides/repository-integration.md
+++ b/docs/guides/repository-integration.md
@@ -23,3 +23,52 @@ credentials alone.
 
 The stable machine interface is selected with global `--json`. Configuration
 resolution always emits canonical compact JSON and never resolves secret values.
+
+## Portable export and import
+
+Portable interchange moves one complete, immutable project generation without
+copying GraphForge's live project layout. Select the current committed
+generation explicitly, or select the generation pinned by a named checkpoint:
+
+```bash
+gf --project-dir . export --current --output .graphforge/exports/current.gfportable
+gf --project-dir . export --checkpoint before-change \
+  --output .graphforge/exports/before-change.gfportable
+```
+
+`--current` is resolved when export starts. `--checkpoint NAME` resolves that
+checkpoint's pinned generation, even when a checkpoint is literally named
+`current`. The two selectors are mutually exclusive. Export verifies the
+selected manifest and every participant, then writes a versioned envelope with
+the capability inventory, participant metadata, sizes, and integrity hashes in
+canonical order. Identical selected state produces identical portable content.
+An existing output path is rejected, preventing accidental replacement of a
+previous export.
+
+An envelope contains only the selected generation. It never contains `CURRENT`,
+checkpoint registries, writer or lease locks, transaction journals, caches,
+temporary files, trash, or another generation discovered beside the selected
+one. It is therefore not a raw archive of `.graphforge/state/`.
+
+Import accepts a portable envelope only into a new, empty, or pristine
+initialized project container. The pristine case is what makes import usable
+immediately after `gf init`; any graph mutation or extra project artifact makes
+the target ineligible:
+
+```bash
+gf --project-dir . import \
+  --input .graphforge/imports/incoming.gfportable \
+  --idempotency-key 4f6a9b78-887d-4b8e-872b-a8b59059f777
+```
+
+Before any project mutation, import validates the envelope format and version,
+bounded sizes and counts, canonical participant identities, source filesystem
+type, every integrity hash, and every required capability version. Any failure
+leaves the target without a newly published `CURRENT`. A successful import
+stages and verifies all participants before atomically publishing the complete
+generation; import does not merge into or overwrite an existing project.
+
+`.graphforge/imports/` and `.graphforge/exports/` are convenience transfer
+areas, not durable project authority. Both are managed Git ignores, so envelopes
+placed there remain outside the code repository. Keep tracked schemas,
+ontology, migrations, and seed recipes separate from these data files.

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add deterministic portable export of the current generation or a named
+  checkpoint and validate-before-mutation atomic import into new or empty
+  projects, excluding live pointers, locks, journals, caches, and trash (#229).
 - Add Rust-owned repository lifecycle commands and APIs for safe `.graphforge/`
   initialization, deterministic configuration resolution, declared-input sync,
   Git provenance, and guarded state-only removal (#228).

--- a/scripts/ci/test-non-cypher-surface-gate.py
+++ b/scripts/ci/test-non-cypher-surface-gate.py
@@ -29,7 +29,7 @@ class SurfaceGateTests(unittest.TestCase):
 
     def test_checked_in_inventory_is_complete(self) -> None:
         self.assertEqual(GATE.validate(), [])
-        self.assertEqual(len(GATE.public_methods()), 259)
+        self.assertEqual(len(GATE.public_methods()), 261)
         self.assertEqual(len(GATE.m18_registry()), 94)
 
     def test_new_or_removed_public_method_fails_frozen_digest(self) -> None:

--- a/tests/contracts/non-cypher-rust-surface.json
+++ b/tests/contracts/non-cypher-rust-surface.json
@@ -1,7 +1,7 @@
 {
   "contract_version": 1,
   "scope": "Rust non-Cypher public release surface",
-  "public_method_digest": "65d91b9fa187393a27796eb34bb2989f49a89c1e5f449aab4106dba432d0003d",
+  "public_method_digest": "01a8d14b3c5a4a76ce5f02ad4a3b65c53e5b53b1557c1cbc8ba2779c9cf79360",
   "method_policy": {
     "receiver_defaults": {
       "GraphForge": "release-tested",
@@ -44,6 +44,8 @@
       "GraphForge.new": "introspection",
       "GraphForge.new_with_options": "introspection",
       "GraphForge.path": "introspection",
+      "GraphForge.export_portable": "designed-only",
+      "GraphForge.import_portable": "designed-only",
       "RepositoryContext.discover": "introspection",
       "CheckpointView.checkpoint_uuid": "introspection",
       "CheckpointView.generation_uuid": "introspection",


### PR DESCRIPTION
Closes #229

## Summary
- add a deterministic, bounded, versioned portable generation envelope
- validate capabilities, identities, sizes, hashes, and filesystem safety before import mutation
- add Rust API and `gf export` / `gf import` with stable human and JSON results
- support new, empty, and strictly pristine initialized targets while preserving prior `CURRENT` on failure
- reject symlink components and existing export destinations

## Acceptance evidence
- `cargo test -p gf-storage project_portable` (11 passed, including subprocess failpoint)
- `cargo test -p gf-api --lib portable::tests` (2 passed)
- `cargo test -p gf-cli --test portable` (4 passed, including `gf init` repository lifecycle)
- `cargo clippy -p gf-storage -p gf-api -p gf-cli -- -D warnings`
- `cargo fmt --all -- --check`
- non-Cypher surface and binding-parity policy gates
- independent acceptance/security re-review: no remaining blocker

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788049362&installation_model_id=20486&pr_number=234&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F234&signature=befcb19afb68356e96998ed49861b570ec2aafd946a508d15a0238eea184cb64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added portable project export and import support.
  * Export the current generation or a named checkpoint to a portable file.
  * Import portable projects into empty or pristine initialized targets.
  * Added `export` and `import` CLI commands with JSON and human-readable output.
  * Added validation, idempotency handling, deterministic results, and safeguards against invalid or unsafe files.

* **Tests**
  * Added coverage for round trips, checkpoints, validation errors, corrupted files, limits, and target protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add portable project interchange with `gf export` and `gf import` CLI commands
> - Adds `encode_portable_project` and `export_portable_project` to [gf-storage](https://github.com/CurateLabs/graphforge/pull/234/files#diff-99e09a558ca9b81c6c2a447a41ab54d76a4a9fe7395019f19b08ce5af8586250) to produce deterministic, SHA-256-verified envelope files from immutable generations (current or named checkpoint), using atomic writes that refuse to overwrite existing files.
> - Adds `import_portable_project` with validate-before-mutate semantics: verifies format, capabilities, participant digests, and resource limits before any filesystem mutation, then atomically publishes the imported generation as CURRENT.
> - Exposes `GraphForge::export_portable` and `GraphForge::import_portable` in [gf-api](https://github.com/CurateLabs/graphforge/pull/234/files#diff-b56b99f33f9c26a15a94c4745091c8ace03d515b147a0053469b1fb3abe40c87); import is restricted to new, empty, or pristine project directories.
> - Adds `gf export` and `gf import` subcommands in [gf-cli](https://github.com/CurateLabs/graphforge/pull/234/files#diff-7f9339b2ddf82c92bbcf53fbef95fafc86052862775d0cddbe509f6182be24a2) with JSON or human-readable output; import requires a canonical UUID idempotency key to support replay detection.
> - Excludes live pointers, locks, journals, caches, and trash from exported envelopes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb70905.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->