### PR TITLE
test(api): make public BDD fail closed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  issues: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -81,6 +82,13 @@ jobs:
 
       - name: Test Python and Node non-Cypher parity policy
         run: python3 scripts/ci/check-binding-parity-policy.py
+
+      - name: Validate fail-closed public API BDD policy
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 scripts/ci/api-bdd-policy.py --check-issues
+          python3 scripts/ci/test-api-bdd-policy.py
 
       - uses: actions/setup-node@v6
         with:
@@ -518,6 +526,9 @@ jobs:
           uv run --no-sync pytest tests/unit tests/integration tests/features \
             -n auto --tb=short
 
+      - name: Prove public API BDD mutations fail closed
+        run: uv run --no-sync python scripts/ci/test-api-bdd-mutations.py
+
       - name: Run audited downstream consumers
         env:
           GRAPHFORGE_WHEEL_SHA: ${{ github.sha }}
@@ -621,8 +632,8 @@ jobs:
             "../api/**/*.feature" \
             --require-module ts-node/register \
             --require "step_definitions/**/*.ts" \
-            --tags "not @skip-node" \
-            --format progress
+            --tags "not @excluded-api-bdd and not @excluded-node-api-bdd" \
+            --format summary
 
       - name: Record and upload addon parity evidence
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,9 @@ check-patch-coverage:  ## Validate patch coverage for changed files (90% thresho
 	fi
 
 pre-push-fast:  ## Run fast checks only — format, lint, type, security, docstrings (no coverage, ~30s)
+	@echo "━━━ Public API BDD policy ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	@python3 scripts/ci/api-bdd-policy.py --check-issues
+	@python3 scripts/ci/test-api-bdd-policy.py
 	@echo "━━━ Format check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 	@$(MAKE) format-check
 	@echo "━━━ Lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
@@ -204,6 +207,8 @@ pre-push:  ## Run local policy checks plus multi-surface coverage thresholds
 	@$(MAKE) pre-push-fast
 	@echo "━━━ Coverage + thresholds (Rust + Python + Node) ━━━━━━━━━━━━━━━━━━━━━━━"
 	@$(MAKE) coverage
+	@echo "━━━ Public API BDD mutation sentinels ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	@uv run --no-sync python scripts/ci/test-api-bdd-mutations.py
 	@echo "✅ All pre-push checks passed!"
 
 clean:  ## Clean up cache files

--- a/crates/graphforge-api/tests/bdd/api_steps.rs
+++ b/crates/graphforge-api/tests/bdd/api_steps.rs
@@ -1,8 +1,8 @@
 //! cucumber-rs step definitions for tests/features/api/*.feature
 //!
-//! All steps are pending at the skeleton stage.  They will be filled in
-//! as real implementations land in graphforge-core milestone by milestone.
+//! Required scenarios call the real Rust facade and assert observable results.
 
+use arrow::array::Array;
 use cucumber::{given, then, when};
 
 use crate::GraphForgeWorld;
@@ -15,21 +15,37 @@ use crate::GraphForgeWorld;
 async fn given_empty_graph(world: &mut GraphForgeWorld) {
     crate::fixture::replace_with_fresh(&mut world.forge);
     world.nodes.clear();
+    world.index_calls = 0;
     world.last_error = None;
     world.last_result = None;
     world.last_algorithm_result = None;
 }
 
 #[given(regex = r#"^a graph with a Person node named "([^"]+)"$"#)]
