### PR TITLE
fix(release): fail closed on Binding RC node-addon staging

### DIFF
--- a/.github/workflows/binding-release-candidate.yml
+++ b/.github/workflows/binding-release-candidate.yml
@@ -460,6 +460,25 @@ jobs:
           path: candidate/release-artifacts/node-addons
           merge-multiple: true
 
+      # Fail closed before pack/rehearsal if matrix addon transfer nested or
+      # emptied the staging directory. Retain later uploads evidence/ + node-addons/.
+      - name: Require staged Node addons for candidate assembly
+        shell: bash
+        run: |
+          shopt -s nullglob
+          addons=(candidate/release-artifacts/node-addons/*.node)
+          if test "${#addons[@]}" -ne 5; then
+            printf 'expected 5 staged Node addons under candidate/release-artifacts/node-addons/, found %s\n' \
+              "${#addons[@]}" >&2
+            if test -d candidate/release-artifacts/node-addons; then
+              find candidate/release-artifacts/node-addons -type f -print >&2
+            else
+              printf 'node-addons staging directory is missing\n' >&2
+            fi
+            exit 1
+          fi
+          printf 'staged_node_addons=%s\n' "${#addons[@]}"
+
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fail closed after Binding RC Node addon download when
+  `candidate/release-artifacts/node-addons/` does not contain exactly five
+  `*.node` files, and reject brace-glob retain paths in CI storage policy
+  (#192).
 - Fix homepage accessibility: label the NetworkX/GraphForge/Neo4j comparison
   table headers (including row scopes) and emit static `tabindex` on Expressive
   Code `<pre>` blocks so keyboard users can reach horizontally scrollable

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fail closed after Binding RC Node addon download when
+  `candidate/release-artifacts/node-addons/` does not contain exactly five
+  `*.node` files, and reject brace-glob retain paths in CI storage policy
+  (#192).
 - Add a Node Plotly.js visualization example over the shared karate projection,
   matching the Python Plotly adapter (circular layout seed `42`, CDN HTML +
   figure JSON) so Plotly is covered in both runtimes (Refs #298).

--- a/scripts/ci/test-binding-release-candidate.py
+++ b/scripts/ci/test-binding-release-candidate.py
@@ -624,6 +624,19 @@ def main() -> None:
     assert release_candidate_job.index("Rehearse exact partitioned release artifacts offline") < (
         release_candidate_job.index("Create and validate the immutable candidate manifest")
     )
+    # Matrix addons must land as flat *.node files before pack/rehearsal/retain.
+    assert "Require staged Node addons for candidate assembly" in release_candidate_job
+    assert "addons=(candidate/release-artifacts/node-addons/*.node)" in release_candidate_job
+    assert release_candidate_job.index("Download exact-run tested Node addons") < (
+        release_candidate_job.index("Require staged Node addons for candidate assembly")
+    )
+    assert release_candidate_job.index("Require staged Node addons for candidate assembly") < (
+        release_candidate_job.index("Assemble and pack every npm package")
+    )
+    # upload-artifact does not expand brace globs; retain must list both dirs.
+    assert "{evidence,node-addons}" not in release_candidate_job
+    assert "candidate/release-artifacts/evidence/" in release_candidate_job
+    assert "candidate/release-artifacts/node-addons/" in release_candidate_job
     for group in ("manifest", "python", "npm", "crates", "evidence"):
         assert (
             f"M1-Release-Candidate-{group}-${{{{ needs.validate_source.outputs.evidence_sha }}}}"

--- a/scripts/ci/test-ci-storage-policy.py
+++ b/scripts/ci/test-ci-storage-policy.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
-import re
 from collections import Counter
 from pathlib import Path
+import re
 
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOWS = ROOT / ".github" / "workflows"

--- a/scripts/ci/test-ci-storage-policy.py
+++ b/scripts/ci/test-ci-storage-policy.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import re
 from collections import Counter
 from pathlib import Path
 
@@ -165,6 +166,13 @@ def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
             f"artifact retention drift: {name}"
         )
         path = field(step, "path")
+        assert path is not None, f"artifact upload has no path: {name}"
+        # upload-artifact does not expand bash brace globs; a literal
+        # `{evidence,node-addons}` path retains zero files after green assembly.
+        # Allow GitHub `${{ }}` expressions; reject comma brace expansions only.
+        assert not re.search(r"(?<!\$)\{[^{}\n]+,[^{}\n]+\}", path), (
+            f"artifact upload path uses brace globs: {name}: {path}"
+        )
         assert path in {
             "binding-rc-reports/${{ matrix.target }}.json",
             "binding-rc-reports/${{ matrix.report_target }}.json",


### PR DESCRIPTION
## Summary
- Run 30710668596 retained nothing for `candidate/release-artifacts/{evidence,node-addons}/` because `upload-artifact` does not expand bash brace globs (#316 already lists both dirs explicitly).
- Assemble logs show Node matrix staging was **not** empty: five `binding-rc-addon-*` artifacts downloaded, `*.node` copied into NAPI pack, and `release-candidate: valid … groups=4` before retain.
- This PR fail-closes immediately after Node addon download when `candidate/release-artifacts/node-addons/` does not contain exactly five flat `*.node` files, bans brace-glob upload paths in CI storage policy, and locks both into Binding RC workflow tests.

Related to #192 (does not close the release tracker).

## Test plan
- [x] `python3 scripts/ci/test-ci-storage-policy.py`
- [x] `python3 scripts/ci/test-binding-release-candidate.py`
- [ ] Binding RC green on the merge SHA (evidence + node-addons retained)


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788199329&installation_model_id=20486&pr_number=317&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F317&signature=8fadb31b4aac1c94fc2d9738e42b1397ffb0bb1cfa8bcb1c6ba7bd1216afc960"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fail closed on binding release candidate assembly when Node addons are missing or incomplete
> - Adds a validation step in [binding-release-candidate.yml](.github/workflows/binding-release-candidate.yml) that requires exactly 5 `*.node` files in `candidate/release-artifacts/node-addons/` before pack/rehearsal steps run.
> - Extends CI storage policy tests to reject brace-glob patterns (e.g. `{evidence,node-addons}`) in artifact upload paths, requiring explicit directory entries instead.
> - Updates [test-binding-release-candidate.py](scripts/ci/test-binding-release-candidate.py) to assert correct step ordering and absence of brace-glob retain paths.
> - Behavioral Change: The candidate assembly job now exits with status 1 if the staging directory is missing or contains a count other than 5 `.node` files, blocking all subsequent steps in that matrix entry.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab0b920.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->