### PR TITLE
fix(release): authenticate immutable release recovery

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -43,6 +43,7 @@ jobs:
         id: source
         shell: bash
         env:
+          GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.release_tag }}
           EVENT_SHA: ${{ github.sha }}
           WAIVE_UNRELEASED_ENTRIES: ${{ inputs.waive_unreleased_entries || false }}

--- a/scripts/ci/test-release-publish-preflight.py
+++ b/scripts/ci/test-release-publish-preflight.py
@@ -106,6 +106,7 @@ assert "refs/remotes/origin/main" in preflight
 assert "workflow_dispatch:" in workflow
 assert "waive_unreleased_entries:" in workflow
 assert "RECOVERY_REASON" in preflight
+assert "GH_TOKEN: ${{ github.token }}" in preflight
 assert "--allow-unreleased-entries" in preflight
 assert "git show" in preflight
 assert "refs/remotes/origin/main:scripts/ci/release-publish-preflight.py" in preflight


### PR DESCRIPTION
Closes #281

Recovery run 30687546572 stopped before every registry write because the source preflight called gh release view without GH_TOKEN. This supplies the existing job token to that step and adds a regression assertion.

Validation:
- release publication preflight tests pass
- workflow validation passes
- git diff check passes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788157287&installation_model_id=20486&pr_number=283&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F283&signature=f38b1e6e5edd1850f726f044a205ed99449127a05421dd3ce8a2816c6ce93d25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate the immutable release recovery step with `GH_TOKEN`
> The 'Require the certified current main commit and release versions' step in [publish.yaml](https://github.com/CurateLabs/graphforge/pull/283/files#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388ca) was missing GitHub authentication, causing failures in release recovery flows. Adds `GH_TOKEN: ${{ github.token }}` to that step's environment and adds a corresponding assertion in [test-release-publish-preflight.py](https://github.com/CurateLabs/graphforge/pull/283/files#diff-f0d80518da11ee77851032bfc3e7ed886e1933e234c8ef3996ce0669b95449bb) to prevent regression.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized df2a16c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->