### PR TITLE
test(dx): prove ontology authority boundaries

### DIFF
--- a/crates/gf-api/src/portable.rs
+++ b/crates/gf-api/src/portable.rs
@@ -173,6 +173,17 @@ fn hex(digest: [u8; 32]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{AdoptOntologyRequest, ClearOntologyRequest, WriteContext};
+    use gf_core::OntologyMode;
+
+    const ONTOLOGY: &str = "ontology_id: portable-authority\nversion: \"1\"\nentity_types:\n  - name: Person\n    abstract: false\nrelation_types: []\n";
+
+    fn write_context(seed: u128) -> WriteContext {
+        WriteContext {
+            operation_uuid: OperationId(Uuid::from_u128(seed)),
+            actor_uuid: None,
+        }
+    }
 
     #[test]
     fn public_facade_round_trips_current_generation_and_reopens_import() {
@@ -238,5 +249,120 @@ mod tests {
 
         assert!(error.to_string().contains("must be empty"));
         assert_eq!(std::fs::read(sentinel).unwrap(), b"preserve me");
+    }
+
+    #[test]
+    fn portable_interchange_preserves_durable_ontology_authority() {
+        let root = tempfile::tempdir().unwrap();
+        let source_path = root.path().join("source");
+        std::fs::create_dir(&source_path).unwrap();
+        let ontology_path = root.path().join("authority.yaml");
+        std::fs::write(&ontology_path, ONTOLOGY).unwrap();
+        let mut source = GraphForge::new(source_path.to_str()).unwrap();
+        source
+            .adopt_ontology(AdoptOntologyRequest {
+                context: write_context(1),
+                path: ontology_path,
+                mode: OntologyMode::Strict,
+            })
+            .unwrap();
+        let expected = source.workspace_ontology().unwrap();
+        let envelope = root.path().join("adopted.gfportable");
+        source
+            .export_portable(PortableExportRequest {
+                selection: PortableSelection::Current,
+                output: envelope.clone(),
+            })
+            .unwrap();
+
+        let target_path = root.path().join("imported-adopted");
+        GraphForge::import_portable(
+            &target_path,
+            &PortableImportRequest {
+                input: envelope,
+                operation_id: OperationId(Uuid::from_u128(2)),
+            },
+        )
+        .unwrap();
+        let imported = GraphForge::new(target_path.to_str()).unwrap();
+
+        assert_eq!(imported.ontology_mode(), OntologyMode::Strict);
+        assert_eq!(imported.workspace_ontology().unwrap(), expected);
+    }
+
+    #[test]
+    fn portable_interchange_excludes_session_load_and_preserves_durable_clear() {
+        let root = tempfile::tempdir().unwrap();
+        let source_path = root.path().join("source");
+        std::fs::create_dir(&source_path).unwrap();
+        let ontology_path = root.path().join("session.yaml");
+        std::fs::write(&ontology_path, ONTOLOGY).unwrap();
+        let mut source = GraphForge::new(source_path.to_str()).unwrap();
+        source
+            .load_ontology(ontology_path.to_str().unwrap())
+            .unwrap();
+        assert_eq!(source.ontology_mode(), OntologyMode::Advisory);
+        let session_envelope = root.path().join("session.gfportable");
+        source
+            .export_portable(PortableExportRequest {
+                selection: PortableSelection::Current,
+                output: session_envelope.clone(),
+            })
+            .unwrap();
+
+        let session_target = root.path().join("imported-session");
+        GraphForge::import_portable(
+            &session_target,
+            &PortableImportRequest {
+                input: session_envelope,
+                operation_id: OperationId(Uuid::from_u128(3)),
+            },
+        )
+        .unwrap();
+        let imported_session = GraphForge::new(session_target.to_str()).unwrap();
+        assert_eq!(imported_session.ontology_mode(), OntologyMode::Exploratory);
+        assert!(
+            imported_session
+                .workspace_ontology()
+                .unwrap()
+                .canonical_ontology
+                .is_none()
+        );
+
+        source
+            .adopt_ontology(AdoptOntologyRequest {
+                context: write_context(4),
+                path: ontology_path,
+                mode: OntologyMode::Advisory,
+            })
+            .unwrap();
+        source
+            .clear_ontology(ClearOntologyRequest {
+                context: write_context(5),
+            })
+            .unwrap();
+        let cleared_envelope = root.path().join("cleared.gfportable");
+        source
+            .export_portable(PortableExportRequest {
+                selection: PortableSelection::Current,
+                output: cleared_envelope.clone(),
+            })
+            .unwrap();
+
+        let cleared_target = root.path().join("imported-cleared");
+        GraphForge::import_portable(
+            &cleared_target,
+            &PortableImportRequest {
+                input: cleared_envelope,
+                operation_id: OperationId(Uuid::from_u128(6)),
+            },
+        )
+        .unwrap();
+        let imported_clear = GraphForge::new(cleared_target.to_str()).unwrap();
+        assert_eq!(imported_clear.ontology_mode(), OntologyMode::Exploratory);
+        assert_eq!(
+            imported_clear.workspace_ontology().unwrap(),
+            source.workspace_ontology().unwrap()
+        );
     }
 }

--- a/crates/gf-api/src/repository.rs
+++ b/crates/gf-api/src/repository.rs
@@ -2954,6 +2954,85 @@ mod tests {
     }
 
     #[test]
+    fn repository_sync_tracks_ontology_definitions_without_changing_authority() {
+        let root = tempdir().unwrap();
+        let context = RepositoryContext::discover(root.path()).unwrap();
+        context.init_without_skills().unwrap();
+        let ontology_path = root.path().join(".graphforge/ontology/authority.yaml");
+        fs::write(
+            &ontology_path,
+            "ontology_id: repository-authority\nversion: \"1\"\nentity_types:\n  - name: Person\n    abstract: false\nrelation_types: []\n",
+        )
+        .unwrap();
+        let mut graph = crate::GraphForge::new(Some(context.state_path.to_str().unwrap())).unwrap();
+        graph
+            .adopt_ontology(crate::AdoptOntologyRequest {
+                context: crate::WriteContext {
+                    operation_uuid: crate::OperationId(Uuid::from_u128(101)),
+                    actor_uuid: None,
+                },
+                path: ontology_path.clone(),
+                mode: gf_core::OntologyMode::Strict,
+            })
+            .unwrap();
+        let authoritative = graph.workspace_ontology().unwrap();
+        drop(graph);
+
+        fs::write(
+            &ontology_path,
+            "ontology_id: repository-authority\nversion: \"2\"\nentity_types:\n  - name: Organization\n    abstract: false\nrelation_types: []\n",
+        )
+        .unwrap();
+        let synced = context
+            .sync(RepositorySyncRequest {
+                check: false,
+                operation_uuid: Some(Uuid::from_u128(102)),
+                actor_uuid: None,
+            })
+            .unwrap();
+        assert_eq!(synced.status, RepositorySyncStatus::Published);
+        assert!(
+            synced
+                .definitions
+                .iter()
+                .any(|definition| definition.definition_id == "ontology")
+        );
+
+        let reopened = crate::GraphForge::new(Some(context.state_path.to_str().unwrap())).unwrap();
+        assert_eq!(reopened.ontology_mode(), gf_core::OntologyMode::Strict);
+        assert_eq!(reopened.workspace_ontology().unwrap(), authoritative);
+
+        drop(reopened);
+        let mut graph = crate::GraphForge::new(Some(context.state_path.to_str().unwrap())).unwrap();
+        graph
+            .clear_ontology(crate::ClearOntologyRequest {
+                context: crate::WriteContext {
+                    operation_uuid: crate::OperationId(Uuid::from_u128(103)),
+                    actor_uuid: None,
+                },
+            })
+            .unwrap();
+        let cleared = graph.workspace_ontology().unwrap();
+        drop(graph);
+        fs::write(&ontology_path, "not: an ontology\n").unwrap();
+        context
+            .sync(RepositorySyncRequest {
+                check: false,
+                operation_uuid: Some(Uuid::from_u128(104)),
+                actor_uuid: None,
+            })
+            .unwrap();
+
+        let reopened_clear =
+            crate::GraphForge::new(Some(context.state_path.to_str().unwrap())).unwrap();
+        assert_eq!(
+            reopened_clear.ontology_mode(),
+            gf_core::OntologyMode::Exploratory
+        );
+        assert_eq!(reopened_clear.workspace_ontology().unwrap(), cleared);
+    }
+
+    #[test]
     fn repository_snapshot_checkpoint_revert_reopens_and_replays() {
         let root = tempdir().unwrap();
         let context = RepositoryContext::discover(root.path()).unwrap();


### PR DESCRIPTION
## Summary

- add direct regression evidence for the #219 repository-sync boundary with #236/#237 ontology authority
- prove portable interchange preserves durable adopt and explicit clear outcomes
- prove session-only ontology loading is not exported as durable authority

This is test/proof debt only. It changes no runtime behavior or public API.

## Acceptance evidence

- repository sync records tracked ontology-definition drift without implicitly validating, adopting, clearing, or changing durable authority
- portable export/import preserves an adopted ontology and enforcement mode exactly
- session-only load state is excluded from portable interchange
- explicit clear remains durable explicit absence after export/import/reopen

## Validation

- cargo fmt --all -- --check
- git diff --check
- cargo test -p gf-api repository::tests:: --lib (22 passed)
- cargo test -p gf-api portable::tests:: --lib (4 passed)
- gf-api clippy currently reaches two pre-existing warnings in unchanged gf-storage project_failpoint.rs on the local Rust toolchain

Closes #219

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788102518&installation_model_id=20486&pr_number=253&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F253&signature=19529bd542f3717f3b3d6fdd8f7f9721bdbc11ac7b925119f128eb676bf5a4b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests proving ontology authority boundaries in portable interchange and repository sync
> - Adds tests in [portable.rs](https://github.com/CurateLabs/graphforge/pull/253/files#diff-b56b99f33f9c26a15a94c4745091c8ace03d515b147a0053469b1fb3abe40c87) verifying that durable ontology authority (Strict mode) is preserved across portable export/import, while session-loaded ontologies and cleared ontologies are excluded or reflected correctly in the imported workspace.
> - Adds a test in [repository.rs](https://github.com/CurateLabs/graphforge/pull/253/files#diff-0c483338ed3b86d8f44ae6fc28d0389d39561d89c232f66c2214253bead5fdda) verifying that repository sync tracks ontology definitions without altering authority mode, and that clearing ontology persists the cleared state across reopens even when the YAML file becomes invalid.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 385092a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->