### PR TITLE
docs: integrate the VS Code extension guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Integrate the GraphForge VS Code extension into the public guide by mechanically importing
+  its curated `docs/published/` pages from an immutable, checksummed revision (#252).
 - Add a runtime- and provider-agnostic deployment specification for Pulumi
   TypeScript/Python and Terraform, projecting digest-pinned core artifacts,
   service/worker/job/host intent, external source/secret references, and

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -1,7 +1,10 @@
 # GraphForge docs site (Astro Starlight)
 
-Public documentation site for GraphForge. Markdown sources live in `../docs/`;
-this package syncs an allowlisted subset into `src/content/docs/` at build time.
+Public documentation site for GraphForge. Most Markdown sources live in `../docs/`;
+this package syncs an allowlisted subset into `src/content/docs/` at build time. The VS Code
+extension guide comes from a checked-in snapshot of the extension repository's public-only
+`docs/published/` subtree, guarded by the immutable revision and SHA-256 checksums in
+`external-docs.json`.
 
 ## Run locally
 
@@ -23,6 +26,10 @@ Or: `make docs-serve` / `make docs-build` / `make docs-clean`.
 | --- | --- |
 | `astro.config.mjs` | Starlight config and **reader-journey** sidebar |
 | `scripts/sync-content.mjs` | Allowlist sync from `docs/` → content collection; rewrites `.md` links to site paths |
+| `external-docs.json` | Pinned `graphforge-vscode` published-page allowlist, destinations, and checksums |
+| `external/graphforge-vscode/` | Mechanically generated, build-verifiable public extension snapshot |
+| `scripts/update-extension-docs.mjs` | Authenticated refresh command; rejects changes to the published-file contract |
+| `scripts/test-extension-docs.mjs` | Offline allowlist, checksum, destination, and private-marker contract test |
 | `scripts/check-links.mjs` | Post-build internal link + stale-base checker |
 | `src/content/docs/` | Generated — do not edit by hand |
 
@@ -33,3 +40,13 @@ Published sidebar order (reader experience): **Get started**, **Use every day**,
 On-disk authoring trees remain Guide / Book / Reference / `engineering/`
 (+ `adr/`, `development/`); product/strategy DocSlime content is not published
 from this repo.
+
+## Updating the extension guide
+
+After public extension documentation changes, authenticate `gh` for the CurateLabs repository
+and run `pnpm docs:update-extension <full-graphforge-vscode-commit-sha>`. The command reads only
+`docs/published/`, refreshes the checked-in snapshot, and updates its SHA-256 values. It stops
+if the upstream published-file set changed so additions require an explicit destination and
+review. Never use a branch name or manually add private extension documents. Run
+`pnpm docs:build` and `pnpm docs:check-links`; normal builds are offline and fail on a missing
+snapshot, mutable revision, unexpected allowlist, or checksum mismatch.

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -37,6 +37,16 @@ export default defineConfig({
           label: 'Use every day',
           items: [
             { label: 'Overview', slug: 'guide/overview' },
+            {
+              label: 'VS Code extension',
+              collapsed: false,
+              items: [
+                { label: 'Overview', slug: 'guide/vscode-extension' },
+                { label: 'Install and choose a runtime', slug: 'guide/vscode-extension/install' },
+                { label: 'Commands', slug: 'guide/vscode-extension/commands' },
+                { label: 'Agent interop', slug: 'guide/vscode-extension/agent-interop' },
+              ],
+            },
             { label: 'Cypher Query Language', slug: 'guide/cypher-guide' },
             { label: 'Graph Construction', slug: 'guide/graph-construction' },
             { label: 'Analytics Integration', slug: 'guide/analytics-integration' },

--- a/docs-site/external-docs.json
+++ b/docs-site/external-docs.json
@@ -1,0 +1,27 @@
+{
+  "repository": "CurateLabs/graphforge-vscode",
+  "revision": "7da03dd6690808c22a5b23b0e71e5810b67904c3",
+  "sourceDirectory": "docs/published",
+  "pages": [
+    {
+      "source": "overview.md",
+      "destination": "guide/vscode-extension/index.md",
+      "sha256": "207980122331d69c59d2294515f62927a572cb76f83b27e576014a6530e76962"
+    },
+    {
+      "source": "install.md",
+      "destination": "guide/vscode-extension/install.md",
+      "sha256": "46987901769db65fdb0642b88c21cdfbb765428a3aae0d206c2473f05bce4899"
+    },
+    {
+      "source": "commands.md",
+      "destination": "guide/vscode-extension/commands.md",
+      "sha256": "bea4c3d8336e4475fc9eae72e2acc75256251a4a582be707a00209b62caff892"
+    },
+    {
+      "source": "agent-interop.md",
+      "destination": "guide/vscode-extension/agent-interop.md",
+      "sha256": "5f7ec827d6c906be49a9be119b763ae8593585086b07223ad2f30bc80cea8575"
+    }
+  ]
+}

--- a/docs-site/external/graphforge-vscode/agent-interop.md
+++ b/docs-site/external/graphforge-vscode/agent-interop.md
@@ -1,0 +1,56 @@
+# Agent interop
+
+Every command in [`commands.md`](commands.md) is a stable ID callable via
+`vscode.commands.executeCommand("graphforge.<id>", ...)` — no Command Palette click required.
+This makes GraphForge drivable end-to-end by an in-editor coding agent (a Cursor agent, GitHub
+Copilot Agent Mode, or any other extension calling the VS Code command API), not just by a
+human clicking through menus.
+
+## The core loop
+
+```mermaid
+flowchart TD
+    A["checkEnvironment({ silent: true })"] -->|runtime.active == 'none'| B["setupNativeBinding or setupPythonBinding"]
+    A -->|project.open == false| C["initializeProjectHere or openProject(path)"]
+    A -->|runtime + project ready| D["runQuery({ cypher, params }) or a verb command"]
+    B --> A
+    C --> A
+    D -->|result.error present| B
+    D -->|success| E["Read the result from the return value or the opened document"]
+```
+
+1. **Check Environment** — `executeCommand("graphforge.checkEnvironment", { silent: true })`.
+   Inspect `runtime.active` (`"node" | "python" | "none"`), `nodeBinding.available`,
+   `python.available`, and `project.open`; the returned `nextAction` string always names the
+   exact next command to run.
+2. **Setup / Init if needed** — if no runtime is usable, run `graphforge.setupNativeBinding`
+   and/or `graphforge.setupPythonBinding`. If a runtime is ready but no project is open, run
+   `graphforge.initializeProjectHere` (new project) or `graphforge.openProject(path)` (existing
+   project — `path` is a plain string arg, no picker needed). Re-run step 1 to confirm.
+3. **Run Query / Rank** — call `graphforge.runQuery({ cypher, params })` for Cypher, or one of
+   the analyst verb commands (these still walk a QuickPick today).
+4. **Read the result** — either the `executeCommand` return value, or the opened JSON document
+   the command also writes for a human pairing with the agent. On failure, the returned
+   object's `error` / `code` / `nextAction` fields tell you exactly what to do next — never a
+   bare exception or a silent no-op.
+
+## What's structured vs. interactive
+
+| Command | Accepts args to skip prompts | Returns |
+|---|---|---|
+| `graphforge.checkEnvironment` | `{ silent?: boolean }` | `EnvironmentReport` always |
+| `graphforge.openProject` | `pathArg?: string` | — |
+| `graphforge.runQuery` / `runQueryWithParams` | `{ cypher?: string; params?: Record<string, unknown> }` | `QueryResult` (`{ columns, rows, rowCount, algorithm? }`) or a structured `{ error, code?, nextAction }` |
+| `graphforge.rank` / `cluster` / `paths` / `analyze` / `similar` / `find` (and `…Advanced…`) | Not yet — still QuickPick-driven | Verb result object (`{ verb, by, label, columns, rows, rowCount, algorithm? }`), `{ error }`, or `{ cancelled: true }` |
+| `graphforge.setupNativeBinding` / `setupPythonBinding` / `initializeProjectHere` / `loadOntology` / `showResultGraphAdvanced` | No — these are inherently human choices (which folder, which binding source) | — |
+
+For a command not listed above, treat it as QuickPick/dialog-driven unless
+`src/test/extension.test.ts` (source of truth, in the repository) says otherwise.
+
+## Runtime awareness
+
+`graphforge.runtime` (default `auto`) selects which engine backs a given call — see
+[`install.md`](install.md) for the full Node-vs-Python policy. An agent that needs the advanced
+Node-only surfaces (checkpoints, embedding spaces, indexing, invocation descriptors, composite
+transactions, knowledge-ledger writes) should check `nodeBinding.available` from
+`checkEnvironment` before calling them, since the Python bridge does not back those yet.

--- a/docs-site/external/graphforge-vscode/commands.md
+++ b/docs-site/external/graphforge-vscode/commands.md
@@ -1,0 +1,120 @@
+# Command map
+
+Every command below is a stable ID, invokable from the Command Palette or programmatically via
+`vscode.commands.executeCommand("<id>", ...)`. Commands marked **Node-only** require the
+`@graphforge/node` runtime — they aren't backed by the Python bridge yet (see
+[`install.md`](install.md)).
+
+## Setup
+
+| Command | ID | What it does |
+|---|---|---|
+| GraphForge: Check Environment | `graphforge.checkEnvironment` | Reports both runtimes' status, which one is active, and the single next step. Accepts optional `{ silent: true }`. |
+| GraphForge: Setup Native Binding | `graphforge.setupNativeBinding` | QuickPick to link/browse/install `@graphforge/node`. |
+| GraphForge: Setup Python Binding | `graphforge.setupPythonBinding` | QuickPick to select a Python interpreter or install `graphforge` via `uv`. |
+| GraphForge: Initialize Project Here | `graphforge.initializeProjectHere` | Creates a new GraphForge project in an empty/uninitialized folder. |
+| GraphForge: Open Project | `graphforge.openProject` | Opens an existing `FORMAT`-marked project; accepts an optional path string arg. |
+| GraphForge: Refresh Explorer | `graphforge.refreshExplorer` | Refreshes the Projects Activity Bar view. |
+| GraphForge: Get Started | `graphforge.getStarted` | Opens the Get Started sidebar (Welcome mode picker on first use, then the runtime → project → query checklist). |
+| GraphForge: Choose Experience Mode… | `graphforge.chooseExperienceMode` | Reopens the Welcome mode picker (Guided/Autonomous) inside Get Started. |
+| GraphForge: Settings | `graphforge.openSettings` | Opens the GraphForge Settings panel — left-nav categories (Runtime / Experience / Advanced) over the same `graphforge.*` settings as the VS Code Settings UI. |
+
+## Cypher
+
+| Command | ID | What it does |
+|---|---|---|
+| GraphForge: Run Query | `graphforge.runQuery` | Runs Cypher from the editor selection, the whole document, or an input box; accepts `{ cypher?, params? }` to skip prompts. |
+| GraphForge: Run Query with Parameters… | `graphforge.runQueryWithParams` | Same as Run Query, plus a JSON parameters prompt (or pass `{ cypher, params }` directly). |
+
+## Analyst verbs
+
+Each verb has a plain command (walks a QuickPick chain: label, then algorithm) and an
+`…Advanced…` variant (adds via/directed/write-property prompts where applicable).
+
+| Verb | Plain | Advanced |
+|---|---|---|
+| Rank | `graphforge.rank` | `graphforge.rankAdvanced` |
+| Cluster | `graphforge.cluster` | `graphforge.clusterAdvanced` |
+| Paths | `graphforge.paths` | `graphforge.pathsAdvanced` |
+| Analyze | `graphforge.analyze` | `graphforge.analyzeAdvanced` |
+| Similar | `graphforge.similar` | `graphforge.similarAdvanced` |
+| Find | `graphforge.find` | — |
+
+## Indexing **(Node-only)**
+
+| Command | ID |
+|---|---|
+| GraphForge: Index Text… | `graphforge.indexText` |
+| GraphForge: Index Vector… | `graphforge.indexVector` |
+| GraphForge: Inspect Text Index… | `graphforge.inspectTextIndex` |
+| GraphForge: Index Adjacency | `graphforge.indexAdjacency` |
+| GraphForge: Inspect Adjacency Index | `graphforge.inspectAdjacency` |
+| GraphForge: Rebuild Adjacency Index | `graphforge.rebuildAdjacency` |
+
+## Checkpoints **(Node-only, ADR 0014)**
+
+| Command | ID |
+|---|---|
+| GraphForge: Create Checkpoint… | `graphforge.createCheckpoint` |
+| GraphForge: List Checkpoints | `graphforge.listCheckpoints` |
+| GraphForge: Open Checkpoint… | `graphforge.openCheckpoint` |
+| GraphForge: Diff Checkpoints… | `graphforge.diffCheckpoints` |
+| GraphForge: Delete Checkpoint… | `graphforge.deleteCheckpoint` |
+| GraphForge: Revert to Checkpoint… | `graphforge.revertToCheckpoint` |
+
+## Embedding spaces **(Node-only)**
+
+| Command | ID |
+|---|---|
+| GraphForge: Embedding Spaces | `graphforge.embeddingSpaces` |
+| GraphForge: Publish Caller Embeddings… | `graphforge.publishCallerEmbeddings` |
+| GraphForge: Bind Embedding Space Alias… | `graphforge.bindEmbeddingSpaceAlias` |
+| GraphForge: Set Default Embedding Space… | `graphforge.setDefaultEmbeddingSpace` |
+| GraphForge: Delete Embedding Space… | `graphforge.deleteEmbeddingSpace` |
+| GraphForge: Inspect Embedding Space Freshness… | `graphforge.inspectEmbeddingSpaceFreshness` |
+
+## Write mode & transactions **(Node-only, ADR 0015)**
+
+| Command | ID |
+|---|---|
+| GraphForge: Enable Capability… | `graphforge.enableCapability` |
+| GraphForge: Open with Write Mode… | `graphforge.openWithWriteMode` |
+| GraphForge: Export Invocation Descriptor… | `graphforge.exportInvocationDescriptor` |
+| GraphForge: List Algorithm Runs | `graphforge.listAlgorithmRuns` |
+| GraphForge: Publish Composite Transaction… (Advanced) | `graphforge.publishCompositeTransaction` |
+
+## Ontology
+
+| Command | ID |
+|---|---|
+| GraphForge: Show Ontology Viewer | `graphforge.showOntology` |
+| GraphForge: Load Ontology… | `graphforge.loadOntology` |
+| GraphForge: Open ontology.json | `graphforge.openOntologyFile` |
+| GraphForge: Explain Ontology Mode | `graphforge.explainOntologyMode` |
+
+## Knowledge ledger
+
+| Command | ID |
+|---|---|
+| GraphForge: List Assertions | `graphforge.listAssertions` |
+| GraphForge: Create Assertion… | `graphforge.createAssertion` |
+| GraphForge: Show Assertion… | `graphforge.showAssertion` |
+| GraphForge: Show Assertion on Graph… | `graphforge.showAssertionOnGraph` |
+| GraphForge: Attach Evidence… (Advanced) | `graphforge.attachEvidence` |
+| GraphForge: Assess Confidence… (Advanced) | `graphforge.assessConfidence` |
+| GraphForge: Record Assertion Status… (Advanced) | `graphforge.recordAssertionStatus` |
+
+Identity UUIDs for assertions/evidence/confidence/status events are minted client-side as
+UUIDv7 (engine-enforced). Knowledge-ledger writes require the Node runtime.
+
+## Result views
+
+| Command | ID |
+|---|---|
+| GraphForge: Show Result Graph | `graphforge.showResultGraph` |
+| GraphForge: Result Graph (Advanced)… | `graphforge.showResultGraphAdvanced` |
+| GraphForge: Show Project Capabilities | `graphforge.showCapabilities` |
+
+See [`agent-interop.md`](agent-interop.md) for which of these accept structured arguments and
+return structured results for programmatic (agent) callers, and the source-of-truth test
+(`src/test/extension.test.ts`) that asserts every command above is registered.

--- a/docs-site/external/graphforge-vscode/install.md
+++ b/docs-site/external/graphforge-vscode/install.md
@@ -1,0 +1,100 @@
+# Install and setup
+
+## Requirements
+
+- VS Code `^1.96.0`
+- One GraphForge engine runtime — Node **or** Python (see below); you don't need both.
+
+## Quick start
+
+1. Install **GraphForge** from the Marketplace (or Open VSX).
+2. Open a folder. Run **`GraphForge: Check Environment`** from the Command Palette.
+3. Follow the single next step it reports — it always names exactly one command to run next,
+   whether that's setting up a runtime or opening/initializing a project.
+
+## Choosing a runtime: Node vs. Python
+
+`graphforge.runtime` (setting, default `auto`) controls which engine backs Cypher execution
+and the analyst verbs:
+
+- **Node (`@graphforge/node`)** — the default for Node-ish and ambiguous workspaces. Fast,
+  in-process, no subprocess. Also the only runtime backing the more advanced surfaces:
+  checkpoints, embedding spaces, indexing, invocation descriptors, composite transactions, and
+  knowledge-ledger writes.
+- **Python (`graphforge` on PyPI)** — a first-class alternative for Cypher execute and the
+  analyst verbs, communicating with a small bundled subprocess over newline-delimited JSON /
+  Arrow IPC. No engine semantics are reimplemented in the extension.
+
+In `auto`, **Node is the global default** — except when the workspace looks like a **Python
+project** and not primarily a Node project, in which case `auto` prefers Python even if
+`@graphforge/node` is also available:
+
+- **Python signals:** `pyproject.toml`, `requirements.txt`, `uv.lock`, `.python-version`,
+  `Pipfile`, `environment.yml`, `setup.py`, a notebook-dominant workspace root, or an explicitly
+  selected VS Code Python interpreter.
+- **Node signals:** a `package.json` at the workspace root.
+- **If both are present:** Python wins only on a strong signal (`pyproject.toml`/`uv.lock`
+  present, or a Python `graphforge` environment already usable); otherwise the workspace is
+  treated as ambiguous and Node stays the default.
+- Set `graphforge.runtime` to `node` or `python` explicitly to bypass detection entirely — an
+  explicit preference never falls back to the other runtime.
+
+Run **`GraphForge: Check Environment`** any time to see both runtimes' status, which one is
+active, and the next step to fix whichever is missing.
+
+## Setting up the Node binding
+
+`@graphforge/node` is an optional peer dependency. Either:
+
+- Run **`GraphForge: Setup Native Binding`** — one QuickPick offering: link a detected sibling
+  build, browse to a built package folder (sets `graphforge.nativeModulePath`), or install it
+  via `npm install @graphforge/node` once it's published; or
+- Set `graphforge.nativeModulePath` yourself to an absolute path.
+
+## Setting up the Python binding
+
+**Package manager policy: [`uv`](https://docs.astral.sh/uv/) only — never `pip`.** If `uv`
+isn't installed, [install it first](https://docs.astral.sh/uv/getting-started/installation/);
+GraphForge will not fall back to `pip install`.
+
+Run **`GraphForge: Setup Python Binding`** — a single QuickPick with up to three choices:
+
+1. **Use detected interpreter** — checked in order: an explicit
+   `graphforge.pythonInterpreterPath`, the interpreter selected in the
+   [Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python),
+   a workspace `.venv`/`venv`/`env` folder, then `python3`/`python` on `PATH`.
+2. **Select interpreter…** — browse for a specific interpreter; sets
+   `graphforge.pythonInterpreterPath`.
+3. **Install via uv** — runs `uv add graphforge` in a uv-managed project (`pyproject.toml` /
+   `uv.lock` present), otherwise `uv pip install --python <interpreter> graphforge`, only after
+   you explicitly confirm. If `uv` isn't installed, the command stops and tells you to install
+   it — it never falls back to `pip`.
+
+Or from a terminal directly:
+
+```bash
+# in a uv-managed project (has pyproject.toml / uv.lock)
+uv add graphforge
+
+# targeting an arbitrary interpreter/venv instead
+uv pip install --python /path/to/python graphforge
+```
+
+Requires the [`pyarrow`](https://pypi.org/project/pyarrow/) package alongside `graphforge`
+(installed automatically as a `graphforge` dependency in most setups).
+
+## Project detection
+
+A folder is a GraphForge project only when it contains a `FORMAT` file whose exact contents
+are `graphforge-project/v1\n` (including the trailing newline) — never inferred from Parquet
+files alone.
+
+No project yet? Run **`GraphForge: Initialize Project Here`** — it picks the current workspace
+folder or one you choose, confirms once, and only ever succeeds on an empty or
+already-initializing directory.
+
+## Neither runtime available yet?
+
+Commands and views still register. Query/open paths fail closed with a status-bar message and
+an error offering both **Setup Native Binding** and **Setup Python Binding** — never a silent
+no-op or an opaque exception.

--- a/docs-site/external/graphforge-vscode/overview.md
+++ b/docs-site/external/graphforge-vscode/overview.md
@@ -1,0 +1,39 @@
+# Overview
+
+**GraphForge for VS Code** (`CurateLabs.graphforge`) brings [GraphForge](https://docs.graphforge.sh/)
+projects into the editor: an openCypher query surface, a set of analyst verbs (Rank, Cluster,
+Paths, Analyze, Similar, Find), a progressive ontology viewer, and an epistemic-aware result
+graph.
+
+## Who it's for
+
+- Analysts and engineers who already have (or are building) a GraphForge project and want to
+  query and explore it without leaving VS Code.
+- Python-first analysts working out of a `pyproject.toml`/`uv`-managed project or a
+  notebook-heavy workspace — the extension runs the same commands against the `graphforge`
+  PyPI package, not just the native Node binding.
+- Coding agents (Cursor, GitHub Copilot Agent Mode, or similar) driving the extension
+  end-to-end via stable `vscode.commands.executeCommand` IDs — see
+  [`agent-interop.md`](agent-interop.md).
+
+## What you get
+
+| Surface | What it does |
+|---|---|
+| **Setup** | `GraphForge: Check Environment` and the two `Setup … Binding` commands are the palette-first, no-dead-end entry point — see [`install.md`](install.md). |
+| **Cypher** | `.cypher` / `.cql` language support with syntax highlighting, plus **Run Query** (and **Run Query with Parameters…**). |
+| **Analyst verbs** | Rank, Cluster, Paths, Analyze, Similar, Find — QuickPick-driven, each with an **Advanced…** variant for optional parameters. |
+| **Projects** | An Activity Bar explorer that lists folders containing a valid GraphForge `FORMAT` marker. |
+| **Ontology** | A mode badge (exploratory/advisory/strict) plus an entity/relation tree and an Ontology Viewer webview, including a **Load Ontology…** action. |
+| **Knowledge** | List, inspect, and create knowledge-ledger assertions, with Advanced commands for attaching evidence, assessing confidence, and recording status. |
+| **Result Graph** | A webview rendering query/verb results as a graph, styled by class and epistemic status. |
+
+## Two runtimes, one extension
+
+The extension can execute Cypher and analyst verbs through either engine binding — a native
+`@graphforge/node` addon, or the `graphforge` Python package — and picks sensibly between them
+by default. See [`install.md`](install.md) for the full setup and selection story.
+
+## License
+
+Apache-2.0 © Curate Labs Inc.

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "sync": "node ./scripts/sync-content.mjs",
     "dev": "node ./scripts/sync-content.mjs && astro dev",
-    "build": "node ./scripts/sync-content.mjs && astro build",
+    "build": "node ./scripts/test-extension-docs.mjs && node ./scripts/sync-content.mjs && astro build",
     "check-links": "node ./scripts/check-links.mjs",
     "preview": "astro preview",
     "astro": "astro"

--- a/docs-site/scripts/sync-content.mjs
+++ b/docs-site/scripts/sync-content.mjs
@@ -2,6 +2,7 @@
 /** Sync allowlisted docs into Starlight content collection. */
 import fs from 'node:fs';
 import path from 'node:path';
+import crypto from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -9,6 +10,7 @@ const siteRoot = path.resolve(__dirname, '..');
 const repoRoot = path.resolve(siteRoot, '..');
 const contentRoot = path.join(siteRoot, 'src/content/docs');
 const docsRoot = path.join(repoRoot, 'docs');
+const externalManifest = JSON.parse(fs.readFileSync(path.join(siteRoot, 'external-docs.json'), 'utf8'));
 
 const GH_DOCS_BLOB = 'https://github.com/CurateLabs/graphforge/blob/main/docs';
 const GH_REPO_BLOB = 'https://github.com/CurateLabs/graphforge/blob/main';
@@ -17,6 +19,7 @@ const GH_DOCS_TREE = 'https://github.com/CurateLabs/graphforge/tree/main/docs';
 /** Directory hrefs with no published index → concrete allowlisted page (docs-relative). */
 const DIRECTORY_DEFAULTS = {
   guide: 'guide/overview.md',
+  'guide/vscode-extension': 'guide/vscode-extension/index.md',
   'guide/datasets': 'guide/datasets/overview.md',
   'book/architecture': 'book/architecture/overview.md',
   'book/use-cases': 'book/use-cases/knowledge-graph-construction.md',
@@ -224,6 +227,9 @@ function sourcePathToSlug(sourceRel) {
     }
     const ext = path.extname(part);
     const stem = path.basename(part, ext);
+    if (stem.toLowerCase() === 'index') {
+      return out.join('/');
+    }
     if (stem.toLowerCase() === 'readme') {
       if (i === 0) return 'documentation';
       return out.join('/');
@@ -337,7 +343,7 @@ function resolveDocsTarget(fromRel, hrefPath) {
  */
 function rewriteMarkdownLinks(md, fromRel) {
   const fromSlug = sourcePathToSlug(fromRel);
-  const allowlist = new Set(PAGES);
+  const allowlist = new Set([...PAGES, ...externalManifest.pages.map((page) => page.destination)]);
 
   // Protect fenced code blocks from link rewriting.
   const fences = [];
@@ -398,6 +404,117 @@ function rewriteMarkdownLinks(md, fromRel) {
   return rewritten.replace(/\0FENCE(\d+)\0/g, (_m, i) => fences[Number(i)]);
 }
 
+function validateExternalManifest(manifest) {
+  if (!/^[0-9a-f]{40}$/.test(manifest.revision)) {
+    throw new Error('External docs revision must be an immutable full commit SHA');
+  }
+  if (manifest.sourceDirectory !== 'docs/published') {
+    throw new Error('External docs may only be imported from docs/published');
+  }
+  if (!/^[\w.-]+\/[\w.-]+$/.test(manifest.repository)) {
+    throw new Error(`Invalid external docs repository: ${manifest.repository}`);
+  }
+  const expected = new Set(['overview.md', 'install.md', 'commands.md', 'agent-interop.md']);
+  const sources = new Set(manifest.pages.map((page) => page.source));
+  if (
+    manifest.pages.length !== expected.size ||
+    sources.size !== expected.size ||
+    [...expected].some((source) => !sources.has(source))
+  ) {
+    throw new Error(`External docs allowlist must be exactly: ${[...expected].join(', ')}`);
+  }
+  const destinations = new Set(manifest.pages.map((page) => page.destination));
+  if (destinations.size !== manifest.pages.length) {
+    throw new Error('External docs destinations must be unique');
+  }
+  for (const page of manifest.pages) {
+    if (page.source.includes('/') || page.source.includes('..')) {
+      throw new Error(`External docs source escapes docs/published: ${page.source}`);
+    }
+    if (!/^guide\/vscode-extension\/[a-z0-9-]+\.md$/.test(page.destination)) {
+      throw new Error(`Invalid external docs destination: ${page.destination}`);
+    }
+    if (!/^[0-9a-f]{64}$/.test(page.sha256)) {
+      throw new Error(`Invalid SHA-256 for external docs page: ${page.source}`);
+    }
+  }
+}
+
+function rewriteExternalMarkdownLinks(md, page, manifest) {
+  const mapping = new Map(manifest.pages.map((item) => [item.source, item.destination]));
+  const fromSlug = sourcePathToSlug(page.destination);
+  const sourceBase = `https://github.com/${manifest.repository}/blob/${manifest.revision}/${manifest.sourceDirectory}`;
+  const fences = [];
+  const withoutFences = md.replace(/```[\s\S]*?```/g, (block) => {
+    const token = `\0EXTERNAL_FENCE${fences.length}\0`;
+    fences.push(block);
+    return token;
+  });
+
+  const rewriteHref = (text, href, wrap) => {
+    if (/^(https?:|mailto:|tel:|#)/i.test(href)) return null;
+    const [hrefPath, hashPart] = href.split('#', 2);
+    const normalized = path.posix.normalize(path.posix.join(path.posix.dirname(page.source), hrefPath));
+    const hash = hashPart ? `#${hashPart}` : '';
+    const destination = mapping.get(normalized);
+    if (destination) {
+      return wrap(text, siteHrefForSlug(fromSlug, sourcePathToSlug(destination), hash));
+    }
+    return wrap(text, `${sourceBase}/${normalized}${hash}`);
+  };
+
+  let rewritten = withoutFences.replace(
+    /\[(!\[[^\]]*\]\([^)\s]+\))\]\(([^)\s]+)\)/g,
+    (full, imageMd, href) => {
+      const out = rewriteHref(imageMd, href, (text, next) => `[${text}](${next})`);
+      return out ?? full;
+    },
+  );
+
+  rewritten = rewritten.replace(/\[([^\]]*)\]\(([^)\s]+)\)/g, (full, text, href) => {
+    const out = rewriteHref(text, href, (label, next) => `[${label}](${next})`);
+    return out ?? full;
+  });
+  return rewritten.replace(/\0EXTERNAL_FENCE(\d+)\0/g, (_match, index) => fences[Number(index)]);
+}
+
+function addExternalSourceMetadata(md, page, manifest) {
+  const sourceUrl = `https://github.com/${manifest.repository}/blob/${manifest.revision}/${manifest.sourceDirectory}/${page.source}`;
+  md = md.replace(/^---\n/, `---\neditUrl: ${JSON.stringify(sourceUrl)}\n`);
+  return md.replace(
+    /\n---\n\n/,
+    `\n---\n\n> This page is synchronized from [\`${manifest.repository}\`](${sourceUrl}) at revision [\`${manifest.revision.slice(0, 12)}\`](https://github.com/${manifest.repository}/commit/${manifest.revision}).\n\n`,
+  );
+}
+
+async function syncExternalDocs(manifest) {
+  validateExternalManifest(manifest);
+  let imported = 0;
+  for (const page of manifest.pages) {
+    const snapshot = path.join(siteRoot, 'external', 'graphforge-vscode', page.source);
+    if (!fs.existsSync(snapshot)) {
+      throw new Error(`Missing external docs snapshot: ${snapshot}`);
+    }
+    let md = fs.readFileSync(snapshot, 'utf8');
+    const actualSha = crypto.createHash('sha256').update(md).digest('hex');
+    if (actualSha !== page.sha256) {
+      throw new Error(`External docs checksum mismatch for ${page.source}: expected ${page.sha256}, got ${actualSha}`);
+    }
+    const title = titleFromMarkdown(md, path.basename(page.source, '.md'));
+    md = upsertFrontmatter(md, title);
+    md = rewriteExternalMarkdownLinks(md, page, manifest);
+    md = addExternalSourceMetadata(md, page, manifest);
+    const destination = path.join(contentRoot, page.destination);
+    ensureDir(path.dirname(destination));
+    fs.writeFileSync(destination, md);
+    imported += 1;
+  }
+  console.log(
+    `Imported ${imported} extension pages from the verified ${manifest.repository}@${manifest.revision} snapshot`,
+  );
+  return imported;
+}
+
 rimrafContent(contentRoot);
 ensureDir(contentRoot);
 
@@ -421,5 +538,7 @@ for (const rel of PAGES) {
   fs.writeFileSync(dest, md);
   count += 1;
 }
+
+count += await syncExternalDocs(externalManifest);
 
 console.log(`Synced ${count} pages into Starlight content collection`);

--- a/docs-site/scripts/test-extension-docs.mjs
+++ b/docs-site/scripts/test-extension-docs.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/** Deterministic contract checks for the checked-in VS Code extension docs snapshot. */
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const siteRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const manifest = JSON.parse(fs.readFileSync(path.join(siteRoot, 'external-docs.json'), 'utf8'));
+const expectedSources = ['agent-interop.md', 'commands.md', 'install.md', 'overview.md'];
+const forbiddenPrivateMarkers = [
+  'Observed need',
+  'Given/When/Then',
+  'Open questions',
+  'docs/REQUIREMENTS',
+  'docs/engineering',
+  'docs/experience',
+  'docs/strategy',
+];
+
+assert.match(manifest.revision, /^[0-9a-f]{40}$/, 'revision must be a full commit SHA');
+assert.equal(manifest.sourceDirectory, 'docs/published');
+assert.match(manifest.repository, /^[\w.-]+\/[\w.-]+$/, 'repository must be a GitHub owner/name pair');
+assert.equal(manifest.pages.length, expectedSources.length, 'duplicate page entries are forbidden');
+assert.deepEqual(
+  manifest.pages.map((page) => page.source).sort(),
+  expectedSources,
+  'only the approved public pages may be imported',
+);
+assert.equal(
+  new Set(manifest.pages.map((page) => page.destination)).size,
+  manifest.pages.length,
+  'destinations must be unique',
+);
+
+for (const page of manifest.pages) {
+  assert.match(page.destination, /^guide\/vscode-extension\/[a-z0-9-]+\.md$/);
+  const snapshot = path.join(siteRoot, 'external', 'graphforge-vscode', page.source);
+  const content = fs.readFileSync(snapshot);
+  assert.equal(crypto.createHash('sha256').update(content).digest('hex'), page.sha256);
+  const markdown = content.toString('utf8');
+  for (const marker of forbiddenPrivateMarkers) {
+    assert.equal(markdown.includes(marker), false, `${page.source} contains private marker: ${marker}`);
+  }
+}
+
+console.log(`Extension docs contract ok: ${manifest.pages.length} pages at ${manifest.revision}`);

--- a/docs-site/scripts/update-extension-docs.mjs
+++ b/docs-site/scripts/update-extension-docs.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+/** Refresh the checked-in GraphForge VS Code documentation snapshot via authenticated gh. */
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const scriptRoot = path.dirname(fileURLToPath(import.meta.url));
+const siteRoot = path.resolve(scriptRoot, '..');
+const manifestPath = path.join(siteRoot, 'external-docs.json');
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+const revision = process.argv[2];
+
+if (!revision || !/^[0-9a-f]{40}$/.test(revision)) {
+  throw new Error('Usage: pnpm docs:update-extension <full-40-character-commit-sha>');
+}
+
+function api(endpoint, jq) {
+  return execFileSync('gh', ['api', endpoint, '--jq', jq], {
+    encoding: 'utf8',
+  }).trim();
+}
+
+const directoryEndpoint = `repos/${manifest.repository}/contents/${manifest.sourceDirectory}?ref=${revision}`;
+const actualFiles = JSON.parse(api(directoryEndpoint, '[.[].name]')).sort();
+const expectedFiles = ['README.md', ...manifest.pages.map((page) => page.source)].sort();
+if (JSON.stringify(actualFiles) !== JSON.stringify(expectedFiles)) {
+  throw new Error(
+    `Published extension docs changed. Review and explicitly map the new contract before updating.\nExpected: ${expectedFiles.join(', ')}\nActual: ${actualFiles.join(', ')}`,
+  );
+}
+
+const snapshotRoot = path.join(siteRoot, 'external', 'graphforge-vscode');
+fs.mkdirSync(snapshotRoot, { recursive: true });
+for (const page of manifest.pages) {
+  const endpoint = `repos/${manifest.repository}/contents/${manifest.sourceDirectory}/${page.source}?ref=${revision}`;
+  const encoded = api(endpoint, '.content').replace(/\n/g, '');
+  const content = Buffer.from(encoded, 'base64');
+  page.sha256 = crypto.createHash('sha256').update(content).digest('hex');
+  fs.writeFileSync(path.join(snapshotRoot, page.source), content);
+}
+manifest.revision = revision;
+fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+console.log(`Updated ${manifest.pages.length} extension pages from ${manifest.repository}@${revision}`);

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,12 @@ pnpm docs:preview      # serve the build output
 Makefile shortcuts: `make docs-serve`, `make docs-build`, `make docs-clean`.
 
 Markdown sources stay in `docs/`; `docs-site/scripts/sync-content.mjs` copies the
-allowlist into the Starlight content collection before `dev` / `build`.
+allowlist into the Starlight content collection before `dev` / `build`. It also imports the
+four public extension pages from a checked-in snapshot of
+`CurateLabs/graphforge-vscode/docs/published/`. The authenticated
+`pnpm docs:update-extension <full-commit-sha>` command refreshes that snapshot; normal builds
+verify the immutable revision and checksums recorded in `docs-site/external-docs.json`. No other
+extension documents are eligible for publication.
 
 ## Published reader map
 

--- a/docs/engineering/TESTING.md
+++ b/docs/engineering/TESTING.md
@@ -96,7 +96,11 @@ as product milestones.
 
 Docs changes run `.github/workflows/docs.yml`: `pnpm docs:build` syncs
 allowlisted `docs/**` into the Starlight site and fails the PR if the site does
-not build. Locally, prefer `pnpm docs:build` and `pnpm docs:check-links` before
+not build. The same command imports only the pinned, checksummed public snapshot declared in
+`docs-site/external-docs.json` from `graphforge-vscode/docs/published/`; mutable revisions,
+missing sources, and checksum drift fail closed without requiring network access. The snapshot
+is refreshed explicitly with `pnpm docs:update-extension <full-commit-sha>`. Locally, prefer
+`pnpm docs:test-extension`, `pnpm docs:build`, and `pnpm docs:check-links` before
 push when editing published pages. Docs green is part of merge readiness for
 docs surfaces; it does not prove runtime behavior.
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -5,6 +5,10 @@ GraphForge **v0.5.0** ships as thin native bindings over a Rust core
 for normal use, or build from source on `main` when developing the engine or
 bindings.
 
+Prefer an editor workflow? The optional [GraphForge VS Code extension](vscode-extension/install.md)
+detects Node- and Python-first workspaces, helps configure the appropriate native binding, and
+uses the same Rust-owned engine described below.
+
 > **Name collision:** PyPI currently lists an unrelated pure-Python package
 > named `graphforge` at **0.4.0** (~279 KB). CurateLabs GraphForge
 > **0.5.0** is the native engine (Rust `.so` / `.node`). Until CurateLabs
@@ -144,6 +148,7 @@ make pre-push
 
 ## Next steps
 
+- [VS Code extension](vscode-extension/install.md) — configure GraphForge inside your editor
 - [Quick Start](quickstart.md) — build your first graph in five minutes
 - [Tutorial](tutorial.md) — step-by-step guided walkthrough
 - [Architecture Overview](../book/architecture/overview.md) — Rust core design

--- a/docs/guide/overview.md
+++ b/docs/guide/overview.md
@@ -12,8 +12,15 @@ trees.
 | [Installation](installation.md) | Install via pip or uv |
 | [Quick Start](quickstart.md) | First graph in five minutes |
 | [Tutorial](tutorial.md) | Step-by-step walkthrough |
+| [VS Code extension](vscode-extension/) | Explore projects, run Cypher, and pair with coding agents inside your editor |
 
 ## Everyday workflows
+
+### [Use GraphForge in VS Code](vscode-extension/)
+The optional GraphForge extension adds project exploration, Cypher execution, analyst verbs,
+ontology views, result graphs, and structured command interop to VS Code-compatible editors.
+It uses the native Node or Python binding; graph behavior remains owned by the Rust engine.
+See the synchronized extension guide for setup, runtime selection, and the complete command map.
 
 ### [Cypher Query Language](cypher-guide.md)
 Learn the openCypher query language — GraphForge's primary interface for working with graphs.
@@ -99,5 +106,6 @@ df = table.to_pandas()
 
 - [Cypher Guide](cypher-guide.md) — complete query language reference
 - [Graph Construction](graph-construction.md) — build graphs with Python
+- [VS Code extension](vscode-extension/) — use GraphForge from your editor or coding agent
 - [Book](../book/README.md) — architecture, research, and deeper usage
 - [Architecture Overview](../book/architecture/overview.md) — Rust core design

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -5,6 +5,7 @@ verb returns an Apache Arrow `Table`. Node and edge handles use stable `.uuid`
 identity (no numeric storage ids).
 
 For full install options, see [Installation](installation.md).
+To run the same engine from your editor, see the [VS Code extension guide](vscode-extension/).
 
 ---
 

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Integrate the GraphForge VS Code extension into the public guide by mechanically importing
+  its curated `docs/published/` pages from an immutable, checksummed revision (#252).
 - Add a runtime- and provider-agnostic deployment specification for Pulumi
   TypeScript/Python and Terraform, projecting digest-pinned core artifacts,
   service/worker/job/host intent, external source/secret references, and

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "docs:dev": "pnpm --filter @graphforge/docs-site dev",
     "docs:build": "pnpm --filter @graphforge/docs-site build",
     "docs:check-links": "pnpm --filter @graphforge/docs-site check-links",
+    "docs:test-extension": "node docs-site/scripts/test-extension-docs.mjs",
+    "docs:update-extension": "node docs-site/scripts/update-extension-docs.mjs",
     "docs:preview": "pnpm --filter @graphforge/docs-site preview"
   },
   "engines": {


### PR DESCRIPTION
## Summary

- mechanically snapshot the curated `graphforge-vscode/docs/published/` pages at an immutable, checksummed revision
- add fail-closed refresh, import, link-rewriting, and private-content contract checks
- integrate extension overview, setup, commands, and agent interop into the GraphForge guide

## Acceptance evidence

- Given the pinned extension revision, the authenticated updater accepts exactly the curated published subtree and records SHA-256 checksums.
- When the offline docs build runs, it rejects mutable revisions, duplicate or invalid manifest entries, missing snapshots, checksum drift, and private DocSlime markers.
- Then Starlight publishes four extension routes with source attribution and correct guide/cross-page links while preserving Rust engine ownership in GraphForge-authored copy.

## Verification

- `pnpm docs:test-extension`
- `pnpm docs:build` (93 pages)
- `pnpm docs:check-links` (10,150 checked; 0 broken; 0 stale)
- CodeRabbit CLI review; verified findings addressed

Refs #252

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788117908&installation_model_id=20486&pr_number=254&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F254&signature=a0949bd0e5f5abf70192ed8768a2065515896c20f776364b57b5233170092726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a dedicated, always-visible VS Code extension section to the documentation sidebar.
  - Added guides covering installation, commands, runtime usage, and agent interoperability.
  - Improved navigation and link handling for imported extension documentation.
  - Added a default overview page for the VS Code extension documentation.

- **Quality Improvements**
  - Added automated checks to verify documentation integrity, completeness, and consistency before site builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Integrate GraphForge VS Code extension guide into the docs site
> - Adds four checked-in snapshot pages (`overview.md`, `install.md`, `commands.md`, `agent-interop.md`) under `docs-site/external/graphforge-vscode/` sourced from the `CurateLabs/graphforge-vscode` repo at a pinned revision.
> - Extends [`docs-site/scripts/sync-content.mjs`](https://github.com/CurateLabs/graphforge/pull/254/files#diff-b4da7c53b10fb11f04eb4de3ed5e79542073063277526d5acce402dcffb53f86) to import, checksum-verify, rewrite links, and inject source metadata for external pages during the content sync.
> - Adds a pre-build contract test in [`docs-site/scripts/test-extension-docs.mjs`](https://github.com/CurateLabs/graphforge/pull/254/files#diff-7ca1aa6e739eedf5f9841306d4d79ee6c4e811515127c244adf85687124c9e29) that validates the manifest structure, allowed page set, and SHA-256 checksums before any build proceeds.
> - Adds [`docs-site/scripts/update-extension-docs.mjs`](https://github.com/CurateLabs/graphforge/pull/254/files#diff-1953394b8af5d54cb5f7fd354b894b65ffd1ea81984e54c3ada980ced7ac3559) (run via `pnpm docs:update-extension`) for controlled snapshot refreshes gated on an immutable commit SHA and published-file contract.
> - Exposes the four pages in the docs site sidebar under a new 'VS Code extension' group in the 'Use every day' section.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 377c8bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->