### PR TITLE
fix: keep M1 npm candidate packaging side-effect free

### DIFF
--- a/.github/workflows/binding-release-candidate.yml
+++ b/.github/workflows/binding-release-candidate.yml
@@ -474,17 +474,17 @@ jobs:
           pnpm exec napi artifacts --output-dir artifacts --npm-dir npm
           python3 "$GITHUB_WORKSPACE/scripts/ci/validate-napi-artifacts.py" \
             --npm-dir npm --manifest package.json
-          pnpm exec napi pre-publish -t npm --skip-optional-publish
+          pnpm exec napi pre-publish -t npm --skip-optional-publish --no-gh-release
           for package_dir in npm/*; do
-            npm pack "$package_dir" --ignore-scripts \
+            npm pack "./$package_dir" --ignore-scripts \
               --pack-destination "$GITHUB_WORKSPACE/candidate/release-artifacts/npm"
           done
           npm pack . --ignore-scripts \
             --pack-destination "$GITHUB_WORKSPACE/candidate/release-artifacts/npm"
           popd
-          npm pack packages/cli --ignore-scripts \
+          npm pack ./packages/cli --ignore-scripts \
             --pack-destination candidate/release-artifacts/npm
-          npm pack packages/agent-skills --ignore-scripts \
+          npm pack ./packages/agent-skills --ignore-scripts \
             --pack-destination candidate/release-artifacts/npm
 
       - name: Package the complete Rust surface
@@ -492,11 +492,17 @@ jobs:
         run: |
           mkdir -p candidate/release-artifacts/crates
           python3 scripts/ci/crate-publish-plan.py check
+          crates=()
+          package_args=()
           while IFS= read -r crate; do
-            cargo package -p "$crate" --allow-dirty --no-verify
+            crates+=("$crate")
+            package_args+=("-p" "$crate")
+          done < <(python3 scripts/ci/crate-publish-plan.py list)
+          cargo package "${package_args[@]}" --allow-dirty --no-verify
+          for crate in "${crates[@]}"; do
             cp "target/release-candidate/package/${crate}-0.5.0.crate" \
               candidate/release-artifacts/crates/
-          done < <(python3 scripts/ci/crate-publish-plan.py list)
+          done
 
       - name: Record license and package evidence
         run: |

--- a/scripts/ci/test-binding-release-candidate.py
+++ b/scripts/ci/test-binding-release-candidate.py
@@ -593,6 +593,12 @@ def main() -> None:
     assert 'node-version: "22"' in release_candidate_job
     assert validator_from_workspace in release_candidate_job
     assert "../../../scripts/ci/validate-napi-artifacts.py" not in release_candidate_job
+    assert "--skip-optional-publish --no-gh-release" in release_candidate_job
+    assert 'npm pack "./$package_dir"' in release_candidate_job
+    assert "npm pack ./packages/cli" in release_candidate_job
+    assert "npm pack ./packages/agent-skills" in release_candidate_job
+    assert 'cargo package "${package_args[@]}" --allow-dirty --no-verify' in (release_candidate_job)
+    assert 'cargo package -p "$crate"' not in release_candidate_job
     assert "scripts/ci/release-candidate.py validate" in rc_workflow_text
     assert "M1-Release-Candidate-${{ needs.validate_source.outputs.evidence_sha }}" in (
         rc_workflow_text


### PR DESCRIPTION
Refs #192

Fixes the exact candidate assembly failure from run 30680468016. N-API pre-publish is explicitly prevented from creating a GitHub Release, and per-platform npm directories are packed as local paths instead of package specs. No publication occurs.

Validation:
- scripts/check-workflows.sh
- python3 scripts/ci/test-binding-release-candidate.py
- pinned napi pre-publish accepts --no-gh-release in dry-run mode
- make pre-push-fast

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788145013&installation_model_id=20486&pr_number=274&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F274&signature=d00089394b0c566d5df469542516bac0ae347d44e2a00ab0dba5c4f6806cf684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix M1 npm candidate packaging to be side-effect free during release candidate assembly
> - Adds `--no-gh-release` to the `napi pre-publish` invocation to prevent unintended GitHub releases during release candidate assembly.
> - Changes `npm pack` calls to use explicit relative paths (e.g. `./$package_dir`) to avoid resolution issues.
> - Batches all `cargo package` calls into a single invocation with `--allow-dirty --no-verify` instead of per-crate calls in a loop.
> - Updates [test-binding-release-candidate.py](https://github.com/CurateLabs/graphforge/pull/274/files#diff-0f46df0941bbc9d37e0287959e672d46800afacfe645b33a298b23229b1f366f) to assert these behaviors are present and that per-crate `cargo package` is absent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 88e512d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->