### PR TITLE
fix(ci): transfer binding evidence across platforms

### DIFF
--- a/.github/workflows/binding-release-candidate.yml
+++ b/.github/workflows/binding-release-candidate.yml
@@ -161,11 +161,12 @@ jobs:
           cp "$PYTHON_RC_EVIDENCE_DIR/${{ matrix.target }}.json" binding-rc-reports/
 
       - name: Save Python report for aggregate job
-        uses: actions/cache/save@v6
+        uses: actions/upload-artifact@v7
         with:
-          path: binding-rc-reports
-          key: binding-rc-transfer-${{ github.run_id }}-${{ matrix.target }}
-          enableCrossOsArchive: true
+          name: binding-rc-report-${{ github.run_id }}-${{ matrix.target }}
+          path: binding-rc-reports/${{ matrix.target }}.json
+          if-no-files-found: error
+          retention-days: 1
 
   node:
     name: Node RC (${{ matrix.target }})
@@ -331,11 +332,12 @@ jobs:
           cp "crates/gf-bindings-node/${{ matrix.report_target }}.json" binding-rc-reports/
 
       - name: Save Node report for aggregate job
-        uses: actions/cache/save@v6
+        uses: actions/upload-artifact@v7
         with:
-          path: binding-rc-reports
-          key: binding-rc-transfer-${{ github.run_id }}-${{ matrix.report_target }}
-          enableCrossOsArchive: true
+          name: binding-rc-report-${{ github.run_id }}-${{ matrix.report_target }}
+          path: binding-rc-reports/${{ matrix.report_target }}.json
+          if-no-files-found: error
+          retention-days: 1
 
   aggregate:
     name: Aggregate binding RC evidence
@@ -350,62 +352,12 @@ jobs:
         with:
           ref: ${{ needs.validate_source.outputs.evidence_sha }}
 
-      - name: Restore Python Ubuntu report
-        uses: actions/cache/restore@v6
+      - name: Download exact-run target reports
+        uses: actions/download-artifact@v8
         with:
+          pattern: binding-rc-report-${{ github.run_id }}-*
           path: binding-rc-reports
