### PR TITLE
fix(release): init project before Binding RC CLI validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Offline Binding RC Node rehearsal installs only the host-compatible native
   npm package alongside main/CLI/skills so platform `os`/`cpu` metadata no
   longer fails the clean consumer with `EBADPLATFORM` (#192).
+- Offline Binding RC CLI rehearsal initializes a git project before
+  `config validate` so the clean consumer matches the real CLI project
+  contract (#192).
 - Replace the Python package README with a concise PyPI landing page: short
   purpose, install path, one minimal first-use example, and canonical
   `docs.graphforge.sh` links instead of a raw CLI command inventory (#304).

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Offline Binding RC Node rehearsal installs only the host-compatible native
   npm package alongside main/CLI/skills so platform `os`/`cpu` metadata no
   longer fails the clean consumer with `EBADPLATFORM` (#192).
+- Offline Binding RC CLI rehearsal initializes a git project before
+  `config validate` so the clean consumer matches the real CLI project
+  contract (#192).
 - Replace the Python package README with a concise PyPI landing page: short
   purpose, install path, one minimal first-use example, and canonical
   `docs.graphforge.sh` links instead of a raw CLI command inventory (#304).

--- a/scripts/ci/release_rehearsal.py
+++ b/scripts/ci/release_rehearsal.py
@@ -244,6 +244,16 @@ def _node_consumer(
             f"expected {manifest['version']}"
         )
     cli = node_root / "node_modules" / "@curatelabs" / "graphforge-cli" / "bin" / "graphforge.js"
+    # Real CLI config validate requires a repository project; init creates one.
+    # Fixture CLI tarballs ignore args and still emit JSON for both steps.
+    _run(["git", "init", "-q"], cwd=node_root, env=environment)
+    init_output = _run(["node", str(cli), "--json", "init"], cwd=node_root, env=environment)
+    try:
+        init_payload = json.loads(init_output)
+    except json.JSONDecodeError as error:
+        raise RehearsalError("clean CLI init did not emit JSON") from error
+    if not isinstance(init_payload, dict):
+        raise RehearsalError("clean CLI init emitted an invalid result")
     cli_output = _run(
         ["node", str(cli), "--json", "config", "validate"], cwd=node_root, env=environment
     )
@@ -253,6 +263,8 @@ def _node_consumer(
         raise RehearsalError("clean CLI consumer did not emit JSON") from error
     if not isinstance(cli_payload, dict):
         raise RehearsalError("clean CLI consumer emitted an invalid result")
+    if cli_payload.get("valid") is False:
+        raise RehearsalError("clean CLI config validate reported invalid")
     skills = (
         node_root
         / "node_modules"

--- a/scripts/ci/test-release-candidate.py
+++ b/scripts/ci/test-release-candidate.py
@@ -107,7 +107,14 @@ def npm_members(name: str, *, package_version: str = VERSION) -> dict[str, bytes
             {
                 "package/bin/graphforge.js": (
                     b"#!/usr/bin/env node\n"
-                    b"process.stdout.write(JSON.stringify({contract:'fixture'}));\n"
+                    b"const args = process.argv.slice(2).join(' ');\n"
+                    b"if (args.includes('config validate')) {\n"
+                    b"  process.stdout.write(JSON.stringify({valid:true}));\n"
+                    b"} else if (args.includes('init')) {\n"
+                    b"  process.stdout.write(JSON.stringify({created_config:true}));\n"
+                    b"} else {\n"
+                    b"  process.stdout.write(JSON.stringify({contract:'fixture'}));\n"
+                    b"}\n"
                 ),
                 "package/lib/run.mjs": b"export function run() {}\n",
                 "package/THIRD_PARTY_NOTICES.md": b"Third party",


### PR DESCRIPTION
## Summary
- After the host-native npm install fix, Binding RC offline rehearsal failed because `graphforge config validate` requires a project (`.graphforge/graphforge.yaml`).
- Clean Node consumer now `git init`s and runs CLI `init` before `config validate`, matching the real CLI contract used by offline lifecycle tests.
- Fixture CLI returns `{valid:true}` / `{created_config:true}` for those invocations.

Related to #192 (does not close the release tracker).

## Test plan
- [x] `python3 scripts/ci/test-release-rehearsal.py`
- [x] `python3 scripts/ci/test-release-candidate.py`
- [ ] Binding RC assemble offline rehearsal green on the merge SHA

Evidence from prior RC `30709323247`: npm install succeeded; failure was `GF_IO` missing `.graphforge/graphforge.yaml`.


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788196849&installation_model_id=20486&pr_number=315&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F315&signature=7e8133db6dd838027911f08f98d74469af6371a6b4d71c0cf92dcc51d58eea04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Initialize git project before running `config validate` in Binding RC CLI rehearsal
> - The `_node_consumer` rehearsal in [release_rehearsal.py](https://github.com/CurateLabs/graphforge/pull/315/files#diff-806bd6517eb51b19db8b22bdb1ee3cdbe18ebe48bb09e449871c28b0c7333255) now runs `graphforge init` and initializes a git repo before calling `config validate`, so the test environment matches the real CLI project contract.
> - Adds validation that `graphforge init` emits valid JSON and that `config validate` does not return `valid: false`, raising a `RehearsalError` on failure.
> - Updates the CLI fixture in [test-release-candidate.py](https://github.com/CurateLabs/graphforge/pull/315/files#diff-3e1e4e1015ad205e865367bff264d855c0062bfbe24c63683445a235914cd4f0) to return context-appropriate JSON for `init` (`{created_config:true}`) and `config validate` (`{valid:true}`) invocations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2a21988.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->