### PR TITLE
feat(dx): atomically reconcile repository snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   projects, excluding live pointers, locks, journals, caches, and trash (#229).
 - Add Rust-owned repository lifecycle commands and APIs for safe `.graphforge/`
   initialization, deterministic configuration resolution, declared-input sync,
-  Git provenance, and guarded state-only removal (#228).
+  Git provenance, and guarded state-only removal (#228), including atomic,
+  generation-managed repository snapshots with non-mutating CI drift checks
+  (#244).
 
 Post-v0.5.0 work lands here. The v0.5.0 publication cut is under `[0.5.0]` below.
 

--- a/crates/gf-api/src/lib.rs
+++ b/crates/gf-api/src/lib.rs
@@ -99,9 +99,10 @@ pub use portable::{
     PortableSelection,
 };
 pub use repository::{
-    GitProvenance, ProjectConfig, RepositoryContext, RepositoryInitReceipt,
-    RepositoryRemoveReceipt, RepositorySyncReceipt, SkillBundle, SkillBundleFile,
-    SkillMutationReceipt, SkillStatus, SkillStatusReceipt,
+    GitProvenance, ProjectConfig, RepositoryContext, RepositoryDefinitionDigest,
+    RepositoryInitReceipt, RepositoryRemoveReceipt, RepositorySourceDigest, RepositorySyncRequest,
+    RepositorySyncResult, RepositorySyncStatus, SkillBundle, SkillBundleFile, SkillMutationReceipt,
+    SkillStatus, SkillStatusReceipt,
 };
 
 // Re-export the foundational types callers need alongside the facade, so a

--- a/crates/gf-api/src/repository.rs
+++ b/crates/gf-api/src/repository.rs
@@ -7,10 +7,11 @@ use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 
 use fs4::fs_std::FileExt;
-use gf_core::GfError;
+use gf_core::{GfError, ProjectErrorCode};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
+use uuid::Uuid;
 
 const CONFIG: &str = ".graphforge/graphforge.yaml";
 const IGNORE_START: &str = "# graphforge: managed data (do not edit)";
@@ -29,8 +30,142 @@ const SKILLS_STAGE: &str = ".graphforge/imports/skills-lifecycle/stage";
 const SKILLS_BACKUP: &str = ".graphforge/imports/skills-lifecycle/backup";
 const MANAGED_SKILL_NAMES: [&str; 2] = ["graphforge-bootstrap", "graphforge-build-knowledge"];
 
+#[cfg(test)]
+#[derive(Clone)]
+struct RepositorySyncTestHook {
+    root: PathBuf,
+    barrier: std::sync::Arc<std::sync::Barrier>,
+}
+
+#[cfg(test)]
+static REPOSITORY_SYNC_BEFORE_STAGE_HOOK: std::sync::OnceLock<
+    std::sync::Mutex<Option<RepositorySyncTestHook>>,
+> = std::sync::OnceLock::new();
+
 fn validation(message: impl Into<String>) -> GfError {
     GfError::Validation(message.into())
+}
+
+fn idempotency_conflict(message: impl Into<String>) -> GfError {
+    GfError::Project {
+        code: ProjectErrorCode::TransactionConflict,
+        message: message.into(),
+    }
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(char::from(HEX[usize::from(byte >> 4)]));
+        output.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    output
+}
+
+fn repository_snapshot_to_participant(
+    snapshot: gf_storage::ProjectParticipantSnapshot,
+) -> Result<gf_storage::ProjectParticipant, GfError> {
+    let encoding = match snapshot.encoding.as_str() {
+        "parquet" => gf_storage::ProjectParticipantEncoding::Parquet,
+        "arrow" => gf_storage::ProjectParticipantEncoding::Arrow,
+        "json" => gf_storage::ProjectParticipantEncoding::Json,
+        _ => {
+            return Err(validation("committed participant has unsupported encoding"));
+        }
+    };
+    Ok(gf_storage::ProjectParticipant {
+        capability_id: snapshot.capability_id,
+        capability_version: snapshot.capability_version,
+        record_family_id: snapshot.record_family_id,
+        record_version: snapshot.record_version,
+        encoding,
+        schema_fingerprint: snapshot.schema_fingerprint,
+        row_count: snapshot.row_count,
+        bytes: snapshot.bytes,
+    })
+}
+
+fn repository_sync_generation_uuid(
+    operation_uuid: Uuid,
+    participants: &[gf_storage::ProjectParticipant],
+) -> Uuid {
+    let mut hasher = Sha256::new();
+    hasher.update(b"graphforge-repository-sync-generation/1");
+    hasher.update(operation_uuid.as_bytes());
+    for participant in participants {
+        hasher.update(participant.capability_id.as_bytes());
+        hasher.update([0]);
+        hasher.update(participant.record_family_id.as_bytes());
+        hasher.update([0]);
+        hasher.update(Sha256::digest(&participant.bytes));
+    }
+    gf_core::canonical::uuid_v8(hasher.finalize().into())
+}
+
+fn validate_repository_snapshot_inventory(
+    participants: &[gf_storage::StagedParticipant],
+    expected_content_sha256: &str,
+) -> Result<(), GfError> {
+    let snapshots = participants
+        .iter()
+        .filter(|participant| {
+            participant.capability_id == gf_storage::WORKSPACE_CAPABILITY_ID
+                && participant.record_family_id == gf_storage::WORKSPACE_REPOSITORY_SNAPSHOT_FAMILY
+        })
+        .collect::<Vec<_>>();
+    if snapshots.len() != 1 {
+        return Err(validation(
+            "workspace generation must contain exactly one repository snapshot",
+        ));
+    }
+    let snapshot = snapshots[0];
+    let expected_schema = encode_hex(&Sha256::digest("workspace/repository_snapshot@1"));
+    if snapshot.capability_version != gf_storage::WORKSPACE_CAPABILITY_VERSION
+        || snapshot.record_version != gf_storage::WORKSPACE_REPOSITORY_SNAPSHOT_VERSION
+        || snapshot.encoding != "json"
+        || snapshot.row_count != 1
+        || snapshot.schema_fingerprint != expected_schema
+        || snapshot.content_sha256 != expected_content_sha256
+    {
+        return Err(validation(
+            "workspace repository snapshot metadata is invalid",
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DesiredRepositorySnapshot {
+    resolved_config_sha256: String,
+    definitions: Vec<gf_storage::WorkspaceRepositoryDefinitionDigest>,
+    sources: Vec<gf_storage::WorkspaceRepositorySourceDigest>,
+    git: gf_storage::WorkspaceRepositoryGitProvenance,
+}
+
+impl DesiredRepositorySnapshot {
+    fn matches(&self, snapshot: &gf_storage::WorkspaceRepositorySnapshot) -> bool {
+        self.resolved_config_sha256 == snapshot.resolved_config_sha256
+            && self.definitions == snapshot.definitions
+            && self.sources == snapshot.sources
+            && self.git == snapshot.git
+    }
+
+    fn into_snapshot(
+        self,
+        operation_uuid: Uuid,
+        actor_uuid: Option<Uuid>,
+    ) -> gf_storage::WorkspaceRepositorySnapshot {
+        gf_storage::WorkspaceRepositorySnapshot {
+            contract_version: gf_storage::WORKSPACE_REPOSITORY_SNAPSHOT_VERSION,
+            resolved_config_sha256: self.resolved_config_sha256,
+            definitions: self.definitions,
+            sources: self.sources,
+            git: self.git,
+            operation_uuid,
+            actor_uuid,
+        }
+    }
 }
 
 #[cfg(not(windows))]
@@ -609,29 +744,266 @@ impl RepositoryContext {
         self.load_config()?.resolve()
     }
 
-    /// Record bounded Git provenance after validating only declared inputs.
-    pub fn sync(&self) -> Result<RepositorySyncReceipt, GfError> {
-        let config = self.load_config()?;
-        let mut definition_digests = BTreeMap::new();
-        for path in config.project.paths() {
-            let resolved = self.contained_path(path)?;
-            if !resolved.is_dir() {
-                return Err(validation(format!(
-                    "declared definition directory is missing: {path}"
-                )));
+    /// Compare or atomically reconcile the declared repository snapshot.
+    ///
+    /// Check mode never initializes or mutates project state. Apply mode
+    /// requires a caller-owned operation UUID only when drift exists.
+    ///
+    /// # Errors
+    /// Returns a structured validation, idempotency, project, or storage error.
+    pub fn sync(&self, request: RepositorySyncRequest) -> Result<RepositorySyncResult, GfError> {
+        let desired = self.desired_repository_snapshot()?;
+        let current = gf_storage::resolve_project_generation(&self.state_path)?;
+        current.validate_complete_participant_inventory()?;
+        let current_snapshot = current
+            .participant_snapshot(
+                gf_storage::WORKSPACE_CAPABILITY_ID,
+                gf_storage::WORKSPACE_REPOSITORY_SNAPSHOT_FAMILY,
+            )?
+            .map(|snapshot| {
+                gf_storage::WorkspaceRepositorySnapshot::from_canonical_json(&snapshot.bytes)
+            })
+            .transpose()?;
+        if current_snapshot
+            .as_ref()
+            .is_some_and(|snapshot| desired.matches(snapshot))
+        {
+            if !request.check
+                && let (Some(requested_operation), Some(snapshot)) =
+                    (request.operation_uuid, current_snapshot.as_ref())
+                && requested_operation == snapshot.operation_uuid
+                && request.actor_uuid != snapshot.actor_uuid
+            {
+                return Err(GfError::Project {
+                    code: gf_core::ProjectErrorCode::TransactionConflict,
+                    message:
+                        "repository sync operation UUID was reused with a different actor identity"
+                            .into(),
+                });
             }
-            definition_digests.insert(path.to_owned(), digest_definition_tree(&resolved)?);
+            let idempotent_replay = !request.check
+                && request.operation_uuid.is_some_and(|operation| {
+                    current_snapshot
+                        .as_ref()
+                        .is_some_and(|snapshot| snapshot.operation_uuid == operation)
+                });
+            return Ok(RepositorySyncResult {
+                status: RepositorySyncStatus::InSync,
+                prior_generation_uuid: current.generation_uuid(),
+                generation_uuid: current.generation_uuid(),
+                requested_operation_uuid: (!request.check)
+                    .then_some(request.operation_uuid)
+                    .flatten(),
+                snapshot_operation_uuid: current_snapshot
+                    .as_ref()
+                    .map(|snapshot| snapshot.operation_uuid),
+                snapshot_actor_uuid: current_snapshot
+                    .as_ref()
+                    .and_then(|snapshot| snapshot.actor_uuid),
+                idempotent_replay,
+                resolved_config_sha256: desired.resolved_config_sha256,
+                definitions: desired
+                    .definitions
+                    .into_iter()
+                    .map(RepositoryDefinitionDigest::from)
+                    .collect(),
+                sources: desired
+                    .sources
+                    .into_iter()
+                    .map(RepositorySourceDigest::from)
+                    .collect(),
+                git: desired.git.into(),
+            });
         }
-        let provenance = self.git_provenance()?;
-        Ok(RepositorySyncReceipt {
-            definitions: config.project.paths().map(str::to_owned).collect(),
-            definition_digests,
-            source_digests: config
-                .sources
-                .iter()
-                .map(|source| source.sha256.clone())
+        if request.check {
+            return Ok(RepositorySyncResult {
+                status: RepositorySyncStatus::Drift,
+                prior_generation_uuid: current.generation_uuid(),
+                generation_uuid: current.generation_uuid(),
+                requested_operation_uuid: None,
+                snapshot_operation_uuid: current_snapshot
+                    .as_ref()
+                    .map(|snapshot| snapshot.operation_uuid),
+                snapshot_actor_uuid: current_snapshot
+                    .as_ref()
+                    .and_then(|snapshot| snapshot.actor_uuid),
+                idempotent_replay: false,
+                resolved_config_sha256: desired.resolved_config_sha256,
+                definitions: desired
+                    .definitions
+                    .into_iter()
+                    .map(RepositoryDefinitionDigest::from)
+                    .collect(),
+                sources: desired
+                    .sources
+                    .into_iter()
+                    .map(RepositorySourceDigest::from)
+                    .collect(),
+                git: desired.git.into(),
+            });
+        }
+        let operation_uuid = request
+            .operation_uuid
+            .ok_or_else(|| validation("sync drift requires an explicit operation UUID"))?;
+        if operation_uuid.is_nil() {
+            return Err(validation("sync operation UUID must not be nil"));
+        }
+        if request.actor_uuid.is_some_and(|actor| actor.is_nil()) {
+            return Err(validation("sync actor UUID must not be nil"));
+        }
+        self.publish_repository_snapshot(&current, desired, operation_uuid, request.actor_uuid)
+    }
+
+    fn publish_repository_snapshot(
+        &self,
+        current: &gf_storage::ResolvedProjectGeneration,
+        desired: DesiredRepositorySnapshot,
+        operation_uuid: Uuid,
+        actor_uuid: Option<Uuid>,
+    ) -> Result<RepositorySyncResult, GfError> {
+        let expected_desired = desired.clone();
+        let snapshot = desired.into_snapshot(operation_uuid, actor_uuid);
+        let mut participants = current
+            .participant_snapshots()?
+            .into_iter()
+            .filter(|participant| {
+                !(participant.capability_id == gf_storage::WORKSPACE_CAPABILITY_ID
+                    && participant.record_family_id
+                        == gf_storage::WORKSPACE_REPOSITORY_SNAPSHOT_FAMILY)
+            })
+            .map(repository_snapshot_to_participant)
+            .collect::<Result<Vec<_>, _>>()?;
+        let snapshot_participant = snapshot.to_project_participant()?;
+        let expected_snapshot_sha256 = encode_hex(&Sha256::digest(&snapshot_participant.bytes));
+        participants.push(snapshot_participant);
+        participants.sort_by(|left, right| {
+            (&left.capability_id, &left.record_family_id)
+                .cmp(&(&right.capability_id, &right.record_family_id))
+        });
+        let generation_uuid = repository_sync_generation_uuid(operation_uuid, &participants);
+        let publication = gf_storage::ProjectGenerationRequest {
+            transaction_uuid: operation_uuid,
+            generation_uuid,
+            capabilities: current
+                .capabilities()
+                .into_iter()
+                .map(|capability| gf_storage::ProjectCapability {
+                    capability_id: capability.capability_id,
+                    capability_version: capability.capability_version,
+                })
                 .collect(),
-            provenance,
+            participants,
+        };
+        #[cfg(test)]
+        if let Some(hook) = REPOSITORY_SYNC_BEFORE_STAGE_HOOK
+            .get_or_init(|| std::sync::Mutex::new(None))
+            .lock()
+            .expect("repository sync test hook lock poisoned")
+            .as_ref()
+            .filter(|hook| hook.root == self.root)
+            .cloned()
+        {
+            hook.barrier.wait();
+            hook.barrier.wait();
+        }
+        let expected_parent = current.generation_uuid();
+        let receipt = match gf_storage::stage_project_generation(&self.state_path, &publication)? {
+            gf_storage::ProjectStageOutcome::AlreadyPublished(receipt) => {
+                if receipt.generation_uuid != expected_parent {
+                    return Err(idempotency_conflict(
+                        "repository sync operation identifies a generation that is no longer authoritative",
+                    ));
+                }
+                receipt
+            }
+            gf_storage::ProjectStageOutcome::Staged(staged) => staged
+                .validate(
+                    |participants| {
+                        validate_repository_snapshot_inventory(
+                            participants,
+                            &expected_snapshot_sha256,
+                        )
+                    },
+                    |actual_parent, _| {
+                        if actual_parent.generation_uuid() != expected_parent {
+                            return Err(validation(
+                                "project generation changed before repository sync publication",
+                            ));
+                        }
+                        if self.desired_repository_snapshot()? != expected_desired {
+                            return Err(validation("repository definitions changed during sync"));
+                        }
+                        Ok(())
+                    },
+                )?
+                .publish()?,
+        };
+        let evidence = expected_desired;
+        Ok(RepositorySyncResult {
+            status: RepositorySyncStatus::Published,
+            prior_generation_uuid: expected_parent,
+            generation_uuid: receipt.generation_uuid,
+            requested_operation_uuid: Some(operation_uuid),
+            snapshot_operation_uuid: Some(operation_uuid),
+            snapshot_actor_uuid: actor_uuid,
+            idempotent_replay: receipt.idempotent_replay,
+            resolved_config_sha256: evidence.resolved_config_sha256,
+            definitions: evidence
+                .definitions
+                .into_iter()
+                .map(RepositoryDefinitionDigest::from)
+                .collect(),
+            sources: evidence
+                .sources
+                .into_iter()
+                .map(RepositorySourceDigest::from)
+                .collect(),
+            git: evidence.git.into(),
+        })
+    }
+
+    fn desired_repository_snapshot(&self) -> Result<DesiredRepositorySnapshot, GfError> {
+        let config = self.load_config()?;
+        let resolved_config = config.resolve()?;
+        let resolved_config_sha256 = encode_hex(&Sha256::digest(
+            serde_json::to_vec(&resolved_config)
+                .map_err(|error| validation(format!("cannot encode resolved config: {error}")))?,
+        ));
+        let definitions = config
+            .project
+            .entries()
+            .into_iter()
+            .map(|(kind, path)| {
+                let resolved = self.contained_path(path)?;
+                if !resolved.is_dir() {
+                    return Err(validation(format!(
+                        "declared definition directory is missing: {path}"
+                    )));
+                }
+                Ok(gf_storage::WorkspaceRepositoryDefinitionDigest {
+                    definition_id: kind.id().into(),
+                    sha256: digest_definition_tree(&resolved, kind)?,
+                })
+            })
+            .collect::<Result<Vec<_>, GfError>>()?;
+        let mut sources = config
+            .sources
+            .iter()
+            .map(|source| gf_storage::WorkspaceRepositorySourceDigest {
+                source_id: source.id.clone(),
+                sha256: source.sha256.clone(),
+            })
+            .collect::<Vec<_>>();
+        sources.sort_by(|left, right| left.source_id.cmp(&right.source_id));
+        let git = self.git_provenance()?;
+        Ok(DesiredRepositorySnapshot {
+            resolved_config_sha256,
+            definitions,
+            sources,
+            git: gf_storage::WorkspaceRepositoryGitProvenance {
+                commit_sha: git.sha,
+                dirty: git.dirty,
+            },
         })
     }
 
@@ -814,7 +1186,31 @@ impl RepositoryContext {
     }
 }
 
-fn digest_definition_tree(root: &Path) -> Result<String, GfError> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DefinitionKind {
+    Migrations,
+    Ontology,
+    Schemas,
+    Seeds,
+}
+
+impl DefinitionKind {
+    const fn id(self) -> &'static str {
+        match self {
+            Self::Migrations => "migrations",
+            Self::Ontology => "ontology",
+            Self::Schemas => "schemas",
+            Self::Seeds => "seeds",
+        }
+    }
+
+    fn allows_extension(self, extension: &str) -> bool {
+        matches!(extension, "json" | "yaml" | "yml")
+            || matches!(self, Self::Migrations) && matches!(extension, "cypher")
+    }
+}
+
+fn digest_definition_tree(root: &Path, definition_kind: DefinitionKind) -> Result<String, GfError> {
     let mut pending = vec![root.to_path_buf()];
     let mut files = Vec::new();
     let mut total = 0_u64;
@@ -848,26 +1244,60 @@ fn digest_definition_tree(root: &Path) -> Result<String, GfError> {
         let extension = path
             .extension()
             .and_then(|value| value.to_str())
-            .unwrap_or_default();
-        if matches!(
-            extension,
-            "arrow" | "parquet" | "db" | "sqlite" | "sqlite3" | "duckdb"
-        ) {
-            return Err(validation(
-                "materialized graph or database data is not a definition",
-            ));
+            .map(str::to_ascii_lowercase)
+            .ok_or_else(|| validation("definition files require a registered extension"))?;
+        if !definition_kind.allows_extension(&extension) {
+            return Err(validation(format!(
+                "{} definitions do not allow .{extension} files",
+                definition_kind.id()
+            )));
         }
         let bytes = fs::read(&path).map_err(|error| GfError::Storage(error.to_string()))?;
+        if bytes.len() > 1024 * 1024 {
+            return Err(validation("definition file exceeds byte bound"));
+        }
         total = total.saturating_add(bytes.len() as u64);
-        if total > 64 * 1024 * 1024 {
+        if total > 16 * 1024 * 1024 {
             return Err(validation("definition tree exceeds byte bound"));
         }
+        validate_definition_document(&bytes, &extension)?;
         hash.update(relative.to_string_lossy().replace('\\', "/").as_bytes());
         hash.update([0]);
         hash.update((bytes.len() as u64).to_be_bytes());
         hash.update(&bytes);
     }
     Ok(format!("{:x}", hash.finalize()))
+}
+
+fn validate_definition_document(bytes: &[u8], extension: &str) -> Result<(), GfError> {
+    let text = std::str::from_utf8(bytes)
+        .map_err(|_| validation("definition file must be canonical UTF-8 text"))?;
+    if text.contains('\0') {
+        return Err(validation("definition file contains binary data"));
+    }
+    match extension {
+        "json" => {
+            let value: Value = serde_json::from_str(text)
+                .map_err(|_| validation("JSON definition is malformed"))?;
+            if !value.is_object() {
+                return Err(validation("JSON definition must be an object"));
+            }
+        }
+        "yaml" | "yml" => {
+            let value: serde_yaml::Value = serde_yaml::from_str(text)
+                .map_err(|_| validation("YAML definition is malformed"))?;
+            if !value.is_mapping() {
+                return Err(validation("YAML definition must be a mapping"));
+            }
+        }
+        "cypher" => {
+            if text.trim().is_empty() {
+                return Err(validation("Cypher migration definition is empty"));
+            }
+        }
+        _ => return Err(validation("unregistered definition file type")),
+    }
+    Ok(())
 }
 
 fn absolute_existing_dir(path: &Path) -> Result<PathBuf, GfError> {
@@ -1072,6 +1502,15 @@ struct DefinitionPaths {
     migrations: String,
 }
 impl DefinitionPaths {
+    fn entries(&self) -> [(DefinitionKind, &str); 4] {
+        [
+            (DefinitionKind::Migrations, &self.migrations),
+            (DefinitionKind::Ontology, &self.ontology),
+            (DefinitionKind::Schemas, &self.schemas),
+            (DefinitionKind::Seeds, &self.seeds),
+        ]
+    }
+
     fn paths(&self) -> impl Iterator<Item = &str> {
         [
             &*self.ontology,
@@ -1599,17 +2038,99 @@ pub struct RepositoryInitReceipt {
     /// Live embedded project location.
     pub state: PathBuf,
 }
-/// Successful sync validation output.
+/// Digest evidence for one declared repository definition family.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct RepositorySyncReceipt {
-    /// Explicitly declared definition paths that were validated.
-    pub definitions: Vec<String>,
-    /// Canonical SHA-256 digest for each declared definition tree.
-    pub definition_digests: BTreeMap<String, String>,
-    /// Digests of explicitly declared external sources.
-    pub source_digests: Vec<String>,
-    /// Bounded Git provenance; no repository data is scanned.
-    pub provenance: GitProvenance,
+pub struct RepositoryDefinitionDigest {
+    /// Stable definition family identifier; never a repository path.
+    pub definition_id: String,
+    /// Canonical SHA-256 digest of the validated definition tree.
+    pub sha256: String,
+}
+
+impl From<gf_storage::WorkspaceRepositoryDefinitionDigest> for RepositoryDefinitionDigest {
+    fn from(value: gf_storage::WorkspaceRepositoryDefinitionDigest) -> Self {
+        Self {
+            definition_id: value.definition_id,
+            sha256: value.sha256,
+        }
+    }
+}
+
+/// Digest evidence for one explicitly declared external source.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RepositorySourceDigest {
+    /// Stable source identifier; never a source URI or path.
+    pub source_id: String,
+    /// Caller-declared canonical SHA-256 digest.
+    pub sha256: String,
+}
+
+impl From<gf_storage::WorkspaceRepositorySourceDigest> for RepositorySourceDigest {
+    fn from(value: gf_storage::WorkspaceRepositorySourceDigest) -> Self {
+        Self {
+            source_id: value.source_id,
+            sha256: value.sha256,
+        }
+    }
+}
+
+impl From<gf_storage::WorkspaceRepositoryGitProvenance> for GitProvenance {
+    fn from(value: gf_storage::WorkspaceRepositoryGitProvenance) -> Self {
+        Self {
+            sha: value.commit_sha,
+            dirty: value.dirty,
+        }
+    }
+}
+
+/// Repository reconciliation request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RepositorySyncRequest {
+    /// Validate and compare without publishing.
+    pub check: bool,
+    /// Caller-owned idempotency identity, required only when applying drift.
+    pub operation_uuid: Option<Uuid>,
+    /// Optional caller-owned actor identity.
+    pub actor_uuid: Option<Uuid>,
+}
+
+/// Deterministic repository reconciliation state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RepositorySyncStatus {
+    /// Desired and authoritative repository snapshots match.
+    InSync,
+    /// Check mode found a difference and did not mutate state.
+    Drift,
+    /// Apply mode atomically published one complete generation.
+    Published,
+}
+
+/// Repository reconciliation result.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RepositorySyncResult {
+    /// Deterministic reconciliation outcome.
+    pub status: RepositorySyncStatus,
+    /// Generation authoritative before this call.
+    pub prior_generation_uuid: Uuid,
+    /// Generation authoritative after this call.
+    pub generation_uuid: Uuid,
+    /// Operation requested for this mutating call; always absent in check mode.
+    pub requested_operation_uuid: Option<Uuid>,
+    /// Operation identity actually recorded in the authoritative snapshot.
+    pub snapshot_operation_uuid: Option<Uuid>,
+    /// Actor identity actually recorded in the authoritative snapshot.
+    pub snapshot_actor_uuid: Option<Uuid>,
+    /// Whether the current desired state was already published by this operation.
+    pub idempotent_replay: bool,
+    /// SHA-256 digest of the canonical, secret-free resolved configuration.
+    pub resolved_config_sha256: String,
+    /// Ordered digest evidence for validated definition families.
+    pub definitions: Vec<RepositoryDefinitionDigest>,
+    /// Ordered identifiers and digests for explicitly declared external sources.
+    pub sources: Vec<RepositorySourceDigest>,
+    /// Bounded Git provenance; never repository contents or unrestricted paths.
+    pub git: GitProvenance,
 }
 /// Successful local-state removal output.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -1763,10 +2284,461 @@ mod tests {
         );
         let context = RepositoryContext::discover(root.path()).unwrap();
         context.init().unwrap();
-        let receipt = context.sync().unwrap();
-        assert_eq!(receipt.provenance.sha, None);
-        assert!(receipt.provenance.dirty);
-        assert_eq!(receipt.definition_digests.len(), 4);
+        let result = context
+            .sync(RepositorySyncRequest {
+                check: true,
+                operation_uuid: None,
+                actor_uuid: None,
+            })
+            .unwrap();
+        assert_eq!(result.git.sha, None);
+        assert!(result.git.dirty);
+        assert_eq!(result.definitions.len(), 4);
+    }
+
+    #[test]
+    fn repository_sync_checks_applies_replays_conflicts_and_preserves_authority() {
+        let root = tempdir().unwrap();
+        let context = RepositoryContext::discover(root.path()).unwrap();
+        context.init_without_skills().unwrap();
+        let initial = gf_storage::resolve_project_generation(&context.state_path).unwrap();
+        let initial_uuid = initial.generation_uuid();
+        let initial_participants = initial.participant_snapshots().unwrap();
+        let initial_ontology = initial
+            .participant_snapshot(
+                gf_storage::WORKSPACE_CAPABILITY_ID,
+                gf_storage::WORKSPACE_ONTOLOGY_FAMILY,
+            )
+            .unwrap()
+            .unwrap()
+            .bytes;
+        let initial_configuration = initial
+            .participant_snapshot(
+                gf_storage::WORKSPACE_CAPABILITY_ID,
+                gf_storage::WORKSPACE_CONFIGURATION_FAMILY,
+            )
+            .unwrap()
+            .unwrap()
+            .bytes;
+        let generation_count = || {
+            fs::read_dir(context.state_path.join("generations"))
+                .unwrap()
+                .count()
+        };
+        let initial_count = generation_count();
+
+        let check = context
+            .sync(RepositorySyncRequest {
+                check: true,
+                operation_uuid: None,
+                actor_uuid: None,
+            })
+            .unwrap();
+        assert_eq!(check.status, RepositorySyncStatus::Drift);
+        assert_eq!(check.generation_uuid, initial_uuid);
+        assert_eq!(check.requested_operation_uuid, None);
+        assert_eq!(check.snapshot_operation_uuid, None);
+        assert_eq!(check.resolved_config_sha256.len(), 64);
+        assert_eq!(
+            check
+                .definitions
+                .iter()
+                .map(|definition| definition.definition_id.as_str())
+                .collect::<Vec<_>>(),
+            ["migrations", "ontology", "schemas", "seeds"]
+        );
+        assert!(check.sources.is_empty());
+        assert_eq!(
+            check.git,
+            GitProvenance {
+                sha: None,
+                dirty: false
+            }
+        );
+        assert_eq!(generation_count(), initial_count);
+        assert_eq!(
+            context
+                .sync(RepositorySyncRequest {
+                    check: false,
+                    operation_uuid: None,
+                    actor_uuid: None,
+                })
+                .unwrap_err()
+                .code(),
+            "GF_VALIDATION"
+        );
+        assert_eq!(generation_count(), initial_count);
+
+        let operation = Uuid::from_bytes([41; 16]);
+        let actor = Uuid::from_bytes([42; 16]);
+        let applied = context
+            .sync(RepositorySyncRequest {
+                check: false,
+                operation_uuid: Some(operation),
+                actor_uuid: Some(actor),
+            })
+            .unwrap();
+        assert_eq!(applied.status, RepositorySyncStatus::Published);
+        assert_eq!(applied.requested_operation_uuid, Some(operation));
+        assert_eq!(applied.snapshot_operation_uuid, Some(operation));
+        assert_eq!(applied.snapshot_actor_uuid, Some(actor));
+        assert_eq!(applied.resolved_config_sha256, check.resolved_config_sha256);
+        assert_eq!(applied.definitions, check.definitions);
+        assert_eq!(applied.sources, check.sources);
+        assert_eq!(applied.git, check.git);
+        assert_ne!(applied.generation_uuid, initial_uuid);
+        assert_eq!(generation_count(), initial_count + 1);
+
+        let published = gf_storage::resolve_project_generation(&context.state_path).unwrap();
+        assert_eq!(published.generation_uuid(), applied.generation_uuid);
+        assert_eq!(
+            published
+                .participant_snapshot(
+                    gf_storage::WORKSPACE_CAPABILITY_ID,
+                    gf_storage::WORKSPACE_ONTOLOGY_FAMILY,
+                )
+                .unwrap()
+                .unwrap()
+                .bytes,
+            initial_ontology
+        );
+        assert_eq!(
+            published
+                .participant_snapshot(
+                    gf_storage::WORKSPACE_CAPABILITY_ID,
+                    gf_storage::WORKSPACE_CONFIGURATION_FAMILY,
+                )
+                .unwrap()
+                .unwrap()
+                .bytes,
+            initial_configuration
+        );
+        let stored_snapshot = published
+            .participant_snapshot(
+                gf_storage::WORKSPACE_CAPABILITY_ID,
+                gf_storage::WORKSPACE_REPOSITORY_SNAPSHOT_FAMILY,
+            )
+            .unwrap()
+            .unwrap();
+        let stored_snapshot =
+            gf_storage::WorkspaceRepositorySnapshot::from_canonical_json(&stored_snapshot.bytes)
+                .unwrap();
+        assert_eq!(stored_snapshot.operation_uuid, operation);
+        assert_eq!(stored_snapshot.actor_uuid, Some(actor));
+        let carried = published
+            .participant_snapshots()
+            .unwrap()
+            .into_iter()
+            .filter(|participant| {
+                participant.record_family_id != gf_storage::WORKSPACE_REPOSITORY_SNAPSHOT_FAMILY
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(carried, initial_participants);
+
+        let replay = context
+            .sync(RepositorySyncRequest {
+                check: false,
+                operation_uuid: Some(operation),
+                actor_uuid: Some(actor),
+            })
+            .unwrap();
+        assert_eq!(replay.status, RepositorySyncStatus::InSync);
+        assert!(replay.idempotent_replay);
+        assert_eq!(replay.requested_operation_uuid, Some(operation));
+        assert_eq!(replay.snapshot_operation_uuid, Some(operation));
+        assert_eq!(replay.generation_uuid, applied.generation_uuid);
+        assert_eq!(generation_count(), initial_count + 1);
+        let actor_conflict = context
+            .sync(RepositorySyncRequest {
+                check: false,
+                operation_uuid: Some(operation),
+                actor_uuid: Some(Uuid::from_bytes([46; 16])),
+            })
+            .unwrap_err();
+        assert_eq!(actor_conflict.code(), "GF_IDEMPOTENCY_CONFLICT");
+        assert_eq!(generation_count(), initial_count + 1);
+
+        let unused_operation = Uuid::from_bytes([44; 16]);
+        let unused_actor = Uuid::from_bytes([45; 16]);
+        let no_op = context
+            .sync(RepositorySyncRequest {
+                check: false,
+                operation_uuid: Some(unused_operation),
+                actor_uuid: Some(unused_actor),
+            })
+            .unwrap();
+        assert_eq!(no_op.status, RepositorySyncStatus::InSync);
+        assert!(!no_op.idempotent_replay);
+        assert_eq!(no_op.requested_operation_uuid, Some(unused_operation));
+        assert_eq!(no_op.snapshot_operation_uuid, Some(operation));
+        assert_eq!(no_op.snapshot_actor_uuid, Some(actor));
+        assert_eq!(generation_count(), initial_count + 1);
+        let check_with_ignored_identities = context
+            .sync(RepositorySyncRequest {
+                check: true,
+                operation_uuid: Some(unused_operation),
+                actor_uuid: Some(unused_actor),
+            })
+            .unwrap();
+        assert_eq!(
+            check_with_ignored_identities.status,
+            RepositorySyncStatus::InSync
+        );
+        assert_eq!(check_with_ignored_identities.requested_operation_uuid, None);
+        assert!(!check_with_ignored_identities.idempotent_replay);
+        assert_eq!(
+            check_with_ignored_identities.snapshot_operation_uuid,
+            Some(operation)
+        );
+
+        fs::write(
+            root.path()
+                .join(".graphforge/ontology")
+                .join("repository-sync-test.yaml"),
+            "version: 1\n",
+        )
+        .unwrap();
+        let drift = context
+            .sync(RepositorySyncRequest {
+                check: true,
+                operation_uuid: None,
+                actor_uuid: None,
+            })
+            .unwrap();
+        assert_eq!(drift.status, RepositorySyncStatus::Drift);
+        assert_eq!(generation_count(), initial_count + 1);
+        let conflict = context
+            .sync(RepositorySyncRequest {
+                check: false,
+                operation_uuid: Some(operation),
+                actor_uuid: Some(actor),
+            })
+            .unwrap_err();
+        assert_eq!(conflict.code(), "GF_IDEMPOTENCY_CONFLICT");
+        assert_eq!(
+            gf_storage::resolve_project_generation(&context.state_path)
+                .unwrap()
+                .generation_uuid(),
+            applied.generation_uuid
+        );
+
+        let second = context
+            .sync(RepositorySyncRequest {
+                check: false,
+                operation_uuid: Some(Uuid::from_bytes([43; 16])),
+                actor_uuid: None,
+            })
+            .unwrap();
+        assert_eq!(second.status, RepositorySyncStatus::Published);
+        fs::remove_file(
+            root.path()
+                .join(".graphforge/ontology")
+                .join("repository-sync-test.yaml"),
+        )
+        .unwrap();
+        let stale_replay = context
+            .sync(RepositorySyncRequest {
+                check: false,
+                operation_uuid: Some(operation),
+                actor_uuid: Some(actor),
+            })
+            .unwrap_err();
+        assert_eq!(stale_replay.code(), "GF_IDEMPOTENCY_CONFLICT");
+        assert_eq!(
+            gf_storage::resolve_project_generation(&context.state_path)
+                .unwrap()
+                .generation_uuid(),
+            second.generation_uuid
+        );
+        assert_eq!(
+            context
+                .sync(RepositorySyncRequest {
+                    check: true,
+                    operation_uuid: None,
+                    actor_uuid: None,
+                })
+                .unwrap()
+                .status,
+            RepositorySyncStatus::Drift
+        );
+        fs::write(
+            root.path()
+                .join(".graphforge/ontology")
+                .join("repository-sync-test.yaml"),
+            "version: 1\n",
+        )
+        .unwrap();
+        let reopened = RepositoryContext::discover(root.path()).unwrap();
+        let reopened_check = reopened
+            .sync(RepositorySyncRequest {
+                check: true,
+                operation_uuid: None,
+                actor_uuid: None,
+            })
+            .unwrap();
+        assert_eq!(reopened_check.status, RepositorySyncStatus::InSync);
+        assert_eq!(reopened_check.generation_uuid, second.generation_uuid);
+    }
+
+    #[test]
+    fn repository_sync_rechecks_definitions_at_publication_boundary() {
+        let root = tempdir().unwrap();
+        let context = RepositoryContext::discover(root.path()).unwrap();
+        context.init_without_skills().unwrap();
+        context
+            .sync(RepositorySyncRequest {
+                check: false,
+                operation_uuid: Some(Uuid::from_bytes([61; 16])),
+                actor_uuid: None,
+            })
+            .unwrap();
+        let prior = gf_storage::resolve_project_generation(&context.state_path)
+            .unwrap()
+            .generation_uuid();
+        let definition = root.path().join(".graphforge/ontology/concurrent.yaml");
+        fs::write(&definition, "version: 1\n").unwrap();
+
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+        *REPOSITORY_SYNC_BEFORE_STAGE_HOOK
+            .get_or_init(|| std::sync::Mutex::new(None))
+            .lock()
+            .unwrap() = Some(RepositorySyncTestHook {
+            root: context.root.clone(),
+            barrier: barrier.clone(),
+        });
+        let mutation = std::thread::spawn(move || {
+            barrier.wait();
+            fs::write(definition, "version: 2\n").unwrap();
+            barrier.wait();
+        });
+        let error = context
+            .sync(RepositorySyncRequest {
+                check: false,
+                operation_uuid: Some(Uuid::from_bytes([62; 16])),
+                actor_uuid: None,
+            })
+            .unwrap_err();
+        mutation.join().unwrap();
+        *REPOSITORY_SYNC_BEFORE_STAGE_HOOK
+            .get()
+            .unwrap()
+            .lock()
+            .unwrap() = None;
+        assert_eq!(error.code(), "GF_VALIDATION");
+        assert!(
+            error
+                .to_string()
+                .contains("definitions changed during sync")
+        );
+        assert_eq!(
+            gf_storage::resolve_project_generation(&context.state_path)
+                .unwrap()
+                .generation_uuid(),
+            prior
+        );
+    }
+
+    #[test]
+    fn repository_definitions_reject_data_and_renamed_binary_files() {
+        for (name, bytes) in [
+            ("data.csv", b"id,name\n1,Ada\n".as_slice()),
+            ("data.jsonl", b"{\"id\":1}\n".as_slice()),
+            ("data.ndjson", b"{\"id\":1}\n".as_slice()),
+            ("data.ipc", b"ARROW1binary".as_slice()),
+            ("data.feather", b"FEA1binary".as_slice()),
+            ("data.avro", b"Obj\x01binary".as_slice()),
+            ("renamed.yaml", b"\0\xff\x10binary".as_slice()),
+            ("renamed.json", b"\0\xff\x10binary".as_slice()),
+        ] {
+            let root = tempdir().unwrap();
+            let context = RepositoryContext::discover(root.path()).unwrap();
+            context.init_without_skills().unwrap();
+            let before = fs::read_dir(context.state_path.join("generations"))
+                .unwrap()
+                .count();
+            fs::write(root.path().join(".graphforge/seeds").join(name), bytes).unwrap();
+            let error = context
+                .sync(RepositorySyncRequest {
+                    check: true,
+                    operation_uuid: None,
+                    actor_uuid: None,
+                })
+                .unwrap_err();
+            assert_eq!(error.code(), "GF_VALIDATION", "{name}");
+            assert_eq!(
+                fs::read_dir(context.state_path.join("generations"))
+                    .unwrap()
+                    .count(),
+                before,
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn repository_sync_failpoint_child() {
+        let Ok(root) = std::env::var("GRAPHFORGE_REPOSITORY_SYNC_TEST_ROOT") else {
+            return;
+        };
+        let context = RepositoryContext::discover(root).unwrap();
+        context
+            .sync(RepositorySyncRequest {
+                check: false,
+                operation_uuid: Some(Uuid::from_bytes([51; 16])),
+                actor_uuid: Some(Uuid::from_bytes([52; 16])),
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn repository_sync_failure_boundaries_recover_to_one_authoritative_state() {
+        for (failpoint, expect_published) in [
+            ("project.after_domain_validation", false),
+            ("project.after_current_replace", true),
+        ] {
+            let root = tempdir().unwrap();
+            let context = RepositoryContext::discover(root.path()).unwrap();
+            context.init_without_skills().unwrap();
+            let initial = gf_storage::resolve_project_generation(&context.state_path)
+                .unwrap()
+                .generation_uuid();
+            let status = Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "repository::tests::repository_sync_failpoint_child",
+                    "--nocapture",
+                ])
+                .env(
+                    "GRAPHFORGE_REPOSITORY_SYNC_TEST_ROOT",
+                    root.path().as_os_str(),
+                )
+                .env(
+                    "GRAPHFORGE_PROJECT_FAILPOINTS",
+                    "graphforge-internal-subprocess-v1",
+                )
+                .env("GRAPHFORGE_PROJECT_FAILPOINT", failpoint)
+                .status()
+                .unwrap();
+            assert_eq!(status.code(), Some(86), "{failpoint}");
+
+            gf_storage::recover_project_transactions(&context.state_path).unwrap();
+            let current = gf_storage::resolve_project_generation(&context.state_path).unwrap();
+            current.validate_complete_participant_inventory().unwrap();
+            let check = context
+                .sync(RepositorySyncRequest {
+                    check: true,
+                    operation_uuid: None,
+                    actor_uuid: None,
+                })
+                .unwrap();
+            if expect_published {
+                assert_ne!(current.generation_uuid(), initial, "{failpoint}");
+                assert_eq!(check.status, RepositorySyncStatus::InSync, "{failpoint}");
+            } else {
+                assert_eq!(current.generation_uuid(), initial, "{failpoint}");
+                assert_eq!(check.status, RepositorySyncStatus::Drift, "{failpoint}");
+            }
+        }
     }
 
     #[test]

--- a/crates/gf-bindings-node/tests/non-cypher-parity-policy.json
+++ b/crates/gf-bindings-node/tests/non-cypher-parity-policy.json
@@ -1,8 +1,8 @@
 {
   "contractVersion": 1,
   "rustManifest": "../../../tests/contracts/non-cypher-rust-surface.json",
-  "releaseSurfaceCount": 184,
-  "releaseSurfaceDigest": "18028d423dc8968ee8512b3cba2098a2d7d28934b3216416e2b4cd4b72982dc4",
+  "releaseSurfaceCount": 185,
+  "releaseSurfaceDigest": "b294b19c0de90e31aebefac7597f336073d6131758612e0586c8a01ac01ed9d7",
   "requiredEquivalent": [
     "GraphForge.adopt_ontology",
     "GraphForge.clear_ontology",
@@ -13,6 +13,7 @@
     "GraphForge.workspace_ontology"
   ],
   "rustEvidenceGroupMap": {
+    "repository-sync": "lifecycleConstruction",
     "ontology-lifecycle": "ontologyLifecycle",
     "lifecycle-construction": "lifecycleConstruction",
     "checkpoint-view": "checkpointView",
@@ -185,7 +186,8 @@
     "notExposedDefaults": {
       "CheckpointView": "Node checkpoint views expose the bounded pinned read surface; unsupported Rust checkpoint operations require an explicit parity decision.",
       "GraphForge": "No shipped Node member exists for this Rust facade entry; adding one requires an explicit parity decision.",
-      "OpenRouterProviderSession": "Rust provider sessions are not exported; Node owns a configured native provider adapter instead."
+      "OpenRouterProviderSession": "Rust provider sessions are not exported; Node owns a configured native provider adapter instead.",
+      "RepositoryContext": "Rust owns repository lifecycle behavior; the Node command wrapper parity is delivered by issue #226."
     }
   },
   "evidence": {

--- a/crates/gf-bindings-py/tests/non_cypher_release.py
+++ b/crates/gf-bindings-py/tests/non_cypher_release.py
@@ -24,9 +24,12 @@ RUST_MANIFEST = ROOT / "tests/contracts/non-cypher-rust-surface.json"
 RUST_GATE = ROOT / "scripts/ci/non-cypher-surface-gate.py"
 PYO3_SOURCE = ROOT / "crates/gf-bindings-py/src/lib.rs"
 EXPECTED_RUST_DIGEST = "35ede905127bf32a6e3048da1f8623f8c8c174bdd3275666164edcbbd1704a02"
-EXPECTED_RELEASE_DIGEST = "18028d423dc8968ee8512b3cba2098a2d7d28934b3216416e2b4cd4b72982dc4"
+EXPECTED_RELEASE_DIGEST = "b294b19c0de90e31aebefac7597f336073d6131758612e0586c8a01ac01ed9d7"
 
 EVIDENCE = {
+    "repository-sync": {
+        "non_cypher_release.py": ["check_lifecycle_checkpoint_errors_and_reopen"],
+    },
     "ontology-lifecycle": {
         "ontology_lifecycle.py": ["main"],
     },
@@ -182,7 +185,7 @@ def _classification_report() -> dict[str, object]:
         for group in manifest["method_evidence_groups"].values()
         for method_id in group["ids"]
     }
-    assert len(release_methods) == 184
+    assert len(release_methods) == 185
     assert _digest(release_methods) == EXPECTED_RELEASE_DIGEST
     assert set(EVIDENCE) == set(manifest["method_evidence_groups"])
 

--- a/crates/gf-cli/src/lib.rs
+++ b/crates/gf-cli/src/lib.rs
@@ -12,8 +12,8 @@ use gf_api::{
     DeleteCheckpointRequest, DiffCheckpointsRequest, ExecutionResult, GraphForge,
     ListCheckpointsRequest, OperationId, PageRequest, PageToken, PortableExportRequest,
     PortableExportResult, PortableImportRequest, PortableImportResult, PortableSelection,
-    PreviewRevertCheckpointRequest, RepositoryContext, RevertCheckpointPreview,
-    RevertCheckpointRequest, ShowCheckpointRequest,
+    PreviewRevertCheckpointRequest, RepositoryContext, RepositorySyncRequest, RepositorySyncStatus,
+    RevertCheckpointPreview, RevertCheckpointRequest, ShowCheckpointRequest,
 };
 use uuid::Uuid;
 
@@ -24,6 +24,7 @@ const MAX_SKILL_FILE_BYTES: u64 = 4 * 1024 * 1024;
 const MAX_SKILL_BUNDLE_BYTES: u64 = 8 * 1024 * 1024;
 const MAX_SKILL_BUNDLE_FILES: usize = 256;
 const MAX_SKILL_PATH_BYTES: usize = 1024;
+const OUT_OF_SYNC_EXIT_CODE: i32 = 4;
 
 fn project_skill_bundle() -> gf_api::SkillBundle<'static> {
     gf_api::SkillBundle {
@@ -236,8 +237,8 @@ struct Cli {
 enum Command {
     /// Initialize repository-local GraphForge definitions and state.
     Init(InitArgs),
-    /// Validate declared definitions and source digests without ingesting data.
-    Sync,
+    /// Compare or reconcile declared definitions and source digests without ingesting data.
+    Sync(SyncArgs),
     /// Remove only repository-local runtime state.
     Remove(RemoveArgs),
     /// Validate or resolve repository configuration.
@@ -268,6 +269,19 @@ struct InitArgs {
     /// Do not install missing project-local GraphForge agent skills.
     #[arg(long)]
     no_skills: bool,
+}
+
+#[derive(Args)]
+struct SyncArgs {
+    /// Compare declared repository state without publishing a generation.
+    #[arg(long, conflicts_with_all = ["idempotency_key", "actor_uuid"])]
+    check: bool,
+    /// Caller-owned operation identity, required only when applying drift.
+    #[arg(long)]
+    idempotency_key: Option<String>,
+    /// Optional caller-owned actor identity for a published snapshot.
+    #[arg(long, requires = "idempotency_key")]
+    actor_uuid: Option<String>,
 }
 
 #[derive(Subcommand)]
@@ -810,7 +824,7 @@ fn run_repository(
     json: bool,
     skill_bundle: &gf_api::SkillBundle<'_>,
     output: &mut dyn Write,
-) -> Result<(), gf_api::GfError> {
+) -> Result<i32, gf_api::GfError> {
     let start = project_dir.unwrap_or(
         std::env::current_dir().map_err(|error| gf_api::GfError::Storage(error.to_string()))?,
     );
@@ -821,6 +835,8 @@ fn run_repository(
             command: ConfigCommand::Resolve
         }
     );
+    let mut exit_code = 0;
+    let mut plain_output = "ok";
     let value = match command {
         Command::Init(args) => {
             let init = repository.init_without_skills()?;
@@ -837,7 +853,26 @@ fn run_repository(
                 "skills": skills
             }))
         }
-        Command::Sync => serde_json::to_value(repository.sync()?),
+        Command::Sync(args) => {
+            let result = repository.sync(RepositorySyncRequest {
+                check: args.check,
+                operation_uuid: args
+                    .idempotency_key
+                    .as_deref()
+                    .map(canonical_uuid)
+                    .transpose()?,
+                actor_uuid: actor(args.actor_uuid.as_deref())?,
+            })?;
+            if args.check && result.status == RepositorySyncStatus::Drift {
+                exit_code = OUT_OF_SYNC_EXIT_CODE;
+            }
+            plain_output = match result.status {
+                RepositorySyncStatus::InSync => "in_sync",
+                RepositorySyncStatus::Drift => "drift",
+                RepositorySyncStatus::Published => "published",
+            };
+            serde_json::to_value(result)
+        }
         Command::Remove(args) => {
             let receipt = repository.remove(args.yes)?;
             serde_json::to_value(serde_json::json!({
@@ -878,9 +913,10 @@ fn run_repository(
         )
         .map_err(|error| gf_api::GfError::Execution(error.to_string()))?;
     } else {
-        writeln!(output, "ok").map_err(|error| gf_api::GfError::Execution(error.to_string()))?;
+        writeln!(output, "{plain_output}")
+            .map_err(|error| gf_api::GfError::Execution(error.to_string()))?;
     }
-    Ok(())
+    Ok(exit_code)
 }
 
 fn run_repository_with_bundle(
@@ -889,7 +925,7 @@ fn run_repository_with_bundle(
     json: bool,
     bundle_dir: Option<&Path>,
     output: &mut dyn Write,
-) -> Result<(), gf_api::GfError> {
+) -> Result<i32, gf_api::GfError> {
     let needs_packaged_bundle = matches!(&command, Command::Init(args) if !args.no_skills)
         || matches!(
             &command,
@@ -938,21 +974,21 @@ fn resolve_project_path(
     }
 }
 
-fn run(cli: Cli, output: &mut dyn Write) -> Result<(), gf_api::GfError> {
+fn run(cli: Cli, output: &mut dyn Write) -> Result<i32, gf_api::GfError> {
     if cli.info {
         writeln!(output, "graphforge {}", env!("CARGO_PKG_VERSION"))
             .map_err(|error| gf_api::GfError::Execution(error.to_string()))?;
-        return Ok(());
+        return Ok(0);
     }
     let Some(command) = cli.command else {
         writeln!(output, "GraphForge — use --help for options")
             .map_err(|error| gf_api::GfError::Execution(error.to_string()))?;
-        return Ok(());
+        return Ok(0);
     };
     if matches!(
         &command,
         Command::Init(_)
-            | Command::Sync
+            | Command::Sync(_)
             | Command::Remove(_)
             | Command::Config { .. }
             | Command::Skills { .. }
@@ -967,25 +1003,25 @@ fn run(cli: Cli, output: &mut dyn Write) -> Result<(), gf_api::GfError> {
     }
     let path = resolve_project_path(cli.project, cli.project_dir)?;
     let command = match command {
-        Command::Import(args) => return run_import(args, &path, cli.json, output),
+        Command::Import(args) => return run_import(args, &path, cli.json, output).map(|()| 0),
         command => command,
     };
     if handle_revert_before_open(&command, &path, cli.json, output)? {
-        return Ok(());
+        return Ok(0);
     }
     let path_text = path
         .to_str()
         .ok_or_else(|| gf_api::GfError::Validation("--project must be valid UTF-8".into()))?;
     let mut graph = GraphForge::new(Some(path_text))?;
     let command = match command {
-        Command::Export(args) => return run_export(&graph, args, cli.json, output),
+        Command::Export(args) => return run_export(&graph, args, cli.json, output).map(|()| 0),
         command => command,
     };
     let command = match command {
         Command::Revert(args)
         | Command::Checkpoint {
             command: CheckpointCommand::Revert(args),
-        } => return run_revert(&mut graph, args, cli.json, output),
+        } => return run_revert(&mut graph, args, cli.json, output).map(|()| 0),
         command => command,
     };
     let result = match command {
@@ -1037,7 +1073,8 @@ fn run(cli: Cli, output: &mut dyn Write) -> Result<(), gf_api::GfError> {
         },
         _ => unreachable!(),
     };
-    write_execution_result(&result, cli.json, output)
+    write_execution_result(&result, cli.json, output)?;
+    Ok(0)
 }
 
 /// Captured result of one Rust-owned CLI invocation.
@@ -1097,11 +1134,12 @@ where
         }
     };
     let json = cli.json;
-    let exit_code = if let Err(error) = run(cli, &mut stdout) {
-        write_error(&error, json, &mut stderr).expect("writing to Vec cannot fail");
-        error_exit_code(&error)
-    } else {
-        0
+    let exit_code = match run(cli, &mut stdout) {
+        Ok(exit_code) => exit_code,
+        Err(error) => {
+            write_error(&error, json, &mut stderr).expect("writing to Vec cannot fail");
+            error_exit_code(&error)
+        }
     };
     CliExecution {
         exit_code,
@@ -1201,11 +1239,18 @@ pub fn run_process() {
     let json = cli.json;
     let stdout = io::stdout();
     let mut output = stdout.lock();
-    if let Err(error) = run(cli, &mut output) {
-        let _ = output.flush();
-        let stderr = io::stderr();
-        write_error(&error, json, &mut stderr.lock()).expect("write CLI stderr");
-        std::process::exit(error_exit_code(&error));
+    match run(cli, &mut output) {
+        Ok(exit_code) if exit_code != 0 => {
+            let _ = output.flush();
+            std::process::exit(exit_code);
+        }
+        Ok(_) => {}
+        Err(error) => {
+            let _ = output.flush();
+            let stderr = io::stderr();
+            write_error(&error, json, &mut stderr.lock()).expect("write CLI stderr");
+            std::process::exit(error_exit_code(&error));
+        }
     }
 }
 
@@ -1427,6 +1472,32 @@ mod tests {
         assert!(Cli::try_parse_from(["gf", "--project-dir", "/tmp/repo", "init"]).is_ok());
         assert!(
             Cli::try_parse_from(["gf", "--project-dir", "/tmp/repo", "config", "resolve"]).is_ok()
+        );
+        assert!(
+            Cli::try_parse_from(["gf", "--project-dir", "/tmp/repo", "sync", "--check",]).is_ok()
+        );
+        assert!(
+            Cli::try_parse_from([
+                "gf",
+                "--project-dir",
+                "/tmp/repo",
+                "sync",
+                "--check",
+                "--idempotency-key",
+                "41414141-4141-4141-4141-414141414141",
+            ])
+            .is_err()
+        );
+        assert!(
+            Cli::try_parse_from([
+                "gf",
+                "--project-dir",
+                "/tmp/repo",
+                "sync",
+                "--actor-uuid",
+                "42424242-4242-4242-4242-424242424242",
+            ])
+            .is_err()
         );
         let cli = Cli::try_parse_from(["gf", "--project-dir", "/tmp/repo", "remove"]).unwrap();
         assert!(matches!(

--- a/crates/gf-cli/tests/repository.rs
+++ b/crates/gf-cli/tests/repository.rs
@@ -10,6 +10,115 @@ fn gf() -> Command {
     Command::new(env!("CARGO_BIN_EXE_gf"))
 }
 
+fn assert_sync_check_publish_and_replay(root: &std::path::Path) {
+    let current_before_check = fs::read_to_string(root.join(".graphforge/state/CURRENT")).unwrap();
+    let plain_check = gf()
+        .args(["--project-dir", root.to_str().unwrap(), "sync", "--check"])
+        .output()
+        .unwrap();
+    assert_eq!(plain_check.status.code(), Some(4));
+    assert_eq!(plain_check.stdout, b"drift\n");
+    assert!(plain_check.stderr.is_empty());
+    assert_eq!(
+        fs::read_to_string(root.join(".graphforge/state/CURRENT")).unwrap(),
+        current_before_check
+    );
+
+    let check = gf()
+        .args([
+            "--project-dir",
+            root.to_str().unwrap(),
+            "--json",
+            "sync",
+            "--check",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(check.status.code(), Some(4));
+    let value: Value = serde_json::from_slice(&check.stdout).unwrap();
+    assert_eq!(value["status"], "drift");
+    assert_eq!(value["requested_operation_uuid"], Value::Null);
+    assert!(check.stderr.is_empty());
+
+    let operation = "41414141-4141-4141-4141-414141414141";
+    let actor = "42424242-4242-4242-4242-424242424242";
+    let sync = gf()
+        .args([
+            "--project-dir",
+            root.to_str().unwrap(),
+            "--json",
+            "sync",
+            "--idempotency-key",
+            operation,
+            "--actor-uuid",
+            actor,
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        sync.status.success(),
+        "{}",
+        String::from_utf8_lossy(&sync.stderr)
+    );
+    let value: Value = serde_json::from_slice(&sync.stdout).unwrap();
+    assert_eq!(value["status"], "published");
+    assert_eq!(value["requested_operation_uuid"], operation);
+    assert_eq!(value["snapshot_operation_uuid"], operation);
+    assert_eq!(value["snapshot_actor_uuid"], actor);
+
+    let replay = gf()
+        .args([
+            "--project-dir",
+            root.to_str().unwrap(),
+            "--json",
+            "sync",
+            "--idempotency-key",
+            operation,
+            "--actor-uuid",
+            actor,
+        ])
+        .output()
+        .unwrap();
+    assert!(replay.status.success());
+    let value: Value = serde_json::from_slice(&replay.stdout).unwrap();
+    assert_eq!(value["status"], "in_sync");
+    assert_eq!(value["idempotent_replay"], true);
+
+    let in_sync = gf()
+        .args([
+            "--project-dir",
+            root.to_str().unwrap(),
+            "--json",
+            "sync",
+            "--check",
+        ])
+        .output()
+        .unwrap();
+    assert!(in_sync.status.success());
+    let value: Value = serde_json::from_slice(&in_sync.stdout).unwrap();
+    assert_eq!(value["status"], "in_sync");
+    assert_eq!(value["requested_operation_uuid"], Value::Null);
+}
+
+fn assert_sync_detects_definition_drift(root: &std::path::Path) {
+    fs::write(root.join(".graphforge/ontology/keep.yaml"), "version: 1\n").unwrap();
+    let drift = gf()
+        .args([
+            "--project-dir",
+            root.to_str().unwrap(),
+            "--json",
+            "sync",
+            "--check",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(drift.status.code(), Some(4));
+    assert_eq!(
+        serde_json::from_slice::<Value>(&drift.stdout).unwrap()["status"],
+        "drift"
+    );
+}
+
 #[test]
 fn repository_lifecycle_emits_stable_json_and_keeps_data_out_of_git() {
     let root = tempdir().unwrap();
@@ -77,24 +186,8 @@ fn repository_lifecycle_emits_stable_json_and_keeps_data_out_of_git() {
     let ignore = fs::read_to_string(root.path().join(".gitignore")).unwrap();
     assert!(!ignore.contains(".agents/"));
 
-    let sync = gf()
-        .args([
-            "--project-dir",
-            root.path().to_str().unwrap(),
-            "--json",
-            "sync",
-        ])
-        .output()
-        .unwrap();
-    assert!(sync.status.success());
-    let value: Value = serde_json::from_slice(&sync.stdout).unwrap();
-    assert!(
-        value["definition_digests"]
-            .as_object()
-            .is_some_and(|value| value.len() == 4)
-    );
-
-    fs::write(root.path().join(".graphforge/ontology/keep.yaml"), "keep").unwrap();
+    assert_sync_check_publish_and_replay(root.path());
+    assert_sync_detects_definition_drift(root.path());
     let remove = gf()
         .args([
             "--project-dir",

--- a/crates/gf-storage/src/lib.rs
+++ b/crates/gf-storage/src/lib.rs
@@ -58,9 +58,14 @@ pub use project_portable::{
 
 pub mod workspace_participants;
 pub use workspace_participants::{
-    WORKSPACE_CAPABILITY_ID, WORKSPACE_CAPABILITY_VERSION, WORKSPACE_CONFIGURATION_FAMILY,
-    WORKSPACE_ONTOLOGY_FAMILY, WorkspaceConfiguration, WorkspaceOntology, WorkspaceOntologyMode,
-    WorkspaceOntologySourceFormat, empty_workspace_participants,
+    MAX_WORKSPACE_REPOSITORY_SNAPSHOT_BYTES, MAX_WORKSPACE_REPOSITORY_SNAPSHOT_ENTRIES,
+    MAX_WORKSPACE_REPOSITORY_SNAPSHOT_ID_BYTES, WORKSPACE_CAPABILITY_ID,
+    WORKSPACE_CAPABILITY_VERSION, WORKSPACE_CONFIGURATION_FAMILY, WORKSPACE_ONTOLOGY_FAMILY,
+    WORKSPACE_REPOSITORY_SNAPSHOT_FAMILY, WORKSPACE_REPOSITORY_SNAPSHOT_VERSION,
+    WorkspaceConfiguration, WorkspaceOntology, WorkspaceOntologyMode,
+    WorkspaceOntologySourceFormat, WorkspaceRepositoryDefinitionDigest,
+    WorkspaceRepositoryGitProvenance, WorkspaceRepositorySnapshot, WorkspaceRepositorySourceDigest,
+    empty_workspace_participants,
 };
 
 pub mod embedding_identity;

--- a/crates/gf-storage/src/workspace_participants.rs
+++ b/crates/gf-storage/src/workspace_participants.rs
@@ -6,6 +6,7 @@ use gf_core::{GfError, OntologyMode, ProjectErrorCode};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
+use uuid::Uuid;
 
 use crate::{ProjectParticipant, ProjectParticipantEncoding};
 
@@ -17,6 +18,16 @@ pub const WORKSPACE_CAPABILITY_VERSION: u32 = 1;
 pub const WORKSPACE_ONTOLOGY_FAMILY: &str = "ontology";
 /// Canonical project-configuration record family.
 pub const WORKSPACE_CONFIGURATION_FAMILY: &str = "configuration";
+/// Canonical repository reconciliation snapshot record family.
+pub const WORKSPACE_REPOSITORY_SNAPSHOT_FAMILY: &str = "repository_snapshot";
+/// Frozen repository snapshot contract version.
+pub const WORKSPACE_REPOSITORY_SNAPSHOT_VERSION: u32 = 1;
+/// Maximum canonical repository snapshot participant size.
+pub const MAX_WORKSPACE_REPOSITORY_SNAPSHOT_BYTES: usize = 1024 * 1024;
+/// Maximum number of declared definitions or external sources in one snapshot.
+pub const MAX_WORKSPACE_REPOSITORY_SNAPSHOT_ENTRIES: usize = 10_000;
+/// Maximum UTF-8 byte length of one stable definition or source identifier.
+pub const MAX_WORKSPACE_REPOSITORY_SNAPSHOT_ID_BYTES: usize = 256;
 
 /// Persisted ontology mode. Absence is explicit rather than inferred from files.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -82,6 +93,56 @@ pub struct WorkspaceConfiguration {
     pub embedding_configuration: BTreeMap<String, Value>,
 }
 
+/// One declared repository definition identified without retaining its path or contents.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkspaceRepositoryDefinitionDigest {
+    /// Stable caller-defined definition identifier.
+    pub definition_id: String,
+    /// SHA-256 of the validated canonical definition tree.
+    pub sha256: String,
+}
+
+/// One declared external source reference; source data is never embedded.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkspaceRepositorySourceDigest {
+    /// Stable caller-defined source identifier.
+    pub source_id: String,
+    /// Caller-declared SHA-256 of the external source.
+    pub sha256: String,
+}
+
+/// Bounded Git provenance recorded without paths, diffs, messages, or repository contents.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkspaceRepositoryGitProvenance {
+    /// Exact hexadecimal Git object ID, absent for repositories without a commit.
+    pub commit_sha: Option<String>,
+    /// Whether tracked repository state differed from the selected commit.
+    pub dirty: bool,
+}
+
+/// Canonical secret-free desired-state evidence published by repository sync.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkspaceRepositorySnapshot {
+    /// Frozen record contract version.
+    pub contract_version: u32,
+    /// SHA-256 of the canonical resolved, secret-free configuration.
+    pub resolved_config_sha256: String,
+    /// Strictly ordered declared-definition identifiers and digests.
+    pub definitions: Vec<WorkspaceRepositoryDefinitionDigest>,
+    /// Strictly ordered external source identifiers and digest references.
+    pub sources: Vec<WorkspaceRepositorySourceDigest>,
+    /// Bounded Git provenance.
+    pub git: WorkspaceRepositoryGitProvenance,
+    /// Caller-owned idempotency identity for the publishing operation.
+    pub operation_uuid: Uuid,
+    /// Optional caller-owned actor identity.
+    pub actor_uuid: Option<Uuid>,
+}
+
 impl WorkspaceOntology {
     /// Construct explicit ontology absence for a new exploratory project.
     #[must_use]
@@ -140,6 +201,49 @@ impl WorkspaceConfiguration {
     /// Returns `GF_PROJECT_CORRUPT` for future, malformed, or noncanonical data.
     pub fn from_canonical_json(bytes: &[u8]) -> Result<Self, GfError> {
         parse_canonical_json(bytes, "workspace configuration", validate_configuration)
+    }
+}
+
+impl WorkspaceRepositorySnapshot {
+    /// Validate and return canonical JSON plus LF.
+    ///
+    /// # Errors
+    /// Returns `GF_PROJECT_CORRUPT` for future, malformed, noncanonical, or
+    /// out-of-bounds snapshots.
+    pub fn to_canonical_json(&self) -> Result<Vec<u8>, GfError> {
+        validate_repository_snapshot(self)?;
+        let bytes = canonical_json(self, "workspace repository snapshot")?;
+        if bytes.len() > MAX_WORKSPACE_REPOSITORY_SNAPSHOT_BYTES {
+            return Err(corrupt("workspace repository snapshot exceeds size limit"));
+        }
+        Ok(bytes)
+    }
+
+    /// Parse exact canonical JSON plus LF and enforce every contract bound.
+    ///
+    /// # Errors
+    /// Returns `GF_PROJECT_CORRUPT` for future, malformed, noncanonical, or
+    /// out-of-bounds snapshots.
+    pub fn from_canonical_json(bytes: &[u8]) -> Result<Self, GfError> {
+        if bytes.len() > MAX_WORKSPACE_REPOSITORY_SNAPSHOT_BYTES {
+            return Err(corrupt("workspace repository snapshot exceeds size limit"));
+        }
+        parse_canonical_json(
+            bytes,
+            "workspace repository snapshot",
+            validate_repository_snapshot,
+        )
+    }
+
+    /// Encode this record as the registered workspace generation participant.
+    ///
+    /// # Errors
+    /// Returns a structured error when the snapshot violates its contract.
+    pub fn to_project_participant(&self) -> Result<ProjectParticipant, GfError> {
+        Ok(participant(
+            WORKSPACE_REPOSITORY_SNAPSHOT_FAMILY,
+            self.to_canonical_json()?,
+        ))
     }
 }
 
@@ -212,6 +316,85 @@ fn validate_configuration(record: &WorkspaceConfiguration) -> Result<(), GfError
     Ok(())
 }
 
+fn validate_repository_snapshot(record: &WorkspaceRepositorySnapshot) -> Result<(), GfError> {
+    if record.contract_version != WORKSPACE_REPOSITORY_SNAPSHOT_VERSION {
+        return Err(corrupt(
+            "unsupported workspace repository snapshot contract",
+        ));
+    }
+    validate_sha256(&record.resolved_config_sha256, "resolved config")?;
+    validate_digest_entries(
+        &record.definitions,
+        |entry| (&entry.definition_id, &entry.sha256),
+        "definition",
+    )?;
+    validate_digest_entries(
+        &record.sources,
+        |entry| (&entry.source_id, &entry.sha256),
+        "source",
+    )?;
+    if let Some(commit_sha) = &record.git.commit_sha
+        && (!matches!(commit_sha.len(), 40 | 64)
+            || !commit_sha.bytes().all(|byte| byte.is_ascii_hexdigit())
+            || commit_sha.bytes().any(|byte| byte.is_ascii_uppercase()))
+    {
+        return Err(corrupt("Git commit SHA is not canonical hexadecimal"));
+    }
+    if record.operation_uuid.is_nil() {
+        return Err(corrupt("repository snapshot operation UUID is nil"));
+    }
+    if record.actor_uuid.is_some_and(|actor| actor.is_nil()) {
+        return Err(corrupt("repository snapshot actor UUID is nil"));
+    }
+    Ok(())
+}
+
+fn validate_digest_entries<T>(
+    entries: &[T],
+    fields: impl for<'a> Fn(&'a T) -> (&'a String, &'a String),
+    name: &str,
+) -> Result<(), GfError> {
+    if entries.len() > MAX_WORKSPACE_REPOSITORY_SNAPSHOT_ENTRIES {
+        return Err(corrupt(format!(
+            "workspace repository {name} count exceeds limit"
+        )));
+    }
+    let mut prior: Option<&str> = None;
+    for entry in entries {
+        let (id, digest) = fields(entry);
+        let canonical_id = !id.is_empty()
+            && id.len() <= MAX_WORKSPACE_REPOSITORY_SNAPSHOT_ID_BYTES
+            && id.bytes().enumerate().all(|(index, byte)| {
+                byte.is_ascii_lowercase()
+                    || index > 0 && byte.is_ascii_digit()
+                    || index > 0 && matches!(byte, b'-' | b'_')
+            });
+        if !canonical_id {
+            return Err(corrupt(format!(
+                "workspace repository {name} identifier is invalid"
+            )));
+        }
+        if prior.is_some_and(|prior| prior >= id.as_str()) {
+            return Err(corrupt(format!(
+                "workspace repository {name} identifiers are not canonical"
+            )));
+        }
+        validate_sha256(digest, name)?;
+        prior = Some(id);
+    }
+    Ok(())
+}
+
+fn validate_sha256(value: &str, name: &str) -> Result<(), GfError> {
+    if value.len() != 64
+        || !value.bytes().all(|byte| byte.is_ascii_hexdigit())
+        || value.bytes().any(|byte| byte.is_ascii_uppercase())
+    {
+        return Err(corrupt(format!("{name} SHA-256 is not canonical")));
+    }
+    Ok(())
+}
+
 fn canonical_json(value: &impl Serialize, name: &str) -> Result<Vec<u8>, GfError> {
     let mut bytes =
         serde_json::to_vec(value).map_err(|_| corrupt(format!("{name} cannot be encoded")))?;
@@ -260,6 +443,33 @@ fn encode_hex(bytes: &[u8]) -> String {
 mod tests {
     use super::*;
 
+    fn repository_snapshot() -> WorkspaceRepositorySnapshot {
+        WorkspaceRepositorySnapshot {
+            contract_version: WORKSPACE_REPOSITORY_SNAPSHOT_VERSION,
+            resolved_config_sha256: "11".repeat(32),
+            definitions: vec![
+                WorkspaceRepositoryDefinitionDigest {
+                    definition_id: "migrations".into(),
+                    sha256: "22".repeat(32),
+                },
+                WorkspaceRepositoryDefinitionDigest {
+                    definition_id: "ontology".into(),
+                    sha256: "33".repeat(32),
+                },
+            ],
+            sources: vec![WorkspaceRepositorySourceDigest {
+                source_id: "customers".into(),
+                sha256: "44".repeat(32),
+            }],
+            git: WorkspaceRepositoryGitProvenance {
+                commit_sha: Some("a1".repeat(20)),
+                dirty: true,
+            },
+            operation_uuid: Uuid::from_bytes([5; 16]),
+            actor_uuid: Some(Uuid::from_bytes([6; 16])),
+        }
+    }
+
     #[test]
     fn empty_records_round_trip_canonically() {
         let ontology = WorkspaceOntology::none();
@@ -307,6 +517,126 @@ mod tests {
         };
         assert_eq!(
             record.to_canonical_json().unwrap_err().code(),
+            "GF_PROJECT_CORRUPT"
+        );
+    }
+
+    #[test]
+    fn repository_snapshot_round_trips_canonically_as_registered_participant() {
+        let snapshot = repository_snapshot();
+        let bytes = snapshot.to_canonical_json().unwrap();
+        assert_eq!(
+            WorkspaceRepositorySnapshot::from_canonical_json(&bytes).unwrap(),
+            snapshot
+        );
+        assert_eq!(bytes.last(), Some(&b'\n'));
+        assert!(!bytes.windows(2).any(|window| window == b"\n\n"));
+        assert!(!String::from_utf8_lossy(&bytes).contains("/Users/"));
+
+        let participant = snapshot.to_project_participant().unwrap();
+        assert_eq!(participant.capability_id, WORKSPACE_CAPABILITY_ID);
+        assert_eq!(
+            participant.record_family_id,
+            WORKSPACE_REPOSITORY_SNAPSHOT_FAMILY
+        );
+        let expected_fingerprint: [u8; 32] =
+            Sha256::digest("workspace/repository_snapshot@1").into();
+        assert_eq!(participant.schema_fingerprint, expected_fingerprint);
+        assert_eq!(participant.bytes, bytes);
+    }
+
+    #[test]
+    fn repository_snapshot_rejects_future_noncanonical_and_unbounded_records() {
+        let mut future = repository_snapshot();
+        future.contract_version += 1;
+        assert_eq!(
+            future.to_canonical_json().unwrap_err().code(),
+            "GF_PROJECT_CORRUPT"
+        );
+
+        let mut unordered = repository_snapshot();
+        unordered.definitions.reverse();
+        assert_eq!(
+            unordered.to_canonical_json().unwrap_err().code(),
+            "GF_PROJECT_CORRUPT"
+        );
+
+        let mut duplicate = repository_snapshot();
+        duplicate.sources.push(duplicate.sources[0].clone());
+        assert_eq!(
+            duplicate.to_canonical_json().unwrap_err().code(),
+            "GF_PROJECT_CORRUPT"
+        );
+
+        let mut oversized_id = repository_snapshot();
+        oversized_id.sources[0].source_id =
+            "x".repeat(MAX_WORKSPACE_REPOSITORY_SNAPSHOT_ID_BYTES + 1);
+        assert_eq!(
+            oversized_id.to_canonical_json().unwrap_err().code(),
+            "GF_PROJECT_CORRUPT"
+        );
+
+        let mut too_many = repository_snapshot();
+        too_many.definitions = (0..=MAX_WORKSPACE_REPOSITORY_SNAPSHOT_ENTRIES)
+            .map(|index| WorkspaceRepositoryDefinitionDigest {
+                definition_id: format!("{index:05}"),
+                sha256: "55".repeat(32),
+            })
+            .collect();
+        assert_eq!(
+            too_many.to_canonical_json().unwrap_err().code(),
+            "GF_PROJECT_CORRUPT"
+        );
+
+        let mut absolute_id = repository_snapshot();
+        absolute_id.sources[0].source_id = "/private/data/customers".into();
+        assert_eq!(
+            absolute_id.to_canonical_json().unwrap_err().code(),
+            "GF_PROJECT_CORRUPT"
+        );
+        for hostile in [
+            "../customers",
+            "file:///private/customers",
+            "customers/data",
+            "customers\\data",
+            ".hidden",
+            "Customers",
+            "9customers",
+        ] {
+            let mut hostile_id = repository_snapshot();
+            hostile_id.sources[0].source_id = hostile.into();
+            assert_eq!(
+                hostile_id.to_canonical_json().unwrap_err().code(),
+                "GF_PROJECT_CORRUPT",
+                "{hostile}"
+            );
+        }
+
+        let oversized = vec![b' '; MAX_WORKSPACE_REPOSITORY_SNAPSHOT_BYTES + 1];
+        assert_eq!(
+            WorkspaceRepositorySnapshot::from_canonical_json(&oversized)
+                .unwrap_err()
+                .code(),
+            "GF_PROJECT_CORRUPT"
+        );
+
+        let with_unrestricted_field = String::from_utf8(
+            repository_snapshot()
+                .to_canonical_json()
+                .unwrap()
+                .into_iter()
+                .collect(),
+        )
+        .unwrap()
+        .replacen(
+            "\"actor_uuid\"",
+            "\"absolute_path\":\"/secret/data\",\"actor_uuid\"",
+            1,
+        );
+        assert_eq!(
+            WorkspaceRepositorySnapshot::from_canonical_json(with_unrestricted_field.as_bytes())
+                .unwrap_err()
+                .code(),
             "GF_PROJECT_CORRUPT"
         );
     }

--- a/docs/contracts/repository-snapshot-v1.schema.json
+++ b/docs/contracts/repository-snapshot-v1.schema.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://graphforge.sh/contracts/repository-snapshot-v1.schema.json",
+  "title": "GraphForge repository snapshot participant v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "contract_version",
+    "resolved_config_sha256",
+    "definitions",
+    "sources",
+    "git",
+    "operation_uuid",
+    "actor_uuid"
+  ],
+  "properties": {
+    "contract_version": {
+      "const": 1
+    },
+    "resolved_config_sha256": {
+      "$ref": "#/$defs/sha256"
+    },
+    "definitions": {
+      "type": "array",
+      "maxItems": 10000,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "definition_id",
+          "sha256"
+        ],
+        "properties": {
+          "definition_id": {
+            "$ref": "#/$defs/stableId"
+          },
+          "sha256": {
+            "$ref": "#/$defs/sha256"
+          }
+        }
+      }
+    },
+    "sources": {
+      "type": "array",
+      "maxItems": 10000,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "source_id",
+          "sha256"
+        ],
+        "properties": {
+          "source_id": {
+            "$ref": "#/$defs/stableId"
+          },
+          "sha256": {
+            "$ref": "#/$defs/sha256"
+          }
+        }
+      }
+    },
+    "git": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "commit_sha",
+        "dirty"
+      ],
+      "properties": {
+        "commit_sha": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "pattern": "^(?:[0-9a-f]{40}|[0-9a-f]{64})$"
+            }
+          ]
+        },
+        "dirty": {
+          "type": "boolean"
+        }
+      }
+    },
+    "operation_uuid": {
+      "$ref": "#/$defs/nonNilUuid"
+    },
+    "actor_uuid": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/nonNilUuid"
+        }
+      ]
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "stableId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256,
+      "pattern": "^[a-z][a-z0-9_-]*$"
+    },
+    "nonNilUuid": {
+      "type": "string",
+      "format": "uuid",
+      "not": {
+        "const": "00000000-0000-0000-0000-000000000000"
+      }
+    }
+  }
+}

--- a/docs/guides/repository-integration.md
+++ b/docs/guides/repository-integration.md
@@ -39,7 +39,11 @@ agent experience across clones.
 gf --project-dir . init
 gf --project-dir . config validate
 gf --project-dir . config resolve --json
-gf --project-dir . sync --json
+gf --project-dir . sync --check --json
+gf --project-dir . sync \
+  --idempotency-key 41414141-4141-4141-4141-414141414141 \
+  --actor-uuid 42424242-4242-4242-4242-424242424242 \
+  --json
 gf --project-dir . remove --yes
 ```
 
@@ -106,6 +110,31 @@ gf --project-dir . revert before-change \
 Omitting `--yes` refuses the mutation. Successful and idempotently replayed
 receipts identify the prior current generation so automation can relate the
 previewed state to the published result.
+
+## Repository synchronization
+
+`sync --check` compares the current repository inputs with the authoritative
+`workspace/repository_snapshot@1` participant without changing `CURRENT` or
+creating a generation. It prints `in_sync` and exits successfully when the
+snapshots match; drift prints `drift` and exits with status 4. With `--json`,
+both outcomes use the same deterministic receipt. The persisted participant is
+closed by
+[`repository-snapshot-v1.schema.json`](../contracts/repository-snapshot-v1.schema.json).
+
+A mutating `sync` publishes only when drift exists and then requires a
+caller-owned `--idempotency-key`; `--actor-uuid` is optional but cannot be
+supplied without the operation identity. The snapshot contains only the
+secret-free resolved-config digest, ordered validated-definition digests,
+ordered external source IDs and declared checksums, bounded Git commit/dirty
+provenance, and caller identity. It contains no definition contents, source or
+graph data, secrets, diffs, commit messages, or unrestricted paths.
+
+Publication replaces only the repository snapshot participant in one complete
+generation. Ontology, configuration, graph, knowledge, and every other
+participant remain byte-identical. Reusing the same operation and actor for the
+same desired state is an idempotent replay; reusing that operation for different
+state or a different actor fails closed. A different operation on unchanged
+desired state is a no-op and is not recorded.
 
 ## Portable export and import
 

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -19,7 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   projects, excluding live pointers, locks, journals, caches, and trash (#229).
 - Add Rust-owned repository lifecycle commands and APIs for safe `.graphforge/`
   initialization, deterministic configuration resolution, declared-input sync,
-  Git provenance, and guarded state-only removal (#228).
+  Git provenance, and guarded state-only removal (#228), including atomic,
+  generation-managed repository snapshots with non-mutating CI drift checks
+  (#244).
 
 Post-v0.5.0 work lands here. The v0.5.0 publication cut is under `[0.5.0]` below.
 

--- a/tests/contracts/non-cypher-rust-surface.json
+++ b/tests/contracts/non-cypher-rust-surface.json
@@ -49,6 +49,7 @@
       "GraphForge.preview_revert_to_checkpoint": "designed-only",
       "GraphForge.show_checkpoint": "designed-only",
       "RepositoryContext.discover": "introspection",
+      "RepositoryContext.sync": "release-tested",
       "CheckpointView.checkpoint_uuid": "introspection",
       "CheckpointView.generation_uuid": "introspection",
       "OpenRouterProviderSession.new": "introspection",
@@ -87,6 +88,16 @@
     }
   },
   "method_evidence_groups": {
+    "repository-sync": {
+      "ids": [
+        "RepositoryContext.sync"
+      ],
+      "test_refs": [
+        {"path": "crates/gf-api/src/repository.rs", "symbol": "repository_sync_checks_applies_replays_conflicts_and_preserves_authority"},
+        {"path": "crates/gf-api/src/repository.rs", "symbol": "repository_sync_rechecks_definitions_at_publication_boundary"},
+        {"path": "crates/gf-api/src/repository.rs", "symbol": "repository_sync_failure_boundaries_recover_to_one_authoritative_state"}
+      ]
+    },
     "ontology-lifecycle": {
       "ids": [
         "GraphForge.export_ontology", "GraphForge.inspect_runtime_catalog",


### PR DESCRIPTION
## Summary
- add the bounded `workspace/repository_snapshot@1` participant and closed JSON Schema
- make Rust-owned `sync --check` non-mutating and mutating sync atomically publish one complete generation
- preserve all other participants byte-for-byte, including the completed #236/#237 ontology/configuration authority
- reject implicit repository/data ingestion and persist only declared definition/source digests
- expose deterministic CLI status, structured evidence, and drift exit code 4
- fail closed for stale idempotent replays and publication-boundary definition changes

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy -p gf-storage -p gf-api -p gf-cli --all-targets -- -D warnings`
- focused storage, API, and CLI repository lifecycle tests
- `uv run python scripts/ci/non-cypher-surface-gate.py`
- `uv run pytest -q scripts/ci/test-non-cypher-surface-gate.py`
- independent review, including X→Y→X stale-replay regression

Closes #244

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788065814&installation_model_id=20486&pr_number=246&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F246&signature=2a976bf32ec3ae51694a2ac3d70afb10ca46198631f70cec6ce54e5ce639884b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add atomic, generation-managed repository snapshot reconciliation with check and apply modes
> - Introduces `WorkspaceRepositorySnapshot` in `gf-storage` as a canonical, bounded JSON participant record capturing config, definition digests, source digests, and Git provenance, with strict validation enforcing SHA-256 format, ordering, and size limits.
> - Replaces `RepositoryContext.sync() -> RepositorySyncReceipt` with `sync(RepositorySyncRequest) -> RepositorySyncResult`, supporting `check` mode (non-mutating drift detection) and apply mode (atomic generation publication with idempotency via `operation_uuid`).
> - `digest_definition_tree` now enforces file type restrictions (JSON object, YAML mapping, non-empty Cypher for migrations), rejects files over 1 MiB, and reduces the total tree bound from 64 MiB to 16 MiB.
> - The `gf sync` CLI command gains `--check`, `--idempotency-key`, and `--actor-uuid` flags; `--check` exits with code 4 on drift and prints `drift`, otherwise prints `in_sync` or `published`.
> - Risk: existing callers of `sync()` must migrate to `RepositorySyncRequest`; `--check` drift now produces a non-zero exit code (4) which may affect CI pipelines.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 40a7fee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->