### PR TITLE
release: preserve exact M1 publication candidate

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,14 +2,15 @@
 
 GraphForge uses one stable required `CI Gate`. A deterministic classifier runs
 only the policy, language, and binding jobs relevant to the pull request.
-Release certification remains in `publish.yaml`.
+Release certification is manual and SHA-bound; `publish.yaml` consumes its
+retained candidate only after a GitHub Release is published.
 
 Linux jobs run on the pinned `blacksmith-4vcpu-ubuntu-2404` image. Native PR
 jobs use Blacksmith sticky disks for job-isolated Cargo `target/` directories,
 while registry and pnpm dependencies use the colocated cache through upstream
 `actions/cache@v6` and `actions/setup-node@v6`. Cargo-lock changes create fresh
-sticky disks; inactive disks expire under Blacksmith's retention policy. The
-M22 host-native load matrix also mounts a sticky `target/` so maturin, Cargo,
+sticky disks; inactive disks expire under Blacksmith's retention policy.
+The M1 host-native release load matrix also mounts a sticky `target/` so maturin, Cargo,
 and napi share one build volume instead of a second root-disk tree.
 
 ## Pull-request contract
@@ -115,7 +116,7 @@ reports without rebuilding the same surfaces on every pull request. Green runs
 are not close criteria for child or construction issues that already met their
 acceptance criteria on ordinary CI.
 
-### `m22-non-cypher-surface-gate.yml`
+### `m1-release-certification.yml`
 
 A maintainer manually dispatches this **release-certification** workflow with
 the exact current `main` SHA and the successful Rust-surface and Binding RC run
@@ -125,18 +126,20 @@ duplicate, or expired component artifacts before any native build. One Linux
 release-machine job then builds one same-SHA Rust probe, Python wheel, and Node
 addon and executes the existing 144-case XS-XL matrix. The final job revalidates
 the Rust, binding, and load ledgers and uploads one
-`M22-Non-Cypher-Surface-Gate-<sha>` artifact. The workflow is manual-only,
+`M1-Release-Certification-<sha>` artifact. The workflow is manual-only,
 non-publishing, and cancels an obsolete duplicate dispatch for the same SHA.
 
 The required Rust + Binding RC run IDs are an input contract for this workflow
 only. They do **not** make the cascade a close gate for child implementation or
 construction issues; those close on outcomes (see `AGENTS.md` § Issue close).
 
-### `fuzz.yml` and `publish.yaml`
+### `binding-release-candidate.yml`, `release-credential-preflight.yml`, and `publish.yaml`
 
-Fuzzing is scheduled/manual. Publishing retains the cross-platform and
-multi-version artifact matrix required for release readiness; ordinary PRs do
-not repeat that certification.
+The exact-SHA Binding RC retains tested release bytes and their checksum record
+for 30 days. Credential preflight verifies the npm/crates.io secret projections
+without publishing. The release-event workflow consumes the retained candidate,
+attaches its record, and publishes PyPI, npm, then crates.io in fail-closed order;
+ordinary PRs do not repeat that certification.
 
 ### `clean-env-verify.yml`
 

