### PR TITLE
docs: install current GraphForge releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 <h1 align="center">GraphForge</h1>
 
 <p align="center">
-  <a href="#installation"><img src="https://img.shields.io/badge/version-v0.5.1-F59E0B.svg" alt="GraphForge v0.5.1" /></a>
+  <a href="https://pypi.org/project/graphforge/"><img src="https://img.shields.io/pypi/v/graphforge.svg?label=PyPI&logo=pypi" alt="PyPI version" /></a>
+  <a href="https://www.npmjs.com/package/@curatelabs/graphforge"><img src="https://img.shields.io/npm/v/%40curatelabs/graphforge.svg?label=npm&logo=npm" alt="npm version" /></a>
   <a href="#installation"><img src="https://img.shields.io/badge/Python-3.10%2B-3776AB.svg?logo=python&logoColor=white" alt="Python 3.10 or newer" /></a>
   <a href="crates/graphforge-bindings-node"><img src="https://img.shields.io/badge/Node.js-20%2B-5FA04E.svg?logo=nodedotjs&logoColor=white" alt="Node.js 20 or newer" /></a>
   <a href="rust-toolchain.toml"><img src="https://img.shields.io/badge/Rust-1.96-000000.svg?logo=rust&logoColor=white" alt="Rust 1.96" /></a>
@@ -50,7 +51,7 @@ first-class Arrow results across language bindings.
 
 | | NetworkX | **GraphForge** | Neo4j / Memgraph |
 |:---|:---|:---|:---|
-| **Setup** | `pip install` | Embedded package (`graphforge==0.5.1`) | Run a server |
+| **Setup** | `pip install` | Embedded package (`graphforge`) | Run a server |
 | **Query language** | Python API | **Full openCypher** | Full Cypher |
 | **Persistence** | Manual | **Parquet project directory** | Native |
 | **Results** | Python objects | **Apache Arrow Tables** | Driver rows |
@@ -71,36 +72,36 @@ aggregations remain edge-count bound. See scale limits for measured ceilings.*
 
 ## Installation
 
-Install GraphForge **v0.5.1** from PyPI or npm. Pin the release version — PyPI
-also lists an unrelated pure-Python `graphforge` **0.4.0**; do not confuse it
-with the CurateLabs native engine.
+Install GraphForge from PyPI or npm. The current `graphforge` package is the
+CurateLabs native engine; earlier pure-Python releases under the same PyPI name
+predate it.
 
 **pip**
 
 ```bash
-pip install "graphforge==0.5.1"
+pip install graphforge
 ```
 
 **uv** (recommended)
 
 ```bash
-uv add "graphforge==0.5.1"
+uv add graphforge
 ```
 
 **npm**
 
 ```bash
-npm install @curatelabs/graphforge@0.5.1
+npm install @curatelabs/graphforge
 ```
 
 **pnpm**
 
 ```bash
-pnpm add @curatelabs/graphforge@0.5.1
+pnpm add @curatelabs/graphforge
 ```
 
 ```bash
-python -c "import graphforge; print(graphforge.__version__)"  # 0.5.1…
+python -c "import graphforge; print(graphforge.__version__)"
 ```
 
 **Requirements:** Python 3.10–3.14

