### PR TITLE
fix(dx): stabilize checkpoint and revert CLI contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Stabilize Rust CLI machine output with repository-relative JSON receipts,
+  bounded structured error details, schema-first checkpoint/revert JSON,
+  authoritative `checkpoint show`, and non-mutating revert preview with
+  required explicit `--yes` confirmation (#243).
 - Package host-discoverable project-local GraphForge skills from one canonical
   source in both the `graphforge` wheel and `@graphforge/cli`, with
   deterministic compatibility metadata and byte-parity checks (#230).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2043,6 +2043,7 @@ dependencies = [
  "arrow",
  "clap",
  "gf-api",
+ "serde",
  "serde_json",
  "tempfile",
  "uuid",

--- a/crates/gf-api/src/checkpoints.rs
+++ b/crates/gf-api/src/checkpoints.rs
@@ -36,6 +36,13 @@ pub struct ListCheckpointsRequest {
     pub page: PageRequest,
 }
 
+/// Show-checkpoint request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ShowCheckpointRequest {
+    /// Exact active checkpoint name.
+    pub name: String,
+}
+
 /// Delete-checkpoint request.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DeleteCheckpointRequest {
@@ -58,6 +65,26 @@ pub struct RevertCheckpointRequest {
     pub idempotency_key: OperationId,
     /// Optional actor identity.
     pub actor_uuid: Option<Uuid>,
+}
+
+/// Non-mutating checkpoint-revert preview request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PreviewRevertCheckpointRequest {
+    /// Exact active checkpoint name.
+    pub name: String,
+}
+
+/// Identities a caller must inspect before authorizing a checkpoint revert.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RevertCheckpointPreview {
+    /// Stable checkpoint identity.
+    pub checkpoint_uuid: Uuid,
+    /// Complete generation pinned by the checkpoint.
+    pub source_generation_uuid: Uuid,
+    /// SHA-256 of the pinned generation's canonical manifest.
+    pub source_manifest_sha256: String,
+    /// Generation that is current at preview time.
+    pub current_generation_uuid: Uuid,
 }
 
 /// Named checkpoint or the current committed generation.
@@ -641,6 +668,35 @@ impl GraphForge {
         // short list still surfaces GF_CANCELLED instead of a late success.
         cancellation(&page)?;
         Ok(result)
+    }
+
+    /// Show the authoritative metadata for one active named checkpoint.
+    pub fn show_checkpoint(
+        &self,
+        request: ShowCheckpointRequest,
+    ) -> Result<ExecutionResult, GfError> {
+        let ShowCheckpointRequest { name } = request;
+        let (checkpoint, _) = gf_storage::open_checkpoint_generation(
+            self.resolved_generation.container_root(),
+            &name,
+        )?;
+        checkpoint_rows(std::slice::from_ref(&checkpoint), None)
+    }
+
+    /// Inspect checkpoint and current-generation identities without mutation.
+    pub fn preview_revert_to_checkpoint(
+        path: impl AsRef<std::path::Path>,
+        request: PreviewRevertCheckpointRequest,
+    ) -> Result<RevertCheckpointPreview, GfError> {
+        let PreviewRevertCheckpointRequest { name } = request;
+        let current = gf_storage::resolve_project_generation(path.as_ref())?;
+        let (checkpoint, _) = gf_storage::open_checkpoint_generation(path.as_ref(), &name)?;
+        Ok(RevertCheckpointPreview {
+            checkpoint_uuid: checkpoint.checkpoint_uuid,
+            source_generation_uuid: checkpoint.generation_uuid,
+            source_manifest_sha256: checkpoint.generation_manifest_sha256,
+            current_generation_uuid: current.generation_uuid(),
+        })
     }
 
     /// Open an immutable view pinned to the named checkpoint generation.
