### PR TITLE
test(cli): prove packed uvx and npx lifecycle parity

### DIFF
--- a/.github/workflows/clean-env-verify.yml
+++ b/.github/workflows/clean-env-verify.yml
@@ -81,7 +81,7 @@ jobs:
           if [[ "$LANES" == "all" ]]; then
             if [[ -z "$RECORD" ]]; then
               # checksums requires a release record; run every other lane when absent
-              for lane in pip npm skills cargo reopen urls; do
+              for lane in pip npm cli skills cargo reopen urls; do
                 args+=(--lane "$lane")
               done
             else

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -243,7 +243,7 @@ jobs:
   # ---- NPX lifecycle CLI (@graphforge/cli) ----
   publish-node-cli:
     name: Publish GraphForge CLI to npm
-    needs: publish-node
+    needs: [publish, publish-node]
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
@@ -266,6 +266,10 @@ jobs:
 
       - name: Offline pack smoke before publish
         run: pnpm --filter @graphforge/cli test:offline
+        working-directory: .
+
+      - name: Verify clean install against published native package
+        run: node scripts/ci/verify-node-cli-release-package.mjs
         working-directory: .
 
       - name: Verify npm publishing identity

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,6 +102,9 @@ jobs:
       - name: Test clean-environment verification harness
         run: python3 scripts/ci/test-clean-env-verify.py
 
+      - name: Test GraphForge CLI publication contract
+        run: python3 scripts/ci/test-publish-cli-contract.py
+
       - name: Enforce domain dependency directions
         run: |
           scripts/ci/check-domain-dependencies.py
