### PR TITLE
chore(release): prepare v0.5.0 publication

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,20 +1,20 @@
 blank_issues_enabled: false
 contact_links:
   - name: 💬 GitHub Discussions
-    url: https://github.com/CurateLabs/graphforge-legecy/discussions
+    url: https://github.com/CurateLabs/graphforge/discussions
     about: Ask questions, share ideas, and discuss GraphForge with the community
   - name: 📚 Documentation
-    url: https://curatelabs.github.io/graphforge-legecy/
+    url: https://docs.graphforge.sh/
     about: Browse the complete documentation including API reference and Cypher guide
   - name: 📖 Contributing Guide
-    url: https://github.com/CurateLabs/graphforge-legecy/blob/main/CONTRIBUTING.md
+    url: https://github.com/CurateLabs/graphforge/blob/main/CONTRIBUTING.md
     about: Learn how to contribute to GraphForge under Apache-2.0
   - name: ⚖️ Licensing
-    url: https://github.com/CurateLabs/graphforge-legecy/blob/main/LICENSE
+    url: https://github.com/CurateLabs/graphforge/blob/main/LICENSE
     about: Apache License 2.0 terms and third-party attribution
   - name: 🤝 Code of Conduct
-    url: https://github.com/CurateLabs/graphforge-legecy/blob/main/CODE_OF_CONDUCT.md
+    url: https://github.com/CurateLabs/graphforge/blob/main/CODE_OF_CONDUCT.md
     about: Community standards and how to report unacceptable behavior
   - name: 🔒 Security Vulnerability
