### PR TITLE
docs: add real-data visualization examples for Python and Node

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -51,6 +51,7 @@ export default defineConfig({
             { label: 'Cypher Query Language', slug: 'guide/cypher-guide' },
             { label: 'Graph Construction', slug: 'guide/graph-construction' },
             { label: 'Analytics Integration', slug: 'guide/analytics-integration' },
+            { label: 'Visualization examples', slug: 'guide/visualization' },
             { label: 'Exploratory Analyst', slug: 'guide/exploratory-analyst' },
           ],
         },

--- a/docs-site/scripts/sync-content.mjs
+++ b/docs-site/scripts/sync-content.mjs
@@ -54,6 +54,7 @@ const PAGES = [
   'guide/cypher-guide.md',
   'guide/graph-construction.md',
   'guide/analytics-integration.md',
+  'guide/visualization.md',
   'guide/exploratory-analyst.md',
   'guides/repository-integration.md',
   'guide/datasets/overview.md',

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,6 +64,7 @@ extension documents are eligible for publication.
 | [`guide/cypher-guide.md`](guide/cypher-guide.md) | openCypher language guide |
 | [`guide/graph-construction.md`](guide/graph-construction.md) | Build graphs with API and Cypher |
 | [`guide/analytics-integration.md`](guide/analytics-integration.md) | Arrow, pandas, Polars, analyst verbs |
+| [`guide/visualization.md`](guide/visualization.md) | Real-data Plotly / Jaal / PyVis / Cytoscape.js / Sigma.js examples |
 | [`guide/datasets/`](guide/datasets/overview.md) | Load real-world networks |
 
 ### Book (research, architecture, deeper usage)

--- a/docs/guide/analytics-integration.md
+++ b/docs/guide/analytics-integration.md
@@ -274,6 +274,7 @@ print(forge.schema())              # Arrow Table — labels, property names, typ
 
 ## Next Steps
 
+- [Visualization examples](visualization.md) — Plotly, Jaal, PyVis, Cytoscape.js, and Sigma.js over one shared real-data projection
 - [Network Analysis use case](../book/use-cases/network-analysis.md) — worked examples on the SNAP ego-Facebook dataset
 - [Knowledge Graph Construction](../book/use-cases/knowledge-graph-construction.md) — LangChain integration and MERGE patterns
 - [API Reference](../reference/api.md) — full method signatures

--- a/docs/guide/overview.md
+++ b/docs/guide/overview.md
@@ -31,6 +31,10 @@ Build graphs programmatically using the Python API.
 ### [Analytics Integration](analytics-integration.md)
 Export graphs to NetworkX, igraph, and pandas for further analysis.
 
+### [Visualization examples](visualization.md)
+Comparable Plotly, Jaal, PyVis, Cytoscape.js, and Sigma.js paths over one shared
+real-data GraphForge projection.
+
 ### Ranking Nodes — `forge.rank()`
 Score every node with a graph centrality algorithm (PageRank, betweenness, closeness, degree,
 clustering coefficient, or triangle count). Returns an Arrow Table with node properties plus a

--- a/docs/guide/visualization.md
+++ b/docs/guide/visualization.md
@@ -1,0 +1,138 @@
+# Visualization examples
+
+GraphForge returns Arrow tables from its public Python and Node APIs. This guide
+shows how to take **one shared real-data projection** and render it with five
+common ecosystem libraries—without adding visualization behavior to GraphForge
+Core.
+
+Runnable sources live under
+[`examples/visualization/`](https://github.com/CurateLabs/graphforge/tree/main/examples/visualization).
+
+## Comparison
+
+| Runtime | Library | Artifact | Layout seed | Notes |
+| --- | --- | --- | --- | --- |
+| Python | [Plotly](https://plotly.com/python/) | `plotly_karate.html` + JSON | Deterministic circular layout using seed `42` | Fully offline-friendly HTML via CDN Plotly.js |
+| Python | [Jaal](https://github.com/imohitmayank/jaal) | `jaal_karate_payload.json` (+ Dash app) | **Not supported** by Jaal `create()`/`plot()` | Interactive view needs a Dash server (`--serve`) |
+| Python | [PyVis](https://pyvis.readthedocs.io/) | `pyvis_karate.html` | `layout.randomSeed = 42` | Writes standalone HTML |
+| Node.js | [Cytoscape.js](https://js.cytoscape.org/) | elements JSON + HTML | cose has no portable seed matching the contract | Closest honest path: cose, `animate: false` |
+| Node.js | [Sigma.js](https://www.sigmajs.org/) | graphology JSON + HTML | Seeded circular coordinates (`42`) | Browser page loads graphology + sigma via import map |
+
+Awkward or limited options stay in the comparison with documented compromises.
+
+## Dataset provenance
+
+| Field | Value |
+| --- | --- |
+| Dataset | Zachary's Karate Club |
+| Source | [Mark Newman network data](https://public.websites.umich.edu/~mejn/netdata/karate.zip) |
+| Version identity | SHA-256 of `karate.zip` recorded in `examples/visualization/dataset/MANIFEST.json` |
+| Nodes / edges | 34 / 78 |
+| Directed | No (undirected friendships) |
+| Citation | W. W. Zachary, *Journal of Anthropological Research* 33, 452–473 (1977) |
+
+Raw archives and extracts are **not** committed. Fetch and verify:
+
+```bash
+python examples/visualization/dataset/fetch.py
+```
+
+## Shared projection contract
+
+All five examples:
+
+1. Download and checksum-verify Newman's `karate.zip`.
+2. Parse `karate.gml` edges.
+3. Load nodes/edges through GraphForge's public API (`add_node` / `add_edge` or
+   Node `addNode` / `addEdge`).
+4. Obtain the projection with public Cypher `execute()` queries defined in
+   `examples/visualization/shared/contract.json`.
+5. Transform that projection into the library's documented input shape.
+
+Projection identity: `karate-member-friend-v1`
+
+- Node label: `Member` with `club_id` (1–34) and display `label` (`M{id}`)
+- Relationship: undirected `FRIEND` (stored once per unordered pair)
+- Style defaults: node color `#2E86AB`, edge color `#A0AEC0`, layout seed `42`
+
+Adapters **must not** open GraphForge storage internals or extend Core for
+rendering.
+
+## Setup
+
+### Python
+
+```bash
+python -m pip install graphforge
+python -m pip install -r examples/visualization/requirements.txt
+python examples/visualization/dataset/fetch.py
+```
+
+Pinned example libraries (install-time versions from the requirements file):
+Plotly, Jaal, PyVis, pandas, pyarrow.
+
+### Node.js
+
+```bash
+cd examples/visualization
+npm install
+# Prefer a built in-repo binding during development:
+# export GRAPHFORGE_NODE_PATH=/absolute/path/to/crates/graphforge-bindings-node/index.js
+```
+
+Node examples depend on `apache-arrow` for IPC decoding and load Cytoscape.js /
+Sigma.js in the generated HTML from public CDNs (no visualization dependency is
+added to GraphForge packages).
+
+## Commands and expected output
+
+```bash
+# Shared projection
+python examples/visualization/shared/projection.py
+# -> examples/visualization/output/projection.json
+
+python examples/visualization/python/plotly_example.py
+# -> output/plotly_karate.html, output/plotly_karate.json
+
+python examples/visualization/python/pyvis_example.py
+# -> output/pyvis_karate.html
+
+python examples/visualization/python/jaal_example.py
+# -> output/jaal_karate_payload.json
+# Local interactive Dash UI: add --serve
+
+node examples/visualization/node/cytoscape_example.mjs
+# -> output/cytoscape_karate_elements.json, output/cytoscape_karate.html
+
+node examples/visualization/node/sigma_example.mjs
+# -> output/sigma_karate_graph.json, output/sigma_karate.html
+```
+
+Open the HTML files in a browser locally. Example tests validate artifact
+construction without launching a browser:
+
+```bash
+python -m pytest examples/visualization/tests/test_python_examples.py -q
+node --test examples/visualization/tests/test_node_examples.mjs
+```
+
+These checks are part of the example suite. They are **not** required CI,
+scheduled CI, or release gates.
+
+## Limitations (honest comparison)
+
+- **Jaal** only becomes interactive through Dash; headless CI constructs the app
+  via `Jaal.create()` and writes a JSON payload. Layout seed is unsupported.
+- **Cytoscape.js `cose`** does not provide a stable, documented seed equivalent
+  to the shared contract; the HTML records the requested seed and uses
+  non-animated cose.
+- **Plotly** has no built-in force-directed seed for graphs; the example uses a
+  deterministic circular layout derived from seed `42`.
+- These examples demonstrate integration paths. They are not library
+  recommendations or scalability proofs.
+
+## Related
+
+- [Analytics Integration](analytics-integration.md) — Arrow → pandas / NetworkX
+- [Graph Construction](graph-construction.md) — public construction API
+- [Network Analysis use case](../book/use-cases/network-analysis.md)

--- a/examples/visualization/.gitignore
+++ b/examples/visualization/.gitignore
@@ -1,0 +1,3 @@
+.cache/
+output/
+node_modules/

--- a/examples/visualization/README.md
+++ b/examples/visualization/README.md
@@ -1,0 +1,62 @@
+# Visualization examples (issue #298)
+
+Comparable, executable paths from a GraphForge public-API result to interactive
+visualizations for:
+
+| Runtime | Library | Entry point |
+| --- | --- | --- |
+| Python | Plotly | `python/plotly_example.py` |
+| Python | Jaal | `python/jaal_example.py` |
+| Python | PyVis | `python/pyvis_example.py` |
+| Node.js | Cytoscape.js | `node/cytoscape_example.mjs` |
+| Node.js | Sigma.js | `node/sigma_example.mjs` |
+
+Reader-facing guide: [`docs/guide/visualization.md`](../../docs/guide/visualization.md).
+
+## Dataset
+
+Zachary's Karate Club via Mark Newman's `karate.zip` (34 nodes / 78 undirected
+edges). Provenance, license/citation, and SHA-256 identities live in
+[`dataset/MANIFEST.json`](dataset/MANIFEST.json). Raw archives are downloaded into
+`.cache/` (gitignored) by `dataset/fetch.py`.
+
+## Setup
+
+```bash
+# Python (from repo root, with GraphForge installed)
+python -m pip install -r examples/visualization/requirements.txt
+python examples/visualization/dataset/fetch.py
+
+# Node (uses in-repo binding when present; else @curatelabs/graphforge@0.5.1)
+cd examples/visualization
+npm install
+```
+
+## Run
+
+```bash
+# Shared projection JSON
+python examples/visualization/shared/projection.py
+node examples/visualization/shared/projection.mjs
+
+# Library adapters (write artifacts under examples/visualization/output/)
+python examples/visualization/python/plotly_example.py
+python examples/visualization/python/pyvis_example.py
+python examples/visualization/python/jaal_example.py
+node examples/visualization/node/cytoscape_example.mjs
+node examples/visualization/node/sigma_example.mjs
+```
+
+## Tests
+
+Not wired into required CI or release gates:
+
+```bash
+python -m pytest examples/visualization/tests/test_python_examples.py -q
+node --test examples/visualization/tests/test_node_examples.mjs
+```
+
+## Boundary
+
+Adapters transform GraphForge public `execute()` results only. No Core, storage,
+or binding visualization behavior is added by this suite.

--- a/examples/visualization/dataset/MANIFEST.json
+++ b/examples/visualization/dataset/MANIFEST.json
@@ -1,0 +1,26 @@
+{
+  "id": "zachary-karate-club",
+  "title": "Zachary's Karate Club",
+  "description": "Undirected friendship network among 34 members of a university karate club.",
+  "source_name": "Mark Newman network data (Karate club)",
+  "source_url": "https://public.websites.umich.edu/~mejn/netdata/karate.zip",
+  "retrieval_note": "Archive retrieved for GraphForge issue #298 visualization examples.",
+  "license": "Public research redistribution with required citation of Zachary (1977); see archive karate.txt.",
+  "citation": "W. W. Zachary, An information flow model for conflict and fission in small groups, Journal of Anthropological Research 33, 452-473 (1977).",
+  "archive": {
+    "filename": "karate.zip",
+    "sha256": "e182d7fabbd44f3c75d307c1cf5259f0c4506954d63c37b9f30e629c78c578f6",
+    "members": {
+      "karate.gml": "f05e321c94b00a5cceab44671a65c34632aac7b152479ba619354be149ba8beb",
+      "karate.txt": "42b1769e51ae6dd09644f71357afadfc18128a29bad3d9c110664d3a75d08566"
+    }
+  },
+  "graph": {
+    "directed": false,
+    "node_count": 34,
+    "edge_count": 78,
+    "node_id_range": [1, 34],
+    "node_label": "Member",
+    "relationship_type": "FRIEND"
+  }
+}

--- a/examples/visualization/dataset/__init__.py
+++ b/examples/visualization/dataset/__init__.py
@@ -1,0 +1,1 @@
+"""Dataset fetch helpers for visualization examples."""

--- a/examples/visualization/dataset/fetch.py
+++ b/examples/visualization/dataset/fetch.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Download and verify the Zachary karate-club archive used by visualization examples.
+
+Raw archives stay under a local cache directory (gitignored). Only MANIFEST.json
+is tracked in git.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+import urllib.request
+import zipfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+MANIFEST_PATH = HERE / "MANIFEST.json"
+DEFAULT_CACHE = ROOT / ".cache"
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def fetch_dataset(cache_dir: Path | None = None, *, force: bool = False) -> Path:
+    """Return the extracted dataset directory after checksum verification."""
+    manifest = load_manifest()
+    cache = cache_dir or DEFAULT_CACHE
+    cache.mkdir(parents=True, exist_ok=True)
+
+    archive_name = manifest["archive"]["filename"]
+    archive_path = cache / archive_name
+    extract_dir = cache / "karate"
+    expected_archive = manifest["archive"]["sha256"]
+
+    if force or not archive_path.is_file() or _sha256(archive_path) != expected_archive:
+        url = manifest["source_url"]
+        print(f"Downloading {url} -> {archive_path}", file=sys.stderr)
+        urllib.request.urlretrieve(url, archive_path)  # noqa: S310 — fixed URL from manifest
+
+    actual = _sha256(archive_path)
+    if actual != expected_archive:
+        raise SystemExit(
+            f"Archive checksum mismatch for {archive_path}: expected {expected_archive}, got {actual}"
+        )
+
+    extract_dir.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(archive_path) as archive:
+        archive.extractall(extract_dir)
+
+    members = manifest["archive"]["members"]
+    for relative, expected in members.items():
+        member_path = extract_dir / relative
+        if not member_path.is_file():
+            raise SystemExit(f"Missing archive member after extract: {relative}")
+        actual_member = _sha256(member_path)
+        if actual_member != expected:
+            raise SystemExit(
+                f"Member checksum mismatch for {relative}: expected {expected}, got {actual_member}"
+            )
+
+    return extract_dir
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=DEFAULT_CACHE,
+        help="Directory for the downloaded archive (default: examples/visualization/.cache)",
+    )
+    parser.add_argument("--force", action="store_true", help="Re-download even if cached")
+    args = parser.parse_args()
+    path = fetch_dataset(args.cache_dir, force=args.force)
+    print(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/visualization/dataset/fetch.py
+++ b/examples/visualization/dataset/fetch.py
@@ -10,10 +10,10 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+from pathlib import Path
 import sys
 import urllib.request
 import zipfile
-from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
 ROOT = HERE.parent
@@ -47,7 +47,7 @@ def fetch_dataset(cache_dir: Path | None = None, *, force: bool = False) -> Path
     if force or not archive_path.is_file() or _sha256(archive_path) != expected_archive:
         url = manifest["source_url"]
         print(f"Downloading {url} -> {archive_path}", file=sys.stderr)
-        urllib.request.urlretrieve(url, archive_path)  # noqa: S310 — fixed URL from manifest
+        urllib.request.urlretrieve(url, archive_path)
 
     actual = _sha256(archive_path)
     if actual != expected_archive:

--- a/examples/visualization/node/cytoscape_example.mjs
+++ b/examples/visualization/node/cytoscape_example.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * Cytoscape.js visualization payload over the shared GraphForge projection.
+ *
+ * Builds a browser-ready HTML page that loads Cytoscape from a CDN and embeds
+ * the shared elements JSON. No interactive browser is opened in CI.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { project } from "../shared/projection.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+export function toCytoscapeElements(projection) {
+  const nodes = projection.nodes.map((node) => ({
+    data: {
+      id: String(node.id),
+      label: node.label,
+      club_id: node.club_id,
+    },
+  }));
+  const edges = projection.edges.map((edge, index) => ({
+    data: {
+      id: `e${index}`,
+      source: String(edge.source),
+      target: String(edge.target),
+    },
+  }));
+  return [...nodes, ...edges];
+}
+
+export function buildHtml(projection, elements) {
+  const style = projection.style;
+  const payload = JSON.stringify(elements);
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Zachary karate club (Cytoscape.js / GraphForge)</title>
+  <script src="https://unpkg.com/cytoscape@3.30.4/dist/cytoscape.min.js"></script>
+  <style>
+    html, body, #cy { width: 100%; height: 100%; margin: 0; padding: 0; }
+  </style>
+</head>
+<body>
+  <div id="cy"></div>
+  <script>
+    const elements = ${payload};
+    cytoscape({
+      container: document.getElementById('cy'),
+      elements,
+      style: [
+        {
+          selector: 'node',
+          style: {
+            'background-color': ${JSON.stringify(style.node_color)},
+            'label': 'data(label)',
+            'width': ${JSON.stringify(style.node_size)},
+            'height': ${JSON.stringify(style.node_size)},
+            'font-size': 10
+          }
+        },
+        {
+          selector: 'edge',
+          style: {
+            'line-color': ${JSON.stringify(style.edge_color)},
+            'width': ${JSON.stringify(style.edge_width)},
+            'curve-style': 'bezier'
+          }
+        }
+      ],
+      layout: {
+        name: 'cose',
+        animate: false,
+        randomize: true
+      },
+      wheelSensitivity: 0.2
+    });
+  </script>
+</body>
+</html>
+`;
+}
+
+export async function run(outputDir = join(ROOT, "output")) {
+  const projection = await project();
+  const elements = toCytoscapeElements(projection);
+  mkdirSync(outputDir, { recursive: true });
+
+  const elementsPath = join(outputDir, "cytoscape_karate_elements.json");
+  const htmlPath = join(outputDir, "cytoscape_karate.html");
+  writeFileSync(
+    elementsPath,
+    `${JSON.stringify(
+      {
+        projection_id: projection.projection_id,
+        layout_seed_requested: projection.layout_seed,
+        limitation:
+          "Cytoscape cose layout does not expose a portable cross-version seed matching GraphForge's contract seed; HTML uses cose with animate:false.",
+        elements,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  writeFileSync(htmlPath, buildHtml(projection, elements));
+  return [elementsPath, htmlPath];
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const outputDir = process.argv.includes("--output-dir")
+    ? process.argv[process.argv.indexOf("--output-dir") + 1]
+    : join(ROOT, "output");
+  for (const path of await run(outputDir)) {
+    console.log(path);
+  }
+}

--- a/examples/visualization/node/sigma_example.mjs
+++ b/examples/visualization/node/sigma_example.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * Sigma.js visualization payload over the shared GraphForge projection.
+ *
+ * Builds a graphology graph export and a browser-ready HTML page that loads
+ * Sigma from a CDN. No interactive browser is opened in CI.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { project } from "../shared/projection.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+function seededUnit(seed, index) {
+  let x = (seed * 1664525 + index * 1013904223) >>> 0;
+  x ^= x << 13;
+  x ^= x >>> 17;
+  x ^= x << 5;
+  return (x >>> 0) / 0xffffffff;
+}
+
+export function toGraphologyExport(projection) {
+  const nodes = projection.nodes.map((node, index) => {
+    const angle = (2 * Math.PI * index) / projection.nodes.length;
+    const jitter = seededUnit(projection.layout_seed, index) * 0.05;
+    return {
+      key: String(node.id),
+      attributes: {
+        label: node.label,
+        club_id: node.club_id,
+        x: Math.cos(angle) + jitter,
+        y: Math.sin(angle) + jitter,
+        size: projection.style.node_size / 4,
+        color: projection.style.node_color,
+      },
+    };
+  });
+  const edges = projection.edges.map((edge, index) => ({
+    key: `e${index}`,
+    source: String(edge.source),
+    target: String(edge.target),
+    attributes: {
+      color: projection.style.edge_color,
+      size: projection.style.edge_width,
+    },
+  }));
+  return {
+    attributes: {
+      name: projection.projection_id,
+      layout_seed: projection.layout_seed,
+    },
+    options: {
+      type: projection.directed ? "directed" : "undirected",
+      multi: false,
+      allowSelfLoops: false,
+    },
+    nodes,
+    edges,
+  };
+}
+
+export function buildHtml(projection, graphExport) {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Zachary karate club (Sigma.js / GraphForge)</title>
+  <style>
+    html, body, #container { width: 100%; height: 100%; margin: 0; padding: 0; }
+  </style>
+</head>
+<body>
+  <div id="container"></div>
+  <script type="importmap">
+  {
+    "imports": {
+      "graphology": "https://cdn.jsdelivr.net/npm/graphology@0.25.4/+esm",
+      "sigma": "https://cdn.jsdelivr.net/npm/sigma@3.0.1/+esm"
+    }
+  }
+  </script>
+  <script type="module">
+    import Graph from "graphology";
+    import Sigma from "sigma";
+    const exported = ${JSON.stringify(graphExport)};
+    const graph = new Graph(exported.options);
+    for (const node of exported.nodes) {
+      graph.addNode(node.key, node.attributes);
+    }
+    for (const edge of exported.edges) {
+      graph.addEdgeWithKey(edge.key, edge.source, edge.target, edge.attributes);
+    }
+    new Sigma(graph, document.getElementById("container"));
+  </script>
+</body>
+</html>
+`;
+}
+
+export async function run(outputDir = join(ROOT, "output")) {
+  const projection = await project();
+  const graphExport = toGraphologyExport(projection);
+  mkdirSync(outputDir, { recursive: true });
+
+  const graphPath = join(outputDir, "sigma_karate_graph.json");
+  const htmlPath = join(outputDir, "sigma_karate.html");
+  writeFileSync(graphPath, `${JSON.stringify(graphExport, null, 2)}\n`);
+  writeFileSync(htmlPath, buildHtml(projection, graphExport));
+  return [graphPath, htmlPath];
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const outputDir = process.argv.includes("--output-dir")
+    ? process.argv[process.argv.indexOf("--output-dir") + 1]
+    : join(ROOT, "output");
+  for (const path of await run(outputDir)) {
+    console.log(path);
+  }
+}

--- a/examples/visualization/package-lock.json
+++ b/examples/visualization/package-lock.json
@@ -1,0 +1,298 @@
+{
+  "name": "graphforge-visualization-examples",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "graphforge-visualization-examples",
+      "dependencies": {
+        "apache-arrow": "^18.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@curatelabs/graphforge": "0.5.1"
+      }
+    },
+    "node_modules/@curatelabs/graphforge": {
+      "optional": true
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@types/command-line-args": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
+      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/command-line-usage": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/apache-arrow": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-18.1.0.tgz",
+      "integrity": "sha512-v/ShMp57iBnBp4lDgV8Jx3d3Q5/Hac25FWmQ98eMahUiHPXcvwIMKJD0hBIgclm/FCG+LwPkAKtkRO1O/W0YGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/command-line-args": "^5.2.3",
+        "@types/command-line-usage": "^5.0.4",
+        "@types/node": "^20.13.0",
+        "command-line-args": "^5.2.1",
+        "command-line-usage": "^7.0.1",
+        "flatbuffers": "^24.3.25",
+        "json-bignum": "^0.0.3",
+        "tslib": "^2.6.2"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.js"
+      }
+    },
+    "node_modules/array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/command-line-args": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.4.tgz",
+      "integrity": "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^4.1.1",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/flatbuffers": {
+      "version": "24.12.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-24.12.23.tgz",
+      "integrity": "sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/json-bignum": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
+      "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table-layout": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "wordwrapjs": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/table-layout/node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/wordwrapjs": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
+      "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    }
+  }
+}

--- a/examples/visualization/package.json
+++ b/examples/visualization/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "graphforge-visualization-examples",
+  "private": true,
+  "type": "module",
+  "description": "Node visualization examples over a shared GraphForge projection (#298)",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "projection": "node shared/projection.mjs",
+    "cytoscape": "node node/cytoscape_example.mjs",
+    "sigma": "node node/sigma_example.mjs",
+    "test": "node --test tests/test_node_examples.mjs"
+  },
+  "dependencies": {
+    "apache-arrow": "^18.1.0"
+  },
+  "optionalDependencies": {
+    "@curatelabs/graphforge": "0.5.1"
+  }
+}

--- a/examples/visualization/package.json
+++ b/examples/visualization/package.json
@@ -1,6 +1,7 @@
 {
   "name": "graphforge-visualization-examples",
   "private": true,
+  "license": "Apache-2.0",
   "type": "module",
   "description": "Node visualization examples over a shared GraphForge projection (#298)",
   "engines": {

--- a/examples/visualization/python/__init__.py
+++ b/examples/visualization/python/__init__.py
@@ -1,0 +1,1 @@
+"""Python visualization example adapters."""

--- a/examples/visualization/python/jaal_example.py
+++ b/examples/visualization/python/jaal_example.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 from pathlib import Path
+import sys
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
@@ -84,8 +84,8 @@ def main() -> None:
             "Jaal.create()/plot() does not accept a layout seed; interactive viewing "
             "requires a Dash server (use --serve locally)."
         ),
-        "node_count": int(len(node_df)),
-        "edge_count": int(len(edge_df)),
+        "node_count": len(node_df),
+        "edge_count": len(edge_df),
         "nodes": node_df.to_dict(orient="records"),
         "edges": edge_df.to_dict(orient="records"),
         "app_constructed": app is not None,

--- a/examples/visualization/python/jaal_example.py
+++ b/examples/visualization/python/jaal_example.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Jaal visualization over the shared GraphForge karate projection.
+
+Limitation: Jaal is a Dash dashboard. Its public interactive path is
+``Jaal(...).plot()`` (or ``create()`` + a WSGI server). This example constructs
+the Jaal app through ``create()`` and writes a browser-ready payload descriptor
+without starting a server in CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from shared.projection import project  # noqa: E402
+
+
+def to_jaal_frames(projection: dict):
+    import pandas as pd
+
+    edge_df = pd.DataFrame(
+        [
+            {
+                "from": edge["source"],
+                "to": edge["target"],
+                "weight": 1,
+            }
+            for edge in projection["edges"]
+        ]
+    )
+    node_df = pd.DataFrame(
+        [
+            {
+                "id": node["id"],
+                "label": node["label"],
+                "club_id": node["club_id"],
+            }
+            for node in projection["nodes"]
+        ]
+    )
+    return edge_df, node_df
+
+
+def build_jaal_app(projection: dict):
+    from jaal import Jaal
+
+    edge_df, node_df = to_jaal_frames(projection)
+    # Jaal/vis.js layout seeding is not exposed as a first-class create() argument.
+    # Documented compromise: use default physics; seed is recorded in the payload.
+    return Jaal(edge_df, node_df).create(directed=projection["directed"])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=ROOT / "output",
+        help="Directory for JSON payload artifacts",
+    )
+    parser.add_argument(
+        "--serve",
+        action="store_true",
+        help="Start Jaal's Dash server for local interactive viewing",
+    )
+    args = parser.parse_args()
+
+    projection = project()
+    edge_df, node_df = to_jaal_frames(projection)
+    app = build_jaal_app(projection)
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "library": "jaal",
+        "projection_id": projection["projection_id"],
+        "layout_seed_requested": projection["layout_seed"],
+        "layout_seed_applied": None,
+        "limitation": (
+            "Jaal.create()/plot() does not accept a layout seed; interactive viewing "
+            "requires a Dash server (use --serve locally)."
+        ),
+        "node_count": int(len(node_df)),
+        "edge_count": int(len(edge_df)),
+        "nodes": node_df.to_dict(orient="records"),
+        "edges": edge_df.to_dict(orient="records"),
+        "app_constructed": app is not None,
+        "app_type": type(app).__name__,
+    }
+    payload_path = args.output_dir / "jaal_karate_payload.json"
+    payload_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print(payload_path)
+
+    if args.serve:
+        from jaal import Jaal
+
+        Jaal(edge_df, node_df).plot(directed=projection["directed"])
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/visualization/python/plotly_example.py
+++ b/examples/visualization/python/plotly_example.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Plotly visualization over the shared GraphForge karate projection."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from shared.projection import project  # noqa: E402
+
+
+def _seeded_layout(node_ids: list[int], seed: int) -> dict[int, tuple[float, float]]:
+    """Deterministic circular layout (Plotly has no graph layout seed of its own)."""
+    count = len(node_ids)
+    positions: dict[int, tuple[float, float]] = {}
+    for index, node_id in enumerate(sorted(node_ids)):
+        angle = (2.0 * math.pi * index / count) + (seed % 360) * math.pi / 180.0
+        positions[node_id] = (math.cos(angle), math.sin(angle))
+    return positions
+
+
+def build_figure(projection: dict):
+    import plotly.graph_objects as go
+
+    positions = _seeded_layout(
+        [node["id"] for node in projection["nodes"]],
+        projection["layout_seed"],
+    )
+    edge_x: list[float | None] = []
+    edge_y: list[float | None] = []
+    for edge in projection["edges"]:
+        x0, y0 = positions[edge["source"]]
+        x1, y1 = positions[edge["target"]]
+        edge_x.extend([x0, x1, None])
+        edge_y.extend([y0, y1, None])
+
+    node_x = [positions[node["id"]][0] for node in projection["nodes"]]
+    node_y = [positions[node["id"]][1] for node in projection["nodes"]]
+    labels = [node["label"] for node in projection["nodes"]]
+
+    fig = go.Figure(
+        data=[
+            go.Scatter(
+                x=edge_x,
+                y=edge_y,
+                mode="lines",
+                line={"width": projection["style"]["edge_width"], "color": projection["style"]["edge_color"]},
+                hoverinfo="none",
+                name="edges",
+            ),
+            go.Scatter(
+                x=node_x,
+                y=node_y,
+                mode="markers+text",
+                text=labels,
+                textposition="top center",
+                marker={
+                    "size": projection["style"]["node_size"],
+                    "color": projection["style"]["node_color"],
+                },
+                name="nodes",
+            ),
+        ],
+        layout=go.Layout(
+            title="Zachary karate club (Plotly / GraphForge projection)",
+            showlegend=False,
+            hovermode="closest",
+            xaxis={"showgrid": False, "zeroline": False, "showticklabels": False},
+            yaxis={"showgrid": False, "zeroline": False, "showticklabels": False},
+        ),
+    )
+    return fig
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=ROOT / "output",
+        help="Directory for HTML/JSON artifacts",
+    )
+    parser.add_argument(
+        "--show",
+        action="store_true",
+        help="Open the interactive figure in a browser (local use only)",
+    )
+    args = parser.parse_args()
+
+    projection = project()
+    fig = build_figure(projection)
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    html_path = args.output_dir / "plotly_karate.html"
+    json_path = args.output_dir / "plotly_karate.json"
+    fig.write_html(str(html_path), include_plotlyjs="cdn", full_html=True)
+    json_path.write_text(json.dumps(fig.to_plotly_json(), indent=2) + "\n", encoding="utf-8")
+    print(html_path)
+    print(json_path)
+    if args.show:
+        fig.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/visualization/python/plotly_example.py
+++ b/examples/visualization/python/plotly_example.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 import argparse
 import json
 import math
-import sys
 from pathlib import Path
+import sys
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
@@ -50,7 +50,10 @@ def build_figure(projection: dict):
                 x=edge_x,
                 y=edge_y,
                 mode="lines",
-                line={"width": projection["style"]["edge_width"], "color": projection["style"]["edge_color"]},
+                line={
+                    "width": projection["style"]["edge_width"],
+                    "color": projection["style"]["edge_color"],
+                },
                 hoverinfo="none",
                 name="edges",
             ),

--- a/examples/visualization/python/pyvis_example.py
+++ b/examples/visualization/python/pyvis_example.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 from pathlib import Path
+import sys
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))

--- a/examples/visualization/python/pyvis_example.py
+++ b/examples/visualization/python/pyvis_example.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""PyVis visualization over the shared GraphForge karate projection."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from shared.projection import project  # noqa: E402
+
+
+def build_network(projection: dict):
+    from pyvis.network import Network
+
+    net = Network(
+        height="700px",
+        width="100%",
+        bgcolor="#ffffff",
+        font_color="#1a202c",
+        directed=projection["directed"],
+    )
+    # PyVis/vis.js accepts a numeric seed for reproducible physics layout.
+    net.set_options(
+        json.dumps(
+            {
+                "physics": {
+                    "enabled": True,
+                    "barnesHut": {"gravitationalConstant": -8000},
+                    "stabilization": {"iterations": 100},
+                },
+                "layout": {"randomSeed": projection["layout_seed"]},
+                "interaction": {"hover": True},
+            }
+        )
+    )
+    for node in projection["nodes"]:
+        net.add_node(
+            node["id"],
+            label=node["label"],
+            color=projection["style"]["node_color"],
+            size=projection["style"]["node_size"],
+        )
+    for edge in projection["edges"]:
+        net.add_edge(
+            edge["source"],
+            edge["target"],
+            color=projection["style"]["edge_color"],
+            width=projection["style"]["edge_width"],
+        )
+    return net
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=ROOT / "output",
+        help="Directory for HTML artifacts",
+    )
+    parser.add_argument(
+        "--show",
+        action="store_true",
+        help="Also open the HTML in a browser (local use only)",
+    )
+    args = parser.parse_args()
+
+    projection = project()
+    net = build_network(projection)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    html_path = args.output_dir / "pyvis_karate.html"
+    net.write_html(str(html_path), open_browser=args.show, notebook=False)
+    print(html_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/visualization/requirements.txt
+++ b/examples/visualization/requirements.txt
@@ -1,0 +1,8 @@
+# Visualization example dependencies (install GraphForge separately).
+# Python: pip install -r requirements.txt
+# GraphForge: pip install graphforge   # or a local maturin wheel
+plotly>=5.18
+pyvis>=0.3.2
+jaal>=0.1.9
+pandas>=2.0
+pyarrow>=15.0

--- a/examples/visualization/shared/__init__.py
+++ b/examples/visualization/shared/__init__.py
@@ -1,0 +1,1 @@
+"""Shared projection helpers for visualization examples."""

--- a/examples/visualization/shared/contract.json
+++ b/examples/visualization/shared/contract.json
@@ -1,0 +1,25 @@
+{
+  "projection_id": "karate-member-friend-v1",
+  "description": "Shared undirected projection for GraphForge visualization examples (#298).",
+  "node": {
+    "identity_field": "club_id",
+    "label_field": "label",
+    "display_label_template": "M{club_id}",
+    "color": "#2E86AB",
+    "size": 18
+  },
+  "edge": {
+    "directed": false,
+    "relationship_type": "FRIEND",
+    "color": "#A0AEC0",
+    "width": 1.5
+  },
+  "layout": {
+    "seed": 42,
+    "note": "Libraries that support a layout seed should use 42; others document the limitation."
+  },
+  "query": {
+    "nodes": "MATCH (n:Member) RETURN n.club_id AS club_id, n.label AS label ORDER BY club_id",
+    "edges": "MATCH (a:Member)-[:FRIEND]-(b:Member) WHERE a.club_id < b.club_id RETURN a.club_id AS source, b.club_id AS target ORDER BY source, target"
+  }
+}

--- a/examples/visualization/shared/projection.mjs
+++ b/examples/visualization/shared/projection.mjs
@@ -1,0 +1,210 @@
+/**
+ * Shared GraphForge projection for Node visualization examples.
+ *
+ * Loads Mark Newman's karate-club GML through GraphForge's public Node API and
+ * returns the same deterministic projection consumed by Cytoscape.js / Sigma.js.
+ */
+
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { createWriteStream } from "node:fs";
+import { pipeline } from "node:stream/promises";
+import { Readable } from "node:stream";
+import { execFileSync } from "node:child_process";
+import { tableFromIPC } from "apache-arrow";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(HERE, "..");
+const MANIFEST_PATH = join(ROOT, "dataset", "MANIFEST.json");
+const CONTRACT_PATH = join(HERE, "contract.json");
+const DEFAULT_CACHE = join(ROOT, ".cache");
+
+function loadJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function sha256File(path) {
+  const hash = createHash("sha256");
+  hash.update(readFileSync(path));
+  return hash.digest("hex");
+}
+
+async function download(url, dest) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Download failed (${response.status}): ${url}`);
+  }
+  await pipeline(Readable.fromWeb(response.body), createWriteStream(dest));
+}
+
+export async function fetchDataset(cacheDir = DEFAULT_CACHE, { force = false } = {}) {
+  const manifest = loadJson(MANIFEST_PATH);
+  mkdirSync(cacheDir, { recursive: true });
+  const archivePath = join(cacheDir, manifest.archive.filename);
+  const extractDir = join(cacheDir, "karate");
+  const expected = manifest.archive.sha256;
+
+  if (force || !existsSync(archivePath) || sha256File(archivePath) !== expected) {
+    await download(manifest.source_url, archivePath);
+  }
+  const actual = sha256File(archivePath);
+  if (actual !== expected) {
+    throw new Error(
+      `Archive checksum mismatch: expected ${expected}, got ${actual}`,
+    );
+  }
+
+  mkdirSync(extractDir, { recursive: true });
+  execFileSync("unzip", ["-o", archivePath, "-d", extractDir], {
+    stdio: "ignore",
+  });
+
+  for (const [relative, memberExpected] of Object.entries(manifest.archive.members)) {
+    const memberPath = join(extractDir, relative);
+    if (!existsSync(memberPath)) {
+      throw new Error(`Missing archive member: ${relative}`);
+    }
+    const memberActual = sha256File(memberPath);
+    if (memberActual !== memberExpected) {
+      throw new Error(
+        `Member checksum mismatch for ${relative}: expected ${memberExpected}, got ${memberActual}`,
+      );
+    }
+  }
+  return extractDir;
+}
+
+export function parseGmlUndirectedEdges(gmlText) {
+  const edges = new Set();
+  const re = /edge\s*\[\s*source\s+(\d+)\s+target\s+(\d+)/g;
+  let match;
+  while ((match = re.exec(gmlText)) !== null) {
+    const left = Number(match[1]);
+    const right = Number(match[2]);
+    if (left === right) continue;
+    const a = Math.min(left, right);
+    const b = Math.max(left, right);
+    edges.add(`${a},${b}`);
+  }
+  return [...edges]
+    .map((key) => key.split(",").map(Number))
+    .sort((x, y) => x[0] - y[0] || x[1] - y[1]);
+}
+
+function resolveGraphForge() {
+  const envPath = process.env.GRAPHFORGE_NODE_PATH;
+  if (envPath) {
+    return import(pathToFileURL(envPath).href);
+  }
+  // Prefer the in-repo binding during development.
+  const localBinding = join(
+    ROOT,
+    "..",
+    "..",
+    "crates",
+    "graphforge-bindings-node",
+    "index.js",
+  );
+  if (existsSync(localBinding)) {
+    return import(pathToFileURL(localBinding).href);
+  }
+  return import("@curatelabs/graphforge");
+}
+
+export async function buildGraphForge(datasetDir) {
+  const [{ GraphForge }, manifest] = await Promise.all([
+    resolveGraphForge(),
+    Promise.resolve(loadJson(MANIFEST_PATH)),
+  ]);
+  const extractDir = datasetDir || (await fetchDataset());
+  const gml = readFileSync(join(extractDir, "karate.gml"), "utf8");
+  const edges = parseGmlUndirectedEdges(gml);
+  if (edges.length !== manifest.graph.edge_count) {
+    throw new Error(
+      `Expected ${manifest.graph.edge_count} edges, found ${edges.length}`,
+    );
+  }
+
+  const forge = new GraphForge();
+  const handles = new Map();
+  const [low, high] = manifest.graph.node_id_range;
+  for (let clubId = low; clubId <= high; clubId += 1) {
+    handles.set(
+      clubId,
+      forge.addNode(manifest.graph.node_label, {
+        club_id: clubId,
+        label: `M${clubId}`,
+      }),
+    );
+  }
+  if (handles.size !== manifest.graph.node_count) {
+    throw new Error(
+      `Expected ${manifest.graph.node_count} nodes, built ${handles.size}`,
+    );
+  }
+
+  const rel = manifest.graph.relationship_type;
+  for (const [source, target] of edges) {
+    forge.addEdge(handles.get(source), rel, handles.get(target));
+  }
+  return forge;
+}
+
+function columnValues(table, name) {
+  return [...table.getChild(name).toArray()].map((value) =>
+    typeof value === "bigint" ? Number(value) : value,
+  );
+}
+
+export async function project(forge, datasetDir) {
+  const contract = loadJson(CONTRACT_PATH);
+  const engine = forge || (await buildGraphForge(datasetDir));
+  const nodeTable = tableFromIPC(engine.execute(contract.query.nodes));
+  const edgeTable = tableFromIPC(engine.execute(contract.query.edges));
+
+  const clubIds = columnValues(nodeTable, "club_id");
+  const labels = columnValues(nodeTable, "label");
+  const sources = columnValues(edgeTable, "source");
+  const targets = columnValues(edgeTable, "target");
+
+  return {
+    projection_id: contract.projection_id,
+    directed: contract.edge.directed,
+    layout_seed: contract.layout.seed,
+    style: {
+      node_color: contract.node.color,
+      node_size: contract.node.size,
+      edge_color: contract.edge.color,
+      edge_width: contract.edge.width,
+    },
+    nodes: clubIds.map((clubId, index) => ({
+      id: Number(clubId),
+      label: String(labels[index]),
+      club_id: Number(clubId),
+    })),
+    edges: sources.map((source, index) => ({
+      source: Number(source),
+      target: Number(targets[index]),
+    })),
+  };
+}
+
+export function writeProjectionJson(path, projection) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(projection, null, 2)}\n`, "utf8");
+  return path;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const out = join(ROOT, "output", "projection.json");
+  const payload = await project();
+  writeProjectionJson(out, payload);
+  console.log(out);
+}

--- a/examples/visualization/shared/projection.py
+++ b/examples/visualization/shared/projection.py
@@ -7,9 +7,9 @@ returns a deterministic node/edge projection consumed by each library adapter.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 import re
 import sys
-from pathlib import Path
 from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/examples/visualization/shared/projection.py
+++ b/examples/visualization/shared/projection.py
@@ -1,0 +1,122 @@
+"""Shared GraphForge projection for visualization examples.
+
+Loads Mark Newman's karate-club GML through GraphForge's public Python API and
+returns a deterministic node/edge projection consumed by each library adapter.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from dataset.fetch import fetch_dataset, load_manifest  # noqa: E402
+
+CONTRACT_PATH = Path(__file__).resolve().parent / "contract.json"
+
+
+def load_contract() -> dict[str, Any]:
+    return json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+
+
+def parse_gml_undirected_edges(gml_text: str) -> list[tuple[int, int]]:
+    """Parse undirected edges from Newman's karate.gml (source < target)."""
+    edges: set[tuple[int, int]] = set()
+    for match in re.finditer(
+        r"edge\s*\[\s*source\s+(\d+)\s+target\s+(\d+)",
+        gml_text,
+    ):
+        left, right = int(match.group(1)), int(match.group(2))
+        if left == right:
+            continue
+        edges.add((left, right) if left < right else (right, left))
+    return sorted(edges)
+
+
+def build_graphforge(dataset_dir: Path | None = None):
+    """Construct an in-memory GraphForge graph from the verified dataset."""
+    from graphforge import GraphForge
+
+    manifest = load_manifest()
+    extract_dir = dataset_dir or fetch_dataset()
+    gml_path = extract_dir / "karate.gml"
+    edges = parse_gml_undirected_edges(gml_path.read_text(encoding="utf-8"))
+
+    expected_nodes = manifest["graph"]["node_count"]
+    expected_edges = manifest["graph"]["edge_count"]
+    if len(edges) != expected_edges:
+        raise RuntimeError(f"Expected {expected_edges} undirected edges, found {len(edges)}")
+
+    forge = GraphForge()
+    handles: dict[int, Any] = {}
+    low, high = manifest["graph"]["node_id_range"]
+    for club_id in range(low, high + 1):
+        handles[club_id] = forge.add_node(
+            manifest["graph"]["node_label"],
+            club_id=club_id,
+            label=f"M{club_id}",
+        )
+    if len(handles) != expected_nodes:
+        raise RuntimeError(f"Expected {expected_nodes} nodes, built {len(handles)}")
+
+    rel = manifest["graph"]["relationship_type"]
+    for source, target in edges:
+        forge.add_edge(handles[source], rel, handles[target])
+
+    return forge
+
+
+def project(forge=None, dataset_dir: Path | None = None) -> dict[str, Any]:
+    """Return the shared projection dict via GraphForge public execute()."""
+    contract = load_contract()
+    engine = forge or build_graphforge(dataset_dir)
+
+    nodes = engine.execute(contract["query"]["nodes"]).to_pylist()
+    edges = engine.execute(contract["query"]["edges"]).to_pylist()
+
+    projection = {
+        "projection_id": contract["projection_id"],
+        "directed": contract["edge"]["directed"],
+        "layout_seed": contract["layout"]["seed"],
+        "style": {
+            "node_color": contract["node"]["color"],
+            "node_size": contract["node"]["size"],
+            "edge_color": contract["edge"]["color"],
+            "edge_width": contract["edge"]["width"],
+        },
+        "nodes": [
+            {
+                "id": int(row["club_id"]),
+                "label": str(row["label"]),
+                "club_id": int(row["club_id"]),
+            }
+            for row in nodes
+        ],
+        "edges": [
+            {
+                "source": int(row["source"]),
+                "target": int(row["target"]),
+            }
+            for row in edges
+        ],
+    }
+    return projection
+
+
+def write_projection_json(path: Path, projection: dict[str, Any] | None = None) -> Path:
+    payload = projection or project()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+if __name__ == "__main__":
+    out = ROOT / "output" / "projection.json"
+    write_projection_json(out)
+    print(out)

--- a/examples/visualization/tests/test_node_examples.mjs
+++ b/examples/visualization/tests/test_node_examples.mjs
@@ -1,0 +1,74 @@
+/**
+ * Focused checks for Node visualization examples (#298).
+ *
+ * Constructs Cytoscape.js and Sigma.js payloads without opening a browser.
+ */
+
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+import test from "node:test";
+import { project } from "../shared/projection.mjs";
+import { toCytoscapeElements, buildHtml as buildCyHtml } from "../node/cytoscape_example.mjs";
+import {
+  toGraphologyExport,
+  buildHtml as buildSigmaHtml,
+} from "../node/sigma_example.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+test("shared projection has karate counts via GraphForge", async () => {
+  const projection = await project();
+  assert.equal(projection.projection_id, "karate-member-friend-v1");
+  assert.equal(projection.nodes.length, 34);
+  assert.equal(projection.edges.length, 78);
+});
+
+test("cytoscape builds elements and html artifact", async () => {
+  const projection = await project();
+  const elements = toCytoscapeElements(projection);
+  assert.equal(elements.filter((el) => el.data.source == null).length, 34);
+  assert.equal(elements.filter((el) => el.data.source != null).length, 78);
+  const html = buildCyHtml(projection, elements);
+  assert.match(html, /cytoscape/);
+  assert.match(html, /M1/);
+});
+
+test("sigma builds graphology export and html artifact", async () => {
+  const projection = await project();
+  const graphExport = toGraphologyExport(projection);
+  assert.equal(graphExport.nodes.length, 34);
+  assert.equal(graphExport.edges.length, 78);
+  assert.equal(graphExport.attributes.layout_seed, 42);
+  const html = buildSigmaHtml(projection, graphExport);
+  assert.match(html, /sigma/i);
+  assert.match(html, /graphology/i);
+});
+
+test("example scripts write artifacts", async () => {
+  const out = mkdtempSync(join(tmpdir(), "gf-viz-node-"));
+  try {
+    for (const script of ["cytoscape_example.mjs", "sigma_example.mjs"]) {
+      const result = spawnSync(
+        process.execPath,
+        [join(ROOT, "node", script), "--output-dir", out],
+        { encoding: "utf8" },
+      );
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+    }
+    assert.match(
+      readFileSync(join(out, "cytoscape_karate.html"), "utf8"),
+      /cytoscape/,
+    );
+    assert.match(
+      readFileSync(join(out, "sigma_karate_graph.json"), "utf8"),
+      /karate-member-friend-v1/,
+    );
+  } finally {
+    rmSync(out, { recursive: true, force: true });
+  }
+});

--- a/examples/visualization/tests/test_python_examples.py
+++ b/examples/visualization/tests/test_python_examples.py
@@ -8,9 +8,10 @@ opening an interactive browser.
 from __future__ import annotations
 
 import json
+import os
+from pathlib import Path
 import subprocess
 import sys
-from pathlib import Path
 
 import pytest
 
@@ -85,7 +86,7 @@ def test_example_scripts_cli(tmp_path):
     """Smoke each example script end-to-end with GraphForge + artifact output."""
     out = tmp_path / "cli"
     out.mkdir()
-    env = {**dict(**{k: v for k, v in __import__("os").environ.items()}), "PYTHONPATH": str(ROOT)}
+    env = {**os.environ, "PYTHONPATH": str(ROOT)}
     scripts = [
         ROOT / "python" / "plotly_example.py",
         ROOT / "python" / "pyvis_example.py",

--- a/examples/visualization/tests/test_python_examples.py
+++ b/examples/visualization/tests/test_python_examples.py
@@ -1,0 +1,103 @@
+"""Focused checks for Python visualization examples (#298).
+
+These are example-suite tests, not required CI / release gates. They construct
+each visualizer far enough to write an artifact or browser-ready payload without
+opening an interactive browser.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+OUTPUT = ROOT / "output" / "test-python"
+
+pytest.importorskip("graphforge")
+pytest.importorskip("plotly")
+pytest.importorskip("pyvis")
+pytest.importorskip("jaal")
+pytest.importorskip("pandas")
+
+
+@pytest.fixture(scope="module")
+def projection():
+    sys.path.insert(0, str(ROOT))
+    from shared.projection import project
+
+    payload = project()
+    assert len(payload["nodes"]) == 34
+    assert len(payload["edges"]) == 78
+    assert payload["projection_id"] == "karate-member-friend-v1"
+    return payload
+
+
+def test_plotly_writes_html_and_json(projection, tmp_path):
+    from python.plotly_example import build_figure
+
+    fig = build_figure(projection)
+    html_path = tmp_path / "plotly_karate.html"
+    json_path = tmp_path / "plotly_karate.json"
+    fig.write_html(str(html_path), include_plotlyjs="cdn", full_html=True)
+    json_path.write_text(json.dumps(fig.to_plotly_json()), encoding="utf-8")
+    assert html_path.is_file() and html_path.stat().st_size > 100
+    assert "plotly" in html_path.read_text(encoding="utf-8").lower()
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    assert "data" in payload and len(payload["data"]) >= 2
+
+
+def test_pyvis_writes_html(projection, tmp_path):
+    from python.pyvis_example import build_network
+
+    net = build_network(projection)
+    html_path = tmp_path / "pyvis_karate.html"
+    net.write_html(str(html_path), open_browser=False, notebook=False)
+    text = html_path.read_text(encoding="utf-8")
+    assert "vis" in text.lower() or "network" in text.lower()
+    assert "M1" in text
+
+
+def test_jaal_constructs_app_and_payload(projection, tmp_path):
+    from python.jaal_example import build_jaal_app, to_jaal_frames
+
+    edge_df, node_df = to_jaal_frames(projection)
+    assert len(node_df) == 34
+    assert len(edge_df) == 78
+    app = build_jaal_app(projection)
+    assert app is not None
+
+    payload = {
+        "app_constructed": True,
+        "app_type": type(app).__name__,
+        "node_count": len(node_df),
+        "edge_count": len(edge_df),
+    }
+    path = tmp_path / "jaal_karate_payload.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    assert json.loads(path.read_text())["node_count"] == 34
+
+
+def test_example_scripts_cli(tmp_path):
+    """Smoke each example script end-to-end with GraphForge + artifact output."""
+    out = tmp_path / "cli"
+    out.mkdir()
+    env = {**dict(**{k: v for k, v in __import__("os").environ.items()}), "PYTHONPATH": str(ROOT)}
+    scripts = [
+        ROOT / "python" / "plotly_example.py",
+        ROOT / "python" / "pyvis_example.py",
+        ROOT / "python" / "jaal_example.py",
+    ]
+    for script in scripts:
+        subprocess.run(
+            [sys.executable, str(script), "--output-dir", str(out)],
+            check=True,
+            cwd=str(ROOT),
+            env=env,
+        )
+    assert (out / "plotly_karate.html").is_file()
+    assert (out / "pyvis_karate.html").is_file()
+    assert (out / "jaal_karate_payload.json").is_file()


### PR DESCRIPTION
## Summary
- Add comparable Plotly, Jaal, PyVis, Cytoscape.js, and Sigma.js examples over one shared Zachary karate-club GraphForge public-API projection (`examples/visualization/`).
- Publish reader guide `docs/guide/visualization.md` (dataset provenance/checksums, projection contract, setup, limitations) and wire it into the Starlight allowlist/nav.
- Add example-suite Python/Node artifact checks that construct visualizers without opening a browser; not wired into required CI or release gates.

Fixes #298

## Test plan
- [ ] `python examples/visualization/dataset/fetch.py` verifies Newman karate.zip checksums
- [ ] With GraphForge installed: `python -m pytest examples/visualization/tests/test_python_examples.py -q`
- [ ] With local/native Node binding: `node --test examples/visualization/tests/test_node_examples.mjs`
- [ ] Spot-check generated HTML/JSON under `examples/visualization/output/` locally
- [ ] Confirm docs sync allowlist includes `guide/visualization.md`


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788191437&installation_model_id=20486&pr_number=312&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F312&signature=d10312238900b8c8f244a2a884c6c887b21225279e0b692c9ad6314c78ffb29f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add real-data visualization examples for Python and Node using the karate club dataset
> - Adds a new `examples/visualization/` directory with end-to-end examples for five libraries: Plotly, Jaal, and PyVis (Python) and Cytoscape.js and Sigma.js (Node).
> - A shared projection layer ([projection.py](https://github.com/CurateLabs/graphforge/pull/312/files#diff-c5508deb4014c98146a5e6b406ff7b51da5df8f716038c2a0c21ff3ac5f77182) and [projection.mjs](https://github.com/CurateLabs/graphforge/pull/312/files#diff-718efefcb16e172acb4d4bd043f183103e79addad12a0b2db5c2404e0cbe95fc)) downloads and verifies the Zachary karate club dataset, builds an in-memory GraphForge graph, and runs Cypher queries to produce a deterministic projection consumed by all adapters.
> - Each adapter writes standalone HTML and/or JSON artifacts to an output directory; CLIs support `--output-dir`, `--show`, and `--serve` flags.
> - Tests in [test_python_examples.py](https://github.com/CurateLabs/graphforge/pull/312/files#diff-9bed27127f49a2958a37084ef2e74e3af738f35cf353ee50c794132dc5e7e14a) and [test_node_examples.mjs](https://github.com/CurateLabs/graphforge/pull/312/files#diff-5fe31ad5fbf689432d4b29e6e3ad14c6a7ce8da85ca31d59fb0c6973e9da096c) validate projection counts and artifact generation without launching a browser.
> - A new [visualization.md](https://github.com/CurateLabs/graphforge/pull/312/files#diff-9ab8d1459a308d33a670a014fb1f2d1143bd87562eb5244fbe6a4da99b13af6c) guide is added to the docs site, linked from the overview, analytics-integration page, and sidebar nav.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ab8ba2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->