### PR TITLE
fix(release): refresh crate observation before authorize

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -542,12 +542,15 @@ jobs:
         shell: bash
         run: |
           # Recovery checkouts the immutable tag SHA for certified crate bytes.
-          # Overlay the durable publisher (429 Retry-After waits) from main without
-          # moving the tag. Never print secrets.
+          # Overlay the durable publisher (429 Retry-After waits) and authorize
+          # diagnostics from main without moving the tag. Never print secrets.
           git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
           git show refs/remotes/origin/main:scripts/publish_crates.py \
             > "$RUNNER_TEMP/publish_crates.py"
           install -m 0755 "$RUNNER_TEMP/publish_crates.py" scripts/publish_crates.py
+          git show refs/remotes/origin/main:scripts/ci/release_action.py \
+            > "$RUNNER_TEMP/release_action.py"
+          install -m 0755 "$RUNNER_TEMP/release_action.py" scripts/ci/release_action.py
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.96.0"
@@ -588,6 +591,12 @@ jobs:
           while IFS= read -r crate; do
             node="crates:$crate"
             planned_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            # Durable crates.io Retry-After waits can exceed MAX_OBSERVATION_AGE
+            # (10m). Refresh this node before authorize so still-absent crates do
+            # not hard-fail as observation_stale / blocked_registry_state.
+            python3 scripts/ci/release_registry.py observe --manifest "candidate/$MANIFEST_NAME" --node "$node" --live --observed-at "$planned_at" --out node-observation.json
+            jq --arg node "$node" --slurpfile current node-observation.json '.observations = ([.observations[] | select(.node_id != $node)] + $current)' observations.json > observations.next.json
+            mv observations.next.json observations.json
             python3 scripts/ci/release_action.py authorize --manifest "candidate/$MANIFEST_NAME" --observations observations.json --availability availability.json --node "$node" --planned-at "$planned_at" --out authorization.json
             if test "$(jq -r .publish authorization.json)" = false; then
               continue