@@ -468,6 +471,8 @@ jobs:
           wheels=(dist/*.whl)
           test "${#wheels[@]}" -eq 1
           uvx --from "${wheels[0]}" graphforge --version
+          GRAPHFORGE_UVX_WHEEL="${wheels[0]}" \
+            python3 crates/gf-bindings-py/tests/cli_lifecycle.py
           uv venv /tmp/gf-native --python 3.13
           uv pip install --python /tmp/gf-native/bin/python "${wheels[0]}"
           /tmp/gf-native/bin/python - <<'PY'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,13 +24,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   deterministic compatibility metadata and byte-parity checks (#230).
 - Add byte-for-byte equivalent `graphforge` wheel and `@graphforge/cli` npm
   entry points backed by the same Rust CLI parser, execution, structured errors,
-  output, and exit codes (#226).
+  output, and exit codes, with packed clean-install `uvx`/offline `npx`
+  acceptance for the complete repository lifecycle. Project `export`/`import`
+  remains whole-generation portable interchange; #236 owns Rust runtime-catalog
+  inspection, ontology suggestion/validation, and document export, while #237
+  owns thin binding parity plus durable adopt/clear behavior (#226).
 - Add Rust-owned deterministic runtime-catalog inspection, conservative ontology
   drafts, structured non-mutating validation, and explicit-source atomic
   YAML/JSON ontology export (#236).
-- Expose the Rust-owned ontology inspection, suggestion, validation, export,
-  durable adoption, inspection, and clear lifecycle consistently in Python and
-  Node, while keeping session loads explicitly non-durable (#237).
+- Expose the #236 Rust-owned runtime-catalog inspection, ontology suggestion,
+  non-mutating validation, and explicit document export consistently in Python
+  and Node, plus durable workspace inspection, adoption, and clear, while
+  keeping session loads explicitly non-durable (#237).
 - Add deterministic portable export of the current generation or a named
   checkpoint and validate-before-mutation atomic import into new or empty
   projects, excluding live pointers, locks, journals, caches, and trash (#229).

--- a/crates/gf-bindings-node/README.md
+++ b/crates/gf-bindings-node/README.md
@@ -54,6 +54,20 @@ The stable mode names are `single_writer` (default), `queued_writer`, and
 attempts to 0–32. Optimistic replay applies only to composite transactions.
 GraphForge remains embedded; remote transports are separate extensions.
 
+## Ontology lifecycle
+
+The native binding exposes the Rust-owned #236 operations through
+`inspectRuntimeCatalog()`, `suggestOntology()`, `validateOntology()`, and
+`exportOntology()`. These inspect or derive explicit artifacts without changing
+durable project authority. Issue #237 supplies the same thin Python/Node parity
+and adds durable `workspaceOntology()`, `adoptOntology()`, and
+`clearOntology()` operations.
+
+These APIs are distinct from the repository CLI's `export` and `import`
+commands, which move one complete portable project generation. Repository
+interchange never implicitly inspects, suggests, validates, exports, adopts, or
+clears an ontology.
+
 ## Documentation and support
 
 - [Documentation](https://github.com/CurateLabs/graphforge/tree/main/docs)

--- a/crates/gf-bindings-py/README.md
+++ b/crates/gf-bindings-py/README.md
@@ -1,0 +1,54 @@
+# GraphForge for Python
+
+`graphforge` is the native Python binding and repository lifecycle CLI for
+GraphForge's Rust-owned engine.
+
+```bash
+uvx graphforge init
+uvx graphforge sync --check
+uvx graphforge sync \
+  --idempotency-key 41414141-4141-4141-4141-414141414141
+uvx graphforge export --current \
+  --output .graphforge/exports/project.gfportable
+uvx graphforge import \
+  --input .graphforge/imports/project.gfportable \
+  --idempotency-key 47474747-4747-4747-4747-474747474747
+uvx graphforge checkpoint create before-refactor \
+  --idempotency-key 43434343-4343-4343-4343-434343434343
+uvx graphforge checkpoint list
+uvx graphforge checkpoint show before-refactor
+uvx graphforge checkpoint diff \
+  --from before-refactor --to-current --scope all --detail summary
+uvx graphforge checkpoint delete before-refactor \
+  --idempotency-key 44444444-4444-4444-4444-444444444444
+uvx graphforge revert before-refactor --reason "restore before refactor" \
+  --idempotency-key 45454545-4545-4545-4545-454545454545 --yes
+uvx graphforge remove --yes
+uvx graphforge skills install
+uvx graphforge skills status
+uvx graphforge skills update
+uvx graphforge skills remove
+uvx graphforge config validate
+uvx graphforge config resolve --json
+uvx graphforge infra validate --target production --json
+```
+
+The `graphforge` console entry point is a thin launcher over the same native
+Rust CLI contract used by `gf` and `npx @graphforge/cli`. Use `--project-dir`
+to select a repository explicitly, `--json` for machine-readable results,
+`sync --check` for CI, `revert --preview` before restoring a checkpoint, and
+`--yes` for non-interactive destructive operations.
+
+Repository `export` and `import` operate on a complete portable GraphForge
+project generation. They are not ontology-document commands. Rust owns the
+#236 runtime-catalog inspection, ontology suggestion, non-mutating validation,
+and YAML/JSON ontology-document export behavior. Python and Node expose that
+contract, plus durable ontology adoption and clearing, as thin #237 bindings.
+The repository CLI does not infer, adopt, clear, or export an ontology
+implicitly.
+
+Project-local GraphForge skills are packaged in the wheel and install directly;
+Python does not invoke NPX or require Node.
+
+See the [GraphForge documentation](https://curatelabs.github.io/graphforge/)
+for the engine and repository-integration contracts.

--- a/crates/gf-bindings-py/pyproject.toml
+++ b/crates/gf-bindings-py/pyproject.toml
@@ -4,11 +4,21 @@ build-backend = "maturin"
 
 [project]
 name = "graphforge"
-description = "GraphForge — an embedded, openCypher-compatible graph engine (native Rust core)"
+description = "GraphForge native graph engine, bindings, and repository lifecycle CLI"
 version = "0.5.0.dev0"
+readme = "README.md"
 requires-python = ">=3.10"
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE", "THIRD_PARTY_NOTICES.md"]
+keywords = ["graph", "openCypher", "Arrow", "embedded", "database"]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Rust",
+  "Topic :: Database :: Database Engines/Servers",
+]
 # `execute()` returns a pyarrow.Table via the Arrow C Data Interface.
 dependencies = ["pyarrow>=14"]
 

--- a/crates/gf-bindings-py/tests/cli_lifecycle.py
+++ b/crates/gf-bindings-py/tests/cli_lifecycle.py
@@ -1,0 +1,423 @@
+"""Packed-wheel acceptance for the complete repository CLI lifecycle.
+
+Every GraphForge invocation starts a new process.  CI can set
+``GRAPHFORGE_UVX_WHEEL`` to exercise the wheel through ``uvx --from``; the
+installed-wheel test loop exercises the same scenario through the generated
+console script.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sysconfig
+import tempfile
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[3]
+CONTRACT = json.loads((ROOT / "tests/contracts/repository-cli-lifecycle.json").read_text())
+IDENTITIES = CONTRACT["identities"]
+REQUIRED_SCENARIOS = {scenario["name"] for scenario in CONTRACT["requiredScenarios"]}
+
+
+def executable() -> list[str]:
+    override = os.environ.get("GRAPHFORGE_CLI")
+    if override:
+        script = Path(override)
+        assert script.is_file(), f"missing GRAPHFORGE_CLI executable: {script}"
+        return [str(script)]
+    wheel = os.environ.get("GRAPHFORGE_UVX_WHEEL")
+    if wheel:
+        return ["uvx", "--offline", "--from", wheel, "graphforge"]
+    scripts = Path(sysconfig.get_path("scripts"))
+    name = "graphforge.exe" if os.name == "nt" else "graphforge"
+    script = scripts / name
+    assert script.is_file(), f"missing installed console script: {script}"
+    return [str(script)]
+
+
+def invoke(
+    command: list[str],
+    project: Path,
+    *,
+    expected: int = 0,
+    json_result: bool = True,
+) -> subprocess.CompletedProcess[bytes]:
+    arguments = [
+        *executable(),
+        "--project-dir",
+        str(project),
+        *(["--json"] if json_result else []),
+        *command,
+    ]
+    completed = subprocess.run(arguments, check=False, capture_output=True)
+    assert completed.returncode == expected, (
+        arguments,
+        completed.returncode,
+        completed.stdout,
+        completed.stderr,
+    )
+    return completed
+
+
+def result(command: list[str], project: Path, *, expected: int = 0) -> Any:
+    completed = invoke(command, project, expected=expected)
+    assert completed.stderr == b"", completed.stderr
+    return json.loads(completed.stdout)
+
+
+def error(command: list[str], project: Path, *, expected: int = 2) -> Any:
+    completed = invoke(command, project, expected=expected)
+    assert completed.stdout == b"", completed.stdout
+    return json.loads(completed.stderr)
+
+
+def git(project: Path, *arguments: str) -> bytes:
+    completed = subprocess.run(
+        ["git", "-C", str(project), *arguments], check=False, capture_output=True
+    )
+    assert completed.returncode == 0, (arguments, completed.stdout, completed.stderr)
+    return completed.stdout
+
+
+def column(result_value: dict[str, Any], name: str) -> Any:
+    names = [item["name"] for item in result_value["columns"]]
+    return result_value["rows"][0][names.index(name)]
+
+
+def assert_git_boundary(project: Path) -> None:
+    ignored_payloads = {
+        ".graphforge/state/should-never-stage.parquet": b"graph data",
+        ".graphforge/imports/source.arrow": b"source data",
+        ".graphforge/exports/archive.gfportable": b"export data",
+    }
+    for relative, payload in ignored_payloads.items():
+        target = project / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(payload)
+
+    git(project, "add", "--all")
+    staged = set(git(project, "diff", "--cached", "--name-only").decode().splitlines())
+    required = {
+        ".graphforge/graphforge.yaml",
+        ".graphforge/ontology/keep.yaml",
+        ".graphforge/schemas/example.json",
+        ".graphforge/migrations/001.yaml",
+        ".graphforge/seeds/example.yaml",
+    }
+    assert required <= staged, (required - staged, staged)
+    assert not (set(ignored_payloads) & staged), set(ignored_payloads) & staged
+    forbidden_suffixes = (".arrow", ".parquet", ".db", ".sqlite", ".gfportable")
+    assert not any(path.endswith(forbidden_suffixes) for path in staged), staged
+
+
+def assert_tracked_data_guard(parent: Path) -> None:
+    unsafe = parent / "unsafe-tracked-data"
+    unsafe.mkdir()
+    git(unsafe, "init", "--quiet")
+    payloads = {
+        ".graphforge/seeds/materialized/seed.json": b"materialized seed",
+        ".graphforge/snapshots/snapshot.json": b"snapshot",
+        ".graphforge/source.parquet": b"source graph",
+    }
+    for relative, payload in payloads.items():
+        target = unsafe / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(payload)
+    git(unsafe, "add", "--force", "--all")
+    rejected = error(["init"], unsafe)
+    assert rejected["error"]["code"] == "GF_VALIDATION"
+    assert "graph data is tracked by Git" in rejected["error"]["message"]
+    assert not (unsafe / ".graphforge/state").exists()
+
+
+def main() -> None:
+    assert CONTRACT["contract"] == "graphforge-packed-cli-lifecycle/1"
+    assert CONTRACT["scope"]["portableInterchange"] == "complete_project_generation"
+    assert CONTRACT["scope"]["ontologyLifecycle"] == {
+        "owner": "#236",
+        "operations": [
+            "inspect_runtime_catalog",
+            "suggest_ontology",
+            "validate_ontology",
+            "export_ontology",
+        ],
+    }
+    assert CONTRACT["scope"]["ontologyBindingParity"] == {
+        "owner": "#237",
+        "operations": [
+            "inspect_runtime_catalog",
+            "suggest_ontology",
+            "validate_ontology",
+            "export_ontology",
+            "adopt_ontology",
+            "clear_ontology",
+        ],
+    }
+    covered: set[str] = set()
+
+    with tempfile.TemporaryDirectory(prefix="graphforge-python-lifecycle-") as directory:
+        parent = Path(directory)
+        source = parent / "source"
+        source.mkdir()
+        git(source, "init", "--quiet")
+
+        initialized = result(["init"], source)
+        assert initialized["created_config"] is True
+        assert initialized["skills"]["changed"] is True
+        assert (source / ".agents/skills/.graphforge-managed.json").is_file()
+        assert (source / ".agents/skills/graphforge-bootstrap/SKILL.md").is_file()
+        assert (source / ".agents/skills/graphforge-build-knowledge/SKILL.md").is_file()
+        first_current = (source / ".graphforge/state/CURRENT").read_bytes()
+
+        reopened = result(["init"], source)
+        assert reopened["created_config"] is False
+        assert reopened["ignore_changed"] is False
+        assert reopened["skills"]["changed"] is False
+        assert (source / ".graphforge/state/CURRENT").read_bytes() == first_current
+        ignore = (source / ".gitignore").read_text()
+        for entry in (
+            "/.graphforge/state/",
+            "/.graphforge/imports/",
+            "/.graphforge/exports/",
+        ):
+            assert ignore.count(entry) == 1, ignore
+        covered.add("init_and_reopen")
+
+        shutil.copyfile(
+            ROOT / "docs/contracts/examples/graphforge-v1.yaml",
+            source / ".graphforge/graphforge.yaml",
+        )
+        before_static = (source / ".graphforge/state/CURRENT").read_bytes()
+        assert result(["config", "validate"], source) == {"valid": True}
+        resolved = invoke(["config", "resolve"], source)
+        assert resolved.stderr == b""
+        assert (
+            resolved.stdout
+            == (ROOT / "docs/contracts/examples/graphforge-resolved-v1.json").read_bytes()
+        )
+        infra = invoke(["infra", "validate", "--target", "production"], source)
+        assert infra.stderr == b""
+        assert (
+            infra.stdout
+            == (
+                ROOT / "docs/contracts/examples/graphforge-infra-validation-production-v1.json"
+            ).read_bytes()
+        )
+        assert (source / ".graphforge/state/CURRENT").read_bytes() == before_static
+        covered.add("configuration_and_static_infra")
+
+        external_payload = source / ".graphforge/imports/unrelated.parquet"
+        external_payload.parent.mkdir(parents=True, exist_ok=True)
+        external_payload.write_bytes(b"must not be scanned or ingested")
+        before_check = (source / ".graphforge/state/CURRENT").read_bytes()
+        check = result(["sync", "--check"], source, expected=4)
+        assert check["status"] == "drift"
+        assert (source / ".graphforge/state/CURRENT").read_bytes() == before_check
+        sync = result(
+            [
+                "sync",
+                "--idempotency-key",
+                IDENTITIES["syncOperation"],
+                "--actor-uuid",
+                IDENTITIES["syncActor"],
+            ],
+            source,
+        )
+        assert sync["status"] == "published"
+        assert sync["requested_operation_uuid"] == IDENTITIES["syncOperation"]
+        assert sync["snapshot_actor_uuid"] == IDENTITIES["syncActor"]
+        after_sync = (source / ".graphforge/state/CURRENT").read_bytes()
+        assert after_sync != before_check
+        replay = result(
+            [
+                "sync",
+                "--idempotency-key",
+                IDENTITIES["syncOperation"],
+                "--actor-uuid",
+                IDENTITIES["syncActor"],
+            ],
+            source,
+        )
+        assert replay["status"] == "in_sync"
+        assert replay["idempotent_replay"] is True
+        assert (source / ".graphforge/state/CURRENT").read_bytes() == after_sync
+        assert result(["sync", "--check"], source)["status"] == "in_sync"
+        assert external_payload.read_bytes() == b"must not be scanned or ingested"
+        covered.add("sync_check_apply_and_replay")
+
+        checkpoint = result(
+            [
+                "checkpoint",
+                "create",
+                "before-change",
+                "--idempotency-key",
+                IDENTITIES["checkpointCreateOperation"],
+            ],
+            source,
+        )
+        checkpoint_uuid = column(checkpoint, "checkpoint_uuid")
+        listed = result(["checkpoint", "list"], source)
+        assert listed["rows"]
+        shown = result(["checkpoint", "show", "before-change"], source)
+        assert column(shown, "checkpoint_uuid") == checkpoint_uuid
+        diff = result(
+            [
+                "checkpoint",
+                "diff",
+                "--from",
+                "before-change",
+                "--to-current",
+                "--scope",
+                "summary",
+                "--detail",
+                "summary",
+            ],
+            source,
+        )
+        assert diff["contract"] == "graphforge-cli-result/1"
+
+        before_revert = (source / ".graphforge/state/CURRENT").read_bytes()
+        preview = result(["revert", "before-change", "--preview"], source)
+        assert preview["contract"] == "graphforge-revert-preview/1"
+        assert (source / ".graphforge/state/CURRENT").read_bytes() == before_revert
+        refusal = error(
+            [
+                "revert",
+                "before-change",
+                "--reason",
+                "packed lifecycle acceptance",
+                "--idempotency-key",
+                IDENTITIES["revertOperation"],
+                "--actor-uuid",
+                IDENTITIES["revertActor"],
+            ],
+            source,
+        )
+        assert refusal["error"]["code"] == "GF_VALIDATION"
+        assert (source / ".graphforge/state/CURRENT").read_bytes() == before_revert
+        reverted = result(
+            [
+                "revert",
+                "before-change",
+                "--reason",
+                "packed lifecycle acceptance",
+                "--idempotency-key",
+                IDENTITIES["revertOperation"],
+                "--actor-uuid",
+                IDENTITIES["revertActor"],
+                "--yes",
+            ],
+            source,
+        )
+        assert column(reverted, "operation_uuid") == IDENTITIES["revertOperation"]
+        after_revert = (source / ".graphforge/state/CURRENT").read_bytes()
+        assert after_revert != before_revert
+        replayed_revert = result(
+            [
+                "revert",
+                "before-change",
+                "--reason",
+                "packed lifecycle acceptance",
+                "--idempotency-key",
+                IDENTITIES["revertOperation"],
+                "--actor-uuid",
+                IDENTITIES["revertActor"],
+                "--yes",
+            ],
+            source,
+        )
+        assert column(replayed_revert, "operation_uuid") == IDENTITIES["revertOperation"]
+        assert (source / ".graphforge/state/CURRENT").read_bytes() == after_revert
+        assert result(["checkpoint", "show", "before-change"], source)["rows"]
+        deleted = result(
+            [
+                "checkpoint",
+                "delete",
+                "before-change",
+                "--idempotency-key",
+                IDENTITIES["checkpointDeleteOperation"],
+            ],
+            source,
+        )
+        assert column(deleted, "operation_uuid") == IDENTITIES["checkpointDeleteOperation"]
+        covered.add("checkpoint_and_top_level_revert")
+
+        exports = source / ".graphforge/exports"
+        exports.mkdir(parents=True, exist_ok=True)
+        envelope = exports / "current.gfportable"
+        exported = result(
+            ["export", "--current", "--output", str(envelope)],
+            source,
+        )
+        assert exported["contract"] == "graphforge-portable-export/1"
+        assert exported["source"] == "current"
+        assert exported["checkpoint"] is None
+        assert envelope.is_file()
+        duplicate = exports / "current-duplicate.gfportable"
+        duplicate_export = result(
+            ["export", "--current", "--output", str(duplicate)],
+            source,
+        )
+        assert duplicate_export["envelope_sha256"] == exported["envelope_sha256"]
+        assert duplicate.read_bytes() == envelope.read_bytes()
+
+        destination = parent / "destination"
+        destination.mkdir()
+        git(destination, "init", "--quiet")
+        result(["init"], destination)
+        imported = result(
+            [
+                "import",
+                "--input",
+                str(envelope),
+                "--idempotency-key",
+                IDENTITIES["importOperation"],
+            ],
+            destination,
+        )
+        assert imported["contract"] == "graphforge-portable-import/1"
+        assert imported["source_generation_uuid"] == exported["generation_uuid"]
+        assert imported["envelope_sha256"] == exported["envelope_sha256"]
+        assert imported["idempotent_replay"] is False
+        destination_current = (destination / ".graphforge/state/CURRENT").read_bytes()
+        assert result(["checkpoint", "list"], destination)["contract"] == (
+            "graphforge-cli-result/1"
+        )
+        assert (destination / ".graphforge/state/CURRENT").read_bytes() == (destination_current)
+        covered.add("portable_export_import_and_reopen")
+
+        for relative, body in {
+            ".graphforge/ontology/keep.yaml": "version: 1\n",
+            ".graphforge/schemas/example.json": "{}\n",
+            ".graphforge/migrations/001.yaml": "version: 1\n",
+            ".graphforge/seeds/example.yaml": "version: 1\n",
+        }.items():
+            path = source / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(body)
+        assert_git_boundary(source)
+        assert_tracked_data_guard(parent)
+        covered.add("git_data_boundary")
+
+        state_before_refusal = (source / ".graphforge/state/CURRENT").read_bytes()
+        remove_error = error(["remove"], source)
+        assert remove_error["error"]["code"] == "GF_VALIDATION"
+        assert (source / ".graphforge/state/CURRENT").read_bytes() == state_before_refusal
+        removed = result(["remove", "--yes"], source)
+        assert removed == {"removed": True, "target": ".graphforge/state"}
+        assert not (source / ".graphforge/state").exists()
+        assert (source / ".graphforge/ontology/keep.yaml").is_file()
+        assert envelope.is_file()
+        assert (source / ".graphforge/imports/source.arrow").is_file()
+        assert (source / ".agents/skills/.graphforge-managed.json").is_file()
+        covered.add("remove_refusal_and_confirmation")
+
+    assert covered == REQUIRED_SCENARIOS, (REQUIRED_SCENARIOS - covered, covered)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/adr/0016-repository-integration-and-deployment-configuration.md
+++ b/docs/adr/0016-repository-integration-and-deployment-configuration.md
@@ -111,11 +111,11 @@ editing, project lifecycle, portable interchange, checkpoint revert, and
 destructive-operation guards. The Rust `gf` CLI is the reference behavior;
 Python and Node expose thin `uvx graphforge` and `npx @graphforge/cli` surfaces.
 Portable interchange packages one complete project generation; it does not
-redefine the ontology-document inspection, suggestion, validation, or export
-contract delivered by #236, nor the thin binding parity and durable
-adopt/clear behavior delivered by #237. Repository and IaC surfaces consume
-only bounded ontology references and digests where needed; they do not infer or
-change ontology authority.
+redefine the runtime-catalog inspection, ontology suggestion and non-mutating
+validation, or explicit ontology-document export contract delivered by #236,
+nor the thin binding parity and durable adopt/clear behavior delivered by #237.
+Repository and IaC surfaces consume only bounded ontology references and
+digests where needed; they do not infer or change ontology authority.
 
 Skills have one checked-in source. Python and npm ship parity-checked copies and
 install directly under `.agents/skills/`; Python never shells out to NPX.

--- a/docs/guides/infrastructure-validation.md
+++ b/docs/guides/infrastructure-validation.md
@@ -47,7 +47,7 @@ must remove only resources recorded by the IaC engine; it must never call
 
 The ontology paths in resolved configuration are bounded repository references
 only. Infrastructure validation never inspects a runtime catalog or suggests,
-validates, exports, loads, adopts, or clears an ontology. It cannot change the
-committed workspace ontology authority delivered by #236 and #237, and it never
-contains ontology documents, observed property values, runtime catalog IDs, or
-graph data.
+validates, exports, loads, adopts, or clears an ontology. It cannot invoke the
+#236 Rust inspection/suggestion/validation/export surface or the #237 thin
+binding parity and durable adopt/clear surface. It never contains ontology
+documents, observed property values, runtime catalog IDs, or graph data.

--- a/docs/guides/repository-integration.md
+++ b/docs/guides/repository-integration.md
@@ -185,11 +185,12 @@ areas, not durable project authority. Both are managed Git ignores, so envelopes
 placed there remain outside the code repository. Keep tracked schemas,
 ontology, migrations, and seed recipes separate from these data files.
 
-This whole-project interchange surface is distinct from ontology-document
-inspection, suggestion, validation, and YAML/JSON export. #236 delivered the
-Rust-owned ontology lifecycle, and #237 delivered thin Python and Node parity
-including durable ontology adoption and clear. Repository `export` never
-substitutes for ontology export, and ontology export never packages graph data
-or a project generation. Repository initialization and synchronization preserve
-that authority boundary: they never suggest, adopt, clear, or export an
+This whole-project interchange surface is distinct from runtime-catalog
+inspection, ontology suggestion and non-mutating validation, and explicit
+YAML/JSON ontology-document export. #236 delivered those Rust-owned operations;
+#237 delivered thin Python and Node parity plus durable ontology adoption and
+clear. Repository `export` never substitutes for ontology export, and ontology
+export never packages graph data or a project generation. Repository
+initialization and synchronization preserve that authority boundary: they never
+inspect a runtime catalog or suggest, validate, adopt, clear, or export an
 ontology implicitly.

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -21,7 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   required explicit `--yes` confirmation (#243).
 - Add byte-for-byte equivalent `graphforge` wheel and `@graphforge/cli` npm
   entry points backed by the same Rust CLI parser, execution, structured errors,
-  output, and exit codes (#226).
+  output, and exit codes, with packed clean-install `uvx`/offline `npx`
+  acceptance for the complete repository lifecycle. Project `export`/`import`
+  remains whole-generation portable interchange; #236 owns Rust runtime-catalog
+  inspection, ontology suggestion/validation, and document export, while #237
+  owns thin binding parity plus durable adopt/clear behavior (#226).
 - Add deterministic portable export of the current generation or a named
   checkpoint and validate-before-mutation atomic import into new or empty
   projects, excluding live pointers, locks, journals, caches, and trash (#229).

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,13 +4,56 @@ Run the GraphForge repository lifecycle CLI without a global installation:
 
 ```bash
 npx @graphforge/cli init
-npx @graphforge/cli sync
+npx @graphforge/cli sync --check
+npx @graphforge/cli sync \
+  --idempotency-key 41414141-4141-4141-4141-414141414141
+npx @graphforge/cli export --current \
+  --output .graphforge/exports/project.gfportable
+npx @graphforge/cli import \
+  --input .graphforge/imports/project.gfportable \
+  --idempotency-key 47474747-4747-4747-4747-474747474747
+npx @graphforge/cli checkpoint create before-refactor \
+  --idempotency-key 43434343-4343-4343-4343-434343434343
+npx @graphforge/cli checkpoint list
+npx @graphforge/cli checkpoint show before-refactor
+npx @graphforge/cli checkpoint diff \
+  --from before-refactor --to-current --scope all --detail summary
+npx @graphforge/cli checkpoint delete before-refactor \
+  --idempotency-key 44444444-4444-4444-4444-444444444444
+npx @graphforge/cli revert before-refactor --reason "restore before refactor" \
+  --idempotency-key 45454545-4545-4545-4545-454545454545 --yes
+npx @graphforge/cli remove --yes
+npx @graphforge/cli skills install
+npx @graphforge/cli skills status
+npx @graphforge/cli skills update
+npx @graphforge/cli skills remove
 npx @graphforge/cli config validate
+npx @graphforge/cli config resolve --json
+npx @graphforge/cli infra validate --target production --json
 ```
 
 The package is a thin launcher for the Rust-owned CLI exposed by
 `@graphforge/node`. It does not parse commands or implement GraphForge behavior
 in JavaScript. Command names, flags, JSON output, errors, and exit codes are the
 same as the native `gf` executable.
+
+Use `--project-dir` to select a repository explicitly and `--json` for
+machine-readable results. Mutating commands accept caller-owned operation and
+actor identities where required. CI can use `sync --check`; checkpoint restore
+supports `revert --preview`; destructive commands require an explicit
+confirmation such as `--yes` when no interactive terminal is available.
+
+Repository `export` and `import` operate on a complete portable GraphForge
+project generation. They are not ontology-document commands. Rust-owned
+runtime-catalog inspection, ontology suggestion, non-mutating validation, and
+YAML/JSON ontology-document export are the #236 API surface; #237 exposes that
+same surface, plus durable ontology adoption and clearing, through thin Python
+and Node bindings. This CLI preserves those APIs and does not infer, adopt,
+clear, or export an ontology implicitly.
+
+See the
+[repository integration guide](https://docs.graphforge.sh/guides/repository-integration/)
+for the tracked `.graphforge/` definition boundary, ignored data surfaces,
+Git behavior, and complete lifecycle contract.
 
 Node.js 20 or newer is required.

--- a/packages/cli/tests/native-offline-lifecycle.mjs
+++ b/packages/cli/tests/native-offline-lifecycle.mjs
@@ -12,18 +12,80 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { isAbsolute, join } from "node:path";
+import { dirname, isAbsolute, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const packageRoot = fileURLToPath(new URL("..", import.meta.url));
-const nativeRoot = fileURLToPath(
-  new URL("../../../crates/gf-bindings-node/", import.meta.url),
+const checkoutRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const nativeRoot = join(checkoutRoot, "crates", "gf-bindings-node");
+const lifecycleContract = JSON.parse(
+  readFileSync(
+    join(checkoutRoot, "tests", "contracts", "repository-cli-lifecycle.json"),
+    "utf8",
+  ),
 );
-const fixture = mkdtempSync(join(tmpdir(), "graphforge-native-skills-"));
+const packageMetadata = JSON.parse(
+  readFileSync(join(packageRoot, "package.json"), "utf8"),
+);
+const fixture = mkdtempSync(join(tmpdir(), "graphforge-native-lifecycle-"));
 const installRoot = join(fixture, "consumer");
 const repository = join(fixture, "repository");
+const destination = join(fixture, "destination");
 mkdirSync(installRoot);
 mkdirSync(repository);
+mkdirSync(destination);
+const npmrc = join(fixture, "empty.npmrc");
+writeFileSync(npmrc, "");
+const childEnvironment = Object.fromEntries(
+  Object.entries(process.env).filter(
+    ([name]) => !name.toLowerCase().startsWith("npm_config_"),
+  ),
+);
+childEnvironment.NPM_CONFIG_USERCONFIG = npmrc;
+
+assert.equal(lifecycleContract.contract, "graphforge-packed-cli-lifecycle/1");
+assert.equal(
+  lifecycleContract.scope.portableInterchange,
+  "complete_project_generation",
+);
+assert.deepEqual(lifecycleContract.scope.ontologyLifecycle, {
+  owner: "#236",
+  operations: [
+    "inspect_runtime_catalog",
+    "suggest_ontology",
+    "validate_ontology",
+    "export_ontology",
+  ],
+});
+assert.deepEqual(lifecycleContract.scope.ontologyBindingParity, {
+  owner: "#237",
+  operations: [
+    "inspect_runtime_catalog",
+    "suggest_ontology",
+    "validate_ontology",
+    "export_ontology",
+    "adopt_ontology",
+    "clear_ontology",
+  ],
+});
+
+const requiredScenarios = new Set(
+  lifecycleContract.requiredScenarios.map(({ name }) => name),
+);
+const coveredScenarios = new Set();
+const cover = (name) => {
+  assert.equal(requiredScenarios.has(name), true, `unknown scenario ${name}`);
+  coveredScenarios.add(name);
+};
+const {
+  syncOperation,
+  syncActor,
+  checkpointCreateOperation,
+  checkpointDeleteOperation,
+  revertOperation,
+  revertActor,
+  importOperation,
+} = lifecycleContract.identities;
 
 const pack = (directory, pnpm = false) => {
   const command = pnpm ? "pnpm" : "npm";
@@ -39,17 +101,36 @@ const pack = (directory, pnpm = false) => {
     : join(fixture, result.filename);
 };
 
+const parseJson = (bytes, context) => {
+  try {
+    return JSON.parse(bytes);
+  } catch (error) {
+    assert.fail(`${context} did not emit JSON: ${error.message}\n${bytes}`);
+  }
+};
+
+const currentBytes = (root = repository) =>
+  readFileSync(join(root, ".graphforge", "state", "CURRENT"));
+
+const resultField = (result, field, row = 0) => {
+  assert.equal(result.contract, "graphforge-cli-result/1");
+  const index = result.columns.findIndex((column) => column.name === field);
+  assert.notEqual(index, -1, `missing result column ${field}`);
+  assert.ok(result.rows[row], `missing result row ${row}`);
+  return result.rows[row][index];
+};
+
 try {
   assert.equal(
     readdirSync(nativeRoot).some((name) => name.endsWith(".node")),
     true,
-    "build @graphforge/node before running the native lifecycle smoke",
+    "build @graphforge/node before running the native lifecycle acceptance",
   );
   const nativeTarball = pack(nativeRoot);
   const cliTarball = pack(packageRoot, true);
   writeFileSync(
     join(installRoot, "package.json"),
-    `${JSON.stringify({ name: "graphforge-skills-smoke", private: true })}\n`,
+    `${JSON.stringify({ name: "graphforge-lifecycle-consumer", private: true })}\n`,
   );
   execFileSync(
     "npm",
@@ -64,44 +145,99 @@ try {
     ],
     { cwd: installRoot, stdio: "pipe" },
   );
-  execFileSync("git", ["init", "-q", repository]);
 
-  const executable = join(installRoot, "node_modules", ".bin", "graphforge");
-  const run = (...args) =>
-    spawnSync(executable, ["--project-dir", repository, "--json", ...args], {
-      cwd: repository,
-      encoding: "utf8",
-    });
-  const success = (...args) => {
-    const result = run(...args);
+  // The public CLI must close over the same-version public native package after
+  // packing. A workspace protocol or an undeclared checkout dependency would
+  // make a clean, offline consumer unusable.
+  const installedCliRoot = join(
+    installRoot,
+    "node_modules",
+    "@graphforge",
+    "cli",
+  );
+  const installedNativeRoot = join(
+    installRoot,
+    "node_modules",
+    "@graphforge",
+    "node",
+  );
+  const installedCli = JSON.parse(
+    readFileSync(join(installedCliRoot, "package.json"), "utf8"),
+  );
+  const installedNative = JSON.parse(
+    readFileSync(join(installedNativeRoot, "package.json"), "utf8"),
+  );
+  assert.equal(installedCli.version, packageMetadata.version);
+  assert.equal(installedNative.version, packageMetadata.version);
+  assert.equal(
+    installedCli.dependencies["@graphforge/node"],
+    packageMetadata.version,
+  );
+  assert.equal(
+    installedCli.dependencies["@graphforge/node"].includes("workspace:"),
+    false,
+  );
+
+  execFileSync("git", ["init", "-q", repository]);
+  execFileSync("git", ["init", "-q", destination]);
+
+  const invocations = [];
+  const runAt = (root, ...args) => {
+    invocations.push(args);
+    // Every call is a new npx and Node process against the packed, offline
+    // consumer. No module instance or in-memory GraphForge state is reused.
+    return spawnSync(
+      "npx",
+      [
+        "--offline",
+        "--no-install",
+        "graphforge",
+        "--project-dir",
+        root,
+        "--json",
+        ...args,
+      ],
+      { cwd: installRoot, encoding: "utf8", env: childEnvironment },
+    );
+  };
+  const run = (...args) => runAt(repository, ...args);
+  const successAt = (root, ...args) => {
+    const result = runAt(root, ...args);
     assert.equal(result.status, 0, result.stderr);
-    return JSON.parse(result.stdout);
+    return parseJson(result.stdout, args.join(" "));
+  };
+  const success = (...args) => successAt(repository, ...args);
+  const failure = (expectedStatus, ...args) => {
+    const result = run(...args);
+    assert.equal(result.status, expectedStatus, result.stderr);
+    return parseJson(result.stderr, args.join(" "));
   };
 
   const initialized = success("init");
+  assert.equal(initialized.created_config, true);
   assert.equal(initialized.skills.changed, true);
+  const initializedCurrent = currentBytes();
+  const reopened = success("init");
+  assert.equal(reopened.created_config, false);
+  assert.equal(reopened.ignore_changed, false);
+  assert.equal(reopened.skills.changed, false);
+  assert.deepEqual(currentBytes(), initializedCurrent);
+  cover("init_and_reopen");
+
   writeFileSync(
     join(repository, ".graphforge", "graphforge.yaml"),
     readFileSync(
-      join(
-        packageRoot,
-        "..",
-        "..",
-        "docs",
-        "contracts",
-        "examples",
-        "graphforge-v1.yaml",
-      ),
+      join(checkoutRoot, "docs", "contracts", "examples", "graphforge-v1.yaml"),
     ),
   );
+  const beforeStaticValidation = currentBytes();
+  assert.deepEqual(success("config", "validate"), { valid: true });
   assert.deepEqual(
     success("config", "resolve"),
     JSON.parse(
       readFileSync(
         join(
-          packageRoot,
-          "..",
-          "..",
+          checkoutRoot,
           "docs",
           "contracts",
           "examples",
@@ -111,14 +247,13 @@ try {
       ),
     ),
   );
+  const infra = success("infra", "validate", "--target", "production");
   assert.deepEqual(
-    success("infra", "validate", "--target", "production"),
+    infra,
     JSON.parse(
       readFileSync(
         join(
-          packageRoot,
-          "..",
-          "..",
+          checkoutRoot,
           "docs",
           "contracts",
           "examples",
@@ -128,13 +263,239 @@ try {
       ),
     ),
   );
-  const packaged = join(
-    installRoot,
-    "node_modules",
-    "@graphforge",
-    "cli",
-    "project-skills",
+  assert.equal(infra.connectivity.status, "not_checked");
+  assert.equal(infra.readiness.status, "not_checked");
+  assert.deepEqual(currentBytes(), beforeStaticValidation);
+  cover("configuration_and_static_infra");
+
+  for (const [path, bytes] of [
+    [".graphforge/ontology/keep.yaml", "version: 1\n"],
+    [".graphforge/schemas/keep.json", "{}\n"],
+    [".graphforge/migrations/001.yaml", "version: 1\n"],
+    [".graphforge/seeds/recipe.yaml", "version: 1\n"],
+    [".graphforge/state/private.parquet", "graph data\n"],
+    [".graphforge/imports/source.arrow", "source data\n"],
+    [".graphforge/imports/materialized-seed.db", "seed rows\n"],
+    [".graphforge/exports/snapshot.gfportable", "snapshot bytes\n"],
+  ]) {
+    const target = join(repository, path);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, bytes);
+  }
+  execFileSync("git", ["-C", repository, "add", "--all"]);
+  const staged = execFileSync(
+    "git",
+    ["-C", repository, "diff", "--cached", "--name-only"],
+    { encoding: "utf8" },
+  )
+    .trim()
+    .split("\n");
+  for (const expected of [
+    ".graphforge/graphforge.yaml",
+    ".graphforge/ontology/keep.yaml",
+    ".graphforge/schemas/keep.json",
+    ".graphforge/migrations/001.yaml",
+    ".graphforge/seeds/recipe.yaml",
+    ".agents/skills/.graphforge-managed.json",
+  ]) {
+    assert.equal(
+      staged.includes(expected),
+      true,
+      `expected ${expected} in Git`,
+    );
+  }
+  for (const forbidden of [
+    ".graphforge/state/",
+    ".graphforge/imports/",
+    ".graphforge/exports/",
+    ".parquet",
+    ".arrow",
+    ".db",
+    ".sqlite",
+    ".duckdb",
+    ".gfportable",
+  ]) {
+    assert.equal(
+      staged.some((path) => path.includes(forbidden)),
+      false,
+      `Git staged data path matching ${forbidden}`,
+    );
+  }
+  cover("git_data_boundary");
+
+  const beforeCheck = currentBytes();
+  const drift = run("sync", "--check");
+  assert.equal(drift.status, 4, drift.stderr);
+  assert.equal(parseJson(drift.stdout, "sync --check").status, "drift");
+  assert.deepEqual(currentBytes(), beforeCheck);
+  const synced = success(
+    "sync",
+    "--idempotency-key",
+    syncOperation,
+    "--actor-uuid",
+    syncActor,
   );
+  assert.equal(synced.status, "published");
+  assert.equal(synced.requested_operation_uuid, syncOperation);
+  assert.equal(synced.snapshot_operation_uuid, syncOperation);
+  assert.equal(synced.snapshot_actor_uuid, syncActor);
+  const publishedCurrent = currentBytes();
+  const replayedSync = success(
+    "sync",
+    "--idempotency-key",
+    syncOperation,
+    "--actor-uuid",
+    syncActor,
+  );
+  assert.equal(replayedSync.status, "in_sync");
+  assert.equal(replayedSync.idempotent_replay, true);
+  assert.deepEqual(currentBytes(), publishedCurrent);
+  assert.equal(success("sync", "--check").status, "in_sync");
+
+  // Repository files not declared by graphforge.yaml are never scanned into
+  // the snapshot. Adding one cannot create sync drift.
+  writeFileSync(join(repository, "unrelated.txt"), "not a definition\n");
+  assert.equal(success("sync", "--check").status, "in_sync");
+  cover("sync_check_apply_and_replay");
+
+  const created = success(
+    "checkpoint",
+    "create",
+    "before-change",
+    "--idempotency-key",
+    checkpointCreateOperation,
+  );
+  assert.equal(
+    resultField(created, "operation_uuid"),
+    checkpointCreateOperation,
+  );
+  const listed = success("checkpoint", "list");
+  assert.equal(resultField(listed, "name"), "before-change");
+  const shown = success("checkpoint", "show", "before-change");
+  assert.equal(resultField(shown, "name"), "before-change");
+  const diff = success(
+    "checkpoint",
+    "diff",
+    "--from",
+    "before-change",
+    "--to-current",
+    "--scope",
+    "all",
+    "--detail",
+    "summary",
+  );
+  assert.equal(diff.contract, "graphforge-cli-result/1");
+
+  const beforePreview = currentBytes();
+  const preview = success("revert", "before-change", "--preview");
+  assert.equal(preview.contract, "graphforge-revert-preview/1");
+  assert.deepEqual(currentBytes(), beforePreview);
+  const refusal = failure(
+    2,
+    "revert",
+    "before-change",
+    "--reason",
+    "packed npm lifecycle acceptance",
+    "--idempotency-key",
+    revertOperation,
+    "--actor-uuid",
+    revertActor,
+  );
+  assert.equal(refusal.error.code, "GF_VALIDATION");
+  assert.deepEqual(currentBytes(), beforePreview);
+  const reverted = success(
+    "revert",
+    "before-change",
+    "--reason",
+    "packed npm lifecycle acceptance",
+    "--idempotency-key",
+    revertOperation,
+    "--actor-uuid",
+    revertActor,
+    "--yes",
+  );
+  const revertedCurrent = currentBytes();
+  assert.notDeepEqual(revertedCurrent, beforePreview);
+  assert.equal(resultField(reverted, "operation_uuid"), revertOperation);
+  const replayedRevert = success(
+    "revert",
+    "before-change",
+    "--reason",
+    "packed npm lifecycle acceptance",
+    "--idempotency-key",
+    revertOperation,
+    "--actor-uuid",
+    revertActor,
+    "--yes",
+  );
+  assert.deepEqual(currentBytes(), revertedCurrent);
+  assert.deepEqual(replayedRevert, reverted);
+  assert.equal(
+    resultField(success("checkpoint", "list"), "name"),
+    "before-change",
+  );
+  const deleted = success(
+    "checkpoint",
+    "delete",
+    "before-change",
+    "--idempotency-key",
+    checkpointDeleteOperation,
+  );
+  assert.equal(
+    resultField(deleted, "operation_uuid"),
+    checkpointDeleteOperation,
+  );
+  cover("checkpoint_and_top_level_revert");
+
+  const envelope = join(
+    repository,
+    ".graphforge",
+    "exports",
+    "current.gfportable",
+  );
+  const secondEnvelope = join(
+    repository,
+    ".graphforge",
+    "exports",
+    "current-copy.gfportable",
+  );
+  const exported = success("export", "--current", "--output", envelope);
+  assert.equal(exported.contract, "graphforge-portable-export/1");
+  assert.equal(exported.source, "current");
+  assert.equal(exported.checkpoint, null);
+  const secondExport = success(
+    "export",
+    "--current",
+    "--output",
+    secondEnvelope,
+  );
+  assert.equal(secondExport.envelope_sha256, exported.envelope_sha256);
+  assert.deepEqual(readFileSync(secondEnvelope), readFileSync(envelope));
+
+  successAt(destination, "init", "--no-skills");
+  const imported = successAt(
+    destination,
+    "import",
+    "--input",
+    envelope,
+    "--idempotency-key",
+    importOperation,
+  );
+  assert.equal(imported.contract, "graphforge-portable-import/1");
+  assert.equal(imported.source_generation_uuid, exported.generation_uuid);
+  assert.equal(imported.envelope_sha256, exported.envelope_sha256);
+  assert.equal(imported.idempotent_replay, false);
+  assert.equal(
+    successAt(destination, "checkpoint", "list").contract,
+    "graphforge-cli-result/1",
+  );
+  assert.equal(
+    existsSync(join(destination, ".graphforge", "state", "CURRENT")),
+    true,
+  );
+  cover("portable_export_import_and_reopen");
+
+  const packaged = join(installedCliRoot, "project-skills");
   const managed = join(repository, ".agents", "skills");
   for (const skill of ["graphforge-bootstrap", "graphforge-build-knowledge"]) {
     assert.deepEqual(
@@ -145,7 +506,7 @@ try {
   assert.equal(success("skills", "status").status, "current");
   assert.equal(success("skills", "install").changed, false);
 
-  // Simulate interruption after the prior generation was moved to backup.
+  // Recover an interrupted publication before reporting status.
   const lifecycle = join(
     repository,
     ".graphforge",
@@ -172,28 +533,68 @@ try {
   const beforeConflict = readFileSync(edited);
   assert.equal(success("skills", "status").status, "conflict");
   const updateConflict = run("skills", "update");
-  assert.notEqual(updateConflict.status, 0);
+  assert.equal(updateConflict.status, 2);
   assert.deepEqual(readFileSync(edited), beforeConflict);
   assert.equal(success("skills", "update", "--force").changed, true);
 
-  // Corruption of the installed npm asset must fail bundle validation. This
-  // proves the package copy, rather than a separately embedded copy, is used.
+  // Corrupting the installed npm asset must fail bundle validation. This proves
+  // the package copy, rather than a separately embedded checkout copy, is used.
   const packagedManifest = join(packaged, "manifest.json");
   const manifestBytes = readFileSync(packagedManifest);
   writeFileSync(packagedManifest, "{}\n");
-  const invalidBundle = run("skills", "status");
-  assert.notEqual(invalidBundle.status, 0);
+  assert.notEqual(run("skills", "status").status, 0);
   writeFileSync(packagedManifest, manifestBytes);
 
   appendFileSync(edited, "\nsecond user edit\n");
-  const removeConflict = run("skills", "remove");
-  assert.notEqual(removeConflict.status, 0);
+  assert.equal(run("skills", "remove").status, 2);
   assert.equal(existsSync(edited), true);
   assert.equal(success("skills", "remove", "--force").changed, true);
   assert.equal(existsSync(join(managed, "graphforge-bootstrap")), false);
   assert.equal(success("skills", "install").changed, true);
 
-  process.stdout.write("native npm project skill lifecycle: verified\n");
+  const beforeRemove = currentBytes();
+  const removeRefusal = failure(2, "remove");
+  assert.equal(removeRefusal.error.code, "GF_VALIDATION");
+  assert.deepEqual(currentBytes(), beforeRemove);
+  const removed = success("remove", "--yes");
+  assert.equal(removed.target, ".graphforge/state");
+  assert.equal(removed.removed, true);
+  assert.equal(existsSync(join(repository, ".graphforge", "state")), false);
+  for (const preserved of [
+    ".graphforge/graphforge.yaml",
+    ".graphforge/ontology/keep.yaml",
+    ".graphforge/schemas/keep.json",
+    ".graphforge/migrations/001.yaml",
+    ".graphforge/seeds/recipe.yaml",
+    ".graphforge/imports/source.arrow",
+    ".graphforge/exports/current.gfportable",
+    ".agents/skills/graphforge-bootstrap/SKILL.md",
+  ]) {
+    assert.equal(
+      existsSync(join(repository, preserved)),
+      true,
+      `remove deleted ${preserved}`,
+    );
+  }
+  cover("remove_refusal_and_confirmation");
+
+  assert.deepEqual(
+    [...coveredScenarios].sort(),
+    [...requiredScenarios].sort(),
+    "packed npm lifecycle did not cover every shared required scenario",
+  );
+  for (const forbidden of lifecycleContract.scope
+    .forbiddenImplicitOntologyOperations) {
+    assert.equal(
+      invocations.some((args) => args.includes(forbidden)),
+      false,
+      `repository lifecycle invoked ontology operation ${forbidden}`,
+    );
+  }
+
+  process.stdout.write(
+    `native offline npx lifecycle: ${coveredScenarios.size} scenarios verified\n`,
+  );
 } finally {
   rmSync(fixture, { recursive: true, force: true });
 }

--- a/scripts/ci/classify-changes.sh
+++ b/scripts/ci/classify-changes.sh
@@ -129,7 +129,9 @@ while IFS= read -r -d '' path; do
       terraform=true
       ;;
 
-    packages/cli/* | packages/cli/**/* | tests/contracts/repository-cli-parity.json)
+    packages/cli/* | packages/cli/**/* | tests/contracts/repository-cli-*.json | \
+      scripts/ci/verify-node-cli-release-package.mjs | \
+      scripts/ci/test-publish-cli-contract.py)
       bindings=true
       ;;
 

