### PR TITLE
docs: align install guidance with v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Align public installation guidance and registry-status wording with the
+  **v0.5.1** release being shipped; pin install examples to `0.5.1` without
+  claiming live PyPI/npm presence until CurateLabs publishes (#197).
+
 ## [0.5.1] - 2026-08-01
 
 - Freeze Cargo, Python, Node/native npm, CLI, and agent-skills surfaces at

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">GraphForge</h1>
 
 <p align="center">
-  <a href="#installation"><img src="https://img.shields.io/badge/version-v0.5--dev-F59E0B.svg" alt="GraphForge v0.5 development line" /></a>
+  <a href="#installation"><img src="https://img.shields.io/badge/version-v0.5.1-F59E0B.svg" alt="GraphForge v0.5.1" /></a>
   <a href="#installation"><img src="https://img.shields.io/badge/Python-3.10%2B-3776AB.svg?logo=python&logoColor=white" alt="Python 3.10 or newer" /></a>
   <a href="crates/graphforge-bindings-node"><img src="https://img.shields.io/badge/Node.js-20%2B-5FA04E.svg?logo=nodedotjs&logoColor=white" alt="Node.js 20 or newer" /></a>
   <a href="rust-toolchain.toml"><img src="https://img.shields.io/badge/Rust-1.96-000000.svg?logo=rust&logoColor=white" alt="Rust 1.96" /></a>
@@ -50,7 +50,7 @@ first-class Arrow results across language bindings.
 
 | | NetworkX | **GraphForge** | Neo4j / Memgraph |
 |:---|:---|:---|:---|
-| **Setup** | `pip install` | Embedded package (v0.5 registries pending) | Run a server |
+| **Setup** | `pip install` | Embedded package (v0.5.1 publishing) | Run a server |
 | **Query language** | Python API | **Full openCypher** | Full Cypher |
 | **Persistence** | Manual | **Parquet project directory** | Native |
 | **Results** | Python objects | **Apache Arrow Tables** | Driver rows |
@@ -71,21 +71,24 @@ aggregations remain edge-count bound. See scale limits for measured ceilings.*
 
 ## Installation
 
-GraphForge v0.5 packages are not published yet. The `graphforge` package currently
-visible on PyPI is the legacy v0.4.0 line, and the v0.5 Node and CLI packages are
-not yet available from npm. Build the current Rust-owned engine from source:
+GraphForge **v0.5.1** is the release being shipped. CurateLabs will publish that
+version to PyPI and npm; until **0.5.1** appears on those registries, build the
+Rust-owned engine from source (pin examples use `0.5.1` as the release version —
+do not assume live registry presence yet). An unrelated pure-Python `graphforge`
+**0.4.0** remains on PyPI; do not confuse it with the CurateLabs native engine.
 
 ```bash
 git clone https://github.com/CurateLabs/graphforge.git
 cd graphforge
 uv sync --dev
 maturin develop --release -m crates/graphforge-bindings-py/Cargo.toml
+python -c "import graphforge; print(graphforge.__version__)"  # 0.5.1…
 ```
 
 **Requirements:** Python 3.10–3.14
 
-See the [installation guide](docs/guide/installation.md) for Node setup, source-build
-requirements, verification, and registry status.
+See the [installation guide](docs/guide/installation.md) for pinned registry
+install commands, Node setup, source-build requirements, and verification.
 
 ### Ways to use GraphForge
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -1,9 +1,9 @@
 # Installation
 
-GraphForge **v0.5.0** ships as thin native bindings over a Rust core
-(Python via maturin; Node via N-API). Install from the published registries
-for normal use, or build from source on `main` when developing the engine or
-bindings.
+GraphForge **v0.5.1** ships as thin native bindings over a Rust core
+(Python via maturin; Node via N-API). When registries carry this release,
+install from the published packages for normal use; otherwise build from
+source on `main` when developing the engine or bindings.
 
 Prefer an editor workflow? The optional [GraphForge VS Code extension](vscode-extension/install.md)
 detects Node- and Python-first workspaces, helps configure the appropriate native binding, and
@@ -11,36 +11,39 @@ uses the same Rust-owned engine described below.
 
 > **Name collision:** PyPI currently lists an unrelated pure-Python package
 > named `graphforge` at **0.4.0** (~279 KB). CurateLabs GraphForge
-> **0.5.0** is the native engine (Rust `.so` / `.node`). Until CurateLabs
-> publishes 0.5.0, prefer source/dev installs from this repository rather than
-> assuming PyPI/npm already ship the native wheels.
+> **0.5.1** is the native engine (Rust `.so` / `.node`). CurateLabs will
+> publish **0.5.1** to PyPI and npm as part of this release; until those
+> packages appear, prefer source/dev installs from this repository (or pin
+> an already-published **0.5.0** only if you intentionally stay on that
+> line). Do not assume `pip install graphforge` without a pin resolves to
+> the CurateLabs native wheel.
 
 ---
 
-## Python package (current — v0.5.0)
+## Python package (current — v0.5.1)
 
 **Requirements:** Python 3.10 or newer (3.10–3.14 tested in CI).
 
 ```bash
-# pip
-pip install graphforge
+# After CurateLabs publishes 0.5.1 (pin the release version):
+pip install "graphforge==0.5.1"
 
 # uv (recommended)
-uv add graphforge
+uv add "graphforge==0.5.1"
 ```
 
 ### Verify
 
 ```python
 import graphforge
-print(graphforge.__version__)   # 0.5.0…
+print(graphforge.__version__)   # 0.5.1…
 ```
 
 ### Optional dependencies
 
 ```bash
 # Polars convenience wrapper around Arrow results
-pip install "graphforge[polars]"
+pip install "graphforge[polars]==0.5.1"
 ```
 
 Results are Apache Arrow tables. Convert with `table.to_pandas()`,
@@ -60,17 +63,19 @@ dependency (not bundled inside the `graphforge` wheel). See
 targets).
 
 ```bash
-npm install @curatelabs/graphforge
+# After CurateLabs publishes 0.5.1:
+npm install @curatelabs/graphforge@0.5.1
 # or
-pnpm add @curatelabs/graphforge
+pnpm add @curatelabs/graphforge@0.5.1
 ```
 
 ```js
 import { GraphForge } from "@curatelabs/graphforge";
 ```
 