-async fn given_person_node(world: &mut GraphForgeWorld, _name: String) {
-    world.forge =
-        Some(graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed"));
+async fn given_person_node(world: &mut GraphForgeWorld, name: String) {
+    let forge = graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed");
+    world.nodes.clear();
+    let props = std::collections::HashMap::from([(
+        "name".to_owned(),
+        graphforge_api::PropValue::Str(name.clone()),
+    )]);
+    let handle = forge.add_node("Person", &props).expect("Person fixture");
+    world.nodes.insert(name, handle);
+    world.forge = Some(forge);
 }
 
 #[given(regex = r#"^a graph with (\d+) Person nodes?$"#)]
-async fn given_n_persons(world: &mut GraphForgeWorld, _n: u32) {
-    world.forge =
-        Some(graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed"));
+async fn given_n_persons(world: &mut GraphForgeWorld, n: u32) {
+    let forge = graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed");
+    world.nodes.clear();
+    for index in 0..n {
+        let props = std::collections::HashMap::from([(
+            "name".to_owned(),
+            graphforge_api::PropValue::Str(format!("Person{index}")),
+        )]);
+        forge.add_node("Person", &props).expect("Person fixture");
+    }
+    world.forge = Some(forge);
 }
 
 #[given(regex = r#"^a graph with 3 Person nodes connected by KNOWS edges$"#)]
@@ -46,14 +62,25 @@ async fn given_3_persons_knows(world: &mut GraphForgeWorld) {
 
 #[given(regex = r#"^a graph with 4 Person nodes in two connected groups$"#)]
 async fn given_4_persons_two_groups(world: &mut GraphForgeWorld) {
-    world.forge =
-        Some(graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed"));
+    let forge = graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed");
+    forge
+        .execute(
+            "CREATE (a:Person {name:'Alice'})-[:KNOWS]->(b:Person {name:'Bob'}), \
+             (c:Person {name:'Carol'})-[:KNOWS]->(d:Person {name:'Dave'})",
+        )
+        .expect("two-component fixture");
+    world.forge = Some(forge);
 }
 
 #[given(regex = r#"^a graph with a Paper node titled "([^"]+)"$"#)]
-async fn given_paper_node(world: &mut GraphForgeWorld, _title: String) {
-    world.forge =
-        Some(graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed"));
+async fn given_paper_node(world: &mut GraphForgeWorld, title: String) {
+    let forge = graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed");
+    let props = std::collections::HashMap::from([(
+        "title".to_owned(),
+        graphforge_api::PropValue::Str(title),
+    )]);
+    forge.add_node("Paper", &props).expect("Paper fixture");
+    world.forge = Some(forge);
 }
 
 #[given(regex = r#"^a graph with a Paper node that has a stored vector embedding$"#)]
@@ -63,33 +90,71 @@ async fn given_paper_with_vector(world: &mut GraphForgeWorld) {
 }
 
 #[given(regex = r#"^a graph with (\d+) Paper nodes with similar titles$"#)]
-async fn given_n_papers_similar(world: &mut GraphForgeWorld, _n: u32) {
-    world.forge =
-        Some(graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed"));
+async fn given_n_papers_similar(world: &mut GraphForgeWorld, n: u32) {
+    create_papers(world, n, true);
 }
 
 #[given(regex = r#"^a graph with (\d+) Paper nodes with title and abstract properties$"#)]
 async fn given_papers_with_abstract(world: &mut GraphForgeWorld, _n: u32) {
-    world.forge =
-        Some(graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed"));
+    let forge = graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed");
+    for index in 0.._n {
+        let props = std::collections::HashMap::from([
+            (
+                "title".to_owned(),
+                graphforge_api::PropValue::Str(format!("Neural networks {index}")),
+            ),
+            (
+                "abstract".to_owned(),
+                graphforge_api::PropValue::Str("graph neural networks".into()),
+            ),
+        ]);
+        forge.add_node("Paper", &props).expect("Paper fixture");
+    }
+    world.forge = Some(forge);
 }
 
 #[given(regex = r#"^a graph with a Paper node$"#)]
 async fn given_single_paper(world: &mut GraphForgeWorld) {
-    world.forge =
-        Some(graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed"));
+    create_papers(world, 1, false);
 }
 
 #[given(regex = r#"^a graph with (\d+) Paper nodes with title properties$"#)]
-async fn given_n_papers_title(world: &mut GraphForgeWorld, _n: u32) {
-    world.forge =
-        Some(graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed"));
+async fn given_n_papers_title(world: &mut GraphForgeWorld, n: u32) {
+    create_papers(world, n, false);
+}
+
+fn create_papers(world: &mut GraphForgeWorld, count: u32, similar: bool) {
+    let forge = graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed");
+    for index in 0..count {
+        let title = if similar {
+            format!("Graph paper {index}")
+        } else {
+            format!("Paper {index}")
+        };
+        let props = std::collections::HashMap::from([(
+            "title".to_owned(),
+            graphforge_api::PropValue::Str(title),
+        )]);
+        forge.add_node("Paper", &props).expect("Paper fixture");
+    }
+    world.forge = Some(forge);
 }
 
 #[given(
-    regex = r#"^a graph with a Person node named "([^"]+)" and a Paper node titled "([^"]+)"$"#
+    regex = r#"^a graph with a (Person node named|Paper node titled) "([^"]+)" and a (Paper node titled|Person node named) "([^"]+)"$"#
 )]
-async fn given_person_and_paper(world: &mut GraphForgeWorld, name: String, title: String) {
+async fn given_person_and_paper(
+    world: &mut GraphForgeWorld,
+    first_kind: String,
+    first_value: String,
+    _second_kind: String,
+    second_value: String,
+) {
+    let (name, title) = if first_kind.starts_with("Person") {
+        (first_value, second_value)
+    } else {
+        (second_value, first_value)
+    };
     let forge = graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed");
     let person_props = std::collections::HashMap::from([(
         "name".to_owned(),
@@ -136,14 +201,12 @@ async fn given_persons_and_papers(world: &mut GraphForgeWorld, np: u32, npa: u32
 
 #[given(regex = r#"^a graph with Person nodes but no Paper nodes$"#)]
 async fn given_persons_no_papers(world: &mut GraphForgeWorld) {
-    world.forge =
-        Some(graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed"));
+    given_n_persons(world, 2).await;
 }
 
 #[given(regex = r#"^a graph with Person nodes connected by KNOWS edges$"#)]
 async fn given_persons_knows_generic(world: &mut GraphForgeWorld) {
-    world.forge =
-        Some(graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed"));
+    given_3_persons_knows(world).await;
 }
 
 #[given(regex = r#"^a graph with Person nodes connected by both KNOWS and FOLLOWS edges$"#)]
@@ -172,8 +235,40 @@ async fn given_directed_knows(world: &mut GraphForgeWorld) {
 
 #[given(regex = r#"^a graph with 2 Person nodes connected by a KNOWS edge$"#)]
 async fn given_2_connected(world: &mut GraphForgeWorld) {
-    world.forge =
-        Some(graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed"));
+    let forge = graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed");
+    let alice = add_named_fixture_node(&forge, "Alice");
+    let bob = add_named_fixture_node(&forge, "Bob");
+    forge
+        .add_edge(&alice, "KNOWS", &bob, &Default::default())
+        .expect("connected fixture edge");
+    world.nodes.insert("Alice".into(), alice);
+    world.nodes.insert("Bob".into(), bob);
+    world.forge = Some(forge);
+}
+
+fn add_named_fixture_node(
+    forge: &graphforge_api::GraphForge,
+    name: &str,
+) -> graphforge_api::NodeHandle {
+    let props = std::collections::HashMap::from([(
+        "name".to_owned(),
+        graphforge_api::PropValue::Str(name.into()),
+    )]);
+    forge
+        .add_node("Person", &props)
+        .expect("named fixture node")
+}
+
+#[given("a graph with a directed cycle")]
+async fn given_directed_cycle(world: &mut GraphForgeWorld) {
+    let forge = graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed");
+    forge
+        .execute(
+            "CREATE (a:Person {name:'Alice'})-[:KNOWS]->(b:Person {name:'Bob'}), \
+             (b)-[:KNOWS]->(a)",
+        )
+        .expect("directed cycle fixture");
+    world.forge = Some(forge);
 }
 
 #[given(regex = r#"^a graph with Paper nodes indexed with (\d+)-dimensional vectors$"#)]
@@ -205,8 +300,7 @@ async fn given_persistent_graph(world: &mut GraphForgeWorld) {
 
 #[given(regex = r#"^a persistent graph at a temporary path$"#)]
 async fn given_persistent_at_tmp(world: &mut GraphForgeWorld) {
-    world.forge =
-        Some(graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed"));
+    given_persistent_graph(world).await;
 }
 
 #[given(regex = r#"^the forge instance is closed$"#)]
@@ -215,8 +309,14 @@ async fn given_forge_closed(world: &mut GraphForgeWorld) {
 }
 
 #[given(regex = r#"^a Person node named "([^"]+)"$"#)]
-async fn given_person_node_plain(_world: &mut GraphForgeWorld, _name: String) {
-    // pending
+async fn given_person_node_plain(world: &mut GraphForgeWorld, name: String) {
+    let forge = world.forge.as_ref().expect("background creates a forge");
+    let props = std::collections::HashMap::from([(
+        "name".to_owned(),
+        graphforge_api::PropValue::Str(name.clone()),
+    )]);
+    let handle = forge.add_node("Person", &props).expect("Person fixture");
+    world.nodes.insert(name, handle);
 }
 
 #[given(regex = r#"^Person nodes named "([^"]+)" and "([^"]+)"$"#)]
@@ -240,6 +340,24 @@ async fn given_named_person_pair(world: &mut GraphForgeWorld, first: String, sec
 async fn given_person_string_age(world: &mut GraphForgeWorld, _name: String, _age: String) {
     world.forge =
         Some(graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed"));
+}
+
+#[given(regex = r#"^a graph with a Person node named "([^"]+)" with age (\d+)$"#)]
+async fn given_person_numeric_age(world: &mut GraphForgeWorld, name: String, age: u32) {
+    let forge = graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed");
+    let props = std::collections::HashMap::from([
+        (
+            "name".to_owned(),
+            graphforge_api::PropValue::Str(name.clone()),
+        ),
+        (
+            "age".to_owned(),
+            graphforge_api::PropValue::Int(i64::from(age)),
+        ),
+    ]);
+    let handle = forge.add_node("Person", &props).expect("Person fixture");
+    world.nodes.insert(name, handle);
+    world.forge = Some(forge);
 }
 
 #[given(
@@ -266,23 +384,41 @@ async fn given_two_persons_edge(world: &mut GraphForgeWorld, a: String, b: Strin
 
 #[given(regex = r#"^a graph with a Person node named "Alice" without an age property$"#)]
 async fn given_person_no_age(world: &mut GraphForgeWorld) {
-    world.forge =
-        Some(graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed"));
+    given_person_node(world, "Alice".into()).await;
 }
 
 #[given(regex = r#"^a valid ontology YAML file defining a Person label$"#)]
-async fn given_valid_ontology_yaml(_world: &mut GraphForgeWorld) {
-    // pending
+async fn given_valid_ontology_yaml(world: &mut GraphForgeWorld) {
+    set_ontology_fixture(
+        world,
+        "ontology.yaml",
+        "ontology_id: people\nversion: \"2026.06\"\nentity_types:\n  - name: Person\nproperties:\n  - name: name\n    owner: Person\n    type: utf8\n",
+    );
 }
 
 #[given(regex = r#"^a valid ontology JSON file defining a Paper label$"#)]
-async fn given_valid_ontology_json(_world: &mut GraphForgeWorld) {
-    // pending
+async fn given_valid_ontology_json(world: &mut GraphForgeWorld) {
+    set_ontology_fixture(
+        world,
+        "ontology.json",
+        r#"{"ontology_id":"papers","version":"2026.06","entity_types":[{"name":"Paper"}],"properties":[{"name":"title","owner":"Paper","type":"utf8"}]}"#,
+    );
 }
 
 #[given(regex = r#"^a file containing invalid YAML$"#)]
-async fn given_invalid_yaml(_world: &mut GraphForgeWorld) {
-    // pending
+async fn given_invalid_yaml(world: &mut GraphForgeWorld) {
+    set_ontology_fixture(world, "bad.yaml", ": this is not: valid: yaml: [");
+}
+
+fn set_ontology_fixture(world: &mut GraphForgeWorld, name: &str, contents: &str) {
+    let fixture = tempfile::TempDir::new().expect("ontology fixture tempdir");
+    let path = fixture.path().join(name);
+    std::fs::write(&path, contents).expect("write ontology fixture");
+    world.ontology_path = Some(path);
+    world.ontology_fixture = Some(fixture);
+    if world.forge.is_none() {
+        world.forge = Some(graphforge_api::GraphForge::new(None).expect("ontology fixture forge"));
+    }
 }
 
 #[given(regex = r#"^a graph with Person nodes connected by KNOWS edges up to 3 hops deep$"#)]
@@ -315,7 +451,14 @@ async fn given_lone_person(world: &mut GraphForgeWorld) {
     regex = r#"^2 other Person nodes connected by a KNOWS edge but isolated from the first pair$"#
 )]
 async fn given_second_component(_world: &mut GraphForgeWorld) {
-    // pending
+    let forge = _world.forge.as_ref().expect("connected fixture");
+    let carol = add_named_fixture_node(forge, "Carol");
+    let dave = add_named_fixture_node(forge, "Dave");
+    forge
+        .add_edge(&carol, "KNOWS", &dave, &Default::default())
+        .expect("second component fixture edge");
+    _world.nodes.insert("Carol".into(), carol);
+    _world.nodes.insert("Dave".into(), dave);
 }
 
 #[given(regex = r#"^a graph with a Paper node titled "([^"]+)" and a stored vector embedding$"#)]
@@ -326,38 +469,64 @@ async fn given_paper_with_title_and_vector(world: &mut GraphForgeWorld, _title: 
 
 #[given(regex = r#"^a graph with 2 Person nodes with ids in columns "src_id" and "dst_id"$"#)]
 async fn given_2_nodes_for_edges(world: &mut GraphForgeWorld) {
-    world.forge =
-        Some(graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed"));
-}
-
-#[given(regex = r#"^I have stored the node id as "paper_id"$"#)]
-async fn given_store_paper_id(_world: &mut GraphForgeWorld) {
-    // pending
-}
-
-#[given(regex = r#"^I have an embedding vector stored as "embedding"$"#)]
-async fn given_store_embedding(_world: &mut GraphForgeWorld) {
-    // pending
-}
-
-#[given(regex = r#"^no explicit index call was made before find$"#)]
-async fn given_no_index_call(_world: &mut GraphForgeWorld) {
-    // pending
-}
-
-#[given(regex = r#"^I index label "([^"]+)" on property "([^"]+)"$"#)]
-async fn given_index_prop(_world: &mut GraphForgeWorld, _label: String, _prop: String) {
-    // pending
+    let forge = graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed");
+    let source = add_named_fixture_node(&forge, "Source");
+    let target = add_named_fixture_node(&forge, "Target");
+    world.nodes.insert("src_id".into(), source);
+    world.nodes.insert("dst_id".into(), target);
+    world.forge = Some(forge);
 }
 
 #[given(regex = r#"^I add a node with label "([^"]+)" named "([^"]+)"$"#)]
-async fn given_add_node(_world: &mut GraphForgeWorld, _label: String, _name: String) {
-    // pending
+async fn given_add_node(world: &mut GraphForgeWorld, label: String, name: String) {
+    let props = std::collections::HashMap::from([(
+        "name".to_owned(),
+        graphforge_api::PropValue::Str(name.clone()),
+    )]);
+    let handle = world
+        .forge
+        .as_ref()
+        .expect("open forge")
+        .add_node(&label, &props)
+        .expect("fixture node");
+    world.nodes.insert(name, handle);
 }
 
 // ---------------------------------------------------------------------------
 // WHEN steps
 // ---------------------------------------------------------------------------
+
+#[when(regex = r#"^I analyze by "([^"]+)"$"#)]
+async fn when_analyze(world: &mut GraphForgeWorld, algorithm: String) {
+    let by = match algorithm.parse::<graphforge_api::AnalyzeAlgorithm>() {
+        Ok(value) => value,
+        Err(error) => {
+            world.last_error = Some(error.to_string());
+            world.last_algorithm_result = None;
+            return;
+        }
+    };
+    let options = graphforge_api::AnalyzeOptions {
+        by,
+        directed: true,
+        ..Default::default()
+    };
+    match world
+        .forge
+        .as_ref()
+        .expect("analyze fixture")
+        .analyze(None, options)
+    {
+        Ok(batch) => {
+            world.last_algorithm_result = Some(batch);
+            world.last_error = None;
+        }
+        Err(error) => {
+            world.last_algorithm_result = None;
+            world.last_error = Some(error.to_string());
+        }
+    }
+}
 
 #[when(regex = r#"^I execute "([^"]*)"$"#)]
 async fn when_execute(world: &mut GraphForgeWorld, query: String) {
@@ -372,7 +541,11 @@ async fn when_execute(world: &mut GraphForgeWorld, query: String) {
 #[when(regex = r#"^I execute "([^"]+)" with parameter name "([^"]+)"$"#)]
 async fn when_execute_param(world: &mut GraphForgeWorld, query: String, _value: String) {
     if let Some(forge) = &world.forge {
-        match forge.execute(&query) {
+        let params = std::collections::HashMap::from([(
+            "name".to_owned(),
+            graphforge_api::IrLiteral::Str(_value),
+        )]);
+        match forge.execute_with_params(&query, &params) {
             Ok(r) => world.last_exec = Some(r),
             Err(e) => world.last_error = Some(e.to_string()),
         }
@@ -433,11 +606,7 @@ async fn when_paths_with_selector_form(
     algorithm: String,
     selector: String,
 ) {
-    let Some(forge) = world.forge.as_ref() else {
-        world.last_error =
-            Some("lifecycle error: operation on a closed GraphForge instance".into());
-        return;
-    };
+    let forge = world.forge.as_ref().expect("open path fixture");
     let alice = world.nodes.get("Alice").expect("Alice handle");
     let bob = world.nodes.get("Bob").expect("Bob handle");
     let (source, target) = match selector.as_str() {
@@ -532,24 +701,58 @@ async fn when_paths_with_invalid_selector(
 }
 
 #[when(regex = r#"^I add a node with label "([^"]*)"$"#)]
-async fn when_add_node_no_props(world: &mut GraphForgeWorld, _label: String) {
-    world.last_error = Some("not implemented".to_string());
+async fn when_add_node_no_props(world: &mut GraphForgeWorld, label: String) {
+    match world
+        .forge
+        .as_ref()
+        .expect("background creates a forge")
+        .add_node(&label, &Default::default())
+    {
+        Ok(handle) => {
+            world.last_node_handle = Some(handle);
+            world.last_error = None;
+        }
+        Err(error) => world.last_error = Some(error.to_string()),
+    }
 }
 
 #[when(regex = r#"^I add a "([^"]+)" edge from "([^"]+)" to "([^"]+)" with since (\d+)$"#)]
 async fn when_add_edge_since(
     world: &mut GraphForgeWorld,
-    _rel: String,
-    _src: String,
-    _dst: String,
-    _year: u32,
+    rel: String,
+    src: String,
+    dst: String,
+    year: u32,
 ) {
-    world.last_error = Some("not implemented".to_string());
+    let props = std::collections::HashMap::from([(
+        "since".to_owned(),
+        graphforge_api::PropValue::Int(i64::from(year)),
+    )]);
+    add_edge(world, rel, src, dst, props);
 }
 
 #[when(regex = r#"^I add a "([^"]*)" edge from "([^"]+)" to "([^"]+)"$"#)]
-async fn when_add_edge(world: &mut GraphForgeWorld, _rel: String, _src: String, _dst: String) {
-    world.last_error = Some("not implemented".to_string());
+async fn when_add_edge(world: &mut GraphForgeWorld, rel: String, src: String, dst: String) {
+    add_edge(world, rel, src, dst, Default::default());
+}
+
+fn add_edge(
+    world: &mut GraphForgeWorld,
+    rel: String,
+    src: String,
+    dst: String,
+    props: std::collections::HashMap<String, graphforge_api::PropValue>,
+) {
+    let forge = world.forge.as_ref().expect("background creates a forge");
+    let source = world.nodes.get(&src).expect("source fixture handle");
+    let target = world.nodes.get(&dst).expect("destination fixture handle");
+    match forge.add_edge(source, &rel, target, &props) {
+        Ok(handle) => {
+            world.last_edge_handle = Some(handle);
+            world.last_error = None;
+        }
+        Err(error) => world.last_error = Some(error.to_string()),
+    }
 }
 
 #[when(regex = r#"^I rank "([^"]+)" by "([^"]+)"$"#)]
@@ -620,105 +823,146 @@ fn run_rank(
 }
 
 #[when(regex = r#"^I cluster "([^"]+)" by "([^"]+)"$"#)]
-async fn when_cluster(world: &mut GraphForgeWorld, _label: String, _algo: String) {
-    world.last_error = Some("not implemented".to_string());
+async fn when_cluster(world: &mut GraphForgeWorld, label: String, algo: String) {
+    run_cluster(world, label, algo, None);
 }
 
 #[when(regex = r#"^I cluster "([^"]+)" by "([^"]+)" writing result to property "([^"]+)"$"#)]
 async fn when_cluster_write(
     world: &mut GraphForgeWorld,
-    _label: String,
-    _algo: String,
-    _prop: String,
+    label: String,
+    algo: String,
+    prop: String,
 ) {
-    world.last_error = Some("not implemented".to_string());
+    run_cluster(world, label, algo, Some(prop));
+}
+
+fn run_cluster(
+    world: &mut GraphForgeWorld,
+    label: String,
+    algo: String,
+    write_property: Option<String>,
+) {
+    let by = match algo.parse::<graphforge_api::ClusterAlgorithm>() {
+        Ok(value) => value,
+        Err(error) => {
+            world.last_error = Some(error.to_string());
+            return;
+        }
+    };
+    let options = graphforge_api::ClusterOptions {
+        by,
+        directed: false,
+        write_property,
+        ..Default::default()
+    };
+    match world
+        .forge
+        .as_ref()
+        .expect("cluster fixture")
+        .cluster(&label, options)
+    {
+        Ok(batch) => {
+            world.last_algorithm_result = Some(batch);
+            world.last_error = None;
+        }
+        Err(error) => world.last_error = Some(error.to_string()),
+    }
 }
 
 #[when(regex = r#"^I find "([^"]+)" in label "([^"]+)"$"#)]
-async fn when_find_text(world: &mut GraphForgeWorld, _query: String, _label: String) {
-    world.last_error = Some("not implemented".to_string());
+async fn when_find_text(world: &mut GraphForgeWorld, query: String, label: String) {
+    run_find(world, Some(query), label, 10, None);
 }
 
 #[when(regex = r#"^I find "([^"]+)" in label "([^"]+)" with limit (\d+)$"#)]
 async fn when_find_text_limit(
     world: &mut GraphForgeWorld,
-    _query: String,
-    _label: String,
-    _limit: u32,
+    query: String,
+    label: String,
+    limit: u32,
 ) {
-    world.last_error = Some("not implemented".to_string());
+    run_find(world, Some(query), label, limit as usize, None);
 }
 
-#[when(regex = r#"^I find by the stored vector in label "([^"]+)"$"#)]
-async fn when_find_vector(world: &mut GraphForgeWorld, _label: String) {
-    world.last_error = Some("not implemented".to_string());
-}
-
-#[when(regex = r#"^I find "([^"]+)" with the stored vector in label "([^"]+)"$"#)]
-async fn when_find_text_vector(world: &mut GraphForgeWorld, _query: String, _label: String) {
-    world.last_error = Some("not implemented".to_string());
+fn run_find(
+    world: &mut GraphForgeWorld,
+    query: Option<String>,
+    label: String,
+    limit: usize,
+    vector: Option<Vec<f32>>,
+) {
+    let options = graphforge_api::FindOptions {
+        query,
+        label: Some(label),
+        vector,
+        limit,
+        ..Default::default()
+    };
+    match world.forge.as_ref().expect("find fixture").find(options) {
+        Ok(batch) => {
+            world.previous_algorithm_result = world.last_algorithm_result.take();
+            world.last_algorithm_result = Some(batch);
+            world.last_error = None;
+        }
+        Err(error) => {
+            world.previous_algorithm_result = world.last_algorithm_result.take();
+            world.last_exec = None;
+            world.last_error = Some(error.to_string());
+        }
+    }
 }
 
 #[when(regex = r#"^I find with no query and no vector in label "([^"]+)"$"#)]
 async fn when_find_no_args(world: &mut GraphForgeWorld, _label: String) {
-    world.last_error = Some("not implemented".to_string());
+    run_find(world, None, _label, 10, None);
 }
 
 #[when(regex = r#"^I find by an empty vector in label "([^"]+)"$"#)]
 async fn when_find_empty_vector(world: &mut GraphForgeWorld, _label: String) {
-    world.last_error = Some("not implemented".to_string());
+    run_find(world, None, _label, 10, Some(Vec::new()));
 }
 
 #[when(regex = r#"^I find by a vector containing NaN in label "([^"]+)"$"#)]
 async fn when_find_nan_vector(world: &mut GraphForgeWorld, _label: String) {
-    world.last_error = Some("not implemented".to_string());
+    run_find(world, None, _label, 10, Some(vec![f32::NAN]));
 }
 
 #[when(regex = r#"^I find by a vector containing infinity in label "([^"]+)"$"#)]
 async fn when_find_inf_vector(world: &mut GraphForgeWorld, _label: String) {
-    world.last_error = Some("not implemented".to_string());
-}
-
-#[when(regex = r#"^I find by a (\d+)-dimensional vector in label "([^"]+)"$"#)]
-async fn when_find_wrong_dim(world: &mut GraphForgeWorld, _dims: u32, _label: String) {
-    world.last_error = Some("not implemented".to_string());
+    run_find(world, None, _label, 10, Some(vec![f32::INFINITY]));
 }
 
 #[when(regex = r#"^I index label "([^"]+)" on properties "([^"]+)" and "([^"]+)"$"#)]
-async fn when_index_two_props(
-    world: &mut GraphForgeWorld,
-    _label: String,
-    _p1: String,
-    _p2: String,
-) {
-    world.last_error = Some("not implemented".to_string());
+async fn when_index_two_props(world: &mut GraphForgeWorld, label: String, p1: String, p2: String) {
+    run_text_index(world, label, Some(vec![p1, p2]));
 }
 
 #[when(regex = r#"^I index label "([^"]+)" on property "([^"]+)"$"#)]
-async fn when_index_one_prop(world: &mut GraphForgeWorld, _label: String, _prop: String) {
-    world.last_error = Some("not implemented".to_string());
-}
-
-#[when(
-    regex = r#"^I index label "([^"]+)" storing the vector for node "([^"]+)" in space "([^"]+)"$"#
-)]
-async fn when_index_vector(
-    world: &mut GraphForgeWorld,
-    _label: String,
-    _node: String,
-    _space: String,
-) {
-    world.last_error = Some("not implemented".to_string());
+async fn when_index_one_prop(world: &mut GraphForgeWorld, label: String, prop: String) {
+    run_text_index(world, label, Some(vec![prop]));
 }
 
 #[when(regex = r#"^I index label "([^"]+)" on an empty properties list$"#)]
 async fn when_index_empty_props(world: &mut GraphForgeWorld, _label: String) {
-    world.last_error = Some("not implemented".to_string());
+    run_text_index(world, _label, Some(Vec::new()));
 }
 
-#[when(regex = r#"^I add a node with label "Paper" titled "Deep Graph Learning"$"#)]
-async fn when_add_deep_graph_paper(world: &mut GraphForgeWorld) {
-    world.last_error = Some("not implemented".to_string());
+fn run_text_index(world: &mut GraphForgeWorld, label: String, properties: Option<Vec<String>>) {
+    world.index_calls += 1;
+    let options = graphforge_api::SearchIndexOptions::Text {
+        properties,
+        rebuild: false,
+    };
+    match world
+        .forge
+        .as_ref()
+        .expect("index fixture")
+        .index_search(&label, options)
+    {
+        Ok(_) => world.last_error = None,
+        Err(error) => world.last_error = Some(error.to_string()),
+    }
 }
 
 #[when(regex = r#"^I call schema$"#)]
@@ -809,174 +1053,241 @@ async fn when_open_bad_path(world: &mut GraphForgeWorld) {
 
 #[when(regex = r#"^I reopen the forge at the same path$"#)]
 async fn when_reopen(world: &mut GraphForgeWorld) {
-    world.last_error = Some("not implemented".to_string());
-}
-
-#[when(regex = r#"^I attempt to call (.+)$"#)]
-async fn when_attempt_call(world: &mut GraphForgeWorld, _method: String) {
-    world.last_error = Some("lifecycle error: not implemented".to_string());
+    let path = world
+        .persistent_fixture
+        .as_ref()
+        .expect("persistent fixture")
+        .path()
+        .to_str()
+        .expect("UTF-8 fixture path")
+        .to_owned();
+    drop(world.forge.take());
+    match graphforge_api::GraphForge::new(Some(&path)) {
+        Ok(forge) => {
+            world.forge = Some(forge);
+            world.last_error = None;
+        }
+        Err(error) => world.last_error = Some(error.to_string()),
+    }
 }
 
 #[when(regex = r#"^I load the ontology from that file$"#)]
 async fn when_load_ontology(world: &mut GraphForgeWorld) {
-    world.last_error = Some("not implemented".to_string());
-}
-
-#[when(
-    regex = r#"^I call neighbourhood for "([^"]+)" with hops (\d+) in label "([^"]+)" using canonical property "([^"]+)"$"#
-)]
-async fn when_neighbourhood(
-    world: &mut GraphForgeWorld,
-    _canonical: String,
-    _hops: u32,
-    _label: String,
-    _prop: String,
-) {
-    world.last_error = Some("not implemented".to_string());
-}
-
-#[when(regex = r#"^I find by the stored embedding in label "([^"]+)" in space "([^"]+)"$"#)]
-async fn when_find_embedding(world: &mut GraphForgeWorld, _label: String, _space: String) {
-    world.last_error = Some("not implemented".to_string());
-}
-
-#[when(regex = r#"^I bulk add nodes with label "([^"]+)" and (\d+) records$"#)]
-async fn when_bulk_add_nodes_list(world: &mut GraphForgeWorld, _label: String, _n: u32) {
-    world.last_error = Some("not implemented".to_string());
-}
-
-#[when(regex = r#"^I bulk add nodes with label "([^"]+)" from an Arrow Table of (\d+) rows$"#)]
-async fn when_bulk_add_nodes_arrow(world: &mut GraphForgeWorld, _label: String, _n: u32) {
-    world.last_error = Some("not implemented".to_string());
+    let path = world
+        .ontology_path
+        .as_ref()
+        .expect("ontology fixture path")
+        .to_str()
+        .expect("UTF-8 ontology path")
+        .to_owned();
+    match world
+        .forge
+        .as_mut()
+        .expect("ontology fixture forge")
+        .load_ontology(&path)
+    {
+        Ok(()) => world.last_error = None,
+        Err(error) => world.last_error = Some(error.to_string()),
+    }
 }
 
 #[when(
     regex = r#"^I bulk add edges with type "([^"]+)" using source column "([^"]+)" and destination column "([^"]+)"$"#
 )]
-async fn when_bulk_add_edges(
-    world: &mut GraphForgeWorld,
-    _rel: String,
-    _src: String,
-    _dst: String,
-) {
-    world.last_error = Some("not implemented".to_string());
-}
+async fn when_bulk_add_edges(world: &mut GraphForgeWorld, rel: String, src: String, dst: String) {
+    use arrow::array::{FixedSizeBinaryBuilder, StringArray};
+    use std::sync::Arc;
 
-#[when(regex = r#"^I add a "KNOWS" edge from a raw integer to the node for "Alice"$"#)]
-async fn when_add_edge_bad_src(world: &mut GraphForgeWorld) {
-    world.last_error = Some("not implemented".to_string());
-}
-
-#[when(regex = r#"^I add a "KNOWS" edge from the node for "Alice" to a raw integer$"#)]
-async fn when_add_edge_bad_dst(world: &mut GraphForgeWorld) {
-    world.last_error = Some("not implemented".to_string());
-}
-
-#[when(regex = r#"^I add a node with label "Person" with an unsupported property value$"#)]
-async fn when_add_node_bad_prop(world: &mut GraphForgeWorld) {
-    world.last_error = Some("not implemented".to_string());
-}
-
-#[when(regex = r#"^I execute "" without parameters$"#)]
-async fn when_execute_no_params(world: &mut GraphForgeWorld) {
-    world.last_error = Some("not implemented".to_string());
+    let source = world.nodes.get(&src).expect("bulk source handle");
+    let target = world.nodes.get(&dst).expect("bulk destination handle");
+    let mut edge_ids = FixedSizeBinaryBuilder::with_capacity(1, 16);
+    edge_ids.append_null();
+    let mut sources = FixedSizeBinaryBuilder::with_capacity(1, 16);
+    sources
+        .append_value(source.uuid.as_bytes())
+        .expect("source UUID");
+    let mut targets = FixedSizeBinaryBuilder::with_capacity(1, 16);
+    targets
+        .append_value(target.uuid.as_bytes())
+        .expect("target UUID");
+    let schema = graphforge_api::bulk_edge_input_schema(Vec::new()).expect("bulk edge schema");
+    let batch = arrow::record_batch::RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(edge_ids.finish()),
+            Arc::new(StringArray::from(vec![rel])),
+            Arc::new(sources.finish()),
+            Arc::new(targets.finish()),
+        ],
+    )
+    .expect("bulk edge batch");
+    match world
+        .forge
+        .as_ref()
+        .expect("bulk edge forge")
+        .publish_bulk_edges(graphforge_api::OperationId(uuid::Uuid::now_v7()), &[batch])
+    {
+        Ok(receipt) => {
+            world.last_algorithm_result = Some(receipt);
+            world.last_error = None;
+        }
+        Err(error) => world.last_error = Some(error.to_string()),
+    }
 }
 
 // ---------------------------------------------------------------------------
 // THEN steps
 // ---------------------------------------------------------------------------
 
+#[then(regex = r#"^the "is_dag" value is (true|false)$"#)]
+async fn then_is_dag(world: &mut GraphForgeWorld, expected: String) {
+    let batch = result_batch(world);
+    assert!(batch.num_rows() > 0, "expected a non-empty is_dag result");
+    let values = batch
+        .column_by_name("is_dag")
+        .expect("is_dag column")
+        .as_any()
+        .downcast_ref::<arrow::array::BooleanArray>()
+        .expect("Boolean is_dag column");
+    assert_eq!(values.value(0), expected == "true");
+}
+
 #[then(regex = r#"^the result is an Arrow Table$"#)]
 async fn then_arrow_table(world: &mut GraphForgeWorld) {
-    if world
-        .last_error
-        .as_deref()
-        .is_some_and(|error| error.contains("not implemented"))
-    {
-        return;
-    }
-    if world.last_algorithm_result.is_none() {
-        return;
-    }
+    assert!(
+        world.last_error.is_none(),
+        "unexpected error: {:?}",
+        world.last_error
+    );
+    assert!(
+        world.last_algorithm_result.is_some() || world.last_exec.is_some(),
+        "expected an Arrow result"
+    );
 }
 
 #[then(regex = r#"^the table has column "([^"]+)"$"#)]
 async fn then_has_column(world: &mut GraphForgeWorld, col: String) {
-    if world
-        .last_error
-        .as_deref()
-        .is_some_and(|error| error.contains("not implemented"))
-    {
-        return;
+    if let Some(batch) = world.last_algorithm_result.as_ref() {
+        batch.schema().field_with_name(&col).expect("result column");
+    } else {
+        world
+            .last_exec
+            .as_ref()
+            .expect("execution result")
+            .schema
+            .field_with_name(&col)
+            .expect("result column");
     }
-    if world.last_algorithm_result.is_none() {
-        return;
-    }
-    world
-        .last_algorithm_result
-        .as_ref()
-        .expect("Arrow result")
-        .schema()
-        .field_with_name(&col)
-        .expect("result column");
 }
 
 #[then(regex = r#"^the result schema contains column "([^"]+)"$"#)]
-async fn then_schema_has_column(_world: &mut GraphForgeWorld, _col: String) {
-    // pending
+async fn then_schema_has_column(world: &mut GraphForgeWorld, col: String) {
+    then_has_column(world, col).await;
 }
 
 #[then(regex = r#"^the table has (\d+) rows?$"#)]
 async fn then_row_count(world: &mut GraphForgeWorld, n: u32) {
-    if world
-        .last_error
-        .as_deref()
-        .is_some_and(|error| error.contains("not implemented"))
-    {
-        return;
-    }
-    let Some(batch) = world.last_algorithm_result.as_ref() else {
-        return;
-    };
-    let rows = batch.num_rows();
+    let rows = result_batches(world)
+        .iter()
+        .map(|batch| batch.num_rows())
+        .sum::<usize>();
     assert_eq!(rows, n as usize);
 }
 
 #[then(regex = r#"^the table has at most (\d+) rows?$"#)]
-async fn then_at_most_rows(_world: &mut GraphForgeWorld, _n: u32) {
-    // pending
+async fn then_at_most_rows(world: &mut GraphForgeWorld, n: u32) {
+    let rows = result_batches(world)
+        .iter()
+        .map(|batch| batch.num_rows())
+        .sum::<usize>();
+    assert!(rows <= n as usize, "expected at most {n} rows, got {rows}");
 }
 
 #[then(regex = r#"^the first row value for "([^"]+)" is "([^"]+)"$"#)]
-async fn then_first_row_str(_world: &mut GraphForgeWorld, _col: String, _val: String) {
-    // pending
+async fn then_first_row_str(world: &mut GraphForgeWorld, col: String, val: String) {
+    let batch = result_batch(world);
+    assert!(batch.num_rows() > 0, "expected a non-empty result batch");
+    let index = batch.schema().index_of(&col).expect("result column");
+    let actual = arrow::util::display::array_value_to_string(batch.column(index), 0)
+        .expect("display Arrow value");
+    assert_eq!(actual, val);
 }
 
 #[then(regex = r#"^the first row value for "([^"]+)" is null$"#)]
-async fn then_first_row_null(_world: &mut GraphForgeWorld, _col: String) {
-    // pending
+async fn then_first_row_null(world: &mut GraphForgeWorld, col: String) {
+    use arrow::array::Array;
+    let batch = result_batch(world);
+    assert!(batch.num_rows() > 0, "expected a non-empty result batch");
+    let index = batch.schema().index_of(&col).expect("result column");
+    let column = batch.column(index);
+    let display = arrow::util::display::array_value_to_string(column, 0)
+        .unwrap_or_else(|error| format!("<display error: {error}>"));
+    assert!(
+        matches!(column.data_type(), arrow::datatypes::DataType::Null) || column.is_null(0),
+        "expected {col} to be null, got type {:?} value {display:?}",
+        column.data_type()
+    );
+}
+
+fn result_batches(world: &GraphForgeWorld) -> Vec<&arrow::record_batch::RecordBatch> {
+    if let Some(batch) = world.last_algorithm_result.as_ref() {
+        return vec![batch];
+    }
+    world
+        .last_exec
+        .as_ref()
+        .expect("Arrow result")
+        .batches
+        .iter()
+        .collect()
+}
+
+fn result_batch(world: &GraphForgeWorld) -> &arrow::record_batch::RecordBatch {
+    result_batches(world)
+        .into_iter()
+        .next()
+        .expect("result batch")
 }
 
 #[then(regex = r#"^a ParseError is raised$"#)]
 async fn then_parse_error(world: &mut GraphForgeWorld) {
-    // In the skeleton the error is always "not implemented" or "parse error".
-    // Accept any error as passing at this stage.
+    let error = world.last_error.as_deref().expect("parse error");
     assert!(
-        world.last_error.is_some(),
-        "expected an error but none was recorded"
+        error.to_ascii_lowercase().contains("parse"),
+        "expected parse error, got {error}"
     );
 }
 
 #[then(regex = r#"^the error includes a source span$"#)]
-async fn then_has_span(_world: &mut GraphForgeWorld) {
-    // pending
+async fn then_has_span(world: &mut GraphForgeWorld) {
+    let error = world.last_error.as_deref().expect("parse error");
+    let lower = error.to_ascii_lowercase();
+    let named_position = ["line", "column", "offset"]
+        .iter()
+        .any(|name| lower.contains(name))
+        && lower.chars().any(|value| value.is_ascii_digit());
+    let numeric_range = lower.split("at ").skip(1).any(|suffix| {
+        let token = suffix
+            .split_whitespace()
+            .next()
+            .unwrap_or_default()
+            .trim_end_matches(|value: char| !value.is_ascii_digit() && value != '.');
+        token.split_once("..").is_some_and(|(start, end)| {
+            start.parse::<usize>().is_ok() && end.parse::<usize>().is_ok()
+        })
+    });
+    assert!(
+        lower.contains("span") || lower.contains("byte") || named_position || numeric_range,
+        "expected source location in parse error, got {error}"
+    );
 }
 
 #[then(regex = r#"^an ExecutionError is raised$"#)]
 async fn then_execution_error(world: &mut GraphForgeWorld) {
+    let error = world.last_error.as_deref().expect("execution error");
     assert!(
-        world.last_error.is_some(),
-        "expected an error but none was recorded"
+        error.to_ascii_lowercase().contains("execution"),
+        "expected execution error, got {error}"
     );
 }
 
@@ -984,7 +1295,7 @@ async fn then_execution_error(world: &mut GraphForgeWorld) {
 async fn then_storage_error(world: &mut GraphForgeWorld) {
     let err = world.last_error.as_deref().unwrap_or("");
     assert!(
-        err.contains("storage") || err.contains("not implemented") || err.contains("path"),
+        err.to_ascii_lowercase().contains("storage") || err.contains("path"),
         "expected storage error, got: {err}"
     );
 }
@@ -1023,13 +1334,11 @@ async fn then_ontology_error(world: &mut GraphForgeWorld) {
 
 #[then(regex = r#"^no error is raised$"#)]
 async fn then_no_error(world: &mut GraphForgeWorld) {
-    // "not implemented" means the step is pending, not a real failure.
-    if let Some(err) = &world.last_error {
-        if err.contains("not implemented") {
-            return; // pending — accept as passing at skeleton stage
-        }
-        panic!("unexpected error: {err}");
-    }
+    assert!(
+        world.last_error.is_none(),
+        "unexpected error: {:?}",
+        world.last_error
+    );
 }
 
 #[then(regex = r#"^the result is a NodeHandle with label "([^"]+)"$"#)]
@@ -1086,19 +1395,13 @@ async fn then_execute_with_uuid(world: &mut GraphForgeWorld, name: String) {
 }
 
 #[then(regex = r#"^the result is an EdgeHandle with UUID identity and no numeric surrogate$"#)]
-async fn then_edge_handle(_world: &mut GraphForgeWorld) {
-    // pending
+async fn then_edge_handle(world: &mut GraphForgeWorld) {
+    let handle = world.last_edge_handle.as_ref().expect("EdgeHandle result");
+    assert_eq!(handle.uuid.get_version_num(), 7);
 }
 
 #[then(regex = r#"^execute "([^"]+)" returns (\d+) rows?$"#)]
 async fn then_execute_n_rows(world: &mut GraphForgeWorld, query: String, n: u32) {
-    if world
-        .last_error
-        .as_deref()
-        .is_some_and(|error| error.contains("not implemented"))
-    {
-        return;
-    }
     let result = world
         .forge
         .as_ref()
@@ -1113,11 +1416,30 @@ async fn then_execute_n_rows(world: &mut GraphForgeWorld, query: String, n: u32)
             .sum::<usize>(),
         n as usize
     );
+    world.last_exec = Some(result);
 }
 
 #[then(regex = r#"^execute "([^"]+)" returns (\d+) rows? with value (\d+)$"#)]
-async fn then_execute_row_value(_world: &mut GraphForgeWorld, _query: String, _n: u32, _val: i64) {
-    // pending
+async fn then_execute_row_value(world: &mut GraphForgeWorld, query: String, n: u32, val: i64) {
+    let result = world
+        .forge
+        .as_ref()
+        .expect("open forge")
+        .execute(&query)
+        .expect("readback query");
+    assert_eq!(
+        result
+            .batches
+            .iter()
+            .map(arrow::array::RecordBatch::num_rows)
+            .sum::<usize>(),
+        n as usize
+    );
+    let batch = result.batches.first().expect("result batch");
+    let actual = arrow::util::display::array_value_to_string(batch.column(0), 0)
+        .expect("display result value");
+    assert_eq!(actual.parse::<i64>().expect("integer result"), val);
+    world.last_exec = Some(result);
 }
 
 #[then(regex = r#"^the string representation contains the NodeHandle UUID$"#)]
@@ -1160,13 +1482,6 @@ async fn then_result_is_n(world: &mut GraphForgeWorld, n: i64) {
 
 #[then(regex = r#"^the result is a non-empty string$"#)]
 async fn then_nonempty_string(world: &mut GraphForgeWorld) {
-    if world
-        .last_error
-        .as_deref()
-        .map_or(false, |e| e.contains("not implemented"))
-    {
-        return; // pending skeleton step — skip gracefully
-    }
     if let Some(rb) = &world.last_result {
         let val = rb
             .columns
@@ -1191,13 +1506,6 @@ async fn then_nonempty_string(world: &mut GraphForgeWorld) {
 
 #[then(regex = r#"^the result contains "([^"]+)"$"#)]
 async fn then_result_contains_text(world: &mut GraphForgeWorld, text: String) {
-    if world
-        .last_error
-        .as_deref()
-        .map_or(false, |e| e.contains("not implemented"))
-    {
-        return; // pending skeleton step — skip gracefully
-    }
     if let Some(rb) = &world.last_result {
         let values = rb.columns.iter().flatten().collect::<Vec<_>>();
         assert!(
@@ -1281,60 +1589,165 @@ async fn then_scores_differ(world: &mut GraphForgeWorld) {
 }
 
 #[then(regex = r#"^the 2 connected nodes share the same community_id$"#)]
-async fn then_connected_same_community(_world: &mut GraphForgeWorld) {
-    // pending
+async fn then_connected_same_community(world: &mut GraphForgeWorld) {
+    let communities = community_by_uuid(world);
+    let alice = world.nodes.get("Alice").expect("Alice handle");
+    let bob = world.nodes.get("Bob").expect("Bob handle");
+    let alice_community = communities
+        .get(alice.uuid.as_bytes().as_slice())
+        .expect("Alice community");
+    let bob_community = communities
+        .get(bob.uuid.as_bytes().as_slice())
+        .expect("Bob community");
+    assert_eq!(alice_community, bob_community);
 }
 
 #[then(regex = r#"^the 2 isolated nodes share a different community_id$"#)]
-async fn then_isolated_different_community(_world: &mut GraphForgeWorld) {
-    // pending
+async fn then_isolated_different_community(world: &mut GraphForgeWorld) {
+    let communities = community_by_uuid(world);
+    let alice = world.nodes.get("Alice").expect("Alice handle");
+    let carol = world.nodes.get("Carol").expect("Carol handle");
+    let dave = world.nodes.get("Dave").expect("Dave handle");
+    let alice_community = communities
+        .get(alice.uuid.as_bytes().as_slice())
+        .expect("Alice community");
+    let carol_community = communities
+        .get(carol.uuid.as_bytes().as_slice())
+        .expect("Carol community");
+    let dave_community = communities
+        .get(dave.uuid.as_bytes().as_slice())
+        .expect("Dave community");
+    assert_eq!(carol_community, dave_community);
+    assert_ne!(alice_community, carol_community);
+}
+
+fn community_by_uuid(world: &GraphForgeWorld) -> std::collections::HashMap<Vec<u8>, String> {
+    let batch = world
+        .last_algorithm_result
+        .as_ref()
+        .expect("cluster result");
+    let ids = batch
+        .column_by_name("node_uuid")
+        .expect("node_uuid column")
+        .as_any()
+        .downcast_ref::<arrow::array::FixedSizeBinaryArray>()
+        .expect("UUID column");
+    let communities = batch
+        .column_by_name("community_id")
+        .expect("community_id column");
+    (0..batch.num_rows())
+        .map(|row| {
+            let value = arrow::util::display::array_value_to_string(communities, row)
+                .expect("community value");
+            (ids.value(row).to_vec(), value)
+        })
+        .collect()
 }
 
 #[then(regex = r#"^no explicit index call was made before find$"#)]
 async fn then_no_index_call(_world: &mut GraphForgeWorld) {
-    // pending
+    assert_eq!(_world.index_calls, 0, "an explicit index call was recorded");
 }
 
 #[then(
-    regex = r#"^for each result row the id is valid in execute "MATCH \(n\) WHERE id\(n\) = \$id RETURN n"$"#
+    regex = r#"^for each result row the id is valid in execute "MATCH \(n\) WHERE n\.node_uuid = \$id RETURN n"$"#
 )]
-async fn then_ids_addressable(_world: &mut GraphForgeWorld) {
-    // pending
+async fn then_ids_addressable(world: &mut GraphForgeWorld) {
+    let batch = result_batch(world);
+    let ids = batch
+        .column_by_name("node_uuid")
+        .expect("node_uuid column")
+        .as_any()
+        .downcast_ref::<arrow::array::FixedSizeBinaryArray>()
+        .expect("fixed-size UUID column");
+    assert!(!ids.is_empty(), "find must return at least one node");
+    for value in ids.iter().flatten() {
+        let bytes: [u8; 16] = value.try_into().expect("16-byte UUID");
+        let params = std::collections::HashMap::from([(
+            "id".to_owned(),
+            graphforge_api::IrLiteral::Uuid(bytes),
+        )]);
+        let result = world
+            .forge
+            .as_ref()
+            .expect("open forge")
+            .execute_with_params(
+                "MATCH (n) WHERE n.node_uuid = $id RETURN n.node_uuid",
+                &params,
+            )
+            .expect("UUID addressability query");
+        assert_eq!(
+            result
+                .batches
+                .iter()
+                .map(arrow::array::RecordBatch::num_rows)
+                .sum::<usize>(),
+            1
+        );
+    }
 }
 
 #[then(regex = r#"^all result rows have label "([^"]+)"$"#)]
-async fn then_all_rows_label(_world: &mut GraphForgeWorld, _label: String) {
-    // pending
-}
-
-#[then(regex = r#"^the result contains that node$"#)]
-async fn then_result_contains_node(_world: &mut GraphForgeWorld) {
-    // pending
+async fn then_all_rows_label(world: &mut GraphForgeWorld, label: String) {
+    let batch = result_batch(world);
+    let ids = batch
+        .column_by_name("node_uuid")
+        .expect("node_uuid column")
+        .as_any()
+        .downcast_ref::<arrow::array::FixedSizeBinaryArray>()
+        .expect("fixed-size UUID column");
+    assert!(!ids.is_empty(), "find must return at least one node");
+    for value in ids.iter().flatten() {
+        let bytes: [u8; 16] = value.try_into().expect("16-byte UUID");
+        let params = std::collections::HashMap::from([(
+            "id".to_owned(),
+            graphforge_api::IrLiteral::Uuid(bytes),
+        )]);
+        let result = world
+            .forge
+            .as_ref()
+            .expect("open forge")
+            .execute_with_params(
+                "MATCH (n) WHERE n.node_uuid = $id RETURN labels(n) AS labels",
+                &params,
+            )
+            .expect("label addressability query");
+        let row = result.batches.first().expect("label row");
+        let actual =
+            arrow::util::display::array_value_to_string(row.column(0), 0).expect("display labels");
+        assert!(
+            actual.contains(&label),
+            "expected label {label}, got {actual}"
+        );
+    }
 }
 
 #[then(
     regex = r#"^find "paper" in label "Paper" returns the same results as after the first index call$"#
 )]
-async fn then_idempotent_index(_world: &mut GraphForgeWorld) {
-    // pending
-}
-
-#[then(regex = r#"^the result contains a row with title "([^"]+)"$"#)]
-async fn then_result_has_title(_world: &mut GraphForgeWorld, _title: String) {
-    // pending
-}
-
-#[then(regex = r#"^the result contains a row for "([^"]+)"$"#)]
-async fn then_result_has_row_for(_world: &mut GraphForgeWorld, _name: String) {
-    // pending
-}
-
-#[then(regex = r#"^the result does not contain a row for "([^"]+)"$"#)]
-async fn then_result_no_row_for(_world: &mut GraphForgeWorld, _name: String) {
-    // pending
+async fn then_idempotent_index(world: &mut GraphForgeWorld) {
+    let first = world
+        .previous_algorithm_result
+        .as_ref()
+        .expect("find result after the first index call");
+    let second = world
+        .last_algorithm_result
+        .as_ref()
+        .expect("find result after the second index call");
+    assert_eq!(first.schema(), second.schema());
+    assert_eq!(first.num_rows(), second.num_rows());
+    for (left, right) in first.columns().iter().zip(second.columns()) {
+        assert_eq!(left.to_data(), right.to_data());
+    }
 }
 
 #[then(regex = r#"^the result is an Arrow Table with at least 1 row$"#)]
-async fn then_arrow_at_least_1(_world: &mut GraphForgeWorld) {
-    // pending
+async fn then_arrow_at_least_1(world: &mut GraphForgeWorld) {
+    assert!(
+        result_batches(world)
+            .iter()
+            .map(|batch| batch.num_rows())
+            .sum::<usize>()
+            >= 1
+    );
 }

--- a/crates/graphforge-api/tests/bdd/api_steps.rs
+++ b/crates/graphforge-api/tests/bdd/api_steps.rs
@@ -17,6 +17,7 @@ async fn given_empty_graph(world: &mut GraphForgeWorld) {
     world.nodes.clear();
     world.index_calls = 0;
     world.last_error = None;
+    world.last_error_code = None;
     world.last_result = None;
     world.last_algorithm_result = None;
 }
@@ -532,8 +533,15 @@ async fn when_analyze(world: &mut GraphForgeWorld, algorithm: String) {
 async fn when_execute(world: &mut GraphForgeWorld, query: String) {
     if let Some(forge) = &world.forge {
         match forge.execute(&query) {
-            Ok(r) => world.last_exec = Some(r),
-            Err(e) => world.last_error = Some(e.to_string()),
+            Ok(r) => {
+                world.last_exec = Some(r);
+                world.last_error = None;
+                world.last_error_code = None;
+            }
+            Err(error) => {
+                world.last_error_code = Some(error.code());
+                world.last_error = Some(error.to_string());
+            }
         }
     }
 }
@@ -1086,8 +1094,14 @@ async fn when_load_ontology(world: &mut GraphForgeWorld) {
         .expect("ontology fixture forge")
         .load_ontology(&path)
     {
-        Ok(()) => world.last_error = None,
-        Err(error) => world.last_error = Some(error.to_string()),
+        Ok(()) => {
+            world.last_error = None;
+            world.last_error_code = None;
+        }
+        Err(error) => {
+            world.last_error_code = Some(error.code());
+            world.last_error = Some(error.to_string());
+        }
     }
 }
 
@@ -1243,17 +1257,21 @@ fn result_batches(world: &GraphForgeWorld) -> Vec<&arrow::record_batch::RecordBa
 }
 
 fn result_batch(world: &GraphForgeWorld) -> &arrow::record_batch::RecordBatch {
-    result_batches(world)
-        .into_iter()
-        .next()
+    let batches = result_batches(world);
+    batches
+        .iter()
+        .find(|batch| batch.num_rows() > 0)
+        .or_else(|| batches.first())
+        .copied()
         .expect("result batch")
 }
 
 #[then(regex = r#"^a ParseError is raised$"#)]
 async fn then_parse_error(world: &mut GraphForgeWorld) {
     let error = world.last_error.as_deref().expect("parse error");
-    assert!(
-        error.to_ascii_lowercase().contains("parse"),
+    assert_eq!(
+        world.last_error_code,
+        Some("GF_PARSE"),
         "expected parse error, got {error}"
     );
 }
@@ -1262,10 +1280,13 @@ async fn then_parse_error(world: &mut GraphForgeWorld) {
 async fn then_has_span(world: &mut GraphForgeWorld) {
     let error = world.last_error.as_deref().expect("parse error");
     let lower = error.to_ascii_lowercase();
-    let named_position = ["line", "column", "offset"]
-        .iter()
-        .any(|name| lower.contains(name))
-        && lower.chars().any(|value| value.is_ascii_digit());
+    let named_position = ["line", "column", "offset"].iter().any(|name| {
+        lower.match_indices(name).any(|(index, _)| {
+            lower[index + name.len()..]
+                .trim_start_matches(|value: char| value == ' ' || value == ':' || value == '=')
+                .starts_with(|value: char| value.is_ascii_digit())
+        })
+    });
     let numeric_range = lower.split("at ").skip(1).any(|suffix| {
         let token = suffix
             .split_whitespace()
@@ -1285,8 +1306,9 @@ async fn then_has_span(world: &mut GraphForgeWorld) {
 #[then(regex = r#"^an ExecutionError is raised$"#)]
 async fn then_execution_error(world: &mut GraphForgeWorld) {
     let error = world.last_error.as_deref().expect("execution error");
-    assert!(
-        error.to_ascii_lowercase().contains("execution"),
+    assert_eq!(
+        world.last_error_code,
+        Some("GF_EXECUTION"),
         "expected execution error, got {error}"
     );
 }
@@ -1326,9 +1348,11 @@ async fn then_validation_error(world: &mut GraphForgeWorld) {
 
 #[then(regex = r#"^an OntologyError is raised$"#)]
 async fn then_ontology_error(world: &mut GraphForgeWorld) {
-    assert!(
-        world.last_error.is_some(),
-        "expected an error but none was recorded"
+    assert_eq!(
+        world.last_error_code,
+        Some("GF_ONTOLOGY"),
+        "expected ontology error, got {:?}",
+        world.last_error
     );
 }
 
@@ -1644,9 +1668,17 @@ fn community_by_uuid(world: &GraphForgeWorld) -> std::collections::HashMap<Vec<u
         .collect()
 }
 
-#[then(regex = r#"^no explicit index call was made before find$"#)]
-async fn then_no_index_call(_world: &mut GraphForgeWorld) {
-    assert_eq!(_world.index_calls, 0, "an explicit index call was recorded");
+#[then(regex = r#"^no index call was made before find$"#)]
+async fn then_no_index_call(world: &mut GraphForgeWorld) {
+    assert_eq!(world.index_calls, 0, "an explicit index call was recorded");
+    let rows = result_batches(world)
+        .iter()
+        .map(|batch| batch.num_rows())
+        .sum::<usize>();
+    assert!(
+        rows > 0,
+        "find must return matches without an explicit index call"
+    );
 }
 
 #[then(
@@ -1661,6 +1693,7 @@ async fn then_ids_addressable(world: &mut GraphForgeWorld) {
         .downcast_ref::<arrow::array::FixedSizeBinaryArray>()
         .expect("fixed-size UUID column");
     assert!(!ids.is_empty(), "find must return at least one node");
+    assert_eq!(ids.null_count(), 0, "find returned a null node_uuid");
     for value in ids.iter().flatten() {
         let bytes: [u8; 16] = value.try_into().expect("16-byte UUID");
         let params = std::collections::HashMap::from([(
@@ -1697,6 +1730,7 @@ async fn then_all_rows_label(world: &mut GraphForgeWorld, label: String) {
         .downcast_ref::<arrow::array::FixedSizeBinaryArray>()
         .expect("fixed-size UUID column");
     assert!(!ids.is_empty(), "find must return at least one node");
+    assert_eq!(ids.null_count(), 0, "find returned a null node_uuid");
     for value in ids.iter().flatten() {
         let bytes: [u8; 16] = value.try_into().expect("16-byte UUID");
         let params = std::collections::HashMap::from([(

--- a/crates/graphforge-api/tests/bdd/main.rs
+++ b/crates/graphforge-api/tests/bdd/main.rs
@@ -1,8 +1,8 @@
 //! cucumber-rs BDD runner for the GraphForge API and TCK feature files.
 //!
 //! Two suites run per `cargo test --test bdd`:
-//!   * GraphForge public-API scenarios under `tests/features/api/` (skeleton:
-//!     pending steps pass as "skipped").
+//!   * Required GraphForge public-API scenarios under `tests/features/api/`,
+//!     which fail closed on failed, skipped, or undefined steps.
 //!   * the WHOLE vendored openCypher TCK corpus under `tests/tck/features/`, run
 //!     **advisorily** — every scenario, no `@skip-rust` filter, via cucumber
 //!     `run()` (which does not exit on failure). A custom writer records the set
@@ -21,7 +21,7 @@ use futures::FutureExt;
 
 use timing::{
     ScenarioTimer, ScenarioTiming, Suite, annotation_messages, baseline_candidate, build_report,
-    escape_github_command, failed_scenario_keys, load_baseline, load_policy, write_artifacts,
+    escape_github_command, load_baseline, load_policy, non_passing_scenario_keys, write_artifacts,
 };
 
 /// Shared cucumber [`World`] for the GraphForge BDD suites (public API + TCK).
@@ -31,6 +31,10 @@ pub struct GraphForgeWorld {
     pub forge: Option<graphforge_api::GraphForge>,
     /// Owns a persistent-project fixture directory for lifecycle scenarios.
     pub persistent_fixture: Option<tempfile::TempDir>,
+    /// Owns an ontology fixture directory for load scenarios.
+    pub ontology_fixture: Option<tempfile::TempDir>,
+    /// Ontology fixture path selected by the Given step.
+    pub ontology_path: Option<std::path::PathBuf>,
     /// Last error returned by a When step.
     pub last_error: Option<String>,
     /// Last interim `RecordBatch` returned by a stubbed When step (schema()/etc.).
@@ -47,6 +51,10 @@ pub struct GraphForgeWorld {
     pub nodes: std::collections::HashMap<String, graphforge_api::NodeHandle>,
     /// Most recently created node handle for result-focused assertions.
     pub last_node_handle: Option<graphforge_api::NodeHandle>,
+    /// Most recently created edge handle for result-focused assertions.
+    pub last_edge_handle: Option<graphforge_api::EdgeHandle>,
+    /// Number of explicit public index calls made in this scenario.
+    pub index_calls: usize,
 }
 
 #[tokio::main]
@@ -65,15 +73,25 @@ async fn main() {
 
     let features_dir = workspace_root.join("tests/features");
 
-    // GraphForge public-API scenarios (skeleton: pending steps pass as skipped).
+    // Required public-API scenarios run strictly. Product gaps use the single
+    // issue-backed exclusion inventory and never contribute to passing totals.
     let api_results = std::sync::Arc::new(std::sync::Mutex::new(ScenarioOutcomes::default()));
+    let api_only = std::env::var("API_ONLY").ok();
     GraphForgeWorld::cucumber()
         .with_writer(cucumber::writer::Tee::new(
             cucumber::writer::Basic::stdout().summarized(),
             ScenarioCollector::new(Suite::Api, std::sync::Arc::clone(&api_results), false),
         ))
         .with_default_cli()
-        .run(features_dir.join("api"))
+        .filter_run(features_dir.join("api"), move |_, _, scenario| {
+            !scenario
+                .tags
+                .iter()
+                .any(|tag| tag == "excluded-api-bdd" || tag == "binding-only")
+                && api_only
+                    .as_deref()
+                    .is_none_or(|needle| scenario.name.contains(needle))
+        })
         .await;
     let api_results = std::sync::Arc::into_inner(api_results)
         .expect("API collector dropped after run")
@@ -143,6 +161,17 @@ async fn main() {
         .expect("collector dropped after run")
         .into_inner()
         .expect("outcomes mutex");
+    let api_passing = api_results.passing.len();
+    let api_skipped = api_results
+        .timings
+        .iter()
+        .filter(|record| record.outcome == timing::ScenarioOutcome::Skipped)
+        .count();
+    let api_failed = api_results
+        .timings
+        .iter()
+        .filter(|record| record.outcome == timing::ScenarioOutcome::Failed)
+        .count();
     let mut timing_records = api_results.timings;
     timing_records.extend(outcomes.timings.iter().cloned());
 
@@ -184,7 +213,7 @@ async fn main() {
         tck_only_filter().is_some(),
     );
 
-    let api_failures = failed_scenario_keys(&timing_records, Suite::Api);
+    let api_failures = non_passing_scenario_keys(&timing_records, Suite::Api);
     assert!(
         api_failures.is_empty(),
         "API BDD correctness failure(s):\n{}",
@@ -194,6 +223,7 @@ async fn main() {
             .collect::<Vec<_>>()
             .join("\n")
     );
+    eprintln!("API BDD required: {api_passing} passed, {api_failed} failed, {api_skipped} skipped");
 
     let actual = outcomes.passing;
 

--- a/crates/graphforge-api/tests/bdd/main.rs
+++ b/crates/graphforge-api/tests/bdd/main.rs
@@ -37,6 +37,8 @@ pub struct GraphForgeWorld {
     pub ontology_path: Option<std::path::PathBuf>,
     /// Last error returned by a When step.
     pub last_error: Option<String>,
+    /// Stable public code for the last typed Rust facade error.
+    pub last_error_code: Option<&'static str>,
     /// Last interim `RecordBatch` returned by a stubbed When step (schema()/etc.).
     pub last_result: Option<graphforge_api::RecordBatch>,
     /// Last Arrow-backed result returned by `execute()`.
@@ -77,6 +79,9 @@ async fn main() {
     // issue-backed exclusion inventory and never contribute to passing totals.
     let api_results = std::sync::Arc::new(std::sync::Mutex::new(ScenarioOutcomes::default()));
     let api_only = std::env::var("API_ONLY").ok();
+    if let Some(needle) = &api_only {
+        eprintln!("API_ONLY subset: only scenarios matching {needle:?} will be evaluated");
+    }
     GraphForgeWorld::cucumber()
         .with_writer(cucumber::writer::Tee::new(
             cucumber::writer::Basic::stdout().summarized(),
@@ -214,6 +219,7 @@ async fn main() {
     );
 
     let api_failures = non_passing_scenario_keys(&timing_records, Suite::Api);
+    eprintln!("API BDD required: {api_passing} passed, {api_failed} failed, {api_skipped} skipped");
     assert!(
         api_failures.is_empty(),
         "API BDD correctness failure(s):\n{}",
@@ -223,8 +229,6 @@ async fn main() {
             .collect::<Vec<_>>()
             .join("\n")
     );
-    eprintln!("API BDD required: {api_passing} passed, {api_failed} failed, {api_skipped} skipped");
-
     let actual = outcomes.passing;
 
     // `TCK_ONLY` subset run (local iteration): report the subset's pass count and

--- a/crates/graphforge-api/tests/bdd/timing.rs
+++ b/crates/graphforge-api/tests/bdd/timing.rs
@@ -328,10 +328,10 @@ pub fn distribution(values: &[u64]) -> Distribution {
     }
 }
 
-pub fn failed_scenario_keys(records: &[ScenarioTiming], suite: Suite) -> Vec<&str> {
+pub fn non_passing_scenario_keys(records: &[ScenarioTiming], suite: Suite) -> Vec<&str> {
     let mut failures: Vec<&str> = records
         .iter()
-        .filter(|record| record.suite == suite && record.outcome == ScenarioOutcome::Failed)
+        .filter(|record| record.suite == suite && record.outcome != ScenarioOutcome::Passed)
         .map(|record| record.key.as_str())
         .collect();
     failures.sort_unstable();

--- a/crates/graphforge-api/tests/bdd_timing.rs
+++ b/crates/graphforge-api/tests/bdd_timing.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use timing::{
     SCHEMA_VERSION, ScenarioOutcome, ScenarioTimer, ScenarioTiming, Suite, TimingBaseline,
     TimingPolicy, annotation_messages, baseline_candidate, build_report, distribution,
-    escape_github_command, failed_scenario_keys, load_baseline, load_policy, render_markdown,
+    escape_github_command, load_baseline, load_policy, non_passing_scenario_keys, render_markdown,
     write_artifacts,
 };
 
@@ -169,16 +169,17 @@ fn distribution_uses_midpoint_median_and_nearest_rank_percentiles() {
 }
 
 #[test]
-fn correctness_failure_keys_are_suite_scoped_and_stably_ordered() {
+fn correctness_failure_keys_include_skips_and_are_suite_scoped_and_stably_ordered() {
     let records = vec![
         record(Suite::Api, "z:1:failed", "z", ScenarioOutcome::Failed, 1),
         record(Suite::Tck, "a:1:failed", "a", ScenarioOutcome::Failed, 1),
         record(Suite::Api, "a:1:failed", "a", ScenarioOutcome::Failed, 1),
+        record(Suite::Api, "s:1:skipped", "s", ScenarioOutcome::Skipped, 1),
         record(Suite::Api, "p:1:passed", "p", ScenarioOutcome::Passed, 1),
     ];
     assert_eq!(
-        failed_scenario_keys(&records, Suite::Api),
-        ["a:1:failed", "z:1:failed"]
+        non_passing_scenario_keys(&records, Suite::Api),
+        ["a:1:failed", "s:1:skipped", "z:1:failed"]
     );
 }
 

--- a/docs/engineering/TESTING.md
+++ b/docs/engineering/TESTING.md
@@ -29,6 +29,36 @@ Consequence for tests:
 - Treat logical-plan construction, wrapper smoke, and “compiled successfully”
   as necessary but **not** sufficient for shippable behavior.
 
+### Public API BDD classifications
+
+The shared scenarios in `tests/features/api/` use three explicit states:
+
+- **Required:** the applicable Rust, Python, and Node runners call the real
+  public surface and assert exact Arrow schema, rows, values, or structured
+  error classes. Missing steps, exceptions, xfail/xpass, pending results, and
+  unexpected skips fail the gate.
+- **Product-excluded:** `@excluded-api-bdd` or
+  `@excluded-node-api-bdd` identifies behavior that has a confirmed product
+  defect. The scenario must appear in
+  `tests/contracts/api-bdd-exclusions.json`, carry exactly one matching open
+  `@issue-N` reference, and contributes only to the excluded total—never the
+  passing total.
+- **Binding-only:** runtime coercion and closed-handle scenarios execute in
+  Python and Node but are reported as not applicable by the statically typed,
+  non-closeable Rust facade. This classification is allowlisted by repository
+  policy and is not a product-behavior exclusion.
+
+`scripts/ci/api-bdd-policy.py` validates the corpus and writes
+`target/api-bdd-policy.json` as machine-readable classification evidence.
+Its policy mutation tests reject stale inventory rows, untracked exclusions,
+language skip tags, xfail conversion, pending Node steps, and manufactured Rust
+errors. The BDD mutation sentinels separately prove that wrong row counts,
+missing columns, wrong values, wrong error classes, and `NotImplementedError`
+all produce failing test processes.
+
+This fail-closed public API model does not change the openCypher TCK. The TCK
+continues to use its separately documented advisory passing-set baseline.
+
 ## Layered gates
 
 Release readiness is a stack. Lower layers run on every applicable PR; higher

--- a/scripts/ci/api-bdd-policy.py
+++ b/scripts/ci/api-bdd-policy.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Validate fail-closed public API BDD classifications and step sources."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+LANGUAGES = {"rust", "python", "node"}
+PRODUCT_TAGS = {
+    "excluded-api-bdd": LANGUAGES,
+    "excluded-node-api-bdd": {"node"},
+}
+BINDING_ONLY_SCENARIOS = {
+    ("Graph Construction API", "Closed instances reject path selectors before coercion"),
+    ("Lifecycle State", "LifecycleError on <method> after close"),
+    ("Type Errors", "TypeError when add_edge source is not a NodeHandle"),
+    ("Type Errors", "TypeError when add_edge destination is not a NodeHandle"),
+    ("Type Errors", "TypeError on unsupported property value type"),
+}
+FORBIDDEN_SOURCE_PATTERNS = {
+    "tests/features/conftest.py": (
+        r"pytest\.xfail",
+        r"pytest_runtest_makereport",
+        r"wasxfail",
+        r"_xfail_not_implemented",
+        r"NotImplementedError",
+    ),
+    "tests/features/steps/api_steps.py": (
+        r"pytest\.xfail",
+        r"_xfail_not_implemented",
+        r"NotImplementedError",
+    ),
+    "tests/features/node/step_definitions/api_steps.ts": (
+        r'return\s+["\']pending["\']',
+        r'new Error\(["\']not implemented["\']\)',
+        r"pending skeleton",
+    ),
+    "crates/graphforge-api/tests/bdd/api_steps.rs": (
+        r'last_error\s*=\s*Some\(["\'](?:lifecycle error:\s*)?not implemented',
+        r"//\s*pending\b",
+        r"pending skeleton",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class Scenario:
+    feature: str
+    name: str
+    tags: frozenset[str]
+    path: str
+    line: int
+
+
+def parse_features(root: Path) -> list[Scenario]:
+    scenarios: list[Scenario] = []
+    for path in sorted((root / "tests/features/api").glob("*.feature")):
+        feature = None
+        feature_tags: set[str] = set()
+        pending_tags: set[str] = set()
+        for line_no, raw in enumerate(path.read_text().splitlines(), 1):
+            line = raw.strip()
+            if line.startswith("@"):
+                pending_tags.update(token.removeprefix("@") for token in line.split())
+            elif line.startswith("Feature:"):
+                feature = line.partition(":")[2].strip()
+                feature_tags = set(pending_tags)
+                pending_tags.clear()
+            elif line.startswith(("Scenario:", "Scenario Outline:")):
+                if feature is None:
+                    raise ValueError(f"{path}:{line_no}: scenario precedes Feature")
+                name = line.partition(":")[2].strip()
+                scenarios.append(
+                    Scenario(
+                        feature,
+                        name,
+                        frozenset(feature_tags | pending_tags),
+                        str(path.relative_to(root)),
+                        line_no,
+                    )
+                )
+                pending_tags.clear()
+            elif line and not line.startswith("#"):
+                pending_tags.clear()
+    return scenarios
+
+
+def load_inventory(root: Path) -> dict:
+    path = root / "tests/contracts/api-bdd-exclusions.json"
+    return json.loads(path.read_text())
+
+
+def validate(root: Path, *, check_issues: bool = False) -> tuple[dict, list[str]]:
+    errors: list[str] = []
+    scenarios = parse_features(root)
+    by_key = {(item.feature, item.name): item for item in scenarios}
+    if len(by_key) != len(scenarios):
+        errors.append("feature corpus contains duplicate feature/scenario keys")
+
+    inventory = load_inventory(root)
+    if not isinstance(inventory, dict):
+        return {}, ["inventory must be an object"]
+    if inventory.get("version") != 1:
+        errors.append("inventory version must be 1")
+    entries = inventory.get("exclusions")
+    if not isinstance(entries, list):
+        return {}, ["inventory exclusions must be a list"]
+
+    inventory_keys: set[tuple[str, str]] = set()
+    issue_numbers: set[int] = set()
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            errors.append(f"inventory exclusion at index {index} must be an object")
+            continue
+        key = (entry.get("feature"), entry.get("scenario"))
+        if key in inventory_keys:
+            errors.append(f"duplicate inventory entry: {key}")
+            continue
+        inventory_keys.add(key)
+        scenario = by_key.get(key)
+        if scenario is None:
+            errors.append(f"stale inventory entry: {key}")
+            continue
+        issue = entry.get("issue")
+        if not isinstance(issue, int) or issue <= 0:
+            errors.append(f"{key}: issue must be a positive integer")
+            continue
+        issue_numbers.add(issue)
+        languages = set(entry.get("languages", []))
+        if not languages or not languages <= LANGUAGES:
+            errors.append(f"{key}: invalid languages {sorted(languages)}")
+        matching_tags = set(PRODUCT_TAGS) & set(scenario.tags)
+        if len(matching_tags) != 1:
+            errors.append(
+                f"{scenario.path}:{scenario.line}: expected exactly one product exclusion tag"
+            )
+            continue
+        tag = matching_tags.pop()
+        if languages != PRODUCT_TAGS[tag]:
+            errors.append(
+                f"{key}: {tag} requires languages {sorted(PRODUCT_TAGS[tag])}, "
+                f"got {sorted(languages)}"
+            )
+        if f"issue-{issue}" not in scenario.tags:
+            errors.append(f"{key}: missing @issue-{issue}")
+        issue_tags = {tag for tag in scenario.tags if re.fullmatch(r"issue-\d+", tag)}
+        if issue_tags != {f"issue-{issue}"}:
+            errors.append(f"{key}: expected exactly @issue-{issue}, got {sorted(issue_tags)}")
+    for scenario in scenarios:
+        product_tags = set(PRODUCT_TAGS) & set(scenario.tags)
+        if product_tags and (scenario.feature, scenario.name) not in inventory_keys:
+            errors.append(f"{scenario.path}:{scenario.line}: exclusion is missing from inventory")
+        if {"skip-node", "skip-rust"} & set(scenario.tags):
+            errors.append(f"{scenario.path}:{scenario.line}: stale language skip tag")
+        if (
+            "binding-only" in scenario.tags
+            and (
+                scenario.feature,
+                scenario.name,
+            )
+            not in BINDING_ONLY_SCENARIOS
+        ):
+            errors.append(
+                f"{scenario.path}:{scenario.line}: unapproved binding-only classification"
+            )
+
+    actual_binding_only = {
+        (scenario.feature, scenario.name)
+        for scenario in scenarios
+        if "binding-only" in scenario.tags
+    }
+    for key in sorted(BINDING_ONLY_SCENARIOS - actual_binding_only):
+        errors.append(f"missing binding-only classification: {key}")
+
+    for relative, patterns in FORBIDDEN_SOURCE_PATTERNS.items():
+        source = root / relative
+        if not source.is_file():
+            errors.append(f"{relative}: required step source is missing")
+            continue
+        text = source.read_text()
+        for pattern in patterns:
+            match = re.search(pattern, text, re.IGNORECASE)
+            if match:
+                line = text.count("\n", 0, match.start()) + 1
+                errors.append(f"{relative}:{line}: forbidden fail-open pattern {pattern!r}")
+
+    if check_issues:
+        for issue in sorted(issue_numbers):
+            try:
+                result = subprocess.run(
+                    [
+                        "gh",
+                        "issue",
+                        "view",
+                        str(issue),
+                        "--json",
+                        "state",
+                        "--jq",
+                        ".state",
+                    ],
+                    cwd=root,
+                    text=True,
+                    capture_output=True,
+                    check=False,
+                    timeout=30,
+                )
+            except (OSError, subprocess.TimeoutExpired) as error:
+                errors.append(f"issue #{issue} could not be verified: {error}")
+                continue
+            if result.returncode != 0:
+                errors.append(f"issue #{issue} could not be verified: {result.stderr.strip()}")
+            elif result.stdout.strip() != "OPEN":
+                errors.append(f"issue #{issue} is not open")
+
+    counts = {
+        "scenarios": len(scenarios),
+        "product_exclusions": len(entries),
+        "binding_only_not_applicable_to_rust": sum(
+            1 for scenario in scenarios if "binding-only" in scenario.tags
+        ),
+        "required": {
+            language: sum(
+                1
+                for scenario in scenarios
+                if "binding-only" not in scenario.tags or language != "rust"
+                if not any(
+                    tag in scenario.tags and language in languages
+                    for tag, languages in PRODUCT_TAGS.items()
+                )
+            )
+            for language in sorted(LANGUAGES)
+        },
+        "issues": sorted(issue_numbers),
+    }
+    return counts, errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[2])
+    parser.add_argument("--check-issues", action="store_true")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    root = args.root.resolve()
+    counts, errors = validate(root, check_issues=args.check_issues)
+    report = {"contract": "graphforge-api-bdd-policy/1", "counts": counts, "errors": errors}
+    output = args.output or root / "target/api-bdd-policy.json"
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    if errors:
+        for error in errors:
+            print(f"api-bdd-policy: {error}", file=sys.stderr)
+        return 1
+    print(json.dumps(report, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/api-bdd-policy.py
+++ b/scripts/ci/api-bdd-policy.py
@@ -132,7 +132,8 @@ def validate(root: Path, *, check_issues: bool = False) -> tuple[dict, list[str]
             errors.append(f"{key}: issue must be a positive integer")
             continue
         issue_numbers.add(issue)
-        languages = set(entry.get("languages", []))
+        raw_languages = entry.get("languages")
+        languages = set(raw_languages) if isinstance(raw_languages, list) else set()
         if not languages or not languages <= LANGUAGES:
             errors.append(f"{key}: invalid languages {sorted(languages)}")
         matching_tags = set(PRODUCT_TAGS) & set(scenario.tags)

--- a/scripts/ci/test-api-bdd-mutations.py
+++ b/scripts/ci/test-api-bdd-mutations.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Prove representative public API contract mutations fail pytest-bdd."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+import textwrap
+
+ROOT = Path(__file__).resolve().parents[2]
+PYTHON = Path(os.environ.get("PYTHON", sys.executable))
+
+MUTATIONS = {
+    "wrong_row_count": (
+        """
+        Feature: mutation
+          Scenario: wrong row count
+            Given a graph with a Person node named "Alice"
+            When I execute "MATCH (p:Person) RETURN p.name AS name"
+            Then the table has 2 rows
+        """,
+        "expected 2 rows, got 1",
+    ),
+    "missing_column": (
+        """
+        Feature: mutation
+          Scenario: missing column
+            Given a graph with a Person node named "Alice"
+            When I execute "MATCH (p:Person) RETURN p.name AS name"
+            Then the table has column "missing"
+        """,
+        "missing result column: missing",
+    ),
+    "wrong_value": (
+        """
+        Feature: mutation
+          Scenario: wrong value
+            Given a graph with a Person node named "Alice"
+            When I execute "MATCH (p:Person) RETURN p.name AS name"
+            Then the first row value for "name" is "Bob"
+        """,
+        "expected first name value 'Bob', got 'Alice'",
+    ),
+    "wrong_error_class": (
+        """
+        Feature: mutation
+          Scenario: wrong error class
+            Given an empty graph
+            When I execute "NOT VALID CYPHER !!!"
+            Then an ExecutionError is raised
+        """,
+        "expected ExecutionError, got ParseError",
+    ),
+    "not_implemented": (
+        """
+        Feature: mutation
+          Scenario: missing behavior
+            When I invoke deliberately missing behavior
+        """,
+        "NotImplementedError: mutation sentinel",
+    ),
+}
+
+
+def run_mutation(name: str, feature: str, expected_failure: str) -> None:
+    with tempfile.TemporaryDirectory(prefix=f"graphforge-api-bdd-{name}-") as directory:
+        temp = Path(directory)
+        feature_path = temp / "mutation.feature"
+        feature_path.write_text(textwrap.dedent(feature).strip() + "\n")
+        runner = temp / "test_mutation.py"
+        extra = ""
+        if name == "not_implemented":
+            extra = textwrap.dedent(
+                """
+                from pytest_bdd import when
+
+                @when("I invoke deliberately missing behavior")
+                def deliberately_missing():
+                    raise NotImplementedError("mutation sentinel")
+                """
+            )
+        runner.write_text(
+            "pytest_plugins = ['tests.features.steps.api_steps']\n"
+            "from pytest_bdd import scenarios\n"
+            f"scenarios({str(feature_path)!r})\n" + extra
+        )
+        result = subprocess.run(
+            [str(PYTHON), "-m", "pytest", str(runner), "-q", "--tb=short"],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        output = result.stdout + result.stderr
+        if result.returncode == 0:
+            raise AssertionError(f"{name} mutation unexpectedly passed:\n{output}")
+        lowered = output.lower()
+        if "xfailed" in lowered or "xpassed" in lowered:
+            raise AssertionError(f"{name} mutation was reclassified instead of failing:\n{output}")
+        failed = re.search(r"\b(\d+) failed\b", lowered)
+        if (
+            failed is None
+            or failed.group(1) != "1"
+            or "error collecting" in lowered
+            or "error at setup" in lowered
+            or re.search(r"\b\d+ errors?\b", lowered) is not None
+        ):
+            raise AssertionError(f"{name} did not fail as one executed scenario:\n{output}")
+        if expected_failure not in output:
+            raise AssertionError(
+                f"{name} failed for the wrong reason; expected {expected_failure!r}:\n{output}"
+            )
+
+
+def main() -> int:
+    if not PYTHON.exists():
+        print(f"Python runtime not found: {PYTHON}", file=sys.stderr)
+        return 2
+    for name, (feature, expected_failure) in MUTATIONS.items():
+        run_mutation(name, feature, expected_failure)
+    print(f"api-bdd-mutations: {len(MUTATIONS)} fail-closed mutations rejected")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test-api-bdd-mutations.py
+++ b/scripts/ci/test-api-bdd-mutations.py
@@ -6,13 +6,14 @@ from __future__ import annotations
 import os
 from pathlib import Path
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
 import textwrap
 
 ROOT = Path(__file__).resolve().parents[2]
-PYTHON = Path(os.environ.get("PYTHON", sys.executable))
+PYTHON = os.environ.get("PYTHON", sys.executable)
 
 MUTATIONS = {
     "wrong_row_count": (
@@ -117,7 +118,7 @@ def run_mutation(name: str, feature: str, expected_failure: str) -> None:
 
 
 def main() -> int:
-    if not PYTHON.exists():
+    if shutil.which(PYTHON) is None:
         print(f"Python runtime not found: {PYTHON}", file=sys.stderr)
         return 2
     for name, (feature, expected_failure) in MUTATIONS.items():

--- a/scripts/ci/test-api-bdd-policy.py
+++ b/scripts/ci/test-api-bdd-policy.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Mutation tests for the public API BDD repository policy."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import shutil
+import sys
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "api_bdd_policy", ROOT / "scripts/ci/api-bdd-policy.py"
+)
+assert SPEC and SPEC.loader
+POLICY = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = POLICY
+SPEC.loader.exec_module(POLICY)
+
+
+class ApiBddPolicyMutationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        for relative in (
+            "tests/features/api",
+            "tests/contracts/api-bdd-exclusions.json",
+            "tests/features/conftest.py",
+            "tests/features/steps/api_steps.py",
+            "tests/features/node/step_definitions/api_steps.ts",
+            "crates/graphforge-api/tests/bdd/api_steps.rs",
+        ):
+            source = ROOT / relative
+            destination = self.root / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            if source.is_dir():
+                shutil.copytree(source, destination)
+            else:
+                shutil.copy2(source, destination)
+        _, errors = POLICY.validate(self.root)
+        self.assertEqual(errors, [])
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def assert_rejected(self, expected: str) -> None:
+        _, errors = POLICY.validate(self.root)
+        self.assertTrue(any(expected in error for error in errors), errors)
+
+    def test_inventory_entry_cannot_be_removed(self) -> None:
+        path = self.root / "tests/contracts/api-bdd-exclusions.json"
+        inventory = json.loads(path.read_text())
+        inventory["exclusions"].pop()
+        path.write_text(json.dumps(inventory))
+        self.assert_rejected("missing from inventory")
+
+    def test_inventory_must_be_an_object(self) -> None:
+        path = self.root / "tests/contracts/api-bdd-exclusions.json"
+        path.write_text("[]")
+        self.assert_rejected("inventory must be an object")
+
+    def test_inventory_entries_must_be_objects(self) -> None:
+        path = self.root / "tests/contracts/api-bdd-exclusions.json"
+        inventory = json.loads(path.read_text())
+        inventory["exclusions"].append("not-an-object")
+        path.write_text(json.dumps(inventory))
+        self.assert_rejected("must be an object")
+
+    def test_issue_tag_must_match_inventory(self) -> None:
+        path = self.root / "tests/features/api/edge_cases.feature"
+        path.write_text(path.read_text().replace("@issue-352", "@issue-999", 1))
+        self.assert_rejected("missing @issue-352")
+
+    def test_stale_skip_tag_is_rejected(self) -> None:
+        path = self.root / "tests/features/api/analyze.feature"
+        path.write_text(path.read_text().replace("@api", "@api @skip-node", 1))
+        self.assert_rejected("stale language skip tag")
+
+    def test_untracked_binding_only_tag_is_rejected(self) -> None:
+        path = self.root / "tests/features/api/analyze.feature"
+        path.write_text(path.read_text().replace("@api", "@api @binding-only", 1))
+        self.assert_rejected("unapproved binding-only classification")
+
+    def test_python_not_implemented_conversion_is_rejected(self) -> None:
+        path = self.root / "tests/features/conftest.py"
+        path.write_text(path.read_text() + "\npytest.xfail('NotImplementedError')\n")
+        self.assert_rejected("forbidden fail-open pattern")
+
+    def test_node_pending_result_is_rejected(self) -> None:
+        path = self.root / "tests/features/node/step_definitions/api_steps.ts"
+        path.write_text(path.read_text() + '\nreturn "pending";\n')
+        self.assert_rejected("forbidden fail-open pattern")
+
+    def test_rust_manufactured_error_is_rejected(self) -> None:
+        path = self.root / "crates/graphforge-api/tests/bdd/api_steps.rs"
+        path.write_text(path.read_text() + '\nworld.last_error = Some("not implemented".into());\n')
+        self.assert_rejected("forbidden fail-open pattern")
+
+    def test_required_step_source_cannot_be_removed(self) -> None:
+        path = self.root / "tests/features/steps/api_steps.py"
+        path.unlink()
+        self.assert_rejected("required step source is missing")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test-api-bdd-policy.py
+++ b/scripts/ci/test-api-bdd-policy.py
@@ -69,6 +69,13 @@ class ApiBddPolicyMutationTests(unittest.TestCase):
         path.write_text(json.dumps(inventory))
         self.assert_rejected("must be an object")
 
+    def test_null_inventory_languages_are_rejected_cleanly(self) -> None:
+        path = self.root / "tests/contracts/api-bdd-exclusions.json"
+        inventory = json.loads(path.read_text())
+        inventory["exclusions"][0]["languages"] = None
+        path.write_text(json.dumps(inventory))
+        self.assert_rejected("invalid languages []")
+
     def test_issue_tag_must_match_inventory(self) -> None:
         path = self.root / "tests/features/api/edge_cases.feature"
         path.write_text(path.read_text().replace("@issue-352", "@issue-999", 1))

--- a/tests/contracts/api-bdd-exclusions.json
+++ b/tests/contracts/api-bdd-exclusions.json
@@ -1,0 +1,150 @@
+{
+  "version": 1,
+  "tag": "excluded-api-bdd",
+  "exclusions": [
+    {
+      "feature": "Edge Cases and Graceful Empty Results",
+      "scenario": "find on a label with no indexed content returns empty Arrow Table",
+      "issue": 352,
+      "languages": ["rust", "python", "node"]
+    },
+    {
+      "feature": "Edge Cases and Graceful Empty Results",
+      "scenario": "find with vector dimension mismatch returns empty Arrow Table",
+      "issue": 352,
+      "languages": ["rust", "python", "node"]
+    },
+    {
+      "feature": "Error Handling",
+      "scenario": "ExecutionError is raised on type mismatch",
+      "issue": 353,
+      "languages": ["rust", "python", "node"]
+    },
+    {
+      "feature": "Error Handling",
+      "scenario": "ParseError on undefined variable in RETURN",
+      "issue": 353,
+      "languages": ["rust", "python", "node"]
+    },
+    {
+      "feature": "Error Handling",
+      "scenario": "ParseError on aggregation used in WHERE clause",
+      "issue": 353,
+      "languages": ["rust", "python", "node"]
+    },
+    {
+      "feature": "Error Handling",
+      "scenario": "ParseError on CREATE with undirected relationship",
+      "issue": 353,
+      "languages": ["rust", "python", "node"]
+    },
+    {
+      "feature": "Error Handling",
+      "scenario": "ParseError on duplicate alias in WITH clause",
+      "issue": 353,
+      "languages": ["rust", "python", "node"]
+    },
+    {
+      "feature": "Error Handling",
+      "scenario": "ExecutionError when a query references an unbound parameter",
+      "issue": 353,
+      "languages": ["rust", "python", "node"]
+    },
+    {
+      "feature": "Explain API",
+      "scenario": "explain does not execute the query",
+      "issue": 354,
+      "languages": ["rust", "python", "node"]
+    },
+    {
+      "feature": "Find API",
+      "scenario": "find by vector returns score and matched_on set to vector",
+      "issue": 352,
+      "languages": ["rust", "python", "node"]
+    },
+    {
+      "feature": "Find API",
+      "scenario": "find with text and vector returns matched_on set to text+vector for fused results",
+      "issue": 352,
+      "languages": ["rust", "python", "node"]
+    },
+    {
+      "feature": "Graph Construction API",
+      "scenario": "bulk add_nodes with a list of records",
+      "issue": 355,
+      "languages": ["rust", "python", "node"]
+    },
+    {
+      "feature": "Graph Construction API",
+      "scenario": "bulk add_nodes with Arrow Table",
+      "issue": 355,
+      "languages": ["rust", "python", "node"]
+    },
+    {
+      "feature": "Index API",
+      "scenario": "index vector upsert stores a vector for a node",
+      "issue": 352,
+      "languages": ["rust", "python", "node"]
+    },
+    {
+      "feature": "Index API",
+      "scenario": "find reflects nodes added after initial index build",
+      "issue": 352,
+      "languages": ["rust", "python", "node"]
+    },
+    {
+      "feature": "Recipes API",
+      "scenario": "neighbourhood returns an Arrow Table",
+      "issue": 356,
+      "languages": ["rust", "python", "node"]
+    },
+    {
+      "feature": "Recipes API",
+      "scenario": "neighbourhood with hops 1 returns only direct neighbours",
+      "issue": 356,
+      "languages": ["rust", "python", "node"]
+    },
+    {
+      "feature": "Recipes API",
+      "scenario": "neighbourhood with hops 2 reaches two-hop neighbours",
+      "issue": 356,
+      "languages": ["rust", "python", "node"]
+    },
+    {
+      "feature": "Recipes API",
+      "scenario": "neighbourhood on a node with no neighbours returns an empty Arrow Table",
+      "issue": 356,
+      "languages": ["rust", "python", "node"]
+    },
+    {
+      "feature": "Recipes API",
+      "scenario": "neighbourhood with non-existent canonical value returns empty Arrow Table",
+      "issue": 356,
+      "languages": ["rust", "python", "node"]
+    },
+    {
+      "feature": "Recipes API",
+      "scenario": "neighbourhood with hops 0 returns empty Arrow Table",
+      "issue": 356,
+      "languages": ["rust", "python", "node"]
+    },
+    {
+      "feature": "Type Errors",
+      "scenario": "TypeError when add_edge source is not a NodeHandle",
+      "issue": 357,
+      "languages": ["node"]
+    },
+    {
+      "feature": "Type Errors",
+      "scenario": "TypeError when add_edge destination is not a NodeHandle",
+      "issue": 357,
+      "languages": ["node"]
+    },
+    {
+      "feature": "Type Errors",
+      "scenario": "TypeError on unsupported property value type",
+      "issue": 357,
+      "languages": ["node"]
+    }
+  ]
+}

--- a/tests/features/api/cluster.feature
+++ b/tests/features/api/cluster.feature
@@ -1,4 +1,4 @@
-@api @cluster @skip-node
+@api @cluster
 Feature: Cluster API
 
   Background:

--- a/tests/features/api/construction.feature
+++ b/tests/features/api/construction.feature
@@ -10,7 +10,7 @@ Feature: Graph Construction API
     And the NodeHandle exposes UUID identity with no numeric surrogate
     And execute readback returns the NodeHandle UUID and name "Alice"
 
-  @construction @skip-node
+  @construction
   Scenario: add a relationship between two nodes
     Given a Person node named "Alice"
     And a Person node named "Bob"
@@ -23,11 +23,13 @@ Feature: Graph Construction API
     Then execute readback returns the NodeHandle UUID and name "Alice"
 
   @construction
+  @excluded-api-bdd @issue-355
   Scenario: bulk add_nodes with a list of records
     When I bulk add nodes with label "Person" and 2 records
     Then execute "MATCH (p:Person) RETURN p.name" returns 2 rows
 
   @construction
+  @excluded-api-bdd @issue-355
   Scenario: bulk add_nodes with Arrow Table
     When I bulk add nodes with label "Person" from an Arrow Table of 5 rows
     Then execute "MATCH (p:Person) RETURN p.name" returns 5 rows
@@ -66,6 +68,7 @@ Feature: Graph Construction API
       | ambiguous   |
       | cross-graph |
 
+  @binding-only
   Scenario: Closed instances reject path selectors before coercion
     Given Person nodes named "Alice" and "Bob"
     And the forge instance is closed

--- a/tests/features/api/edge_cases.feature
+++ b/tests/features/api/edge_cases.feature
@@ -1,4 +1,4 @@
-@api @edge_cases @skip-node
+@api @edge_cases
 Feature: Edge Cases and Graceful Empty Results
 
   Scenario Outline: rank on <condition> returns empty Arrow Table
@@ -23,12 +23,14 @@ Feature: Edge Cases and Graceful Empty Results
       | a label with no nodes  | a graph with Person nodes but no Paper nodes  | Paper       |
       | a non-existent label   | an empty graph                                | NonExistent |
 
+  @excluded-api-bdd @issue-352
   Scenario: find on a label with no indexed content returns empty Arrow Table
     Given an empty graph
     When I find "anything" in label "Paper"
     Then the result is an Arrow Table
     And the table has 0 rows
 
+  @excluded-api-bdd @issue-352
   Scenario: find with vector dimension mismatch returns empty Arrow Table
     Given a graph with Paper nodes indexed with 128-dimensional vectors
     When I find by a 64-dimensional vector in label "Paper"

--- a/tests/features/api/errors.feature
+++ b/tests/features/api/errors.feature
@@ -12,7 +12,8 @@ Feature: Error Handling
     When I execute "MATCH (n) RETURN n BLARG"
     Then a ParseError is raised
 
-  @skip-node
+
+  @excluded-api-bdd @issue-353
   Scenario: ExecutionError is raised on type mismatch
     Given a graph with a Person node with age stored as a string "not-a-number"
     When I execute "MATCH (p:Person) RETURN p.age + 1 AS result"
@@ -24,19 +25,22 @@ Feature: Error Handling
     And I execute "MATCH (n) RETURN n"
     Then a StorageError is raised
 
-  @skip-node
+
+  @excluded-api-bdd @issue-353
   Scenario: ParseError on undefined variable in RETURN
     Given an empty graph
     When I execute "MATCH (n:Person) RETURN x.name AS name"
     Then a ParseError is raised
 
-  @skip-node
+
+  @excluded-api-bdd @issue-353
   Scenario: ParseError on aggregation used in WHERE clause
     Given a graph with 3 Person nodes
     When I execute "MATCH (n:Person) WHERE count(n) > 1 RETURN n"
     Then a ParseError is raised
 
-  @skip-node
+
+  @excluded-api-bdd @issue-353
   Scenario: ParseError on CREATE with undirected relationship
     Given an empty graph
     When I execute "CREATE (a:Person)-[:KNOWS]-(b:Person)"
@@ -47,25 +51,27 @@ Feature: Error Handling
     When I execute "CREATE (a:Person)-[:KNOWS|LIKES]->(b:Person)"
     Then a ParseError is raised
 
-  @skip-node
+
+  @excluded-api-bdd @issue-353
   Scenario: ParseError on duplicate alias in WITH clause
     Given a graph with a Person node named "Alice"
     When I execute "MATCH (n:Person) WITH n.name AS x, n.name AS x RETURN x"
     Then a ParseError is raised
 
-  @skip-node
+
   Scenario: ExecutionError when deleting a node that has relationships without DETACH
     Given a graph with a Person node named "Alice" connected by a KNOWS edge to a Person node named "Bob"
     When I execute "MATCH (p:Person {name: 'Alice'}) DELETE p"
     Then an ExecutionError is raised
 
-  @skip-node
+
+  @excluded-api-bdd @issue-353
   Scenario: ExecutionError when a query references an unbound parameter
     Given an empty graph
     When I execute "MATCH (p:Person) WHERE p.name = $name RETURN p" without parameters
     Then an ExecutionError is raised
 
-  @skip-node
+
   Scenario: property access on NULL returns NULL without error
     Given a graph with a Person node named "Alice" without an age property
     When I execute "MATCH (p:Person) RETURN p.age AS age"

--- a/tests/features/api/execute.feature
+++ b/tests/features/api/execute.feature
@@ -14,7 +14,7 @@ Feature: Cypher Execute API
     Then the result schema contains column "person_name"
     And the result schema contains column "person_age"
 
-  @skip-node
+
   Scenario: empty result returns Arrow Table with correct schema and zero rows
     Given an empty graph
     When I execute "MATCH (p:Person) RETURN p.name AS name"

--- a/tests/features/api/explain.feature
+++ b/tests/features/api/explain.feature
@@ -1,4 +1,4 @@
-@api @explain @skip-node
+@api @explain
 Feature: Explain API
 
   Scenario: explain returns a non-empty string
@@ -12,6 +12,7 @@ Feature: Explain API
     Then the result contains "AST"
     And the result contains "GraphIR"
 
+  @excluded-api-bdd @issue-354
   Scenario: explain does not execute the query
     Given an empty graph
     When I call explain on "CREATE (:Person {name: 'Ghost'})"

--- a/tests/features/api/find.feature
+++ b/tests/features/api/find.feature
@@ -1,4 +1,4 @@
-@api @find @skip-node
+@api @find
 Feature: Find API
 
   Scenario: find by text builds index lazily on first call
@@ -14,12 +14,14 @@ Feature: Find API
     And the table has column "matched_on"
     And the first row value for "matched_on" is "text"
 
+  @excluded-api-bdd @issue-352
   Scenario: find by vector returns score and matched_on set to vector
     Given a graph with a Paper node that has a stored vector embedding
     When I find by the stored vector in label "Paper"
     Then the table has column "score"
     And the first row value for "matched_on" is "vector"
 
+  @excluded-api-bdd @issue-352
   Scenario: find with text and vector returns matched_on set to text+vector for fused results
     Given a graph with a Paper node titled "Graph Neural Networks" and a stored vector embedding
     When I find "graph neural networks" with the stored vector in label "Paper"
@@ -28,7 +30,7 @@ Feature: Find API
   Scenario: find result node ids are addressable in execute
     Given a graph with a Paper node titled "Graph Neural Networks"
     When I find "graph neural networks" in label "Paper"
-    Then for each result row the id is valid in execute "MATCH (n) WHERE id(n) = $id RETURN n"
+    Then for each result row the id is valid in execute "MATCH (n) WHERE n.node_uuid = $id RETURN n"
 
   Scenario: find with label filters results to one node label
     Given a graph with a Paper node titled "test" and a Person node named "test"

--- a/tests/features/api/find.feature
+++ b/tests/features/api/find.feature
@@ -5,7 +5,7 @@ Feature: Find API
     Given a graph with a Paper node titled "Graph Neural Networks"
     When I find "graph neural networks" in label "Paper"
     Then the result is an Arrow Table
-    And no explicit index call was made before find
+    And no index call was made before find
 
   Scenario: find by text returns score and matched_on columns
     Given a graph with a Paper node titled "Graph Neural Networks"

--- a/tests/features/api/index.feature
+++ b/tests/features/api/index.feature
@@ -1,4 +1,4 @@
-@api @index @skip-node
+@api @index
 Feature: Index API
 
   Scenario: index with properties makes subsequent find faster
@@ -7,6 +7,7 @@ Feature: Index API
     And I find "neural networks" in label "Paper"
     Then the result is an Arrow Table with at least 1 row
 
+  @excluded-api-bdd @issue-352
   Scenario: index vector upsert stores a vector for a node
     Given a graph with a Paper node
     And I have stored the node id as "paper_id"
@@ -18,10 +19,13 @@ Feature: Index API
   Scenario: calling index twice is idempotent
     Given a graph with 3 Paper nodes with title properties
     When I index label "Paper" on property "title"
+    And I find "paper" in label "Paper"
     And I index label "Paper" on property "title"
+    And I find "paper" in label "Paper"
     Then no error is raised
     And find "paper" in label "Paper" returns the same results as after the first index call
 
+  @excluded-api-bdd @issue-352
   Scenario: find reflects nodes added after initial index build
     Given a graph with a Paper node titled "Graph Neural Networks"
     And I index label "Paper" on property "title"

--- a/tests/features/api/lifecycle.feature
+++ b/tests/features/api/lifecycle.feature
@@ -1,6 +1,7 @@
-@api @lifecycle @skip-node
+@api @lifecycle
 Feature: Lifecycle State
 
+  @binding-only
   Scenario Outline: LifecycleError on <method> after close
     Given a graph with a Person node named "Alice"
     And the forge instance is closed

--- a/tests/features/api/ontology.feature
+++ b/tests/features/api/ontology.feature
@@ -1,4 +1,4 @@
-@api @ontology @skip-node
+@api @ontology
 Feature: Ontology API
 
   Scenario: load_ontology from a valid YAML file succeeds

--- a/tests/features/api/rank.feature
+++ b/tests/features/api/rank.feature
@@ -1,4 +1,4 @@
-@api @rank @skip-node
+@api @rank
 Feature: Rank API
 
   Background:

--- a/tests/features/api/recipes.feature
+++ b/tests/features/api/recipes.feature
@@ -1,35 +1,41 @@
-@api @recipes @skip-node
+@api @recipes
 Feature: Recipes API
 
+  @excluded-api-bdd @issue-356
   Scenario: neighbourhood returns an Arrow Table
     Given a graph with Person nodes connected by KNOWS edges up to 3 hops deep
     When I call neighbourhood for "Alice" with hops 2 in label "Person" using canonical property "name"
     Then the result is an Arrow Table
 
+  @excluded-api-bdd @issue-356
   Scenario: neighbourhood with hops 1 returns only direct neighbours
     Given a graph where Alice knows Bob and Bob knows Charlie but Alice does not know Charlie
     When I call neighbourhood for "Alice" with hops 1 in label "Person" using canonical property "name"
     Then the result contains a row for "Bob"
     And the result does not contain a row for "Charlie"
 
+  @excluded-api-bdd @issue-356
   Scenario: neighbourhood with hops 2 reaches two-hop neighbours
     Given a graph where Alice knows Bob and Bob knows Charlie but Alice does not know Charlie
     When I call neighbourhood for "Alice" with hops 2 in label "Person" using canonical property "name"
     Then the result contains a row for "Bob"
     And the result contains a row for "Charlie"
 
+  @excluded-api-bdd @issue-356
   Scenario: neighbourhood on a node with no neighbours returns an empty Arrow Table
     Given a graph with a single Person node named "Lone"
     When I call neighbourhood for "Lone" with hops 1 in label "Person" using canonical property "name"
     Then the result is an Arrow Table
     And the table has 0 rows
 
+  @excluded-api-bdd @issue-356
   Scenario: neighbourhood with non-existent canonical value returns empty Arrow Table
     Given a graph with Person nodes connected by KNOWS edges
     When I call neighbourhood for "NonExistent" with hops 2 in label "Person" using canonical property "name"
     Then the result is an Arrow Table
     And the table has 0 rows
 
+  @excluded-api-bdd @issue-356
   Scenario: neighbourhood with hops 0 returns empty Arrow Table
     Given a graph where Alice knows Bob
     When I call neighbourhood for "Alice" with hops 0 in label "Person" using canonical property "name"

--- a/tests/features/api/type_errors.feature
+++ b/tests/features/api/type_errors.feature
@@ -1,19 +1,22 @@
-@api @types @skip-node
+@api @types
 Feature: Type Errors
 
   Background:
     Given an empty graph
 
+  @binding-only @excluded-node-api-bdd @issue-357
   Scenario: TypeError when add_edge source is not a NodeHandle
     Given a Person node named "Alice"
     When I add a "KNOWS" edge from a raw integer to the node for "Alice"
     Then a TypeError is raised
 
+  @binding-only @excluded-node-api-bdd @issue-357
   Scenario: TypeError when add_edge destination is not a NodeHandle
     Given a Person node named "Alice"
     When I add a "KNOWS" edge from the node for "Alice" to a raw integer
     Then a TypeError is raised
 
+  @binding-only @excluded-node-api-bdd @issue-357
   Scenario: TypeError on unsupported property value type
     When I add a node with label "Person" with an unsupported property value
     Then a TypeError is raised

--- a/tests/features/api/validation.feature
+++ b/tests/features/api/validation.feature
@@ -1,4 +1,4 @@
-@api @validation @skip-node
+@api @validation
 Feature: Input Validation Errors
 
   Background:

--- a/tests/features/conftest.py
+++ b/tests/features/conftest.py
@@ -7,54 +7,24 @@ import pytest
 pytest_plugins = ["tests.features.steps.api_steps"]
 
 
-# Feature areas that are entirely unimplemented in the native engine (the write
-# API and explicit transactions land with M18/M19 + the write path). Their
-# scenarios set up state via add_node/add_edge/begin, so the NotImplementedError
-# is swallowed inside a When step and a *later* step fails with a different
-# exception (PlanError on an empty graph, an AssertionError, …). Mark the whole
-# area xfail so the cutover gate is honest; each flips to a real pass — surfaced
-# as an xpass — the moment its native implementation lands.
-_UNIMPLEMENTED_TAGS = ("construction", "transactions")
-
-
-def pytest_collection_modifyitems(config, items):
+def pytest_collection_modifyitems(items):
+    """Report issue-backed product gaps as excluded, never passed or xfailed."""
     for item in items:
-        for tag in _UNIMPLEMENTED_TAGS:
-            if item.get_closest_marker(tag) is not None:
-                item.add_marker(
-                    pytest.mark.xfail(
-                        reason=f"native '{tag}' implementation pending (M18/M19 + write API)",
-                        strict=False,
-                    )
-                )
-                break
-
-
-@pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_makereport(item, call):
-    """Convert a ``NotImplementedError`` (setup or call) into an xfail.
-
-    This cannot mask a regression in an *implemented* area: the native engine
-    raises ``NotImplementedError`` **only** from the genuinely-pending surface —
-    the ``GfError::NotImplemented`` mapping (analyst verbs, introspection,
-    transactions) and the ``add_node``/``add_edge`` write stubs, including the
-    ``Given`` setup steps that build graphs through them. The implemented
-    operations (execute/explain, parse, ontology loading, lifecycle) raise typed
-    ``GfError`` variants (Parse/Plan/Execution/Storage/Lifecycle/…), never
-    ``NotImplementedError`` — so a regression there still surfaces as a different
-    exception or an assertion and fails loudly. Each converted xfail flips to a
-    real pass automatically once its native implementation lands.
-    """
-    outcome = yield
-    rep = outcome.get_result()
-    if (
-        rep.when in ("setup", "call")
-        and rep.failed
-        and call.excinfo is not None
-        and call.excinfo.errisinstance(NotImplementedError)
-    ):
-        rep.outcome = "skipped"
-        rep.wasxfail = "native implementation pending (M18/M19 + write API)"
+        if (
+            item.get_closest_marker("excluded-api-bdd") is None
+            and item.get_closest_marker("excluded_api_bdd") is None
+        ):
+            continue
+        issue_markers = [
+            marker.name.removeprefix("issue_").removeprefix("issue-")
+            for marker in item.iter_markers()
+            if marker.name.startswith(("issue_", "issue-"))
+        ]
+        if len(issue_markers) != 1:
+            raise RuntimeError("excluded API BDD scenario needs one issue tag")
+        item.add_marker(
+            pytest.mark.skip(reason=f"excluded API BDD contract: issue #{issue_markers[0]}")
+        )
 
 
 # Register markers so --strict-markers doesn't reject them.
@@ -75,13 +45,19 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "ontology: ontology API scenarios")
     config.addinivalue_line("markers", "transactions: transaction scenarios")
     config.addinivalue_line("markers", "persistence: persistence scenarios")
-    # The @skip-node tag (added in #872) gates only the Node BDD strict run; it
-    # is a no-op for Python (whose own NotImplementedError->xfail hook handles
-    # the unimplemented surface). Register both the verbatim and underscored
-    # forms so --strict-markers accepts it regardless of how pytest-bdd maps the
-    # tag. Tracked for removal in #971.
-    config.addinivalue_line("markers", "skip-node: excluded from the Node BDD strict gate (#971)")
-    config.addinivalue_line("markers", "skip_node: excluded from the Node BDD strict gate (#971)")
+    config.addinivalue_line("markers", "excluded-api-bdd: issue-backed product exclusion")
+    config.addinivalue_line("markers", "excluded_api_bdd: issue-backed product exclusion")
+    config.addinivalue_line("markers", "excluded-node-api-bdd: Node-only issue-backed exclusion")
+    config.addinivalue_line("markers", "excluded_node_api_bdd: Node-only issue-backed exclusion")
+    config.addinivalue_line(
+        "markers", "binding-only: runtime binding contract not applicable to Rust"
+    )
+    config.addinivalue_line(
+        "markers", "binding_only: runtime binding contract not applicable to Rust"
+    )
+    for issue in (352, 353, 354, 355, 356, 357):
+        config.addinivalue_line("markers", f"issue-{issue}: exclusion tracking issue")
+        config.addinivalue_line("markers", f"issue_{issue}: exclusion tracking issue")
 
 
 @pytest.fixture

--- a/tests/features/node/step_definitions/api_steps.ts
+++ b/tests/features/node/step_definitions/api_steps.ts
@@ -74,7 +74,7 @@ class GraphForgeWorld extends World implements GFWorld {
   error: Error | null = null;
   nodes: Record<string, any> = {};
   edges: any[] = [];
-  extra: Record<string, unknown> = {};
+  extra: Record<string, unknown> = { index_called: false };
   tmpDir: string | null = null;
 
   constructor(options: IWorldOptions) {
@@ -221,7 +221,7 @@ Before(function (this: GraphForgeWorld) {
   this.error = null;
   this.nodes = {};
   this.edges = [];
-  this.extra = {};
+  this.extra = { index_called: false };
   this.tmpDir = null;
 });
 
@@ -1028,7 +1028,8 @@ When("I call clear", function (this: GraphForgeWorld) {
 });
 
 When("I open a graph at that path", function (this: GraphForgeWorld) {
-  const p = (this.extra["path"] as string) || "/nonexistent/path";
+  const p = this.extra["path"] as string | undefined;
+  if (!p) throw new Error("no path fixture was set before opening a graph");
   _catch(this, () => {
     const forge = new GraphForge(p);
     this.forge = forge;
@@ -1434,16 +1435,15 @@ Then("the 2 isolated nodes share a different community_id", function (this: Grap
   }
 });
 
-// Used as both Given (setup) and Then (assertion) in find.feature
-Given("no explicit index call was made before find", function (this: GraphForgeWorld) {
+Then("no index call was made before find", function (this: GraphForgeWorld) {
   if (!("index_called" in this.extra)) {
-    // Given context — initialise the flag
-    this.extra["index_called"] = false;
-  } else {
-    // Then context — assert
-    if (this.extra["index_called"]) {
-      throw new Error("Index was called before find");
-    }
+    throw new Error("index tracking was never initialised for this scenario");
+  }
+  if (this.extra["index_called"]) {
+    throw new Error("Index was called before find");
+  }
+  if (resultTable(this).numRows < 1) {
+    throw new Error("find returned no matches without an explicit index call");
   }
 });
 
@@ -1520,7 +1520,9 @@ Then(
   /^the result does not contain a row for "([^"]*)"$/,
   function (this: GraphForgeWorld, name: string) {
     const table = resultTable(this);
-    const names = [...(table.getChild("name")?.toArray() ?? [])].map(String);
+    const column = table.getChild("name");
+    if (!column) throw new Error('result is missing the "name" column');
+    const names = [...column.toArray()].map(String);
     if (names.includes(name)) throw new Error(`result unexpectedly included row for ${name}`);
   },
 );

--- a/tests/features/node/step_definitions/api_steps.ts
+++ b/tests/features/node/step_definitions/api_steps.ts
@@ -1,8 +1,8 @@
 /**
  * cucumber-js step definitions for tests/features/api/*.feature
  *
- * Implemented steps call the native addon strictly; unsupported milestone
- * areas remain pending. The same features run against Python, Rust, and Node.
+ * Required steps call the native addon strictly. Issue-backed product gaps are
+ * excluded by policy and never contribute to passing totals.
  */
 
 import {
@@ -14,7 +14,16 @@ import {
   IWorldOptions,
   World,
 } from "@cucumber/cucumber";
-import { Field, FixedSizeBinary, RecordBatchStreamWriter, Schema, tableFromIPC, Table, Utf8, vectorFromArray } from "apache-arrow";
+import {
+  Field,
+  FixedSizeBinary,
+  RecordBatchStreamWriter,
+  Schema,
+  tableFromIPC,
+  Table,
+  Utf8,
+  vectorFromArray,
+} from "apache-arrow";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -23,10 +32,14 @@ import * as path from "path";
 // Import the native binding (built by `napi build`; see the node-native-build
 // CI job). napi-rs cannot export JS Error subclasses, so the fault domain is
 // carried on `err.code` (see crates/graphforge-bindings-node/src/error.rs); assertions
-// below match on that code. Construction handles are native and UUID-only;
-// EdgeHandle values remain pending until the Rust construction path lands.
+// below match on that code. Construction handles are native and UUID-only.
 // ---------------------------------------------------------------------------
-const { GraphForge, NodeHandle, EdgeHandle, version } = require("../../../../crates/graphforge-bindings-node/index.js");
+const {
+  GraphForge,
+  NodeHandle,
+  EdgeHandle,
+  version,
+} = require("../../../../crates/graphforge-bindings-node/index.js");
 void version;
 
 /** The fault-domain code on a thrown native error (`err.code`). */
@@ -75,10 +88,7 @@ setWorldConstructor(GraphForgeWorld);
 // Helpers
 // ---------------------------------------------------------------------------
 
-function _catch(
-  world: GraphForgeWorld,
-  fn: () => unknown
-): void {
+function _catch(world: GraphForgeWorld, fn: () => unknown): void {
   try {
     world.result = fn();
     world.error = null;
@@ -99,7 +109,7 @@ function _mkTmp(world: GraphForgeWorld): string {
  * Decode the `execute()` result — an Arrow IPC stream `Buffer` (the native
  * binding returns `result_to_ipc` bytes) — into an Arrow `Table`. Throws
  * (failing the step) if the query errored or the result is not a Buffer, so
- * strict mode surfaces a misuse as a failure rather than a pending skeleton.
+ * strict mode surfaces a misuse as a failure.
  */
 function resultTable(world: GraphForgeWorld): Table {
   if (world.error) {
@@ -201,7 +211,11 @@ function createNode(world: GraphForgeWorld, label: string, props: Record<string,
 // ---------------------------------------------------------------------------
 
 Before(function (this: GraphForgeWorld) {
-  try { this.forge?.close(); } catch { /* ignore */ }
+  try {
+    this.forge?.close();
+  } catch {
+    /* ignore */
+  }
   this.forge = null;
   this.result = null;
   this.error = null;
@@ -224,7 +238,7 @@ Given("a graph with a directed cycle", function (this: GraphForgeWorld) {
   this.forge.execute(
     "CREATE (a:Person {name:'Alice'})-[:KNOWS]->" +
       "(b:Person {name:'Bob'})-[:KNOWS]->" +
-      "(c:Person {name:'Carol'})-[:KNOWS]->(a)"
+      "(c:Person {name:'Carol'})-[:KNOWS]->(a)",
   );
 });
 
@@ -233,7 +247,7 @@ Given(
   function (this: GraphForgeWorld, name: string) {
     this.forge = new GraphForge();
     createNode(this, "Person", { name });
-  }
+  },
 );
 
 Given(
@@ -241,55 +255,46 @@ Given(
   function (this: GraphForgeWorld, name: string, ageStr: string) {
     this.forge = new GraphForge();
     createNode(this, "Person", { name, age: parseInt(ageStr, 10) });
-  }
+  },
 );
 
-Given(
-  /^a graph with (\d+) Person nodes$/,
-  function (this: GraphForgeWorld, nStr: string) {
-    const n = parseInt(nStr, 10);
-    this.forge = new GraphForge();
-    for (let i = 0; i < n; i++) {
-      createNode(this, "Person", { name: `Person${i}` });
-    }
+Given(/^a graph with (\d+) Person nodes$/, function (this: GraphForgeWorld, nStr: string) {
+  const n = parseInt(nStr, 10);
+  this.forge = new GraphForge();
+  for (let i = 0; i < n; i++) {
+    createNode(this, "Person", { name: `Person${i}` });
   }
-);
+});
 
-Given(
-  "a graph with 3 Person nodes connected by KNOWS edges",
-  function (this: GraphForgeWorld) {
-    this.forge = new GraphForge();
-    const names = ["Alice", "Bob", "Carol"];
-    const handles = names.map((n) => {
-      const h = this.forge!.addNode("Person", { name: n });
-      this.nodes[n] = h;
-      return h;
-    });
-    this.forge.addEdge(handles[0], "KNOWS", handles[1]);
-    this.forge.addEdge(handles[1], "KNOWS", handles[2]);
-  }
-);
+Given("a graph with 3 Person nodes connected by KNOWS edges", function (this: GraphForgeWorld) {
+  this.forge = new GraphForge();
+  const names = ["Alice", "Bob", "Carol"];
+  const handles = names.map((n) => {
+    const h = this.forge!.addNode("Person", { name: n });
+    this.nodes[n] = h;
+    return h;
+  });
+  this.forge.addEdge(handles[0], "KNOWS", handles[1]);
+  this.forge.addEdge(handles[1], "KNOWS", handles[2]);
+});
 
-Given(
-  "a graph with 4 Person nodes in two connected groups",
-  function (this: GraphForgeWorld) {
-    this.forge = new GraphForge();
-    const g1 = ["Alice", "Bob"].map((n) => {
-      const h = this.forge!.addNode("Person", { name: n });
-      this.nodes[n] = h;
-      return h;
-    });
-    const g2 = ["Carol", "Dave"].map((n) => {
-      const h = this.forge!.addNode("Person", { name: n });
-      this.nodes[n] = h;
-      return h;
-    });
-    this.forge.addEdge(g1[0], "KNOWS", g1[1]);
-    this.forge.addEdge(g2[0], "KNOWS", g2[1]);
-    this.extra["group1"] = g1;
-    this.extra["group2"] = g2;
-  }
-);
+Given("a graph with 4 Person nodes in two connected groups", function (this: GraphForgeWorld) {
+  this.forge = new GraphForge();
+  const g1 = ["Alice", "Bob"].map((n) => {
+    const h = this.forge!.addNode("Person", { name: n });
+    this.nodes[n] = h;
+    return h;
+  });
+  const g2 = ["Carol", "Dave"].map((n) => {
+    const h = this.forge!.addNode("Person", { name: n });
+    this.nodes[n] = h;
+    return h;
+  });
+  this.forge.addEdge(g1[0], "KNOWS", g1[1]);
+  this.forge.addEdge(g2[0], "KNOWS", g2[1]);
+  this.extra["group1"] = g1;
+  this.extra["group2"] = g2;
+});
 
 Given(
   /^a graph with a Paper node titled "([^"]*)"$/,
@@ -297,7 +302,7 @@ Given(
     this.forge = new GraphForge();
     const h = this.forge.addNode("Paper", { title });
     this.nodes[title] = h;
-  }
+  },
 );
 
 Given(
@@ -307,7 +312,7 @@ Given(
     const h = this.forge.addNode("Paper", { title: "Stub Paper" });
     this.nodes["Stub Paper"] = h;
     this.extra["vector"] = new Array(128).fill(1.0);
-  }
+  },
 );
 
 Given(
@@ -317,7 +322,7 @@ Given(
     const h = this.forge.addNode("Paper", { title });
     this.nodes[title] = h;
     this.extra["vector"] = new Array(128).fill(1.0);
-  }
+  },
 );
 
 Given(
@@ -326,7 +331,7 @@ Given(
     this.forge = new GraphForge();
     this.nodes[title] = this.forge.addNode("Paper", { title });
     this.nodes[name] = this.forge.addNode("Person", { name });
-  }
+  },
 );
 
 Given(
@@ -338,7 +343,7 @@ Given(
       const t = `Graph Theory Paper ${i}`;
       this.nodes[t] = this.forge.addNode("Paper", { title: t });
     }
-  }
+  },
 );
 
 Given(
@@ -350,29 +355,23 @@ Given(
       const t = `Neural Networks Paper ${i}`;
       this.nodes[t] = this.forge.addNode("Paper", { title: t, abstract: "About neural networks" });
     }
-  }
+  },
 );
 
-Given(
-  "a graph with a Paper node",
-  function (this: GraphForgeWorld) {
-    this.forge = new GraphForge();
-    const h = this.forge.addNode("Paper", { title: "Stub Paper" });
-    this.nodes["paper"] = h;
-    this.extra["paper_id"] = h.uuid;
-  }
-);
+Given("a graph with a Paper node", function (this: GraphForgeWorld) {
+  this.forge = new GraphForge();
+  const h = this.forge.addNode("Paper", { title: "Stub Paper" });
+  this.nodes["paper"] = h;
+  this.extra["paper_id"] = h.uuid;
+});
 
-Given(
-  /^a graph with 3 Paper nodes with title properties$/,
-  function (this: GraphForgeWorld) {
-    this.forge = new GraphForge();
-    for (let i = 0; i < 3; i++) {
-      const t = `Paper ${i}`;
-      this.nodes[t] = this.forge.addNode("Paper", { title: t });
-    }
+Given(/^a graph with 3 Paper nodes with title properties$/, function (this: GraphForgeWorld) {
+  this.forge = new GraphForge();
+  for (let i = 0; i < 3; i++) {
+    const t = `Paper ${i}`;
+    this.nodes[t] = this.forge.addNode("Paper", { title: t });
   }
-);
+});
 
 Given(
   /^a graph with a Person node named "([^"]*)" and a Paper node titled "([^"]*)"$/,
@@ -380,7 +379,7 @@ Given(
     this.forge = new GraphForge();
     this.nodes[name] = this.forge.addNode("Person", { name });
     this.nodes[title] = this.forge.addNode("Paper", { title });
-  }
+  },
 );
 
 Given(
@@ -395,7 +394,7 @@ Given(
     this.nodes["Alice"] = alice;
     this.nodes["Bob"] = bob;
     this.nodes["paper"] = paper;
-  }
+  },
 );
 
 Given(
@@ -410,18 +409,15 @@ Given(
     for (let i = 0; i < npa; i++) {
       this.nodes[`paper${i}`] = this.forge.addNode("Paper", { title: `Paper${i}` });
     }
-  }
+  },
 );
 
-Given(
-  "a graph with Person nodes but no Paper nodes",
-  function (this: GraphForgeWorld) {
-    this.forge = new GraphForge();
-    for (const name of ["Alice", "Bob"]) {
-      this.nodes[name] = this.forge.addNode("Person", { name });
-    }
+Given("a graph with Person nodes but no Paper nodes", function (this: GraphForgeWorld) {
+  this.forge = new GraphForge();
+  for (const name of ["Alice", "Bob"]) {
+    this.nodes[name] = this.forge.addNode("Person", { name });
   }
-);
+});
 
 Given(
   /^a graph with Paper nodes indexed with (\d+)-dimensional vectors$/,
@@ -430,23 +426,20 @@ Given(
     const h = this.forge.addNode("Paper", { title: "Stub" });
     this.nodes["paper"] = h;
     this.extra["vector_dim"] = parseInt(nStr, 10);
-  }
+  },
 );
 
-Given(
-  "a graph with Person nodes connected by KNOWS edges",
-  function (this: GraphForgeWorld) {
-    this.forge = new GraphForge();
-    const names = ["Alice", "Bob", "Carol"];
-    const handles = names.map((n) => {
-      const h = this.forge!.addNode("Person", { name: n });
-      this.nodes[n] = h;
-      return h;
-    });
-    this.forge.addEdge(handles[0], "KNOWS", handles[1]);
-    this.forge.addEdge(handles[1], "KNOWS", handles[2]);
-  }
-);
+Given("a graph with Person nodes connected by KNOWS edges", function (this: GraphForgeWorld) {
+  this.forge = new GraphForge();
+  const names = ["Alice", "Bob", "Carol"];
+  const handles = names.map((n) => {
+    const h = this.forge!.addNode("Person", { name: n });
+    this.nodes[n] = h;
+    return h;
+  });
+  this.forge.addEdge(handles[0], "KNOWS", handles[1]);
+  this.forge.addEdge(handles[1], "KNOWS", handles[2]);
+});
 
 Given(
   "a graph with Person nodes connected by both KNOWS and FOLLOWS edges",
@@ -458,7 +451,7 @@ Given(
     this.forge.addEdge(bob, "FOLLOWS", alice);
     this.nodes["Alice"] = alice;
     this.nodes["Bob"] = bob;
-  }
+  },
 );
 
 Given(
@@ -473,7 +466,7 @@ Given(
     });
     this.forge.addEdge(handles[0], "KNOWS", handles[1]);
     this.forge.addEdge(handles[1], "KNOWS", handles[2]);
-  }
+  },
 );
 
 Given(
@@ -485,29 +478,23 @@ Given(
     this.nodes["Carol"] = carol;
     this.nodes["Dave"] = dave;
     this.extra["group2"] = [carol, dave];
-  }
+  },
 );
 
-Given(
-  /^a graph with 2 Person nodes connected by a KNOWS edge$/,
-  function (this: GraphForgeWorld) {
-    this.forge = new GraphForge();
-    const alice = this.forge.addNode("Person", { name: "Alice" });
-    const bob = this.forge.addNode("Person", { name: "Bob" });
-    this.forge.addEdge(alice, "KNOWS", bob);
-    this.nodes["Alice"] = alice;
-    this.nodes["Bob"] = bob;
-    this.extra["group1"] = [alice, bob];
-  }
-);
+Given(/^a graph with 2 Person nodes connected by a KNOWS edge$/, function (this: GraphForgeWorld) {
+  this.forge = new GraphForge();
+  const alice = this.forge.addNode("Person", { name: "Alice" });
+  const bob = this.forge.addNode("Person", { name: "Bob" });
+  this.forge.addEdge(alice, "KNOWS", bob);
+  this.nodes["Alice"] = alice;
+  this.nodes["Bob"] = bob;
+  this.extra["group1"] = [alice, bob];
+});
 
-Given(
-  /^a Person node named "([^"]*)"$/,
-  function (this: GraphForgeWorld, name: string) {
-    const h = this.forge!.addNode("Person", { name });
-    this.nodes[name] = h;
-  }
-);
+Given(/^a Person node named "([^"]*)"$/, function (this: GraphForgeWorld, name: string) {
+  const h = this.forge!.addNode("Person", { name });
+  this.nodes[name] = h;
+});
 
 Given(
   /^Person nodes named "([^"]*)" and "([^"]*)"$/,
@@ -515,7 +502,7 @@ Given(
     for (const name of [first, second]) {
       this.nodes[name] = this.forge!.addNode("Person", { name });
     }
-  }
+  },
 );
 
 Given(
@@ -523,55 +510,43 @@ Given(
   function (this: GraphForgeWorld, val: string) {
     this.forge = new GraphForge();
     createNode(this, "Person", { name: "Alice", age: val });
-  }
+  },
 );
 
-Given(
-  "a path that does not exist on disk",
-  function (this: GraphForgeWorld) {
-    const tmp = _mkTmp(this);
-    this.extra["path"] = path.join(tmp, "does_not_exist");
-    this.forge = null;
-  }
-);
+Given("a path that does not exist on disk", function (this: GraphForgeWorld) {
+  const tmp = _mkTmp(this);
+  this.extra["path"] = path.join(tmp, "does_not_exist");
+  this.forge = null;
+});
 
-Given(
-  "a persistent graph backed by Parquet",
-  function (this: GraphForgeWorld) {
-    const tmp = _mkTmp(this);
-    const d = path.join(tmp, "graph");
-    fs.mkdirSync(d, { recursive: true });
-    this.forge = new GraphForge(d);
-    this.extra["path"] = d;
-  }
-);
+Given("a persistent graph backed by Parquet", function (this: GraphForgeWorld) {
+  const tmp = _mkTmp(this);
+  const d = path.join(tmp, "graph");
+  fs.mkdirSync(d, { recursive: true });
+  this.forge = new GraphForge(d);
+  this.extra["path"] = d;
+});
 
-Given(
-  "a persistent graph at a temporary path",
-  function (this: GraphForgeWorld) {
-    const tmp = _mkTmp(this);
-    const d = path.join(tmp, "graph2");
-    fs.mkdirSync(d, { recursive: true });
-    this.forge = new GraphForge(d);
-    this.extra["path"] = d;
-  }
-);
+Given("a persistent graph at a temporary path", function (this: GraphForgeWorld) {
+  const tmp = _mkTmp(this);
+  const d = path.join(tmp, "graph2");
+  fs.mkdirSync(d, { recursive: true });
+  this.forge = new GraphForge(d);
+  this.extra["path"] = d;
+});
 
-Given(
-  "the forge instance is closed",
-  function (this: GraphForgeWorld) {
-    this.forge!.close();
-  }
-);
+Given("the forge instance is closed", function (this: GraphForgeWorld) {
+  this.forge!.close();
+});
 
 Given(
   /^a graph with a Person node named "([^"]*)" connected by a KNOWS edge to a Person node named "([^"]*)"$/,
   function (this: GraphForgeWorld, name: string, name2: string) {
     this.forge = new GraphForge();
     this.forge.execute(
-      `CREATE (:Person {name: ${cypherLit(name)}})-[:KNOWS]->(:Person {name: ${cypherLit(name2)}})`
+      `CREATE (:Person {name: ${cypherLit(name)}})-[:KNOWS]->(:Person {name: ${cypherLit(name2)}})`,
     );
-  }
+  },
 );
 
 Given(
@@ -579,41 +554,43 @@ Given(
   function (this: GraphForgeWorld) {
     this.forge = new GraphForge();
     createNode(this, "Person", { name: "Alice" });
-  }
+  },
 );
 
-Given(
-  "a valid ontology YAML file defining a Person label",
-  function (this: GraphForgeWorld) {
-    const tmp = _mkTmp(this);
-    const p = path.join(tmp, "ontology.yaml");
-    fs.writeFileSync(p, "labels:\n  Person:\n    properties:\n      name: string\n");
-    this.extra["ontology_path"] = p;
-    this.forge = new GraphForge();
-  }
-);
+Given("a valid ontology YAML file defining a Person label", function (this: GraphForgeWorld) {
+  const tmp = _mkTmp(this);
+  const p = path.join(tmp, "ontology.yaml");
+  fs.writeFileSync(
+    p,
+    'ontology_id: people\nversion: "2026.06"\nentity_types:\n  - name: Person\nproperties:\n  - name: name\n    owner: Person\n    type: utf8\n',
+  );
+  this.extra["ontology_path"] = p;
+  this.forge = new GraphForge();
+});
 
-Given(
-  "a valid ontology JSON file defining a Paper label",
-  function (this: GraphForgeWorld) {
-    const tmp = _mkTmp(this);
-    const p = path.join(tmp, "ontology.json");
-    fs.writeFileSync(p, JSON.stringify({ labels: { Paper: { properties: { title: "string" } } } }));
-    this.extra["ontology_path"] = p;
-    this.forge = new GraphForge();
-  }
-);
+Given("a valid ontology JSON file defining a Paper label", function (this: GraphForgeWorld) {
+  const tmp = _mkTmp(this);
+  const p = path.join(tmp, "ontology.json");
+  fs.writeFileSync(
+    p,
+    JSON.stringify({
+      ontology_id: "papers",
+      version: "2026.06",
+      entity_types: [{ name: "Paper" }],
+      properties: [{ name: "title", owner: "Paper", type: "utf8" }],
+    }),
+  );
+  this.extra["ontology_path"] = p;
+  this.forge = new GraphForge();
+});
 
-Given(
-  "a file containing invalid YAML",
-  function (this: GraphForgeWorld) {
-    const tmp = _mkTmp(this);
-    const p = path.join(tmp, "bad.yaml");
-    fs.writeFileSync(p, ": this is not: valid: yaml: [");
-    this.extra["ontology_path"] = p;
-    this.forge = new GraphForge();
-  }
-);
+Given("a file containing invalid YAML", function (this: GraphForgeWorld) {
+  const tmp = _mkTmp(this);
+  const p = path.join(tmp, "bad.yaml");
+  fs.writeFileSync(p, ": this is not: valid: yaml: [");
+  this.extra["ontology_path"] = p;
+  this.forge = new GraphForge();
+});
 
 Given(
   "a graph with Person nodes connected by KNOWS edges up to 3 hops deep",
@@ -628,7 +605,7 @@ Given(
     for (let i = 0; i < handles.length - 1; i++) {
       this.forge.addEdge(handles[i], "KNOWS", handles[i + 1]);
     }
-  }
+  },
 );
 
 Given(
@@ -641,28 +618,22 @@ Given(
     this.forge.addEdge(alice, "KNOWS", bob);
     this.forge.addEdge(bob, "KNOWS", charlie);
     this.nodes = { Alice: alice, Bob: bob, Charlie: charlie };
-  }
+  },
 );
 
-Given(
-  "a graph where Alice knows Bob",
-  function (this: GraphForgeWorld) {
-    this.forge = new GraphForge();
-    const alice = this.forge.addNode("Person", { name: "Alice" });
-    const bob = this.forge.addNode("Person", { name: "Bob" });
-    this.forge.addEdge(alice, "KNOWS", bob);
-    this.nodes = { Alice: alice, Bob: bob };
-  }
-);
+Given("a graph where Alice knows Bob", function (this: GraphForgeWorld) {
+  this.forge = new GraphForge();
+  const alice = this.forge.addNode("Person", { name: "Alice" });
+  const bob = this.forge.addNode("Person", { name: "Bob" });
+  this.forge.addEdge(alice, "KNOWS", bob);
+  this.nodes = { Alice: alice, Bob: bob };
+});
 
-Given(
-  'a graph with a single Person node named "Lone"',
-  function (this: GraphForgeWorld) {
-    this.forge = new GraphForge();
-    const h = this.forge.addNode("Person", { name: "Lone" });
-    this.nodes["Lone"] = h;
-  }
-);
+Given('a graph with a single Person node named "Lone"', function (this: GraphForgeWorld) {
+  this.forge = new GraphForge();
+  const h = this.forge.addNode("Person", { name: "Lone" });
+  this.nodes["Lone"] = h;
+});
 
 Given(
   'a graph with 2 Person nodes with ids in columns "src_id" and "dst_id"',
@@ -670,52 +641,43 @@ Given(
     this.forge = new GraphForge();
     this.nodes["SrcNode"] = this.forge.addNode("Person", { name: "SrcNode" });
     this.nodes["DstNode"] = this.forge.addNode("Person", { name: "DstNode" });
-  }
+  },
 );
 
-Given(
-  'I have stored the node id as "paper_id"',
-  function (this: GraphForgeWorld) {
-    const first = this.nodes["paper"] || Object.values(this.nodes)[0];
-    if (first) this.extra["paper_id"] = first.uuid;
-  }
-);
+Given('I have stored the node id as "paper_id"', function (this: GraphForgeWorld) {
+  const paper = this.nodes["paper"];
+  if (!paper) throw new Error('no "paper" node was created before storing the node id');
+  this.extra["paper_id"] = paper.uuid;
+});
 
-Given(
-  'I have an embedding vector stored as "embedding"',
-  function (this: GraphForgeWorld) {
-    this.extra["embedding"] = new Array(128).fill(1.0);
-  }
-);
-
-
+Given('I have an embedding vector stored as "embedding"', function (this: GraphForgeWorld) {
+  this.extra["embedding"] = new Array(128).fill(1.0);
+});
 
 // ---------------------------------------------------------------------------
 // WHEN steps
 // ---------------------------------------------------------------------------
 
-When(
-  /^I execute "([^"]*)"$/,
-  function (this: GraphForgeWorld, query: string) {
-    if (this.forge === null) return;
-    _catch(this, () => this.forge!.execute(query));
-  }
-);
+When(/^I execute "([^"]*)"$/, function (this: GraphForgeWorld, query: string) {
+  const priorError = this.error;
+  _catch(this, () => {
+    if (this.forge === null) {
+      throw priorError ?? new Error("no forge instance is open for this scenario");
+    }
+    return this.forge.execute(query);
+  });
+});
 
 When(
   /^I execute "([^"]*)" with parameter name "([^"]*)"$/,
   function (this: GraphForgeWorld, query: string, value: string) {
     _catch(this, () => this.forge!.execute(query, { name: value }));
-  }
+  },
 );
 
-
-When(
-  /^I execute "([^"]*)" without parameters$/,
-  function (this: GraphForgeWorld, query: string) {
-    _catch(this, () => this.forge!.execute(query, undefined));
-  }
-);
+When(/^I execute "([^"]*)" without parameters$/, function (this: GraphForgeWorld, query: string) {
+  _catch(this, () => this.forge!.execute(query, undefined));
+});
 
 When(
   /^I add a node with label "([^"]*)" named "([^"]*)"$/,
@@ -725,7 +687,7 @@ When(
       this.nodes[name] = h;
       return h;
     });
-  }
+  },
 );
 
 When(
@@ -736,7 +698,7 @@ When(
       this.nodes[name] = h;
       return h;
     });
-  }
+  },
 );
 
 When(
@@ -759,7 +721,7 @@ When(
       throw new Error(`unknown selector form ${selector}`);
     }
     _catch(this, () => this.forge!.paths(source, target, algorithm));
-  }
+  },
 );
 
 When(
@@ -782,27 +744,29 @@ When(
       throw new Error(`unknown invalid selector case ${selectorCase}`);
     }
     _catch(this, () => this.forge!.paths(source, bob, algorithm));
-  }
+  },
 );
 
-When(
-  /^I add a node with label "([^"]*)"$/,
-  function (this: GraphForgeWorld, label: string) {
-    _catch(this, () => this.forge!.addNode(label));
-  }
-);
-
+When(/^I add a node with label "([^"]*)"$/, function (this: GraphForgeWorld, label: string) {
+  _catch(this, () => this.forge!.addNode(label));
+});
 
 When(
   'I add a node with label "Person" with an unsupported property value',
   function (this: GraphForgeWorld) {
     _catch(this, () => this.forge!.addNode("Person", { data: function () {} }));
-  }
+  },
 );
 
 When(
   /^I add a "([^"]*)" edge from "([^"]*)" to "([^"]*)" with since (\d+)$/,
-  function (this: GraphForgeWorld, relType: string, srcName: string, dstName: string, yearStr: string) {
+  function (
+    this: GraphForgeWorld,
+    relType: string,
+    srcName: string,
+    dstName: string,
+    yearStr: string,
+  ) {
     const src = this.nodes[srcName];
     const dst = this.nodes[dstName];
     _catch(this, () => {
@@ -810,7 +774,7 @@ When(
       this.edges.push(h);
       return h;
     });
-  }
+  },
 );
 
 When(
@@ -823,16 +787,15 @@ When(
       return;
     }
     _catch(this, () => this.forge!.addEdge(src, relType, dst));
-  }
+  },
 );
-
 
 When(
   'I add a "KNOWS" edge from a raw integer to the node for "Alice"',
   function (this: GraphForgeWorld) {
     const dst = this.nodes["Alice"];
     _catch(this, () => this.forge!.addEdge(42, "KNOWS", dst));
-  }
+  },
 );
 
 When(
@@ -840,20 +803,14 @@ When(
   function (this: GraphForgeWorld) {
     const src = this.nodes["Alice"];
     _catch(this, () => this.forge!.addEdge(src, "KNOWS", 42));
-  }
+  },
 );
 
-When(
-  'I bulk add nodes with label "Person" and 2 records',
-  function (this: GraphForgeWorld) {
-    _catch(this, () =>
-      this.forge!.publishBulkNodes(
-        BDD_NODE_OPERATION,
-        tableToIpc(bulkNodeTable(["Alice", "Bob"]))
-      )
-    );
-  }
-);
+When('I bulk add nodes with label "Person" and 2 records', function (this: GraphForgeWorld) {
+  _catch(this, () =>
+    this.forge!.publishBulkNodes(BDD_NODE_OPERATION, tableToIpc(bulkNodeTable(["Alice", "Bob"]))),
+  );
+});
 
 When(
   'I bulk add nodes with label "Person" from an Arrow Table of 5 rows',
@@ -885,130 +842,121 @@ When(
 When(
   /^I rank "([^"]*)" by "([^"]*)"$/,
   function (this: GraphForgeWorld, label: string, algorithm: string) {
-    _catch(this, () => this.forge!.rank(label, { by: algorithm }));
+    _catch(this, () => this.forge!.rank(label, algorithm));
     this.extra["last_rank"] = this.result;
-  }
+  },
 );
 
 When(
   /^I rank "([^"]*)" by "([^"]*)" writing result to property "([^"]*)"$/,
   function (this: GraphForgeWorld, label: string, algorithm: string, prop: string) {
-    _catch(this, () => this.forge!.rank(label, { by: algorithm, writeProperty: prop }));
-  }
+    _catch(this, () => this.forge!.rank(label, algorithm, undefined, undefined, prop));
+  },
 );
 
 When(
   /^I rank "([^"]*)" by "([^"]*)" via relationship type "([^"]*)"$/,
   function (this: GraphForgeWorld, label: string, algorithm: string, via: string) {
-    _catch(this, () => this.forge!.rank(label, { by: algorithm, via }));
-  }
+    _catch(this, () => this.forge!.rank(label, algorithm, via));
+  },
 );
 
 When(
   /^I rank "([^"]*)" by "([^"]*)" treating edges as directed$/,
   function (this: GraphForgeWorld, label: string, algorithm: string) {
-    _catch(this, () => this.forge!.rank(label, { by: algorithm, directed: true }));
+    _catch(this, () => this.forge!.rank(label, algorithm, undefined, true));
     this.extra["rank_directed"] = this.result;
-  }
+    this.extra["rank_directed_error"] = this.error;
+  },
 );
 
 When(
   /^I rank "([^"]*)" by "([^"]*)" treating edges as undirected$/,
   function (this: GraphForgeWorld, label: string, algorithm: string) {
-    _catch(this, () => this.forge!.rank(label, { by: algorithm, directed: false }));
+    _catch(this, () => this.forge!.rank(label, algorithm, undefined, false));
     this.extra["rank_undirected"] = this.result;
-  }
+    this.extra["rank_undirected_error"] = this.error;
+  },
 );
 
 When(
   /^I cluster "([^"]*)" by "([^"]*)"$/,
   function (this: GraphForgeWorld, label: string, algorithm: string) {
-    _catch(this, () => this.forge!.cluster(label, { by: algorithm }));
-  }
+    _catch(this, () => this.forge!.cluster(label, algorithm));
+  },
 );
 
 When(
   /^I cluster "([^"]*)" by "([^"]*)" writing result to property "([^"]*)"$/,
   function (this: GraphForgeWorld, label: string, algorithm: string, prop: string) {
-    _catch(this, () => this.forge!.cluster(label, { by: algorithm, writeProperty: prop }));
-  }
+    _catch(this, () => this.forge!.cluster(label, algorithm, undefined, undefined, prop));
+  },
 );
 
 When(
   /^I find "([^"]*)" in label "([^"]*)"$/,
   function (this: GraphForgeWorld, query: string, label: string) {
-    _catch(this, () => this.forge!.find(query, { label }));
+    _catch(this, () => this.forge!.find(query, label));
     if (!("first_find_result" in this.extra) && this.extra["first_index_done"]) {
       this.extra["first_find_result"] = this.result;
     }
-  }
+  },
 );
 
 When(
   /^I find "([^"]*)" in label "([^"]*)" with limit (\d+)$/,
   function (this: GraphForgeWorld, query: string, label: string, limitStr: string) {
-    _catch(this, () => this.forge!.find(query, { label, limit: parseInt(limitStr, 10) }));
-  }
+    _catch(this, () =>
+      this.forge!.find(query, label, undefined, undefined, undefined, parseInt(limitStr, 10)),
+    );
+  },
 );
 
-When(
-  'I find by the stored vector in label "Paper"',
-  function (this: GraphForgeWorld) {
-    const vec = this.extra["vector"] as number[];
-    _catch(this, () => this.forge!.find(undefined, { label: "Paper", vector: vec }));
-  }
-);
+When('I find by the stored vector in label "Paper"', function (this: GraphForgeWorld) {
+  const vec = this.extra["vector"] as number[];
+  _catch(this, () => this.forge!.find(undefined, "Paper", vec));
+});
 
 When(
   /^I find by the stored embedding in label "([^"]*)" in space "([^"]*)"$/,
   function (this: GraphForgeWorld, label: string, space: string) {
     const vec = this.extra["embedding"] as number[];
-    _catch(this, () => this.forge!.find(undefined, { label, vector: vec, space }));
-  }
+    _catch(this, () =>
+      this.forge!.find(undefined, label, vec, undefined, undefined, undefined, space),
+    );
+  },
 );
 
 When(
   /^I find "([^"]*)" with the stored vector in label "([^"]*)"$/,
   function (this: GraphForgeWorld, query: string, label: string) {
     const vec = this.extra["vector"] as number[];
-    _catch(this, () => this.forge!.find(query, { label, vector: vec }));
-  }
+    _catch(this, () => this.forge!.find(query, label, vec));
+  },
 );
 
-When(
-  'I find with no query and no vector in label "Paper"',
-  function (this: GraphForgeWorld) {
-    _catch(this, () => this.forge!.find(undefined, { label: "Paper" }));
-  }
-);
+When('I find with no query and no vector in label "Paper"', function (this: GraphForgeWorld) {
+  _catch(this, () => this.forge!.find(undefined, "Paper"));
+});
 
-When(
-  'I find by an empty vector in label "Paper"',
-  function (this: GraphForgeWorld) {
-    _catch(this, () => this.forge!.find(undefined, { label: "Paper", vector: [] }));
-  }
-);
+When('I find by an empty vector in label "Paper"', function (this: GraphForgeWorld) {
+  _catch(this, () => this.forge!.find(undefined, "Paper", []));
+});
 
-When(
-  'I find by a vector containing NaN in label "Paper"',
-  function (this: GraphForgeWorld) {
-    _catch(this, () => this.forge!.find(undefined, { label: "Paper", vector: [NaN, 1.0] }));
-  }
-);
+When('I find by a vector containing NaN in label "Paper"', function (this: GraphForgeWorld) {
+  _catch(this, () => this.forge!.find(undefined, "Paper", [NaN, 1.0]));
+});
 
-When(
-  'I find by a vector containing infinity in label "Paper"',
-  function (this: GraphForgeWorld) {
-    _catch(this, () => this.forge!.find(undefined, { label: "Paper", vector: [Infinity, 1.0] }));
-  }
-);
+When('I find by a vector containing infinity in label "Paper"', function (this: GraphForgeWorld) {
+  _catch(this, () => this.forge!.find(undefined, "Paper", [Infinity, 1.0]));
+});
 
 When(
   /^I find by a (\d+)-dimensional vector in label "([^"]*)"$/,
   function (this: GraphForgeWorld, nStr: string, label: string) {
     const vec = new Array(parseInt(nStr, 10)).fill(1.0);
-    _catch(this, () => this.forge!.find(undefined, { label, vector: vec }));
-  }
+    _catch(this, () => this.forge!.find(undefined, label, vec));
+  },
 );
 
 When(
@@ -1016,7 +964,7 @@ When(
   function (this: GraphForgeWorld, label: string, p1: string, p2: string) {
     _catch(this, () => this.forge!.index(label, { properties: [p1, p2] }));
     this.extra["index_called"] = true;
-  }
+  },
 );
 
 When(
@@ -1025,156 +973,112 @@ When(
     _catch(this, () => this.forge!.index(label, { properties: [prop] }));
     this.extra["index_called"] = true;
     if (!("first_find_result" in this.extra)) {
+      this.extra["first_find_result"] = this.forge!.find("paper", label);
       this.extra["first_index_done"] = true;
     }
-  }
+  },
 );
 
 When(
   /^I index label "([^"]*)" storing the vector for node "([^"]*)" in space "([^"]*)"$/,
   function (this: GraphForgeWorld, label: string, nodeKey: string, space: string) {
-    const nodeId = (this.extra["paper_id"] as string) || (this.nodes[nodeKey]?.uuid);
     const vec = this.extra["embedding"] as number[];
-    _catch(this, () => this.forge!.index(label, { nodeId, vector: vec, space }));
-  }
+    _catch(this, () => {
+      const nodeId = this.nodes[nodeKey]?.uuid ?? (this.extra[nodeKey] as string | undefined);
+      if (!nodeId) throw new Error(`unknown stored node identifier: ${nodeKey}`);
+      return this.forge!.index(label, { nodeId, vector: vec, space });
+    });
+  },
 );
 
-When(
-  'I index label "Paper" on an empty properties list',
-  function (this: GraphForgeWorld) {
-    _catch(this, () => this.forge!.index("Paper", { properties: [] }));
-  }
-);
+When('I index label "Paper" on an empty properties list', function (this: GraphForgeWorld) {
+  _catch(this, () => this.forge!.index("Paper", { properties: [] }));
+});
 
 When(
   'I add a node with label "Paper" titled "Deep Graph Learning"',
   function (this: GraphForgeWorld) {
     const h = this.forge!.addNode("Paper", { title: "Deep Graph Learning" });
     this.nodes["Deep Graph Learning"] = h;
-  }
+  },
 );
 
-When(
-  "I call schema",
-  function (this: GraphForgeWorld) {
-    _catch(this, () => this.forge!.schema());
-  }
-);
+When("I call schema", function (this: GraphForgeWorld) {
+  _catch(this, () => this.forge!.schema());
+});
 
-When(
-  "I call labels",
-  function (this: GraphForgeWorld) {
-    _catch(this, () => this.forge!.labels());
-  }
-);
+When("I call labels", function (this: GraphForgeWorld) {
+  _catch(this, () => this.forge!.labels());
+});
 
-When(
-  "I call relationship_types",
-  function (this: GraphForgeWorld) {
-    _catch(this, () => this.forge!.relationshipTypes());
-  }
-);
+When("I call relationship_types", function (this: GraphForgeWorld) {
+  _catch(this, () => this.forge!.relationshipTypes());
+});
 
-When(
-  /^I call node_count for label "([^"]*)"$/,
-  function (this: GraphForgeWorld, label: string) {
-    _catch(this, () => this.forge!.nodeCount(label));
-  }
-);
+When(/^I call node_count for label "([^"]*)"$/, function (this: GraphForgeWorld, label: string) {
+  _catch(this, () => this.forge!.nodeCount(label));
+});
 
-When(
-  /^I call explain on "([^"]*)"$/,
-  function (this: GraphForgeWorld, query: string) {
-    _catch(this, () => this.forge!.explain(query));
-  }
-);
+When(/^I call explain on "([^"]*)"$/, function (this: GraphForgeWorld, query: string) {
+  _catch(this, () => this.forge!.explain(query));
+});
 
-When(
-  "I call clear",
-  function (this: GraphForgeWorld) {
-    _catch(this, () => this.forge!.clear());
-  }
-);
+When("I call clear", function (this: GraphForgeWorld) {
+  _catch(this, () => this.forge!.clear());
+});
 
-When(
-  "I open a graph at that path",
-  function (this: GraphForgeWorld) {
-    const p = this.extra["path"] as string || "/nonexistent/path";
-    _catch(this, () => {
-      const forge = new GraphForge(p);
-      this.forge = forge;
-      return forge;
-    });
-  }
-);
+When("I open a graph at that path", function (this: GraphForgeWorld) {
+  const p = (this.extra["path"] as string) || "/nonexistent/path";
+  _catch(this, () => {
+    const forge = new GraphForge(p);
+    this.forge = forge;
+    return forge;
+  });
+});
 
-When(
-  "I reopen the forge at the same path",
-  function (this: GraphForgeWorld) {
-    const p = this.extra["path"] as string;
-    _catch(this, () => {
-      this.forge = new GraphForge(p);
-      return this.forge;
-    });
-  }
-);
+When("I reopen the forge at the same path", function (this: GraphForgeWorld) {
+  const p = this.extra["path"] as string;
+  _catch(this, () => {
+    this.forge = new GraphForge(p);
+    return this.forge;
+  });
+});
 
-When(
-  /^I attempt to call (.+)$/,
-  function (this: GraphForgeWorld, method: string) {
-    method = method.trim();
-    if (method.startsWith("execute with query")) {
-      const q = method.split('"')[1];
-      _catch(this, () => this.forge!.execute(q));
-    } else if (method.startsWith("rank with label")) {
-      const parts = method.split('"');
-      _catch(this, () => this.forge!.rank(parts[1], { by: parts[3] }));
-    } else if (method.startsWith("find with text")) {
-      const parts = method.split('"');
-      _catch(this, () => this.forge!.find(parts[1], { label: parts[3] }));
-    } else if (method.startsWith("add_node with label")) {
-      const parts = method.split('"');
-      _catch(this, () => this.forge!.addNode(parts[1], { name: parts[3] }));
-    } else {
-      this.error = codedError("LifecycleError", `Unknown method in step: ${method}`);
-    }
+When(/^I attempt to call (.+)$/, function (this: GraphForgeWorld, method: string) {
+  method = method.trim();
+  if (method.startsWith("execute with query")) {
+    const q = method.split('"')[1];
+    _catch(this, () => this.forge!.execute(q));
+  } else if (method.startsWith("rank with label")) {
+    const parts = method.split('"');
+    _catch(this, () => this.forge!.rank(parts[1], parts[3]));
+  } else if (method.startsWith("find with text")) {
+    const parts = method.split('"');
+    _catch(this, () => this.forge!.find(parts[1], parts[3]));
+  } else if (method.startsWith("add_node with label")) {
+    const parts = method.split('"');
+    _catch(this, () => this.forge!.addNode(parts[1], { name: parts[3] }));
+  } else {
+    throw new Error(`unmapped method in step: ${method}`);
   }
-);
+});
 
-When(
-  "I load the ontology from that file",
-  function (this: GraphForgeWorld) {
-    const p = this.extra["ontology_path"] as string;
-    _catch(this, () => this.forge!.loadOntology(p));
-  }
-);
+When("I load the ontology from that file", function (this: GraphForgeWorld) {
+  const p = this.extra["ontology_path"] as string;
+  _catch(this, () => this.forge!.loadOntology(p));
+});
 
-When(
-  /^I analyze by "([^"]*)"$/,
-  function (this: GraphForgeWorld, algorithm: string) {
-    _catch(this, () => this.forge!.analyze(algorithm));
-  }
-);
-
-When(
-  /^I call neighbourhood for "([^"]*)" with hops (\d+) in label "([^"]*)" using canonical property "([^"]*)"$/,
-  function (this: GraphForgeWorld, canonical: string, hopsStr: string, label: string, prop: string) {
-    // neighbourhood recipe not yet implemented at Node skeleton stage
-    this.result = null;
-    this.error = new Error("not implemented");
-  }
-);
+When(/^I analyze by "([^"]*)"$/, function (this: GraphForgeWorld, algorithm: string) {
+  _catch(this, () => this.forge!.analyze(algorithm));
+});
 
 // ---------------------------------------------------------------------------
 // THEN steps
 // ---------------------------------------------------------------------------
 
-Then(
-  "the result is an Arrow Table",
-  function (this: GraphForgeWorld) {
-    resultTable(this); // throws if the query errored or the result is not Arrow IPC
-  }
-);
+Then("the result is an Arrow Table", function (this: GraphForgeWorld) {
+  resultTable(this); // throws if the query errored or the result is not Arrow IPC
+});
 
 function assertHasColumn(world: GraphForgeWorld, col: string): void {
   const table = resultTable(world);
@@ -1192,7 +1096,7 @@ Then(
   /^the result schema contains column "([^"]*)"$/,
   function (this: GraphForgeWorld, col: string) {
     assertHasColumn(this, col);
-  }
+  },
 );
 
 function assertRowCount(world: GraphForgeWorld, n: number, atMost = false): void {
@@ -1227,20 +1131,19 @@ Then(
   function (this: GraphForgeWorld, col: string, val: string) {
     const got = firstRowValue(this, col);
     if (String(got) !== val) {
-      throw new Error(`first row "${col}": expected ${JSON.stringify(val)}, got ${JSON.stringify(got)}`);
+      throw new Error(
+        `first row "${col}": expected ${JSON.stringify(val)}, got ${JSON.stringify(got)}`,
+      );
     }
-  }
+  },
 );
 
-Then(
-  /^the first row value for "([^"]*)" is null$/,
-  function (this: GraphForgeWorld, col: string) {
-    const got = firstRowValue(this, col);
-    if (got !== null) {
-      throw new Error(`first row "${col}": expected null, got ${JSON.stringify(got)}`);
-    }
+Then(/^the first row value for "([^"]*)" is null$/, function (this: GraphForgeWorld, col: string) {
+  const got = firstRowValue(this, col);
+  if (got !== null) {
+    throw new Error(`first row "${col}": expected null, got ${JSON.stringify(got)}`);
   }
-);
+});
 
 function expectErrCode(world: GraphForgeWorld, code: string): void {
   const got = errCode(world.error);
@@ -1288,14 +1191,11 @@ Then("an OntologyError is raised", function (this: GraphForgeWorld) {
   expectErrCode(this, "OntologyError");
 });
 
-Then(
-  "no error is raised",
-  function (this: GraphForgeWorld) {
-    if (this.error !== null) {
-      throw new Error(`Unexpected error: ${this.error.message}`);
-    }
+Then("no error is raised", function (this: GraphForgeWorld) {
+  if (this.error !== null) {
+    throw new Error(`Unexpected error: ${this.error.message}`);
   }
-);
+});
 
 Then(
   /^the result is a NodeHandle with label "([^"]*)"$/,
@@ -1307,7 +1207,7 @@ Then(
     if (handle.label !== label) {
       throw new Error(`expected label ${label}, got ${handle.label}`);
     }
-  }
+  },
 );
 
 Then(
@@ -1320,7 +1220,7 @@ Then(
     if ("id" in handle || "get" in handle) {
       throw new Error("NodeHandle exposed a surrogate or property cache");
     }
-  }
+  },
 );
 
 Then(
@@ -1329,8 +1229,8 @@ Then(
     const escapedName = name.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
     const table = tableFromIPC(
       this.forge!.execute(
-        `MATCH (n {name: '${escapedName}'}) RETURN n.node_uuid AS uuid, n.name AS name`
-      )
+        `MATCH (n {name: '${escapedName}'}) RETURN n.node_uuid AS uuid, n.name AS name`,
+      ),
     );
     if (table.numRows !== 1 || table.getChild("name")?.get(0) !== name) {
       throw new Error(`UUID readback did not return ${name}`);
@@ -1340,32 +1240,34 @@ Then(
     if (actual !== this.nodes[name].uuid.replaceAll("-", "")) {
       throw new Error(`UUID readback ${actual} did not match ${this.nodes[name].uuid}`);
     }
-  }
+  },
 );
 
 Then(
   "the result is an EdgeHandle with UUID identity and no numeric surrogate",
   function (this: GraphForgeWorld) {
     if (!(this.result instanceof EdgeHandle)) {
-      return "pending";
+      throw new Error(`expected native EdgeHandle, got ${String(this.result)}`);
     }
     const handle = this.result as { uuid?: unknown; id?: unknown };
     if (typeof handle.uuid !== "string" || "id" in handle) {
       throw new Error("EdgeHandle exposed a numeric surrogate");
     }
-  }
+  },
 );
 
 Then(
   /^execute "([^"]*)" returns (\d+) rows$/,
   function (this: GraphForgeWorld, query: string, nStr: string) {
     const buf = this.forge!.execute(query);
+    this.result = buf;
+    this.error = null;
     const table = tableFromIPC(buf as Buffer);
     const want = parseInt(nStr, 10);
     if (table.numRows !== want) {
       throw new Error(`execute "${query}": expected ${want} rows, got ${table.numRows}`);
     }
-  }
+  },
 );
 
 Then(
@@ -1387,20 +1289,24 @@ Then(
 
 Then(
   /^execute "([^"]*)" returns (\d+) row$/,
-  function (this: GraphForgeWorld, _query: string, _nStr: string) {
-    return "pending";
-  }
+  function (this: GraphForgeWorld, query: string, nStr: string) {
+    const buf = this.forge!.execute(query) as Buffer;
+    this.result = buf;
+    this.error = null;
+    const table = tableFromIPC(buf);
+    const want = parseInt(nStr, 10);
+    if (table.numRows !== want) {
+      throw new Error(`execute "${query}": expected ${want} row, got ${table.numRows}`);
+    }
+  },
 );
 
-Then(
-  "the string representation contains the NodeHandle UUID",
-  function (this: GraphForgeWorld) {
-    const handle = this.result as { uuid: string; toString(): string };
-    if (!handle.toString().includes(handle.uuid)) {
-      throw new Error(`handle representation omitted UUID: ${handle.toString()}`);
-    }
+Then("the string representation contains the NodeHandle UUID", function (this: GraphForgeWorld) {
+  const handle = this.result as { uuid: string; toString(): string };
+  if (!handle.toString().includes(handle.uuid)) {
+    throw new Error(`handle representation omitted UUID: ${handle.toString()}`);
   }
-);
+});
 
 Then(
   /^the string representation does not contain cached property "([^"]*)"$/,
@@ -1408,7 +1314,7 @@ Then(
     if (String(this.result).includes(property)) {
       throw new Error(`handle representation cached property ${property}`);
     }
-  }
+  },
 );
 
 Then("the path request reaches Rust dispatch", function (this: GraphForgeWorld) {
@@ -1427,60 +1333,46 @@ Then("a structured selector error is raised", function (this: GraphForgeWorld) {
   expectErrCode(this, "ValidationError");
 });
 
-Then(
-  /^the result is (\d+)$/,
-  function (this: GraphForgeWorld, nStr: string) {
-    if (this.error) throw this.error;
-    const expected = parseInt(nStr, 10);
-    if (this.result !== expected) {
-      throw new Error(`expected ${expected}, got ${String(this.result)}`);
-    }
+Then(/^the result is (\d+)$/, function (this: GraphForgeWorld, nStr: string) {
+  if (this.error) throw this.error;
+  const expected = parseInt(nStr, 10);
+  if (this.result !== expected) {
+    throw new Error(`expected ${expected}, got ${String(this.result)}`);
   }
-);
+});
 
-Then(
-  "the result is a non-empty string",
-  function (this: GraphForgeWorld) {
-    if (this.error) throw new Error(`expected a string result, but errored: ${this.error.message}`);
-    if (typeof this.result !== "string" || this.result.length === 0) {
-      throw new Error(`expected a non-empty string, got: ${JSON.stringify(this.result)}`);
-    }
+Then("the result is a non-empty string", function (this: GraphForgeWorld) {
+  if (this.error) throw new Error(`expected a string result, but errored: ${this.error.message}`);
+  if (typeof this.result !== "string" || this.result.length === 0) {
+    throw new Error(`expected a non-empty string, got: ${JSON.stringify(this.result)}`);
   }
-);
+});
 
-Then(
-  /^the result contains "([^"]*)"$/,
-  function (this: GraphForgeWorld, text: string) {
-    if (this.error) throw new Error(`expected a result, but errored: ${this.error.message}`);
-    if (typeof this.result === "string") {
-      if (!this.result.includes(text)) throw new Error(`result string does not contain "${text}"`);
-    } else if (Array.isArray(this.result)) {
-      if (!(this.result as string[]).includes(text)) throw new Error(`result list does not contain "${text}"`);
-    } else {
-      throw new Error(`expected a string or list result, got: ${typeof this.result}`);
-    }
+Then(/^the result contains "([^"]*)"$/, function (this: GraphForgeWorld, text: string) {
+  if (this.error) throw new Error(`expected a result, but errored: ${this.error.message}`);
+  if (typeof this.result === "string") {
+    if (!this.result.includes(text)) throw new Error(`result string does not contain "${text}"`);
+  } else if (Array.isArray(this.result)) {
+    if (!(this.result as string[]).includes(text))
+      throw new Error(`result list does not contain "${text}"`);
+  } else {
+    throw new Error(`expected a string or list result, got: ${typeof this.result}`);
   }
-);
+});
 
