### PR TITLE
feat(release): orchestrate resumable publication

### DIFF
--- a/.github/workflows/binding-release-candidate.yml
+++ b/.github/workflows/binding-release-candidate.yml
@@ -564,10 +564,42 @@ jobs:
             --expected-sha "$EVIDENCE_SHA" \
             --version "$RELEASE_VERSION"
 
-      - name: Retain the release candidate for publication
+      - name: Retain the candidate manifest for publication
         uses: actions/upload-artifact@v7
         with:
-          name: M1-Release-Candidate-${{ needs.validate_source.outputs.evidence_sha }}
-          path: candidate/
+          name: M1-Release-Candidate-manifest-${{ needs.validate_source.outputs.evidence_sha }}
+          path: candidate/v${{ env.RELEASE_VERSION }}-artifacts.json
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Retain the Python candidate partition
+        uses: actions/upload-artifact@v7
+        with:
+          name: M1-Release-Candidate-python-${{ needs.validate_source.outputs.evidence_sha }}
+          path: candidate/release-artifacts/python/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Retain the npm candidate partition
+        uses: actions/upload-artifact@v7
+        with:
+          name: M1-Release-Candidate-npm-${{ needs.validate_source.outputs.evidence_sha }}
+          path: candidate/release-artifacts/npm/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Retain the crates candidate partition
+        uses: actions/upload-artifact@v7
+        with:
+          name: M1-Release-Candidate-crates-${{ needs.validate_source.outputs.evidence_sha }}
+          path: candidate/release-artifacts/crates/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Retain the evidence candidate partition
+        uses: actions/upload-artifact@v7
+        with:
+          name: M1-Release-Candidate-evidence-${{ needs.validate_source.outputs.evidence_sha }}
+          path: candidate/release-artifacts/{evidence,node-addons}/
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: Existing immutable release tag to resume
+        description: Existing immutable v2 release tag to resume
         required: true
-        default: v0.5.0
+        default: v0.5.1
         type: string
       waive_unreleased_entries:
         description: Waive only the tagged CHANGELOG Unreleased-entry check
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   candidate-preflight:
-    name: Verify immutable M1 release candidate
+    name: Validate immutable partitioned candidate
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       actions: read
@@ -33,13 +33,16 @@ jobs:
     outputs:
       candidate_run_id: ${{ steps.candidate.outputs.run_id }}
       release_sha: ${{ steps.source.outputs.release_sha }}
+      release_version: ${{ steps.source.outputs.release_version }}
+      manifest_name: ${{ steps.source.outputs.manifest_name }}
+      release_tag: ${{ steps.source.outputs.release_tag }}
     steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.release_tag }}
           fetch-depth: 0
 
-      - name: Require the certified current main commit and release versions
+      - name: Require one immutable v2 release identity
         id: source
         shell: bash
         env:
@@ -49,46 +52,37 @@ jobs:
           WAIVE_UNRELEASED_ENTRIES: ${{ inputs.waive_unreleased_entries || false }}
           RECOVERY_REASON: ${{ inputs.recovery_reason || '' }}
         run: |
-          git fetch --no-tags origin \
-            +refs/heads/main:refs/remotes/origin/main
-          RELEASE_SHA="$(git rev-parse "$RELEASE_TAG^{}")"
-          test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
-          test "$(git rev-parse "$RELEASE_TAG^{}")" = "$RELEASE_SHA"
-          preflight_args=(--tag "$RELEASE_TAG" --expected-sha "$RELEASE_SHA")
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          release_sha="$(git rev-parse "$RELEASE_TAG^{}")"
+          release_version="${RELEASE_TAG#v}"
+          test "$RELEASE_TAG" = "v$release_version"
+          test "$release_version" != 0.5.0
+          test "$(git rev-parse HEAD)" = "$release_sha"
+          test "$(git rev-parse "$RELEASE_TAG^{}")" = "$release_sha"
+          preflight_args=(--tag "$RELEASE_TAG" --expected-sha "$release_sha")
           if test "$GITHUB_EVENT_NAME" = release; then
-            test "$EVENT_SHA" = "$RELEASE_SHA"
-            test "$(git rev-parse refs/remotes/origin/main)" = "$RELEASE_SHA"
+            test "$EVENT_SHA" = "$release_sha"
+            test "$(git rev-parse refs/remotes/origin/main)" = "$release_sha"
           else
             test "$WAIVE_UNRELEASED_ENTRIES" = true
             test -n "$RECOVERY_REASON"
             gh release view "$RELEASE_TAG" >/dev/null
-            git merge-base --is-ancestor "$RELEASE_SHA" refs/remotes/origin/main
-            git show \
-              refs/remotes/origin/main:scripts/ci/release-publish-preflight.py \
+            git merge-base --is-ancestor "$release_sha" refs/remotes/origin/main
+            git show refs/remotes/origin/main:scripts/ci/release-publish-preflight.py \
               > "$RUNNER_TEMP/release-publish-preflight.py"
-            install -m 0755 \
-              "$RUNNER_TEMP/release-publish-preflight.py" \
+            install -m 0755 "$RUNNER_TEMP/release-publish-preflight.py" \
               scripts/ci/release-publish-preflight.py
             preflight_args+=(--allow-unreleased-entries)
             printf 'Recovery reason: %s\n' "$RECOVERY_REASON"
           fi
           python3 scripts/ci/release-publish-preflight.py "${preflight_args[@]}"
-          printf 'release_sha=%s\n' "$RELEASE_SHA" >> "$GITHUB_OUTPUT"
+          python3 scripts/set_release_version.py --check
+          printf 'release_sha=%s\n' "$release_sha" >> "$GITHUB_OUTPUT"
+          printf 'release_version=%s\n' "$release_version" >> "$GITHUB_OUTPUT"
+          printf 'manifest_name=v%s-artifacts.json\n' "$release_version" >> "$GITHUB_OUTPUT"
+          printf 'release_tag=%s\n' "$RELEASE_TAG" >> "$GITHUB_OUTPUT"
 
-      - name: Verify release license policy
-        run: python3 scripts/license_check.py --report license-compliance-report.json
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Verify npm publication identity before any registry write
-        run: npm whoami
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Resolve successful same-SHA candidate run
+      - name: Resolve the complete retained candidate
         id: candidate
         shell: bash
         env:
@@ -99,96 +93,200 @@ jobs:
             "repos/$GITHUB_REPOSITORY/actions/workflows/binding-release-candidate.yml/runs?event=workflow_dispatch&status=success&head_sha=$RELEASE_SHA&per_page=20" \
             --jq '.workflow_runs | map(select(.head_sha == env.RELEASE_SHA)) | first | .id // empty')"
           test -n "$run_id"
-          artifact_name="M1-Release-Candidate-$RELEASE_SHA"
-          artifact_count="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/artifacts" \
-            --jq "[.artifacts[] | select(.name == \"$artifact_name\" and .expired == false)] | length")"
-          test "$artifact_count" = 1
+          for group in manifest python npm crates evidence; do
+            artifact_name="M1-Release-Candidate-$group-$RELEASE_SHA"
+            count="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/artifacts" \
+              --jq "[.artifacts[] | select(.name == \"$artifact_name\" and .expired == false)] | length")"
+            test "$count" = 1
+          done
           printf 'run_id=%s\n' "$run_id" >> "$GITHUB_OUTPUT"
 
-      - name: Download exact-SHA candidate
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_SHA: ${{ steps.source.outputs.release_sha }}
-          CANDIDATE_RUN_ID: ${{ steps.candidate.outputs.run_id }}
-        run: |
-          gh run download "$CANDIDATE_RUN_ID" \
-            --name "M1-Release-Candidate-$RELEASE_SHA" \
-            --dir candidate
+      - name: Download candidate manifest
+        uses: actions/download-artifact@v8
+        with:
+          name: M1-Release-Candidate-manifest-${{ steps.source.outputs.release_sha }}
+          path: candidate
+          run-id: ${{ steps.candidate.outputs.run_id }}
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
 
-      - name: Validate candidate bytes and checksum record
+      - name: Download Python partition
+        uses: actions/download-artifact@v8
+        with:
+          name: M1-Release-Candidate-python-${{ steps.source.outputs.release_sha }}
+          path: candidate/release-artifacts/python
+          run-id: ${{ steps.candidate.outputs.run_id }}
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+
+      - name: Download npm partition
+        uses: actions/download-artifact@v8
+        with:
+          name: M1-Release-Candidate-npm-${{ steps.source.outputs.release_sha }}
+          path: candidate/release-artifacts/npm
+          run-id: ${{ steps.candidate.outputs.run_id }}
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+
+      - name: Download crates partition
+        uses: actions/download-artifact@v8
+        with:
+          name: M1-Release-Candidate-crates-${{ steps.source.outputs.release_sha }}
+          path: candidate/release-artifacts/crates
+          run-id: ${{ steps.candidate.outputs.run_id }}
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+
+      - name: Download evidence partition
+        uses: actions/download-artifact@v8
+        with:
+          name: M1-Release-Candidate-evidence-${{ steps.source.outputs.release_sha }}
+          path: candidate/release-artifacts
+          run-id: ${{ steps.candidate.outputs.run_id }}
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+
+      - name: Revalidate completeness and offline rehearsal
         env:
           RELEASE_SHA: ${{ steps.source.outputs.release_sha }}
+          RELEASE_VERSION: ${{ steps.source.outputs.release_version }}
+          MANIFEST_NAME: ${{ steps.source.outputs.manifest_name }}
         run: |
           python3 scripts/ci/release-candidate.py validate \
-            --record candidate/v0.5.0-artifacts.json \
+            --record "candidate/$MANIFEST_NAME" \
             --artifacts-dir candidate/release-artifacts \
             --expected-sha "$RELEASE_SHA" \
-            --version 0.5.0
+            --version "$RELEASE_VERSION"
+          jq -e \
+            --arg sha "$RELEASE_SHA" \
+            --arg version "$RELEASE_VERSION" \
+            '.schema == "graphforge-release-artifact-rehearsal-v1" and
+             .candidate_sha == $sha and .version == $version and
+             .offline == true and .registry_writes == 0 and .status == "passed"' \
+            candidate/release-artifacts/evidence/offline-rehearsal.json
 
-      - name: Attach checksum record without replacing different bytes
+      - name: Observe initial public registry truth
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MANIFEST_NAME: ${{ steps.source.outputs.manifest_name }}
+          RELEASE_TAG: ${{ steps.source.outputs.release_tag }}
+          RELEASE_VERSION: ${{ steps.source.outputs.release_version }}
+        run: |
+          bash scripts/ci/download-release-write-evidence.sh \
+            "$RELEASE_TAG" "$RELEASE_VERSION" write-evidence
+          observed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          python3 scripts/ci/release_registry.py observe-all \
+            --manifest "candidate/$MANIFEST_NAME" \
+            --attempts-dir write-evidence/attempts \
+            --receipts-dir write-evidence/receipts \
+            --observed-at "$observed_at" \
+            --out candidate/initial-observations.json
+          printf '{"python":true,"npm":true,"crates":true,"evidence":true}\n' \
+            > candidate/artifact-availability.json
+          python3 scripts/ci/release_registry.py plan \
+            --manifest "candidate/$MANIFEST_NAME" \
+            --observations candidate/initial-observations.json \
+            --availability candidate/artifact-availability.json \
+            --planned-at "$observed_at" \
+            --out candidate/initial-plan.json
+
+      - name: Attach candidate manifest without replacing different bytes
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.release_tag }}
+          MANIFEST_NAME: ${{ steps.source.outputs.manifest_name }}
         run: |
-          asset_name="v0.5.0-artifacts.json"
-          asset_count="$(gh release view "$RELEASE_TAG" --json assets \
-            --jq "[.assets[] | select(.name == \"$asset_name\")] | length")"
-          if test "$asset_count" = 0; then
-            gh release upload "$RELEASE_TAG" "candidate/$asset_name"
+          count="$(gh release view "$RELEASE_TAG" --json assets \
+            --jq "[.assets[] | select(.name == \"$MANIFEST_NAME\")] | length")"
+          if test "$count" = 0; then
+            gh release upload "$RELEASE_TAG" "candidate/$MANIFEST_NAME"
           else
-            test "$asset_count" = 1
+            test "$count" = 1
             mkdir -p existing-release-asset
-            gh release download "$RELEASE_TAG" --pattern "$asset_name" \
+            gh release download "$RELEASE_TAG" --pattern "$MANIFEST_NAME" \
               --dir existing-release-asset
-            cmp "candidate/$asset_name" "existing-release-asset/$asset_name"
+            cmp "candidate/$MANIFEST_NAME" "existing-release-asset/$MANIFEST_NAME"
           fi
 
   publish-pypi:
-    name: Publish exact candidate to PyPI
+    name: PyPI node
     needs: candidate-preflight
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       actions: read
-      contents: read
+      contents: write
       id-token: write
     steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ needs.candidate-preflight.outputs.release_sha }}
-
       - uses: astral-sh/setup-uv@v9.0.0
-
-      - name: Download exact-SHA candidate
+      - name: Download manifest and Python partition
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ needs.candidate-preflight.outputs.candidate_run_id }}
+          RELEASE_SHA: ${{ needs.candidate-preflight.outputs.release_sha }}
+        run: |
+          gh run download "$RUN_ID" --name "M1-Release-Candidate-manifest-$RELEASE_SHA" --dir candidate
+          gh run download "$RUN_ID" --name "M1-Release-Candidate-python-$RELEASE_SHA" --dir candidate/release-artifacts/python
+      - name: Authorize from fresh PyPI truth
+        id: authorize
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_SHA: ${{ needs.candidate-preflight.outputs.release_sha }}
-          CANDIDATE_RUN_ID: ${{ needs.candidate-preflight.outputs.candidate_run_id }}
-        run: >-
-          gh run download "$CANDIDATE_RUN_ID"
-          --name "M1-Release-Candidate-$RELEASE_SHA"
-          --dir candidate
-
-      - name: Revalidate candidate
+          RELEASE_VERSION: ${{ needs.candidate-preflight.outputs.release_version }}
+          MANIFEST_NAME: ${{ needs.candidate-preflight.outputs.manifest_name }}
+          RELEASE_TAG: ${{ needs.candidate-preflight.outputs.release_tag }}
+        run: |
+          now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          bash scripts/ci/download-release-write-evidence.sh "$RELEASE_TAG" "$RELEASE_VERSION" write-evidence
+          python3 scripts/ci/release_action.py validate-partition --manifest "candidate/$MANIFEST_NAME" --artifacts-dir candidate/release-artifacts --group python --expected-sha "$RELEASE_SHA" --version "$RELEASE_VERSION" --checked-at "$now"
+          python3 scripts/ci/release_registry.py observe-all --manifest "candidate/$MANIFEST_NAME" --registry pypi --attempts-dir write-evidence/attempts --receipts-dir write-evidence/receipts --observed-at "$now" --out observations.json
+          printf '{"python":true,"npm":false,"crates":false,"evidence":false}\n' > availability.json
+          python3 scripts/ci/release_action.py authorize --manifest "candidate/$MANIFEST_NAME" --observations observations.json --availability availability.json --node pypi:graphforge --planned-at "$now" --out authorization.json
+          printf 'publish=%s\n' "$(jq -r .publish authorization.json)" >> "$GITHUB_OUTPUT"
+      - name: Persist PyPI write attempt before publication
+        if: steps.authorize.outputs.publish == 'true'
         env:
-          RELEASE_SHA: ${{ needs.candidate-preflight.outputs.release_sha }}
-        run: >-
-          python3 scripts/ci/release-candidate.py validate
-          --record candidate/v0.5.0-artifacts.json
-          --artifacts-dir candidate/release-artifacts
-          --expected-sha "$RELEASE_SHA"
-          --version 0.5.0
+          GH_TOKEN: ${{ github.token }}
+          MANIFEST_NAME: ${{ needs.candidate-preflight.outputs.manifest_name }}
+          RELEASE_TAG: ${{ needs.candidate-preflight.outputs.release_tag }}
+          RELEASE_VERSION: ${{ needs.candidate-preflight.outputs.release_version }}
+        run: |
+          attempt="v$RELEASE_VERSION-attempt-pypi-graphforge.json"
+          python3 scripts/ci/release_action.py attempt --manifest "candidate/$MANIFEST_NAME" --node pypi:graphforge --started-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --out "$attempt"
+          gh release upload "$RELEASE_TAG" "$attempt"
+      - name: Publish exact Python artifacts once
+        if: steps.authorize.outputs.publish == 'true'
+        run: uv publish candidate/release-artifacts/python/*
+      - name: Observe PyPI once after an accepted write
+        if: steps.authorize.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MANIFEST_NAME: ${{ needs.candidate-preflight.outputs.manifest_name }}
+          RELEASE_TAG: ${{ needs.candidate-preflight.outputs.release_tag }}
+          RELEASE_VERSION: ${{ needs.candidate-preflight.outputs.release_version }}
+        run: |
+          accepted_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          receipt="v$RELEASE_VERSION-accepted-pypi-graphforge.json"
+          python3 scripts/ci/release_action.py receipt --manifest "candidate/$MANIFEST_NAME" --node pypi:graphforge --accepted-at "$accepted_at" --out "$receipt"
+          gh release upload "$RELEASE_TAG" "$receipt"
+          python3 scripts/ci/release_registry.py observe --manifest "candidate/$MANIFEST_NAME" --node pypi:graphforge --live --accepted-receipt "$receipt" --observed-at "$accepted_at" --out post-write.json
+          jq '{node_id,state,reason}' post-write.json >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Publish the recorded Python files
-        run: >-
-          uv publish
-          --check-url https://pypi.org/simple/
-          candidate/release-artifacts/python/*
-
-  publish-npm:
-    name: Publish exact candidate to npm
-    needs: [candidate-preflight, publish-pypi]
+  npm-native:
+    name: Native npm (${{ matrix.package }})
+    needs: candidate-preflight
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - graphforge-darwin-arm64
+          - graphforge-darwin-x64
+          - graphforge-linux-arm64-gnu
+          - graphforge-linux-x64-gnu
+          - graphforge-win32-x64-msvc
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       actions: read
@@ -197,116 +295,313 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ needs.candidate-preflight.outputs.release_sha }}
-
-      - name: Load reviewed npm recovery publisher
-        if: github.event_name == 'workflow_dispatch'
-        shell: bash
-        run: |
-          git fetch --no-tags origin \
-            +refs/heads/main:refs/remotes/origin/main
-          git show refs/remotes/origin/main:scripts/publish_npm_artifacts.py \
-            > "$RUNNER_TEMP/publish_npm_artifacts.py"
-          install -m 0755 \
-            "$RUNNER_TEMP/publish_npm_artifacts.py" \
-            scripts/publish_npm_artifacts.py
-          git show refs/remotes/origin/main:scripts/amend_npm_main_artifact.py \
-            > "$RUNNER_TEMP/amend_npm_main_artifact.py"
-          install -m 0755 \
-            "$RUNNER_TEMP/amend_npm_main_artifact.py" \
-            scripts/amend_npm_main_artifact.py
-
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
-
-      - uses: pnpm/action-setup@v4
-
-      - name: Install release verification dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Download exact-SHA candidate
+          node-version: "22"
+          registry-url: https://registry.npmjs.org
+      - name: Download manifest and npm partition
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ needs.candidate-preflight.outputs.candidate_run_id }}
+          RELEASE_SHA: ${{ needs.candidate-preflight.outputs.release_sha }}
+        run: |
+          gh run download "$RUN_ID" --name "M1-Release-Candidate-manifest-$RELEASE_SHA" --dir candidate
+          gh run download "$RUN_ID" --name "M1-Release-Candidate-npm-$RELEASE_SHA" --dir candidate/release-artifacts/npm
+      - name: Authorize native node from fresh npm truth
+        id: authorize
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_SHA: ${{ needs.candidate-preflight.outputs.release_sha }}
-          CANDIDATE_RUN_ID: ${{ needs.candidate-preflight.outputs.candidate_run_id }}
-        run: >-
-          gh run download "$CANDIDATE_RUN_ID"
-          --name "M1-Release-Candidate-$RELEASE_SHA"
-          --dir candidate
-
-      - name: Apply authorized unpublished main npm amendment
-        if: github.event_name == 'workflow_dispatch' && inputs.release_tag == 'v0.5.0'
-        shell: bash
+          RELEASE_VERSION: ${{ needs.candidate-preflight.outputs.release_version }}
+          MANIFEST_NAME: ${{ needs.candidate-preflight.outputs.manifest_name }}
+          NODE_ID: npm:@curatelabs/${{ matrix.package }}
+          RELEASE_TAG: ${{ needs.candidate-preflight.outputs.release_tag }}
+        run: |
+          now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          bash scripts/ci/download-release-write-evidence.sh "$RELEASE_TAG" "$RELEASE_VERSION" write-evidence
+          python3 scripts/ci/release_action.py validate-partition --manifest "candidate/$MANIFEST_NAME" --artifacts-dir candidate/release-artifacts --group npm --expected-sha "$RELEASE_SHA" --version "$RELEASE_VERSION" --checked-at "$now"
+          python3 scripts/ci/release_registry.py observe-all --manifest "candidate/$MANIFEST_NAME" --registry npm --attempts-dir write-evidence/attempts --receipts-dir write-evidence/receipts --observed-at "$now" --out observations.json
+          printf '{"python":false,"npm":true,"crates":false,"evidence":false}\n' > availability.json
+          python3 scripts/ci/release_action.py authorize --manifest "candidate/$MANIFEST_NAME" --observations observations.json --availability availability.json --node "$NODE_ID" --planned-at "$now" --out authorization.json
+          printf 'publish=%s\n' "$(jq -r .publish authorization.json)" >> "$GITHUB_OUTPUT"
+      - name: Persist native npm write attempt before publication
+        if: steps.authorize.outputs.publish == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
+          MANIFEST_NAME: ${{ needs.candidate-preflight.outputs.manifest_name }}
+          RELEASE_TAG: ${{ needs.candidate-preflight.outputs.release_tag }}
+          RELEASE_VERSION: ${{ needs.candidate-preflight.outputs.release_version }}
+          NODE_ID: npm:@curatelabs/${{ matrix.package }}
         run: |
-          supplement="v0.5.0-npm-amendment.json"
-          archive="curatelabs-graphforge-0.5.0-amended.tgz"
-          supplement_count="$(gh release view "$RELEASE_TAG" --json assets \
-            --jq "[.assets[] | select(.name == \"$supplement\")] | length")"
-          archive_count="$(gh release view "$RELEASE_TAG" --json assets \
-            --jq "[.assets[] | select(.name == \"$archive\")] | length")"
-          if test "$supplement_count" = 0 && test "$archive_count" = 0; then
-            python3 scripts/amend_npm_main_artifact.py create \
-              --record candidate/v0.5.0-artifacts.json \
-              --artifacts-dir candidate/release-artifacts \
-              --amended-archive "candidate/$archive" \
-              --supplement "candidate/$supplement"
-            gh release upload "$RELEASE_TAG" \
-              "candidate/$archive" "candidate/$supplement"
-          else
-            test "$supplement_count" = 1
-            test "$archive_count" = 1
-            mkdir -p candidate/amendment
-            gh release download "$RELEASE_TAG" \
-              --pattern "$supplement" --pattern "$archive" \
-              --dir candidate/amendment
-            python3 scripts/amend_npm_main_artifact.py apply \
-              --record candidate/v0.5.0-artifacts.json \
-              --artifacts-dir candidate/release-artifacts \
-              --amended-archive "candidate/amendment/$archive" \
-              --supplement "candidate/amendment/$supplement"
-          fi
-          python3 scripts/ci/release-candidate.py validate \
-            --record candidate/v0.5.0-artifacts.json \
-            --artifacts-dir candidate/release-artifacts \
-            --expected-sha "${{ needs.candidate-preflight.outputs.release_sha }}" \
-            --version 0.5.0
-
-      - name: Publish recorded npm tarballs in dependency order
-        shell: bash
+          attempt="v$RELEASE_VERSION-attempt-npm-${{ matrix.package }}.json"
+          python3 scripts/ci/release_action.py attempt --manifest "candidate/$MANIFEST_NAME" --node "$NODE_ID" --started-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --out "$attempt"
+          gh release upload "$RELEASE_TAG" "$attempt"
+      - name: Publish one exact native tarball
+        if: steps.authorize.outputs.publish == 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           RELEASE_SHA: ${{ needs.candidate-preflight.outputs.release_sha }}
+          RELEASE_VERSION: ${{ needs.candidate-preflight.outputs.release_version }}
+          MANIFEST_NAME: ${{ needs.candidate-preflight.outputs.manifest_name }}
         run: |
           npm whoami
-          python3 scripts/publish_npm_artifacts.py \
-            --release-record candidate/v0.5.0-artifacts.json \
-            --artifacts-dir candidate/release-artifacts \
-            --expected-sha "$RELEASE_SHA" \
-            --version 0.5.0 \
-            --group native
-          node scripts/ci/verify-node-cli-release-package.mjs
-          pnpm --filter @curatelabs/graphforge-cli test:offline
-          python3 scripts/publish_npm_artifacts.py \
-            --release-record candidate/v0.5.0-artifacts.json \
-            --artifacts-dir candidate/release-artifacts \
-            --expected-sha "$RELEASE_SHA" \
-            --version 0.5.0 \
-            --group cli
-          pnpm --filter @curatelabs/graphforge-agent-skills test:offline
-          python3 scripts/publish_npm_artifacts.py \
-            --release-record candidate/v0.5.0-artifacts.json \
-            --artifacts-dir candidate/release-artifacts \
-            --expected-sha "$RELEASE_SHA" \
-            --version 0.5.0 \
-            --group skills
+          python3 scripts/publish_npm_artifacts.py --release-record "candidate/$MANIFEST_NAME" --artifacts-dir candidate/release-artifacts --expected-sha "$RELEASE_SHA" --version "$RELEASE_VERSION" --package "@curatelabs/${{ matrix.package }}"
+      - name: Observe native npm once after an accepted write
+        if: steps.authorize.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MANIFEST_NAME: ${{ needs.candidate-preflight.outputs.manifest_name }}
+          NODE_ID: npm:@curatelabs/${{ matrix.package }}
+          RELEASE_TAG: ${{ needs.candidate-preflight.outputs.release_tag }}
+          RELEASE_VERSION: ${{ needs.candidate-preflight.outputs.release_version }}
+        run: |
+          accepted_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          receipt="v$RELEASE_VERSION-accepted-npm-${{ matrix.package }}.json"
+          python3 scripts/ci/release_action.py receipt --manifest "candidate/$MANIFEST_NAME" --node "$NODE_ID" --accepted-at "$accepted_at" --out "$receipt"
+          gh release upload "$RELEASE_TAG" "$receipt"
+          python3 scripts/ci/release_registry.py observe --manifest "candidate/$MANIFEST_NAME" --node "$NODE_ID" --live --accepted-receipt "$receipt" --observed-at "$accepted_at" --out post-write.json
+          jq '{node_id,state,reason}' post-write.json >> "$GITHUB_STEP_SUMMARY"
+
+  npm-main:
+    name: npm main fan-in
+    needs: [candidate-preflight, npm-native]
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.candidate-preflight.outputs.release_sha }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          registry-url: https://registry.npmjs.org
+      - name: Download manifest and npm partition
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ needs.candidate-preflight.outputs.candidate_run_id }}
+          RELEASE_SHA: ${{ needs.candidate-preflight.outputs.release_sha }}
+        run: |
+          gh run download "$RUN_ID" --name "M1-Release-Candidate-manifest-$RELEASE_SHA" --dir candidate
+          gh run download "$RUN_ID" --name "M1-Release-Candidate-npm-$RELEASE_SHA" --dir candidate/release-artifacts/npm
+      - name: Require verified native fan-in and authorize main
+        id: authorize
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ needs.candidate-preflight.outputs.release_sha }}
+          RELEASE_VERSION: ${{ needs.candidate-preflight.outputs.release_version }}
+          MANIFEST_NAME: ${{ needs.candidate-preflight.outputs.manifest_name }}
+          RELEASE_TAG: ${{ needs.candidate-preflight.outputs.release_tag }}
+        run: |
+          now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          bash scripts/ci/download-release-write-evidence.sh "$RELEASE_TAG" "$RELEASE_VERSION" write-evidence
+          python3 scripts/ci/release_action.py validate-partition --manifest "candidate/$MANIFEST_NAME" --artifacts-dir candidate/release-artifacts --group npm --expected-sha "$RELEASE_SHA" --version "$RELEASE_VERSION" --checked-at "$now"
+          python3 scripts/ci/release_registry.py observe-all --manifest "candidate/$MANIFEST_NAME" --registry npm --attempts-dir write-evidence/attempts --receipts-dir write-evidence/receipts --observed-at "$now" --out observations.json
+          printf '{"python":false,"npm":true,"crates":false,"evidence":false}\n' > availability.json
+          python3 scripts/ci/release_action.py authorize --manifest "candidate/$MANIFEST_NAME" --observations observations.json --availability availability.json --node npm:@curatelabs/graphforge --planned-at "$now" --out authorization.json
+          printf 'publish=%s\n' "$(jq -r .publish authorization.json)" >> "$GITHUB_OUTPUT"
+      - name: Persist npm main write attempt before publication
+        if: steps.authorize.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MANIFEST_NAME: ${{ needs.candidate-preflight.outputs.manifest_name }}
+          RELEASE_TAG: ${{ needs.candidate-preflight.outputs.release_tag }}
+          RELEASE_VERSION: ${{ needs.candidate-preflight.outputs.release_version }}
+        run: |
+          attempt="v$RELEASE_VERSION-attempt-npm-graphforge.json"
+          python3 scripts/ci/release_action.py attempt --manifest "candidate/$MANIFEST_NAME" --node npm:@curatelabs/graphforge --started-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --out "$attempt"
+          gh release upload "$RELEASE_TAG" "$attempt"
+      - name: Publish exact npm main tarball once
+        if: steps.authorize.outputs.publish == 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          RELEASE_SHA: ${{ needs.candidate-preflight.outputs.release_sha }}
+          RELEASE_VERSION: ${{ needs.candidate-preflight.outputs.release_version }}
+          MANIFEST_NAME: ${{ needs.candidate-preflight.outputs.manifest_name }}
+        run: |
+          npm whoami
+          python3 scripts/publish_npm_artifacts.py --release-record "candidate/$MANIFEST_NAME" --artifacts-dir candidate/release-artifacts --expected-sha "$RELEASE_SHA" --version "$RELEASE_VERSION" --package @curatelabs/graphforge
+      - name: Observe npm main once after an accepted write
+        if: steps.authorize.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MANIFEST_NAME: ${{ needs.candidate-preflight.outputs.manifest_name }}
+          RELEASE_TAG: ${{ needs.candidate-preflight.outputs.release_tag }}
+          RELEASE_VERSION: ${{ needs.candidate-preflight.outputs.release_version }}
+        run: |
+          accepted_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          receipt="v$RELEASE_VERSION-accepted-npm-graphforge.json"
+          python3 scripts/ci/release_action.py receipt --manifest "candidate/$MANIFEST_NAME" --node npm:@curatelabs/graphforge --accepted-at "$accepted_at" --out "$receipt"
+          gh release upload "$RELEASE_TAG" "$receipt"
+          python3 scripts/ci/release_registry.py observe --manifest "candidate/$MANIFEST_NAME" --node npm:@curatelabs/graphforge --live --accepted-receipt "$receipt" --observed-at "$accepted_at" --out post-write.json
+          jq '{node_id,state,reason}' post-write.json >> "$GITHUB_STEP_SUMMARY"
+
+  npm-cli:
+    name: npm CLI after verified main
+    needs: [candidate-preflight, npm-main]
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.candidate-preflight.outputs.release_sha }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          registry-url: https://registry.npmjs.org
+      - name: Download, authorize, and publish CLI if absent
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          RUN_ID: ${{ needs.candidate-preflight.outputs.candidate_run_id }}
+          RELEASE_SHA: ${{ needs.candidate-preflight.outputs.release_sha }}
+          RELEASE_VERSION: ${{ needs.candidate-preflight.outputs.release_version }}
+          MANIFEST_NAME: ${{ needs.candidate-preflight.outputs.manifest_name }}
+          RELEASE_TAG: ${{ needs.candidate-preflight.outputs.release_tag }}
+        run: |
+          gh run download "$RUN_ID" --name "M1-Release-Candidate-manifest-$RELEASE_SHA" --dir candidate
+          gh run download "$RUN_ID" --name "M1-Release-Candidate-npm-$RELEASE_SHA" --dir candidate/release-artifacts/npm
+          now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          bash scripts/ci/download-release-write-evidence.sh "$RELEASE_TAG" "$RELEASE_VERSION" write-evidence
+          python3 scripts/ci/release_action.py validate-partition --manifest "candidate/$MANIFEST_NAME" --artifacts-dir candidate/release-artifacts --group npm --expected-sha "$RELEASE_SHA" --version "$RELEASE_VERSION" --checked-at "$now"
+          python3 scripts/ci/release_registry.py observe-all --manifest "candidate/$MANIFEST_NAME" --registry npm --attempts-dir write-evidence/attempts --receipts-dir write-evidence/receipts --observed-at "$now" --out observations.json
+          printf '{"python":false,"npm":true,"crates":false,"evidence":false}\n' > availability.json
+          python3 scripts/ci/release_action.py authorize --manifest "candidate/$MANIFEST_NAME" --observations observations.json --availability availability.json --node npm:@curatelabs/graphforge-cli --planned-at "$now" --out authorization.json
+          if test "$(jq -r .publish authorization.json)" = true; then
+            attempt="v$RELEASE_VERSION-attempt-npm-graphforge-cli.json"
+            python3 scripts/ci/release_action.py attempt --manifest "candidate/$MANIFEST_NAME" --node npm:@curatelabs/graphforge-cli --started-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --out "$attempt"
+            gh release upload "$RELEASE_TAG" "$attempt"
+            npm whoami
+            python3 scripts/publish_npm_artifacts.py --release-record "candidate/$MANIFEST_NAME" --artifacts-dir candidate/release-artifacts --expected-sha "$RELEASE_SHA" --version "$RELEASE_VERSION" --package @curatelabs/graphforge-cli
+            accepted_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            receipt="v$RELEASE_VERSION-accepted-npm-graphforge-cli.json"
+            python3 scripts/ci/release_action.py receipt --manifest "candidate/$MANIFEST_NAME" --node npm:@curatelabs/graphforge-cli --accepted-at "$accepted_at" --out "$receipt"
+            gh release upload "$RELEASE_TAG" "$receipt"
+            python3 scripts/ci/release_registry.py observe --manifest "candidate/$MANIFEST_NAME" --node npm:@curatelabs/graphforge-cli --live --accepted-receipt "$receipt" --observed-at "$accepted_at" --out post-write.json
+            jq '{node_id,state,reason}' post-write.json >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  npm-skills:
+    name: npm agent skills after verified CLI
+    needs: [candidate-preflight, npm-cli]
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.candidate-preflight.outputs.release_sha }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          registry-url: https://registry.npmjs.org
+      - name: Download, authorize, and publish skills if absent
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          RUN_ID: ${{ needs.candidate-preflight.outputs.candidate_run_id }}
+          RELEASE_SHA: ${{ needs.candidate-preflight.outputs.release_sha }}
+          RELEASE_VERSION: ${{ needs.candidate-preflight.outputs.release_version }}
+          MANIFEST_NAME: ${{ needs.candidate-preflight.outputs.manifest_name }}
+          RELEASE_TAG: ${{ needs.candidate-preflight.outputs.release_tag }}
+        run: |
+          gh run download "$RUN_ID" --name "M1-Release-Candidate-manifest-$RELEASE_SHA" --dir candidate
+          gh run download "$RUN_ID" --name "M1-Release-Candidate-npm-$RELEASE_SHA" --dir candidate/release-artifacts/npm
+          now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          bash scripts/ci/download-release-write-evidence.sh "$RELEASE_TAG" "$RELEASE_VERSION" write-evidence
+          python3 scripts/ci/release_action.py validate-partition --manifest "candidate/$MANIFEST_NAME" --artifacts-dir candidate/release-artifacts --group npm --expected-sha "$RELEASE_SHA" --version "$RELEASE_VERSION" --checked-at "$now"
+          python3 scripts/ci/release_registry.py observe-all --manifest "candidate/$MANIFEST_NAME" --registry npm --attempts-dir write-evidence/attempts --receipts-dir write-evidence/receipts --observed-at "$now" --out observations.json
+          printf '{"python":false,"npm":true,"crates":false,"evidence":false}\n' > availability.json
+          python3 scripts/ci/release_action.py authorize --manifest "candidate/$MANIFEST_NAME" --observations observations.json --availability availability.json --node npm:@curatelabs/graphforge-agent-skills --planned-at "$now" --out authorization.json
+          if test "$(jq -r .publish authorization.json)" = true; then
+            attempt="v$RELEASE_VERSION-attempt-npm-graphforge-agent-skills.json"
+            python3 scripts/ci/release_action.py attempt --manifest "candidate/$MANIFEST_NAME" --node npm:@curatelabs/graphforge-agent-skills --started-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --out "$attempt"
+            gh release upload "$RELEASE_TAG" "$attempt"
+            npm whoami
+            python3 scripts/publish_npm_artifacts.py --release-record "candidate/$MANIFEST_NAME" --artifacts-dir candidate/release-artifacts --expected-sha "$RELEASE_SHA" --version "$RELEASE_VERSION" --package @curatelabs/graphforge-agent-skills
+            accepted_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            receipt="v$RELEASE_VERSION-accepted-npm-graphforge-agent-skills.json"
+            python3 scripts/ci/release_action.py receipt --manifest "candidate/$MANIFEST_NAME" --node npm:@curatelabs/graphforge-agent-skills --accepted-at "$accepted_at" --out "$receipt"
+            gh release upload "$RELEASE_TAG" "$receipt"
+            python3 scripts/ci/release_registry.py observe --manifest "candidate/$MANIFEST_NAME" --node npm:@curatelabs/graphforge-agent-skills --live --accepted-receipt "$receipt" --observed-at "$accepted_at" --out post-write.json
+            jq '{node_id,state,reason}' post-write.json >> "$GITHUB_STEP_SUMMARY"
+          fi
 
   publish-crates:
-    name: Publish recorded Rust crates to crates.io
-    needs: [candidate-preflight, publish-npm]
+    name: Dependency-ordered crates lane
+    needs: candidate-preflight
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.candidate-preflight.outputs.release_sha }}
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.96.0"
+      - name: Download manifest and crates partition
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ needs.candidate-preflight.outputs.candidate_run_id }}
+          RELEASE_SHA: ${{ needs.candidate-preflight.outputs.release_sha }}
+        run: |
+          gh run download "$RUN_ID" --name "M1-Release-Candidate-manifest-$RELEASE_SHA" --dir candidate
+          gh run download "$RUN_ID" --name "M1-Release-Candidate-crates-$RELEASE_SHA" --dir candidate/release-artifacts/crates
+      - name: Publish dependency-ready crates with one observation per accepted write
+        shell: bash
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          RELEASE_SHA: ${{ needs.candidate-preflight.outputs.release_sha }}
+          RELEASE_VERSION: ${{ needs.candidate-preflight.outputs.release_version }}
+          MANIFEST_NAME: ${{ needs.candidate-preflight.outputs.manifest_name }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.candidate-preflight.outputs.release_tag }}
+        run: |
+          now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          bash scripts/ci/download-release-write-evidence.sh "$RELEASE_TAG" "$RELEASE_VERSION" write-evidence
+          python3 scripts/ci/release_action.py validate-partition --manifest "candidate/$MANIFEST_NAME" --artifacts-dir candidate/release-artifacts --group crates --expected-sha "$RELEASE_SHA" --version "$RELEASE_VERSION" --checked-at "$now"
+          python3 scripts/ci/release_registry.py observe-all --manifest "candidate/$MANIFEST_NAME" --registry crates --attempts-dir write-evidence/attempts --receipts-dir write-evidence/receipts --observed-at "$now" --out observations.json
+          printf '{"python":false,"npm":false,"crates":true,"evidence":false}\n' > availability.json
+          while IFS= read -r crate; do
+            node="crates:$crate"
+            planned_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            python3 scripts/ci/release_action.py authorize --manifest "candidate/$MANIFEST_NAME" --observations observations.json --availability availability.json --node "$node" --planned-at "$planned_at" --out authorization.json
+            if test "$(jq -r .publish authorization.json)" = false; then
+              continue
+            fi
+            attempt="v$RELEASE_VERSION-attempt-crates-$crate.json"
+            python3 scripts/ci/release_action.py attempt --manifest "candidate/$MANIFEST_NAME" --node "$node" --started-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --out "$attempt"
+            gh release upload "$RELEASE_TAG" "$attempt"
+            python3 scripts/publish_crates.py --release-record "candidate/$MANIFEST_NAME" --artifacts-dir candidate/release-artifacts --crate "$crate"
+            accepted_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            receipt="v$RELEASE_VERSION-accepted-crates-$crate.json"
+            python3 scripts/ci/release_action.py receipt --manifest "candidate/$MANIFEST_NAME" --node "$node" --accepted-at "$accepted_at" --out "$receipt"
+            gh release upload "$RELEASE_TAG" "$receipt"
+            python3 scripts/ci/release_registry.py observe --manifest "candidate/$MANIFEST_NAME" --node "$node" --live --accepted-receipt "$receipt" --observed-at "$accepted_at" --out post-write.json
+            jq --arg node "$node" --slurpfile current post-write.json '.observations = ([.observations[] | select(.node_id != $node)] + $current)' observations.json > observations.next.json
+            mv observations.next.json observations.json
+            if test "$(jq -r .state post-write.json)" != verified; then
+              break
+            fi
+          done < <(python3 scripts/ci/crate-publish-plan.py list)
+
+  reconcile:
+    name: Always reconcile all 24 public nodes
+    if: always()
+    needs:
+      - candidate-preflight
+      - publish-pypi
+      - npm-native
+      - npm-main
+      - npm-cli
+      - npm-skills
+      - publish-crates
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       actions: read
@@ -314,26 +609,59 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ needs.candidate-preflight.outputs.release_sha }}
-
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: "1.96.0"
-
-      - name: Download exact-SHA candidate
+          ref: ${{ needs.candidate-preflight.outputs.release_sha || github.sha }}
+      - name: Download retained manifest when available
+        if: needs.candidate-preflight.result == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ needs.candidate-preflight.outputs.candidate_run_id }}
           RELEASE_SHA: ${{ needs.candidate-preflight.outputs.release_sha }}
-          CANDIDATE_RUN_ID: ${{ needs.candidate-preflight.outputs.candidate_run_id }}
-        run: >-
-          gh run download "$CANDIDATE_RUN_ID"
-          --name "M1-Release-Candidate-$RELEASE_SHA"
-          --dir candidate
-
-      - name: Publish the complete ordered Rust surface
-        run: >-
-          python3 scripts/publish_crates.py
-          --release-record candidate/v0.5.0-artifacts.json
-          --artifacts-dir candidate/release-artifacts
+        run: gh run download "$RUN_ID" --name "M1-Release-Candidate-manifest-$RELEASE_SHA" --dir candidate
+      - name: Reconcile from live registry truth and every job outcome
+        shell: bash
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          PREFLIGHT_RESULT: ${{ needs.candidate-preflight.result }}
+          PYPI_RESULT: ${{ needs.publish-pypi.result }}
+          NATIVE_RESULT: ${{ needs.npm-native.result }}
+          MAIN_RESULT: ${{ needs.npm-main.result }}
+          CLI_RESULT: ${{ needs.npm-cli.result }}
+          SKILLS_RESULT: ${{ needs.npm-skills.result }}
+          CRATES_RESULT: ${{ needs.publish-crates.result }}
+          MANIFEST_NAME: ${{ needs.candidate-preflight.outputs.manifest_name }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.candidate-preflight.outputs.release_tag }}
+          RELEASE_VERSION: ${{ needs.candidate-preflight.outputs.release_version }}
+        run: |
+          mkdir -p reconciliation
+          if test "$PREFLIGHT_RESULT" = success && test -f "candidate/$MANIFEST_NAME"; then
+            bash scripts/ci/download-release-write-evidence.sh \
+              "$RELEASE_TAG" "$RELEASE_VERSION" write-evidence
+            now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            python3 scripts/ci/release_registry.py observe-all --manifest "candidate/$MANIFEST_NAME" --attempts-dir write-evidence/attempts --receipts-dir write-evidence/receipts --observed-at "$now" --out observations.json
+            printf '{"python":true,"npm":true,"crates":true,"evidence":true}\n' > availability.json
+            jq -n --arg pypi "$PYPI_RESULT" --arg native "$NATIVE_RESULT" --arg main "$MAIN_RESULT" --arg cli "$CLI_RESULT" --arg skills "$SKILLS_RESULT" --arg crates "$CRATES_RESULT" '{"pypi:graphforge":$pypi,"npm:@curatelabs/graphforge-darwin-arm64":$native,"npm:@curatelabs/graphforge-darwin-x64":$native,"npm:@curatelabs/graphforge-linux-arm64-gnu":$native,"npm:@curatelabs/graphforge-linux-x64-gnu":$native,"npm:@curatelabs/graphforge-win32-x64-msvc":$native,"npm:@curatelabs/graphforge":$main,"npm:@curatelabs/graphforge-cli":$cli,"npm:@curatelabs/graphforge-agent-skills":$skills}' > job-outcomes.json
+            for crate in $(python3 scripts/ci/crate-publish-plan.py list); do jq --arg node "crates:$crate" --arg result "$CRATES_RESULT" '. + {($node):$result}' job-outcomes.json > job-outcomes.next.json; mv job-outcomes.next.json job-outcomes.json; done
+            python3 scripts/ci/release_rehearsal.py reconcile --manifest "candidate/$MANIFEST_NAME" --observations observations.json --availability availability.json --job-outcomes job-outcomes.json --reconciled-at "$now" --out reconciliation/summary.json
+          else
+            python3 - <<'PY'
+          import json, os
+          from pathlib import Path
+          import sys
+          sys.path.insert(0, "scripts/ci")
+          from release_candidate_manifest import CRATES, NPM_PACKAGES
+          nodes = ["pypi:graphforge", *(f"npm:{name}" for name in NPM_PACKAGES), *(f"crates:{name}" for name in CRATES)]
+          result = {"schema":"graphforge-release-reconciliation-v1","candidate_available":False,"complete":False,"nodes":[{"node_id":node,"registry_state":"indeterminate","disposition":"blocked_candidate_unavailable","job_outcome":"not_scheduled"} for node in sorted(nodes)],"jobs":{"candidate-preflight":os.environ["PREFLIGHT_RESULT"],"publish-pypi":os.environ["PYPI_RESULT"],"npm-native":os.environ["NATIVE_RESULT"],"npm-main":os.environ["MAIN_RESULT"],"npm-cli":os.environ["CLI_RESULT"],"npm-skills":os.environ["SKILLS_RESULT"],"publish-crates":os.environ["CRATES_RESULT"]}}
+          Path("reconciliation/summary.json").write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+          PY
+          fi
+          jq '{complete, nodes: (.nodes | length), summary, jobs}' reconciliation/summary.json >> "$GITHUB_STEP_SUMMARY"
+      - name: Retain reconciliation summary
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: M1-Release-Reconciliation-${{ github.run_id }}
+          path: reconciliation/summary.json
+          if-no-files-found: error
+          retention-days: 30
+      - name: Require complete public verification
+        run: jq -e '.complete == true and (.nodes | length) == 24' reconciliation/summary.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Partition the immutable candidate into independently retained Python, npm,
+  crates, evidence, and manifest artifacts; authorize every write from fresh
+  registry truth; parallelize only the five native npm packages with verified
+  main/CLI/skills fan-in; isolate registry credentials; remove polling sleeps;
+  and always reconcile all 24 public nodes across partial job outcomes (#296).
 - Add a deterministic pre-write release rehearsal that installs and executes
   the exact candidate through clean Python, Node/native, CLI, and agent-skills
   consumers, validates all crate packages and dependencies, and proves the

--- a/docs/development/publication-order.md
+++ b/docs/development/publication-order.md
@@ -1,102 +1,83 @@
-# Publication order and rollback (v0.5.0)
+# Publication and recovery order (v0.5.1)
 
-This is the written publication order and stop/rollback policy for GraphForge
-registry publication. §6 executors follow this document; do not invent a
-different order at publish time.
+GraphForge v0.5.1 is one 24-node release: 15 crates.io crates, one PyPI
+project, five native npm packages, the npm main package, CLI, and agent skills.
+[ADR 0017](../adr/0017-unified-release-version.md) forbids a registry-specific
+version. Existing v0.5.0 tags, records, supplements, and published packages are
+immutable incident evidence; the v2 workflow rejects v0.5.0 rather than
+mutating or reinterpreting those records.
 
-Tracks the human release-close issue
-[#192](https://github.com/CurateLabs/graphforge/issues/192) and its ordered
-native publication children [#193](https://github.com/CurateLabs/graphforge/issues/193)
-through [#199](https://github.com/CurateLabs/graphforge/issues/199).
+This document describes the executable order in
+`.github/workflows/publish.yaml`. It does not authorize a tag, GitHub Release,
+or registry write.
 
-Related operational docs:
-[`PUBLISHING.md`](../engineering/PUBLISHING.md),
-[`release-process.md`](release-process.md),
-`.github/workflows/publish.yaml`.
+## Candidate preconditions
 
-## Shared-version invariant
+Before a maintainer authorizes publication:
 
-[ADR 0017](../adr/0017-unified-release-version.md) applies to every normal and
-recovery path. The 15 public crates, PyPI package, npm main/native packages,
-CLI, and agent skills form one release set with one exact version. Package jobs
-may resume independently, but package versions may not.
+1. The intended tag resolves to the current reviewed `main` commit and the root
+   version is aligned across Cargo, PyPI, Node/native npm, CLI, and agent skills.
+2. A successful same-SHA Binding Release Candidate run retains five 30-day
+   artifacts: `manifest`, `python`, `npm`, `crates`, and `evidence`.
+3. The v2 manifest validates the complete file inventory and dependency graph.
+   A matching checksum alone is not sufficient.
+4. `evidence/offline-rehearsal.json` proves the exact partitions passed clean
+   Python, Node/native, CLI, and skills consumers and crate/dependency checks
+   with zero registry writes.
+5. PyPI trusted publishing is configured for `CurateLabs/graphforge` and
+   `publish.yaml`; the npm token has scoped public-package write access and
+   Bypass 2FA; the crates.io token belongs to `DecisionNerd`.
+6. The maintainer explicitly decides to create the immutable v0.5.1 tag and
+   GitHub Release. Implementation CI and ordinary issue close do not run a
+   release-certification cascade.
 
-A partial publication has only two valid dispositions: resume an absent
-artifact from the same immutable candidate, or prepare one coordinated new
-version for the complete release set. A plan that advances only an adapter,
-registry, native package, CLI, skills package, or crate fails before every
-write. Existing tags, release records, and registry artifacts remain immutable
-historical evidence.
+## Planner-driven execution
 
-## Preconditions (must be true before step 1)
+Every lane downloads the small manifest and only its registry partition,
+revalidates those exact bytes, obtains fresh public registry observations, and
+asks the pure recovery planner to authorize one node. `verified` nodes are
+skipped. Only an authoritatively `absent`, dependency-ready node with an
+unexpired partition receives a write action. Conflict, indeterminate state,
+failed observation, pending visibility, missing artifacts, or unverified
+dependencies stop the lane.
 
-1. §5 version freeze is complete: Cargo workspace, Python binding, Node binding,
-   NPX CLI/skills, and generated metadata all report `0.5.0` (not `0.5.0-dev` /
-   `0.5.0.dev0`) on the intended RC commit.
-2. A successful same-SHA `Binding Release Candidate` run has retained
-   `M1-Release-Candidate-<sha>` for 30 days. That bundle contains the tested
-   wheels/addons, Python sdist, all npm tarballs, all 15 `.crate` archives,
-   publication dry-run evidence, license reports, and
-   `v0.5.0-artifacts.json`. Publication consumes this bundle; it does not
-   rebuild Python/npm bytes.
-3. First-party packages declare `Apache-2.0` with `LICENSE` / `NOTICE` (and
-   third-party notices intact), and the public legal surface in
-   [#200](https://github.com/CurateLabs/graphforge/issues/200) is complete.
-4. Dry-runs are green for applicable surfaces: Python sdist/wheel packaging and
-   clean install, `npm publish --dry-run` for Node + CLI + skills, and docs
-   preview. All 15 Rust crates pass package inventory checks; the topological
-   publish plan passes before any crates.io write.
-5. Required release-certification evidence for the RC SHA is assembled per
-   `AGENTS.md` / `#192` (Binding RC, load matrix, gates as required for
-   **publication**, not for ordinary child-issue close).
-6. The embedded write modes in
-   [#211](https://github.com/CurateLabs/graphforge/issues/211) and the
-   Apache-2.0 outcome in
-   [#218](https://github.com/CurateLabs/graphforge/issues/218) are complete.
-7. Secrets, trusted-publisher configuration, registry ownership, and explicit
-   maintainer publication authorization are in place (see Human blockers).
+The independent work is:
 
-## Ordered execution
+- PyPI may run independently with OIDC and the Python partition.
+- crates.io may run independently with only its token and the crates partition;
+  crates remain in the checked topological order below.
+- the five native npm packages run as a fail-slow parallel matrix with only the
+  npm token and npm partition.
 
-Execute **in this order**. Do not start a later step until the prior step has
-deterministic success evidence (or an explicit maintainer disposition to skip).
+The npm dependency fan-in is strict:
 
-| Step | Action | Issue | Evidence |
-| --- | --- | --- | --- |
-| 1 | Annotate tag `v0.5.0` on the verified RC commit on `main` | [#193](https://github.com/CurateLabs/graphforge/issues/193) | `git rev-parse v0.5.0^{}` == RC SHA |
-| 2 | Publish GitHub Release for `v0.5.0` with final CHANGELOG notes + checksum links/attachments | [#194](https://github.com/CurateLabs/graphforge/issues/194) | Release URL; notes match CHANGELOG; `Publish to PyPI, npm, and crates.io` run starts |
-| 3 | `publish.yaml` builds and publishes **Python** to PyPI | [#195](https://github.com/CurateLabs/graphforge/issues/195) | Workflow green; `graphforge==0.5.0` on PyPI; checksums match RC record |
-| 4 | Same workflow publishes **Node** `@curatelabs/graphforge` and platform packages to npm | [#198](https://github.com/CurateLabs/graphforge/issues/198) | npm `0.5.0`; target inventory and checksums match |
-| 5 | Same workflow publishes **NPX CLI** `@curatelabs/graphforge-cli` to npm | [#198](https://github.com/CurateLabs/graphforge/issues/198) | npm `0.5.0`; clean-consumer handoff passed |
-| 6 | Same workflow publishes **NPX skills** `@curatelabs/graphforge-agent-skills` to npm | [#198](https://github.com/CurateLabs/graphforge/issues/198) | npm `0.5.0`; packed offline contract passed |
-| 7 | Same workflow publishes the complete 15-crate **Rust** surface to crates.io in dependency order | [#196](https://github.com/CurateLabs/graphforge/issues/196) | Workflow green; all packages at `0.5.0`; checksums match; `DecisionNerd` owns each crate |
-| 8 | Deploy / confirm documentation for the release commit/tag | [#197](https://github.com/CurateLabs/graphforge/issues/197) | Pages run green; live anonymous URLs serve the RC docs set |
-| 9 | Verify registry/package **metadata** (repo, license, docs, tag) | [#199](https://github.com/CurateLabs/graphforge/issues/199) | Concise surface checklist on #199 |
+```text
+five native packages (parallel)
+            ↓ fresh public verification of all five
+@curatelabs/graphforge
+            ↓ fresh public verification
+@curatelabs/graphforge-cli
+            ↓ fresh public verification
+@curatelabs/graphforge-agent-skills
+```
 
-Notes:
+A successful upload response creates a sanitized accepted-write receipt. The
+lane performs exactly one immediate public observation. It never polls, sleeps,
+blindly retries, or repeats a pending write. If propagation has not completed,
+the observation is `accepted_pending_visibility`; a later recovery dispatch
+performs another bounded observation rather than another upload.
 
-- Steps 3–7 are automated by `.github/workflows/publish.yaml` once the GitHub
-  Release is published. It resolves the successful, unexpired same-SHA
-  `Binding Release Candidate` run, validates every recorded checksum, and
-  attaches the checksum record before its first registry write. Python and npm
-  publish the exact retained files. The crates.io publisher re-packages the
-  immutable tagged tree only after proving each deterministic `.crate`
-  checksum equals the retained record. Maintainers watch that run; they do not
-  rebuild different bytes under `0.5.0` if a job fails.
-- Before any registry write, the workflow requires the release tag, current
-  `main` SHA, five version surfaces, dated CHANGELOG section, Apache-2.0 policy,
-  and npm publishing identity to pass its fail-closed preflight.
-- Docs deploy today follows `docs.yml` on `main` (GitHub Pages). Step 8 confirms
-  the release SHA’s docs set is what is live (or redeploys that SHA); it does
-  not authorize inventing a second docs tree under the same version label.
-- Clean-environment verification after publication is tracked by
-  [#167](https://github.com/CurateLabs/graphforge/issues/167), not this order.
+Immediately before a write, the lane persists an immutable attempt record on
+the same GitHub Release. A successful registry response adds a separate
+accepted receipt. Later preflight and reconciliation runs load both before
+observing. A 404 after an accepted receipt is pending; a 404 after an attempt
+without an accepted receipt is indeterminate because a cancelled or timed-out
+job may have crossed the registry boundary. Neither state permits a repeat
+write. Exhausted evidence requires a human decision.
 
-## Crates.io dependency order
+## Crates.io order
 
-Rust crates publish in topological order of workspace path dependencies. The
-Python and Node binding implementation crates remain private to Cargo because
-their public artifacts ship through PyPI/npm; the Rust CLI is public:
+The finite order is generated by `scripts/ci/crate-publish-plan.py`:
 
 1. `graphforge-core`
 2. `graphforge-ast`
@@ -114,95 +95,52 @@ their public artifacts ship through PyPI/npm; the Rust CLI is public:
 14. `graphforge-api`
 15. `graphforge-cli`
 
-Generate or verify this list with:
+Each invocation validates the retained `.crate` checksum before `cargo publish`.
+After an accepted write it observes the public version once. A verified result
+may unlock the next crate; pending or unsafe truth stops the finite loop.
 
-```bash
-python3 scripts/ci/crate-publish-plan.py list
-python3 scripts/ci/crate-publish-plan.py check
-```
+## Always-running reconciliation
 
-`check` fails closed on non-`graphforge-*` names, missing `version` alongside
-normal path dependencies (required for `cargo publish`), and cycles. Workspace
-dev-dependencies remain path-only so Cargo excludes those test-only edges from
-published manifests, preventing first-publication cycles.
+The final job uses `if: always()` and records every lane conclusion, including
+failure, cancellation, timeout, and skip. When the candidate is available it
+re-observes all three registries and produces one stable 24-node summary. Job
+history is operator context only; registry state and the next safe actions come
+from the immutable candidate plus live registry truth.
 
-### Crates.io publication decision (v0.5.0)
+If candidate preflight failed before a manifest was available, reconciliation
+still emits all 24 node identities as `indeterminate` and identifies the
+candidate blocker. The workflow is green only when all 24 nodes are publicly
+`verified`. The summary is retained for 30 days and contains no credentials,
+headers, cookies, tokens, or raw registry bodies.
 
-**Final maintainer decision:** GraphForge v0.5.0 publishes the complete
-15-crate Rust surface above to crates.io under `graphforge-*` names. This is
-tracked by [#196](https://github.com/CurateLabs/graphforge/issues/196); no
-partial alternative package set is permitted.
+## Recovery and stop conditions
 
-The previous `gf-*` names were abandoned because `gf-core` and `gf-cli` are
-owned by unrelated projects. On 2026-07-31 the official crates.io API returned
-not-found for all 15 `graphforge-*` names. Every normal workspace path
-dependency declares both `path` and version `0.5.0` so Cargo can publish the
-runtime graph; path-only dev-dependencies are intentionally not published.
+Re-run `publish.yaml` only for the same immutable v0.5.1 tag and provide a
+public recovery reason. The new run re-observes the registries, skips verified
+nodes without downloading unrelated partitions, and schedules only eligible
+absent work.
 
-The evidence command remains:
+Stop and require a human decision when:
 
-```bash
-python3 scripts/ci/crate-publish-plan.py check
-```
+- an existing public identity has different bytes, metadata, dependency
+  versions, license, ownership, or file inventory (`conflict`);
+- registry truth is unavailable, stale, rate-limited, malformed, or past the
+  bounded visibility window (`indeterminate`);
+- retained artifacts are missing or expired;
+- a credential or trusted-publisher configuration fails; or
+- correction would require different bytes or a different version.
 
-The release workflow invokes `scripts/publish_crates.py` after the npm surfaces.
-That publisher packages each crate, checks its SHA-256, publishes once, waits
-for crates.io indexing, verifies `DecisionNerd` ownership, and resumes only
-when an existing `0.5.0` checksum matches the local archive.
+Never move a tag, replace a release asset with different bytes, weaken a check,
+or advance only an adapter. For incorrect public bytes, use the registry's
+yank/deprecate mechanism and prepare one coordinated later GraphForge version.
 
-## Stop conditions
+## Remaining human decisions
 
-Stop the release train immediately if any of the following occur:
+Automation stops before these actions unless separately authorized:
 
-1. Any step fails (tag, GitHub Release, PyPI, npm Node, npm skills, crates.io,
-   docs deploy, or metadata verification).
-2. Published bytes would differ from the RC artifact record / checksums for
-   `0.5.0`.
-3. A registry rejects the package for license, ownership, name conflict, or
-   trusted-publishing misconfiguration.
-4. Legal or maintainer halt.
-
-**Hard rule:** do not rebuild different bytes and re-publish under the same
-version. Yank or deprecate per registry rules if needed; cut a new patch
-version for corrected bits.
-
-## Rollback
-
-| Surface | Recovery |
-| --- | --- |
-| Annotated tag | Do **not** move `v0.5.0` to another commit. Leave the tag; cut `v0.5.1` (or later) for corrections. |
-| GitHub Release | Edit notes only if text-only; do not replace attached artifacts with different checksums under the same tag. |
-| PyPI | Yank the bad file(s) if policy allows; publish a new version for fixed bits. |
-| npm | Deprecate or unpublish per npm policy; publish a new version for fixed bits. |
-| crates.io | Yank the bad version; publish a new version for fixed bits. |
-| Docs site | Redeploy last known-good commit from `main` / Pages history. |
-
-Agents assemble evidence and automation; maintainers authorize execution and
-final #192 close.
-
-## Human blockers (checklist)
-
-- [ ] Version freeze PR merged on the RC commit and every SHA-bound release
-      certification workflow passes for that exact commit
-- [ ] The same-SHA `Binding Release Candidate` run contains an unexpired
-      `M1-Release-Candidate-<sha>` bundle and its release record validates
-- [x] The owned npm organization is `@curatelabs`; do not publish the retired
-      `@graphforge/*` candidate names
-- [ ] `NPM_TOKEN` is a granular token with read/write package and scope access
-      to `@curatelabs`, has **Bypass 2FA** enabled, is stored as a repository
-      Actions secret, and passes the workflow's `npm whoami` preflight
-- [ ] After the first publish, configure trusted publishing for each npm package
-      before removing the token path; npm requires an existing package and a
-      supported GitHub-hosted runner
-- [ ] PyPI trusted publishing OIDC is configured for
-      `CurateLabs/graphforge`, workflow `publish.yaml`, with no environment name
-- [x] All 15 `graphforge-*` names were available on crates.io when checked
-- [x] The crates.io credential is stored in Pulumi ESC
-      `curatelabs/graphforge/release` and projected to the repository's
-      encrypted `CARGO_REGISTRY_TOKEN` Actions secret
-- [x] Public Apache-2.0 legal and contribution docs are deployed (#200)
-- [ ] Maintainer authorization to create annotated tag + GitHub Release
-- [x] Repository and release documentation are publicly readable
-
-The exact operator commands, evidence queries, and stop points are in
-[`v0.5.0-release-operator-runbook.md`](v0.5.0-release-operator-runbook.md).
+- choose the final v0.5.1 commit after normal exact-head PR CI;
+- create the immutable v0.5.1 tag and GitHub Release;
+- allow the release-triggered publication workflow to make registry writes;
+- decide any registry-specific yank/deprecation if reconciliation finds a
+  conflict; and
+- close the human release tracker only after the 24-node summary is complete.

--- a/docs/development/release-artifact-record.md
+++ b/docs/development/release-artifact-record.md
@@ -183,3 +183,22 @@ future write. Accepted-but-not-visible packages receive only a bounded
 visibility check; conflict, indeterminate state, and expired artifacts remain
 blocked. Every scenario lists every node, its registry state, disposition, and
 sanitized job outcome without credentials or raw registry bodies.
+
+## Partitioned orchestration
+
+The Binding Release Candidate retains the manifest and its `python`, `npm`,
+`crates`, and `evidence` groups as five separately downloadable 30-day
+artifacts. Publication jobs download the manifest plus only their own registry
+group and run `release_action.py validate-partition` before observing or
+writing. The five native npm packages are the only parallel publication
+matrix; fresh verification fans into main, CLI, and skills. PyPI and crates.io
+remain independent, credential-isolated lanes.
+
+Before a write the lane persists a sanitized immutable attempt record; after a
+successful registry response it persists an accepted receipt and performs one
+public observation. Later recovery runs load both, so cancellation, timeout,
+or propagation delay cannot become permission for a second write. There is no polling loop. The `always()`
+reconciliation job then observes all 24 nodes and combines those states with
+job conclusions for operator context. See
+[`publication-order.md`](publication-order.md) for the recovery and human stop
+decisions.

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -207,7 +207,7 @@ GraphForge is currently in **0.x.x** (pre-1.0.0):
 
 ## Creating a Release
 
-For v0.5.0 registry sequencing, stop conditions, and rollback, follow
+For current v0.5.1 registry sequencing, stop conditions, and rollback, follow
 [`publication-order.md`](publication-order.md) (authoritative for §5/§6).
 
 ### Step-by-Step Guide

--- a/docs/engineering/PUBLISHING.md
+++ b/docs/engineering/PUBLISHING.md
@@ -30,9 +30,9 @@ multi-tenant service. Operational detail:
   [`../development/release-process.md`](../development/release-process.md).
 - Commit messages follow Conventional Commit–style scopes used in the repo history; do not
   add new enforcement without maintainer agreement.
-- Release close-out for v0.5.0 is human-authorized on
-  [#192](https://github.com/CurateLabs/graphforge/issues/192);
-  docs/legal trackers stay open until manual approval.
+- M1 release close-out now targets one coordinated v0.5.1 publication on
+  [#192](https://github.com/CurateLabs/graphforge/issues/192). The partial
+  v0.5.0 records remain immutable historical evidence.
 
 ## Build and continuous delivery
 
@@ -55,10 +55,12 @@ make publish-dry-run-cargo
 # Node / CLI / skills: npm publish --dry-run
 ```
 
-The release-event workflow runs `release-publish-preflight.py` and `npm whoami`
-before any registry write. The release tag must resolve to the current certified
-`main` SHA; Cargo, Python, Node, CLI, and skills versions must match the tag;
-the dated CHANGELOG section must be cut; and the npm token must authenticate.
+The release-event workflow runs `release-publish-preflight.py`, validates the
+complete partitioned candidate and offline rehearsal, and obtains fresh public
+registry truth before any registry write. The release tag must resolve to the
+reviewed `main` SHA; Cargo, Python, Node, CLI, and skills versions must match
+the tag; and the dated CHANGELOG section must be cut. `npm whoami` runs only in
+an npm write step so registry credentials remain isolated.
 
 Required TESTING.md gates (TCK, contract gates applicable to the release, binding RC evidence)
 must be green on the **same SHA** that is tagged for publication.
@@ -68,7 +70,7 @@ must be green on the **same SHA** that is tagged for publication.
 | From | To | Required evidence / approval |
 | --- | --- | --- |
 | PR branch | `main` | Focused PR, green CI Gate, clean review threads |
-| `main` SHA | Release candidate | Milestone gates for the release issue (#192 for v0.5.0) |
+| `main` SHA | Release candidate | Complete v0.5.1 candidate manifest and offline rehearsal for #192 |
 | Release candidate | Registries + GitHub Release | Dry-runs, checksums/SBOM where configured, human release execution |
 | Published artifacts | Clean-install verification | Fresh pip/npm/Cargo consumers use only public registries |
 | `main` docs | Public docs site | Green `docs.yml` / Starlight build for the deployed commit |
@@ -97,8 +99,8 @@ Authoritative stop/rollback table:
 - **GitHub Release / tag:** do not move an annotated release tag to a different commit; cut a
   new patch version if needed.
 - **Docs site:** redeploy last known-good commit from `main` / hosting history.
-- Authority: maintainers executing the release plan; agents assemble evidence but do not
-  authorize final #192 closure.
+- Authority: maintainers explicitly authorize the immutable tag, GitHub
+  Release, registry writes, and final #192 closure.
 
 ## Official references
 

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Partition the immutable candidate into independently retained Python, npm,
+  crates, evidence, and manifest artifacts; authorize every write from fresh
+  registry truth; parallelize only the five native npm packages with verified
+  main/CLI/skills fan-in; isolate registry credentials; remove polling sleeps;
+  and always reconcile all 24 public nodes across partial job outcomes (#296).
 - Add a deterministic pre-write release rehearsal that installs and executes
   the exact candidate through clean Python, Node/native, CLI, and agent-skills
   consumers, validates all crate packages and dependencies, and proves the

--- a/scripts/ci/download-release-write-evidence.sh
+++ b/scripts/ci/download-release-write-evidence.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+release_tag="${1:?release tag is required}"
+release_version="${2:?release version is required}"
+destination="${3:?destination is required}"
+
+mkdir -p "$destination/attempts" "$destination/receipts"
+assets="$(gh release view "$release_tag" --json assets --jq '.assets[].name')"
+has_attempt=false
+has_receipt=false
+while IFS= read -r asset; do
+  case "$asset" in
+    "v$release_version-attempt-"*.json) has_attempt=true ;;
+    "v$release_version-accepted-"*.json) has_receipt=true ;;
+  esac
+done <<<"$assets"
+
+if test "$has_attempt" = true; then
+  gh release download "$release_tag" \
+    --pattern "v$release_version-attempt-*.json" \
+    --dir "$destination/attempts"
+fi
+
+if test "$has_receipt" = true; then
+  gh release download "$release_tag" \
+    --pattern "v$release_version-accepted-*.json" \
+    --dir "$destination/receipts"
+fi

--- a/scripts/ci/release_action.py
+++ b/scripts/ci/release_action.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Validate a retained partition and authorize one release-graph action."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timedelta, timezone
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+import release_candidate_manifest as candidate
+import release_registry as registry
+
+
+class ActionError(ValueError):
+    """A partition or requested action is not safe to execute."""
+
+
+def _load(path: Path, context: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ActionError(f"cannot read {context} {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise ActionError(f"{context} must be a JSON object")
+    return value
+
+
+def validate_partition(
+    manifest: dict[str, Any],
+    artifacts_dir: Path,
+    group_id: str,
+    *,
+    expected_sha: str,
+    version: str,
+    checked_at: str,
+) -> dict[str, Any]:
+    if manifest.get("schema") != candidate.SCHEMA:
+        raise ActionError("partition publication requires the v2 candidate manifest")
+    if manifest.get("commit_sha") != expected_sha:
+        raise ActionError("partition candidate SHA diverges")
+    if manifest.get("version") != version or manifest.get("tag") != f"v{version}":
+        raise ActionError("partition root version diverges")
+    try:
+        now = datetime.fromisoformat(checked_at.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ActionError("checked_at must be an ISO-8601 timestamp") from error
+    if now.tzinfo is None:
+        raise ActionError("checked_at must include a timezone")
+    groups = {
+        group.get("id"): group
+        for group in manifest.get("artifact_groups", [])
+        if isinstance(group, dict)
+    }
+    if group_id not in candidate.GROUPS or set(groups) != set(candidate.GROUPS):
+        raise ActionError("candidate artifact groups are incomplete")
+    group = groups[group_id]
+    try:
+        expiry = datetime.fromisoformat(str(group.get("expires_at")).replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ActionError(f"artifact partition {group_id} expiry is invalid") from error
+    if now >= expiry:
+        raise ActionError(f"artifact partition {group_id} has expired")
+    expected_paths = group.get("artifact_paths")
+    if not isinstance(expected_paths, list) or not expected_paths:
+        raise ActionError(f"artifact partition {group_id} is empty")
+    by_path = {
+        item.get("path"): item
+        for item in manifest.get("artifacts", [])
+        if isinstance(item, dict) and item.get("group") == group_id
+    }
+    if set(by_path) != set(expected_paths):
+        raise ActionError(f"artifact partition {group_id} inventory diverges")
+    actual_paths = {
+        path.relative_to(artifacts_dir).as_posix()
+        for path in artifacts_dir.rglob("*")
+        if path.is_file() and not path.name.startswith(".")
+    }
+    if actual_paths != set(expected_paths):
+        raise ActionError(
+            f"artifact partition {group_id} files diverge: "
+            f"missing={sorted(set(expected_paths) - actual_paths)} "
+            f"extra={sorted(actual_paths - set(expected_paths))}"
+        )
+    for relative in sorted(expected_paths):
+        item = by_path[relative]
+        path = artifacts_dir / relative
+        if item.get("version") != version:
+            raise ActionError(f"partition artifact version diverges: {relative}")
+        if path.stat().st_size != item.get("bytes"):
+            raise ActionError(f"partition artifact byte count diverges: {relative}")
+        if candidate.sha256_file(path) != item.get("sha256"):
+            raise ActionError(f"partition artifact checksum diverges: {relative}")
+        integrities = candidate._integrities(path)
+        if item.get("integrity") != integrities[0] or item.get("integrities") != integrities:
+            raise ActionError(f"partition artifact integrity diverges: {relative}")
+        artifact_class = item.get("class")
+        if artifact_class in {"python-wheel", "python-sdist", "npm-tarball", "rust-crate"}:
+            if item.get("archive") != candidate.inspect_archive(path, artifact_class, version):
+                raise ActionError(f"partition archive completeness diverges: {relative}")
+    return {
+        "schema": "graphforge-release-partition-validation-v1",
+        "candidate_sha": expected_sha,
+        "version": version,
+        "group": group_id,
+        "checked_at": now.astimezone(timezone.utc).isoformat(),
+        "artifact_paths": sorted(expected_paths),
+        "status": "passed",
+    }
+
+
+def authorize(
+    manifest: dict[str, Any],
+    observations: dict[str, Any],
+    availability: dict[str, Any],
+    node_id: str,
+    *,
+    planned_at: str,
+) -> dict[str, Any]:
+    node = next((item for item in manifest.get("nodes", []) if item.get("id") == node_id), None)
+    if node is None:
+        raise ActionError(f"requested node is not in the candidate: {node_id}")
+    plan = registry.plan_recovery(
+        manifest,
+        observations,
+        availability,
+        planned_at=planned_at,
+        registries={node["registry"]},
+    )
+    decision = next(item for item in plan["decisions"] if item["node_id"] == node_id)
+    action = next((item for item in plan["actions"] if item["node_id"] == node_id), None)
+    if decision["disposition"] not in {"publish", "skip_verified"}:
+        raise ActionError(
+            f"node {node_id} is not safe to publish: "
+            f"{decision['disposition']} ({decision['state']})"
+        )
+    return {
+        "schema": "graphforge-release-action-authorization-v1",
+        "candidate_sha": manifest["commit_sha"],
+        "version": manifest["version"],
+        "node_id": node_id,
+        "registry": node["registry"],
+        "disposition": decision["disposition"],
+        "publish": decision["disposition"] == "publish",
+        "artifact_paths": action.get("artifact_paths", []) if action else [],
+        "credential_scope": action.get("credential_scope") if action else None,
+    }
+
+
+def accepted_receipt(manifest: dict[str, Any], node_id: str, *, accepted_at: str) -> dict[str, Any]:
+    if node_id not in {node.get("id") for node in manifest.get("nodes", [])}:
+        raise ActionError("accepted receipt node is outside the candidate")
+    try:
+        moment = datetime.fromisoformat(accepted_at.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ActionError("accepted_at must be an ISO-8601 timestamp") from error
+    if moment.tzinfo is None:
+        raise ActionError("accepted_at must include a timezone")
+    moment = moment.astimezone(timezone.utc)
+    return {
+        "node_id": node_id,
+        "version": manifest["version"],
+        "accepted_at": moment.isoformat(),
+        "visibility_deadline": (moment + timedelta(minutes=15)).isoformat(),
+        "observation_count": 0,
+    }
+
+
+def write_attempt(manifest: dict[str, Any], node_id: str, *, started_at: str) -> dict[str, Any]:
+    if node_id not in {node.get("id") for node in manifest.get("nodes", [])}:
+        raise ActionError("write attempt node is outside the candidate")
+    try:
+        moment = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ActionError("started_at must be an ISO-8601 timestamp") from error
+    if moment.tzinfo is None:
+        raise ActionError("started_at must include a timezone")
+    return {
+        "schema": "graphforge-release-write-attempt-v1",
+        "node_id": node_id,
+        "version": manifest["version"],
+        "candidate_sha": manifest["commit_sha"],
+        "started_at": moment.astimezone(timezone.utc).isoformat(),
+    }
+
+
+def _write(value: dict[str, Any], output: Path | None) -> None:
+    text = json.dumps(value, indent=2, sort_keys=True) + "\n"
+    if output:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(text, encoding="utf-8")
+    else:
+        sys.stdout.write(text)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    partition = commands.add_parser("validate-partition")
+    partition.add_argument("--manifest", type=Path, required=True)
+    partition.add_argument("--artifacts-dir", type=Path, required=True)
+    partition.add_argument("--group", choices=candidate.GROUPS, required=True)
+    partition.add_argument("--expected-sha", required=True)
+    partition.add_argument("--version", required=True)
+    partition.add_argument("--checked-at", required=True)
+    partition.add_argument("--out", type=Path)
+    action = commands.add_parser("authorize")
+    action.add_argument("--manifest", type=Path, required=True)
+    action.add_argument("--observations", type=Path, required=True)
+    action.add_argument("--availability", type=Path, required=True)
+    action.add_argument("--node", required=True)
+    action.add_argument("--planned-at", required=True)
+    action.add_argument("--out", type=Path)
+    receipt = commands.add_parser("receipt")
+    receipt.add_argument("--manifest", type=Path, required=True)
+    receipt.add_argument("--node", required=True)
+    receipt.add_argument("--accepted-at", required=True)
+    receipt.add_argument("--out", type=Path)
+    attempt = commands.add_parser("attempt")
+    attempt.add_argument("--manifest", type=Path, required=True)
+    attempt.add_argument("--node", required=True)
+    attempt.add_argument("--started-at", required=True)
+    attempt.add_argument("--out", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        manifest = _load(args.manifest, "candidate manifest")
+        if args.command == "validate-partition":
+            result = validate_partition(
+                manifest,
+                args.artifacts_dir,
+                args.group,
+                expected_sha=args.expected_sha,
+                version=args.version,
+                checked_at=args.checked_at,
+            )
+        elif args.command == "authorize":
+            result = authorize(
+                manifest,
+                _load(args.observations, "registry observations"),
+                _load(args.availability, "artifact availability"),
+                args.node,
+                planned_at=args.planned_at,
+            )
+        elif args.command == "receipt":
+            result = accepted_receipt(manifest, args.node, accepted_at=args.accepted_at)
+        else:
+            result = write_attempt(manifest, args.node, started_at=args.started_at)
+        _write(result, args.out)
+        return 0
+    except (ActionError, candidate.CandidateError, registry.RegistryError) as error:
+        print(f"release-action: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/release_action.py
+++ b/scripts/ci/release_action.py
@@ -129,7 +129,9 @@ def authorize(
         planned_at=planned_at,
         registries={node["registry"]},
     )
-    decision = next(item for item in plan["decisions"] if item["node_id"] == node_id)
+    decision = next((item for item in plan["decisions"] if item["node_id"] == node_id), None)
+    if decision is None:
+        raise ActionError(f"planner returned no decision for node {node_id}")
     action = next((item for item in plan["actions"] if item["node_id"] == node_id), None)
     if decision["disposition"] not in {"publish", "skip_verified"}:
         raise ActionError(
@@ -160,8 +162,10 @@ def accepted_receipt(manifest: dict[str, Any], node_id: str, *, accepted_at: str
         raise ActionError("accepted_at must include a timezone")
     moment = moment.astimezone(timezone.utc)
     return {
+        "schema": "graphforge-release-accepted-receipt-v1",
         "node_id": node_id,
         "version": manifest["version"],
+        "candidate_sha": manifest["commit_sha"],
         "accepted_at": moment.isoformat(),
         "visibility_deadline": (moment + timedelta(minutes=15)).isoformat(),
         "observation_count": 0,

--- a/scripts/ci/release_registry.py
+++ b/scripts/ci/release_registry.py
@@ -144,10 +144,16 @@ def _receipt(
     *,
     node_id: str,
     version: str,
+    candidate_sha: str,
 ) -> dict[str, Any] | None:
     if value is None:
         return None
-    if value.get("node_id") != node_id or value.get("version") != version:
+    if (
+        value.get("schema") != "graphforge-release-accepted-receipt-v1"
+        or value.get("node_id") != node_id
+        or value.get("version") != version
+        or value.get("candidate_sha") != candidate_sha
+    ):
         raise RegistryError("accepted-write receipt identity diverges from the candidate")
     accepted_at = _parse_time(value.get("accepted_at"), field="receipt.accepted_at")
     deadline = _parse_time(value.get("visibility_deadline"), field="receipt.visibility_deadline")
@@ -385,7 +391,12 @@ def observe(
     expected = _node_expected(manifest, node_id)
     node = expected["node"]
     now = _parse_time(observed_at, field="observed_at")
-    receipt = _receipt(accepted_receipt, node_id=node_id, version=expected["version"])
+    receipt = _receipt(
+        accepted_receipt,
+        node_id=node_id,
+        version=expected["version"],
+        candidate_sha=expected["commit_sha"],
+    )
     if receipt is not None and now < _parse_time(
         receipt["accepted_at"], field="receipt.accepted_at"
     ):
@@ -797,10 +808,18 @@ def main(argv: list[str] | None = None) -> int:
                 for path in sorted(args.receipts_dir.glob("*.json")):
                     value = _load_json(path, context="accepted-write receipt")
                     node_id = value.get("node_id")
+                    if (
+                        value.get("schema") != "graphforge-release-accepted-receipt-v1"
+                        or node_id not in nodes
+                        or value.get("candidate_sha") != manifest["commit_sha"]
+                        or value.get("version") != manifest["version"]
+                    ):
+                        raise RegistryError(
+                            f"accepted-write receipt identity diverges: {path.name}"
+                        )
                     if node_id in receipts:
                         raise RegistryError(f"duplicate accepted-write receipt: {node_id}")
-                    if isinstance(node_id, str):
-                        receipts[node_id] = value
+                    receipts[node_id] = value
             attempts: dict[str, dict[str, Any]] = {}
             if args.attempts_dir:
                 for path in sorted(args.attempts_dir.glob("*.json")):

--- a/scripts/ci/release_registry.py
+++ b/scripts/ci/release_registry.py
@@ -751,6 +751,16 @@ def main(argv: list[str] | None = None) -> int:
     observe_parser.add_argument("--observed-at", required=True)
     observe_parser.add_argument("--out", type=Path)
 
+    observe_all_parser = commands.add_parser("observe-all")
+    observe_all_parser.add_argument("--manifest", type=Path, required=True)
+    observe_all_parser.add_argument(
+        "--registry", action="append", choices=("pypi", "npm", "crates")
+    )
+    observe_all_parser.add_argument("--observed-at", required=True)
+    observe_all_parser.add_argument("--receipts-dir", type=Path)
+    observe_all_parser.add_argument("--attempts-dir", type=Path)
+    observe_all_parser.add_argument("--out", type=Path)
+
     plan_parser = commands.add_parser("plan")
     plan_parser.add_argument("--manifest", type=Path, required=True)
     plan_parser.add_argument("--observations", type=Path, required=True)
@@ -779,6 +789,66 @@ def main(argv: list[str] | None = None) -> int:
                 observed_at=args.observed_at,
                 accepted_receipt=receipt,
             )
+        elif args.command == "observe-all":
+            selected = set(args.registry or ("pypi", "npm", "crates"))
+            nodes, _, _ = _manifest_indexes(manifest)
+            receipts: dict[str, dict[str, Any]] = {}
+            if args.receipts_dir:
+                for path in sorted(args.receipts_dir.glob("*.json")):
+                    value = _load_json(path, context="accepted-write receipt")
+                    node_id = value.get("node_id")
+                    if node_id in receipts:
+                        raise RegistryError(f"duplicate accepted-write receipt: {node_id}")
+                    if isinstance(node_id, str):
+                        receipts[node_id] = value
+            attempts: dict[str, dict[str, Any]] = {}
+            if args.attempts_dir:
+                for path in sorted(args.attempts_dir.glob("*.json")):
+                    value = _load_json(path, context="write attempt")
+                    node_id = value.get("node_id")
+                    if (
+                        value.get("schema") != "graphforge-release-write-attempt-v1"
+                        or node_id not in nodes
+                        or value.get("candidate_sha") != manifest["commit_sha"]
+                        or value.get("version") != manifest["version"]
+                    ):
+                        raise RegistryError(f"write attempt identity diverges: {path.name}")
+                    _parse_time(value.get("started_at"), field=f"{path.name}.started_at")
+                    if node_id in attempts:
+                        raise RegistryError(f"duplicate write attempt: {node_id}")
+                    attempts[node_id] = value
+
+            def observe_node(node_id: str) -> dict[str, Any]:
+                result = observe(
+                    manifest,
+                    node_id,
+                    live_response(manifest, node_id),
+                    observed_at=args.observed_at,
+                    accepted_receipt=receipts.get(node_id),
+                )
+                if result["state"] == "absent" and node_id in attempts and node_id not in receipts:
+                    result = {
+                        **result,
+                        "state": "indeterminate",
+                        "reason": "write_attempt_outcome_unknown",
+                        "evidence": {
+                            **result["evidence"],
+                            "attempt_started_at": attempts[node_id]["started_at"],
+                        },
+                    }
+                return result
+
+            result = {
+                "schema": OBSERVATION_SET_SCHEMA,
+                "candidate_sha": manifest["commit_sha"],
+                "version": manifest["version"],
+                "observations": [
+                    observe_node(node_id)
+                    for node_id, node in sorted(nodes.items())
+                    if node["registry"] in selected
+                ],
+            }
+            _assert_safe_output(result)
         else:
             observations = _load_json(args.observations, context="registry observations")
             availability = _load_json(args.availability, context="artifact availability")

--- a/scripts/ci/test-binding-release-candidate.py
+++ b/scripts/ci/test-binding-release-candidate.py
@@ -617,16 +617,17 @@ def main() -> None:
     assert release_candidate_job.index("Rehearse exact partitioned release artifacts offline") < (
         release_candidate_job.index("Create and validate the immutable candidate manifest")
     )
-    assert "M1-Release-Candidate-${{ needs.validate_source.outputs.evidence_sha }}" in (
-        rc_workflow_text
-    )
+    for group in ("manifest", "python", "npm", "crates", "evidence"):
+        assert (
+            f"M1-Release-Candidate-{group}-${{{{ needs.validate_source.outputs.evidence_sha }}}}"
+        ) in rc_workflow_text
 
     publish_workflow_text = PUBLISH_WORKFLOW.read_text()
-    assert "M1-Release-Candidate-$RELEASE_SHA" in publish_workflow_text
+    assert "M1-Release-Candidate-manifest-$RELEASE_SHA" in publish_workflow_text
     assert "PyO3/maturin-action" not in publish_workflow_text
     assert "napi build" not in publish_workflow_text
     assert "candidate/release-artifacts/python/*" in publish_workflow_text
-    assert "--check-url https://pypi.org/simple/" in publish_workflow_text
+    assert "uv publish candidate/release-artifacts/python/*" in publish_workflow_text
 
     with tempfile.TemporaryDirectory() as directory:
         temp = Path(directory)
@@ -780,7 +781,7 @@ def main() -> None:
     publish_text = PUBLISH_WORKFLOW.read_text()
     assert "exec napi build --platform --release" not in publish_text
     assert ARTIFACT_COMMAND not in publish_text
-    assert "M1-Release-Candidate-$RELEASE_SHA" in publish_text
+    assert "M1-Release-Candidate-manifest-$RELEASE_SHA" in publish_text
 
     pnpm = shutil.which("pnpm")
     assert pnpm is not None, "pnpm is required for napi CLI contract validation"

--- a/scripts/ci/test-ci-storage-policy.py
+++ b/scripts/ci/test-ci-storage-policy.py
@@ -17,7 +17,12 @@ EXPECTED_ARTIFACT_UPLOADS = Counter(
         "M1-Rust-Non-Cypher-${{ env.EVIDENCE_SHA }}": 1,
         "M1-Binding-Release-Candidate-${{ needs.validate_source.outputs.evidence_sha }}": 1,
         "M1-Release-Load-${{ github.run_id }}": 1,
-        "M1-Release-Candidate-${{ needs.validate_source.outputs.evidence_sha }}": 1,
+        "M1-Release-Candidate-manifest-${{ needs.validate_source.outputs.evidence_sha }}": 1,
+        "M1-Release-Candidate-python-${{ needs.validate_source.outputs.evidence_sha }}": 1,
+        "M1-Release-Candidate-npm-${{ needs.validate_source.outputs.evidence_sha }}": 1,
+        "M1-Release-Candidate-crates-${{ needs.validate_source.outputs.evidence_sha }}": 1,
+        "M1-Release-Candidate-evidence-${{ needs.validate_source.outputs.evidence_sha }}": 1,
+        "M1-Release-Reconciliation-${{ github.run_id }}": 1,
     }
 )
 EXPECTED_ARTIFACT_DOWNLOADS = Counter(
@@ -28,6 +33,11 @@ EXPECTED_ARTIFACT_DOWNLOADS = Counter(
         "M1-Rust-Non-Cypher-${{ needs.validate_source.outputs.evidence_sha }}": 1,
         "M1-Binding-Release-Candidate-${{ needs.validate_source.outputs.evidence_sha }}": 1,
         "M1-Release-Load-${{ github.run_id }}": 1,
+        "M1-Release-Candidate-manifest-${{ steps.source.outputs.release_sha }}": 1,
+        "M1-Release-Candidate-python-${{ steps.source.outputs.release_sha }}": 1,
+        "M1-Release-Candidate-npm-${{ steps.source.outputs.release_sha }}": 1,
+        "M1-Release-Candidate-crates-${{ steps.source.outputs.release_sha }}": 1,
+        "M1-Release-Candidate-evidence-${{ steps.source.outputs.release_sha }}": 1,
     }
 )
 EXPECTED_DEPENDENCY_KEYS = Counter(
@@ -147,7 +157,12 @@ def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
             "non-cypher-evidence/",
             "binding-rc-aggregate/report.json",
             "m1-release-load-evidence",
-            "candidate/",
+            "candidate/v${{ env.RELEASE_VERSION }}-artifacts.json",
+            "candidate/release-artifacts/python/",
+            "candidate/release-artifacts/npm/",
+            "candidate/release-artifacts/crates/",
+            "candidate/release-artifacts/{evidence,node-addons}/",
+            "reconciliation/summary.json",
         }, f"artifact upload contains unapproved bytes: {path}"
         uploaded.append(name)
     for step in action_steps(text, "actions/download-artifact@"):
@@ -165,6 +180,10 @@ def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
             "non-cypher-evidence",
             "binding-rc-aggregate",
             "m1-release-load-evidence",
+            "candidate",
+            "candidate/release-artifacts/npm",
+            "candidate/release-artifacts/crates",
+            "candidate/release-artifacts",
         }, f"artifact download path drift: {selector}"
         if pattern is not None:
             assert field(step, "merge-multiple") == "true", (
@@ -188,6 +207,11 @@ def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
                 expected_run_id = {
                     "non-cypher-evidence": "${{ inputs.rust_run_id }}",
                     "binding-rc-aggregate": "${{ inputs.binding_rc_run_id }}",
+                    "candidate": "${{ steps.candidate.outputs.run_id }}",
+                    "candidate/release-artifacts/python": ("${{ steps.candidate.outputs.run_id }}"),
+                    "candidate/release-artifacts/npm": "${{ steps.candidate.outputs.run_id }}",
+                    "candidate/release-artifacts/crates": ("${{ steps.candidate.outputs.run_id }}"),
+                    "candidate/release-artifacts": "${{ steps.candidate.outputs.run_id }}",
                 }[path]
                 assert field(step, "run-id") == expected_run_id, (
                     f"cross-run artifact run ID drift: {name}"

--- a/scripts/ci/test-publish-cli-contract.py
+++ b/scripts/ci/test-publish-cli-contract.py
@@ -1,30 +1,32 @@
 #!/usr/bin/env python3
-"""Static contract for ordered, clean-consumer @curatelabs/graphforge-cli publication."""
+"""Static contract for npm native fan-in, CLI, and skills publication."""
 
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = ROOT / ".github" / "workflows" / "publish.yaml"
-VERIFY = ROOT / "scripts" / "ci" / "verify-node-cli-release-package.mjs"
 
 
 def main() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
-    _, found, tail = text.partition("  publish-npm:\n")
-    assert found
-    npm_job, found, _ = tail.partition("\n  publish-crates:\n")
-    assert found
-    assert "needs: [candidate-preflight, publish-pypi]" in npm_job
-    assert "pnpm --filter @curatelabs/graphforge-cli test:offline" in npm_job
-    assert "node scripts/ci/verify-node-cli-release-package.mjs" in npm_job
-    assert npm_job.count("python3 scripts/publish_npm_artifacts.py") == 3
-    assert "Load reviewed npm recovery publisher" in npm_job
-    assert npm_job.index("--group native") < npm_job.index("verify-node-cli-release-package.mjs")
-    assert npm_job.index("verify-node-cli-release-package.mjs") < npm_job.index("--group cli")
-    assert npm_job.index("--group cli") < npm_job.index("--group skills")
-    assert "continue-on-error" not in npm_job
-    assert "|| true" not in npm_job
-    assert VERIFY.is_file()
+    native = text.split("  npm-native:\n", 1)[1].split("\n  npm-main:", 1)[0]
+    main_job = text.split("  npm-main:\n", 1)[1].split("\n  npm-cli:", 1)[0]
+    cli = text.split("  npm-cli:\n", 1)[1].split("\n  npm-skills:", 1)[0]
+    skills = text.split("  npm-skills:\n", 1)[1].split("\n  publish-crates:", 1)[0]
+    assert native.count("- graphforge-") == 5
+    assert "fail-fast: false" in native
+    assert "needs: [candidate-preflight, npm-native]" in main_job
+    assert "needs: [candidate-preflight, npm-main]" in cli
+    assert "needs: [candidate-preflight, npm-cli]" in skills
+    assert "npm:@curatelabs/graphforge" in main_job
+    assert "npm:@curatelabs/graphforge-cli" in cli
+    assert "npm:@curatelabs/graphforge-agent-skills" in skills
+    for job in (native, main_job, cli, skills):
+        assert "--registry npm" in job
+        assert "release_action.py authorize" in job
+        assert "scripts/publish_npm_artifacts.py" in job
+        assert "secrets.NPM_TOKEN" in job
+        assert "time.sleep" not in job
     print("publish CLI contract tests passed")
 
 

--- a/scripts/ci/test-publish-cli-contract.py
+++ b/scripts/ci/test-publish-cli-contract.py
@@ -2,6 +2,7 @@
 """Static contract for npm native fan-in, CLI, and skills publication."""
 
 from pathlib import Path
+import re
 
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = ROOT / ".github" / "workflows" / "publish.yaml"
@@ -13,7 +14,14 @@ def main() -> None:
     main_job = text.split("  npm-main:\n", 1)[1].split("\n  npm-cli:", 1)[0]
     cli = text.split("  npm-cli:\n", 1)[1].split("\n  npm-skills:", 1)[0]
     skills = text.split("  npm-skills:\n", 1)[1].split("\n  publish-crates:", 1)[0]
-    assert native.count("- graphforge-") == 5
+    native_packages = re.findall(r"^          - (graphforge-[a-z0-9-]+)$", native, re.MULTILINE)
+    assert native_packages == [
+        "graphforge-darwin-arm64",
+        "graphforge-darwin-x64",
+        "graphforge-linux-arm64-gnu",
+        "graphforge-linux-x64-gnu",
+        "graphforge-win32-x64-msvc",
+    ]
     assert "fail-fast: false" in native
     assert "needs: [candidate-preflight, npm-native]" in main_job
     assert "needs: [candidate-preflight, npm-main]" in cli
@@ -23,10 +31,10 @@ def main() -> None:
     assert "npm:@curatelabs/graphforge-agent-skills" in skills
     for job in (native, main_job, cli, skills):
         assert "--registry npm" in job
-        assert "release_action.py authorize" in job
-        assert "scripts/publish_npm_artifacts.py" in job
+        assert job.count("release_action.py authorize") == 1
+        assert job.count("scripts/publish_npm_artifacts.py") == 1
         assert "secrets.NPM_TOKEN" in job
-        assert "time.sleep" not in job
+        assert not re.search(r"(?m)(?:^|\s|[;&|])sleep(?:\s|$)", job)
     print("publish CLI contract tests passed")
 
 

--- a/scripts/ci/test-publish-crates.py
+++ b/scripts/ci/test-publish-crates.py
@@ -25,28 +25,34 @@ mod = load_module()
 assert mod.VERSION == "0.5.0"
 
 commands: list[list[str]] = []
-waits: list[tuple[str, str, int]] = []
 mod.package_checksum = lambda _name, expected=None: expected or "abc123"
 mod.owner_logins = lambda _name: {"DecisionNerd"}
 mod.run = commands.append
-mod.wait_for_version = lambda name, checksum, timeout: waits.append((name, checksum, timeout))
 
 mod.version_record = lambda _name: {"checksum": "abc123"}
 assert (
-    mod.publish_one("graphforge-core", timeout_seconds=30, expected_checksum="abc123")
-    == "already published; checksum matches"
+    mod.publish_one("graphforge-core", expected_checksum="abc123")
+    == "already published; checksum and owner match"
 )
 assert commands == []
-assert waits == []
 
 mod.version_record = lambda _name: None
-assert mod.publish_one("graphforge-core", timeout_seconds=30) == "published"
+assert (
+    mod.publish_one("graphforge-core")
+    == "accepted; public checksum and owner verification required"
+)
 assert commands == [["cargo", "publish", "-p", "graphforge-core", "--locked"]]
-assert waits == [("graphforge-core", "abc123", 30)]
+
+commands.clear()
+assert (
+    mod.publish_authorized("graphforge-core", "abc123")
+    == "accepted; public checksum and owner verification required"
+)
+assert commands == [["cargo", "publish", "-p", "graphforge-core", "--locked"]]
 
 mod.version_record = lambda _name: {"checksum": "different"}
 try:
-    mod.publish_one("graphforge-core", timeout_seconds=30)
+    mod.publish_one("graphforge-core")
     raise AssertionError("expected an existing-version checksum mismatch")
 except RuntimeError as exc:
     assert "refusing to resume" in str(exc)
@@ -54,7 +60,7 @@ except RuntimeError as exc:
 mod.version_record = lambda _name: {"checksum": "abc123"}
 mod.owner_logins = lambda _name: {"someone-else"}
 try:
-    mod.publish_one("graphforge-core", timeout_seconds=30)
+    mod.publish_one("graphforge-core")
     raise AssertionError("expected the owner assertion to fail")
 except RuntimeError as exc:
     assert "DecisionNerd is not an owner" in str(exc)

--- a/scripts/ci/test-publish-npm-artifacts.py
+++ b/scripts/ci/test-publish-npm-artifacts.py
@@ -29,18 +29,17 @@ with tempfile.TemporaryDirectory() as temp:
     publisher.publish_archive = published.append
     integrity = "sha512-" + base64.b64encode(hashlib.sha512(b"candidate").digest()).decode()
     publisher.published_integrity = lambda _name, _version: integrity
-    assert publisher.publish_one(item, root, 1) == "already published; integrity matches"
+    assert publisher.publish_one(item, root) == "already published; integrity matches"
     assert published == []
 
-    responses = iter((None, integrity))
-    publisher.published_integrity = lambda _name, _version: next(responses)
-    assert publisher.publish_one(item, root, 1) == "published"
+    publisher.published_integrity = lambda _name, _version: None
+    assert publisher.publish_one(item, root) == "accepted; public verification required"
     assert published == [archive]
 
     different = "sha512-" + base64.b64encode(hashlib.sha512(b"different").digest()).decode()
     publisher.published_integrity = lambda _name, _version: different
     try:
-        publisher.publish_one(item, root, 1)
+        publisher.publish_one(item, root)
     except RuntimeError as error:
         assert "refusing to resume" in str(error)
     else:
@@ -57,4 +56,7 @@ with tempfile.TemporaryDirectory() as temp:
 assert publisher.GROUPS["native"] == slice(0, 6)
 assert publisher.GROUPS["cli"] == slice(6, 7)
 assert publisher.GROUPS["skills"] == slice(7, 8)
+source = SCRIPT.read_text(encoding="utf-8")
+assert "time.sleep" not in source
+assert "while " not in source
 print("publish npm artifact tests passed")

--- a/scripts/ci/test-release-action.py
+++ b/scripts/ci/test-release-action.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Mutation tests for partition validation and one-node authorization."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import shutil
+import tempfile
+
+import release_action as action
+import release_registry as registry
+
+
+def _module(filename: str, name: str):
+    path = Path(__file__).with_name(filename)
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+candidate_fixture = _module("test-release-candidate.py", "release_action_candidate_fixture")
+registry_fixture = _module("test-release-registry.py", "release_action_registry_fixture")
+
+
+def test_partition() -> None:
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        _, artifacts, manifest = candidate_fixture.create_candidate(root / "source")
+        partition = root / "partition"
+        npm_paths = next(
+            group["artifact_paths"] for group in manifest["artifact_groups"] if group["id"] == "npm"
+        )
+        for relative in npm_paths:
+            destination = partition / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(artifacts / relative, destination)
+        report = action.validate_partition(
+            manifest,
+            partition,
+            "npm",
+            expected_sha=candidate_fixture.SHA,
+            version=candidate_fixture.VERSION,
+            checked_at=manifest["recorded_at"],
+        )
+        assert report["status"] == "passed"
+        assert len(report["artifact_paths"]) == 8
+        target = partition / npm_paths[0]
+        target.write_bytes(b"different")
+        try:
+            action.validate_partition(
+                manifest,
+                partition,
+                "npm",
+                expected_sha=candidate_fixture.SHA,
+                version=candidate_fixture.VERSION,
+                checked_at=manifest["recorded_at"],
+            )
+        except action.ActionError as error:
+            assert "byte count diverges" in str(error)
+        else:
+            raise AssertionError("mutated partition passed validation")
+
+
+def test_authorization() -> None:
+    manifest = registry_fixture.candidate()
+    verified = registry_fixture.observation_set(manifest)
+    availability = dict.fromkeys(("python", "npm", "crates", "evidence"), True)
+    skipped = action.authorize(
+        manifest,
+        verified,
+        availability,
+        "pypi:graphforge",
+        planned_at=registry_fixture.NOW,
+    )
+    assert skipped["disposition"] == "skip_verified"
+    assert skipped["publish"] is False
+
+    absent = copy.deepcopy(verified)
+    replacement = registry_fixture.observed(manifest, "pypi:graphforge", {"status": 404})
+    registry_fixture.replace_observation(absent, replacement)
+    authorized = action.authorize(
+        manifest,
+        absent,
+        availability,
+        "pypi:graphforge",
+        planned_at=registry_fixture.NOW,
+    )
+    assert authorized["publish"] is True
+    assert authorized["credential_scope"] == "pypi-oidc"
+
+    blocked = copy.deepcopy(verified)
+    registry_fixture.replace_observation(
+        blocked,
+        registry_fixture.observed(
+            manifest, "npm:@curatelabs/graphforge-linux-x64-gnu", {"status": 404}
+        ),
+    )
+    registry_fixture.replace_observation(
+        blocked,
+        registry_fixture.observed(manifest, "npm:@curatelabs/graphforge", {"status": 404}),
+    )
+    try:
+        action.authorize(
+            manifest,
+            blocked,
+            availability,
+            "npm:@curatelabs/graphforge",
+            planned_at=registry_fixture.NOW,
+        )
+    except action.ActionError as error:
+        assert "blocked_dependencies" in str(error)
+    else:
+        raise AssertionError("dependency-blocked npm main was authorized")
+
+    receipt = action.accepted_receipt(
+        manifest, "pypi:graphforge", accepted_at="2030-01-01T12:00:00Z"
+    )
+    assert receipt == {
+        "node_id": "pypi:graphforge",
+        "version": manifest["version"],
+        "accepted_at": "2030-01-01T12:00:00+00:00",
+        "visibility_deadline": "2030-01-01T12:15:00+00:00",
+        "observation_count": 0,
+    }
+    attempt = action.write_attempt(manifest, "pypi:graphforge", started_at="2030-01-01T11:59:00Z")
+    assert attempt["schema"] == "graphforge-release-write-attempt-v1"
+    assert attempt["candidate_sha"] == manifest["commit_sha"]
+
+
+def test_observe_all() -> None:
+    manifest = registry_fixture.candidate()
+    original = registry.live_response
+
+    def fixture_response(value, node_id):
+        return registry_fixture.response_for(value, node_id)
+
+    registry.live_response = fixture_response
+    try:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest_path = root / "manifest.json"
+            output = root / "observations.json"
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+            assert (
+                registry.main(
+                    [
+                        "observe-all",
+                        "--manifest",
+                        str(manifest_path),
+                        "--registry",
+                        "npm",
+                        "--observed-at",
+                        registry_fixture.NOW,
+                        "--out",
+                        str(output),
+                    ]
+                )
+                == 0
+            )
+            observations = json.loads(output.read_text(encoding="utf-8"))
+            assert len(observations["observations"]) == 8
+            assert all(value["state"] == "verified" for value in observations["observations"])
+
+            receipts = root / "receipts"
+            receipts.mkdir()
+            (receipts / "pypi.json").write_text(
+                json.dumps(
+                    action.accepted_receipt(
+                        manifest,
+                        "pypi:graphforge",
+                        accepted_at="2030-01-01T12:00:00Z",
+                    )
+                ),
+                encoding="utf-8",
+            )
+
+            def not_visible(_value, _node_id):
+                return {"status": 404}
+
+            registry.live_response = not_visible
+            assert (
+                registry.main(
+                    [
+                        "observe-all",
+                        "--manifest",
+                        str(manifest_path),
+                        "--registry",
+                        "pypi",
+                        "--receipts-dir",
+                        str(receipts),
+                        "--observed-at",
+                        registry_fixture.NOW,
+                        "--out",
+                        str(output),
+                    ]
+                )
+                == 0
+            )
+            pending = json.loads(output.read_text(encoding="utf-8"))["observations"]
+            assert pending[0]["state"] == "accepted_pending_visibility"
+
+            receipts.joinpath("pypi.json").unlink()
+            attempts = root / "attempts"
+            attempts.mkdir()
+            (attempts / "pypi.json").write_text(
+                json.dumps(
+                    action.write_attempt(
+                        manifest,
+                        "pypi:graphforge",
+                        started_at="2030-01-01T11:59:00Z",
+                    )
+                ),
+                encoding="utf-8",
+            )
+            assert (
+                registry.main(
+                    [
+                        "observe-all",
+                        "--manifest",
+                        str(manifest_path),
+                        "--registry",
+                        "pypi",
+                        "--attempts-dir",
+                        str(attempts),
+                        "--observed-at",
+                        registry_fixture.NOW,
+                        "--out",
+                        str(output),
+                    ]
+                )
+                == 0
+            )
+            unknown = json.loads(output.read_text(encoding="utf-8"))["observations"]
+            assert unknown[0]["state"] == "indeterminate"
+            assert unknown[0]["reason"] == "write_attempt_outcome_unknown"
+    finally:
+        registry.live_response = original
+
+
+def main() -> None:
+    test_partition()
+    test_authorization()
+    test_observe_all()
+    print("release-action tests: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/test-release-action.py
+++ b/scripts/ci/test-release-action.py
@@ -50,6 +50,21 @@ def test_partition() -> None:
         assert report["status"] == "passed"
         assert len(report["artifact_paths"]) == 8
         target = partition / npm_paths[0]
+        original = target.read_bytes()
+        target.write_bytes(b"\x00" * len(original))
+        try:
+            action.validate_partition(
+                manifest,
+                partition,
+                "npm",
+                expected_sha=candidate_fixture.SHA,
+                version=candidate_fixture.VERSION,
+                checked_at=manifest["recorded_at"],
+            )
+        except action.ActionError as error:
+            assert "checksum diverges" in str(error)
+        else:
+            raise AssertionError("same-size mutation passed validation")
         target.write_bytes(b"different")
         try:
             action.validate_partition(
@@ -121,8 +136,10 @@ def test_authorization() -> None:
         manifest, "pypi:graphforge", accepted_at="2030-01-01T12:00:00Z"
     )
     assert receipt == {
+        "schema": "graphforge-release-accepted-receipt-v1",
         "node_id": "pypi:graphforge",
         "version": manifest["version"],
+        "candidate_sha": manifest["commit_sha"],
         "accepted_at": "2030-01-01T12:00:00+00:00",
         "visibility_deadline": "2030-01-01T12:15:00+00:00",
         "observation_count": 0,
@@ -238,6 +255,34 @@ def test_observe_all() -> None:
             unknown = json.loads(output.read_text(encoding="utf-8"))["observations"]
             assert unknown[0]["state"] == "indeterminate"
             assert unknown[0]["reason"] == "write_attempt_outcome_unknown"
+            assert unknown[0]["evidence"]["attempt_started_at"] == ("2030-01-01T11:59:00+00:00")
+
+            receipts.mkdir(exist_ok=True)
+            bad_receipt = action.accepted_receipt(
+                manifest,
+                "pypi:graphforge",
+                accepted_at="2030-01-01T12:00:00Z",
+            )
+            bad_receipt["candidate_sha"] = "f" * 40
+            receipts.joinpath("pypi.json").write_text(json.dumps(bad_receipt), encoding="utf-8")
+            assert (
+                registry.main(
+                    [
+                        "observe-all",
+                        "--manifest",
+                        str(manifest_path),
+                        "--registry",
+                        "pypi",
+                        "--receipts-dir",
+                        str(receipts),
+                        "--observed-at",
+                        registry_fixture.NOW,
+                        "--out",
+                        str(output),
+                    ]
+                )
+                == 1
+            )
     finally:
         registry.live_response = original
 

--- a/scripts/ci/test-release-candidate.py
+++ b/scripts/ci/test-release-candidate.py
@@ -365,6 +365,10 @@ def main() -> None:
         [sys.executable, str(Path(__file__).with_name("test-release-rehearsal.py"))],
         check=True,
     )
+    subprocess.run(
+        [sys.executable, str(Path(__file__).with_name("test-release-action.py"))],
+        check=True,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test-release-publish-preflight.py
+++ b/scripts/ci/test-release-publish-preflight.py
@@ -134,7 +134,7 @@ assert "release_rehearsal.py reconcile" in summary
 assert "M1-Release-Reconciliation-${{ github.run_id }}" in summary
 assert ".complete == true and (.nodes | length) == 24" in summary
 
-assert "time.sleep" not in workflow
+assert "sleep" not in workflow
 assert "continue-on-error" not in workflow
 assert "|| true" not in workflow
 assert WRITE_EVIDENCE.is_file()

--- a/scripts/ci/test-release-publish-preflight.py
+++ b/scripts/ci/test-release-publish-preflight.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Deterministic tests for the release publication preflight and workflow gate."""
+"""Deterministic contract for the planner-driven publication workflow."""
 
 from __future__ import annotations
 
@@ -10,6 +10,7 @@ ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = Path(__file__).with_name("release-publish-preflight.py")
 WORKFLOW = ROOT / ".github" / "workflows" / "publish.yaml"
 CREDENTIAL_WORKFLOW = ROOT / ".github" / "workflows" / "release-credential-preflight.yml"
+WRITE_EVIDENCE = ROOT / "scripts" / "ci" / "download-release-write-evidence.sh"
 
 
 def load_module():
@@ -22,30 +23,23 @@ def load_module():
 
 mod = load_module()
 sha = "a" * 40
-versions = {
-    "cargo": "0.5.0",
-    "python": "0.5.0",
-    "node": "0.5.0",
-    "cli": "0.5.0",
-    "skills": "0.5.0",
-}
+versions = dict.fromkeys(("cargo", "python", "node", "cli", "skills"), "0.5.1")
 changelog = """# Changelog
 
 ## [Unreleased]
 
 _Nothing yet._
 
-## [0.5.0] - 2026-07-31
+## [0.5.1] - 2026-08-01
 
 - Release GraphForge.
 
-[Unreleased]: https://github.com/CurateLabs/graphforge/compare/v0.5.0...HEAD
-[0.5.0]: https://github.com/CurateLabs/graphforge/releases/tag/v0.5.0
+[Unreleased]: https://github.com/CurateLabs/graphforge/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/CurateLabs/graphforge/releases/tag/v0.5.1
 """
-
 assert (
     mod.validate(
-        tag="v0.5.0",
+        tag="v0.5.1",
         expected_sha=sha,
         actual_sha=sha,
         versions=versions,
@@ -54,113 +48,106 @@ assert (
     )
     == []
 )
-assert mod.validate_metadata() == []
-assert mod.load_version_module().check_aligned() == []
-
-mutations = [
-    {"tag": "0.5.0"},
-    {"actual_sha": "b" * 40},
-    {"versions": {**versions, "python": "0.5.0.dev0"}},
-    # ADR 0017: a registry-specific adapter patch is forbidden even when the
-    # Rust and Python surfaces still agree.
-    {"versions": {**versions, "node": "0.5.1"}},
-    {"changelog": changelog.replace("## [0.5.0] - 2026-07-31", "## [0.5.0]")},
-    {"changelog": changelog.replace("_Nothing yet._", "- Stale release entry")},
-    {
-        "changelog": changelog.replace(
-            "CurateLabs/graphforge/compare",
-            "CurateLabs/graphforge-legecy/compare",
-        )
-    },
-    {"docs_changelog": changelog.replace("Release GraphForge.", "Stale public changelog.")},
-]
-for mutation in mutations:
-    values = {
-        "tag": "v0.5.0",
-        "expected_sha": sha,
-        "actual_sha": sha,
-        "versions": versions,
-        "changelog": changelog,
-        "docs_changelog": changelog,
-        **mutation,
-    }
-    assert mod.validate(**values), mutation
-
-stale_changelog = changelog.replace("_Nothing yet._", "- Stale release entry")
-assert (
-    mod.validate(
-        tag="v0.5.0",
-        expected_sha=sha,
-        actual_sha=sha,
-        versions=versions,
-        changelog=stale_changelog,
-        docs_changelog=stale_changelog,
-        allow_unreleased_entries=True,
-    )
-    == []
+assert mod.validate(
+    tag="v0.5.1",
+    expected_sha=sha,
+    actual_sha=sha,
+    versions={**versions, "skills": "0.5.2"},
+    changelog=changelog,
+    docs_changelog=changelog,
 )
 
 workflow = WORKFLOW.read_text(encoding="utf-8")
+assert "default: v0.5.1" in workflow
+assert 'test "$release_version" != 0.5.0' in workflow
+assert "candidate/v0.5.0-artifacts.json" not in workflow
+assert "v0.5.0-npm-amendment.json" not in workflow
+assert "scripts/set_release_version.py --check" in workflow
+for group in ("manifest", "python", "npm", "crates", "evidence"):
+    assert f"M1-Release-Candidate-{group}-" in workflow
+
 preflight = workflow.split("  candidate-preflight:\n", 1)[1].split("\n  publish-pypi:", 1)[0]
 assert "release-publish-preflight.py" in preflight
-assert "github.event.release.tag_name" in preflight
-assert "github.sha" in preflight
-assert "refs/remotes/origin/main" in preflight
-assert "workflow_dispatch:" in workflow
-assert "waive_unreleased_entries:" in workflow
-assert "RECOVERY_REASON" in preflight
-assert "GH_TOKEN: ${{ github.token }}" in preflight
-assert "--allow-unreleased-entries" in preflight
-assert "git show" in preflight
-assert "refs/remotes/origin/main:scripts/ci/release-publish-preflight.py" in preflight
-assert "npm whoami" in preflight
-assert "secrets.NPM_TOKEN" in preflight
-assert "M1-Release-Candidate-$RELEASE_SHA" in preflight
-assert "scripts/ci/release-candidate.py validate" in preflight
-assert "gh release upload" in preflight
-assert preflight.index("release-publish-preflight.py") < preflight.index("npm whoami")
-assert preflight.index("npm whoami") < preflight.index("gh release upload")
+assert "release_registry.py observe-all" in preflight
+assert "release_registry.py plan" in preflight
+assert "--attempts-dir write-evidence/attempts" in preflight
+assert "--receipts-dir write-evidence/receipts" in preflight
+assert "offline-rehearsal.json" in preflight
+assert "secrets." not in preflight
 
-pypi_job = workflow.split("  publish-pypi:\n", 1)[1].split("\n  publish-npm:", 1)[0]
-assert "needs: candidate-preflight" in pypi_job
-assert "--check-url https://pypi.org/simple/" in pypi_job
-assert "candidate/release-artifacts/python/*" in pypi_job
+pypi = workflow.split("  publish-pypi:\n", 1)[1].split("\n  npm-native:", 1)[0]
+native = workflow.split("  npm-native:\n", 1)[1].split("\n  npm-main:", 1)[0]
+main = workflow.split("  npm-main:\n", 1)[1].split("\n  npm-cli:", 1)[0]
+cli = workflow.split("  npm-cli:\n", 1)[1].split("\n  npm-skills:", 1)[0]
+skills = workflow.split("  npm-skills:\n", 1)[1].split("\n  publish-crates:", 1)[0]
+crates = workflow.split("  publish-crates:\n", 1)[1].split("\n  reconcile:", 1)[0]
+summary = workflow.split("  reconcile:\n", 1)[1]
 
-npm_job = workflow.split("  publish-npm:\n", 1)[1].split("\n  publish-crates:", 1)[0]
-assert "needs: [candidate-preflight, publish-pypi]" in npm_job
-assert "scripts/publish_npm_artifacts.py" in npm_job
-assert "Load reviewed npm recovery publisher" in npm_job
-assert "refs/remotes/origin/main:scripts/publish_npm_artifacts.py" in npm_job
-assert "scripts/amend_npm_main_artifact.py" in npm_job
-assert "Apply authorized unpublished main npm amendment" in npm_job
-assert "v0.5.0-npm-amendment.json" in npm_job
-assert "curatelabs-graphforge-0.5.0-amended.tgz" in npm_job
-assert "contents: write" in npm_job
-assert "--group native" in npm_job
-assert "--group cli" in npm_job
-assert "--group skills" in npm_job
-assert "verify-node-cli-release-package.mjs" in npm_job
+assert "needs: candidate-preflight" in pypi
+assert "id-token: write" in pypi
+assert "uv publish candidate/release-artifacts/python/*" in pypi
+assert "secrets.NPM_TOKEN" not in pypi
+assert "secrets.CARGO_REGISTRY_TOKEN" not in pypi
 
-crates_job = workflow.split("  publish-crates:\n", 1)[1]
-assert "needs: [candidate-preflight, publish-npm]" in crates_job
-assert "scripts/publish_crates.py" in crates_job
-assert "--release-record candidate/v0.5.0-artifacts.json" in crates_job
-assert "secrets.CARGO_REGISTRY_TOKEN" in crates_job
-assert "cargo publish" not in crates_job
-for retired_job in ("build-wheels", "build-sdist", "build-node", "publish-node-cli"):
-    assert f"  {retired_job}:" not in workflow
+assert "fail-fast: false" in native
+assert native.count("- graphforge-") == 5
+assert "needs: candidate-preflight" in native
+assert '--package "@curatelabs/${{ matrix.package }}"' in native
+assert "secrets.NPM_TOKEN" in native
+assert "secrets.CARGO_REGISTRY_TOKEN" not in native
+
+assert "needs: [candidate-preflight, npm-native]" in main
+assert "Require verified native fan-in and authorize main" in main
+assert "--node npm:@curatelabs/graphforge" in main
+assert "needs: [candidate-preflight, npm-main]" in cli
+assert "--node npm:@curatelabs/graphforge-cli" in cli
+assert "needs: [candidate-preflight, npm-cli]" in skills
+assert "--node npm:@curatelabs/graphforge-agent-skills" in skills
+
+assert "needs: candidate-preflight" in crates
+assert "scripts/ci/crate-publish-plan.py list" in crates
+assert "scripts/publish_crates.py" in crates
+assert '--crate "$crate"' in crates
+assert "secrets.CARGO_REGISTRY_TOKEN" in crates
+assert "secrets.NPM_TOKEN" not in crates
+
+for lane in (pypi, native, main, cli, skills, crates):
+    assert "release_action.py" in lane
+    assert "release_registry.py" in lane
+    assert "release_action.py attempt" in lane
+    assert "gh release upload" in lane
+    assert "--attempts-dir write-evidence/attempts" in lane
+    assert "--receipts-dir write-evidence/receipts" in lane
+
+assert "if: always()" in summary
+for job in (
+    "candidate-preflight",
+    "publish-pypi",
+    "npm-native",
+    "npm-main",
+    "npm-cli",
+    "npm-skills",
+    "publish-crates",
+):
+    assert f"- {job}" in summary
+assert "release_rehearsal.py reconcile" in summary
+assert "M1-Release-Reconciliation-${{ github.run_id }}" in summary
+assert ".complete == true and (.nodes | length) == 24" in summary
+
+assert "time.sleep" not in workflow
+assert "continue-on-error" not in workflow
+assert "|| true" not in workflow
+assert WRITE_EVIDENCE.is_file()
+write_evidence = WRITE_EVIDENCE.read_text(encoding="utf-8")
+assert "gh release view" in write_evidence
+assert "gh release download" in write_evidence
+assert "sleep" not in write_evidence
 
 credential_workflow = CREDENTIAL_WORKFLOW.read_text(encoding="utf-8")
-assert "workflow_dispatch:" in credential_workflow
-assert "commit_sha:" in credential_workflow
 assert "npm whoami" in credential_workflow
 assert "secrets.NPM_TOKEN" in credential_workflow
 assert "secrets.CARGO_REGISTRY_TOKEN" in credential_workflow
 for forbidden in ("npm publish", "uv publish", "cargo publish", "release:\n"):
     assert forbidden not in credential_workflow
-
-for job in (preflight, pypi_job, npm_job, crates_job, credential_workflow):
-    assert "continue-on-error" not in job
-    assert "|| true" not in job
 
 print("release publish preflight tests passed")

--- a/scripts/ci/test-release-registry.py
+++ b/scripts/ci/test-release-registry.py
@@ -237,8 +237,10 @@ def main() -> None:
     assert_state(observed(manifest, "crates:graphforge-core", crates_conflict), "conflict")
 
     receipt = {
+        "schema": "graphforge-release-accepted-receipt-v1",
         "node_id": "npm:@curatelabs/graphforge",
         "version": VERSION,
+        "candidate_sha": SHA,
         "accepted_at": "2030-01-01T12:00:00+00:00",
         "visibility_deadline": "2030-01-01T12:10:00+00:00",
         "observation_count": 0,

--- a/scripts/ci/test-release-rehearsal.py
+++ b/scripts/ci/test-release-rehearsal.py
@@ -207,8 +207,10 @@ def test_sequential_reconciliation() -> None:
     assert skipped["next_actions"][0]["kind"] == "publish"
 
     receipt = {
+        "schema": "graphforge-release-accepted-receipt-v1",
         "node_id": "npm:@curatelabs/graphforge",
         "version": manifest["version"],
+        "candidate_sha": manifest["commit_sha"],
         "accepted_at": "2030-01-01T12:00:00+00:00",
         "visibility_deadline": "2030-01-01T12:10:00+00:00",
         "observation_count": 0,

--- a/scripts/publish_crates.py
+++ b/scripts/publish_crates.py
@@ -22,7 +22,6 @@ from pathlib import Path
 import re
 import subprocess
 import sys
-import time
 from typing import Any
 import urllib.error
 import urllib.request
@@ -107,26 +106,9 @@ def package_checksum(name: str, expected_checksum: str | None = None) -> str:
     return checksum
 
 
-def wait_for_version(name: str, checksum: str, timeout_seconds: int) -> None:
-    deadline = time.monotonic() + timeout_seconds
-    while time.monotonic() < deadline:
-        record = version_record(name)
-        if record is not None:
-            registry_checksum = record.get("checksum")
-            if registry_checksum != checksum:
-                raise RuntimeError(
-                    f"{name} {VERSION} checksum mismatch: "
-                    f"local={checksum} registry={registry_checksum}"
-                )
-            return
-        time.sleep(3)
-    raise RuntimeError(f"timed out waiting for crates.io to index {name} {VERSION}")
-
-
 def publish_one(
     name: str,
     *,
-    timeout_seconds: int,
     expected_checksum: str | None = None,
 ) -> str:
     checksum = package_checksum(name, expected_checksum)
@@ -138,18 +120,26 @@ def publish_one(
                 f"refusing to resume {name} {VERSION}: existing checksum "
                 f"{registry_checksum} differs from local {checksum}"
             )
-        outcome = "already published; checksum matches"
+        owners = owner_logins(name)
+        if "DecisionNerd" not in owners:
+            raise RuntimeError(
+                f"{name} {VERSION} is indexed but DecisionNerd is not an owner: {sorted(owners)}"
+            )
+        outcome = "already published; checksum and owner match"
     else:
         run(["cargo", "publish", "-p", name, "--locked"])
-        wait_for_version(name, checksum, timeout_seconds)
-        outcome = "published"
+        outcome = "accepted; public checksum and owner verification required"
 
-    owners = owner_logins(name)
-    if "DecisionNerd" not in owners:
-        raise RuntimeError(
-            f"{name} {VERSION} is indexed but DecisionNerd is not an owner: {sorted(owners)}"
-        )
-    print(f"{name} {VERSION}: {outcome}; owner=DecisionNerd")
+    print(f"{name} {VERSION}: {outcome}")
+    return outcome
+
+
+def publish_authorized(name: str, expected_checksum: str) -> str:
+    """Execute one planner-authorized absent-node write without reclassification."""
+    package_checksum(name, expected_checksum)
+    run(["cargo", "publish", "-p", name, "--locked"])
+    outcome = "accepted; public checksum and owner verification required"
+    print(f"{name} {VERSION}: {outcome}")
     return outcome
 
 
@@ -206,12 +196,7 @@ def release_record_checksums(record_path: Path, artifacts_dir: Path) -> dict[str
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--index-timeout",
-        type=int,
-        default=300,
-        help="Seconds to wait for each successful upload to appear in crates.io",
-    )
+    parser.add_argument("--crate", required=True, help="One planner-authorized crate name")
     parser.add_argument(
         "--release-record",
         type=Path,
@@ -257,18 +242,14 @@ def main(argv: list[str] | None = None) -> int:
     if check.returncode != 0:
         return check.returncode
 
-    print(f"Publishing {len(order)} crates in dependency order:")
-    for index, name in enumerate(order, start=1):
-        print(f"  {index:02d}. {name}")
-
-    for name in order:
-        publish_one(
-            name,
-            timeout_seconds=args.index_timeout,
-            expected_checksum=expected_checksums.get(name),
-        )
-
-    print(f"crates.io publication complete: {len(order)} crates at {VERSION}")
+    if args.crate not in order:
+        print(f"requested crate is outside the publication plan: {args.crate}", file=sys.stderr)
+        return 2
+    expected = expected_checksums.get(args.crate)
+    if expected is None:
+        print(f"candidate checksum is missing for {args.crate}", file=sys.stderr)
+        return 2
+    publish_authorized(args.crate, expected)
     return 0
 
 

--- a/scripts/publish_npm_artifacts.py
+++ b/scripts/publish_npm_artifacts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+from datetime import datetime, timezone
 import hashlib
 import importlib.util
 import json
@@ -12,7 +13,6 @@ import os
 from pathlib import Path
 import subprocess
 import sys
-import time
 from typing import Any
 import urllib.error
 import urllib.parse
@@ -20,6 +20,9 @@ import urllib.request
 
 ROOT = Path(__file__).resolve().parents[1]
 CANDIDATE_SCRIPT = ROOT / "scripts" / "ci" / "release-candidate.py"
+sys.path.insert(0, str(ROOT / "scripts" / "ci"))
+import release_action  # noqa: E402
+
 REGISTRY = "https://registry.npmjs.org"
 USER_AGENT = "GraphForge npm publisher (github.com/CurateLabs/graphforge)"
 GROUPS = {
@@ -92,7 +95,7 @@ def publish_archive(path: Path) -> None:
     )
 
 
-def publish_one(item: dict[str, Any], artifacts_dir: Path, timeout_seconds: int) -> str:
+def publish_one(item: dict[str, Any], artifacts_dir: Path) -> str:
     name = item["name"]
     version = item["version"]
     expected = item["sha256"]
@@ -107,19 +110,7 @@ def publish_one(item: dict[str, Any], artifacts_dir: Path, timeout_seconds: int)
         outcome = "already published; integrity matches"
     else:
         publish_archive(path)
-        deadline = time.monotonic() + timeout_seconds
-        while time.monotonic() < deadline:
-            existing = published_integrity(name, version)
-            if existing is not None:
-                break
-            time.sleep(3)
-        if existing is None:
-            raise RuntimeError(f"timed out waiting for npm to index {name}@{version}")
-        if not archive_matches_integrity(path, existing):
-            raise RuntimeError(
-                f"npm indexed different bytes for {name}@{version}; candidate sha256 is {expected}"
-            )
-        outcome = "published"
+        outcome = "accepted; public verification required"
     print(f"{name}@{version}: {outcome}")
     return outcome
 
@@ -130,24 +121,39 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--artifacts-dir", type=Path, required=True)
     parser.add_argument("--expected-sha", required=True)
     parser.add_argument("--version", required=True)
-    parser.add_argument("--group", choices=tuple(GROUPS), required=True)
-    parser.add_argument("--index-timeout", type=int, default=300)
+    selection = parser.add_mutually_exclusive_group(required=True)
+    selection.add_argument("--group", choices=tuple(GROUPS))
+    selection.add_argument("--package")
     args = parser.parse_args(argv)
     if not os.environ.get("NODE_AUTH_TOKEN", "").strip():
         print("NODE_AUTH_TOKEN is required", file=sys.stderr)
         return 2
 
     candidate = load_candidate_module()
-    record = candidate.validate(
-        args.release_record,
+    try:
+        record = json.loads(args.release_record.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        print(f"cannot read candidate manifest: {error}", file=sys.stderr)
+        return 2
+    release_action.validate_partition(
+        record,
         args.artifacts_dir,
-        args.expected_sha,
-        args.version,
+        "npm",
+        expected_sha=args.expected_sha,
+        version=args.version,
+        checked_at=datetime.now(timezone.utc).isoformat(),
     )
     by_name = {item["name"]: item for item in record["artifacts"] if item.get("surface") == "npm"}
-    names = candidate.NPM_PACKAGES[GROUPS[args.group]]
+    names = candidate.NPM_PACKAGES[GROUPS[args.group]] if args.group else (args.package,)
+    if any(name not in candidate.NPM_PACKAGES for name in names):
+        print("requested npm package is outside the candidate", file=sys.stderr)
+        return 2
     for name in names:
-        publish_one(by_name[name], args.artifacts_dir, args.index_timeout)
+        if args.package:
+            publish_archive(args.artifacts_dir / by_name[name]["path"])
+            print(f"{name}@{args.version}: accepted; public verification required")
+        else:
+            publish_one(by_name[name], args.artifacts_dir)
     return 0
 
 


### PR DESCRIPTION
## Summary
- retain the v2 manifest and Python/npm/crates/evidence partitions independently for 30 days and validate only the exact partition each credential-isolated lane consumes
- authorize every registry write from fresh observations, run the five native npm nodes in parallel, and require verified native → main → CLI → skills fan-in while keeping PyPI and crates independent
- persist immutable pre-write attempts and accepted receipts, perform one post-acceptance observation without polling, and always reconcile all 24 nodes plus every job conclusion
- reject the historical v0.5.0 record path in the v2 orchestrator so the partial-release evidence and amendment assets remain unchanged

## Validation
- `python3 scripts/ci/test-release-candidate.py`
- `python3 scripts/ci/test-publish-npm-artifacts.py`
- `python3 scripts/ci/test-publish-crates.py`
- `python3 scripts/ci/test-release-publish-preflight.py`
- `python3 scripts/ci/test-publish-cli-contract.py`
- `python3 scripts/ci/test-binding-release-candidate.py`
- `python3 scripts/ci/test-ci-storage-policy.py`
- `scripts/check-workflows.sh`
- `make pre-push-fast`

No tag, GitHub Release, registry write, publication dispatch, or release-certification workflow was run.

Closes #296

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788186216&installation_model_id=20486&pr_number=305&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F305&signature=04fd877e12947c1968838ea05dd19aedc2481d45f41dc5c007b8fef261755d95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added release-action tooling to validate artifacts, authorize publication, and generate receipts and write-attempt records.
  - Added registry observation support for tracking verified, pending-visibility, and indeterminate release states.
  - Added evidence retrieval for release attempts and accepted receipts.

- **Improvements**
  - Publishing now uses planner-authorized artifacts and verifies checksums, ownership, and package selection.
  - Package and crate publishing reports when public verification is still required instead of waiting for registry indexing.
  - Expanded release preflight checks for artifact handling, reconciliation, credentials, and version consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Orchestrate resumable partitioned publication across PyPI, npm, and crates.io
> - Splits the release candidate into five partitioned artifacts (manifest, python, npm, crates, evidence) in [binding-release-candidate.yml](.github/workflows/binding-release-candidate.yml); each publish job downloads only its own partition and validates bytes via `release_action.py validate-partition` before writing.
> - Introduces [release_action.py](scripts/ci/release_action.py) with `validate_partition`, `authorize`, `accepted_receipt`, and `write_attempt` functions plus a CLI; authorization is derived from a fresh registry observation via the planner rather than stored state.
> - Rewrites [publish.yaml](.github/workflows/publish.yaml) into per-lane jobs (PyPI, npm-native/main/cli/skills fan-in, crates.io) that persist immutable attempt and receipt JSON to the GitHub release before and after each write, enabling safe resume without duplicate writes.
> - Adds an always-running reconciliation job that aggregates all 24 registry nodes into a `graphforge-release-reconciliation-v1` summary and fails the workflow unless all nodes are complete.
> - Removes all polling sleep loops from [publish_crates.py](scripts/publish_crates.py) and [publish_npm_artifacts.py](scripts/publish_npm_artifacts.py); post-publish indexing verification is deferred to a subsequent observation pass.
> - Risk: the reconciliation hard-fail on fewer than 24 nodes means any partial registry failure blocks workflow completion until manually resumed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 017d920.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->