-Until the CurateLabs package is published to npm, install from a local
-release build or path dependency in this repository.
+Until **0.5.1** is published to npm, install from a local release build or
+path dependency in this repository (published **0.5.0** packages may already
+exist under `@curatelabs/graphforge` if you intentionally stay on that line).
 
 ---
 
@@ -88,8 +93,8 @@ query/bench results.
 
 **Caveats**
 
-- Measured on **local macOS arm64 (darwin-arm64)** release builds of unpublished
-  **0.5.0-dev**. Other OS/arch combinations will differ.
+- Measured on **local macOS arm64 (darwin-arm64)** release builds of
+  **0.5.1**. Other OS/arch combinations will differ.
 - Almost all of the GraphForge footprint is the **Rust native binary**; the
   thin Python/JS wrappers are negligible by comparison.
 - **PyArrow is separate** — it is not inside the `graphforge` wheel. Budget it

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 **Composable graph tooling for analysis, construction, and refinement**
 
-[![Version](https://img.shields.io/badge/version-v0.5--dev-F59E0B.svg)](guide/installation.md)
+[![Version](https://img.shields.io/badge/version-v0.5.1-F59E0B.svg)](guide/installation.md)
 [![Python](https://img.shields.io/badge/Python-3.10%2B-3776AB.svg?logo=python&logoColor=white)](guide/installation.md)
 [![Node.js](https://img.shields.io/badge/Node.js-20%2B-5FA04E.svg?logo=nodedotjs&logoColor=white)](guide/installation.md)
 [![Rust](https://img.shields.io/badge/Rust-1.96-000000.svg?logo=rust&logoColor=white)](development/contributing.md)
@@ -15,10 +15,11 @@ results, and Parquet persistence. It brings openCypher and analyst-intent verbs 
 scripts, repositories, and editor workflows without requiring a database server. The v0.5
 development line passes all **3,897 openCypher TCK scenarios**.
 
-> **Registry status:** GraphForge v0.5 packages are not published yet. PyPI currently serves
-> the legacy `graphforge` v0.4.0 line, while `@curatelabs/graphforge` and `@curatelabs/graphforge-cli` are not yet
-> available from npm. Follow the [installation guide](guide/installation.md) to build the
-> current Rust-owned engine from source.
+> **Registry status:** CurateLabs will publish GraphForge **v0.5.1** to PyPI (`graphforge`)
+> and npm (`@curatelabs/graphforge`, `@curatelabs/graphforge-cli`) as part of this release.
+> Until **0.5.1** appears, prefer a [source install](guide/installation.md). PyPI still lists
+> an unrelated pure-Python `graphforge` **0.4.0**; pin the CurateLabs release version and do
+> not assume an unpinned install resolves to the native engine.
 
 ```python
 from graphforge import GraphForge

--- a/docs/legal/licensing.md
+++ b/docs/legal/licensing.md
@@ -1,6 +1,6 @@
 # GraphForge Licensing
 
-GraphForge `main` and the v0.5.0 release line are open source under the
+GraphForge `main` and the v0.5.x release line are open source under the
 Apache License 2.0 (`Apache-2.0`). The repository-root [LICENSE](../../LICENSE)
 contains the authoritative terms.
 

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Align public installation guidance and registry-status wording with the
+  **v0.5.1** release being shipped; pin install examples to `0.5.1` without
+  claiming live PyPI/npm presence until CurateLabs publishes (#197).
+
 ## [0.5.1] - 2026-08-01
 
 - Freeze Cargo, Python, Node/native npm, CLI, and agent-skills surfaces at


### PR DESCRIPTION
## Summary
- Align public installation guidance (`docs/guide/installation.md`), docs homepage registry status/badge, and root README install framing with **v0.5.1** as the release being shipped.
- Pin Python/npm install examples to `0.5.1` and use **will publish** / prefer-source wording until CurateLabs packages appear (PyPI/npm do not serve `0.5.1` yet; `0.5.0` may already be present).
- Minimal licensing tweak: `v0.5.0 release line` → `v0.5.x release line` (historical “first Apache-2.0 release” sentence unchanged).
- Changelog `[Unreleased]` + mirrored `docs/reference/changelog.md`.

Refs #197

## Test plan
- [x] `pnpm docs:build` succeeds in isolated worktree
- [x] Built `/guide/installation/` shows `current — v0.5.1` and `graphforge==0.5.1`
- [ ] Confirm live docs after merge/deploy no longer present v0.5.0 as current on `/guide/installation/`
- [ ] Leave release trackers #192 and #194 untouched (no tags, no registry publish)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update install docs to pin GraphForge release version to v0.5.1
> - Updates version badges, comparison table, and installation instructions across [README.md](https://github.com/CurateLabs/graphforge/pull/309/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5), [docs/index.md](https://github.com/CurateLabs/graphforge/pull/309/files#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6), and [docs/guide/installation.md](https://github.com/CurateLabs/graphforge/pull/309/files#diff-d263b74a9d72c503fdf0d416adb3177cbee379d055f65740d1e564d3c2f814e3) from v0.5-dev/v0.5.0 to v0.5.1.
> - Clarifies that CurateLabs will publish v0.5.1 to PyPI and npm, and advises building from source until the package appears in registries.
> - Adds explicit version pinning (`graphforge==0.5.1`) to all install commands and warns that an unrelated pure-Python 0.4.0 package exists on PyPI under the same name.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aff2162.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->