### PR TITLE
fix(release): durable crates.io 429 Retry-After waits

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -528,6 +528,8 @@ jobs:
     name: Dependency-ordered crates lane
     needs: candidate-preflight
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    # New-crate rate limits are ~10 minutes each; remaining surface may need ~90+ minutes.
+    timeout-minutes: 180
     permissions:
       actions: read
       contents: write
@@ -535,6 +537,17 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ needs.candidate-preflight.outputs.release_sha }}
+      - name: Use main-branch crates publisher for recovery
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: |
+          # Recovery checkouts the immutable tag SHA for certified crate bytes.
+          # Overlay the durable publisher (429 Retry-After waits) from main without
+          # moving the tag. Never print secrets.
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          git show refs/remotes/origin/main:scripts/publish_crates.py \
+            > "$RUNNER_TEMP/publish_crates.py"
+          install -m 0755 "$RUNNER_TEMP/publish_crates.py" scripts/publish_crates.py
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.96.0"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,7 +114,9 @@ jobs:
           scripts/ci/test-domain-dependencies.py
 
       - name: Test crates.io publish plan helper
-        run: python3 scripts/ci/test-crate-publish-plan.py
+        run: |
+          python3 scripts/ci/test-crate-publish-plan.py
+          python3 scripts/ci/test-publish-crates.py
 
       - name: Test release publication preflight
         run: |

--- a/scripts/ci/test-publish-crates.py
+++ b/scripts/ci/test-publish-crates.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 import hashlib
 import importlib.util
 import json
@@ -45,31 +46,117 @@ except ValueError as exc:
     assert "non-printable" in str(exc)
     assert "\x85" not in str(exc)
 
-commands: list[list[str]] = []
+RATE_BODY = (
+    "error: failed to publish graphforge-plan v0.5.1 to registry at https://crates.io\n"
+    "Caused by:\n"
+    "  the remote server responded with an error (status 429 Too Many Requests): "
+    "You have published too many new crates in a short period of time. "
+    "Please try again after Sat, 01 Aug 2026 19:40:15 GMT and see "
+    "https://crates.io/docs/rate-limits for more details.\n"
+)
+fixed_now = datetime(2026, 8, 1, 19, 35, 47, tzinfo=timezone.utc)
+wait = mod.parse_rate_limit_retry_wait(RATE_BODY, now=fixed_now)
+# 19:40:15 - 19:35:47 = 268s, plus the small post-window buffer.
+assert wait == 268 + mod.RATE_LIMIT_BUFFER_SECONDS
+assert mod.parse_rate_limit_retry_wait("error: something else\n") is None
+assert (
+    mod.parse_rate_limit_retry_wait(
+        "status 429 Too Many Requests\nRetry-After: 42\n",
+        now=fixed_now,
+    )
+    == 42 + mod.RATE_LIMIT_BUFFER_SECONDS
+)
+# 429 without a parseable wait hint must not invent a backoff.
+assert (
+    mod.parse_rate_limit_retry_wait(
+        "the remote server responded with an error (status 429 Too Many Requests)\n",
+        now=fixed_now,
+    )
+    is None
+)
+# Past retry timestamps still apply the buffer rather than sleeping forever or negative.
+past = mod.parse_rate_limit_retry_wait(
+    "status 429 Too Many Requests: Please try again after Sat, 01 Aug 2026 19:30:00 GMT\n",
+    now=fixed_now,
+)
+assert past == float(mod.RATE_LIMIT_BUFFER_SECONDS)
+
+publish_calls: list[list[str]] = []
+sleeps: list[float] = []
+
+
+def fake_publish(command: list[str]) -> subprocess.CompletedProcess[str]:
+    publish_calls.append(command)
+    if len(publish_calls) == 1:
+        return subprocess.CompletedProcess(command, 101, stdout="", stderr=RATE_BODY)
+    return subprocess.CompletedProcess(command, 0, stdout="ok\n", stderr="")
+
+
+mod.cargo_publish(
+    "graphforge-plan",
+    sleep=sleeps.append,
+    run_publish=fake_publish,
+    now=lambda: fixed_now,
+)
+assert publish_calls == [
+    ["cargo", "publish", "-p", "graphforge-plan", "--locked"],
+    ["cargo", "publish", "-p", "graphforge-plan", "--locked"],
+]
+assert sleeps == [268 + mod.RATE_LIMIT_BUFFER_SECONDS]
+
+# Non-429 failures must surface immediately without sleeping.
+publish_calls.clear()
+sleeps.clear()
+
+
+def permanent_failure(command: list[str]) -> subprocess.CompletedProcess[str]:
+    publish_calls.append(command)
+    return subprocess.CompletedProcess(
+        command,
+        101,
+        stdout="",
+        stderr="error: failed to publish: checksum mismatch\n",
+    )
+
+
+try:
+    mod.cargo_publish(
+        "graphforge-plan",
+        sleep=sleeps.append,
+        run_publish=permanent_failure,
+        now=lambda: fixed_now,
+    )
+    raise AssertionError("expected non-429 publish failure")
+except subprocess.CalledProcessError as exc:
+    assert exc.returncode == 101
+assert publish_calls == [["cargo", "publish", "-p", "graphforge-plan", "--locked"]]
+assert sleeps == []
+
+published: list[str] = []
 mod.package_checksum = lambda _name, expected=None: expected or "abc123"
 mod.owner_logins = lambda _name: {"DecisionNerd"}