@@ -1731,6 +1787,13 @@ fn receipt_result(row: &gf_storage::CheckpointReceipt) -> ExecutionResult {
     source
         .append_value(row.source_generation_uuid.as_bytes())
         .expect("UUID width is fixed by the checkpoint receipt contract");
+    let mut prior_current = FixedSizeBinaryBuilder::with_capacity(1, 16);
+    match row.prior_current_generation_uuid {
+        Some(value) => prior_current
+            .append_value(value.as_bytes())
+            .expect("UUID width is fixed by the checkpoint receipt contract"),
+        None => prior_current.append_null(),
+    }
     let mut result = FixedSizeBinaryBuilder::with_capacity(1, 16);
     match row.result_generation_uuid {
         Some(value) => result
@@ -1751,6 +1814,11 @@ fn receipt_result(row: &gf_storage::CheckpointReceipt) -> ExecutionResult {
             "source_generation_uuid",
             DataType::FixedSizeBinary(16),
             false,
+        ),
+        Field::new(
+            "prior_current_generation_uuid",
+            DataType::FixedSizeBinary(16),
+            true,
         ),
         Field::new(
             "result_generation_uuid",
@@ -1774,6 +1842,7 @@ fn receipt_result(row: &gf_storage::CheckpointReceipt) -> ExecutionResult {
                 Arc::new(checkpoint.finish()),
                 Arc::new(name.finish()),
                 Arc::new(source.finish()),
+                Arc::new(prior_current.finish()),
                 Arc::new(result.finish()),
                 Arc::new(revision.finish()),
                 Arc::new(at.finish()),
@@ -2081,6 +2150,81 @@ mod tests {
 
         assert_eq!(error.code(), "GF_VALIDATION");
         assert!(error.to_string().contains("dangling confidence assertion"));
+    }
+
+    #[test]
+    fn revert_preview_is_non_mutating_and_receipt_identifies_prior_current() {
+        let directory = tempdir().unwrap();
+        let path = directory.path().to_str().unwrap();
+        let mut graph = GraphForge::new(Some(path)).unwrap();
+        graph
+            .execute("CREATE (:State {value: 'checkpoint'})")
+            .unwrap();
+        graph
+            .checkpoint(CheckpointRequest {
+                name: "Before".into(),
+                description: Some("preview target".into()),
+                idempotency_key: operation(140),
+                actor_uuid: None,
+            })
+            .unwrap();
+        let (checkpoint, _) =
+            gf_storage::open_checkpoint_generation(directory.path(), "Before").unwrap();
+        graph.execute("CREATE (:State {value: 'current'})").unwrap();
+        let current_before = graph.generation_for_read().unwrap().generation_uuid();
+        let generations_before = std::fs::read_dir(directory.path().join("generations"))
+            .unwrap()
+            .count();
+
+        let preview = GraphForge::preview_revert_to_checkpoint(
+            directory.path(),
+            PreviewRevertCheckpointRequest {
+                name: "Before".into(),
+            },
+        )
+        .unwrap();
+        assert_eq!(preview.checkpoint_uuid, checkpoint.checkpoint_uuid);
+        assert_eq!(preview.source_generation_uuid, checkpoint.generation_uuid);
+        assert_eq!(
+            preview.source_manifest_sha256,
+            checkpoint.generation_manifest_sha256
+        );
+        assert_eq!(preview.current_generation_uuid, current_before);
+        assert_eq!(
+            graph.generation_for_read().unwrap().generation_uuid(),
+            current_before
+        );
+        assert_eq!(
+            std::fs::read_dir(directory.path().join("generations"))
+                .unwrap()
+                .count(),
+            generations_before
+        );
+
+        let missing = GraphForge::preview_revert_to_checkpoint(
+            directory.path(),
+            PreviewRevertCheckpointRequest {
+                name: "Missing".into(),
+            },
+        )
+        .unwrap_err();
+        assert_eq!(missing.code(), "GF_CHECKPOINT_NOT_FOUND");
+
+        let receipt = graph
+            .revert_to_checkpoint(RevertCheckpointRequest {
+                name: "Before".into(),
+                reason: "previewed identities".into(),
+                idempotency_key: operation(141),
+                actor_uuid: None,
+            })
+            .unwrap();
+        let prior_current = receipt.batches[0]
+            .column_by_name("prior_current_generation_uuid")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .unwrap();
+        assert_eq!(prior_current.value(0), current_before.as_bytes());
     }
 
     #[test]
@@ -2535,6 +2679,41 @@ mod tests {
                 .code(),
             "GF_PAGE_SNAPSHOT_GONE"
         );
+    }
+
+    #[test]
+    fn show_checkpoint_returns_the_exact_list_metadata_row_and_rejects_unknown_names() {
+        let directory = tempdir().unwrap();
+        let graph = GraphForge::new(Some(directory.path().to_str().unwrap())).unwrap();
+        let actor_uuid = Uuid::from_u128(91);
+        graph
+            .checkpoint(CheckpointRequest {
+                name: "Release".into(),
+                description: Some("ready to publish".into()),
+                idempotency_key: operation(90),
+                actor_uuid: Some(actor_uuid),
+            })
+            .unwrap();
+
+        let listed = graph
+            .list_checkpoints(ListCheckpointsRequest::default())
+            .unwrap();
+        let shown = graph
+            .show_checkpoint(ShowCheckpointRequest {
+                name: "Release".into(),
+            })
+            .unwrap();
+
+        assert_eq!(shown.schema, listed.schema);
+        assert_eq!(shown.batches, listed.batches);
+        assert_eq!(shown.batches[0].num_rows(), 1);
+
+        let error = graph
+            .show_checkpoint(ShowCheckpointRequest {
+                name: "release".into(),
+            })
+            .unwrap_err();
+        assert_eq!(error.code(), "GF_CHECKPOINT_NOT_FOUND");
     }
 
     #[test]

--- a/crates/gf-api/src/lib.rs
+++ b/crates/gf-api/src/lib.rs
@@ -151,7 +151,8 @@ pub use capabilities::{
 pub use checkpoints::{
     CheckpointDiffDetail, CheckpointDiffScope, CheckpointRequest, CheckpointSelector,
     CheckpointView, DeleteCheckpointRequest, DiffCheckpointsRequest, ListCheckpointsRequest,
-    RevertCheckpointRequest,
+    PreviewRevertCheckpointRequest, RevertCheckpointPreview, RevertCheckpointRequest,
+    ShowCheckpointRequest,
 };
 pub use composite_receipt::{
     authorize_composite_transaction, composite_generation_uuid, composite_receipt_schema,

--- a/crates/gf-bindings-py/tests/cli_smoke.py
+++ b/crates/gf-bindings-py/tests/cli_smoke.py
@@ -39,8 +39,9 @@ def main() -> None:
     assert invalid.returncode == 3, invalid
     error = json.loads(invalid.stderr)
     assert list(error) == ["error"]
-    assert list(error["error"]) == ["code", "message"]
+    assert list(error["error"]) == ["code", "message", "details"]
     assert error["error"]["code"] == "GF_IO"
+    assert error["error"]["details"] == {"source": "runtime", "kind": "storage"}
     assert invalid.stdout == ""
 
 

--- a/crates/gf-bindings-py/tests/non_cypher_release.py
+++ b/crates/gf-bindings-py/tests/non_cypher_release.py
@@ -23,7 +23,7 @@ ROOT = Path(__file__).resolve().parents[3]
 RUST_MANIFEST = ROOT / "tests/contracts/non-cypher-rust-surface.json"
 RUST_GATE = ROOT / "scripts/ci/non-cypher-surface-gate.py"
 PYO3_SOURCE = ROOT / "crates/gf-bindings-py/src/lib.rs"
-EXPECTED_RUST_DIGEST = "0a70ef6973c53b43c7dd8fba453edb702c01dd7a57ad2a6f5d7b641325be6db2"
+EXPECTED_RUST_DIGEST = "35ede905127bf32a6e3048da1f8623f8c8c174bdd3275666164edcbbd1704a02"
 EXPECTED_RELEASE_DIGEST = "18028d423dc8968ee8512b3cba2098a2d7d28934b3216416e2b4cd4b72982dc4"
 
 EVIDENCE = {

--- a/crates/gf-cli/Cargo.toml
+++ b/crates/gf-cli/Cargo.toml
@@ -16,6 +16,7 @@ arrow = { workspace = true }
 gf-api = { path = "../gf-api" }
 clap = { workspace = true }
 uuid = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]

--- a/crates/gf-cli/src/lib.rs
+++ b/crates/gf-cli/src/lib.rs
@@ -4,6 +4,7 @@
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 
+use arrow::datatypes::DataType;
 use arrow::ipc::writer::StreamWriter;
 use clap::{Args, Parser, Subcommand, ValueEnum, error::ErrorKind};
 use gf_api::{
@@ -11,7 +12,8 @@ use gf_api::{
     DeleteCheckpointRequest, DiffCheckpointsRequest, ExecutionResult, GraphForge,
     ListCheckpointsRequest, OperationId, PageRequest, PageToken, PortableExportRequest,
     PortableExportResult, PortableImportRequest, PortableImportResult, PortableSelection,
-    RepositoryContext, RevertCheckpointRequest,
+    PreviewRevertCheckpointRequest, RepositoryContext, RevertCheckpointPreview,
+    RevertCheckpointRequest, ShowCheckpointRequest,
 };
 use uuid::Uuid;
 
@@ -218,7 +220,7 @@ struct Cli {
     #[arg(long, global = true)]
     project_dir: Option<PathBuf>,
 
-    /// Emit the stable JSON result for repository lifecycle commands.
+    /// Emit the stable machine-readable JSON result when supported.
     #[arg(long, global = true)]
     json: bool,
 
@@ -308,6 +310,8 @@ enum CheckpointCommand {
     Create(CreateArgs),
     /// List active checkpoints in canonical order.
     List(PageArgs),
+    /// Show authoritative metadata for one active checkpoint.
+    Show(ShowArgs),
     /// Execute one read-only Cypher query against a checkpoint.
     Open(OpenArgs),
     /// Delete an active checkpoint reference.
@@ -335,6 +339,11 @@ struct PageArgs {
     limit: u32,
     #[arg(long)]
     after: Option<String>,
+}
+
+#[derive(Args)]
+struct ShowArgs {
+    name: String,
 }
 
 #[derive(Args)]
@@ -399,13 +408,19 @@ struct DiffArgs {
 struct RevertArgs {
     name: String,
     /// Required bounded audit reason.
-    #[arg(long)]
-    reason: String,
+    #[arg(long, required_unless_present = "preview")]
+    reason: Option<String>,
     /// Required canonical UUID used for idempotent replay.
-    #[arg(long)]
-    idempotency_key: String,
+    #[arg(long, required_unless_present = "preview")]
+    idempotency_key: Option<String>,
     #[arg(long)]
     actor_uuid: Option<String>,
+    /// Explicitly authorize this destructive operation in automation.
+    #[arg(long, conflicts_with = "preview")]
+    yes: bool,
+    /// Inspect the checkpoint and current generation without mutation.
+    #[arg(long)]
+    preview: bool,
 }
 
 #[derive(Args)]
@@ -488,6 +503,108 @@ fn write_result(result: &ExecutionResult, output: &mut dyn Write) -> Result<(), 
     output
         .flush()
         .map_err(|error| gf_api::GfError::Execution(error.to_string()))
+}
+
+#[derive(serde::Serialize)]
+struct JsonResultColumn<'a> {
+    name: &'a str,
+    data_type: String,
+    nullable: bool,
+}
+
+#[derive(serde::Serialize)]
+struct JsonExecutionResult<'a> {
+    contract: &'static str,
+    columns: Vec<JsonResultColumn<'a>>,
+    metadata: std::collections::BTreeMap<&'a str, &'a str>,
+    rows: Vec<Vec<serde_json::Value>>,
+}
+
+fn canonical_json_value(
+    value: serde_json::Value,
+    data_type: &DataType,
+) -> Result<serde_json::Value, gf_api::GfError> {
+    match (value, data_type) {
+        (serde_json::Value::String(hex), DataType::FixedSizeBinary(16)) => {
+            if hex.len() != 32 {
+                return Err(gf_api::GfError::Execution(
+                    "invalid 16-byte JSON result value".into(),
+                ));
+            }
+            let bytes = (0..hex.len())
+                .step_by(2)
+                .map(|index| u8::from_str_radix(&hex[index..index + 2], 16))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|error| gf_api::GfError::Execution(error.to_string()))?;
+            Ok(serde_json::Value::String(
+                Uuid::from_slice(&bytes)
+                    .map_err(|error| gf_api::GfError::Execution(error.to_string()))?
+                    .hyphenated()
+                    .to_string(),
+            ))
+        }
+        (value, _) => Ok(value),
+    }
+}
+
+fn write_json_result(
+    result: &ExecutionResult,
+    output: &mut dyn Write,
+) -> Result<(), gf_api::GfError> {
+    let mut encoded = arrow::json::ArrayWriter::new(Vec::new());
+    let batches = result.batches.iter().collect::<Vec<_>>();
+    encoded
+        .write_batches(&batches)
+        .and_then(|()| encoded.finish())
+        .map_err(|error| gf_api::GfError::Execution(error.to_string()))?;
+    let objects: Vec<serde_json::Map<String, serde_json::Value>> =
+        serde_json::from_slice(&encoded.into_inner())
+            .map_err(|error| gf_api::GfError::Execution(error.to_string()))?;
+    let fields = result.schema.fields();
+    let mut rows = Vec::with_capacity(objects.len());
+    for mut object in objects {
+        let mut row = Vec::with_capacity(fields.len());
+        for field in fields {
+            let value = object
+                .remove(field.name())
+                .unwrap_or(serde_json::Value::Null);
+            row.push(canonical_json_value(value, field.data_type())?);
+        }
+        rows.push(row);
+    }
+    let value = JsonExecutionResult {
+        contract: "graphforge-cli-result/1",
+        columns: fields
+            .iter()
+            .map(|field| JsonResultColumn {
+                name: field.name(),
+                data_type: field.data_type().to_string(),
+                nullable: field.is_nullable(),
+            })
+            .collect(),
+        metadata: result
+            .schema
+            .metadata()
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_str()))
+            .collect(),
+        rows,
+    };
+    serde_json::to_writer(&mut *output, &value)
+        .map_err(|error| gf_api::GfError::Execution(error.to_string()))?;
+    writeln!(output).map_err(|error| gf_api::GfError::Execution(error.to_string()))
+}
+
+fn write_execution_result(
+    result: &ExecutionResult,
+    json: bool,
+    output: &mut dyn Write,
+) -> Result<(), gf_api::GfError> {
+    if json {
+        write_json_result(result, output)
+    } else {
+        write_result(result, output)
+    }
 }
 
 fn write_export_result(
@@ -582,6 +699,111 @@ fn run_export(
     write_export_result(&result, json, output)
 }
 
+#[derive(serde::Serialize)]
+struct JsonRevertPreview<'a> {
+    contract: &'static str,
+    checkpoint_uuid: Uuid,
+    source_generation_uuid: Uuid,
+    source_manifest_sha256: &'a str,
+    current_generation_uuid: Uuid,
+}
+
+fn write_revert_preview(
+    preview: &RevertCheckpointPreview,
+    json: bool,
+    output: &mut dyn Write,
+) -> Result<(), gf_api::GfError> {
+    if json {
+        serde_json::to_writer(
+            &mut *output,
+            &JsonRevertPreview {
+                contract: "graphforge-revert-preview/1",
+                checkpoint_uuid: preview.checkpoint_uuid,
+                source_generation_uuid: preview.source_generation_uuid,
+                source_manifest_sha256: &preview.source_manifest_sha256,
+                current_generation_uuid: preview.current_generation_uuid,
+            },
+        )
+        .map_err(|error| gf_api::GfError::Execution(error.to_string()))?;
+        writeln!(output).map_err(|error| gf_api::GfError::Execution(error.to_string()))?;
+    } else {
+        writeln!(
+            output,
+            "checkpoint {} pins generation {} (sha256 {}); current generation is {}",
+            preview.checkpoint_uuid,
+            preview.source_generation_uuid,
+            preview.source_manifest_sha256,
+            preview.current_generation_uuid
+        )
+        .map_err(|error| gf_api::GfError::Execution(error.to_string()))?;
+    }
+    Ok(())
+}
+
+fn run_revert_preview(
+    path: &Path,
+    name: String,
+    json: bool,
+    output: &mut dyn Write,
+) -> Result<(), gf_api::GfError> {
+    let preview =
+        GraphForge::preview_revert_to_checkpoint(path, PreviewRevertCheckpointRequest { name })?;
+    write_revert_preview(&preview, json, output)
+}
+
+fn run_revert(
+    graph: &mut GraphForge,
+    args: RevertArgs,
+    json: bool,
+    output: &mut dyn Write,
+) -> Result<(), gf_api::GfError> {
+    debug_assert!(args.yes && !args.preview);
+    let result = graph.revert_to_checkpoint(RevertCheckpointRequest {
+        name: args.name,
+        reason: args
+            .reason
+            .expect("clap requires --reason unless --preview is present"),
+        idempotency_key: OperationId(canonical_uuid(
+            args.idempotency_key
+                .as_deref()
+                .expect("clap requires --idempotency-key unless --preview is present"),
+        )?),
+        actor_uuid: actor(args.actor_uuid.as_deref())?,
+    })?;
+    write_execution_result(&result, json, output)
+}
+
+fn revert_args(command: &Command) -> Option<&RevertArgs> {
+    match command {
+        Command::Revert(args)
+        | Command::Checkpoint {
+            command: CheckpointCommand::Revert(args),
+        } => Some(args),
+        _ => None,
+    }
+}
+
+fn handle_revert_before_open(
+    command: &Command,
+    path: &Path,
+    json: bool,
+    output: &mut dyn Write,
+) -> Result<bool, gf_api::GfError> {
+    let Some(args) = revert_args(command) else {
+        return Ok(false);
+    };
+    if args.preview {
+        run_revert_preview(path, args.name.clone(), json, output)?;
+        return Ok(true);
+    }
+    if !args.yes {
+        return Err(gf_api::GfError::Validation(
+            "revert requires explicit confirmation with --yes".into(),
+        ));
+    }
+    Ok(false)
+}
+
 fn run_repository(
     command: Command,
     project_dir: Option<PathBuf>,
@@ -608,15 +830,21 @@ fn run_repository(
                 Some(repository.skills_install(skill_bundle, false)?)
             };
             serde_json::to_value(serde_json::json!({
-                "root": init.root,
+                "root": ".",
                 "created_config": init.created_config,
                 "ignore_changed": init.ignore_changed,
-                "state": init.state,
+                "state": ".graphforge/state",
                 "skills": skills
             }))
         }
         Command::Sync => serde_json::to_value(repository.sync()?),
-        Command::Remove(args) => serde_json::to_value(repository.remove(args.yes)?),
+        Command::Remove(args) => {
+            let receipt = repository.remove(args.yes)?;
+            serde_json::to_value(serde_json::json!({
+                "target": ".graphforge/state",
+                "removed": receipt.removed
+            }))
+        }
         Command::Config {
             command: ConfigCommand::Validate,
         } => {
@@ -742,21 +970,25 @@ fn run(cli: Cli, output: &mut dyn Write) -> Result<(), gf_api::GfError> {
         Command::Import(args) => return run_import(args, &path, cli.json, output),
         command => command,
     };
-    let path = path
+    if handle_revert_before_open(&command, &path, cli.json, output)? {
+        return Ok(());
+    }
+    let path_text = path
         .to_str()
         .ok_or_else(|| gf_api::GfError::Validation("--project must be valid UTF-8".into()))?;
-    let mut graph = GraphForge::new(Some(path))?;
+    let mut graph = GraphForge::new(Some(path_text))?;
     let command = match command {
         Command::Export(args) => return run_export(&graph, args, cli.json, output),
         command => command,
     };
+    let command = match command {
+        Command::Revert(args)
+        | Command::Checkpoint {
+            command: CheckpointCommand::Revert(args),
+        } => return run_revert(&mut graph, args, cli.json, output),
+        command => command,
+    };
     let result = match command {
-        Command::Revert(args) => graph.revert_to_checkpoint(RevertCheckpointRequest {
-            name: args.name,
-            reason: args.reason,
-            idempotency_key: OperationId(canonical_uuid(&args.idempotency_key)?),
-            actor_uuid: actor(args.actor_uuid.as_deref())?,
-        })?,
         Command::Checkpoint { command } => match command {
             CheckpointCommand::Create(args) => graph.checkpoint(CheckpointRequest {
                 name: args.name,
@@ -766,6 +998,9 @@ fn run(cli: Cli, output: &mut dyn Write) -> Result<(), gf_api::GfError> {
             })?,
             CheckpointCommand::List(args) => {
                 graph.list_checkpoints(ListCheckpointsRequest { page: page(&args)? })?
+            }
+            CheckpointCommand::Show(args) => {
+                graph.show_checkpoint(ShowCheckpointRequest { name: args.name })?
             }
             CheckpointCommand::Open(args) => {
                 let view = graph.open_checkpoint(&args.name)?;
@@ -798,18 +1033,11 @@ fn run(cli: Cli, output: &mut dyn Write) -> Result<(), gf_api::GfError> {
                 },
                 page: page(&args.page)?,
             })?,
-            CheckpointCommand::Revert(args) => {
-                graph.revert_to_checkpoint(RevertCheckpointRequest {
-                    name: args.name,
-                    reason: args.reason,
-                    idempotency_key: OperationId(canonical_uuid(&args.idempotency_key)?),
-                    actor_uuid: actor(args.actor_uuid.as_deref())?,
-                })?
-            }
+            CheckpointCommand::Revert(_) => unreachable!("revert handled before result dispatch"),
         },
         _ => unreachable!(),
     };
-    write_result(&result, output)
+    write_execution_result(&result, cli.json, output)
 }
 
 /// Captured result of one Rust-owned CLI invocation.
@@ -848,10 +1076,14 @@ where
             ) {
                 stdout = error.to_string().into_bytes();
             } else if json {
-                writeln!(
-                    stderr,
-                    "{}",
-                    serde_json::json!({"error":{"code":"GF_VALIDATION","message":error.to_string()}})
+                write_json_error(
+                    &mut stderr,
+                    "GF_VALIDATION",
+                    &error.to_string(),
+                    JsonErrorDetails {
+                        source: "argument_parser",
+                        kind: clap_error_kind(error.kind()),
+                    },
                 )
                 .expect("writing to Vec cannot fail");
             } else {
@@ -880,13 +1112,94 @@ where
 
 fn write_error(error: &gf_api::GfError, json: bool, output: &mut dyn Write) -> io::Result<()> {
     if json {
-        writeln!(
+        write_json_error(
             output,
-            "{}",
-            serde_json::json!({"error":{"code":error.code(),"message":error.to_string()}})
+            error.code(),
+            &error.to_string(),
+            JsonErrorDetails {
+                source: "runtime",
+                kind: runtime_error_kind(error),
+            },
         )
     } else {
         writeln!(output, "{}: {error}", error.code())
+    }
+}
+
+#[derive(serde::Serialize)]
+struct JsonErrorDetails {
+    source: &'static str,
+    kind: &'static str,
+}
+
+#[derive(serde::Serialize)]
+struct JsonErrorBody<'a> {
+    code: &'static str,
+    message: &'a str,
+    details: JsonErrorDetails,
+}
+
+#[derive(serde::Serialize)]
+struct JsonErrorEnvelope<'a> {
+    error: JsonErrorBody<'a>,
+}
+
+fn write_json_error(
+    output: &mut dyn Write,
+    code: &'static str,
+    message: &str,
+    details: JsonErrorDetails,
+) -> io::Result<()> {
+    serde_json::to_writer(
+        &mut *output,
+        &JsonErrorEnvelope {
+            error: JsonErrorBody {
+                code,
+                message,
+                details,
+            },
+        },
+    )
+    .map_err(io::Error::other)?;
+    output.write_all(b"\n")
+}
+
+const fn clap_error_kind(kind: ErrorKind) -> &'static str {
+    match kind {
+        ErrorKind::InvalidValue => "invalid_value",
+        ErrorKind::UnknownArgument => "unknown_argument",
+        ErrorKind::InvalidSubcommand => "invalid_subcommand",
+        ErrorKind::NoEquals => "missing_equals",
+        ErrorKind::ValueValidation => "value_validation",
+        ErrorKind::TooManyValues => "too_many_values",
+        ErrorKind::TooFewValues => "too_few_values",
+        ErrorKind::WrongNumberOfValues => "wrong_number_of_values",
+        ErrorKind::ArgumentConflict => "argument_conflict",
+        ErrorKind::MissingRequiredArgument => "missing_required_argument",
+        ErrorKind::MissingSubcommand => "missing_subcommand",
+        ErrorKind::DisplayHelp => "display_help",
+        ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand => "display_help_on_missing_input",
+        ErrorKind::DisplayVersion => "display_version",
+        ErrorKind::Io => "io",
+        ErrorKind::Format => "format",
+        _ => "other",
+    }
+}
+
+const fn runtime_error_kind(error: &gf_api::GfError) -> &'static str {
+    match error {
+        gf_api::GfError::NotImplemented(_) => "not_implemented",
+        gf_api::GfError::Parse { .. } => "parse",
+        gf_api::GfError::Bind { .. } => "bind",
+        gf_api::GfError::Plan(_) => "plan",
+        gf_api::GfError::Execution(_) => "execution",
+        gf_api::GfError::Provider { .. } => "provider",
+        gf_api::GfError::Storage(_) => "storage",
+        gf_api::GfError::Project { .. } => "project",
+        gf_api::GfError::Api { .. } => "api",
+        gf_api::GfError::Lifecycle(_) => "lifecycle",
+        gf_api::GfError::Validation(_) => "validation",
+        gf_api::GfError::Ontology(_) => "ontology",
     }
 }
 
@@ -945,12 +1258,62 @@ mod tests {
         let error: serde_json::Value =
             serde_json::from_slice(&invalid.stderr).expect("structured CLI error");
         assert_eq!(error["error"]["code"], "GF_VALIDATION");
+        assert_eq!(
+            error["error"]["details"],
+            serde_json::json!({
+                "source": "argument_parser",
+                "kind": "invalid_subcommand"
+            })
+        );
+        assert!(
+            String::from_utf8(invalid.stderr.clone())
+                .unwrap()
+                .starts_with("{\"error\":{\"code\":\"GF_VALIDATION\",\"message\":")
+        );
         assert!(
             error["error"]["message"]
                 .as_str()
                 .expect("error message")
                 .contains("Usage: graphforge")
         );
+    }
+
+    #[test]
+    fn runtime_json_errors_include_stable_safe_details_without_changing_message() {
+        let cases = [
+            (
+                gf_api::GfError::Validation("invalid repository input".into()),
+                "GF_VALIDATION",
+                "validation",
+                2,
+            ),
+            (
+                gf_api::GfError::Storage("unavailable".into()),
+                "GF_IO",
+                "storage",
+                3,
+            ),
+        ];
+        for (error, code, kind, exit_code) in cases {
+            let message = error.to_string();
+            let mut output = Vec::new();
+            write_error(&error, true, &mut output).unwrap();
+            let serialized = String::from_utf8(output.clone()).unwrap();
+            assert!(
+                serialized.starts_with(&format!("{{\"error\":{{\"code\":\"{code}\",\"message\":"))
+            );
+            assert!(
+                serialized.find("\"message\":").unwrap() < serialized.find("\"details\":").unwrap()
+            );
+            let value: serde_json::Value = serde_json::from_slice(&output).unwrap();
+            assert_eq!(value["error"]["code"], code);
+            assert_eq!(value["error"]["message"], message);
+            assert_eq!(
+                value["error"]["details"],
+                serde_json::json!({"source": "runtime", "kind": kind})
+            );
+            assert_eq!(error_exit_code(&error), exit_code);
+        }
     }
 
     #[test]
@@ -978,6 +1341,20 @@ mod tests {
             "undo invalid import",
         ]);
         assert!(missing_key.is_err());