--- a/scripts/ci/clean-env-verify.py
+++ b/scripts/ci/clean-env-verify.py
@@ -34,6 +34,7 @@ DEFAULT_CRATES = ("gf-api",)
 LANE_ISSUES = {
     "pip": 2809,
     "npm": 2810,
+    "cli": 226,
     "skills": 2811,
     "cargo": 2812,
     "reopen": 2813,
@@ -191,6 +192,8 @@ def registry_urls(version: str, crates: tuple[str, ...], docs_base: str) -> dict
         "pypi_project": f"https://pypi.org/project/graphforge/{version}/",
         "npm_node": f"https://registry.npmjs.org/@graphforge/node/{version}",
         "npm_node_page": f"https://www.npmjs.com/package/@graphforge/node/v/{version}",
+        "npm_cli": f"https://registry.npmjs.org/@graphforge/cli/{version}",
+        "npm_cli_page": f"https://www.npmjs.com/package/@graphforge/cli/v/{version}",
         "npm_skills": f"https://registry.npmjs.org/@graphforge/agent-skills/{version}",
         "npm_skills_page": f"https://www.npmjs.com/package/@graphforge/agent-skills/v/{version}",
         "docs_quickstart": f"{docs}/guide/quickstart/",
@@ -216,7 +219,7 @@ def probe_published(ctx: Context) -> dict[str, Any]:
     urls = registry_urls(ctx.version, ctx.crates, ctx.docs_base)
     probes: dict[str, Any] = {}
     missing: list[str] = []
-    for key in ("pypi_json", "npm_node", "npm_skills"):
+    for key in ("pypi_json", "npm_node", "npm_cli", "npm_skills"):
         status, body, _ = ctx.fetch(urls[key])
         probes[key] = {"url": urls[key], "status": status}
         if status != 200:
@@ -258,7 +261,8 @@ def run_preflight(ctx: Context) -> LaneResult:
         return result
     result.ok = True
     result.notes.append(
-        "PyPI, npm (@graphforge/node, @graphforge/agent-skills), and crates probes OK"
+        "PyPI, npm (@graphforge/node, @graphforge/cli, "
+        "@graphforge/agent-skills), and crates probes OK"
     )
     return result
 
@@ -412,6 +416,37 @@ console.log("npm-smoke-ok", reported);
     return result
 
 
+def lane_cli(ctx: Context) -> LaneResult:
+    """Install the published CLI and execute it without workspace resolution."""
+    result = LaneResult(name="cli", issue=LANE_ISSUES["cli"], ok=False)
+    if not ctx.allow_network_install:
+        result.error = "network installs disabled"
+        return result
+    work = ctx.work_root / "cli"
+    if work.exists():
+        shutil.rmtree(work)
+    work.mkdir(parents=True)
+    result.commands.append("npm init -y")
+    _run(ctx, ["npm", "init", "-y"], cwd=work)
+    package = f"@graphforge/cli@{ctx.version}"
+    result.commands.append(f"npm install {package}")
+    _run(ctx, ["npm", "install", package], cwd=work)
+    result.commands.append("npx --offline --no-install graphforge --version")
+    out = _run(
+        ctx,
+        ["npx", "--offline", "--no-install", "graphforge", "--version"],
+        cwd=work,
+    )
+    reported = out.strip()
+    if ctx.version not in reported:
+        raise VerifyError(
+            f"@graphforge/cli version mismatch: expected {ctx.version!r} in {reported!r}"
+        )
+    result.notes.append(f"published CLI executable ok: {reported}")
+    result.ok = True
+    return result
+
+
 def lane_skills(ctx: Context) -> LaneResult:
     result = LaneResult(name="skills", issue=LANE_ISSUES["skills"], ok=False)
     if not ctx.allow_network_install:
@@ -495,6 +530,7 @@ def lane_urls(ctx: Context) -> LaneResult:
         "docs_installation",
         "pypi_project",
         "npm_node_page",
+        "npm_cli_page",
         "npm_skills_page",
         "github_release",
         *[f"crates_page_{crate}" for crate in ctx.crates],
@@ -600,6 +636,7 @@ def lane_checksums(ctx: Context) -> LaneResult:
     observed["pypi"] = _pypi_file_digests(ctx)
     for package, surface_key in (
         ("@graphforge/node", "npm"),
+        ("@graphforge/cli", "npm"),
         ("@graphforge/agent-skills", "npm"),
     ):
         filename, digest = _npm_dist_digest(ctx, package)
@@ -669,6 +706,7 @@ def lane_checksums(ctx: Context) -> LaneResult:
 LANE_RUNNERS: dict[str, Callable[[Context], LaneResult]] = {
     "pip": lane_pip,
     "npm": lane_npm,
+    "cli": lane_cli,
     "skills": lane_skills,
     "cargo": lane_cargo,
     "reopen": lane_reopen,

--- a/scripts/ci/test-classify-changes.sh
+++ b/scripts/ci/test-classify-changes.sh
@@ -65,6 +65,10 @@ assert_classification "$binding_only" packages/cli/bin/graphforge.js node-cli
 assert_classification "$binding_rust_python" \
   project-skills/graphforge-bootstrap/SKILL.md project-skill-source
 assert_classification "$binding_only" tests/contracts/repository-cli-parity.json cli-parity-fixture
+assert_classification "$binding_only" \
+  tests/contracts/repository-cli-lifecycle.json cli-lifecycle-fixture
+assert_classification "$binding_only" \
+  scripts/ci/verify-node-cli-release-package.mjs cli-release-verifier
 assert_classification "$binding_rust" tests/contracts/checkpoint-recovery-matrix.json checkpoint-recovery-fixture
 assert_classification "$gherkin_rust" tests/features/tck/features/query.feature gherkin
 assert_classification "$binding_python" tests/unit/kernel_test.py python-test

--- a/scripts/ci/test-clean-env-verify.py
+++ b/scripts/ci/test-clean-env-verify.py
@@ -114,6 +114,8 @@ def test_preflight_ok_when_published() -> None:
             return 200, json.dumps({"info": {"version": "0.5.0"}}).encode(), {}
         if "registry.npmjs.org/@graphforge/node/0.5.0" in url:
             return 200, b"{}", {}
+        if "registry.npmjs.org/@graphforge/cli/0.5.0" in url:
+            return 200, b"{}", {}
         if "registry.npmjs.org/@graphforge/agent-skills/0.5.0" in url:
             return 200, b"{}", {}
         if "crates.io/api/v1/crates/gf-api/0.5.0" in url:
@@ -189,6 +191,19 @@ def test_checksums_match_release_record() -> None:
                 ).encode(),
                 {},
             )