--- a/.github/workflows/binding-release-candidate.yml
+++ b/.github/workflows/binding-release-candidate.yml
@@ -168,6 +168,14 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+      - name: Save tested wheel for release-candidate assembly
+        uses: actions/upload-artifact@v7
+        with:
+          name: binding-rc-wheel-${{ github.run_id }}-${{ matrix.target }}
+          path: dist/*.whl
+          if-no-files-found: error
+          retention-days: 1
+
   node:
     name: Node RC (${{ matrix.target }})
     needs: validate_source
@@ -339,6 +347,14 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+      - name: Save tested addon for release-candidate assembly
+        uses: actions/upload-artifact@v7
+        with:
+          name: binding-rc-addon-${{ github.run_id }}-${{ matrix.target }}
+          path: crates/graphforge-bindings-node/*.node
+          if-no-files-found: error
+          retention-days: 1
+
   aggregate:
     name: Aggregate binding RC evidence
     if: always() && needs.validate_source.result == 'success'
@@ -367,8 +383,147 @@ jobs:
           --expected-sha "${{ needs.validate_source.outputs.evidence_sha }}"
           --output binding-rc-aggregate/report.json
 
-      - name: Save fail-closed aggregate for M22
+      - name: Save fail-closed aggregate for M1 certification
         uses: actions/cache/save@v6
         with:
           path: binding-rc-aggregate/report.json
           key: binding-release-candidate-${{ needs.validate_source.outputs.evidence_sha }}
+
+      - name: Retain aggregate publication evidence
+        uses: actions/upload-artifact@v7
+        with:
+          name: M1-Binding-Release-Candidate-${{ needs.validate_source.outputs.evidence_sha }}
+          path: binding-rc-aggregate/report.json
+          if-no-files-found: error
+          retention-days: 30
+
+  release_candidate:
+    name: Assemble immutable M1 release candidate
+    needs: [validate_source, aggregate]
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 90
+    env:
+      EVIDENCE_SHA: ${{ needs.validate_source.outputs.evidence_sha }}
+      CARGO_INCREMENTAL: 0
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target/release-candidate
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.validate_source.outputs.evidence_sha }}
+
+      - name: Verify immutable checkout
+        shell: bash
+        run: |
+          [[ "$EVIDENCE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          test "$(git rev-parse HEAD)" = "$EVIDENCE_SHA"
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - uses: astral-sh/setup-uv@v9.0.0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.96.0"
+
+      - name: Download exact-run tested wheels
+        uses: actions/download-artifact@v8
+        with:
+          pattern: binding-rc-wheel-${{ github.run_id }}-*
+          path: candidate/release-artifacts/python
+          merge-multiple: true
+
+      - name: Download exact-run tested Node addons
+        uses: actions/download-artifact@v8
+        with:
+          pattern: binding-rc-addon-${{ github.run_id }}-*
+          path: candidate/release-artifacts/node-addons
+          merge-multiple: true
+
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Record publication dry-runs
+        run: >-
+          python3 scripts/publish_dry_run.py
+          --surface npm,docs,python,cargo-package
+          --report candidate/release-artifacts/evidence/publication-dry-run.json
+
+      - name: Build Python source distribution
+        run: >-
+          uv run maturin sdist
+          --manifest-path crates/graphforge-bindings-py/Cargo.toml
+          --out candidate/release-artifacts/python
+
+      - name: Assemble and pack every npm package
+        shell: bash
+        run: |
+          mkdir -p candidate/release-artifacts/npm
+          mkdir -p crates/graphforge-bindings-node/artifacts
+          cp candidate/release-artifacts/node-addons/*.node \
+            crates/graphforge-bindings-node/artifacts/
+          pushd crates/graphforge-bindings-node
+          pnpm exec napi create-npm-dirs
+          pnpm exec napi artifacts --output-dir artifacts --npm-dir npm
+          python3 ../../../scripts/ci/validate-napi-artifacts.py \
+            --npm-dir npm --manifest package.json
+          pnpm exec napi pre-publish -t npm --skip-optional-publish
+          for package_dir in npm/*; do
+            npm pack "$package_dir" --ignore-scripts \
+              --pack-destination "$GITHUB_WORKSPACE/candidate/release-artifacts/npm"
+          done
+          npm pack . --ignore-scripts \
+            --pack-destination "$GITHUB_WORKSPACE/candidate/release-artifacts/npm"
+          popd
+          npm pack packages/cli --ignore-scripts \
+            --pack-destination candidate/release-artifacts/npm
+          npm pack packages/agent-skills --ignore-scripts \
+            --pack-destination candidate/release-artifacts/npm
+
+      - name: Package the complete Rust surface
+        shell: bash
+        run: |
+          mkdir -p candidate/release-artifacts/crates
+          python3 scripts/ci/crate-publish-plan.py check
+          while IFS= read -r crate; do
+            cargo package -p "$crate" --allow-dirty --no-verify
+            cp "target/release-candidate/package/${crate}-0.5.0.crate" \
+              candidate/release-artifacts/crates/
+          done < <(python3 scripts/ci/crate-publish-plan.py list)
+
+      - name: Record license and package evidence
+        run: |
+          python3 scripts/license_check.py \
+            --report candidate/release-artifacts/evidence/license-compliance-report.json
+          python3 scripts/verify_package_licenses.py \
+            --report candidate/release-artifacts/evidence/package-license-report.json
+
+      - name: Create and validate the immutable checksum record
+        run: |
+          python3 scripts/record_release_artifacts.py \
+            --version 0.5.0 \
+            --dist-dir candidate/release-artifacts \
+            --out candidate/v0.5.0-artifacts.json \
+            --notes "M1 Binding Release Candidate run $GITHUB_RUN_ID; exact SHA $EVIDENCE_SHA"
+          python3 scripts/ci/clean-env-verify.py validate-release-record \
+            candidate/v0.5.0-artifacts.json
+          python3 scripts/ci/release-candidate.py validate \
+            --record candidate/v0.5.0-artifacts.json \
+            --artifacts-dir candidate/release-artifacts \
+            --expected-sha "$EVIDENCE_SHA" \
+            --version 0.5.0
+
+      - name: Retain the release candidate for publication
+        uses: actions/upload-artifact@v7
+        with:
+          name: M1-Release-Candidate-${{ needs.validate_source.outputs.evidence_sha }}
+          path: candidate/
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/m1-release-certification.yml
+++ b/.github/workflows/m1-release-certification.yml
@@ -1,6 +1,6 @@
 # Release-certification only for #742 publication readiness.
 # Not a close gate for child implementation/construction issues (AGENTS.md).
-name: M22 Non-Cypher Surface Gate
+name: M1 Release Certification Gate
 
 on:
   workflow_dispatch:
@@ -23,7 +23,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: m22-non-cypher-${{ inputs.commit_sha }}
+  group: m1-release-certification-${{ inputs.commit_sha }}
   cancel-in-progress: true
 
 jobs:
@@ -62,7 +62,7 @@ jobs:
           mkdir -p component-validation
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUST_RUN_ID" > component-validation/rust-run.json
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$BINDING_RUN_ID" > component-validation/binding-run.json
-          python3 scripts/ci/m22-non-cypher-surface-gate.py validate-runs \
+          python3 scripts/ci/m1-release-certification.py validate-runs \
             --rust-run component-validation/rust-run.json \
             --binding-run component-validation/binding-run.json \
             --expected-sha "$EXPECTED_SHA" \
@@ -84,7 +84,7 @@ jobs:
           requested = os.environ["REQUESTED_SHA"]
           identity = requested if re.fullmatch(r"[0-9a-f]{40}", requested) else "invalid-sha"
           report = {
-              "schema": "graphforge-m22-non-cypher-surface-gate/1",
+              "schema": "graphforge-m1-release-certification/1",
               "source_sha": identity,
               "status": "failed",
               "sanitized_failure": "current-main or component-run validation failed",
@@ -129,7 +129,7 @@ jobs:
         uses: useblacksmith/stickydisk@v1
         with:
           # Per-certification workspace; cleanup_load_disk deletes it after load.
-          key: ${{ github.repository }}-m22-load-${{ inputs.commit_sha }}-target-v3
+          key: ${{ github.repository }}-m1-release-load-${{ inputs.commit_sha }}-target-v3
           path: target
       - name: Install workspace dependencies
         run: pnpm install
@@ -156,7 +156,7 @@ jobs:
         shell: bash
         run: |
           python3 scripts/ci/prepare-rustc-wrapper.py \
-            --platform m22-load-linux --contract m22-native-load-contracts
+            --platform m1-release-load-linux --contract m1-release-native-load-contracts
       - name: Prepare native load artifacts
         shell: bash
         run: |
@@ -187,9 +187,9 @@ jobs:
       - name: Execute fail-closed release load matrix
         shell: bash
         env:
-          GF_LOAD_WORK: ${{ runner.temp }}/graphforge-m22-load-work
-          GF_LOAD_OUTPUT: ${{ github.workspace }}/m22-load-evidence/report.json
-          TMPDIR: ${{ runner.temp }}/graphforge-m22-load-tmp
+          GF_LOAD_WORK: ${{ runner.temp }}/graphforge-m1-release-load-work
+          GF_LOAD_OUTPUT: ${{ github.workspace }}/m1-release-load-evidence/report.json
+          TMPDIR: ${{ runner.temp }}/graphforge-m1-release-load-tmp
         run: |
           wheels=(dist/*.whl)
           test "${#wheels[@]}" -eq 1
@@ -202,22 +202,22 @@ jobs:
       - name: Save load report for aggregate job
         uses: actions/cache/save@v6
         with:
-          path: m22-load-evidence
-          key: m22-load-${{ github.run_id }}
+          path: m1-release-load-evidence
+          key: m1-release-load-${{ github.run_id }}
 
   cleanup_load_disk:
-    name: Delete one-run M22 build disk
+    name: Delete one-run M1 certification build disk
     if: always()
     needs: load
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - name: Delete M22 build disk
+      - name: Delete M1 certification build disk
         uses: useblacksmith/stickydisk-delete@v1
         with:
-          delete-key: ${{ github.repository }}-m22-load-${{ inputs.commit_sha }}-target-v3
+          delete-key: ${{ github.repository }}-m1-release-load-${{ inputs.commit_sha }}-target-v3
 
   aggregate:
-    name: Aggregate final M22 non-Cypher evidence
+    name: Aggregate final M1 release certification evidence
     if: always() && needs.validate_source.result == 'success'
     needs: [validate_source, load, cleanup_load_disk]
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -239,7 +239,7 @@ jobs:
           mkdir -p evidence/component-validation-final
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUST_RUN_ID" > evidence/component-validation-final/rust-run.json
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$BINDING_RUN_ID" > evidence/component-validation-final/binding-run.json
-          python3 scripts/ci/m22-non-cypher-surface-gate.py validate-runs \
+          python3 scripts/ci/m1-release-certification.py validate-runs \
             --rust-run evidence/component-validation-final/rust-run.json \
             --binding-run evidence/component-validation-final/binding-run.json \
             --expected-sha "$EXPECTED_SHA" \
@@ -257,16 +257,16 @@ jobs:
       - uses: actions/cache/restore@v6
         if: needs.load.result == 'success'
         with:
-          path: m22-load-evidence
-          key: m22-load-${{ github.run_id }}
+          path: m1-release-load-evidence
+          key: m1-release-load-${{ github.run_id }}
           fail-on-cache-miss: true
       - name: Validate and aggregate every required component
         if: needs.load.result == 'success'
         run: >-
-          python3 scripts/ci/m22-non-cypher-surface-gate.py aggregate
+          python3 scripts/ci/m1-release-certification.py aggregate
           --rust-report non-cypher-evidence/report.json
           --binding-report binding-rc-aggregate/report.json
-          --load-report m22-load-evidence/report.json
+          --load-report m1-release-load-evidence/report.json
           --run-validation evidence/component-validation-final/report.json
           --expected-sha "${{ needs.validate_source.outputs.evidence_sha }}"
           --load-run-id "${{ github.run_id }}"
@@ -282,7 +282,7 @@ jobs:
           python3 - <<'PY'
           import json, os
           report = {
-              "schema": "graphforge-m22-non-cypher-surface-gate/1",
+              "schema": "graphforge-m1-release-certification/1",
               "source_sha": os.environ["SOURCE_SHA"],
               "status": "failed",
               "sanitized_failure": "load job did not succeed: " + os.environ["LOAD_RESULT"],

--- a/.github/workflows/non-cypher-surface-gate.yml
+++ b/.github/workflows/non-cypher-surface-gate.yml
@@ -141,7 +141,7 @@ jobs:
           )
           PY
 
-      - name: Save Rust report for M22
+      - name: Save Rust report for M1 certification
         uses: actions/cache/save@v6
         with:
           path: non-cypher-evidence/

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,15 +8,23 @@ permissions:
   contents: read
 
 jobs:
-  license-compliance:
-    name: Release publication preflight
+  candidate-preflight:
+    name: Verify immutable M1 release candidate
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      actions: read
+      contents: write
+    outputs:
+      candidate_run_id: ${{ steps.candidate.outputs.run_id }}
+      release_sha: ${{ steps.source.outputs.release_sha }}
     steps:
       - uses: actions/checkout@v7
         with:
+          ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0
 
       - name: Require the certified current main commit and release versions
+        id: source
         shell: bash
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
@@ -25,10 +33,12 @@ jobs:
           git fetch --no-tags origin \
             +refs/heads/main:refs/remotes/origin/main
           test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
+          test "$(git rev-parse "$RELEASE_TAG^{}")" = "$RELEASE_SHA"
           test "$(git rev-parse refs/remotes/origin/main)" = "$RELEASE_SHA"
           python3 scripts/ci/release-publish-preflight.py \
             --tag "$RELEASE_TAG" \
             --expected-sha "$RELEASE_SHA"
+          printf 'release_sha=%s\n' "$RELEASE_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Verify release license policy
         run: python3 scripts/license_check.py --report license-compliance-report.json
@@ -38,331 +48,200 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
 
-      # This runs before any PyPI or npm write. A missing/invalid token therefore
-      # fails the release without leaving only the Python surface published.
-      - name: Verify npm publication identity
+      - name: Verify npm publication identity before any registry write
         run: npm whoami
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  # Build the native abi3 wheel per OS. abi3-py310 → one wheel per OS covers
-  # CPython 3.10+; the binding's pyproject is the canonical `graphforge` dist.
-  build-wheels:
-    name: Build wheel on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    needs: license-compliance
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [blacksmith-4vcpu-ubuntu-2404, blacksmith-6vcpu-macos-15, blacksmith-4vcpu-windows-2025]
-    steps:
-      - uses: actions/checkout@v7
+      - name: Resolve successful same-SHA candidate run
+        id: candidate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ steps.source.outputs.release_sha }}
+        run: |
+          run_id="$(gh api \
+            "repos/$GITHUB_REPOSITORY/actions/workflows/binding-release-candidate.yml/runs?event=workflow_dispatch&status=success&head_sha=$RELEASE_SHA&per_page=20" \
+            --jq '.workflow_runs | map(select(.head_sha == env.RELEASE_SHA)) | first | .id // empty')"
+          test -n "$run_id"
+          artifact_name="M1-Release-Candidate-$RELEASE_SHA"
+          artifact_count="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/artifacts" \
+            --jq "[.artifacts[] | select(.name == \"$artifact_name\" and .expired == false)] | length")"
+          test "$artifact_count" = 1
+          printf 'run_id=%s\n' "$run_id" >> "$GITHUB_OUTPUT"
 
-      - name: Build the native wheel (maturin)
-        uses: PyO3/maturin-action@v1
-        with:
-          command: build
-          args: --release --manifest-path crates/graphforge-bindings-py/Cargo.toml --out dist
-          manylinux: auto # builds the Linux wheel in a manylinux container
-          sccache: "false"
+      - name: Download exact-SHA candidate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ steps.source.outputs.release_sha }}
+          CANDIDATE_RUN_ID: ${{ steps.candidate.outputs.run_id }}
+        run: |
+          gh run download "$CANDIDATE_RUN_ID" \
+            --name "M1-Release-Candidate-$RELEASE_SHA" \
+            --dir candidate
 
-      - name: Save wheel for publish job
-        uses: actions/cache/save@v6
-        with:
-          path: dist
-          key: publish-python-${{ github.run_id }}-${{ matrix.os }}
-          enableCrossOsArchive: true
+      - name: Validate candidate bytes and checksum record
+        env:
+          RELEASE_SHA: ${{ steps.source.outputs.release_sha }}
+        run: |
+          python3 scripts/ci/release-candidate.py validate \
+            --record candidate/v0.5.0-artifacts.json \
+            --artifacts-dir candidate/release-artifacts \
+            --expected-sha "$RELEASE_SHA" \
+            --version 0.5.0
 
-  build-sdist:
-    name: Build sdist
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: license-compliance
-    steps:
-      - uses: actions/checkout@v7
+      - name: Attach checksum record without replacing different bytes
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          asset_name="v0.5.0-artifacts.json"
+          asset_count="$(gh release view "$RELEASE_TAG" --json assets \
+            --jq "[.assets[] | select(.name == \"$asset_name\")] | length")"
+          if test "$asset_count" = 0; then
+            gh release upload "$RELEASE_TAG" "candidate/$asset_name"
+          else
+            test "$asset_count" = 1
+            mkdir -p existing-release-asset
+            gh release download "$RELEASE_TAG" --pattern "$asset_name" \
+              --dir existing-release-asset
+            cmp "candidate/$asset_name" "existing-release-asset/$asset_name"
+          fi
 
-      - name: Build sdist (maturin)
-        uses: PyO3/maturin-action@v1
-        with:
-          command: sdist
-          args: --manifest-path crates/graphforge-bindings-py/Cargo.toml --out dist
-
-      - name: Save sdist for publish job
-        uses: actions/cache/save@v6
-        with:
-          path: dist
-          key: publish-python-${{ github.run_id }}-sdist
-          enableCrossOsArchive: true
-
-  publish:
-    name: Publish to PyPI
-    needs: [build-wheels, build-sdist]
+  publish-pypi:
+    name: Publish exact candidate to PyPI
+    needs: candidate-preflight
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
-      id-token: write # PyPI trusted publishing (OIDC) — no API token needed
+      actions: read
+      contents: read
+      id-token: write
     steps:
-      - uses: actions/cache/restore@v6
+      - uses: actions/checkout@v7
         with:
-          path: dist
-          key: publish-python-${{ github.run_id }}-blacksmith-4vcpu-ubuntu-2404
-          fail-on-cache-miss: true
-          enableCrossOsArchive: true
-      - uses: actions/cache/restore@v6
-        with:
-          path: dist
-          key: publish-python-${{ github.run_id }}-blacksmith-6vcpu-macos-15
-          fail-on-cache-miss: true
-          enableCrossOsArchive: true
-      - uses: actions/cache/restore@v6
-        with:
-          path: dist
-          key: publish-python-${{ github.run_id }}-blacksmith-4vcpu-windows-2025
-          fail-on-cache-miss: true
-          enableCrossOsArchive: true
-      - uses: actions/cache/restore@v6
-        with:
-          path: dist
-          key: publish-python-${{ github.run_id }}-sdist
-          fail-on-cache-miss: true
-          enableCrossOsArchive: true
+          ref: ${{ needs.candidate-preflight.outputs.release_sha }}
 
       - uses: astral-sh/setup-uv@v9.0.0
 
-      - name: Publish to PyPI
-        run: uv publish dist/*
+      - name: Download exact-SHA candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ needs.candidate-preflight.outputs.release_sha }}
+          CANDIDATE_RUN_ID: ${{ needs.candidate-preflight.outputs.candidate_run_id }}
+        run: >-
+          gh run download "$CANDIDATE_RUN_ID"
+          --name "M1-Release-Candidate-$RELEASE_SHA"
+          --dir candidate
 
-  # ---- Node binding (@graphforge/node) ----
-  # Cross-build the napi addon for every target, then publish to npm. This only
-  # runs on a release; the cross-compilation (esp. the Linux-arm `--use-napi-cross`
-  # path) and npm auth are validated at the first real release.
-  build-node:
-    name: Build addon (${{ matrix.settings.target }})
-    runs-on: ${{ matrix.settings.host }}
-    needs: license-compliance
-    strategy:
-      fail-fast: false
-      matrix:
-        settings:
-          - { host: blacksmith-6vcpu-macos-15, target: x86_64-apple-darwin }
-          - { host: blacksmith-6vcpu-macos-15, target: aarch64-apple-darwin }
-          - { host: blacksmith-4vcpu-ubuntu-2404, target: x86_64-unknown-linux-gnu }
-          - { host: blacksmith-4vcpu-ubuntu-2404, target: aarch64-unknown-linux-gnu, cross: "--use-napi-cross", arm_cflags: "-D__ARM_ARCH=8" }
-          - { host: blacksmith-4vcpu-windows-2025, target: x86_64-pc-windows-msvc }
+      - name: Revalidate candidate
+        env:
+          RELEASE_SHA: ${{ needs.candidate-preflight.outputs.release_sha }}
+        run: >-
+          python3 scripts/ci/release-candidate.py validate
+          --record candidate/v0.5.0-artifacts.json
+          --artifacts-dir candidate/release-artifacts
+          --expected-sha "$RELEASE_SHA"
+          --version 0.5.0
+
+      - name: Publish the recorded Python files
+        run: >-
+          uv publish
+          --check-url https://pypi.org/simple/
+          candidate/release-artifacts/python/*
+
+  publish-npm:
+    name: Publish exact candidate to npm
+    needs: [candidate-preflight, publish-pypi]
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      actions: read
+      contents: read
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.candidate-preflight.outputs.release_sha }}
 
       - uses: actions/setup-node@v6
         with:
           node-version: "20"
+          registry-url: "https://registry.npmjs.org"
 
       - uses: pnpm/action-setup@v4
 
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: "1.96.0"
-          targets: ${{ matrix.settings.target }}
+      - name: Install release verification dependencies
+        run: pnpm install --frozen-lockfile
 
-      - name: Install workspace dependencies
-        run: pnpm install
-
-      - name: Build the addon for ${{ matrix.settings.target }}
+      - name: Download exact-SHA candidate
         env:
-          CFLAGS_aarch64_unknown_linux_gnu: ${{ matrix.settings.arm_cflags || '' }}
-        run: pnpm --filter @graphforge/node exec napi build --platform --release --target ${{ matrix.settings.target }} ${{ matrix.settings.cross || '' }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ needs.candidate-preflight.outputs.release_sha }}
+          CANDIDATE_RUN_ID: ${{ needs.candidate-preflight.outputs.candidate_run_id }}
+        run: >-
+          gh run download "$CANDIDATE_RUN_ID"
+          --name "M1-Release-Candidate-$RELEASE_SHA"
+          --dir candidate
 
-      - name: Stage addon for publish job
+      - name: Publish recorded npm tarballs in dependency order
         shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          RELEASE_SHA: ${{ needs.candidate-preflight.outputs.release_sha }}
         run: |
-          mkdir -p node-artifacts
-          cp crates/graphforge-bindings-node/*.node node-artifacts/
+          npm whoami
+          python3 scripts/publish_npm_artifacts.py \
+            --release-record candidate/v0.5.0-artifacts.json \
+            --artifacts-dir candidate/release-artifacts \
+            --expected-sha "$RELEASE_SHA" \
+            --version 0.5.0 \
+            --group native
+          node scripts/ci/verify-node-cli-release-package.mjs
+          pnpm --filter @graphforge/cli test:offline
+          python3 scripts/publish_npm_artifacts.py \
+            --release-record candidate/v0.5.0-artifacts.json \
+            --artifacts-dir candidate/release-artifacts \
+            --expected-sha "$RELEASE_SHA" \
+            --version 0.5.0 \
+            --group cli
+          pnpm --filter @graphforge/agent-skills test:offline
+          python3 scripts/publish_npm_artifacts.py \
+            --release-record candidate/v0.5.0-artifacts.json \
+            --artifacts-dir candidate/release-artifacts \
+            --expected-sha "$RELEASE_SHA" \
+            --version 0.5.0 \
+            --group skills
 
-      - name: Save addon for publish job
-        uses: actions/cache/save@v6
-        with:
-          path: node-artifacts
-          key: publish-node-${{ github.run_id }}-${{ matrix.settings.target }}
-          enableCrossOsArchive: true
-
-  publish-node:
-    name: Publish to npm
-    needs: [build-node, publish]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    permissions:
-      contents: read
-    defaults:
-      run:
-        working-directory: crates/graphforge-bindings-node
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
-
-      - uses: pnpm/action-setup@v4
-
-      - name: Install workspace dependencies
-        run: pnpm install
-        working-directory: .
-
-      - name: Restore x86_64 macOS addon
-        uses: actions/cache/restore@v6
-        with:
-          path: node-artifacts
-          key: publish-node-${{ github.run_id }}-x86_64-apple-darwin
-          fail-on-cache-miss: true
-          enableCrossOsArchive: true
-      - name: Restore aarch64 macOS addon
-        uses: actions/cache/restore@v6
-        with:
-          path: node-artifacts
-          key: publish-node-${{ github.run_id }}-aarch64-apple-darwin
-          fail-on-cache-miss: true
-          enableCrossOsArchive: true
-      - name: Restore x86_64 Linux addon
-        uses: actions/cache/restore@v6
-        with:
-          path: node-artifacts
-          key: publish-node-${{ github.run_id }}-x86_64-unknown-linux-gnu
-          fail-on-cache-miss: true
-          enableCrossOsArchive: true
-      - name: Restore aarch64 Linux addon
-        uses: actions/cache/restore@v6
-        with:
-          path: node-artifacts
-          key: publish-node-${{ github.run_id }}-aarch64-unknown-linux-gnu
-          fail-on-cache-miss: true
-          enableCrossOsArchive: true
-      - name: Restore Windows addon
-        uses: actions/cache/restore@v6
-        with:
-          path: node-artifacts
-          key: publish-node-${{ github.run_id }}-x86_64-pc-windows-msvc
-          fail-on-cache-miss: true
-          enableCrossOsArchive: true
-
-      - name: Stage restored addons
-        run: |
-          mkdir -p artifacts
-          cp ../../node-artifacts/*.node artifacts/
-
-      - name: Assemble per-platform npm packages
-        # create-npm-dirs scaffolds npm/<platform>/, artifacts moves each built
-        # .node into the matching platform package.
-        run: |
-          pnpm exec napi create-npm-dirs
-          pnpm exec napi artifacts --output-dir artifacts --npm-dir npm
-          python3 ../../../scripts/ci/validate-napi-artifacts.py \
-            --npm-dir npm --manifest package.json
-
-      - name: Verify npm publishing identity
-        run: npm whoami
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Publish platform packages and main package
-        # npm invokes prepublishOnly exactly once. napi then publishes each
-        # generated public platform package and wires those exact versions into
-        # the main package before npm publishes it.
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-  # ---- NPX lifecycle CLI (@graphforge/cli) ----
-  publish-node-cli:
-    name: Publish GraphForge CLI to npm
-    needs: [publish, publish-node]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    permissions:
-      contents: read
-    defaults:
-      run:
-        working-directory: packages/cli
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
-
-      - uses: pnpm/action-setup@v4
-
-      - name: Install workspace dependencies
-        run: pnpm install
-        working-directory: .
-
-      - name: Offline pack smoke before publish
-        run: pnpm --filter @graphforge/cli test:offline
-        working-directory: .
-
-      - name: Verify clean install against published native package
-        run: node scripts/ci/verify-node-cli-release-package.mjs
-        working-directory: .
-
-      - name: Verify npm publishing identity
-        run: npm whoami
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Publish @graphforge/cli
-        run: pnpm publish --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-  # ---- NPX agent skills (@graphforge/agent-skills) ----
-  publish-agent-skills:
-    name: Publish agent-skills to npm
-    needs: publish-node-cli
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    permissions:
-      contents: read
-    defaults:
-      run:
-        working-directory: packages/agent-skills
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
-
-      - uses: pnpm/action-setup@v4
-
-      - name: Install workspace dependencies
-        run: pnpm install
-        working-directory: .
-
-      - name: Offline pack smoke before publish
-        run: pnpm --filter @graphforge/agent-skills test:offline
-        working-directory: .
-
-      - name: Verify npm publishing identity
-        run: npm whoami
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Publish @graphforge/agent-skills
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-  # ---- Rust crates (crates.io) ----
-  # Publish last so an earlier PyPI/npm failure cannot leave only a Rust
-  # surface behind. The publisher is checksum-safe and resumable.
   publish-crates:
-    name: Publish Rust crates to crates.io
-    needs: publish-agent-skills
+    name: Publish recorded Rust crates to crates.io
+    needs: [candidate-preflight, publish-npm]
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      actions: read
+      contents: read
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.candidate-preflight.outputs.release_sha }}
 
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.96.0"
+
+      - name: Download exact-SHA candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ needs.candidate-preflight.outputs.release_sha }}
+          CANDIDATE_RUN_ID: ${{ needs.candidate-preflight.outputs.candidate_run_id }}
+        run: >-
+          gh run download "$CANDIDATE_RUN_ID"
+          --name "M1-Release-Candidate-$RELEASE_SHA"
+          --dir candidate
 
       - name: Publish the complete ordered Rust surface
-        run: python3 scripts/publish_crates.py
+        run: >-
+          python3 scripts/publish_crates.py
+          --release-record candidate/v0.5.0-artifacts.json
+          --artifacts-dir candidate/release-artifacts
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-credential-preflight.yml
+++ b/.github/workflows/release-credential-preflight.yml
@@ -1,0 +1,54 @@
+name: Release Credential Preflight
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Exact current main SHA being prepared for M1
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  credentials:
+    name: Verify projected publication credentials
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 1
+
+      - name: Require exact current main
+        shell: bash
+        env:
+          REQUESTED_SHA: ${{ inputs.commit_sha }}
+        run: |
+          [[ "$REQUESTED_SHA" =~ ^[0-9a-f]{40}$ ]]
+          git fetch --no-tags --depth=1 origin \
+            +refs/heads/main:refs/remotes/origin/main
+          test "$REQUESTED_SHA" = "$(git rev-parse refs/remotes/origin/main)"
+          test "$REQUESTED_SHA" = "$(git rev-parse HEAD)"
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Verify npm token identity
+        run: npm whoami
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Verify crates.io token projection without printing it
+        shell: bash
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          test -n "$CARGO_REGISTRY_TOKEN"
+          test "${#CARGO_REGISTRY_TOKEN}" -ge 20
+
+      - name: Record non-publishing result
+        run: echo "Credential projection is present; this workflow performs no registry writes."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,8 +99,8 @@ jobs:
           python3 scripts/ci/test-release-load-matrix.py
           python3 scripts/ci/test-release-load-executor.py
 
-      - name: Test final M22 non-Cypher surface gate
-        run: python3 scripts/ci/test-m22-non-cypher-surface-gate.py
+      - name: Test final M1 release certification gate
+        run: python3 scripts/ci/test-m1-release-certification.py
 
       - name: Test clean-environment verification harness
         run: python3 scripts/ci/test-clean-env-verify.py
@@ -117,7 +117,11 @@ jobs:
         run: python3 scripts/ci/test-crate-publish-plan.py
 
       - name: Test release publication preflight
-        run: python3 scripts/ci/test-release-publish-preflight.py
+        run: |
+          python3 scripts/ci/test-release-publish-preflight.py
+          python3 scripts/ci/test-release-candidate.py
+          python3 scripts/ci/test-release-notes.py
+          python3 scripts/ci/test-publish-npm-artifacts.py
 
       - name: Test CI storage policy
         run: python3 scripts/ci/test-ci-storage-policy.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ _Nothing yet._
 
 ## [0.5.0] - 2026-07-31
 
+- Preserve one exact-SHA M1 release-candidate bundle for 30 days, record and
+  validate every Python/npm/crates.io checksum before publication, publish the
+  recorded Python/npm bytes without rebuilding, bind crates.io packaging to the
+  same record, and add a non-publishing credential preflight plus ordered
+  operator runbook (#192).
 - Rename the complete Cargo workspace from `gf-*` / `gf_*` to the public
   `graphforge-*` / `graphforge_*` namespace, publish the 14 Rust libraries plus
   `graphforge-cli` to crates.io in dependency order, and keep the Python/Node
@@ -89,7 +94,7 @@ _Nothing yet._
 
 - Minimize Blacksmith CI storage by removing speculative caches from infrequent
   gates, sharing dependency caches by lockfile identity, and deleting the
-  one-run M22 build disk after certification (#207).
+  one-run M1 certification build disk after certification (#207).
 - Remove unconsumed CI artifacts and move required cross-job transfers to
   Blacksmith-backed cache storage, eliminating GitHub artifact-quota failures
   from the required CI Gate (#205).
@@ -207,7 +212,7 @@ the authoritative runnable corpus enforced by the BDD gate.
 
 - Record local host-native release load-matrix evidence (144/144 passed on
   `ec81fd8f…`) in [Release Load Matrix Results](docs/reference/load-matrix-results.md);
-  CI `M22-Load-Matrix-<sha>` upload for #2765 remains pending.
+  CI `M1-Release-Load-Matrix-<sha>` upload for #2765 remains pending.
 
 - Align release-load probe result fingerprints across bindings: Node canonicalizes
   whole floats as `1.0` (matching Python/Rust JSON), and the Rust probe uses the
@@ -221,7 +226,7 @@ the authoritative runnable corpus enforced by the BDD gate.
   keep `engineering/` contributor docs and ADRs under **Engineering** (not
   Understand), alongside Guide / Book / Reference / development (#2772).
 
-- After manylinux maturin on the M22 load sticky disk, reclaim `target/`
+- After manylinux maturin on the M1 release load sticky disk, reclaim `target/`
   ownership for the host runner so Cargo can open `.cargo-build-lock` (#2765).
 
 - Place Architecture Decision Records under **Engineering** in the published
@@ -368,11 +373,11 @@ the authoritative runnable corpus enforced by the BDD gate.
   Arrow/IPC equality, structured `GF_WRITER_BUSY` rejection before staging, and
   pinned-reader reopen visibility (#2416).
 
-- Build M22 release-load fixtures through atomic `publish_bulk_nodes` /
+- Build M1 release-load fixtures through atomic `publish_bulk_nodes` /
   `publish_bulk_edges` on Rust, Python, and Node so dense L/XL cases stay inside
   the project recovery publication bound instead of exhausting disk (#2431).
 
-- Add the manual, exact-current-main M22 non-Cypher surface gate that validates
+- Add the manual, exact-current-main M1 release certification gate that validates
   immutable Rust and cross-platform binding evidence before executing the
   standardized 144-case host load matrix and emitting one fail-closed aggregate
   artifact (#2431).
@@ -505,7 +510,7 @@ the authoritative runnable corpus enforced by the BDD gate.
   exact tagged Node `{ "$uuid": "..." }` projections for graph identity predicates
   (#2580).
 
-- Add the versioned M22 release-workflow registry, static validator, deterministic
+- Add the versioned M1 release-workflow registry, static validator, deterministic
   selected/all orchestrator, ontology taxonomy, and SHA-bound evidence envelope
   scaffolding (#2582).
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help lint format type-check security workflow-lint license-check third-party-notices third-party-notices-check cargo-deny-licenses test pre-push pre-push-fast clean test-tck docstring-coverage test-network benchmark test-perf test-perf-xs test-perf-slow test-perf-large coverage coverage-rust coverage-python coverage-node coverage-quick coverage-report coverage-diff coverage-strict check-coverage check-coverage-rust check-coverage-python check-coverage-node check-patch-coverage test-durations test-analytics docs-serve docs-build docs-clean cargo-build bench-traversal bench-fixed-hop-limit bench-fixed-hop-livejournal native-consumers release-load-matrix-check release-load-matrix bulk-construction-conformance-check bulk-construction-conformance cargo-test cargo-check cargo-clippy cargo-fmt cargo-fmt-check clean-builds clean-builds-all pnpm-install pnpm-build pnpm-test-bdd install build release-version-check package-license-verify publish-dry-run publish-dry-run-npm publish-dry-run-docs publish-dry-run-python publish-dry-run-cargo record-release-artifacts clean-env-verify-check clean-env-verify-preflight clean-env-verify
+.PHONY: help lint format type-check security workflow-lint license-check third-party-notices third-party-notices-check cargo-deny-licenses test pre-push pre-push-fast clean test-tck docstring-coverage test-network benchmark test-perf test-perf-xs test-perf-slow test-perf-large coverage coverage-rust coverage-python coverage-node coverage-quick coverage-report coverage-diff coverage-strict check-coverage check-coverage-rust check-coverage-python check-coverage-node check-patch-coverage test-durations test-analytics docs-serve docs-build docs-clean cargo-build bench-traversal bench-fixed-hop-limit bench-fixed-hop-livejournal native-consumers release-load-matrix-check release-load-matrix bulk-construction-conformance-check bulk-construction-conformance cargo-test cargo-check cargo-clippy cargo-fmt cargo-fmt-check clean-builds clean-builds-all pnpm-install pnpm-build pnpm-test-bdd install build release-version-check release-notes package-license-verify publish-dry-run publish-dry-run-npm publish-dry-run-docs publish-dry-run-python publish-dry-run-cargo record-release-artifacts clean-env-verify-check clean-env-verify-preflight clean-env-verify
 
 help:  ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -26,6 +26,9 @@ license-check:  ## Verify Apache-2.0 metadata and distributed copies
 
 release-version-check:  ## Verify Cargo/Python/Node/skills versions align
 	python3 scripts/set_release_version.py --check
+
+release-notes:  ## Extract the canonical CHANGELOG section for VERSION
+	python3 scripts/ci/release-notes.py $${VERSION:?set VERSION} --out $${OUT:-target/release-notes-v$${VERSION}.md}
 
 package-license-verify:  ## Verify packaged Cargo/npm/Python artifacts include LICENSE+NOTICE
 	python3 scripts/verify_package_licenses.py
@@ -292,9 +295,9 @@ bulk-construction-conformance:  ## Run same-SHA Rust/Python/Node bulk constructi
 
 .PHONY: bulk-construction-conformance-check bulk-construction-conformance
 
-.PHONY: m22-non-cypher-gate-check
-m22-non-cypher-gate-check:  ## Validate the final M22 non-Cypher aggregate gate
-	python3 scripts/ci/test-m22-non-cypher-surface-gate.py
+.PHONY: m1-release-certification-check
+m1-release-certification-check:  ## Validate the final M1 release certification aggregate gate
+	python3 scripts/ci/test-m1-release-certification.py
 
 cargo-check:  ## Type-check all Rust workspace crates (fast)
 	cargo check --workspace

--- a/docs/development/publication-order.md
+++ b/docs/development/publication-order.md
@@ -19,8 +19,12 @@ Related operational docs:
 1. §5 version freeze is complete: Cargo workspace, Python binding, Node binding,
    NPX CLI/skills, and generated metadata all report `0.5.0` (not `0.5.0-dev` /
    `0.5.0.dev0`) on the intended RC commit.
-2. Artifact checksum / SBOM / license record exists for that same commit
-   and is retained with the #192 release evidence.
+2. A successful same-SHA `Binding Release Candidate` run has retained
+   `M1-Release-Candidate-<sha>` for 30 days. That bundle contains the tested
+   wheels/addons, Python sdist, all npm tarballs, all 15 `.crate` archives,
+   publication dry-run evidence, license reports, and
+   `v0.5.0-artifacts.json`. Publication consumes this bundle; it does not
+   rebuild Python/npm bytes.
 3. First-party packages declare `Apache-2.0` with `LICENSE` / `NOTICE` (and
    third-party notices intact), and the public legal surface in
    [#200](https://github.com/CurateLabs/graphforge/issues/200) is complete.
@@ -58,8 +62,13 @@ deterministic success evidence (or an explicit maintainer disposition to skip).
 Notes:
 
 - Steps 3–7 are automated by `.github/workflows/publish.yaml` once the GitHub
-  Release is published. Maintainers watch that run; they do not re-build
-  different bytes under `0.5.0` if a job fails.
+  Release is published. It resolves the successful, unexpired same-SHA
+  `Binding Release Candidate` run, validates every recorded checksum, and
+  attaches the checksum record before its first registry write. Python and npm
+  publish the exact retained files. The crates.io publisher re-packages the
+  immutable tagged tree only after proving each deterministic `.crate`
+  checksum equals the retained record. Maintainers watch that run; they do not
+  rebuild different bytes under `0.5.0` if a job fails.
 - Before any registry write, the workflow requires the release tag, current
   `main` SHA, five version surfaces, dated CHANGELOG section, Apache-2.0 policy,
   and npm publishing identity to pass its fail-closed preflight.
@@ -161,6 +170,8 @@ final #192 close.
 
 - [ ] Version freeze PR merged on the RC commit and every SHA-bound release
       certification workflow passes for that exact commit
+- [ ] The same-SHA `Binding Release Candidate` run contains an unexpired
+      `M1-Release-Candidate-<sha>` bundle and its release record validates
 - [ ] `@graphforge` npm organization exists and the publishing maintainer can
       create public organization-scoped packages
 - [ ] `NPM_TOKEN` is a granular token authorized for the `@graphforge` scope,
@@ -178,3 +189,6 @@ final #192 close.
 - [x] Public Apache-2.0 legal and contribution docs are deployed (#200)
 - [ ] Maintainer authorization to create annotated tag + GitHub Release
 - [x] Repository and release documentation are publicly readable
+
+The exact operator commands, evidence queries, and stop points are in
+[`v0.5.0-release-operator-runbook.md`](v0.5.0-release-operator-runbook.md).

--- a/docs/development/release-artifact-record.md
+++ b/docs/development/release-artifact-record.md
@@ -17,9 +17,11 @@ commits under the same version.
 ## How to record
 
 1. Freeze the RC SHA and surface versions (`scripts/set_release_version.py` / #192).
-2. Build or collect artifacts for that SHA into a directory (wheels, sdists,
-   npm tarballs, all 15 `.crate` archives, and SBOM/provenance if emitted).
-3. Run:
+2. Dispatch `Binding Release Candidate` for that exact current `main` SHA. Its
+   final job builds `M1-Release-Candidate-<sha>` from the tested wheels/addons,
+   then adds the sdist, npm tarballs, all 15 `.crate` archives, dry-run evidence,
+   and license reports.
+3. The workflow runs the equivalent of:
 
 ```bash
 python3 scripts/record_release_artifacts.py \
@@ -29,7 +31,8 @@ python3 scripts/record_release_artifacts.py \
   --notes "RC sha=<40-char> built via <workflow/run>"
 ```
 
-4. Attach the JSON (or its checksums table) to the GitHub Release (#194).
+4. `publish.yaml` validates the complete bundle and attaches the JSON to the
+   GitHub Release before the first registry write (#194).
 5. Post-release clean-env verification (#167) matches `sha256` values from this record.
 
 The generated document uses the same `graphforge-release-record-v1` schema

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -151,10 +151,10 @@ GraphForge is currently in **0.x.x** (pre-1.0.0):
       release-candidate SHA and retain the accepted evidence bundle in the
       publication record
 - [ ] After the exact-SHA Rust surface and Binding Release Candidate runs pass,
-      dispatch `M22 Non-Cypher Surface Gate` with the current `main` SHA and
+      dispatch `M1 Release Certification Gate` with the current `main` SHA and
       those two immutable run IDs. Confirm its 144-case load job and final
-      `M22-Non-Cypher-Surface-Gate-<sha>` aggregate artifact for the v0.5.0 publication close-out issue
-      publication readiness. This cascade is release certification; it is not a
+      `M1-Release-Certification-<sha>` aggregate artifact for v0.5.0 publication
+      readiness. This cascade is release certification; it is not a
       close criterion for child implementation or construction issues (see
       `AGENTS.md` § Issue close)
 - [ ] Test installation from built package: `uv build && uv tool install dist/graphforge-*.whl`

--- a/docs/development/v0.5.0-release-operator-runbook.md
+++ b/docs/development/v0.5.0-release-operator-runbook.md
@@ -1,0 +1,225 @@
+# GraphForge v0.5.0 release operator runbook
+
+This is the ordered operator procedure for the human-gated M1 close tracker
+[#192](https://github.com/CurateLabs/graphforge/issues/192). It complements the
+authoritative stop and recovery rules in
+[`publication-order.md`](publication-order.md).
+
+Do not skip ahead. Stop on the first failed check or publication. Never move
+`v0.5.0`, replace published bytes, or rerun from a different commit.
+
+## 1. Complete account setup (human)
+
+These account-level actions cannot be completed from repository automation:
+
+1. Create or confirm the public npm `@graphforge` organization/scope and grant
+   the publishing maintainer permission to create its packages.
+2. Create a granular npm token permitted to publish public packages under
+   `@graphforge`, compatible with the account's 2FA policy. Store it without
+   putting the value on the command line:
+
+   ```bash
+   gh secret set NPM_TOKEN --repo CurateLabs/graphforge
+   ```
+
+3. Configure a PyPI pending trusted publisher for the not-yet-created
+   `graphforge` project:
+
+   - owner: `CurateLabs`
+   - repository: `graphforge`
+   - workflow: `publish.yaml`
+   - environment: leave blank
+
+4. Confirm the crates.io token remains in Pulumi ESC
+   `curatelabs/graphforge/release` and that the repository lists the encrypted
+   `CARGO_REGISTRY_TOKEN` secret. Do not print either value.
+
+The npm and crates.io secret projections can then be tested without publishing:
+
+```bash
+RC_SHA="$(git rev-parse origin/main)"
+gh workflow run release-credential-preflight.yml \
+  --repo CurateLabs/graphforge \
+  --ref main \
+  -f commit_sha="$RC_SHA"
+```
+
+Wait for `Release Credential Preflight` to pass. PyPI validates its OIDC
+configuration only when the release publication job requests a token; a PyPI
+failure is therefore a hard stop.
+
+## 2. Freeze and certify one current-main SHA (automated, non-publishing)
+
+Start from a clean, synchronized checkout:
+
+```bash
+git switch main
+git pull --ff-only origin main
+test -z "$(git status --short)"
+RC_SHA="$(git rev-parse HEAD)"
+test "$RC_SHA" = "$(git rev-parse origin/main)"
+python3 scripts/set_release_version.py --check 0.5.0
+python3 scripts/ci/release-publish-preflight.py \
+  --tag v0.5.0 \
+  --expected-sha "$RC_SHA"
+```
+
+Dispatch the two independent exact-SHA inputs:
+
+```bash
+gh workflow run non-cypher-surface-gate.yml \
+  --repo CurateLabs/graphforge --ref main
+gh workflow run binding-release-candidate.yml \
+  --repo CurateLabs/graphforge --ref main \
+  -f commit_sha="$RC_SHA"
+```
+
+Wait for both runs and capture their immutable IDs:
+
+```bash
+RUST_RUN_ID="$(gh run list --repo CurateLabs/graphforge \
+  --workflow non-cypher-surface-gate.yml --commit "$RC_SHA" --limit 1 \
+  --json databaseId,conclusion --jq '.[0] | select(.conclusion == "success") | .databaseId')"
+BINDING_RUN_ID="$(gh run list --repo CurateLabs/graphforge \
+  --workflow binding-release-candidate.yml --commit "$RC_SHA" --limit 1 \
+  --json databaseId,conclusion --jq '.[0] | select(.conclusion == "success") | .databaseId')"
+test -n "$RUST_RUN_ID"
+test -n "$BINDING_RUN_ID"
+```
+
+The Binding RC must contain the 30-day publication artifact. Download and
+verify it locally:
+
+```bash
+candidate_dir="$(mktemp -d)"
+gh run download "$BINDING_RUN_ID" --repo CurateLabs/graphforge \
+  --name "M1-Release-Candidate-$RC_SHA" --dir "$candidate_dir"
+python3 scripts/ci/release-candidate.py validate \
+  --record "$candidate_dir/v0.5.0-artifacts.json" \
+  --artifacts-dir "$candidate_dir/release-artifacts" \
+  --expected-sha "$RC_SHA" --version 0.5.0
+```
+
+Now run the final M1 aggregate certification:
+
+```bash
+gh workflow run m1-release-certification.yml \
+  --repo CurateLabs/graphforge --ref main \
+  -f commit_sha="$RC_SHA" \
+  -f rust_run_id="$RUST_RUN_ID" \
+  -f binding_rc_run_id="$BINDING_RUN_ID"
+```
+
+Wait for `M1 Release Certification Gate` to pass. Immediately before tagging,
+repeat:
+
+```bash
+git fetch origin main
+test "$RC_SHA" = "$(git rev-parse origin/main)"
+```
+
+If `main` moved, discard these IDs and repeat this section for the new SHA.
+
+## 3. Create the immutable annotated tag (#193, human authorization)
+
+```bash
+git tag -a v0.5.0 "$RC_SHA" -m "GraphForge v0.5.0"
+test "$(git rev-parse 'v0.5.0^{}')" = "$RC_SHA"
+git push origin v0.5.0
+```
+
+Record the full SHA and verification result on #193, then close #193. Never
+move or recreate this tag.
+
+## 4. Publish the GitHub Release (#194, starts registry publication)
+
+Extract release notes directly from the canonical changelog:
+
+```bash
+notes_file="$(mktemp)"
+python3 scripts/ci/release-notes.py 0.5.0 --out "$notes_file"
+gh release create v0.5.0 \
+  --repo CurateLabs/graphforge \
+  --verify-tag \
+  --title "GraphForge v0.5.0" \
+  --notes-file "$notes_file"
+```
+
+Publishing the GitHub Release triggers `Publish to PyPI, npm, and crates.io`.
+Its preflight must resolve the successful, unexpired same-SHA candidate,
+revalidate every byte, verify npm identity, and attach
+`v0.5.0-artifacts.json` before the first registry write.
+
+Record the release URL and publication run URL on #194. Do not close registry
+issues merely because the workflow started.
+
+## 5. Watch the single ordered registry workflow (#195, #198, #196)
+
+The workflow order is fixed:
+
+1. PyPI: the three recorded wheels and recorded sdist.
+2. npm: five recorded native platform packages, then `@graphforge/node`.
+3. npm: clean-consumer verification, then recorded `@graphforge/cli`.
+4. npm: offline verification, then recorded `@graphforge/agent-skills`.
+5. crates.io: all 15 crates in the documented topological order, with each
+   packaged checksum checked against the release record and `DecisionNerd`
+   ownership verified after indexing.
+
+Watch it to completion:
+
+```bash
+PUBLISH_RUN_ID="$(gh run list --repo CurateLabs/graphforge \
+  --workflow publish.yaml --event release --limit 1 \
+  --json databaseId,headSha --jq ".[0] | select(.headSha == \"$RC_SHA\") | .databaseId")"
+test -n "$PUBLISH_RUN_ID"
+gh run watch "$PUBLISH_RUN_ID" --repo CurateLabs/graphforge --exit-status
+```
+
+On any failure, stop. Follow `publication-order.md`; do not manually continue
+with a later registry and do not attempt different bytes under `0.5.0`.
+
+After a green run, verify and record the public URLs on #195, #198, and #196,
+including registry digests/checksums and crates.io ownership, then close each
+issue only when its live acceptance criteria are proven.
+
+## 6. Confirm release documentation (#197)
+
+Confirm the successful `Documentation` run for `RC_SHA` and anonymously open:
+
+- `https://docs.graphforge.sh/`
+- installation and package pages
+- repository, license, and release links
+
+Record the workflow and public URLs on #197, then close it.
+
+## 7. Verify all public metadata (#199)
+
+Download the attached record and run the public preflight:
+
+```bash
+record_dir="$(mktemp -d)"
+gh release download v0.5.0 --repo CurateLabs/graphforge \
+  --pattern v0.5.0-artifacts.json --dir "$record_dir"
+make clean-env-verify-preflight VERSION=0.5.0
+```
+
+Complete #199's surface-by-surface checklist: versions, repository/issues URLs,
+Apache-2.0 metadata and packaged notices, documentation/homepage URLs, immutable
+tag/release links, and public file checksums against the attached record. Close
+#199 only after every live surface agrees.
+
+The broader clean-environment behavioral run belongs to post-release #167 and
+is not a prerequisite for M1 close, but may begin immediately afterward:
+
+```bash
+make clean-env-verify VERSION=0.5.0 \
+  RELEASE_RECORD="$record_dir/v0.5.0-artifacts.json"
+```
+
+## 8. Close #192 and M1
+
+Re-read #193 through #199, the tag, GitHub Release, public registries, attached
+record, docs deployment, and native sub-issue states. Post a concise evidence
+ledger on #192. Close #192 only when every acceptance criterion and every
+native release sub-issue is complete. Then close milestone M1. Post-release
+#167, #188, and #189 remain separate and do not block M1.

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -11,6 +11,11 @@ _Nothing yet._
 
 ## [0.5.0] - 2026-07-31
 
+- Preserve one exact-SHA M1 release-candidate bundle for 30 days, record and
+  validate every Python/npm/crates.io checksum before publication, publish the
+  recorded Python/npm bytes without rebuilding, bind crates.io packaging to the
+  same record, and add a non-publishing credential preflight plus ordered
+  operator runbook (#192).
 - Rename the complete Cargo workspace from `gf-*` / `gf_*` to the public
   `graphforge-*` / `graphforge_*` namespace, publish the 14 Rust libraries plus
   `graphforge-cli` to crates.io in dependency order, and keep the Python/Node
@@ -89,7 +94,7 @@ _Nothing yet._
 
 - Minimize Blacksmith CI storage by removing speculative caches from infrequent
   gates, sharing dependency caches by lockfile identity, and deleting the
-  one-run M22 build disk after certification (#207).
+  one-run M1 certification build disk after certification (#207).
 - Remove unconsumed CI artifacts and move required cross-job transfers to
   Blacksmith-backed cache storage, eliminating GitHub artifact-quota failures
   from the required CI Gate (#205).
@@ -207,7 +212,7 @@ the authoritative runnable corpus enforced by the BDD gate.
 
 - Record local host-native release load-matrix evidence (144/144 passed on
   `ec81fd8f…`) in [Release Load Matrix Results](docs/reference/load-matrix-results.md);
-  CI `M22-Load-Matrix-<sha>` upload for #2765 remains pending.
+  CI `M1-Release-Load-Matrix-<sha>` upload for #2765 remains pending.
 
 - Align release-load probe result fingerprints across bindings: Node canonicalizes
   whole floats as `1.0` (matching Python/Rust JSON), and the Rust probe uses the
@@ -221,7 +226,7 @@ the authoritative runnable corpus enforced by the BDD gate.
   keep `engineering/` contributor docs and ADRs under **Engineering** (not
   Understand), alongside Guide / Book / Reference / development (#2772).
 
-- After manylinux maturin on the M22 load sticky disk, reclaim `target/`
+- After manylinux maturin on the M1 release load sticky disk, reclaim `target/`
   ownership for the host runner so Cargo can open `.cargo-build-lock` (#2765).
 
 - Place Architecture Decision Records under **Engineering** in the published
@@ -368,11 +373,11 @@ the authoritative runnable corpus enforced by the BDD gate.
   Arrow/IPC equality, structured `GF_WRITER_BUSY` rejection before staging, and
   pinned-reader reopen visibility (#2416).
 
-- Build M22 release-load fixtures through atomic `publish_bulk_nodes` /
+- Build M1 release-load fixtures through atomic `publish_bulk_nodes` /
   `publish_bulk_edges` on Rust, Python, and Node so dense L/XL cases stay inside
   the project recovery publication bound instead of exhausting disk (#2431).
 
-- Add the manual, exact-current-main M22 non-Cypher surface gate that validates
+- Add the manual, exact-current-main M1 release certification gate that validates
   immutable Rust and cross-platform binding evidence before executing the
   standardized 144-case host load matrix and emitting one fail-closed aggregate
   artifact (#2431).
@@ -505,7 +510,7 @@ the authoritative runnable corpus enforced by the BDD gate.
   exact tagged Node `{ "$uuid": "..." }` projections for graph identity predicates
   (#2580).
 
-- Add the versioned M22 release-workflow registry, static validator, deterministic
+- Add the versioned M1 release-workflow registry, static validator, deterministic
   selected/all orchestrator, ontology taxonomy, and SHA-bound evidence envelope
   scaffolding (#2582).
 

--- a/docs/reference/load-matrix-results.md
+++ b/docs/reference/load-matrix-results.md
@@ -17,7 +17,7 @@ For what each size/density class proves against published limits, see
 Host-native evidence is green on `main` tip
 `ec81fd8f35eda9cd59247865c79e296875d3ebf9` (merge of #2779 binding-parity
 fix). Issue #2765 closed on outcome-based criteria (infra + local 144/144 +
-this page); a downloadable `M22-Load-Matrix-<sha>` CI artifact is **not**
+this page); a downloadable `M1-Release-Load-Matrix-<sha>` CI artifact is **not**
 required for that close.
 
 | Field | Value |
@@ -26,8 +26,8 @@ required for that close.
 | Date (UTC) | 2026-07-28 |
 | Evidence source | Local host-native run (worktree `graphforge-worktrees/load-matrix-main`) |
 | Evidence path | `build/release-load-evidence.json` (`schema`: `graphforge-load-evidence/1`, `status`: `passed`) |
-| CI run URL | Optional — M22 Non-Cypher Surface Gate artifact upload not required for #2765 close |
-| Artifact name | Optional — `M22-Load-Matrix-<sha>` when a publication run uploads one |
+| CI run URL | Optional — M1 Release Certification Gate artifact upload not required for #2765 close |
+| Artifact name | Optional — `M1-Release-Load-Matrix-<sha>` when a publication run uploads one |
 | Pass summary | 144/144 cases `passed` (48 Rust / 48 Python / 48 Node); same SHA; attempt=1 only; no retries, skips, parity diffs, or sanitized errors |
 
 ### Case-level summary
@@ -45,7 +45,7 @@ Languages: Rust, Python, Node (48 cases each).
 ## How to update this page
 
 1. Prefer a same-SHA green host-native or CI matrix run with case-level evidence.
-2. Optionally record a CI run URL and `M22-Load-Matrix-<sha>` when a gate upload
+2. Optionally record a CI run URL and `M1-Release-Load-Matrix-<sha>` when a gate upload
    exists (useful for release publication; not an ordinary issue-close blocker).
 3. Record SHA, UTC date, evidence source/path, and a short pass summary
    (accepted case count, binding languages, any diagnostic notes that are not

--- a/scripts/ci/m1-release-certification.py
+++ b/scripts/ci/m1-release-certification.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate and aggregate the exact-SHA M22 non-Cypher release gate."""
+"""Validate and aggregate the exact-SHA M1 release certification release gate."""
 
 from __future__ import annotations
 
@@ -19,7 +19,7 @@ LOAD_MATRIX = ROOT / "tests/contracts/load-workload-matrix.json"
 BINDING_TARGETS = ROOT / "tests/contracts/binding-release-candidate-targets.json"
 REPOSITORY = "CurateLabs/graphforge"
 
-SCHEMA = "graphforge-m22-non-cypher-surface-gate/1"
+SCHEMA = "graphforge-m1-release-certification/1"
 RUST_SCHEMA = "graphforge-rust-non-cypher-evidence/1"
 BINDING_SCHEMA = "graphforge-binding-rc-aggregate/1"
 LOAD_SCHEMA = "graphforge-load-evidence/1"
@@ -197,7 +197,7 @@ def validate_binding(report: dict[str, Any], expected_sha: str) -> dict[str, Any
     if report.get("source_sha") != expected_sha:
         raise ValueError("binding component SHA drift")
     validator = import_script(
-        "m22_binding_validator", ROOT / "scripts/ci/validate-binding-release-candidate.py"
+        "m1_binding_validator", ROOT / "scripts/ci/validate-binding-release-candidate.py"
     )
     targets = report.get("targets")
     if not isinstance(targets, list):
@@ -237,7 +237,7 @@ def validate_load(report: dict[str, Any], expected_sha: str) -> dict[str, Any]:
         raise ValueError("load taxonomy digest drift")
     if report.get("matrix_sha256") != digest(LOAD_MATRIX):
         raise ValueError("load workload matrix digest drift")
-    load_validator = import_script("m22_load_validator", ROOT / "scripts/ci/release-load-matrix.py")
+    load_validator = import_script("m1_load_validator", ROOT / "scripts/ci/release-load-matrix.py")
     matrix = load_json(LOAD_MATRIX)
     _surface, selectors = load_validator.inventory(matrix)
     expected_inventory = {name: sorted(values) for name, values in sorted(selectors.items())}
@@ -438,7 +438,7 @@ def main() -> int:
             }
             args.output.parent.mkdir(parents=True, exist_ok=True)
             args.output.write_bytes(canonical(failure))
-        print(f"M22 non-Cypher surface gate failed: {error}")
+        print(f"M1 release certification gate failed: {error}")
         return 1
     return 0
 

--- a/scripts/ci/release-candidate.py
+++ b/scripts/ci/release-candidate.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Validate and query the immutable M1 release-candidate artifact bundle."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any
+
+SCHEMA = "graphforge-release-record-v1"
+SHA_RE = re.compile(r"[0-9a-f]{40}")
+HASH_RE = re.compile(r"[0-9a-f]{64}")
+CRATES = (
+    "graphforge-core",
+    "graphforge-ast",
+    "graphforge-knowledge",
+    "graphforge-ontology",
+    "graphforge-provenance",
+    "graphforge-ir",
+    "graphforge-plan",
+    "graphforge-storage",
+    "graphforge-io",
+    "graphforge-rel",
+    "graphforge-search",
+    "graphforge-cypher",
+    "graphforge-exec",
+    "graphforge-api",
+    "graphforge-cli",
+)
+NPM_PACKAGES = (
+    "@graphforge/node-darwin-arm64",
+    "@graphforge/node-darwin-x64",
+    "@graphforge/node-linux-arm64-gnu",
+    "@graphforge/node-linux-x64-gnu",
+    "@graphforge/node-win32-x64-msvc",
+    "@graphforge/node",
+    "@graphforge/cli",
+    "@graphforge/agent-skills",
+)
+
+
+class CandidateError(ValueError):
+    """The candidate bundle does not satisfy the release contract."""
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise CandidateError(f"cannot read release record {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise CandidateError("release record must be a JSON object")
+    return value
+
+
+def validate(
+    record_path: Path, artifacts_dir: Path, expected_sha: str, version: str
+) -> dict[str, Any]:
+    if SHA_RE.fullmatch(expected_sha) is None:
+        raise CandidateError("expected SHA must be 40 lowercase hexadecimal characters")
+    record = _load(record_path)
+    if record.get("schema") != SCHEMA:
+        raise CandidateError(f"unexpected release record schema: {record.get('schema')!r}")
+    if record.get("version") != version or record.get("tag") != f"v{version}":
+        raise CandidateError("release record version/tag does not match the requested version")
+    if record.get("commit_sha") != expected_sha:
+        raise CandidateError("release record commit does not match the requested SHA")
+
+    items = record.get("artifacts")
+    if not isinstance(items, list) or not items:
+        raise CandidateError("release record has no artifacts")
+
+    seen_paths: set[str] = set()
+    names_by_surface: dict[str, set[str]] = {"pypi": set(), "npm": set(), "crates": set()}
+    wheel_count = 0
+    sdist_count = 0
+    addon_count = 0
+    for index, item in enumerate(items):
+        if not isinstance(item, dict):
+            raise CandidateError(f"artifacts[{index}] must be an object")
+        relative = item.get("path")
+        digest = item.get("sha256")
+        if not isinstance(relative, str) or not relative or relative.startswith(("/", "../")):
+            raise CandidateError(f"artifacts[{index}] has an unsafe path")
+        if relative in seen_paths:
+            raise CandidateError(f"duplicate artifact path: {relative}")
+        seen_paths.add(relative)
+        path = artifacts_dir / relative
+        if not path.is_file():
+            raise CandidateError(f"recorded artifact is missing: {relative}")
+        if not isinstance(digest, str) or HASH_RE.fullmatch(digest) is None:
+            raise CandidateError(f"artifacts[{index}] has an invalid SHA-256")
+        if _sha256(path) != digest:
+            raise CandidateError(f"artifact checksum mismatch: {relative}")
+        if item.get("version") != version:
+            raise CandidateError(f"artifact version mismatch: {relative}")
+        surface = item.get("surface")
+        name = item.get("name")
+        if surface in names_by_surface and isinstance(name, str):
+            names_by_surface[surface].add(name)
+        if item.get("class") == "python-wheel":
+            wheel_count += 1
+        elif item.get("class") == "python-sdist":
+            sdist_count += 1
+        elif item.get("class") == "node-addon":
+            addon_count += 1
+
+    actual_files = {
+        str(path.relative_to(artifacts_dir))
+        for path in artifacts_dir.rglob("*")
+        if path.is_file() and not path.name.startswith(".")
+    }
+    if actual_files != seen_paths:
+        missing = sorted(seen_paths - actual_files)
+        extra = sorted(actual_files - seen_paths)
+        raise CandidateError(f"record/file inventory drift: missing={missing} extra={extra}")
+    if wheel_count != 3 or sdist_count != 1 or names_by_surface["pypi"] != {"graphforge"}:
+        raise CandidateError("candidate must contain three graphforge wheels plus its sdist")
+    if addon_count != 5:
+        raise CandidateError("candidate must contain the five tested Node addons")
+    if names_by_surface["npm"] != set(NPM_PACKAGES):
+        raise CandidateError(
+            "candidate npm set mismatch: "
+            f"expected={list(NPM_PACKAGES)} actual={sorted(names_by_surface['npm'])}"
+        )
+    if names_by_surface["crates"] != set(CRATES):
+        raise CandidateError(
+            f"candidate crates set mismatch: expected={list(CRATES)} "
+            f"actual={sorted(names_by_surface['crates'])}"
+        )
+    return record
+
+
+def npm_paths(record: dict[str, Any]) -> list[str]:
+    by_name = {
+        item["name"]: item["path"] for item in record["artifacts"] if item.get("surface") == "npm"
+    }
+    return [by_name[name] for name in NPM_PACKAGES]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("validate", "npm-paths"))
+    parser.add_argument("--record", type=Path, required=True)
+    parser.add_argument("--artifacts-dir", type=Path, required=True)
+    parser.add_argument("--expected-sha", required=True)
+    parser.add_argument("--version", required=True)
+    args = parser.parse_args(argv)
+    try:
+        record = validate(args.record, args.artifacts_dir, args.expected_sha, args.version)
+        if args.command == "npm-paths":
+            print("\n".join(npm_paths(record)))
+        else:
+            print(
+                f"release-candidate: valid version={args.version} "
+                f"sha={args.expected_sha} artifacts={len(record['artifacts'])}"
+            )
+        return 0
+    except CandidateError as error:
+        print(f"release-candidate: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/release-notes.py
+++ b/scripts/ci/release-notes.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Extract exact release notes from the canonical CHANGELOG section."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import re
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+CHANGELOG = ROOT / "CHANGELOG.md"
+DOCS_CHANGELOG = ROOT / "docs" / "reference" / "changelog.md"
+
+
+def extract(text: str, version: str) -> str:
+    match = re.search(
+        rf"(?ms)^## \[{re.escape(version)}\] - \d{{4}}-\d{{2}}-\d{{2}}\s*\n"
+        r"(?P<body>.*?)(?=^## \[|^\[[^\n]+\]:|\Z)",
+        text,
+    )
+    if match is None:
+        raise ValueError(f"CHANGELOG lacks a dated [{version}] section")
+    body = match.group("body").strip()
+    if not body:
+        raise ValueError(f"CHANGELOG [{version}] section is empty")
+    return body + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version")
+    parser.add_argument("--out", type=Path)
+    args = parser.parse_args(argv)
+    canonical = CHANGELOG.read_text(encoding="utf-8")
+    if DOCS_CHANGELOG.read_text(encoding="utf-8") != canonical:
+        print("release-notes: docs changelog does not mirror CHANGELOG.md", file=sys.stderr)
+        return 1
+    try:
+        notes = extract(canonical, args.version)
+    except ValueError as error:
+        print(f"release-notes: {error}", file=sys.stderr)
+        return 1
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(notes, encoding="utf-8")
+        print(f"release-notes: wrote {args.out}")
+    else:
+        sys.stdout.write(notes)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test-binding-release-candidate.py
+++ b/scripts/ci/test-binding-release-candidate.py
@@ -234,11 +234,18 @@ def validate_windows_node_cold_start_policy(workflow_text: str) -> None:
     assert "actions/cache@v6" not in node_job
     assert "actions/cache/restore@v6" not in node_job
     assert "actions/cache/save@v6" not in node_job
-    assert node_job.count("actions/upload-artifact@v7") == 1
+    assert node_job.count("actions/upload-artifact@v7") == 2
     assert_active_lines(
         node_job,
         "name: binding-rc-report-${{ github.run_id }}-${{ matrix.report_target }}",
         "path: binding-rc-reports/${{ matrix.report_target }}.json",
+        "if-no-files-found: error",
+        "retention-days: 1",
+    )
+    assert_active_lines(
+        node_job,
+        "name: binding-rc-addon-${{ github.run_id }}-${{ matrix.target }}",
+        "path: crates/graphforge-bindings-node/*.node",
         "if-no-files-found: error",
         "retention-days: 1",
     )
@@ -579,21 +586,20 @@ def main() -> None:
     assert "../../../scripts/ci/validate-napi-artifacts.py" not in package_validation_step
     assert (ROOT / "scripts/ci/validate-napi-artifacts.py").samefile(ARTIFACT_VALIDATOR)
 
-    publish_workflow_text = PUBLISH_WORKFLOW.read_text()
-    publish_wheel_job = publish_workflow_text.split("  build-wheels:", 1)[1].split(
-        "  build-sdist:", 1
-    )[0]
-    post_maturin = publish_wheel_job.split("uses: PyO3/maturin-action@v1", 1)[1]
-    assert "cargo " not in post_maturin.lower()
-    assert "tests/*.py" not in post_maturin
-    assert "native contract" not in post_maturin.lower()
-    publish_transfer = workflow_step(post_maturin, "uses: actions/cache/save@v6")
-    assert_active_lines(
-        publish_transfer,
-        "uses: actions/cache/save@v6",
-        "path: dist",
-        "key: publish-python-${{ github.run_id }}-${{ matrix.os }}",
+    assert "Save tested wheel for release-candidate assembly" in rc_workflow_text
+    assert "Save tested addon for release-candidate assembly" in rc_workflow_text
+    assert "Assemble immutable M1 release candidate" in rc_workflow_text
+    assert "scripts/ci/release-candidate.py validate" in rc_workflow_text
+    assert "M1-Release-Candidate-${{ needs.validate_source.outputs.evidence_sha }}" in (
+        rc_workflow_text
     )
+
+    publish_workflow_text = PUBLISH_WORKFLOW.read_text()
+    assert "M1-Release-Candidate-$RELEASE_SHA" in publish_workflow_text
+    assert "PyO3/maturin-action" not in publish_workflow_text
+    assert "napi build" not in publish_workflow_text
+    assert "candidate/release-artifacts/python/*" in publish_workflow_text
+    assert "--check-url https://pypi.org/simple/" in publish_workflow_text
 
     with tempfile.TemporaryDirectory() as directory:
         temp = Path(directory)
@@ -714,7 +720,7 @@ def main() -> None:
         ]
         assert wrapper_log.read_text().splitlines()
 
-    for workflow in (RC_WORKFLOW, PUBLISH_WORKFLOW):
+    for workflow in (RC_WORKFLOW,):
         workflow_text = workflow.read_text()
         assert "run build --" not in workflow_text, (
             f"{workflow.name} forwards napi options to Cargo after `--`"
@@ -737,12 +743,17 @@ def main() -> None:
         assert "arm_cflags || ''" in workflow_text, (
             f"{workflow.name} must source target-scoped CFLAGS from its matrix entry"
         )
-        assert workflow_text.count(ARTIFACT_COMMAND) == 1, (
+        assert workflow_text.count(ARTIFACT_COMMAND) == 2, (
             f"{workflow.name} must use the shared explicit napi artifact command"
         )
         assert "napi artifacts --dir" not in workflow_text, (
             f"{workflow.name} uses the unsupported napi artifacts --dir option"
         )
+
+    publish_text = PUBLISH_WORKFLOW.read_text()
+    assert "exec napi build --platform --release" not in publish_text
+    assert ARTIFACT_COMMAND not in publish_text
+    assert "M1-Release-Candidate-$RELEASE_SHA" in publish_text
 
     pnpm = shutil.which("pnpm")
     assert pnpm is not None, "pnpm is required for napi CLI contract validation"

--- a/scripts/ci/test-ci-storage-policy.py
+++ b/scripts/ci/test-ci-storage-policy.py
@@ -12,9 +12,19 @@ EXPECTED_ARTIFACT_UPLOADS = Counter(
     {
         "binding-rc-report-${{ github.run_id }}-${{ matrix.target }}": 1,
         "binding-rc-report-${{ github.run_id }}-${{ matrix.report_target }}": 1,
+        "binding-rc-wheel-${{ github.run_id }}-${{ matrix.target }}": 1,
+        "binding-rc-addon-${{ github.run_id }}-${{ matrix.target }}": 1,
+        "M1-Binding-Release-Candidate-${{ needs.validate_source.outputs.evidence_sha }}": 1,
+        "M1-Release-Candidate-${{ needs.validate_source.outputs.evidence_sha }}": 1,
     }
 )
-EXPECTED_ARTIFACT_DOWNLOADS = Counter({"binding-rc-report-${{ github.run_id }}-*": 1})
+EXPECTED_ARTIFACT_DOWNLOADS = Counter(
+    {
+        "binding-rc-report-${{ github.run_id }}-*": 1,
+        "binding-rc-wheel-${{ github.run_id }}-*": 1,
+        "binding-rc-addon-${{ github.run_id }}-*": 1,
+    }
+)
 EXPECTED_DEPENDENCY_KEYS = Counter(
     {
         "${{ runner.os }}-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}": 7,
@@ -28,11 +38,11 @@ EXPECTED_STICKY_KEYS = Counter(
             "${{ github.repository }}-daily-fuzz-"
             "${{ hashFiles('fuzz/Cargo.toml', '**/Cargo.lock') }}-target-v1"
         ): 1,