+
+        let preview = Cli::try_parse_from([
+            "gf",
+            "--project",
+            "/tmp/project",
+            "revert",
+            "before-change",
+            "--preview",
+        ])
+        .expect("preview does not require mutation identity");
+        assert!(matches!(
+            preview.command,
+            Some(Command::Revert(RevertArgs { preview: true, .. }))
+        ));
     }
 
     #[test]
@@ -1040,6 +1417,25 @@ mod tests {
         };
         assert_eq!(args.name, "before-change");
         assert_eq!(args.query.join(" "), "MATCH (n) RETURN n");
+    }
+
+    #[test]
+    fn show_accepts_exactly_one_checkpoint_name() {
+        let cli = Cli::try_parse_from([
+            "gf",
+            "--project",
+            "/tmp/project",
+            "checkpoint",
+            "show",
+            "before-change",
+        ])
+        .expect("valid checkpoint show command");
+        assert!(matches!(
+            cli.command,
+            Some(Command::Checkpoint {
+                command: CheckpointCommand::Show(ShowArgs { name })
+            }) if name == "before-change"
+        ));
     }
 
     #[test]

--- a/crates/gf-cli/src/lib.rs
+++ b/crates/gf-cli/src/lib.rs
@@ -1126,22 +1126,9 @@ fn write_error(error: &gf_api::GfError, json: bool, output: &mut dyn Write) -> i
     }
 }
 