-Then(
-  "the result is an empty list",
-  function (this: GraphForgeWorld) {
-    if (this.error) throw this.error;
-    if (!Array.isArray(this.result) || (this.result as unknown[]).length !== 0) {
-      throw new Error(`expected an empty list, got ${JSON.stringify(this.result)}`);
-    }
+Then("the result is an empty list", function (this: GraphForgeWorld) {
+  if (this.error) throw this.error;
+  if (!Array.isArray(this.result) || (this.result as unknown[]).length !== 0) {
+    throw new Error(`expected an empty list, got ${JSON.stringify(this.result)}`);
   }
-);
+});
 
-Then(
-  "calling relationship_types also returns an empty list",
-  function (this: GraphForgeWorld) {
-    const result = this.forge!.relationshipTypes();
-    if (!Array.isArray(result) || result.length !== 0) {
-      throw new Error(`expected no relationship types, got ${JSON.stringify(result)}`);
-    }
+Then("calling relationship_types also returns an empty list", function (this: GraphForgeWorld) {
+  const result = this.forge!.relationshipTypes();
+  if (!Array.isArray(result) || result.length !== 0) {
+    throw new Error(`expected no relationship types, got ${JSON.stringify(result)}`);
   }
-);
+});
 
 Then(
   /^the table contains an entry for label "([^"]*)"$/,
@@ -1490,106 +1382,150 @@ Then(
     if (!labels || ![...labels.toArray()].includes(label)) {
       throw new Error(`schema does not contain label ${label}`);
     }
-  }
+  },
 );
 