-        "${{ github.repository }}-m22-load-${{ inputs.commit_sha }}-target-v3": 1,
+        "${{ github.repository }}-m1-release-load-${{ inputs.commit_sha }}-target-v3": 1,
     }
 )
 EXPECTED_STICKY_DELETES = Counter(
-    {"${{ github.repository }}-m22-load-${{ inputs.commit_sha }}-target-v3": 1}
+    {"${{ github.repository }}-m1-release-load-${{ inputs.commit_sha }}-target-v3": 1}
 )
 EXPECTED_SAVES = Counter(
     {
@@ -46,10 +56,7 @@ EXPECTED_SAVES = Counter(
         "m21-transfer-${{ github.run_id }}-rust": 1,
         "m21-transfer-${{ github.run_id }}-python": 1,
         "m21-transfer-${{ github.run_id }}-node": 1,
-        "m22-load-${{ github.run_id }}": 1,
-        "publish-node-${{ github.run_id }}-${{ matrix.settings.target }}": 1,
-        "publish-python-${{ github.run_id }}-${{ matrix.os }}": 1,
-        "publish-python-${{ github.run_id }}-sdist": 1,
+        "m1-release-load-${{ github.run_id }}": 1,
         "rust-non-cypher-${{ env.EVIDENCE_SHA }}": 1,
     }
 )
@@ -65,16 +72,7 @@ EXPECTED_RESTORES = Counter(
         "m21-transfer-${{ github.run_id }}-rust": 1,
         "m21-transfer-${{ github.run_id }}-python": 1,
         "m21-transfer-${{ github.run_id }}-node": 1,
-        "m22-load-${{ github.run_id }}": 1,
-        "publish-node-${{ github.run_id }}-x86_64-apple-darwin": 1,
-        "publish-node-${{ github.run_id }}-aarch64-apple-darwin": 1,
-        "publish-node-${{ github.run_id }}-x86_64-unknown-linux-gnu": 1,
-        "publish-node-${{ github.run_id }}-aarch64-unknown-linux-gnu": 1,
-        "publish-node-${{ github.run_id }}-x86_64-pc-windows-msvc": 1,
-        "publish-python-${{ github.run_id }}-blacksmith-4vcpu-ubuntu-2404": 1,
-        "publish-python-${{ github.run_id }}-blacksmith-6vcpu-macos-15": 1,
-        "publish-python-${{ github.run_id }}-blacksmith-4vcpu-windows-2025": 1,
-        "publish-python-${{ github.run_id }}-sdist": 1,
+        "m1-release-load-${{ github.run_id }}": 1,
         "rust-non-cypher-${{ needs.validate_source.outputs.evidence_sha }}": 1,
     }
 )
