### PR TITLE
fix(storage): abort stale optimistic validation attempts

### DIFF
--- a/crates/graphforge-storage/src/project_publication.rs
+++ b/crates/graphforge-storage/src/project_publication.rs
@@ -758,7 +758,18 @@ impl StagedProjectGeneration {
             "VALIDATED",
             false,
         )?;
-        composite_validation(&self.parent, &self.participants)?;
+        if let Err(error) = composite_validation(&self.parent, &self.participants) {
+            // An optimistic caller uses `GF_WRITE_CONFLICT` to request a rebase
+            // after CURRENT changes between staging and composite validation.
+            // Retaining that private attempt would make the retry collide with
+            // its own non-published journal even though the logical operation
+            // identity is unchanged. Abort only that transaction-owned attempt
+            // before returning the stable conflict to the caller.
+            if self.requires_promotion && error.code() == "GF_WRITE_CONFLICT" {
+                abort_stale_generation(&self)?;
+            }
+            return Err(error);
+        }
         project_failpoint::hit(
             "project.after_composite_validation",
             Some(self.transaction_uuid),
@@ -2207,6 +2218,65 @@ mod tests {
                 .generation_uuid(),
             second.generation_uuid
         );
+    }
+
+    #[test]
+    fn optimistic_validation_conflict_aborts_only_its_own_rebase_attempt() {
+        let root = project();
+        let mut stale_request = request(vec![participant("graph", "nodes", b"attempt")]);
+        let operation: [u8; 32] = Sha256::digest(b"logical-validation-rebase").into();
+        let ProjectStageOutcome::Staged(staged) =
+            stage_project_generation_optimistic(root.path(), &stale_request, operation).unwrap()
+        else {
+            panic!("optimistic operation replayed unexpectedly");
+        };
+
+        publish(
+            root.path(),
+            request(vec![participant("graph", "nodes", b"concurrent")]),
+        );
+        let error = staged
+            .validate(
+                |_| Ok(()),
+                |parent, _| {
+                    let current = resolve_project_generation(root.path())?;
+                    if current.generation_uuid() != parent.generation_uuid() {
+                        return Err(project_error(
+                            ProjectErrorCode::WriteConflict,
+                            "project generation changed before composite validation",
+                        ));
+                    }
+                    Ok(())
+                },
+            )
+            .err()
+            .expect("stale optimistic validation must request a rebase");
+        assert_eq!(error.code(), "GF_WRITE_CONFLICT");
+        assert_eq!(
+            read_journal(&journal_path(root.path(), stale_request.transaction_uuid,))
+                .unwrap()
+                .phase,
+            JournalPhase::Aborted
+        );
+
+        let different_operation: [u8; 32] = Sha256::digest(b"different-operation").into();
+        let identity_error =
+            stage_project_generation_optimistic(root.path(), &stale_request, different_operation)
+                .err()
+                .expect("different logical identity must not reuse the aborted transaction");
+        assert_eq!(identity_error.code(), "GF_IDEMPOTENCY_CONFLICT");
+
+        stale_request.participants[0].bytes = b"rebased-attempt".to_vec();
+        let ProjectStageOutcome::Staged(rebased) =
+            stage_project_generation_optimistic(root.path(), &stale_request, operation).unwrap()
+        else {
+            panic!("aborted optimistic operation did not permit a rebase attempt");
+        };
+        rebased
+            .validate(|_| Ok(()), |_, _| Ok(()))
+            .unwrap()
+            .publish()
+            .unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- abort transaction-owned optimistic staging after composite validation detects parent drift
- allow the same logical operation to rebase without colliding with its own stale journal
- preserve `GF_IDEMPOTENCY_CONFLICT` for genuine transaction identity reuse
- add deterministic storage coverage for cleanup, reuse, and identity isolation

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- `cargo test -p graphforge-storage`
- API optimistic rebase test plus API BDD and TCK suites
- real Node concurrency parity suite (5/5), with the exact optimistic case also passing 10/10 stress iterations
- `make pre-push-fast`
- `make pre-push` Rust gate: 86.46%; Python unit behavior: 100/100 passed

The aggregate `make pre-push` command is currently prevented from completing on unchanged `main` by #363: its Python coverage policy includes the public CLI shim without any CLI unit tests, producing 55.32% against the 85% floor. This PR does not weaken or bypass that independent gate defect.

Closes #290

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788342398&installation_model_id=20486&pr_number=364&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F364&signature=9ada914debfa6850e1dc1cb96a601bbebdb966eb59bbacdffb09ebe8fdeadefc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Abort stale optimistic validation attempts on `GF_WRITE_CONFLICT` in `StagedProjectGeneration.validate`
> When composite validation fails with `GF_WRITE_CONFLICT` during an optimistic promotion, the staged generation is now aborted before the error is returned. Previously, the stale transaction was left in an unresolved state. A new test covers the full rebase cycle: conflict aborts the current attempt, a different logical identity cannot reuse the aborted transaction, and the same identity can re-stage and publish after rebasing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf64316.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of write conflicts during generation validation.
  * Conflicting operations now cleanly abort their temporary attempt and can be retried successfully with the original operation identity.
  * Preserved stable conflict errors while preventing incompatible retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->