--- a/crates/graphforge-bindings-node/README.md
+++ b/crates/graphforge-bindings-node/README.md
@@ -9,13 +9,13 @@ JavaScript fallback engine.
 **npm**
 
 ```bash
-npm install @curatelabs/graphforge@0.5.1
+npm install @curatelabs/graphforge
 ```
 
 **pnpm**
 
 ```bash
-pnpm add @curatelabs/graphforge@0.5.1
+pnpm add @curatelabs/graphforge
 ```
 
 Decode Arrow IPC results with [`apache-arrow`](https://www.npmjs.com/package/apache-arrow)

--- a/crates/graphforge-bindings-py/README.md
+++ b/crates/graphforge-bindings-py/README.md
@@ -8,13 +8,13 @@ with Rust-owned behavior, Arrow results, and a thin repository lifecycle CLI.
 **pip**
 
 ```bash
-pip install "graphforge==0.5.1"
+pip install graphforge
 ```
 
 **uv** (recommended)
 
 ```bash
-uv add "graphforge==0.5.1"
+uv add graphforge
 ```
 
 ## First use

--- a/docs/book/use-cases/agent-grounding.md
+++ b/docs/book/use-cases/agent-grounding.md
@@ -29,7 +29,7 @@ A knowledge graph provides:
 | Feature | GraphForge | Neo4j |
 |---------|-----------|-------|
 | **Deployment** | Embedded in Python process | Requires server setup |
-| **Setup** | `pip install "graphforge==0.5.1"` | Install server, configure ports, manage service |
+| **Setup** | `pip install graphforge` | Install server, configure ports, manage service |
 | **Integration** | Native Python API | HTTP API or driver |
 | **Agent workflow** | Direct in-process access | Network calls add latency |
 | **Development** | Zero config, instant start | Configuration, connection strings |
@@ -436,7 +436,7 @@ def get_authorized_tools(gf, user_role):
 - **Debugging**: Use standard Python debuggers and tools
 
 ### 3. Development Velocity
-- **Instant setup**: `pip install "graphforge==0.5.1"` and you're running
+- **Instant setup**: `pip install graphforge` and you're running
 - **Rapid iteration**: No server restarts or connection management
 - **Portable**: Works in notebooks, scripts, containers, serverless
 
@@ -479,13 +479,13 @@ def get_authorized_tools(gf, user_role):
 **pip**
 
 ```bash
-pip install "graphforge==0.5.1"
+pip install graphforge
 ```
 
 **uv** (recommended)
 
 ```bash
-uv add "graphforge==0.5.1"
+uv add graphforge
 ```
 
 ### Quick Example

--- a/docs/book/use-cases/network-analysis.md
+++ b/docs/book/use-cases/network-analysis.md
@@ -23,13 +23,13 @@ Both tools are complementary. GraphForge excels at storage, querying, and sharin
 **pip**
 
 ```bash
-pip install "graphforge==0.5.1"
+pip install graphforge
 ```
 
 **uv** (recommended)
 
 ```bash
-uv add "graphforge==0.5.1"
+uv add graphforge
 ```
 
 For persistent notebooks, use a Parquet-backed project directory so results survive kernel restarts:

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-GraphForge **v0.5.1** ships as thin native bindings over a Rust core
+GraphForge ships as thin native bindings over a Rust core
 (Python via maturin; Node via N-API). Install the published packages for
 normal use; build from source on `main` when developing the engine or
 bindings.
@@ -10,41 +10,40 @@ detects Node- and Python-first workspaces, helps configure the appropriate nativ
 uses the same Rust-owned engine described below.
 
 > **Name collision:** PyPI also lists an unrelated pure-Python package
-> named `graphforge` at **0.4.0** (~279 KB). CurateLabs GraphForge
-> **0.5.1** is the native engine (Rust `.so` / `.node`) on PyPI and npm.
-> Pin the release version (`graphforge==0.5.1`) — do not assume an unpinned
-> `pip install graphforge` resolves to the CurateLabs native wheel.
+> named `graphforge` at **0.4.0** (~279 KB). Current CurateLabs GraphForge
+> releases are native wheels (Rust `.so` / `.node`) on PyPI and npm. Install
+> by package name to receive the current release.
 
 ---
 
-## Python package (v0.5.1)
+## Python package
 
 **Requirements:** Python 3.10 or newer (3.10–3.14 tested in CI).
 
 **pip**
 
 ```bash
-pip install "graphforge==0.5.1"
+pip install graphforge
 ```
 
 **uv** (recommended)
 
 ```bash
-uv add "graphforge==0.5.1"
+uv add graphforge
 ```
 
 ### Verify
 
 ```python
 import graphforge
-print(graphforge.__version__)   # 0.5.1…
+print(graphforge.__version__)
 ```
 
 ### Optional dependencies
 
 ```bash
 # Polars convenience wrapper around Arrow results
-pip install "graphforge[polars]==0.5.1"
+pip install "graphforge[polars]"
 ```
 
 Results are Apache Arrow tables. Convert with `table.to_pandas()`,
@@ -58,7 +57,7 @@ dependency (not bundled inside the `graphforge` wheel). See
 
 ---
 
-## Node package (@curatelabs/graphforge, v0.5.1)
+## Node package (`@curatelabs/graphforge`)
 
 **Requirements:** a current Node.js LTS (CI covers the binding’s supported
 targets).
@@ -66,13 +65,13 @@ targets).
 **npm**
 
 ```bash
-npm install @curatelabs/graphforge@0.5.1
+npm install @curatelabs/graphforge
 ```
 
 **pnpm**
 
 ```bash
-pnpm add @curatelabs/graphforge@0.5.1
+pnpm add @curatelabs/graphforge
 ```
 
 ```js

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -1,6 +1,6 @@
 # Quick Start
 
-Get a graph running in five minutes on the v0.5.1 API. Choose **Python** or
+Get a graph running in five minutes. Choose **Python** or
 **Node** — both are thin bindings over the same Rust engine. Every query and
 analyst verb returns Apache Arrow results. Node and edge handles use stable
 `.uuid` identity (no numeric storage ids).
@@ -24,13 +24,13 @@ For full install options, see [Installation](installation.md).
 **pip**
 
 ```bash
