### PR TITLE
fix(release): preserve project skill bytes on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,6 @@
 /crates/gf-bindings-node/tests/*.mjs text eol=lf
 /package.json text eol=lf
 /pnpm-lock.yaml text eol=lf
+/project-skills/** text eol=lf
+/crates/gf-bindings-py/python/graphforge/_project_skills/** text eol=lf
+/packages/cli/project-skills/** text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ _Nothing yet._
 - Package host-discoverable project-local GraphForge skills from one canonical
   source in both the `graphforge` wheel and `@graphforge/cli`, with
   deterministic compatibility metadata and byte-parity checks (#230).
+- Preserve LF bytes for canonical and packaged project skills on Windows
+  checkouts so release-candidate wheels satisfy their recorded SHA-256 digests
+  (#259).
 - Add byte-for-byte equivalent `graphforge` wheel and `@graphforge/cli` npm
   entry points backed by the same Rust CLI parser, execution, structured errors,
   output, and exit codes, with packed clean-install `uvx`/offline `npx`

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -40,6 +40,9 @@ _Nothing yet._
 - Package host-discoverable project-local GraphForge skills from one canonical
   source in both the `graphforge` wheel and `@graphforge/cli`, with
   deterministic compatibility metadata and byte-parity checks (#230).
+- Preserve LF bytes for canonical and packaged project skills on Windows
+  checkouts so release-candidate wheels satisfy their recorded SHA-256 digests
+  (#259).
 - Add byte-for-byte equivalent `graphforge` wheel and `@graphforge/cli` npm
   entry points backed by the same Rust CLI parser, execution, structured errors,
   output, and exit codes, with packed clean-install `uvx`/offline `npx`

--- a/tests/unit/test_project_skill_assets.py
+++ b/tests/unit/test_project_skill_assets.py
@@ -49,6 +49,26 @@ def test_python_and_npm_payloads_are_exact_copies() -> None:
         assert packaged == canonical
 
 
+def test_digest_protected_assets_are_checked_out_with_lf_bytes() -> None:
+    protected = [
+        path.relative_to(ROOT)
+        for base in (SOURCE, PYTHON_COPY, NPM_COPY)
+        for path in base.rglob("*")
+        if path.is_file()
+    ]
+    result = subprocess.run(
+        ["git", "check-attr", "eol", "--", *(str(path) for path in protected)],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    observed = {
+        Path(line.split(": ", 2)[0]): line.rsplit(": ", 1)[1] for line in result.stdout.splitlines()
+    }
+    assert observed == dict.fromkeys(protected, "lf")
+
+
 def test_sync_script_is_importable_without_mutating_assets() -> None:
     spec = importlib.util.spec_from_file_location(
         "sync_project_skills", ROOT / "scripts" / "sync_project_skills.py"


### PR DESCRIPTION
## Summary

- force LF checkout semantics for every canonical and packaged project-skill asset
- regress the Git attribute contract across the complete digest-protected bundle
- preserve byte-for-byte runtime digest validation

## Validation

- `uv run pytest tests/unit/test_project_skill_assets.py -q`
- `python3 scripts/sync_project_skills.py`
- `uv run ruff check tests/unit/test_project_skill_assets.py`
- `uv run ruff format --check tests/unit/test_project_skill_assets.py`
- `python3 scripts/ci/test-release-publish-preflight.py`

Closes #259.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788126158&installation_model_id=20486&pr_number=261&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F261&signature=af69b8e75f02e2b68f5e1b205f1fa0d17899309691528db49e3cc42e642113c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve LF line endings for project skill assets on Windows checkouts
> - Adds `.gitattributes` rules forcing `eol=lf` for files under `project-skills/`, `crates/gf-bindings-py/python/graphforge/_project_skills/`, and `packages/cli/project-skills/` so SHA-256 digests remain valid on Windows.
> - Adds a unit test in [`tests/unit/test_project_skill_assets.py`](https://github.com/CurateLabs/graphforge/pull/261/files#diff-c045cfdf4b5885329bea136bb32012e2022f94a10c5f76c499e9ea7cc8b04c0e) that runs `git check-attr eol` on all protected asset paths and asserts each reports `lf`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c0ae14.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->