-#[derive(serde::Serialize)]
 struct JsonErrorDetails {
     source: &'static str,
     kind: &'static str,
-}
-
-#[derive(serde::Serialize)]
-struct JsonErrorBody<'a> {
-    code: &'static str,
-    message: &'a str,
-    details: JsonErrorDetails,
-}
-
-#[derive(serde::Serialize)]
-struct JsonErrorEnvelope<'a> {
-    error: JsonErrorBody<'a>,
 }
 
 fn write_json_error(
@@ -1150,18 +1137,14 @@ fn write_json_error(
     message: &str,
     details: JsonErrorDetails,
 ) -> io::Result<()> {
-    serde_json::to_writer(
-        &mut *output,
-        &JsonErrorEnvelope {
-            error: JsonErrorBody {
-                code,
-                message,
-                details,
-            },
-        },
+    let code = serde_json::to_string(code).map_err(io::Error::other)?;
+    let message = serde_json::to_string(message).map_err(io::Error::other)?;
+    let source = serde_json::to_string(details.source).map_err(io::Error::other)?;
+    let kind = serde_json::to_string(details.kind).map_err(io::Error::other)?;
+    writeln!(
+        output,
+        "{{\"error\":{{\"code\":{code},\"message\":{message},\"details\":{{\"source\":{source},\"kind\":{kind}}}}}}}"
     )
-    .map_err(io::Error::other)?;
-    output.write_all(b"\n")
 }
 
 const fn clap_error_kind(kind: ErrorKind) -> &'static str {

--- a/crates/gf-cli/src/lib.rs
+++ b/crates/gf-cli/src/lib.rs
@@ -1126,6 +1126,7 @@ fn write_error(error: &gf_api::GfError, json: bool, output: &mut dyn Write) -> i
     }
 }
 
