### PR TITLE
feat(release): plan recovery from registry truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Derive publication recovery from the immutable candidate plus fresh PyPI,
+  npm, and crates.io truth: normalize absence, accepted propagation, verified
+  bytes, conflict, failure, and indeterminate evidence; bound visibility checks
+  without sleeps or repeat writes; and schedule only dependency-valid absent
+  nodes with available retained artifacts (#294).
 - Replace checksum-only release records with a deterministic, partitioned
   candidate manifest that enforces the complete 24-node public package set,
   one root version, exact dependency edges, archive entrypoints/legal files,

--- a/docs/development/release-artifact-record.md
+++ b/docs/development/release-artifact-record.md
@@ -55,6 +55,77 @@ workflow job result: `not_attempted`, `absent`, `accepted_pending_visibility`,
 recovery planning define how those states are reached; the candidate only fixes
 their meanings and the bytes being observed.
 
+## Registry truth contracts
+
+Registry observations are fresh, bounded evidence about one manifest node. A
+GitHub Actions job conclusion is never a package state.
+
+| Registry | Authoritative public observation | Verified identity and metadata | Digest comparison |
+| --- | --- | --- | --- |
+| PyPI | `GET https://pypi.org/pypi/{name}/{version}/json` | project name/version, Apache-2.0, and the exact wheel/sdist filename set | every `urls[].digests.sha256` equals the candidate |
+| npm | `GET https://registry.npmjs.org/{encoded-name}/{version}` | package name/version, Apache-2.0, and exact first-party dependency versions | a supported `dist.integrity` SHA-256 or SHA-512 token equals the candidate |
+| crates.io | `GET https://crates.io/api/v1/crates/{name}/{version}` plus `/owners` | crate name/version, Apache-2.0, not yanked, and `DecisionNerd` ownership | `version.checksum` equals the candidate SHA-256 |
+
+The adapters classify results consistently:
+
+- an authoritative 404 with no accepted-write receipt is `absent`;
+- an existing identity with different bytes, metadata, dependencies, owner, or
+  file set is `conflict`;
+- authorization failure or another deterministic invalid operation is `failed`;
+- rate limiting, service failure, timeout, malformed evidence, or stale evidence
+  is `indeterminate`;
+- exact public identity, bytes, and required metadata is `verified`.
+
+An accepted registry write is not yet public verification. Its sanitized receipt
+records the node, root version, acceptance time, a visibility deadline no more
+than 15 minutes later, and an observation count. One invocation performs one
+authoritative observation—there is no internal retry loop or sleep. An absent or
+incomplete public response before the deadline becomes
+`accepted_pending_visibility`; four observations or the deadline exhaust the
+bound and become `indeterminate`. Verification-only continuation can never emit
+another write action.
+
+## Recovery planning
+
+`scripts/ci/release_registry.py` creates a machine-readable plan from only:
+
+1. the immutable candidate manifest;
+2. fresh normalized registry observations; and
+3. current retained-group availability.
+
+Only `absent` nodes whose dependencies are already `verified` and whose exact
+artifact group is available can receive a `publish` action. `not_attempted`
+nodes receive an observation action, accepted-but-not-visible nodes receive a
+visibility-verification action, and `verified` nodes are skipped without an
+artifact download. Conflict, indeterminate, failed, stale, dependency-blocked,
+or expired-artifact nodes fail closed.
+
+The graph preserves crate topological order and npm native → main → CLI → skills
+gates. A registry-scoped recovery plan does not download or schedule unrelated
+surfaces. Extra workflow-job history is ignored, and normalized output contains
+no response bodies, credentials, authorization headers, cookies, or tokens.
+
+Fixture-driven commands are safe for offline planning:
+
+```bash
+python3 scripts/ci/release_registry.py observe \
+  --manifest candidate/vX.Y.Z-artifacts.json \
+  --node npm:@curatelabs/graphforge \
+  --response npm-response.json \
+  --observed-at 2030-01-01T12:00:00Z \
+  --out npm-observation.json
+
+python3 scripts/ci/release_registry.py plan \
+  --manifest candidate/vX.Y.Z-artifacts.json \
+  --observations registry-observations.json \
+  --availability artifact-availability.json \
+  --planned-at 2030-01-01T12:01:00Z \
+  --out recovery-plan.json
+```
+
+`observe --live` performs the same public, read-only registry requests. Neither
+command has a registry-write path.
+
 ## Build and validate offline
 
 After the binding workflow has assembled the four directories, it creates the

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Derive publication recovery from the immutable candidate plus fresh PyPI,
+  npm, and crates.io truth: normalize absence, accepted propagation, verified
+  bytes, conflict, failure, and indeterminate evidence; bound visibility checks
+  without sleeps or repeat writes; and schedule only dependency-valid absent
+  nodes with available retained artifacts (#294).
 - Replace checksum-only release records with a deterministic, partitioned
   candidate manifest that enforces the complete 24-node public package set,
   one root version, exact dependency edges, archive entrypoints/legal files,

--- a/scripts/ci/release_registry.py
+++ b/scripts/ci/release_registry.py
@@ -1,0 +1,805 @@
+#!/usr/bin/env python3
+"""Registry truth adapters and pure recovery planning for GraphForge releases."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+from datetime import datetime, timedelta, timezone
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from release_candidate_manifest import GROUPS, PUBLICATION_STATES
+from release_candidate_manifest import SCHEMA as CANDIDATE_SCHEMA
+
+OBSERVATION_SCHEMA = "graphforge-registry-observation-v1"
+OBSERVATION_SET_SCHEMA = "graphforge-registry-observations-v1"
+PLAN_SCHEMA = "graphforge-release-recovery-plan-v1"
+MAX_VISIBILITY_SECONDS = 15 * 60
+MAX_VISIBILITY_OBSERVATIONS = 4
+MAX_OBSERVATION_AGE_SECONDS = 10 * 60
+USER_AGENT = "GraphForge release observer (github.com/CurateLabs/graphforge)"
+SHA_RE = re.compile(r"[0-9a-f]{40}")
+FORBIDDEN_OUTPUT_KEYS = ("authorization", "cookie", "password", "secret", "token")
+
+
+class RegistryError(ValueError):
+    """Registry evidence or a recovery input is unsafe or malformed."""
+
+
+def _parse_time(value: str, *, field: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (TypeError, ValueError) as error:
+        raise RegistryError(f"{field} must be an ISO-8601 timestamp") from error
+    if parsed.tzinfo is None:
+        raise RegistryError(f"{field} must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def _load_json(path: Path, *, context: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise RegistryError(f"cannot read {context} {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise RegistryError(f"{context} must be a JSON object")
+    return value
+
+
+def _manifest_indexes(
+    manifest: dict[str, Any],
+) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]], dict[str, str]]:
+    if manifest.get("schema") != CANDIDATE_SCHEMA:
+        raise RegistryError("recovery requires graphforge-release-candidate-v2")
+    version = manifest.get("version")
+    commit_sha = manifest.get("commit_sha")
+    if not isinstance(version, str) or not version:
+        raise RegistryError("candidate root version is missing")
+    if not isinstance(commit_sha, str) or SHA_RE.fullmatch(commit_sha) is None:
+        raise RegistryError("candidate commit SHA is invalid")
+    nodes_raw = manifest.get("nodes")
+    artifacts_raw = manifest.get("artifacts")
+    groups_raw = manifest.get("artifact_groups")
+    if not all(isinstance(value, list) for value in (nodes_raw, artifacts_raw, groups_raw)):
+        raise RegistryError("candidate nodes, artifacts, and groups must be arrays")
+    nodes: dict[str, dict[str, Any]] = {}
+    for node in nodes_raw:
+        if not isinstance(node, dict) or not isinstance(node.get("id"), str):
+            raise RegistryError("candidate contains an invalid public node")
+        if "version" in node:
+            raise RegistryError("candidate public nodes may not override the root version")
+        if node["id"] in nodes:
+            raise RegistryError(f"candidate contains duplicate node {node['id']}")
+        registry = node.get("registry")
+        name = node.get("name")
+        if registry not in {"pypi", "npm", "crates"} or not isinstance(name, str):
+            raise RegistryError(f"candidate node {node['id']} has invalid registry identity")
+        if node["id"] != f"{registry}:{name}":
+            raise RegistryError(f"candidate node identity mismatch: {node['id']}")
+        nodes[node["id"]] = node
+    artifacts: dict[str, dict[str, Any]] = {}
+    path_to_group: dict[str, str] = {}
+    for artifact in artifacts_raw:
+        if not isinstance(artifact, dict) or not isinstance(artifact.get("path"), str):
+            raise RegistryError("candidate contains an invalid artifact")
+        path = artifact["path"]
+        if path in artifacts:
+            raise RegistryError(f"candidate contains duplicate artifact {path}")
+        if artifact.get("version") != version:
+            raise RegistryError(f"candidate artifact version diverges: {path}")
+        group = artifact.get("group")
+        if group not in GROUPS:
+            raise RegistryError(f"candidate artifact group is invalid: {path}")
+        artifacts[path] = artifact
+        path_to_group[path] = group
+    for node_id, node in nodes.items():
+        paths = node.get("artifact_paths")
+        if not isinstance(paths, list) or not paths:
+            raise RegistryError(f"candidate node {node_id} has no artifact paths")
+        for path in paths:
+            artifact = artifacts.get(path)
+            if artifact is None:
+                raise RegistryError(f"candidate node {node_id} references missing artifact {path}")
+            if artifact.get("surface") != node["registry"] or artifact.get("name") != node["name"]:
+                raise RegistryError(f"candidate node/artifact identity mismatch: {node_id}")
+    return nodes, artifacts, path_to_group
+
+
+def _node_expected(manifest: dict[str, Any], node_id: str) -> dict[str, Any]:
+    nodes, artifacts, _ = _manifest_indexes(manifest)
+    try:
+        node = nodes[node_id]
+    except KeyError as error:
+        raise RegistryError(f"unknown candidate node: {node_id}") from error
+    selected = [artifacts[path] for path in node["artifact_paths"]]
+    return {
+        "node": node,
+        "artifacts": selected,
+        "version": manifest["version"],
+        "commit_sha": manifest["commit_sha"],
+    }
+
+
+def endpoint_for(registry: str, name: str, version: str) -> str:
+    if registry == "pypi":
+        return f"https://pypi.org/pypi/{urllib.parse.quote(name, safe='')}/{version}/json"
+    if registry == "npm":
+        encoded = urllib.parse.quote(name, safe="")
+        return f"https://registry.npmjs.org/{encoded}/{version}"
+    if registry == "crates":
+        return f"https://crates.io/api/v1/crates/{urllib.parse.quote(name, safe='')}/{version}"
+    raise RegistryError(f"unsupported registry: {registry}")
+
+
+def _receipt(
+    value: dict[str, Any] | None,
+    *,
+    node_id: str,
+    version: str,
+) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if value.get("node_id") != node_id or value.get("version") != version:
+        raise RegistryError("accepted-write receipt identity diverges from the candidate")
+    accepted_at = _parse_time(value.get("accepted_at"), field="receipt.accepted_at")
+    deadline = _parse_time(value.get("visibility_deadline"), field="receipt.visibility_deadline")
+    if deadline <= accepted_at or deadline > accepted_at + timedelta(
+        seconds=MAX_VISIBILITY_SECONDS
+    ):
+        raise RegistryError("accepted-write visibility deadline is not bounded")
+    observations = value.get("observation_count", 0)
+    if not isinstance(observations, int) or observations < 0:
+        raise RegistryError("accepted-write observation_count is invalid")
+    return {
+        "accepted_at": accepted_at.isoformat(),
+        "visibility_deadline": deadline.isoformat(),
+        "observation_count": observations,
+    }
+
+
+def _pending_or_indeterminate(
+    receipt: dict[str, Any] | None,
+    observed_at: datetime,
+    *,
+    pending_reason: str,
+) -> tuple[str, str, dict[str, Any]]:
+    if receipt is None:
+        return "indeterminate", pending_reason, {}
+    deadline = _parse_time(receipt["visibility_deadline"], field="receipt.visibility_deadline")
+    count = receipt["observation_count"] + 1
+    evidence = {
+        "accepted_at": receipt["accepted_at"],
+        "visibility_deadline": receipt["visibility_deadline"],
+        "observation_count": count,
+        "max_observations": MAX_VISIBILITY_OBSERVATIONS,
+    }
+    if observed_at <= deadline and count < MAX_VISIBILITY_OBSERVATIONS:
+        return "accepted_pending_visibility", pending_reason, evidence
+    return "indeterminate", "visibility_bound_exhausted", evidence
+
+
+def _pypi(
+    expected: dict[str, Any], payload: dict[str, Any], receipt: dict[str, Any] | None, now: datetime
+) -> tuple[str, str, dict[str, Any]]:
+    info = payload.get("info")
+    urls = payload.get("urls")
+    if not isinstance(info, dict) or not isinstance(urls, list):
+        return _pending_or_indeterminate(receipt, now, pending_reason="pypi_metadata_incomplete")
+    name = info.get("name")
+    version = info.get("version")
+    if not isinstance(name, str) or not isinstance(version, str):
+        return _pending_or_indeterminate(receipt, now, pending_reason="pypi_identity_pending")
+    if name != expected["node"]["name"] or version != expected["version"]:
+        return (
+            "conflict",
+            "pypi_identity_mismatch",
+            {"observed_name": name, "observed_version": version},
+        )
+    license_value = info.get("license_expression") or info.get("license")
+    if license_value != "Apache-2.0":
+        if license_value in {None, ""}:
+            return _pending_or_indeterminate(receipt, now, pending_reason="pypi_license_pending")
+        return "conflict", "pypi_license_mismatch", {"observed_license": str(license_value)}
+    actual: dict[str, str] = {}
+    for item in urls:
+        if not isinstance(item, dict):
+            return _pending_or_indeterminate(
+                receipt, now, pending_reason="pypi_file_metadata_invalid"
+            )
+        filename = item.get("filename")
+        digest = (
+            item.get("digests", {}).get("sha256") if isinstance(item.get("digests"), dict) else None
+        )
+        if not isinstance(filename, str) or not isinstance(digest, str):
+            return _pending_or_indeterminate(
+                receipt, now, pending_reason="pypi_file_metadata_invalid"
+            )
+        if re.fullmatch(r"[0-9a-f]{64}", digest) is None:
+            return "indeterminate", "pypi_checksum_malformed", {"filename": filename}
+        actual[filename] = digest
+    wanted = {item["filename"]: item["sha256"] for item in expected["artifacts"]}
+    if set(actual) != set(wanted):
+        return (
+            "conflict",
+            "pypi_file_set_mismatch",
+            {
+                "missing_files": sorted(set(wanted) - set(actual)),
+                "unexpected_files": sorted(set(actual) - set(wanted)),
+            },
+        )
+    mismatches = sorted(name for name in wanted if actual[name] != wanted[name])
+    if mismatches:
+        return "conflict", "pypi_checksum_mismatch", {"mismatched_files": mismatches}
+    return (
+        "verified",
+        "pypi_public_files_match",
+        {
+            "filenames": sorted(wanted),
+            "sha256_verified": True,
+            "license": "Apache-2.0",
+        },
+    )
+
+
+def _npm(
+    expected: dict[str, Any], payload: dict[str, Any], receipt: dict[str, Any] | None, now: datetime
+) -> tuple[str, str, dict[str, Any]]:
+    name = payload.get("name")
+    version = payload.get("version")
+    if not isinstance(name, str) or not isinstance(version, str):
+        return _pending_or_indeterminate(receipt, now, pending_reason="npm_identity_pending")
+    if name != expected["node"]["name"] or version != expected["version"]:
+        return (
+            "conflict",
+            "npm_identity_mismatch",
+            {"observed_name": name, "observed_version": version},
+        )
+    license_value = payload.get("license")
+    if license_value != "Apache-2.0":
+        if license_value in {None, ""}:
+            return _pending_or_indeterminate(receipt, now, pending_reason="npm_license_pending")
+        return "conflict", "npm_license_mismatch", {"observed_license": str(license_value)}
+    dist = payload.get("dist")
+    integrity = dist.get("integrity") if isinstance(dist, dict) else None
+    if not isinstance(integrity, str) or not integrity.strip():
+        return _pending_or_indeterminate(receipt, now, pending_reason="npm_integrity_pending")
+    tokens = set(integrity.split())
+    supported: set[str] = set()
+    for token in tokens:
+        algorithm, separator, encoded = token.partition("-")
+        if not separator or algorithm not in {"sha256", "sha512"}:
+            continue
+        try:
+            decoded = base64.b64decode(encoded, validate=True)
+        except (binascii.Error, ValueError):
+            return "indeterminate", "npm_integrity_malformed", {"algorithm": algorithm}
+        if len(decoded) != {"sha256": 32, "sha512": 64}[algorithm]:
+            return "indeterminate", "npm_integrity_malformed", {"algorithm": algorithm}
+        supported.add(token)
+    if not supported:
+        return "indeterminate", "npm_integrity_unsupported", {}
+    artifact = expected["artifacts"][0]
+    wanted_integrities = set(artifact.get("integrities", []))
+    if not supported.intersection(wanted_integrities):
+        return (
+            "conflict",
+            "npm_integrity_mismatch",
+            {"algorithms": sorted(token.split("-", 1)[0] for token in supported)},
+        )
+    package = (artifact.get("archive") or {}).get("package", {})
+    wanted_dependencies = package.get("dependencies", {})
+    actual_dependencies: dict[str, str] = {}
+    for field in ("dependencies", "optionalDependencies"):
+        value = payload.get(field)
+        if isinstance(value, dict):
+            actual_dependencies.update(
+                {key: str(item) for key, item in value.items() if key.startswith("@curatelabs/")}
+            )
+    if actual_dependencies != wanted_dependencies:
+        return (
+            "conflict",
+            "npm_dependency_mismatch",
+            {
+                "expected_dependencies": sorted(wanted_dependencies),
+                "observed_dependencies": sorted(actual_dependencies),
+            },
+        )
+    return (
+        "verified",
+        "npm_public_integrity_matches",
+        {
+            "integrity_algorithms": sorted(token.split("-", 1)[0] for token in supported),
+            "license": "Apache-2.0",
+            "dependency_names": sorted(wanted_dependencies),
+        },
+    )
+
+
+def _crates(
+    expected: dict[str, Any], payload: dict[str, Any], receipt: dict[str, Any] | None, now: datetime
+) -> tuple[str, str, dict[str, Any]]:
+    version_record = payload.get("version")
+    if not isinstance(version_record, dict):
+        return _pending_or_indeterminate(receipt, now, pending_reason="crates_version_pending")
+    name = version_record.get("crate")
+    version = version_record.get("num")
+    if not isinstance(name, str) or not isinstance(version, str):
+        return _pending_or_indeterminate(receipt, now, pending_reason="crates_identity_pending")
+    if name != expected["node"]["name"] or version != expected["version"]:
+        return (
+            "conflict",
+            "crates_identity_mismatch",
+            {
+                "observed_name": name,
+                "observed_version": version,
+            },
+        )
+    checksum = version_record.get("checksum")
+    if not isinstance(checksum, str) or re.fullmatch(r"[0-9a-f]{64}", checksum) is None:
+        return "indeterminate", "crates_checksum_malformed", {}
+    if checksum != expected["artifacts"][0]["sha256"]:
+        return "conflict", "crates_checksum_mismatch", {"sha256_present": isinstance(checksum, str)}
+    if version_record.get("yanked") is not False:
+        return "conflict", "crates_version_yanked", {"yanked": version_record.get("yanked")}
+    license_value = version_record.get("license")
+    if license_value != "Apache-2.0":
+        if license_value in {None, ""}:
+            return _pending_or_indeterminate(receipt, now, pending_reason="crates_license_pending")
+        return "conflict", "crates_license_mismatch", {"observed_license": str(license_value)}
+    owners = payload.get("owners")
+    users = owners.get("users") if isinstance(owners, dict) else None
+    if not isinstance(users, list):
+        return _pending_or_indeterminate(receipt, now, pending_reason="crates_owners_pending")
+    logins = sorted(
+        str(user.get("login")) for user in users if isinstance(user, dict) and user.get("login")
+    )
+    if "DecisionNerd" not in logins:
+        return "conflict", "crates_owner_mismatch", {"owner_logins": logins}
+    return (
+        "verified",
+        "crates_public_checksum_matches",
+        {
+            "sha256_verified": True,
+            "license": "Apache-2.0",
+            "owner_logins": logins,
+        },
+    )
+
+
+def observe(
+    manifest: dict[str, Any],
+    node_id: str,
+    response: dict[str, Any],
+    *,
+    observed_at: str,
+    accepted_receipt: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    expected = _node_expected(manifest, node_id)
+    node = expected["node"]
+    now = _parse_time(observed_at, field="observed_at")
+    receipt = _receipt(accepted_receipt, node_id=node_id, version=expected["version"])
+    if receipt is not None and now < _parse_time(
+        receipt["accepted_at"], field="receipt.accepted_at"
+    ):
+        raise RegistryError("registry observation predates accepted-write evidence")
+    status = response.get("status")
+    if not isinstance(status, int):
+        raise RegistryError("registry transport response requires integer status")
+    payload = response.get("json")
+    evidence: dict[str, Any] = {"http_status": status}
+    if status == 404:
+        if receipt is None:
+            state, reason = "absent", f"{node['registry']}_authoritative_not_found"
+        else:
+            state, reason, pending = _pending_or_indeterminate(
+                receipt, now, pending_reason=f"{node['registry']}_accepted_not_visible"
+            )
+            evidence.update(pending)
+    elif status in {401, 403}:
+        state, reason = "failed", f"{node['registry']}_authorization_failed"
+    elif status in {0, 408, 425, 429} or status >= 500:
+        state, reason = "indeterminate", f"{node['registry']}_transport_indeterminate"
+        retry_after = response.get("retry_after_seconds")
+        if isinstance(retry_after, int) and 0 <= retry_after <= MAX_VISIBILITY_SECONDS:
+            evidence["retry_after_seconds"] = retry_after
+    elif status != 200:
+        state, reason = "failed", f"{node['registry']}_unexpected_status"
+    elif not isinstance(payload, dict):
+        state, reason = "indeterminate", f"{node['registry']}_malformed_response"
+    else:
+        adapter = {"pypi": _pypi, "npm": _npm, "crates": _crates}[node["registry"]]
+        state, reason, adapter_evidence = adapter(expected, payload, receipt, now)
+        evidence.update(adapter_evidence)
+    observation = {
+        "schema": OBSERVATION_SCHEMA,
+        "candidate_sha": expected["commit_sha"],
+        "version": expected["version"],
+        "node_id": node_id,
+        "registry": node["registry"],
+        "name": node["name"],
+        "state": state,
+        "reason": reason,
+        "observed_at": now.isoformat(),
+        "endpoint": endpoint_for(node["registry"], node["name"], expected["version"]),
+        "evidence": evidence,
+    }
+    _assert_safe_output(observation)
+    return observation
+
+
+def _assert_safe_output(value: Any, *, path: str = "root") -> None:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            lowered = str(key).lower()
+            if any(forbidden in lowered for forbidden in FORBIDDEN_OUTPUT_KEYS):
+                raise RegistryError(f"sensitive key is forbidden in output: {path}.{key}")
+            _assert_safe_output(item, path=f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            _assert_safe_output(item, path=f"{path}[{index}]")
+
+
+def _validate_normalized_observation(value: dict[str, Any], node: dict[str, Any]) -> None:
+    state = value["state"]
+    reason = value["reason"]
+    evidence = value.get("evidence")
+    if not isinstance(evidence, dict) or not isinstance(evidence.get("http_status"), int):
+        raise RegistryError(f"observation evidence is incomplete: {node['id']}")
+    status = evidence["http_status"]
+    registry_name = node["registry"]
+    if state == "not_attempted":
+        raise RegistryError("not_attempted is represented by an omitted observation")
+    if state == "absent":
+        if status != 404 or reason != f"{registry_name}_authoritative_not_found":
+            raise RegistryError(f"absent observation lacks authoritative evidence: {node['id']}")
+    elif state == "accepted_pending_visibility":
+        required = {"accepted_at", "visibility_deadline", "observation_count", "max_observations"}
+        if status not in {200, 404} or not required.issubset(evidence):
+            raise RegistryError(f"pending observation lacks accepted-write evidence: {node['id']}")
+    elif state == "verified":
+        expected_reason = {
+            "pypi": "pypi_public_files_match",
+            "npm": "npm_public_integrity_matches",
+            "crates": "crates_public_checksum_matches",
+        }[registry_name]
+        if status != 200 or reason != expected_reason:
+            raise RegistryError(f"verified observation evidence is invalid: {node['id']}")
+        if registry_name in {"pypi", "crates"} and evidence.get("sha256_verified") is not True:
+            raise RegistryError(f"verified observation lacks checksum proof: {node['id']}")
+        if registry_name == "npm" and not evidence.get("integrity_algorithms"):
+            raise RegistryError(f"verified npm observation lacks integrity proof: {node['id']}")
+    elif state == "conflict" and status != 200:
+        raise RegistryError(f"conflict observation lacks existing public identity: {node['id']}")
+    elif state == "failed" and status in {0, 200, 404, 408, 425, 429}:
+        raise RegistryError(
+            f"failed observation lacks deterministic failure evidence: {node['id']}"
+        )
+
+
+def _observation_map(
+    manifest: dict[str, Any], observations: dict[str, Any], now: datetime
+) -> dict[str, dict[str, Any]]:
+    nodes, _, _ = _manifest_indexes(manifest)
+    if observations.get("schema") != OBSERVATION_SET_SCHEMA:
+        raise RegistryError("observation set schema is invalid")
+    if observations.get("candidate_sha") != manifest["commit_sha"]:
+        raise RegistryError("observation set candidate SHA diverges")
+    if observations.get("version") != manifest["version"]:
+        raise RegistryError("observation set version diverges")
+    values = observations.get("observations")
+    if not isinstance(values, list):
+        raise RegistryError("observation set observations must be an array")
+    result: dict[str, dict[str, Any]] = {}
+    for value in values:
+        if not isinstance(value, dict) or value.get("schema") != OBSERVATION_SCHEMA:
+            raise RegistryError("observation set contains an invalid observation")
+        node_id = value.get("node_id")
+        if node_id not in nodes or node_id in result:
+            raise RegistryError(f"observation node is missing or duplicated: {node_id}")
+        if (
+            value.get("candidate_sha") != manifest["commit_sha"]
+            or value.get("version") != manifest["version"]
+        ):
+            raise RegistryError(f"observation identity diverges: {node_id}")
+        if value.get("state") not in PUBLICATION_STATES:
+            raise RegistryError(f"observation state is invalid: {node_id}")
+        node = nodes[node_id]
+        if (
+            value.get("registry") != node["registry"]
+            or value.get("name") != node["name"]
+            or value.get("endpoint")
+            != endpoint_for(node["registry"], node["name"], manifest["version"])
+        ):
+            raise RegistryError(f"observation registry identity diverges: {node_id}")
+        reason = value.get("reason")
+        if not isinstance(reason, str) or re.fullmatch(r"[a-z0-9_]+", reason) is None:
+            raise RegistryError(f"observation reason is unsafe: {node_id}")
+        _validate_normalized_observation(value, node)
+        normalized = value
+        observed_at = _parse_time(value.get("observed_at"), field=f"{node_id}.observed_at")
+        if observed_at > now or now - observed_at > timedelta(seconds=MAX_OBSERVATION_AGE_SECONDS):
+            normalized = {
+                **value,
+                "state": "indeterminate",
+                "reason": "observation_stale",
+                "evidence": {"max_age_seconds": MAX_OBSERVATION_AGE_SECONDS},
+            }
+        result[node_id] = normalized
+    return result
+
+
+def _group_availability(
+    manifest: dict[str, Any], availability: dict[str, Any], now: datetime
+) -> dict[str, bool]:
+    groups = manifest.get("artifact_groups")
+    if not isinstance(groups, list):
+        raise RegistryError("candidate artifact groups are invalid")
+    manifest_groups = {group.get("id"): group for group in groups if isinstance(group, dict)}
+    if set(manifest_groups) != set(GROUPS):
+        raise RegistryError("candidate artifact groups are incomplete")
+    result: dict[str, bool] = {}
+    for group_id in GROUPS:
+        value = availability.get(group_id, False)
+        available = (
+            value
+            if isinstance(value, bool)
+            else value.get("available", False)
+            if isinstance(value, dict)
+            else False
+        )
+        expiry = _parse_time(
+            manifest_groups[group_id].get("expires_at"),
+            field=f"artifact_groups.{group_id}.expires_at",
+        )
+        result[group_id] = bool(available and now < expiry)
+    return result
+
+
+def plan_recovery(
+    manifest: dict[str, Any],
+    observations: dict[str, Any],
+    availability: dict[str, Any],
+    *,
+    planned_at: str,
+    registries: set[str] | None = None,
+) -> dict[str, Any]:
+    nodes, _, path_to_group = _manifest_indexes(manifest)
+    now = _parse_time(planned_at, field="planned_at")
+    observed = _observation_map(manifest, observations, now)
+    available = _group_availability(manifest, availability, now)
+    selected_registries = registries or {"pypi", "npm", "crates"}
+    if not selected_registries.issubset({"pypi", "npm", "crates"}):
+        raise RegistryError("recovery registry filter is invalid")
+    dependency_map: dict[str, list[str]] = {node_id: [] for node_id in nodes}
+    edges = manifest.get("dependencies")
+    if not isinstance(edges, list):
+        raise RegistryError("candidate dependencies are invalid")
+    for edge in edges:
+        if not isinstance(edge, dict):
+            raise RegistryError("candidate dependency edge is invalid")
+        node_id = edge.get("from")
+        dependency = edge.get("requires")
+        if node_id not in nodes or dependency not in nodes:
+            raise RegistryError("candidate dependency edge references a missing node")
+        dependency_map[node_id].append(dependency)
+
+    actions: list[dict[str, Any]] = []
+    decisions: list[dict[str, Any]] = []
+    blockers: list[dict[str, Any]] = []
+    for node_id in sorted(nodes):
+        node = nodes[node_id]
+        if node["registry"] not in selected_registries:
+            continue
+        observation = observed.get(
+            node_id,
+            {
+                "state": "not_attempted",
+                "reason": "fresh_registry_observation_required",
+            },
+        )
+        state = observation["state"]
+        decision: dict[str, Any] = {
+            "node_id": node_id,
+            "registry": node["registry"],
+            "state": state,
+            "reason": observation.get("reason"),
+        }
+        if state == "verified":
+            decision["disposition"] = "skip_verified"
+        elif state == "not_attempted":
+            decision["disposition"] = "observe"
+            actions.append({"node_id": node_id, "kind": "observe", "registry": node["registry"]})
+        elif state == "accepted_pending_visibility":
+            decision["disposition"] = "verify_visibility"
+            actions.append(
+                {"node_id": node_id, "kind": "verify_visibility", "registry": node["registry"]}
+            )
+        elif state == "absent":
+            dependencies = sorted(dependency_map[node_id])
+            dependency_states = {
+                dependency: observed.get(dependency, {"state": "not_attempted"})["state"]
+                for dependency in dependencies
+            }
+            if any(state != "verified" for state in dependency_states.values()):
+                decision["disposition"] = "blocked_dependencies"
+                decision["dependency_states"] = dependency_states
+                blockers.append(
+                    {
+                        "node_id": node_id,
+                        "reason": "dependencies_not_verified",
+                        "dependency_states": dependency_states,
+                    }
+                )
+            else:
+                paths = nodes[node_id]["artifact_paths"]
+                groups = sorted({path_to_group[path] for path in paths})
+                unavailable = [group for group in groups if not available[group]]
+                if unavailable:
+                    decision["disposition"] = "blocked_artifacts"
+                    blockers.append(
+                        {
+                            "node_id": node_id,
+                            "reason": "artifact_group_unavailable_or_expired",
+                            "artifact_groups": unavailable,
+                        }
+                    )
+                else:
+                    decision["disposition"] = "publish"
+                    actions.append(
+                        {
+                            "node_id": node_id,
+                            "kind": "publish",
+                            "registry": node["registry"],
+                            "artifact_groups": groups,
+                            "artifact_paths": paths,
+                            "credential_scope": {
+                                "pypi": "pypi-oidc",
+                                "npm": "npm",
+                                "crates": "crates.io",
+                            }[node["registry"]],
+                        }
+                    )
+        else:
+            decision["disposition"] = "blocked_registry_state"
+            blockers.append({"node_id": node_id, "reason": f"registry_state_{state}"})
+        decisions.append(decision)
+
+    download_groups = sorted(
+        {
+            group
+            for action in actions
+            if action["kind"] == "publish"
+            for group in action["artifact_groups"]
+        }
+    )
+    plan = {
+        "schema": PLAN_SCHEMA,
+        "candidate_sha": manifest["commit_sha"],
+        "version": manifest["version"],
+        "planned_at": now.isoformat(),
+        "registry_scope": sorted(selected_registries),
+        "actions": actions,
+        "decisions": decisions,
+        "download_groups": download_groups,
+        "blockers": blockers,
+        "summary": {
+            "publish": sum(action["kind"] == "publish" for action in actions),
+            "observe": sum(action["kind"] == "observe" for action in actions),
+            "verify_visibility": sum(action["kind"] == "verify_visibility" for action in actions),
+            "blocked": len(blockers),
+            "verified": sum(decision["state"] == "verified" for decision in decisions),
+        },
+    }
+    _assert_safe_output(plan)
+    return plan
+
+
+def _transport(url: str) -> dict[str, Any]:
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = json.load(response)
+            return {"status": response.status, "json": payload}
+    except urllib.error.HTTPError as error:
+        retry_after = error.headers.get("Retry-After") if error.headers is not None else None
+        return {
+            "status": error.code,
+            **(
+                {"retry_after_seconds": int(retry_after)}
+                if retry_after is not None and retry_after.isdigit()
+                else {}
+            ),
+        }
+    except (OSError, json.JSONDecodeError):
+        return {"status": 0}
+
+
+def live_response(manifest: dict[str, Any], node_id: str) -> dict[str, Any]:
+    expected = _node_expected(manifest, node_id)
+    node = expected["node"]
+    response = _transport(endpoint_for(node["registry"], node["name"], expected["version"]))
+    if node["registry"] == "crates" and response.get("status") == 200:
+        owners_url = (
+            f"https://crates.io/api/v1/crates/{urllib.parse.quote(node['name'], safe='')}/owners"
+        )
+        owners = _transport(owners_url)
+        if owners.get("status") == 200 and isinstance(response.get("json"), dict):
+            response["json"]["owners"] = owners.get("json")
+        elif isinstance(response.get("json"), dict):
+            response["json"]["owners"] = None
+    return response
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    observe_parser = commands.add_parser("observe")
+    observe_parser.add_argument("--manifest", type=Path, required=True)
+    observe_parser.add_argument("--node", required=True)
+    source = observe_parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--response", type=Path)
+    source.add_argument("--live", action="store_true")
+    observe_parser.add_argument("--accepted-receipt", type=Path)
+    observe_parser.add_argument("--observed-at", required=True)
+    observe_parser.add_argument("--out", type=Path)
+
+    plan_parser = commands.add_parser("plan")
+    plan_parser.add_argument("--manifest", type=Path, required=True)
+    plan_parser.add_argument("--observations", type=Path, required=True)
+    plan_parser.add_argument("--availability", type=Path, required=True)
+    plan_parser.add_argument("--planned-at", required=True)
+    plan_parser.add_argument("--registry", action="append", choices=("pypi", "npm", "crates"))
+    plan_parser.add_argument("--out", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        manifest = _load_json(args.manifest, context="candidate manifest")
+        if args.command == "observe":
+            response = (
+                live_response(manifest, args.node)
+                if args.live
+                else _load_json(args.response, context="registry response")
+            )
+            receipt = (
+                _load_json(args.accepted_receipt, context="accepted-write receipt")
+                if args.accepted_receipt
+                else None
+            )
+            result = observe(
+                manifest,
+                args.node,
+                response,
+                observed_at=args.observed_at,
+                accepted_receipt=receipt,
+            )
+        else:
+            observations = _load_json(args.observations, context="registry observations")
+            availability = _load_json(args.availability, context="artifact availability")
+            result = plan_recovery(
+                manifest,
+                observations,
+                availability,
+                planned_at=args.planned_at,
+                registries=set(args.registry) if args.registry else None,
+            )
+        output = json.dumps(result, indent=2, sort_keys=True) + "\n"
+        if args.out:
+            args.out.parent.mkdir(parents=True, exist_ok=True)
+            args.out.write_text(output, encoding="utf-8")
+        else:
+            sys.stdout.write(output)
+        return 0
+    except RegistryError as error:
+        print(f"release-registry: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test-release-candidate.py
+++ b/scripts/ci/test-release-candidate.py
@@ -10,6 +10,8 @@ import io
 import json
 from pathlib import Path
 import shutil
+import subprocess
+import sys
 import tarfile
 import tempfile
 import zipfile
@@ -349,6 +351,10 @@ def main() -> None:
         rejected(write_mutation(root, malformed), artifacts, "unexpected candidate manifest schema")
 
     print("release-candidate tests: ok")
+    subprocess.run(
+        [sys.executable, str(Path(__file__).with_name("test-release-registry.py"))],
+        check=True,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test-release-registry.py
+++ b/scripts/ci/test-release-registry.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env python3
+"""Deterministic registry-observer and recovery-planner tests."""
+
+from __future__ import annotations
+
+import base64
+import copy
+import hashlib
+import json
+from pathlib import Path
+import tempfile
+
+from release_candidate_manifest import CRATES, NATIVE_NPM_PACKAGES, NPM_PACKAGES
+import release_registry as registry
+
+VERSION = "0.5.1"
+SHA = "a" * 40
+NOW = "2030-01-01T12:02:00+00:00"
+
+
+def artifact(path: str, group: str, surface: str, name: str, *, dependencies=None):
+    data = name.encode()
+    sha256 = hashlib.sha256(data).digest()
+    sha512 = hashlib.sha512(data).digest()
+    digest = sha256.hex()
+    return {
+        "path": path,
+        "group": group,
+        "surface": surface,
+        "name": name,
+        "version": VERSION,
+        "filename": path.rsplit("/", 1)[-1],
+        "sha256": digest,
+        "integrity": "sha256-" + base64.b64encode(sha256).decode("ascii"),
+        "integrities": [
+            "sha256-" + base64.b64encode(sha256).decode("ascii"),
+            "sha512-" + base64.b64encode(sha512).decode("ascii"),
+        ],
+        "archive": {
+            "package": {
+                "name": name,
+                "version": VERSION,
+                "dependencies": dependencies or {},
+            }
+        },
+    }
+
+
+def candidate() -> dict[str, object]:
+    artifacts = []
+    python_paths = []
+    for filename in (
+        f"graphforge-{VERSION}-linux.whl",
+        f"graphforge-{VERSION}-macos.whl",
+        f"graphforge-{VERSION}-windows.whl",
+        f"graphforge-{VERSION}.tar.gz",
+    ):
+        path = f"python/{filename}"
+        python_paths.append(path)
+        artifacts.append(artifact(path, "python", "pypi", "graphforge"))
+    nodes = [
+        {
+            "id": "pypi:graphforge",
+            "registry": "pypi",
+            "name": "graphforge",
+            "artifact_paths": python_paths,
+        }
+    ]
+    dependencies = []
+    for name in NPM_PACKAGES:
+        package_dependencies = {}
+        if name == "@curatelabs/graphforge":
+            package_dependencies = dict.fromkeys(NATIVE_NPM_PACKAGES, VERSION)
+        elif name == "@curatelabs/graphforge-cli":
+            package_dependencies = {"@curatelabs/graphforge": VERSION}
+        path = f"npm/{name.removeprefix('@curatelabs/').replace('/', '-')}-{VERSION}.tgz"
+        artifacts.append(artifact(path, "npm", "npm", name, dependencies=package_dependencies))
+        node_id = f"npm:{name}"
+        nodes.append({"id": node_id, "registry": "npm", "name": name, "artifact_paths": [path]})
+        for dependency in package_dependencies:
+            dependencies.append({"from": node_id, "requires": f"npm:{dependency}"})
+    dependencies.append(
+        {
+            "from": "npm:@curatelabs/graphforge-agent-skills",
+            "requires": "npm:@curatelabs/graphforge-cli",
+        }
+    )
+    for name in CRATES:
+        package_dependencies = {} if name == "graphforge-core" else {"graphforge-core": VERSION}
+        path = f"crates/{name}-{VERSION}.crate"
+        artifacts.append(
+            artifact(path, "crates", "crates", name, dependencies=package_dependencies)
+        )
+        node_id = f"crates:{name}"
+        nodes.append({"id": node_id, "registry": "crates", "name": name, "artifact_paths": [path]})
+        for dependency in package_dependencies:
+            dependencies.append({"from": node_id, "requires": f"crates:{dependency}"})
+    return {
+        "schema": "graphforge-release-candidate-v2",
+        "version": VERSION,
+        "tag": f"v{VERSION}",
+        "commit_sha": SHA,
+        "recorded_at": "2029-12-31T12:00:00+00:00",
+        "nodes": sorted(nodes, key=lambda item: item["id"]),
+        "dependencies": sorted(dependencies, key=lambda item: (item["from"], item["requires"])),
+        "artifacts": sorted(artifacts, key=lambda item: item["path"]),
+        "artifact_groups": [
+            {
+                "id": group,
+                "expires_at": "2030-01-30T12:00:00+00:00",
+                "artifact_paths": [item["path"] for item in artifacts if item["group"] == group],
+            }
+            for group in ("python", "npm", "crates", "evidence")
+        ],
+    }
+
+
+def response_for(manifest: dict[str, object], node_id: str) -> dict[str, object]:
+    expected = registry._node_expected(manifest, node_id)
+    node = expected["node"]
+    if node["registry"] == "pypi":
+        return {
+            "status": 200,
+            "json": {
+                "info": {"name": node["name"], "version": VERSION, "license": "Apache-2.0"},
+                "urls": [
+                    {"filename": item["filename"], "digests": {"sha256": item["sha256"]}}
+                    for item in expected["artifacts"]
+                ],
+            },
+        }
+    if node["registry"] == "npm":
+        package = expected["artifacts"][0]["archive"]["package"]
+        payload = {
+            "name": node["name"],
+            "version": VERSION,
+            "license": "Apache-2.0",
+            "dist": {"integrity": expected["artifacts"][0]["integrities"][1]},
+        }
+        if package["dependencies"]:
+            field = (
+                "optionalDependencies"
+                if node["name"] == "@curatelabs/graphforge"
+                else "dependencies"
+            )
+            payload[field] = package["dependencies"]
+        return {"status": 200, "json": payload}
+    return {
+        "status": 200,
+        "json": {
+            "version": {
+                "crate": node["name"],
+                "num": VERSION,
+                "checksum": expected["artifacts"][0]["sha256"],
+                "yanked": False,
+                "license": "Apache-2.0",
+            },
+            "owners": {"users": [{"login": "DecisionNerd"}]},
+        },
+    }
+
+
+def observed(manifest, node_id, response=None, receipt=None, at=NOW):
+    return registry.observe(
+        manifest,
+        node_id,
+        response or response_for(manifest, node_id),
+        observed_at=at,
+        accepted_receipt=receipt,
+    )
+
+
+def observation_set(manifest):
+    return {
+        "schema": registry.OBSERVATION_SET_SCHEMA,
+        "candidate_sha": SHA,
+        "version": VERSION,
+        "observations": [observed(manifest, node["id"]) for node in manifest["nodes"]],
+    }
+
+
+def replace_observation(values, replacement):
+    values["observations"] = [
+        replacement if item["node_id"] == replacement["node_id"] else item
+        for item in values["observations"]
+    ]
+
+
+def plan(manifest, observations, availability=None, registries=None, at=NOW):
+    return registry.plan_recovery(
+        manifest,
+        observations,
+        availability or dict.fromkeys(("python", "npm", "crates", "evidence"), True),
+        planned_at=at,
+        registries=registries,
+    )
+
+
+def assert_state(value, expected):
+    assert value["state"] == expected, value
+
+
+def main() -> None:
+    manifest = candidate()
+    all_verified = observation_set(manifest)
+    result = plan(manifest, all_verified)
+    assert result["actions"] == []
+    assert result["download_groups"] == []
+    assert result["summary"]["verified"] == 24
+
+    for node_id in (
+        "pypi:graphforge",
+        "npm:@curatelabs/graphforge",
+        "crates:graphforge-core",
+    ):
+        assert_state(observed(manifest, node_id), "verified")
+        assert_state(observed(manifest, node_id, {"status": 404}), "absent")
+        assert_state(observed(manifest, node_id, {"status": 403}), "failed")
+        assert_state(
+            observed(manifest, node_id, {"status": 429, "retry_after_seconds": 30}), "indeterminate"
+        )
+        assert_state(observed(manifest, node_id, {"status": 200, "json": []}), "indeterminate")
+
+    pypi_conflict = response_for(manifest, "pypi:graphforge")
+    pypi_conflict["json"]["urls"][0]["digests"]["sha256"] = "f" * 64
+    assert_state(observed(manifest, "pypi:graphforge", pypi_conflict), "conflict")
+    npm_conflict = response_for(manifest, "npm:@curatelabs/graphforge")
+    npm_conflict["json"]["dist"]["integrity"] = "sha512-" + base64.b64encode(
+        hashlib.sha512(b"conflict").digest()
+    ).decode("ascii")
+    assert_state(observed(manifest, "npm:@curatelabs/graphforge", npm_conflict), "conflict")
+    npm_malformed = response_for(manifest, "npm:@curatelabs/graphforge")
+    npm_malformed["json"]["dist"]["integrity"] = "sha512-not-base64"
+    assert_state(observed(manifest, "npm:@curatelabs/graphforge", npm_malformed), "indeterminate")
+    crates_conflict = response_for(manifest, "crates:graphforge-core")
+    crates_conflict["json"]["version"]["checksum"] = "f" * 64
+    assert_state(observed(manifest, "crates:graphforge-core", crates_conflict), "conflict")
+
+    receipt = {
+        "node_id": "npm:@curatelabs/graphforge",
+        "version": VERSION,
+        "accepted_at": "2030-01-01T12:00:00+00:00",
+        "visibility_deadline": "2030-01-01T12:10:00+00:00",
+        "observation_count": 0,
+        "authorization": "must-not-escape",
+    }
+    pending = observed(
+        manifest,
+        "npm:@curatelabs/graphforge",
+        {"status": 404, "json": {"token": "must-not-escape"}},
+        receipt,
+    )
+    assert_state(pending, "accepted_pending_visibility")
+    assert "must-not-escape" not in json.dumps(pending)
+    exhausted = observed(
+        manifest,
+        "npm:@curatelabs/graphforge",
+        {"status": 404},
+        {**receipt, "observation_count": registry.MAX_VISIBILITY_OBSERVATIONS - 1},
+    )
+    assert_state(exhausted, "indeterminate")
+
+    observations = copy.deepcopy(all_verified)
+    absent_pypi = observed(manifest, "pypi:graphforge", {"status": 404})
+    replace_observation(observations, absent_pypi)
+    result = plan(manifest, observations)
+    assert [action["node_id"] for action in result["actions"]] == ["pypi:graphforge"]
+    assert result["actions"][0]["kind"] == "publish"
+    assert result["download_groups"] == ["python"]
+
+    observations = copy.deepcopy(all_verified)
+    replace_observation(observations, pending)
+    result = plan(manifest, observations)
+    assert result["actions"] == [
+        {"node_id": "npm:@curatelabs/graphforge", "kind": "verify_visibility", "registry": "npm"}
+    ]
+    assert result["download_groups"] == []
+
+    observations = copy.deepcopy(all_verified)
+    for name in NATIVE_NPM_PACKAGES:
+        replace_observation(observations, observed(manifest, f"npm:{name}", {"status": 404}))
+    replace_observation(
+        observations,
+        observed(manifest, "npm:@curatelabs/graphforge", {"status": 404}),
+    )
+    result = plan(manifest, observations, registries={"npm"})
+    publishes = [action["node_id"] for action in result["actions"] if action["kind"] == "publish"]
+    assert publishes == sorted(f"npm:{name}" for name in NATIVE_NPM_PACKAGES)
+    main_decision = next(
+        item for item in result["decisions"] if item["node_id"] == "npm:@curatelabs/graphforge"
+    )
+    assert main_decision["disposition"] == "blocked_dependencies"
+
+    unavailable = dict.fromkeys(("python", "npm", "crates", "evidence"), True)
+    unavailable["npm"] = False
+    result = plan(manifest, observations, unavailable, registries={"npm"})
+    assert not any(action["kind"] == "publish" for action in result["actions"])
+    assert result["download_groups"] == []
+
+    observations = copy.deepcopy(all_verified)
+    replace_observation(
+        observations,
+        observed(manifest, "crates:graphforge-core", {"status": 404}),
+    )
+    replace_observation(
+        observations,
+        observed(manifest, "crates:graphforge-api", {"status": 404}),
+    )
+    result = plan(manifest, observations, registries={"crates"})
+    assert [action["node_id"] for action in result["actions"]] == ["crates:graphforge-core"]
+    assert result["download_groups"] == ["crates"]
+
+    observations = copy.deepcopy(all_verified)
+    core_conflict = response_for(manifest, "crates:graphforge-core")
+    core_conflict["json"]["version"]["checksum"] = "f" * 64
+    replace_observation(
+        observations,
+        observed(manifest, "crates:graphforge-core", core_conflict),
+    )
+    replace_observation(
+        observations,
+        observed(manifest, "crates:graphforge-api", {"status": 404}),
+    )
+    result = plan(manifest, observations, registries={"crates"})
+    api_blocker = next(
+        item for item in result["blockers"] if item["node_id"] == "crates:graphforge-api"
+    )
+    assert api_blocker["dependency_states"] == {"crates:graphforge-core": "conflict"}
+    assert not any(action["node_id"] == "crates:graphforge-api" for action in result["actions"])
+
+    no_observations = {
+        "schema": registry.OBSERVATION_SET_SCHEMA,
+        "candidate_sha": SHA,
+        "version": VERSION,
+        "observations": [],
+    }
+    result = plan(manifest, no_observations, registries={"pypi"})
+    assert result["actions"] == [
+        {"node_id": "pypi:graphforge", "kind": "observe", "registry": "pypi"}
+    ]
+    assert result["download_groups"] == []
+
+    job_history = copy.deepcopy(all_verified)
+    job_history["github_actions_job_history"] = {"publish-npm": "failure"}
+    assert plan(manifest, job_history) == plan(manifest, all_verified)
+
+    divergent = copy.deepcopy(all_verified)
+    divergent["observations"][0]["version"] = "0.5.2"
+    try:
+        plan(manifest, divergent)
+    except registry.RegistryError as error:
+        assert "identity diverges" in str(error)
+    else:
+        raise AssertionError("version-divergent observation was accepted")
+
+    forged_absence = copy.deepcopy(all_verified)
+    forged_absence["observations"][0].update(
+        {"state": "absent", "reason": "crates_authoritative_not_found"}
+    )
+    try:
+        plan(manifest, forged_absence)
+    except registry.RegistryError as error:
+        assert "authoritative evidence" in str(error)
+    else:
+        raise AssertionError("absence without a registry 404 was accepted")
+
+    stale = copy.deepcopy(all_verified)
+    stale["observations"][0]["observed_at"] = "2029-12-31T00:00:00+00:00"
+    result = plan(manifest, stale)
+    assert result["blockers"][0]["reason"] == "registry_state_indeterminate"
+
+    expired = copy.deepcopy(manifest)
+    for group in expired["artifact_groups"]:
+        if group["id"] == "python":
+            group["expires_at"] = "2030-01-01T12:01:00+00:00"
+    observations = copy.deepcopy(all_verified)
+    replace_observation(observations, absent_pypi)
+    result = plan(expired, observations)
+    assert result["actions"] == []
+    assert result["blockers"][0]["reason"] == "artifact_group_unavailable_or_expired"
+
+    crates_only = plan(manifest, all_verified, registries={"crates"})
+    assert crates_only["download_groups"] == []
+    assert all(item["registry"] == "crates" for item in crates_only["decisions"])
+    assert not any(word in json.dumps(result).lower() for word in ("password", "secret", "token"))
+    source = Path(registry.__file__).read_text(encoding="utf-8")
+    assert "time.sleep" not in source
+    assert "while " not in source
+
+    with tempfile.TemporaryDirectory() as temp:
+        root = Path(temp)
+        manifest_path = root / "manifest.json"
+        response_path = root / "response.json"
+        observation_path = root / "observation.json"
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        response_path.write_text(
+            json.dumps(response_for(manifest, "pypi:graphforge")), encoding="utf-8"
+        )
+        assert (
+            registry.main(
+                [
+                    "observe",
+                    "--manifest",
+                    str(manifest_path),
+                    "--node",
+                    "pypi:graphforge",
+                    "--response",
+                    str(response_path),
+                    "--observed-at",
+                    NOW,
+                    "--out",
+                    str(observation_path),
+                ]
+            )
+            == 0
+        )
+        assert json.loads(observation_path.read_text(encoding="utf-8"))["state"] == "verified"
+    print("release-registry tests: ok")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add registry-specific PyPI, npm, and crates.io observers with canonical public endpoints, identity/metadata requirements, checksum or integrity normalization, and fail-closed error classification
- separate accepted-write receipts from public visibility with one observation per invocation, a 15-minute deadline, and a four-observation cap—no sleep loops or repeated writes
- add a pure recovery planner driven only by the immutable candidate, fresh normalized observations, dependency state, and retained-artifact availability
- schedule writes only for absent dependency-ready nodes; skip verified nodes, verify accepted-pending nodes without writing, and block conflict, indeterminate, failed, stale, divergent, or expired inputs
- document the registry truth contracts and recovery model

## Validation

- `python3 scripts/ci/test-release-registry.py`
- `python3 scripts/ci/test-release-candidate.py` (runs the registry contract suite)
- `make pre-push-fast`
- `uv run ruff format --check .`
- `uv run ruff check .`

Fixtures cover absent, verified, conflicting bytes, malformed payloads/integrities, authorization failure, rate limiting, propagation delay, bounded exhaustion, stale evidence, version divergence, dependency conflict, unavailable/expired artifacts, registry-scoped recovery, and secret redaction. No live registry write, tag, release, or certification workflow was run.

Closes #294

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788184558&installation_model_id=20486&pr_number=302&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F302&signature=e7543edc4d4530ca5c92637ea0bea0ed63438ad4acfbc66e6e7584a07e6b90f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add registry observation and recovery planning CLI for PyPI, npm, and crates.io releases
> - Adds [scripts/ci/release_registry.py](https://github.com/CurateLabs/graphforge/pull/302/files#diff-13313135168f6adf892ceb5f59113d2a6f7f578b0697794580b2f6289c3be74e) with `observe` and `plan` subcommands; `observe` fetches and normalizes live or fixture registry responses into a bounded observation object, and `plan` produces dependency-aware publish/observe/verify_visibility actions without performing any writes.
> - Observations are classified as absent, conflict, failed, indeterminate, or verified per registry using checksum/integrity validation, license checks, and ownership verification specific to PyPI, npm, and crates.io adapters.
> - Recovery plans are gated by dependency verification and artifact-group availability; publish actions are only scheduled for absent nodes whose dependencies are verified and whose artifact groups are present and unexpired.
> - Stale observations are downgraded to indeterminate at plan time; sensitive keys (tokens, passwords, secrets) are recursively scrubbed from all outputs.
> - Adds [scripts/ci/test-release-registry.py](https://github.com/CurateLabs/graphforge/pull/302/files#diff-e75fee0392600a881f1541d29e84e2ca5cdd7db748bccae6c258dde614dc5d2b) covering state classification, visibility bounds, dependency gating, staleness, sensitivity scrubbing, and CLI behavior; invoked automatically by [scripts/ci/test-release-candidate.py](https://github.com/CurateLabs/graphforge/pull/302/files#diff-3e1e4e1015ad205e865367bff264d855c0062bfbe24c63683445a235914cd4f0).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff10e37.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->