### PR TITLE
fix(ci): stabilize text bytes across platforms

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
+* text=auto eol=lf
+
 /.github/workflows/test.yml text eol=lf
 /crates/gf-bindings-node/package.json text eol=lf
 /crates/gf-bindings-node/tests/*.mjs text eol=lf

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Test changed-path classifier
         run: scripts/ci/test-classify-changes.sh
 
+      - name: Test text checkout byte policy
+        run: python3 scripts/ci/test-text-checkout-policy.py
+
       - name: Test aggregate merge gate
         run: scripts/ci/test-require-gates.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ _Nothing yet._
 - Preserve LF bytes for canonical and packaged project skills on Windows
   checkouts so release-candidate wheels satisfy their recorded SHA-256 digests
   (#259).
+- Make tracked text checkout bytes LF-stable across platforms so Windows
+  release gates compare configuration, ontology, manifest, and checksum
+  fixtures without newline conversion (#263).
 - Add byte-for-byte equivalent `graphforge` wheel and `@graphforge/cli` npm
   entry points backed by the same Rust CLI parser, execution, structured errors,
   output, and exit codes, with packed clean-install `uvx`/offline `npx`

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -43,6 +43,9 @@ _Nothing yet._
 - Preserve LF bytes for canonical and packaged project skills on Windows
   checkouts so release-candidate wheels satisfy their recorded SHA-256 digests
   (#259).
+- Make tracked text checkout bytes LF-stable across platforms so Windows
+  release gates compare configuration, ontology, manifest, and checksum
+  fixtures without newline conversion (#263).
 - Add byte-for-byte equivalent `graphforge` wheel and `@graphforge/cli` npm
   entry points backed by the same Rust CLI parser, execution, structured errors,
   output, and exit codes, with packed clean-install `uvx`/offline `npx`

--- a/scripts/ci/test-text-checkout-policy.py
+++ b/scripts/ci/test-text-checkout-policy.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Require deterministic LF checkout bytes for every tracked text file."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+ROOT = Path(__file__).resolve().parents[2]
+ATTRIBUTES = ROOT / ".gitattributes"
+POLICY = "* text=auto eol=lf"
+
+
+def tracked_paths() -> list[str]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+    )
+    return [value.decode() for value in result.stdout.rstrip(b"\0").split(b"\0")]
+
+
+def resolved_attributes(paths: list[str]) -> dict[str, dict[str, str]]:
+    result = subprocess.run(
+        ["git", "check-attr", "-z", "--stdin", "text", "eol"],
+        cwd=ROOT,
+        input=b"\0".join(path.encode() for path in paths) + b"\0",
+        check=True,
+        capture_output=True,
+    )
+    fields = result.stdout.rstrip(b"\0").split(b"\0")
+    assert len(fields) % 3 == 0, "git check-attr returned a malformed response"
+    resolved: dict[str, dict[str, str]] = {}
+    for index in range(0, len(fields), 3):
+        path, attribute, value = (field.decode() for field in fields[index : index + 3])
+        resolved.setdefault(path, {})[attribute] = value
+    return resolved
+
+
+def main() -> None:
+    active = [
+        line.strip()
+        for line in ATTRIBUTES.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    assert active and active[0] == POLICY, "global LF text policy is missing or shadowed"
+
+    paths = tracked_paths()
+    assert paths, "repository has no tracked files"
+    resolved = resolved_attributes(paths)
+    assert set(resolved) == set(paths), "Git attributes did not resolve every tracked path"
+    invalid = {
+        path: values
+        for path, values in resolved.items()
+        if values.get("text") not in {"auto", "set", "unset"} or values.get("eol") != "lf"
+    }
+    assert not invalid, f"tracked paths violate LF checkout policy: {invalid}"
+    print(f"text checkout policy passed: {len(paths)} tracked paths resolve to LF")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/test-text-checkout-policy.py
+++ b/scripts/ci/test-text-checkout-policy.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 import subprocess
 
@@ -18,22 +19,27 @@ def tracked_paths() -> list[str]:
         check=True,
         capture_output=True,
     )
-    return [value.decode() for value in result.stdout.rstrip(b"\0").split(b"\0")]
+    if not result.stdout:
+        return []
+    return [os.fsdecode(value) for value in result.stdout.rstrip(b"\0").split(b"\0")]
 
 
 def resolved_attributes(paths: list[str]) -> dict[str, dict[str, str]]:
     result = subprocess.run(
         ["git", "check-attr", "-z", "--stdin", "text", "eol"],
         cwd=ROOT,
-        input=b"\0".join(path.encode() for path in paths) + b"\0",
+        input=b"\0".join(os.fsencode(path) for path in paths) + b"\0",
         check=True,
         capture_output=True,
     )
     fields = result.stdout.rstrip(b"\0").split(b"\0")
-    assert len(fields) % 3 == 0, "git check-attr returned a malformed response"
+    if len(fields) % 3 != 0:
+        raise RuntimeError("git check-attr returned a malformed response")
     resolved: dict[str, dict[str, str]] = {}
     for index in range(0, len(fields), 3):
-        path, attribute, value = (field.decode() for field in fields[index : index + 3])
+        path = os.fsdecode(fields[index])
+        attribute = fields[index + 1].decode("ascii")
+        value = fields[index + 2].decode("ascii")
         resolved.setdefault(path, {})[attribute] = value
     return resolved
 
@@ -44,18 +50,22 @@ def main() -> None:
         for line in ATTRIBUTES.read_text(encoding="utf-8").splitlines()
         if line.strip() and not line.lstrip().startswith("#")
     ]
-    assert active and active[0] == POLICY, "global LF text policy is missing or shadowed"
+    if not active or active[0] != POLICY:
+        raise RuntimeError("global LF text policy is missing or shadowed")
 
     paths = tracked_paths()
-    assert paths, "repository has no tracked files"
+    if not paths:
+        raise RuntimeError("repository has no tracked files")
     resolved = resolved_attributes(paths)
-    assert set(resolved) == set(paths), "Git attributes did not resolve every tracked path"
+    if set(resolved) != set(paths):
+        raise RuntimeError("Git attributes did not resolve every tracked path")
     invalid = {
         path: values
         for path, values in resolved.items()
         if values.get("text") not in {"auto", "set", "unset"} or values.get("eol") != "lf"
     }
-    assert not invalid, f"tracked paths violate LF checkout policy: {invalid}"
+    if invalid:
+        raise RuntimeError(f"tracked paths violate LF checkout policy: {invalid}")
     print(f"text checkout policy passed: {len(paths)} tracked paths resolve to LF")
 
 


### PR DESCRIPTION
## Summary

- enforce automatic text detection with LF checkout bytes repository-wide
- audit every tracked path in Repository Policy so byte-sensitive release fixtures cannot silently drift on Windows
- retain strict runtime digest and golden-byte comparisons without normalizing them in code

## Validation

- `python3 scripts/ci/test-text-checkout-policy.py`
- `python3 scripts/ci/test-ci-storage-policy.py`
- `python3 scripts/ci/test-binding-release-candidate.py`
- `python3 scripts/sync_project_skills.py`
- `uv run pytest tests/unit/test_project_skill_assets.py -q`
- `scripts/check-workflows.sh`
- `python3 scripts/ci/test-release-publish-preflight.py`
- `git add --renormalize .` produced no content-only rewrites

Closes #263.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788127981&installation_model_id=20486&pr_number=264&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F264&signature=09ea72ba599072b7fa15d2dea8077d431c341710eef21955359e2fbd3259f5c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce LF line endings for all tracked text files across platforms in CI
> - Adds `* text=auto eol=lf` to [.gitattributes](https://github.com/CurateLabs/graphforge/pull/264/files#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393e) to ensure all tracked text files check out with LF endings on all platforms, including Windows.
> - Adds [scripts/ci/test-text-checkout-policy.py](https://github.com/CurateLabs/graphforge/pull/264/files#diff-5cb206ea1dc2fd1443d9c3e411c174e15829674900b5746fd212b10dec32d098), a script that validates the `.gitattributes` policy line and checks every tracked file's resolved `text` and `eol` attributes via `git check-attr`.
> - Wires the new script into the `policy` job in [.github/workflows/test.yml](https://github.com/CurateLabs/graphforge/pull/264/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88) as a required CI step.
> - Behavioral Change: Windows checkouts will now receive LF line endings instead of CRLF for all tracked text files.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6332747.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized repository text files to use LF line endings.
  * Enabled automatic text-file detection.

* **Tests**
  * Added automated validation to ensure tracked files follow the repository’s text checkout policy.
  * Added checks for missing or conflicting line-ending attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->