+#[derive(Clone, Copy)]
 struct JsonErrorDetails {
     source: &'static str,
     kind: &'static str,

--- a/crates/gf-cli/tests/checkpoints.rs
+++ b/crates/gf-cli/tests/checkpoints.rs
@@ -5,6 +5,7 @@ use std::process::{Command, Output};
 
 use arrow::array::FixedSizeBinaryArray;
 use arrow::ipc::reader::StreamReader;
+use serde_json::Value;
 use tempfile::TempDir;
 use uuid::Uuid;
 
@@ -59,6 +60,7 @@ fn checkpoint_cli_emits_arrow_and_stable_errors() {
             "checkpoint_uuid",
             "name",
             "source_generation_uuid",
+            "prior_current_generation_uuid",
             "result_generation_uuid",
             "registry_revision",
             "committed_at",
@@ -100,6 +102,10 @@ fn checkpoint_cli_emits_arrow_and_stable_errors() {
             .sum::<usize>(),
         1
     );
+    let (show_columns, show_batches) =
+        read_ipc(&gf(&project, &["checkpoint", "show", "before-change"]));
+    assert_eq!(show_columns, list_columns);
+    assert_eq!(show_batches, list_batches);
 
     let missing = gf(
         &project,
@@ -120,4 +126,149 @@ fn checkpoint_cli_emits_arrow_and_stable_errors() {
         "stable error code is emitted: {}",
         String::from_utf8_lossy(&missing.stderr)
     );
+}
+
+#[test]
+fn checkpoint_cli_json_is_schema_first_and_canonical() {
+    let project = TempDir::new().expect("temporary project");
+    let create = gf(
+        &project,
+        &[
+            "--json",
+            "checkpoint",
+            "create",
+            "before-change",
+            "--idempotency-key",
+            "00000000-0000-0000-0000-000000000001",
+        ],
+    );
+    assert!(
+        create.status.success(),
+        "{}",
+        String::from_utf8_lossy(&create.stderr)
+    );
+    let raw = String::from_utf8(create.stdout).unwrap();
+    assert!(raw.starts_with("{\"contract\":\"graphforge-cli-result/1\",\"columns\":"));
+    let value: Value = serde_json::from_str(&raw).unwrap();
+    assert_eq!(
+        value["columns"][0],
+        serde_json::json!({
+            "name": "operation",
+            "data_type": "Utf8",
+            "nullable": false
+        })
+    );
+    assert_eq!(value["rows"][0][1], "00000000-0000-0000-0000-000000000001");
+    assert!(
+        value["rows"][0][2]
+            .as_str()
+            .is_some_and(|checkpoint| Uuid::parse_str(checkpoint).is_ok())
+    );
+}
+
+#[test]
+fn revert_preview_is_non_mutating_and_automation_requires_yes() {
+    let project = TempDir::new().expect("temporary project");
+    assert!(
+        gf(
+            &project,
+            &[
+                "checkpoint",
+                "create",
+                "before-change",
+                "--idempotency-key",
+                "00000000-0000-0000-0000-000000000011",
+            ],
+        )
+        .status
+        .success()
+    );
+    let current_path = project.path().join("CURRENT");
+    let before = std::fs::read(&current_path).unwrap();
+
+    let preview = gf(
+        &project,
+        &["--json", "revert", "before-change", "--preview"],
+    );
+    assert!(
+        preview.status.success(),
+        "{}",
+        String::from_utf8_lossy(&preview.stderr)
+    );
+    let preview: Value = serde_json::from_slice(&preview.stdout).unwrap();
+    assert_eq!(preview["contract"], "graphforge-revert-preview/1");
+    assert_eq!(std::fs::read(&current_path).unwrap(), before);
+
+    let refused = gf(
+        &project,
+        &[
+            "--json",
+            "revert",
+            "before-change",
+            "--reason",
+            "restore known state",
+            "--idempotency-key",
+            "00000000-0000-0000-0000-000000000012",
+        ],
+    );
+    assert_eq!(refused.status.code(), Some(2));
+    let error: Value = serde_json::from_slice(&refused.stderr).unwrap();
+    assert_eq!(error["error"]["code"], "GF_VALIDATION");
+    assert_eq!(std::fs::read(&current_path).unwrap(), before);
+
+    let accepted = gf(
+        &project,
+        &[
+            "--json",
+            "revert",
+            "before-change",
+            "--reason",
+            "restore known state",
+            "--idempotency-key",
+            "00000000-0000-0000-0000-000000000012",
+            "--yes",
+        ],
+    );
+    assert!(
+        accepted.status.success(),
+        "{}",
+        String::from_utf8_lossy(&accepted.stderr)
+    );
+    let accepted: Value = serde_json::from_slice(&accepted.stdout).unwrap();
+    let columns = accepted["columns"].as_array().unwrap();
+    let prior_index = columns
+        .iter()
+        .position(|column| column["name"] == "prior_current_generation_uuid")
+        .unwrap();
+    assert_eq!(
+        accepted["rows"][0][prior_index],
+        preview["current_generation_uuid"]
+    );
+    assert_ne!(std::fs::read(&current_path).unwrap(), before);
+}
+
+#[test]
+fn preview_and_refusal_do_not_initialize_or_reconcile_a_project() {
+    for preview in [true, false] {
+        let project = TempDir::new().expect("temporary project");
+        let args = if preview {
+            vec!["--json", "revert", "missing", "--preview"]
+        } else {
+            vec![
+                "--json",
+                "revert",
+                "missing",
+                "--reason",
+                "must not open",
+                "--idempotency-key",
+                "00000000-0000-0000-0000-000000000021",
+            ]
+        };
+        let output = gf(&project, &args);
+        assert!(!output.status.success());
+        assert!(
+            std::fs::read_dir(project.path()).unwrap().next().is_none(),
+            "preview/refusal must not initialize the project"
+        );
+    }
 }

--- a/crates/gf-cli/tests/checkpoints.rs
+++ b/crates/gf-cli/tests/checkpoints.rs
@@ -69,7 +69,7 @@ fn checkpoint_cli_emits_arrow_and_stable_errors() {
     assert_eq!(
         create_batches
             .iter()
-            .map(|batch| batch.num_rows())
+            .map(arrow::array::RecordBatch::num_rows)
             .sum::<usize>(),
         1
     );
@@ -98,7 +98,7 @@ fn checkpoint_cli_emits_arrow_and_stable_errors() {
     assert_eq!(
         list_batches
             .iter()
-            .map(|batch| batch.num_rows())
+            .map(arrow::array::RecordBatch::num_rows)
             .sum::<usize>(),
         1
     );

--- a/crates/gf-cli/tests/repository.rs
+++ b/crates/gf-cli/tests/repository.rs
@@ -37,6 +37,9 @@ fn repository_lifecycle_emits_stable_json_and_keeps_data_out_of_git() {
         String::from_utf8_lossy(&init.stderr)
     );
     let value: Value = serde_json::from_slice(&init.stdout).unwrap();
+    assert_eq!(value["root"], ".");
+    assert_eq!(value["state"], ".graphforge/state");
+    assert!(!String::from_utf8_lossy(&init.stdout).contains(root.path().to_str().unwrap()));
     assert_eq!(value["created_config"], true);
     assert_eq!(value["skills"]["changed"], true);
     assert!(
@@ -103,8 +106,38 @@ fn repository_lifecycle_emits_stable_json_and_keeps_data_out_of_git() {
         .output()
         .unwrap();
     assert!(remove.status.success());
+    let value: Value = serde_json::from_slice(&remove.stdout).unwrap();
+    assert_eq!(value["target"], ".graphforge/state");
+    assert!(!String::from_utf8_lossy(&remove.stdout).contains(root.path().to_str().unwrap()));
     assert!(root.path().join(".graphforge/ontology/keep.yaml").exists());
     assert!(!root.path().join(".graphforge/state").exists());
+}
+
+#[test]
+fn repository_receipts_are_byte_identical_across_private_absolute_roots() {
+    let roots = [tempdir().unwrap(), tempdir().unwrap()];
+    let mut receipts = Vec::new();
+    for root in &roots {
+        let output = gf()
+            .args([
+                "--project-dir",
+                root.path().to_str().unwrap(),
+                "--json",
+                "init",
+                "--no-skills",
+            ])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(!String::from_utf8_lossy(&output.stdout).contains(root.path().to_str().unwrap()));
+        let _: Value = serde_json::from_slice(&output.stdout).unwrap();
+        receipts.push(output.stdout);
+    }
+    assert_eq!(receipts[0], receipts[1]);
 }
 
 #[test]

--- a/crates/gf-storage/src/project_checkpoints.rs
+++ b/crates/gf-storage/src/project_checkpoints.rs
@@ -133,7 +133,7 @@ struct CheckpointTombstone {
 /// Stable mutation receipt.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CheckpointReceipt {
-    /// Operation name (`checkpoint` or `delete_checkpoint`).
+    /// Operation name (`checkpoint`, `delete_checkpoint`, or `revert_to_checkpoint`).
     pub operation: &'static str,
     /// Idempotency UUID.
     pub operation_uuid: Uuid,
@@ -143,6 +143,8 @@ pub struct CheckpointReceipt {
     pub name: String,
     /// Pinned generation UUID.
     pub source_generation_uuid: Uuid,
+    /// Generation that was current immediately before a revert; absent for registry-only operations.
+    pub prior_current_generation_uuid: Option<Uuid>,
     /// Newly published generation for revert; absent for registry-only operations.
     pub result_generation_uuid: Option<Uuid>,
     /// Resulting registry revision.
@@ -710,6 +712,7 @@ where
             checkpoint_uuid: checkpoint.checkpoint_uuid,
             name: requested_name,
             source_generation_uuid: source.generation_uuid(),
+            prior_current_generation_uuid: Some(original_prior_uuid),
             result_generation_uuid: Some(receipt.generation_uuid),
             registry_revision,
             committed_at: restored_at,
@@ -771,6 +774,7 @@ fn revert_receipt(
         checkpoint_uuid: parse_uuid(&extension.checkpoint_uuid)?,
         name: name.to_owned(),
         source_generation_uuid: parse_uuid(&extension.source_generation_uuid)?,
+        prior_current_generation_uuid: Some(parse_uuid(&extension.prior_current_generation_uuid)?),
         result_generation_uuid: Some(result_generation_uuid),
         registry_revision: extension.registry_revision,
         committed_at: extension.restored_at,
@@ -817,6 +821,7 @@ fn create_receipt(row: &CheckpointRecord) -> CheckpointReceipt {
         checkpoint_uuid: row.checkpoint_uuid,
         name: row.name.clone(),
         source_generation_uuid: row.generation_uuid,
+        prior_current_generation_uuid: None,
         result_generation_uuid: None,
         registry_revision: row.created_revision,
         committed_at: row.created_at,
@@ -830,6 +835,7 @@ fn create_tombstone_receipt(row: &CheckpointTombstone) -> CheckpointReceipt {
         checkpoint_uuid: row.checkpoint_uuid,
         name: row.name.clone(),
         source_generation_uuid: row.generation_uuid,
+        prior_current_generation_uuid: None,
         result_generation_uuid: None,
         registry_revision: row.created_revision,
         committed_at: row.created_at,
@@ -843,6 +849,7 @@ fn delete_receipt(row: &CheckpointTombstone) -> CheckpointReceipt {
         checkpoint_uuid: row.checkpoint_uuid,
         name: row.name.clone(),
         source_generation_uuid: row.generation_uuid,
+        prior_current_generation_uuid: None,
         result_generation_uuid: None,
         registry_revision: row.deleted_revision,
         committed_at: row.deleted_at,
@@ -2059,6 +2066,7 @@ mod tests {
         .unwrap();
         assert_eq!(restored.parent_generation_uuid(), Some(prior_current));
         assert_eq!(receipt.source_generation_uuid, source.generation_uuid());
+        assert_eq!(receipt.prior_current_generation_uuid, Some(prior_current));
         assert_eq!(receipt.registry_revision, created.registry_revision);
         assert_eq!(list_checkpoints(directory.path()).unwrap().len(), 1);
         let restoration_count = restored
@@ -2086,6 +2094,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(replay, receipt);
+        assert_eq!(replay.prior_current_generation_uuid, Some(prior_current));
         assert_eq!(
             replayed_generation.generation_uuid(),
             restored.generation_uuid()

--- a/docs/adr/0014-workspace-checkpoints.md
+++ b/docs/adr/0014-workspace-checkpoints.md
@@ -484,10 +484,14 @@ Arrow records through the existing output formatter. Bindings accept the same
 canonical UUIDs, names, limits, cursors, cancellation, and idempotency inputs.
 They do not implement registry, diff, revert, validation, or schema logic.
 
-CLI commands are `gf checkpoint create|list|open|delete|diff|revert`.
-`open` accepts a read command after `--`; it does not start a mutable shell.
-Destructive revert requires `--reason` but no interactive prompt at the engine
-layer. Automation and embedded callers therefore remain deterministic.
+CLI commands are `gf checkpoint create|list|show|open|delete|diff` plus
+top-level `gf revert` (`gf checkpoint revert` follows the same Rust path).
+`show` returns the authoritative named metadata record. `open` accepts a read
+command after `--`; it remains the query surface and does not start a mutable
+shell. `revert --preview` resolves the source and current generation without
+mutation. Destructive CLI revert requires `--reason`, an idempotency key, and
+explicit `--yes`; omission fails closed instead of prompting. Embedded callers
+remain deterministic and use the typed engine request directly.
 
 Graph-only and Cypher reads through a view retain ADR 0012 isolation: they open
 only graph participants. analyst-verb/find opens graph plus their registered primary

--- a/docs/adr/0016-repository-integration-and-deployment-configuration.md
+++ b/docs/adr/0016-repository-integration-and-deployment-configuration.md
@@ -104,8 +104,11 @@ editing, project lifecycle, portable interchange, checkpoint revert, and
 destructive-operation guards. The Rust `gf` CLI is the reference behavior;
 Python and Node expose thin `uvx graphforge` and `npx @graphforge/cli` surfaces.
 Portable interchange packages one complete project generation; it does not
-define the ontology-document inspection, suggestion, validation, or export
-contract owned by #236, nor the thin binding parity owned by #237.
+redefine the ontology-document inspection, suggestion, validation, or export
+contract delivered by #236, nor the thin binding parity and durable
+adopt/clear behavior delivered by #237. Repository and IaC surfaces consume
+only bounded ontology references and digests where needed; they do not infer or
+change ontology authority.
 
 Skills have one checked-in source. Python and npm ship parity-checked copies and
 install directly under `.agents/skills/`; Python never shells out to NPX.

--- a/docs/contracts/checkpoint-api-v1.json
+++ b/docs/contracts/checkpoint-api-v1.json
@@ -132,9 +132,22 @@
       "request": ["limit", "after", "cancellation"],
       "result_schema": "checkpoint@1"
     },
+    "show_checkpoint": {
+      "request": ["name"],
+      "result_schema": "checkpoint@1"
+    },
     "open_checkpoint": {
       "request": ["name"],
       "result": "CheckpointView"
+    },
+    "preview_revert_to_checkpoint": {
+      "request": ["project_path", "name"],
+      "result": [
+        "checkpoint_uuid",
+        "source_generation_uuid",
+        "source_manifest_sha256",
+        "current_generation_uuid"
+      ]
     },
     "revert_to_checkpoint": {
       "request": ["name", "reason", "idempotency_key", "actor_uuid"],
@@ -162,6 +175,7 @@
         ["checkpoint_uuid", "FixedSizeBinary(16)", false],
         ["name", "Utf8", false],
         ["source_generation_uuid", "FixedSizeBinary(16)", false],
+        ["prior_current_generation_uuid", "FixedSizeBinary(16)", true],
         ["result_generation_uuid", "FixedSizeBinary(16)", true],
         ["registry_revision", "UInt64", false],
         ["committed_at", "Timestamp(Microsecond, UTC)", false]

--- a/docs/guides/repository-integration.md
+++ b/docs/guides/repository-integration.md
@@ -157,7 +157,10 @@ placed there remain outside the code repository. Keep tracked schemas,
 ontology, migrations, and seed recipes separate from these data files.
 
 This whole-project interchange surface is distinct from ontology-document
-inspection, suggestion, validation, and YAML/JSON export. The Rust-owned
-ontology lifecycle is tracked by #236, with thin Python and Node parity tracked
-by #237. Repository `export` never substitutes for ontology export, and
-ontology export never packages graph data or a project generation.
+inspection, suggestion, validation, and YAML/JSON export. #236 delivered the
+Rust-owned ontology lifecycle, and #237 delivered thin Python and Node parity
+including durable ontology adoption and clear. Repository `export` never
+substitutes for ontology export, and ontology export never packages graph data
+or a project generation. Repository initialization and synchronization preserve
+that authority boundary: they never suggest, adopt, clear, or export an
+ontology implicitly.

--- a/docs/guides/repository-integration.md
+++ b/docs/guides/repository-integration.md
@@ -54,6 +54,58 @@ credentials alone.
 
 The stable machine interface is selected with global `--json`. Configuration
 resolution always emits canonical compact JSON and never resolves secret values.
+Repository lifecycle receipts identify files and directories relative to the
+discovered repository root, using `/` separators. They never expose a checkout,
+home-directory, or other machine-private absolute path.
+
+Successful Arrow-backed commands use the versioned
+`graphforge-cli-result/1` JSON envelope when `--json` is selected. The envelope
+is schema-first: `columns` declares each name, Arrow data type, and nullability
+before `metadata` and positional `rows`. UUID and binary values use canonical
+portable text encodings. The default output remains Arrow IPC.
+
+JSON failures use a stable `error` object with ordered `code`, `message`, and
+bounded safe `details`. Details may identify the operation or a
+repository-relative path, but never include credentials, raw data, unrestricted
+paths, descriptions, or revert reasons. Parse failures and runtime failures
+retain their established nonzero exit codes.
+
+## Checkpoint inspection and revert
+
+Checkpoint metadata inspection and checkpoint queries are separate:
+
+```bash
+gf --project-dir . checkpoint show before-change
+gf --project-dir . checkpoint open before-change -- \
+  "MATCH (n) RETURN n"
+```
+
+`checkpoint show` resolves and verifies the authoritative active checkpoint
+record, then returns the same one-row metadata schema used by `checkpoint
+list`. `checkpoint open` remains the read-only query surface and never creates
+a mutable shell. Global `--json` selects the schema-first JSON result for
+checkpoint commands; without it, the native result is Arrow IPC.
+
+Revert is fail-closed. Preview resolves the checkpoint and current generation
+without publishing anything and does not require mutation identity:
+
+```bash
+gf --project-dir . --json revert before-change --preview
+```
+
+An actual revert requires `--reason`, `--idempotency-key`, and explicit
+non-interactive confirmation with `--yes`:
+
+```bash
+gf --project-dir . revert before-change \
+  --reason "restore known state" \
+  --idempotency-key 4f6a9b78-887d-4b8e-872b-a8b59059f777 \
+  --yes
+```
+
+Omitting `--yes` refuses the mutation. Successful and idempotently replayed
+receipts identify the prior current generation so automation can relate the
+previewed state to the published result.
 
 ## Portable export and import
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -3611,11 +3611,15 @@ checkpoint binding contract described below.
 
 ### Named checkpoints
 
-`GraphForge.checkpoint`, `list_checkpoints`, `open_checkpoint`,
-`diff_checkpoints`, `revert_to_checkpoint`, and `delete_checkpoint` expose the
-Rust-owned [`graphforge-checkpoint-api/1`](../contracts/checkpoint-api-v1.json)
-contract in Python and Node. Python returns `pyarrow.Table`; Node returns Arrow
-IPC buffers. `open_checkpoint(name)` returns a pinned, read-only
+`gf-api` exposes `GraphForge.checkpoint`, `list_checkpoints`,
+`show_checkpoint`, `open_checkpoint`, `diff_checkpoints`,
+`revert_to_checkpoint`, and `delete_checkpoint` as the Rust-owned
+[`graphforge-checkpoint-api/1`](../contracts/checkpoint-api-v1.json) contract.
+Existing thin Python and Node checkpoint projections return `pyarrow.Table`
+and Arrow IPC buffers, respectively. `show_checkpoint(name)` resolves and
+verifies one authoritative active checkpoint record and returns the exact
+one-row metadata schema used by `list_checkpoints`.
+`open_checkpoint(name)` remains the query surface: it returns a pinned, read-only
 `CheckpointView` with `checkpoint_uuid`, `generation_uuid`, `execute`, and
 `project_capabilities`. It intentionally exposes no mutation methods.
 
@@ -3631,15 +3635,26 @@ The CLI mirrors these operations and writes Arrow IPC to stdout:
 ```text
 gf --project PATH checkpoint create NAME --idempotency-key UUID [--description TEXT]
 gf --project PATH checkpoint list [--limit N] [--after TOKEN]
+gf --project PATH checkpoint show NAME
 gf --project PATH checkpoint open NAME -- MATCH (n) RETURN n
 gf --project PATH checkpoint diff --from NAME --to-current --scope graph --detail records
-gf --project PATH checkpoint revert NAME --reason TEXT --idempotency-key UUID
+gf --project PATH --json revert NAME --preview
+gf --project PATH revert NAME --reason TEXT --idempotency-key UUID --yes
 gf --project PATH checkpoint delete NAME --idempotency-key UUID
 ```
 
-The CLI accepts checkpoint names, never generation paths. `open` runs one
-read-only query and does not create a mutable shell. Failures write the stable
-GraphForge error code to stderr and exit nonzero.
+The CLI accepts checkpoint names, never generation paths. `show` inspects
+metadata; `open` runs one read-only query and does not create a mutable shell.
+Revert preview is non-mutating. An actual revert fails closed unless `--yes`
+explicitly authorizes it, and its success/replay receipt includes the prior
+current generation.
+
+The default native result surface is Arrow IPC. Global `--json` emits
+`graphforge-cli-result/1`, with schema-first `columns` (`name`, Arrow
+`data_type`, and `nullable`), followed by metadata and positional rows.
+Structured JSON failures contain stable `code`, `message`, and bounded safe
+`details`; they never expose credentials, raw project data, descriptions,
+reasons, or unrestricted filesystem paths. Exit codes remain stable.
 
 ---
 

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Stabilize Rust CLI machine output with repository-relative JSON receipts,
+  bounded structured error details, schema-first checkpoint/revert JSON,
+  authoritative `checkpoint show`, and non-mutating revert preview with
+  required explicit `--yes` confirmation (#243).
 - Add byte-for-byte equivalent `graphforge` wheel and `@graphforge/cli` npm
   entry points backed by the same Rust CLI parser, execution, structured errors,
   output, and exit codes (#226).

--- a/scripts/ci/test-non-cypher-surface-gate.py
+++ b/scripts/ci/test-non-cypher-surface-gate.py
@@ -29,7 +29,7 @@ class SurfaceGateTests(unittest.TestCase):
 
     def test_checked_in_inventory_is_complete(self) -> None:
         self.assertEqual(GATE.validate(), [])
-        self.assertEqual(len(GATE.public_methods()), 270)
+        self.assertEqual(len(GATE.public_methods()), 272)
         self.assertEqual(len(GATE.m18_registry()), 94)
 
     def test_new_or_removed_public_method_fails_frozen_digest(self) -> None:

--- a/tests/contracts/non-cypher-rust-surface.json
+++ b/tests/contracts/non-cypher-rust-surface.json
@@ -1,7 +1,7 @@
 {
   "contract_version": 1,
   "scope": "Rust non-Cypher public release surface",
-  "public_method_digest": "0a70ef6973c53b43c7dd8fba453edb702c01dd7a57ad2a6f5d7b641325be6db2",
+  "public_method_digest": "35ede905127bf32a6e3048da1f8623f8c8c174bdd3275666164edcbbd1704a02",
   "method_policy": {
     "receiver_defaults": {
       "GraphForge": "release-tested",
@@ -46,6 +46,8 @@
       "GraphForge.path": "introspection",
       "GraphForge.export_portable": "designed-only",
       "GraphForge.import_portable": "designed-only",
+      "GraphForge.preview_revert_to_checkpoint": "designed-only",
+      "GraphForge.show_checkpoint": "designed-only",
       "RepositoryContext.discover": "introspection",
       "CheckpointView.checkpoint_uuid": "introspection",
       "CheckpointView.generation_uuid": "introspection",

--- a/tests/contracts/repository-cli-parity.json
+++ b/tests/contracts/repository-cli-parity.json
@@ -13,7 +13,7 @@
       "args": ["--json", "unknown-command"],
       "exitCode": 2,
       "stdout": "",
-      "stderr": "{\"error\":{\"code\":\"GF_VALIDATION\",\"message\":\"error: unrecognized subcommand 'unknown-command'\\n\\nUsage: graphforge [OPTIONS] [COMMAND]\\n\\nFor more information, try '--help'.\\n\"}}\n"
+      "stderr": "{\"error\":{\"code\":\"GF_VALIDATION\",\"message\":\"error: unrecognized subcommand 'unknown-command'\\n\\nUsage: graphforge [OPTIONS] [COMMAND]\\n\\nFor more information, try '--help'.\\n\",\"details\":{\"source\":\"argument_parser\",\"kind\":\"invalid_subcommand\"}}}\n"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- add authoritative `checkpoint show` while preserving `checkpoint open` as the query surface
- add schema-first stable checkpoint/revert JSON and bounded structured error details
- make repository lifecycle receipts repository-relative and path-safe
- add non-mutating revert preview, explicit `--yes` confirmation, and prior-current generation evidence
- freeze the updated checkpoint and Rust surface contracts and document the workflow

## Safety

Preview and missing-confirmation refusal are handled before mutable `GraphForge` open. Preview resolves the published generation and verified checkpoint directly; an empty project remains byte-for-byte uninitialized. Actual revert continues through the existing atomic Rust API.

## Validation

- `cargo test -p gf-cli --lib` (14 passed)
- `cargo test -p gf-cli --test checkpoints` (4 passed)
- `cargo test -p gf-cli --test repository` (7 passed)
- `cargo test -p gf-api --lib checkpoints::tests::` (12 passed)
- focused `gf-storage` revert/recovery tests (5 passed)
- `cargo clippy -p gf-cli --lib -- -D warnings`
- Rust non-Cypher surface gate and binding parity policy
- Ruff format/lint for changed Python policy files
- `cargo fmt --all -- --check`
- JSON contract parse and `git diff --check`
- independent review and safety re-review: no remaining blocker

Closes #243

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788063949&installation_model_id=20486&pr_number=245&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F245&signature=88c8d7d4febcadaa99ec774ef4bbc54a4953278c7bf3039f4d69786147219984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stabilize checkpoint show, revert preview, and machine-readable JSON CLI contracts
> - Adds `checkpoint show` subcommand returning authoritative single-checkpoint metadata via a new `GraphForge::show_checkpoint` API method.
> - Adds non-mutating `revert --preview` that resolves identities without mutation; actual revert now requires explicit `--yes` and fails closed without it.
> - Stabilizes `--json` output to a schema-first envelope (contract name, columns, metadata, rows) with canonical UUID formatting for `FixedSizeBinary(16)` fields.
> - Repository lifecycle JSON receipts now use repository-relative paths (`root: "."`, `state: ".graphforge/state"`) and never leak absolute paths.
> - Extends `CheckpointReceipt` and the Arrow result schema with `prior_current_generation_uuid`, populated on revert (including replay) and null otherwise.
> - Structured `details` object (source + kind) is now included in JSON error output for both parser and runtime errors.
> - Risk: `revert` without `--yes` now returns a validation error instead of proceeding; automation scripts must be updated to pass `--yes`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec8f8d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->