### PR TITLE
docs(release): require one shared product version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Adopt ADR 0017's single-version release invariant: all public Rust crates,
+  Python and Node/native adapters, CLI, and agent skills must publish one exact
+  GraphForge version, and partial-publication recovery may not introduce
+  temporary or registry-specific version divergence (#292).
 - Split native binaries out of the main `@curatelabs/graphforge` npm tarball,
   and add the explicitly authorized v0.5.0 supplemental artifact/checksum
   record so the previously unpublished main package stays below npm's payload

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -233,6 +233,10 @@ export default defineConfig({
                   label: '0016 — Repository Integration',
                   slug: 'adr/0016-repository-integration-and-deployment-configuration',
                 },
+                {
+                  label: '0017 — Unified Release Version',
+                  slug: 'adr/0017-unified-release-version',
+                },
               ],
             },
           ],

--- a/docs-site/scripts/sync-content.mjs
+++ b/docs-site/scripts/sync-content.mjs
@@ -110,7 +110,7 @@ const PAGES = [
   'development/clean-environment-verification.md',
   'development/release-strategy.md',
   'development/release-workflows.md',
-  // ADRs after #2725 cull/renumber (0001–0014)
+  // Accepted ADRs after #2725 cull/renumber.
   'adr/README.md',
   'adr/0001-rust-core.md',
   'adr/0002-lr1-grammar.md',
@@ -128,6 +128,7 @@ const PAGES = [
   'adr/0014-workspace-checkpoints.md',
   'adr/0015-embedded-write-modes.md',
   'adr/0016-repository-integration-and-deployment-configuration.md',
+  'adr/0017-unified-release-version.md',
   'releases/roadmap.md',
   'legal/licensing.md',
   'community/security.md',

--- a/docs/adr/0017-unified-release-version.md
+++ b/docs/adr/0017-unified-release-version.md
@@ -1,0 +1,119 @@
+# ADR 0017: One version across core and adapters
+
+**Status:** Accepted
+
+**Date:** 2026-08-01
+
+**Build target:** v0.5.1 and later
+
+**Related:** ADR 0001 (Rust core), issue #288 (resumable publication), issue
+#291 (incomplete npm v0.5.0 artifact), and issue #292
+
+## Context
+
+GraphForge is one product. Rust owns behavior; the Python and Node packages are
+thin adapters over that Rust implementation. The public Rust crates, language
+packages, native npm packages, command-line package, and agent-skills package
+are assembled and released together.
+
+The v0.5.0 publication stopped after PyPI, five native npm packages, and an
+incomplete npm main package had become immutable. One proposed recovery would
+have advanced only npm to v0.5.1 while leaving Rust and Python at v0.5.0. That
+would make the same GraphForge version mean different behavior and provenance
+depending on the registry. Users and support tooling could no longer infer
+which Rust core an adapter exposes from its public version.
+
+Registry immutability makes partial publication expensive, but it does not
+change the product boundary. Operational convenience cannot turn thin adapters
+into independently versioned products.
+
+## Options considered
+
+1. **One version for the complete first-party release set.** Recovery advances
+   the whole set together. This may publish byte-identical packages again at a
+   new version, but preserves an unambiguous product identity.
+2. **Independently version each registry surface.** This makes registry-local
+   patches easy, but version equality no longer communicates compatibility or
+   provenance.
+3. **Keep core aligned but version CLI and skills independently.** These
+   packages still participate in one tested release graph and declare exact
+   compatibility with the bindings. A second version policy would add another
+   recovery and support matrix.
+4. **Reuse a partially published version after replacing bad bytes.** Public
+   registries do not generally permit this, and replacing immutable release
+   identity would invalidate recorded checksums and user trust.
+
+## Decision
+
+### Shared release set
+
+Every first-party artifact in one GraphForge release uses the same exact
+Semantic Version:
+
+- all 15 public `graphforge-*` crates on crates.io;
+- `graphforge` on PyPI;
+- `@curatelabs/graphforge` and its five native npm platform packages;
+- `@curatelabs/graphforge-cli`;
+- `@curatelabs/graphforge-agent-skills`.
+
+The release version is declared once at the root of the release candidate.
+Package records and publication or recovery plans derive from it and cannot
+override it. Ecosystem-specific development syntax may differ (`-dev`,
+`.dev0`, or `-dev.0`), but a public release normalizes to the same exact
+`MAJOR.MINOR.PATCH` value everywhere.
+
+### Recovery rule
+
+Independent publication and resumability mean that already verified nodes may
+skip work; they do not permit independent version selection. After a partial
+publication failure, maintainers may:
+
+1. resume missing artifacts at the same version only when their immutable
+   candidate bytes remain valid and the registry version is absent; or
+2. issue a coordinated new version for the entire shared release set.
+
+They may not advance only one registry, adapter, CLI, skills package, native
+package, or crate. Temporary divergence is still divergence. A recovery plan
+containing more than one release version fails before every registry write.
+
+Historical partial artifacts remain accurately documented. Tags, GitHub
+Releases, registry files, and checksum records are never moved, replaced, or
+misrepresented as a successful unified release.
+
+### Enforcement
+
+Repository version tooling validates the Cargo workspace, Cargo lockfile,
+Python metadata, Node binding, CLI, skills package, and skills compatibility
+metadata as one set. Candidate validation verifies every recorded Python, npm,
+and crates.io artifact carries the candidate's root version and exact expected
+package inventory. Publication preflight verifies the tag, repository version
+surfaces, candidate record, and changelog before credentials can write.
+
+Release-orchestration work in #288 extends this invariant into the canonical
+manifest and recovery planner. Workflow job state never authorizes a version
+override.
+
+## Consequences
+
+### Positive
+
+- One version identifies one GraphForge product across every installation path.
+- Adapter compatibility and Rust-core provenance remain understandable.
+- Release notes, support reports, SBOMs, and checksum records share one key.
+- Recovery cannot quietly turn operational failure into ecosystem drift.
+
+### Negative
+
+- A defect in one immutable registry artifact can require a coordinated patch
+  release across packages whose bytes did not otherwise change.
+- More packages may be published during recovery than a registry-local policy
+  would require.
+- Candidate construction and recovery planning need stronger fail-closed
+  version validation.
+
+### Compatibility and follow-up
+
+The incomplete v0.5.0 npm package and other partial v0.5.0 artifacts remain
+historical registry facts. M1 targets a coordinated v0.5.1 release. Issue #288
+owns the manifest, observation, recovery, and orchestration changes needed to
+apply this decision without replaying already verified work.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,7 +1,7 @@
-# Architecture Decision Records (v0.5.0)
+# Architecture Decision Records
 
 Contiguous ADR sequence for decisions that remain part of the shipped / current
-v0.5.0 product architecture. Superseded tooling pins and post-0.5.0 roadmap ADRs
+GraphForge product architecture. Superseded tooling pins and roadmap-only ADRs
 are not retained in this tree.
 
 | ADR | Title | File |
@@ -22,6 +22,7 @@ are not retained in this tree.
 | 0014 | [Complete-workspace checkpoints and generation-preserving revert](0014-workspace-checkpoints.md) | `0014-workspace-checkpoints.md` |
 | 0015 | [Three embedded project-write modes](0015-embedded-write-modes.md) | `0015-embedded-write-modes.md` |
 | 0016 | [Repository integration and deployment configuration boundary](0016-repository-integration-and-deployment-configuration.md) | `0016-repository-integration-and-deployment-configuration.md` |
+| 0017 | [One version across core and adapters](0017-unified-release-version.md) | `0017-unified-release-version.md` |
 
 ## Numbering
 

--- a/docs/book/architecture/overview.md
+++ b/docs/book/architecture/overview.md
@@ -267,4 +267,5 @@ Shipped v0.5.0 expects these surfaces to stay green on `main`:
 - [ADR 0014: Workspace Checkpoints](../../adr/0014-workspace-checkpoints.md) — complete-workspace checkpoints and revert
 - [ADR 0015: Embedded Write Modes](../../adr/0015-embedded-write-modes.md) — single, queued, and optimistic project writes
 - [ADR 0016: Repository integration and deployment configuration](../../adr/0016-repository-integration-and-deployment-configuration.md) — tracked definitions, local data, CLI, skills, and IaC ownership boundaries
+- [ADR 0017: One version across core and adapters](../../adr/0017-unified-release-version.md) — one public version for the Rust core, bindings, CLI, and skills release set
 - [Roadmap](../../releases/roadmap.md) — Milestones and timeline

--- a/docs/development/publication-order.md
+++ b/docs/development/publication-order.md
@@ -14,6 +14,20 @@ Related operational docs:
 [`release-process.md`](release-process.md),
 `.github/workflows/publish.yaml`.
 
+## Shared-version invariant
+
+[ADR 0017](../adr/0017-unified-release-version.md) applies to every normal and
+recovery path. The 15 public crates, PyPI package, npm main/native packages,
+CLI, and agent skills form one release set with one exact version. Package jobs
+may resume independently, but package versions may not.
+
+A partial publication has only two valid dispositions: resume an absent
+artifact from the same immutable candidate, or prepare one coordinated new
+version for the complete release set. A plan that advances only an adapter,
+registry, native package, CLI, skills package, or crate fails before every
+write. Existing tags, release records, and registry artifacts remain immutable
+historical evidence.
+
 ## Preconditions (must be true before step 1)
 
 1. §5 version freeze is complete: Cargo workspace, Python binding, Node binding,

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -27,6 +27,21 @@ Example: 1.2.3
          └─────── MAJOR: Breaking changes
 ```
 
+### One product version across registries
+
+[ADR 0017](../adr/0017-unified-release-version.md) defines one shared release
+set. All public `graphforge-*` crates, the `graphforge` Python package,
+`@curatelabs/graphforge` and its five native npm packages, the CLI, and agent
+skills use the same exact public `MAJOR.MINOR.PATCH` version.
+
+Bindings are thin adapters over the Rust-owned product, not independently
+versioned products. A partial registry failure does not authorize a
+registry-specific patch version, even temporarily. Recovery either resumes
+absent artifacts from the same immutable candidate or advances the complete
+shared release set to one coordinated new version. Run
+`python3 scripts/set_release_version.py --check` and validate the complete
+candidate record before any publication credential can write.
+
 ### Version Increments
 
 **MAJOR version** (1.0.0 → 2.0.0) when:

--- a/docs/development/v0.5.0-release-operator-runbook.md
+++ b/docs/development/v0.5.0-release-operator-runbook.md
@@ -1,5 +1,23 @@
 # GraphForge v0.5.0 release operator runbook
 
+> **Historical incident runbook.** The v0.5.0 publication ended in a partial,
+> unusable public release. Do not use this procedure to publish additional
+> v0.5.0 artifacts or to advance only one ecosystem. M1 now targets a
+> coordinated v0.5.1 release under
+> [ADR 0017](../adr/0017-unified-release-version.md) and #288. The commands
+> below remain as the record of the v0.5.0 operator contract; #288 owns the
+> replacement resumable runbook.
+
+## Shared-version recovery guard
+
+Before any recovery decision, compare Cargo/crates, PyPI, npm main/native, CLI,
+and skills versions as one set. Independent job recovery may skip a package
+whose exact candidate is already publicly verified; it may not select a new
+version for only that package or registry. If immutable registry state prevents
+completion at the existing version, stop and prepare one coordinated patch
+version across the entire release set. Never move or replace the earlier tag,
+release record, or registry artifacts.
+
 This is the ordered operator procedure for the human-gated M1 close tracker
 [#192](https://github.com/CurateLabs/graphforge/issues/192). It complements the
 authoritative stop and recovery rules in

--- a/docs/engineering/ARCHITECTURE.md
+++ b/docs/engineering/ARCHITECTURE.md
@@ -119,6 +119,7 @@ The DocSlime index is [`adrs/README.md`](adrs/README.md) (links only; does not r
 | [0014](../adr/0014-workspace-checkpoints.md) | Complete-workspace checkpoints |
 | [0015](../adr/0015-embedded-write-modes.md) | Three embedded project-write modes |
 | [0016](../adr/0016-repository-integration-and-deployment-configuration.md) | Repository integration and deployment configuration boundary |
+| [0017](../adr/0017-unified-release-version.md) | One version across core and adapters |
 
 ## Risks & trade-offs
 

--- a/docs/engineering/adrs/README.md
+++ b/docs/engineering/adrs/README.md
@@ -7,7 +7,7 @@ Decisions are immutable once accepted: to change one, add a new ADR that superse
 ## Path coordination
 
 DocSlime’s canonical directory is `docs/engineering/adrs/`. GraphForge’s accepted ADR bodies
-live in [`../../adr/`](../../adr/) as a contiguous v0.5.0 sequence (`0001`–`0014`) after the
+live in [`../../adr/`](../../adr/) as one contiguous sequence after the
 [#2730](https://github.com/CurateLabs/graphforge-legecy/pull/2730) cull/renumber
 ([#2725](https://github.com/CurateLabs/graphforge-legecy/issues/2725)). This folder is an
 **index only** — do not duplicate ADR bodies or fork a second numbering sequence here.
@@ -53,3 +53,4 @@ Keeper set after #2730 (mirrors [`../../adr/README.md`](../../adr/README.md)):
 | 0014 | Complete-workspace checkpoints | Accepted | [`../../adr/0014-workspace-checkpoints.md`](../../adr/0014-workspace-checkpoints.md) |
 | 0015 | Three embedded project-write modes | Accepted | [`../../adr/0015-embedded-write-modes.md`](../../adr/0015-embedded-write-modes.md) |
 | 0016 | Repository integration and deployment configuration boundary | Accepted | [`../../adr/0016-repository-integration-and-deployment-configuration.md`](../../adr/0016-repository-integration-and-deployment-configuration.md) |
+| 0017 | One version across core and adapters | Accepted | [`../../adr/0017-unified-release-version.md`](../../adr/0017-unified-release-version.md) |

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Adopt ADR 0017's single-version release invariant: all public Rust crates,
+  Python and Node/native adapters, CLI, and agent skills must publish one exact
+  GraphForge version, and partial-publication recovery may not introduce
+  temporary or registry-specific version divergence (#292).
 - Split native binaries out of the main `@curatelabs/graphforge` npm tarball,
   and add the explicitly authorized v0.5.0 supplemental artifact/checksum
   record so the previously unpublished main package stays below npm's payload

--- a/scripts/ci/test-release-candidate.py
+++ b/scripts/ci/test-release-candidate.py
@@ -82,6 +82,20 @@ def main() -> None:
         else:
             raise AssertionError("checksum mutation should fail")
 
+    with tempfile.TemporaryDirectory() as temp:
+        root = Path(temp) / "artifacts"
+        record_path, artifacts_dir = _fixture(root)
+        record = json.loads(record_path.read_text(encoding="utf-8"))
+        npm_item = next(item for item in record["artifacts"] if item["surface"] == "npm")
+        npm_item["version"] = "0.5.1"
+        record_path.write_text(json.dumps(record), encoding="utf-8")
+        try:
+            release_candidate.validate(record_path, artifacts_dir, "a" * 40, "0.5.0")
+        except release_candidate.CandidateError as error:
+            assert "artifact version mismatch" in str(error)
+        else:
+            raise AssertionError("ADR 0017 forbids npm/core version divergence")
+
     print("release-candidate tests: ok")
 
 

--- a/scripts/ci/test-release-publish-preflight.py
+++ b/scripts/ci/test-release-publish-preflight.py
@@ -61,6 +61,9 @@ mutations = [
     {"tag": "0.5.0"},
     {"actual_sha": "b" * 40},
     {"versions": {**versions, "python": "0.5.0.dev0"}},
+    # ADR 0017: a registry-specific adapter patch is forbidden even when the
+    # Rust and Python surfaces still agree.
+    {"versions": {**versions, "node": "0.5.1"}},
     {"changelog": changelog.replace("## [0.5.0] - 2026-07-31", "## [0.5.0]")},
     {"changelog": changelog.replace("_Nothing yet._", "- Stale release entry")},
     {


### PR DESCRIPTION
Closes #292.

## Summary

- accept ADR 0017: all public Rust crates, Python/Node/native adapters, CLI, and skills share one exact release version
- document coordinated recovery and preserve immutable partial-release records
- make repository preflight and candidate tests reject adapter/core version divergence
- publish ADR 0017 through both decision indexes and the Starlight allowlist/navigation

## Validation

- `python3 scripts/ci/test-release-publish-preflight.py`
- `python3 scripts/ci/test-release-candidate.py`
- `python3 scripts/set_release_version.py --check`
- `pnpm docs:build`
- `pnpm docs:check-links`
- `make pre-push-fast`

No versions, tags, releases, packages, or registry state are changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788182400&installation_model_id=20486&pr_number=297&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F297&signature=5aa5e2926fb2cbfe83f637019789102ca45e800555df0285d1eb0abf90df3f96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the “Unified Release Version” architecture decision record to the published documentation and navigation.

* **Tests**
  * Added coverage ensuring release validation rejects artifacts with mismatched versions.
  * Added coverage for registry-specific Node version mismatches during publish preflight validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document and enforce a single shared product version across all release surfaces
> - Adds [ADR 0017](https://github.com/CurateLabs/graphforge/pull/297/files#diff-5aa4216b5757cc8c7089a1e1fcf4607a029775595a922dd3de108f48c0e3719e) establishing that Rust crates, Python/Node adapters, CLI, and agent skills must share one version at every release, forbidding registry-specific patch versions.
> - Updates release process, publication order, and v0.5.0 operator runbook docs to reference ADR 0017 and describe valid recovery dispositions.
> - Adds test cases in [test-release-candidate.py](https://github.com/CurateLabs/graphforge/pull/297/files#diff-3e1e4e1015ad205e865367bff264d855c0062bfbe24c63683445a235914cd4f0) and [test-release-publish-preflight.py](https://github.com/CurateLabs/graphforge/pull/297/files#diff-f0d80518da11ee77851032bfc3e7ed886e1933e234c8ef3996ce0669b95449bb) that assert validation fails when any adapter version diverges from the expected release version.
> - Registers ADR 0017 in the docs site sidebar and content sync allowlist so it appears in the published documentation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9aad072.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->