-mod.run = commands.append
+mod.cargo_publish = lambda name, **_kwargs: published.append(name)
 
 mod.version_record = lambda _name: {"checksum": "abc123"}
 assert (
     mod.publish_one("graphforge-core", expected_checksum="abc123")
     == "already published; checksum and owner match"
 )
-assert commands == []
+assert published == []
 
 mod.version_record = lambda _name: None
 assert (
     mod.publish_one("graphforge-core")
     == "accepted; public checksum and owner verification required"
 )
-assert commands == [["cargo", "publish", "-p", "graphforge-core", "--locked"]]
+assert published == ["graphforge-core"]
 
-commands.clear()
+published.clear()
 assert (
     mod.publish_authorized("graphforge-core", "abc123")
     == "accepted; public checksum and owner verification required"
 )
-assert commands == [["cargo", "publish", "-p", "graphforge-core", "--locked"]]
+assert published == ["graphforge-core"]
 
 mod.version_record = lambda _name: {"checksum": "different"}
 try:

--- a/scripts/ci/test-release-publish-preflight.py
+++ b/scripts/ci/test-release-publish-preflight.py
@@ -97,6 +97,9 @@ assert "needs: [candidate-preflight, npm-cli]" in skills
 assert "--node npm:@curatelabs/graphforge-agent-skills" in skills
 
 assert "needs: candidate-preflight" in crates
+assert "timeout-minutes: 180" in crates
+assert "Use main-branch crates publisher for recovery" in crates
+assert "refs/remotes/origin/main:scripts/publish_crates.py" in crates
 assert "scripts/ci/crate-publish-plan.py list" in crates
 assert "scripts/publish_crates.py" in crates
 assert '--crate "$crate"' in crates

--- a/scripts/publish_crates.py
+++ b/scripts/publish_crates.py
@@ -12,11 +12,19 @@ credential is projected from Pulumi ESC into the GitHub Actions secret used by
 
 The token is normalized before ``cargo publish``: leading/trailing whitespace
 and CR/LF are stripped. The value is never logged.
