### PR TITLE
fix: resolve M1 candidate validator from workspace

### DIFF
--- a/.github/workflows/binding-release-candidate.yml
+++ b/.github/workflows/binding-release-candidate.yml
@@ -472,7 +472,7 @@ jobs:
           pushd crates/graphforge-bindings-node
           pnpm exec napi create-npm-dirs
           pnpm exec napi artifacts --output-dir artifacts --npm-dir npm
-          python3 ../../../scripts/ci/validate-napi-artifacts.py \
+          python3 "$GITHUB_WORKSPACE/scripts/ci/validate-napi-artifacts.py" \
             --npm-dir npm --manifest package.json
           pnpm exec napi pre-publish -t npm --skip-optional-publish
           for package_dir in npm/*; do

--- a/scripts/ci/test-binding-release-candidate.py
+++ b/scripts/ci/test-binding-release-candidate.py
@@ -591,6 +591,8 @@ def main() -> None:
     assert "Assemble immutable M1 release candidate" in rc_workflow_text
     release_candidate_job = rc_workflow_text.split("  release_candidate:\n", 1)[1]
     assert 'node-version: "22"' in release_candidate_job
+    assert validator_from_workspace in release_candidate_job
+    assert "../../../scripts/ci/validate-napi-artifacts.py" not in release_candidate_job
     assert "scripts/ci/release-candidate.py validate" in rc_workflow_text
     assert "M1-Release-Candidate-${{ needs.validate_source.outputs.evidence_sha }}" in (
         rc_workflow_text


### PR DESCRIPTION
Refs #192

Fixes the exact Binding Release Candidate assembly failure from run 30679835791. The npm assembly step now resolves the N-API validator from GITHUB_WORKSPACE after entering the Node crate, with a regression assertion rejecting the escaping relative path.

Validation:
- scripts/check-workflows.sh
- python3 scripts/ci/test-binding-release-candidate.py
- make pre-push-fast

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788143775&installation_model_id=20486&pr_number=273&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F273&signature=d85f245b09acacb42695272c4cd36ce54f13325c8f7d4ac92a74a15efe88559f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix M1 candidate validator script path using `$GITHUB_WORKSPACE` in binding release workflow
> Replaces the relative path `../../../scripts/ci/validate-napi-artifacts.py` with an absolute `$GITHUB_WORKSPACE`-based path in the 'Assemble and pack every npm package' CI step. This fixes script resolution on M1 runners where the relative path fails. A corresponding test assertion in [test-binding-release-candidate.py](https://github.com/CurateLabs/graphforge/pull/273/files#diff-0f46df0941bbc9d37e0287959e672d46800afacfe645b33a298b23229b1f366f) enforces the new path and rejects the old one.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 07a715f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->