+        if "registry.npmjs.org/@graphforge/cli/0.5.0" in url:
+            return (
+                200,
+                json.dumps(
+                    {
+                        "dist": {
+                            "tarball": "https://example.test/graphforge-cli-0.5.0.tgz",
+                            "integrity": "sha256-cli",
+                        }
+                    }
+                ).encode(),
+                {},
+            )
         if "registry.npmjs.org/@graphforge/agent-skills/0.5.0" in url:
             return (
                 200,
@@ -226,6 +241,39 @@ def test_checksums_match_release_record() -> None:
         assert "graphforge-0.5.0-py3-none-any.whl" in " ".join(result.artifacts["matched"])
 
 
+def test_cli_lane_installs_and_executes_published_package() -> None:
+    commands: list[list[str]] = []
+
+    def run(
+        argv: list[str],
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        commands.append(argv)
+        stdout = "graphforge 0.5.0\n" if argv[0] == "npx" else ""
+        return subprocess.CompletedProcess(argv, 0, stdout=stdout, stderr="")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        ctx = cev.Context(
+            version="0.5.0",
+            work_root=Path(tmp),
+            docs_base=cev.DEFAULT_DOCS_BASE,
+            crates=("gf-api",),
+            release_record=None,
+            fetch=lambda _url: (200, b"{}", {}),
+            run_cmd=run,
+        )
+        result = cev.lane_cli(ctx)
+        assert result.ok is True, result.error
+        assert ["npm", "install", "@graphforge/cli@0.5.0"] in commands
+        assert [
+            "npx",
+            "--offline",
+            "--no-install",
+            "graphforge",
+            "--version",
+        ] in commands
+
+
 def test_cli_validate_release_record() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         path = Path(tmp) / "record.json"
@@ -259,6 +307,7 @@ def main() -> None:
     test_preflight_ok_when_published()
     test_urls_lane_reports_failures()
     test_checksums_match_release_record()
+    test_cli_lane_installs_and_executes_published_package()
     test_cli_validate_release_record()
     test_cli_run_refuses_without_lanes()
     print("clean-env-verify tests passed")

--- a/scripts/ci/test-publish-cli-contract.py
+++ b/scripts/ci/test-publish-cli-contract.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Static contract for ordered, clean-consumer @graphforge/cli publication."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "publish.yaml"
+VERIFY = ROOT / "scripts" / "ci" / "verify-node-cli-release-package.mjs"
+
+
+def section(text: str, start: str, end: str) -> str:
+    _, found, tail = text.partition(start)
+    assert found, f"missing workflow marker: {start.strip()}"
+    body, found, _ = tail.partition(end)
+    assert found, f"missing workflow marker: {end.strip()}"
+    return body
+
+
+def main() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    native = section(text, "  publish-node:\n", "  # ---- NPX lifecycle CLI")
+    cli = section(text, "  publish-node-cli:\n", "  # ---- NPX agent skills")
+
+    assert "needs: [build-node, publish]" in native
+    assert "needs: [publish, publish-node]" in cli
+    assert "pnpm --filter @graphforge/cli test:offline" in cli
+    assert "node scripts/ci/verify-node-cli-release-package.mjs" in cli
+    assert cli.index("verify-node-cli-release-package.mjs") < cli.index("Publish @graphforge/cli")
+    assert "continue-on-error" not in cli
+    assert "|| true" not in cli
+    assert VERIFY.is_file()
+    print("publish CLI contract tests passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/verify-node-cli-release-package.mjs
+++ b/scripts/ci/verify-node-cli-release-package.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * Pack @graphforge/cli, install it with the already-published native package in
+ * a clean consumer directory, then execute through npx without registry access.
+ *
+ * This runs after @graphforge/node publication. It deliberately does not use
+ * the workspace-linked native addon, so a missing or unusable public dependency
+ * blocks publishing the CLI.
+ */
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(fileURLToPath(new URL("../..", import.meta.url)));
+const packageRoot = join(root, "packages", "cli");
+const metadata = JSON.parse(
+  readFileSync(join(packageRoot, "package.json"), "utf8"),
+);
+const fixture = mkdtempSync(join(tmpdir(), "graphforge-cli-release-"));
+const consumer = join(fixture, "consumer");
+mkdirSync(consumer);
+
+const run = (command, args, cwd) =>
+  execFileSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, npm_config_audit: "false", npm_config_fund: "false" },
+  });
+
+try {
+  writeFileSync(
+    join(consumer, "package.json"),
+    `${JSON.stringify({ name: "graphforge-cli-release-probe", private: true })}\n`,
+  );
+  const packed = JSON.parse(
+    run(
+      "pnpm",
+      ["pack", "--json", "--pack-destination", fixture],
+      packageRoot,
+    ),
+  );
+  const result = Array.isArray(packed) ? packed[0] : packed;
+  const tarball = isAbsolute(result.filename)
+    ? result.filename
+    : join(fixture, result.filename);
+
+  run(
+    "npm",
+    [
+      "install",
+      "--no-audit",
+      "--no-fund",
+      `@graphforge/node@${metadata.version}`,
+      tarball,
+    ],
+    consumer,
+  );
+  const output = run(
+    "npx",
+    ["--offline", "--no-install", "graphforge", "--version"],
+    consumer,
+  ).trim();
+  assert.match(output, new RegExp(metadata.version.replaceAll(".", "\\.")));
+  process.stdout.write(`clean @graphforge/cli package ok: ${output}\n`);
+} finally {
+  rmSync(fixture, { recursive: true, force: true });
+}