-Then(
-  "the two score results are not identical",
-  function (this: GraphForgeWorld) {
-    return "pending";
+Then("the two score results are not identical", function (this: GraphForgeWorld) {
+  const directedError = this.extra["rank_directed_error"] as Error | null;
+  const undirectedError = this.extra["rank_undirected_error"] as Error | null;
+  if (directedError) throw directedError;
+  if (undirectedError) throw undirectedError;
+  const scores = (value: unknown) => {
+    if (!(value instanceof Buffer)) throw new Error("rank result was not Arrow IPC");
+    return [...(tableFromIPC(value).getChild("score")?.toArray() ?? [])].map(Number);
+  };
+  const directed = scores(this.extra["rank_directed"]);
+  const undirected = scores(this.extra["rank_undirected"]);
+  if (JSON.stringify(directed) === JSON.stringify(undirected)) {
+    throw new Error(`directed and undirected scores were identical: ${JSON.stringify(directed)}`);
   }
-);
+});
 
-Then(
-  "the 2 connected nodes share the same community_id",
-  function (this: GraphForgeWorld) {
-    return "pending";
+Then("the 2 connected nodes share the same community_id", function (this: GraphForgeWorld) {
+  const table = resultTable(this);
+  const nameColumn = table.getChild("name");
+  const communityColumn = table.getChild("community_id");
+  if (!nameColumn || !communityColumn) {
+    throw new Error('cluster result requires "name" and "community_id" columns');
   }
-);
+  const names = nameColumn.toArray();
+  const communities = communityColumn.toArray();
+  const byName = new Map([...names].map((name, index) => [String(name), communities[index]]));
+  for (const required of ["Alice", "Bob"]) {
+    if (!byName.has(required)) throw new Error(`cluster result omitted row for ${required}`);
+  }
+  if (byName.get("Alice") !== byName.get("Bob")) {
+    throw new Error("Alice and Bob did not share a community_id");
+  }
+  this.extra["communities"] = byName;
+});
 
-Then(
-  "the 2 isolated nodes share a different community_id",
-  function (this: GraphForgeWorld) {
-    return "pending";
+Then("the 2 isolated nodes share a different community_id", function (this: GraphForgeWorld) {
+  const byName = this.extra["communities"] as Map<string, unknown>;
+  if (!byName) throw new Error("community map was not captured by the preceding step");
+  for (const required of ["Carol", "Dave"]) {
+    if (!byName.has(required)) throw new Error(`cluster result omitted row for ${required}`);
   }
-);
+  if (byName.get("Carol") !== byName.get("Dave")) {
+    throw new Error("Carol and Dave did not share a community_id");
+  }
+  if (byName.get("Alice") === byName.get("Carol")) {
+    throw new Error("disconnected groups shared a community_id");
+  }
+});
 
 // Used as both Given (setup) and Then (assertion) in find.feature
-Given(
-  "no explicit index call was made before find",
-  function (this: GraphForgeWorld) {
-    if (!("index_called" in this.extra)) {
-      // Given context — initialise the flag
-      this.extra["index_called"] = false;
-    } else {
-      // Then context — assert
-      if (this.extra["index_called"]) {
-        throw new Error("Index was called before find");
-      }
+Given("no explicit index call was made before find", function (this: GraphForgeWorld) {
+  if (!("index_called" in this.extra)) {
+    // Given context — initialise the flag
+    this.extra["index_called"] = false;
+  } else {
+    // Then context — assert
+    if (this.extra["index_called"]) {
+      throw new Error("Index was called before find");
     }
   }
-);
+});
 
 Then(
   /^for each result row the id is valid in execute "([^"]*)"$/,
-  function (this: GraphForgeWorld, _query: string) {
-    if (this.error) return "pending";
-    return "pending";
-  }
+  function (this: GraphForgeWorld, query: string) {
+    const table = resultTable(this);
+    const ids = table.getChild("node_uuid");
+    if (!ids || table.numRows === 0) throw new Error("find returned no node_uuid rows");
+    for (const value of ids.toArray()) {
+      const hex = Buffer.from(value as Uint8Array).toString("hex");
+      const uuid = `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+      const readback = tableFromIPC(this.forge!.execute(query, { id: { $uuid: uuid } }));
+      if (readback.numRows !== 1) throw new Error(`node_uuid ${uuid} was not addressable`);
+    }
+  },
 );
 
-Then(
-  /^all result rows have label "([^"]*)"$/,
-  function (this: GraphForgeWorld, _label: string) {
-    if (this.error) return "pending";
-    return "pending";
+Then(/^all result rows have label "([^"]*)"$/, function (this: GraphForgeWorld, label: string) {
+  const table = resultTable(this);
+  const ids = table.getChild("node_uuid");
+  if (!ids || table.numRows === 0) throw new Error("find returned no rows to validate");
+  for (const value of ids.toArray()) {
+    const hex = Buffer.from(value as Uint8Array).toString("hex");
+    const uuid = `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+    const query = `MATCH (n:${label}) WHERE n.node_uuid = $id RETURN n.node_uuid`;
+    const readback = tableFromIPC(this.forge!.execute(query, { id: { $uuid: uuid } }));
+    if (readback.numRows !== 1) throw new Error(`node_uuid ${uuid} was not a ${label}`);
   }
-);
+});
 
-Then(
-  "the result contains that node",
-  function (this: GraphForgeWorld) {
-    if (this.error) return "pending";
-    return "pending";
-  }
-);
+Then("the result contains that node", function (this: GraphForgeWorld) {
+  const table = resultTable(this);
+  const ids = table.getChild("node_uuid");
+  const expected = String(this.extra["paper_id"] ?? "").replace(/-/g, "");
+  const actual = [...(ids?.toArray() ?? [])].map((value) =>
+    Buffer.from(value as Uint8Array).toString("hex"),
+  );
+  if (!actual.includes(expected)) throw new Error(`result omitted node ${expected}`);
+});
 
 Then(
   'find "paper" in label "Paper" returns the same results as after the first index call',
   function (this: GraphForgeWorld) {
-    if (this.error) return "pending";
-    return "pending";
-  }
+    if (this.error) throw this.error;
+    const first = this.extra["first_find_result"];
+    const second = this.forge!.find("paper", "Paper");
+    const rows = (value: unknown, which: string) => {
+      if (!(value instanceof Buffer)) throw new Error(`${which} find result was not Arrow IPC`);
+      return JSON.stringify(tableFromIPC(value).toArray());
+    };
+    if (rows(first, "first") !== rows(second, "second")) {
+      throw new Error("repeated index changed deterministic find results");
+    }
+  },
 );
 
 Then(
   /^the result contains a row with title "([^"]*)"$/,
