### PR TITLE
fix(release): refresh crate deps before authorize

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -551,6 +551,10 @@ jobs:
           git show refs/remotes/origin/main:scripts/ci/release_action.py \
             > "$RUNNER_TEMP/release_action.py"
           install -m 0755 "$RUNNER_TEMP/release_action.py" scripts/ci/release_action.py
+          git show refs/remotes/origin/main:scripts/ci/crate-authorize-refresh-nodes.py \
+            > "$RUNNER_TEMP/crate-authorize-refresh-nodes.py"
+          install -m 0755 "$RUNNER_TEMP/crate-authorize-refresh-nodes.py" \
+            scripts/ci/crate-authorize-refresh-nodes.py
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.96.0"
@@ -599,21 +603,7 @@ jobs:
               python3 scripts/ci/release_registry.py observe --manifest "candidate/$MANIFEST_NAME" --node "$refresh_node" --live --observed-at "$planned_at" --out node-observation.json
               jq --arg node "$refresh_node" --slurpfile current node-observation.json '.observations = ([.observations[] | select(.node_id != $node)] + $current)' observations.json > observations.next.json
               mv observations.next.json observations.json
-            done < <(python3 -c "
-import json, sys
-manifest = json.load(open(sys.argv[1], encoding='utf-8'))
-node = sys.argv[2]
-deps = sorted({
-    edge['requires']
-    for edge in manifest.get('dependencies', [])
-    if isinstance(edge, dict)
-    and edge.get('from') == node
-    and isinstance(edge.get('requires'), str)
-    and edge['requires'].startswith('crates:')
-})
-for item in [node, *deps]:
-    print(item)
-" "candidate/$MANIFEST_NAME" "$node")
+            done < <(python3 scripts/ci/crate-authorize-refresh-nodes.py --manifest "candidate/$MANIFEST_NAME" --node "$node")
             python3 scripts/ci/release_action.py authorize --manifest "candidate/$MANIFEST_NAME" --observations observations.json --availability availability.json --node "$node" --planned-at "$planned_at" --out authorization.json
             if test "$(jq -r .publish authorization.json)" = false; then
               continue

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -592,11 +592,28 @@ jobs:
             node="crates:$crate"
             planned_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
             # Durable crates.io Retry-After waits can exceed MAX_OBSERVATION_AGE
-            # (10m). Refresh this node before authorize so still-absent crates do
-            # not hard-fail as observation_stale / blocked_registry_state.
-            python3 scripts/ci/release_registry.py observe --manifest "candidate/$MANIFEST_NAME" --node "$node" --live --observed-at "$planned_at" --out node-observation.json
-            jq --arg node "$node" --slurpfile current node-observation.json '.observations = ([.observations[] | select(.node_id != $node)] + $current)' observations.json > observations.next.json
-            mv observations.next.json observations.json
+            # (10m). Refresh this node and its crates dependencies before authorize
+            # so still-absent crates and verified deps do not hard-fail as
+            # observation_stale / blocked_registry_state / blocked_dependencies.
+            while IFS= read -r refresh_node; do
+              python3 scripts/ci/release_registry.py observe --manifest "candidate/$MANIFEST_NAME" --node "$refresh_node" --live --observed-at "$planned_at" --out node-observation.json
+              jq --arg node "$refresh_node" --slurpfile current node-observation.json '.observations = ([.observations[] | select(.node_id != $node)] + $current)' observations.json > observations.next.json
+              mv observations.next.json observations.json
+            done < <(python3 -c "
+import json, sys
+manifest = json.load(open(sys.argv[1], encoding='utf-8'))
+node = sys.argv[2]
+deps = sorted({
+    edge['requires']
+    for edge in manifest.get('dependencies', [])
+    if isinstance(edge, dict)
+    and edge.get('from') == node
+    and isinstance(edge.get('requires'), str)
+    and edge['requires'].startswith('crates:')
+})
+for item in [node, *deps]:
+    print(item)
+" "candidate/$MANIFEST_NAME" "$node")
             python3 scripts/ci/release_action.py authorize --manifest "candidate/$MANIFEST_NAME" --observations observations.json --availability availability.json --node "$node" --planned-at "$planned_at" --out authorization.json
             if test "$(jq -r .publish authorization.json)" = false; then
               continue

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,6 +116,7 @@ jobs:
       - name: Test crates.io publish plan helper
         run: |
           python3 scripts/ci/test-crate-publish-plan.py
+          python3 scripts/ci/test-crate-authorize-refresh-nodes.py
           python3 scripts/ci/test-publish-crates.py
 
       - name: Test release publication preflight

--- a/scripts/ci/crate-authorize-refresh-nodes.py
+++ b/scripts/ci/crate-authorize-refresh-nodes.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""List a crates node and its crates dependencies for pre-authorize refresh."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--node", required=True)
+    args = parser.parse_args(argv)
+    try:
+        manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        print(f"crate-authorize-refresh-nodes: {error}", file=sys.stderr)
+        return 1
+    if not args.node.startswith("crates:"):
+        print(
+            f"crate-authorize-refresh-nodes: node must be a crates node: {args.node}",
+            file=sys.stderr,
+        )
+        return 1
+    edges = manifest.get("dependencies")
+    if not isinstance(edges, list):
+        print("crate-authorize-refresh-nodes: candidate dependencies are invalid", file=sys.stderr)
+        return 1
+    deps = sorted(
+        {
+            edge["requires"]
+            for edge in edges
+            if isinstance(edge, dict)
+            and edge.get("from") == args.node
+            and isinstance(edge.get("requires"), str)
+            and edge["requires"].startswith("crates:")
+        }
+    )
+    for item in [args.node, *deps]:
+        print(item)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/release_action.py
+++ b/scripts/ci/release_action.py
@@ -139,6 +139,12 @@ def authorize(
         if isinstance(reason, str) and reason:
             detail += f": {reason}"
         detail += ")"
+        dependency_states = decision.get("dependency_states")
+        if isinstance(dependency_states, dict) and dependency_states:
+            rendered = ", ".join(
+                f"{dependency}={state}" for dependency, state in sorted(dependency_states.items())
+            )
+            detail += f" deps[{rendered}]"
         raise ActionError(f"node {node_id} is not safe to publish: {detail}")
     return {
         "schema": "graphforge-release-action-authorization-v1",

--- a/scripts/ci/test-crate-authorize-refresh-nodes.py
+++ b/scripts/ci/test-crate-authorize-refresh-nodes.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Tests for scripts/ci/crate-authorize-refresh-nodes.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+SCRIPT = Path(__file__).with_name("crate-authorize-refresh-nodes.py")
+
+
+def run(manifest: dict, node: str) -> list[str]:
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "manifest.json"
+        path.write_text(json.dumps(manifest), encoding="utf-8")
+        completed = subprocess.run(
+            [sys.executable, str(SCRIPT), "--manifest", str(path), "--node", node],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    return [line for line in completed.stdout.splitlines() if line]
+
+
+def main() -> None:
+    manifest = {
+        "dependencies": [
+            {"from": "crates:graphforge-api", "requires": "crates:graphforge-core"},
+            {"from": "crates:graphforge-api", "requires": "crates:graphforge-search"},
+            {"from": "crates:graphforge-api", "requires": "npm:@curatelabs/graphforge"},
+            {"from": "crates:graphforge-cli", "requires": "crates:graphforge-api"},
+        ]
+    }
+    assert run(manifest, "crates:graphforge-api") == [
+        "crates:graphforge-api",
+        "crates:graphforge-core",
+        "crates:graphforge-search",
+    ]
+    assert run(manifest, "crates:graphforge-cli") == [
+        "crates:graphforge-cli",
+        "crates:graphforge-api",
+    ]
+    assert run({"dependencies": []}, "crates:graphforge-core") == ["crates:graphforge-core"]
+    print("crate-authorize-refresh-nodes tests passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/test-release-action.py
+++ b/scripts/ci/test-release-action.py
@@ -128,9 +128,39 @@ def test_authorization() -> None:
             planned_at=registry_fixture.NOW,
         )
     except action.ActionError as error:
-        assert "blocked_dependencies" in str(error)
+        message = str(error)
+        assert "blocked_dependencies" in message
+        assert "deps[" in message
+        assert "npm:@curatelabs/graphforge-linux-x64-gnu=absent" in message
     else:
         raise AssertionError("dependency-blocked npm main was authorized")
+
+    stale_dep_manifest = copy.deepcopy(manifest)
+    stale_dep_manifest["dependencies"].append(
+        {"from": "crates:graphforge-api", "requires": "crates:graphforge-search"}
+    )
+    stale_dep = copy.deepcopy(verified)
+    registry_fixture.replace_observation(
+        stale_dep,
+        registry_fixture.observed(manifest, "crates:graphforge-api", {"status": 404}),
+    )
+    stale_search = registry_fixture.observed(manifest, "crates:graphforge-search")
+    stale_search["observed_at"] = "2029-12-31T00:00:00+00:00"
+    registry_fixture.replace_observation(stale_dep, stale_search)
+    try:
+        action.authorize(
+            stale_dep_manifest,
+            stale_dep,
+            availability,
+            "crates:graphforge-api",
+            planned_at=registry_fixture.NOW,
+        )
+    except action.ActionError as error:
+        message = str(error)
+        assert "blocked_dependencies" in message
+        assert "crates:graphforge-search=indeterminate" in message
+    else:
+        raise AssertionError("stale crate dependency was authorized")
 
     stale = copy.deepcopy(verified)
     stale_obs = registry_fixture.observed(manifest, "crates:graphforge-search", {"status": 404})

--- a/scripts/ci/test-release-publish-preflight.py
+++ b/scripts/ci/test-release-publish-preflight.py
@@ -101,6 +101,7 @@ assert "timeout-minutes: 180" in crates
 assert "Use main-branch crates publisher for recovery" in crates
 assert "refs/remotes/origin/main:scripts/publish_crates.py" in crates
 assert "refs/remotes/origin/main:scripts/ci/release_action.py" in crates
+assert "refs/remotes/origin/main:scripts/ci/crate-authorize-refresh-nodes.py" in crates
 assert "scripts/ci/crate-publish-plan.py list" in crates
 assert "scripts/publish_crates.py" in crates
 assert '--crate "$crate"' in crates
@@ -109,11 +110,11 @@ assert "CARGO_REGISTRY_TOKEN is empty after trim" in crates
 assert "Never print the value" in crates
 assert "secrets.NPM_TOKEN" not in crates
 assert "Refresh this node and its crates dependencies before authorize" in crates
+assert "scripts/ci/crate-authorize-refresh-nodes.py" in crates
 assert (
     'release_registry.py observe --manifest "candidate/$MANIFEST_NAME" '
     '--node "$refresh_node" --live' in crates
 )
-assert "edge.get('from') == node" in crates
 observe_marker = (
     'release_registry.py observe --manifest "candidate/$MANIFEST_NAME" '
     '--node "$refresh_node" --live'

--- a/scripts/ci/test-release-publish-preflight.py
+++ b/scripts/ci/test-release-publish-preflight.py
@@ -108,13 +108,15 @@ assert "secrets.CARGO_REGISTRY_TOKEN" in crates
 assert "CARGO_REGISTRY_TOKEN is empty after trim" in crates
 assert "Never print the value" in crates
 assert "secrets.NPM_TOKEN" not in crates
-assert "Refresh this node before authorize" in crates
+assert "Refresh this node and its crates dependencies before authorize" in crates
 assert (
-    'release_registry.py observe --manifest "candidate/$MANIFEST_NAME" --node "$node" --live'
-    in crates
+    'release_registry.py observe --manifest "candidate/$MANIFEST_NAME" '
+    '--node "$refresh_node" --live' in crates
 )
+assert "edge.get('from') == node" in crates
 observe_marker = (
-    'release_registry.py observe --manifest "candidate/$MANIFEST_NAME" --node "$node" --live'
+    'release_registry.py observe --manifest "candidate/$MANIFEST_NAME" '
+    '--node "$refresh_node" --live'
 )
 authorize_marker = (
     'release_action.py authorize --manifest "candidate/$MANIFEST_NAME" '


### PR DESCRIPTION
## Summary
- Latest recovery [30717011503](https://github.com/CurateLabs/graphforge/actions/runs/30717011503) reached 13/15, then authorize for `graphforge-api` failed with `blocked_dependencies` after a 470s Retry-After on `exec`.
- Missing on crates.io: `graphforge-api`, `graphforge-cli`. Tag stays at `dd1fd8c`.
- Root cause: #326 refreshes only the current node; verified deps (e.g. `search` accepted ~10m earlier) age to `observation_stale` and block dependents.
- Refresh the current node and its crates dependencies before authorize; include `dependency_states` in authorize error text.

## Test plan
- [x] `python3 scripts/ci/test-release-publish-preflight.py`
- [x] `python3 scripts/ci/test-release-action.py`
- [ ] Required CI / CI Gate green on exact head SHA
- [ ] After merge: one `publish.yaml` workflow_dispatch for v0.5.1 to finish api+cli

Closes #327


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788209045&installation_model_id=20486&pr_number=328&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F328&signature=6800507e2734ded9d49d97b2e5471694f98106bd8ed58112633d89c86b3b13af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refresh crate dependencies before authorization in the publish workflow
> - Adds [crate-authorize-refresh-nodes.py](https://github.com/CurateLabs/graphforge/pull/328/files#diff-a07482da8a2c1a9fe2b3dea72d8e9afd5b06d6a1ea48bd1da1c52636290978c8), a CLI script that enumerates a crates node and its crates dependencies from a JSON manifest, for use by the publish workflow.
> - Updates the publish workflow to iterate over all dependency nodes (not just the current node) and refresh each one before authorization.
> - Authorization failures in `release_action.authorize` now include dependency state details (e.g. `deps[dep=indeterminate]`) in the exception message.
> - Adds tests for the new helper script and extends existing authorization and preflight tests to cover these behaviors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e769ed2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->