--- a/scripts/set_release_version.py
+++ b/scripts/set_release_version.py
@@ -5,6 +5,7 @@ Surfaces:
 - Cargo workspace ``[workspace.package].version``
 - Python ``crates/gf-bindings-py/pyproject.toml`` (PEP 440)
 - Node ``crates/gf-bindings-node/package.json``
+- NPX lifecycle CLI ``packages/cli/package.json``
 - NPX skills ``packages/agent-skills/package.json``
 
 Usage:
@@ -30,6 +31,7 @@ ROOT = Path(__file__).resolve().parents[1]
 CARGO_TOML = ROOT / "Cargo.toml"
 PYPROJECT = ROOT / "crates" / "gf-bindings-py" / "pyproject.toml"
 NODE_PACKAGE = ROOT / "crates" / "gf-bindings-node" / "package.json"
+CLI_PACKAGE = ROOT / "packages" / "cli" / "package.json"
 SKILLS_PACKAGE = ROOT / "packages" / "agent-skills" / "package.json"
 
 
@@ -69,6 +71,7 @@ def read_current() -> dict[str, str]:
         PYPROJECT.read_text(encoding="utf-8"),
     )
     node = json.loads(NODE_PACKAGE.read_text(encoding="utf-8"))["version"]
+    cli = json.loads(CLI_PACKAGE.read_text(encoding="utf-8"))["version"]
     skills = json.loads(SKILLS_PACKAGE.read_text(encoding="utf-8"))["version"]
     if not cargo or not py:
         raise ValueError("could not read Cargo or Python version")