@@ -136,11 +134,19 @@ def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
         assert field(step, "if-no-files-found") == "error", (
             f"artifact upload is not fail-closed: {name}"
         )
-        assert field(step, "retention-days") == "1", f"artifact retention is not one day: {name}"
+        publication = name.startswith("M1-")
+        expected_retention = "30" if publication else "1"
+        assert field(step, "retention-days") == expected_retention, (
+            f"artifact retention drift: {name}"
+        )
         path = field(step, "path")
         assert path in {
             "binding-rc-reports/${{ matrix.target }}.json",
             "binding-rc-reports/${{ matrix.report_target }}.json",
+            "dist/*.whl",
+            "crates/graphforge-bindings-node/*.node",
+            "binding-rc-aggregate/report.json",
+            "candidate/",
         }, f"artifact upload contains unapproved bytes: {path}"
         uploaded.append(name)
     for step in action_steps(text, "actions/download-artifact@"):
@@ -148,9 +154,11 @@ def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
         assert uses == "actions/download-artifact@v8", f"unapproved artifact action: {uses}"
         pattern = field(step, "pattern")
         assert pattern is not None, "artifact download has no exact-run pattern"
-        assert field(step, "path") == "binding-rc-reports", (
-            f"artifact download path drift: {pattern}"
-        )
+        assert field(step, "path") in {
+            "binding-rc-reports",
+            "candidate/release-artifacts/python",
+            "candidate/release-artifacts/node-addons",
+        }, f"artifact download path drift: {pattern}"
         assert field(step, "merge-multiple") == "true", (
             f"artifact reports are not merged: {pattern}"
         )
