### PR TITLE
fix(storage): close handles before Windows optimistic promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ _Nothing yet._
 - Make tracked text checkout bytes LF-stable across platforms so Windows
   release gates compare configuration, ontology, manifest, and checksum
   fixtures without newline conversion (#263).
+- Close staged lease and manifest file handles before optimistic generation
+  promotion so Windows can atomically rename the durable directory (#265).
 - Add byte-for-byte equivalent `graphforge` wheel and `@graphforge/cli` npm
   entry points backed by the same Rust CLI parser, execution, structured errors,
   output, and exit codes, with packed clean-install `uvx`/offline `npx`

--- a/crates/gf-storage/src/project_publication.rs
+++ b/crates/gf-storage/src/project_publication.rs
@@ -901,6 +901,10 @@ fn make_generation_durable(staged: &StagedProjectGeneration) -> Result<[u8; 32],
         .open(&lease_path)
         .map_err(publication_io)?;
     lease.sync_all().map_err(publication_io)?;
+    // Windows rejects a parent-directory rename while a descendant file handle
+    // is still live. The transaction lock, not this newly created lease file,
+    // owns the staged attempt, so release the handle after its durability sync.
+    drop(lease);
 
     let manifest = GenerationManifestRecord {
         format: "graphforge-generation".into(),
@@ -929,6 +933,9 @@ fn make_generation_durable(staged: &StagedProjectGeneration) -> Result<[u8; 32],
         false,
     )?;
     manifest_file.sync_all().map_err(publication_io)?;
+    // Optimistic publication promotes the complete staging directory below.
+    // Close the manifest handle before that rename for Windows parity.
+    drop(manifest_file);
     project_failpoint::hit(
         "project.after_manifest_fsync",
         Some(staged.transaction_uuid),
@@ -2199,6 +2206,32 @@ mod tests {
                 .unwrap()
                 .generation_uuid(),
             second.generation_uuid
+        );
+    }
+
+    #[test]
+    fn optimistic_promotion_closes_staged_handles_before_directory_rename() {
+        let root = project();
+        let request = request(vec![participant("graph", "nodes", b"promoted")]);
+        let generation_uuid = request.generation_uuid;
+        let operation: [u8; 32] = Sha256::digest(b"windows-promotion-handles").into();
+
+        let ProjectStageOutcome::Staged(staged) =
+            stage_project_generation_optimistic(root.path(), &request, operation).unwrap()
+        else {
+            panic!("optimistic operation replayed unexpectedly");
+        };
+        staged
+            .validate(|_| Ok(()), |_, _| Ok(()))
+            .unwrap()
+            .publish()
+            .unwrap();
+
+        assert_eq!(
+            resolve_project_generation(root.path())
+                .unwrap()
+                .generation_uuid(),
+            generation_uuid
         );
     }
 

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -46,6 +46,8 @@ _Nothing yet._
 - Make tracked text checkout bytes LF-stable across platforms so Windows
   release gates compare configuration, ontology, manifest, and checksum
   fixtures without newline conversion (#263).
+- Close staged lease and manifest file handles before optimistic generation
+  promotion so Windows can atomically rename the durable directory (#265).
 - Add byte-for-byte equivalent `graphforge` wheel and `@graphforge/cli` npm
   entry points backed by the same Rust CLI parser, execution, structured errors,
   output, and exit codes, with packed clean-install `uvx`/offline `npx`


### PR DESCRIPTION
## Summary

- close the newly durable lease and manifest handles before promoting an optimistic staged generation
- preserve the transaction-lock and durability ordering while allowing the parent-directory rename on Windows
- add a focused optimistic-promotion regression and record the v0.5.0 fix

## Root cause

Binding RC run 30670531402 reached the Windows Python optimistic multi-writer contract, then `std::fs::rename` of the staged generation failed with `Access is denied (os error 5)`. The lease and manifest file handles created inside that directory were still live at promotion time.

## Validation

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/graphforge-265-target cargo clippy -p gf-storage -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/graphforge-265-target cargo test -p gf-storage` (301 unit tests passed, 1 ignored subprocess helper; 41 integration tests passed)
- `python3 scripts/ci/test-text-checkout-policy.py` (1,618 tracked paths)
- root and docs changelogs are byte-identical

Closes #265

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788130877&installation_model_id=20486&pr_number=266&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F266&signature=f06f8c1d29ce474003f1c5530ff1b7c9b26f91e97cbcc48ca4f1f8f39e8b263d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Close staged file handles before optimistic directory rename in `make_generation_durable`
> On Windows, a directory cannot be atomically renamed while descendant file handles remain open. In [`make_generation_durable`](https://github.com/CurateLabs/graphforge/pull/266/files#diff-2251b90e0879846b0169bbadcb1d96eba3d8626a73302c7a484349f919acb4df), the staged lease handle and generation manifest handle are now explicitly dropped after fsyncing, before the optimistic promotion renames the staging directory.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b03d3e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->