@@ -76,6 +79,7 @@ def read_current() -> dict[str, str]:
         "cargo": cargo.group(1),
         "python": py.group(1),
         "node": node,
+        "cli": cli,
         "skills": skills,
     }
 
@@ -85,6 +89,7 @@ def expected_for(base: str, *, dev: bool) -> dict[str, str]:
         "cargo": cargo_version(base, dev=dev),
         "python": python_version(base, dev=dev),
         "node": npm_version(base, dev=dev),
+        "cli": npm_version(base, dev=dev),
         "skills": npm_version(base, dev=dev),
     }
 
@@ -132,7 +137,11 @@ def apply_version(base: str, *, dev: bool, dry_run: bool) -> dict[str, str]:
         raise ValueError("failed to update Python pyproject version")
     PYPROJECT.write_text(py_text, encoding="utf-8")
 
-    for path, key in ((NODE_PACKAGE, "node"), (SKILLS_PACKAGE, "skills")):
+    for path, key in (
+        (NODE_PACKAGE, "node"),
+        (CLI_PACKAGE, "cli"),
+        (SKILLS_PACKAGE, "skills"),
+    ):
         meta = json.loads(path.read_text(encoding="utf-8"))
         meta["version"] = expected[key]
         path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")

--- a/tests/contracts/repository-cli-lifecycle.json
+++ b/tests/contracts/repository-cli-lifecycle.json
@@ -1,0 +1,128 @@
+{
+  "schemaVersion": 1,
+  "contract": "graphforge-packed-cli-lifecycle/1",
+  "scope": {
+    "portableInterchange": "complete_project_generation",
+    "ontologyLifecycle": {
+      "owner": "#236",
+      "operations": [
+        "inspect_runtime_catalog",
+        "suggest_ontology",
+        "validate_ontology",
+        "export_ontology"
+      ]
+    },
+    "ontologyBindingParity": {
+      "owner": "#237",
+      "operations": [
+        "inspect_runtime_catalog",
+        "suggest_ontology",
+        "validate_ontology",
+        "export_ontology",
+        "adopt_ontology",
+        "clear_ontology"
+      ]
+    },
+    "forbiddenImplicitOntologyOperations": [
+      "inspect_runtime_catalog",
+      "suggest_ontology",
+      "validate_ontology",
+      "export_ontology",
+      "adopt_ontology",
+      "clear_ontology"
+    ]
+  },
+  "identities": {
+    "syncOperation": "41414141-4141-4141-4141-414141414141",
+    "syncActor": "42424242-4242-4242-4242-424242424242",
+    "checkpointCreateOperation": "43434343-4343-4343-4343-434343434343",
+    "checkpointDeleteOperation": "44444444-4444-4444-4444-444444444444",
+    "revertOperation": "45454545-4545-4545-4545-454545454545",
+    "revertActor": "46464646-4646-4646-4646-464646464646",
+    "importOperation": "47474747-4747-4747-4747-474747474747"
+  },
+  "requiredScenarios": [
+    {
+      "name": "init_and_reopen",
+      "commands": ["init", "init"],
+      "invariants": [
+        "tracked_definition_scaffold_preserved",
+        "ignored_state_imports_exports",
+        "skills_installed_from_package",
+        "second_init_idempotent",
+        "fresh_process_reopens_current"
+      ]
+    },
+    {
+      "name": "configuration_and_static_infra",
+      "commands": ["config validate", "config resolve", "infra validate"],
+      "invariants": [
+        "canonical_secret_free_resolved_json",
+        "static_validation_does_not_open_or_mutate_project_state",
+        "readiness_reported_separately"
+      ]
+    },
+    {
+      "name": "sync_check_apply_and_replay",
+      "commands": ["sync --check", "sync", "sync", "sync --check"],
+      "exitCodes": [4, 0, 0, 0],
+      "statuses": ["drift", "published", "in_sync", "in_sync"],
+      "invariants": [
+        "check_does_not_publish",
+        "caller_operation_and_actor_preserved",
+        "replay_does_not_publish",
+        "only_declared_definition_digests_reconciled"
+      ]
+    },
+    {
+      "name": "checkpoint_and_top_level_revert",
+      "commands": [
+        "checkpoint create",
+        "checkpoint list",
+        "checkpoint show",
+        "checkpoint diff",
+        "revert --preview",
+        "revert without --yes",
+        "revert --yes",
+        "revert --yes replay",
+        "checkpoint delete"
+      ],
+      "exitCodes": [0, 0, 0, 0, 0, 2, 0, 0, 0],
+      "invariants": [
+        "checkpoint_pins_complete_generation",
+        "preview_and_refusal_do_not_change_current",
+        "revert_publishes_new_complete_generation",
+        "revert_replay_does_not_publish",
+        "fresh_process_reopens_reverted_state"
+      ]
+    },
+    {
+      "name": "portable_export_import_and_reopen",
+      "commands": ["export --current", "import", "checkpoint list"],
+      "invariants": [
+        "envelope_is_deterministic_and_checksum_verified",
+        "envelope_contains_complete_generation_not_ontology_document",
+        "import_stages_all_participants_before_publication",
+        "fresh_process_reopens_imported_current"
+      ]
+    },
+    {
+      "name": "remove_refusal_and_confirmation",
+      "commands": ["remove", "remove --yes"],
+      "exitCodes": [2, 0],
+      "invariants": [
+        "refusal_does_not_change_state",
+        "only_state_removed",
+        "tracked_definitions_imports_exports_and_skills_preserved"
+      ]
+    },
+    {
+      "name": "git_data_boundary",
+      "commands": ["git add --all", "git diff --cached --name-only"],
+      "invariants": [
+        "tracked_config_ontology_schemas_migrations_seed_recipes_allowed",
+        "state_imports_exports_materialized_seeds_snapshots_graph_and_source_data_absent"
+      ]
+    }
+  ]
+}