@@ -272,7 +280,7 @@ def main() -> None:
         f"{len(artifact_downloads)} consumer, {len(saved)} cache transfer producers, "
         f"{len(restored)} consumers, "
         f"{len(dependency_keys)} dependency caches, {len(sticky_keys)} bounded sticky disks, "
-        "one-day binding-report artifact retention"
+        "one-day transfer and 30-day publication artifact retention"
     )
 
 

--- a/scripts/ci/test-m1-release-certification.py
+++ b/scripts/ci/test-m1-release-certification.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Mutation-sensitive tests for the final M22 non-Cypher surface gate."""
+"""Mutation-sensitive tests for the final M1 release certification gate."""
 
 from __future__ import annotations
 
@@ -11,9 +11,9 @@ import tempfile
 import unittest
 
 ROOT = Path(__file__).resolve().parents[2]
-SCRIPT = ROOT / "scripts/ci/m22-non-cypher-surface-gate.py"
+SCRIPT = ROOT / "scripts/ci/m1-release-certification.py"
 LOAD_TEST = ROOT / "scripts/ci/test-release-load-matrix.py"
-WORKFLOW = ROOT / ".github/workflows/m22-non-cypher-surface-gate.yml"
+WORKFLOW = ROOT / ".github/workflows/m1-release-certification.yml"
 SHA = "a" * 40
 
 
@@ -25,11 +25,11 @@ def import_file(name: str, path: Path):
     return module
 
 
-GATE = import_file("m22_surface_gate", SCRIPT)
-LOAD_TESTS = import_file("m22_load_test_helpers", LOAD_TEST)
+GATE = import_file("m1_release_certification", SCRIPT)
+LOAD_TESTS = import_file("m1_release_load_test_helpers", LOAD_TEST)
 
 
-class M22SurfaceGateTests(unittest.TestCase):
+class M1ReleaseCertificationTests(unittest.TestCase):
     def setUp(self) -> None:
         self.rust_run = {
             "id": 101,
@@ -90,7 +90,7 @@ class M22SurfaceGateTests(unittest.TestCase):
         self.assertIn("workflow_dispatch:", header)
         for forbidden in ("push:", "pull_request:", "schedule:"):
             self.assertNotIn(forbidden, header)
-        self.assertIn("group: m22-non-cypher-${{ inputs.commit_sha }}", header)
+        self.assertIn("group: m1-release-certification-${{ inputs.commit_sha }}", header)
         self.assertIn("cancel-in-progress: true", header)
         self.assertNotIn("gh workflow run", text)
         validate = jobs.index("  validate_source:")
@@ -115,7 +115,7 @@ class M22SurfaceGateTests(unittest.TestCase):
         self.assertIn("release-load-matrix.py run", load_job)
         self.assertIn("useblacksmith/stickydisk@v1", load_job)
         self.assertIn(
-            "${{ github.repository }}-m22-load-${{ inputs.commit_sha }}-target-v3",
+            "${{ github.repository }}-m1-release-load-${{ inputs.commit_sha }}-target-v3",
             load_job,
         )
         self.assertIn("useblacksmith/stickydisk-delete@v1", load_job)
@@ -127,8 +127,8 @@ class M22SurfaceGateTests(unittest.TestCase):
             load_job,
         )
         self.assertIn("Reclaim root-disk headroom before the matrix", load_job)
-        self.assertIn("TMPDIR: ${{ runner.temp }}/graphforge-m22-load-tmp", load_job)
-        self.assertNotIn("graphforge-m22-load-target", load_job)
+        self.assertIn("TMPDIR: ${{ runner.temp }}/graphforge-m1-release-load-tmp", load_job)
+        self.assertNotIn("graphforge-m1-release-load-target", load_job)
         maturin_step = load_job.index("- name: Build one exact-SHA Python wheel")
         reclaim_step = load_job.index("- name: Reclaim sticky-disk ownership after maturin")
         wrapper_step = load_job.index(
@@ -218,7 +218,7 @@ class M22SurfaceGateTests(unittest.TestCase):
 
     def binding_report(self) -> dict:
         validator = GATE.import_script(
-            "m22_test_binding", ROOT / "scripts/ci/validate-binding-release-candidate.py"
+            "m1_test_binding", ROOT / "scripts/ci/validate-binding-release-candidate.py"
         )
         contract = GATE.load_json(GATE.BINDING_TARGETS)
         reports = []

--- a/scripts/ci/test-publish-cli-contract.py
+++ b/scripts/ci/test-publish-cli-contract.py
@@ -8,26 +8,21 @@ WORKFLOW = ROOT / ".github" / "workflows" / "publish.yaml"
 VERIFY = ROOT / "scripts" / "ci" / "verify-node-cli-release-package.mjs"
 
 
-def section(text: str, start: str, end: str) -> str:
-    _, found, tail = text.partition(start)
-    assert found, f"missing workflow marker: {start.strip()}"
-    body, found, _ = tail.partition(end)
-    assert found, f"missing workflow marker: {end.strip()}"
-    return body
-
-
 def main() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
-    native = section(text, "  publish-node:\n", "  # ---- NPX lifecycle CLI")
-    cli = section(text, "  publish-node-cli:\n", "  # ---- NPX agent skills")
-
-    assert "needs: [build-node, publish]" in native
-    assert "needs: [publish, publish-node]" in cli
-    assert "pnpm --filter @graphforge/cli test:offline" in cli
-    assert "node scripts/ci/verify-node-cli-release-package.mjs" in cli
-    assert cli.index("verify-node-cli-release-package.mjs") < cli.index("Publish @graphforge/cli")
-    assert "continue-on-error" not in cli
-    assert "|| true" not in cli
+    _, found, tail = text.partition("  publish-npm:\n")
+    assert found
+    npm_job, found, _ = tail.partition("\n  publish-crates:\n")
+    assert found
+    assert "needs: [candidate-preflight, publish-pypi]" in npm_job
+    assert "pnpm --filter @graphforge/cli test:offline" in npm_job
+    assert "node scripts/ci/verify-node-cli-release-package.mjs" in npm_job
+    assert npm_job.count("scripts/publish_npm_artifacts.py") == 3
+    assert npm_job.index("--group native") < npm_job.index("verify-node-cli-release-package.mjs")
+    assert npm_job.index("verify-node-cli-release-package.mjs") < npm_job.index("--group cli")
+    assert npm_job.index("--group cli") < npm_job.index("--group skills")
+    assert "continue-on-error" not in npm_job
+    assert "|| true" not in npm_job
     assert VERIFY.is_file()
     print("publish CLI contract tests passed")
 

--- a/scripts/ci/test-publish-crates.py
+++ b/scripts/ci/test-publish-crates.py
@@ -3,8 +3,12 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
+import json
 from pathlib import Path
+import subprocess
+import tempfile
 
 SCRIPT = Path(__file__).parents[1] / "publish_crates.py"
 
@@ -54,5 +58,56 @@ try:
     raise AssertionError("expected the owner assertion to fail")
 except RuntimeError as exc:
     assert "DecisionNerd is not an owner" in str(exc)
+
+with tempfile.TemporaryDirectory() as temp:
+    root = Path(temp)
+    artifacts = root / "artifacts"
+    artifacts.mkdir()
+    archive = artifacts / "graphforge-core-0.5.0.crate"
+    archive.write_bytes(b"certified crate")
+    sha = hashlib.sha256(archive.read_bytes()).hexdigest()
+    record = {
+        "schema": "graphforge-release-record-v1",
+        "version": "0.5.0",
+        "tag": "v0.5.0",
+        "commit_sha": "release-sha",
+        "artifacts": [
+            {
+                "surface": "crates",
+                "name": "graphforge-core",
+                "version": "0.5.0",
+                "path": archive.name,
+                "sha256": sha,
+            }
+        ],
+    }
+    record_path = root / "record.json"
+    original_run = subprocess.run
+
+    def release_sha(*args, **_kwargs):
+        return subprocess.CompletedProcess(args[0], 0, stdout="release-sha\n")
+
+    mod.subprocess.run = release_sha
+    record_path.write_text(json.dumps(record), encoding="utf-8")
+    assert mod.release_record_checksums(record_path, artifacts) == {"graphforge-core": sha}
+
+    for escaped in ("../outside.crate", "nested/../../outside.crate", "/etc/passwd"):
+        record["artifacts"][0]["path"] = escaped
+        record_path.write_text(json.dumps(record), encoding="utf-8")
+        try:
+            mod.release_record_checksums(record_path, artifacts)
+            raise AssertionError("expected escaped artifact path to fail")
+        except RuntimeError as exc:
+            assert "escapes artifact root" in str(exc)
+
+    record["artifacts"][0]["path"] = archive.name
+    record["artifacts"][0]["version"] = "0.5.1"
+    record_path.write_text(json.dumps(record), encoding="utf-8")
+    try:
+        mod.release_record_checksums(record_path, artifacts)
+        raise AssertionError("expected artifact version mismatch to fail")
+    except RuntimeError as exc:
+        assert "version mismatch" in str(exc)
+    mod.subprocess.run = original_run
 
 print("publish crates tests passed")

--- a/scripts/ci/test-publish-crates.py
+++ b/scripts/ci/test-publish-crates.py
@@ -22,14 +22,15 @@ assert mod.VERSION == "0.5.0"
 
 commands: list[list[str]] = []
 waits: list[tuple[str, str, int]] = []
-mod.package_checksum = lambda _name: "abc123"
+mod.package_checksum = lambda _name, expected=None: expected or "abc123"
 mod.owner_logins = lambda _name: {"DecisionNerd"}
 mod.run = commands.append
 mod.wait_for_version = lambda name, checksum, timeout: waits.append((name, checksum, timeout))
 
 mod.version_record = lambda _name: {"checksum": "abc123"}
 assert (
-    mod.publish_one("graphforge-core", timeout_seconds=30) == "already published; checksum matches"
+    mod.publish_one("graphforge-core", timeout_seconds=30, expected_checksum="abc123")
+    == "already published; checksum matches"
 )
 assert commands == []
 assert waits == []

--- a/scripts/ci/test-publish-npm-artifacts.py
+++ b/scripts/ci/test-publish-npm-artifacts.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Deterministic tests for checksum-safe npm publication."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import tempfile
+
+SCRIPT = Path(__file__).parents[1] / "publish_npm_artifacts.py"
+SPEC = importlib.util.spec_from_file_location("publish_npm_artifacts", SCRIPT)
+assert SPEC and SPEC.loader
+publisher = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(publisher)
+
+with tempfile.TemporaryDirectory() as temp:
+    root = Path(temp)
+    archive = root / "package.tgz"
+    archive.write_bytes(b"candidate")
+    item = {
+        "name": "@graphforge/node",
+        "version": "0.5.0",
+        "path": archive.name,
+        "sha256": "abc123",
+    }
+    published: list[Path] = []
+    publisher.publish_archive = published.append
+    publisher.published_checksum = lambda _name, _version: "abc123"
+    assert publisher.publish_one(item, root, 1) == "already published; checksum matches"
+    assert published == []
+
+    responses = iter((None, "abc123"))
+    publisher.published_checksum = lambda _name, _version: next(responses)
+    assert publisher.publish_one(item, root, 1) == "published"
+    assert published == [archive]
+
+    publisher.published_checksum = lambda _name, _version: "different"
+    try:
+        publisher.publish_one(item, root, 1)
+    except RuntimeError as error:
+        assert "refusing to resume" in str(error)
+    else:
+        raise AssertionError("checksum drift should fail")
+
+assert publisher.GROUPS["native"] == slice(0, 6)
+assert publisher.GROUPS["cli"] == slice(6, 7)
+assert publisher.GROUPS["skills"] == slice(7, 8)
+print("publish npm artifact tests passed")

--- a/scripts/ci/test-release-candidate.py
+++ b/scripts/ci/test-release-candidate.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Mutation-sensitive tests for the immutable M1 release-candidate bundle."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+
+SCRIPT = Path(__file__).with_name("release-candidate.py")
+SPEC = importlib.util.spec_from_file_location("release_candidate", SCRIPT)
+assert SPEC and SPEC.loader
+release_candidate = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(release_candidate)
+
+
+def _artifact(root: Path, relative: str, surface: str, name: str, kind: str) -> dict[str, object]:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(relative.encode())
+    return {
+        "path": relative,
+        "class": kind,
+        "surface": surface,
+        "name": name,
+        "version": "0.5.0",
+        "filename": path.name,
+        "bytes": path.stat().st_size,
+        "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+    }
+
+
+def _fixture(root: Path) -> tuple[Path, Path]:
+    artifacts: list[dict[str, object]] = []
+    for platform in ("linux", "macos", "windows"):
+        artifacts.append(
+            _artifact(
+                root, f"python/graphforge-{platform}.whl", "pypi", "graphforge", "python-wheel"
+            )
+        )
+    for target in ("darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64", "win32-x64"):
+        artifacts.append(
+            _artifact(root, f"node-addons/graphforge.{target}.node", "github", target, "node-addon")
+        )
+    artifacts.append(
+        _artifact(root, "python/graphforge-0.5.0.tar.gz", "pypi", "graphforge", "python-sdist")
+    )
+    for index, name in enumerate(release_candidate.NPM_PACKAGES):
+        artifacts.append(_artifact(root, f"npm/{index}.tgz", "npm", name, "npm-tarball"))
+    for name in release_candidate.CRATES:
+        artifacts.append(
+            _artifact(root, f"crates/{name}-0.5.0.crate", "crates", name, "rust-crate")
+        )
+    record = {
+        "schema": release_candidate.SCHEMA,
+        "version": "0.5.0",
+        "tag": "v0.5.0",
+        "commit_sha": "a" * 40,
+        "artifacts": artifacts,
+    }
+    record_path = root.parent / "record.json"
+    record_path.write_text(json.dumps(record), encoding="utf-8")
+    return record_path, root
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as temp:
+        root = Path(temp) / "artifacts"
+        record_path, artifacts_dir = _fixture(root)
+        record = release_candidate.validate(record_path, artifacts_dir, "a" * 40, "0.5.0")
+        assert len(release_candidate.npm_paths(record)) == 8
+        assert release_candidate.npm_paths(record)[-3:] == ["npm/5.tgz", "npm/6.tgz", "npm/7.tgz"]
+
+        target = artifacts_dir / record["artifacts"][0]["path"]
+        target.write_bytes(b"mutated")
+        try:
+            release_candidate.validate(record_path, artifacts_dir, "a" * 40, "0.5.0")
+        except release_candidate.CandidateError as error:
+            assert "checksum mismatch" in str(error)
+        else:
+            raise AssertionError("checksum mutation should fail")
+
+    print("release-candidate tests: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/test-release-notes.py
+++ b/scripts/ci/test-release-notes.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Deterministic checks for release-note extraction."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("release-notes.py")
+SPEC = importlib.util.spec_from_file_location("release_notes", SCRIPT)
+assert SPEC and SPEC.loader
+release_notes = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(release_notes)
+
+sample = """# Changelog
+
+## [Unreleased]
+
+_Nothing yet._
+
+## [0.5.0] - 2026-07-31
+
+### Added
+
+- Public release.
+
+## [0.4.0] - 2026-01-01
+
+- Previous.
+
+[0.5.0]: https://example.invalid/v0.5.0
+"""
+assert release_notes.extract(sample, "0.5.0") == "### Added\n\n- Public release.\n"
+try:
+    release_notes.extract(sample, "0.6.0")
+except ValueError as error:
+    assert "lacks a dated" in str(error)
+else:
+    raise AssertionError("missing release section should fail")
+
+print("release notes tests passed")

--- a/scripts/ci/test-release-publish-preflight.py
+++ b/scripts/ci/test-release-publish-preflight.py
@@ -9,6 +9,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = Path(__file__).with_name("release-publish-preflight.py")
 WORKFLOW = ROOT / ".github" / "workflows" / "publish.yaml"
+CREDENTIAL_WORKFLOW = ROOT / ".github" / "workflows" / "release-credential-preflight.yml"
 
 
 def load_module():
@@ -83,29 +84,48 @@ for mutation in mutations:
     assert mod.validate(**values), mutation
 
 workflow = WORKFLOW.read_text(encoding="utf-8")
-license_job = workflow.split("  license-compliance:\n", 1)[1].split("\n  build-wheels:", 1)[0]
-assert "release-publish-preflight.py" in license_job
-assert "github.event.release.tag_name" in license_job
-assert "github.sha" in license_job
-assert "refs/remotes/origin/main" in license_job
-assert "npm whoami" in license_job
-assert "secrets.NPM_TOKEN" in license_job
-assert license_job.index("release-publish-preflight.py") < license_job.index("npm whoami")
-for build_job, next_job in (
-    ("build-wheels", "build-sdist"),
-    ("build-sdist", "publish"),
-    ("build-node", "publish-node"),
-):
-    section = workflow.split(f"  {build_job}:\n", 1)[1].split(f"\n  {next_job}:\n", 1)[0]
-    assert "needs: license-compliance" in section, build_job
+preflight = workflow.split("  candidate-preflight:\n", 1)[1].split("\n  publish-pypi:", 1)[0]
+assert "release-publish-preflight.py" in preflight
+assert "github.event.release.tag_name" in preflight
+assert "github.sha" in preflight
+assert "refs/remotes/origin/main" in preflight
+assert "npm whoami" in preflight
+assert "secrets.NPM_TOKEN" in preflight
+assert "M1-Release-Candidate-$RELEASE_SHA" in preflight
+assert "scripts/ci/release-candidate.py validate" in preflight
+assert "gh release upload" in preflight
+assert preflight.index("release-publish-preflight.py") < preflight.index("npm whoami")
+assert preflight.index("npm whoami") < preflight.index("gh release upload")
 
-skills_job = workflow.split("  publish-agent-skills:\n", 1)[1].split("\n  # ---- Rust crates", 1)[0]
-assert "needs: publish-node-cli" in skills_job
+pypi_job = workflow.split("  publish-pypi:\n", 1)[1].split("\n  publish-npm:", 1)[0]
+assert "needs: candidate-preflight" in pypi_job
+assert "--check-url https://pypi.org/simple/" in pypi_job
+assert "candidate/release-artifacts/python/*" in pypi_job
+
+npm_job = workflow.split("  publish-npm:\n", 1)[1].split("\n  publish-crates:", 1)[0]
+assert "needs: [candidate-preflight, publish-pypi]" in npm_job
+assert "scripts/publish_npm_artifacts.py" in npm_job
+assert "--group native" in npm_job
+assert "--group cli" in npm_job
+assert "--group skills" in npm_job
+assert "verify-node-cli-release-package.mjs" in npm_job
 
 crates_job = workflow.split("  publish-crates:\n", 1)[1]
-assert "needs: publish-agent-skills" in crates_job
+assert "needs: [candidate-preflight, publish-npm]" in crates_job
 assert "scripts/publish_crates.py" in crates_job
+assert "--release-record candidate/v0.5.0-artifacts.json" in crates_job
 assert "secrets.CARGO_REGISTRY_TOKEN" in crates_job
 assert "cargo publish" not in crates_job
+for retired_job in ("build-wheels", "build-sdist", "build-node", "publish-node-cli"):
+    assert f"  {retired_job}:" not in workflow
+
+credential_workflow = CREDENTIAL_WORKFLOW.read_text(encoding="utf-8")
+assert "workflow_dispatch:" in credential_workflow
+assert "commit_sha:" in credential_workflow
+assert "npm whoami" in credential_workflow
+assert "secrets.NPM_TOKEN" in credential_workflow
+assert "secrets.CARGO_REGISTRY_TOKEN" in credential_workflow
+for forbidden in ("npm publish", "uv publish", "cargo publish", "release:\n"):
+    assert forbidden not in credential_workflow
 
 print("release publish preflight tests passed")

--- a/scripts/ci/test-release-publish-preflight.py
+++ b/scripts/ci/test-release-publish-preflight.py
@@ -128,4 +128,8 @@ assert "secrets.CARGO_REGISTRY_TOKEN" in credential_workflow
 for forbidden in ("npm publish", "uv publish", "cargo publish", "release:\n"):
     assert forbidden not in credential_workflow
 
+for job in (preflight, pypi_job, npm_job, crates_job, credential_workflow):
+    assert "continue-on-error" not in job
+    assert "|| true" not in job
+
 print("release publish preflight tests passed")

--- a/scripts/publish_crates.py
+++ b/scripts/publish_crates.py
@@ -82,7 +82,7 @@ def owner_logins(name: str) -> set[str]:
     return {owner["login"] for owner in payload.get("users", [])}
 
 
-def package_checksum(name: str) -> str:
+def package_checksum(name: str, expected_checksum: str | None = None) -> str:
     run(
         [
             "cargo",
@@ -98,7 +98,13 @@ def package_checksum(name: str) -> str:
     archive = target_dir / "package" / f"{name}-{VERSION}.crate"
     if not archive.is_file():
         raise RuntimeError(f"cargo package did not create {archive}")
-    return hashlib.sha256(archive.read_bytes()).hexdigest()
+    checksum = hashlib.sha256(archive.read_bytes()).hexdigest()
+    if expected_checksum is not None and checksum != expected_checksum:
+        raise RuntimeError(
+            f"{name} {VERSION} packaged checksum {checksum} differs from "
+            f"the certified release record {expected_checksum}"
+        )
+    return checksum
 
 
 def wait_for_version(name: str, checksum: str, timeout_seconds: int) -> None:
@@ -117,8 +123,13 @@ def wait_for_version(name: str, checksum: str, timeout_seconds: int) -> None:
     raise RuntimeError(f"timed out waiting for crates.io to index {name} {VERSION}")
 
 
-def publish_one(name: str, *, timeout_seconds: int) -> str:
-    checksum = package_checksum(name)
+def publish_one(
+    name: str,
+    *,
+    timeout_seconds: int,
+    expected_checksum: str | None = None,
+) -> str:
+    checksum = package_checksum(name, expected_checksum)
     existing = version_record(name)
     if existing is not None:
         registry_checksum = existing.get("checksum")
@@ -142,6 +153,49 @@ def publish_one(name: str, *, timeout_seconds: int) -> str:
     return outcome
 
 
+def release_record_checksums(record_path: Path, artifacts_dir: Path) -> dict[str, str]:
+    try:
+        record = json.loads(record_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise RuntimeError(f"cannot read release record {record_path}: {error}") from error
+    if record.get("schema") != "graphforge-release-record-v1":
+        raise RuntimeError("unexpected release record schema")
+    if record.get("version") != VERSION or record.get("tag") != f"v{VERSION}":
+        raise RuntimeError("release record version/tag does not match the Cargo version")
+    if (
+        record.get("commit_sha")
+        != subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        ).stdout.strip()
+    ):
+        raise RuntimeError("release record commit does not match the checked-out commit")
+
+    checksums: dict[str, str] = {}
+    for item in record.get("artifacts", []):
+        if item.get("surface") != "crates":
+            continue
+        name = item.get("name")
+        relative = item.get("path")
+        checksum = item.get("sha256")
+        if not all(isinstance(value, str) for value in (name, relative, checksum)):
+            raise RuntimeError("release record contains an invalid crates.io artifact")
+        if name in checksums:
+            raise RuntimeError(f"release record contains duplicate crate {name}")
+        archive = artifacts_dir / relative
+        if not archive.is_file():
+            raise RuntimeError(f"certified crate archive is missing: {relative}")
+        actual = hashlib.sha256(archive.read_bytes()).hexdigest()
+        if actual != checksum:
+            raise RuntimeError(f"certified crate archive checksum mismatch: {relative}")
+        checksums[name] = checksum
+    return checksums
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -150,7 +204,21 @@ def main(argv: list[str] | None = None) -> int:
         default=300,
         help="Seconds to wait for each successful upload to appear in crates.io",
     )
+    parser.add_argument(
+        "--release-record",
+        type=Path,
+        help="Certified graphforge-release-record-v1 JSON",
+    )
+    parser.add_argument(
+        "--artifacts-dir",
+        type=Path,
+        help="Root containing the certified artifact paths",
+    )
     args = parser.parse_args(argv)
+
+    if (args.release_record is None) != (args.artifacts_dir is None):
+        print("--release-record and --artifacts-dir must be provided together", file=sys.stderr)
+        return 2
 
     if not os.environ.get("CARGO_REGISTRY_TOKEN", "").strip():
         print("CARGO_REGISTRY_TOKEN is required", file=sys.stderr)
@@ -162,6 +230,16 @@ def main(argv: list[str] | None = None) -> int:
     if len(order) != 15:
         print(f"refusing unexpected publish-set size: {len(order)}", file=sys.stderr)
         return 2
+
+    expected_checksums: dict[str, str] = {}
+    if args.release_record is not None and args.artifacts_dir is not None:
+        expected_checksums = release_record_checksums(args.release_record, args.artifacts_dir)
+        if set(expected_checksums) != set(order):
+            print(
+                "release record crates do not match the complete publication plan",
+                file=sys.stderr,
+            )
+            return 2
 
     check = subprocess.run(
         [sys.executable, str(PLAN_SCRIPT), "check"],
@@ -176,7 +254,11 @@ def main(argv: list[str] | None = None) -> int:
         print(f"  {index:02d}. {name}")
 
     for name in order:
-        publish_one(name, timeout_seconds=args.index_timeout)
+        publish_one(
+            name,
+            timeout_seconds=args.index_timeout,
+            expected_checksum=expected_checksums.get(name),
+        )
 
     print(f"crates.io publication complete: {len(order)} crates at {VERSION}")
     return 0

--- a/scripts/publish_crates.py
+++ b/scripts/publish_crates.py
@@ -176,6 +176,7 @@ def release_record_checksums(record_path: Path, artifacts_dir: Path) -> dict[str
         raise RuntimeError("release record commit does not match the checked-out commit")
 
     checksums: dict[str, str] = {}
+    artifacts_root = artifacts_dir.resolve()
     for item in record.get("artifacts", []):
         if item.get("surface") != "crates":
             continue
@@ -184,9 +185,13 @@ def release_record_checksums(record_path: Path, artifacts_dir: Path) -> dict[str
         checksum = item.get("sha256")
         if not all(isinstance(value, str) for value in (name, relative, checksum)):
             raise RuntimeError("release record contains an invalid crates.io artifact")
+        if item.get("version") != VERSION:
+            raise RuntimeError(f"release record version mismatch for crate {name}")
         if name in checksums:
             raise RuntimeError(f"release record contains duplicate crate {name}")
-        archive = artifacts_dir / relative
+        archive = (artifacts_dir / relative).resolve()
+        if not archive.is_relative_to(artifacts_root):
+            raise RuntimeError(f"certified crate archive escapes artifact root: {relative}")
         if not archive.is_file():
             raise RuntimeError(f"certified crate archive is missing: {relative}")
         actual = hashlib.sha256(archive.read_bytes()).hexdigest()

--- a/scripts/publish_npm_artifacts.py
+++ b/scripts/publish_npm_artifacts.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Publish recorded npm tarballs with checksum-safe resumability."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+from typing import Any
+import urllib.error
+import urllib.parse
+import urllib.request
+
+ROOT = Path(__file__).resolve().parents[1]
+CANDIDATE_SCRIPT = ROOT / "scripts" / "ci" / "release-candidate.py"
+REGISTRY = "https://registry.npmjs.org"
+USER_AGENT = "GraphForge npm publisher (github.com/CurateLabs/graphforge)"
+GROUPS = {
+    "native": slice(0, 6),
+    "cli": slice(6, 7),
+    "skills": slice(7, 8),
+}
+
+
+def load_candidate_module():
+    spec = importlib.util.spec_from_file_location("release_candidate", CANDIDATE_SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {CANDIDATE_SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _json(url: str) -> dict[str, Any] | None:
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = json.load(response)
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            return None
+        raise
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"npm returned a non-object response for {url}")
+    return payload
+
+
+def published_checksum(name: str, version: str) -> str | None:
+    encoded = urllib.parse.quote(name, safe="")
+    record = _json(f"{REGISTRY}/{encoded}/{version}")
+    if record is None:
+        return None
+    tarball = record.get("dist", {}).get("tarball")
+    if not isinstance(tarball, str) or not tarball.startswith("https://registry.npmjs.org/"):
+        raise RuntimeError(f"npm {name}@{version} lacks a trusted registry tarball URL")
+    request = urllib.request.Request(tarball, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(request, timeout=60) as response:
+        return _sha256_bytes(response.read())
+
+
+def publish_archive(path: Path) -> None:
+    subprocess.run(
+        ["npm", "publish", str(path), "--access", "public"],
+        cwd=ROOT,
+        check=True,
+        env=os.environ.copy(),
+    )
+
+
+def publish_one(item: dict[str, Any], artifacts_dir: Path, timeout_seconds: int) -> str:
+    name = item["name"]
+    version = item["version"]
+    expected = item["sha256"]
+    path = artifacts_dir / item["path"]
+    existing = published_checksum(name, version)
+    if existing is not None:
+        if existing != expected:
+            raise RuntimeError(
+                f"refusing to resume {name}@{version}: registry checksum {existing} "
+                f"differs from candidate {expected}"
+            )
+        outcome = "already published; checksum matches"
+    else:
+        publish_archive(path)
+        deadline = time.monotonic() + timeout_seconds
+        while time.monotonic() < deadline:
+            existing = published_checksum(name, version)
+            if existing is not None:
+                break
+            time.sleep(3)
+        if existing is None:
+            raise RuntimeError(f"timed out waiting for npm to index {name}@{version}")
+        if existing != expected:
+            raise RuntimeError(
+                f"npm indexed different bytes for {name}@{version}: "
+                f"registry={existing} candidate={expected}"
+            )
+        outcome = "published"
+    print(f"{name}@{version}: {outcome}")
+    return outcome
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--release-record", type=Path, required=True)
+    parser.add_argument("--artifacts-dir", type=Path, required=True)
+    parser.add_argument("--expected-sha", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--group", choices=tuple(GROUPS), required=True)
+    parser.add_argument("--index-timeout", type=int, default=300)
+    args = parser.parse_args(argv)
+    if not os.environ.get("NODE_AUTH_TOKEN", "").strip():
+        print("NODE_AUTH_TOKEN is required", file=sys.stderr)
+        return 2
+
+    candidate = load_candidate_module()
+    record = candidate.validate(
+        args.release_record,
+        args.artifacts_dir,
+        args.expected_sha,
+        args.version,
+    )
+    by_name = {item["name"]: item for item in record["artifacts"] if item.get("surface") == "npm"}
+    names = candidate.NPM_PACKAGES[GROUPS[args.group]]
+    for name in names:
+        publish_one(by_name[name], args.artifacts_dir, args.index_timeout)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/publish_npm_artifacts.py
+++ b/scripts/publish_npm_artifacts.py
@@ -64,8 +64,13 @@ def published_checksum(name: str, version: str) -> str | None:
     if not isinstance(tarball, str) or not tarball.startswith("https://registry.npmjs.org/"):
         raise RuntimeError(f"npm {name}@{version} lacks a trusted registry tarball URL")
     request = urllib.request.Request(tarball, headers={"User-Agent": USER_AGENT})
-    with urllib.request.urlopen(request, timeout=60) as response:
-        return _sha256_bytes(response.read())
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            return _sha256_bytes(response.read())
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            return None
+        raise
 
 
 def publish_archive(path: Path) -> None:


### PR DESCRIPTION
## Summary

- rename the active publication certification workflow from stale M22 language to M1
- retain one exact-SHA Binding RC bundle containing tested wheels/addons, packaged Python/npm/crates.io artifacts, dry-run and license evidence, and a complete checksum record
- publish the recorded Python/npm bytes without rebuilding; make PyPI/npm/crates.io reruns checksum-safe and fail closed on drift
- add a non-publishing credential projection check, canonical CHANGELOG note extraction, and the ordered v0.5.0 operator runbook

## Verification

- `make pre-push-fast`
- `make release-version-check`
- `make license-check`
- `make package-license-verify`
- `make publish-dry-run`
- `make publish-dry-run-cargo`
- release-candidate, release-notes, npm/crates publisher, publication preflight, Binding RC, M1 certification, CLI publication, CI storage, and workflow static contracts

Refs #192. This PR intentionally does not close the human release gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788140576&installation_model_id=20486&pr_number=271&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F271&signature=cdb124a4d587a368322755f9bf8d58731f157d5adefe24ce5e191a6fe2b3195a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release-note extraction with changelog validation and file or terminal output.
  * Added immutable release-candidate validation for artifact versions, paths, inventories, and checksums.
  * Added checksum-aware publishing for npm and Rust packages, including safe resume behavior.
  * Added release certification and release-note command targets.

* **Bug Fixes**
  * Improved publication safeguards by detecting missing or mismatched artifact checksums.

* **Tests**
  * Expanded coverage for release candidates, release notes, artifact publication, certification, and CI policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve an exact-SHA M1 release candidate bundle and consume it during publish
> - Adds a `release_candidate` job to [binding-release-candidate.yml](https://github.com/CurateLabs/graphforge/pull/271/files#diff-735f23ab6fdd90d2ccfdace46553969c425da5baf1ccae2f98a37b3e3ed9b6b3) that assembles a single immutable, SHA-bound bundle (Python sdist, npm packs, Node addons, packaged crates, checksums) and retains it for 30 days as `M1-Release-Candidate-<sha>`.
> - Rewrites [publish.yaml](https://github.com/CurateLabs/graphforge/pull/271/files#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388ca) to consume the pre-built candidate bundle instead of rebuilding artifacts at publish time; a new `candidate-preflight` job verifies tag/SHA alignment, validates checksums, and attaches the release record to the GitHub Release before any registry write.
> - Adds [scripts/ci/release-candidate.py](https://github.com/CurateLabs/graphforge/pull/271/files#diff-1ea98be7e0e46cee451c2fd6bf1d2d0fe17d7c883dda1729f62776ff8be3ed05) with `validate` and `npm-paths` CLI commands that enforce schema, per-artifact SHA-256 integrity, surface/name accounting, and exact npm/crate set membership.
> - Adds [scripts/ci/release-notes.py](https://github.com/CurateLabs/graphforge/pull/271/files#diff-f9bccb94e24b0e65917613228b75b8288ed0d682b28ae317030afaaf446845dd) and a `release-notes` Makefile target to extract the dated changelog section for a given version into a markdown file.
> - Adds [.github/workflows/release-credential-preflight.yml](https://github.com/CurateLabs/graphforge/pull/271/files#diff-472d8accde0a2b597f2f22cdb5c78d5cecb7277bf216af9bc90023221c1d706b), a manually-dispatched workflow that validates npm and crates.io credentials for a given SHA without performing any registry writes.
> - Renames the M22 certification gate to M1 across workflow files, scripts, tests, and documentation (`m1-release-certification.yml`, `m1-release-certification.py`, `m1-release-certification-check` Makefile target).
> - Extends [scripts/publish_crates.py](https://github.com/CurateLabs/graphforge/pull/271/files#diff-bb71aff20a43fb0aa201b792e8bbfd985ff1afca4dc73c357f6c720e38603775) with `release_record_checksums` and optional `--release-record`/`--artifacts-dir` flags so crate publishing verifies certified checksums before uploading.
> - Risk: publish.yaml no longer builds wheels or addons at publish time; if no valid `M1-Release-Candidate-<sha>` artifact exists for the release SHA the publish job will fail hard.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1bedd28.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->