### PR TITLE
test(release): isolate npm publication dry-run policy

### DIFF
--- a/scripts/coverage-rust.sh
+++ b/scripts/coverage-rust.sh
@@ -99,10 +99,7 @@ export LLVM_PROFILE_FILE="$PROFILE_DIR/python-%p-%10m.profraw"
 for test_file in crates/graphforge-bindings-py/tests/*.py; do
   CARGO_TARGET_DIR="$CORE_TARGET_DIR" uv run --no-sync python "$test_file"
 done
-# The publication dry-run invokes pnpm publish hooks that replace the measured
-# addon; #365 tracks separating that integration check from adapter acceptance.
 uv run --no-sync pytest tests/unit tests/integration tests/features \
-  --ignore=tests/unit/test_publish_dry_run.py \
   -n "${PYTEST_WORKERS:-4}" --tb=short
 
 echo "━━━ Node native acceptance ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/tests/unit/test_publish_dry_run.py
+++ b/tests/unit/test_publish_dry_run.py
@@ -3,6 +3,8 @@
 import importlib.util
 from pathlib import Path
 
+import yaml
+
 SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "publish_dry_run.py"
 SPEC = importlib.util.spec_from_file_location("publish_dry_run", SCRIPT)
 assert SPEC and SPEC.loader
@@ -19,8 +21,101 @@ def test_cargo_order_contains_complete_public_surface() -> None:
     assert "graphforge-bindings-node" not in order
 
 
-def test_npm_dry_run_surfaces_ok() -> None:
+def _step(cmd: list[str], *, ok: bool = True) -> dict[str, object]:
+    return {
+        "cmd": cmd,
+        "cwd": ".",
+        "exit_code": 0 if ok else 1,
+        "seconds": 0,
+        "stdout_tail": "",
+        "stderr_tail": "",
+        "ok": ok,
+    }
+
+
+def test_npm_dry_run_constructs_every_publication_command(monkeypatch) -> None:
+    calls: list[tuple[list[str], Path | None]] = []
+
+    def fake_run(cmd: list[str], *, cwd: Path | None = None) -> dict[str, object]:
+        calls.append((cmd, cwd))
+        return _step(cmd)
+
+    monkeypatch.setattr(publish_dry_run, "_run", fake_run)
     steps = publish_dry_run.dry_run_npm()
+
     assert len(steps) == 4
-    assert steps[0]["cmd"] == ["pnpm", "install", "--frozen-lockfile"]
     assert all(step["ok"] for step in steps)
+    assert calls == [
+        (["pnpm", "install", "--frozen-lockfile"], None),
+        (
+            [
+                "npm",
+                "publish",
+                "--dry-run",
+                "--ignore-scripts",
+                "--tag",
+                "dry-run",
+            ],
+            publish_dry_run.NPM_PACKAGES[0],
+        ),
+        (
+            [
+                "pnpm",
+                "publish",
+                "--dry-run",
+                "--no-git-checks",
+                "--tag",
+                "dry-run",
+            ],
+            publish_dry_run.NPM_PACKAGES[1],
+        ),
+        (
+            [
+                "npm",
+                "publish",
+                "--dry-run",
+                "--ignore-scripts",
+                "--tag",
+                "dry-run",
+            ],
+            publish_dry_run.NPM_PACKAGES[2],
+        ),
+    ]
+
+
+def test_npm_dry_run_stops_when_dependency_install_fails(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], *, cwd: Path | None = None) -> dict[str, object]:
+        del cwd
+        calls.append(cmd)
+        return _step(cmd, ok=False)
+
+    monkeypatch.setattr(publish_dry_run, "_run", fake_run)
+
+    assert publish_dry_run.dry_run_npm() == [
+        _step(["pnpm", "install", "--frozen-lockfile"], ok=False)
+    ]
+    assert calls == [["pnpm", "install", "--frozen-lockfile"]]
+
+
+def test_release_candidate_keeps_the_real_npm_dry_run_gate() -> None:
+    workflow_path = (
+        Path(__file__).resolve().parents[2]
+        / ".github"
+        / "workflows"
+        / "binding-release-candidate.yml"
+    )
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["release_candidate"]["steps"]
+    publication_step = next(
+        step for step in steps if step.get("name") == "Record publication dry-runs"
+    )
+    assert publication_step["run"].split() == [
+        "python3",
+        "scripts/publish_dry_run.py",
+        "--surface",
+        "npm,docs,python,cargo-package",
+        "--report",
+        "candidate/release-artifacts/evidence/publication-dry-run.json",
+    ]


### PR DESCRIPTION
## Summary

- replace the live npm registry publication attempt in unit coverage with deterministic command-construction and failure-propagation tests
- retain the real npm/docs/Python/Cargo dry run in the Binding Release Candidate workflow
- remove the publication dry-run test module from the Python adapter coverage exclusions

## Verification

- `CARGO_TARGET_DIR=/tmp/graphforge-target-365 make pre-push`
- 235 Python adapter coverage items, including the four publication dry-run unit tests
- Node native 219/219 and Node BDD 102/102
- all Rust facade, BDD, TCK, coverage, and mutation gates passed

Closes #365

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788366001&installation_model_id=20486&pr_number=377&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F377&signature=0684a0b64d117b730dc00ebe92b4074cde4134d3f14b920c7b35be62574308fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Isolate npm publication dry-run policy into dedicated, thorough tests
> - Replaces the prior shallow success-only test in [`test_publish_dry_run.py`](https://github.com/CurateLabs/graphforge/pull/377/files#diff-62d7ff0bf0560f77875f5c5244d2848e76dfe37743430d7ecf41e47df3dd5b37) with three focused tests: one verifying the exact command sequence for `pnpm install` and each npm package publish dry-run, one asserting early exit when the dependency install fails, and one reading [`.github/workflows/binding-release-candidate.yml`](https://github.com/CurateLabs/graphforge/pull/377/files#diff-735f23ab6fdd90d2ccfdace46553969c425da5baf1ccae2f98a37b3e3ed9b6b3) to assert the exact CLI invocation used in CI.
> - Removes the `--ignore=tests/unit/test_publish_dry_run.py` exclusion from [`scripts/coverage-rust.sh`](https://github.com/CurateLabs/graphforge/pull/377/files#diff-ba8f769c5f416a174372d309110af994b61b2ab4c2d033b4d6aac34ba43c5674) so the new tests are included in coverage runs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9f9d0a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded dry-run coverage for npm publication commands, including package-specific options and working directories.
  * Added validation that dependency-installation failures stop subsequent publication steps.
  * Added checks confirming release-candidate dry-run gates remain configured.
  * Included the publish dry-run test in Python acceptance coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->