-          key: binding-rc-transfer-${{ github.run_id }}-python-ubuntu
-          fail-on-cache-miss: true
-          enableCrossOsArchive: true
-      - name: Restore Python macOS report
-        uses: actions/cache/restore@v6
-        with:
-          path: binding-rc-reports
-          key: binding-rc-transfer-${{ github.run_id }}-python-macos
-          fail-on-cache-miss: true
-          enableCrossOsArchive: true
-      - name: Restore Python Windows report
-        uses: actions/cache/restore@v6
-        with:
-          path: binding-rc-reports
-          key: binding-rc-transfer-${{ github.run_id }}-python-windows
-          fail-on-cache-miss: true
-          enableCrossOsArchive: true
-      - name: Restore Node x86_64 macOS report
-        uses: actions/cache/restore@v6
-        with:
-          path: binding-rc-reports
-          key: binding-rc-transfer-${{ github.run_id }}-node-x86_64-apple-darwin
-          fail-on-cache-miss: true
-          enableCrossOsArchive: true
-      - name: Restore Node aarch64 macOS report
-        uses: actions/cache/restore@v6
-        with:
-          path: binding-rc-reports
-          key: binding-rc-transfer-${{ github.run_id }}-node-aarch64-apple-darwin
-          fail-on-cache-miss: true
-          enableCrossOsArchive: true
-      - name: Restore Node x86_64 Linux report
-        uses: actions/cache/restore@v6
-        with:
-          path: binding-rc-reports
-          key: binding-rc-transfer-${{ github.run_id }}-node-x86_64-unknown-linux-gnu
-          fail-on-cache-miss: true
-          enableCrossOsArchive: true
-      - name: Restore Node aarch64 Linux report
-        uses: actions/cache/restore@v6
-        with:
-          path: binding-rc-reports
-          key: binding-rc-transfer-${{ github.run_id }}-node-aarch64-unknown-linux-gnu
-          fail-on-cache-miss: true
-          enableCrossOsArchive: true
-      - name: Restore Node Windows report
-        uses: actions/cache/restore@v6
-        with:
-          path: binding-rc-reports
-          key: binding-rc-transfer-${{ github.run_id }}-node-x86_64-pc-windows-msvc
-          fail-on-cache-miss: true
-          enableCrossOsArchive: true
+          merge-multiple: true
 
       - name: Validate and aggregate
         run: >-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,9 @@ _Nothing yet._
 - Remove unconsumed CI artifacts and move required cross-job transfers to
   Blacksmith-backed cache storage, eliminating GitHub artifact-quota failures
   from the required CI Gate (#205).
+- Use one-day GitHub artifacts only for cross-OS binding release-candidate JSON
+  reports after colocated caches proved unreliable across runner platforms;
+  ordinary CI artifacts and publication bytes remain prohibited (#260).
 - Restore local multi-surface coverage via `make coverage`: Rust (`cargo llvm-cov` →
   `build/coverage-rust/`), Python wrapper (`pytest-cov` on
   `crates/gf-bindings-py/python/graphforge`), and Node (`c8` on `@graphforge/node`

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -82,6 +82,9 @@ _Nothing yet._
 - Remove unconsumed CI artifacts and move required cross-job transfers to
   Blacksmith-backed cache storage, eliminating GitHub artifact-quota failures
   from the required CI Gate (#205).
+- Use one-day GitHub artifacts only for cross-OS binding release-candidate JSON
+  reports after colocated caches proved unreliable across runner platforms;
+  ordinary CI artifacts and publication bytes remain prohibited (#260).
 - Restore local multi-surface coverage via `make coverage`: Rust (`cargo llvm-cov` →
   `build/coverage-rust/`), Python wrapper (`pytest-cov` on
   `crates/gf-bindings-py/python/graphforge`), and Node (`c8` on `@graphforge/node`

--- a/scripts/ci/test-binding-release-candidate.py
+++ b/scripts/ci/test-binding-release-candidate.py
@@ -132,7 +132,7 @@ def validate_python_evidence_policy(workflow_text: str) -> None:
     native_step = "Clean-install and execute native contract"
     write_step = "Write target evidence"
     stage_step = "Stage Python report for aggregate job"
-    transfer_step = "uses: actions/cache/save@v6"
+    transfer_step = "uses: actions/upload-artifact@v7"
     assert workflow_text.count(prepare_step) == 1
     python_job = required_section(workflow_text, "  python:\n", "  node:\n")
     assert (
@@ -195,8 +195,10 @@ def validate_python_evidence_policy(workflow_text: str) -> None:
     assert_active_lines(
         transfer,
         transfer_step,
-        "path: binding-rc-reports",
-        "key: binding-rc-transfer-${{ github.run_id }}-${{ matrix.target }}",
+        "name: binding-rc-report-${{ github.run_id }}-${{ matrix.target }}",
+        "path: binding-rc-reports/${{ matrix.target }}.json",
+        "if-no-files-found: error",
+        "retention-days: 1",
     )
     for forbidden in ("chmod", "chown", "continue-on-error", "|| true", "retry"):
         assert forbidden not in post_maturin.lower()
@@ -231,11 +233,14 @@ def validate_windows_node_cold_start_policy(workflow_text: str) -> None:
 
     assert "actions/cache@v6" not in node_job
     assert "actions/cache/restore@v6" not in node_job
-    assert node_job.count("actions/cache/save@v6") == 1
+    assert "actions/cache/save@v6" not in node_job
+    assert node_job.count("actions/upload-artifact@v7") == 1
     assert_active_lines(
         node_job,
-        "path: binding-rc-reports",
-        "key: binding-rc-transfer-${{ github.run_id }}-${{ matrix.report_target }}",
+        "name: binding-rc-report-${{ github.run_id }}-${{ matrix.report_target }}",
+        "path: binding-rc-reports/${{ matrix.report_target }}.json",
+        "if-no-files-found: error",
+        "retention-days: 1",
     )
     assert "Restore Windows Node Cargo build state" not in node_job
     assert node_job.index("uses: dtolnay/rust-toolchain@master") < node_job.index(
@@ -266,6 +271,10 @@ def validate_windows_node_cold_start_policy(workflow_text: str) -> None:
     )
     assert_active_lines(
         aggregate,
+        "uses: actions/download-artifact@v8",
+        "pattern: binding-rc-report-${{ github.run_id }}-*",
+        "path: binding-rc-reports",
+        "merge-multiple: true",
         "python3 scripts/ci/validate-binding-release-candidate.py",
     )
     assert "continue-on-error" not in aggregate.lower()
@@ -435,7 +444,7 @@ def main() -> None:
     prepare_marker = "Prepare writable Python RC evidence directory"
     native_marker = "Clean-install and execute native contract"
     write_marker = "Write target evidence"
-    transfer_marker = "uses: actions/cache/save@v6"
+    transfer_marker = "uses: actions/upload-artifact@v7"
     for marker, active_line in (
         (
             prepare_marker,
@@ -470,7 +479,7 @@ def main() -> None:
         (write_marker, '--output "$PYTHON_RC_EVIDENCE_DIR/${{ matrix.target }}.json"'),
         (
             transfer_marker,
-            "path: binding-rc-reports",
+            "path: binding-rc-reports/${{ matrix.target }}.json",
         ),
     ):
         prefix, marker_found, remainder = rc_workflow_text.partition(marker)
@@ -490,7 +499,7 @@ def main() -> None:
         "Prepare writable Python RC evidence directory",
         "Clean-install and execute native contract",
         "Write target evidence",
-        "uses: actions/cache/save@v6",
+        "uses: actions/upload-artifact@v7",
     ):
         rejected_python_evidence_policy(rc_workflow_text.replace(marker, "", 1))
     wrapper_step = "Prepare Rust compiler wrapper for native contracts"

--- a/scripts/ci/test-ci-storage-policy.py
+++ b/scripts/ci/test-ci-storage-policy.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Enforce Blacksmith-only, consumer-driven CI transfer storage."""
+"""Enforce bounded, consumer-driven CI transfer storage."""
 
 from __future__ import annotations
 
@@ -8,7 +8,13 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOWS = ROOT / ".github" / "workflows"
-FORBIDDEN = ("actions/upload-artifact@", "actions/download-artifact@", "retention-days:")
+EXPECTED_ARTIFACT_UPLOADS = Counter(
+    {
+        "binding-rc-report-${{ github.run_id }}-${{ matrix.target }}": 1,
+        "binding-rc-report-${{ github.run_id }}-${{ matrix.report_target }}": 1,
+    }
+)
+EXPECTED_ARTIFACT_DOWNLOADS = Counter({"binding-rc-report-${{ github.run_id }}-*": 1})
 EXPECTED_DEPENDENCY_KEYS = Counter(
     {
         "${{ runner.os }}-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}": 7,
@@ -30,8 +36,6 @@ EXPECTED_STICKY_DELETES = Counter(
 )
 EXPECTED_SAVES = Counter(
     {
-        "binding-rc-transfer-${{ github.run_id }}-${{ matrix.target }}": 1,
-        "binding-rc-transfer-${{ github.run_id }}-${{ matrix.report_target }}": 1,
         "binding-release-candidate-${{ needs.validate_source.outputs.evidence_sha }}": 1,
         "checkpoint-transfer-${{ github.run_id }}-rust": 1,
         "checkpoint-transfer-${{ github.run_id }}-python": 1,
@@ -51,14 +55,6 @@ EXPECTED_SAVES = Counter(
 )
 EXPECTED_RESTORES = Counter(
     {
-        "binding-rc-transfer-${{ github.run_id }}-python-ubuntu": 1,
-        "binding-rc-transfer-${{ github.run_id }}-python-macos": 1,
-        "binding-rc-transfer-${{ github.run_id }}-python-windows": 1,
-        "binding-rc-transfer-${{ github.run_id }}-node-x86_64-apple-darwin": 1,
-        "binding-rc-transfer-${{ github.run_id }}-node-aarch64-apple-darwin": 1,
-        "binding-rc-transfer-${{ github.run_id }}-node-x86_64-unknown-linux-gnu": 1,
-        "binding-rc-transfer-${{ github.run_id }}-node-aarch64-unknown-linux-gnu": 1,
-        "binding-rc-transfer-${{ github.run_id }}-node-x86_64-pc-windows-msvc": 1,
         "binding-release-candidate-${{ needs.validate_source.outputs.evidence_sha }}": 1,
         "checkpoint-transfer-${{ github.run_id }}-rust": 1,
         "checkpoint-transfer-${{ github.run_id }}-python": 1,
@@ -122,11 +118,44 @@ def cache_steps(text: str) -> list[list[str]]:
 
 
 def field(step: list[str], name: str) -> str | None:
-    for line in step:
+    for line in reversed(step):
         stripped = line.strip().removeprefix("- ")
         if stripped.startswith(name + ":"):
             return stripped.split(":", 1)[1].strip().strip("'\"")
     return None
+
+
+def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
+    uploaded: list[str] = []
+    downloaded: list[str] = []
+    for step in action_steps(text, "actions/upload-artifact@"):
+        uses = field(step, "uses")
+        assert uses == "actions/upload-artifact@v7", f"unapproved artifact action: {uses}"
+        name = field(step, "name")
+        assert name is not None, "artifact upload has no exact name"
+        assert field(step, "if-no-files-found") == "error", (
+            f"artifact upload is not fail-closed: {name}"
+        )
+        assert field(step, "retention-days") == "1", f"artifact retention is not one day: {name}"
+        path = field(step, "path")
+        assert path in {
+            "binding-rc-reports/${{ matrix.target }}.json",
+            "binding-rc-reports/${{ matrix.report_target }}.json",
+        }, f"artifact upload contains unapproved bytes: {path}"
+        uploaded.append(name)
+    for step in action_steps(text, "actions/download-artifact@"):
+        uses = field(step, "uses")
+        assert uses == "actions/download-artifact@v8", f"unapproved artifact action: {uses}"
+        pattern = field(step, "pattern")
+        assert pattern is not None, "artifact download has no exact-run pattern"
+        assert field(step, "path") == "binding-rc-reports", (
+            f"artifact download path drift: {pattern}"
+        )
+        assert field(step, "merge-multiple") == "true", (
+            f"artifact reports are not merged: {pattern}"
+        )
+        downloaded.append(pattern)
+    return uploaded, downloaded
 
 
 def cache_contracts(text: str) -> tuple[list[str], list[str]]:
@@ -207,16 +236,18 @@ def validate_test_suite_trigger(text: str) -> None:
 def main() -> None:
     texts = {path: path.read_text(encoding="utf-8") for path in sorted(WORKFLOWS.glob("*.y*ml"))}
     validate_test_suite_trigger(texts[WORKFLOWS / "test.yml"])
-    for path, text in texts.items():
-        for forbidden in FORBIDDEN:
-            assert forbidden not in text, f"{path.relative_to(ROOT)} uses {forbidden}"
 
+    artifact_uploads: list[str] = []
+    artifact_downloads: list[str] = []
     saved: list[str] = []
     restored: list[str] = []
     dependency_keys: list[str] = []
     sticky_keys: list[str] = []
     sticky_deletes: list[str] = []
     for text in texts.values():
+        file_uploads, file_downloads = artifact_contracts(text)
+        artifact_uploads.extend(file_uploads)
+        artifact_downloads.extend(file_downloads)
         file_saves, file_restores = cache_contracts(text)
         saved.extend(file_saves)
         restored.extend(file_restores)
@@ -225,15 +256,23 @@ def main() -> None:
         sticky_keys.extend(file_sticky)
         sticky_deletes.extend(file_deletes)
         validate_maturin_storage(text)
+    assert Counter(artifact_uploads) == EXPECTED_ARTIFACT_UPLOADS, (
+        "CI artifact producer contract drift"
+    )
+    assert Counter(artifact_downloads) == EXPECTED_ARTIFACT_DOWNLOADS, (
+        "CI artifact consumer contract drift"
+    )
     assert Counter(saved) == EXPECTED_SAVES, "CI transfer producer contract drift"
     assert Counter(restored) == EXPECTED_RESTORES, "CI transfer consumer contract drift"
     assert Counter(dependency_keys) == EXPECTED_DEPENDENCY_KEYS, "dependency cache contract drift"
     assert Counter(sticky_keys) == EXPECTED_STICKY_KEYS, "sticky-disk contract drift"
     assert Counter(sticky_deletes) == EXPECTED_STICKY_DELETES, "sticky-disk cleanup contract drift"
     print(
-        f"CI storage policy passed: {len(saved)} transfer producers, {len(restored)} consumers, "
+        f"CI storage policy passed: {len(artifact_uploads)} bounded artifact producers, "
+        f"{len(artifact_downloads)} consumer, {len(saved)} cache transfer producers, "
+        f"{len(restored)} consumers, "
         f"{len(dependency_keys)} dependency caches, {len(sticky_keys)} bounded sticky disks, "
-        "zero retained GitHub artifacts"
+        "one-day binding-report artifact retention"
     )
 
 


### PR DESCRIPTION
## Summary

- replace Blacksmith colocated-cache handoff for binding RC target reports with run-scoped GitHub artifacts
- retain only the tiny target JSON reports for one day and download them fail-closed into the existing aggregate validator
- keep ordinary artifacts and publication bytes prohibited through the repository storage-policy ledger

## Validation

- `python3 scripts/ci/test-binding-release-candidate.py`
- `python3 scripts/ci/test-ci-storage-policy.py`
- `python3 scripts/ci/test-release-publish-preflight.py`
- `scripts/check-workflows.sh`
- `uv run ruff check scripts/ci/test-binding-release-candidate.py scripts/ci/test-ci-storage-policy.py`
- `uv run ruff format --check scripts/ci/test-binding-release-candidate.py scripts/ci/test-ci-storage-policy.py`

Closes #260.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788126399&installation_model_id=20486&pr_number=262&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F262&signature=26e3613a578f2482f7654bd853d8598c511da1c66f5d49c52ab278b3e4b37604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace cache-based report transfer with GitHub artifacts in binding release candidate CI
> - Replaces `actions/cache/save@v6` and `actions/cache/restore@v6` with `actions/upload-artifact@v7` and `actions/download-artifact@v8` for transferring binding RC JSON reports across platforms, as cross-OS runner caches are unreliable.
> - Python and Node jobs each upload a single JSON report as a short-lived artifact (1-day retention) keyed by `run_id` and matrix target.
> - The aggregate job downloads all matching artifacts via a `binding-rc-report-${{ github.run_id }}-*` pattern with `merge-multiple: true`.
> - The CI storage policy test in [test-ci-storage-policy.py](https://github.com/CurateLabs/graphforge/pull/262/files#diff-855ed98597547ac200b4015777e47aa99dda2b0ac141e95ffab9c0d96e87c1a0) is updated to explicitly allow and validate this bounded artifact usage while disallowing the old cache-based transfer.
> - Behavioral Change: binding RC report transfer now uses GitHub artifact storage instead of the cache API; `if-no-files-found: error` makes missing reports a hard failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 038afde.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->