### PR TITLE
fix(ci): retain certification evidence as artifacts

### DIFF
--- a/.github/workflows/binding-release-candidate.yml
+++ b/.github/workflows/binding-release-candidate.yml
@@ -383,12 +383,6 @@ jobs:
           --expected-sha "${{ needs.validate_source.outputs.evidence_sha }}"
           --output binding-rc-aggregate/report.json
 
-      - name: Save fail-closed aggregate for M1 certification
-        uses: actions/cache/save@v6
-        with:
-          path: binding-rc-aggregate/report.json
-          key: binding-release-candidate-${{ needs.validate_source.outputs.evidence_sha }}
-
       - name: Retain aggregate publication evidence
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/m1-release-certification.yml
+++ b/.github/workflows/m1-release-certification.yml
@@ -199,11 +199,13 @@ jobs:
           uv run --isolated --no-project --with "${wheels[0]}" \
             python scripts/ci/release-load-matrix.py run \
               --sha "$EVIDENCE_SHA" --work "$GF_LOAD_WORK" --output "$GF_LOAD_OUTPUT"
-      - name: Save load report for aggregate job
-        uses: actions/cache/save@v6
+      - name: Retain load report for aggregate job
+        uses: actions/upload-artifact@v7
         with:
+          name: M1-Release-Load-${{ github.run_id }}
           path: m1-release-load-evidence
-          key: m1-release-load-${{ github.run_id }}
+          if-no-files-found: error
+          retention-days: 30
 
   cleanup_load_disk:
     name: Delete one-run M1 certification build disk
@@ -244,22 +246,28 @@ jobs:
             --binding-run evidence/component-validation-final/binding-run.json \
             --expected-sha "$EXPECTED_SHA" \
             --output evidence/component-validation-final/report.json
-      - uses: actions/cache/restore@v6
+      - name: Download exact-run Rust evidence
+        uses: actions/download-artifact@v8
         with:
+          name: M1-Rust-Non-Cypher-${{ needs.validate_source.outputs.evidence_sha }}
           path: non-cypher-evidence
-          key: rust-non-cypher-${{ needs.validate_source.outputs.evidence_sha }}
-          fail-on-cache-miss: true
-      - uses: actions/cache/restore@v6
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.rust_run_id }}
+      - name: Download exact-run binding evidence
+        uses: actions/download-artifact@v8
         with:
+          name: M1-Binding-Release-Candidate-${{ needs.validate_source.outputs.evidence_sha }}
           path: binding-rc-aggregate
-          key: binding-release-candidate-${{ needs.validate_source.outputs.evidence_sha }}
-          fail-on-cache-miss: true
-      - uses: actions/cache/restore@v6
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.binding_rc_run_id }}
+      - name: Download exact-run load evidence
+        uses: actions/download-artifact@v8
         if: needs.load.result == 'success'
         with:
+          name: M1-Release-Load-${{ github.run_id }}
           path: m1-release-load-evidence
-          key: m1-release-load-${{ github.run_id }}
-          fail-on-cache-miss: true
       - name: Validate and aggregate every required component
         if: needs.load.result == 'success'
         run: >-

--- a/.github/workflows/non-cypher-surface-gate.yml
+++ b/.github/workflows/non-cypher-surface-gate.yml
@@ -141,8 +141,10 @@ jobs:
           )
           PY
 
-      - name: Save Rust report for M1 certification
-        uses: actions/cache/save@v6
+      - name: Retain Rust report for M1 certification
+        uses: actions/upload-artifact@v7
         with:
+          name: M1-Rust-Non-Cypher-${{ env.EVIDENCE_SHA }}
           path: non-cypher-evidence/
-          key: rust-non-cypher-${{ env.EVIDENCE_SHA }}
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/ci/m1-release-certification.py
+++ b/scripts/ci/m1-release-certification.py
@@ -71,17 +71,17 @@ def validate_component_runs(
             "rust",
             rust_run,
             ".github/workflows/non-cypher-surface-gate.yml",
-            "rust-non-cypher-" + expected_sha,
+            "M1-Rust-Non-Cypher-" + expected_sha,
         ),
         (
             "binding",
             binding_run,
             ".github/workflows/binding-release-candidate.yml",
-            "binding-release-candidate-" + expected_sha,
+            "M1-Binding-Release-Candidate-" + expected_sha,
         ),
     )
     components: dict[str, Any] = {}
