### PR TITLE
fix(release): reference M1 publication tracker

### DIFF
--- a/.github/workflows/m1-release-certification.yml
+++ b/.github/workflows/m1-release-certification.yml
@@ -1,4 +1,4 @@
-# Release-certification only for #742 publication readiness.
+# Release-certification only for #192 publication readiness.
 # Not a close gate for child implementation/construction issues (AGENTS.md).
 name: M1 Release Certification Gate
 
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       commit_sha:
-        description: Exact current main SHA for publication certification (#742)
+        description: Exact current main SHA for publication certification (#192)
         required: true
         type: string
       rust_run_id:

--- a/scripts/ci/test-m1-release-certification.py
+++ b/scripts/ci/test-m1-release-certification.py
@@ -86,6 +86,8 @@ class M1ReleaseCertificationTests(unittest.TestCase):
 
     def test_workflow_is_manual_exact_main_and_validates_before_building(self) -> None:
         text = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("#192 publication readiness", text)
+        self.assertNotIn("#742", text)
         header, jobs = text.split("jobs:\n", 1)
         self.assertIn("workflow_dispatch:", header)
         for forbidden in ("push:", "pull_request:", "schedule:"):


### PR DESCRIPTION
## Summary
- point the M1 certification workflow at the authoritative publication tracker, #192
- guard against the retired #742 reference returning

## Verification
- `python3 scripts/ci/test-m1-release-certification.py`
- `scripts/check-workflows.sh`
- `make pre-push-fast`
- `git diff --check`

Related to #192; this PR does not close the publication tracker.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788148138&installation_model_id=20486&pr_number=276&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F276&signature=6f98b20b040d3824c2c31c13046f433a358e4a83e4497eb9ae4704a478bc7a0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix M1 publication tracker reference from #742 to #192 in release certification workflow
> Updates the inline comment and `workflow_dispatch` input description in [m1-release-certification.yml](https://github.com/CurateLabs/graphforge/pull/276/files#diff-d74731c1dcd81eeab7d746e86e1055534d78289de590376b4b0f5578ab0fec59) to reference issue #192 instead of the stale #742. The corresponding test in [test-m1-release-certification.py](https://github.com/CurateLabs/graphforge/pull/276/files#diff-5b71d930622eb33de26b675c20941fb923756c05a5035eb0ca7fc511315172c4) now asserts that the workflow contains `#192 publication readiness` and does not contain `#742`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec76d25.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->