### PR TITLE
fix(bindings): repair Node bulk API contract

### DIFF
--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -1184,22 +1184,6 @@ impl GraphForge {
         }
     }
 
-    /// Bulk-add nodes of one label.
-    ///
-    /// # Errors
-    /// Returns [`GfError::NotImplemented`] until the write API is wired.
-    pub fn add_nodes(&self) -> Result<(), GfError> {
-        Err(GfError::NotImplemented("add_nodes"))
-    }
-
-    /// Bulk-add edges of one relationship type.
-    ///
-    /// # Errors
-    /// Returns [`GfError::NotImplemented`] until the write API is wired.
-    pub fn add_edges(&self) -> Result<(), GfError> {
-        Err(GfError::NotImplemented("add_edges"))
-    }
-
     /// Remove all nodes and edges (in-memory instances only).
     ///
     /// # Errors

--- a/crates/graphforge-api/tests/public_facade_remaining_conformance.rs
+++ b/crates/graphforge-api/tests/public_facade_remaining_conformance.rs
@@ -111,8 +111,6 @@ fn public_lifecycle_inventory_covers_remaining_facade_methods() {
         )
         .unwrap();
 
-    assert_eq!(graph.add_nodes().unwrap_err().code(), "GF_NOT_IMPLEMENTED");
-    assert_eq!(graph.add_edges().unwrap_err().code(), "GF_NOT_IMPLEMENTED");
     assert_eq!(graph.labels().unwrap(), ["Person".to_owned()]);
     assert!(graph.relationship_types().unwrap().is_empty());
     assert_eq!(graph.node_count("").unwrap(), 1);

--- a/crates/graphforge-bindings-node/src/error.rs
+++ b/crates/graphforge-bindings-node/src/error.rs
@@ -26,6 +26,7 @@ fn error_code(err: &GfError) -> &'static str {
         GfError::Lifecycle(_) => "LifecycleError",
         GfError::Validation(message)
             if is_uuid_parameter_validation(message)
+                || is_bulk_validation(message)
                 || is_ontology_lifecycle_validation(message) =>
         {
             "GF_VALIDATION"
@@ -34,6 +35,10 @@ fn error_code(err: &GfError) -> &'static str {
         GfError::Ontology(_) => "OntologyError",
         GfError::NotImplemented(_) => "NotImplementedError",
     }
+}
+
+fn is_bulk_validation(message: &str) -> bool {
+    message.starts_with("GF_BULK_VALIDATION(")
 }
 
 fn is_ontology_lifecycle_validation(message: &str) -> bool {
@@ -174,6 +179,15 @@ mod tests {
             assert_eq!(mapped.status, "GF_VALIDATION");
             assert_eq!(mapped.reason, message);
         }
+    }
+
+    #[test]
+    fn bulk_validation_uses_the_stable_public_code() {
+        let message =
+            "GF_BULK_VALIDATION(invalid_uuid): bulk node row 0 field \"node_uuid\": invalid UUID";
+        let mapped = to_napi_err(&GfError::Validation(message.into()));
+        assert_eq!(mapped.status, "GF_VALIDATION");
+        assert_eq!(mapped.reason, message);
     }
 
     #[test]

--- a/crates/graphforge-bindings-node/src/lib.rs
+++ b/crates/graphforge-bindings-node/src/lib.rs
@@ -5686,22 +5686,6 @@ impl GraphForge {
         composite::publish_composite_transaction(&graph, request)
     }
 
