### PR TITLE
fix: use supported Node for M1 release assembly

### DIFF
--- a/.github/workflows/binding-release-candidate.yml
+++ b/.github/workflows/binding-release-candidate.yml
@@ -425,7 +425,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
 
       - uses: pnpm/action-setup@v4
 

--- a/scripts/ci/test-binding-release-candidate.py
+++ b/scripts/ci/test-binding-release-candidate.py
@@ -589,6 +589,8 @@ def main() -> None:
     assert "Save tested wheel for release-candidate assembly" in rc_workflow_text
     assert "Save tested addon for release-candidate assembly" in rc_workflow_text
     assert "Assemble immutable M1 release candidate" in rc_workflow_text
+    release_candidate_job = rc_workflow_text.split("  release_candidate:\n", 1)[1]
+    assert 'node-version: "22"' in release_candidate_job
     assert "scripts/ci/release-candidate.py validate" in rc_workflow_text
     assert "M1-Release-Candidate-${{ needs.validate_source.outputs.evidence_sha }}" in (
         rc_workflow_text


### PR DESCRIPTION
Refs #192

Fixes the exact post-merge Binding Release Candidate failure from run 30679161521. Astro now requires Node >=22.12, so the immutable candidate assembly uses Node 22 while target-specific Node binding builds retain their declared runtime.

Validation:
- scripts/check-workflows.sh
- python3 scripts/ci/test-binding-release-candidate.py
- make pre-push-fast

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788142646&installation_model_id=20486&pr_number=272&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F272&signature=5c5eb79c926e5b060f42de0b2664768a2976cf5f5d32c2354d2aafb5329bc293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->