--- a/tests/unit/test_set_release_version.py
+++ b/tests/unit/test_set_release_version.py
@@ -25,12 +25,14 @@ def test_expected_mapping() -> None:
         "cargo": "0.5.0",
         "python": "0.5.0",
         "node": "0.5.0",
+        "cli": "0.5.0",
         "skills": "0.5.0",
     }
     dev = set_release_version.expected_for("0.5.0", dev=True)
     assert dev["cargo"] == "0.5.0-dev"
     assert dev["python"] == "0.5.0.dev0"
     assert dev["node"] == "0.5.0-dev.0"
+    assert dev["cli"] == "0.5.0-dev.0"
     assert dev["skills"] == "0.5.0-dev.0"
 
 


### PR DESCRIPTION
Closes #226

## Summary
- prove the complete repository lifecycle through clean packed `uvx graphforge` and offline `npx @graphforge/cli` consumers using one shared contract
- ship public Python/npm command documentation and release-order verification for the CLI packages
- preserve the ontology boundary: issue 236 owns Rust runtime-catalog inspection, suggestion, validation, and ontology-document export; issue 237 owns thin binding parity plus durable adopt/clear; repository export/import remains whole-project portable interchange
- verify project skills, Git data exclusions, reopen behavior, structured results, confirmations, identities, checkpoints, revert, and static IaC validation

