### PR TITLE
fix(release): resume immutable v0.5.0 publication

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,6 +3,22 @@ name: Publish to PyPI, npm, and crates.io
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing immutable release tag to resume
+        required: true
+        default: v0.5.0
+        type: string
+      waive_unreleased_entries:
+        description: Waive only the tagged CHANGELOG Unreleased-entry check
+        required: true
+        default: false
+        type: boolean
+      recovery_reason:
+        description: Public maintainer reason for the recovery dispatch
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -20,24 +36,42 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.release_tag }}
           fetch-depth: 0
 
       - name: Require the certified current main commit and release versions
         id: source
         shell: bash
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-          RELEASE_SHA: ${{ github.sha }}
+          RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.release_tag }}
+          EVENT_SHA: ${{ github.sha }}
+          WAIVE_UNRELEASED_ENTRIES: ${{ inputs.waive_unreleased_entries || false }}
+          RECOVERY_REASON: ${{ inputs.recovery_reason || '' }}
         run: |
           git fetch --no-tags origin \
             +refs/heads/main:refs/remotes/origin/main
+          RELEASE_SHA="$(git rev-parse "$RELEASE_TAG^{}")"
           test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
           test "$(git rev-parse "$RELEASE_TAG^{}")" = "$RELEASE_SHA"
-          test "$(git rev-parse refs/remotes/origin/main)" = "$RELEASE_SHA"
-          python3 scripts/ci/release-publish-preflight.py \
-            --tag "$RELEASE_TAG" \
-            --expected-sha "$RELEASE_SHA"
+          preflight_args=(--tag "$RELEASE_TAG" --expected-sha "$RELEASE_SHA")
+          if test "$GITHUB_EVENT_NAME" = release; then
+            test "$EVENT_SHA" = "$RELEASE_SHA"
+            test "$(git rev-parse refs/remotes/origin/main)" = "$RELEASE_SHA"
+          else
+            test "$WAIVE_UNRELEASED_ENTRIES" = true
+            test -n "$RECOVERY_REASON"
+            gh release view "$RELEASE_TAG" >/dev/null
+            git merge-base --is-ancestor "$RELEASE_SHA" refs/remotes/origin/main
+            git show \
+              refs/remotes/origin/main:scripts/ci/release-publish-preflight.py \
+              > "$RUNNER_TEMP/release-publish-preflight.py"
+            install -m 0755 \
+              "$RUNNER_TEMP/release-publish-preflight.py" \
+              scripts/ci/release-publish-preflight.py
+            preflight_args+=(--allow-unreleased-entries)
+            printf 'Recovery reason: %s\n' "$RECOVERY_REASON"
+          fi
+          python3 scripts/ci/release-publish-preflight.py "${preflight_args[@]}"
           printf 'release_sha=%s\n' "$RELEASE_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Verify release license policy
@@ -95,7 +129,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.release_tag }}
         run: |
           asset_name="v0.5.0-artifacts.json"
           asset_count="$(gh release view "$RELEASE_TAG" --json assets \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add an explicit, maintainer-reasoned publication recovery dispatch that can
