### PR TITLE
fix(checkpoints): restore repository snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Register generation-managed repository snapshots with complete-workspace
+  checkpoint diff/revert validation so checkpoints created after repository
+  sync can be restored and reopened deterministically (#248).
 - Add offline `infra validate --target` with a versioned provider-neutral
   ontology-neutral receipt, explicit deployment ownership and
   validity/plan/connectivity/readiness/capability states, and

--- a/crates/gf-api/src/checkpoints.rs
+++ b/crates/gf-api/src/checkpoints.rs
@@ -1049,6 +1049,9 @@ fn logical_records(
                 gf_storage::WORKSPACE_CONFIGURATION_FAMILY => {
                     gf_storage::WorkspaceConfiguration::from_canonical_json(&snapshot.bytes)?;
                 }
+                gf_storage::WORKSPACE_REPOSITORY_SNAPSHOT_FAMILY => {
+                    gf_storage::WorkspaceRepositorySnapshot::from_canonical_json(&snapshot.bytes)?;
+                }
                 _ => {
                     return Err(GfError::Api {
                         code: ApiErrorCode::SchemaMismatch,

--- a/crates/gf-api/src/repository.rs
+++ b/crates/gf-api/src/repository.rs
@@ -2954,6 +2954,121 @@ mod tests {
     }
 
     #[test]
+    fn repository_snapshot_checkpoint_revert_reopens_and_replays() {
+        let root = tempdir().unwrap();
+        let context = RepositoryContext::discover(root.path()).unwrap();
+        context.init_without_skills().unwrap();
+
+        let first_operation = Uuid::from_bytes([71; 16]);
+        let first = context
+            .sync(RepositorySyncRequest {
+                check: false,
+                operation_uuid: Some(first_operation),
+                actor_uuid: Some(Uuid::from_bytes([72; 16])),
+            })
+            .unwrap();
+        assert_eq!(first.status, RepositorySyncStatus::Published);
+
+        let graph = crate::GraphForge::new(Some(context.state_path.to_str().unwrap())).unwrap();
+        graph
+            .checkpoint(crate::CheckpointRequest {
+                name: "Before definition change".into(),
+                description: None,
+                idempotency_key: crate::OperationId(Uuid::from_bytes([73; 16])),
+                actor_uuid: None,
+            })
+            .unwrap();
+        drop(graph);
+
+        fs::write(
+            root.path().join(".graphforge/ontology/changed.yaml"),
+            "version: 1\n",
+        )
+        .unwrap();
+        let second = context
+            .sync(RepositorySyncRequest {
+                check: false,
+                operation_uuid: Some(Uuid::from_bytes([74; 16])),
+                actor_uuid: None,
+            })
+            .unwrap();
+        assert_eq!(second.status, RepositorySyncStatus::Published);
+        assert_ne!(second.generation_uuid, first.generation_uuid);
+
+        let mut graph = crate::GraphForge::new(Some(context.state_path.to_str().unwrap())).unwrap();
+        let diff = graph
+            .diff_checkpoints(crate::DiffCheckpointsRequest {
+                from: crate::CheckpointSelector::Named("Before definition change".into()),
+                to: crate::CheckpointSelector::Current,
+                scope: crate::CheckpointDiffScope::All,
+                detail: crate::CheckpointDiffDetail::Records,
+                page: crate::PageRequest::default(),
+            })
+            .unwrap();
+        assert_eq!(diff.batches[0].num_rows(), 1);
+
+        let preview = crate::GraphForge::preview_revert_to_checkpoint(
+            &context.state_path,
+            crate::PreviewRevertCheckpointRequest {
+                name: "Before definition change".into(),
+            },
+        )
+        .unwrap();
+        assert_eq!(preview.source_generation_uuid, first.generation_uuid);
+        assert_eq!(preview.current_generation_uuid, second.generation_uuid);
+
+        let generation_count = || {
+            fs::read_dir(context.state_path.join("generations"))
+                .unwrap()
+                .count()
+        };
+        let before_revert_count = generation_count();
+        let request = crate::RevertCheckpointRequest {
+            name: "Before definition change".into(),
+            reason: "restore repository snapshot".into(),
+            idempotency_key: crate::OperationId(Uuid::from_bytes([75; 16])),
+            actor_uuid: Some(Uuid::from_bytes([76; 16])),
+        };
+        let first_receipt = graph.revert_to_checkpoint(request.clone()).unwrap();
+        let reverted = gf_storage::resolve_project_generation(&context.state_path).unwrap();
+        assert_ne!(reverted.generation_uuid(), second.generation_uuid);
+        assert_eq!(generation_count(), before_revert_count + 1);
+        let snapshot = reverted
+            .participant_snapshot(
+                gf_storage::WORKSPACE_CAPABILITY_ID,
+                gf_storage::WORKSPACE_REPOSITORY_SNAPSHOT_FAMILY,
+            )
+            .unwrap()
+            .unwrap();
+        let snapshot =
+            gf_storage::WorkspaceRepositorySnapshot::from_canonical_json(&snapshot.bytes).unwrap();
+        assert_eq!(snapshot.operation_uuid, first_operation);
+
+        let replay_receipt = graph.revert_to_checkpoint(request).unwrap();
+        assert_eq!(replay_receipt.schema, first_receipt.schema);
+        assert_eq!(replay_receipt.batches[0].num_rows(), 1);
+        assert_eq!(generation_count(), before_revert_count + 1);
+        drop(graph);
+
+        let reopened = crate::GraphForge::new(Some(context.state_path.to_str().unwrap())).unwrap();
+        let checkpoints = reopened
+            .list_checkpoints(crate::ListCheckpointsRequest::default())
+            .unwrap();
+        assert_eq!(checkpoints.batches[0].num_rows(), 1);
+        let reopened_snapshot = reopened
+            .generation_for_read()
+            .unwrap()
+            .participant_snapshot(
+                gf_storage::WORKSPACE_CAPABILITY_ID,
+                gf_storage::WORKSPACE_REPOSITORY_SNAPSHOT_FAMILY,
+            )
+            .unwrap()
+            .unwrap();
+        gf_storage::WorkspaceRepositorySnapshot::from_canonical_json(&reopened_snapshot.bytes)
+            .unwrap();
+    }
+
+    #[test]
     fn repository_sync_rechecks_definitions_at_publication_boundary() {
         let root = tempdir().unwrap();
         let context = RepositoryContext::discover(root.path()).unwrap();

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Register generation-managed repository snapshots with complete-workspace
+  checkpoint diff/revert validation so checkpoints created after repository
+  sync can be restored and reopened deterministically (#248).
 - Add offline `infra validate --target` with a versioned provider-neutral
   ontology-neutral receipt, explicit deployment ownership and
   validity/plan/connectivity/readiness/capability states, and


### PR DESCRIPTION
## Summary

- register the generation-managed `workspace/repository_snapshot` participant with checkpoint logical diff and revert validation
- validate repository snapshots through their canonical Rust decoder while retaining fail-closed handling for unknown workspace participants
- add end-to-end native regression coverage for sync, record diff, preview, revert, idempotent replay, and reopen

## Validation

- `cargo test -p gf-api --lib repository_snapshot_checkpoint_revert_reopens_and_replays`
- `cargo test -p gf-api --lib repository::tests` (21 passed)
- `cargo test -p gf-api --lib checkpoints::tests` (12 passed)
- `cargo clippy -p gf-api --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #248

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788072582&installation_model_id=20486&pr_number=249&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F249&signature=6fdba7a971226b28a31dc060582c5d062891a169a0fda53286a96d7e37f71b3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix checkpoint diff/revert to restore repository snapshots
> - Registers `WORKSPACE_REPOSITORY_SNAPSHOT_FAMILY` in [`checkpoints.rs`](https://github.com/CurateLabs/graphforge/pull/249/files#diff-9d46980497b72c73a27dd0bd201d260dcc9459de314c9f340da3bb9df011692c) so checkpoint diff/revert no longer errors when a workspace repository snapshot participant is present.
> - Validates the snapshot by deserializing bytes into `WorkspaceRepositorySnapshot` from canonical JSON during record extraction.
> - Adds an integration test in [`repository.rs`](https://github.com/CurateLabs/graphforge/pull/249/files#diff-0c483338ed3b86d8f44ae6fc28d0389d39561d89c232f66c2214253bead5fdda) covering the full cycle: sync, checkpoint, mutate, revert, idempotent replay, and reopen with snapshot validation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 42ff3f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->