### PR TITLE
feat(api): add deterministic ontology lifecycle surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add byte-for-byte equivalent `graphforge` wheel and `@graphforge/cli` npm
   entry points backed by the same Rust CLI parser, execution, structured errors,
   output, and exit codes (#226).
+- Add Rust-owned deterministic runtime-catalog inspection, conservative ontology
+  drafts, structured non-mutating validation, and explicit-source atomic
+  YAML/JSON ontology export (#236).
 - Add deterministic portable export of the current generation or a named
   checkpoint and validate-before-mutation atomic import into new or empty
   projects, excluding live pointers, locks, journals, caches, and trash (#229).

--- a/crates/gf-api/src/embedding_refresh.rs
+++ b/crates/gf-api/src/embedding_refresh.rs
@@ -260,6 +260,7 @@ impl GraphForge {
             workspace_guard: Arc::clone(&self.workspace_guard),
             tempdir: self.tempdir.clone(),
             ontology: self.ontology.clone(),
+            ontology_document: self.ontology_document.clone(),
             runtime_catalog: Arc::clone(&self.runtime_catalog),
             procedures: Arc::clone(&self.procedures),
             ontology_mode: self.ontology_mode,

--- a/crates/gf-api/src/lib.rs
+++ b/crates/gf-api/src/lib.rs
@@ -405,19 +405,20 @@ impl std::fmt::Debug for GraphForge {
 impl GraphForge {
     /// Create a new in-memory (`None`) or Parquet-backed (`Some(path)`) instance.
     ///
-    /// For a Parquet-backed instance, the directory must exist; a
-    /// `graphforge.yaml` manifest is loaded if present (otherwise defaults are
-    /// used), and the [`OntologyMode`] is resolved per the manifest's default-mode
-    /// logic (an `ontology.yaml` present on disk → advisory). When an ontology
-    /// file is found it is compiled and applied. An existing
-    /// `topology/runtime_catalog.parquet` seeds the runtime catalog.
+    /// For a persistent instance, the directory must exist. Ontology authority
+    /// and enforcement mode are resolved from the committed workspace ontology
+    /// and configuration participants in the selected project generation.
+    /// Loose `graphforge.yaml` or `ontology.yaml` files are not authority and
+    /// are not loaded implicitly. An existing runtime-catalog participant seeds
+    /// the runtime catalog.
     ///
     /// An in-memory instance is exploratory and backed by a temp directory.
     ///
     /// # Errors
     /// Returns [`GfError::Storage`] if `path` does not exist or the temp dir
-    /// cannot be created, [`GfError::Validation`] for a malformed manifest, and
-    /// [`GfError::Ontology`] if the ontology file cannot be loaded or compiled.
+    /// cannot be created, [`GfError::Validation`] for malformed committed
+    /// workspace records, and [`GfError::Ontology`] if the adopted ontology
+    /// cannot be decoded or compiled.
     /// Opening a persistent project can also return structured knowledge,
     /// provenance, or publication errors while reconciling an interrupted
     /// recorded algorithm run.
@@ -2524,11 +2525,12 @@ impl GraphForge {
     /// mode-dependent, so a stale provider would scan the wrong edge files).
     ///
     /// **Session-scoped**: the ontology is applied to this live instance only —
-    /// it is **not** written to disk and the project manifest is not updated, so
-    /// reopening a Parquet-backed project does not see it. Because the on-disk
+    /// it is **not** published to the committed workspace ontology/configuration
+    /// records, so reopening a persistent project does not see it. Because the on-disk
     /// layout differs by mode, this is intended for a fresh instance (or before
-    /// writing data); to permanently type a project, place an `ontology.yaml` in
-    /// the project directory and open it with [`new`](Self::new).
+    /// writing data). Durable authority changes only through
+    /// [`adopt_ontology`](Self::adopt_ontology) and
+    /// [`clear_ontology`](Self::clear_ontology).
     ///
     /// # Errors
     /// Returns [`GfError::Ontology`] if the file cannot be loaded or compiled.

--- a/crates/gf-api/src/lib.rs
+++ b/crates/gf-api/src/lib.rs
@@ -30,7 +30,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use arrow::datatypes::SchemaRef;
 use gf_core::{GraphIdentity, TypeId};
 use gf_ir::{BindError, Binder, GraphOp, GraphPlan, IrExpr, ProcedureRegistry, RuntimeCatalog};
-use gf_ontology::{OntologyCompiler, OntologyHandle, OntologyLoader};
+use gf_ontology::{OntologyCompiler, OntologyDoc, OntologyHandle, OntologyLoader};
 use gf_storage::GraphCatalog;
 use gf_storage::ResolvedProjectGeneration;
 use sha2::{Digest, Sha256};
@@ -69,6 +69,7 @@ mod m18_embedding_publication;
 #[cfg(test)]
 mod multi_process_publication_tests;
 mod node_selector;
+mod ontology_lifecycle;
 mod paging;
 mod portable;
 mod provenance;
@@ -223,6 +224,11 @@ pub use knowledge::{
     ListConfidenceAssessmentsRequest, ListEvidenceLinksRequest, ListReasoningRequest,
     RecordAssertionStatusRequest, RecordReasoningRequest, SupersedeAssertionRequest,
 };
+pub use ontology_lifecycle::{
+    CatalogEntryKind, OntologyExportFormat, OntologyExportSource, OntologySuggestion,
+    OntologySuggestionOptions, OntologyValidationReport, RuntimeCatalogEntry,
+    RuntimeCatalogSnapshot,
+};
 pub use paging::{CancellationToken, DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT, PageRequest, PageToken};
 pub use provenance::ProvenanceHistoryRequest;
 pub use search_index::{AdjacencyInspection, TextIndexInspection};
@@ -330,6 +336,8 @@ pub struct GraphForge {
     tempdir: Option<Arc<tempfile::TempDir>>,
     /// Compiled ontology, present in advisory/strict mode.
     ontology: Option<OntologyHandle>,
+    /// Source document backing the live, session-scoped compiled ontology.
+    ontology_document: Option<OntologyDoc>,
     /// Shared runtime catalog (grown by the binder during `execute`).
     runtime_catalog: Arc<Mutex<RuntimeCatalog>>,
     /// Procedures available to `CALL` clauses on this engine instance.
@@ -436,7 +444,8 @@ impl GraphForge {
             .map_err(|e| GfError::Storage(format!("failed to create temp dir: {e}")))?;
         let resolved_generation = gf_storage::open_or_initialize_project(tmp.path())?;
         let generation_uuid = resolved_generation.generation_uuid();
-        let (ontology_mode, ontology) = load_workspace_ontology(&resolved_generation)?;
+        let (ontology_mode, ontology, ontology_document) =
+            load_workspace_ontology(&resolved_generation)?;
         let workspace = hydrate_graph_workspace(&resolved_generation)?;
         let dir = workspace.path().to_path_buf();
         Ok(Self {
@@ -465,6 +474,7 @@ impl GraphForge {
             workspace_guard: workspace,
             tempdir: Some(Arc::new(tmp)),
             ontology,
+            ontology_document,
             runtime_catalog: Arc::new(Mutex::new(RuntimeCatalog::new())),
             procedures: Arc::new(Mutex::new(ProcedureRegistry::new())),
             ontology_mode,
@@ -509,7 +519,8 @@ impl GraphForge {
         write_options: GraphForgeOptions,
     ) -> Result<Self, GfError> {
         let generation_uuid = resolved_generation.generation_uuid();
-        let (ontology_mode, ontology) = load_workspace_ontology(&resolved_generation)?;
+        let (ontology_mode, ontology, ontology_document) =
+            load_workspace_ontology(&resolved_generation)?;
         let workspace = hydrate_graph_workspace(&resolved_generation)?;
         let dir = workspace.path().to_path_buf();
 
@@ -541,6 +552,7 @@ impl GraphForge {
             workspace_guard: workspace,
             tempdir: None,
             ontology,
+            ontology_document,
             runtime_catalog: Arc::new(Mutex::new(runtime_catalog)),
             procedures: Arc::new(Mutex::new(ProcedureRegistry::new())),
             ontology_mode,
@@ -2526,6 +2538,7 @@ impl GraphForge {
         let runtime = OntologyCompiler::compile(&doc)
             .map_err(|e| GfError::Ontology(format!("failed to compile ontology: {e}")))?;
         self.ontology = Some(OntologyHandle::new(runtime));
+        self.ontology_document = Some(doc);
         if matches!(self.ontology_mode, OntologyMode::Exploratory) {
             self.ontology_mode = OntologyMode::Advisory;
             // The provider caches the construction-time mode and drives edge
@@ -2950,7 +2963,7 @@ fn hydrate_graph_workspace(
 
 fn load_workspace_ontology(
     generation: &ResolvedProjectGeneration,
-) -> Result<(OntologyMode, Option<OntologyHandle>), GfError> {
+) -> Result<(OntologyMode, Option<OntologyHandle>, Option<OntologyDoc>), GfError> {
     generation.require_capability(
         gf_storage::WORKSPACE_CAPABILITY_ID,
         gf_storage::WORKSPACE_CAPABILITY_VERSION,
@@ -2992,18 +3005,24 @@ fn load_workspace_ontology(
         ));
     }
     let mode = ontology_record.mode.execution_mode();
-    let ontology = ontology_record
+    let document = ontology_record
         .canonical_ontology
         .map(|document| {
             let document: gf_ontology::OntologyDoc = serde_json::from_value(document)
                 .map_err(|error| GfError::Ontology(format!("invalid adopted ontology: {error}")))?;
-            let runtime = OntologyCompiler::compile(&document).map_err(|error| {
+            Ok::<OntologyDoc, GfError>(document)
+        })
+        .transpose()?;
+    let ontology = document
+        .as_ref()
+        .map(|document| {
+            let runtime = OntologyCompiler::compile(document).map_err(|error| {
                 GfError::Ontology(format!("failed to compile ontology: {error}"))
             })?;
             Ok::<OntologyHandle, GfError>(OntologyHandle::new(runtime))
         })
         .transpose()?;
-    Ok((mode, ontology))
+    Ok((mode, ontology, document))
 }
 
 fn participant_encoding(value: &str) -> Result<gf_storage::ProjectParticipantEncoding, GfError> {

--- a/crates/gf-api/src/ontology_lifecycle.rs
+++ b/crates/gf-api/src/ontology_lifecycle.rs
@@ -4,10 +4,11 @@ use std::path::Path;
 use std::{fmt::Write as _, io::Write as _};
 
 use arrow::array::{Array, StringArray, UInt64Array};
-use gf_core::GfError;
+use arrow::record_batch::RecordBatch;
+use gf_core::{ApiErrorCode, GfError};
 use gf_ontology::{
-    EntityTypeDef, OntologyDoc, OntologyValidationError, OntologyValidator, PropertyDef,
-    PropertyValueType,
+    ConstraintKind, EntityTypeDef, OntologyDoc, OntologyValidationError, OntologyValidator,
+    PropertyDef, PropertyValueType,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -91,7 +92,8 @@ pub enum OntologyExportFormat {
 /// Explicit authority source for ontology export.
 #[derive(Debug, Clone, PartialEq)]
 pub enum OntologyExportSource {
-    /// A caller-reviewed or freshly generated draft.
+    /// A caller-reviewed or freshly generated draft. Its declaration vectors
+    /// are canonicalized before validation, fingerprinting, and serialization.
     Suggested(OntologyDoc),
     /// The ontology currently loaded in this live facade.
     Loaded,
@@ -104,53 +106,13 @@ impl GraphForge {
     ///
     /// Runtime IDs and first/last-seen timestamps are implementation state and
     /// intentionally excluded from this stable product contract.
-    #[must_use]
-    pub fn inspect_runtime_catalog(&self) -> RuntimeCatalogSnapshot {
+    pub fn inspect_runtime_catalog(&self) -> Result<RuntimeCatalogSnapshot, GfError> {
         let batch = self
             .runtime_catalog
             .lock()
-            .expect("runtime catalog poisoned")
+            .map_err(|_| GfError::Storage("runtime catalog lock poisoned".into()))?
             .to_record_batch();
-        let kinds = batch
-            .column(0)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .expect("catalog schema");
-        let names = batch
-            .column(1)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .expect("catalog schema");
-        let counts = batch
-            .column(3)
-            .as_any()
-            .downcast_ref::<UInt64Array>()
-            .expect("catalog schema");
-        let owners = batch
-            .column(6)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .expect("catalog schema");
-        let mut entries = (0..batch.num_rows())
-            .map(|row| RuntimeCatalogEntry {
-                kind: match kinds.value(row) {
-                    "entity_type" => CatalogEntryKind::EntityType,
-                    "relation_type" => CatalogEntryKind::RelationType,
-                    "property" => CatalogEntryKind::Property,
-                    _ => unreachable!("runtime catalog emitted an unknown entry kind"),
-                },
-                name: names.value(row).to_owned(),
-                owner: (!owners.is_null(row)).then(|| owners.value(row).to_owned()),
-                observation_count: counts.value(row),
-            })
-            .collect::<Vec<_>>();
-        entries.sort_by(|left, right| {
-            (&left.kind, &left.owner, &left.name).cmp(&(&right.kind, &right.owner, &right.name))
-        });
-        RuntimeCatalogSnapshot {
-            contract_version: 1,
-            entries,
-        }
+        snapshot_from_batch(&batch)
     }
 
     /// Suggest a conservative ontology draft from structural observations.
@@ -167,7 +129,7 @@ impl GraphForge {
                 "ontology_id and version must be non-empty".into(),
             ));
         }
-        let snapshot = self.inspect_runtime_catalog();
+        let snapshot = self.inspect_runtime_catalog()?;
         let entity_names = snapshot
             .entries
             .iter()
@@ -205,7 +167,7 @@ impl GraphForge {
             .filter(|entry| entry.kind == CatalogEntryKind::RelationType)
             .map(|entry| entry.name.clone())
             .collect();
-        let document = OntologyDoc {
+        let document = canonicalize_document(OntologyDoc {
             ontology_id: options.ontology_id,
             version: options.version,
             entity_types,
@@ -213,7 +175,7 @@ impl GraphForge {
             properties,
             constraints: Vec::new(),
             migrations: Vec::new(),
-        };
+        });
         let report = self.validate_ontology(&document);
         if !report.valid {
             return Err(GfError::Ontology(format!(
@@ -248,7 +210,8 @@ impl GraphForge {
 
     /// Atomically export one explicit ontology source as YAML or JSON.
     ///
-    /// Validation and serialization complete before the destination is replaced.
+    /// All declaration vectors are canonicalized first. Validation and
+    /// serialization complete before the destination is replaced.
     pub fn export_ontology(
         &self,
         source: OntologyExportSource,
@@ -271,6 +234,7 @@ impl GraphForge {
                 })?
             }
         };
+        let document = canonicalize_document(document);
         let report = self.validate_ontology(&document);
         if !report.valid {
             return Err(GfError::Ontology(format!(
@@ -286,6 +250,110 @@ impl GraphForge {
                 .map_err(|error| GfError::Ontology(format!("failed to encode JSON: {error}")))?,
         };
         atomic_replace(destination, &bytes)
+    }
+}
+
+fn snapshot_from_batch(batch: &RecordBatch) -> Result<RuntimeCatalogSnapshot, GfError> {
+    let schema_error = |message: String| GfError::Api {
+        code: ApiErrorCode::SchemaMismatch,
+        message,
+    };
+    let column = |index: usize, name: &str| {
+        batch
+            .columns()
+            .get(index)
+            .ok_or_else(|| schema_error(format!("runtime catalog is missing column '{name}'")))
+    };
+    let kinds = column(0, "entry_kind")?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| schema_error("runtime catalog entry_kind is not Utf8".into()))?;
+    let names = column(1, "name")?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| schema_error("runtime catalog name is not Utf8".into()))?;
+    let counts = column(3, "observation_count")?
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .ok_or_else(|| schema_error("runtime catalog observation_count is not UInt64".into()))?;
+    let owners = column(6, "owner_label")?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| schema_error("runtime catalog owner_label is not Utf8".into()))?;
+    let mut entries = Vec::with_capacity(batch.num_rows());
+    for row in 0..batch.num_rows() {
+        if kinds.is_null(row) || names.is_null(row) || counts.is_null(row) {
+            return Err(schema_error(format!(
+                "runtime catalog row {row} has a null required field"
+            )));
+        }
+        entries.push(RuntimeCatalogEntry {
+            kind: match kinds.value(row) {
+                "entity_type" => CatalogEntryKind::EntityType,
+                "relation_type" => CatalogEntryKind::RelationType,
+                "property" => CatalogEntryKind::Property,
+                other => {
+                    return Err(schema_error(format!(
+                        "runtime catalog row {row} has unknown entry kind '{other}'"
+                    )));
+                }
+            },
+            name: names.value(row).to_owned(),
+            owner: (!owners.is_null(row)).then(|| owners.value(row).to_owned()),
+            observation_count: counts.value(row),
+        });
+    }
+    entries.sort_by(|left, right| {
+        (&left.kind, &left.owner, &left.name).cmp(&(&right.kind, &right.owner, &right.name))
+    });
+    Ok(RuntimeCatalogSnapshot {
+        contract_version: 1,
+        entries,
+    })
+}
+
+fn canonicalize_document(mut document: OntologyDoc) -> OntologyDoc {
+    document
+        .entity_types
+        .sort_by(|left, right| left.name.cmp(&right.name));
+    document.relation_types.sort_by(|left, right| {
+        (&left.name, &left.src, &left.dst).cmp(&(&right.name, &right.src, &right.dst))
+    });
+    document
+        .properties
+        .sort_by(|left, right| (&left.owner, &left.name).cmp(&(&right.owner, &right.name)));
+    document.constraints.sort_by(|left, right| {
+        (&left.owner, constraint_rank(&left.kind), &left.expr_json).cmp(&(
+            &right.owner,
+            constraint_rank(&right.kind),
+            &right.expr_json,
+        ))
+    });
+    document.migrations.sort_by(|left, right| {
+        (
+            &left.from_version,
+            &left.to_version,
+            &left.transform_kind,
+            &left.script_ref,
+            &left.checksum,
+        )
+            .cmp(&(
+                &right.from_version,
+                &right.to_version,
+                &right.transform_kind,
+                &right.script_ref,
+                &right.checksum,
+            ))
+    });
+    document
+}
+
+const fn constraint_rank(kind: &ConstraintKind) -> u8 {
+    match kind {
+        ConstraintKind::UniqueProperty => 0,
+        ConstraintKind::RequiredProperty => 1,
+        ConstraintKind::RangeCheck => 2,
+        ConstraintKind::CustomExpr => 3,
     }
 }
 
@@ -323,7 +391,10 @@ fn hex_sha256(bytes: &[u8]) -> String {
 mod tests {
     use super::*;
     use crate::{AdoptOntologyRequest, OperationId, WriteContext};
+    use arrow::array::{ArrayRef, Int64Array};
+    use arrow::datatypes::{DataType, Field, Schema};
     use gf_core::OntologyMode;
+    use std::sync::Arc;
 
     fn observations(first_order: bool) -> GraphForge {
         let graph = GraphForge::new(None).unwrap();
@@ -348,22 +419,97 @@ mod tests {
             ontology_id: "draft".into(),
             version: "0.1.0".into(),
         };
-        let left = observations(true).suggest_ontology(options()).unwrap();
-        let right = observations(false).suggest_ontology(options()).unwrap();
+        let left_graph = observations(true);
+        let right_graph = observations(false);
+        let left = left_graph.suggest_ontology(options()).unwrap();
+        let right = right_graph.suggest_ontology(options()).unwrap();
         assert_eq!(left, right);
         assert_eq!(left.omitted_relation_types, vec!["WORKS_AT"]);
         assert!(left.document.relation_types.is_empty());
         assert!(observations(true).validate_ontology(&left.document).valid);
+
+        let directory = tempfile::tempdir().unwrap();
+        for (format, extension) in [
+            (OntologyExportFormat::Yaml, "yaml"),
+            (OntologyExportFormat::Json, "json"),
+        ] {
+            let left_path = directory.path().join(format!("left.{extension}"));
+            let right_path = directory.path().join(format!("right.{extension}"));
+            left_graph
+                .export_ontology(
+                    OntologyExportSource::Suggested(left.document.clone()),
+                    &left_path,
+                    format,
+                )
+                .unwrap();
+            right_graph
+                .export_ontology(
+                    OntologyExportSource::Suggested(right.document.clone()),
+                    &right_path,
+                    format,
+                )
+                .unwrap();
+            assert_eq!(
+                std::fs::read(left_path).unwrap(),
+                std::fs::read(right_path).unwrap()
+            );
+        }
     }
 
     #[test]
     fn snapshot_hides_runtime_identity_and_orders_entries() {
-        let snapshot = observations(false).inspect_runtime_catalog();
+        let snapshot = observations(false).inspect_runtime_catalog().unwrap();
         let json = serde_json::to_string(&snapshot).unwrap();
         assert!(!json.contains("runtime_id"));
         assert!(!json.contains("first_seen"));
         assert_eq!(snapshot.entries[0].name, "Organization");
         assert_eq!(snapshot.entries[1].name, "Person");
+    }
+
+    #[test]
+    fn catalog_inspection_reports_poisoned_lock_and_schema_mismatch() {
+        let graph = GraphForge::new(None).unwrap();
+        let catalog = graph.runtime_catalog();
+        let poison = std::thread::spawn(move || {
+            let _guard = catalog.lock().unwrap();
+            panic!("poison runtime catalog for error-path test");
+        });
+        assert!(poison.join().is_err());
+        assert!(matches!(
+            graph.inspect_runtime_catalog(),
+            Err(GfError::Storage(message)) if message == "runtime catalog lock poisoned"
+        ));
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("entry_kind", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, false),
+            Field::new("runtime_id", DataType::UInt32, false),
+            Field::new("observation_count", DataType::UInt64, false),
+            Field::new("first_seen", DataType::Int64, false),
+            Field::new("last_seen", DataType::Int64, false),
+            Field::new("owner_label", DataType::Utf8, true),
+        ]));
+        let empty_strings = || Arc::new(StringArray::from(Vec::<&str>::new())) as ArrayRef;
+        let malformed = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(Vec::<i64>::new())),
+                empty_strings(),
+                Arc::new(arrow::array::UInt32Array::from(Vec::<u32>::new())),
+                Arc::new(UInt64Array::from(Vec::<u64>::new())),
+                Arc::new(Int64Array::from(Vec::<i64>::new())),
+                Arc::new(Int64Array::from(Vec::<i64>::new())),
+                empty_strings(),
+            ],
+        )
+        .unwrap();
+        assert!(matches!(
+            snapshot_from_batch(&malformed),
+            Err(GfError::Api {
+                code: ApiErrorCode::SchemaMismatch,
+                ..
+            })
+        ));
     }
 
     #[test]
@@ -391,6 +537,59 @@ mod tests {
             assert_eq!(
                 gf_ontology::OntologyLoader::load_file(&path).unwrap(),
                 suggestion.document
+            );
+        }
+    }
+
+    #[test]
+    fn suggested_source_is_canonicalized_before_serialization() {
+        let graph = GraphForge::new(None).unwrap();
+        let ordered = OntologyDoc {
+            ontology_id: "draft".into(),
+            version: "1".into(),
+            entity_types: vec![
+                EntityTypeDef {
+                    name: "Organization".into(),
+                    r#abstract: false,
+                    parent: None,
+                },
+                EntityTypeDef {
+                    name: "Person".into(),
+                    r#abstract: false,
+                    parent: None,
+                },
+            ],
+            relation_types: vec![],
+            properties: vec![],
+            constraints: vec![],
+            migrations: vec![],
+        };
+        let mut reversed = ordered.clone();
+        reversed.entity_types.reverse();
+        let directory = tempfile::tempdir().unwrap();
+        for (format, extension) in [
+            (OntologyExportFormat::Yaml, "yaml"),
+            (OntologyExportFormat::Json, "json"),
+        ] {
+            let ordered_path = directory.path().join(format!("ordered.{extension}"));
+            let reversed_path = directory.path().join(format!("reversed.{extension}"));
+            graph
+                .export_ontology(
+                    OntologyExportSource::Suggested(ordered.clone()),
+                    &ordered_path,
+                    format,
+                )
+                .unwrap();
+            graph
+                .export_ontology(
+                    OntologyExportSource::Suggested(reversed.clone()),
+                    &reversed_path,
+                    format,
+                )
+                .unwrap();
+            assert_eq!(
+                std::fs::read(ordered_path).unwrap(),
+                std::fs::read(reversed_path).unwrap()
             );
         }
     }
@@ -438,12 +637,35 @@ mod tests {
     fn loaded_and_adopted_sources_are_explicit_and_leave_authority_unchanged() {
         let project = tempfile::tempdir().unwrap();
         let files = tempfile::tempdir().unwrap();
-        let input = files.path().join("input.yaml");
-        let yaml = "ontology_id: reviewed\nversion: \"1\"\nentity_types:\n  - name: Person\n";
-        std::fs::write(&input, yaml).unwrap();
+        let adopted_input = files.path().join("adopted-input.yaml");
+        let loaded_input = files.path().join("loaded-input.yaml");
+        std::fs::write(
+            &adopted_input,
+            "ontology_id: durable\nversion: \"1\"\nentity_types:\n  - name: Person\n",
+        )
+        .unwrap();
+        std::fs::write(
+            &loaded_input,
+            "ontology_id: session\nversion: \"2\"\nentity_types:\n  - name: Organization\n",
+        )
+        .unwrap();
         let mut graph = GraphForge::new(Some(project.path().to_str().unwrap())).unwrap();
 
-        graph.load_ontology(input.to_str().unwrap()).unwrap();
+        graph
+            .adopt_ontology(AdoptOntologyRequest {
+                context: WriteContext {
+                    operation_uuid: OperationId(uuid::Uuid::from_u128(236)),
+                    actor_uuid: None,
+                },
+                path: adopted_input,
+                mode: OntologyMode::Strict,
+            })
+            .unwrap();
+        let generation = *graph
+            .current_generation_uuid
+            .lock()
+            .expect("generation UUID lock poisoned");
+        graph.load_ontology(loaded_input.to_str().unwrap()).unwrap();
         let loaded = files.path().join("loaded.json");
         graph
             .export_ontology(
@@ -452,22 +674,6 @@ mod tests {
                 OntologyExportFormat::Json,
             )
             .unwrap();
-        assert_eq!(graph.ontology_mode(), OntologyMode::Advisory);
-
-        graph
-            .adopt_ontology(AdoptOntologyRequest {
-                context: WriteContext {
-                    operation_uuid: OperationId(uuid::Uuid::from_u128(236)),
-                    actor_uuid: None,
-                },
-                path: input,
-                mode: OntologyMode::Strict,
-            })
-            .unwrap();
-        let generation = *graph
-            .current_generation_uuid
-            .lock()
-            .expect("generation UUID lock poisoned");
         let adopted = files.path().join("adopted.yaml");
         graph
             .export_ontology(
@@ -477,6 +683,19 @@ mod tests {
             )
             .unwrap();
         assert_eq!(graph.ontology_mode(), OntologyMode::Strict);
+        let loaded_doc = gf_ontology::OntologyLoader::load_file(&loaded).unwrap();
+        let adopted_doc = gf_ontology::OntologyLoader::load_file(&adopted).unwrap();
+        assert_eq!(loaded_doc.ontology_id, "session");
+        assert_eq!(adopted_doc.ontology_id, "durable");
+        assert_ne!(loaded_doc, adopted_doc);
+        assert_eq!(
+            graph
+                .workspace_ontology()
+                .unwrap()
+                .canonical_ontology
+                .unwrap()["ontology_id"],
+            "durable"
+        );
         assert_eq!(
             *graph
                 .current_generation_uuid
@@ -484,9 +703,76 @@ mod tests {
                 .expect("generation UUID lock poisoned"),
             generation
         );
+
+        drop(graph);
+        let reopened = GraphForge::new(Some(project.path().to_str().unwrap())).unwrap();
+        assert_eq!(reopened.ontology_mode(), OntologyMode::Strict);
+        let reopened_path = files.path().join("reopened.json");
+        reopened
+            .export_ontology(
+                OntologyExportSource::Loaded,
+                &reopened_path,
+                OntologyExportFormat::Json,
+            )
+            .unwrap();
         assert_eq!(
-            gf_ontology::OntologyLoader::load_file(&loaded).unwrap(),
-            gf_ontology::OntologyLoader::load_file(&adopted).unwrap()
+            gf_ontology::OntologyLoader::load_file(&reopened_path).unwrap(),
+            adopted_doc
         );
+    }
+
+    #[test]
+    fn filesystem_failure_preserves_destination_and_cleans_temporary_file() {
+        let graph = observations(true);
+        let suggestion = graph
+            .suggest_ontology(OntologySuggestionOptions {
+                ontology_id: "draft".into(),
+                version: "1".into(),
+            })
+            .unwrap();
+        let parent = tempfile::tempdir().unwrap();
+        let destination = parent.path().join("destination-is-a-directory");
+        std::fs::create_dir(&destination).unwrap();
+        let before = std::fs::read_dir(parent.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect::<Vec<_>>();
+
+        assert!(matches!(
+            graph.export_ontology(
+                OntologyExportSource::Suggested(suggestion.document),
+                &destination,
+                OntologyExportFormat::Json,
+            ),
+            Err(GfError::Storage(_))
+        ));
+        assert!(destination.is_dir());
+        let after = std::fs::read_dir(parent.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            before, after,
+            "failed persist must clean its sibling temp file"
+        );
+
+        let missing_parent = parent.path().join("missing").join("ontology.json");
+        assert!(matches!(
+            graph.export_ontology(
+                OntologyExportSource::Suggested(
+                    graph
+                        .suggest_ontology(OntologySuggestionOptions {
+                            ontology_id: "draft".into(),
+                            version: "1".into(),
+                        })
+                        .unwrap()
+                        .document,
+                ),
+                &missing_parent,
+                OntologyExportFormat::Json,
+            ),
+            Err(GfError::Storage(_))
+        ));
+        assert!(!missing_parent.exists());
     }
 }

--- a/crates/gf-api/src/ontology_lifecycle.rs
+++ b/crates/gf-api/src/ontology_lifecycle.rs
@@ -92,8 +92,9 @@ pub enum OntologyExportFormat {
 /// Explicit authority source for ontology export.
 #[derive(Debug, Clone, PartialEq)]
 pub enum OntologyExportSource {
-    /// A caller-reviewed or freshly generated draft. Its declaration vectors
-    /// are canonicalized before validation, fingerprinting, and serialization.
+    /// A caller-reviewed or freshly generated draft. Non-migration declaration
+    /// vectors are canonicalized before validation and serialization; authored
+    /// migration order is preserved as a semantic tie-breaker.
     Suggested(OntologyDoc),
     /// The ontology currently loaded in this live facade.
     Loaded,
@@ -210,8 +211,9 @@ impl GraphForge {
 
     /// Atomically export one explicit ontology source as YAML or JSON.
     ///
-    /// All declaration vectors are canonicalized first. Validation and
-    /// serialization complete before the destination is replaced.
+    /// Non-migration declaration vectors are canonicalized first. Authored
+    /// migration order is preserved. Validation and serialization complete
+    /// before the destination is replaced.
     pub fn export_ontology(
         &self,
         source: OntologyExportSource,
@@ -329,22 +331,8 @@ fn canonicalize_document(mut document: OntologyDoc) -> OntologyDoc {
             &right.expr_json,
         ))
     });
-    document.migrations.sort_by(|left, right| {
-        (
-            &left.from_version,
-            &left.to_version,
-            &left.transform_kind,
-            &left.script_ref,
-            &left.checksum,
-        )
-            .cmp(&(
-                &right.from_version,
-                &right.to_version,
-                &right.transform_kind,
-                &right.script_ref,
-                &right.checksum,
-            ))
-    });
+    // Authored migration order is semantic: MigrationEngine's BFS uses it to
+    // break ties between equal-length routes. Never reorder it on round-trip.
     document
 }
 
@@ -592,6 +580,77 @@ mod tests {
                 std::fs::read(reversed_path).unwrap()
             );
         }
+    }
+
+    #[test]
+    fn export_round_trip_preserves_migration_route_tie_breaking() {
+        let graph = GraphForge::new(None).unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        let input = directory.path().join("authored.yaml");
+        let output = directory.path().join("exported.yaml");
+        let authored = OntologyDoc {
+            ontology_id: "migration-order".into(),
+            version: "1".into(),
+            entity_types: vec![],
+            relation_types: vec![],
+            properties: vec![],
+            constraints: vec![],
+            migrations: vec![
+                gf_ontology::MigrationDef {
+                    from_version: "1".into(),
+                    to_version: "3".into(),
+                    transform_kind: "add_type:ViaThree".into(),
+                    script_ref: None,
+                    checksum: None,
+                },
+                gf_ontology::MigrationDef {
+                    from_version: "3".into(),
+                    to_version: "4".into(),
+                    transform_kind: "add_type:TargetThree".into(),
+                    script_ref: None,
+                    checksum: None,
+                },
+                gf_ontology::MigrationDef {
+                    from_version: "1".into(),
+                    to_version: "2".into(),
+                    transform_kind: "add_type:ViaTwo".into(),
+                    script_ref: None,
+                    checksum: None,
+                },
+                gf_ontology::MigrationDef {
+                    from_version: "2".into(),
+                    to_version: "4".into(),
+                    transform_kind: "add_type:TargetTwo".into(),
+                    script_ref: None,
+                    checksum: None,
+                },
+            ],
+        };
+        std::fs::write(&input, serde_yaml::to_string(&authored).unwrap()).unwrap();
+        let mut graph = graph;
+        graph.load_ontology(input.to_str().unwrap()).unwrap();
+        let before = gf_ontology::MigrationEngine::plan("1", "4", &authored.migrations)
+            .unwrap()
+            .into_iter()
+            .map(|step| step.to_version)
+            .collect::<Vec<_>>();
+        assert_eq!(before, vec!["3", "4"]);
+
+        graph
+            .export_ontology(
+                OntologyExportSource::Loaded,
+                &output,
+                OntologyExportFormat::Yaml,
+            )
+            .unwrap();
+        let round_tripped = gf_ontology::OntologyLoader::load_file(&output).unwrap();
+        let after = gf_ontology::MigrationEngine::plan("1", "4", &round_tripped.migrations)
+            .unwrap()
+            .into_iter()
+            .map(|step| step.to_version)
+            .collect::<Vec<_>>();
+        assert_eq!(after, before);
+        assert_eq!(round_tripped.migrations, authored.migrations);
     }
 
     #[test]

--- a/crates/gf-api/src/ontology_lifecycle.rs
+++ b/crates/gf-api/src/ontology_lifecycle.rs
@@ -1,0 +1,492 @@
+//! Deterministic, non-mutating ontology inspection, suggestion, validation, and export.
+
+use std::path::Path;
+use std::{fmt::Write as _, io::Write as _};
+
+use arrow::array::{Array, StringArray, UInt64Array};
+use gf_core::GfError;
+use gf_ontology::{
+    EntityTypeDef, OntologyDoc, OntologyValidationError, OntologyValidator, PropertyDef,
+    PropertyValueType,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::GraphForge;
+
+/// Stable kind of one observed runtime-catalog entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CatalogEntryKind {
+    /// Observed node label.
+    EntityType,
+    /// Observed edge type. Endpoints are not inferred by the runtime catalog.
+    RelationType,
+    /// Observed property name and optional owning label.
+    Property,
+}
+
+/// One portable structural observation. Runtime IDs and timestamps are deliberately absent.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeCatalogEntry {
+    /// Observation category.
+    pub kind: CatalogEntryKind,
+    /// Observed label, edge type, or property name.
+    pub name: String,
+    /// Owning label for a property, otherwise `None`.
+    pub owner: Option<String>,
+    /// Number of observations recorded by this catalog.
+    pub observation_count: u64,
+}
+
+/// Immutable, deterministically ordered public runtime-catalog view.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeCatalogSnapshot {
+    /// Contract version for forward-compatible consumers.
+    pub contract_version: u32,
+    /// Entries ordered by kind, owner, and name.
+    pub entries: Vec<RuntimeCatalogEntry>,
+}
+
+/// Caller-owned stable identity for a generated draft.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OntologySuggestionOptions {
+    /// Stable ontology identifier to place in the draft.
+    pub ontology_id: String,
+    /// Version to place in the draft.
+    pub version: String,
+}
+
+/// Explicitly non-authoritative ontology draft.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OntologySuggestion {
+    /// Always true; callers must explicitly load or adopt the document.
+    pub draft: bool,
+    /// Canonically ordered ontology document.
+    pub document: OntologyDoc,
+    /// SHA-256 of canonical JSON bytes.
+    pub fingerprint_sha256: String,
+    /// Observed relation types omitted because the catalog has no endpoint evidence.
+    pub omitted_relation_types: Vec<String>,
+}
+
+/// Structured result of non-mutating semantic validation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OntologyValidationReport {
+    /// Whether the document is valid.
+    pub valid: bool,
+    /// Every semantic diagnostic, in validator order.
+    pub diagnostics: Vec<OntologyValidationError>,
+}
+
+/// Serialization format for an ontology-only export.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OntologyExportFormat {
+    /// YAML document.
+    Yaml,
+    /// Pretty JSON document.
+    Json,
+}
+
+/// Explicit authority source for ontology export.
+#[derive(Debug, Clone, PartialEq)]
+pub enum OntologyExportSource {
+    /// A caller-reviewed or freshly generated draft.
+    Suggested(OntologyDoc),
+    /// The ontology currently loaded in this live facade.
+    Loaded,
+    /// The ontology adopted in the committed workspace generation.
+    Adopted,
+}
+
+impl GraphForge {
+    /// Return an immutable, portable snapshot of structural observations.
+    ///
+    /// Runtime IDs and first/last-seen timestamps are implementation state and
+    /// intentionally excluded from this stable product contract.
+    #[must_use]
+    pub fn inspect_runtime_catalog(&self) -> RuntimeCatalogSnapshot {
+        let batch = self
+            .runtime_catalog
+            .lock()
+            .expect("runtime catalog poisoned")
+            .to_record_batch();
+        let kinds = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("catalog schema");
+        let names = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("catalog schema");
+        let counts = batch
+            .column(3)
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .expect("catalog schema");
+        let owners = batch
+            .column(6)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("catalog schema");
+        let mut entries = (0..batch.num_rows())
+            .map(|row| RuntimeCatalogEntry {
+                kind: match kinds.value(row) {
+                    "entity_type" => CatalogEntryKind::EntityType,
+                    "relation_type" => CatalogEntryKind::RelationType,
+                    "property" => CatalogEntryKind::Property,
+                    _ => unreachable!("runtime catalog emitted an unknown entry kind"),
+                },
+                name: names.value(row).to_owned(),
+                owner: (!owners.is_null(row)).then(|| owners.value(row).to_owned()),
+                observation_count: counts.value(row),
+            })
+            .collect::<Vec<_>>();
+        entries.sort_by(|left, right| {
+            (&left.kind, &left.owner, &left.name).cmp(&(&right.kind, &right.owner, &right.name))
+        });
+        RuntimeCatalogSnapshot {
+            contract_version: 1,
+            entries,
+        }
+    }
+
+    /// Suggest a conservative ontology draft from structural observations.
+    ///
+    /// Properties are nullable UTF-8 because the runtime catalog records no
+    /// values or value types. Relations are reported as omitted because it
+    /// records no source/destination evidence. No constraints or semantics are guessed.
+    pub fn suggest_ontology(
+        &self,
+        options: OntologySuggestionOptions,
+    ) -> Result<OntologySuggestion, GfError> {
+        if options.ontology_id.trim().is_empty() || options.version.trim().is_empty() {
+            return Err(GfError::Validation(
+                "ontology_id and version must be non-empty".into(),
+            ));
+        }
+        let snapshot = self.inspect_runtime_catalog();
+        let entity_names = snapshot
+            .entries
+            .iter()
+            .filter(|entry| entry.kind == CatalogEntryKind::EntityType)
+            .map(|entry| entry.name.clone())
+            .collect::<std::collections::BTreeSet<_>>();
+        let entity_types = entity_names
+            .iter()
+            .map(|name| EntityTypeDef {
+                name: name.clone(),
+                r#abstract: false,
+                parent: None,
+            })
+            .collect();
+        let properties = snapshot
+            .entries
+            .iter()
+            .filter_map(|entry| {
+                let owner = entry.owner.as_ref()?;
+                (entry.kind == CatalogEntryKind::Property && entity_names.contains(owner)).then(
+                    || PropertyDef {
+                        owner: owner.clone(),
+                        name: entry.name.clone(),
+                        value_type: PropertyValueType::Utf8,
+                        nullable: true,
+                        multivalued: false,
+                        default_json: None,
+                    },
+                )
+            })
+            .collect();
+        let omitted_relation_types = snapshot
+            .entries
+            .iter()
+            .filter(|entry| entry.kind == CatalogEntryKind::RelationType)
+            .map(|entry| entry.name.clone())
+            .collect();
+        let document = OntologyDoc {
+            ontology_id: options.ontology_id,
+            version: options.version,
+            entity_types,
+            relation_types: Vec::new(),
+            properties,
+            constraints: Vec::new(),
+            migrations: Vec::new(),
+        };
+        let report = self.validate_ontology(&document);
+        if !report.valid {
+            return Err(GfError::Ontology(format!(
+                "suggested ontology failed validation with {} diagnostic(s)",
+                report.diagnostics.len()
+            )));
+        }
+        let canonical = serde_json::to_vec(&document)
+            .map_err(|error| GfError::Ontology(format!("failed to encode suggestion: {error}")))?;
+        Ok(OntologySuggestion {
+            draft: true,
+            document,
+            fingerprint_sha256: hex_sha256(&canonical),
+            omitted_relation_types,
+        })
+    }
+
+    /// Validate an ontology document without changing live or durable state.
+    #[must_use]
+    pub fn validate_ontology(&self, document: &OntologyDoc) -> OntologyValidationReport {
+        match OntologyValidator::validate(document) {
+            Ok(()) => OntologyValidationReport {
+                valid: true,
+                diagnostics: Vec::new(),
+            },
+            Err(diagnostics) => OntologyValidationReport {
+                valid: false,
+                diagnostics,
+            },
+        }
+    }
+
+    /// Atomically export one explicit ontology source as YAML or JSON.
+    ///
+    /// Validation and serialization complete before the destination is replaced.
+    pub fn export_ontology(
+        &self,
+        source: OntologyExportSource,
+        destination: &Path,
+        format: OntologyExportFormat,
+    ) -> Result<(), GfError> {
+        let document = match source {
+            OntologyExportSource::Suggested(document) => document,
+            OntologyExportSource::Loaded => self
+                .ontology_document
+                .clone()
+                .ok_or_else(|| GfError::Ontology("no ontology is loaded in this facade".into()))?,
+            OntologyExportSource::Adopted => {
+                let record = self.workspace_ontology()?;
+                let value = record.canonical_ontology.ok_or_else(|| {
+                    GfError::Ontology("the current workspace has no adopted ontology".into())
+                })?;
+                serde_json::from_value(value).map_err(|error| {
+                    GfError::Ontology(format!("invalid adopted ontology: {error}"))
+                })?
+            }
+        };
+        let report = self.validate_ontology(&document);
+        if !report.valid {
+            return Err(GfError::Ontology(format!(
+                "ontology export rejected {} validation diagnostic(s)",
+                report.diagnostics.len()
+            )));
+        }
+        let bytes = match format {
+            OntologyExportFormat::Yaml => serde_yaml::to_string(&document)
+                .map(String::into_bytes)
+                .map_err(|error| GfError::Ontology(format!("failed to encode YAML: {error}")))?,
+            OntologyExportFormat::Json => serde_json::to_vec_pretty(&document)
+                .map_err(|error| GfError::Ontology(format!("failed to encode JSON: {error}")))?,
+        };
+        atomic_replace(destination, &bytes)
+    }
+}
+
+fn atomic_replace(destination: &Path, bytes: &[u8]) -> Result<(), GfError> {
+    let parent = destination
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let mut temporary = tempfile::NamedTempFile::new_in(parent).map_err(|error| {
+        GfError::Storage(format!("create ontology export temporary file: {error}"))
+    })?;
+    temporary
+        .write_all(bytes)
+        .and_then(|()| temporary.as_file().sync_all())
+        .map_err(|error| GfError::Storage(format!("write ontology export: {error}")))?;
+    temporary.persist(destination).map_err(|error| {
+        GfError::Storage(format!(
+            "replace ontology export {}: {error}",
+            destination.display()
+        ))
+    })?;
+    Ok(())
+}
+
+fn hex_sha256(bytes: &[u8]) -> String {
+    Sha256::digest(bytes)
+        .iter()
+        .fold(String::with_capacity(64), |mut output, byte| {
+            write!(output, "{byte:02x}").expect("writing to String cannot fail");
+            output
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{AdoptOntologyRequest, OperationId, WriteContext};
+    use gf_core::OntologyMode;
+
+    fn observations(first_order: bool) -> GraphForge {
+        let graph = GraphForge::new(None).unwrap();
+        let catalog = graph.runtime_catalog();
+        let mut catalog = catalog.lock().unwrap();
+        if first_order {
+            catalog.intern_label("Person");
+            catalog.intern_label("Organization");
+        } else {
+            catalog.intern_label("Organization");
+            catalog.intern_label("Person");
+        }
+        catalog.intern_property("name", Some("Person"));
+        catalog.intern_relation_type("WORKS_AT");
+        drop(catalog);
+        graph
+    }
+
+    #[test]
+    fn equivalent_observation_order_produces_identical_suggestion() {
+        let options = || OntologySuggestionOptions {
+            ontology_id: "draft".into(),
+            version: "0.1.0".into(),
+        };
+        let left = observations(true).suggest_ontology(options()).unwrap();
+        let right = observations(false).suggest_ontology(options()).unwrap();
+        assert_eq!(left, right);
+        assert_eq!(left.omitted_relation_types, vec!["WORKS_AT"]);
+        assert!(left.document.relation_types.is_empty());
+        assert!(observations(true).validate_ontology(&left.document).valid);
+    }
+
+    #[test]
+    fn snapshot_hides_runtime_identity_and_orders_entries() {
+        let snapshot = observations(false).inspect_runtime_catalog();
+        let json = serde_json::to_string(&snapshot).unwrap();
+        assert!(!json.contains("runtime_id"));
+        assert!(!json.contains("first_seen"));
+        assert_eq!(snapshot.entries[0].name, "Organization");
+        assert_eq!(snapshot.entries[1].name, "Person");
+    }
+
+    #[test]
+    fn yaml_and_json_exports_are_atomic_valid_documents() {
+        let graph = observations(true);
+        let suggestion = graph
+            .suggest_ontology(OntologySuggestionOptions {
+                ontology_id: "draft".into(),
+                version: "0.1.0".into(),
+            })
+            .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        for (format, name) in [
+            (OntologyExportFormat::Yaml, "ontology.yaml"),
+            (OntologyExportFormat::Json, "ontology.json"),
+        ] {
+            let path = dir.path().join(name);
+            graph
+                .export_ontology(
+                    OntologyExportSource::Suggested(suggestion.document.clone()),
+                    &path,
+                    format,
+                )
+                .unwrap();
+            assert_eq!(
+                gf_ontology::OntologyLoader::load_file(&path).unwrap(),
+                suggestion.document
+            );
+        }
+    }
+
+    #[test]
+    fn validation_and_failed_export_do_not_replace_destination() {
+        let graph = GraphForge::new(None).unwrap();
+        let invalid = OntologyDoc {
+            ontology_id: "bad".into(),
+            version: "1".into(),
+            entity_types: vec![
+                EntityTypeDef {
+                    name: "Duplicate".into(),
+                    r#abstract: false,
+                    parent: None,
+                },
+                EntityTypeDef {
+                    name: "Duplicate".into(),
+                    r#abstract: false,
+                    parent: None,
+                },
+            ],
+            relation_types: vec![],
+            properties: vec![],
+            constraints: vec![],
+            migrations: vec![],
+        };
+        assert!(!graph.validate_ontology(&invalid).valid);
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ontology.json");
+        std::fs::write(&path, b"existing").unwrap();
+        assert!(
+            graph
+                .export_ontology(
+                    OntologyExportSource::Suggested(invalid),
+                    &path,
+                    OntologyExportFormat::Json,
+                )
+                .is_err()
+        );
+        assert_eq!(std::fs::read(path).unwrap(), b"existing");
+    }
+
+    #[test]
+    fn loaded_and_adopted_sources_are_explicit_and_leave_authority_unchanged() {
+        let project = tempfile::tempdir().unwrap();
+        let files = tempfile::tempdir().unwrap();
+        let input = files.path().join("input.yaml");
+        let yaml = "ontology_id: reviewed\nversion: \"1\"\nentity_types:\n  - name: Person\n";
+        std::fs::write(&input, yaml).unwrap();
+        let mut graph = GraphForge::new(Some(project.path().to_str().unwrap())).unwrap();
+
+        graph.load_ontology(input.to_str().unwrap()).unwrap();
+        let loaded = files.path().join("loaded.json");
+        graph
+            .export_ontology(
+                OntologyExportSource::Loaded,
+                &loaded,
+                OntologyExportFormat::Json,
+            )
+            .unwrap();
+        assert_eq!(graph.ontology_mode(), OntologyMode::Advisory);
+
+        graph
+            .adopt_ontology(AdoptOntologyRequest {
+                context: WriteContext {
+                    operation_uuid: OperationId(uuid::Uuid::from_u128(236)),
+                    actor_uuid: None,
+                },
+                path: input,
+                mode: OntologyMode::Strict,
+            })
+            .unwrap();
+        let generation = *graph
+            .current_generation_uuid
+            .lock()
+            .expect("generation UUID lock poisoned");
+        let adopted = files.path().join("adopted.yaml");
+        graph
+            .export_ontology(
+                OntologyExportSource::Adopted,
+                &adopted,
+                OntologyExportFormat::Yaml,
+            )
+            .unwrap();
+        assert_eq!(graph.ontology_mode(), OntologyMode::Strict);
+        assert_eq!(
+            *graph
+                .current_generation_uuid
+                .lock()
+                .expect("generation UUID lock poisoned"),
+            generation
+        );
+        assert_eq!(
+            gf_ontology::OntologyLoader::load_file(&loaded).unwrap(),
+            gf_ontology::OntologyLoader::load_file(&adopted).unwrap()
+        );
+    }
+}

--- a/crates/gf-api/src/workspace_ontology.rs
+++ b/crates/gf-api/src/workspace_ontology.rs
@@ -100,6 +100,7 @@ impl GraphForge {
             &configuration,
         )?;
         self.ontology = Some(OntologyHandle::new(runtime));
+        self.ontology_document = Some(document);
         self.ontology_mode = requested_mode;
         self.adjacency_provider = std::sync::Arc::new(gf_exec::PersistentAdjacencyProvider::new(
             self.dir.clone(),
@@ -124,6 +125,7 @@ impl GraphForge {
             &configuration,
         )?;
         self.ontology = None;
+        self.ontology_document = None;
         self.ontology_mode = OntologyMode::Exploratory;
         self.adjacency_provider = std::sync::Arc::new(gf_exec::PersistentAdjacencyProvider::new(
             self.dir.clone(),

--- a/crates/gf-bindings-node/tests/non-cypher-parity-policy.json
+++ b/crates/gf-bindings-node/tests/non-cypher-parity-policy.json
@@ -1,9 +1,10 @@
 {
   "contractVersion": 1,
   "rustManifest": "../../../tests/contracts/non-cypher-rust-surface.json",
-  "releaseSurfaceCount": 180,
-  "releaseSurfaceDigest": "ca1d54b28ed0cb6b2e57b081020494c35c5c8842a37c6bc349bfa6936cf067a8",
+  "releaseSurfaceCount": 184,
+  "releaseSurfaceDigest": "18028d423dc8968ee8512b3cba2098a2d7d28934b3216416e2b4cd4b72982dc4",
   "rustEvidenceGroupMap": {
+    "ontology-lifecycle": "lifecycleConstruction",
     "lifecycle-construction": "lifecycleConstruction",
     "checkpoint-view": "checkpointView",
     "m18": "m18",

--- a/crates/gf-bindings-py/tests/non_cypher_release.py
+++ b/crates/gf-bindings-py/tests/non_cypher_release.py
@@ -23,10 +23,13 @@ ROOT = Path(__file__).resolve().parents[3]
 RUST_MANIFEST = ROOT / "tests/contracts/non-cypher-rust-surface.json"
 RUST_GATE = ROOT / "scripts/ci/non-cypher-surface-gate.py"
 PYO3_SOURCE = ROOT / "crates/gf-bindings-py/src/lib.rs"
-EXPECTED_RUST_DIGEST = "01a8d14b3c5a4a76ce5f02ad4a3b65c53e5b53b1557c1cbc8ba2779c9cf79360"
-EXPECTED_RELEASE_DIGEST = "ca1d54b28ed0cb6b2e57b081020494c35c5c8842a37c6bc349bfa6936cf067a8"
+EXPECTED_RUST_DIGEST = "7a6ae2cd6d779505cc55246263ec2d9c6557a8da2c2f4499891109f2da1c9196"
+EXPECTED_RELEASE_DIGEST = "18028d423dc8968ee8512b3cba2098a2d7d28934b3216416e2b4cd4b72982dc4"
 
 EVIDENCE = {
+    "ontology-lifecycle": {
+        "non_cypher_release.py": ["check_lifecycle_checkpoint_errors_and_reopen"],
+    },
     "lifecycle-construction": {
         "non_cypher_release.py": ["check_lifecycle_checkpoint_errors_and_reopen"],
     },
@@ -179,7 +182,7 @@ def _classification_report() -> dict[str, object]:
         for group in manifest["method_evidence_groups"].values()
         for method_id in group["ids"]
     }
-    assert len(release_methods) == 180
+    assert len(release_methods) == 184
     assert _digest(release_methods) == EXPECTED_RELEASE_DIGEST
     assert set(EVIDENCE) == set(manifest["method_evidence_groups"])
 

--- a/crates/gf-ontology/src/ontology.rs
+++ b/crates/gf-ontology/src/ontology.rs
@@ -36,7 +36,8 @@ pub struct OntologyDoc {
     /// Validation constraints.
     #[serde(default)]
     pub constraints: Vec<ConstraintDef>,
-    /// Versioned upgrade transforms.
+    /// Versioned upgrade transforms. Authored order is semantic: the migration
+    /// planner uses it to break ties between equal-length routes.
     #[serde(default)]
     pub migrations: Vec<MigrationDef>,
 }

--- a/docs/adr/0003-progressive-ontology.md
+++ b/docs/adr/0003-progressive-ontology.md
@@ -24,7 +24,7 @@ Without an explicit progressive model, several defaults would force ontology-fir
 - The binder would reject unknown labels/types/properties
 - Typed edge tables would require ontology-driven file layout before any write
 - The `GraphPlan` IR envelope would treat `ontology_version` as always required
-- Project layout would assume `ontology.yaml` is always present
+- Project layout would assume an authoritative ontology is always present
 
 This ADR resolves that tension by formalising **three progressive ontology modes**.
 
@@ -46,7 +46,7 @@ GraphForge supports three ontology modes that determine how the system responds 
 - The RuntimeCatalog is persisted to `topology/runtime_catalog.parquet`
 - Typed edge tables are not used in exploratory mode — all edges go to `topology/edges/_exploratory.parquet`
 - The IR envelope carries `ontology_version: None`
-- This is the **default mode when no `ontology.yaml` is present**
+- This is the mode recorded when the committed workspace has no adopted ontology
 
 ### Mode 2: `advisory`
 
@@ -58,7 +58,7 @@ GraphForge supports three ontology modes that determine how the system responds 
 - The RuntimeCatalog tracks schema drift: new types, renamed types, property mismatches
 - Typed edge tables are used for known relation types; unknown types fall back to `_exploratory.parquet`
 - The system may suggest ontology improvements but never blocks data ingestion or queries
-- This is the **default mode when `ontology.yaml` is present** and `ontology_mode` is not explicitly set
+- This mode is selected only by explicit durable ontology adoption
 
 ### Mode 3: `strict`
 
@@ -70,17 +70,20 @@ GraphForge supports three ontology modes that determine how the system responds 
 - All edge types must be declared in the ontology; typed edge tables cover all edges
 - The IR envelope carries a required `ontology_version`
 - Appropriate for production deployments, validated knowledge graphs, compliance workflows
-- Must be **explicitly enabled** via `ontology_mode: strict` in `graphforge.yaml`
+- Must be explicitly selected during durable ontology adoption
 
 ### Default mode logic
 
-| Condition | Default mode |
+| Committed workspace authority | Effective mode |
 |---|---|
-| No `ontology.yaml`, no `ontology_mode` in manifest | `exploratory` |
-| `ontology.yaml` present, no `ontology_mode` in manifest | `advisory` |
-| `ontology_mode: strict` in manifest | `strict` |
-| `ontology_mode: exploratory` in manifest | `exploratory` (override) |
-| `ontology_mode: advisory` in manifest | `advisory` (override) |
+| Explicit ontology absence, published by project initialization or `clear_ontology` | `exploratory` |
+| Adopted ontology with advisory enforcement | `advisory` |
+| Adopted ontology with strict enforcement | `strict` |
+
+Loose `graphforge.yaml` and `ontology.yaml` files are inputs or repository
+configuration, not runtime authority. `load_ontology` is a session-scoped
+override. Only `adopt_ontology` and `clear_ontology` publish durable ontology
+authority and enforcement mode into one committed project generation.
 
 ---
 
@@ -147,32 +150,17 @@ All edge types are pre-declared; typed edge tables cover all edges; `_explorator
 
 ---
 
-## `graphforge.yaml` manifest changes
+## Durable authority amendment
 
-The project manifest gains an `ontology_mode` field:
+The original manifest-based proposal has been superseded by the committed
+workspace ontology and configuration records. Adoption validates the input
+document, publishes its canonical content and advisory/strict mode atomically,
+and then updates the live facade. Clearing publishes explicit ontology absence
+and exploratory mode atomically. Reopen reads only those committed records.
 
-```yaml
-# Exploratory project (no ontology)
-project_uuid: "0195f3a2-..."
-name: "OSINT Investigation Alpha"
-version: "1"
-ontology_mode: exploratory   # default when no ontology.yaml present
-ontology: null
-
-# Advisory project (ontology present, non-enforcing)
-project_uuid: "0195f3a2-..."
-name: "Entity Graph v2"
-version: "1"
-ontology_mode: advisory      # default when ontology.yaml present
-ontology: "./ontology.yaml"
-
-# Strict project (fully validated)
-project_uuid: "0195f3a2-..."
-name: "Production Knowledge Base"
-version: "1"
-ontology_mode: strict        # must be explicitly declared
-ontology: "./ontology.yaml"
-```
+`graphforge.yaml` may describe repository integration, and an ontology YAML/JSON
+file may be passed to `load_ontology` or `adopt_ontology`, but neither loose file
+becomes authority merely by existing in the project directory.
 
 ---
 

--- a/docs/adr/0003-progressive-ontology.md
+++ b/docs/adr/0003-progressive-ontology.md
@@ -105,7 +105,8 @@ RuntimeCatalog
 - Persisted to `topology/runtime_catalog.parquet`
 - Exposed through a deterministic snapshot that omits runtime IDs and timestamps
 - Suggestible as a non-authoritative draft and atomically exportable as YAML/JSON
-- Survives project merges (UUIDs for RuntimeCatalog entries follow the same UUID identity model)
+- Persists within its project generation as `topology/runtime_catalog.parquet`;
+  cross-project merge identity is not defined
 - RuntimeTypeIds are **local** integers (not globally stable like UUID identity) — suitable for query planning within a session, not for cross-project references
 
 Suggestion uses only supported structural evidence: observed labels become

--- a/docs/adr/0003-progressive-ontology.md
+++ b/docs/adr/0003-progressive-ontology.md
@@ -94,15 +94,23 @@ RuntimeCatalog
 ├── relation_types    name → RuntimeTypeId
 ├── property_names    name → RuntimePropId
 ├── statistics        observation counts, first-seen, last-seen timestamps
-└── inference_hints   suggested ontology entries based on observed patterns
+└── observations      structural evidence for conservative ontology drafts
 ```
 
 **Key properties:**
 - Always present (even in strict mode — records what was observed)
 - Persisted to `topology/runtime_catalog.parquet`
-- Exportable to `ontology.yaml` via `forge.export_ontology()` (future feature)
+- Exposed through a deterministic snapshot that omits runtime IDs and timestamps
+- Suggestible as a non-authoritative draft and atomically exportable as YAML/JSON
 - Survives project merges (UUIDs for RuntimeCatalog entries follow the same UUID identity model)
 - RuntimeTypeIds are **local** integers (not globally stable like UUID identity) — suitable for query planning within a session, not for cross-project references
+
+Suggestion uses only supported structural evidence: observed labels become
+entity types and entity-owned properties become nullable UTF-8 declarations.
+Relationship names are surfaced but omitted from the draft because the catalog
+does not retain endpoint evidence. Constraints, inheritance, cardinality,
+semantics, and value types are never guessed. Loading a draft is session-scoped;
+durable authority still requires explicit ontology adoption.
 
 **RuntimeCatalog in the binder (exploratory/advisory modes):**
 

--- a/docs/guide/exploratory-analyst.md
+++ b/docs/guide/exploratory-analyst.md
@@ -121,7 +121,8 @@ configuration, or durable generation.
 
 ## GraphForge Exploratory Mode Features
 
-When no ontology is present (or `ontology_mode: exploratory` is set in `graphforge.yaml`):
+When the committed workspace records explicit ontology absence (at project
+initialization or after `clear_ontology`):
 
 - **No ontology required** — start immediately with `forge.add_node()` / `forge.add_edge()`
 - **Arbitrary labels** — any string is a valid label

--- a/docs/guide/exploratory-analyst.md
+++ b/docs/guide/exploratory-analyst.md
@@ -58,64 +58,60 @@ GraphForge accepts all of this without complaint. The RuntimeCatalog records eve
 
 As the graph grows, the analyst runs queries to discover patterns. GraphForge works with whatever labels and types have been ingested, even without a formal ontology.
 
-```python
-# Who is connected to Alice?
-result = forge.execute("""
-    MATCH (a:Person {name: 'Alice'})-[r]->(b)
-    RETURN b.name, type(r)
-""")
-
-# What entity types have I seen so far?
-catalog = forge.runtime_catalog()
-print(catalog.entity_types())    # ["Person", "Organization", "Document", "UnknownEntity"]
-print(catalog.relation_types())  # ["WORKS_AT", "MENTIONED_IN"]
-
-# What properties have I seen on Person nodes?
-print(catalog.properties_for("Person"))  # ["name", "source"]
+```rust
+// The Rust facade returns a frozen, deterministically ordered product view.
+let catalog = forge.inspect_runtime_catalog();
+for entry in catalog.entries {
+    println!("{:?}: {} ({})", entry.kind, entry.name, entry.observation_count);
+}
 ```
+
+The snapshot deliberately excludes mutable catalog handles, runtime IDs, and
+first/last-seen timestamps. Python and Node parity is tracked separately.
 
 ### Phase 3: Refinement — structure emerges
 
 After exploring the data, the analyst understands the domain better. They start renaming and normalising.
 
-```python
-# I realise "UnknownEntity" should be "Location"
-forge.execute("""
-    MATCH (n:UnknownEntity)
-    SET n:Location
-    REMOVE n:UnknownEntity
-""")
+```rust
+use gf_api::OntologySuggestionOptions;
 
-# I want to see what an ontology would look like for this graph
-suggested_ontology = forge.suggest_ontology()
-print(suggested_ontology)
-# entity_types: [Person, Organization, Document, Location]
-# relation_types: [WORKS_AT, MENTIONED_IN]
-# properties: {Person: [name, source], Organization: [name]}
+let suggestion = forge.suggest_ontology(OntologySuggestionOptions {
+    ontology_id: "analyst-draft".into(),
+    version: "0.1.0".into(),
+})?;
+assert!(suggestion.draft);
+assert!(forge.validate_ontology(&suggestion.document).valid);
 ```
+
+Suggestion is deliberately conservative. Observed labels become concrete entity
+types, and properties with a known entity owner become nullable UTF-8 properties.
+No constraints, inheritance, cardinality, semantic flags, or property value
+types are guessed. Observed relationship names are reported in
+`omitted_relation_types` because the runtime catalog does not retain endpoint
+evidence sufficient to create a valid relation declaration.
 
 ### Phase 4: Formalisation — optional structure
 
 If the analyst wants to enforce constraints or share a validated graph, they can graduate to an ontology.
 
-```python
-# Export a draft ontology
-forge.export_ontology("ontology.yaml")
+```rust
+use gf_api::{OntologyExportFormat, OntologyExportSource};
 
-# Edit ontology.yaml to add constraints, types, cardinality...
-# Then switch to advisory mode
-forge.set_ontology_mode("advisory")
-forge.load_ontology("ontology.yaml")
+forge.export_ontology(
+    OntologyExportSource::Suggested(suggestion.document),
+    std::path::Path::new("ontology.yaml"),
+    OntologyExportFormat::Yaml,
+)?;
 
-# Now the system will warn on schema violations but still accept data
+// Edit and review the draft, then choose authority explicitly:
+forge.load_ontology("ontology.yaml")?; // session-scoped
+// or forge.adopt_ontology(...)?;      // durable project authority
 ```
 
-For production graphs, strict mode enforces all constraints:
-
-```python
-forge.set_ontology_mode("strict")
-# Now unknown labels will raise BindError
-```
+`Loaded` and `Adopted` are also explicit export sources. Export validates and
+serializes before atomically replacing the destination; it never changes the
+live mode, loaded ontology, project configuration, or durable generation.
 
 ---
 

--- a/docs/guide/exploratory-analyst.md
+++ b/docs/guide/exploratory-analyst.md
@@ -60,7 +60,7 @@ As the graph grows, the analyst runs queries to discover patterns. GraphForge wo
 
 ```rust
 // The Rust facade returns a frozen, deterministically ordered product view.
-let catalog = forge.inspect_runtime_catalog();
+let catalog = forge.inspect_runtime_catalog()?;
 for entry in catalog.entries {
     println!("{:?}: {} ({})", entry.kind, entry.name, entry.observation_count);
 }
@@ -110,8 +110,10 @@ forge.load_ontology("ontology.yaml")?; // session-scoped
 ```
 
 `Loaded` and `Adopted` are also explicit export sources. Export validates and
-serializes before atomically replacing the destination; it never changes the
-live mode, loaded ontology, project configuration, or durable generation.
+canonicalizes declaration order before serializing and atomically replacing the
+destination. This applies to caller-supplied `Suggested` documents as well as
+loaded and adopted documents. Export never changes the live mode, loaded
+ontology, project configuration, or durable generation.
 
 ---
 

--- a/docs/guide/exploratory-analyst.md
+++ b/docs/guide/exploratory-analyst.md
@@ -110,10 +110,12 @@ forge.load_ontology("ontology.yaml")?; // session-scoped
 ```
 
 `Loaded` and `Adopted` are also explicit export sources. Export validates and
-canonicalizes declaration order before serializing and atomically replacing the
-destination. This applies to caller-supplied `Suggested` documents as well as
-loaded and adopted documents. Export never changes the live mode, loaded
-ontology, project configuration, or durable generation.
+canonicalizes entity, relation, property, and constraint declaration order
+before serializing and atomically replacing the destination. Authored migration
+order is preserved because it breaks ties between equal-length migration routes.
+This applies to caller-supplied `Suggested` documents as well as loaded and
+adopted documents. Export never changes the live mode, loaded ontology, project
+configuration, or durable generation.
 
 ---
 

--- a/scripts/ci/test-non-cypher-surface-gate.py
+++ b/scripts/ci/test-non-cypher-surface-gate.py
@@ -29,7 +29,7 @@ class SurfaceGateTests(unittest.TestCase):
 
     def test_checked_in_inventory_is_complete(self) -> None:
         self.assertEqual(GATE.validate(), [])
-        self.assertEqual(len(GATE.public_methods()), 261)
+        self.assertEqual(len(GATE.public_methods()), 265)
         self.assertEqual(len(GATE.m18_registry()), 94)
 
     def test_new_or_removed_public_method_fails_frozen_digest(self) -> None:

--- a/tests/contracts/non-cypher-rust-surface.json
+++ b/tests/contracts/non-cypher-rust-surface.json
@@ -92,9 +92,13 @@
       ],
       "test_refs": [
         {"path": "crates/gf-api/src/ontology_lifecycle.rs", "symbol": "snapshot_hides_runtime_identity_and_orders_entries"},
+        {"path": "crates/gf-api/src/ontology_lifecycle.rs", "symbol": "catalog_inspection_reports_poisoned_lock_and_schema_mismatch"},
         {"path": "crates/gf-api/src/ontology_lifecycle.rs", "symbol": "equivalent_observation_order_produces_identical_suggestion"},
         {"path": "crates/gf-api/src/ontology_lifecycle.rs", "symbol": "yaml_and_json_exports_are_atomic_valid_documents"},
-        {"path": "crates/gf-api/src/ontology_lifecycle.rs", "symbol": "validation_and_failed_export_do_not_replace_destination"}
+        {"path": "crates/gf-api/src/ontology_lifecycle.rs", "symbol": "suggested_source_is_canonicalized_before_serialization"},
+        {"path": "crates/gf-api/src/ontology_lifecycle.rs", "symbol": "validation_and_failed_export_do_not_replace_destination"},
+        {"path": "crates/gf-api/src/ontology_lifecycle.rs", "symbol": "loaded_and_adopted_sources_are_explicit_and_leave_authority_unchanged"},
+        {"path": "crates/gf-api/src/ontology_lifecycle.rs", "symbol": "filesystem_failure_preserves_destination_and_cleans_temporary_file"}
       ]
     },
     "lifecycle-construction": {

--- a/tests/contracts/non-cypher-rust-surface.json
+++ b/tests/contracts/non-cypher-rust-surface.json
@@ -96,6 +96,7 @@
         {"path": "crates/gf-api/src/ontology_lifecycle.rs", "symbol": "equivalent_observation_order_produces_identical_suggestion"},
         {"path": "crates/gf-api/src/ontology_lifecycle.rs", "symbol": "yaml_and_json_exports_are_atomic_valid_documents"},
         {"path": "crates/gf-api/src/ontology_lifecycle.rs", "symbol": "suggested_source_is_canonicalized_before_serialization"},
+        {"path": "crates/gf-api/src/ontology_lifecycle.rs", "symbol": "export_round_trip_preserves_migration_route_tie_breaking"},
         {"path": "crates/gf-api/src/ontology_lifecycle.rs", "symbol": "validation_and_failed_export_do_not_replace_destination"},
         {"path": "crates/gf-api/src/ontology_lifecycle.rs", "symbol": "loaded_and_adopted_sources_are_explicit_and_leave_authority_unchanged"},
         {"path": "crates/gf-api/src/ontology_lifecycle.rs", "symbol": "filesystem_failure_preserves_destination_and_cleans_temporary_file"}

--- a/tests/contracts/non-cypher-rust-surface.json
+++ b/tests/contracts/non-cypher-rust-surface.json
@@ -1,7 +1,7 @@
 {
   "contract_version": 1,
   "scope": "Rust non-Cypher public release surface",
-  "public_method_digest": "01a8d14b3c5a4a76ce5f02ad4a3b65c53e5b53b1557c1cbc8ba2779c9cf79360",
+  "public_method_digest": "7a6ae2cd6d779505cc55246263ec2d9c6557a8da2c2f4499891109f2da1c9196",
   "method_policy": {
     "receiver_defaults": {
       "GraphForge": "release-tested",
@@ -85,6 +85,18 @@
     }
   },
   "method_evidence_groups": {
+    "ontology-lifecycle": {
+      "ids": [
+        "GraphForge.export_ontology", "GraphForge.inspect_runtime_catalog",
+        "GraphForge.suggest_ontology", "GraphForge.validate_ontology"
+      ],
+      "test_refs": [
+        {"path": "crates/gf-api/src/ontology_lifecycle.rs", "symbol": "snapshot_hides_runtime_identity_and_orders_entries"},
+        {"path": "crates/gf-api/src/ontology_lifecycle.rs", "symbol": "equivalent_observation_order_produces_identical_suggestion"},
+        {"path": "crates/gf-api/src/ontology_lifecycle.rs", "symbol": "yaml_and_json_exports_are_atomic_valid_documents"},
+        {"path": "crates/gf-api/src/ontology_lifecycle.rs", "symbol": "validation_and_failed_export_do_not_replace_destination"}
+      ]
+    },
     "lifecycle-construction": {
       "ids": [
         "GraphForge.add_edge", "GraphForge.add_edges", "GraphForge.add_node", "GraphForge.add_nodes",


### PR DESCRIPTION
## Summary

- expose a fallible, immutable, deterministically ordered runtime-catalog snapshot without runtime IDs, timestamps, locks, mutable state, or panic paths
- generate conservative non-authoritative ontology drafts with canonical fingerprints and explicit omitted-relation evidence
- add structured non-mutating validation and explicit `Suggested` / `Loaded` / `Adopted` atomic YAML/JSON export
- canonicalize non-migration declarations before serialization while preserving authored migration order as a semantic route tie-breaker
- retain the live ontology source document so session-loaded and adopted exports preserve distinct reviewed contracts
- correct authority and catalog identity docs: only `adopt_ontology` / `clear_ontology` publish durable authority, and runtime catalog IDs remain project-local
- update `[Unreleased]`, the non-Cypher Rust inventory, and Python/Node parity projections

Closes #236

## Inference and canonicalization policy

- observed labels become concrete entity types
- entity-owned observed properties become nullable UTF-8 properties because the catalog has no value evidence
- relation names are returned in `omitted_relation_types`; endpoints are not guessed
- constraints, inheritance, cardinality, semantic flags, property value types, defaults, and multivalue claims are never inferred
- entity, relation, property, and constraint declaration vectors are deterministically sorted before export
- migration order is preserved because `MigrationEngine::plan` uses authored adjacency order to break ties between equal-length routes

## BDD evidence

- catalog identity/order: `snapshot_hides_runtime_identity_and_orders_entries`
- poisoned lock and schema mismatch errors: `catalog_inspection_reports_poisoned_lock_and_schema_mismatch`
- equivalent observation order plus byte-identical YAML/JSON: `equivalent_observation_order_produces_identical_suggestion`
- YAML/JSON round-trip validation: `yaml_and_json_exports_are_atomic_valid_documents`
- caller-supplied suggestion canonicalization: `suggested_source_is_canonicalized_before_serialization`
- competing shortest migration route preservation: `export_round_trip_preserves_migration_route_tie_breaking`
- validation failure / destination preservation: `validation_and_failed_export_do_not_replace_destination`
- distinct session-loaded vs durable adopted authority and reopen: `loaded_and_adopted_sources_are_explicit_and_leave_authority_unchanged`
- filesystem failure and sibling-temp cleanup: `filesystem_failure_preserves_destination_and_cleans_temporary_file`

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo test -p gf-api ontology_lifecycle --lib` — passed (9 tests)
- `cargo clippy -p gf-api --lib --no-deps -- -D warnings` — passed
- `python3 scripts/ci/non-cypher-surface-gate.py` — passed (265 methods, 94 M18 entries, 22 M19 contracts)
- `python3 scripts/ci/test-non-cypher-surface-gate.py` — passed (12 tests)
- Python parity classification projection — passed (265 classified methods)
- Node parity policy count/digest/group projection — passed (184 release methods); the complete local Node test could not run because this isolated worktree has no installed `apache-arrow` dependency
- CodeRabbit local re-review of the corrective diff — 0 findings

Full dependency lint is not claimed green on the current base. `cargo clippy -p gf-api --all-targets -- -D warnings` stops in unchanged `crates/gf-storage/src/project_failpoint.rs:39,42` on two pre-existing `clippy::map_unwrap_or` findings. The all-targets change-local pass also reports existing test-only `gf-api` lints outside this diff; this PR does not alter or suppress them.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add deterministic ontology lifecycle surface to `GraphForge`
> - Adds four new `GraphForge` methods: `inspect_runtime_catalog()` for a stable ID/timestamp-free catalog snapshot, `suggest_ontology()` for a conservative draft derived from observations, `validate_ontology()` for non-mutating structured validation, and `export_ontology()` for atomic YAML/JSON export from an explicit source (Suggested/Loaded/Adopted).
> - `GraphForge` now retains the loaded `OntologyDoc` through all construction paths (`new`, `open_resolved_with_options`, `load_ontology`, `adopt_ontology`), and clears it on `clear_ontology`.
> - Export canonicalizes declaration order (preserving authored migration order for semantic correctness), validates the document, and atomically replaces the destination file.
> - Public API surface count increases from 261 to 265; new types (`CatalogEntryKind`, `OntologyExportFormat`, `OntologyExportSource`, `OntologySuggestion`, `OntologyValidationReport`, etc.) are re-exported from `gf-api`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 840346a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->