-    url: https://github.com/CurateLabs/graphforge-legecy/security/advisories/new
+    url: https://github.com/CurateLabs/graphforge/security/advisories/new
     about: Report security vulnerabilities privately

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -8,7 +8,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Have a question about GraphForge? Ask away! Consider using [GitHub Discussions](https://github.com/CurateLabs/graphforge-legecy/discussions) for open-ended discussions.
+        Have a question about GraphForge? Ask away! Consider using [GitHub Discussions](https://github.com/CurateLabs/graphforge/discussions) for open-ended discussions.
 
   - type: textarea
     id: question

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -23,7 +23,7 @@ Please do not report security vulnerabilities through public GitHub issues.
 
 Use GitHub's private vulnerability reporting:
 
-1. Go to the [Security tab](https://github.com/CurateLabs/graphforge-legecy/security)
+1. Go to the [Security tab](https://github.com/CurateLabs/graphforge/security)
 2. Click "Report a vulnerability"
 3. Fill out the form with details
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -141,8 +141,8 @@ not repeat that certification.
 ### `clean-env-verify.yml`
 
 Maintainer `workflow_dispatch` after section 6 publication. Installs from **public**
-PyPI/npm/crates.io only and runs the #742 section 7 / #2795 lanes (pip quickstart, npm
-smoke, NPX skills compatibility, cargo add smoke, create/close/reopen Arrow
+PyPI/npm only and runs the #167 lanes (pip quickstart, npm
+smoke, NPX CLI and skills compatibility, create/close/reopen Arrow
 rows, docs/package URL resolve, optional checksum match against a
 `graphforge-release-record-v1` file). Preflight fails closed when the requested
 version is unpublished. Ordinary PRs run only the harness unit tests via

--- a/.github/workflows/clean-env-verify.yml
+++ b/.github/workflows/clean-env-verify.yml
@@ -1,6 +1,6 @@
 name: Clean Environment Verify
 
-# Post-publication only. Proves #742 section 7 / #2795 lanes against public registries.
+# Post-publication only. Proves #167 lanes against public registries.
 # Do not treat missing packages as success.
 
 on:
@@ -21,12 +21,6 @@ on:
         required: false
         type: string
         default: ""
-      crate:
-        description: crates.io crate for cargo smoke (default gf-api)
-        required: false
-        type: string
-        default: "gf-api"
-
 permissions:
   contents: read
 
@@ -63,7 +57,6 @@ jobs:
           set -euo pipefail
           python3 scripts/ci/clean-env-verify.py preflight \
             --version "${{ inputs.version }}" \
-            --crate "${{ inputs.crate }}" \
             --output clean-env-preflight.json
 
       - name: Run clean-environment lanes
@@ -71,17 +64,16 @@ jobs:
           VERSION: ${{ inputs.version }}
           LANES: ${{ inputs.lanes }}
           RECORD: ${{ inputs.release_record_path }}
-          CRATE: ${{ inputs.crate }}
         run: |
           set -euo pipefail
-          args=(--version "$VERSION" --crate "$CRATE" --output clean-env-evidence.json --work "$RUNNER_TEMP/gf-clean-env")
+          args=(--version "$VERSION" --output clean-env-evidence.json --work "$RUNNER_TEMP/gf-clean-env")
           if [[ -n "$RECORD" ]]; then
             args+=(--release-record "$RECORD")
           fi
           if [[ "$LANES" == "all" ]]; then
             if [[ -z "$RECORD" ]]; then
               # checksums requires a release record; run every other lane when absent
-              for lane in pip npm cli skills cargo reopen urls; do
+              for lane in pip npm cli skills reopen urls; do
                 args+=(--lane "$lane")
               done
             else

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,13 +9,41 @@ permissions:
 
 jobs:
   license-compliance:
-    name: License Compliance
+    name: Release publication preflight
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Require the certified current main commit and release versions
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_SHA: ${{ github.sha }}
+        run: |
+          git fetch --no-tags origin \
+            +refs/heads/main:refs/remotes/origin/main
+          test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
+          test "$(git rev-parse refs/remotes/origin/main)" = "$RELEASE_SHA"
+          python3 scripts/ci/release-publish-preflight.py \
+            --tag "$RELEASE_TAG" \
+            --expected-sha "$RELEASE_SHA"
 
       - name: Verify release license policy
         run: python3 scripts/license_check.py --report license-compliance-report.json
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      # This runs before any PyPI or npm write. A missing/invalid token therefore
+      # fails the release without leaving only the Python surface published.
+      - name: Verify npm publication identity
+        run: npm whoami
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   # Build the native abi3 wheel per OS. abi3-py310 → one wheel per OS covers
   # CPython 3.10+; the binding's pyproject is the canonical `graphforge` dist.
@@ -285,7 +313,7 @@ jobs:
   # ---- NPX agent skills (@graphforge/agent-skills) ----
   publish-agent-skills:
     name: Publish agent-skills to npm
-    needs: publish-node
+    needs: publish-node-cli
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,6 +113,9 @@ jobs:
       - name: Test crates.io publish plan helper
         run: python3 scripts/ci/test-crate-publish-plan.py
 
+      - name: Test release publication preflight
+        run: python3 scripts/ci/test-release-publish-preflight.py
+
       - name: Test CI storage policy
         run: python3 scripts/ci/test-ci-storage-policy.py
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [0.5.0] - 2026-07-31
+
+- Freeze Cargo, Python, Node, CLI, and agent-skills release metadata at
+  `0.5.0`; fail closed before registry writes on SHA/version/changelog/npm
+  drift; align publication, release-record, certification, and clean-environment
+  tooling with the current repository and approved no-crates disposition (#192).
 - Align the published homepage and root README with the v0.5 development line, remove legacy
   PyPI v0.4 badges/install claims, and route readers to current Python, Node, CLI, and VS Code
   workflows (#255).
@@ -55,8 +63,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   generation-managed repository snapshots with non-mutating CI drift checks
   (#244).
 
-Post-v0.5.0 work lands here. The v0.5.0 publication cut is under `[0.5.0]` below.
-
 - Define the `.graphforge/` repository integration and deployment configuration
   boundary, including closed versioned contracts, ignored data surfaces,
   secret-free IaC resolution, and cross-ecosystem ownership (#225).
@@ -96,8 +102,6 @@ Post-v0.5.0 work lands here. The v0.5.0 publication cut is under `[0.5.0]` below
   (#2792).
 - Realign root `CONTRIBUTING.md` with the Rust-owned workspace and Apache-2.0
   inbound contribution terms (#218).
-
-## [0.5.0]
 
 First public **Rust-core** GraphForge line: openCypher over DataFusion, Arrow
 results, Parquet-backed project generations, thin Python (PyO3) and Node
@@ -3448,8 +3452,8 @@ None. All changes maintain backward compatibility with v0.2.0 and v0.2.1.
 - 81% code coverage
 - Multi-OS, multi-Python CI/CD (3 OS × 4 Python versions)
 
-[Unreleased]: https://github.com/CurateLabs/graphforge-legecy/compare/v0.5.0...HEAD
-[0.5.0]: https://github.com/CurateLabs/graphforge-legecy/compare/v0.4.0...v0.5.0
+[Unreleased]: https://github.com/CurateLabs/graphforge/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/CurateLabs/graphforge/releases/tag/v0.5.0
 [0.4.0]: https://github.com/CurateLabs/graphforge-legecy/compare/v0.3.10...v0.4.0
 [0.3.0]: https://github.com/CurateLabs/graphforge-legecy/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/CurateLabs/graphforge-legecy/compare/v0.2.0...v0.2.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,8 @@ make pre-push
 
 ## Getting help
 
-- **Questions:** [GitHub Discussions](https://github.com/CurateLabs/graphforge-legecy/discussions)
-- **Bugs:** [GitHub Issues](https://github.com/CurateLabs/graphforge-legecy/issues)
+- **Questions:** [GitHub Discussions](https://github.com/CurateLabs/graphforge/discussions)
+- **Bugs:** [GitHub Issues](https://github.com/CurateLabs/graphforge/issues)
 - **Security:** report privately via [SECURITY.md](.github/SECURITY.md)
 - **Conduct:** [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1971,7 +1971,7 @@ dependencies = [
 
 [[package]]
 name = "gf-api"
-version = "0.5.0-dev"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "cucumber",
@@ -2001,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "gf-ast"
-version = "0.5.0-dev"
+version = "0.5.0"
 dependencies = [
  "gf-core",
  "serde",
@@ -2011,7 +2011,7 @@ dependencies = [
 
 [[package]]
 name = "gf-bindings-node"
-version = "0.5.0-dev"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "gf-api",
@@ -2025,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "gf-bindings-py"
-version = "0.5.0-dev"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "futures",
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "gf-cli"
-version = "0.5.0-dev"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "clap",
@@ -2051,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "gf-core"
-version = "0.5.0-dev"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_yaml_ng",
@@ -2062,7 +2062,7 @@ dependencies = [
 
 [[package]]
 name = "gf-cypher"
-version = "0.5.0-dev"
+version = "0.5.0"
 dependencies = [
  "gf-ast",
  "gf-core",
@@ -2074,7 +2074,7 @@ dependencies = [
 
 [[package]]
 name = "gf-exec"
-version = "0.5.0-dev"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2099,7 +2099,7 @@ dependencies = [
 
 [[package]]
 name = "gf-io"
-version = "0.5.0-dev"
+version = "0.5.0"
 dependencies = [
  "gf-core",
  "gf-storage",
@@ -2108,7 +2108,7 @@ dependencies = [
 
 [[package]]
 name = "gf-ir"
-version = "0.5.0-dev"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "gf-ast",
@@ -2123,7 +2123,7 @@ dependencies = [
 
 [[package]]
 name = "gf-knowledge"
-version = "0.5.0-dev"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "gf-core",
@@ -2136,7 +2136,7 @@ dependencies = [
 
 [[package]]
 name = "gf-ontology"
-version = "0.5.0-dev"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "gf-core",
@@ -2151,7 +2151,7 @@ dependencies = [
 
 [[package]]
 name = "gf-plan"
-version = "0.5.0-dev"
+version = "0.5.0"
 dependencies = [
  "datafusion",
  "gf-core",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "gf-provenance"
-version = "0.5.0-dev"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "gf-core",
@@ -2172,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "gf-rel"
-version = "0.5.0-dev"
+version = "0.5.0"
 dependencies = [
  "arrow-data",
  "chrono",
@@ -2192,7 +2192,7 @@ dependencies = [
 
 [[package]]
 name = "gf-search"
-version = "0.5.0-dev"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "gf-core",
@@ -2207,7 +2207,7 @@ dependencies = [
 
 [[package]]
 name = "gf-storage"
-version = "0.5.0-dev"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,11 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0-dev"
+version = "0.5.0"
 edition = "2024"
 license = "Apache-2.0"
 license-file = "LICENSE"
-repository = "https://github.com/CurateLabs/graphforge-legecy"
+repository = "https://github.com/CurateLabs/graphforge"
 
 [workspace.dependencies]
 # Error handling

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ release-version-check:  ## Verify Cargo/Python/Node/skills versions align
 package-license-verify:  ## Verify packaged Cargo/npm/Python artifacts include LICENSE+NOTICE
 	python3 scripts/verify_package_licenses.py
 
-publish-dry-run:  ## Local publish dry-runs (npm/docs/cargo-package/python); never prod registries
-	python3 scripts/publish_dry_run.py --surface npm,docs,cargo-package,python --report target/publish-dry-run/evidence.json
+publish-dry-run:  ## Local v0.5 publish dry-runs (npm/docs/python); never prod registries
+	python3 scripts/publish_dry_run.py --surface npm,docs,python --report target/publish-dry-run/evidence.json
 publish-dry-run-npm:  ## npm publish --dry-run for Node binding + agent-skills
 	python3 scripts/publish_dry_run.py --surface npm
 publish-dry-run-docs:  ## Docs preview build (pnpm docs:build)
@@ -273,14 +273,12 @@ clean-env-verify-check:  ## Unit-test the post-publication clean-env harness (#2
 clean-env-verify-preflight:  ## Probe public registries for VERSION (fails closed if unpublished)
 	@test -n "$(VERSION)" || (echo "VERSION is required (e.g. VERSION=0.5.0)" && exit 2)
 	python3 scripts/ci/clean-env-verify.py preflight --version "$(VERSION)" \
-		$(if $(CRATE),--crate "$(CRATE)",) \
 		$(if $(OUTPUT),--output "$(OUTPUT)",)
 
 clean-env-verify:  ## Run clean-env lanes against public registries (post-§6 only)
 	@test -n "$(VERSION)" || (echo "VERSION is required (e.g. VERSION=0.5.0)" && exit 2)
 	python3 scripts/ci/clean-env-verify.py run --version "$(VERSION)" \
-		$(if $(CRATE),--crate "$(CRATE)",--crate gf-api) \
-		$(if $(RELEASE_RECORD),--release-record "$(RELEASE_RECORD)" --all,--lane pip --lane npm --lane skills --lane cargo --lane reopen --lane urls) \
+		$(if $(RELEASE_RECORD),--release-record "$(RELEASE_RECORD)" --all,--lane pip --lane npm --lane cli --lane skills --lane reopen --lane urls) \
 		$(if $(OUTPUT),--output "$(OUTPUT)",) \
 		$(if $(WORK),--work "$(WORK)",)
 

--- a/crates/gf-bindings-node/package.json
+++ b/crates/gf-bindings-node/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@graphforge/node",
-  "version": "0.5.0-dev.0",
+  "version": "0.5.0",
   "description": "Native Node.js bindings for the GraphForge embedded graph engine",
   "license": "Apache-2.0",
-  "homepage": "https://github.com/CurateLabs/graphforge",
+  "homepage": "https://docs.graphforge.sh/",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/CurateLabs/graphforge.git",

--- a/crates/gf-bindings-py/pyproject.toml
+++ b/crates/gf-bindings-py/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "graphforge"
 description = "GraphForge native graph engine, bindings, and repository lifecycle CLI"
-version = "0.5.0.dev0"
+version = "0.5.0"
 readme = "README.md"
 requires-python = ">=3.10"
 license = "Apache-2.0"
@@ -26,8 +26,8 @@ dependencies = ["pyarrow>=14"]
 graphforge = "graphforge.cli:main"
 
 [project.urls]
-Homepage = "https://curatelabs.github.io/graphforge/"
-Documentation = "https://curatelabs.github.io/graphforge/"
+Homepage = "https://docs.graphforge.sh/"
+Documentation = "https://docs.graphforge.sh/"
 Repository = "https://github.com/CurateLabs/graphforge"
 Issues = "https://github.com/CurateLabs/graphforge/issues"
 

--- a/docs/book/use-cases/agent-grounding.md
+++ b/docs/book/use-cases/agent-grounding.md
@@ -579,7 +579,7 @@ fetches additional structured metadata. Results stay in the canonical Arrow/UUID
 
 ### Run the Native Notebook
 
-The [e-commerce agent notebook](https://github.com/CurateLabs/graphforge-legecy/blob/main/examples/agent_grounding/ecommerce_agent.ipynb)
+The [e-commerce agent notebook](https://github.com/CurateLabs/graphforge/blob/main/examples/agent_grounding/ecommerce_agent.ipynb)
 is the executable version of this workflow. After building a wheel into `dist/`, run the same
 two-clean-run gate used by CI:
 
@@ -611,7 +611,7 @@ compares bounded evidence from two independent temporary projects and kernels.
 - [GraphForge Documentation](../../index.md)
 - [openCypher Tutorial](../../guide/tutorial.md)
 - [API Reference](../../reference/api.md)
-- [Example: E-commerce Agent](https://github.com/CurateLabs/graphforge-legecy/blob/main/examples/agent_grounding/ecommerce_agent.ipynb)
+- [Example: E-commerce Agent](https://github.com/CurateLabs/graphforge/blob/main/examples/agent_grounding/ecommerce_agent.ipynb)
 
 ## Conclusion
 

--- a/docs/community/code-of-conduct.md
+++ b/docs/community/code-of-conduct.md
@@ -1,7 +1,7 @@
 # Code of Conduct
 
 This page summarizes the canonical
-[`CODE_OF_CONDUCT.md`](https://github.com/CurateLabs/graphforge-legecy/blob/main/CODE_OF_CONDUCT.md)
+[`CODE_OF_CONDUCT.md`](https://github.com/CurateLabs/graphforge/blob/main/CODE_OF_CONDUCT.md)
 in the repository root. Where the two differ, the repository-root document
 controls.
 

--- a/docs/community/security.md
+++ b/docs/community/security.md
@@ -23,7 +23,7 @@ Please do not report security vulnerabilities through public GitHub issues.
 
 Use GitHub's private vulnerability reporting:
 
-1. Go to the [Security tab](https://github.com/CurateLabs/graphforge-legecy/security)
+1. Go to the [Security tab](https://github.com/CurateLabs/graphforge/security)
 2. Click "Report a vulnerability"
 3. Fill out the form with details
 

--- a/docs/development/clean-environment-verification.md
+++ b/docs/development/clean-environment-verification.md
@@ -1,6 +1,6 @@
 # Clean-environment verification
 
-Post-publication proof for **#742 section 7** / tracker **#2795**: from new clean
+Post-publication proof for release tracker **#192** / follow-up tracker **#167**: from new clean
 environments, using only public registries, install and exercise GraphForge
 release artifacts.
 
@@ -13,27 +13,24 @@ artifacts.
 
 | Lane | Child | Outcome |
 | --- | --- | --- |
-| `pip` | #2809 | `pip install graphforge==<version>` + documented quickstart E2E |
-| `npm` | #2810 | Install `@graphforge/node@<version>` + smoke execute/Arrow decode |
-| `skills` | #2811 | Install `@graphforge/agent-skills@<version>` + offline `compatibility --json` |
-| `cargo` | #2812 | `cargo add <crate>@<version>` + `cargo check` (default crate: `gf-api`) |
-| `reopen` | #2813 | Create/close/reopen project; Arrow rows survive reopen |
-| `urls` | #2814 | Published docs + package/registry URLs resolve |
-| `checksums` | #2815 | Registry digests match `graphforge-release-record-v1` from #2798 + #2803 |
+| `pip` | #180 | `pip install graphforge==<version>` + documented quickstart E2E |
+| `npm` / `cli` | #183 | Install `@graphforge/node@<version>` and `@graphforge/cli@<version>` + smoke execution |
+| `skills` | #182 | Install `@graphforge/agent-skills@<version>` + offline `compatibility --json` |
+| `reopen` | #184 | Create/close/reopen project; Arrow rows survive reopen |
+| `urls` | #186 | Published docs + package/registry URLs resolve |
+| `checksums` | #187 | Registry digests match `graphforge-release-record-v1` |
 
 Close each child only with commands + outcomes (or an explicit disposition). The
-tracker (#2795) blocks #742 until children complete; it does **not** auto-close
-#742.
+tracker (#167) is intentionally post-release and does not block or auto-close #192.
 
 ## Upstream blockers
 
 | Child | Wait on |
 | --- | --- |
-| #2809, #2813 | PyPI publish (#2805) under #2794 |
-| #2810, #2811 | npm publish (#2806) under #2794 |
-| #2812 | crates.io publish (#2804) under #2794 |
-| #2814 | docs deploy (#2807) + registry metadata (#2808) |
-| #2815 | release record (#2798) + GitHub Release checksums (#2803) |
+| #180, #184 | PyPI publish (#195) |
+| #182, #183 | npm publish (#198) |
+| #186 | docs deploy (#197) + registry metadata (#199) |
+| #187 | release record + published package checksums |
 
 ## Harness
 
@@ -57,9 +54,13 @@ python3 scripts/ci/clean-env-verify.py run \
 ```
 
 CI: workflow_dispatch **Clean Environment Verify**
-(`.github/workflows/clean-env-verify.yml`). Inputs: `version`, `lanes`, optional
-`release_record_path`, `crate`. Upload the evidence artifact to the matching
-child issues.
+(`.github/workflows/clean-env-verify.yml`). Inputs: `version`, `lanes`, and optional
+`release_record_path`. Upload the evidence artifact to the matching child issues.
+
+GraphForge v0.5.0 intentionally has no crates.io publication surface; the
+approved disposition is recorded in #196 and post-release child #185 is not
+applicable. The harness therefore
+does not probe crates.io or run a Cargo clean-install lane for this release.
 
 ## Release record schema
 
@@ -83,7 +84,7 @@ child issues.
 }
 ```
 
-Surfaces: `pypi`, `npm`, `crates`, `github`. Produced under #2798 and attached to
+Surfaces: `pypi`, `npm`, and `github`. Produced under #2798 and attached to
 the GitHub Release (#2803). Validate with:
 
 ```bash
@@ -103,5 +104,5 @@ python3 scripts/ci/clean-env-verify.py validate-evidence build/clean-env-evidenc
 
 - [`PUBLISHING.md`](../engineering/PUBLISHING.md) — promotion to clean-install verification
 - [`release-process.md`](release-process.md) — release checklist
-- Umbrella: [#742](https://github.com/CurateLabs/graphforge-legecy/issues/742) section 7
-- Tracker: [#2795](https://github.com/CurateLabs/graphforge-legecy/issues/2795)
+- Release tracker: [#192](https://github.com/CurateLabs/graphforge/issues/192)
+- Post-release tracker: [#167](https://github.com/CurateLabs/graphforge/issues/167)

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -20,7 +20,7 @@ product work targets `main`.
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 rustup update stable
 
-git clone https://github.com/CurateLabs/graphforge-legecy.git
+git clone https://github.com/CurateLabs/graphforge.git
 cd graphforge
 
 # Install Python dev dependencies
@@ -269,8 +269,8 @@ See [release-process.md](release-process.md) for the full release procedure and
 
 ## Getting Help
 
-- **Questions:** [GitHub Discussions](https://github.com/CurateLabs/graphforge-legecy/discussions)
-- **Bugs:** [GitHub Issues](https://github.com/CurateLabs/graphforge-legecy/issues)
+- **Questions:** [GitHub Discussions](https://github.com/CurateLabs/graphforge/discussions)
+- **Bugs:** [GitHub Issues](https://github.com/CurateLabs/graphforge/issues)
 
 ## License
 

--- a/docs/development/publication-order.md
+++ b/docs/development/publication-order.md
@@ -4,11 +4,10 @@ This is the written publication order and stop/rollback policy for GraphForge
 registry publication. §6 executors follow this document; do not invent a
 different order at publish time.
 
-Tracks [#2801](https://github.com/CurateLabs/graphforge-legecy/issues/2801)
-(§5 prep under [#2793](https://github.com/CurateLabs/graphforge-legecy/issues/2793))
-and unblocks §6 execution
-([#2794](https://github.com/CurateLabs/graphforge-legecy/issues/2794) /
-[#742](https://github.com/CurateLabs/graphforge-legecy/issues/742)).
+Tracks the human release-close issue
+[#192](https://github.com/CurateLabs/graphforge/issues/192) and its ordered
+native publication children [#193](https://github.com/CurateLabs/graphforge/issues/193)
+through [#199](https://github.com/CurateLabs/graphforge/issues/199).
 
 Related operational docs:
 [`PUBLISHING.md`](../engineering/PUBLISHING.md),
@@ -18,22 +17,26 @@ Related operational docs:
 ## Preconditions (must be true before step 1)
 
 1. §5 version freeze is complete: Cargo workspace, Python binding, Node binding,
-   NPX skills, and generated metadata all report `0.5.0` (not `0.5.0-dev` /
-   `0.5.0.dev0`) on the intended RC commit ([#2796](https://github.com/CurateLabs/graphforge-legecy/issues/2796)).
+   NPX CLI/skills, and generated metadata all report `0.5.0` (not `0.5.0-dev` /
+   `0.5.0.dev0`) on the intended RC commit.
 2. Artifact checksum / SBOM / license record exists for that same commit
-   ([#2798](https://github.com/CurateLabs/graphforge-legecy/issues/2798)).
+   and is retained with the #192 release evidence.
 3. First-party packages declare `Apache-2.0` with `LICENSE` / `NOTICE` (and
-   third-party notices intact) ([#2799](https://github.com/CurateLabs/graphforge-legecy/issues/2799)).
-4. Dry-runs are green for applicable surfaces: `cargo publish --dry-run` (see
-   crates disposition below), TestPyPI/wheel clean-install, `npm publish
-   --dry-run` for Node + skills, docs preview
-   ([#2800](https://github.com/CurateLabs/graphforge-legecy/issues/2800)).
+   third-party notices intact), and the public legal surface in
+   [#200](https://github.com/CurateLabs/graphforge/issues/200) is complete.
+4. Dry-runs are green for applicable surfaces: Python sdist/wheel packaging and
+   clean install, `npm publish --dry-run` for Node + CLI + skills, and docs
+   preview. The approved crates.io no-publish disposition replaces a Cargo
+   publish dry-run for v0.5.0.
 5. Required release-certification evidence for the RC SHA is assembled per
-   `AGENTS.md` / `#742` (Binding RC, load matrix, gates as required for
+   `AGENTS.md` / `#192` (Binding RC, load matrix, gates as required for
    **publication**, not for ordinary child-issue close).
-6. Legal activation [#2434](https://github.com/CurateLabs/graphforge-legecy/issues/2434)
-   is resolved enough that maintainers authorize public registry publication.
-7. Secrets and registry ownership are in place (see Human blockers).
+6. The embedded write modes in
+   [#211](https://github.com/CurateLabs/graphforge/issues/211) and the
+   Apache-2.0 outcome in
+   [#218](https://github.com/CurateLabs/graphforge/issues/218) are complete.
+7. Secrets, trusted-publisher configuration, registry ownership, and explicit
+   maintainer publication authorization are in place (see Human blockers).
 
 ## Ordered execution
 
@@ -42,25 +45,29 @@ deterministic success evidence (or an explicit maintainer disposition to skip).
 
 | Step | Action | Issue | Evidence |
 | --- | --- | --- | --- |
-| 1 | Annotate tag `v0.5.0` on the verified RC commit on `main` | [#2802](https://github.com/CurateLabs/graphforge-legecy/issues/2802) | `git rev-parse v0.5.0` == RC SHA |
-| 2 | Publish GitHub Release for `v0.5.0` with final CHANGELOG notes + checksum links/attachments | [#2803](https://github.com/CurateLabs/graphforge-legecy/issues/2803) | Release URL; notes match CHANGELOG |
-| 3 | `publish.yaml` (triggered by the published release) builds and publishes **Python** to PyPI | [#2805](https://github.com/CurateLabs/graphforge-legecy/issues/2805) | Workflow green; `graphforge==0.5.0` on PyPI; checksums match RC record |
-| 4 | Same workflow publishes **Node** `@graphforge/node` to npm | [#2806](https://github.com/CurateLabs/graphforge-legecy/issues/2806) | Workflow green; npm `0.5.0`; checksums match |
-| 5 | Same workflow publishes **NPX skills** `@graphforge/agent-skills` to npm | [#2806](https://github.com/CurateLabs/graphforge-legecy/issues/2806) | Workflow green; npm `0.5.0`; checksums match |
-| 6 | Record the approved **no crates.io publication** disposition for v0.5.0 | [#196](https://github.com/CurateLabs/graphforge/issues/196) | Plan script output + this recorded disposition |
-| 7 | Deploy / confirm **versioned docs** for the release commit/tag | [#2807](https://github.com/CurateLabs/graphforge-legecy/issues/2807) | Live docs URL(s) for v0.5.0 set |
-| 8 | Verify registry/package **metadata** (repo, license, docs, tag) | [#2808](https://github.com/CurateLabs/graphforge-legecy/issues/2808) | Checklist evidence on #2808 |
+| 1 | Annotate tag `v0.5.0` on the verified RC commit on `main` | [#193](https://github.com/CurateLabs/graphforge/issues/193) | `git rev-parse v0.5.0^{}` == RC SHA |
+| 2 | Publish GitHub Release for `v0.5.0` with final CHANGELOG notes + checksum links/attachments | [#194](https://github.com/CurateLabs/graphforge/issues/194) | Release URL; notes match CHANGELOG; `Publish to PyPI and npm` run starts |
+| 3 | `publish.yaml` builds and publishes **Python** to PyPI | [#195](https://github.com/CurateLabs/graphforge/issues/195) | Workflow green; `graphforge==0.5.0` on PyPI; checksums match RC record |
+| 4 | Same workflow publishes **Node** `@graphforge/node` and platform packages to npm | [#198](https://github.com/CurateLabs/graphforge/issues/198) | npm `0.5.0`; target inventory and checksums match |
+| 5 | Same workflow publishes **NPX CLI** `@graphforge/cli` to npm | [#198](https://github.com/CurateLabs/graphforge/issues/198) | npm `0.5.0`; clean-consumer handoff passed |
+| 6 | Same workflow publishes **NPX skills** `@graphforge/agent-skills` to npm | [#198](https://github.com/CurateLabs/graphforge/issues/198) | npm `0.5.0`; packed offline contract passed |
+| 7 | Record the approved **no crates.io publication** disposition for v0.5.0 | [#196](https://github.com/CurateLabs/graphforge/issues/196) | Plan script output + this recorded disposition |
+| 8 | Deploy / confirm documentation for the release commit/tag | [#197](https://github.com/CurateLabs/graphforge/issues/197) | Pages run green; live anonymous URLs serve the RC docs set |
+| 9 | Verify registry/package **metadata** (repo, license, docs, tag) | [#199](https://github.com/CurateLabs/graphforge/issues/199) | Concise surface checklist on #199 |
 
 Notes:
 
-- Steps 3–5 are automated by `.github/workflows/publish.yaml` once the GitHub
+- Steps 3–6 are automated by `.github/workflows/publish.yaml` once the GitHub
   Release is published. Maintainers watch that run; they do not re-build
   different bytes under `0.5.0` if a job fails.
-- Docs deploy today follows `docs.yml` on `main` (GitHub Pages). Step 7 confirms
+- Before any registry write, the workflow requires the release tag, current
+  `main` SHA, five version surfaces, dated CHANGELOG section, Apache-2.0 policy,
+  and npm publishing identity to pass its fail-closed preflight.
+- Docs deploy today follows `docs.yml` on `main` (GitHub Pages). Step 8 confirms
   the release SHA’s docs set is what is live (or redeploys that SHA); it does
   not authorize inventing a second docs tree under the same version label.
-- Clean-environment verification after publication is **§7**
-  ([#2795](https://github.com/CurateLabs/graphforge-legecy/issues/2795)), not this order.
+- Clean-environment verification after publication is tracked by
+  [#167](https://github.com/CurateLabs/graphforge/issues/167), not this order.
 
 ## Crates.io dependency order
 
@@ -129,7 +136,7 @@ Stop the release train immediately if any of the following occur:
    `0.5.0`.
 3. A registry rejects the package for license, ownership, name conflict, or
    trusted-publishing misconfiguration.
-4. Legal / counsel halt (#2434) or maintainer halt.
+4. Legal or maintainer halt.
 
 **Hard rule:** do not rebuild different bytes and re-publish under the same
 version. Yank or deprecate per registry rules if needed; cut a new patch
@@ -147,23 +154,24 @@ version for corrected bits.
 | Docs site | Redeploy last known-good commit from `main` / Pages history. |
 
 Agents assemble evidence and automation; maintainers authorize execution and
-final `#742` close.
+final #192 close.
 
 ## Human blockers (checklist)
 
-- [ ] Version freeze PR merged on the RC commit (#2796)
+- [ ] Version freeze PR merged on the RC commit and every SHA-bound release
+      certification workflow passes for that exact commit
 - [ ] `@graphforge` npm organization exists and the publishing maintainer can
       create public organization-scoped packages
 - [ ] `NPM_TOKEN` is a granular token authorized for the `@graphforge` scope,
-      can bypass 2FA for CI publishing, and is available to `publish.yaml`
+      can satisfy the account's 2FA policy for CI publishing, is stored as a
+      repository Actions secret, and passes the workflow's `npm whoami` preflight
 - [ ] After the first publish, configure trusted publishing for each npm package
       before removing the token path; npm requires an existing package and a
-      supported GitHub-hosted runner (the repository is currently private, so
-      npm provenance is not available)
-- [ ] PyPI trusted publishing OIDC configured for this repo / environment
-- [ ] `CARGO_REGISTRY_TOKEN` (or crates.io trusted publishing) once crates.io
-      names are resolved
-- [ ] crates.io crate rename / ownership disposition for conflicting names
+      supported GitHub-hosted runner
+- [ ] PyPI trusted publishing OIDC is configured for
+      `CurateLabs/graphforge`, workflow `publish.yaml`, with no environment name
+- [x] Crates.io no-publish disposition is recorded for v0.5.0 (#196); no Cargo
+      registry credential is required for this release
+- [x] Public Apache-2.0 legal and contribution docs are deployed (#200)
 - [ ] Maintainer authorization to create annotated tag + GitHub Release
-- [ ] Legal activation sufficient for public registries (#2434)
-- [ ] Repo visibility / registry org access as required for the publish path
+- [x] Repository and release documentation are publicly readable

--- a/docs/development/release-artifact-record.md
+++ b/docs/development/release-artifact-record.md
@@ -18,7 +18,7 @@ commits under the same version.
 
 1. Freeze the RC SHA and surface versions (`scripts/set_release_version.py` / #2796).
 2. Build or collect artifacts for that SHA into a directory (wheels, sdists, npm
-   tarballs, crates, SBOM/provenance if emitted).
+   tarballs, SBOM/provenance if emitted). v0.5.0 has no crates.io artifacts.
 3. Run:
 
 ```bash
@@ -31,6 +31,14 @@ python3 scripts/record_release_artifacts.py \
 
 4. Attach the JSON (or its checksums table) to the GitHub Release at §6 (#2794).
 5. §7 clean-env verification matches `sha256` values from this record.
+
+The generated document uses the same `graphforge-release-record-v1` schema
+consumed by `clean-env-verify.py`. Validate it before attaching:
+
+```bash
+python3 scripts/ci/clean-env-verify.py validate-release-record \
+  docs/releases/records/v0.5.0-artifacts.json
+```
 
 Template-only (no files yet):
 

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -332,7 +332,7 @@ EOF
 ```
 
 Or use the GitHub web interface:
-1. Go to https://github.com/CurateLabs/graphforge-legecy/releases
+1. Go to https://github.com/CurateLabs/graphforge/releases
 2. Click "Draft a new release"
 3. Choose tag: `v0.2.0`
 4. Release title: `GraphForge v0.2.0`

--- a/docs/development/workflow.md
+++ b/docs/development/workflow.md
@@ -27,7 +27,7 @@ This document describes GraphForge's development workflow, CI/CD pipeline, and b
 
 ```bash
 # Clone the repository
-git clone https://github.com/CurateLabs/graphforge-legecy.git
+git clone https://github.com/CurateLabs/graphforge.git
 cd graphforge
 
 # Install uv (if not already installed)
@@ -402,11 +402,11 @@ Triggered on GitHub release publication.
 Add to README.md:
 
 ```markdown
-![Tests](https://github.com/CurateLabs/graphforge-legecy/workflows/Test%20Suite/badge.svg)
-![Coverage](https://codecov.io/gh/CurateLabs/graphforge-legecy/branch/main/graph/badge.svg)
+![Tests](https://github.com/CurateLabs/graphforge/workflows/Test%20Suite/badge.svg)
+![Coverage](https://codecov.io/gh/CurateLabs/graphforge/branch/main/graph/badge.svg)
 ![Python](https://img.shields.io/pypi/pyversions/graphforge)
 ![PyPI](https://img.shields.io/pypi/v/graphforge)
-![License](https://img.shields.io/github/license/CurateLabs/graphforge-legecy)
+![License](https://img.shields.io/github/license/CurateLabs/graphforge)
 ```
 
 ---
@@ -522,7 +522,7 @@ uv run pytest -v --tb=long --showlocals
 **Setup:**
 
 1. Install CodeRabbit app from [GitHub Marketplace](https://github.com/marketplace/coderabbitai)
-2. Authorize for the CurateLabs/graphforge-legecy repository
+2. Authorize for the CurateLabs/graphforge repository
 3. Configuration is in `.coderabbit.yaml`
 
 **Features:**
@@ -898,4 +898,4 @@ git rebase --continue
 
 **Last Updated:** January 31, 2026
 
-For questions about the development workflow, open a [discussion](https://github.com/CurateLabs/graphforge-legecy/discussions) or create an issue.
+For questions about the development workflow, open a [discussion](https://github.com/CurateLabs/graphforge/discussions) or create an issue.

--- a/docs/engineering/ARCHITECTURE.md
+++ b/docs/engineering/ARCHITECTURE.md
@@ -48,7 +48,7 @@ flowchart LR
 - **Results** — Arrow tables/batches as the cross-language contract.
 - **On disk** — Parquet for graph data; JSON for metadata and contracts.
 
-Schemas and frozen inventories also live under [`../contracts/`](https://github.com/CurateLabs/graphforge-legecy/tree/main/docs/contracts) and
+Schemas and frozen inventories also live under [`../contracts/`](https://github.com/CurateLabs/graphforge/tree/main/docs/contracts) and
 architecture deep-dives in [`../book/architecture/`](../book/architecture/overview.md).
 
 ## Problem model and terminology

--- a/docs/engineering/PUBLISHING.md
+++ b/docs/engineering/PUBLISHING.md
@@ -16,6 +16,7 @@ multi-tenant service. Operational detail:
 | Rust crates | No crates.io publication for v0.5.0; future surface requires a separate naming decision | SemVer / git tag | Maintainers |
 | Python package (wheels/sdist) | PyPI | Same release version | Maintainers |
 | Node binding package | npm | Same release version | Maintainers |
+| Lifecycle CLI package | npm (`@graphforge/cli`) | Same release version | Maintainers |
 | Agent skills package | npm (`npx` skills) | Same release line | Maintainers |
 | Source archive / GitHub Release | GitHub | Annotated tag | Maintainers |
 | Documentation site | Astro Starlight (`docs-site/`; CI via `docs.yml`) | Commit / release | Maintainers |
@@ -30,7 +31,7 @@ multi-tenant service. Operational detail:
 - Commit messages follow Conventional Commit–style scopes used in the repo history; do not
   add new enforcement without maintainer agreement.
 - Release close-out for v0.5.0 is human-authorized on
-  [#742](https://github.com/CurateLabs/graphforge-legecy/issues/742);
+  [#192](https://github.com/CurateLabs/graphforge/issues/192);
   docs/legal trackers stay open until manual approval.
 
 ## Build and continuous delivery
@@ -50,8 +51,13 @@ pnpm docs:build
 python3 scripts/ci/crate-publish-plan.py check
 # v0.5.0: check intentionally fails closed and no cargo publish is run.
 # Python: maturin / TestPyPI clean-install checks
-# Node / skills: npm publish --dry-run
+# Node / CLI / skills: npm publish --dry-run
 ```
+
+The release-event workflow runs `release-publish-preflight.py` and `npm whoami`
+before any registry write. The release tag must resolve to the current certified
+`main` SHA; Cargo, Python, Node, CLI, and skills versions must match the tag;
+the dated CHANGELOG section must be cut; and the npm token must authenticate.
 
 Required TESTING.md gates (TCK, contract gates applicable to the release, binding RC evidence)
 must be green on the **same SHA** that is tagged for publication.
@@ -61,9 +67,9 @@ must be green on the **same SHA** that is tagged for publication.
 | From | To | Required evidence / approval |
 | --- | --- | --- |
 | PR branch | `main` | Focused PR, green CI Gate, clean review threads |
-| `main` SHA | Release candidate | Milestone gates for the release issue (#742 for v0.5.0) |
+| `main` SHA | Release candidate | Milestone gates for the release issue (#192 for v0.5.0) |
 | Release candidate | Registries + GitHub Release | Dry-runs, checksums/SBOM where configured, human release execution |
-| Published artifacts | Clean-install verification | Fresh env smokes for pip/npm/cargo paths |
+| Published artifacts | Clean-install verification | Fresh env smokes for pip/npm paths; no crates.io surface in v0.5.0 |
 | `main` docs | Public docs site | Green `docs.yml` / Starlight build for the deployed commit |
 
 ## Deployment verification
@@ -72,7 +78,7 @@ must be green on the **same SHA** that is tagged for publication.
   Book + allowlisted lifecycle pages.
 - **Packages:** clean-environment quickstart / smoke from public registries only
   ([`../development/clean-environment-verification.md`](../development/clean-environment-verification.md),
-  tracker [#2795](https://github.com/CurateLabs/graphforge-legecy/issues/2795) / #742 §7).
+  tracker [#167](https://github.com/CurateLabs/graphforge/issues/167)).
   Fail closed when the requested version is unpublished — never check off against missing
   artifacts.
 - **Skills:** packed artifact hashes and offline compatibility check
@@ -91,7 +97,7 @@ Authoritative stop/rollback table:
   new patch version if needed.
 - **Docs site:** redeploy last known-good commit from `main` / hosting history.
 - Authority: maintainers executing the release plan; agents assemble evidence but do not
-  authorize final #742 closure.
+  authorize final #192 closure.
 
 ## Official references
 

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -28,7 +28,7 @@ flowchart LR
 | --- | --- |
 | [`../book/architecture/`](../book/architecture/overview.md) | Deep architecture notes, pipeline, storage, embedding contracts |
 | [`../development/`](../development/contributing.md) | Contributor workflow, testing detail, release process |
-| [`../contracts/`](https://github.com/CurateLabs/graphforge-legecy/tree/main/docs/contracts) | Frozen public API / fingerprint JSON contracts |
+| [`../contracts/`](https://github.com/CurateLabs/graphforge/tree/main/docs/contracts) | Frozen public API / fingerprint JSON contracts |
 | [`../reference/`](../reference/api.md) | Compatibility, TCK, scale limits, column naming |
 | Root `AGENTS.md` | Agent workflow and validation gates |
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -118,7 +118,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 rustup update stable
 
 # 2. Clone
-git clone https://github.com/CurateLabs/graphforge-legecy.git
+git clone https://github.com/CurateLabs/graphforge.git
 cd graphforge
 
 # 3. Install Python dev dependencies

--- a/docs/guide/tutorial.md
+++ b/docs/guide/tutorial.md
@@ -819,5 +819,5 @@ Congratulations! You've learned the fundamentals of GraphForge.
 
 ### Join the Community
 
-- Report issues on [GitHub](https://github.com/CurateLabs/graphforge-legecy/issues)
+- Report issues on [GitHub](https://github.com/CurateLabs/graphforge/issues)
 - Continue in the [Book](../book/README.md) for architecture and deeper usage

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [0.5.0] - 2026-07-31
+
+- Freeze Cargo, Python, Node, CLI, and agent-skills release metadata at
+  `0.5.0`; fail closed before registry writes on SHA/version/changelog/npm
+  drift; align publication, release-record, certification, and clean-environment
+  tooling with the current repository and approved no-crates disposition (#192).
 - Align the published homepage and root README with the v0.5 development line, remove legacy
   PyPI v0.4 badges/install claims, and route readers to current Python, Node, CLI, and VS Code
   workflows (#255).
@@ -29,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bounded structured error details, schema-first checkpoint/revert JSON,
   authoritative `checkpoint show`, and non-mutating revert preview with
   required explicit `--yes` confirmation (#243).
+- Package host-discoverable project-local GraphForge skills from one canonical
+  source in both the `graphforge` wheel and `@graphforge/cli`, with
+  deterministic compatibility metadata and byte-parity checks (#230).
 - Add byte-for-byte equivalent `graphforge` wheel and `@graphforge/cli` npm
   entry points backed by the same Rust CLI parser, execution, structured errors,
   output, and exit codes, with packed clean-install `uvx`/offline `npx`
@@ -36,6 +47,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   remains whole-generation portable interchange; #236 owns Rust runtime-catalog
   inspection, ontology suggestion/validation, and document export, while #237
   owns thin binding parity plus durable adopt/clear behavior (#226).
+- Add Rust-owned deterministic runtime-catalog inspection, conservative ontology
+  drafts, structured non-mutating validation, and explicit-source atomic
+  YAML/JSON ontology export (#236).
+- Expose the #236 Rust-owned runtime-catalog inspection, ontology suggestion,
+  non-mutating validation, and explicit document export consistently in Python
+  and Node, plus durable workspace inspection, adoption, and clear, while
+  keeping session loads explicitly non-durable (#237).
 - Add deterministic portable export of the current generation or a named
   checkpoint and validate-before-mutation atomic import into new or empty
   projects, excluding live pointers, locks, journals, caches, and trash (#229).
@@ -45,12 +63,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   generation-managed repository snapshots with non-mutating CI drift checks
   (#244).
 
-Post-v0.5.0 work lands here. The v0.5.0 publication cut is under `[0.5.0]` below.
-
 - Define the `.graphforge/` repository integration and deployment configuration
   boundary, including closed versioned contracts, ignored data surfaces,
   secret-free IaC resolution, and cross-ecosystem ownership (#225).
+- Publish the GitHub Pages documentation at `https://docs.graphforge.sh`, with
+  root-relative site URLs and current `CurateLabs/graphforge` source links (#223).
 
+- Stop rerunning the full Test Suite after an already-green pull request is
+  squash-merged; exact-head pull-request CI remains the required merge gate
+  ([#209](https://github.com/CurateLabs/graphforge/issues/209)).
+
+- Minimize Blacksmith CI storage by removing speculative caches from infrequent
+  gates, sharing dependency caches by lockfile identity, and deleting the
+  one-run M22 build disk after certification (#207).
+- Remove unconsumed CI artifacts and move required cross-job transfers to
+  Blacksmith-backed cache storage, eliminating GitHub artifact-quota failures
+  from the required CI Gate (#205).
 - Restore local multi-surface coverage via `make coverage`: Rust (`cargo llvm-cov` →
   `build/coverage-rust/`), Python wrapper (`pytest-cov` on
   `crates/gf-bindings-py/python/graphforge`), and Node (`c8` on `@graphforge/node`
@@ -74,8 +102,6 @@ Post-v0.5.0 work lands here. The v0.5.0 publication cut is under `[0.5.0]` below
   (#2792).
 - Realign root `CONTRIBUTING.md` with the Rust-owned workspace and Apache-2.0
   inbound contribution terms (#218).
-
-## [0.5.0]
 
 First public **Rust-core** GraphForge line: openCypher over DataFusion, Arrow
 results, Parquet-backed project generations, thin Python (PyO3) and Node
@@ -136,6 +162,10 @@ the authoritative runnable corpus enforced by the BDD gate.
   Node constructor options, thread explicit selections through agent workflows,
   and verify compatible multi-agent publication, reopen, identity preservation,
   and conflict atomicity across the native concurrency matrix (#214).
+
+- Add transaction-addressed optimistic project staging with OS-backed attempt
+  leases, exact-base commit comparison, atomic generation promotion, and
+  recovery that preserves live attempts while removing abandoned ones (#212).
 
 - Add `scripts/record_release_artifacts.py` and
   `docs/development/release-artifact-record.md` for RC checksum/SBOM/contents
@@ -3422,8 +3452,8 @@ None. All changes maintain backward compatibility with v0.2.0 and v0.2.1.
 - 81% code coverage
 - Multi-OS, multi-Python CI/CD (3 OS × 4 Python versions)
 
-[Unreleased]: https://github.com/CurateLabs/graphforge-legecy/compare/v0.5.0...HEAD
-[0.5.0]: https://github.com/CurateLabs/graphforge-legecy/compare/v0.4.0...v0.5.0
+[Unreleased]: https://github.com/CurateLabs/graphforge/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/CurateLabs/graphforge/releases/tag/v0.5.0
 [0.4.0]: https://github.com/CurateLabs/graphforge-legecy/compare/v0.3.10...v0.4.0
 [0.3.0]: https://github.com/CurateLabs/graphforge-legecy/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/CurateLabs/graphforge-legecy/compare/v0.2.0...v0.2.1

--- a/docs/reference/column-naming-behavior.md
+++ b/docs/reference/column-naming-behavior.md
@@ -195,5 +195,5 @@ All 153 integration tests verify this behavior.
 ## See Also
 
 - CHANGELOG.md (in repository root) - Version history and changes
-- [CHANGELOG.md](https://github.com/CurateLabs/graphforge-legecy/blob/main/CHANGELOG.md) - Version history
+- [CHANGELOG.md](https://github.com/CurateLabs/graphforge/blob/main/CHANGELOG.md) - Version history
 - [tck-compliance.md](tck-compliance.md) - openCypher TCK compliance documentation

--- a/docs/reference/opencypher-compatibility-matrix.md
+++ b/docs/reference/opencypher-compatibility-matrix.md
@@ -465,5 +465,5 @@ Focus: Native social network analysis (SNA) algorithms exposed as CALL procedure
 
 - OpenCypher Specification: https://opencypher.org/resources/
 - OpenCypher TCK: https://github.com/opencypher/openCypher/tree/master/tck
-- GraphForge Repository: https://github.com/CurateLabs/graphforge-legecy
+- GraphForge Repository: https://github.com/CurateLabs/graphforge
 - GQL Standard (ISO/IEC 39075): https://www.iso.org/standard/76120.html

--- a/docs/reference/scale-limits.md
+++ b/docs/reference/scale-limits.md
@@ -55,7 +55,7 @@ GF_LIVEJOURNAL_PROJECT=/path/to/cached/project \
   make bench-fixed-hop-livejournal
 ```
 
-See [Traversal Scaling](https://github.com/CurateLabs/graphforge-legecy/blob/main/benchmarks/traversal_scaling.md)
+See [Traversal Scaling](https://github.com/CurateLabs/graphforge/blob/main/benchmarks/traversal_scaling.md)
 for the fixed-hop and variable-length benchmark methodology.
 
 ---
@@ -134,5 +134,5 @@ artifact. Until then that page stays an explicit pending placeholder.
 - [Install footprint](../guide/installation.md#install-footprint) — download and on-disk package sizes for Python/Node (not query scale)
 - [Release Load Matrix Results](load-matrix-results.md) — evidence landing for accepted matrix runs
 - [Standardized Release Load Matrix](../development/release-load-matrix.md) — contracts, executor, reproduce
-- [CHANGELOG.md](https://github.com/CurateLabs/graphforge-legecy/blob/main/CHANGELOG.md) — release notes
+- [CHANGELOG.md](https://github.com/CurateLabs/graphforge/blob/main/CHANGELOG.md) — release notes
 - [Architecture Overview](../book/architecture/overview.md) — Rust core design and DataFusion execution model

--- a/packages/agent-skills/compatibility.json
+++ b/packages/agent-skills/compatibility.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "package": "@graphforge/agent-skills",
-  "package_version": "0.5.0-dev.0",
+  "package_version": "0.5.0",
   "graphforge_release": "0.5.0",
   "graphforge_version_range": ">=0.5.0 <0.6.0",
   "security_contract": {

--- a/packages/agent-skills/package.json
+++ b/packages/agent-skills/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@graphforge/agent-skills",
-  "version": "0.5.0-dev.0",
+  "version": "0.5.0",
   "description": "NPX-distributed agent skills and adapters for GraphForge",
   "license": "Apache-2.0",
-  "homepage": "https://curatelabs.github.io/graphforge-legecy/",
+  "homepage": "https://docs.graphforge.sh/",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/CurateLabs/graphforge-x.git",
+    "url": "git+https://github.com/CurateLabs/graphforge.git",
     "directory": "packages/agent-skills"
   },
   "bugs": {
-    "url": "https://github.com/CurateLabs/graphforge-x/issues"
+    "url": "https://github.com/CurateLabs/graphforge/issues"
   },
   "keywords": [
     "graphforge",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@graphforge/cli",
-  "version": "0.5.0-dev.0",
+  "version": "0.5.0",
   "description": "GraphForge repository lifecycle CLI",
   "license": "Apache-2.0",
-  "homepage": "https://github.com/CurateLabs/graphforge",
+  "homepage": "https://docs.graphforge.sh/",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/CurateLabs/graphforge.git",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,9 +51,9 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://curatelabs.github.io/graphforge-legecy/"
-Repository = "https://github.com/CurateLabs/graphforge-legecy"
-Issues = "https://github.com/CurateLabs/graphforge-legecy/issues"
+Homepage = "https://docs.graphforge.sh/"
+Repository = "https://github.com/CurateLabs/graphforge"
+Issues = "https://github.com/CurateLabs/graphforge/issues"
 
 [build-system]
 requires = ["hatchling"]

--- a/scripts/ci/clean-env-verify.py
+++ b/scripts/ci/clean-env-verify.py
@@ -28,18 +28,17 @@ ROOT = Path(__file__).resolve().parents[2]
 EVIDENCE_SCHEMA = "graphforge-clean-env-evidence-v1"
 RELEASE_RECORD_SCHEMA = "graphforge-release-record-v1"
 DEFAULT_VERSION = "0.5.0"
-DEFAULT_DOCS_BASE = "https://curatelabs.github.io/graphforge-legecy"
-DEFAULT_CRATES = ("gf-api",)
+DEFAULT_DOCS_BASE = "https://docs.graphforge.sh"
+DEFAULT_CRATES: tuple[str, ...] = ()
 
 LANE_ISSUES = {
-    "pip": 2809,
-    "npm": 2810,
-    "cli": 226,
-    "skills": 2811,
-    "cargo": 2812,
-    "reopen": 2813,
-    "urls": 2814,
-    "checksums": 2815,
+    "pip": 180,
+    "npm": 183,
+    "cli": 183,
+    "skills": 182,
+    "reopen": 184,
+    "urls": 186,
+    "checksums": 187,
 }
 ALL_LANES = tuple(LANE_ISSUES)
 
@@ -198,9 +197,7 @@ def registry_urls(version: str, crates: tuple[str, ...], docs_base: str) -> dict
         "npm_skills_page": f"https://www.npmjs.com/package/@graphforge/agent-skills/v/{version}",
         "docs_quickstart": f"{docs}/guide/quickstart/",
         "docs_installation": f"{docs}/guide/installation/",
-        "github_release": (
-            f"https://github.com/CurateLabs/graphforge-legecy/releases/tag/v{version}"
-        ),
+        "github_release": (f"https://github.com/CurateLabs/graphforge/releases/tag/v{version}"),
     }
     for crate in crates:
         urls[f"crates_{crate}"] = f"https://crates.io/api/v1/crates/{crate}/{version}"
@@ -254,7 +251,7 @@ def run_preflight(ctx: Context) -> LaneResult:
         result.error = (
             "public v"
             + ctx.version
-            + " artifacts not available; blocked on #742 section 6 publication (#2794). "
+            + " artifacts not available; blocked on #192 publication (#195/#198). "
             "missing: " + ", ".join(probe["missing"])
         )
         result.notes.append("do not fake green checkoffs against unpublished packages")
@@ -262,7 +259,7 @@ def run_preflight(ctx: Context) -> LaneResult:
     result.ok = True
     result.notes.append(
         "PyPI, npm (@graphforge/node, @graphforge/cli, "
-        "@graphforge/agent-skills), and crates probes OK"
+        "and @graphforge/agent-skills) probes OK; v0.5.0 has no crates.io surface"
     )
     return result
 
@@ -695,7 +692,7 @@ def lane_checksums(ctx: Context) -> LaneResult:
     if not matched:
         result.error = (
             "release record had no overlapping sha256 artifacts with observed "
-            "PyPI/crates digests; update the record filenames/surfaces"
+            "PyPI digests; update the record filenames/surfaces"
         )
         return result
     result.ok = True
@@ -708,7 +705,6 @@ LANE_RUNNERS: dict[str, Callable[[Context], LaneResult]] = {
     "npm": lane_npm,
     "cli": lane_cli,
     "skills": lane_skills,
-    "cargo": lane_cargo,
     "reopen": lane_reopen,
     "urls": lane_urls,
     "checksums": lane_checksums,
@@ -749,8 +745,8 @@ def build_evidence(
         "ok": ok,
         "lanes": lanes,
         "issue_map": dict(LANE_ISSUES),
-        "tracker": 2795,
-        "umbrella": 742,
+        "tracker": 167,
+        "umbrella": 192,
     }
 
 

--- a/scripts/ci/clean-env-verify.py
+++ b/scripts/ci/clean-env-verify.py
@@ -257,10 +257,12 @@ def run_preflight(ctx: Context) -> LaneResult:
         result.notes.append("do not fake green checkoffs against unpublished packages")
         return result
     result.ok = True
-    result.notes.append(
-        "PyPI, npm (@graphforge/node, @graphforge/cli, "
-        "and @graphforge/agent-skills) probes OK; v0.5.0 has no crates.io surface"
-    )
+    registry_note = "PyPI and npm (@graphforge/node, @graphforge/cli, @graphforge/agent-skills)"
+    if ctx.crates:
+        registry_note += f", plus crates.io ({', '.join(ctx.crates)})"
+    else:
+        registry_note += "; no crates.io packages configured"
+    result.notes.append(f"{registry_note}; probes OK for v{ctx.version}")
     return result
 
 

--- a/scripts/ci/concurrency-recovery-gate.py
+++ b/scripts/ci/concurrency-recovery-gate.py
@@ -550,8 +550,12 @@ def resolve_ci_evidence(value: object, sha: str, api_get: Any = github_json) -> 
     repository = value["repository"]
     run_id = value["run_id"]
     job_id = value["job_id"]
-    if repository != REPOSITORY or not isinstance(run_id, int) or not isinstance(job_id, int):
+    valid_run_id = isinstance(run_id, int) and not isinstance(run_id, bool) and run_id > 0
+    valid_job_id = isinstance(job_id, int) and not isinstance(job_id, bool) and job_id > 0
+    if repository != REPOSITORY or not valid_run_id or not valid_job_id:
         raise GateError("CI evidence repository or immutable IDs are invalid")
+    expected_run_url = f"https://github.com/{repository}/actions/runs/{run_id}"
+    expected_job_url = f"{expected_run_url}/job/{job_id}"
     run = api_get(f"repos/{repository}/actions/runs/{run_id}")
     if (
         run.get("id") != run_id
@@ -559,6 +563,7 @@ def resolve_ci_evidence(value: object, sha: str, api_get: Any = github_json) -> 
         or run.get("name") != "Test Suite"
         or run.get("conclusion") != "success"
         or run.get("repository", {}).get("full_name") != repository
+        or run.get("html_url") != expected_run_url
     ):
         raise GateError("GitHub Test Suite run does not match repository, SHA, or success")
     jobs = api_get(f"repos/{repository}/actions/runs/{run_id}/jobs?per_page=100")
@@ -567,22 +572,18 @@ def resolve_ci_evidence(value: object, sha: str, api_get: Any = github_json) -> 
         len(matching) != 1
         or matching[0].get("name") != "CI Gate"
         or matching[0].get("conclusion") != "success"
+        or matching[0].get("html_url") != expected_job_url
     ):
         raise GateError("GitHub CI Gate job is absent, duplicated, or unsuccessful")
-    url_prefix = f"https://github.com/{repository}/actions/runs/"
-    if not str(run.get("html_url", "")).startswith(url_prefix) or not str(
-        matching[0].get("html_url", "")
-    ).startswith(url_prefix):
-        raise GateError("GitHub run or job URL does not belong to the required repository")
     return {
         "repository": repository,
         "commit_sha": sha,
         "workflow": "Test Suite",
         "run_id": run_id,
-        "run_url": run.get("html_url"),
+        "run_url": expected_run_url,
         "job": "CI Gate",
         "job_id": job_id,
-        "job_url": matching[0].get("html_url"),
+        "job_url": expected_job_url,
         "conclusion": "success",
     }
 

--- a/scripts/ci/concurrency-recovery-gate.py
+++ b/scripts/ci/concurrency-recovery-gate.py
@@ -16,6 +16,7 @@ import time
 from typing import Any
 
 ROOT = Path(__file__).resolve().parents[2]
+REPOSITORY = "CurateLabs/graphforge"
 MATRIX_PATH = ROOT / "tests/contracts/concurrency-recovery-matrix.json"
 REQUIRED_SLICES = {
     "same-process": 2541,
@@ -549,11 +550,7 @@ def resolve_ci_evidence(value: object, sha: str, api_get: Any = github_json) -> 
     repository = value["repository"]
     run_id = value["run_id"]
     job_id = value["job_id"]
-    if (
-        repository != "CurateLabs/graphforge-legecy"
-        or not isinstance(run_id, int)
-        or not isinstance(job_id, int)
-    ):
+    if repository != REPOSITORY or not isinstance(run_id, int) or not isinstance(job_id, int):
         raise GateError("CI evidence repository or immutable IDs are invalid")
     run = api_get(f"repos/{repository}/actions/runs/{run_id}")
     if (

--- a/scripts/ci/m22-non-cypher-surface-gate.py
+++ b/scripts/ci/m22-non-cypher-surface-gate.py
@@ -17,6 +17,7 @@ SURFACE = ROOT / "tests/contracts/non-cypher-rust-surface.json"
 LOAD_TAXONOMY = ROOT / "tests/contracts/load-dataset-taxonomy.json"
 LOAD_MATRIX = ROOT / "tests/contracts/load-workload-matrix.json"
 BINDING_TARGETS = ROOT / "tests/contracts/binding-release-candidate-targets.json"
+REPOSITORY = "CurateLabs/graphforge"
 
 SCHEMA = "graphforge-m22-non-cypher-surface-gate/1"
 RUST_SCHEMA = "graphforge-rust-non-cypher-evidence/1"
@@ -90,9 +91,9 @@ def validate_component_runs(
             raise ValueError(f"{owner}: referenced run was not manually dispatched")
         if run.get("path") != workflow_path:
             raise ValueError(f"{owner}: unexpected workflow path")
-        if run.get("repository", {}).get("full_name") != "CurateLabs/graphforge-legecy":
+        if run.get("repository", {}).get("full_name") != REPOSITORY:
             raise ValueError(f"{owner}: unexpected source repository")
-        expected_url = "https://github.com/CurateLabs/graphforge-legecy/actions/runs/" + str(run_id)
+        expected_url = f"https://github.com/{REPOSITORY}/actions/runs/{run_id}"
         if run.get("html_url") != expected_url:
             raise ValueError(f"{owner}: unexpected run URL")
         if (
@@ -330,7 +331,7 @@ def aggregate(
             raise ValueError(f"{name}: component-run field ledger mismatch")
         run_id = _run_id(component["run_id"], f"{name} run")
         run_attempt = _run_id(component["run_attempt"], f"{name} attempt")
-        expected_url = "https://github.com/CurateLabs/graphforge-legecy/actions/runs/" + str(run_id)
+        expected_url = f"https://github.com/{REPOSITORY}/actions/runs/{run_id}"
         expected_cache = {
             "rust": "rust-non-cypher-" + expected_sha,
             "binding": "binding-release-candidate-" + expected_sha,

--- a/scripts/ci/release-publish-preflight.py
+++ b/scripts/ci/release-publish-preflight.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Fail closed before a GitHub Release can publish registry artifacts.
+
+The release workflow invokes this against the immutable release-event SHA. It
+verifies that the tag, every publishable version surface, and the dated
+CHANGELOG section describe the same non-development version.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+VERSION_SCRIPT = ROOT / "scripts" / "set_release_version.py"
+CHANGELOG = ROOT / "CHANGELOG.md"
+DOCS_CHANGELOG = ROOT / "docs" / "reference" / "changelog.md"
+DOCS_URL = "https://docs.graphforge.sh/"
+REPOSITORY_URL = "https://github.com/CurateLabs/graphforge"
+REPOSITORY_GIT_URL = "git+https://github.com/CurateLabs/graphforge.git"
+ISSUES_URL = f"{REPOSITORY_URL}/issues"
+
+
+def load_version_module():
+    spec = importlib.util.spec_from_file_location("set_release_version", VERSION_SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {VERSION_SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def git_head() -> str:
+    result = subprocess.run(
+        ["git", "-C", str(ROOT), "rev-parse", "--verify", "HEAD"],
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    return result.stdout.strip() if result.returncode == 0 else "unknown"
+
+
+def release_version(tag: str) -> str | None:
+    match = re.fullmatch(r"v(\d+\.\d+\.\d+)", tag)
+    return match.group(1) if match else None
+
+
+def unreleased_body(changelog: str) -> str | None:
+    match = re.search(
+        r"(?ms)^## \[Unreleased\]\s*\n(?P<body>.*?)(?=^## \[)",
+        changelog,
+    )
+    return match.group("body") if match else None
+
+
+def validate_metadata() -> list[str]:
+    """Validate the URLs projected into every published package surface."""
+    errors: list[str] = []
+
+    cargo = (ROOT / "Cargo.toml").read_text(encoding="utf-8")
+    if f'repository = "{REPOSITORY_URL}"' not in cargo:
+        errors.append("Cargo workspace repository URL does not target CurateLabs/graphforge")
+
+    for path in (
+        ROOT / "pyproject.toml",
+        ROOT / "crates" / "gf-bindings-py" / "pyproject.toml",
+    ):
+        text = path.read_text(encoding="utf-8")
+        if f'Homepage = "{DOCS_URL}"' not in text:
+            errors.append(f"{path.relative_to(ROOT)} Homepage does not target {DOCS_URL}")
+        if f'Repository = "{REPOSITORY_URL}"' not in text:
+            errors.append(f"{path.relative_to(ROOT)} Repository does not target {REPOSITORY_URL}")
+        if f'Issues = "{ISSUES_URL}"' not in text:
+            errors.append(f"{path.relative_to(ROOT)} Issues does not target {ISSUES_URL}")
+        if "Documentation =" in text and f'Documentation = "{DOCS_URL}"' not in text:
+            errors.append(f"{path.relative_to(ROOT)} Documentation does not target {DOCS_URL}")
+
+    for path in (
+        ROOT / "crates" / "gf-bindings-node" / "package.json",
+        ROOT / "packages" / "cli" / "package.json",
+        ROOT / "packages" / "agent-skills" / "package.json",
+    ):
+        package = json.loads(path.read_text(encoding="utf-8"))
+        label = path.relative_to(ROOT)
+        if package.get("homepage") != DOCS_URL:
+            errors.append(f"{label} homepage does not target {DOCS_URL}")
+        if package.get("repository", {}).get("url") != REPOSITORY_GIT_URL:
+            errors.append(f"{label} repository does not target CurateLabs/graphforge")
+        if package.get("bugs", {}).get("url") != ISSUES_URL:
+            errors.append(f"{label} bugs URL does not target {ISSUES_URL}")
+    return errors
+
+
+def validate(
+    *,
+    tag: str,
+    expected_sha: str,
+    actual_sha: str,
+    versions: dict[str, str],
+    changelog: str,
+    docs_changelog: str,
+) -> list[str]:
+    errors: list[str] = []
+    version = release_version(tag)
+    if version is None:
+        return [f"release tag must be exactly vMAJOR.MINOR.PATCH, got {tag!r}"]
+
+    if not re.fullmatch(r"[0-9a-f]{40}", expected_sha):
+        errors.append("expected SHA must be a lowercase 40-character commit SHA")
+    if actual_sha != expected_sha:
+        errors.append(f"checked-out SHA {actual_sha!r} does not match event SHA {expected_sha!r}")
+
+    version_module = load_version_module()
+    wanted = version_module.expected_for(version, dev=False)
+    for surface, expected in wanted.items():
+        actual = versions.get(surface)
+        if actual != expected:
+            errors.append(f"{surface} version is {actual!r}; expected release version {expected!r}")
+
+    dated_heading = re.compile(rf"(?m)^## \[{re.escape(version)}\] - \d{{4}}-\d{{2}}-\d{{2}}\s*$")
+    if not dated_heading.search(changelog):
+        errors.append(f"CHANGELOG lacks a dated [{version}] release heading")
+
+    body = unreleased_body(changelog)
+    if body is None:
+        errors.append("CHANGELOG lacks an [Unreleased] section before the release section")
+    elif re.search(r"(?m)^\s*[-*]\s+", body):
+        errors.append("CHANGELOG [Unreleased] still contains release-note entries")
+
+    current_repo = "https://github.com/CurateLabs/graphforge"
+    if f"[Unreleased]: {current_repo}/compare/v{version}...HEAD" not in changelog:
+        errors.append("CHANGELOG [Unreleased] comparison link does not target the current repo")
+    if f"[{version}]: {current_repo}/releases/tag/v{version}" not in changelog:
+        errors.append(f"CHANGELOG [{version}] link does not target the current repo release")
+    if docs_changelog != changelog:
+        errors.append("docs/reference/changelog.md does not exactly mirror CHANGELOG.md")
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", required=True, help="Release tag, e.g. v0.5.0")
+    parser.add_argument("--expected-sha", required=True, help="Release-event commit SHA")
+    args = parser.parse_args(argv)
+
+    version_module = load_version_module()
+    errors = validate(
+        tag=args.tag,
+        expected_sha=args.expected_sha,
+        actual_sha=git_head(),
+        versions=version_module.read_current(),
+        changelog=CHANGELOG.read_text(encoding="utf-8"),
+        docs_changelog=DOCS_CHANGELOG.read_text(encoding="utf-8"),
+    )
+    errors.extend(version_module.check_aligned())
+    errors.extend(validate_metadata())
+    if errors:
+        for error in errors:
+            print(f"release-publish-preflight: {error}", file=sys.stderr)
+        return 1
+    print(f"release-publish-preflight: ready tag={args.tag} sha={args.expected_sha}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test-clean-env-verify.py
+++ b/scripts/ci/test-clean-env-verify.py
@@ -38,13 +38,6 @@ def sample_record(version: str = "0.5.0") -> dict[str, Any]:
                 "filename": f"graphforge-{version}-py3-none-any.whl",
                 "sha256": "b" * 64,
             },
-            {
-                "surface": "crates",
-                "name": "gf-api",
-                "version": version,
-                "filename": f"gf-api-{version}.crate",
-                "sha256": "c" * 64,
-            },
         ],
     }
 
@@ -76,14 +69,14 @@ def test_validate_evidence_ok() -> None:
     evidence = cev.build_evidence(
         "0.5.0",
         [
-            cev.LaneResult(name="pip", issue=2809, ok=True),
-            cev.LaneResult(name="urls", issue=2814, ok=True),
+            cev.LaneResult(name="pip", issue=180, ok=True),
+            cev.LaneResult(name="urls", issue=186, ok=True),
         ],
         preflight=cev.LaneResult(name="preflight", issue=None, ok=True),
     )
     cev.validate_evidence(evidence)
     assert evidence["ok"] is True
-    assert evidence["issue_map"]["pip"] == 2809
+    assert evidence["issue_map"]["pip"] == 180
 
 
 def test_preflight_fails_closed_when_unpublished() -> None:
@@ -95,7 +88,7 @@ def test_preflight_fails_closed_when_unpublished() -> None:
             version="0.5.0",
             work_root=Path(tmp),
             docs_base=cev.DEFAULT_DOCS_BASE,
-            crates=("gf-api",),
+            crates=(),
             release_record=None,
             fetch=fetch,
             run_cmd=cev.run_subprocess,
@@ -104,7 +97,7 @@ def test_preflight_fails_closed_when_unpublished() -> None:
         result = cev.run_preflight(ctx)
         assert result.ok is False
         assert result.error is not None
-        assert "#2794" in result.error
+        assert "#192" in result.error
         assert "unpublished" in " ".join(result.notes)
 
 
@@ -118,8 +111,6 @@ def test_preflight_ok_when_published() -> None:
             return 200, b"{}", {}
         if "registry.npmjs.org/@graphforge/agent-skills/0.5.0" in url:
             return 200, b"{}", {}
-        if "crates.io/api/v1/crates/gf-api/0.5.0" in url:
-            return 200, json.dumps({"version": {"num": "0.5.0"}}).encode(), {}
         return 404, b"", {}
 
     with tempfile.TemporaryDirectory() as tmp:
@@ -127,7 +118,7 @@ def test_preflight_ok_when_published() -> None:
             version="0.5.0",
             work_root=Path(tmp),
             docs_base=cev.DEFAULT_DOCS_BASE,
-            crates=("gf-api",),
+            crates=(),
             release_record=None,
             fetch=fetch,
             run_cmd=cev.run_subprocess,
@@ -148,7 +139,7 @@ def test_urls_lane_reports_failures() -> None:
             version="0.5.0",
             work_root=Path(tmp),
             docs_base=cev.DEFAULT_DOCS_BASE,
-            crates=("gf-api",),
+            crates=(),
             release_record=None,
             fetch=fetch,
             run_cmd=cev.run_subprocess,
@@ -217,12 +208,6 @@ def test_checksums_match_release_record() -> None:
                 ).encode(),
                 {},
             )
-        if "crates.io/api/v1/crates/gf-api/0.5.0" in url:
-            return (
-                200,
-                json.dumps({"version": {"checksum": "c" * 64}}).encode(),
-                {},
-            )
         return 404, b"", {}
 
     with tempfile.TemporaryDirectory() as tmp:
@@ -230,7 +215,7 @@ def test_checksums_match_release_record() -> None:
             version="0.5.0",
             work_root=Path(tmp),
             docs_base=cev.DEFAULT_DOCS_BASE,
-            crates=("gf-api",),
+            crates=(),
             release_record=record,
             fetch=fetch,
             run_cmd=cev.run_subprocess,
@@ -257,7 +242,7 @@ def test_cli_lane_installs_and_executes_published_package() -> None:
             version="0.5.0",
             work_root=Path(tmp),
             docs_base=cev.DEFAULT_DOCS_BASE,
-            crates=("gf-api",),
+            crates=(),
             release_record=None,
             fetch=lambda _url: (200, b"{}", {}),
             run_cmd=run,

--- a/scripts/ci/test-clean-env-verify.py
+++ b/scripts/ci/test-clean-env-verify.py
@@ -111,6 +111,8 @@ def test_preflight_ok_when_published() -> None:
             return 200, b"{}", {}
         if "registry.npmjs.org/@graphforge/agent-skills/0.5.0" in url:
             return 200, b"{}", {}
+        if "crates.io/api/v1/crates/gf-api/0.5.0" in url:
+            return 200, json.dumps({"version": {"num": "0.5.0"}}).encode(), {}
         return 404, b"", {}
 
     with tempfile.TemporaryDirectory() as tmp:
@@ -126,6 +128,27 @@ def test_preflight_ok_when_published() -> None:
         )
         result = cev.run_preflight(ctx)
         assert result.ok is True, result.error
+        assert result.notes == [
+            "PyPI and npm (@graphforge/node, @graphforge/cli, @graphforge/agent-skills); "
+            "no crates.io packages configured; probes OK for v0.5.0"
+        ]
+
+        crate_ctx = cev.Context(
+            version="0.5.0",
+            work_root=Path(tmp),
+            docs_base=cev.DEFAULT_DOCS_BASE,
+            crates=("gf-api",),
+            release_record=None,
+            fetch=fetch,
+            run_cmd=cev.run_subprocess,
+            allow_network_install=False,
+        )
+        crate_result = cev.run_preflight(crate_ctx)
+        assert crate_result.ok is True, crate_result.error
+        assert crate_result.notes == [
+            "PyPI and npm (@graphforge/node, @graphforge/cli, @graphforge/agent-skills), "
+            "plus crates.io (gf-api); probes OK for v0.5.0"
+        ]
 
 
 def test_urls_lane_reports_failures() -> None:

--- a/scripts/ci/test-concurrency-recovery-gate.py
+++ b/scripts/ci/test-concurrency-recovery-gate.py
@@ -308,6 +308,54 @@ fn cited<'a, 'b>() {
         assert any(path.endswith("/jobs?per_page=100") for path in api_paths)
         GATE.verify_report(output, fragments, ci_path, fake_api)
 
+        valid_ci = {
+            "repository": "CurateLabs/graphforge",
+            "run_id": 101,
+            "job_id": 202,
+        }
+
+        def expect_ci_rejection(value: dict[str, object], message: str) -> None:
+            try:
+                GATE.resolve_ci_evidence(value, sha, fake_api)
+            except GATE.GateError:
+                return
+            raise AssertionError(message)
+
+        for field, invalid in (
+            ("run_id", True),
+            ("run_id", 0),
+            ("run_id", -1),
+            ("job_id", False),
+            ("job_id", 0),
+            ("job_id", -1),
+        ):
+            expect_ci_rejection(
+                {**valid_ci, field: invalid},
+                f"CI evidence accepted invalid {field}={invalid!r}",
+            )
+
+        original_run_url = run_payload["html_url"]
+        run_payload["html_url"] = "https://github.com/CurateLabs/graphforge/actions/runs/999"
+        try:
+            GATE.resolve_ci_evidence(valid_ci, sha, fake_api)
+        except GATE.GateError:
+            pass
+        else:
+            raise AssertionError("CI evidence accepted a mismatched same-repository run URL")
+        run_payload["html_url"] = original_run_url
+
+        original_job_url = jobs_payload["jobs"][0]["html_url"]
+        jobs_payload["jobs"][0]["html_url"] = (
+            "https://github.com/CurateLabs/graphforge/actions/runs/101/job/999"
+        )
+        try:
+            GATE.resolve_ci_evidence(valid_ci, sha, fake_api)
+        except GATE.GateError:
+            pass
+        else:
+            raise AssertionError("CI evidence accepted a mismatched same-repository job URL")
+        jobs_payload["jobs"][0]["html_url"] = original_job_url
+
         report_path = output / "concurrency-recovery-report.json"
         original_report = report_path.read_text(encoding="utf-8")
         report_path.write_text(original_report + " ", encoding="utf-8")

--- a/scripts/ci/test-concurrency-recovery-gate.py
+++ b/scripts/ci/test-concurrency-recovery-gate.py
@@ -266,7 +266,7 @@ fn cited<'a, 'b>() {
         ci_path.write_text(
             json.dumps(
                 {
-                    "repository": "CurateLabs/graphforge-legecy",
+                    "repository": "CurateLabs/graphforge",
                     "run_id": 101,
                     "job_id": 202,
                 }
@@ -278,8 +278,8 @@ fn cited<'a, 'b>() {
             "head_sha": sha,
             "name": "Test Suite",
             "conclusion": "success",
-            "html_url": "https://github.com/CurateLabs/graphforge-legecy/actions/runs/101",
-            "repository": {"full_name": "CurateLabs/graphforge-legecy"},
+            "html_url": "https://github.com/CurateLabs/graphforge/actions/runs/101",
+            "repository": {"full_name": "CurateLabs/graphforge"},
         }
         jobs_payload = {
             "jobs": [
@@ -288,7 +288,7 @@ fn cited<'a, 'b>() {
                     "name": "CI Gate",
                     "conclusion": "success",
                     "html_url": (
-                        "https://github.com/CurateLabs/graphforge-legecy/actions/runs/101/job/202"
+                        "https://github.com/CurateLabs/graphforge/actions/runs/101/job/202"
                     ),
                 }
             ]
@@ -431,14 +431,14 @@ fn cited<'a, 'b>() {
         ci_path.write_text(
             json.dumps(
                 {
-                    "repository": "CurateLabs/graphforge-legecy",
+                    "repository": "CurateLabs/graphforge",
                     "run_id": 101,
                     "job_id": 202,
                 }
             ),
             encoding="utf-8",
         )
-        wrong_run = {"repository": "CurateLabs/graphforge-legecy", "run_id": 999, "job_id": 202}
+        wrong_run = {"repository": "CurateLabs/graphforge", "run_id": 999, "job_id": 202}
         ci_path.write_text(json.dumps(wrong_run), encoding="utf-8")
         try:
             GATE.build_report(sha, fragments, ci_path, output, fake_api)
@@ -446,7 +446,7 @@ fn cited<'a, 'b>() {
             pass
         else:
             raise AssertionError("report accepted a mismatched immutable run ID")
-        wrong_job = {"repository": "CurateLabs/graphforge-legecy", "run_id": 101, "job_id": 999}
+        wrong_job = {"repository": "CurateLabs/graphforge", "run_id": 101, "job_id": 999}
         ci_path.write_text(json.dumps(wrong_job), encoding="utf-8")
         try:
             GATE.build_report(sha, fragments, ci_path, output, fake_api)
@@ -457,7 +457,7 @@ fn cited<'a, 'b>() {
         ci_path.write_text(
             json.dumps(
                 {
-                    "repository": "CurateLabs/graphforge-legecy",
+                    "repository": "CurateLabs/graphforge",
                     "run_id": 101,
                     "job_id": 202,
                 }

--- a/scripts/ci/test-m22-non-cypher-surface-gate.py
+++ b/scripts/ci/test-m22-non-cypher-surface-gate.py
@@ -39,8 +39,8 @@ class M22SurfaceGateTests(unittest.TestCase):
             "head_sha": SHA,
             "event": "workflow_dispatch",
             "path": ".github/workflows/non-cypher-surface-gate.yml",
-            "repository": {"full_name": "CurateLabs/graphforge-legecy"},
-            "html_url": "https://github.com/CurateLabs/graphforge-legecy/actions/runs/101",
+            "repository": {"full_name": "CurateLabs/graphforge"},
+            "html_url": "https://github.com/CurateLabs/graphforge/actions/runs/101",
         }
         self.binding_run = {
             "id": 102,
@@ -50,8 +50,8 @@ class M22SurfaceGateTests(unittest.TestCase):
             "head_sha": SHA,
             "event": "workflow_dispatch",
             "path": ".github/workflows/binding-release-candidate.yml",
-            "repository": {"full_name": "CurateLabs/graphforge-legecy"},
-            "html_url": "https://github.com/CurateLabs/graphforge-legecy/actions/runs/102",
+            "repository": {"full_name": "CurateLabs/graphforge"},
+            "html_url": "https://github.com/CurateLabs/graphforge/actions/runs/102",
         }
 
     def rejected_runs(self, expected: str, **changes) -> None:

--- a/scripts/ci/test-release-publish-preflight.py
+++ b/scripts/ci/test-release-publish-preflight.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Deterministic tests for the release publication preflight and workflow gate."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = Path(__file__).with_name("release-publish-preflight.py")
+WORKFLOW = ROOT / ".github" / "workflows" / "publish.yaml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("release_publish_preflight", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = load_module()
+sha = "a" * 40
+versions = {
+    "cargo": "0.5.0",
+    "python": "0.5.0",
+    "node": "0.5.0",
+    "cli": "0.5.0",
+    "skills": "0.5.0",
+}
+changelog = """# Changelog
+
+## [Unreleased]
+
+_Nothing yet._
+
+## [0.5.0] - 2026-07-31
+
+- Release GraphForge.
+
+[Unreleased]: https://github.com/CurateLabs/graphforge/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/CurateLabs/graphforge/releases/tag/v0.5.0
+"""
+
+assert (
+    mod.validate(
+        tag="v0.5.0",
+        expected_sha=sha,
+        actual_sha=sha,
+        versions=versions,
+        changelog=changelog,
+        docs_changelog=changelog,
+    )
+    == []
+)
+assert mod.validate_metadata() == []
+assert mod.load_version_module().check_aligned() == []
+
+mutations = [
+    {"tag": "0.5.0"},
+    {"actual_sha": "b" * 40},
+    {"versions": {**versions, "python": "0.5.0.dev0"}},
+    {"changelog": changelog.replace("## [0.5.0] - 2026-07-31", "## [0.5.0]")},
+    {"changelog": changelog.replace("_Nothing yet._", "- Stale release entry")},
+    {
+        "changelog": changelog.replace(
+            "CurateLabs/graphforge/compare",
+            "CurateLabs/graphforge-legecy/compare",
+        )
+    },
+    {"docs_changelog": changelog.replace("Release GraphForge.", "Stale public changelog.")},
+]
+for mutation in mutations:
+    values = {
+        "tag": "v0.5.0",
+        "expected_sha": sha,
+        "actual_sha": sha,
+        "versions": versions,
+        "changelog": changelog,
+        "docs_changelog": changelog,
+        **mutation,
+    }
+    assert mod.validate(**values), mutation
+
+workflow = WORKFLOW.read_text(encoding="utf-8")
+license_job = workflow.split("  license-compliance:\n", 1)[1].split("\n  build-wheels:", 1)[0]
+assert "release-publish-preflight.py" in license_job
+assert "github.event.release.tag_name" in license_job
+assert "github.sha" in license_job
+assert "refs/remotes/origin/main" in license_job
+assert "npm whoami" in license_job
+assert "secrets.NPM_TOKEN" in license_job
+assert license_job.index("release-publish-preflight.py") < license_job.index("npm whoami")
+for build_job, next_job in (
+    ("build-wheels", "build-sdist"),
+    ("build-sdist", "publish"),
+    ("build-node", "publish-node"),
+):
+    section = workflow.split(f"  {build_job}:\n", 1)[1].split(f"\n  {next_job}:\n", 1)[0]
+    assert "needs: license-compliance" in section, build_job
+
+skills_job = workflow.split("  publish-agent-skills:\n", 1)[1].split("\n  # ---- Rust crates", 1)[0]
+assert "needs: publish-node-cli" in skills_job
+
+print("release publish preflight tests passed")

--- a/scripts/publish_dry_run.py
+++ b/scripts/publish_dry_run.py
@@ -15,7 +15,7 @@ present; otherwise uses a conservative fallback that excludes bindings/CLI.
 
 Usage:
     python3 scripts/publish_dry_run.py --surface npm,docs --report /tmp/dry-run.json
-    python3 scripts/publish_dry_run.py --surface cargo-package,python,npm,docs
+    python3 scripts/publish_dry_run.py --surface python,npm,docs
     make publish-dry-run
 """
 
@@ -165,7 +165,9 @@ def dry_run_cargo_publish() -> list[dict[str, Any]]:
 def dry_run_npm() -> list[dict[str, Any]]:
     # Prerelease versions (e.g. 0.5.0-dev.0) require an explicit --tag; dry-run
     # never publishes, so a disposable tag keeps the check green before freeze.
-    steps = []
+    steps = [_run(["pnpm", "install", "--frozen-lockfile"])]
+    if not steps[0]["ok"]:
+        return steps
     for package_dir in NPM_PACKAGES:
         if package_dir.name == "cli":
             command = [
@@ -216,7 +218,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--surface",
-        default="npm,docs,cargo-package,python",
+        default="npm,docs,python",
         help="Comma list: npm,docs,cargo-package,cargo-publish,python,all",
     )
     parser.add_argument(
@@ -229,7 +231,7 @@ def main(argv: list[str] | None = None) -> int:
 
     surfaces = {part.strip() for part in args.surface.split(",") if part.strip()}
     if "all" in surfaces:
-        surfaces = {"npm", "docs", "cargo-package", "python"}
+        surfaces = {"npm", "docs", "python"}
         if not args.skip_cargo_publish:
             surfaces.add("cargo-publish")
 

--- a/scripts/record_release_artifacts.py
+++ b/scripts/record_release_artifacts.py
@@ -26,6 +26,7 @@ import sys
 from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
+RELEASE_RECORD_SCHEMA = "graphforge-release-record-v1"
 
 
 def _git_sha() -> str:
@@ -66,7 +67,21 @@ def classify(path: Path) -> str:
     return "other"
 
 
-def scan_dist(dist_dir: Path) -> list[dict[str, Any]]:
+def artifact_identity(path: Path, artifact_class: str, version: str) -> tuple[str, str]:
+    """Return the public registry surface and package name for an artifact."""
+    if artifact_class in {"python-wheel", "python-sdist"}:
+        return "pypi", "graphforge"
+    if artifact_class == "npm-tarball":
+        suffix = f"-{version}.tgz"
+        normalized = path.name
+        if normalized.startswith("graphforge-") and normalized.endswith(suffix):
+            package = normalized[len("graphforge-") : -len(suffix)]
+            return "npm", f"@graphforge/{package}"
+        return "npm", path.stem
+    return "github", path.name
+
+
+def scan_dist(dist_dir: Path, version: str) -> list[dict[str, Any]]:
     artifacts: list[dict[str, Any]] = []
     if not dist_dir.exists():
         return artifacts
@@ -76,10 +91,16 @@ def scan_dist(dist_dir: Path) -> list[dict[str, Any]]:
         if path.name.startswith("."):
             continue
         rel = str(path.relative_to(dist_dir))
+        artifact_class = classify(path)
+        surface, name = artifact_identity(path, artifact_class, version)
         artifacts.append(
             {
                 "path": rel,
-                "class": classify(path),
+                "class": artifact_class,
+                "surface": surface,
+                "name": name,
+                "version": version,
+                "filename": path.name,
                 "bytes": path.stat().st_size,
                 "sha256": sha256_file(path),
             }
@@ -93,16 +114,19 @@ def build_record(
     dist_dir: Path,
     notes: str | None,
 ) -> dict[str, Any]:
-    artifacts = scan_dist(dist_dir)
+    artifacts = scan_dist(dist_dir, version)
+    commit_sha = _git_sha()
     return {
-        "schema_version": 1,
+        "schema": RELEASE_RECORD_SCHEMA,
         "version": version,
-        "git_sha": _git_sha(),
+        "tag": f"v{version}",
+        "commit_sha": commit_sha,
         "recorded_at": datetime.now(timezone.utc).isoformat(),
         "dist_dir": str(dist_dir),
         "same_tagged_commit_policy": (
             "Every first-party publishable artifact for this version must be built "
-            f"from git_sha (the eventual v{version} tag target) or have an explicit "
+            f"from commit_sha {commit_sha} (the eventual v{version} tag target) "
+            "or have an explicit "
             "reproducible link recorded in notes/links."
         ),
         "licenses": {

--- a/scripts/set_release_version.py
+++ b/scripts/set_release_version.py
@@ -3,10 +3,12 @@
 
 Surfaces:
 - Cargo workspace ``[workspace.package].version``
+- Cargo lockfile entries for workspace packages
 - Python ``crates/gf-bindings-py/pyproject.toml`` (PEP 440)
 - Node ``crates/gf-bindings-node/package.json``
 - NPX lifecycle CLI ``packages/cli/package.json``
 - NPX skills ``packages/agent-skills/package.json``
+- NPX skills ``packages/agent-skills/compatibility.json``
 
 Usage:
     python3 scripts/set_release_version.py --check
@@ -29,10 +31,18 @@ import sys
 
 ROOT = Path(__file__).resolve().parents[1]
 CARGO_TOML = ROOT / "Cargo.toml"
+CARGO_LOCK = ROOT / "Cargo.lock"
 PYPROJECT = ROOT / "crates" / "gf-bindings-py" / "pyproject.toml"
 NODE_PACKAGE = ROOT / "crates" / "gf-bindings-node" / "package.json"
 CLI_PACKAGE = ROOT / "packages" / "cli" / "package.json"
 SKILLS_PACKAGE = ROOT / "packages" / "agent-skills" / "package.json"
+SKILLS_COMPATIBILITY = ROOT / "packages" / "agent-skills" / "compatibility.json"
+
+
+def cargo_lock_versions() -> dict[str, str]:
+    """Return versions for local gf-* packages recorded in Cargo.lock."""
+    text = CARGO_LOCK.read_text(encoding="utf-8")
+    return dict(re.findall(r'(?m)^name = "(gf-[^"]+)"\nversion = "([^"]+)"$', text))
 
 
 def parse_base(version: str) -> tuple[str, bool]:
@@ -107,6 +117,16 @@ def check_aligned() -> list[str]:
         got = current[key]
         if got != want:
             errors.append(f"{key}: got {got!r}, expected {want!r} for cargo base {base} dev={dev}")
+    lock_versions = cargo_lock_versions()
+    for package, got in sorted(lock_versions.items()):
+        if got != expected["cargo"]:
+            errors.append(f"Cargo.lock {package}: got {got!r}, expected {expected['cargo']!r}")
+    compatibility = json.loads(SKILLS_COMPATIBILITY.read_text(encoding="utf-8"))
+    if compatibility.get("package_version") != expected["skills"]:
+        errors.append(
+            "skills compatibility package_version: got "
+            f"{compatibility.get('package_version')!r}, expected {expected['skills']!r}"
+        )
     return errors
 
 
@@ -125,6 +145,20 @@ def apply_version(base: str, *, dev: bool, dry_run: bool) -> dict[str, str]:
     if n != 1:
         raise ValueError("failed to update Cargo.toml workspace version")
     CARGO_TOML.write_text(cargo_text, encoding="utf-8")
+
+    lock_text = CARGO_LOCK.read_text(encoding="utf-8")
+
+    def update_lock(match: re.Match[str]) -> str:
+        return f"{match.group(1)}{expected['cargo']}{match.group(2)}"
+
+    lock_text, lock_count = re.subn(
+        r'(?m)^(name = "gf-[^"]+"\nversion = ")[^"]+(")$',
+        update_lock,
+        lock_text,
+    )
+    if lock_count == 0:
+        raise ValueError("failed to update Cargo.lock workspace package versions")
+    CARGO_LOCK.write_text(lock_text, encoding="utf-8")
 
     py_text = PYPROJECT.read_text(encoding="utf-8")
     py_text, n = re.subn(
@@ -145,6 +179,10 @@ def apply_version(base: str, *, dev: bool, dry_run: bool) -> dict[str, str]:
         meta = json.loads(path.read_text(encoding="utf-8"))
         meta["version"] = expected[key]
         path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+
+    compatibility = json.loads(SKILLS_COMPATIBILITY.read_text(encoding="utf-8"))
+    compatibility["package_version"] = expected["skills"]
+    SKILLS_COMPATIBILITY.write_text(json.dumps(compatibility, indent=2) + "\n", encoding="utf-8")
 
     return expected
 

--- a/tests/unit/test_publish_dry_run.py
+++ b/tests/unit/test_publish_dry_run.py
@@ -21,5 +21,6 @@ def test_cargo_order_skips_gf_core_conflict() -> None:
 
 def test_npm_dry_run_surfaces_ok() -> None:
     steps = publish_dry_run.dry_run_npm()
-    assert len(steps) == 3
+    assert len(steps) == 4
+    assert steps[0]["cmd"] == ["pnpm", "install", "--frozen-lockfile"]
     assert all(step["ok"] for step in steps)

--- a/tests/unit/test_record_release_artifacts.py
+++ b/tests/unit/test_record_release_artifacts.py
@@ -19,10 +19,17 @@ def test_classify_and_hash(tmp_path: Path) -> None:
         dist_dir=tmp_path,
         notes="test",
     )
+    assert record["schema"] == "graphforge-release-record-v1"
     assert record["version"] == "0.5.0"
+    assert record["tag"] == "v0.5.0"
+    assert len(record["commit_sha"]) == 40
     assert record["licenses"]["first_party_spdx"] == "Apache-2.0"
     assert record["contents_summary"]["total_artifacts"] == 1
     assert record["artifacts"][0]["class"] == "python-wheel"
+    assert record["artifacts"][0]["surface"] == "pypi"
+    assert record["artifacts"][0]["name"] == "graphforge"
+    assert record["artifacts"][0]["version"] == "0.5.0"
+    assert record["artifacts"][0]["filename"] == wheel.name
     assert len(record["artifacts"][0]["sha256"]) == 64
     assert "same_tagged_commit_policy" in record
 
@@ -40,3 +47,4 @@ def test_cli_writes_json(tmp_path: Path) -> None:
     )
     payload = json.loads(out.read_text(encoding="utf-8"))
     assert payload["artifacts"][0]["class"] == "npm-tarball"
+    assert payload["artifacts"][0]["surface"] == "npm"


### PR DESCRIPTION
## Summary

- freeze Cargo, Python, Node, CLI, skills, lockfile, and packaged compatibility metadata at `0.5.0`
- cut and mirror the dated v0.5.0 changelog and align package/public metadata with `CurateLabs/graphforge`
- fail closed before registry writes on release SHA, main, tag, versions, changelog, license, and npm identity
- preserve the required Python -> Node -> CLI -> skills publication order and the approved no-crates disposition
- repair current-repository release certification, artifact-record, and post-release verification paths

## Verification

- `make publish-dry-run` (Python sdist, Node/CLI/skills npm dry-runs, docs build)
- `make package-license-verify`
- `pnpm docs:check-links` (10,348 links; 0 broken/stale)
- release preflight, M22 run validator, concurrency recovery, clean-env harness, version/artifact unit tests
- `scripts/check-workflows.sh`
- `cargo check --workspace --locked --offline`
- `cargo fmt --all -- --check`
- `python3 scripts/license_check.py`

## Scope

This prepares #192 but intentionally does not create `v0.5.0`, publish a GitHub Release, or write to PyPI/npm. Those remain human-authorized release steps after exact-SHA certification and registry credentials are ready.

Refs #192

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788123380&installation_model_id=20486&pr_number=258&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F258&signature=521bfe2aafe5c381541559acdac28ea6fb87b3f381e85036272bde61053ca923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced stronger release-readiness checks covering version consistency, changelogs, package metadata, tags, and release commits.
  - Improved release artifact records with package identity, registry details, version, and commit information.
- **Release Updates**
  - Updated packages and documentation to the 0.5.0 release.
  - Replaced legacy repository and website links with the current GraphForge documentation and repository.
- **Bug Fixes**
  - Updated verification and CI checks to use current repository references and release tracking details.
  - Improved dry-run publishing behavior and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release v0.5.0 by bumping versions, updating repository URLs, and adding publication preflight validation
> - Bumps all package versions from `0.5.0-dev.0` to `0.5.0` across Cargo, Python, Node, CLI, and agent-skills packages and updates all repository URLs from `graphforge-legecy` to `graphforge`.
> - Adds a new [`release-publish-preflight.py`](https://github.com/CurateLabs/graphforge/pull/258/files#diff-5e372062d1c0aa4a92f36465aa83ed2decdb594a471060eb06ebfd9df6d73ed7) script that validates tag format, commit SHA alignment, version consistency across surfaces, changelog formatting, and npm credentials before any registry write.
> - Removes `cargo-package` from publish dry-run and clean-env-verify surfaces; the `cargo` lane is no longer invocable and `make clean-env-verify` now defaults to `cli` instead of `cargo`.
> - Enriches the release artifact record schema (`graphforge-release-record-v1`) with per-artifact `surface`, `name`, `version`, and `filename` fields; `scan_dist` and `build_record` in [`record_release_artifacts.py`](https://github.com/CurateLabs/graphforge/pull/258/files#diff-016f5fae813a6c738c68837730de16fd08f8249f510e5461a6d6ed982a58b0a3) are updated accordingly.
> - Extends [`set_release_version.py`](https://github.com/CurateLabs/graphforge/pull/258/files#diff-528cea51961c7a16745e651cf6b6d1b99f36b9f25a68ee52c98f5a63fad5c624) to update `Cargo.lock` workspace package versions and sync `packages/agent-skills/compatibility.json` when applying a release version.
> - Adds the `release-publish-preflight.py` test suite to CI via [`test.yml`](https://github.com/CurateLabs/graphforge/pull/258/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88) and wires the preflight script into [`publish.yaml`](https://github.com/CurateLabs/graphforge/pull/258/files#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388ca) before any publication steps.
> - Risk: the publish workflow now fails early if the release tag does not match the current certified main SHA or if npm credentials are missing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ab0547.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->