### PR TITLE
feat(release): prove recovery sequentially

### DIFF
--- a/.github/workflows/binding-release-candidate.yml
+++ b/.github/workflows/binding-release-candidate.yml
@@ -526,14 +526,35 @@ jobs:
           python3 scripts/verify_package_licenses.py \
             --report candidate/release-artifacts/evidence/package-license-report.json
 
-      - name: Create and validate the immutable checksum record
+      - name: Create the pre-rehearsal candidate manifest
         run: |
           recorded_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          printf 'CANDIDATE_RECORDED_AT=%s\n' "$recorded_at" >> "$GITHUB_ENV"
+          python3 scripts/record_release_artifacts.py \
+            --version "$RELEASE_VERSION" \
+            --dist-dir candidate/release-artifacts \
+            --out candidate/rehearsal-manifest.json \
+            --recorded-at "$recorded_at" \
+            --notes "M1 Binding Release Candidate run $GITHUB_RUN_ID; exact SHA $EVIDENCE_SHA"
+
+      - name: Rehearse exact partitioned release artifacts offline
+        run: |
+          python3 scripts/ci/release_rehearsal.py artifacts \
+            --manifest candidate/rehearsal-manifest.json \
+            --artifacts-dir candidate/release-artifacts \
+            --expected-sha "$EVIDENCE_SHA" \
+            --version "$RELEASE_VERSION" \
+            --rehearsed-at "$CANDIDATE_RECORDED_AT" \
+            --out candidate/release-artifacts/evidence/offline-rehearsal.json
+
+      - name: Create and validate the immutable candidate manifest
+        run: |
+          rm candidate/rehearsal-manifest.json
           python3 scripts/record_release_artifacts.py \
             --version "$RELEASE_VERSION" \
             --dist-dir candidate/release-artifacts \
             --out "candidate/v${RELEASE_VERSION}-artifacts.json" \
-            --recorded-at "$recorded_at" \
+            --recorded-at "$CANDIDATE_RECORDED_AT" \
             --notes "M1 Binding Release Candidate run $GITHUB_RUN_ID; exact SHA $EVIDENCE_SHA"
           python3 scripts/ci/clean-env-verify.py validate-release-record \
             "candidate/v${RELEASE_VERSION}-artifacts.json"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add a deterministic pre-write release rehearsal that installs and executes
