### PR TITLE
fix(release): clobber attempt/receipt uploads on recovery

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -249,7 +249,7 @@ jobs:
         run: |
           attempt="v$RELEASE_VERSION-attempt-pypi-graphforge.json"
           python3 scripts/ci/release_action.py attempt --manifest "candidate/$MANIFEST_NAME" --node pypi:graphforge --started-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --out "$attempt"
-          gh release upload "$RELEASE_TAG" "$attempt"
+          gh release upload "$RELEASE_TAG" "$attempt" --clobber
       - name: Publish exact Python artifacts once
         if: steps.authorize.outputs.publish == 'true'
         run: uv publish candidate/release-artifacts/python/*
@@ -264,7 +264,7 @@ jobs:
           accepted_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           receipt="v$RELEASE_VERSION-accepted-pypi-graphforge.json"
           python3 scripts/ci/release_action.py receipt --manifest "candidate/$MANIFEST_NAME" --node pypi:graphforge --accepted-at "$accepted_at" --out "$receipt"
-          gh release upload "$RELEASE_TAG" "$receipt"
+          gh release upload "$RELEASE_TAG" "$receipt" --clobber
           python3 scripts/ci/release_registry.py observe --manifest "candidate/$MANIFEST_NAME" --node pypi:graphforge --live --accepted-receipt "$receipt" --observed-at "$accepted_at" --out post-write.json
           jq '{node_id,state,reason}' post-write.json >> "$GITHUB_STEP_SUMMARY"
 
@@ -328,7 +328,7 @@ jobs:
         run: |
           attempt="v$RELEASE_VERSION-attempt-npm-${{ matrix.package }}.json"
           python3 scripts/ci/release_action.py attempt --manifest "candidate/$MANIFEST_NAME" --node "$NODE_ID" --started-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --out "$attempt"
-          gh release upload "$RELEASE_TAG" "$attempt"
+          gh release upload "$RELEASE_TAG" "$attempt" --clobber
       - name: Publish one exact native tarball
         if: steps.authorize.outputs.publish == 'true'
         env:
@@ -351,7 +351,7 @@ jobs:
           accepted_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           receipt="v$RELEASE_VERSION-accepted-npm-${{ matrix.package }}.json"
           python3 scripts/ci/release_action.py receipt --manifest "candidate/$MANIFEST_NAME" --node "$NODE_ID" --accepted-at "$accepted_at" --out "$receipt"
-          gh release upload "$RELEASE_TAG" "$receipt"
+          gh release upload "$RELEASE_TAG" "$receipt" --clobber
           python3 scripts/ci/release_registry.py observe --manifest "candidate/$MANIFEST_NAME" --node "$NODE_ID" --live --accepted-receipt "$receipt" --observed-at "$accepted_at" --out post-write.json
           jq '{node_id,state,reason}' post-write.json >> "$GITHUB_STEP_SUMMARY"
 
@@ -404,7 +404,7 @@ jobs:
         run: |
           attempt="v$RELEASE_VERSION-attempt-npm-graphforge.json"
           python3 scripts/ci/release_action.py attempt --manifest "candidate/$MANIFEST_NAME" --node npm:@curatelabs/graphforge --started-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --out "$attempt"
-          gh release upload "$RELEASE_TAG" "$attempt"
+          gh release upload "$RELEASE_TAG" "$attempt" --clobber
       - name: Publish exact npm main tarball once
         if: steps.authorize.outputs.publish == 'true'
         env:
@@ -426,7 +426,7 @@ jobs:
           accepted_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           receipt="v$RELEASE_VERSION-accepted-npm-graphforge.json"
           python3 scripts/ci/release_action.py receipt --manifest "candidate/$MANIFEST_NAME" --node npm:@curatelabs/graphforge --accepted-at "$accepted_at" --out "$receipt"
-          gh release upload "$RELEASE_TAG" "$receipt"
+          gh release upload "$RELEASE_TAG" "$receipt" --clobber
           python3 scripts/ci/release_registry.py observe --manifest "candidate/$MANIFEST_NAME" --node npm:@curatelabs/graphforge --live --accepted-receipt "$receipt" --observed-at "$accepted_at" --out post-write.json
           jq '{node_id,state,reason}' post-write.json >> "$GITHUB_STEP_SUMMARY"
 
@@ -466,13 +466,13 @@ jobs:
           if test "$(jq -r .publish authorization.json)" = true; then
             attempt="v$RELEASE_VERSION-attempt-npm-graphforge-cli.json"
             python3 scripts/ci/release_action.py attempt --manifest "candidate/$MANIFEST_NAME" --node npm:@curatelabs/graphforge-cli --started-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --out "$attempt"
-            gh release upload "$RELEASE_TAG" "$attempt"
+            gh release upload "$RELEASE_TAG" "$attempt" --clobber
             npm whoami
             python3 scripts/publish_npm_artifacts.py --release-record "candidate/$MANIFEST_NAME" --artifacts-dir candidate/release-artifacts --expected-sha "$RELEASE_SHA" --version "$RELEASE_VERSION" --package @curatelabs/graphforge-cli
             accepted_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
             receipt="v$RELEASE_VERSION-accepted-npm-graphforge-cli.json"
             python3 scripts/ci/release_action.py receipt --manifest "candidate/$MANIFEST_NAME" --node npm:@curatelabs/graphforge-cli --accepted-at "$accepted_at" --out "$receipt"
-            gh release upload "$RELEASE_TAG" "$receipt"
+            gh release upload "$RELEASE_TAG" "$receipt" --clobber
             python3 scripts/ci/release_registry.py observe --manifest "candidate/$MANIFEST_NAME" --node npm:@curatelabs/graphforge-cli --live --accepted-receipt "$receipt" --observed-at "$accepted_at" --out post-write.json
             jq '{node_id,state,reason}' post-write.json >> "$GITHUB_STEP_SUMMARY"
           fi
@@ -513,13 +513,13 @@ jobs:
           if test "$(jq -r .publish authorization.json)" = true; then
             attempt="v$RELEASE_VERSION-attempt-npm-graphforge-agent-skills.json"
             python3 scripts/ci/release_action.py attempt --manifest "candidate/$MANIFEST_NAME" --node npm:@curatelabs/graphforge-agent-skills --started-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --out "$attempt"
-            gh release upload "$RELEASE_TAG" "$attempt"
+            gh release upload "$RELEASE_TAG" "$attempt" --clobber
             npm whoami
             python3 scripts/publish_npm_artifacts.py --release-record "candidate/$MANIFEST_NAME" --artifacts-dir candidate/release-artifacts --expected-sha "$RELEASE_SHA" --version "$RELEASE_VERSION" --package @curatelabs/graphforge-agent-skills
             accepted_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
             receipt="v$RELEASE_VERSION-accepted-npm-graphforge-agent-skills.json"
             python3 scripts/ci/release_action.py receipt --manifest "candidate/$MANIFEST_NAME" --node npm:@curatelabs/graphforge-agent-skills --accepted-at "$accepted_at" --out "$receipt"
-            gh release upload "$RELEASE_TAG" "$receipt"
+            gh release upload "$RELEASE_TAG" "$receipt" --clobber
             python3 scripts/ci/release_registry.py observe --manifest "candidate/$MANIFEST_NAME" --node npm:@curatelabs/graphforge-agent-skills --live --accepted-receipt "$receipt" --observed-at "$accepted_at" --out post-write.json
             jq '{node_id,state,reason}' post-write.json >> "$GITHUB_STEP_SUMMARY"
           fi
@@ -613,12 +613,12 @@ jobs:
             fi
             attempt="v$RELEASE_VERSION-attempt-crates-$crate.json"
             python3 scripts/ci/release_action.py attempt --manifest "candidate/$MANIFEST_NAME" --node "$node" --started-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --out "$attempt"
-            gh release upload "$RELEASE_TAG" "$attempt"
+            gh release upload "$RELEASE_TAG" "$attempt" --clobber
             python3 scripts/publish_crates.py --release-record "candidate/$MANIFEST_NAME" --artifacts-dir candidate/release-artifacts --crate "$crate"
             accepted_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
             receipt="v$RELEASE_VERSION-accepted-crates-$crate.json"
             python3 scripts/ci/release_action.py receipt --manifest "candidate/$MANIFEST_NAME" --node "$node" --accepted-at "$accepted_at" --out "$receipt"
-            gh release upload "$RELEASE_TAG" "$receipt"
+            gh release upload "$RELEASE_TAG" "$receipt" --clobber
             python3 scripts/ci/release_registry.py observe --manifest "candidate/$MANIFEST_NAME" --node "$node" --live --accepted-receipt "$receipt" --observed-at "$accepted_at" --out post-write.json
             jq --arg node "$node" --slurpfile current post-write.json '.observations = ([.observations[] | select(.node_id != $node)] + $current)' observations.json > observations.next.json
             mv observations.next.json observations.json

--- a/scripts/ci/test-release-publish-preflight.py
+++ b/scripts/ci/test-release-publish-preflight.py
@@ -130,7 +130,8 @@ for lane in (pypi, native, main, cli, skills, crates):
     assert "release_action.py" in lane
     assert "release_registry.py" in lane
     assert "release_action.py attempt" in lane
-    assert "gh release upload" in lane
+    assert 'gh release upload "$RELEASE_TAG" "$attempt" --clobber' in lane
+    assert 'gh release upload "$RELEASE_TAG" "$receipt" --clobber' in lane
     assert "--attempts-dir write-evidence/attempts" in lane
     assert "--receipts-dir write-evidence/receipts" in lane
 


### PR DESCRIPTION
## Summary
- Recovery [30718666479](https://github.com/CurateLabs/graphforge/actions/runs/30718666479) authorized `graphforge-cli` after #330, then failed on duplicate `v0.5.1-attempt-crates-graphforge-cli.json` upload before publish.
- Add `--clobber` to attempt/receipt `gh release upload` across publish lanes; keep candidate-manifest upload unchanged.
- Tag stays `dd1fd8c`. Still 14/15 (`graphforge-cli` missing).

## Test plan
- [x] `python3 scripts/ci/test-release-publish-preflight.py`
- [ ] Required CI / CI Gate green
- [ ] One publish.yaml recovery for cli after merge

Closes #331


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788211107&installation_model_id=20486&pr_number=332&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F332&signature=3766283db79df5c9e97dd7e4b61636235022f46bc85a80226a3816b97d7ac762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--clobber` flag to attempt and receipt uploads on release recovery
> When a release publish is retried after a partial failure, re-uploading attempt and receipt files to the GitHub release would fail if assets with the same name already existed. Adding `--clobber` to each `gh release upload` call in [publish.yaml](.github/workflows/publish.yaml) causes existing assets to be overwritten instead. The preflight test in [test-release-publish-preflight.py](scripts/ci/test-release-publish-preflight.py) is updated to assert the flag is present for all lanes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 053fe51.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated release workflow checks to verify separate uploads for attempt and receipt artifacts.
  * Confirmed uploads use overwrite behavior to reliably replace existing artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->