### PR TITLE
docs(release): record v0.5.0 crates.io no-publish disposition

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -321,9 +321,9 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   # ---- Rust crates (crates.io) ----
-  # Automation records the ordered plan. Real `cargo publish` stays
-  # maintainer-gated until name conflicts / path+version deps are resolved
-  # (see docs/development/publication-order.md).
+  # v0.5.0 has an approved no-publish disposition. Automation records the
+  # ordered plan and fail-closed blockers; it never runs `cargo publish`
+  # (see docs/development/publication-order.md and #196).
   crates-publish-plan:
     name: Record crates.io publish plan
     needs: license-compliance

--- a/docs/development/publication-order.md
+++ b/docs/development/publication-order.md
@@ -47,7 +47,7 @@ deterministic success evidence (or an explicit maintainer disposition to skip).
 | 3 | `publish.yaml` (triggered by the published release) builds and publishes **Python** to PyPI | [#2805](https://github.com/CurateLabs/graphforge-legecy/issues/2805) | Workflow green; `graphforge==0.5.0` on PyPI; checksums match RC record |
 | 4 | Same workflow publishes **Node** `@graphforge/node` to npm | [#2806](https://github.com/CurateLabs/graphforge-legecy/issues/2806) | Workflow green; npm `0.5.0`; checksums match |
 | 5 | Same workflow publishes **NPX skills** `@graphforge/agent-skills` to npm | [#2806](https://github.com/CurateLabs/graphforge-legecy/issues/2806) | Workflow green; npm `0.5.0`; checksums match |
-| 6 | Publish applicable **Rust crates** to crates.io in dependency order (see disposition) | [#2804](https://github.com/CurateLabs/graphforge-legecy/issues/2804) | Plan script + publish evidence, or recorded skip disposition |
+| 6 | Record the approved **no crates.io publication** disposition for v0.5.0 | [#196](https://github.com/CurateLabs/graphforge/issues/196) | Plan script output + this recorded disposition |
 | 7 | Deploy / confirm **versioned docs** for the release commit/tag | [#2807](https://github.com/CurateLabs/graphforge-legecy/issues/2807) | Live docs URL(s) for v0.5.0 set |
 | 8 | Verify registry/package **metadata** (repo, license, docs, tag) | [#2808](https://github.com/CurateLabs/graphforge-legecy/issues/2808) | Checklist evidence on #2808 |
 
@@ -95,18 +95,29 @@ python3 scripts/ci/crate-publish-plan.py check
 
 ### Crates.io disposition (v0.5.0)
 
-As of the prep of this document, **`gf-core` and `gf-cli` crate names are
-already occupied on crates.io by unrelated projects**. GraphForge must not
-attempt to overwrite or squat those names. Until maintainers choose and land a
-rename (or an alternate publish set) and crate ownership is confirmed:
+**Final maintainer disposition:** GraphForge v0.5.0 publishes no Rust crates to
+crates.io. This is the approved no-publish outcome tracked by
+[#196](https://github.com/CurateLabs/graphforge/issues/196); it applies to the
+complete 14-crate plan above, so no partial GraphForge crate set may be
+published as `0.5.0`.
 
-- Treat step 6 / [#2804](https://github.com/CurateLabs/graphforge-legecy/issues/2804)
-  as **blocked** (human disposition required).
-- Do **not** partial-publish a subset under conflicting names.
-- Binding and skills publication (steps 3–5) may still proceed once other
-  preconditions hold; they do not depend on crates.io.
+The disposition is required because **`gf-core` is already owned on crates.io
+by an unrelated project**. The excluded `gf-cli` name is also foreign-owned,
+and the planned library crates still lack the path-plus-`version` dependency
+metadata required by `cargo publish`. Resolving those blockers would require a
+separate, maintainer-approved crate naming and publication project; renaming
+the crate graph during v0.5.0 release execution is outside #196.
 
-Record the disposition on #2804 before closing that child.
+The evidence command remains:
+
+```bash
+python3 scripts/ci/crate-publish-plan.py check
+```
+
+It intentionally fails closed while reporting the ordered plan's name and
+manifest blockers. The release workflow records the same output without
+running `cargo publish`. Python, Node, and agent-skills publication may proceed
+once their own preconditions hold because they do not depend on crates.io.
 
 ## Stop conditions
 

--- a/docs/engineering/PUBLISHING.md
+++ b/docs/engineering/PUBLISHING.md
@@ -13,7 +13,7 @@ multi-tenant service. Operational detail:
 
 | Artifact | Destination | Versioned by | Owner |
 | --- | --- | --- | --- |
-| Rust crates | crates.io | SemVer / git tag | Maintainers |
+| Rust crates | No crates.io publication for v0.5.0; future surface requires a separate naming decision | SemVer / git tag | Maintainers |
 | Python package (wheels/sdist) | PyPI | Same release version | Maintainers |
 | Node binding package | npm | Same release version | Maintainers |
 | Agent skills package | npm (`npx` skills) | Same release line | Maintainers |
@@ -48,7 +48,7 @@ pnpm docs:build
 # Publication tooling — authoritative order:
 # docs/development/publication-order.md
 python3 scripts/ci/crate-publish-plan.py check
-python3 scripts/ci/crate-publish-plan.py dry-run-commands
+# v0.5.0: check intentionally fails closed and no cargo publish is run.
 # Python: maturin / TestPyPI clean-install checks
 # Node / skills: npm publish --dry-run
 ```


### PR DESCRIPTION
## Summary

- record the final maintainer-approved v0.5.0 no-publish disposition for the complete 14-crate crates.io plan
- retain fail-closed evidence for the foreign `gf-core` name and missing path-plus-version metadata
- align the publishing guide and release workflow comments so no v0.5.0 `cargo publish` is implied or executed

## Testing

- `python3 scripts/ci/test-crate-publish-plan.py`
- `python3 scripts/ci/crate-publish-plan.py list`
- `python3 scripts/ci/crate-publish-plan.py check` (expected exit 1 with the recorded blockers)
- `pnpm docs:build`
- `pnpm docs:check-links`
- `git diff --check`

Closes #196
Refs #192

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788120939&installation_model_id=20486&pr_number=257&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F257&signature=d22e4a428e54e08334da81995fc9570a89c29eb184bb150fee3122232cd63320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Record approved no-publish disposition for v0.5.0 Rust crates
> Documents the final maintainer decision to skip crates.io publication for v0.5.0 due to name ownership blockers (`gf-core`, `gf-cli`) and missing path-plus-version dependency support. Updates [publication-order.md](https://github.com/CurateLabs/graphforge/pull/257/files#diff-829f9cf32a204fa61ff3101e12637e9b28447ce45883a6487b3756e5ea5e3114), [PUBLISHING.md](https://github.com/CurateLabs/graphforge/pull/257/files#diff-8cf3f6c59229d9eee8062f78e5abbefcbee7cd160305b7fa7e5f70f1aca1d97c), and [publish.yaml](https://github.com/CurateLabs/graphforge/pull/257/files#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388ca) to reflect that the CI check intentionally fails closed and `cargo publish` is never run. Notes that Python, Node, and agent-skills artifacts can proceed independently, and that resolving Rust publication requires a separate naming project.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 73c9c8c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->