+
+crates.io new-crate rate limits (HTTP 429) are handled durably: the publisher
+parses ``Retry-After`` / ``try again after …`` from cargo's error output, sleeps
+until that time (plus a small buffer), and retries the same crate publish.
+Total wait is capped so a full remaining surface (~10 new crates at ~10 minutes)
+can finish in one job without hiding non-429 failures.
 """
 
 from __future__ import annotations
 
 import argparse
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 import hashlib
 import importlib.util
 import json
@@ -25,7 +33,8 @@ from pathlib import Path
 import re
 import subprocess
 import sys
-from typing import Any
+import time
+from typing import Any, Callable
 import urllib.error
 import urllib.request
 
@@ -33,6 +42,15 @@ ROOT = Path(__file__).resolve().parents[1]
 PLAN_SCRIPT = ROOT / "scripts" / "ci" / "crate-publish-plan.py"
 CRATES_API = "https://crates.io/api/v1/crates"
 USER_AGENT = "GraphForge crates.io publisher (github.com/CurateLabs/graphforge)"
+# New-crate limit is 1 / 10 minutes after the burst; leave headroom for ~10 crates.
+RATE_LIMIT_BUFFER_SECONDS = 15
+MAX_SINGLE_RATE_LIMIT_WAIT_SECONDS = 20 * 60
+MAX_TOTAL_RATE_LIMIT_WAIT_SECONDS = 2 * 60 * 60
+_TRY_AGAIN_AFTER = re.compile(
+    r"try again after ([A-Za-z]{3}, \d{2} [A-Za-z]{3} \d{4} \d{2}:\d{2}:\d{2} GMT)",
+    re.IGNORECASE,
+)
+_RETRY_AFTER_HEADER = re.compile(r"(?im)^retry-after:\s*(\d+)\s*$")
 _VERSION_MATCH = re.search(
     r'(?ms)^\[workspace\.package\].*?^version\s*=\s*"([^"]+)"',
     (ROOT / "Cargo.toml").read_text(encoding="utf-8"),
@@ -69,6 +87,113 @@ def load_plan_module():
 def run(command: list[str]) -> None:
     print("+ " + " ".join(command), flush=True)
     subprocess.run(command, cwd=ROOT, check=True)
+
+
+def _is_rate_limit_output(output: str) -> bool:
+    lowered = output.lower()
+    return "status 429" in lowered or "too many requests" in lowered
+
+
+def parse_rate_limit_retry_wait(
+    output: str,
+    *,
+    now: datetime | None = None,
+) -> float | None:
+    """Return seconds to sleep for a crates.io 429, or None if not rate-limited.
+
+    Prefers the ``try again after <HTTP-date>`` timestamp in the crates.io body,
+    then a ``Retry-After: <seconds>`` header line if cargo surfaces one. Never
+    inspects or returns credential material.
+    """
+    if not _is_rate_limit_output(output):
+        return None
+
+    match = _TRY_AGAIN_AFTER.search(output)
+    if match is not None:
+        when = parsedate_to_datetime(match.group(1))
+        if when.tzinfo is None:
+            when = when.replace(tzinfo=timezone.utc)
+        current = now if now is not None else datetime.now(timezone.utc)
+        delay = (when - current).total_seconds() + RATE_LIMIT_BUFFER_SECONDS
+        return max(delay, float(RATE_LIMIT_BUFFER_SECONDS))
+
+    header = _RETRY_AFTER_HEADER.search(output)
+    if header is not None:
+        return float(int(header.group(1))) + RATE_LIMIT_BUFFER_SECONDS
+
+    # Recognized 429 without a parseable wait hint: fail closed (no blind backoff).
+    return None
+
+
+def _default_cargo_publish_run(command: list[str]) -> subprocess.CompletedProcess[str]:
+    print("+ " + " ".join(command), flush=True)
+    return subprocess.run(
+        command,
+        cwd=ROOT,
+        check=False,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+    )
+
+
+def _emit_process_output(result: subprocess.CompletedProcess[str]) -> None:
+    for stream in (result.stdout, result.stderr):
+        if not stream:
+            continue
+        print(stream, end="" if stream.endswith("\n") else "\n", flush=True)
+
+
+def cargo_publish(
+    name: str,
+    *,
+    sleep: Callable[[float], None] = time.sleep,
+    run_publish: Callable[[list[str]], subprocess.CompletedProcess[str]] | None = None,
+    now: Callable[[], datetime] | None = None,
+) -> None:
+    """Run ``cargo publish`` for one crate, sleeping through bounded 429 waits."""
+    command = ["cargo", "publish", "-p", name, "--locked"]
+    runner = run_publish or _default_cargo_publish_run
+    clock = now or (lambda: datetime.now(timezone.utc))
+    waited = 0.0
+    while True:
+        result = runner(command)
+        if result.returncode == 0:
+            _emit_process_output(result)
+            return
+
+        combined = f"{result.stdout or ''}{result.stderr or ''}"
+        wait = parse_rate_limit_retry_wait(combined, now=clock())
+        if wait is None:
+            _emit_process_output(result)
+            raise subprocess.CalledProcessError(
+                result.returncode,
+                command,
+                output=result.stdout,
+                stderr=result.stderr,
+            )
+
+        if wait > MAX_SINGLE_RATE_LIMIT_WAIT_SECONDS:
+            raise RuntimeError(
+                f"crates.io rate-limit wait for {name} is {wait:.0f}s; "
+                f"refusing waits above {MAX_SINGLE_RATE_LIMIT_WAIT_SECONDS}s"
+            )
+        if waited + wait > MAX_TOTAL_RATE_LIMIT_WAIT_SECONDS:
+            raise RuntimeError(
+                f"crates.io rate-limit wait budget exhausted for {name}: "
+                f"already waited {waited:.0f}s, next wait {wait:.0f}s, "
+                f"cap {MAX_TOTAL_RATE_LIMIT_WAIT_SECONDS}s "
+                f"(~10 new crates at ~10 minutes each)"
+            )
+
+        print(
+            f"{name}: crates.io 429 rate limit; sleeping {wait:.0f}s before retry "
+            f"(waited {waited:.0f}s / {MAX_TOTAL_RATE_LIMIT_WAIT_SECONDS}s budget)",
+            flush=True,
+        )
+        sleep(wait)
+        waited += wait
 
 
 def registry_json(path: str) -> dict[str, Any] | None:
@@ -145,7 +270,7 @@ def publish_one(
             )
         outcome = "already published; checksum and owner match"
     else:
-        run(["cargo", "publish", "-p", name, "--locked"])
+        cargo_publish(name)
         outcome = "accepted; public checksum and owner verification required"
 
     print(f"{name} {VERSION}: {outcome}")
@@ -155,7 +280,7 @@ def publish_one(
 def publish_authorized(name: str, expected_checksum: str) -> str:
     """Execute one planner-authorized absent-node write without reclassification."""
     package_checksum(name, expected_checksum)
-    run(["cargo", "publish", "-p", name, "--locked"])
+    cargo_publish(name)
     outcome = "accepted; public checksum and owner verification required"
     print(f"{name} {VERSION}: {outcome}")
     return outcome

--- a/scripts/publish_crates.py
+++ b/scripts/publish_crates.py
@@ -23,6 +23,7 @@ can finish in one job without hiding non-429 failures.
 from __future__ import annotations
 
 import argparse
+from collections.abc import Callable
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
 import hashlib
@@ -34,7 +35,7 @@ import re
 import subprocess
 import sys
 import time
-from typing import Any, Callable
+from typing import Any
 import urllib.error
 import urllib.request
 


### PR DESCRIPTION
## Summary
- Teach `scripts/publish_crates.py` to parse crates.io `429` / `try again after …` (and `Retry-After` seconds), sleep until then with a small buffer, and retry the same crate publish.
- Bound total wait at 2 hours (~10 new crates at ~10 minutes) and fail closed on non-429 errors or unparseable 429 bodies; never log the registry token.
- On recovery (`workflow_dispatch`), overlay the main-branch publisher onto the immutable tag checkout, raise the crates lane timeout to 180 minutes, and cover parsing/retry in unit + workflow contract tests.

Related to #196.

## Test plan
- [x] `python3 scripts/ci/test-publish-crates.py`
- [x] `python3 scripts/ci/test-release-publish-preflight.py`
- [ ] CI green on this PR
- [ ] After merge: one v0.5.1 publish recovery after 19:40:15 GMT; expect skip of 6 live crates and continue plan→cli with in-job 429 waits


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788205135&installation_model_id=20486&pr_number=324&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F324&signature=21b294c6f42ce8d492fb2cdff802c0c4088e9d4a99bee1d9d95fc301a18f4104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix durable crates.io 429 retry handling in `cargo_publish`
> - Adds a new `cargo_publish` function in [`scripts/publish_crates.py`](https://github.com/CurateLabs/graphforge/pull/324/files#diff-bb71aff20a43fb0aa201b792e8bbfd985ff1afca4dc73c357f6c720e38603775) that wraps `cargo publish` with automatic retry logic on 429 rate limit responses, parsing wait hints from `Retry-After` headers or `try again after ... GMT` body text.
> - Enforces per-wait (`MAX_SINGLE_RATE_LIMIT_WAIT_SECONDS=1200`) and total (`MAX_TOTAL_RATE_LIMIT_WAIT_SECONDS=7200`) caps, adds a 15-second buffer, and fails fast on non-429 errors.
> - Both `publish_one` and `publish_authorized` now route through `cargo_publish` instead of calling `cargo publish` directly.
> - Adds a 180-minute job timeout and a `workflow_dispatch` recovery step to the [`publish.yaml`](https://github.com/CurateLabs/graphforge/pull/324/files#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388ca) CI job that overlays `scripts/publish_crates.py` from `main` before publishing.
> - Adds tests in [`scripts/ci/test-publish-crates.py`](https://github.com/CurateLabs/graphforge/pull/324/files#diff-05b8afc21c4cc4310bfc6102bd6648b3b28037d588d95f59ec2a01b8d1be5b7b) covering rate limit parsing, retry behavior, and permanent failure fast-path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 433fcd6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->