### PR TITLE
fix(release): amend unpublished main npm artifact

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -192,7 +192,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       actions: read
-      contents: read
+      contents: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -209,6 +209,11 @@ jobs:
           install -m 0755 \
             "$RUNNER_TEMP/publish_npm_artifacts.py" \
             scripts/publish_npm_artifacts.py
+          git show refs/remotes/origin/main:scripts/amend_npm_main_artifact.py \
+            > "$RUNNER_TEMP/amend_npm_main_artifact.py"
+          install -m 0755 \
+            "$RUNNER_TEMP/amend_npm_main_artifact.py" \
+            scripts/amend_npm_main_artifact.py
 
       - uses: actions/setup-node@v6
         with:
@@ -229,6 +234,46 @@ jobs:
           gh run download "$CANDIDATE_RUN_ID"
           --name "M1-Release-Candidate-$RELEASE_SHA"
           --dir candidate
+
+      - name: Apply authorized unpublished main npm amendment
+        if: github.event_name == 'workflow_dispatch' && inputs.release_tag == 'v0.5.0'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          supplement="v0.5.0-npm-amendment.json"
+          archive="curatelabs-graphforge-0.5.0-amended.tgz"
+          supplement_count="$(gh release view "$RELEASE_TAG" --json assets \
+            --jq "[.assets[] | select(.name == \"$supplement\")] | length")"
+          archive_count="$(gh release view "$RELEASE_TAG" --json assets \
+            --jq "[.assets[] | select(.name == \"$archive\")] | length")"
+          if test "$supplement_count" = 0 && test "$archive_count" = 0; then
+            python3 scripts/amend_npm_main_artifact.py create \
+              --record candidate/v0.5.0-artifacts.json \
+              --artifacts-dir candidate/release-artifacts \
+              --amended-archive "candidate/$archive" \
+              --supplement "candidate/$supplement"
+            gh release upload "$RELEASE_TAG" \
+              "candidate/$archive" "candidate/$supplement"
+          else
+            test "$supplement_count" = 1
+            test "$archive_count" = 1
+            mkdir -p candidate/amendment
+            gh release download "$RELEASE_TAG" \
+              --pattern "$supplement" --pattern "$archive" \
+              --dir candidate/amendment
+            python3 scripts/amend_npm_main_artifact.py apply \
+              --record candidate/v0.5.0-artifacts.json \
+              --artifacts-dir candidate/release-artifacts \
+              --amended-archive "candidate/amendment/$archive" \
+              --supplement "candidate/amendment/$supplement"
+          fi
+          python3 scripts/ci/release-candidate.py validate \
+            --record candidate/v0.5.0-artifacts.json \
+            --artifacts-dir candidate/release-artifacts \
+            --expected-sha "${{ needs.candidate-preflight.outputs.release_sha }}" \
+            --version 0.5.0
 
       - name: Publish recorded npm tarballs in dependency order
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,6 +122,7 @@ jobs:
           python3 scripts/ci/test-release-candidate.py
           python3 scripts/ci/test-release-notes.py
           python3 scripts/ci/test-publish-npm-artifacts.py
+          python3 scripts/ci/test-amend-npm-main-artifact.py
 
       - name: Test CI storage policy
         run: python3 scripts/ci/test-ci-storage-policy.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Split native binaries out of the main `@curatelabs/graphforge` npm tarball,
+  and add the explicitly authorized v0.5.0 supplemental artifact/checksum
+  record so the previously unpublished main package stays below npm's payload
+  limit while reusing the already-published platform packages (#287).
 - Verify newly published and resumed npm packages immediately against npm's
   `dist.integrity` metadata, preserving exact-byte checks without failing while
   the registry's public tarball CDN is still replicating (#284).

--- a/crates/graphforge-bindings-node/package.json
+++ b/crates/graphforge-bindings-node/package.json
@@ -30,8 +30,7 @@
     "README.md",
     "LICENSE",
     "NOTICE",
-    "THIRD_PARTY_NOTICES.md",
-    "*.node"
+    "THIRD_PARTY_NOTICES.md"
   ],
   "napi": {
     "binaryName": "graphforge",

--- a/docs/development/v0.5.0-release-operator-runbook.md
+++ b/docs/development/v0.5.0-release-operator-runbook.md
@@ -196,6 +196,15 @@ check using the reviewed recovery validator from current `main`. It does not
 move the tag, rebuild bytes, or bypass candidate checksum, license, npm
 identity, registry ordering, or publication failure checks.
 
+The maintainer-authorized #287 recovery is narrower still: when npm has not
+accepted the recorded main `@curatelabs/graphforge` tarball because its bundled
+native files exceed the registry payload limit, the recovery job removes only
+those five binaries already published in the platform packages. Before the
+main package is published, the job attaches both the amended tarball and
+`v0.5.0-npm-amendment.json` to the GitHub Release. Later resumes must download
+and checksum-match those exact amendment assets; the original release record
+is retained and never replaced.
+
 After a green run, verify and record the public URLs on #195, #198, and #196,
 including registry digests/checksums and crates.io ownership, then close each
 issue only when its live acceptance criteria are proven.

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Split native binaries out of the main `@curatelabs/graphforge` npm tarball,
+  and add the explicitly authorized v0.5.0 supplemental artifact/checksum
+  record so the previously unpublished main package stays below npm's payload
+  limit while reusing the already-published platform packages (#287).
 - Verify newly published and resumed npm packages immediately against npm's
   `dist.integrity` metadata, preserving exact-byte checks without failing while
   the registry's public tarball CDN is still replicating (#284).

--- a/packages/cli/tests/native-offline-lifecycle.mjs
+++ b/packages/cli/tests/native-offline-lifecycle.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
 import {
   appendFileSync,
+  copyFileSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -121,11 +122,32 @@ const resultField = (result, field, row = 0) => {
 };
 
 try {
-  assert.equal(
-    readdirSync(nativeRoot).some((name) => name.endsWith(".node")),
-    true,
+  const nativeBinary = readdirSync(nativeRoot).find((name) =>
+    name.endsWith(".node"),
+  );
+  assert.ok(
+    nativeBinary,
     "build @curatelabs/graphforge before running the native lifecycle acceptance",
   );
+  const platformSuffix = nativeBinary
+    .replace(/^graphforge\./, "")
+    .replace(/\.node$/, "");
+  const platformRoot = join(fixture, platformSuffix);
+  mkdirSync(platformRoot);
+  copyFileSync(
+    join(nativeRoot, nativeBinary),
+    join(platformRoot, nativeBinary),
+  );
+  writeFileSync(
+    join(platformRoot, "package.json"),
+    `${JSON.stringify({
+      name: `@curatelabs/graphforge-${platformSuffix}`,
+      version: packageMetadata.version,
+      files: [nativeBinary],
+      main: nativeBinary,
+    })}\n`,
+  );
+  const platformTarball = pack(platformRoot);
   const nativeTarball = pack(nativeRoot);
   const cliTarball = pack(packageRoot, true);
   writeFileSync(
@@ -140,6 +162,7 @@ try {
       "--ignore-scripts",
       "--no-audit",
       "--no-fund",
+      platformTarball,
       nativeTarball,
       cliTarball,
     ],

--- a/scripts/amend_npm_main_artifact.py
+++ b/scripts/amend_npm_main_artifact.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Create or apply the authorized slim v0.5.0 main npm artifact amendment."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import tarfile
+import tempfile
+from typing import Any
+
+PACKAGE = "@curatelabs/graphforge"
+VERSION = "0.5.0"
+SCHEMA = "graphforge-release-amendment-v1"
+MAX_PACKED_BYTES = 100_000_000
+PLATFORMS = (
+    "darwin-arm64",
+    "darwin-x64",
+    "linux-arm64-gnu",
+    "linux-x64-gnu",
+    "win32-x64-msvc",
+)
+NATIVE_FILES = {f"graphforge.{target}.node" for target in PLATFORMS}
+OPTIONAL_DEPENDENCIES = {f"@curatelabs/graphforge-{target}": VERSION for target in PLATFORMS}
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def main_item(record: dict[str, Any]) -> dict[str, Any]:
+    matches = [
+        item
+        for item in record.get("artifacts", [])
+        if item.get("surface") == "npm" and item.get("name") == PACKAGE
+    ]
+    if len(matches) != 1:
+        raise ValueError(f"release record must contain exactly one {PACKAGE} artifact")
+    return matches[0]
+
+
+def safe_extract(archive: Path, destination: Path) -> None:
+    with tarfile.open(archive, "r:gz") as bundle:
+        for member in bundle.getmembers():
+            parts = Path(member.name).parts
+            if not parts or parts[0] != "package" or ".." in parts:
+                raise ValueError(f"unsafe npm archive member: {member.name}")
+            if member.issym() or member.islnk():
+                raise ValueError(f"npm amendment rejects links: {member.name}")
+            target = destination.joinpath(*parts)
+            if member.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+            elif member.isfile():
+                target.parent.mkdir(parents=True, exist_ok=True)
+                source = bundle.extractfile(member)
+                if source is None:
+                    raise ValueError(f"cannot read npm archive member: {member.name}")
+                with source, target.open("wb") as output:
+                    shutil.copyfileobj(source, output)
+            else:
+                raise ValueError(f"unsupported npm archive member: {member.name}")
+
+
+def pack_slim_archive(original: Path, output: Path) -> list[str]:
+    with tempfile.TemporaryDirectory() as temp:
+        root = Path(temp)
+        safe_extract(original, root)
+        package_dir = root / "package"
+        native = {path.name for path in package_dir.glob("*.node")}
+        if native != NATIVE_FILES:
+            raise ValueError(
+                f"main npm archive native set mismatch: expected={sorted(NATIVE_FILES)} "
+                f"actual={sorted(native)}"
+            )
+        for path in package_dir.glob("*.node"):
+            path.unlink()
+
+        manifest_path = package_dir / "package.json"
+        manifest = load_json(manifest_path)
+        if manifest.get("name") != PACKAGE or manifest.get("version") != VERSION:
+            raise ValueError("main npm archive identity mismatch")
+        if manifest.get("optionalDependencies") != OPTIONAL_DEPENDENCIES:
+            raise ValueError("main npm archive optionalDependencies mismatch")
+        files = manifest.get("files")
+        if not isinstance(files, list) or "*.node" not in files:
+            raise ValueError("main npm archive does not declare its embedded native files")
+        manifest["files"] = [entry for entry in files if entry != "*.node"]
+        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+        pack_dir = root / "packed"
+        pack_dir.mkdir()
+        result = subprocess.run(
+            [
+                "npm",
+                "pack",
+                str(package_dir),
+                "--ignore-scripts",
+                "--pack-destination",
+                str(pack_dir),
+                "--json",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+        packed = json.loads(result.stdout)
+        if not isinstance(packed, list) or len(packed) != 1:
+            raise ValueError("npm pack did not return exactly one amended archive")
+        source = pack_dir / packed[0]["filename"]
+        output.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, output)
+    return sorted(NATIVE_FILES)
+
+
+def amended_record(record: dict[str, Any], supplement: dict[str, Any]) -> dict[str, Any]:
+    updated = copy.deepcopy(record)
+    item = main_item(updated)
+    item["sha256"] = supplement["amended_artifact"]["sha256"]
+    item["bytes"] = supplement["amended_artifact"]["bytes"]
+    updated["amendments"] = [
+        {
+            "schema": SCHEMA,
+            "issue": "#287",
+            "artifact": PACKAGE,
+            "supplement": supplement["asset_name"],
+            "reason": supplement["reason"],
+        }
+    ]
+    updated["notes"] = (
+        str(updated.get("notes", "")).rstrip()
+        + "\n#287 authorizes the unpublished main npm tarball amendment; "
+        + "see v0.5.0-npm-amendment.json."
+    ).lstrip()
+    return updated
+
+
+def create(record_path: Path, artifacts_dir: Path, archive_out: Path, supplement_out: Path) -> None:
+    record = load_json(record_path)
+    item = main_item(record)
+    original = artifacts_dir / item["path"]
+    if sha256_file(original) != item["sha256"]:
+        raise ValueError("original main npm archive does not match the release record")
+    excluded = pack_slim_archive(original, archive_out)
+    if archive_out.stat().st_size >= MAX_PACKED_BYTES:
+        raise ValueError("amended main npm archive still exceeds the 100 MB safety limit")
+    supplement = {
+        "schema": SCHEMA,
+        "tag": "v0.5.0",
+        "commit_sha": record.get("commit_sha"),
+        "issue": "#287",
+        "asset_name": supplement_out.name,
+        "reason": (
+            "npm rejected the unpublished recorded main package with HTTP 413; "
+            "remove native binaries already published in optional platform packages"
+        ),
+        "original_release_record_sha256": sha256_file(record_path),
+        "original_artifact": {
+            "path": item["path"],
+            "sha256": item["sha256"],
+            "bytes": item["bytes"],
+        },
+        "amended_artifact": {
+            "asset_name": archive_out.name,
+            "path": item["path"],
+            "sha256": sha256_file(archive_out),
+            "bytes": archive_out.stat().st_size,
+        },
+        "excluded_files": excluded,
+        "unchanged_artifacts": "All other v0.5.0 release-record entries remain unchanged.",
+    }
+    supplement_out.write_text(json.dumps(supplement, indent=2) + "\n", encoding="utf-8")
+    apply(record_path, artifacts_dir, archive_out, supplement_out)
+
+
+def apply(record_path: Path, artifacts_dir: Path, archive: Path, supplement_path: Path) -> None:
+    record = load_json(record_path)
+    supplement = load_json(supplement_path)
+    if supplement.get("schema") != SCHEMA or supplement.get("issue") != "#287":
+        raise ValueError("unexpected npm amendment supplement")
+    if sha256_file(record_path) != supplement.get("original_release_record_sha256"):
+        raise ValueError("npm amendment does not target this original release record")
+    amended = supplement.get("amended_artifact", {})
+    if sha256_file(archive) != amended.get("sha256"):
+        raise ValueError("amended npm archive checksum mismatch")
+    item = main_item(record)
+    destination = artifacts_dir / item["path"]
+    shutil.copyfile(archive, destination)
+    updated = amended_record(record, supplement)
+    record_path.write_text(json.dumps(updated, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("create", "apply"))
+    parser.add_argument("--record", type=Path, required=True)
+    parser.add_argument("--artifacts-dir", type=Path, required=True)
+    parser.add_argument("--amended-archive", type=Path, required=True)
+    parser.add_argument("--supplement", type=Path, required=True)
+    args = parser.parse_args()
+    if args.command == "create":
+        create(args.record, args.artifacts_dir, args.amended_archive, args.supplement)
+    else:
+        apply(args.record, args.artifacts_dir, args.amended_archive, args.supplement)
+    print(f"npm-main-amendment: {args.command} complete")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test-amend-npm-main-artifact.py
+++ b/scripts/ci/test-amend-npm-main-artifact.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Deterministic contract for the authorized v0.5.0 npm amendment."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import tarfile
+import tempfile
+
+SCRIPT = Path(__file__).parents[1] / "amend_npm_main_artifact.py"
+SPEC = importlib.util.spec_from_file_location("amend_npm_main_artifact", SCRIPT)
+assert SPEC and SPEC.loader
+amend = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(amend)
+
+source_manifest = amend.load_json(
+    Path(__file__).parents[2] / "crates" / "graphforge-bindings-node" / "package.json"
+)
+assert "*.node" not in source_manifest["files"]
+
+with tempfile.TemporaryDirectory() as temp:
+    root = Path(temp)
+    source = root / "source" / "package"
+    source.mkdir(parents=True)
+    manifest = {
+        "name": amend.PACKAGE,
+        "version": amend.VERSION,
+        "files": ["index.js", "*.node"],
+        "optionalDependencies": amend.OPTIONAL_DEPENDENCIES,
+    }
+    (source / "package.json").write_text(json.dumps(manifest), encoding="utf-8")
+    (source / "index.js").write_text("module.exports = {}\n", encoding="utf-8")
+    for name in amend.NATIVE_FILES:
+        (source / name).write_bytes(name.encode())
+
+    artifacts = root / "artifacts"
+    original = artifacts / "npm" / "curatelabs-graphforge-0.5.0.tgz"
+    original.parent.mkdir(parents=True)
+    with tarfile.open(original, "w:gz") as bundle:
+        bundle.add(source, arcname="package")
+    record = {
+        "schema": "graphforge-release-record-v1",
+        "version": "0.5.0",
+        "tag": "v0.5.0",
+        "commit_sha": "a" * 40,
+        "artifacts": [
+            {
+                "path": "npm/curatelabs-graphforge-0.5.0.tgz",
+                "surface": "npm",
+                "name": amend.PACKAGE,
+                "version": amend.VERSION,
+                "bytes": original.stat().st_size,
+                "sha256": amend.sha256_file(original),
+            }
+        ],
+    }
+    record_path = root / "record.json"
+    record_path.write_text(json.dumps(record), encoding="utf-8")
+    archive_out = root / "curatelabs-graphforge-0.5.0-amended.tgz"
+    supplement = root / "v0.5.0-npm-amendment.json"
+
+    amend.create(record_path, artifacts, archive_out, supplement)
+    updated = amend.load_json(record_path)
+    item = amend.main_item(updated)
+    assert item["sha256"] == amend.sha256_file(archive_out)
+    assert item["bytes"] < record["artifacts"][0]["bytes"]
+    assert updated["amendments"][0]["issue"] == "#287"
+    details = amend.load_json(supplement)
+    assert set(details["excluded_files"]) == amend.NATIVE_FILES
+
+    extracted = root / "extracted"
+    amend.safe_extract(archive_out, extracted)
+    assert not list((extracted / "package").glob("*.node"))
+    amended_manifest = amend.load_json(extracted / "package" / "package.json")
+    assert "*.node" not in amended_manifest["files"]
+    assert amended_manifest["optionalDependencies"] == amend.OPTIONAL_DEPENDENCIES
+
+print("npm main amendment tests passed")

--- a/scripts/ci/test-release-publish-preflight.py
+++ b/scripts/ci/test-release-publish-preflight.py
@@ -128,6 +128,11 @@ assert "needs: [candidate-preflight, publish-pypi]" in npm_job
 assert "scripts/publish_npm_artifacts.py" in npm_job
 assert "Load reviewed npm recovery publisher" in npm_job
 assert "refs/remotes/origin/main:scripts/publish_npm_artifacts.py" in npm_job
+assert "scripts/amend_npm_main_artifact.py" in npm_job
+assert "Apply authorized unpublished main npm amendment" in npm_job
+assert "v0.5.0-npm-amendment.json" in npm_job
+assert "curatelabs-graphforge-0.5.0-amended.tgz" in npm_job
+assert "contents: write" in npm_job
 assert "--group native" in npm_job
 assert "--group cli" in npm_job
 assert "--group skills" in npm_job


### PR DESCRIPTION
Closes #287

## Summary
- remove embedded native binaries from future main @curatelabs/graphforge tarballs
- create the explicitly authorized v0.5.0 npm-only amendment from the retained original candidate
- attach the amended tarball and supplemental checksum record before publication
- require every resume to reuse and checksum-match those exact amendment assets

## Evidence
- amendment unit contract passes
- release workflow contracts pass
- main package dry run is 32,509 bytes with no .node files
- optional platform dependency contract is preserved
- make pre-push-fast passes

Authorization: https://github.com/CurateLabs/graphforge/issues/192#issuecomment-5150352447 and maintainer choice 2 in the release task.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788161591&installation_model_id=20486&pr_number=289&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F289&signature=6a6ef18ad6f19c038aea3bd51d6d483b40211b90bef05ab4e62b0d040bb354ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the npm package release process to remove embedded native binaries from the main package artifact.
  * Added validation to ensure amended packages meet size, integrity, and metadata requirements.

* **Tests**
  * Added automated coverage for package amendment, archive contents, checksums, and release metadata.
  * Expanded publish preflight checks to verify required amendment steps and permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix unpublished v0.5.0 main npm artifact by stripping native binaries and repacking
> - Adds [`scripts/amend_npm_main_artifact.py`](https://github.com/CurateLabs/graphforge/pull/289/files#diff-45c8ca3e314f49eff961e4a3eea24ac2f03725e97bf95e74278a90aa31b1a904), a tool that strips native `.node` binaries from the v0.5.0 main npm tarball, repacks it, and updates the release record with amendment metadata and a supplement JSON (`v0.5.0-npm-amendment.json`).
> - Adds a manual-dispatch step in the [`publish.yaml`](https://github.com/CurateLabs/graphforge/pull/289/files#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388ca) workflow (gated to `v0.5.0`) that uploads or downloads the amended tarball and supplement from the GitHub Release, then applies the amendment script.
> - Removes `"*.node"` from the `files` array in [`crates/graphforge-bindings-node/package.json`](https://github.com/CurateLabs/graphforge/pull/289/files#diff-a953ca76f4654449a65b08475e1ed6bcca8297b81a486186c6d7526eaed1428c) so future publishes exclude native binaries from the main package.
> - Updates the offline lifecycle test to install a synthesized platform-specific package alongside the main and CLI tarballs, reflecting the native binary split.
> - Risk: the `publish-npm` job now requires `contents: write` permission to upload release assets.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 85a9a21.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->