-  function (this: GraphForgeWorld, _title: string) {
-    if (this.error) return "pending";
-    return "pending";
-  }
+  function (this: GraphForgeWorld, title: string) {
+    const table = resultTable(this);
+    const titles = [...(table.getChild("title")?.toArray() ?? [])].map(String);
+    if (!titles.includes(title)) throw new Error(`result omitted title ${title}`);
+  },
 );
 
-Then(
-  /^the result contains a row for "([^"]*)"$/,
-  function (this: GraphForgeWorld, _name: string) {
-    if (this.error) return "pending";
-    return "pending";
-  }
-);
+Then(/^the result contains a row for "([^"]*)"$/, function (this: GraphForgeWorld, name: string) {
+  const table = resultTable(this);
+  const names = [...(table.getChild("name")?.toArray() ?? [])].map(String);
+  if (!names.includes(name)) throw new Error(`result omitted row for ${name}`);
+});
 
 Then(
   /^the result does not contain a row for "([^"]*)"$/,
-  function (this: GraphForgeWorld, _name: string) {
-    if (this.error) return "pending";
-    return "pending";
-  }
+  function (this: GraphForgeWorld, name: string) {
+    const table = resultTable(this);
+    const names = [...(table.getChild("name")?.toArray() ?? [])].map(String);
+    if (names.includes(name)) throw new Error(`result unexpectedly included row for ${name}`);
+  },
 );
 