--- a/scripts/ci/release_action.py
+++ b/scripts/ci/release_action.py
@@ -134,10 +134,12 @@ def authorize(
         raise ActionError(f"planner returned no decision for node {node_id}")
     action = next((item for item in plan["actions"] if item["node_id"] == node_id), None)
     if decision["disposition"] not in {"publish", "skip_verified"}:
-        raise ActionError(
-            f"node {node_id} is not safe to publish: "
-            f"{decision['disposition']} ({decision['state']})"
-        )
+        reason = decision.get("reason")
+        detail = f"{decision['disposition']} ({decision['state']}"
+        if isinstance(reason, str) and reason:
+            detail += f": {reason}"
+        detail += ")"
+        raise ActionError(f"node {node_id} is not safe to publish: {detail}")
     return {
         "schema": "graphforge-release-action-authorization-v1",
         "candidate_sha": manifest["commit_sha"],

--- a/scripts/ci/test-release-action.py
+++ b/scripts/ci/test-release-action.py
@@ -132,6 +132,25 @@ def test_authorization() -> None:
     else:
         raise AssertionError("dependency-blocked npm main was authorized")
 
+    stale = copy.deepcopy(verified)
+    stale_obs = registry_fixture.observed(manifest, "crates:graphforge-search", {"status": 404})
+    stale_obs["observed_at"] = "2029-12-31T00:00:00+00:00"
+    registry_fixture.replace_observation(stale, stale_obs)
+    try:
+        action.authorize(
+            manifest,
+            stale,
+            availability,
+            "crates:graphforge-search",
+            planned_at=registry_fixture.NOW,
+        )
+    except action.ActionError as error:
+        message = str(error)
+        assert "blocked_registry_state" in message
+        assert "observation_stale" in message
+    else:
+        raise AssertionError("stale crate observation was authorized")
+
     receipt = action.accepted_receipt(
         manifest, "pypi:graphforge", accepted_at="2030-01-01T12:00:00Z"
     )

--- a/scripts/ci/test-release-publish-preflight.py
+++ b/scripts/ci/test-release-publish-preflight.py
@@ -113,13 +113,14 @@ assert (
     'release_registry.py observe --manifest "candidate/$MANIFEST_NAME" --node "$node" --live'
     in crates
 )
-observe_before_authorize = crates.index(
+observe_marker = (
     'release_registry.py observe --manifest "candidate/$MANIFEST_NAME" --node "$node" --live'
 )
-authorize_index = crates.index(
-    'release_action.py authorize --manifest "candidate/$MANIFEST_NAME" --observations observations.json'
+authorize_marker = (
+    'release_action.py authorize --manifest "candidate/$MANIFEST_NAME" '
+    "--observations observations.json"
 )
-assert observe_before_authorize < authorize_index
+assert crates.index(observe_marker) < crates.index(authorize_marker)
 
 for lane in (pypi, native, main, cli, skills, crates):
     assert "release_action.py" in lane

--- a/scripts/ci/test-release-publish-preflight.py
+++ b/scripts/ci/test-release-publish-preflight.py
@@ -100,6 +100,7 @@ assert "needs: candidate-preflight" in crates
 assert "timeout-minutes: 180" in crates
 assert "Use main-branch crates publisher for recovery" in crates
 assert "refs/remotes/origin/main:scripts/publish_crates.py" in crates
+assert "refs/remotes/origin/main:scripts/ci/release_action.py" in crates
 assert "scripts/ci/crate-publish-plan.py list" in crates
 assert "scripts/publish_crates.py" in crates
 assert '--crate "$crate"' in crates
@@ -107,6 +108,15 @@ assert "secrets.CARGO_REGISTRY_TOKEN" in crates
 assert "CARGO_REGISTRY_TOKEN is empty after trim" in crates
 assert "Never print the value" in crates
 assert "secrets.NPM_TOKEN" not in crates
+assert "Refresh this node before authorize" in crates
+assert 'release_registry.py observe --manifest "candidate/$MANIFEST_NAME" --node "$node" --live' in crates
+observe_before_authorize = crates.index(
+    'release_registry.py observe --manifest "candidate/$MANIFEST_NAME" --node "$node" --live'
+)
+authorize_index = crates.index(
+    'release_action.py authorize --manifest "candidate/$MANIFEST_NAME" --observations observations.json'
+)
+assert observe_before_authorize < authorize_index
 
 for lane in (pypi, native, main, cli, skills, crates):
     assert "release_action.py" in lane

--- a/scripts/ci/test-release-publish-preflight.py
+++ b/scripts/ci/test-release-publish-preflight.py
@@ -109,7 +109,10 @@ assert "CARGO_REGISTRY_TOKEN is empty after trim" in crates
 assert "Never print the value" in crates
 assert "secrets.NPM_TOKEN" not in crates
 assert "Refresh this node before authorize" in crates
-assert 'release_registry.py observe --manifest "candidate/$MANIFEST_NAME" --node "$node" --live' in crates
+assert (
+    'release_registry.py observe --manifest "candidate/$MANIFEST_NAME" --node "$node" --live'
+    in crates
+)
 observe_before_authorize = crates.index(
     'release_registry.py observe --manifest "candidate/$MANIFEST_NAME" --node "$node" --live'
 )


### PR DESCRIPTION
## Summary
- Root cause of run [30715697365](https://github.com/CurateLabs/graphforge/actions/runs/30715697365): after a 523s crates.io `Retry-After` wait, authorize for `graphforge-search` used a >10m-old observe-all snapshot, which `plan_recovery` rewrote to `observation_stale` → `blocked_registry_state (indeterminate)`.
- Live crates.io confirms `graphforge-search` is absent (404); no attempt/receipt orphan. Tag `v0.5.1` stays at `dd1fd8c`.
- Refresh each crate's live observation immediately before authorize; include observation reason in authorize failures; overlay `release_action.py` from main on recovery checkouts.

## Test plan
- [x] `python3 scripts/ci/test-release-publish-preflight.py`
- [x] `python3 scripts/ci/test-release-action.py`
- [ ] Required CI / CI Gate green on exact head SHA
- [ ] After merge: one `publish.yaml` workflow_dispatch recovery for v0.5.1

Closes #325


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788207318&installation_model_id=20486&pr_number=326&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F326&signature=f360cf3f370e91dd46302a6f419827d3f51143a278ab328f10096b13b755aa0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved unsafe-publication error messages by including the planner’s reason, disposition, and current state.
  - Release authorization now clearly identifies stale registry observations and the blocked registry condition.

- **Tests**
  - Expanded release workflow validation to confirm registry observations are refreshed and verified before authorization.
  - Added coverage for stale registry data and required release-action behavior on the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refresh crate observation before authorization in the crates publishing workflow
> - Before each crate node's authorization step, the workflow now fetches a live observation via `release_registry.py observe --live` and merges it into `observations.json` using `jq`, ensuring stale data does not affect authorization outcomes.
> - The recovery overlay step now also fetches `scripts/ci/release_action.py` from main, alongside `scripts/publish_crates.py`.
> - `authorize()` in [release_action.py](https://github.com/CurateLabs/graphforge/pull/326/files#diff-5d3eecb48a8a9137639cc8e51bc210ed33e0e80170c6c823677db532b8e394fd) now includes the planner's `decision.reason` in `ActionError` messages when a node is not publishable, improving error visibility.
> - Behavioral Change: nodes with previously stale observations may now be blocked at authorization where they previously were not.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a68f4a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->