-    /// Bulk-add nodes (Arrow IPC / records).
-    #[napi]
-    #[allow(unused_variables)]
-    pub fn add_nodes(&self, label: String, data: Buffer) -> Result<()> {
-        let g = self.open_guard()?;
-        g.add_nodes().map_err(|e| to_napi_err(&e))
-    }
-
-    /// Bulk-add edges (Arrow IPC / records).
-    #[napi]
-    #[allow(unused_variables)]
-    pub fn add_edges(&self, rel_type: String, data: Buffer) -> Result<()> {
-        let g = self.open_guard()?;
-        g.add_edges().map_err(|e| to_napi_err(&e))
-    }
-
     /// Remove all nodes and edges (in-memory instances only).
     #[napi]
     pub fn clear(&self) -> Result<()> {

--- a/crates/graphforge-bindings-node/tests/bulk_construction.test.mjs
+++ b/crates/graphforge-bindings-node/tests/bulk_construction.test.mjs
@@ -185,6 +185,7 @@ test("publishBulkNodes/Edges accept canonical IPC and reopen identically", () =>
     assert.equal(edgeReceipt.numRows, 1);
     assert.deepEqual([...edgeReceipt.getChild("rel_type")], ["KNOWS"]);
 
+    forge.close();
     forge = new GraphForge(project);
     const reopened = tableFromIPC(
       forge.execute(
@@ -201,7 +202,6 @@ test("publishBulkNodes/Edges accept canonical IPC and reopen identically", () =>
       [...reopened.getChild("since")].map((value) => Number(value)),
       [2020],
     );
-
     let malformed = false;
     try {
       forge.publishBulkNodes(EDGE_OPERATION, Buffer.from("not-ipc"));
@@ -209,6 +209,7 @@ test("publishBulkNodes/Edges accept canonical IPC and reopen identically", () =>
       malformed = true;
     }
     assert.equal(malformed, true);
+    forge.close();
   } finally {
     rmSync(project, { recursive: true, force: true });
   }

--- a/crates/graphforge-bindings-node/tests/core.test.mjs
+++ b/crates/graphforge-bindings-node/tests/core.test.mjs
@@ -166,15 +166,18 @@ function checkInspectionSurface() {
   }
 }
 
-function checkTransactionSurfaceIsAbsent() {
-  for (const name of ["begin", "commit", "rollback"]) {
+function checkRemovedSurfaceIsAbsent() {
+  for (const name of ["begin", "commit", "rollback", "addNodes", "addEdges"]) {
     assert.equal(name in GraphForge.prototype, false, `${name} must not ship`);
   }
   const declarations = readFileSync(
     new URL("../index.d.ts", import.meta.url),
     "utf8",
   );
-  assert.doesNotMatch(declarations, /^\s+(?:begin|commit|rollback)\(\):/m);
+  assert.doesNotMatch(
+    declarations,
+    /^\s+(?:begin|commit|rollback|addNodes|addEdges)\([^)]*\):/m,
+  );
 }
 
 function checkFind() {
@@ -244,5 +247,8 @@ test("parse error", checkParseError);
 test("pre-v1 project error", checkPreV1ProjectError);
 test("find", checkFind);
 test("graph inspection surface", checkInspectionSurface);
-test("generic transaction surface is absent", checkTransactionSurfaceIsAbsent);
+test(
+  "generic transaction and bulk convenience stub surfaces are absent",
+  checkRemovedSurfaceIsAbsent,
+);
 test("plan handle", checkPlanHandle);

--- a/crates/graphforge-bindings-node/tests/non-cypher-parity-policy.json
+++ b/crates/graphforge-bindings-node/tests/non-cypher-parity-policy.json
@@ -1,8 +1,8 @@
 {
   "contractVersion": 1,
   "rustManifest": "../../../tests/contracts/non-cypher-rust-surface.json",
-  "releaseSurfaceCount": 183,
-  "releaseSurfaceDigest": "b08b40684ddd01a0b17f87f94b008b129ee49d62614d9b8a7c4a2f6b701be27b",
+  "releaseSurfaceCount": 181,
+  "releaseSurfaceDigest": "c36590ea5e3427d3a3db1a80f5375f51c9071a1d9d951f9da4b9c56446e9a16d",
   "requiredEquivalent": [
     "GraphForge.adopt_ontology",
     "GraphForge.clear_ontology",
@@ -31,9 +31,7 @@
       "CheckpointView.inspect_adjacency",
       "CheckpointView.project_capabilities",
       "GraphForge.add_edge",
-      "GraphForge.add_edges",
       "GraphForge.add_node",
-      "GraphForge.add_nodes",
       "GraphForge.adopt_ontology",
       "GraphForge.algorithm_run",
       "GraphForge.algorithm_run_events",

--- a/crates/graphforge-bindings-py/tests/bulk_construction.py
+++ b/crates/graphforge-bindings-py/tests/bulk_construction.py
@@ -177,6 +177,7 @@ def check_bulk_construction(project: Path) -> None:
     assert edge_receipt.num_rows == 1, edge_receipt
     assert edge_receipt.column("rel_type").to_pylist() == ["KNOWS"]
 
+    forge.close()
     forge = g.GraphForge(str(project))
     reopened = forge.execute(
         "MATCH (a:Person)-[r:KNOWS]->(b:Person) "
@@ -197,6 +198,7 @@ def check_bulk_construction(project: Path) -> None:
     else:
         raise SystemExit("expected TypeError for malformed bulk container")
     assert project_digest(project) == before
+    forge.close()
 
 
 if __name__ == "__main__":

--- a/crates/graphforge-bindings-py/tests/non_cypher_release.py
+++ b/crates/graphforge-bindings-py/tests/non_cypher_release.py
@@ -23,8 +23,43 @@ ROOT = Path(__file__).resolve().parents[3]
 RUST_MANIFEST = ROOT / "tests/contracts/non-cypher-rust-surface.json"
 RUST_GATE = ROOT / "scripts/ci/non-cypher-surface-gate.py"
 PYO3_SOURCE = ROOT / "crates/graphforge-bindings-py/src/lib.rs"
-EXPECTED_RUST_DIGEST = "7b9704118564c177abc8d7a69919c8f2d863770f95af9f706f4cd8ac3b3a9b18"
-EXPECTED_RELEASE_DIGEST = "b08b40684ddd01a0b17f87f94b008b129ee49d62614d9b8a7c4a2f6b701be27b"
+EXPECTED_RUST_DIGEST = "d867e276ca262c52acd087475d4cc3b3ebf2295b0419d50926b5c9048f35ce27"
+EXPECTED_RELEASE_DIGEST = "c36590ea5e3427d3a3db1a80f5375f51c9071a1d9d951f9da4b9c56446e9a16d"
+
+PYTHON_ONLY_METHODS = frozenset(
+    {
+        "CancellationToken.__init__",
+        "EdgeHandle.__repr__",
+        "EdgeHandle.__str__",
+        "EdgeHandle.rel_type",
+        "EdgeHandle.uuid",
+        "GraphForge.__init__",
+        "GraphForge.__repr__",
+        "GraphForge.add_edges",
+        "GraphForge.add_nodes",
+        "GraphForge.close",
+        "GraphForge.configure_openrouter",
+        "GraphForge.execute_polars",
+        "GraphForge.load_ontology",
+        "GraphForge.ontology_mode",
+        "GraphForge.path",
+        "InvocationDescriptor.algorithm",
+        "InvocationDescriptor.fingerprint",
+        "InvocationDescriptor.projection_fingerprint",
+        "InvocationDescriptor.verb",
+        "NodeHandle.__repr__",
+        "NodeHandle.__str__",
+        "NodeHandle.label",
+        "NodeHandle.uuid",
+        "ResolvedBeliefProjection.graph_content_fingerprint",
+        "ResolvedBeliefProjection.policy_fingerprint",
+        "ResolvedBeliefProjection.snapshot_fingerprint",
+        "ResolvedBeliefProjection.source_generation_uuid",
+        "ResolvedBeliefProjection.transaction_cutoff",
+        "ResolvedBeliefProjection.valid_time",
+        "ResolvedBeliefProjection.valid_time_fingerprint",
+    }
+)
 
 EVIDENCE = {
     "infra-validation": {
@@ -188,7 +223,7 @@ def _classification_report() -> dict[str, object]:
         for group in manifest["method_evidence_groups"].values()
         for method_id in group["ids"]
     }
-    assert len(release_methods) == 183
+    assert len(release_methods) == 181
     assert _digest(release_methods) == EXPECTED_RELEASE_DIGEST
     assert set(EVIDENCE) == set(manifest["method_evidence_groups"])
 
@@ -261,36 +296,7 @@ def _classification_report() -> dict[str, object]:
     # A newly exposed Python product method must be deliberately projected or
     # explicitly listed as Python-only. This catches silent binding expansion.
     projected = {item["python_id"] for item in classifications.values() if item["python_id"]}
-    python_only = {
-        "CancellationToken.__init__",
-        "EdgeHandle.__repr__",
-        "EdgeHandle.__str__",
-        "EdgeHandle.rel_type",
-        "EdgeHandle.uuid",
-        "GraphForge.__init__",
-        "GraphForge.__repr__",
-        "GraphForge.close",
-        "GraphForge.configure_openrouter",
-        "GraphForge.execute_polars",
-        "GraphForge.load_ontology",
-        "GraphForge.ontology_mode",
-        "GraphForge.path",
-        "InvocationDescriptor.algorithm",
-        "InvocationDescriptor.fingerprint",
-        "InvocationDescriptor.projection_fingerprint",
-        "InvocationDescriptor.verb",
-        "NodeHandle.__repr__",
-        "NodeHandle.__str__",
-        "NodeHandle.label",
-        "NodeHandle.uuid",
-        "ResolvedBeliefProjection.graph_content_fingerprint",
-        "ResolvedBeliefProjection.policy_fingerprint",
-        "ResolvedBeliefProjection.snapshot_fingerprint",
-        "ResolvedBeliefProjection.source_generation_uuid",
-        "ResolvedBeliefProjection.transaction_cutoff",
-        "ResolvedBeliefProjection.valid_time",
-        "ResolvedBeliefProjection.valid_time_fingerprint",
-    }
+    python_only = set(PYTHON_ONLY_METHODS)
     unclassified_python = sorted(python_methods - projected - python_only)
     assert not unclassified_python, f"unclassified compiled Python methods: {unclassified_python}"
     return {

--- a/docs/guide/graph-construction.md
+++ b/docs/guide/graph-construction.md
@@ -191,6 +191,11 @@ Rust and Node project onto the same bulk contracts. Identity, ontology
 validation, idempotency, and publication stay Rust-owned; bindings only convert
 at the boundary.
 
+Node intentionally exposes only `publishBulkNodes` / `publishBulkEdges` for
+bulk construction. The Python-only `add_nodes` / `add_edges` helpers normalize
+Python containers before calling those same Rust-owned publication operations;
+there are no Node `addNodes` / `addEdges` stubs or JavaScript publication path.
+
 ```rust
 // Rust — publish_bulk_nodes / publish_bulk_edges on graphforge_api::GraphForge
 ```

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -126,6 +126,15 @@ derived provenance identity used by explicit lineage and knowledge rows.
 
 ### Construction
 
+Python exposes `add_nodes` / `add_edges` as language-specific container
+normalizers over the Rust-owned publication methods. Node accepts canonical
+Arrow IPC through `publishBulkNodes` / `publishBulkEdges`; it does not expose
+`addNodes` / `addEdges` convenience methods. Both bindings therefore exercise
+the same atomic publication, receipt, idempotency, and reopen contract without
+duplicating normalization behavior in JavaScript.
+The former Node convenience stubs were removed as an intentional compile-time
+break; callers migrate directly to the two `publishBulk*` methods.
+
 #### `add_node(label, **props)` → `NodeHandle`
 
 Add a single node. Returns a `NodeHandle` exposing stable `.uuid` identity and
@@ -146,7 +155,7 @@ bulk receipt table (`entity_uuid`, `row_ordinal`, generation identity, …).
 receipt = forge.publish_bulk_nodes(operation_uuid, node_table)
 ```
 
-#### `add_nodes(label, data, *, operation_uuid)` → `pyarrow.Table`
+#### Python: `add_nodes(label, data, *, operation_uuid)` → `pyarrow.Table`
 
 Convenience projection onto `publish_bulk_nodes`. `data` may be an Arrow Table,
 a pandas or Polars DataFrame, or a `list[dict]`. Missing `label` / `node_uuid`
@@ -178,7 +187,7 @@ Returns the canonical bulk receipt table.
 receipt = forge.publish_bulk_edges(operation_uuid, edge_table)
 ```
 
-#### `add_edges(rel_type, data, *, operation_uuid, src="src_id", dst="dst_id")` → `pyarrow.Table`
+#### Python: `add_edges(rel_type, data, *, operation_uuid, src="src_id", dst="dst_id")` → `pyarrow.Table`
 
 Convenience projection onto `publish_bulk_edges`. `src` / `dst` name endpoint
 columns (default `src_id` / `dst_id`) and are renamed to `source_uuid` /

--- a/scripts/ci/bulk-construction-parity.py
+++ b/scripts/ci/bulk-construction-parity.py
@@ -26,6 +26,7 @@ import graphforge as g
 
 ROOT = Path(__file__).resolve().parents[2]
 NODE_PKG = ROOT / "crates" / "graphforge-bindings-node"
+NODE_PROBE_TIMEOUT_SECONDS = 300
 
 NODE_A = uuid.UUID("018f0f4e-7b8c-7000-8000-00000000d001")
 NODE_B = uuid.UUID("018f0f4e-7b8c-7000-8000-00000000d002")
@@ -109,6 +110,10 @@ def empty_node_table() -> pa.Table:
 
 def run_python(project: Path) -> dict:
     forge = g.GraphForge(str(project))
+    assert callable(forge.publish_bulk_nodes)
+    assert callable(forge.publish_bulk_edges)
+    assert callable(forge.add_nodes), "Python container normalization must remain available"
+    assert callable(forge.add_edges), "Python container normalization must remain available"
     empty = forge.publish_bulk_nodes(OP_NODES, empty_node_table())
     assert empty.num_rows == 0
 
@@ -173,6 +178,7 @@ def run_python(project: Path) -> dict:
     assert edges.num_rows == 1
     assert edges.column("rel_type").to_pylist() == ["KNOWS"]
 
+    forge.close()
     forge = g.GraphForge(str(project))
     reopened = forge.execute(
         "MATCH (a:Person)-[r:KNOWS]->(b:Person) "
@@ -186,6 +192,7 @@ def run_python(project: Path) -> dict:
         "node_ids": [str(value) for value in ids],
         "digest": project_digest(project),
     }
+    forge.close()
     return payload
 
 
@@ -293,6 +300,10 @@ function projectDigest(root) {{
 rmSync(project, {{ recursive: true, force: true }});
 mkdirSync(project, {{ recursive: true }});
 let forge = new GraphForge(project);
+assert.equal("addNodes" in forge, false);
+assert.equal("addEdges" in forge, false);
+assert.equal(typeof forge.publishBulkNodes, "function");
+assert.equal(typeof forge.publishBulkEdges, "function");
 
 const empty = tableFromIPC(forge.publishBulkNodes(OP_NODES, tableToIpc(new Table(bulkNodeSchema))));
 assert.equal(empty.numRows, 0);
@@ -359,6 +370,7 @@ const edge = new Table(bulkEdgeSchema, {{
 const edgeReceipt = tableFromIPC(forge.publishBulkEdges(OP_EDGES, tableToIpc(edge)));
 assert.equal(edgeReceipt.numRows, 1);
 
+forge.close();
 forge = new GraphForge(project);
 const reopened = tableFromIPC(
   forge.execute(
@@ -373,6 +385,7 @@ const payload = {{
   since: [...reopened.getChild("since")].map((value) => Number(value)),
   node_ids: receivedIds,
 }};
+forge.close();
 writeFileSync(outPath, JSON.stringify(payload));
 """,
         encoding="utf-8",
@@ -380,17 +393,47 @@ writeFileSync(outPath, JSON.stringify(payload));
 
 
 def run_node(project: Path) -> dict:
-    script = project.parent / "node-bulk-parity.mjs"
-    write_node_probe(project, script)
-    completed = subprocess.run(
-        ["node", str(script)],
-        cwd=ROOT,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-    if completed.returncode != 0:
-        raise SystemExit(f"node parity probe failed: {completed.stdout}\n{completed.stderr}")
+    with tempfile.NamedTemporaryFile(
+        dir=NODE_PKG,
+        prefix=".node-bulk-parity-",
+        suffix=".mjs",
+        delete=False,
+    ) as handle:
+        script = Path(handle.name)
+    try:
+        write_node_probe(project, script)
+        node = shutil.which("node")
+        if node is None:
+            raise SystemExit("node parity probe requires a Node.js executable on PATH")
+        try:
+            # Fixed argument vector with shell disabled; the executable is resolved above.
+            completed = subprocess.run(
+                [node, str(script)],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=NODE_PROBE_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired as error:
+            source = script.read_text(encoding="utf-8").splitlines()
+            numbered = "\n".join(
+                f"{line_number}: {line}" for line_number, line in enumerate(source, start=1)
+            )
+            raise SystemExit(
+                f"node parity probe timed out after {NODE_PROBE_TIMEOUT_SECONDS}s: "
+                f"{error.stdout or ''}\n{error.stderr or ''}\n{numbered}"
+            ) from error
+        if completed.returncode != 0:
+            source = script.read_text(encoding="utf-8").splitlines()
+            numbered = "\n".join(
+                f"{line_number}: {line}" for line_number, line in enumerate(source, start=1)
+            )
+            raise SystemExit(
+                f"node parity probe failed: {completed.stdout}\n{completed.stderr}\n{numbered}"
+            )
+    finally:
+        script.unlink(missing_ok=True)
     return json.loads((project / "node-parity.json").read_text(encoding="utf-8"))
 
 

--- a/scripts/ci/test-binding-parity-policy.py
+++ b/scripts/ci/test-binding-parity-policy.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Mutation tests for the non-Cypher binding parity policy."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[2]
+CHECKER_PATH = ROOT / "scripts/ci/check-binding-parity-policy.py"
+PYTHON_GATE_PATH = ROOT / "crates/graphforge-bindings-py/tests/non_cypher_release.py"
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def expect_rejection(call, message: str) -> None:
+    try:
+        call()
+    except AssertionError:
+        return
+    raise AssertionError(message)
+
+
+def main() -> None:
+    checker = load_module("binding_parity_checker", CHECKER_PATH)
+    checker.main()
+
+    node_policy = json.loads(checker.NODE_POLICY.read_text(encoding="utf-8"))
+    node_policy["classification"]["equivalent"].append("GraphForge.add_nodes")
+    with tempfile.TemporaryDirectory(prefix="gf-binding-parity-") as directory:
+        mutated_policy = Path(directory) / "node-policy.json"
+        mutated_policy.write_text(json.dumps(node_policy), encoding="utf-8")
+        checker.NODE_POLICY = mutated_policy
+        expect_rejection(
+            checker.main,
+            "Node parity accepted a removed Rust method based on name coincidence",
+        )
+
+    python_gate = load_module("python_binding_parity_mutation", PYTHON_GATE_PATH)
+    python_gate.PYTHON_ONLY_METHODS = frozenset(
+        python_gate.PYTHON_ONLY_METHODS - {"GraphForge.add_nodes", "GraphForge.add_edges"}
+    )
+    expect_rejection(
+        python_gate._classification_report,
+        "Python parity accepted unclassified language-specific convenience methods",
+    )
+    print("binding parity policy mutation tests passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/test-non-cypher-surface-gate.py
+++ b/scripts/ci/test-non-cypher-surface-gate.py
@@ -29,7 +29,7 @@ class SurfaceGateTests(unittest.TestCase):
 
     def test_checked_in_inventory_is_complete(self) -> None:
         self.assertEqual(GATE.validate(), [])
-        self.assertEqual(len(GATE.public_methods()), 270)
+        self.assertEqual(len(GATE.public_methods()), 268)
         self.assertEqual(len(GATE.m18_registry()), 94)
 
     def test_new_or_removed_public_method_fails_frozen_digest(self) -> None:

--- a/tests/contracts/non-cypher-rust-surface.json
+++ b/tests/contracts/non-cypher-rust-surface.json
@@ -1,7 +1,7 @@
 {
   "contract_version": 1,
   "scope": "Rust non-Cypher public release surface",
-  "public_method_digest": "7b9704118564c177abc8d7a69919c8f2d863770f95af9f706f4cd8ac3b3a9b18",
+  "public_method_digest": "d867e276ca262c52acd087475d4cc3b3ebf2295b0419d50926b5c9048f35ce27",
   "method_policy": {
     "receiver_defaults": {
       "GraphForge": "release-tested",
@@ -124,7 +124,7 @@
     },
     "lifecycle-construction": {
       "ids": [
-        "GraphForge.add_edge", "GraphForge.add_edges", "GraphForge.add_node", "GraphForge.add_nodes",
+        "GraphForge.add_edge", "GraphForge.add_node",
         "GraphForge.adopt_ontology", "GraphForge.clear_ontology", "GraphForge.labels", "GraphForge.node_count",
         "GraphForge.ontology_mode", "GraphForge.publish_bulk_edges", "GraphForge.publish_bulk_nodes",
         "GraphForge.relationship_types", "GraphForge.workspace_configuration", "GraphForge.workspace_ontology"

--- a/tests/features/api/construction.feature
+++ b/tests/features/api/construction.feature
@@ -22,17 +22,17 @@ Feature: Graph Construction API
     When I add a node with label "Person" named "Alice"
     Then execute readback returns the NodeHandle UUID and name "Alice"
 
-  @construction @skip-node
+  @construction
   Scenario: bulk add_nodes with a list of records
     When I bulk add nodes with label "Person" and 2 records
     Then execute "MATCH (p:Person) RETURN p.name" returns 2 rows
 
-  @construction @skip-node
+  @construction
   Scenario: bulk add_nodes with Arrow Table
     When I bulk add nodes with label "Person" from an Arrow Table of 5 rows
     Then execute "MATCH (p:Person) RETURN p.name" returns 5 rows
 
-  @construction @skip-node
+  @construction
   Scenario: bulk add_edges with src and dst column names
     Given a graph with 2 Person nodes with ids in columns "src_id" and "dst_id"
     When I bulk add edges with type "KNOWS" using source column "src_id" and destination column "dst_id"

--- a/tests/features/node/step_definitions/api_steps.ts
+++ b/tests/features/node/step_definitions/api_steps.ts
@@ -14,7 +14,7 @@ import {
   IWorldOptions,
   World,
 } from "@cucumber/cucumber";
-import { tableFromIPC, Table } from "apache-arrow";
+import { Field, FixedSizeBinary, RecordBatchStreamWriter, Schema, tableFromIPC, Table, Utf8, vectorFromArray } from "apache-arrow";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -125,6 +125,63 @@ function firstRowValue(world: GraphForgeWorld, col: string): unknown {
 /** Format a JS value as a Cypher literal for a CREATE property map. */
 function cypherLit(v: unknown): string {
   return typeof v === "number" ? String(v) : JSON.stringify(v);
+}
+
+const BDD_NODE_OPERATION = "018f0f4e-7b8c-7000-8000-000000003481";
+const BDD_NODE_TABLE_OPERATION = "018f0f4e-7b8c-7000-8000-000000003482";
+const BDD_EDGE_OPERATION = "018f0f4e-7b8c-7000-8000-000000003483";
+
+function tableToIpc(table: Table): Buffer {
+  return Buffer.from(RecordBatchStreamWriter.writeAll(table).toUint8Array(true));
+}
+
+function bulkNodeTable(names: string[]): Table {
+  const schema = new Schema(
+    [
+      new Field("node_uuid", new FixedSizeBinary(16), true),
+      new Field("label", new Utf8(), false),
+      new Field("name", new Utf8(), false),
+    ],
+    new Map([
+      ["graphforge.bulk_contract_version", "1"],
+      ["graphforge.bulk_kind", "node"],
+      ["graphforge.row_order", "logical_input_order"],
+    ]),
+  );
+  return new Table(schema, {
+    node_uuid: vectorFromArray(
+      names.map(() => null),
+      new FixedSizeBinary(16),
+    ),
+    label: vectorFromArray(
+      names.map(() => "Person"),
+      new Utf8(),
+    ),
+    name: vectorFromArray(names, new Utf8()),
+  });
+}
+
+function bulkEdgeTable(sourceUuid: string, targetUuid: string): Table {
+  const schema = new Schema(
+    [
+      new Field("edge_uuid", new FixedSizeBinary(16), true),
+      new Field("rel_type", new Utf8(), false),
+      new Field("source_uuid", new FixedSizeBinary(16), false),
+      new Field("target_uuid", new FixedSizeBinary(16), false),
+    ],
+    new Map([
+      ["graphforge.bulk_contract_version", "1"],
+      ["graphforge.bulk_kind", "edge"],
+      ["graphforge.row_order", "logical_input_order"],
+    ]),
+  );
+  const uuidBytes = (value: string) => Buffer.from(value.replace(/-/g, ""), "hex");
+  return new Table(schema, {
+    edge_uuid: vectorFromArray([null], new FixedSizeBinary(16)),
+    rel_type: vectorFromArray(["KNOWS"], new Utf8()),
+    source_uuid: vectorFromArray([uuidBytes(sourceUuid)], new FixedSizeBinary(16)),
+    target_uuid: vectorFromArray([uuidBytes(targetUuid)], new FixedSizeBinary(16)),
+  });
 }
 
 /**
@@ -789,16 +846,23 @@ When(
 When(
   'I bulk add nodes with label "Person" and 2 records',
   function (this: GraphForgeWorld) {
-    _catch(this, () => this.forge!.addNodes("Person", [{ name: "Alice" }, { name: "Bob" }]));
+    _catch(this, () =>
+      this.forge!.publishBulkNodes(
+        BDD_NODE_OPERATION,
+        tableToIpc(bulkNodeTable(["Alice", "Bob"]))
+      )
+    );
   }
 );
 
 When(
   'I bulk add nodes with label "Person" from an Arrow Table of 5 rows',
   function (this: GraphForgeWorld) {
-    const rows = [0, 1, 2, 3, 4].map((i) => ({ name: String.fromCharCode(65 + i) }));
-    _catch(this, () => this.forge!.addNodes("Person", rows));
-  }
+    const names = [0, 1, 2, 3, 4].map((i) => String.fromCharCode(65 + i));
+    _catch(this, () =>
+      this.forge!.publishBulkNodes(BDD_NODE_TABLE_OPERATION, tableToIpc(bulkNodeTable(names))),
+    );
+  },
 );
 
 When(
@@ -809,11 +873,14 @@ When(
       this.error = codedError("ValidationError", "Need 2 nodes");
       return;
     }
-    const records = [{ src_id: nodes[0].uuid, dst_id: nodes[1].uuid }];
-    _catch(this, () => this.forge!.addEdges("KNOWS", records, "src_id", "dst_id"));
-  }
+    _catch(this, () =>
+      this.forge!.publishBulkEdges(
+        BDD_EDGE_OPERATION,
+        tableToIpc(bulkEdgeTable(nodes[0].uuid, nodes[1].uuid)),
+      ),
+    );
+  },
 );
-
 
 When(
   /^I rank "([^"]*)" by "([^"]*)"$/,
@@ -1303,9 +1370,19 @@ Then(
 
 Then(
   /^execute "([^"]*)" returns (\d+) row with value (\d+)$/,
-  function (this: GraphForgeWorld, _query: string, _nStr: string, _val: string) {
-    return "pending";
-  }
+  function (this: GraphForgeWorld, query: string, nStr: string, val: string) {
+    const table = tableFromIPC(this.forge!.execute(query) as Buffer);
+    const expectedRows = parseInt(nStr, 10);
+    if (table.numRows !== expectedRows) {
+      throw new Error(`execute "${query}": expected ${expectedRows} row, got ${table.numRows}`);
+    }
+    const column = table.getChildAt(0);
+    if (!column || Number(column.get(0)) !== parseInt(val, 10)) {
+      throw new Error(
+        `execute "${query}": expected first value ${val}, got ${String(column?.get(0))}`,
+      );
+    }
+  },
 );
 
 Then(


### PR DESCRIPTION
## Summary

- remove nonfunctional Rust and Node `addNodes`/`addEdges` convenience stubs
- preserve Python normalization helpers as explicitly Python-only APIs over Rust atomic publication
- exercise canonical Node Arrow IPC publication, structured failures, identity parity, and reopen behavior
- harden parity policy so method-name coincidence and `NotImplementedError` cannot count as functional evidence

## BDD evidence

- Node canonical node and edge IPC publication passes with Rust-owned receipts and reopen readback
- runtime and generated Node surfaces omit the removed stubs while retaining `publishBulkNodes`/`publishBulkEdges`
- Python and Node publish identical fixed UUID identities and durable query results
- parity mutation tests reject reclassification of removed Node methods and require explicit Python-only classification

## Verification

- Rust coverage: 86.46%; all 126 API BDD scenarios and 3,897 openCypher TCK scenarios passed
- Node native coverage: 218/218 tests, 100% measured wrapper coverage
- non-Cypher surface gate: 268 methods, 94 M18 entries, 22 M19 contracts
- binding parity policy and mutation tests
- Python/Node bulk parity identity and reopen probe
- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`

`make pre-push` reaches and passes Rust coverage, then current `main` is blocked by pre-existing Python coverage/publication checks: the wrapper target measures 55.32% because `cli.py` is unexercised, and npm dry-run rejects already-published version `0.5.1`. No assertion was weakened or skipped in this change.

Closes #348

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/351"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788308510&installation_model_id=20486&pr_number=351&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F351&signature=7b2245cb9cbcadf28a43479bae2035cb92852c0a2affb69eafa2ce6ef2012615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Removed the unimplemented bulk `addNodes` and `addEdges` convenience methods from the core and Node.js APIs.
  - Applications using bulk graph construction should use the supported Arrow-based publication APIs instead.

- **Bug Fixes**
  - Bulk validation failures now consistently use the standard validation error code while preserving detailed messages.

- **Tests**
  - Expanded coverage for Arrow-based bulk node and edge publication, malformed input handling, API compatibility, and cross-language behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `addNodes`/`addEdges` stubs from Node bindings and wire bulk steps to `publishBulkNodes`/`publishBulkEdges`
> - Deletes `GraphForge::add_nodes` and `GraphForge::add_edges` from the Rust API and their N-API wrappers; Node callers must now use `publishBulkNodes`/`publishBulkEdges` (Arrow IPC-based APIs).
> - Updates BDD step definitions in [`api_steps.ts`](https://github.com/CurateLabs/graphforge/pull/351/files#diff-2b22eded4dfb6c358e13599b249a0266663c59b4e3aa2e1b468a330120637793) to build Arrow IPC buffers and call the `publishBulk*` methods, removing the `@skip-node` tag from bulk construction scenarios.
> - Extends `error_code` in [`error.rs`](https://github.com/CurateLabs/graphforge/pull/351/files#diff-3896f86edbfb062334cdf867b60b707ad3bedd3a416a5e24260bf798320040b0) so bulk validation messages prefixed with `GF_BULK_VALIDATION(` map to `GF_VALIDATION` status.
> - Updates surface-count manifests, parity policy JSON, and CI scripts to reflect the reduced public surface (181 methods).
> - Behavioral Change: `addNodes` and `addEdges` no longer exist on the JS `GraphForge` prototype; any code calling them will throw a runtime error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0618157.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->