### PR TITLE
fix(release): load reviewed npm recovery publisher

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -198,6 +198,18 @@ jobs:
         with:
           ref: ${{ needs.candidate-preflight.outputs.release_sha }}
 
+      - name: Load reviewed npm recovery publisher
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: |
+          git fetch --no-tags origin \
+            +refs/heads/main:refs/remotes/origin/main
+          git show refs/remotes/origin/main:scripts/publish_npm_artifacts.py \
+            > "$RUNNER_TEMP/publish_npm_artifacts.py"
+          install -m 0755 \
+            "$RUNNER_TEMP/publish_npm_artifacts.py" \
+            scripts/publish_npm_artifacts.py
+
       - uses: actions/setup-node@v6
         with:
           node-version: "20"

--- a/scripts/ci/test-publish-cli-contract.py
+++ b/scripts/ci/test-publish-cli-contract.py
@@ -17,7 +17,8 @@ def main() -> None:
     assert "needs: [candidate-preflight, publish-pypi]" in npm_job
     assert "pnpm --filter @curatelabs/graphforge-cli test:offline" in npm_job
     assert "node scripts/ci/verify-node-cli-release-package.mjs" in npm_job
-    assert npm_job.count("scripts/publish_npm_artifacts.py") == 3
+    assert npm_job.count("python3 scripts/publish_npm_artifacts.py") == 3
+    assert "Load reviewed npm recovery publisher" in npm_job
     assert npm_job.index("--group native") < npm_job.index("verify-node-cli-release-package.mjs")
     assert npm_job.index("verify-node-cli-release-package.mjs") < npm_job.index("--group cli")
     assert npm_job.index("--group cli") < npm_job.index("--group skills")

--- a/scripts/ci/test-release-publish-preflight.py
+++ b/scripts/ci/test-release-publish-preflight.py
@@ -126,6 +126,8 @@ assert "candidate/release-artifacts/python/*" in pypi_job
 npm_job = workflow.split("  publish-npm:\n", 1)[1].split("\n  publish-crates:", 1)[0]
 assert "needs: [candidate-preflight, publish-pypi]" in npm_job
 assert "scripts/publish_npm_artifacts.py" in npm_job
+assert "Load reviewed npm recovery publisher" in npm_job
+assert "refs/remotes/origin/main:scripts/publish_npm_artifacts.py" in npm_job
 assert "--group native" in npm_job
 assert "--group cli" in npm_job
 assert "--group skills" in npm_job


### PR DESCRIPTION
Closes #284

Recovery run 30688555125 still executed the immutable tag older publisher, published the third native package, and stopped on its retired CDN wait. This overlays only the reviewed publisher control script from main during manual recovery; all release bytes remain the retained exact-tag candidate.

Validation:
- release publication contract tests pass
- workflow validation passes
- git diff check passes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788159649&installation_model_id=20486&pr_number=286&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F286&signature=2a1f43889f8a31191493a385f3cfc2e6219b4694c77e3cfd7fc529701606bcc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Load reviewed npm recovery publisher from main branch in workflow_dispatch runs
> Adds a conditional step in the `publish-npm` job that fetches `scripts/publish_npm_artifacts.py` from `refs/heads/main` and installs it into the runner before subsequent steps execute. This only runs on `workflow_dispatch` events, ensuring manual recovery runs use the reviewed version of the publish script from main rather than whatever is in the current ref. Tests in [`test-publish-cli-contract.py`](https://github.com/CurateLabs/graphforge/pull/286/files#diff-2aec030884dbd98568504908221948bb31023f08772bccca4682dc1085af08f3) and [`test-release-publish-preflight.py`](https://github.com/CurateLabs/graphforge/pull/286/files#diff-f0d80518da11ee77851032bfc3e7ed886e1933e234c8ef3996ce0669b95449bb) are updated to assert the new step and `python3` invocation are present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 35bf9aa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->