-Then(
-  "the result is an Arrow Table with at least 1 row",
-  function (this: GraphForgeWorld) {
-    if (this.error) return "pending";
-    return "pending";
-  }
-);
+Then("the result is an Arrow Table with at least 1 row", function (this: GraphForgeWorld) {
+  const table = resultTable(this);
+  if (table.numRows < 1) throw new Error("expected at least one Arrow row");
+});

--- a/tests/features/steps/api_steps.py
+++ b/tests/features/steps/api_steps.py
@@ -1,11 +1,12 @@
 """pytest-bdd steps shared by the public API feature corpus.
 
-Implemented surfaces run strictly; unsupported milestone areas remain xfailed.
+Required public API behavior runs strictly and fails closed.
 """
 
 from __future__ import annotations
 
 from typing import Any
+import uuid
 
 import pyarrow as pa
 import pytest
@@ -64,10 +65,6 @@ def ctx():
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _xfail_not_implemented():
-    pytest.xfail("Stub: real implementation not yet available")
 
 
 def _catch(fn, *args, **kwargs):
@@ -803,7 +800,12 @@ def when_bulk_add_edges(ctx):
         return
     records = [{"src_id": nodes[0].uuid, "dst_id": nodes[1].uuid}]
     ctx.result, ctx.error = _catch(
-        ctx.forge.add_edges, "KNOWS", records, src="src_id", dst="dst_id"
+        ctx.forge.add_edges,
+        "KNOWS",
+        records,
+        operation_uuid=nodes[0].uuid,
+        src="src_id",
+        dst="dst_id",
     )
 
 
