### PR TITLE
docs: align public homepage and guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Align the published homepage and root README with the v0.5 development line, remove legacy
+  PyPI v0.4 badges/install claims, and route readers to current Python, Node, CLI, and VS Code
+  workflows (#255).
 - Integrate the GraphForge VS Code extension into the public guide by mechanically importing
   its curated `docs/published/` pages from an immutable, checksummed revision (#252).
 - Add a runtime- and provider-agnostic deployment specification for Pulumi
@@ -193,17 +196,15 @@ the authoritative runnable corpus enforced by the BDD gate.
 - Align the Python release-load probe bulk Arrow schema with Node/Rust probes so
   required columns (including `label`) are non-nullable (#2776).
 
-- Move DocSlime product & strategy docs (`PRODUCT`, `DESIGN`, `REQUIREMENTS`,
-  `strategy/`, `experience/`) to private `graphforge-nextjs`; drop the Product &
-  strategy Starlight group; keep public `engineering/` contributor docs and ADRs
-  under **Engineering** (not Understand); keep Guide / Book / Reference /
-  development public (#2772).
+- Keep the Starlight site focused on public user and contributor documentation;
+  keep `engineering/` contributor docs and ADRs under **Engineering** (not
+  Understand), alongside Guide / Book / Reference / development (#2772).
 
 - After manylinux maturin on the M22 load sticky disk, reclaim `target/`
   ownership for the host runner so Cargo can open `.cargo-build-lock` (#2765).
 
-- Place Architecture Decision Records under **Product & strategy → Engineering** in
-  the published Starlight sidebar (no longer under Understand → Decisions); keep
+- Place Architecture Decision Records under **Engineering** in the published
+  Starlight sidebar (no longer under Understand → Decisions); keep
   `docs/adr/` body paths stable (#2770).
 
 - Bump the Python `ruff` development dependency from 0.15.20 to 0.16.0 and
@@ -225,14 +226,13 @@ the authoritative runnable corpus enforced by the BDD gate.
 - Drop M## milestone staging labels from published docs (book architecture, API reference, roadmap, ADRs, engineering indexes, and light testing/release-process prose), rewriting shipped capability as present-tense **v0.5.0** language; keep literal CI artifact/workflow names, schema inventory filenames, and test binary ids (`m22_m18_public_surface`, etc.) (#2761).
 
 - Reorganize the published Starlight docs site around reader journeys (Get started,
-  Use every day, Understand, Reference, Contribute & operate, Product & strategy,
-  Community) instead of DocSlime/Guide/Book-first left nav; keep content paths stable
+  Use every day, Understand, Reference, Contribute & operate, Engineering,
+  Community) instead of Guide/Book-first left nav; keep content paths stable
   and update the homepage / docs map accordingly (#2757).
 
-- Deepen DocSlime strategy, experience, and engineering lifecycle docs from authoritative
-  repo sources (market/positioning/roadmap summaries; analyst, ontology, reopen, and agent
-  journeys; testing/publishing/observability detail), with Starlight referenced as the
-  current docs site (#2729).
+- Deepen public engineering lifecycle docs from authoritative repository sources,
+  covering testing, publishing, and observability with Starlight as the current
+  docs site (#2729).
 
 - Fix README and docs homepage badges: drop DecisionNerd / private-repo Actions
   and Codecov images that 404 anonymously, and use public shields.io badges for
@@ -288,9 +288,9 @@ the authoritative runnable corpus enforced by the BDD gate.
   core, Arrow results, Parquet projects, analyst verbs) without prior-release
   product narrative (#2723).
 
-- Add DocSlime 0.3.0 lifecycle documentation under `docs/` (`PRODUCT.md`, `DESIGN.md`,
-  `REQUIREMENTS.md`, `strategy/`, `experience/`, `engineering/`) filled from existing
-  architecture, testing, and release sources, with ADR bodies still indexed from `docs/adr/`.
+- Add engineering lifecycle documentation under `docs/`, filled from existing
+  architecture, testing, and release sources, with ADR bodies still indexed from
+  `docs/adr/`.
 
 - Remove past GitHub issue numbers and historical milestone cross-references from documentation, replacing them with durable module, behavior, and process wording.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 <h1 align="center">GraphForge</h1>
 
 <p align="center">
-  <a href="https://pypi.org/project/graphforge/"><img src="https://img.shields.io/pypi/v/graphforge.svg?label=PyPI&logo=pypi" alt="PyPI version" /></a>
-  <a href="https://pypi.org/project/graphforge/"><img src="https://img.shields.io/pypi/dm/graphforge.svg?label=Downloads" alt="Monthly downloads" /></a>
+  <a href="#installation"><img src="https://img.shields.io/badge/version-v0.5--dev-F59E0B.svg" alt="GraphForge v0.5 development line" /></a>
   <a href="#installation"><img src="https://img.shields.io/badge/Python-3.10%2B-3776AB.svg?logo=python&logoColor=white" alt="Python 3.10 or newer" /></a>
-  <a href="https://github.com/CurateLabs/graphforge-x/tree/main/crates/gf-bindings-node"><img src="https://img.shields.io/badge/Node.js-20%2B-5FA04E.svg?logo=nodedotjs&logoColor=white" alt="Node.js 20 or newer" /></a>
-  <a href="https://github.com/CurateLabs/graphforge-x/blob/main/rust-toolchain.toml"><img src="https://img.shields.io/badge/Rust-1.96-000000.svg?logo=rust&logoColor=white" alt="Rust 1.96" /></a>
-  <a href="https://github.com/CurateLabs/graphforge-x/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/CurateLabs/graphforge-x/test.yml?branch=main&label=CI&logo=github" alt="Test Suite status" /></a>
+  <a href="crates/gf-bindings-node"><img src="https://img.shields.io/badge/Node.js-20%2B-5FA04E.svg?logo=nodedotjs&logoColor=white" alt="Node.js 20 or newer" /></a>
+  <a href="rust-toolchain.toml"><img src="https://img.shields.io/badge/Rust-1.96-000000.svg?logo=rust&logoColor=white" alt="Rust 1.96" /></a>
+  <a href="https://github.com/CurateLabs/graphforge/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/CurateLabs/graphforge/test.yml?branch=main&label=CI&logo=github" alt="Test Suite status" /></a>
   <a href="https://docs.graphforge.sh/"><img src="https://img.shields.io/badge/docs-online-0A66C2.svg" alt="Documentation" /></a>
   <a href="https://docs.graphforge.sh/reference/tck-compliance/"><img src="https://img.shields.io/badge/openCypher%20TCK-3897%2F3897-brightgreen.svg" alt="openCypher TCK" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="Apache License 2.0" /></a>
@@ -51,7 +50,7 @@ first-class Arrow results across language bindings.
 
 | | NetworkX | **GraphForge** | Neo4j / Memgraph |
 |:---|:---|:---|:---|
-| **Setup** | `pip install` | `pip install` | Run a server |
+| **Setup** | `pip install` | Embedded package (v0.5 registries pending) | Run a server |
 | **Query language** | Python API | **Full openCypher** | Full Cypher |
 | **Persistence** | Manual | **Parquet project directory** | Native |
 | **Results** | Python objects | **Apache Arrow Tables** | Driver rows |
@@ -72,13 +71,32 @@ aggregations remain edge-count bound. See scale limits for measured ceilings.*
 
 ## Installation
 
+GraphForge v0.5 packages are not published yet. The `graphforge` package currently
+visible on PyPI is the legacy v0.4.0 line, and the v0.5 Node and CLI packages are
+not yet available from npm. Build the current Rust-owned engine from source:
+
 ```bash
-pip install graphforge
-# or
-uv add graphforge
+git clone https://github.com/CurateLabs/graphforge.git
+cd graphforge
+uv sync --dev
+maturin develop --release -m crates/gf-bindings-py/Cargo.toml
 ```
 
 **Requirements:** Python 3.10–3.14
+
+See the [installation guide](docs/guide/installation.md) for Node setup, source-build
+requirements, verification, and registry status.
+
+### Ways to use GraphForge
+
+| Surface | Current role |
+|---|---|
+| [Python](crates/gf-bindings-py/README.md) | Thin PyO3 binding, Arrow results, and the `graphforge` CLI launcher |
+| [Node](crates/gf-bindings-node/README.md) | Thin N-API binding over the same Rust-owned behavior |
+| [CLI](packages/cli/README.md) | Repository lifecycle, configuration, checkpoints, and portable import/export |
+| [VS Code extension](https://docs.graphforge.sh/guide/vscode-extension/) | Project exploration, Cypher, analyst verbs, result views, and agent interop |
+
+Swift and Kotlin bindings remain planned; they are not shipped surfaces.
 
 ---
 
@@ -299,7 +317,7 @@ heads and stale commits before any platform matrix build starts.
 
 | Version | Focus | Status |
 |---------|-------|--------|
-| **v0.5.0** | Rust core, Arrow results, Parquet projects, seven analyst verbs | **Current** |
+| **v0.5.0** | Rust core, Arrow results, Parquet projects, seven analyst verbs | **Development line** |
 | v0.5.1 | Swift + Kotlin bindings (UniFFI) | Planned |
 | v1.0 | Long-term API stability commitment | Future |
 

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -38,8 +38,7 @@ Published sidebar order (reader experience): **Get started**, **Use every day**,
 **Engineering** (includes ADRs), and **Community**.
 
 On-disk authoring trees remain Guide / Book / Reference / `engineering/`
-(+ `adr/`, `development/`); product/strategy DocSlime content is not published
-from this repo.
+(+ `adr/`, `development/`). Only explicitly allowlisted public sources are published.
 
 ## Updating the extension guide
 

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -31,6 +31,7 @@ export default defineConfig({
             { label: 'Installation', slug: 'guide/installation' },
             { label: 'Quick Start', slug: 'guide/quickstart' },
             { label: 'Tutorial', slug: 'guide/tutorial' },
+            { label: 'CLI & repositories', slug: 'guides/repository-integration' },
           ],
         },
         {

--- a/docs-site/scripts/sync-content.mjs
+++ b/docs-site/scripts/sync-content.mjs
@@ -32,12 +32,12 @@ const DIRECTORY_DEFAULTS = {
 /**
  * Public site pages (allowlist). Published left nav is reader-journey ordered in
  * `astro.config.mjs`; paths here keep the Guide / Book / Reference / engineering
- * on-disk layout so URLs stay stable. Product/strategy DocSlime content lives in
- * private `graphforge-nextjs` and is not published here.
+ * on-disk layout so URLs stay stable. Only explicitly allowlisted public sources
+ * are eligible for publication.
  */
 const PAGES = [
   'index.md',
-  // Public documentation map (product/strategy DocSlime lives in private graphforge-nextjs)
+  // Public documentation map
   'README.md',
   // Public contributor engineering lifecycle (ADRs under Engineering per #2771)
   'engineering/README.md',
@@ -55,6 +55,7 @@ const PAGES = [
   'guide/graph-construction.md',
   'guide/analytics-integration.md',
   'guide/exploratory-analyst.md',
+  'guides/repository-integration.md',
   'guide/datasets/overview.md',
   'guide/datasets/ldbc.md',
   'guide/datasets/neo4j-examples.md',

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,11 +10,8 @@ The **published Starlight site** is organized around **reader journeys** (Diáta
 6. **Engineering** — contributor lifecycle summaries and ADRs
 7. **Community** — licensing, security, code of conduct
 
-On disk, public sources live in Guide / Book / Reference / `engineering/` plus supporting
-folders. **Product & strategy** DocSlime lifecycle docs (PRODUCT, DESIGN, REQUIREMENTS,
-strategy, experience) live in the private
-[`CurateLabs/graphforge-nextjs`](https://github.com/CurateLabs/graphforge-nextjs) repository
-and are not published on GitHub Pages.
+On disk, published sources live in Guide / Book / Reference / `engineering/` plus supporting
+folders. This repository contains only current user and contributor documentation.
 
 The Astro Starlight site (`docs-site/`) syncs an allowlisted subset of these trees.
 Sidebar labels follow reader journeys; **content paths / URLs stay on the Guide / Book /
@@ -99,18 +96,11 @@ extension documents are eligible for publication.
 | [`adr/`](adr/) | ADR bodies (v0.5.0 keepers `0001`–`0014`) |
 | [`releases/roadmap.md`](releases/roadmap.md) | Public product roadmap |
 
-### Private product & strategy
-
-Maintainer-oriented DocSlime product planning (market, positioning, requirements, experience
-journeys) is in
-[`graphforge-nextjs` `docs/`](https://github.com/CurateLabs/graphforge-nextjs/tree/main/docs)
-([#2772](https://github.com/CurateLabs/graphforge-legecy/issues/2772)). Public engineering
-contributor docs remain in this repository.
-
 ## Conventions
 
 - **Keep docs current.** When behavior changes, update the doc in the same change.
-- **Link, don't duplicate.** Deep dives stay in `book/`; product strategy stays private.
+- **Link, don't duplicate.** Deep dives stay in `book/`; published pages stay focused on
+  current product behavior and contributor operations.
 - **Decisions are recorded.** Significant choices get ADRs under [`adr/`](adr/), indexed from
   [`engineering/adrs/`](engineering/adrs/).
 - **Site tooling is separate.** Starlight config under `docs-site/` owns published nav.

--- a/docs/book/README.md
+++ b/docs/book/README.md
@@ -4,8 +4,7 @@ Deeper GraphForge material: architecture, research notes, and richer usage narra
 
 This is the explanation and deep-usage layer. For install and everyday workflows, start in
 the [Guide](../guide/overview.md). Contributor engineering lifecycle docs live under
-[`../engineering/`](../engineering/README.md). Private product/strategy DocSlime docs live in
-[`graphforge-nextjs`](https://github.com/CurateLabs/graphforge-nextjs).
+[`../engineering/`](../engineering/README.md).
 
 ## Contents
 

--- a/docs/engineering/ARCHITECTURE.md
+++ b/docs/engineering/ARCHITECTURE.md
@@ -4,8 +4,7 @@ GraphForge is a Rust-core embedded workbench: Cypher and analyst verbs converge 
 DataFusion execution and Arrow results, with Parquet/JSON project storage and thin
 language bindings. Detail and status banners live in
 [`../book/architecture/overview.md`](../book/architecture/overview.md); this document is the
-DocSlime lifecycle summary that serves private
-[`REQUIREMENTS.md`](https://github.com/CurateLabs/graphforge-nextjs/blob/main/docs/REQUIREMENTS.md).
+public contributor lifecycle summary.
 
 ## Context diagram
 

--- a/docs/engineering/OBSERVABILITY.md
+++ b/docs/engineering/OBSERVABILITY.md
@@ -3,8 +3,8 @@
 GraphForge is local-first and embedded: there is no multi-tenant production service with
 classic uptime SLOs. “Production” means published artifacts running in user notebooks, agent
 loops, and CI. Observability therefore emphasizes **correctness signals, release health, and
-developer/agent outcomes**, feeding learning back into private
-[experience journeys](https://github.com/CurateLabs/graphforge-nextjs/tree/main/docs/experience).
+developer/agent outcomes**, feeding validated learning into bounded issues, regression tests,
+and current documentation.
 
 Roadmap merge gates also name product-facing diagnostic surfaces: `explain`, query IDs,
 provenance IDs, and structured errors ([`../releases/roadmap.md`](../releases/roadmap.md)).
@@ -75,11 +75,6 @@ There is no hosted ops dashboard product; CI and release artifacts are the share
 
 1. CI and release gates surface correctness or DX failures.
 2. Maintainers file bounded issues (root cause, not log-line spam) per `AGENTS.md` failure handling.
-3. Update private
-   [experience journeys](https://github.com/CurateLabs/graphforge-nextjs/tree/main/docs/experience)
-   when a recurring user/agent friction appears.
-4. Promote validated needs into private
-   [`REQUIREMENTS.md`](https://github.com/CurateLabs/graphforge-nextjs/blob/main/docs/REQUIREMENTS.md)
-   and tests.
-5. Docs narrative and Starlight site reflect current behavior — not historical archaeology.
-6. Strategy/roadmap pages stay linked summaries; do not fork a second milestone tracker here.
+3. Translate validated failures into regression tests and explicit public contracts.
+4. Docs narrative and the Starlight site reflect current behavior — not historical archaeology.
+5. The roadmap stays a linked summary; do not fork a second milestone tracker here.

--- a/docs/engineering/PUBLISHING.md
+++ b/docs/engineering/PUBLISHING.md
@@ -102,5 +102,3 @@ Authoritative stop/rollback table:
 - [`../development/release-process.md`](../development/release-process.md)
 - [`../development/release-workflows.md`](../development/release-workflows.md)
 - `.github/workflows/publish.yaml`
-- Strategy summary (private):
-  [`strategy/roadmap.md`](https://github.com/CurateLabs/graphforge-nextjs/blob/main/docs/strategy/roadmap.md)

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -1,20 +1,16 @@
 # Engineering
 
-Engineering begins with the shared requirements contract and follows it through design,
-pre-release evidence, continuous delivery, and production learning.
+Engineering follows public behavior through design, pre-release evidence, continuous
+delivery, and production learning.
 
 ```mermaid
 flowchart LR
-    Req["REQUIREMENTS.md"] --> Arch["ARCHITECTURE.md"]
+    Issue["Bounded issue"] --> Arch["ARCHITECTURE.md"]
     Arch --> Test["TESTING.md"]
     Test --> Pub["PUBLISHING.md"]
     Pub --> Obs["OBSERVABILITY.md"]
-    Obs -. "experience / requirements" .-> Req
+    Obs -. "validated feedback" .-> Issue
 ```
-
-Private product planning (`REQUIREMENTS.md`, experience journeys) lives in
-[`graphforge-nextjs`](https://github.com/CurateLabs/graphforge-nextjs/tree/main/docs);
-the engineering pages below stay public for contributors.
 
 ## Lifecycle
 
@@ -34,9 +30,6 @@ the engineering pages below stay public for contributors.
 | [`../development/`](../development/contributing.md) | Contributor workflow, testing detail, release process |
 | [`../contracts/`](https://github.com/CurateLabs/graphforge-legecy/tree/main/docs/contracts) | Frozen public API / fingerprint JSON contracts |
 | [`../reference/`](../reference/api.md) | Compatibility, TCK, scale limits, column naming |
-| [Private experience journeys](https://github.com/CurateLabs/graphforge-nextjs/tree/main/docs/experience) | Journeys that requirements and tests must cover |
-| [Private strategy](https://github.com/CurateLabs/graphforge-nextjs/tree/main/docs/strategy) | Positioning and roadmap summary |
-
 | Root `AGENTS.md` | Agent workflow and validation gates |
 
 ## Decision records

--- a/docs/engineering/TESTING.md
+++ b/docs/engineering/TESTING.md
@@ -148,18 +148,14 @@ weakened assertions (`AGENTS.md`).
 | NFR-1 TCK | Given the authoritative corpus, when BDD runs, then runnable scenarios pass | `make test-tck` (3897 scenarios) |
 | NFR-7 Surface inventory | Given public non-Cypher methods, when gate runs, then all classified | `tests/contracts/non-cypher-rust-surface.json` + gate script |
 
-Journeys (private):
-[experience/](https://github.com/CurateLabs/graphforge-nextjs/tree/main/docs/experience).
-
 ## Traceability contract
 
 | Link | Evidence |
 | --- | --- |
-| Product goal → experience | Private [`PRODUCT.md`](https://github.com/CurateLabs/graphforge-nextjs/blob/main/docs/PRODUCT.md), [experience/](https://github.com/CurateLabs/graphforge-nextjs/tree/main/docs/experience) |
-| Experience → requirement | IDs in private [`REQUIREMENTS.md`](https://github.com/CurateLabs/graphforge-nextjs/blob/main/docs/REQUIREMENTS.md) |
-| Requirement → BDD / scenario | Behavior trace in REQUIREMENTS.md; TCK scenarios for Cypher |
+| Public behavior → architecture / ADR | [`ARCHITECTURE.md`](ARCHITECTURE.md), [`../adr/`](../adr/) |
+| Behavior → BDD / scenario | TCK scenarios for Cypher; documented behavior tables for other surfaces |
 | Scenario → test | Paths above; contract manifests under `tests/contracts/` |
-| Model → architecture / ADR | [`ARCHITECTURE.md`](ARCHITECTURE.md), [`../adr/`](../adr/) |
+| Public API → contract inventory | Versioned manifests under `tests/contracts/` and their gate scripts |
 
 ## Evaluation against product goals
 

--- a/docs/guides/repository-integration.md
+++ b/docs/guides/repository-integration.md
@@ -4,7 +4,12 @@ GraphForge uses one `.graphforge/` directory. Definitions in `graphforge.yaml`,
 `ontology/`, `schemas/`, `seeds/`, and `migrations/` are ordinary reviewable Git
 content. Runtime state, imports, and exports are data and must not be committed.
 
-Run the same native lifecycle contract from either published package:
+> **Registry status:** The v0.5 Python and npm packages are not published yet. From a source
+> checkout, run the native CLI with `cargo run -p gf-cli -- <arguments>`. The `uvx` and `npx`
+> forms below document the package entry points that become available when v0.5 is published;
+> they do not currently resolve to the v0.5 engine from public registries.
+
+The Python and Node packages project the same native lifecycle contract:
 
 ```bash
 uvx graphforge init

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,140 +1,137 @@
 # GraphForge
 
-**An embedded, openCypher-compatible graph database for Python, Node, Swift, and Kotlin**
+**Composable graph tooling for analysis, construction, and refinement**
 
-[![PyPI](https://img.shields.io/pypi/v/graphforge.svg)](https://pypi.org/project/graphforge/)
-[![Python](https://img.shields.io/pypi/pyversions/graphforge.svg)](https://pypi.org/project/graphforge/)
-[![Docs](https://img.shields.io/badge/docs-online-0A66C2.svg)](https://docs.graphforge.sh/)
+[![Version](https://img.shields.io/badge/version-v0.5--dev-F59E0B.svg)](guide/installation.md)
+[![Python](https://img.shields.io/badge/Python-3.10%2B-3776AB.svg?logo=python&logoColor=white)](guide/installation.md)
+[![Node.js](https://img.shields.io/badge/Node.js-20%2B-5FA04E.svg?logo=nodedotjs&logoColor=white)](guide/installation.md)
+[![Rust](https://img.shields.io/badge/Rust-1.96-000000.svg?logo=rust&logoColor=white)](development/contributing.md)
+[![CI](https://img.shields.io/github/actions/workflow/status/CurateLabs/graphforge/test.yml?branch=main&label=CI&logo=github)](https://github.com/CurateLabs/graphforge/actions/workflows/test.yml)
 [![openCypher TCK](https://img.shields.io/badge/openCypher%20TCK-3897%2F3897-brightgreen.svg)](reference/tck-compliance.md)
 [![Apache License 2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](../LICENSE)
 
-GraphForge lets you write openCypher queries against an in-memory or Parquet-backed graph
-with no external services. The v0.5.0 release passes **all 3,897 openCypher TCK scenarios**
-and provides seven analyst-intent methods — all returning Apache Arrow Tables.
+GraphForge is an embedded, local-first graph execution environment with a Rust core, Arrow
+results, and Parquet persistence. It brings openCypher and analyst-intent verbs to notebooks,
+scripts, repositories, and editor workflows without requiring a database server. The v0.5
+development line passes all **3,897 openCypher TCK scenarios**.
+
+> **Registry status:** GraphForge v0.5 packages are not published yet. PyPI currently serves
+> the legacy `graphforge` v0.4.0 line, while `@graphforge/node` and `@graphforge/cli` are not yet
+> available from npm. Follow the [installation guide](guide/installation.md) to build the
+> current Rust-owned engine from source.
 
 ```python
 from graphforge import GraphForge
 
-forge = GraphForge()                    # in-memory
-# forge = GraphForge("path/to/graph/") # or Parquet-backed (directory must exist)
-
+forge = GraphForge()
 alice = forge.add_node("Person", name="Alice", age=30)
-bob   = forge.add_node("Person", name="Bob",   age=25)
+bob = forge.add_node("Person", name="Bob", age=25)
 forge.add_edge(alice, "KNOWS", bob, since=2020)
 
-# openCypher — returns an Arrow Table
 table = forge.execute("""
     MATCH (p:Person)-[:KNOWS]->(friend)
     RETURN p.name AS person, friend.name AS friend
 """)
 
-# Consume with pandas, Polars, or iterate directly
-df = table.to_pandas()
-print(df)
-#   person friend
-# 0  Alice    Bob
+print(table.to_pandas())
 ```
+
+Every query and analyst verb returns an Apache Arrow Table. Python and Node are thin bindings;
+they never replace or fall back from the Rust engine.
 
 ---
 
 ## Get started
 
-| | |
+| Page | Job |
 |---|---|
-| [Installation](guide/installation.md) | Install via pip or uv |
-| [Quick Start](guide/quickstart.md) | Your first graph in five minutes |
-| [Tutorial](guide/tutorial.md) | Step-by-step guided walkthrough |
+| [Installation](guide/installation.md) | Check registry status and build Python or Node from source |
+| [Quick Start](guide/quickstart.md) | Create, query, and persist your first graph |
+| [Tutorial](guide/tutorial.md) | Work through a complete citation-network example |
+| [CLI and repository integration](guides/repository-integration.md) | Initialize, validate, synchronize, checkpoint, export, and import a project |
+| [VS Code extension](guide/vscode-extension/) | Explore projects, run Cypher, and pair with coding agents in your editor |
+
+---
+
+## Why GraphForge?
+
+Modern research and investigation produce graph-shaped data: entity relationships extracted by
+LLMs, citation networks, dependency graphs, social connections, and evolving knowledge bases.
+GraphForge makes those graphs portable and inspectable without turning them into an application
+database or requiring a long-running service.
+
+| | NetworkX | **GraphForge** | Neo4j / Memgraph |
+|:---|:---|:---|:---|
+| **Setup** | Python package | Embedded package | Run a server |
+| **Query language** | Python API | **Full openCypher** | Full Cypher |
+| **Persistence** | Manual | **Parquet project directory** | Native |
+| **Results** | Python objects | **Apache Arrow Tables** | Driver rows |
+| **Notebook-friendly** | ✓ | ✓ | Requires connection |
+| **Primary role** | In-memory graph library | Local knowledge-analysis workbench | Operational graph database |
+
+Use GraphForge for knowledge graphs, citation networks, LLM output storage, repository-aware
+analysis, and social-network research. Use an operational database for high-throughput,
+multi-user application workloads or graphs beyond the documented
+[scale limits](reference/scale-limits.md).
 
 ---
 
 ## Use every day
 
-| | |
+| Page | Job |
 |---|---|
-| [Guide overview](guide/overview.md) | Everyday workflows index |
-| [Cypher Reference](guide/cypher-guide.md) | Full openCypher language guide |
-| [Graph Construction](guide/graph-construction.md) | Build graphs with Python API and Cypher |
-| [Analytics Integration](guide/analytics-integration.md) | Arrow, pandas, Polars, rank, cluster, find |
-
----
-
-## Understand
-
-| | |
-|---|---|
-| [Book map](book/README.md) | Architecture, research, and deeper usage index |
-| [Architecture Overview](book/architecture/overview.md) | Pipeline, storage, execution model |
-| [Algorithm Catalog](book/architecture/algorithms.md) | All algorithms across rank/cluster/paths/analyze/similar |
-| [Knowledge Graph Construction](book/use-cases/knowledge-graph-construction.md) | Extract entities, build and refine ontologies |
-| [Network Analysis](book/use-cases/network-analysis.md) | Degree, paths, communities — in notebooks |
-| [LLM-Powered Workflows](book/use-cases/llm-workflows.md) | Store LLM extractions, build retrieval context |
-| [AI Agent Tool Recall](book/use-cases/agent-tool-recall.md) | Graph-structured tool libraries for LLM agents |
-| [Agent Grounding](book/use-cases/agent-grounding.md) | Ground agents in domain ontologies |
-
----
-
-## Reference
-
-| | |
-|---|---|
-| [API Reference](reference/api.md) | Full method reference — all seven verbs |
-| [OpenCypher Compatibility](reference/opencypher-compatibility.md) | Feature matrix — v0.5.0 (100%) |
-| [TCK Compliance](reference/tck-compliance.md) | 3,897 / 3,897 passing |
-| [Datasets (backlog)](guide/datasets/overview.md) | Planned open-dataset catalogs — not shipped in v0.5.0 |
-| [Changelog](reference/changelog.md) | Keep a Changelog notes |
-
----
-
-## Design Principles
-
-1. **Correctness over performance** — openCypher semantics verified against the full TCK
-2. **Zero configuration** — `pip install graphforge`, no servers, no connection strings
-3. **Inspectable** — `explain` at every compiler stage; structured errors with source spans
-4. **Arrow-first results** — every method returns an Apache Arrow Table
-
----
-
-## Contribute & operate
-
-| | |
-|---|---|
-| [Documentation map](README.md) | Public docs map and site tooling |
-| [Contributing](development/contributing.md) | How to develop and send changes |
-| [Testing strategy](engineering/TESTING.md) | How we prove correctness |
-| [Release process](development/release-process.md) | How verified artifacts ship |
-| [Product roadmap](releases/roadmap.md) | Near-term product direction |
-
----
-
-## Engineering
-
-| | |
-|---|---|
-| [Engineering overview](engineering/README.md) | Lifecycle: architecture → test → publish → observe |
-| [Architecture Decision Records](adr/README.md) | Engineering decisions for the v0.5.0 keepers (nav: Engineering) |
-| [ADR decision log](engineering/adrs/README.md) | Index linking the `docs/adr/` bodies |
-
-Private product & strategy DocSlime docs live in
-[`graphforge-nextjs`](https://github.com/CurateLabs/graphforge-nextjs) (not on this site).
+| [Guide overview](guide/overview.md) | Navigate everyday GraphForge workflows |
+| [Cypher guide](guide/cypher-guide.md) | Query and mutate graphs with openCypher |
+| [Graph construction](guide/graph-construction.md) | Build graphs through Rust-owned APIs and Cypher |
+| [Analytics integration](guide/analytics-integration.md) | Work with Arrow, pandas, Polars, and analyst verbs |
+| [VS Code commands](guide/vscode-extension/commands.md) | Run GraphForge from VS Code or a compatible editor |
+| [Agent interop](guide/vscode-extension/agent-interop.md) | Drive structured extension commands from coding agents |
 
 ---
 
 ## Architecture at a glance
 
-GraphForge exposes seven analyst-intent methods that share a single Parquet-backed storage layer.
+GraphForge exposes one Rust-owned engine through Cypher, analyst-intent APIs, and repository
+lifecycle commands:
 
+```text
+Python (PyO3, thin) ─┐
+Node (N-API, thin) ──┼──> gf-api ──> Arrow results
+CLI (thin launcher) ─┘
+
+Cypher: gf-cypher ──> gf-ir ──> gf-rel ──> gf-exec
+                                                   └──> gf-storage (Parquet + JSON metadata)
+Analyst verbs bypass the Cypher parser and dispatch through Rust-owned typed handlers.
 ```
-forge.execute("MATCH …")         →  Cypher path     (parser → binder → Graph IR → DataFusion)
-forge.rank("Person", by=…)       →  Algorithm path  (centrality / structural scoring)
-forge.cluster("Person", by=…)    →  Algorithm path  (community detection, components)
-forge.paths(alice, bob, by=…)    →  Algorithm path  (shortest paths, flow, reachability)
-forge.analyze(by=…)              →  Algorithm path  (DAG, coloring, spanning trees, embeddings)
-forge.similar("Person", by=…)    →  Algorithm path  (pairwise node similarity)
-forge.find("query", …)           →  Search path     (text + vector hybrid search)
-```
 
-The Rust core uses a hand-written recursive-descent + Pratt expression parser, DataFusion-backed
-query execution, and Parquet storage. First-class bindings for Python (PyO3/maturin),
-Node (napi-rs), Swift (UniFFI), and Kotlin (UniFFI) all return Arrow results.
+Python, Node, the CLI, and the VS Code extension project the same engine behavior. Swift and
+Kotlin bindings are planned rather than shipped. See the
+[architecture overview](book/architecture/overview.md) for storage, execution, ontology,
+knowledge, checkpoint, and compatibility contracts.
 
-See [Architecture Overview](book/architecture/overview.md).
+---
+
+## Understand and reference
+
+| Page | Job |
+|---|---|
+| [Book](book/README.md) | Explore architecture, research, and deeper usage narratives |
+| [API reference](reference/api.md) | Look up engine, lifecycle, and analyst surfaces |
+| [Algorithm catalog](book/architecture/algorithms.md) | Choose rank, cluster, paths, analyze, or similar algorithms |
+| [OpenCypher compatibility](reference/opencypher-compatibility.md) | Inspect supported language behavior |
+| [TCK compliance](reference/tck-compliance.md) | Review the 3,897 / 3,897 language gate |
+| [Changelog](reference/changelog.md) | Track current behavior changes |
+
+---
+
+## Contribute and operate
+
+| Page | Job |
+|---|---|
+| [Documentation map](README.md) | Understand the public information architecture |
+| [Contributing](development/contributing.md) | Develop and send focused changes |
+| [Testing](engineering/TESTING.md) | See how GraphForge proves behavior |
+| [Publishing](engineering/PUBLISHING.md) | Follow package and release boundaries |
+| [Roadmap](releases/roadmap.md) | Review current and planned product surfaces |
+
+GraphForge is open source under the [Apache License 2.0](legal/licensing.md).

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Align the published homepage and root README with the v0.5 development line, remove legacy
+  PyPI v0.4 badges/install claims, and route readers to current Python, Node, CLI, and VS Code
+  workflows (#255).
 - Integrate the GraphForge VS Code extension into the public guide by mechanically importing
   its curated `docs/published/` pages from an immutable, checksummed revision (#252).
 - Add a runtime- and provider-agnostic deployment specification for Pulumi
@@ -167,17 +170,15 @@ the authoritative runnable corpus enforced by the BDD gate.
 - Align the Python release-load probe bulk Arrow schema with Node/Rust probes so
   required columns (including `label`) are non-nullable (#2776).
 
-- Move DocSlime product & strategy docs (`PRODUCT`, `DESIGN`, `REQUIREMENTS`,
-  `strategy/`, `experience/`) to private `graphforge-nextjs`; drop the Product &
-  strategy Starlight group; keep public `engineering/` contributor docs and ADRs
-  under **Engineering** (not Understand); keep Guide / Book / Reference /
-  development public (#2772).
+- Keep the Starlight site focused on public user and contributor documentation;
+  keep `engineering/` contributor docs and ADRs under **Engineering** (not
+  Understand), alongside Guide / Book / Reference / development (#2772).
 
 - After manylinux maturin on the M22 load sticky disk, reclaim `target/`
   ownership for the host runner so Cargo can open `.cargo-build-lock` (#2765).
 
-- Place Architecture Decision Records under **Product & strategy → Engineering** in
-  the published Starlight sidebar (no longer under Understand → Decisions); keep
+- Place Architecture Decision Records under **Engineering** in the published
+  Starlight sidebar (no longer under Understand → Decisions); keep
   `docs/adr/` body paths stable (#2770).
 
 - Bump the Python `ruff` development dependency from 0.15.20 to 0.16.0 and
@@ -199,14 +200,13 @@ the authoritative runnable corpus enforced by the BDD gate.
 - Drop M## milestone staging labels from published docs (book architecture, API reference, roadmap, ADRs, engineering indexes, and light testing/release-process prose), rewriting shipped capability as present-tense **v0.5.0** language; keep literal CI artifact/workflow names, schema inventory filenames, and test binary ids (`m22_m18_public_surface`, etc.) (#2761).
 
 - Reorganize the published Starlight docs site around reader journeys (Get started,
-  Use every day, Understand, Reference, Contribute & operate, Product & strategy,
-  Community) instead of DocSlime/Guide/Book-first left nav; keep content paths stable
+  Use every day, Understand, Reference, Contribute & operate, Engineering,
+  Community) instead of Guide/Book-first left nav; keep content paths stable
   and update the homepage / docs map accordingly (#2757).
 
-- Deepen DocSlime strategy, experience, and engineering lifecycle docs from authoritative
-  repo sources (market/positioning/roadmap summaries; analyst, ontology, reopen, and agent
-  journeys; testing/publishing/observability detail), with Starlight referenced as the
-  current docs site (#2729).
+- Deepen public engineering lifecycle docs from authoritative repository sources,
+  covering testing, publishing, and observability with Starlight as the current
+  docs site (#2729).
 
 - Fix README and docs homepage badges: drop DecisionNerd / private-repo Actions
   and Codecov images that 404 anonymously, and use public shields.io badges for
@@ -262,9 +262,9 @@ the authoritative runnable corpus enforced by the BDD gate.
   core, Arrow results, Parquet projects, analyst verbs) without prior-release
   product narrative (#2723).
 
-- Add DocSlime 0.3.0 lifecycle documentation under `docs/` (`PRODUCT.md`, `DESIGN.md`,
-  `REQUIREMENTS.md`, `strategy/`, `experience/`, `engineering/`) filled from existing
-  architecture, testing, and release sources, with ADR bodies still indexed from `docs/adr/`.
+- Add engineering lifecycle documentation under `docs/`, filled from existing
+  architecture, testing, and release sources, with ADR bodies still indexed from
+  `docs/adr/`.
 
 - Remove past GitHub issue numbers and historical milestone cross-references from documentation, replacing them with durable module, behavior, and process wording.
 


### PR DESCRIPTION
## Summary

- align the README and docs homepage with the current v0.5 development line and shipped surfaces
- publish the repository integration guide and connect Python, Node, CLI, and VS Code entry points
- remove all references to separate product-planning documentation from the public GraphForge docs
- replace misleading registry badges and install commands with accurate source-build guidance

## Verification

- `pnpm docs:build`
- `pnpm docs:check-links` (10,348 hrefs; 0 broken; 0 stale)
- repository-wide leakage scan returned no matches
- `git diff --check`

Refs #255

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788120205&installation_model_id=20486&pr_number=256&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F256&signature=58b55387d3a0e47e77a01f5632766e97dfd50508a99db411c88fa66a0eb5dadb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align public docs homepage and guides with v0.5 development line
> - Updates [README.md](https://github.com/CurateLabs/graphforge/pull/256/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) and [docs/index.md](https://github.com/CurateLabs/graphforge/pull/256/files#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6) to reflect v0.5 dev status: replaces PyPI v0.4 badges, adds build-from-source instructions, and documents Python, Node, CLI, and VS Code surfaces.
> - Removes references to private DocSlime product/strategy content across engineering docs, refocusing all published sources on current user and contributor documentation.
> - Adds `guides/repository-integration.md` to the docs-site content allowlist and sidebar under "Get started" so the CLI & repositories guide is publicly accessible.
> - Adds a registry status note in the repository integration guide clarifying that v0.5 Python and npm packages are not yet published and directing users to `cargo run -p gf-cli`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 94f3ea1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->