### PR TITLE
Use crates.io Trusted Publishing for crate releases

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -533,6 +533,7 @@ jobs:
     permissions:
       actions: read
       contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -572,24 +573,13 @@ jobs:
       - name: Publish dependency-ready crates with one observation per accepted write
         shell: bash
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CRATES_IO_TRUSTED_PUBLISHING: "true"
           RELEASE_SHA: ${{ needs.candidate-preflight.outputs.release_sha }}
           RELEASE_VERSION: ${{ needs.candidate-preflight.outputs.release_version }}
           MANIFEST_NAME: ${{ needs.candidate-preflight.outputs.manifest_name }}
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ needs.candidate-preflight.outputs.release_tag }}
         run: |
-          # Defensive: ESC/GitHub secret projection can append CR/LF/whitespace.
-          # Recovery checkouts the immutable tag SHA, so normalize here in the
-          # main-branch workflow before cargo publish. Never print the value.
-          CARGO_REGISTRY_TOKEN="${CARGO_REGISTRY_TOKEN//$'\r'/}"
-          CARGO_REGISTRY_TOKEN="${CARGO_REGISTRY_TOKEN#"${CARGO_REGISTRY_TOKEN%%[![:space:]]*}"}"
-          CARGO_REGISTRY_TOKEN="${CARGO_REGISTRY_TOKEN%"${CARGO_REGISTRY_TOKEN##*[![:space:]]}"}"
-          export CARGO_REGISTRY_TOKEN
-          if test -z "$CARGO_REGISTRY_TOKEN"; then
-            echo "CARGO_REGISTRY_TOKEN is empty after trim" >&2
-            exit 1
-          fi
           now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           bash scripts/ci/download-release-write-evidence.sh "$RELEASE_TAG" "$RELEASE_VERSION" write-evidence
           python3 scripts/ci/release_action.py validate-partition --manifest "candidate/$MANIFEST_NAME" --artifacts-dir candidate/release-artifacts --group crates --expected-sha "$RELEASE_SHA" --version "$RELEASE_VERSION" --checked-at "$now"

--- a/.github/workflows/release-credential-preflight.yml
+++ b/.github/workflows/release-credential-preflight.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   credentials:
-    name: Verify projected publication credentials
+    name: Verify projected npm credential
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v7
@@ -42,20 +42,5 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Verify crates.io token projection without printing it
-        shell: bash
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: |
-          # Same defensive trim as publish.yaml — never print the value.
-          CARGO_REGISTRY_TOKEN="${CARGO_REGISTRY_TOKEN//$'\r'/}"
-          CARGO_REGISTRY_TOKEN="${CARGO_REGISTRY_TOKEN#"${CARGO_REGISTRY_TOKEN%%[![:space:]]*}"}"
-          CARGO_REGISTRY_TOKEN="${CARGO_REGISTRY_TOKEN%"${CARGO_REGISTRY_TOKEN##*[![:space:]]}"}"
-          export CARGO_REGISTRY_TOKEN
-          test -n "$CARGO_REGISTRY_TOKEN"
-          test "${#CARGO_REGISTRY_TOKEN}" -ge 20
-          # Reject residual control / non-ISO-8859-1 bytes without echoing them.
-          python3 -c 'import os, sys; t = os.environ["CARGO_REGISTRY_TOKEN"]; bad = any(not (0x20 <= ord(c) <= 0x7E or 0xA0 <= ord(c) <= 0xFF) for c in t); sys.exit(1 if bad else 0)'
-
       - name: Record non-publishing result
-        run: echo "Credential projection is present; this workflow performs no registry writes."
+        run: echo "npm credential projection succeeded; crates.io Trusted Publishing is verified in publish.yaml."

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,7 +10,7 @@ are in
 - The release version is aligned across every public package surface.
 - Normal PR CI is green on the intended `main` commit.
 - The retained partitioned candidate and offline rehearsal are complete.
-- Registry credentials and PyPI trusted publishing are configured.
+- The npm token and PyPI/crates.io trusted publishing are configured.
 - A maintainer has explicitly authorized the immutable tag, GitHub Release, and
   registry writes.
 

--- a/docs/development/publication-order.md
+++ b/docs/development/publication-order.md
@@ -24,9 +24,9 @@ Before a maintainer authorizes publication:
 4. `evidence/offline-rehearsal.json` proves the exact partitions passed clean
    Python, Node/native, CLI, and skills consumers and crate/dependency checks
    with zero registry writes.
-5. PyPI trusted publishing is configured for `CurateLabs/graphforge` and
-   `publish.yaml`; the npm token has scoped public-package write access and
-   Bypass 2FA; the crates.io token belongs to `DecisionNerd`.
+5. PyPI and crates.io trusted publishing are configured for
+   `CurateLabs/graphforge` and `publish.yaml`; the npm token has scoped
+   public-package write access and Bypass 2FA.
 6. The maintainer explicitly decides to create the immutable v0.5.1 tag and
    GitHub Release. Implementation CI and ordinary issue close do not run a
    release-certification cascade.
@@ -44,8 +44,8 @@ dependencies stop the lane.
 The independent work is:
 
 - PyPI may run independently with OIDC and the Python partition.
-- crates.io may run independently with only its token and the crates partition;
-  crates remain in the checked topological order below.
+- crates.io may run independently with its short-lived trusted-publishing token
+  and the crates partition; crates remain in the checked topological order below.
 - the five native npm packages run as a fail-slow parallel matrix with only the
   npm token and npm partition.
 

--- a/docs/development/v0.5.0-release-operator-runbook.md
+++ b/docs/development/v0.5.0-release-operator-runbook.md
@@ -51,11 +51,11 @@ These account-level actions cannot be completed from repository automation:
    - workflow: `publish.yaml`
    - environment: leave blank
 
-4. Confirm the crates.io token remains in Pulumi ESC
-   `curatelabs/graphforge/release` and that the repository lists the encrypted
-   `CARGO_REGISTRY_TOKEN` secret. Do not print either value.
+4. Confirm every crates.io crate has the configured trusted publisher for
+   `CurateLabs/graphforge` and `publish.yaml`. The publication workflow obtains
+   only short-lived tokens from GitHub Actions OIDC.
 
-The npm and crates.io secret projections can then be tested without publishing:
+The npm secret projection can then be tested without publishing:
 
 ```bash
 RC_SHA="$(git rev-parse origin/main)"
@@ -65,9 +65,9 @@ gh workflow run release-credential-preflight.yml \
   -f commit_sha="$RC_SHA"
 ```
 
-Wait for `Release Credential Preflight` to pass. PyPI validates its OIDC
-configuration only when the release publication job requests a token; a PyPI
-failure is therefore a hard stop.
+Wait for `Release Credential Preflight` to pass. PyPI and crates.io validate
+their OIDC configurations only when the release publication job requests a
+token; either failure is a hard stop.
 
 ## 2. Freeze and certify one current-main SHA (automated, non-publishing)
 

--- a/scripts/ci/test-publish-crates.py
+++ b/scripts/ci/test-publish-crates.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 import hashlib
 import importlib.util
 import json
+import os
 from pathlib import Path
 import subprocess
 import tempfile
@@ -45,6 +46,54 @@ try:
 except ValueError as exc:
     assert "non-printable" in str(exc)
     assert "\x85" not in str(exc)
+
+# Trusted Publishing performs a fresh OIDC exchange for every cargo attempt.
+original_environ = os.environ.copy()
+original_urlopen = mod.urllib.request.urlopen
+requests = []
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self, *_args):
+        return json.dumps(self.payload).encode("utf-8")
+
+
+def fake_urlopen(request, timeout):
+    requests.append((request, timeout))
+    if request.full_url.startswith(os.environ["ACTIONS_ID_TOKEN_REQUEST_URL"]):
+        return FakeResponse({"value": "signed-oidc-jwt"})
+    if request.get_method() == "POST":
+        return FakeResponse({"token": "trusted-token"})
+    return FakeResponse({})
+
+
+os.environ.update(
+    {
+        mod.TRUSTED_PUBLISHING_ENV: "true",
+        "ACTIONS_ID_TOKEN_REQUEST_URL": "https://oidc.example/token",
+        "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "request-token",
+    }
+)
+mod.urllib.request.urlopen = fake_urlopen
+assert mod.request_trusted_publishing_token() == "trusted-token"
+assert requests[0][0].full_url == "https://oidc.example/token?audience=crates.io"
+assert requests[0][0].get_header("Authorization") == "Bearer request-token"
+assert json.loads(requests[1][0].data) == {"jwt": "signed-oidc-jwt"}
+mod.revoke_trusted_publishing_token("trusted-token")
+assert requests[2][0].get_method() == "DELETE"
+assert requests[2][0].get_header("Authorization") == "Bearer trusted-token"
+mod.urllib.request.urlopen = original_urlopen
+os.environ.clear()
+os.environ.update(original_environ)
 
 RATE_BODY = (
     "error: failed to publish graphforge-plan v0.5.1 to registry at https://crates.io\n"

--- a/scripts/ci/test-publish-crates.py
+++ b/scripts/ci/test-publish-crates.py
@@ -84,16 +84,18 @@ os.environ.update(
     }
 )
 mod.urllib.request.urlopen = fake_urlopen
-assert mod.request_trusted_publishing_token() == "trusted-token"
-assert requests[0][0].full_url == "https://oidc.example/token?audience=crates.io"
-assert requests[0][0].get_header("Authorization") == "Bearer request-token"
-assert json.loads(requests[1][0].data) == {"jwt": "signed-oidc-jwt"}
-mod.revoke_trusted_publishing_token("trusted-token")
-assert requests[2][0].get_method() == "DELETE"
-assert requests[2][0].get_header("Authorization") == "Bearer trusted-token"
-mod.urllib.request.urlopen = original_urlopen
-os.environ.clear()
-os.environ.update(original_environ)
+try:
+    assert mod.request_trusted_publishing_token() == "trusted-token"
+    assert requests[0][0].full_url == "https://oidc.example/token?audience=crates.io"
+    assert requests[0][0].get_header("Authorization") == "Bearer request-token"
+    assert json.loads(requests[1][0].data) == {"jwt": "signed-oidc-jwt"}
+    mod.revoke_trusted_publishing_token("trusted-token")
+    assert requests[2][0].get_method() == "DELETE"
+    assert requests[2][0].get_header("Authorization") == "Bearer trusted-token"
+finally:
+    mod.urllib.request.urlopen = original_urlopen
+    os.environ.clear()
+    os.environ.update(original_environ)
 
 RATE_BODY = (
     "error: failed to publish graphforge-plan v0.5.1 to registry at https://crates.io\n"
@@ -180,6 +182,33 @@ except subprocess.CalledProcessError as exc:
     assert exc.returncode == 101
 assert publish_calls == [["cargo", "publish", "-p", "graphforge-plan", "--locked", "--no-verify"]]
 assert sleeps == []
+
+# A revoke outage is visible to the operator but cannot turn an accepted publish
+# into a failed, potentially duplicate recovery attempt.
+original_request_token = mod.request_trusted_publishing_token
+original_revoke_token = mod.revoke_trusted_publishing_token
+original_environ = os.environ.copy()
+os.environ[mod.TRUSTED_PUBLISHING_ENV] = "true"
+mod.request_trusted_publishing_token = lambda: "trusted-token"
+
+
+def revoke_failure(_token):
+    raise mod.urllib.error.URLError("unavailable")
+
+
+mod.revoke_trusted_publishing_token = revoke_failure
+try:
+    mod.cargo_publish(
+        "graphforge-plan",
+        run_publish=lambda command: subprocess.CompletedProcess(
+            command, 0, stdout="ok\n", stderr=""
+        ),
+    )
+finally:
+    mod.request_trusted_publishing_token = original_request_token
+    mod.revoke_trusted_publishing_token = original_revoke_token
+    os.environ.clear()
+    os.environ.update(original_environ)
 
 published: list[str] = []
 mod.package_checksum = lambda _name, expected=None: expected or "abc123"

--- a/scripts/ci/test-release-publish-preflight.py
+++ b/scripts/ci/test-release-publish-preflight.py
@@ -106,9 +106,10 @@ assert "refs/remotes/origin/main:scripts/ci/release_registry.py" in crates
 assert "scripts/ci/crate-publish-plan.py list" in crates
 assert "scripts/publish_crates.py" in crates
 assert '--crate "$crate"' in crates
-assert "secrets.CARGO_REGISTRY_TOKEN" in crates
-assert "CARGO_REGISTRY_TOKEN is empty after trim" in crates
-assert "Never print the value" in crates
+assert "id-token: write" in crates
+assert 'CRATES_IO_TRUSTED_PUBLISHING: "true"' in crates
+assert "rust-lang/crates-io-auth-action" not in crates
+assert "secrets.CARGO_REGISTRY_TOKEN" not in crates
 assert "secrets.NPM_TOKEN" not in crates
 assert "Refresh this node and its crates dependencies before authorize" in crates
 assert "scripts/ci/crate-authorize-refresh-nodes.py" in crates
@@ -162,8 +163,8 @@ assert "sleep" not in write_evidence
 credential_workflow = CREDENTIAL_WORKFLOW.read_text(encoding="utf-8")
 assert "npm whoami" in credential_workflow
 assert "secrets.NPM_TOKEN" in credential_workflow
-assert "secrets.CARGO_REGISTRY_TOKEN" in credential_workflow
-assert "never print the value" in credential_workflow.lower()
+assert "secrets.CARGO_REGISTRY_TOKEN" not in credential_workflow
+assert "crates-io-auth-action" not in credential_workflow
 for forbidden in ("npm publish", "uv publish", "cargo publish", "release:\n"):
     assert forbidden not in credential_workflow
 

--- a/scripts/publish_crates.py
+++ b/scripts/publish_crates.py
@@ -7,8 +7,8 @@ the archive checksum. If that exact version already exists, publication only
 continues when crates.io reports the same checksum.
 
 Requires ``CARGO_REGISTRY_TOKEN`` in the environment. The maintained release
-credential is projected from Pulumi ESC into the GitHub Actions secret used by
-``publish.yaml``.
+workflow obtains a fresh short-lived value through crates.io Trusted Publishing
+for every ``cargo publish`` attempt.
 
 The token is normalized before ``cargo publish``: leading/trailing whitespace
 and CR/LF are stripped. The value is never logged.
@@ -37,11 +37,14 @@ import sys
 import time
 from typing import Any
 import urllib.error
+import urllib.parse
 import urllib.request
 
 ROOT = Path(__file__).resolve().parents[1]
 PLAN_SCRIPT = ROOT / "scripts" / "ci" / "crate-publish-plan.py"
 CRATES_API = "https://crates.io/api/v1/crates"
+TRUSTED_PUBLISHING_TOKENS_API = "https://crates.io/api/v1/trusted_publishing/tokens"
+TRUSTED_PUBLISHING_ENV = "CRATES_IO_TRUSTED_PUBLISHING"
 USER_AGENT = "GraphForge crates.io publisher (github.com/CurateLabs/graphforge)"
 # New-crate limit is 1 / 10 minutes after the burst; leave headroom for ~10 crates.
 RATE_LIMIT_BUFFER_SECONDS = 15
@@ -74,6 +77,54 @@ def normalize_registry_token(raw: str) -> str:
     if any(not (0x20 <= ord(ch) <= 0x7E or 0xA0 <= ord(ch) <= 0xFF) for ch in token):
         raise ValueError("CARGO_REGISTRY_TOKEN contains non-printable or non-ISO-8859-1 characters")
     return token
+
+
+def trusted_publishing_enabled() -> bool:
+    """Return whether this process should obtain per-attempt OIDC tokens."""
+    return os.environ.get(TRUSTED_PUBLISHING_ENV) == "true"
+
+
+def request_trusted_publishing_token() -> str:
+    """Exchange this GitHub Actions job's OIDC identity for a crates.io token."""
+    request_url = os.environ.get("ACTIONS_ID_TOKEN_REQUEST_URL")
+    request_token = os.environ.get("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+    if not request_url or not request_token:
+        raise RuntimeError("Trusted Publishing requires GitHub Actions id-token: write permission")
+
+    separator = "&" if "?" in request_url else "?"
+    oidc_request = urllib.request.Request(
+        f"{request_url}{separator}{urllib.parse.urlencode({'audience': 'crates.io'})}",
+        headers={"Authorization": f"Bearer {request_token}", "Accept": "application/json"},
+    )
+    with urllib.request.urlopen(oidc_request, timeout=30) as response:
+        oidc_payload = json.load(response)
+    jwt = oidc_payload.get("value")
+    if not isinstance(jwt, str) or not jwt:
+        raise RuntimeError("GitHub Actions did not return an OIDC token")
+
+    exchange_request = urllib.request.Request(
+        TRUSTED_PUBLISHING_TOKENS_API,
+        data=json.dumps({"jwt": jwt}).encode("utf-8"),
+        headers={"Content-Type": "application/json", "User-Agent": USER_AGENT},
+        method="POST",
+    )
+    with urllib.request.urlopen(exchange_request, timeout=30) as response:
+        exchange_payload = json.load(response)
+    token = exchange_payload.get("token")
+    if not isinstance(token, str) or not token:
+        raise RuntimeError("crates.io did not return a Trusted Publishing token")
+    return normalize_registry_token(token)
+
+
+def revoke_trusted_publishing_token(token: str) -> None:
+    """Revoke a per-attempt token after Cargo no longer needs it."""
+    request = urllib.request.Request(
+        TRUSTED_PUBLISHING_TOKENS_API,
+        headers={"Authorization": f"Bearer {token}", "User-Agent": USER_AGENT},
+        method="DELETE",
+    )
+    with urllib.request.urlopen(request, timeout=30):
+        pass
 
 
 def load_plan_module():
@@ -165,7 +216,14 @@ def cargo_publish(
     clock = now or (lambda: datetime.now(timezone.utc))
     waited = 0.0
     while True:
-        result = runner(command)
+        trusted_token = request_trusted_publishing_token() if trusted_publishing_enabled() else None
+        if trusted_token is not None:
+            os.environ["CARGO_REGISTRY_TOKEN"] = trusted_token
+        try:
+            result = runner(command)
+        finally:
+            if trusted_token is not None:
+                revoke_trusted_publishing_token(trusted_token)
         if result.returncode == 0:
             _emit_process_output(result)
             return
@@ -363,13 +421,14 @@ def main(argv: list[str] | None = None) -> int:
         print("--release-record and --artifacts-dir must be provided together", file=sys.stderr)
         return 2
 
-    try:
-        os.environ["CARGO_REGISTRY_TOKEN"] = normalize_registry_token(
-            os.environ.get("CARGO_REGISTRY_TOKEN", "")
-        )
-    except ValueError as error:
-        print(str(error), file=sys.stderr)
-        return 2
+    if not trusted_publishing_enabled():
+        try:
+            os.environ["CARGO_REGISTRY_TOKEN"] = normalize_registry_token(
+                os.environ.get("CARGO_REGISTRY_TOKEN", "")
+            )
+        except ValueError as error:
+            print(str(error), file=sys.stderr)
+            return 2
 
     plan = load_plan_module()
     crates = plan.load_workspace()

--- a/scripts/publish_crates.py
+++ b/scripts/publish_crates.py
@@ -223,7 +223,14 @@ def cargo_publish(
             result = runner(command)
         finally:
             if trusted_token is not None:
-                revoke_trusted_publishing_token(trusted_token)
+                try:
+                    revoke_trusted_publishing_token(trusted_token)
+                except (OSError, urllib.error.URLError) as error:
+                    print(
+                        f"{name}: warning: Trusted Publishing token revocation failed "
+                        f"({type(error).__name__}); it will expire normally",
+                        file=sys.stderr,
+                    )
         if result.returncode == 0:
             _emit_process_output(result)
             return


### PR DESCRIPTION
## Summary

- replace the long-lived crates.io secret with GitHub Actions OIDC Trusted Publishing
- exchange and revoke a fresh crates.io token for each publish attempt, including 429 recovery
- keep credential preflight npm-only because its workflow identity is not a registered crates.io publisher

## Verification

- `python3 -m py_compile scripts/publish_crates.py scripts/ci/test-publish-crates.py scripts/ci/test-release-publish-preflight.py`
- `python3 scripts/ci/test-publish-crates.py`
- `python3 scripts/ci/test-release-publish-preflight.py`
- YAML parse and `git diff --check`

Fixes #349

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788301340&installation_model_id=20486&pr_number=350&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F350&signature=f8701b64901079f9c7b361dfd74911e8bde20bc2b87250a08a7ed715896c1d7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for crates.io Trusted Publishing using short-lived OIDC credentials during releases.
  * Credentials are automatically revoked after publishing.
  * Existing static-token publishing remains available when Trusted Publishing is not enabled.

* **Documentation**
  * Updated publishing guidance to describe the Trusted Publishing workflow.

* **Tests**
  * Added coverage for credential acquisition, publishing requests, revocation, and workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use crates.io Trusted Publishing (OIDC) for crate releases instead of a static token
> - Replaces the long-lived `CARGO_REGISTRY_TOKEN` secret with crates.io Trusted Publishing: each `cargo publish` attempt in [publish_crates.py](https://github.com/CurateLabs/graphforge/pull/350/files#diff-bb71aff20a43fb0aa201b792e8bbfd985ff1afca4dc73c357f6c720e38603775) now performs a two-step OIDC exchange (GitHub Actions JWT → crates.io short-lived token), then revokes the token after use.
> - The publish workflow gains `id-token: write` permission and sets `CRATES_IO_TRUSTED_PUBLISHING=true` instead of injecting `CARGO_REGISTRY_TOKEN`.
> - The preflight credential check in [release-credential-preflight.yml](https://github.com/CurateLabs/graphforge/pull/350/files#diff-472d8accde0a2b597f2f22cdb5c78d5cecb7277bf216af9bc90023221c1d706b) drops crates.io token validation; only npm credentials are verified there.
> - Revocation failures raise a stderr warning but do not fail the publish job.
> - Risk: if the GitHub OIDC endpoint or crates.io token API is unavailable at publish time, the release will fail with a `RuntimeError` rather than falling back to a static token.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c272e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->