### PR TITLE
fix(release): verify npm integrity before CDN replication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Verify newly published and resumed npm packages immediately against npm's
+  `dist.integrity` metadata, preserving exact-byte checks without failing while
+  the registry's public tarball CDN is still replicating (#284).
 - Add an explicit, maintainer-reasoned publication recovery dispatch that can
   resume the immutable `v0.5.0` tag and retained candidate after waiving only
   the tagged changelog's stale `[Unreleased]` entries; all artifact, checksum,

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Verify newly published and resumed npm packages immediately against npm's
+  `dist.integrity` metadata, preserving exact-byte checks without failing while
+  the registry's public tarball CDN is still replicating (#284).
 - Add an explicit, maintainer-reasoned publication recovery dispatch that can
   resume the immutable `v0.5.0` tag and retained candidate after waiving only
   the tagged changelog's stale `[Unreleased]` entries; all artifact, checksum,

--- a/scripts/ci/test-publish-npm-artifacts.py
+++ b/scripts/ci/test-publish-npm-artifacts.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import importlib.util
 from pathlib import Path
 import tempfile
@@ -25,22 +27,32 @@ with tempfile.TemporaryDirectory() as temp:
     }
     published: list[Path] = []
     publisher.publish_archive = published.append
-    publisher.published_checksum = lambda _name, _version: "abc123"
-    assert publisher.publish_one(item, root, 1) == "already published; checksum matches"
+    integrity = "sha512-" + base64.b64encode(hashlib.sha512(b"candidate").digest()).decode()
+    publisher.published_integrity = lambda _name, _version: integrity
+    assert publisher.publish_one(item, root, 1) == "already published; integrity matches"
     assert published == []
 
-    responses = iter((None, "abc123"))
-    publisher.published_checksum = lambda _name, _version: next(responses)
+    responses = iter((None, integrity))
+    publisher.published_integrity = lambda _name, _version: next(responses)
     assert publisher.publish_one(item, root, 1) == "published"
     assert published == [archive]
 
-    publisher.published_checksum = lambda _name, _version: "different"
+    different = "sha512-" + base64.b64encode(hashlib.sha512(b"different").digest()).decode()
+    publisher.published_integrity = lambda _name, _version: different
     try:
         publisher.publish_one(item, root, 1)
     except RuntimeError as error:
         assert "refusing to resume" in str(error)
     else:
         raise AssertionError("checksum drift should fail")
+
+    assert publisher.archive_matches_integrity(archive, f"md5-AAAA {integrity}")
+    try:
+        publisher.archive_matches_integrity(archive, "md5-AAAA")
+    except RuntimeError as error:
+        assert "no supported" in str(error)
+    else:
+        raise AssertionError("unsupported integrity should fail")
 
 assert publisher.GROUPS["native"] == slice(0, 6)
 assert publisher.GROUPS["cli"] == slice(6, 7)

--- a/scripts/publish_npm_artifacts.py
+++ b/scripts/publish_npm_artifacts.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import hashlib
 import importlib.util
 import json
@@ -37,10 +38,6 @@ def load_candidate_module():
     return module
 
 
-def _sha256_bytes(data: bytes) -> str:
-    return hashlib.sha256(data).hexdigest()
-
-
 def _json(url: str) -> dict[str, Any] | None:
     request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
     try:
@@ -55,22 +52,35 @@ def _json(url: str) -> dict[str, Any] | None:
     return payload
 
 
-def published_checksum(name: str, version: str) -> str | None:
+def published_integrity(name: str, version: str) -> str | None:
     encoded = urllib.parse.quote(name, safe="")
     record = _json(f"{REGISTRY}/{encoded}/{version}")
     if record is None:
         return None