## Acceptance evidence
- `pnpm --filter @graphforge/cli test:lifecycle` — 7 packed offline npx scenarios verified
- `GRAPHFORGE_UVX_WHEEL=<wheel> python3 crates/gf-bindings-py/tests/cli_lifecycle.py` — passed through `uvx --offline --from`
- installed wheel: CLI entrypoint, smoke, project-skills, and lifecycle tests — passed
- `pnpm test:node-cli`, `pnpm smoke:node-cli`, `pnpm format:node-cli` — passed
- clean-environment, publish-contract, change-classification, release-version, and workflow checks — passed
- the prerequisite repository snapshot revert fix is already merged

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add packed uvx and offline npx lifecycle acceptance tests for the GraphForge CLI
> - Adds [cli_lifecycle.py](https://github.com/CurateLabs/graphforge/pull/250/files#diff-b82bddc9c6ba876d83ff1a9b4e3d03e585f62270adfb2e9150e80eafb6fd73f3) — a full lifecycle acceptance test for the Python binding covering init, sync, checkpoint, revert, export/import, skills, and guarded remove via `uvx`.
> - Adds [native-offline-lifecycle.mjs](https://github.com/CurateLabs/graphforge/pull/250/files#diff-238fc0496f7669798b3fd70c9368a3e26b5f1cb31756c0276239ed48dda7fcf6) — an equivalent offline `npx` acceptance test for the Node CLI covering the same lifecycle scenarios plus dependency closure and forbidden ontology operation checks.
> - Adds [verify-node-cli-release-package.mjs](https://github.com/CurateLabs/graphforge/pull/250/files#diff-3fe10e6baf4873ecfd7430dd670d08a9f8ac42dd8bc9d4fe63237c87ad482a06) — a pre-publish CI step that packs `@graphforge/cli`, installs it against the published native package, and verifies offline execution before allowing publication.
> - Adds a `cli` lane to [clean-env-verify.py](https://github.com/CurateLabs/graphforge/pull/250/files#diff-e3d9e60251ea05fe4384401a204098ca35bef1d9b322b0fd3a0039637ae0df81) that installs the published `@graphforge/cli` and runs `npx --offline graphforge --version` in a clean environment.
> - Adds [test-publish-cli-contract.py](https://github.com/CurateLabs/graphforge/pull/250/files#diff-2aec030884dbd98568504908221948bb31023f08772bccca4682dc1085af08f3) to enforce correct publish workflow job ordering and step presence.
> - Adds a shared [repository-cli-lifecycle.json](https://github.com/CurateLabs/graphforge/pull/250/files#diff-3ee4f1e389518ca74088e4e9dfc0d57b1a62d676dce32eb7ececb8ebaaf9c87d) contract that both the Python and Node acceptance tests read to track required scenario coverage.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 201d8a2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->