### PR TITLE
docs(release): describe host-native offline npm rehearsal

### DIFF
--- a/docs/development/release-artifact-record.md
+++ b/docs/development/release-artifact-record.md
@@ -131,10 +131,12 @@ command has a registry-write path.
 After the binding workflow has assembled the four directories, it creates a
 temporary manifest and runs a clean-consumer rehearsal before any registry
 write. The rehearsal installs the compatible exact wheel without an index,
-imports the native Python module, installs all eight npm tarballs offline,
-loads the Node native binding through the main package, executes the CLI and
-agent-skills entrypoints, and validates all 15 crate archives and their exact
-dependency graph. Only a passing report is added to the evidence partition;
+imports the native Python module, validates the full eight-package npm
+inventory, then installs only the host-compatible native tarball with
+main/CLI/skills offline, loads the Node native binding through the main
+package, executes the CLI and agent-skills entrypoints, and validates all
+15 crate archives and their exact dependency graph. Only a passing report is
+added to the evidence partition;
 the temporary manifest is then removed and the final manifest is recorded over
 the now-complete inventory.
 


### PR DESCRIPTION
## Summary
- Update `release-artifact-record.md` so it no longer claims rehearsal installs all eight npm tarballs offline.
- Matches the #314 Binding RC consumer behavior: full inventory validation, host-native install subset.

Refs #192

## Test plan
- [x] Docs-only change; wording matches `scripts/ci/release_rehearsal.py`


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788200025&installation_model_id=20486&pr_number=318&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F318&signature=51720ccd534a429e14417735034f69fc752d1c5fb02e04b3d59ae49335914302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clarify host-native offline npm install steps in release artifact docs
> Updates [release-artifact-record.md](https://github.com/CurateLabs/graphforge/pull/318/files#diff-0cbc90decc3ab7886d05ca868862539b09cbfe3961e44ff5176f570107dfbdc2) to more precisely describe the clean-consumer rehearsal process. The revised text distinguishes between validating the full eight-package npm inventory and installing only the host-compatible native tarball, then clarifies the sequence: validate inventory, targeted install, load Node native binding, execute CLI and agent-skills entrypoints, and validate all 15 crate archives.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3edc8e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->