@@ -925,7 +927,7 @@ def when_find_wrong_dim(ctx, n, label):
 def when_index_two_props(ctx, label, p1, p2):
     ctx.result, ctx.error = _catch(ctx.forge.index, label, properties=[p1, p2])
     if isinstance(ctx.error, TypeError):
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
     ctx.extra["index_called"] = True
 
 
@@ -933,9 +935,10 @@ def when_index_two_props(ctx, label, p1, p2):
 def when_index_one_prop(ctx, label, prop):
     ctx.result, ctx.error = _catch(ctx.forge.index, label, properties=[prop])
     if isinstance(ctx.error, TypeError):
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
     ctx.extra["index_called"] = True
     if "first_find_result" not in ctx.extra:
+        ctx.extra["first_find_result"] = ctx.forge.find("paper", label=label)
         ctx.extra["first_index_done"] = True
 
 
@@ -1067,18 +1070,16 @@ def when_find_text_shared(ctx, query_text, label):
 
 @then("the result is an Arrow Table")
 def then_arrow_table(ctx):
-    if ctx.error:
-        _xfail_not_implemented()
+    assert ctx.error is None, f"unexpected error: {ctx.error!r}"
     assert isinstance(ctx.result, pa.Table), f"Expected Arrow Table, got {type(ctx.result)}"
 
 
 @then(parsers.parse('the table has column "{col}"'))
 def then_has_column(ctx, col):
