### PR TITLE
fix(release): host-native npm only in Binding RC offline rehearsal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Generate the gitignored NAPI-RS `index.js` / `index.d.ts` entrypoints
   during Binding RC candidate assembly so the main npm tarball is complete
   before offline rehearsal (#192).
+- Offline Binding RC Node rehearsal installs only the host-compatible native
+  npm package alongside main/CLI/skills so platform `os`/`cpu` metadata no
+  longer fails the clean consumer with `EBADPLATFORM` (#192).
 - Replace the Python package README with a concise PyPI landing page: short
   purpose, install path, one minimal first-use example, and canonical
   `docs.graphforge.sh` links instead of a raw CLI command inventory (#304).

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Generate the gitignored NAPI-RS `index.js` / `index.d.ts` entrypoints
   during Binding RC candidate assembly so the main npm tarball is complete
   before offline rehearsal (#192).
+- Offline Binding RC Node rehearsal installs only the host-compatible native
+  npm package alongside main/CLI/skills so platform `os`/`cpu` metadata no
+  longer fails the clean consumer with `EBADPLATFORM` (#192).
 - Replace the Python package README with a concise PyPI landing page: short
   purpose, install path, one minimal first-use example, and canonical
   `docs.graphforge.sh` links instead of a raw CLI command inventory (#304).

--- a/scripts/ci/release_candidate_manifest.py
+++ b/scripts/ci/release_candidate_manifest.py
@@ -52,6 +52,22 @@ NATIVE_NPM_PACKAGES = (
     "@curatelabs/graphforge-linux-x64-gnu",
     "@curatelabs/graphforge-win32-x64-msvc",
 )
+# Exact napi platform package.json constraints (os/cpu[/libc]).
+NATIVE_PLATFORM_CONSTRAINTS: dict[str, dict[str, list[str]]] = {
+    "@curatelabs/graphforge-darwin-arm64": {"os": ["darwin"], "cpu": ["arm64"]},
+    "@curatelabs/graphforge-darwin-x64": {"os": ["darwin"], "cpu": ["x64"]},
+    "@curatelabs/graphforge-linux-arm64-gnu": {
+        "os": ["linux"],
+        "cpu": ["arm64"],
+        "libc": ["glibc"],
+    },
+    "@curatelabs/graphforge-linux-x64-gnu": {
+        "os": ["linux"],
+        "cpu": ["x64"],
+        "libc": ["glibc"],
+    },
+    "@curatelabs/graphforge-win32-x64-msvc": {"os": ["win32"], "cpu": ["x64"]},
+}
 NPM_PACKAGES = (
     *NATIVE_NPM_PACKAGES,
     "@curatelabs/graphforge",
@@ -249,6 +265,14 @@ def _validate_npm(view: ArchiveView, version: str) -> dict[str, Any]:
         }
         if not isinstance(files, list) or not expected_files.issubset(set(files)):
             raise CandidateError(f"npm native package {name} files metadata is incomplete")
+        expected_platform = NATIVE_PLATFORM_CONSTRAINTS[name]
+        for field, expected in expected_platform.items():
+            if metadata.get(field) != expected:
+                raise CandidateError(
+                    f"npm native package {name} {field} metadata must be {expected}"
+                )
+        if "libc" not in expected_platform and "libc" in metadata:
+            raise CandidateError(f"npm native package {name} must not declare libc")
     elif name == "@curatelabs/graphforge":
         required += [
             "package/index.js",

--- a/scripts/ci/release_rehearsal.py
+++ b/scripts/ci/release_rehearsal.py
@@ -215,9 +215,7 @@ def _node_consumer(
             "npm_config_update_notifier": "false",
         }
     )
-    tarballs = [
-        str((artifacts_dir / by_name[name]["path"]).resolve()) for name in install_names
-    ]
+    tarballs = [str((artifacts_dir / by_name[name]["path"]).resolve()) for name in install_names]
     _run(
         ["npm", "install", "--offline", "--ignore-scripts", "--no-audit", "--no-fund", *tarballs],
         cwd=node_root,

--- a/scripts/ci/release_rehearsal.py
+++ b/scripts/ci/release_rehearsal.py
@@ -64,10 +64,25 @@ def _run(command: list[str], *, cwd: Path, env: dict[str, str] | None = None) ->
     except (OSError, subprocess.TimeoutExpired) as error:
         raise RehearsalError(f"offline consumer could not execute {command[0]}: {error}") from error
     if result.returncode != 0:
-        stderr = result.stderr.strip().splitlines()
-        detail = stderr[-1] if stderr else f"exit {result.returncode}"
+        detail = _command_failure_detail(result.stderr, result.returncode)
         raise RehearsalError(f"offline consumer {command[0]} failed: {detail}")
     return result.stdout.strip()
+
+
+def _command_failure_detail(stderr: str, returncode: int) -> str:
+    """Surface actionable stderr; npm ends with a log-path line that hides the cause."""
+    lines = [line.strip() for line in stderr.splitlines() if line.strip()]
+    if not lines:
+        return f"exit {returncode}"
+    useful = [
+        line
+        for line in lines
+        if "complete log of this run" not in line.lower()
+        and not line.lower().startswith("npm notice")
+    ]
+    selected = useful or lines
+    # Prefer the last few diagnostic lines (code + notsup + wanted/current).
+    return " | ".join(selected[-4:])
 
 
 def _compatible_wheel(artifacts: list[dict[str, Any]]) -> dict[str, Any]:
@@ -97,6 +112,33 @@ def _compatible_wheel(artifacts: list[dict[str, Any]]) -> dict[str, Any]:
             f"found {len(matches)}"
         )
     return matches[0]
+
+
+def _compatible_native_npm_name() -> str:
+    """Return the one optional native npm package that can install on this host."""
+    system = sys.platform
+    machine = platform.machine().lower()
+    if system == "darwin":
+        name = (
+            "@curatelabs/graphforge-darwin-arm64"
+            if machine == "arm64"
+            else "@curatelabs/graphforge-darwin-x64"
+        )
+    elif system.startswith("linux"):
+        name = (
+            "@curatelabs/graphforge-linux-arm64-gnu"
+            if machine in {"aarch64", "arm64"}
+            else "@curatelabs/graphforge-linux-x64-gnu"
+        )
+    elif system == "win32":
+        if machine not in {"amd64", "x86_64"}:
+            raise RehearsalError(f"unsupported rehearsal platform: {system}/{machine}")
+        name = "@curatelabs/graphforge-win32-x64-msvc"
+    else:
+        raise RehearsalError(f"unsupported rehearsal platform: {system}/{machine}")
+    if name not in candidate_contract.NATIVE_NPM_PACKAGES:
+        raise RehearsalError(f"native npm package mapping is outside the candidate: {name}")
+    return name
 
 
 def _python_consumer(
@@ -142,6 +184,21 @@ def _node_consumer(
     )
     if len(npm_items) != len(candidate_contract.NPM_PACKAGES):
         raise RehearsalError("candidate npm inventory is incomplete")
+    by_name = {item["name"]: item for item in npm_items}
+    # Platform packages declare os/cpu (and linux libc). Installing every
+    # native tarball as a top-level dependency fails with EBADPLATFORM on the
+    # host; keep the full inventory checked above, but install only packages a
+    # clean consumer on this runner can accept offline.
+    host_native = _compatible_native_npm_name()
+    install_names = (
+        "@curatelabs/graphforge",
+        "@curatelabs/graphforge-cli",
+        "@curatelabs/graphforge-agent-skills",
+        host_native,
+    )
+    missing = [name for name in install_names if name not in by_name]
+    if missing:
+        raise RehearsalError(f"candidate npm inventory is missing {missing}")
     node_root = consumer_root / "node"
     node_root.mkdir()
     (node_root / "package.json").write_text(
@@ -158,7 +215,9 @@ def _node_consumer(
             "npm_config_update_notifier": "false",
         }
     )
-    tarballs = [str((artifacts_dir / item["path"]).resolve()) for item in npm_items]
+    tarballs = [
+        str((artifacts_dir / by_name[name]["path"]).resolve()) for name in install_names
+    ]
     _run(
         ["npm", "install", "--offline", "--ignore-scripts", "--no-audit", "--no-fund", *tarballs],
         cwd=node_root,
@@ -208,6 +267,8 @@ def _node_consumer(
         raise RehearsalError("agent-skills compatibility release diverges from the root version")
     return {
         "artifacts": [item["path"] for item in npm_items],
+        "installed_packages": list(install_names),
+        "host_native_package": host_native,
         "agent_skills_release": compatibility["graphforge_release"],
         "cli_status": "passed",
         "loaded_version": node_version,

--- a/scripts/ci/release_rehearsal.py
+++ b/scripts/ci/release_rehearsal.py
@@ -119,17 +119,24 @@ def _compatible_native_npm_name() -> str:
     system = sys.platform
     machine = platform.machine().lower()
     if system == "darwin":
-        name = (
-            "@curatelabs/graphforge-darwin-arm64"
-            if machine == "arm64"
-            else "@curatelabs/graphforge-darwin-x64"
-        )
+        if machine == "arm64":
+            name = "@curatelabs/graphforge-darwin-arm64"
+        elif machine == "x86_64":
+            name = "@curatelabs/graphforge-darwin-x64"
+        else:
+            raise RehearsalError(f"unsupported rehearsal platform: {system}/{machine}")
     elif system.startswith("linux"):
-        name = (
-            "@curatelabs/graphforge-linux-arm64-gnu"
-            if machine in {"aarch64", "arm64"}
-            else "@curatelabs/graphforge-linux-x64-gnu"
-        )
+        libc_name, _ = platform.libc_ver()
+        if libc_name.lower() != "glibc":
+            raise RehearsalError(
+                f"unsupported rehearsal platform: {system}/{machine} libc={libc_name or 'unknown'}"
+            )
+        if machine in {"aarch64", "arm64"}:
+            name = "@curatelabs/graphforge-linux-arm64-gnu"
+        elif machine == "x86_64":
+            name = "@curatelabs/graphforge-linux-x64-gnu"
+        else:
+            raise RehearsalError(f"unsupported rehearsal platform: {system}/{machine}")
     elif system == "win32":
         if machine not in {"amd64", "x86_64"}:
             raise RehearsalError(f"unsupported rehearsal platform: {system}/{machine}")

--- a/scripts/ci/test-release-candidate.py
+++ b/scripts/ci/test-release-candidate.py
@@ -79,18 +79,7 @@ def npm_members(name: str, *, package_version: str = VERSION) -> dict[str, bytes
         ]
         # Mirror napi platform package.json so offline install tests catch
         # EBADPLATFORM when every native tarball is installed top-level.
-        platform_constraints = {
-            "@curatelabs/graphforge-darwin-arm64": (["darwin"], ["arm64"]),
-            "@curatelabs/graphforge-darwin-x64": (["darwin"], ["x64"]),
-            "@curatelabs/graphforge-linux-arm64-gnu": (["linux"], ["arm64"]),
-            "@curatelabs/graphforge-linux-x64-gnu": (["linux"], ["x64"]),
-            "@curatelabs/graphforge-win32-x64-msvc": (["win32"], ["x64"]),
-        }
-        os_values, cpu_values = platform_constraints[name]
-        metadata["os"] = os_values
-        metadata["cpu"] = cpu_values
-        if os_values == ["linux"]:
-            metadata["libc"] = ["glibc"]
+        metadata.update(manifest_module.NATIVE_PLATFORM_CONSTRAINTS[name])
     elif name == "@curatelabs/graphforge":
         metadata.update(
             {
@@ -314,6 +303,26 @@ def main() -> None:
             root = Path(temp)
             manifest_path, artifacts, _ = create_candidate(root, **options)
             rejected(manifest_path, artifacts, message)
+
+    with tempfile.TemporaryDirectory() as temp:
+        root = Path(temp)
+        _manifest_path, artifacts, manifest = create_candidate(root)
+        members = npm_members("@curatelabs/graphforge-linux-x64-gnu")
+        metadata = json.loads(members["package/package.json"])
+        del metadata["os"]
+        members["package/package.json"] = json.dumps(metadata, sort_keys=True).encode()
+        write_tar(
+            artifacts / "npm" / f"curatelabs-graphforge-linux-x64-gnu-{VERSION}.tgz",
+            members,
+        )
+        rebuilt = manifest_module.build_manifest(
+            version=VERSION,
+            dist_dir=artifacts,
+            commit_sha=SHA,
+            recorded_at=manifest["recorded_at"],
+            notes="missing native os metadata",
+        )
+        rejected(write_mutation(root, rebuilt), artifacts, "os metadata must be")
 
     with tempfile.TemporaryDirectory() as temp:
         root = Path(temp)

--- a/scripts/ci/test-release-candidate.py
+++ b/scripts/ci/test-release-candidate.py
@@ -77,6 +77,20 @@ def npm_members(name: str, *, package_version: str = VERSION) -> dict[str, bytes
             "NOTICE",
             "THIRD_PARTY_NOTICES.md",
         ]
+        # Mirror napi platform package.json so offline install tests catch
+        # EBADPLATFORM when every native tarball is installed top-level.
+        platform_constraints = {
+            "@curatelabs/graphforge-darwin-arm64": (["darwin"], ["arm64"]),
+            "@curatelabs/graphforge-darwin-x64": (["darwin"], ["x64"]),
+            "@curatelabs/graphforge-linux-arm64-gnu": (["linux"], ["arm64"]),
+            "@curatelabs/graphforge-linux-x64-gnu": (["linux"], ["x64"]),
+            "@curatelabs/graphforge-win32-x64-msvc": (["win32"], ["x64"]),
+        }
+        os_values, cpu_values = platform_constraints[name]
+        metadata["os"] = os_values
+        metadata["cpu"] = cpu_values
+        if os_values == ["linux"]:
+            metadata["libc"] = ["glibc"]
     elif name == "@curatelabs/graphforge":
         metadata.update(
             {

--- a/scripts/ci/test-release-rehearsal.py
+++ b/scripts/ci/test-release-rehearsal.py
@@ -310,6 +310,46 @@ def test_compatible_native_npm_and_npm_errors() -> None:
     assert "EBADPLATFORM" in detail
     assert "complete log" not in detail
 
+    original_platform = rehearsal.sys.platform
+    original_machine = rehearsal.platform.machine
+    original_libc = rehearsal.platform.libc_ver
+    try:
+        cases = [
+            ("darwin", "arm64", ("", ""), "@curatelabs/graphforge-darwin-arm64"),
+            ("darwin", "x86_64", ("", ""), "@curatelabs/graphforge-darwin-x64"),
+            ("linux", "x86_64", ("glibc", "2.39"), "@curatelabs/graphforge-linux-x64-gnu"),
+            ("linux", "aarch64", ("glibc", "2.39"), "@curatelabs/graphforge-linux-arm64-gnu"),
+            ("win32", "AMD64", ("", ""), "@curatelabs/graphforge-win32-x64-msvc"),
+        ]
+        for system, machine, libc, expected in cases:
+            rehearsal.sys.platform = system
+            rehearsal.platform.machine = lambda machine=machine: machine
+            rehearsal.platform.libc_ver = lambda libc=libc: libc
+            assert rehearsal._compatible_native_npm_name() == expected
+
+        rehearsal.sys.platform = "linux"
+        rehearsal.platform.machine = lambda: "x86_64"
+        rehearsal.platform.libc_ver = lambda: ("", "")
+        try:
+            rehearsal._compatible_native_npm_name()
+        except rehearsal.RehearsalError as error:
+            assert "unsupported rehearsal platform" in str(error)
+        else:
+            raise AssertionError("musl Linux host was accepted")
+
+        rehearsal.sys.platform = "darwin"
+        rehearsal.platform.machine = lambda: "powerpc"
+        try:
+            rehearsal._compatible_native_npm_name()
+        except rehearsal.RehearsalError as error:
+            assert "unsupported rehearsal platform" in str(error)
+        else:
+            raise AssertionError("unsupported Darwin arch was accepted")
+    finally:
+        rehearsal.sys.platform = original_platform
+        rehearsal.platform.machine = original_machine
+        rehearsal.platform.libc_ver = original_libc
+
 
 def main() -> None:
     test_artifact_rehearsal()

--- a/scripts/ci/test-release-rehearsal.py
+++ b/scripts/ci/test-release-rehearsal.py
@@ -112,9 +112,16 @@ def test_artifact_rehearsal() -> None:
             assert report["status"] == "passed"
             assert report["registry_writes"] == 0
             assert report["checks"]["candidate_completeness"]["nodes"] == 24
-            assert report["checks"]["node_cli_skills_clean_consumer"]["loaded_version"] == (
-                candidate_fixture.VERSION
-            )
+            node_check = report["checks"]["node_cli_skills_clean_consumer"]
+            assert node_check["loaded_version"] == candidate_fixture.VERSION
+            host_native = rehearsal._compatible_native_npm_name()
+            assert node_check["host_native_package"] == host_native
+            assert node_check["installed_packages"] == [
+                "@curatelabs/graphforge",
+                "@curatelabs/graphforge-cli",
+                "@curatelabs/graphforge-agent-skills",
+                host_native,
+            ]
             assert len(report["checks"]["rust_packages"]["packages"]) == 15
             assert not any(word in json.dumps(report).lower() for word in rehearsal.FORBIDDEN_TEXT)
 
@@ -287,9 +294,27 @@ def test_sequential_reconciliation() -> None:
     assert not any(word in json.dumps(report).lower() for word in rehearsal.FORBIDDEN_TEXT)
 
 
+def test_compatible_native_npm_and_npm_errors() -> None:
+    host = rehearsal._compatible_native_npm_name()
+    assert host in candidate_contract.NATIVE_NPM_PACKAGES
+    detail = rehearsal._command_failure_detail(
+        "\n".join(
+            [
+                "npm error code EBADPLATFORM",
+                "npm error notsup Unsupported platform for @curatelabs/graphforge-darwin-x64@0.5.1",
+                "npm error A complete log of this run can be found in: /tmp/npm.log",
+            ]
+        ),
+        1,
+    )
+    assert "EBADPLATFORM" in detail
+    assert "complete log" not in detail
+
+
 def main() -> None:
     test_artifact_rehearsal()
     test_sequential_reconciliation()
+    test_compatible_native_npm_and_npm_errors()
     print("release-rehearsal tests: ok")
 
 


### PR DESCRIPTION
## Summary
- Binding RC offline Node rehearsal was installing every platform npm tarball as a top-level dependency; real napi packages declare `os`/`cpu`, so npm failed with `EBADPLATFORM` on the assemble host.
- Keep full candidate npm inventory validation, but install only `@curatelabs/graphforge`, CLI, agent-skills, and the host-compatible native package.
- Improve `_run` failure detail so npm’s trailing log-path line no longer hides the real error; fixture native packages now include `os`/`cpu` to lock the regression.

Related to #192 (does not close the release tracker; publish lanes remain maintainer-authorized).

## Test plan
- [x] `python3 scripts/ci/test-release-rehearsal.py`
- [x] `python3 scripts/ci/test-release-candidate.py`
- [x] Local repro: all-8 platform tarballs → `EBADPLATFORM`; host-only set → install succeeds
- [ ] Binding RC assemble offline rehearsal green on the merge SHA


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788194683&installation_model_id=20486&pr_number=314&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F314&signature=4a17dfcb2f1b7e2449c76a429c6db3cf4aa021ffcb6f89de4f52e3890ecc85f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release validation diagnostics by filtering noisy npm output and reporting actionable errors.
  * Added platform-aware selection of compatible native packages during Node package installation.
  * Added validation that installed packages and native package versions match the release inventory.

* **Tests**
  * Expanded rehearsal coverage for platform compatibility, package detection, CLI version loading, and npm error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix offline Binding RC rehearsal to install only the host-compatible native npm package
> - The Node offline consumer in [`release_rehearsal.py`](https://github.com/CurateLabs/graphforge/pull/314/files#diff-806bd6517eb51b19db8b22bdb1ee3cdbe18ebe48bb09e449871c28b0c7333255) now installs only the single native npm package matching the current host OS/arch/libc instead of all native tarballs, avoiding `EBADPLATFORM` errors.
> - A new `_compatible_native_npm_name` helper detects the host platform (including glibc check on Linux) and returns the matching package name, failing fast on unsupported hosts.
> - [`release_candidate_manifest.py`](https://github.com/CurateLabs/graphforge/pull/314/files#diff-1e4d4017cfa1197955bd94c05d9689a0f8298c1748558f4143149809a0a78e64) adds `NATIVE_PLATFORM_CONSTRAINTS` and validates that each native npm package's `os`/`cpu`/`libc` metadata exactly matches expected values, rejecting candidates with mismatches.
> - Subprocess error reporting now surfaces condensed, actionable stderr lines by filtering out npm notices and log path lines.
> - Behavioral Change: the rehearsal report now includes `installed_packages` and `host_native_package` fields, and validation rejects native packages with incorrect platform metadata.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 39b014c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->