### PR TITLE
chore(release): freeze GraphForge surfaces at 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-08-01
+
+- Freeze Cargo, Python, Node/native npm, CLI, and agent-skills surfaces at
+  `0.5.1` and cut the dated changelog for the coordinated M1 corrective
+  release (#192).
 - Replace the Python package README with a concise PyPI landing page: short
   purpose, install path, one minimal first-use example, and canonical
   `docs.graphforge.sh` links instead of a raw CLI command inventory (#304).
@@ -3517,7 +3522,8 @@ None. All changes maintain backward compatibility with v0.2.0 and v0.2.1.
 - 81% code coverage
 - Multi-OS, multi-Python CI/CD (3 OS × 4 Python versions)
 
-[Unreleased]: https://github.com/CurateLabs/graphforge/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/CurateLabs/graphforge/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/CurateLabs/graphforge/releases/tag/v0.5.1
 [0.5.0]: https://github.com/CurateLabs/graphforge/releases/tag/v0.5.0
 [0.4.0]: https://github.com/CurateLabs/graphforge-legecy/compare/v0.3.10...v0.4.0
 [0.3.0]: https://github.com/CurateLabs/graphforge-legecy/compare/v0.2.1...v0.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-api"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arrow",
  "cucumber",
@@ -2048,7 +2048,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-ast"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "graphforge-core",
  "serde",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-bindings-node"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arrow",
  "graphforge-api",
@@ -2072,7 +2072,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-bindings-py"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arrow",
  "futures",
@@ -2085,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arrow",
  "clap",
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-core"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "serde",
  "serde_yaml_ng",
@@ -2109,7 +2109,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-cypher"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "graphforge-ast",
  "graphforge-core",
@@ -2121,7 +2121,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-exec"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2146,7 +2146,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-io"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "graphforge-core",
  "graphforge-storage",
@@ -2155,7 +2155,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-ir"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arrow",
  "graphforge-ast",
@@ -2170,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-knowledge"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arrow",
  "graphforge-core",
@@ -2183,7 +2183,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-ontology"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arrow",
  "graphforge-core",
@@ -2198,7 +2198,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-plan"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "datafusion",
  "graphforge-core",
@@ -2208,7 +2208,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-provenance"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arrow",
  "graphforge-core",
@@ -2219,7 +2219,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-rel"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arrow-data",
  "chrono",
@@ -2239,7 +2239,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-search"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arrow",
  "graphforge-core",
@@ -2254,7 +2254,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-storage"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arrow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 license = "Apache-2.0"
 license-file = "LICENSE"

--- a/crates/graphforge-bindings-node/package.json
+++ b/crates/graphforge-bindings-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curatelabs/graphforge",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Native Node.js bindings for the GraphForge embedded graph engine",
   "license": "Apache-2.0",
   "homepage": "https://docs.graphforge.sh/",

--- a/crates/graphforge-bindings-py/pyproject.toml
+++ b/crates/graphforge-bindings-py/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "graphforge"
 description = "GraphForge native graph engine, bindings, and repository lifecycle CLI"
-version = "0.5.0"
+version = "0.5.1"
 readme = "README.md"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-08-01
+
+- Freeze Cargo, Python, Node/native npm, CLI, and agent-skills surfaces at
+  `0.5.1` and cut the dated changelog for the coordinated M1 corrective
+  release (#192).
 - Replace the Python package README with a concise PyPI landing page: short
   purpose, install path, one minimal first-use example, and canonical
   `docs.graphforge.sh` links instead of a raw CLI command inventory (#304).
@@ -3517,7 +3522,8 @@ None. All changes maintain backward compatibility with v0.2.0 and v0.2.1.
 - 81% code coverage
 - Multi-OS, multi-Python CI/CD (3 OS × 4 Python versions)
 
-[Unreleased]: https://github.com/CurateLabs/graphforge/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/CurateLabs/graphforge/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/CurateLabs/graphforge/releases/tag/v0.5.1
 [0.5.0]: https://github.com/CurateLabs/graphforge/releases/tag/v0.5.0
 [0.4.0]: https://github.com/CurateLabs/graphforge-legecy/compare/v0.3.10...v0.4.0
 [0.3.0]: https://github.com/CurateLabs/graphforge-legecy/compare/v0.2.1...v0.3.0

--- a/packages/agent-skills/compatibility.json
+++ b/packages/agent-skills/compatibility.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "package": "@curatelabs/graphforge-agent-skills",
-  "package_version": "0.5.0",
-  "graphforge_release": "0.5.0",
+  "package_version": "0.5.1",
+  "graphforge_release": "0.5.1",
   "graphforge_version_range": ">=0.5.0 <0.6.0",
   "security_contract": {
     "subprocess": "unsupported",

--- a/packages/agent-skills/package.json
+++ b/packages/agent-skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curatelabs/graphforge-agent-skills",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "NPX-distributed agent skills and adapters for GraphForge",
   "license": "Apache-2.0",
   "homepage": "https://docs.graphforge.sh/",

--- a/packages/agent-skills/package.json
+++ b/packages/agent-skills/package.json
@@ -48,7 +48,7 @@
   },
   "graphforgeCompatibility": {
     "schemaVersion": 1,
-    "release": "0.5.0",
+    "release": "0.5.1",
     "range": ">=0.5.0 <0.6.0"
   },
   "scripts": {

--- a/packages/agent-skills/scripts/run-native-rc-e2e.mjs
+++ b/packages/agent-skills/scripts/run-native-rc-e2e.mjs
@@ -150,7 +150,10 @@ const compatibility = JSON.parse(
     { cwd: consumer, encoding: "utf8" },
   ),
 );
-assert.equal(compatibility.graphforge_release, "0.5.0");
+const packageMetadata = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+);
+assert.equal(compatibility.graphforge_release, packageMetadata.version);
 
 const analystPath = realpathSync(mkdtempSync(join(temporary, "analyst-")));
 const developerPath = realpathSync(mkdtempSync(join(temporary, "developer-")));

--- a/packages/agent-skills/tests/cli.test.mjs
+++ b/packages/agent-skills/tests/cli.test.mjs
@@ -34,7 +34,7 @@ test("reports the machine-readable GraphForge compatibility contract", () => {
   );
   assert.equal(compatibility.package, packageMetadata.name);
   assert.equal(compatibility.package_version, packageMetadata.version);
-  assert.equal(compatibility.graphforge_release, "0.5.0");
+  assert.equal(compatibility.graphforge_release, packageMetadata.version);
   assert.equal(
     compatibility.graphforge_release,
     packageMetadata.graphforgeCompatibility.release,

--- a/packages/agent-skills/tests/offline-pack-smoke.mjs
+++ b/packages/agent-skills/tests/offline-pack-smoke.mjs
@@ -86,8 +86,14 @@ const output = execFileSync(
   { cwd: consumer, encoding: "utf8" },
 );
 const compatibility = JSON.parse(output);
-assert.equal(compatibility.graphforge_release, "0.5.0");
-assert.equal(compatibility.graphforge_version_range, ">=0.5.0 <0.6.0");
+const packageMetadata = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+);
+assert.equal(compatibility.graphforge_release, packageMetadata.version);
+assert.equal(
+  compatibility.graphforge_version_range,
+  packageMetadata.graphforgeCompatibility.range,
+);
 assert.deepEqual(compatibility.security_contract, {
   max_value_depth: 16,
   max_value_entries: 4096,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curatelabs/graphforge-cli",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "GraphForge repository lifecycle CLI",
   "license": "Apache-2.0",
   "homepage": "https://docs.graphforge.sh/",

--- a/scripts/set_release_version.py
+++ b/scripts/set_release_version.py
@@ -140,6 +140,13 @@ def check_aligned() -> list[str]:
             "skills compatibility graphforge_release: got "
             f"{compatibility.get('graphforge_release')!r}, expected {expected['skills']!r}"
         )
+    skills_meta = json.loads(SKILLS_PACKAGE.read_text(encoding="utf-8"))
+    skills_release = (skills_meta.get("graphforgeCompatibility") or {}).get("release")
+    if skills_release != expected["skills"]:
+        errors.append(
+            "skills package graphforgeCompatibility.release: got "
+            f"{skills_release!r}, expected {expected['skills']!r}"
+        )
     for path in native_npm_packages():
         meta = json.loads(path.read_text(encoding="utf-8"))
         got = meta.get("version")
@@ -198,6 +205,9 @@ def apply_version(base: str, *, dev: bool, dry_run: bool) -> dict[str, str]:
     ):
         meta = json.loads(path.read_text(encoding="utf-8"))
         meta["version"] = expected[key]
+        if path == SKILLS_PACKAGE:
+            compatibility_meta = meta.setdefault("graphforgeCompatibility", {})
+            compatibility_meta["release"] = expected[key]
         path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
 
     for path in native_npm_packages():

--- a/scripts/set_release_version.py
+++ b/scripts/set_release_version.py
@@ -34,9 +34,17 @@ CARGO_TOML = ROOT / "Cargo.toml"
 CARGO_LOCK = ROOT / "Cargo.lock"
 PYPROJECT = ROOT / "crates" / "graphforge-bindings-py" / "pyproject.toml"
 NODE_PACKAGE = ROOT / "crates" / "graphforge-bindings-node" / "package.json"
+NODE_NPM_DIR = ROOT / "crates" / "graphforge-bindings-node" / "npm"
 CLI_PACKAGE = ROOT / "packages" / "cli" / "package.json"
 SKILLS_PACKAGE = ROOT / "packages" / "agent-skills" / "package.json"
 SKILLS_COMPATIBILITY = ROOT / "packages" / "agent-skills" / "compatibility.json"
+
+
+def native_npm_packages() -> list[Path]:
+    """Return checked-in native platform package.json paths."""
+    if not NODE_NPM_DIR.is_dir():
+        return []
+    return sorted(NODE_NPM_DIR.glob("*/package.json"))
 
 
 def cargo_lock_versions() -> dict[str, str]:
@@ -127,6 +135,18 @@ def check_aligned() -> list[str]:
             "skills compatibility package_version: got "
             f"{compatibility.get('package_version')!r}, expected {expected['skills']!r}"
         )
+    if compatibility.get("graphforge_release") != expected["skills"]:
+        errors.append(
+            "skills compatibility graphforge_release: got "
+            f"{compatibility.get('graphforge_release')!r}, expected {expected['skills']!r}"
+        )
+    for path in native_npm_packages():
+        meta = json.loads(path.read_text(encoding="utf-8"))
+        got = meta.get("version")
+        if got != expected["node"]:
+            errors.append(
+                f"native npm {path.parent.name}: got {got!r}, expected {expected['node']!r}"
+            )
     return errors
 
 
@@ -180,8 +200,14 @@ def apply_version(base: str, *, dev: bool, dry_run: bool) -> dict[str, str]:
         meta["version"] = expected[key]
         path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
 
+    for path in native_npm_packages():
+        meta = json.loads(path.read_text(encoding="utf-8"))
+        meta["version"] = expected["node"]
+        path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+
     compatibility = json.loads(SKILLS_COMPATIBILITY.read_text(encoding="utf-8"))
     compatibility["package_version"] = expected["skills"]
+    compatibility["graphforge_release"] = expected["skills"]
     SKILLS_COMPATIBILITY.write_text(json.dumps(compatibility, indent=2) + "\n", encoding="utf-8")
 
     return expected

--- a/tests/unit/test_set_release_version.py
+++ b/tests/unit/test_set_release_version.py
@@ -1,6 +1,7 @@
 """Tests for multi-surface release version alignment."""
 
 import importlib.util
+import json
 from pathlib import Path
 
 import pytest
@@ -39,6 +40,15 @@ def test_expected_mapping() -> None:
 def test_current_tree_is_aligned() -> None:
     assert len(set_release_version.cargo_lock_versions()) == 17
     assert set_release_version.check_aligned() == []
+    compatibility = json.loads(
+        set_release_version.SKILLS_COMPATIBILITY.read_text(encoding="utf-8")
+    )
+    current = set_release_version.read_current()
+    assert compatibility["package_version"] == current["skills"]
+    assert compatibility["graphforge_release"] == current["skills"]
+    for path in set_release_version.native_npm_packages():
+        meta = json.loads(path.read_text(encoding="utf-8"))
+        assert meta["version"] == current["node"]
 
 
 def test_dry_run_does_not_write(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_set_release_version.py
+++ b/tests/unit/test_set_release_version.py
@@ -40,9 +40,7 @@ def test_expected_mapping() -> None:
 def test_current_tree_is_aligned() -> None:
     assert len(set_release_version.cargo_lock_versions()) == 17
     assert set_release_version.check_aligned() == []
-    compatibility = json.loads(
-        set_release_version.SKILLS_COMPATIBILITY.read_text(encoding="utf-8")
-    )
+    compatibility = json.loads(set_release_version.SKILLS_COMPATIBILITY.read_text(encoding="utf-8"))
     current = set_release_version.read_current()
     assert compatibility["package_version"] == current["skills"]
     assert compatibility["graphforge_release"] == current["skills"]


### PR DESCRIPTION
## Summary
- Freeze Cargo, Python, Node, CLI, and agent-skills package versions at `0.5.1`
- Cut dated `[0.5.1] - 2026-08-01` changelog notes and mirror `docs/reference/changelog.md`
- Extend `set_release_version.py` so skills `graphforge_release` and present native npm package metadata stay aligned with the root version

Refs #192
Refs #194

This prepares the release candidate; it does not create the tag, GitHub Release, or publish registries.

## Test plan
- [x] `python3 scripts/set_release_version.py --check`
- [x] `uv run pytest tests/unit/test_set_release_version.py -q`
- [x] `python3 scripts/ci/release-publish-preflight.py --tag v0.5.1 --expected-sha <HEAD>`
- [ ] CI Gate green on exact PR head


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788188883&installation_model_id=20486&pr_number=307&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F307&signature=222b4f9f06b6f078817cae243d5811732a102028ed5e2d12da33750ebcb1ecee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump GraphForge surfaces to version 0.5.1
> - Updates version fields to 0.5.1 across Cargo workspace, Python bindings, Node bindings, CLI, and agent-skills packages.
> - Extends [`set_release_version.py`](https://github.com/CurateLabs/graphforge/pull/307/files#diff-528cea51961c7a16745e651cf6b6d1b99f36b9f25a68ee52c98f5a63fad5c624) to also update `graphforgeCompatibility.release` in agent-skills, `graphforge_release` in `compatibility.json`, and versions of all checked-in native npm packages under `crates/graphforge-bindings-node/npm`.
> - Replaces hardcoded `'0.5.0'` version assertions in test scripts and E2E scripts with dynamic lookups from `package.json`, so these checks stay correct across future releases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4848e92.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->