-pip install "graphforge==0.5.1"
+pip install graphforge
 ```
 
 **uv** (recommended)
 
 ```bash
-uv add "graphforge==0.5.1"
+uv add graphforge
 ```
 
 ### Node
@@ -38,13 +38,13 @@ uv add "graphforge==0.5.1"
 **npm**
 
 ```bash
-npm install @curatelabs/graphforge@0.5.1
+npm install @curatelabs/graphforge
 ```
 
 **pnpm**
 
 ```bash
-pnpm add @curatelabs/graphforge@0.5.1
+pnpm add @curatelabs/graphforge
 ```
 
 Node query and analyst-verb results are Arrow IPC buffers. Decode them with

--- a/docs/guide/tutorial.md
+++ b/docs/guide/tutorial.md
@@ -31,13 +31,13 @@ Install GraphForge using uv (recommended) or pip:
 **uv** (recommended)
 
 ```bash
-uv add "graphforge==0.5.1"
+uv add graphforge
 ```
 
 **pip**
 
 ```bash
-pip install "graphforge==0.5.1"
+pip install graphforge
 ```
 
 Verify the installation:

--- a/docs/guide/visualization.md
+++ b/docs/guide/visualization.md
@@ -64,7 +64,7 @@ rendering.
 ### Python
 
 ```bash
-python -m pip install "graphforge==0.5.1"
+python -m pip install graphforge
 ```
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,8 @@
 
 **Composable graph tooling for analysis, construction, and refinement**
 
-[![Version](https://img.shields.io/badge/version-v0.5.1-F59E0B.svg)](guide/installation.md)
+[![PyPI](https://img.shields.io/pypi/v/graphforge.svg?label=PyPI&logo=pypi)](https://pypi.org/project/graphforge/)
+[![npm](https://img.shields.io/npm/v/%40curatelabs/graphforge.svg?label=npm&logo=npm)](https://www.npmjs.com/package/@curatelabs/graphforge)
 [![Python](https://img.shields.io/badge/Python-3.10%2B-3776AB.svg?logo=python&logoColor=white)](guide/installation.md)
 [![Node.js](https://img.shields.io/badge/Node.js-20%2B-5FA04E.svg?logo=nodedotjs&logoColor=white)](guide/installation.md)
 [![Rust](https://img.shields.io/badge/Rust-1.96-000000.svg?logo=rust&logoColor=white)](development/contributing.md)
@@ -15,10 +16,10 @@ results, and Parquet persistence. It brings openCypher and analyst-intent verbs 
 scripts, repositories, and editor workflows without requiring a database server. The current
 v0.5 engine passes all **3,897 openCypher TCK scenarios**.
 
-> **Install tip:** Pin GraphForge **v0.5.1** from PyPI (`graphforge==0.5.1`) or npm
-> (`@curatelabs/graphforge@0.5.1`). PyPI also lists an unrelated pure-Python `graphforge`
-> **0.4.0**; do not assume an unpinned install resolves to the CurateLabs native engine.
-> See [Installation](guide/installation.md).
+> **Install tip:** Install GraphForge from PyPI (`pip install graphforge`) or npm
+> (`npm install @curatelabs/graphforge`) to receive the current native release.
+> Earlier pure-Python releases under the `graphforge` PyPI name predate the
+> CurateLabs engine. See [Installation](guide/installation.md).
 
 ```python
 from graphforge import GraphForge

--- a/examples/visualization/README.md
+++ b/examples/visualization/README.md
@@ -28,7 +28,7 @@ edges). Provenance, license/citation, and SHA-256 identities live in
 python -m pip install -r examples/visualization/requirements.txt
 python examples/visualization/dataset/fetch.py
 