-    for owner, run, workflow_path, cache_key in specifications:
+    for owner, run, workflow_path, artifact_name in specifications:
         run_id = _run_id(run.get("id"), owner)
         if run.get("status") != "completed" or run.get("conclusion") != "success":
             raise ValueError(f"{owner}: referenced run is not completed successfully")
@@ -107,7 +107,7 @@ def validate_component_runs(
             "run_url": expected_url,
             "run_attempt": run["run_attempt"],
             "workflow_path": workflow_path,
-            "cache_key": cache_key,
+            "artifact_name": artifact_name,
         }
     return {"source_sha": expected_sha, "components": components}
 
@@ -325,7 +325,7 @@ def aggregate(
         "run_url",
         "run_attempt",
         "workflow_path",
-        "cache_key",
+        "artifact_name",
     }
     for name, component in components.items():
         if not isinstance(component, dict) or set(component) != component_keys:
@@ -333,14 +333,14 @@ def aggregate(
         run_id = _run_id(component["run_id"], f"{name} run")
         run_attempt = _run_id(component["run_attempt"], f"{name} attempt")
         expected_url = f"https://github.com/{REPOSITORY}/actions/runs/{run_id}"
-        expected_cache = {
-            "rust": "rust-non-cypher-" + expected_sha,
-            "binding": "binding-release-candidate-" + expected_sha,
+        expected_artifact = {
+            "rust": "M1-Rust-Non-Cypher-" + expected_sha,
+            "binding": "M1-Binding-Release-Candidate-" + expected_sha,
         }[name]
         if (
             component["run_url"] != expected_url
             or component["workflow_path"] != expected_workflows[name]
-            or component["cache_key"] != expected_cache
+            or component["artifact_name"] != expected_artifact
         ):
             raise ValueError(f"{name}: component-run provenance drift")
         normalized_components[name] = {
@@ -348,7 +348,7 @@ def aggregate(
             "run_url": expected_url,
             "run_attempt": run_attempt,
             "workflow_path": expected_workflows[name],
-            "cache_key": expected_cache,
+            "artifact_name": expected_artifact,
         }
     rust_report, binding_report, load_report = (
         load_json(rust_path),

--- a/scripts/ci/test-ci-storage-policy.py
+++ b/scripts/ci/test-ci-storage-policy.py
@@ -14,7 +14,9 @@ EXPECTED_ARTIFACT_UPLOADS = Counter(
         "binding-rc-report-${{ github.run_id }}-${{ matrix.report_target }}": 1,
         "binding-rc-wheel-${{ github.run_id }}-${{ matrix.target }}": 1,
         "binding-rc-addon-${{ github.run_id }}-${{ matrix.target }}": 1,
+        "M1-Rust-Non-Cypher-${{ env.EVIDENCE_SHA }}": 1,
         "M1-Binding-Release-Candidate-${{ needs.validate_source.outputs.evidence_sha }}": 1,
+        "M1-Release-Load-${{ github.run_id }}": 1,
         "M1-Release-Candidate-${{ needs.validate_source.outputs.evidence_sha }}": 1,
     }
 )
@@ -23,6 +25,9 @@ EXPECTED_ARTIFACT_DOWNLOADS = Counter(
         "binding-rc-report-${{ github.run_id }}-*": 1,
         "binding-rc-wheel-${{ github.run_id }}-*": 1,
         "binding-rc-addon-${{ github.run_id }}-*": 1,
+        "M1-Rust-Non-Cypher-${{ needs.validate_source.outputs.evidence_sha }}": 1,
+        "M1-Binding-Release-Candidate-${{ needs.validate_source.outputs.evidence_sha }}": 1,
+        "M1-Release-Load-${{ github.run_id }}": 1,
     }
 )
 EXPECTED_DEPENDENCY_KEYS = Counter(
@@ -46,7 +51,6 @@ EXPECTED_STICKY_DELETES = Counter(
 )
 EXPECTED_SAVES = Counter(
     {
-        "binding-release-candidate-${{ needs.validate_source.outputs.evidence_sha }}": 1,
         "checkpoint-transfer-${{ github.run_id }}-rust": 1,
         "checkpoint-transfer-${{ github.run_id }}-python": 1,
         "checkpoint-transfer-${{ github.run_id }}-node": 1,
@@ -56,13 +60,10 @@ EXPECTED_SAVES = Counter(
         "m21-transfer-${{ github.run_id }}-rust": 1,
         "m21-transfer-${{ github.run_id }}-python": 1,
         "m21-transfer-${{ github.run_id }}-node": 1,
-        "m1-release-load-${{ github.run_id }}": 1,
-        "rust-non-cypher-${{ env.EVIDENCE_SHA }}": 1,
     }
 )
 EXPECTED_RESTORES = Counter(
     {
-        "binding-release-candidate-${{ needs.validate_source.outputs.evidence_sha }}": 1,
         "checkpoint-transfer-${{ github.run_id }}-rust": 1,
         "checkpoint-transfer-${{ github.run_id }}-python": 1,
         "checkpoint-transfer-${{ github.run_id }}-node": 1,
@@ -72,8 +73,6 @@ EXPECTED_RESTORES = Counter(
         "m21-transfer-${{ github.run_id }}-rust": 1,
         "m21-transfer-${{ github.run_id }}-python": 1,
         "m21-transfer-${{ github.run_id }}-node": 1,
-        "m1-release-load-${{ github.run_id }}": 1,
-        "rust-non-cypher-${{ needs.validate_source.outputs.evidence_sha }}": 1,
     }
 )
 
@@ -145,7 +144,9 @@ def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
             "binding-rc-reports/${{ matrix.report_target }}.json",
             "dist/*.whl",
             "crates/graphforge-bindings-node/*.node",
+            "non-cypher-evidence/",
             "binding-rc-aggregate/report.json",
+            "m1-release-load-evidence",
             "candidate/",
         }, f"artifact upload contains unapproved bytes: {path}"
         uploaded.append(name)
@@ -153,16 +154,46 @@ def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
         uses = field(step, "uses")
         assert uses == "actions/download-artifact@v8", f"unapproved artifact action: {uses}"
         pattern = field(step, "pattern")
-        assert pattern is not None, "artifact download has no exact-run pattern"
-        assert field(step, "path") in {
+        name = field(step, "name")
+        selector = pattern if pattern is not None else name
+        assert selector is not None
+        path = field(step, "path")
+        assert path in {
             "binding-rc-reports",
             "candidate/release-artifacts/python",
             "candidate/release-artifacts/node-addons",
-        }, f"artifact download path drift: {pattern}"
-        assert field(step, "merge-multiple") == "true", (
-            f"artifact reports are not merged: {pattern}"
-        )
-        downloaded.append(pattern)
+            "non-cypher-evidence",
+            "binding-rc-aggregate",
+            "m1-release-load-evidence",
+        }, f"artifact download path drift: {selector}"
+        if pattern is not None:
+            assert field(step, "merge-multiple") == "true", (
+                f"artifact reports are not merged: {pattern}"
+            )
+        else:
+            assert field(step, "merge-multiple") is None, (
+                f"single artifact unexpectedly merged: {name}"
+            )
+            cross_run = name != "M1-Release-Load-${{ github.run_id }}"
+            if cross_run:
+                assert field(step, "github-token") == "${{ github.token }}", (
+                    f"cross-run artifact has no token: {name}"
+                )
+                assert field(step, "repository") == "${{ github.repository }}", (
+                    f"cross-run artifact repository drift: {name}"
+                )
+                expected_run_id = {
+                    "non-cypher-evidence": "${{ inputs.rust_run_id }}",
+                    "binding-rc-aggregate": "${{ inputs.binding_rc_run_id }}",
+                }[path]
+                assert field(step, "run-id") == expected_run_id, (
+                    f"cross-run artifact run ID drift: {name}"
+                )
+            else:
+                assert field(step, "run-id") is None, (
+                    f"same-run load artifact unexpectedly crosses runs: {name}"
+                )
+        downloaded.append(selector)
     return uploaded, downloaded
 
 

--- a/scripts/ci/test-ci-storage-policy.py
+++ b/scripts/ci/test-ci-storage-policy.py
@@ -170,6 +170,9 @@ def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
             assert field(step, "merge-multiple") == "true", (
                 f"artifact reports are not merged: {pattern}"
             )
+            assert field(step, "run-id") is None, (
+                f"same-run artifact pattern unexpectedly crosses runs: {pattern}"
+            )
         else:
             assert field(step, "merge-multiple") is None, (
                 f"single artifact unexpectedly merged: {name}"

--- a/scripts/ci/test-m1-release-certification.py
+++ b/scripts/ci/test-m1-release-certification.py
@@ -69,7 +69,10 @@ class M1ReleaseCertificationTests(unittest.TestCase):
             self.binding_run,
             SHA,
         )
-        self.assertEqual(result["components"]["rust"]["cache_key"], "rust-non-cypher-" + SHA)
+        self.assertEqual(
+            result["components"]["rust"]["artifact_name"],
+            "M1-Rust-Non-Cypher-" + SHA,
+        )
         for key, value, message in (
             ("status", "in_progress", "not completed"),
             ("conclusion", "failure", "not completed"),
@@ -151,7 +154,10 @@ class M1ReleaseCertificationTests(unittest.TestCase):
         self.assertLess(rust_build, node_build)
         final_job = jobs[aggregate:]
         self.assertIn("Revalidate current main and component artifacts", final_job)
-        self.assertIn("actions/cache/restore@v6", final_job)
+        self.assertNotIn("actions/cache/restore@v6", final_job)
+        self.assertEqual(final_job.count("actions/download-artifact@v8"), 3)
+        self.assertIn("run-id: ${{ inputs.rust_run_id }}", final_job)
+        self.assertIn("run-id: ${{ inputs.binding_rc_run_id }}", final_job)
 
     def rust_report(self) -> dict:
         inventory = GATE.load_json(GATE.SURFACE)


### PR DESCRIPTION
## Summary
- replace evictable cross-run release-evidence caches with bounded retained artifacts
- download Rust and binding evidence from the exact component run IDs already validated by M1 certification
- transfer the same-run load report as a bounded artifact
- record artifact provenance in final certification evidence and enforce the contract in storage-policy tests

## Failure evidence
- M1 certification run 30683371297 passed source validation and the complete 144-case load matrix
- its aggregate job then failed restoring `rust-non-cypher-690ef42c55db4b37428546cf3fa78863565aa82e`
- Rust run 30682846838 had logged that exact key as saved, while the live cache inventory was empty

## Verification
- `python3 scripts/ci/test-ci-storage-policy.py`
- `scripts/check-workflows.sh`
- `python3 scripts/ci/test-binding-release-candidate.py`
- `python3 scripts/ci/test-m1-release-certification.py`
- `make pre-push-fast`
- `git diff --check`

Closes #277.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788152025&installation_model_id=20486&pr_number=278&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F278&signature=b6784decd32d6110b8f51368699c574f92516db2021500769508d28e7c2e777a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release validation to associate component evidence with the correct commit-specific artifacts.
  * Added stronger checks for artifact provenance, repository settings, authentication, run identifiers, and permitted destinations.
  * Updated release workflows to validate Rust and binding evidence downloads more reliably.

* **Tests**
  * Expanded CI coverage for release-candidate, release-load, and Rust evidence artifacts.
  * Removed obsolete cache-transfer expectations from release certification checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace GitHub Actions cache with named artifacts for CI certification evidence
> - Certification evidence (Rust non-Cypher, Binding RC, and load results) is now uploaded as named artifacts with 30-day retention instead of being saved to the Actions cache.
> - The `m1-release-certification` aggregate job downloads exact-run artifacts using `run-id` scoping for Rust and Binding evidence, and a same-run download for load evidence.
> - [m1-release-certification.py](https://github.com/CurateLabs/graphforge/pull/278/files#diff-20d9369bcb3fead7a937243aef134fb9315b0ce3730ed73397bd25e421cfa60b) renames the provenance field from `cache_key` to `artifact_name` and updates expected artifact names to the `M1-*` naming scheme.
> - Test files are updated to assert artifact upload/download contracts and remove cache-related expectations.
> - Behavioral Change: component provenance records must now carry `artifact_name` (not `cache_key`); existing evidence records using the old field will fail validation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3bea6e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->