### PR TITLE
fix(release): align crate path+version pins to 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Freeze Cargo, Python, Node/native npm, CLI, and agent-skills surfaces at
   `0.5.1` and cut the dated changelog for the coordinated M1 corrective
   release (#192).
+- Keep first-party crate path+version dependency pins on the same root
+  version so Binding RC offline rehearsal and crates.io packaging accept
+  the complete 15-crate graph (#192).
 - Replace the Python package README with a concise PyPI landing page: short
   purpose, install path, one minimal first-use example, and canonical
   `docs.graphforge.sh` links instead of a raw CLI command inventory (#304).

--- a/crates/graphforge-api/Cargo.toml
+++ b/crates/graphforge-api/Cargo.toml
@@ -8,16 +8,16 @@ license-file.workspace = true
 repository.workspace = true
 
 [dependencies]
-graphforge-core = { version = "0.5.0", path = "../graphforge-core" }
-graphforge-ir = { version = "0.5.0", path = "../graphforge-ir" }
-graphforge-ontology = { version = "0.5.0", path = "../graphforge-ontology" }
-graphforge-provenance = { version = "0.5.0", path = "../graphforge-provenance" }
-graphforge-knowledge = { version = "0.5.0", path = "../graphforge-knowledge" }
-graphforge-cypher = { version = "0.5.0", path = "../graphforge-cypher" }
-graphforge-rel = { version = "0.5.0", path = "../graphforge-rel" }
-graphforge-storage = { version = "0.5.0", path = "../graphforge-storage" }
-graphforge-exec = { version = "0.5.0", path = "../graphforge-exec" }
-graphforge-search = { version = "0.5.0", path = "../graphforge-search" }
+graphforge-core = { version = "0.5.1", path = "../graphforge-core" }
+graphforge-ir = { version = "0.5.1", path = "../graphforge-ir" }
+graphforge-ontology = { version = "0.5.1", path = "../graphforge-ontology" }
+graphforge-provenance = { version = "0.5.1", path = "../graphforge-provenance" }
+graphforge-knowledge = { version = "0.5.1", path = "../graphforge-knowledge" }
+graphforge-cypher = { version = "0.5.1", path = "../graphforge-cypher" }
+graphforge-rel = { version = "0.5.1", path = "../graphforge-rel" }
+graphforge-storage = { version = "0.5.1", path = "../graphforge-storage" }
+graphforge-exec = { version = "0.5.1", path = "../graphforge-exec" }
+graphforge-search = { version = "0.5.1", path = "../graphforge-search" }
 arrow = { workspace = true }
 datafusion = { workspace = true }
 futures = { workspace = true }

--- a/crates/graphforge-ast/Cargo.toml
+++ b/crates/graphforge-ast/Cargo.toml
@@ -8,7 +8,7 @@ license-file.workspace = true
 repository.workspace = true
 
 [dependencies]
-graphforge-core = { version = "0.5.0", path = "../graphforge-core" }
+graphforge-core = { version = "0.5.1", path = "../graphforge-core" }
 serde = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/graphforge-bindings-node/Cargo.toml
+++ b/crates/graphforge-bindings-node/Cargo.toml
@@ -12,8 +12,8 @@ repository.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-graphforge-api = { version = "0.5.0", path = "../graphforge-api" }
-graphforge-cli = { version = "0.5.0", path = "../graphforge-cli" }
+graphforge-api = { version = "0.5.1", path = "../graphforge-api" }
+graphforge-cli = { version = "0.5.1", path = "../graphforge-cli" }
 # `ipc` (default in arrow 58) serializes execute() results to an Arrow IPC
 # stream Buffer for the JS side to decode with apache-arrow.
 arrow = { workspace = true }

--- a/crates/graphforge-bindings-py/Cargo.toml
+++ b/crates/graphforge-bindings-py/Cargo.toml
@@ -12,8 +12,8 @@ repository.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-graphforge-api = { version = "0.5.0", path = "../graphforge-api" }
-graphforge-cli = { version = "0.5.0", path = "../graphforge-cli" }
+graphforge-api = { version = "0.5.1", path = "../graphforge-api" }
+graphforge-cli = { version = "0.5.1", path = "../graphforge-cli" }
 # `StreamExt::next` drives the facade's async streaming query one batch per pull
 # in the synchronous RecordBatchReader adapter (execute_stream, #587).
 futures = { workspace = true }

--- a/crates/graphforge-cli/Cargo.toml
+++ b/crates/graphforge-cli/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 arrow = { workspace = true }
-graphforge-api = { version = "0.5.0", path = "../graphforge-api" }
+graphforge-api = { version = "0.5.1", path = "../graphforge-api" }
 clap = { workspace = true }
 uuid = { workspace = true }
 serde = { workspace = true }

--- a/crates/graphforge-cypher/Cargo.toml
+++ b/crates/graphforge-cypher/Cargo.toml
@@ -8,10 +8,10 @@ license-file.workspace = true
 repository.workspace = true
 
 [dependencies]
-graphforge-core = { version = "0.5.0", path = "../graphforge-core" }
-graphforge-ast = { version = "0.5.0", path = "../graphforge-ast" }
-graphforge-ir = { version = "0.5.0", path = "../graphforge-ir" }
-graphforge-rel = { version = "0.5.0", path = "../graphforge-rel" }
+graphforge-core = { version = "0.5.1", path = "../graphforge-core" }
+graphforge-ast = { version = "0.5.1", path = "../graphforge-ast" }
+graphforge-ir = { version = "0.5.1", path = "../graphforge-ir" }
+graphforge-rel = { version = "0.5.1", path = "../graphforge-rel" }
 thiserror = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/graphforge-exec/Cargo.toml
+++ b/crates/graphforge-exec/Cargo.toml
@@ -8,12 +8,12 @@ license-file.workspace = true
 repository.workspace = true
 
 [dependencies]
-graphforge-core = { version = "0.5.0", path = "../graphforge-core" }
-graphforge-ir = { version = "0.5.0", path = "../graphforge-ir" }
-graphforge-ontology = { version = "0.5.0", path = "../graphforge-ontology" }
-graphforge-plan = { version = "0.5.0", path = "../graphforge-plan" }
-graphforge-rel = { version = "0.5.0", path = "../graphforge-rel" }
-graphforge-storage = { version = "0.5.0", path = "../graphforge-storage" }
+graphforge-core = { version = "0.5.1", path = "../graphforge-core" }
+graphforge-ir = { version = "0.5.1", path = "../graphforge-ir" }
+graphforge-ontology = { version = "0.5.1", path = "../graphforge-ontology" }
+graphforge-plan = { version = "0.5.1", path = "../graphforge-plan" }
+graphforge-rel = { version = "0.5.1", path = "../graphforge-rel" }
+graphforge-storage = { version = "0.5.1", path = "../graphforge-storage" }
 arrow = { workspace = true }
 datafusion = { workspace = true }
 datafusion-datasource = { workspace = true }

--- a/crates/graphforge-io/Cargo.toml
+++ b/crates/graphforge-io/Cargo.toml
@@ -8,8 +8,8 @@ license-file.workspace = true
 repository.workspace = true
 
 [dependencies]
-graphforge-core = { version = "0.5.0", path = "../graphforge-core" }
-graphforge-storage = { version = "0.5.0", path = "../graphforge-storage" }
+graphforge-core = { version = "0.5.1", path = "../graphforge-core" }
+graphforge-storage = { version = "0.5.1", path = "../graphforge-storage" }
 thiserror = { workspace = true }
 
 [lints]

--- a/crates/graphforge-ir/Cargo.toml
+++ b/crates/graphforge-ir/Cargo.toml
@@ -8,9 +8,9 @@ license-file.workspace = true
 repository.workspace = true
 
 [dependencies]
-graphforge-core = { version = "0.5.0", path = "../graphforge-core" }
-graphforge-ast = { version = "0.5.0", path = "../graphforge-ast" }
-graphforge-ontology = { version = "0.5.0", path = "../graphforge-ontology" }
+graphforge-core = { version = "0.5.1", path = "../graphforge-core" }
+graphforge-ast = { version = "0.5.1", path = "../graphforge-ast" }
+graphforge-ontology = { version = "0.5.1", path = "../graphforge-ontology" }
 arrow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/graphforge-knowledge/Cargo.toml
+++ b/crates/graphforge-knowledge/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 
 [dependencies]
 arrow = { workspace = true }
-graphforge-core = { version = "0.5.0", path = "../graphforge-core" }
+graphforge-core = { version = "0.5.1", path = "../graphforge-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/graphforge-ontology/Cargo.toml
+++ b/crates/graphforge-ontology/Cargo.toml
@@ -8,7 +8,7 @@ license-file.workspace = true
 repository.workspace = true
 
 [dependencies]
-graphforge-core = { version = "0.5.0", path = "../graphforge-core" }
+graphforge-core = { version = "0.5.1", path = "../graphforge-core" }
 arrow = { workspace = true }
 parquet = { workspace = true }
 serde = { workspace = true }

--- a/crates/graphforge-plan/Cargo.toml
+++ b/crates/graphforge-plan/Cargo.toml
@@ -8,8 +8,8 @@ license-file.workspace = true
 repository.workspace = true
 
 [dependencies]
-graphforge-core = { version = "0.5.0", path = "../graphforge-core" }
-graphforge-ir = { version = "0.5.0", path = "../graphforge-ir" }
+graphforge-core = { version = "0.5.1", path = "../graphforge-core" }
+graphforge-ir = { version = "0.5.1", path = "../graphforge-ir" }
 datafusion = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/graphforge-provenance/Cargo.toml
+++ b/crates/graphforge-provenance/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 
 [dependencies]
 arrow = { workspace = true }
-graphforge-core = { version = "0.5.0", path = "../graphforge-core" }
+graphforge-core = { version = "0.5.1", path = "../graphforge-core" }
 serde = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }

--- a/crates/graphforge-rel/Cargo.toml
+++ b/crates/graphforge-rel/Cargo.toml
@@ -8,11 +8,11 @@ license-file.workspace = true
 repository.workspace = true
 
 [dependencies]
-graphforge-core = { version = "0.5.0", path = "../graphforge-core" }
-graphforge-ir = { version = "0.5.0", path = "../graphforge-ir" }
-graphforge-ontology = { version = "0.5.0", path = "../graphforge-ontology" }
-graphforge-plan = { version = "0.5.0", path = "../graphforge-plan" }
-graphforge-storage = { version = "0.5.0", path = "../graphforge-storage" }
+graphforge-core = { version = "0.5.1", path = "../graphforge-core" }
+graphforge-ir = { version = "0.5.1", path = "../graphforge-ir" }
+graphforge-ontology = { version = "0.5.1", path = "../graphforge-ontology" }
+graphforge-plan = { version = "0.5.1", path = "../graphforge-plan" }
+graphforge-storage = { version = "0.5.1", path = "../graphforge-storage" }
 datafusion = { workspace = true }
 arrow-data = { workspace = true }
 datafusion-functions-aggregate = "53"

--- a/crates/graphforge-search/Cargo.toml
+++ b/crates/graphforge-search/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 
 [dependencies]
 arrow = { workspace = true }
-graphforge-storage = { version = "0.5.0", path = "../graphforge-storage" }
+graphforge-storage = { version = "0.5.1", path = "../graphforge-storage" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tantivy = { workspace = true }

--- a/crates/graphforge-storage/Cargo.toml
+++ b/crates/graphforge-storage/Cargo.toml
@@ -14,9 +14,9 @@ default = []
 test-failpoints = []
 
 [dependencies]
-graphforge-core = { version = "0.5.0", path = "../graphforge-core" }
-graphforge-ir = { version = "0.5.0", path = "../graphforge-ir" }
-graphforge-ontology = { version = "0.5.0", path = "../graphforge-ontology" }
+graphforge-core = { version = "0.5.1", path = "../graphforge-core" }
+graphforge-ir = { version = "0.5.1", path = "../graphforge-ir" }
+graphforge-ontology = { version = "0.5.1", path = "../graphforge-ontology" }
 arrow = { workspace = true }
 async-trait = "0.1"
 atomicwrites = "0.4.4"

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Freeze Cargo, Python, Node/native npm, CLI, and agent-skills surfaces at
   `0.5.1` and cut the dated changelog for the coordinated M1 corrective
   release (#192).
+- Keep first-party crate path+version dependency pins on the same root
+  version so Binding RC offline rehearsal and crates.io packaging accept
+  the complete 15-crate graph (#192).
 - Replace the Python package README with a concise PyPI landing page: short
   purpose, install path, one minimal first-use example, and canonical
   `docs.graphforge.sh` links instead of a raw CLI command inventory (#304).

--- a/scripts/set_release_version.py
+++ b/scripts/set_release_version.py
@@ -198,8 +198,8 @@ def apply_version(base: str, *, dev: bool, dry_run: bool) -> dict[str, str]:
     )
     if n != 1:
         raise ValueError("failed to update Cargo.toml workspace version")
-    CARGO_TOML.write_text(cargo_text, encoding="utf-8")
 
+    staged_manifests: list[tuple[Path, str]] = []
     pin_updates = 0
     for path in crate_manifests():
         text = path.read_text(encoding="utf-8")
@@ -208,7 +208,7 @@ def apply_version(base: str, *, dev: bool, dry_run: bool) -> dict[str, str]:
             text,
         )
         if count:
-            path.write_text(updated, encoding="utf-8")
+            staged_manifests.append((path, updated))
             pin_updates += count
     if pin_updates == 0:
         raise ValueError("failed to update any path+version graphforge crate dependencies")
@@ -225,7 +225,6 @@ def apply_version(base: str, *, dev: bool, dry_run: bool) -> dict[str, str]:
     )
     if lock_count == 0:
         raise ValueError("failed to update Cargo.lock workspace package versions")
-    CARGO_LOCK.write_text(lock_text, encoding="utf-8")
 
     py_text = PYPROJECT.read_text(encoding="utf-8")
     py_text, n = re.subn(
@@ -236,8 +235,8 @@ def apply_version(base: str, *, dev: bool, dry_run: bool) -> dict[str, str]:
     )
     if n != 1:
         raise ValueError("failed to update Python pyproject version")
-    PYPROJECT.write_text(py_text, encoding="utf-8")
 
+    staged_packages: list[tuple[Path, dict]] = []
     for path, key in (
         (NODE_PACKAGE, "node"),
         (CLI_PACKAGE, "cli"),
@@ -248,16 +247,25 @@ def apply_version(base: str, *, dev: bool, dry_run: bool) -> dict[str, str]:
         if path == SKILLS_PACKAGE:
             compatibility_meta = meta.setdefault("graphforgeCompatibility", {})
             compatibility_meta["release"] = expected[key]
-        path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+        staged_packages.append((path, meta))
 
     for path in native_npm_packages():
         meta = json.loads(path.read_text(encoding="utf-8"))
         meta["version"] = expected["node"]
-        path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+        staged_packages.append((path, meta))
 
     compatibility = json.loads(SKILLS_COMPATIBILITY.read_text(encoding="utf-8"))
     compatibility["package_version"] = expected["skills"]
     compatibility["graphforge_release"] = expected["skills"]
+
+    # Commit writes only after all updates validate.
+    CARGO_TOML.write_text(cargo_text, encoding="utf-8")
+    for path, updated in staged_manifests:
+        path.write_text(updated, encoding="utf-8")
+    CARGO_LOCK.write_text(lock_text, encoding="utf-8")
+    PYPROJECT.write_text(py_text, encoding="utf-8")
+    for path, meta in staged_packages:
+        path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
     SKILLS_COMPATIBILITY.write_text(json.dumps(compatibility, indent=2) + "\n", encoding="utf-8")
 
     return expected

--- a/scripts/set_release_version.py
+++ b/scripts/set_release_version.py
@@ -47,6 +47,27 @@ def native_npm_packages() -> list[Path]:
     return sorted(NODE_NPM_DIR.glob("*/package.json"))
 
 
+PATH_VERSION_DEP = re.compile(
+    r'(?m)^(graphforge-[a-z0-9-]+\s*=\s*\{\s*version\s*=\s*")([^"]+)("\s*,\s*path\s*=)'
+)
+
+
+def crate_manifests() -> list[Path]:
+    """Return first-party crate Cargo.toml paths under crates/."""
+    return sorted((ROOT / "crates").glob("*/Cargo.toml"))
+
+
+def path_version_pins() -> list[tuple[Path, str, str]]:
+    """Return (manifest, dependency, version) for path+version graphforge deps."""
+    pins: list[tuple[Path, str, str]] = []
+    for path in crate_manifests():
+        text = path.read_text(encoding="utf-8")
+        for match in PATH_VERSION_DEP.finditer(text):
+            dependency = match.group(1).split("=", 1)[0].strip()
+            pins.append((path, dependency, match.group(2)))
+    return pins
+
+
 def cargo_lock_versions() -> dict[str, str]:
     """Return versions for local graphforge-* packages recorded in Cargo.lock."""
     text = CARGO_LOCK.read_text(encoding="utf-8")
@@ -154,6 +175,12 @@ def check_aligned() -> list[str]:
             errors.append(
                 f"native npm {path.parent.name}: got {got!r}, expected {expected['node']!r}"
             )
+    for path, dependency, got in path_version_pins():
+        if got != expected["cargo"]:
+            errors.append(
+                f"{path.relative_to(ROOT)} dependency {dependency}: "
+                f"got {got!r}, expected {expected['cargo']!r}"
+            )
     return errors
 
 
@@ -172,6 +199,19 @@ def apply_version(base: str, *, dev: bool, dry_run: bool) -> dict[str, str]:
     if n != 1:
         raise ValueError("failed to update Cargo.toml workspace version")
     CARGO_TOML.write_text(cargo_text, encoding="utf-8")
+
+    pin_updates = 0
+    for path in crate_manifests():
+        text = path.read_text(encoding="utf-8")
+        updated, count = PATH_VERSION_DEP.subn(
+            rf"\g<1>{expected['cargo']}\3",
+            text,
+        )
+        if count:
+            path.write_text(updated, encoding="utf-8")
+            pin_updates += count
+    if pin_updates == 0:
+        raise ValueError("failed to update any path+version graphforge crate dependencies")
 
     lock_text = CARGO_LOCK.read_text(encoding="utf-8")
 

--- a/tests/unit/test_set_release_version.py
+++ b/tests/unit/test_set_release_version.py
@@ -82,14 +82,12 @@ def test_check_aligned_rejects_stale_path_pin(
         lambda: [(path, dependency, "0.5.0")],
     )
     errors = set_release_version.check_aligned()
-    assert any(
-        dependency in error and "0.5.0" in error and "0.5.1" in error for error in errors
-    ), errors
+    assert any(dependency in error and "0.5.0" in error and "0.5.1" in error for error in errors), (
+        errors
+    )
 
 
-def test_apply_version_rewrites_path_pins(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_apply_version_rewrites_path_pins(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     cargo = tmp_path / "Cargo.toml"
     cargo.write_text('[workspace.package]\nversion = "0.5.0"\n', encoding="utf-8")
     lock = tmp_path / "Cargo.lock"
@@ -101,8 +99,7 @@ def test_apply_version_rewrites_path_pins(
     manifest = crates / "graphforge-api" / "Cargo.toml"
     manifest.parent.mkdir()
     manifest.write_text(
-        '[dependencies]\n'
-        'graphforge-core = { version = "0.5.0", path = "../graphforge-core" }\n',
+        '[dependencies]\ngraphforge-core = { version = "0.5.0", path = "../graphforge-core" }\n',
         encoding="utf-8",
     )
     for path, content in (

--- a/tests/unit/test_set_release_version.py
+++ b/tests/unit/test_set_release_version.py
@@ -136,3 +136,47 @@ def test_apply_version_rewrites_path_pins(tmp_path: Path, monkeypatch: pytest.Mo
     text = manifest.read_text(encoding="utf-8")
     assert 'version = "0.5.1"' in text
     assert 'version = "0.5.0"' not in text
+
+
+def test_apply_version_rejects_missing_pins_without_writes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fail closed before writing when no path+version pins are discovered."""
+    cargo = tmp_path / "Cargo.toml"
+    before = '[workspace.package]\nversion = "0.5.0"\n'
+    cargo.write_text(before, encoding="utf-8")
+    lock = tmp_path / "Cargo.lock"
+    lock.write_text('name = "graphforge-core"\nversion = "0.5.0"\n', encoding="utf-8")
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[project]\nversion = "0.5.0"\n', encoding="utf-8")
+    for path, content in (
+        (tmp_path / "node" / "package.json", '{"version":"0.5.0"}\n'),
+        (tmp_path / "cli" / "package.json", '{"version":"0.5.0"}\n'),
+        (
+            tmp_path / "skills" / "package.json",
+            '{"version":"0.5.0","graphforgeCompatibility":{"release":"0.5.0"}}\n',
+        ),
+        (
+            tmp_path / "skills" / "compatibility.json",
+            '{"package_version":"0.5.0","graphforge_release":"0.5.0"}\n',
+        ),
+    ):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+    monkeypatch.setattr(set_release_version, "ROOT", tmp_path)
+    monkeypatch.setattr(set_release_version, "CARGO_TOML", cargo)
+    monkeypatch.setattr(set_release_version, "CARGO_LOCK", lock)
+    monkeypatch.setattr(set_release_version, "PYPROJECT", pyproject)
+    monkeypatch.setattr(set_release_version, "NODE_PACKAGE", tmp_path / "node" / "package.json")
+    monkeypatch.setattr(set_release_version, "CLI_PACKAGE", tmp_path / "cli" / "package.json")
+    monkeypatch.setattr(set_release_version, "SKILLS_PACKAGE", tmp_path / "skills" / "package.json")
+    monkeypatch.setattr(
+        set_release_version, "SKILLS_COMPATIBILITY", tmp_path / "skills" / "compatibility.json"
+    )
+    monkeypatch.setattr(set_release_version, "native_npm_packages", list)
+    monkeypatch.setattr(set_release_version, "crate_manifests", list)
+
+    with pytest.raises(ValueError, match=r"path\+version"):
+        set_release_version.apply_version("0.5.1", dev=False, dry_run=False)
+    assert cargo.read_text(encoding="utf-8") == before

--- a/tests/unit/test_set_release_version.py
+++ b/tests/unit/test_set_release_version.py
@@ -57,3 +57,85 @@ def test_dry_run_does_not_write(tmp_path: Path, monkeypatch: pytest.MonkeyPatch)
     mapping = set_release_version.apply_version("0.5.0", dev=False, dry_run=True)
     assert mapping["cargo"] == "0.5.0"
     assert cargo.read_text(encoding="utf-8") == before
+
+
+def test_path_version_pins_match_root() -> None:
+    """Every first-party path+version dep must match workspace.package.version."""
+    current = set_release_version.read_current()
+    pins = set_release_version.path_version_pins()
+    assert pins, "expected first-party path+version dependency pins"
+    assert all(version == current["cargo"] for _, _, version in pins)
+
+
+def test_check_aligned_rejects_stale_path_pin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stale path+version pins must fail --check before Binding RC rehearsal."""
+    current = set_release_version.read_current()
+    assert current["cargo"] == "0.5.1"
+    pins = set_release_version.path_version_pins()
+    assert pins
+    path, dependency, _version = pins[0]
+    monkeypatch.setattr(
+        set_release_version,
+        "path_version_pins",
+        lambda: [(path, dependency, "0.5.0")],
+    )
+    errors = set_release_version.check_aligned()
+    assert any(
+        dependency in error and "0.5.0" in error and "0.5.1" in error for error in errors
+    ), errors
+
+
+def test_apply_version_rewrites_path_pins(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cargo = tmp_path / "Cargo.toml"
+    cargo.write_text('[workspace.package]\nversion = "0.5.0"\n', encoding="utf-8")
+    lock = tmp_path / "Cargo.lock"
+    lock.write_text('name = "graphforge-core"\nversion = "0.5.0"\n', encoding="utf-8")
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[project]\nversion = "0.5.0"\n', encoding="utf-8")
+    crates = tmp_path / "crates"
+    crates.mkdir()
+    manifest = crates / "graphforge-api" / "Cargo.toml"
+    manifest.parent.mkdir()
+    manifest.write_text(
+        '[dependencies]\n'
+        'graphforge-core = { version = "0.5.0", path = "../graphforge-core" }\n',
+        encoding="utf-8",
+    )
+    for path, content in (
+        (tmp_path / "node" / "package.json", '{"version":"0.5.0"}\n'),
+        (tmp_path / "cli" / "package.json", '{"version":"0.5.0"}\n'),
+        (
+            tmp_path / "skills" / "package.json",
+            '{"version":"0.5.0","graphforgeCompatibility":{"release":"0.5.0"}}\n',
+        ),
+        (
+            tmp_path / "skills" / "compatibility.json",
+            '{"package_version":"0.5.0","graphforge_release":"0.5.0"}\n',
+        ),
+    ):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+    monkeypatch.setattr(set_release_version, "ROOT", tmp_path)
+    monkeypatch.setattr(set_release_version, "CARGO_TOML", cargo)
+    monkeypatch.setattr(set_release_version, "CARGO_LOCK", lock)
+    monkeypatch.setattr(set_release_version, "PYPROJECT", pyproject)
+    monkeypatch.setattr(set_release_version, "NODE_PACKAGE", tmp_path / "node" / "package.json")
+    monkeypatch.setattr(set_release_version, "CLI_PACKAGE", tmp_path / "cli" / "package.json")
+    monkeypatch.setattr(set_release_version, "SKILLS_PACKAGE", tmp_path / "skills" / "package.json")
+    monkeypatch.setattr(
+        set_release_version, "SKILLS_COMPATIBILITY", tmp_path / "skills" / "compatibility.json"
+    )
+    monkeypatch.setattr(set_release_version, "native_npm_packages", list)
+    monkeypatch.setattr(
+        set_release_version, "crate_manifests", lambda: sorted(crates.glob("*/Cargo.toml"))
+    )
+
+    set_release_version.apply_version("0.5.1", dev=False, dry_run=False)
+    text = manifest.read_text(encoding="utf-8")
+    assert 'version = "0.5.1"' in text
+    assert 'version = "0.5.0"' not in text


### PR DESCRIPTION
## Summary
- Bump every first-party `graphforge-*` path+version Cargo dependency pin to `0.5.1`
- Extend `set_release_version.py` so future freezes keep those pins aligned and `check` fails closed on drift

Fixes Binding RC failure on SHA `1441540` (`release-rehearsal: crate graphforge-api dependency graphforge-core does not use root version 0.5.1`).

Refs #192

## Evidence
- Failed run: https://github.com/CurateLabs/graphforge/actions/runs/30705692622
- `python3 scripts/set_release_version.py --check` aligned after the pin bump
- `uv run pytest tests/unit/test_set_release_version.py -q`

## Test plan
- [x] Local version alignment check
- [ ] CI Gate green
- [ ] Re-dispatch Binding RC on the merge SHA


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788190626&installation_model_id=20486&pr_number=308&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F308&signature=055595ae4d5984bd3e36523494dc92919ad4f41853755fb90ee341da09f0658b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GraphForge components to release version 0.5.1 for consistent packaging and distribution.
  * Improved release version management to identify and update all applicable component references automatically.
  * Added validation to detect inconsistent version references and report incomplete updates during release preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align first-party crate path+version pins to 0.5.1 and enforce alignment in release tooling
> - Bumps all internal `graphforge-*` path+version dependency pins from `0.5.0` to `0.5.1` across every first-party `Cargo.toml` manifest.
> - Extends [`set_release_version.py`](https://github.com/CurateLabs/graphforge/pull/308/files#diff-528cea51961c7a16745e651cf6b6d1b99f36b9f25a68ee52c98f5a63fad5c624) with a `PATH_VERSION_DEP` regex, `path_version_pins` scanner, and updates to `check_aligned` and `apply_version` to detect, validate, and rewrite these pins as part of the release process.
> - `apply_version` now stages all file writes in memory and commits them only after all validations pass, raising `ValueError` if no path+version pins are found.
> - Adds four unit tests in [`test_set_release_version.py`](https://github.com/CurateLabs/graphforge/pull/308/files#diff-e2045c8daf8aa8eda95e503e971a9d37783ac40c6ccf8d67e8892a54b7dec27d) covering pin discovery, stale-pin rejection, rewrite correctness, and the no-pins error path.
> - Documents the alignment requirement in both [`CHANGELOG.md`](https://github.com/CurateLabs/graphforge/pull/308/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed) and [`docs/reference/changelog.md`](https://github.com/CurateLabs/graphforge/pull/308/files#diff-436986e5647dd6ef4324e286b4e49f5f4b37474f5fbffcfe17e7f7f2c3287cb9).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 209d372.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->