-# Node (uses in-repo binding when present; else @curatelabs/graphforge@0.5.1)
+# Node (uses in-repo binding when present; else @curatelabs/graphforge)
 cd examples/visualization
 npm install
 ```

--- a/examples/visualization/requirements.txt
+++ b/examples/visualization/requirements.txt
@@ -1,6 +1,6 @@
 # Visualization example dependencies (install GraphForge separately).
 # Python: pip install -r requirements.txt
-# GraphForge: pip install "graphforge==0.5.1"   # or a local maturin wheel
+# GraphForge: pip install graphforge   # or a local maturin wheel
 plotly>=5.18
 pyvis>=0.3.2
 jaal>=0.1.9

--- a/tests/unit/test_python_package_readme.py
+++ b/tests/unit/test_python_package_readme.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import email.parser
 from pathlib import Path
+import re
 import subprocess
 import tarfile
 import tempfile
@@ -25,7 +26,19 @@ def _has_unpinned_pip_install(text: str) -> bool:
 
 
 def _has_pinned_pip_install(text: str) -> bool:
-    return "pip install graphforge==" in text or 'pip install "graphforge==' in text
+    return bool(
+        re.search(
+            r"""\bpip\s+install\b[^\n]*?[\"']?graphforge(?:\[[^\]\n]+\])?[\"']?\s*(?:===|==|~=|!=|<=|>=|<|>|@)""",
+            text,
+        )
+    )
+
+
+def test_pinned_pip_install_detector_covers_quotes_and_options() -> None:
+    assert _has_pinned_pip_install('pip install "graphforge==0.5.1"')
+    assert _has_pinned_pip_install("pip install 'graphforge==0.5.1'")
+    assert _has_pinned_pip_install("pip install --upgrade graphforge==0.5.1")
+    assert _has_pinned_pip_install("pip install --upgrade 'graphforge==0.5.1'")
 
 
 def test_python_readme_is_concise_pypi_landing_page() -> None:

--- a/tests/unit/test_python_package_readme.py
+++ b/tests/unit/test_python_package_readme.py
@@ -13,22 +13,27 @@ README = ROOT / "crates" / "graphforge-bindings-py" / "README.md"
 PYPROJECT = ROOT / "crates" / "graphforge-bindings-py" / "pyproject.toml"
 CANONICAL_DOCS = "https://docs.graphforge.sh/"
 STALE_DOCS = "https://curatelabs.github.io/graphforge/"
-# Public install docs must pin the published release (name collision / pin).
-PINNED_PIP_INSTALLS = (
-    'pip install "graphforge==0.5.1"',
-    "pip install graphforge==0.5.1",
+# Public install docs must install the current published release by package name.
+UNPINNED_PIP_INSTALLS = (
+    'pip install "graphforge"',
+    "pip install graphforge",
 )
 
 
+def _has_unpinned_pip_install(text: str) -> bool:
+    return any(snippet in text for snippet in UNPINNED_PIP_INSTALLS)
+
+
 def _has_pinned_pip_install(text: str) -> bool:
-    return any(snippet in text for snippet in PINNED_PIP_INSTALLS)
+    return "pip install graphforge==" in text or 'pip install "graphforge==' in text
 
 
 def test_python_readme_is_concise_pypi_landing_page() -> None:
     text = README.read_text(encoding="utf-8")
     lines = [line.rstrip() for line in text.splitlines()]
     assert lines[0] == "# GraphForge for Python"
-    assert _has_pinned_pip_install(text)
+    assert _has_unpinned_pip_install(text)
+    assert not _has_pinned_pip_install(text)
     assert "from graphforge import GraphForge" in text
     assert "forge.execute(" in text
     assert CANONICAL_DOCS in text
@@ -84,7 +89,8 @@ def test_python_sdist_embeds_readme_in_pkg_info() -> None:
     description = metadata.get_payload()
     assert isinstance(description, str)
     assert "# GraphForge for Python" in description
-    assert _has_pinned_pip_install(description)
+    assert _has_unpinned_pip_install(description)
+    assert not _has_pinned_pip_install(description)
     assert "from graphforge import GraphForge" in description
     assert CANONICAL_DOCS in description
     assert STALE_DOCS not in description


### PR DESCRIPTION
## Summary

- remove fixed release pins from public Python and Node install commands
- replace static README and documentation-home version badges with live PyPI and npm badges
- add a README regression check that rejects pinned Python installs

## Acceptance evidence

- reader-facing README, guides, binding READMEs, use cases, and examples install by package name
- live package badges link to PyPI and npm
- focused package README test and docs build pass

Closes #374

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788358875&installation_model_id=20486&pr_number=375&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F375&signature=cf9a31b724d4422ddd0882717014914e17469b903d4f82c4e0c93805e013b58d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Package installation examples are now validated to use the standard unpinned `pip install graphforge` command.
  * Generated package metadata is checked to ensure its installation instructions remain consistent.

* **Tests**
  * Added coverage to detect pinned installation commands and prevent inconsistent package installation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace pinned version installs with unpinned commands across all GraphForge docs
> - Replaces all `pip install graphforge==0.5.1`, `npm install @curatelabs/graphforge@0.5.1`, and equivalent pinned commands with unpinned forms across README files, guides, and example docs.
> - Updates dynamic version badges in `README.md` and `docs/index.md` to pull live versions from PyPI and npm instead of showing a hardcoded `v0.5.1` badge.
> - Updates [test_python_package_readme.py](https://github.com/CurateLabs/graphforge/pull/375/files#diff-52f5964532e83cc776a55ee6933b8bdafc85684badf2dbd4364ee6eb957c899c) to enforce unpinned install instructions and reject pinned/constrained forms, with a broader regex detector covering quoted and option-bearing pip commands.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d6a8ff5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->