### PR TITLE
fix(release): generate npm entrypoints in Binding RC assemble

### DIFF
--- a/.github/workflows/binding-release-candidate.yml
+++ b/.github/workflows/binding-release-candidate.yml
@@ -483,6 +483,12 @@ jobs:
           cp candidate/release-artifacts/node-addons/*.node \
             crates/graphforge-bindings-node/artifacts/
           pushd crates/graphforge-bindings-node
+          # index.js / index.d.ts are gitignored NAPI-RS outputs. Generate them
+          # here before packing the main package; matrix jobs already retained
+          # the tested native addons that napi artifacts will distribute.
+          pnpm exec napi build --platform --release --target x86_64-unknown-linux-gnu
+          test -f index.js
+          test -f index.d.ts
           pnpm exec napi create-npm-dirs
           pnpm exec napi artifacts --output-dir artifacts --npm-dir npm
           python3 "$GITHUB_WORKSPACE/scripts/ci/validate-napi-artifacts.py" \
@@ -496,6 +502,21 @@ jobs:
           done
           npm pack . --ignore-scripts \
             --pack-destination "$GITHUB_WORKSPACE/candidate/release-artifacts/npm"
+          python3 - <<PY
+          import tarfile
+          from pathlib import Path
+          npm_dir = Path("$GITHUB_WORKSPACE") / "candidate" / "release-artifacts" / "npm"
+          packs = [
+              path
+              for path in sorted(npm_dir.glob("curatelabs-graphforge-*.tgz"))
+              if path.name.count("-") == 2  # curatelabs-graphforge-<version>.tgz
+          ]
+          assert len(packs) == 1, packs
+          with tarfile.open(packs[0], "r:gz") as archive:
+              names = set(archive.getnames())
+          missing = {"package/index.js", "package/index.d.ts"} - names
+          assert not missing, f"{packs[0].name} missing {sorted(missing)}"
+          PY
           popd
           pnpm --dir packages/cli pack \
             --pack-destination "$GITHUB_WORKSPACE/candidate/release-artifacts/npm"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Keep first-party crate path+version dependency pins on the same root
   version so Binding RC offline rehearsal and crates.io packaging accept
   the complete 15-crate graph (#192).
+- Generate the gitignored NAPI-RS `index.js` / `index.d.ts` entrypoints
+  during Binding RC candidate assembly so the main npm tarball is complete
+  before offline rehearsal (#192).
 - Replace the Python package README with a concise PyPI landing page: short
   purpose, install path, one minimal first-use example, and canonical
   `docs.graphforge.sh` links instead of a raw CLI command inventory (#304).

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Keep first-party crate path+version dependency pins on the same root
   version so Binding RC offline rehearsal and crates.io packaging accept
   the complete 15-crate graph (#192).
+- Generate the gitignored NAPI-RS `index.js` / `index.d.ts` entrypoints
+  during Binding RC candidate assembly so the main npm tarball is complete
+  before offline rehearsal (#192).
 - Replace the Python package README with a concise PyPI landing page: short
   purpose, install path, one minimal first-use example, and canonical
   `docs.graphforge.sh` links instead of a raw CLI command inventory (#304).

--- a/scripts/ci/test-binding-release-candidate.py
+++ b/scripts/ci/test-binding-release-candidate.py
@@ -596,6 +596,13 @@ def main() -> None:
     assert "--skip-optional-publish --no-gh-release" in release_candidate_job
     assert 'npm pack "./$package_dir"' in release_candidate_job
     assert "scripts/ci/prepare-napi-packages.py" in release_candidate_job
+    assert (
+        "pnpm exec napi build --platform --release --target x86_64-unknown-linux-gnu"
+        in release_candidate_job
+    ), "assemble must generate gitignored index.js/index.d.ts before packing the main package"
+    assert "test -f index.js" in release_candidate_job
+    assert "test -f index.d.ts" in release_candidate_job
+    assert 'package/index.js' in release_candidate_job
     assert "pnpm --dir packages/cli pack" in release_candidate_job
     assert "pnpm --dir packages/agent-skills pack" in release_candidate_job
     assert 'cargo package "${package_args[@]}" --allow-dirty --no-verify' in (release_candidate_job)

--- a/scripts/ci/test-binding-release-candidate.py
+++ b/scripts/ci/test-binding-release-candidate.py
@@ -602,7 +602,7 @@ def main() -> None:
     ), "assemble must generate gitignored index.js/index.d.ts before packing the main package"
     assert "test -f index.js" in release_candidate_job
     assert "test -f index.d.ts" in release_candidate_job
-    assert 'package/index.js' in release_candidate_job
+    assert "package/index.js" in release_candidate_job
     assert "pnpm --dir packages/cli pack" in release_candidate_job
     assert "pnpm --dir packages/agent-skills pack" in release_candidate_job
     assert 'cargo package "${package_args[@]}" --allow-dirty --no-verify' in (release_candidate_job)


### PR DESCRIPTION
## Summary
- Generate gitignored NAPI-RS `index.js` / `index.d.ts` during Binding RC candidate assembly before packing the main `@curatelabs/graphforge` tarball
- Fail closed if the packed main archive omits those entrypoints
- Add Binding RC workflow contract coverage for the assemble step

Fixes Binding RC assemble failure on SHA `46acd59`:
`curatelabs-graphforge-0.5.1.tgz is incomplete; missing required files: ['package/index.d.ts', 'package/index.js']`

Failed run: https://github.com/CurateLabs/graphforge/actions/runs/30707001756

Refs #192

## Test plan
- [x] `python3 scripts/ci/test-binding-release-candidate.py`
- [x] `scripts/check-workflows.sh`
- [ ] CI Gate green
- [ ] Re-dispatch Binding RC on the merge SHA


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788192682&installation_model_id=20486&pr_number=313&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F313&signature=3b4d6f107e75477ed267695b4ee6a8676aa3614e36247fa49a0d12d4f7886ae2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Generate npm entrypoints during Binding RC assembly to ensure complete tarballs
> - The [binding-release-candidate.yml](.github/workflows/binding-release-candidate.yml) workflow now runs `pnpm exec napi build` to generate gitignored NAPI-RS `index.js` and `index.d.ts` files before packing the npm tarball.
> - File presence is asserted with `test -f` checks before packing, and a Python script validates that `package/index.js` and `package/index.d.ts` are present inside the produced `.tgz`.
> - The [test script](scripts/ci/test-binding-release-candidate.py) is updated to assert all new build and validation steps are present in the workflow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c8479b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->