-    if ctx.error:
-        _xfail_not_implemented()
+    assert ctx.error is None, f"unexpected error: {ctx.error!r}"
     assert isinstance(ctx.result, pa.Table)
     if col not in ctx.result.schema.names:
-        _xfail_not_implemented()
+        raise AssertionError(f"missing result column: {col}")
 
 
 @then(parsers.parse('the result schema contains column "{col}"'))
@@ -1088,11 +1089,10 @@ def then_schema_has_column(ctx, col):
 
 @then(parsers.parse("the table has {n:d} rows"))
 def then_row_count(ctx, n):
-    if ctx.error:
-        _xfail_not_implemented()
+    assert ctx.error is None, f"unexpected error: {ctx.error!r}"
     assert isinstance(ctx.result, pa.Table)
     if ctx.result.num_rows != n:
-        _xfail_not_implemented()
+        raise AssertionError(f"expected {n} rows, got {ctx.result.num_rows}")
 
 
 @then(parsers.parse("the table has {n:d} row"))
@@ -1108,83 +1108,81 @@ def then_is_dag_value(ctx, expected):
 
 @then(parsers.parse("the table has at most {n:d} rows"))
 def then_at_most_rows(ctx, n):
-    if ctx.error:
-        _xfail_not_implemented()
+    assert ctx.error is None, f"unexpected error: {ctx.error!r}"
     assert isinstance(ctx.result, pa.Table)
     if ctx.result.num_rows > n:
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
 
 
 @then(parsers.parse('the first row value for "{col}" is "{val}"'))
 def then_first_row_str(ctx, col, val):
-    if ctx.error:
-        _xfail_not_implemented()
+    assert ctx.error is None, f"unexpected error: {ctx.error!r}"
     assert isinstance(ctx.result, pa.Table)
     if ctx.result.num_rows == 0 or col not in ctx.result.schema.names:
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
     actual = ctx.result.column(col)[0].as_py()
     if actual != val:
-        _xfail_not_implemented()
+        raise AssertionError(f"expected first {col} value {val!r}, got {actual!r}")
 
 
 @then(parsers.parse('the first row value for "{col}" is null'))
 def then_first_row_null(ctx, col):
-    if ctx.error:
-        _xfail_not_implemented()
+    assert ctx.error is None, f"unexpected error: {ctx.error!r}"
     assert isinstance(ctx.result, pa.Table)
     if ctx.result.num_rows == 0 or col not in ctx.result.schema.names:
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
     actual = ctx.result.column(col)[0].as_py()
     if actual is not None:
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
 
 
 @then("a ParseError is raised")
 def then_parse_error(ctx):
     if not isinstance(ctx.error, ParseError):
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
 
 
 @then("the error includes a source span")
 def then_has_span(ctx):
     if not isinstance(ctx.error, ParseError) or ctx.error.span is None:
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
 
 
 @then("an ExecutionError is raised")
 def then_execution_error(ctx):
     if not isinstance(ctx.error, ExecutionError):
-        _xfail_not_implemented()
+        actual = type(ctx.error).__name__ if ctx.error is not None else "no error"
+        raise AssertionError(f"expected ExecutionError, got {actual}")
 
 
 @then("a StorageError is raised")
 def then_storage_error(ctx):
     if not isinstance(ctx.error, StorageError):
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
 
 
 @then("a LifecycleError is raised")
 def then_lifecycle_error(ctx):
     if not isinstance(ctx.error, LifecycleError):
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
 
 
 @then("a TypeError is raised")
 def then_type_error(ctx):
     if not isinstance(ctx.error, TypeError):
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
 
 
 @then("a ValidationError is raised")
 def then_validation_error(ctx):
     if not isinstance(ctx.error, ValidationError):
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
 
 
 @then("an OntologyError is raised")
 def then_ontology_error(ctx):
     if not isinstance(ctx.error, OntologyError):
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
 
 
 @then("no error is raised")
@@ -1196,7 +1194,7 @@ def then_no_error(ctx):
 @then(parsers.parse('the result is a NodeHandle with label "{label}"'))
 def then_node_handle(ctx, label):
     if ctx.error or not isinstance(ctx.result, NodeHandle):
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
     assert NodeHandle is graphforge.NodeHandle
     assert ctx.result.label == label
 
@@ -1204,7 +1202,7 @@ def then_node_handle(ctx, label):
 @then("the NodeHandle exposes UUID identity with no numeric surrogate")
 def then_node_handle_uuid_only(ctx):
     if ctx.error or not isinstance(ctx.result, NodeHandle):
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
     assert isinstance(ctx.result.uuid, str)
     assert not hasattr(ctx.result, "id")
     assert not hasattr(ctx.result, "get")
@@ -1224,7 +1222,7 @@ def then_execute_with_uuid_returns_name(ctx, name):
 @then("the result is an EdgeHandle with UUID identity and no numeric surrogate")
 def then_edge_handle(ctx):
     if ctx.error or not isinstance(ctx.result, EdgeHandle):
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
     assert isinstance(ctx.result.uuid, str)
     assert not hasattr(ctx.result, "id")
     assert not hasattr(ctx.result, "edge_id")
@@ -1234,27 +1232,30 @@ def then_edge_handle(ctx):
 def then_execute_n_rows(ctx, query, n):
     ctx.result = ctx.forge.execute(query)
     if ctx.result.num_rows != n:
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
 
 
 @then(parsers.parse('execute "{query}" returns {n:d} row with value {val:d}'))
 def then_execute_1_row_value(ctx, query, n, val):
     result = ctx.forge.execute(query)
     if result.num_rows != n:
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
+    if result.num_rows == 0 or result.column(0)[0].as_py() != val:
+        raise AssertionError("required public API contract was not satisfied")
+    ctx.result = result
 
 
 @then("the string representation contains the NodeHandle UUID")
 def then_handle_repr_contains_uuid(ctx):
     if ctx.error or not isinstance(ctx.result, NodeHandle):
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
     assert ctx.result.uuid in str(ctx.result)
 
 
 @then(parsers.parse('the string representation does not contain cached property "{text}"'))
 def then_repr_excludes_cached_property(ctx, text):
     if ctx.error or not isinstance(ctx.result, NodeHandle):
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
     assert text not in str(ctx.result)
 
 
@@ -1273,35 +1274,31 @@ def then_structured_selector_error(ctx):
 
 @then(parsers.parse("the result is {n:d}"))
 def then_result_is_n(ctx, n):
-    if ctx.error:
-        _xfail_not_implemented()
+    assert ctx.error is None, f"unexpected error: {ctx.error!r}"
     if ctx.result != n:
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
 
 
 @then("the result is a non-empty string")
 def then_nonempty_string(ctx):
-    if ctx.error:
-        _xfail_not_implemented()
+    assert ctx.error is None, f"unexpected error: {ctx.error!r}"
     assert isinstance(ctx.result, str) and len(ctx.result) > 0
 
 
 @then(parsers.parse('the result contains "{text}"'))
 def then_result_contains_text(ctx, text):
-    if ctx.error:
-        _xfail_not_implemented()
+    assert ctx.error is None, f"unexpected error: {ctx.error!r}"
     if isinstance(ctx.result, str):
         assert text in ctx.result, f"{text!r} not in explain output"
     elif isinstance(ctx.result, list):
         assert text in ctx.result, f"{text!r} not in list result"
     else:
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
 
 
 @then("the result is an empty list")
 def then_empty_list(ctx):
-    if ctx.error:
-        _xfail_not_implemented()
+    assert ctx.error is None, f"unexpected error: {ctx.error!r}"
     assert ctx.result == []
 
 
@@ -1314,12 +1311,12 @@ def then_rel_types_empty(ctx):
 @then(parsers.parse('the table contains an entry for label "{label}"'))
 def then_schema_has_label(ctx, label):
     if ctx.error or not isinstance(ctx.result, pa.Table):
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
     if "label" not in ctx.result.schema.names:
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
     labels = ctx.result.column("label").to_pylist()
     if label not in labels:
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
 
 
 @then("the two score results are not identical")
@@ -1327,12 +1324,12 @@ def then_scores_differ(ctx):
     d = ctx.extra.get("rank_directed")
     u = ctx.extra.get("rank_undirected")
     if d is None or u is None:
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
     if d.num_rows == 0:
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
     # Compare score columns
     if d.equals(u):
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
 
 
 @then("the 2 connected nodes share the same community_id")
@@ -1367,80 +1364,109 @@ def then_no_index_call(ctx):
     assert not ctx.extra.get("index_called", False)
 
 
-@then('for each result row the id is valid in execute "MATCH (n) WHERE id(n) = $id RETURN n"')
+@then('for each result row the id is valid in execute "MATCH (n) WHERE n.node_uuid = $id RETURN n"')
 def then_ids_addressable(ctx):
-    if ctx.error or not isinstance(ctx.result, pa.Table):
-        _xfail_not_implemented()
-    if ctx.result.num_rows == 0:
-        _xfail_not_implemented()
+    assert ctx.error is None, f"unexpected error: {ctx.error!r}"
+    assert isinstance(ctx.result, pa.Table)
+    ids = ctx.result.column("node_uuid").to_pylist()
+    assert ids
+    for value in ids:
+        identifier = uuid.UUID(bytes=value) if isinstance(value, bytes) else uuid.UUID(str(value))
+        result = ctx.forge.execute(
+            "MATCH (n) WHERE n.node_uuid = $id RETURN n",
+            {"id": identifier},
+        )
+        assert result.num_rows == 1
 
 
 @then(parsers.parse('all result rows have label "{label}"'))
 def then_all_rows_label(ctx, label):
-    if ctx.error or not isinstance(ctx.result, pa.Table):
-        _xfail_not_implemented()
-    if ctx.result.num_rows == 0:
-        _xfail_not_implemented()
+    assert ctx.error is None, f"unexpected error: {ctx.error!r}"
+    assert isinstance(ctx.result, pa.Table)
+    ids = ctx.result.column("node_uuid").to_pylist()
+    assert ids
+    for value in ids:
+        identifier = uuid.UUID(bytes=value) if isinstance(value, bytes) else uuid.UUID(str(value))
+        result = ctx.forge.execute(
+            f"MATCH (n:{label}) WHERE n.node_uuid = $id RETURN n.node_uuid",
+            {"id": identifier},
+        )
+        assert result.num_rows == 1
 
 
 @then("the result contains that node")
 def then_result_contains_node(ctx):
     if ctx.error or not isinstance(ctx.result, pa.Table):
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
     if ctx.result.num_rows == 0:
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
+    if "node_uuid" not in ctx.result.schema.names:
+        raise AssertionError("required public API contract was not satisfied")
+    expected = str(ctx.extra["paper_id"]).replace("-", "").lower()
+    actual = {
+        value.hex() if isinstance(value, bytes) else str(value).replace("-", "").lower()
+        for value in ctx.result.column("node_uuid").to_pylist()
+    }
+    if expected not in actual:
+        raise AssertionError("required public API contract was not satisfied")
 
 
 @then('find "paper" in label "Paper" returns the same results as after the first index call')
 def then_idempotent_index(ctx):
-    if ctx.error:
-        _xfail_not_implemented()
-    # Idempotency: second call should not error. Result equality is out of scope for stub.
+    assert ctx.error is None, f"unexpected error: {ctx.error!r}"
+    second = ctx.forge.find("paper", label="Paper")
+    assert ctx.extra["first_find_result"].equals(second)
 
 
 @then(parsers.parse('the result contains a row with title "{title}"'))
 def then_result_has_title(ctx, title):
     if ctx.error or not isinstance(ctx.result, pa.Table):
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
     if "title" not in ctx.result.schema.names or ctx.result.num_rows == 0:
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
     titles = ctx.result.column("title").to_pylist()
     if title not in titles:
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
 
 
 @then(parsers.parse('the result contains a row for "{name}"'))
 def then_result_has_row_for(ctx, name):
-    if ctx.error:
-        _xfail_not_implemented()
+    assert ctx.error is None, f"unexpected error: {ctx.error!r}"
     if isinstance(ctx.result, pa.Table):
-        if ctx.result.num_rows == 0:
-            _xfail_not_implemented()
+        if "name" not in ctx.result.schema.names:
+            raise AssertionError("required public API contract was not satisfied")
+        if name not in ctx.result.column("name").to_pylist():
+            raise AssertionError("required public API contract was not satisfied")
     elif isinstance(ctx.result, list):
         names = [r.get("name") or r.get("canonical") for r in ctx.result]
         if name not in names:
-            _xfail_not_implemented()
+            raise AssertionError("required public API contract was not satisfied")
+    else:
+        raise AssertionError("required public API contract was not satisfied")
 
 
 @then(parsers.parse('the result does not contain a row for "{name}"'))
 def then_result_no_row_for(ctx, name):
-    if ctx.error:
-        _xfail_not_implemented()
+    assert ctx.error is None, f"unexpected error: {ctx.error!r}"
     if isinstance(ctx.result, pa.Table):
-        if ctx.result.num_rows == 0:
-            return  # empty — does not contain it, pass
+        if "name" not in ctx.result.schema.names:
+            raise AssertionError("required public API contract was not satisfied")
+        if name in ctx.result.column("name").to_pylist():
+            raise AssertionError("required public API contract was not satisfied")
     elif isinstance(ctx.result, list):
         names = [r.get("name") or r.get("canonical") for r in ctx.result]
         if name in names:
-            _xfail_not_implemented()
+            raise AssertionError("required public API contract was not satisfied")
+    else:
+        raise AssertionError("required public API contract was not satisfied")
 
 
 @then("the result is an Arrow Table with at least 1 row")
 def then_arrow_at_least_1(ctx):
     if ctx.error or not isinstance(ctx.result, pa.Table):
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
     if ctx.result.num_rows < 1:
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
 
 
 # ---------------------------------------------------------------------------
@@ -1455,14 +1481,14 @@ def then_arrow_at_least_1(ctx):
 def then_execute_returns_n_rows(ctx, query, n):
     ctx.result = ctx.forge.execute(query)
     if ctx.result.num_rows != n:
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
 
 
 @then(parsers.parse('execute "{query}" returns {n:d} row'))
 def then_execute_returns_n_row(ctx, query, n):
     ctx.result = ctx.forge.execute(query)
     if ctx.result.num_rows != n:
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
 
 
 # Given step used in construction Background (Given form, not When)
@@ -1485,7 +1511,7 @@ def given_2_nodes_for_edges_given():
 def given_index_one_prop(ctx, label, prop):
     _, error = _catch(ctx.forge.index, label, properties=[prop])
     if isinstance(error, TypeError):
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")
     ctx.extra["index_called"] = True
     ctx.extra["first_index_done"] = True
 
@@ -1520,14 +1546,6 @@ def given_add_node_inline(ctx, label, name):
     ctx.nodes[name] = h
 
 
-# Then "execute ... returns 1 row" with value for introspection
-@then(parsers.parse('execute "{query}" returns {n:d} row with value {val:d}'))
-def then_execute_row_value(ctx, query, n, val):
-    result = ctx.forge.execute(query)
-    if result.num_rows != n:
-        _xfail_not_implemented()
-
-
 # StorageError test needs forge=None handling in when_execute
 # The scenario uses "Given a path that does not exist" then "When I open" then "execute"
 # The forge is set during "When I open" — if StorageError was raised during open,
@@ -1535,4 +1553,4 @@ def then_execute_row_value(ctx, query, n, val):
 @then("a StorageError is raised")
 def then_storage_error_v2(ctx):
     if not isinstance(ctx.error, StorageError):
-        _xfail_not_implemented()
+        raise AssertionError("required public API contract was not satisfied")

--- a/tests/features/steps/api_steps.py
+++ b/tests/features/steps/api_steps.py
@@ -5,6 +5,7 @@ Required public API behavior runs strictly and fails closed.
 
 from __future__ import annotations
 
+import time
 from typing import Any
 import uuid
 
@@ -26,6 +27,16 @@ from graphforge.exceptions import (
     StorageError,
     ValidationError,
 )
+
+
+def _uuid7() -> str:
+    """Return a distinct RFC 9562 UUIDv7 on Python versions without uuid.uuid7()."""
+    raw = bytearray(uuid.uuid4().bytes)
+    raw[:6] = int(time.time_ns() // 1_000_000).to_bytes(6, "big")
+    raw[6] = (raw[6] & 0x0F) | 0x70
+    raw[8] = (raw[8] & 0x3F) | 0x80
+    return str(uuid.UUID(bytes=bytes(raw)))
+
 
 # ---------------------------------------------------------------------------
 # Shared context holder
@@ -53,7 +64,7 @@ def ctx():
     c = _Ctx()
     c.nodes = {}
     c.edges = []
-    c.extra = {}
+    c.extra = {"index_called": False}
     yield c
     if c.forge is not None:
         try:
@@ -176,7 +187,7 @@ def given_paper_node(title):
     c = _Ctx()
     c.nodes = {}
     c.edges = []
-    c.extra = {}
+    c.extra = {"index_called": False}
     c.forge = GraphForge()
     h = c.forge.add_node("Paper", title=title)
     c.nodes[title] = h
@@ -653,11 +664,6 @@ def given_store_embedding(ctx):
     ctx.extra["embedding"] = np.ones(128, dtype=float)
 
 
-@given("no explicit index call was made before find")
-def given_no_index_call(ctx):
-    ctx.extra["index_called"] = False
-
-
 # ---------------------------------------------------------------------------
 # WHEN steps
 # ---------------------------------------------------------------------------
@@ -803,7 +809,7 @@ def when_bulk_add_edges(ctx):
         ctx.forge.add_edges,
         "KNOWS",
         records,
-        operation_uuid=nodes[0].uuid,
+        operation_uuid=_uuid7(),
         src="src_id",
         dst="dst_id",
     )
@@ -1327,9 +1333,12 @@ def then_scores_differ(ctx):
         raise AssertionError("required public API contract was not satisfied")
     if d.num_rows == 0:
         raise AssertionError("required public API contract was not satisfied")
-    # Compare score columns
-    if d.equals(u):
-        raise AssertionError("required public API contract was not satisfied")
+    if "score" not in d.schema.names or "score" not in u.schema.names:
+        raise AssertionError('rank result is missing the "score" column')
+    directed = d.column("score").to_pylist()
+    undirected = u.column("score").to_pylist()
+    if directed == undirected:
+        raise AssertionError(f"directed and undirected scores were identical: {directed!r}")
 
 
 @then("the 2 connected nodes share the same community_id")
@@ -1359,9 +1368,12 @@ def then_isolated_different_community(ctx):
     assert values["Alice"] != values["Carol"]
 
 
-@then("no explicit index call was made before find")
+@then("no index call was made before find")
 def then_no_index_call(ctx):
-    assert not ctx.extra.get("index_called", False)
+    if "index_called" not in ctx.extra:
+        raise AssertionError("index tracking was never initialized for this scenario")
+    assert not ctx.extra["index_called"]
+    assert ctx.result.num_rows > 0, "find returned no matches without an explicit index call"
 
 
 @then('for each result row the id is valid in execute "MATCH (n) WHERE n.node_uuid = $id RETURN n"')

--- a/tests/features/test_api_bdd.py
+++ b/tests/features/test_api_bdd.py
@@ -3,8 +3,8 @@
 scenarios() is called here (in the test file) so pytest-bdd can resolve
 feature paths relative to this file's location.
 
-All scenarios are expected to xfail at the stub stage. They are un-xfailed
-milestone by milestone as real implementations land.
+Required scenarios fail on missing behavior, incorrect results, and unexpected
+exceptions. Deliberate exclusions are validated separately by policy.
 """
 
 from pathlib import Path


### PR DESCRIPTION
## Summary

- replace Rust, Python, and Node API BDD placeholders with real public API calls and exact result/error assertions
- classify genuine product gaps through a frozen issue-backed exclusion inventory while preserving the advisory openCypher TCK model
- add fail-closed repository policy, live behavior mutations, binding coverage, and testing documentation

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- Rust API BDD: 97 passed, 0 failed, 0 skipped
- Python API BDD: 105 passed, 21 issue-backed exclusions
- Node API BDD: 102 scenarios / 387 steps passed
- Node native coverage: 218 tests passed, 100% JavaScript lines
- API BDD policy: 10 mutation tests passed
- live BDD mutations: 5/5 rejected
- `make pre-push` reached Rust coverage at 86.46%; the pre-existing Python wrapper aggregate remains 55.32% because `cli.py` is untested, below the repository-wide 85% threshold

Closes #347

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788322870&installation_model_id=20486&pr_number=358&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F358&signature=f400b334ae3ddf02dfffe75db1afa1cf2e0cda1d7f5df1ff44af29e9741bb097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded API BDD coverage across graph creation, persistence, ontology, search, indexing, analysis, clustering, and mutations.
  * Replaced pending or skipped checks with strict result, schema, UUID, error, and idempotency assertions.
  * Enabled additional API scenarios across supported language bindings.

* **CI & Validation**
  * Added policy checks and mutation tests to detect missing or weakened API coverage.
  * Added tracked exclusions with validation to ensure excluded scenarios remain documented and accountable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make the public API BDD suite fail closed by replacing xfail/skip with hard assertions and tag-based exclusions
> - Replaces `pytest.xfail`/`NotImplementedError` soft failures with `AssertionError` hard failures across Python, Node, and Rust BDD step implementations, so unimplemented contract steps fail the suite instead of being silently skipped.
> - Introduces `@excluded-api-bdd` and `@binding-only` tags to formally exclude known product gaps (tracked by `@issue-352` through `@issue-357`) from required evaluation, with an inventory in [api-bdd-exclusions.json](https://github.com/CurateLabs/graphforge/pull/358/files#diff-0c0a4463cb04df8d80ed405eb1b57bbcd80a642abe625e354c2c57eae3adffa0).
> - Adds [scripts/ci/api-bdd-policy.py](https://github.com/CurateLabs/graphforge/pull/358/files#diff-e9f2fbff6fc3da7472bbd05eae873008cdd48c4c91718465fa372ba75089ef11) to validate the exclusion inventory, scan step sources for forbidden fail-open patterns, and optionally verify GitHub issues are still open; runs in CI and as a pre-push gate.
> - Adds [scripts/ci/test-api-bdd-mutations.py](https://github.com/CurateLabs/graphforge/pull/358/files#diff-eb6e57c0aa196d8bc41302f9f1dc722b2aa77bb403e2c79deca4e4e9ebc12f9d) and [scripts/ci/test-api-bdd-policy.py](https://github.com/CurateLabs/graphforge/pull/358/files#diff-292a3e96660520fc133d7c240c7bc76c77fd681d60177cbfa52476f521e4f6d4) to confirm the fail-closed model itself cannot regress.
> - The Rust BDD runner switches from `run()` to `filter_run()`, treats skipped/undefined scenarios as non-passing, and prints a per-API pass/fail/skip summary before asserting.
> - Risk: any previously silently-skipped scenario that lacks an `@excluded-api-bdd` tag will now cause CI to fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d8e72b4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->