+  resume the immutable `v0.5.0` tag and retained candidate after waiving only
+  the tagged changelog's stale `[Unreleased]` entries; all artifact, checksum,
+  identity, ordering, and fail-closed registry checks remain required (#281).
 - Move all public npm packages from the unavailable `@graphforge` scope to the
   Curate Labs-owned `@curatelabs` scope, using `@curatelabs/graphforge` for the
   native binding and `@curatelabs/graphforge-*` for platform, CLI, and agent

--- a/docs/development/v0.5.0-release-operator-runbook.md
+++ b/docs/development/v0.5.0-release-operator-runbook.md
@@ -179,6 +179,23 @@ gh run watch "$PUBLISH_RUN_ID" --repo CurateLabs/graphforge --exit-status
 On any failure, stop. Follow `publication-order.md`; do not manually continue
 with a later registry and do not attempt different bytes under `0.5.0`.
 
+If the immutable tag's first publication run stopped before any registry write
+only because its `[Unreleased]` section still held entries, record an explicit
+maintainer waiver and resume the same retained candidate with:
+
+```bash
+gh workflow run publish.yaml --repo CurateLabs/graphforge --ref main \
+  -f release_tag=v0.5.0 \
+  -f waive_unreleased_entries=true \
+  -f recovery_reason="Maintainer waived tagged Unreleased entries under #281"
+```
+
+This recovery path requires the existing GitHub Release, requires the tagged
+commit to remain an ancestor of `main`, and waives only that changelog hygiene
+check using the reviewed recovery validator from current `main`. It does not
+move the tag, rebuild bytes, or bypass candidate checksum, license, npm
+identity, registry ordering, or publication failure checks.
+
 After a green run, verify and record the public URLs on #195, #198, and #196,
 including registry digests/checksums and crates.io ownership, then close each
 issue only when its live acceptance criteria are proven.

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add an explicit, maintainer-reasoned publication recovery dispatch that can
+  resume the immutable `v0.5.0` tag and retained candidate after waiving only
+  the tagged changelog's stale `[Unreleased]` entries; all artifact, checksum,
+  identity, ordering, and fail-closed registry checks remain required (#281).
 - Move all public npm packages from the unavailable `@graphforge` scope to the
   Curate Labs-owned `@curatelabs` scope, using `@curatelabs/graphforge` for the
   native binding and `@curatelabs/graphforge-*` for platform, CLI, and agent

--- a/scripts/ci/release-publish-preflight.py
+++ b/scripts/ci/release-publish-preflight.py
@@ -105,6 +105,7 @@ def validate(
     versions: dict[str, str],
     changelog: str,
     docs_changelog: str,
+    allow_unreleased_entries: bool = False,
 ) -> list[str]:
     errors: list[str] = []
     version = release_version(tag)
@@ -130,7 +131,7 @@ def validate(
     body = unreleased_body(changelog)
     if body is None:
         errors.append("CHANGELOG lacks an [Unreleased] section before the release section")
-    elif re.search(r"(?m)^\s*[-*]\s+", body):
+    elif re.search(r"(?m)^\s*[-*]\s+", body) and not allow_unreleased_entries:
         errors.append("CHANGELOG [Unreleased] still contains release-note entries")
 
     current_repo = "https://github.com/CurateLabs/graphforge"
@@ -147,6 +148,11 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--tag", required=True, help="Release tag, e.g. v0.5.0")
     parser.add_argument("--expected-sha", required=True, help="Release-event commit SHA")
+    parser.add_argument(
+        "--allow-unreleased-entries",
+        action="store_true",
+        help="Waive only the [Unreleased] entry check for an immutable-tag recovery",
+    )
     args = parser.parse_args(argv)
 
     version_module = load_version_module()
@@ -157,6 +163,7 @@ def main(argv: list[str] | None = None) -> int:
         versions=version_module.read_current(),
         changelog=CHANGELOG.read_text(encoding="utf-8"),
         docs_changelog=DOCS_CHANGELOG.read_text(encoding="utf-8"),
+        allow_unreleased_entries=args.allow_unreleased_entries,
     )
     errors.extend(version_module.check_aligned())
     errors.extend(validate_metadata())

--- a/scripts/ci/test-release-publish-preflight.py
+++ b/scripts/ci/test-release-publish-preflight.py
@@ -83,12 +83,32 @@ for mutation in mutations:
     }
     assert mod.validate(**values), mutation
 
+stale_changelog = changelog.replace("_Nothing yet._", "- Stale release entry")
+assert (
+    mod.validate(
+        tag="v0.5.0",
+        expected_sha=sha,
+        actual_sha=sha,
+        versions=versions,
+        changelog=stale_changelog,
+        docs_changelog=stale_changelog,
+        allow_unreleased_entries=True,
+    )
+    == []
+)
+
 workflow = WORKFLOW.read_text(encoding="utf-8")
 preflight = workflow.split("  candidate-preflight:\n", 1)[1].split("\n  publish-pypi:", 1)[0]
 assert "release-publish-preflight.py" in preflight
 assert "github.event.release.tag_name" in preflight
 assert "github.sha" in preflight
 assert "refs/remotes/origin/main" in preflight
+assert "workflow_dispatch:" in workflow
+assert "waive_unreleased_entries:" in workflow
+assert "RECOVERY_REASON" in preflight
+assert "--allow-unreleased-entries" in preflight
+assert "git show" in preflight
+assert "refs/remotes/origin/main:scripts/ci/release-publish-preflight.py" in preflight
 assert "npm whoami" in preflight
 assert "secrets.NPM_TOKEN" in preflight
 assert "M1-Release-Candidate-$RELEASE_SHA" in preflight


### PR DESCRIPTION
Closes #281

## Summary
- add an explicit manual recovery dispatch for the existing immutable v0.5.0 tag
- require a public maintainer reason and waive only stale tagged Unreleased entries
- reuse the exact retained same-SHA candidate while preserving every identity, checksum, license, ordering, and fail-closed publication check

## Evidence
- initial release run 30687300759 stopped before every registry write
- retained candidate run 30686731253 passed with 35 validated artifacts
- release publication preflight tests pass
- workflow validation passes
- make pre-push-fast passes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788156915&installation_model_id=20486&pr_number=282&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F282&signature=6fd95212ea0ae41d1bb11dd35e84ca971c1db061ca8e315d79b4e39d97155579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release validation can now proceed with unreleased changelog entries when explicitly permitted.
  * Manual release workflows include clearer waiver handling and recovery reason tracking.

* **Bug Fixes**
  * Improved release preflight validation to consistently apply the configured unreleased-entry exception.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add manual recovery dispatch to resume immutable v0.5.0 publication
> - Adds a `workflow_dispatch` trigger to [publish.yaml](.github/workflows/publish.yaml) with `release_tag`, `waive_unreleased_entries`, and `recovery_reason` inputs to allow restarting a stalled release.
> - When triggered manually, the `candidate-preflight` job verifies the immutable tag exists and is an ancestor of `main`, fetches the current `release-publish-preflight.py` from `origin/main`, and runs it with `--allow-unreleased-entries` to waive only the stale `[Unreleased]` changelog check.
> - Adds `--allow-unreleased-entries` flag to [release-publish-preflight.py](scripts/ci/release-publish-preflight.py) so the validator can skip the non-empty `[Unreleased]` section error when explicitly requested.
> - Normal release-event triggers retain all prior strict checks (event SHA must match release SHA and `origin/main` tip).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ce3ce2c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->