+  the exact candidate through clean Python, Node/native, CLI, and agent-skills
+  consumers, validates all crate packages and dependencies, and proves the
+  24-node recovery graph sequentially across partial success, cancelled,
+  timed-out, skipped, propagation-delayed, conflicting, indeterminate, and
+  expired-artifact outcomes (#295).
 - Derive publication recovery from the immutable candidate plus fresh PyPI,
   npm, and crates.io truth: normalize absence, accepted propagation, verified
   bytes, conflict, failure, and indeterminate evidence; bound visibility checks

--- a/docs/development/release-artifact-record.md
+++ b/docs/development/release-artifact-record.md
@@ -128,9 +128,22 @@ command has a registry-write path.
 
 ## Build and validate offline
 
-After the binding workflow has assembled the four directories, it creates the
-manifest and immediately validates the complete candidate before any registry
-write:
+After the binding workflow has assembled the four directories, it creates a
+temporary manifest and runs a clean-consumer rehearsal before any registry
+write. The rehearsal installs the compatible exact wheel without an index,
+imports the native Python module, installs all eight npm tarballs offline,
+loads the Node native binding through the main package, executes the CLI and
+agent-skills entrypoints, and validates all 15 crate archives and their exact
+dependency graph. Only a passing report is added to the evidence partition;
+the temporary manifest is then removed and the final manifest is recorded over
+the now-complete inventory.
+
+The rehearsal is a local byte/runtime proof, not a publication or release
+certification workflow. It performs zero registry writes and cannot create a
+tag. A missing runtime entrypoint or any version divergence fails before the
+final candidate exists.
+
+The final validation remains fully offline:
 
 ```bash
 python3 scripts/record_release_artifacts.py \
@@ -153,3 +166,20 @@ registry access, tag creation, release creation, or publication.
 `clean-env-verify.py` continues to accept historical
 `graphforge-release-record-v1` documents while also reading the v2 artifact list.
 Historical v0.5.0 records remain immutable.
+
+## Sequential recovery proof
+
+`scripts/ci/release_rehearsal.py` also produces a stable reconciliation report
+for all 24 public nodes. Its sequential simulator accepts only actions emitted
+by the pure recovery planner, applies one supplied live observation at a time,
+and re-plans from the updated registry truth. This proves dependency order and
+partial recovery before workflow parallelism is introduced.
+
+The report records job outcomes such as `cancelled`, `timed_out`, and `skipped`
+for operator context, but those labels never determine package state. For
+example, a timed-out job whose package is publicly verified is skipped, while
+a cancelled job whose package remains authoritatively absent is eligible for a
+future write. Accepted-but-not-visible packages receive only a bounded
+visibility check; conflict, indeterminate state, and expired artifacts remain
+blocked. Every scenario lists every node, its registry state, disposition, and
+sanitized job outcome without credentials or raw registry bodies.

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add a deterministic pre-write release rehearsal that installs and executes
+  the exact candidate through clean Python, Node/native, CLI, and agent-skills
+  consumers, validates all crate packages and dependencies, and proves the
+  24-node recovery graph sequentially across partial success, cancelled,
+  timed-out, skipped, propagation-delayed, conflicting, indeterminate, and
+  expired-artifact outcomes (#295).
 - Derive publication recovery from the immutable candidate plus fresh PyPI,
   npm, and crates.io truth: normalize absence, accepted propagation, verified
   bytes, conflict, failure, and indeterminate evidence; bound visibility checks

--- a/scripts/ci/release_rehearsal.py
+++ b/scripts/ci/release_rehearsal.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""Offline release-artifact rehearsal and sequential recovery proof."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import platform
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+import release_candidate_manifest as candidate_contract
+import release_registry as registry
+
+ARTIFACT_REPORT_SCHEMA = "graphforge-release-artifact-rehearsal-v1"
+RECONCILIATION_SCHEMA = "graphforge-release-reconciliation-v1"
+JOB_OUTCOMES = {
+    "success",
+    "failure",
+    "cancelled",
+    "timed_out",
+    "skipped",
+    "not_scheduled",
+}
+FORBIDDEN_TEXT = ("authorization", "cookie", "password", "secret", "token")
+
+
+class RehearsalError(ValueError):
+    """The release rehearsal could not prove a safe outcome."""
+
+
+def _load(path: Path, *, context: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise RehearsalError(f"cannot read {context} {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise RehearsalError(f"{context} must be a JSON object")
+    return value
+
+
+def _safe_report(value: Any) -> None:
+    serialized = json.dumps(value, sort_keys=True).lower()
+    if any(word in serialized for word in FORBIDDEN_TEXT):
+        raise RehearsalError("rehearsal output contains a credential-shaped field")
+
+
+def _run(command: list[str], *, cwd: Path, env: dict[str, str] | None = None) -> str:
+    try:
+        result = subprocess.run(
+            command,
+            cwd=cwd,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise RehearsalError(f"offline consumer could not execute {command[0]}: {error}") from error
+    if result.returncode != 0:
+        stderr = result.stderr.strip().splitlines()
+        detail = stderr[-1] if stderr else f"exit {result.returncode}"
+        raise RehearsalError(f"offline consumer {command[0]} failed: {detail}")
+    return result.stdout.strip()
+
+
+def _compatible_wheel(artifacts: list[dict[str, Any]]) -> dict[str, Any]:
+    wheels = [item for item in artifacts if item.get("class") == "python-wheel"]
+    system = sys.platform
+    machine = platform.machine().lower()
+    if system.startswith("linux"):
+        platform_tokens = ("manylinux", "musllinux", "-linux")
+        arch_tokens = ("aarch64", "arm64") if machine in {"aarch64", "arm64"} else ("x86_64",)
+    elif system == "darwin":
+        platform_tokens = ("macosx", "-macos")
+        arch_tokens = ("arm64", "universal2") if machine == "arm64" else ("x86_64", "universal2")
+    elif system == "win32":
+        platform_tokens = ("win_amd64",) if machine in {"amd64", "x86_64"} else ("win_arm64",)
+        arch_tokens = platform_tokens
+    else:
+        raise RehearsalError(f"unsupported rehearsal platform: {system}/{machine}")
+    matches = [
+        item
+        for item in wheels
+        if any(token in item["filename"].lower() for token in platform_tokens)
+        and any(token in item["filename"].lower() for token in arch_tokens)
+    ]
+    if len(matches) != 1:
+        raise RehearsalError(
+            f"candidate requires exactly one compatible wheel for {system}/{machine}; "
+            f"found {len(matches)}"
+        )
+    return matches[0]
+
+
+def _python_consumer(
+    manifest: dict[str, Any], artifacts_dir: Path, consumer_root: Path
+) -> dict[str, Any]:
+    wheel = _compatible_wheel(manifest["artifacts"])
+    environment = consumer_root / "python"
+    _run([sys.executable, "-m", "venv", str(environment)], cwd=consumer_root)
+    python = environment / ("Scripts/python.exe" if sys.platform == "win32" else "bin/python")
+    _run(
+        [
+            str(python),
+            "-m",
+            "pip",
+            "install",
+            "--no-index",
+            "--no-deps",
+            str((artifacts_dir / wheel["path"]).resolve()),
+        ],
+        cwd=consumer_root,
+    )
+    output = _run(
+        [
+            str(python),
+            "-c",
+            "import graphforge; print(graphforge.__version__)",
+        ],
+        cwd=consumer_root,
+    )
+    if output != manifest["version"]:
+        raise RehearsalError(
+            f"clean Python consumer loaded version {output!r}, expected {manifest['version']}"
+        )
+    return {"artifact": wheel["path"], "imported_version": output, "status": "passed"}
+
+
+def _node_consumer(
+    manifest: dict[str, Any], artifacts_dir: Path, consumer_root: Path
+) -> dict[str, Any]:
+    npm_items = sorted(
+        (item for item in manifest["artifacts"] if item.get("surface") == "npm"),
+        key=lambda item: item["name"],
+    )
+    if len(npm_items) != len(candidate_contract.NPM_PACKAGES):
+        raise RehearsalError("candidate npm inventory is incomplete")
+    node_root = consumer_root / "node"
+    node_root.mkdir()
+    (node_root / "package.json").write_text(
+        '{"name":"graphforge-release-rehearsal","private":true,"type":"module"}\n',
+        encoding="utf-8",
+    )
+    environment = dict(os.environ)
+    environment.update(
+        {
+            "npm_config_audit": "false",
+            "npm_config_fund": "false",
+            "npm_config_ignore_scripts": "true",
+            "npm_config_offline": "true",
+            "npm_config_update_notifier": "false",
+        }
+    )
+    tarballs = [str((artifacts_dir / item["path"]).resolve()) for item in npm_items]
+    _run(
+        ["npm", "install", "--offline", "--ignore-scripts", "--no-audit", "--no-fund", *tarballs],
+        cwd=node_root,
+        env=environment,
+    )
+    node_version = _run(
+        [
+            "node",
+            "--input-type=module",
+            "--eval",
+            "import { version } from '@curatelabs/graphforge'; process.stdout.write(version())",
+        ],
+        cwd=node_root,
+        env=environment,
+    )
+    if node_version != manifest["version"]:
+        raise RehearsalError(
+            f"clean Node/native consumer loaded version {node_version!r}, "
+            f"expected {manifest['version']}"
+        )
+    cli = node_root / "node_modules" / "@curatelabs" / "graphforge-cli" / "bin" / "graphforge.js"
+    cli_output = _run(
+        ["node", str(cli), "--json", "config", "validate"], cwd=node_root, env=environment
+    )
+    try:
+        cli_payload = json.loads(cli_output)
+    except json.JSONDecodeError as error:
+        raise RehearsalError("clean CLI consumer did not emit JSON") from error
+    if not isinstance(cli_payload, dict):
+        raise RehearsalError("clean CLI consumer emitted an invalid result")
+    skills = (
+        node_root
+        / "node_modules"
+        / "@curatelabs"
+        / "graphforge-agent-skills"
+        / "bin"
+        / "graphforge-agent-skills.js"
+    )
+    compatibility_text = _run(
+        ["node", str(skills), "compatibility", "--json"], cwd=node_root, env=environment
+    )
+    try:
+        compatibility = json.loads(compatibility_text)
+    except json.JSONDecodeError as error:
+        raise RehearsalError("clean agent-skills consumer did not emit JSON") from error
+    if compatibility.get("graphforge_release") != manifest["version"]:
+        raise RehearsalError("agent-skills compatibility release diverges from the root version")
+    return {
+        "artifacts": [item["path"] for item in npm_items],
+        "agent_skills_release": compatibility["graphforge_release"],
+        "cli_status": "passed",
+        "loaded_version": node_version,
+        "native_addon_status": "loaded_through_main_package",
+        "status": "passed",
+    }
+
+
+def rehearse_artifacts(
+    manifest_path: Path,
+    artifacts_dir: Path,
+    *,
+    expected_sha: str,
+    version: str,
+    rehearsed_at: str,
+) -> dict[str, Any]:
+    try:
+        moment = datetime.fromisoformat(rehearsed_at.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise RehearsalError("rehearsed_at must be an ISO-8601 timestamp") from error
+    if moment.tzinfo is None:
+        raise RehearsalError("rehearsed_at must include a timezone")
+    manifest = candidate_contract.validate(
+        manifest_path, artifacts_dir, expected_sha, version, as_of=moment
+    )
+    crate_nodes = [node for node in manifest["nodes"] if node["registry"] == "crates"]
+    crate_edges = [edge for edge in manifest["dependencies"] if edge["from"].startswith("crates:")]
+    with tempfile.TemporaryDirectory(prefix="graphforge-release-rehearsal-") as temporary:
+        consumer_root = Path(temporary)
+        python_result = _python_consumer(manifest, artifacts_dir, consumer_root)
+        node_result = _node_consumer(manifest, artifacts_dir, consumer_root)
+    report = {
+        "schema": ARTIFACT_REPORT_SCHEMA,
+        "candidate_sha": expected_sha,
+        "version": version,
+        "rehearsed_at": moment.astimezone(timezone.utc).isoformat(),
+        "offline": True,
+        "registry_writes": 0,
+        "checks": {
+            "candidate_completeness": {"nodes": len(manifest["nodes"]), "status": "passed"},
+            "python_clean_consumer": python_result,
+            "node_cli_skills_clean_consumer": node_result,
+            "rust_packages": {
+                "dependency_edges": len(crate_edges),
+                "packages": [node["name"] for node in crate_nodes],
+                "status": "passed",
+            },
+            "shared_version": {"root_version": version, "status": "passed"},
+        },
+        "status": "passed",
+    }
+    _safe_report(report)
+    return report
+
+
+def _observation_set(manifest: dict[str, Any], values: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "schema": registry.OBSERVATION_SET_SCHEMA,
+        "candidate_sha": manifest["commit_sha"],
+        "version": manifest["version"],
+        "observations": values,
+    }
+
+
+def reconcile(
+    manifest: dict[str, Any],
+    observations: dict[str, Any],
+    availability: dict[str, Any],
+    *,
+    reconciled_at: str,
+    job_outcomes: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    outcomes = job_outcomes or {}
+    node_ids = {node["id"] for node in manifest.get("nodes", [])}
+    if not set(outcomes).issubset(node_ids):
+        raise RehearsalError("job outcome references a node outside the candidate")
+    if any(outcome not in JOB_OUTCOMES for outcome in outcomes.values()):
+        raise RehearsalError("job outcome is invalid")
+    plan = registry.plan_recovery(manifest, observations, availability, planned_at=reconciled_at)
+    decisions = {item["node_id"]: item for item in plan["decisions"]}
+    nodes = [
+        {
+            "node_id": node_id,
+            "registry": decisions[node_id]["registry"],
+            "registry_state": decisions[node_id]["state"],
+            "disposition": decisions[node_id]["disposition"],
+            "job_outcome": outcomes.get(node_id, "not_scheduled"),
+        }
+        for node_id in sorted(node_ids)
+    ]
+    report = {
+        "schema": RECONCILIATION_SCHEMA,
+        "candidate_sha": manifest["commit_sha"],
+        "version": manifest["version"],
+        "reconciled_at": plan["planned_at"],
+        "complete": all(node["registry_state"] == "verified" for node in nodes),
+        "nodes": nodes,
+        "next_actions": plan["actions"],
+        "blockers": plan["blockers"],
+        "summary": {**plan["summary"], "nodes": len(nodes)},
+    }
+    _safe_report(report)
+    return report
+
+
+def simulate_sequential(
+    manifest: dict[str, Any],
+    observations: dict[str, Any],
+    availability: dict[str, Any],
+    transitions: list[dict[str, Any]],
+    *,
+    simulated_at: str,
+) -> dict[str, Any]:
+    current = list(observations.get("observations", []))
+    outcomes: dict[str, str] = {}
+    events: list[dict[str, Any]] = []
+    for index, transition in enumerate(transitions):
+        node_id = transition.get("node_id")
+        action_kind = transition.get("action_kind")
+        outcome = transition.get("job_outcome")
+        observation = transition.get("observation")
+        if outcome not in JOB_OUTCOMES - {"not_scheduled"}:
+            raise RehearsalError(f"transition {index} has an invalid job outcome")
+        before = registry.plan_recovery(
+            manifest,
+            _observation_set(manifest, current),
+            availability,
+            planned_at=simulated_at,
+        )
+        eligible = {(action["node_id"], action["kind"]) for action in before["actions"]}
+        if (node_id, action_kind) not in eligible:
+            raise RehearsalError(
+                f"transition {index} is not dependency-ready: {node_id}/{action_kind}"
+            )
+        if not isinstance(observation, dict) or observation.get("node_id") != node_id:
+            raise RehearsalError(f"transition {index} lacks matching live registry evidence")
+        current = [item for item in current if item.get("node_id") != node_id]
+        current.append(observation)
+        current.sort(key=lambda item: item["node_id"])
+        # Validation of the new observation is deliberately delegated to the pure planner.
+        registry.plan_recovery(
+            manifest,
+            _observation_set(manifest, current),
+            availability,
+            planned_at=simulated_at,
+        )
+        outcomes[node_id] = outcome
+        events.append(
+            {
+                "sequence": index + 1,
+                "node_id": node_id,
+                "action_kind": action_kind,
+                "job_outcome": outcome,
+                "observed_state": observation["state"],
+            }
+        )
+    final = reconcile(
+        manifest,
+        _observation_set(manifest, current),
+        availability,
+        reconciled_at=simulated_at,
+        job_outcomes=outcomes,
+    )
+    final["events"] = events
+    final["sequential"] = True
+    _safe_report(final)
+    return final
+
+
+def _write_or_print(value: dict[str, Any], output: Path | None) -> None:
+    text = json.dumps(value, indent=2, sort_keys=True) + "\n"
+    if output:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(text, encoding="utf-8")
+    else:
+        sys.stdout.write(text)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    artifacts = commands.add_parser("artifacts")
+    artifacts.add_argument("--manifest", type=Path, required=True)
+    artifacts.add_argument("--artifacts-dir", type=Path, required=True)
+    artifacts.add_argument("--expected-sha", required=True)
+    artifacts.add_argument("--version", required=True)
+    artifacts.add_argument("--rehearsed-at", required=True)
+    artifacts.add_argument("--out", type=Path)
+    reconciliation = commands.add_parser("reconcile")
+    reconciliation.add_argument("--manifest", type=Path, required=True)
+    reconciliation.add_argument("--observations", type=Path, required=True)
+    reconciliation.add_argument("--availability", type=Path, required=True)
+    reconciliation.add_argument("--job-outcomes", type=Path)
+    reconciliation.add_argument("--reconciled-at", required=True)
+    reconciliation.add_argument("--out", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "artifacts":
+            result = rehearse_artifacts(
+                args.manifest,
+                args.artifacts_dir,
+                expected_sha=args.expected_sha,
+                version=args.version,
+                rehearsed_at=args.rehearsed_at,
+            )
+        else:
+            manifest = _load(args.manifest, context="candidate manifest")
+            observations = _load(args.observations, context="registry observations")
+            availability = _load(args.availability, context="artifact availability")
+            outcomes = _load(args.job_outcomes, context="job outcomes") if args.job_outcomes else {}
+            result = reconcile(
+                manifest,
+                observations,
+                availability,
+                reconciled_at=args.reconciled_at,
+                job_outcomes=outcomes,
+            )
+        _write_or_print(result, args.out)
+        return 0
+    except (RehearsalError, candidate_contract.CandidateError, registry.RegistryError) as error:
+        print(f"release-rehearsal: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test-binding-release-candidate.py
+++ b/scripts/ci/test-binding-release-candidate.py
@@ -606,6 +606,17 @@ def main() -> None:
     assert "--version 0.5.0" not in release_candidate_job
     assert "${crate}-0.5.0.crate" not in release_candidate_job
     assert "scripts/ci/release-candidate.py validate" in rc_workflow_text
+    assert "Create the pre-rehearsal candidate manifest" in release_candidate_job
+    assert "Rehearse exact partitioned release artifacts offline" in release_candidate_job
+    assert "scripts/ci/release_rehearsal.py artifacts" in release_candidate_job
+    assert "--manifest candidate/rehearsal-manifest.json" in release_candidate_job
+    assert "--out candidate/release-artifacts/evidence/offline-rehearsal.json" in (
+        release_candidate_job
+    )
+    assert "rm candidate/rehearsal-manifest.json" in release_candidate_job
+    assert release_candidate_job.index("Rehearse exact partitioned release artifacts offline") < (
+        release_candidate_job.index("Create and validate the immutable candidate manifest")
+    )
     assert "M1-Release-Candidate-${{ needs.validate_source.outputs.evidence_sha }}" in (
         rc_workflow_text
     )

--- a/scripts/ci/test-release-candidate.py
+++ b/scripts/ci/test-release-candidate.py
@@ -87,7 +87,7 @@ def npm_members(name: str, *, package_version: str = VERSION) -> dict[str, bytes
         )
         members.update(
             {
-                "package/index.js": b"module.exports = {}\n",
+                "package/index.js": (f"exports.version = () => '{package_version}';\n").encode(),
                 "package/index.d.ts": b"export declare function version(): string\n",
                 "package/lib/index.mjs": b"export const loaded = true\n",
                 "package/THIRD_PARTY_NOTICES.md": b"Third party",
@@ -102,7 +102,10 @@ def npm_members(name: str, *, package_version: str = VERSION) -> dict[str, bytes
         )
         members.update(
             {
-                "package/bin/graphforge.js": b"#!/usr/bin/env node\n",
+                "package/bin/graphforge.js": (
+                    b"#!/usr/bin/env node\n"
+                    b"process.stdout.write(JSON.stringify({contract:'fixture'}));\n"
+                ),
                 "package/lib/run.mjs": b"export function run() {}\n",
                 "package/THIRD_PARTY_NOTICES.md": b"Third party",
             }
@@ -112,7 +115,10 @@ def npm_members(name: str, *, package_version: str = VERSION) -> dict[str, bytes
         metadata["graphforgeCompatibility"] = {"release": package_version}
         members.update(
             {
-                "package/bin/graphforge-agent-skills.js": b"#!/usr/bin/env node\n",
+                "package/bin/graphforge-agent-skills.js": (
+                    "#!/usr/bin/env node\n"
+                    f"process.stdout.write(JSON.stringify({{graphforge_release:'{package_version}'}}));\n"
+                ).encode(),
                 "package/adapter/index.js": b"export {}\n",
                 "package/schemas/validator.js": b"export {}\n",
                 "package/workflows/index.js": b"export {}\n",
@@ -353,6 +359,10 @@ def main() -> None:
     print("release-candidate tests: ok")
     subprocess.run(
         [sys.executable, str(Path(__file__).with_name("test-release-registry.py"))],
+        check=True,
+    )
+    subprocess.run(
+        [sys.executable, str(Path(__file__).with_name("test-release-rehearsal.py"))],
         check=True,
     )
 

--- a/scripts/ci/test-release-rehearsal.py
+++ b/scripts/ci/test-release-rehearsal.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Deterministic tests for offline rehearsal and sequential reconciliation."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+
+import release_candidate_manifest as candidate_contract
+import release_registry as registry
+import release_rehearsal as rehearsal
+
+
+def _module(filename: str, name: str):
+    path = Path(__file__).with_name(filename)
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+registry_fixture = _module("test-release-registry.py", "release_registry_fixture")
+candidate_fixture = _module("test-release-candidate.py", "release_candidate_fixture")
+NOW = registry_fixture.NOW
+
+
+def _availability(value: bool = True) -> dict[str, bool]:
+    return dict.fromkeys(candidate_contract.GROUPS, value)
+
+
+def _set(manifest, values):
+    return {
+        "schema": registry.OBSERVATION_SET_SCHEMA,
+        "candidate_sha": manifest["commit_sha"],
+        "version": manifest["version"],
+        "observations": sorted(values, key=lambda item: item["node_id"]),
+    }
+
+
+def _all(manifest, response):
+    return _set(
+        manifest,
+        [registry_fixture.observed(manifest, node["id"], response) for node in manifest["nodes"]],
+    )
+
+
+def _replace(values, replacement):
+    result = copy.deepcopy(values)
+    result["observations"] = [
+        replacement if item["node_id"] == replacement["node_id"] else item
+        for item in result["observations"]
+    ]
+    return result
+
+
+def _verified(manifest, node_id):
+    return registry_fixture.observed(manifest, node_id)
+
+
+def _absent(manifest, node_id):
+    return registry_fixture.observed(manifest, node_id, {"status": 404})
+
+
+def _sequential_happy_path(manifest):
+    current = _all(manifest, {"status": 404})
+    transitions = []
+    while True:
+        plan = registry_fixture.plan(manifest, current)
+        publishes = [action for action in plan["actions"] if action["kind"] == "publish"]
+        if not publishes:
+            break
+        action = publishes[0]
+        observation = _verified(manifest, action["node_id"])
+        transitions.append(
+            {
+                "node_id": action["node_id"],
+                "action_kind": "publish",
+                "job_outcome": "success",
+                "observation": observation,
+            }
+        )
+        current = _replace(current, observation)
+    return transitions
+
+
+def test_artifact_rehearsal() -> None:
+    original_python = rehearsal._python_consumer
+
+    def fake_python(manifest, _artifacts, _root):
+        return {
+            "artifact": "python/fixture.whl",
+            "imported_version": manifest["version"],
+            "status": "passed",
+        }
+
+    rehearsal._python_consumer = fake_python
+    try:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest_path, artifacts, manifest = candidate_fixture.create_candidate(root)
+            report = rehearsal.rehearse_artifacts(
+                manifest_path,
+                artifacts,
+                expected_sha=candidate_fixture.SHA,
+                version=candidate_fixture.VERSION,
+                rehearsed_at=manifest["recorded_at"],
+            )
+            assert report["status"] == "passed"
+            assert report["registry_writes"] == 0
+            assert report["checks"]["candidate_completeness"]["nodes"] == 24
+            assert report["checks"]["node_cli_skills_clean_consumer"]["loaded_version"] == (
+                candidate_fixture.VERSION
+            )
+            assert len(report["checks"]["rust_packages"]["packages"]) == 15
+            assert not any(word in json.dumps(report).lower() for word in rehearsal.FORBIDDEN_TEXT)
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest_path, artifacts, manifest = candidate_fixture.create_candidate(root)
+            main_name = "@curatelabs/graphforge"
+            main_path = next(
+                artifacts / item["path"]
+                for item in manifest["artifacts"]
+                if item.get("name") == main_name
+            )
+            members = candidate_fixture.npm_members(main_name)
+            members["package/index.js"] = b"exports.notVersion = true;\n"
+            candidate_fixture.write_tar(main_path, members)
+            rebuilt = candidate_contract.build_manifest(
+                version=candidate_fixture.VERSION,
+                dist_dir=artifacts,
+                commit_sha=candidate_fixture.SHA,
+                recorded_at=manifest["recorded_at"],
+                notes="missing runtime entrypoint fixture",
+            )
+            manifest_path.write_text(
+                json.dumps(rebuilt, indent=2, sort_keys=True), encoding="utf-8"
+            )
+            try:
+                rehearsal.rehearse_artifacts(
+                    manifest_path,
+                    artifacts,
+                    expected_sha=candidate_fixture.SHA,
+                    version=candidate_fixture.VERSION,
+                    rehearsed_at=rebuilt["recorded_at"],
+                )
+            except rehearsal.RehearsalError as error:
+                assert "offline consumer node failed" in str(error)
+            else:
+                raise AssertionError("missing Node runtime entrypoint passed rehearsal")
+    finally:
+        rehearsal._python_consumer = original_python
+
+
+def test_sequential_reconciliation() -> None:
+    manifest = registry_fixture.candidate()
+    availability = _availability()
+    absent = _all(manifest, {"status": 404})
+    transitions = _sequential_happy_path(manifest)
+    assert len(transitions) == 24
+    report = rehearsal.simulate_sequential(
+        manifest, absent, availability, transitions, simulated_at=NOW
+    )
+    assert report["complete"] is True
+    assert report["summary"]["nodes"] == 24
+    assert report["summary"]["verified"] == 24
+    assert len(report["events"]) == 24
+    assert all(event["sequence"] == index for index, event in enumerate(report["events"], 1))
+
+    all_verified = registry_fixture.observation_set(manifest)
+    pypi_absent = _replace(all_verified, _absent(manifest, "pypi:graphforge"))
+    pypi_report = rehearsal.reconcile(
+        manifest,
+        pypi_absent,
+        availability,
+        reconciled_at=NOW,
+        job_outcomes={"pypi:graphforge": "cancelled"},
+    )
+    assert [action["node_id"] for action in pypi_report["next_actions"]] == ["pypi:graphforge"]
+    pypi_node = next(node for node in pypi_report["nodes"] if node["node_id"] == "pypi:graphforge")
+    assert pypi_node["job_outcome"] == "cancelled"
+    assert pypi_node["disposition"] == "publish"
+
+    timed_out = rehearsal.reconcile(
+        manifest,
+        all_verified,
+        availability,
+        reconciled_at=NOW,
+        job_outcomes={"pypi:graphforge": "timed_out"},
+    )
+    assert timed_out["complete"] is True
+    assert timed_out["next_actions"] == []
+
+    cli_absent = _replace(all_verified, _absent(manifest, "npm:@curatelabs/graphforge-cli"))
+    skipped = rehearsal.reconcile(
+        manifest,
+        cli_absent,
+        availability,
+        reconciled_at=NOW,
+        job_outcomes={"npm:@curatelabs/graphforge-cli": "skipped"},
+    )
+    assert skipped["next_actions"][0]["node_id"] == "npm:@curatelabs/graphforge-cli"
+    assert skipped["next_actions"][0]["kind"] == "publish"
+
+    receipt = {
+        "node_id": "npm:@curatelabs/graphforge",
+        "version": manifest["version"],
+        "accepted_at": "2030-01-01T12:00:00+00:00",
+        "visibility_deadline": "2030-01-01T12:10:00+00:00",
+        "observation_count": 0,
+    }
+    pending_observation = registry_fixture.observed(
+        manifest,
+        "npm:@curatelabs/graphforge",
+        {"status": 404},
+        receipt,
+    )
+    pending = rehearsal.reconcile(
+        manifest,
+        _replace(all_verified, pending_observation),
+        availability,
+        reconciled_at=NOW,
+        job_outcomes={"npm:@curatelabs/graphforge": "success"},
+    )
+    assert pending["next_actions"] == [
+        {
+            "node_id": "npm:@curatelabs/graphforge",
+            "kind": "verify_visibility",
+            "registry": "npm",
+        }
+    ]
+
+    conflict_response = registry_fixture.response_for(manifest, "crates:graphforge-core")
+    conflict_response["json"]["version"]["checksum"] = "f" * 64
+    conflict_observation = registry_fixture.observed(
+        manifest, "crates:graphforge-core", conflict_response
+    )
+    conflict = rehearsal.reconcile(
+        manifest,
+        _replace(all_verified, conflict_observation),
+        availability,
+        reconciled_at=NOW,
+    )
+    assert conflict["complete"] is False
+    assert conflict["blockers"][0]["reason"] == "registry_state_conflict"
+
+    indeterminate_observation = registry_fixture.observed(
+        manifest, "pypi:graphforge", {"status": 429}
+    )
+    indeterminate = rehearsal.reconcile(
+        manifest,
+        _replace(all_verified, indeterminate_observation),
+        availability,
+        reconciled_at=NOW,
+    )
+    assert indeterminate["blockers"][0]["reason"] == "registry_state_indeterminate"
+
+    expired_manifest = copy.deepcopy(manifest)
+    for group in expired_manifest["artifact_groups"]:
+        if group["id"] == "python":
+            group["expires_at"] = "2030-01-01T12:01:00+00:00"
+    expired = rehearsal.reconcile(expired_manifest, pypi_absent, availability, reconciled_at=NOW)
+    assert expired["blockers"][0]["reason"] == "artifact_group_unavailable_or_expired"
+
+    partial_npm = copy.deepcopy(all_verified)
+    missing_native = "npm:@curatelabs/graphforge-linux-x64-gnu"
+    partial_npm = _replace(partial_npm, _absent(manifest, missing_native))
+    partial_npm = _replace(partial_npm, _absent(manifest, "npm:@curatelabs/graphforge"))
+    partial = rehearsal.reconcile(manifest, partial_npm, availability, reconciled_at=NOW)
+    assert [action["node_id"] for action in partial["next_actions"]] == [missing_native]
+
+    partial_crates = copy.deepcopy(all_verified)
+    partial_crates = _replace(partial_crates, _absent(manifest, "crates:graphforge-core"))
+    partial_crates = _replace(partial_crates, _absent(manifest, "crates:graphforge-api"))
+    crates = rehearsal.reconcile(manifest, partial_crates, availability, reconciled_at=NOW)
+    assert [action["node_id"] for action in crates["next_actions"]] == ["crates:graphforge-core"]
+
+    assert rehearsal.reconcile(
+        manifest, pypi_absent, availability, reconciled_at=NOW
+    ) == rehearsal.reconcile(manifest, pypi_absent, availability, reconciled_at=NOW)
+    assert not any(word in json.dumps(report).lower() for word in rehearsal.FORBIDDEN_TEXT)
+
+
+def main() -> None:
+    test_artifact_rehearsal()
+    test_sequential_reconciliation()
+    print("release-rehearsal tests: ok")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- rehearse the exact immutable candidate offline through clean Python, Node/native, CLI, and agent-skills consumers before the final manifest exists
- add a stable 24-node reconciliation report and sequential recovery simulator driven only by the pure planner and supplied live registry observations
- cover partial PyPI/npm/crates recovery plus cancelled, timed-out, skipped, pending-visibility, conflict, indeterminate, expiry, and runtime-entrypoint failures

## Validation
- `python3 scripts/ci/test-release-candidate.py`
- `python3 scripts/ci/test-binding-release-candidate.py`
- `make pre-push-fast`
- `cmp -s CHANGELOG.md docs/reference/changelog.md`

No tag, release, registry write, publication workflow, or release-certification workflow was run.

Closes #295

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788185072&installation_model_id=20486&pr_number=303&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F303&signature=349683dcabf704f05ba22cb84b2b686e3406f492de56a50332bf83d5713cbd5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add offline release rehearsal and sequential 24-node recovery proof to the binding RC workflow
> - Adds [scripts/ci/release_rehearsal.py](https://github.com/CurateLabs/graphforge/pull/303/files#diff-806bd6517eb51b19db8b22bdb1ee3cdbe18ebe48bb09e449871c28b0c7333255) with two CLI subcommands: `artifacts` (offline rehearsal) and `reconcile` (recovery planning).
> - The `artifacts` command installs exact candidate wheels and npm tarballs into isolated temp dirs, validates versions and entrypoints, inventories crate packages, and emits a signed-off rehearsal report — no registry writes occur.
> - The `simulate_sequential` command walks the 24-node release graph one planner-eligible step at a time, recording outcome/state/disposition events to produce a deterministic recovery proof.
> - The [binding-release-candidate.yml](https://github.com/CurateLabs/graphforge/pull/303/files#diff-735f23ab6fdd90d2ccfdace46553969c425da5baf1ccae2f98a37b3e3ed9b6b3) workflow now writes a temporary manifest, runs the offline rehearsal, removes the temporary manifest, then records the final immutable manifest using the previously captured timestamp.
> - New test suites in [test-release-rehearsal.py](https://github.com/CurateLabs/graphforge/pull/303/files#diff-e2e78cb55e9aad83304e1614f3717ab7e9c1c6ac2d7a3cb22169ab92fe15aec5) cover happy-path rehearsal, missing entrypoints, cancelled/timed-out/skipped nodes, registry conflicts, partial recovery, idempotence, and report sanitization.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b3d138d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->