### PR TITLE
fix(release): align artifact records with M1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ _Nothing yet._
   fixtures without newline conversion (#263).
 - Close staged lease and manifest file handles before optimistic generation
   promotion so Windows can atomically rename the durable directory (#265).
+- Emit v0.5.0 artifact records with current M1, release, and legal tracker
+  lineage instead of retired pre-migration issue references (#267).
 - Add byte-for-byte equivalent `graphforge` wheel and `@graphforge/cli` npm
   entry points backed by the same Rust CLI parser, execution, structured errors,
   output, and exit codes, with packed clean-install `uvx`/offline `npx`

--- a/docs/development/release-artifact-record.md
+++ b/docs/development/release-artifact-record.md
@@ -2,12 +2,12 @@
 
 This page is the §5 checklist home for **checksums, SBOM/provenance, licenses, and
 contents** of v0.5.0 release-candidate artifacts
-([#2798](https://github.com/CurateLabs/graphforge-legecy/issues/2798)).
+([M1 #192](https://github.com/CurateLabs/graphforge/issues/192)).
 
 It does **not** replace the authoritative publication order / stop conditions in
-[`publication-order.md`](publication-order.md) ([#2801](https://github.com/CurateLabs/graphforge-legecy/issues/2801) / [#2820](https://github.com/CurateLabs/graphforge-legecy/pull/2820)).
+[`publication-order.md`](publication-order.md).
 
-## Same-tagged-commit rule ([#2797](https://github.com/CurateLabs/graphforge-legecy/issues/2797))
+## Same-tagged-commit rule
 
 Every first-party publishable artifact for version `0.5.0` must be built from one
 verified commit (the eventual `v0.5.0` tag target) or have an explicit reproducible
@@ -16,7 +16,7 @@ commits under the same version.
 
 ## How to record
 
-1. Freeze the RC SHA and surface versions (`scripts/set_release_version.py` / #2796).
+1. Freeze the RC SHA and surface versions (`scripts/set_release_version.py` / #192).
 2. Build or collect artifacts for that SHA into a directory (wheels, sdists, npm
    tarballs, SBOM/provenance if emitted). v0.5.0 has no crates.io artifacts.
 3. Run:
@@ -29,8 +29,8 @@ python3 scripts/record_release_artifacts.py \
   --notes "RC sha=<40-char> built via <workflow/run>"
 ```
 
-4. Attach the JSON (or its checksums table) to the GitHub Release at §6 (#2794).
-5. §7 clean-env verification matches `sha256` values from this record.
+4. Attach the JSON (or its checksums table) to the GitHub Release (#194).
+5. Post-release clean-env verification (#167) matches `sha256` values from this record.
 
 The generated document uses the same `graphforge-release-record-v1` schema
 consumed by `clean-env-verify.py`. Validate it before attaching:
@@ -53,8 +53,7 @@ python3 scripts/record_release_artifacts.py \
 ## License / third-party pointers
 
 - First-party: `Apache-2.0`, shipped `LICENSE` + `NOTICE` (`make package-license-verify` / #218).
-- Third-party inventory: [`legal/THIRD_PARTY_NOTICES.md`](../../legal/THIRD_PARTY_NOTICES.md) (#2783).
-- Do not duplicate counsel work on #2434 / #2726 here.
+- Third-party inventory: [`legal/THIRD_PARTY_NOTICES.md`](../../legal/THIRD_PARTY_NOTICES.md) (#218).
 
 ## SBOM / provenance
 

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -48,6 +48,8 @@ _Nothing yet._
   fixtures without newline conversion (#263).
 - Close staged lease and manifest file handles before optimistic generation
   promotion so Windows can atomically rename the durable directory (#265).
+- Emit v0.5.0 artifact records with current M1, release, and legal tracker
+  lineage instead of retired pre-migration issue references (#267).
 - Add byte-for-byte equivalent `graphforge` wheel and `@graphforge/cli` npm
   entry points backed by the same Rust CLI parser, execution, structured errors,
   output, and exit codes, with packed clean-install `uvx`/offline `npx`

--- a/scripts/ci/clean-env-verify.py
+++ b/scripts/ci/clean-env-verify.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Post-publication clean-environment verification (#2795 / #742 section 7).
+"""Post-publication clean-environment verification (#167 / M1 #192).
 
 Fails closed when public registry artifacts for the requested version are
 missing. Never treats unpublished packages as success.

--- a/scripts/record_release_artifacts.py
+++ b/scripts/record_release_artifacts.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Record checksums and a contents inventory for release-candidate artifacts.
 
-Builds a JSON record suitable for GitHub Release notes (#742 §6) and clean-env
-checksum matching (#742 §7). Does not create the GitHub Release.
+Builds a JSON record suitable for the M1 release close (#192), the GitHub
+Release outcome (#194), and post-release clean-env checksum matching (#167).
+Does not create the GitHub Release.
 
 Usage:
     python3 scripts/record_release_artifacts.py \\
@@ -133,7 +134,7 @@ def build_record(
             "first_party_spdx": "Apache-2.0",
             "license_files": ["LICENSE", "NOTICE"],
             "third_party_notices": "legal/THIRD_PARTY_NOTICES.md",
-            "related_issues": ["#2783", "#2799"],
+            "related_issues": ["#218", "#200"],
         },
         "artifacts": artifacts,
         "contents_summary": {
@@ -151,8 +152,8 @@ def build_record(
         "links": {
             "publishing": "docs/engineering/PUBLISHING.md",
             "third_party": "legal/THIRD_PARTY_NOTICES.md",
-            "parent_tracker": "#2793",
-            "execution_tracker": "#2794",
+            "parent_tracker": "#192",
+            "execution_tracker": "#194",
         },
     }
 

--- a/tests/unit/test_record_release_artifacts.py
+++ b/tests/unit/test_record_release_artifacts.py
@@ -24,6 +24,9 @@ def test_classify_and_hash(tmp_path: Path) -> None:
     assert record["tag"] == "v0.5.0"
     assert len(record["commit_sha"]) == 40
     assert record["licenses"]["first_party_spdx"] == "Apache-2.0"
+    assert record["licenses"]["related_issues"] == ["#218", "#200"]
+    assert record["links"]["parent_tracker"] == "#192"
+    assert record["links"]["execution_tracker"] == "#194"
     assert record["contents_summary"]["total_artifacts"] == 1
     assert record["artifacts"][0]["class"] == "python-wheel"
     assert record["artifacts"][0]["surface"] == "pypi"
@@ -32,6 +35,9 @@ def test_classify_and_hash(tmp_path: Path) -> None:
     assert record["artifacts"][0]["filename"] == wheel.name
     assert len(record["artifacts"][0]["sha256"]) == 64
     assert "same_tagged_commit_policy" in record
+    serialized = json.dumps(record)
+    for retired_tracker in ("#742", "#2783", "#2793", "#2794", "#2799"):
+        assert retired_tracker not in serialized
 
 
 def test_cli_writes_json(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- replace retired legacy tracker IDs in `graphforge-release-record-v1` output with current M1 #192, GitHub Release #194, and legal #218/#200 lineage
- align the artifact-record guide and post-release verifier description with #192/#194/#167
- add regression assertions that current records cannot silently reintroduce the retired tracker set

## Validation

- `uv run pytest tests/unit/test_record_release_artifacts.py -q` (2 passed)
- `uv run ruff check scripts/record_release_artifacts.py scripts/ci/clean-env-verify.py tests/unit/test_record_release_artifacts.py`
- generated an exact v0.5.0 test record and validated it with `clean-env-verify.py validate-release-record`
- verified generated JSON contains none of `#742/#2783/#2793/#2794/#2799`
- `python3 scripts/ci/test-text-checkout-policy.py` (1,618 tracked paths)
- root and docs changelogs are byte-identical

Closes #267

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788133714&installation_model_id=20486&pr_number=268&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F268&signature=6573a32bb3c0ca8cd9b15e580e5985e5e87d37dfa457150be3801143149ee7ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update release artifact records to reference current M1 tracker issues
> - Updates static tracker references in [`scripts/record_release_artifacts.py`](https://github.com/CurateLabs/graphforge/pull/268/files#diff-016f5fae813a6c738c68837730de16fd08f8249f510e5461a6d6ed982a58b0a3): `licenses.related_issues` changes from `['#2783', '#2799']` to `['#218', '#200']`, `links.parent_tracker` from `#2793` to `#192`, and `links.execution_tracker` from `#2794` to `#194`.
> - Updates docstrings in [`scripts/ci/clean-env-verify.py`](https://github.com/CurateLabs/graphforge/pull/268/files#diff-e3d9e60251ea05fe4384401a204098ca35bef1d9b322b0fd3a0039637ae0df81) and `record_release_artifacts.py` to reference current M1 issue numbers instead of retired pre-migration ones.
> - Adds unit test assertions in [`tests/unit/test_record_release_artifacts.py`](https://github.com/CurateLabs/graphforge/pull/268/files#diff-9925f79a4a1dd2fc2c2b487ada6bd2946290d96fe008c59723a6e75235464eda) to enforce current references and verify that retired tracker IDs (`#742`, `#2783`, `#2793`, `#2794`, `#2799`) do not appear in generated JSON.
> - Updates release process documentation and changelog to reflect the new lineage.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b3895ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded release artifact coverage to verify tracker links, parent metadata, and removal of retired references.

* **Documentation**
  * Updated issue and tracking references in release artifact documentation and verification materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->