### PR TITLE
fix(release): trim CARGO_REGISTRY_TOKEN before cargo publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -556,6 +556,17 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ needs.candidate-preflight.outputs.release_tag }}
         run: |
+          # Defensive: ESC/GitHub secret projection can append CR/LF/whitespace.
+          # Recovery checkouts the immutable tag SHA, so normalize here in the
+          # main-branch workflow before cargo publish. Never print the value.
+          CARGO_REGISTRY_TOKEN="${CARGO_REGISTRY_TOKEN//$'\r'/}"
+          CARGO_REGISTRY_TOKEN="${CARGO_REGISTRY_TOKEN#"${CARGO_REGISTRY_TOKEN%%[![:space:]]*}"}"
+          CARGO_REGISTRY_TOKEN="${CARGO_REGISTRY_TOKEN%"${CARGO_REGISTRY_TOKEN##*[![:space:]]}"}"
+          export CARGO_REGISTRY_TOKEN
+          if test -z "$CARGO_REGISTRY_TOKEN"; then
+            echo "CARGO_REGISTRY_TOKEN is empty after trim" >&2
+            exit 1
+          fi
           now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           bash scripts/ci/download-release-write-evidence.sh "$RELEASE_TAG" "$RELEASE_VERSION" write-evidence
           python3 scripts/ci/release_action.py validate-partition --manifest "candidate/$MANIFEST_NAME" --artifacts-dir candidate/release-artifacts --group crates --expected-sha "$RELEASE_SHA" --version "$RELEASE_VERSION" --checked-at "$now"

--- a/.github/workflows/release-credential-preflight.yml
+++ b/.github/workflows/release-credential-preflight.yml
@@ -55,7 +55,7 @@ jobs:
           test -n "$CARGO_REGISTRY_TOKEN"
           test "${#CARGO_REGISTRY_TOKEN}" -ge 20
           # Reject residual control / non-ISO-8859-1 bytes without echoing them.
-          python3 -c 'import os, sys; t = os.environ["CARGO_REGISTRY_TOKEN"]; bad = any(ord(c) < 32 or ord(c) == 127 or ord(c) > 255 for c in t); sys.exit(1 if bad else 0)'
+          python3 -c 'import os, sys; t = os.environ["CARGO_REGISTRY_TOKEN"]; bad = any(not (0x20 <= ord(c) <= 0x7E or 0xA0 <= ord(c) <= 0xFF) for c in t); sys.exit(1 if bad else 0)'
 
       - name: Record non-publishing result
         run: echo "Credential projection is present; this workflow performs no registry writes."

--- a/.github/workflows/release-credential-preflight.yml
+++ b/.github/workflows/release-credential-preflight.yml
@@ -47,8 +47,15 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
+          # Same defensive trim as publish.yaml — never print the value.
+          CARGO_REGISTRY_TOKEN="${CARGO_REGISTRY_TOKEN//$'\r'/}"
+          CARGO_REGISTRY_TOKEN="${CARGO_REGISTRY_TOKEN#"${CARGO_REGISTRY_TOKEN%%[![:space:]]*}"}"
+          CARGO_REGISTRY_TOKEN="${CARGO_REGISTRY_TOKEN%"${CARGO_REGISTRY_TOKEN##*[![:space:]]}"}"
+          export CARGO_REGISTRY_TOKEN
           test -n "$CARGO_REGISTRY_TOKEN"
           test "${#CARGO_REGISTRY_TOKEN}" -ge 20
+          # Reject residual control / non-ISO-8859-1 bytes without echoing them.
+          python3 -c 'import os, sys; t = os.environ["CARGO_REGISTRY_TOKEN"]; bad = any(ord(c) < 32 or ord(c) == 127 or ord(c) > 255 for c in t); sys.exit(1 if bad else 0)'
 
       - name: Record non-publishing result
         run: echo "Credential projection is present; this workflow performs no registry writes."

--- a/scripts/ci/test-publish-crates.py
+++ b/scripts/ci/test-publish-crates.py
@@ -22,7 +22,21 @@ def load_module():
 
 
 mod = load_module()
-assert mod.VERSION == "0.5.0"
+assert mod.VERSION == "0.5.1"
+
+assert mod.normalize_registry_token("  abc\n") == "abc"
+assert mod.normalize_registry_token("abc\r\n") == "abc"
+try:
+    mod.normalize_registry_token("   \n")
+    raise AssertionError("expected empty token after trim to fail")
+except ValueError as exc:
+    assert "empty after trim" in str(exc)
+try:
+    mod.normalize_registry_token("abc\x00def")
+    raise AssertionError("expected control character to fail")
+except ValueError as exc:
+    assert "non-printable" in str(exc)
+    assert "\x00" not in str(exc)
 
 commands: list[list[str]] = []
 mod.package_checksum = lambda _name, expected=None: expected or "abc123"
@@ -69,19 +83,19 @@ with tempfile.TemporaryDirectory() as temp:
     root = Path(temp)
     artifacts = root / "artifacts"
     artifacts.mkdir()
-    archive = artifacts / "graphforge-core-0.5.0.crate"
+    archive = artifacts / "graphforge-core-0.5.1.crate"
     archive.write_bytes(b"certified crate")
     sha = hashlib.sha256(archive.read_bytes()).hexdigest()
     record = {
         "schema": "graphforge-release-record-v1",
-        "version": "0.5.0",
-        "tag": "v0.5.0",
+        "version": "0.5.1",
+        "tag": "v0.5.1",
         "commit_sha": "release-sha",
         "artifacts": [
             {
                 "surface": "crates",
                 "name": "graphforge-core",
-                "version": "0.5.0",
+                "version": "0.5.1",
                 "path": archive.name,
                 "sha256": sha,
             }
@@ -107,7 +121,7 @@ with tempfile.TemporaryDirectory() as temp:
             assert "escapes artifact root" in str(exc)
 
     record["artifacts"][0]["path"] = archive.name
-    record["artifacts"][0]["version"] = "0.5.1"
+    record["artifacts"][0]["version"] = "0.5.0"
     record_path.write_text(json.dumps(record), encoding="utf-8")
     try:
         mod.release_record_checksums(record_path, artifacts)

--- a/scripts/ci/test-publish-crates.py
+++ b/scripts/ci/test-publish-crates.py
@@ -23,6 +23,7 @@ def load_module():
 
 mod = load_module()
 assert mod.VERSION == "0.5.1"
+v = mod.VERSION
 
 assert mod.normalize_registry_token("  abc\n") == "abc"
 assert mod.normalize_registry_token("abc\r\n") == "abc"
@@ -83,19 +84,19 @@ with tempfile.TemporaryDirectory() as temp:
     root = Path(temp)
     artifacts = root / "artifacts"
     artifacts.mkdir()
-    archive = artifacts / "graphforge-core-0.5.1.crate"
+    archive = artifacts / f"graphforge-core-{v}.crate"
     archive.write_bytes(b"certified crate")
     sha = hashlib.sha256(archive.read_bytes()).hexdigest()
     record = {
         "schema": "graphforge-release-record-v1",
-        "version": "0.5.1",
-        "tag": "v0.5.1",
+        "version": v,
+        "tag": f"v{v}",
         "commit_sha": "release-sha",
         "artifacts": [
             {
                 "surface": "crates",
                 "name": "graphforge-core",
-                "version": "0.5.1",
+                "version": v,
                 "path": archive.name,
                 "sha256": sha,
             }
@@ -121,7 +122,8 @@ with tempfile.TemporaryDirectory() as temp:
             assert "escapes artifact root" in str(exc)
 
     record["artifacts"][0]["path"] = archive.name
-    record["artifacts"][0]["version"] = "0.5.0"
+    # Intentional mismatch: distinct wrong literal, not another copy of current.
+    record["artifacts"][0]["version"] = "0.0.0"
     record_path.write_text(json.dumps(record), encoding="utf-8")
     try:
         mod.release_record_checksums(record_path, artifacts)

--- a/scripts/ci/test-publish-crates.py
+++ b/scripts/ci/test-publish-crates.py
@@ -38,6 +38,12 @@ try:
 except ValueError as exc:
     assert "non-printable" in str(exc)
     assert "\x00" not in str(exc)
+try:
+    mod.normalize_registry_token("abc\x85def")
+    raise AssertionError("expected ISO-8859-1 C1 control to fail")
+except ValueError as exc:
+    assert "non-printable" in str(exc)
+    assert "\x85" not in str(exc)
 
 commands: list[list[str]] = []
 mod.package_checksum = lambda _name, expected=None: expected or "abc123"

--- a/scripts/ci/test-release-publish-preflight.py
+++ b/scripts/ci/test-release-publish-preflight.py
@@ -101,6 +101,8 @@ assert "scripts/ci/crate-publish-plan.py list" in crates
 assert "scripts/publish_crates.py" in crates
 assert '--crate "$crate"' in crates
 assert "secrets.CARGO_REGISTRY_TOKEN" in crates
+assert "CARGO_REGISTRY_TOKEN is empty after trim" in crates
+assert "Never print the value" in crates
 assert "secrets.NPM_TOKEN" not in crates
 
 for lane in (pypi, native, main, cli, skills, crates):
@@ -139,6 +141,7 @@ credential_workflow = CREDENTIAL_WORKFLOW.read_text(encoding="utf-8")
 assert "npm whoami" in credential_workflow
 assert "secrets.NPM_TOKEN" in credential_workflow
 assert "secrets.CARGO_REGISTRY_TOKEN" in credential_workflow
+assert "never print the value" in credential_workflow.lower()
 for forbidden in ("npm publish", "uv publish", "cargo publish", "release:\n"):
     assert forbidden not in credential_workflow
 

--- a/scripts/publish_crates.py
+++ b/scripts/publish_crates.py
@@ -9,6 +9,9 @@ continues when crates.io reports the same checksum.
 Requires ``CARGO_REGISTRY_TOKEN`` in the environment. The maintained release
 credential is projected from Pulumi ESC into the GitHub Actions secret used by
 ``publish.yaml``.
+
+The token is normalized before ``cargo publish``: leading/trailing whitespace
+and CR/LF are stripped. The value is never logged.
 """
 
 from __future__ import annotations
@@ -37,6 +40,23 @@ _VERSION_MATCH = re.search(
 if _VERSION_MATCH is None:
     raise RuntimeError("Cargo.toml lacks [workspace.package] version")
 VERSION = _VERSION_MATCH.group(1)
+
+
+def normalize_registry_token(raw: str) -> str:
+    """Return a cargo-safe registry token, or raise ValueError without echoing it.
+
+    Cargo rejects tokens with non-printable / non-ISO-8859-1 characters. Secret
+    projection and pasted GitHub secrets commonly introduce a trailing newline.
+    """
+    token = raw.strip()
+    if not token:
+        raise ValueError("CARGO_REGISTRY_TOKEN is empty after trim")
+    # Printable ISO-8859-1: exclude C0 controls, DEL, and code points above 255.
+    if any(ord(ch) < 32 or ord(ch) == 127 or ord(ch) > 255 for ch in token):
+        raise ValueError(
+            "CARGO_REGISTRY_TOKEN contains non-printable or non-ISO-8859-1 characters"
+        )
+    return token
 
 
 def load_plan_module():
@@ -213,8 +233,12 @@ def main(argv: list[str] | None = None) -> int:
         print("--release-record and --artifacts-dir must be provided together", file=sys.stderr)
         return 2
 
-    if not os.environ.get("CARGO_REGISTRY_TOKEN", "").strip():
-        print("CARGO_REGISTRY_TOKEN is required", file=sys.stderr)
+    try:
+        os.environ["CARGO_REGISTRY_TOKEN"] = normalize_registry_token(
+            os.environ.get("CARGO_REGISTRY_TOKEN", "")
+        )
+    except ValueError as error:
+        print(str(error), file=sys.stderr)
         return 2
 
     plan = load_plan_module()

--- a/scripts/publish_crates.py
+++ b/scripts/publish_crates.py
@@ -51,8 +51,8 @@ def normalize_registry_token(raw: str) -> str:
     token = raw.strip()
     if not token:
         raise ValueError("CARGO_REGISTRY_TOKEN is empty after trim")
-    # Printable ISO-8859-1: exclude C0 controls, DEL, and code points above 255.
-    if any(ord(ch) < 32 or ord(ch) == 127 or ord(ch) > 255 for ch in token):
+    # Printable ISO-8859-1 only: 0x20-0x7E and 0xA0-0xFF (not C0/C1/DEL).
+    if any(not (0x20 <= ord(ch) <= 0x7E or 0xA0 <= ord(ch) <= 0xFF) for ch in token):
         raise ValueError("CARGO_REGISTRY_TOKEN contains non-printable or non-ISO-8859-1 characters")
     return token
 

--- a/scripts/publish_crates.py
+++ b/scripts/publish_crates.py
@@ -53,9 +53,7 @@ def normalize_registry_token(raw: str) -> str:
         raise ValueError("CARGO_REGISTRY_TOKEN is empty after trim")
     # Printable ISO-8859-1: exclude C0 controls, DEL, and code points above 255.
     if any(ord(ch) < 32 or ord(ch) == 127 or ord(ch) > 255 for ch in token):
-        raise ValueError(
-            "CARGO_REGISTRY_TOKEN contains non-printable or non-ISO-8859-1 characters"
-        )
+        raise ValueError("CARGO_REGISTRY_TOKEN contains non-printable or non-ISO-8859-1 characters")
     return token
 
 


### PR DESCRIPTION
## Summary
- Defensively strip CR/LF/whitespace from `CARGO_REGISTRY_TOKEN` in `publish.yaml` before `cargo publish` (recovery dispatches use main workflow YAML while checking out the immutable tag SHA).
- Normalize the same way in `scripts/publish_crates.py` for future releases; never log the token.
- Harden credential preflight with the same trim + printable ISO-8859-1 check.
- Related to #196 / #192 (crates.io v0.5.1 publication still blocked by polluted/trailing-newline token). Does **not** close those issues.

## Test plan
- [x] `python3 scripts/ci/test-publish-crates.py`
- [x] `python3 scripts/ci/test-release-publish-preflight.py`
- [ ] Required CI / CI Gate green on PR head
- [ ] After merge: clear orphan `v0.5.1-attempt-crates-graphforge-core.json` (known-failed write; crate absent on crates.io), then redispatch publish recovery for `v0.5.1`


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788202670&installation_model_id=20486&pr_number=323&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F323&signature=7aef5dd5d48b675dc150bf39ece3da8b14e0b51d1aa2e80ff9b29dcdca70060d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Trim and validate `CARGO_REGISTRY_TOKEN` before `cargo publish`
> - Adds `normalize_registry_token` in [`scripts/publish_crates.py`](https://github.com/CurateLabs/graphforge/pull/323/files#diff-bb71aff20a43fb0aa201b792e8bbfd985ff1afca4dc73c357f6c720e38603775) to strip CR/LF and surrounding whitespace, fail with a clear message if the token is empty after trimming, and reject tokens containing non-printable or non-ISO-8859-1 characters without echoing the value.
> - Updates the publish workflow and credential preflight to apply the same normalization and validation before invoking `cargo publish`.
> - Behavioral Change: tokens with control characters or unexpected whitespace that previously passed silently will now cause the job to fail early with a specific error message.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0624003.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->