### PR TITLE
docs(python): make PyPI README a concise landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Replace the Python package README with a concise PyPI landing page: short
+  purpose, install path, one minimal first-use example, and canonical
+  `docs.graphforge.sh` links instead of a raw CLI command inventory (#304).
 - Partition the immutable candidate into independently retained Python, npm,
   crates, evidence, and manifest artifacts; authorize every write from fresh
   registry truth; parallelize only the five native npm packages with verified

--- a/crates/graphforge-bindings-py/README.md
+++ b/crates/graphforge-bindings-py/README.md
@@ -1,54 +1,42 @@
 # GraphForge for Python
 
-`graphforge` is the native Python binding and repository lifecycle CLI for
-GraphForge's Rust-owned engine.
+Native Python bindings for GraphForge — an embedded openCypher graph engine
+with Rust-owned behavior, Arrow results, and a thin repository lifecycle CLI.
+
+## Install
 
 ```bash
-uvx graphforge init
-uvx graphforge sync --check
-uvx graphforge sync \
-  --idempotency-key 41414141-4141-4141-4141-414141414141
-uvx graphforge export --current \
-  --output .graphforge/exports/project.gfportable
-uvx graphforge import \
-  --input .graphforge/imports/project.gfportable \
-  --idempotency-key 47474747-4747-4747-4747-474747474747
-uvx graphforge checkpoint create before-refactor \
-  --idempotency-key 43434343-4343-4343-4343-434343434343
-uvx graphforge checkpoint list
-uvx graphforge checkpoint show before-refactor
-uvx graphforge checkpoint diff \
-  --from before-refactor --to-current --scope all --detail summary
-uvx graphforge checkpoint delete before-refactor \
-  --idempotency-key 44444444-4444-4444-4444-444444444444
-uvx graphforge revert before-refactor --reason "restore before refactor" \
-  --idempotency-key 45454545-4545-4545-4545-454545454545 --yes
-uvx graphforge remove --yes
-uvx graphforge skills install
-uvx graphforge skills status
-uvx graphforge skills update
-uvx graphforge skills remove
-uvx graphforge config validate
-uvx graphforge config resolve --json
-uvx graphforge infra validate --target production --json
+pip install graphforge
+# or
+uv add graphforge
 ```
 
-The `graphforge` console entry point is a thin launcher over the same native
-Rust CLI contract used by `gf` and `npx @curatelabs/graphforge-cli`. Use `--project-dir`
-to select a repository explicitly, `--json` for machine-readable results,
-`sync --check` for CI, `revert --preview` before restoring a checkpoint, and
-`--yes` for non-interactive destructive operations.
+## First use
 
-Repository `export` and `import` operate on a complete portable GraphForge
-project generation. They are not ontology-document commands. Rust owns the
-#236 runtime-catalog inspection, ontology suggestion, non-mutating validation,
-and YAML/JSON ontology-document export behavior. Python and Node expose that
-contract, plus durable ontology adoption and clearing, as thin #237 bindings.
-The repository CLI does not infer, adopt, clear, or export an ontology
-implicitly.
+```python
+from graphforge import GraphForge
 
-Project-local GraphForge skills are packaged in the wheel and install directly;
-Python does not invoke NPX or require Node.
+forge = GraphForge()  # in-memory; pass a directory path for persistence
 
-See the [GraphForge documentation](https://curatelabs.github.io/graphforge/)
-for the engine and repository-integration contracts.
+alice = forge.add_node("Person", name="Alice", age=30)
+bob = forge.add_node("Person", name="Bob", age=25)
+forge.add_edge(alice, "KNOWS", bob, since=2020)
+
+table = forge.execute("""
+    MATCH (p:Person)-[:KNOWS]->(friend:Person)
+    WHERE p.age > 25
+    RETURN p.name AS person, friend.name AS friend
+""")
+print(table.to_pandas())
+```
+
+`execute()` returns an Apache Arrow `Table`. The `graphforge` console entry
+point launches the same Rust-owned repository CLI used by `gf` and
+`npx @curatelabs/graphforge-cli`.
+
+## Documentation
+
+- [Quick start](https://docs.graphforge.sh/guide/quickstart/)
+- [Installation](https://docs.graphforge.sh/guide/installation/)
+- [Repository integration](https://docs.graphforge.sh/guides/repository-integration/)
+- [Full documentation](https://docs.graphforge.sh/)

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Replace the Python package README with a concise PyPI landing page: short
+  purpose, install path, one minimal first-use example, and canonical
+  `docs.graphforge.sh` links instead of a raw CLI command inventory (#304).
 - Partition the immutable candidate into independently retained Python, npm,
   crates, evidence, and manifest artifacts; authorize every write from fresh
   registry truth; parallelize only the five native npm packages with verified

--- a/tests/unit/test_python_package_readme.py
+++ b/tests/unit/test_python_package_readme.py
@@ -1,0 +1,82 @@
+"""PyPI landing-page contract for the Python package README (#304)."""
+
+from __future__ import annotations
+
+import email.parser
+import subprocess
+import tarfile
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+README = ROOT / "crates" / "graphforge-bindings-py" / "README.md"
+PYPROJECT = ROOT / "crates" / "graphforge-bindings-py" / "pyproject.toml"
+CANONICAL_DOCS = "https://docs.graphforge.sh/"
+STALE_DOCS = "https://curatelabs.github.io/graphforge/"
+
+
+def test_python_readme_is_concise_pypi_landing_page() -> None:
+    text = README.read_text(encoding="utf-8")
+    lines = [line.rstrip() for line in text.splitlines()]
+    assert lines[0] == "# GraphForge for Python"
+    assert "pip install graphforge" in text
+    assert "from graphforge import GraphForge" in text
+    assert "forge.execute(" in text
+    assert CANONICAL_DOCS in text
+    assert STALE_DOCS not in text
+    # Must not open with an uncontextualized CLI command inventory.
+    first_fence = text.find("```")
+    assert first_fence > 0
+    assert "uvx graphforge init" not in text[:first_fence]
+    assert text.count("uvx graphforge") == 0
+    assert len(text) < 2500
+
+
+def test_pyproject_points_at_readme_and_canonical_docs() -> None:
+    text = PYPROJECT.read_text(encoding="utf-8")
+    assert 'readme = "README.md"' in text
+    assert f'Homepage = "{CANONICAL_DOCS}"' in text
+    assert f'Documentation = "{CANONICAL_DOCS}"' in text
+
+
+def test_python_sdist_embeds_readme_in_pkg_info() -> None:
+    """Build a local sdist and verify PKG-INFO carries the landing-page README."""
+    out = Path(tempfile.mkdtemp(prefix="graphforge-py-readme-"))
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "maturin",
+            "sdist",
+            "--manifest-path",
+            "crates/graphforge-bindings-py/Cargo.toml",
+            "--out",
+            str(out),
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+    sdists = sorted(out.glob("graphforge-*.tar.gz"))
+    assert len(sdists) == 1, sdists
+
+    with tarfile.open(sdists[0], "r:gz") as archive:
+        members = archive.getnames()
+        pkg_info_name = next(name for name in members if name.endswith("/PKG-INFO"))
+        extracted = archive.extractfile(pkg_info_name)
+        assert extracted is not None
+        metadata = email.parser.Parser().parsestr(extracted.read().decode("utf-8"))
+
+    assert metadata.get("Name") == "graphforge"
+    assert metadata.get("Description-Content-Type", "").startswith("text/markdown")
+    description = metadata.get_payload()
+    assert isinstance(description, str)
+    assert "# GraphForge for Python" in description
+    assert "pip install graphforge" in description
+    assert "from graphforge import GraphForge" in description
+    assert CANONICAL_DOCS in description
+    assert STALE_DOCS not in description
+    assert "uvx graphforge init" not in description

--- a/tests/unit/test_python_package_readme.py
+++ b/tests/unit/test_python_package_readme.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import email.parser
+from pathlib import Path
 import subprocess
 import tarfile
 import tempfile
-from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 README = ROOT / "crates" / "graphforge-bindings-py" / "README.md"


### PR DESCRIPTION
## Summary
- Replace the Python package README CLI command inventory with a concise PyPI landing page: purpose, install, one minimal first-use example, and canonical `docs.graphforge.sh` links
- Add unit coverage that asserts README shape and that a local maturin sdist embeds the same description in `PKG-INFO`
- Mirror the changelog entry in `docs/reference/changelog.md`

Closes #304
Refs #192

## Test plan
- [x] `uv run pytest tests/unit/test_python_package_readme.py -q --timeout=120` (3 passed)
- [ ] CI Gate green on exact PR head


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788188292&installation_model_id=20486&pr_number=306&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F306&signature=d7785e363f5768a3c53784e61a01c872b5f5bbe8062ce452d61f7349dd83edbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace Python package README with a concise PyPI landing page
> - Rewrites [README.md](https://github.com/CurateLabs/graphforge/pull/306/files#diff-93acfe10241b5e12894505c233a11da9216a824c733015f1202883e2e5049160) to include a short description, pip/uv install instructions, a minimal first-use Python example, and links to canonical docs at docs.graphforge.sh.
> - Removes the previous CLI-command inventory and legacy curatelabs.github.io references.
> - Adds tests in [test_python_package_readme.py](https://github.com/CurateLabs/graphforge/pull/306/files#diff-52f5964532e83cc776a55ee6933b8bdafc85684badf2dbd4364ee6eb957c899c) that assert README structure, length (<2500 chars), canonical links, absence of legacy URLs, and correct pyproject.toml metadata; also verifies the built sdist embeds the updated README content.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8288754.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->