### PR TITLE
fix(release): retain Binding RC evidence without brace globs

### DIFF
--- a/.github/workflows/binding-release-candidate.yml
+++ b/.github/workflows/binding-release-candidate.yml
@@ -621,6 +621,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: M1-Release-Candidate-evidence-${{ needs.validate_source.outputs.evidence_sha }}
-          path: candidate/release-artifacts/{evidence,node-addons}/
+          # upload-artifact does not expand bash brace globs; list both dirs.
+          path: |
+            candidate/release-artifacts/evidence/
+            candidate/release-artifacts/node-addons/
           if-no-files-found: error
           retention-days: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Offline Binding RC CLI rehearsal initializes a git project before
   `config validate` so the clean consumer matches the real CLI project
   contract (#192).
+- Retain Binding RC evidence and node-addon partitions with a multiline
+  upload-artifact path so brace globs are not treated as a missing file
+  set (#192).
 - Replace the Python package README with a concise PyPI landing page: short
   purpose, install path, one minimal first-use example, and canonical
   `docs.graphforge.sh` links instead of a raw CLI command inventory (#304).

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -41,6 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Offline Binding RC CLI rehearsal initializes a git project before
   `config validate` so the clean consumer matches the real CLI project
   contract (#192).
+- Retain Binding RC evidence and node-addon partitions with a multiline
+  upload-artifact path so brace globs are not treated as a missing file
+  set (#192).
 - Replace the Python package README with a concise PyPI landing page: short
   purpose, install path, one minimal first-use example, and canonical
   `docs.graphforge.sh` links instead of a raw CLI command inventory (#304).

--- a/scripts/ci/test-ci-storage-policy.py
+++ b/scripts/ci/test-ci-storage-policy.py
@@ -177,10 +177,7 @@ def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
             "candidate/release-artifacts/python/",
             "candidate/release-artifacts/npm/",
             "candidate/release-artifacts/crates/",
-            (
-                "candidate/release-artifacts/evidence/\n"
-                "candidate/release-artifacts/node-addons/"
-            ),
+            ("candidate/release-artifacts/evidence/\ncandidate/release-artifacts/node-addons/"),
             "reconciliation/summary.json",
             "examples/visualization/stress/results/",
         }, f"artifact upload contains unapproved bytes: {path}"

--- a/scripts/ci/test-ci-storage-policy.py
+++ b/scripts/ci/test-ci-storage-policy.py
@@ -126,11 +126,26 @@ def cache_steps(text: str) -> list[list[str]]:
 
 
 def field(step: list[str], name: str) -> str | None:
-    for line in reversed(step):
+    matched: str | None = None
+    for index, line in enumerate(step):
         stripped = line.strip().removeprefix("- ")
-        if stripped.startswith(name + ":"):
-            return stripped.split(":", 1)[1].strip().strip("'\"")
-    return None
+        if not stripped.startswith(name + ":"):
+            continue
+        value = stripped.split(":", 1)[1].strip().strip("'\"")
+        if value in {"|", "|-", ">", ">-"}:
+            indent = len(line) - len(line.lstrip())
+            collected: list[str] = []
+            for follow in step[index + 1 :]:
+                if not follow.strip():
+                    continue
+                follow_indent = len(follow) - len(follow.lstrip())
+                if follow_indent <= indent:
+                    break
+                collected.append(follow.strip())
+            matched = "\n".join(collected)
+        else:
+            matched = value
+    return matched
 
 
 def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
@@ -162,7 +177,10 @@ def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
             "candidate/release-artifacts/python/",
             "candidate/release-artifacts/npm/",
             "candidate/release-artifacts/crates/",
-            "candidate/release-artifacts/{evidence,node-addons}/",
+            (
+                "candidate/release-artifacts/evidence/\n"
+                "candidate/release-artifacts/node-addons/"
+            ),
             "reconciliation/summary.json",
             "examples/visualization/stress/results/",
         }, f"artifact upload contains unapproved bytes: {path}"


### PR DESCRIPTION
## Summary
- Binding RC @ `9736041` completed offline rehearsal and candidate validation (`release-candidate: valid … nodes=24`), then failed only on evidence artifact retention.
- `actions/upload-artifact` does not expand `candidate/release-artifacts/{evidence,node-addons}/`; switch to an explicit multiline path.
- Update the CI storage-policy allowlist/parser for block-scalar paths.

Related to #192 (does not close the release tracker).

## Test plan
- [x] `python3 scripts/ci/test-ci-storage-policy.py`
- [ ] Binding RC green on the merge SHA (evidence partition retained)


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/316"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788198374&installation_model_id=20486&pr_number=316&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F316&signature=55b03342eb5ba8f12942f0a82706b2a7ca03d31ad9cd04c5ca97605ec00d98c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of multiline configuration values in validation checks.
  * Updated artifact upload path validation to recognize approved evidence and native module paths correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Binding RC evidence upload by replacing brace glob with explicit multiline paths
> - `upload-artifact` does not expand bash brace globs, so `candidate/release-artifacts/{evidence,node-addons}/` was not uploading both directories.
> - [binding-release-candidate.yml](.github/workflows/binding-release-candidate.yml) now lists `evidence/` and `node-addons/` as separate lines in a YAML block scalar.
> - The `field` parser in [test-ci-storage-policy.py](https://github.com/CurateLabs/graphforge/pull/316/files#diff-855ed98597547ac200b4015777e47aa99dda2b0ac141e95ffab9c0d96e87c1a0) is updated to handle YAML block scalars (`|`, `|-`, `>`, `>-`) and return the last matching field when duplicates exist.
> - The artifact contract allowlist is updated to match the new multiline path format.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 219e8ee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->