-    tarball = record.get("dist", {}).get("tarball")
-    if not isinstance(tarball, str) or not tarball.startswith("https://registry.npmjs.org/"):
-        raise RuntimeError(f"npm {name}@{version} lacks a trusted registry tarball URL")
-    request = urllib.request.Request(tarball, headers={"User-Agent": USER_AGENT})
-    try:
-        with urllib.request.urlopen(request, timeout=60) as response:
-            return _sha256_bytes(response.read())
-    except urllib.error.HTTPError as error:
-        if error.code == 404:
-            return None
-        raise
+    integrity = record.get("dist", {}).get("integrity")
+    if not isinstance(integrity, str) or not integrity.strip():
+        raise RuntimeError(f"npm {name}@{version} lacks dist.integrity")
+    return integrity
+
+
+def archive_matches_integrity(path: Path, integrity: str) -> bool:
+    """Compare an archive to one or more npm Subresource Integrity digests."""
+    data = path.read_bytes()
+    supported = False
+    for token in integrity.split():
+        algorithm, separator, encoded = token.partition("-")
+        if not separator or algorithm not in {"sha256", "sha384", "sha512"}:
+            continue
+        supported = True
+        try:
+            expected = base64.b64decode(encoded, validate=True)
+        except ValueError as error:
+            raise RuntimeError(f"npm returned malformed {algorithm} integrity") from error
+        if hashlib.new(algorithm, data).digest() == expected:
+            return True
+    if not supported:
+        raise RuntimeError("npm returned no supported integrity digest")
+    return False
 
 
 def publish_archive(path: Path) -> None:
@@ -87,28 +97,27 @@ def publish_one(item: dict[str, Any], artifacts_dir: Path, timeout_seconds: int)
     version = item["version"]
     expected = item["sha256"]
     path = artifacts_dir / item["path"]
-    existing = published_checksum(name, version)
+    existing = published_integrity(name, version)
     if existing is not None:
-        if existing != expected:
+        if not archive_matches_integrity(path, existing):
             raise RuntimeError(
-                f"refusing to resume {name}@{version}: registry checksum {existing} "
-                f"differs from candidate {expected}"
+                f"refusing to resume {name}@{version}: registry integrity differs "
+                f"from candidate sha256 {expected}"
             )
-        outcome = "already published; checksum matches"
+        outcome = "already published; integrity matches"
     else:
         publish_archive(path)
         deadline = time.monotonic() + timeout_seconds
         while time.monotonic() < deadline:
-            existing = published_checksum(name, version)
+            existing = published_integrity(name, version)
             if existing is not None:
                 break
             time.sleep(3)
         if existing is None:
             raise RuntimeError(f"timed out waiting for npm to index {name}@{version}")
-        if existing != expected:
+        if not archive_matches_integrity(path, existing):
             raise RuntimeError(
-                f"npm indexed different bytes for {name}@{version}: "
-                f"registry={existing} candidate={expected}"
+                f"npm indexed different bytes for {name}@{version}; candidate sha256 is {expected}"
             )
         outcome = "published"
     print(f"{name}@{version}: {outcome}")


### PR DESCRIPTION
Closes #284

## Summary
- verify existing and newly published npm tarballs against npm dist.integrity
- avoid false failures while the public tarball CDN is still replicating
- retain fail-closed exact-byte comparison and checksum-safe resume

## Evidence
- npm metadata for the published package was live while its tarball URL returned HTTP 404
- deterministic publisher tests cover matching, newly indexed, drift, and unsupported integrity
- make pre-push-fast passes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788158824&installation_model_id=20486&pr_number=285&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F285&signature=37f8b7f728b68d89c91a0df2486032a62ef739581ff264e4ac6bae336dae8e29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Verify npm package integrity against dist.integrity before CDN replication
> - Replaces checksum-based verification in [`publish_npm_artifacts.py`](https://github.com/CurateLabs/graphforge/pull/285/files#diff-15015e0343acc4d499ac41521b716e1d8b637e1ef012bf18c1458a5dfb7294e2) with SRI-based integrity checks using npm's `dist.integrity` metadata.
> - Adds `published_integrity(name, version)` to fetch `dist.integrity` from the npm registry instead of downloading and hashing the tarball.
> - Adds `archive_matches_integrity(path, integrity)` to validate the local archive against one or more SRI tokens (sha256/sha384/sha512); raises if no supported digest is present or if encoding is malformed.
> - Updates `publish_one` to call these new helpers, report `'integrity matches'` on success, and raise on mismatch during both pre-publish checks and post-publish polling.
> - Behavioral Change: previously published packages returning a 404 on the tarball would yield `None`; now a missing `dist.integrity` field raises an error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 051160b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->