### PR TITLE
test(core): enforce coverage ledger and foundational contracts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,9 @@ test-tck:  ## Run TCK compliance tests via Rust BDD runner
 	cargo test -p graphforge-core --test bdd
 
 # Multi-surface coverage thresholds (#742 §2). Override per surface as needed.
-COVERAGE_FAIL_UNDER_RUST ?= 85
+COVERAGE_FAIL_UNDER_RUST ?= 93.5
+COVERAGE_FAIL_UNDER_RUST_CRATE ?= 80
+COVERAGE_FAIL_UNDER_RUST_PATCH ?= 90
 COVERAGE_FAIL_UNDER_RUST_PYTHON_ADAPTER ?= 80
 COVERAGE_FAIL_UNDER_RUST_NODE_ADAPTER ?= 80
 COVERAGE_FAIL_UNDER_PYTHON ?= 85
@@ -139,10 +141,12 @@ check-coverage-python:  ## Validate Python wrapper coverage (≥85% default)
 		(echo "❌ Python wrapper coverage below $(COVERAGE_FAIL_UNDER_PYTHON)%" && exit 1)
 	@echo "✅ Python wrapper coverage meets threshold"
 
-check-coverage-rust:  ## Validate core Rust (≥85%) and each native adapter (≥80%)
+check-coverage-rust:  ## Validate core (≥93.5%), crates (≥80%), patch (≥90%), adapters (≥80%)
 	@test -f build/coverage-rust/ledger.json || \
 		(echo "❌ Missing build/coverage-rust/ledger.json — run make coverage-rust first"; exit 1)
 	@COVERAGE_FAIL_UNDER_RUST=$(COVERAGE_FAIL_UNDER_RUST) \
+		COVERAGE_FAIL_UNDER_RUST_CRATE=$(COVERAGE_FAIL_UNDER_RUST_CRATE) \
+		COVERAGE_FAIL_UNDER_RUST_PATCH=$(COVERAGE_FAIL_UNDER_RUST_PATCH) \
 		COVERAGE_FAIL_UNDER_RUST_PYTHON_ADAPTER=$(COVERAGE_FAIL_UNDER_RUST_PYTHON_ADAPTER) \
 		COVERAGE_FAIL_UNDER_RUST_NODE_ADAPTER=$(COVERAGE_FAIL_UNDER_RUST_NODE_ADAPTER) \
 		bash scripts/check-coverage-rust.sh
@@ -250,6 +254,8 @@ cargo-test:  ## Run all Rust workspace tests
 # Prefer an isolated CARGO_TARGET_DIR when other builds are running (AGENTS.md).
 coverage-rust:  ## Core + same-SHA Python/Node adapter Rust coverage ledger
 	@COVERAGE_FAIL_UNDER_RUST=$(COVERAGE_FAIL_UNDER_RUST) \
+		COVERAGE_FAIL_UNDER_RUST_CRATE=$(COVERAGE_FAIL_UNDER_RUST_CRATE) \
+		COVERAGE_FAIL_UNDER_RUST_PATCH=$(COVERAGE_FAIL_UNDER_RUST_PATCH) \
 		COVERAGE_FAIL_UNDER_RUST_PYTHON_ADAPTER=$(COVERAGE_FAIL_UNDER_RUST_PYTHON_ADAPTER) \
 		COVERAGE_FAIL_UNDER_RUST_NODE_ADAPTER=$(COVERAGE_FAIL_UNDER_RUST_NODE_ADAPTER) \
 		bash scripts/coverage-rust.sh

--- a/crates/graphforge-ast/src/tests.rs
+++ b/crates/graphforge-ast/src/tests.rs
@@ -70,6 +70,53 @@ fn token_non_trivia() {
 }
 
 #[test]
+fn every_token_variant_preserves_its_source_span() {
+    let span = Span::new(7, 19);
+    let tokens = vec![
+        Token::Keyword(Keyword::Match, span),
+        Token::IntLit(42, span),
+        Token::FloatLit(4.2, span),
+        Token::StrLit("value".into(), span),
+        Token::BoolLit(true, span),
+        Token::NullLit(span),
+        Token::Ident("name".into(), span),
+        Token::Param("parameter".into(), span),
+        Token::LParen(span),
+        Token::RParen(span),
+        Token::LBracket(span),
+        Token::RBracket(span),
+        Token::LBrace(span),
+        Token::RBrace(span),
+        Token::Dot(span),
+        Token::Comma(span),
+        Token::Colon(span),
+        Token::Semi(span),
+        Token::Pipe(span),
+        Token::DotDot(span),
+        Token::Eq(span),
+        Token::Neq(span),
+        Token::Lt(span),
+        Token::Lte(span),
+        Token::Gt(span),
+        Token::Gte(span),
+        Token::Plus(span),
+        Token::Minus(span),
+        Token::Star(span),
+        Token::Slash(span),
+        Token::Percent(span),
+        Token::Caret(span),
+        Token::RegexMatch(span),
+        Token::Whitespace(span),
+        Token::Comment("comment".into(), span),
+        Token::Eof(span),
+    ];
+
+    for token in tokens {
+        assert_eq!(token.span(), span, "token {token:?} lost its source span");
+    }
+}
+
+#[test]
 fn token_int_lit() {
     let tok = Token::IntLit(42, Span::new(0, 2));
     assert_eq!(tok.span(), Span::new(0, 2));
@@ -202,6 +249,26 @@ fn ast_expr_var_span() {
 }
 
 #[test]
+fn ast_leaf_and_parenthesized_expression_spans() {
+    let span = Span::new(4, 9);
+    let expressions = [
+        Expr::Literal(Literal::Int(1, span)),
+        Expr::Param(ParamRef {
+            name: "value".into(),
+            span,
+        }),
+        Expr::Parenthesized {
+            inner: Box::new(Expr::Literal(Literal::Int(1, span))),
+            span,
+        },
+    ];
+
+    for expression in expressions {
+        assert_eq!(expression.span(), span);
+    }
+}
+
+#[test]
 fn ast_expr_property_access() {
     let e = Expr::Property(PropertyAccess {
         object: Box::new(Expr::Var(VarRef {
@@ -228,6 +295,7 @@ fn ast_binary_op_roundtrip() {
         right: Box::new(Expr::Literal(Literal::Int(1, zero()))),
         span: Span::new(0, 5),
     });
+    assert_eq!(e.span(), Span::new(0, 5));
     let json = serde_json::to_string(&e).unwrap();
     let back: Expr = serde_json::from_str(&json).unwrap();
     assert_eq!(e, back);
@@ -245,6 +313,7 @@ fn ast_function_call_roundtrip() {
         })],
         span: Span::new(0, 10),
     });
+    assert_eq!(e.span(), Span::new(0, 10));
     let json = serde_json::to_string(&e).unwrap();
     let back: Expr = serde_json::from_str(&json).unwrap();
     assert_eq!(e, back);
@@ -259,6 +328,7 @@ fn ast_list_literal_roundtrip() {
         ],
         span: zero(),
     });
+    assert_eq!(e.span(), zero());
     let json = serde_json::to_string(&e).unwrap();
     let back: Expr = serde_json::from_str(&json).unwrap();
     assert_eq!(e, back);
@@ -278,6 +348,7 @@ fn ast_map_literal_roundtrip() {
         key_spans,
         span: zero(),
     });
+    assert_eq!(e.span(), zero());
     assert_eq!(e.clone(), e);
     let json = serde_json::to_string(&e).unwrap();
     let back: Expr = serde_json::from_str(&json).unwrap();
@@ -315,6 +386,7 @@ fn ast_is_null_expr_roundtrip() {
         negated: false,
         span: Span::new(0, 10),
     };
+    assert_eq!(e.span(), Span::new(0, 10));
     let json = serde_json::to_string(&e).unwrap();
     let back: Expr = serde_json::from_str(&json).unwrap();
     assert_eq!(e, back);
@@ -334,6 +406,7 @@ fn ast_in_list_expr_roundtrip() {
         negated: false,
         span: zero(),
     };
+    assert_eq!(e.span(), zero());
     let json = serde_json::to_string(&e).unwrap();
     let back: Expr = serde_json::from_str(&json).unwrap();
     assert_eq!(e, back);
@@ -350,6 +423,7 @@ fn ast_string_op_roundtrip() {
         pattern: Box::new(Expr::Literal(Literal::Str("Al".into(), zero()))),
         span: zero(),
     };
+    assert_eq!(e.span(), zero());
     let json = serde_json::to_string(&e).unwrap();
     let back: Expr = serde_json::from_str(&json).unwrap();
     assert_eq!(e, back);
@@ -365,6 +439,7 @@ fn ast_regex_match_roundtrip() {
         pattern: Box::new(Expr::Literal(Literal::Str("A.*".into(), zero()))),
         span: zero(),
     };
+    assert_eq!(e.span(), zero());
     let json = serde_json::to_string(&e).unwrap();
     let back: Expr = serde_json::from_str(&json).unwrap();
     assert_eq!(e, back);
@@ -382,6 +457,7 @@ fn ast_case_expr_roundtrip() {
         else_expr: Some(Box::new(Expr::Literal(Literal::Int(0, zero())))),
         span: zero(),
     });
+    assert_eq!(e.span(), zero());
     let json = serde_json::to_string(&e).unwrap();
     let back: Expr = serde_json::from_str(&json).unwrap();
     assert_eq!(e, back);

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -5200,13 +5200,372 @@ const _: fn() = || {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use datafusion::logical_expr::{Extension, LogicalPlanBuilder, lit};
+    use datafusion::physical_plan::empty::EmptyExec;
     use graphforge_ir::RuntimeCatalog;
+    use graphforge_plan::{
+        GraphDeleteNode, GraphRemoveNode, GraphSetNode, RemoveTarget, SetTarget,
+    };
     use tempfile::TempDir;
 
     fn make_session() -> ExecutionSession {
         let dir = TempDir::new().unwrap();
         let catalog = GraphCatalog::open(dir.path(), None, &RuntimeCatalog::new()).unwrap();
         ExecutionSession::new(catalog, None).unwrap()
+    }
+
+    fn empty_write_input() -> (Arc<LogicalPlan>, Arc<dyn ExecutionPlan>) {
+        let logical = Arc::new(LogicalPlanBuilder::empty(false).build().unwrap());
+        let physical: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(Arc::new(
+            logical.schema().as_arrow().clone(),
+        )));
+        (logical, physical)
+    }
+
+    #[test]
+    fn write_execs_expose_stable_plan_contracts_and_reject_invalid_shape() {
+        let dir = TempDir::new().unwrap();
+        let (logical, physical) = empty_write_input();
+        let delete: Arc<dyn ExecutionPlan> = Arc::new(GraphDeleteExec::new(
+            &GraphDeleteNode::new(
+                logical.clone(),
+                vec![DeleteTarget {
+                    var: 0,
+                    is_edge: false,
+                }],
+                true,
+                dir.path().to_path_buf(),
+                OntologyMode::Exploratory,
+            ),
+            physical.clone(),
+        ));
+        let set: Arc<dyn ExecutionPlan> = Arc::new(GraphSetExec::new(
+            &GraphSetNode::new(
+                logical.clone(),
+                vec![SetTarget {
+                    var: 0,
+                    is_edge: false,
+                    prop_name: "score".into(),
+                    value: lit(1_i64),
+                }],
+                HashMap::new(),
+                dir.path().to_path_buf(),
+                OntologyMode::Exploratory,
+            ),
+            physical.clone(),
+        ));
+        let remove: Arc<dyn ExecutionPlan> = Arc::new(GraphRemoveExec::new(
+            &GraphRemoveNode::new(
+                logical,
+                vec![RemoveTarget {
+                    var: 0,
+                    is_edge: false,
+                    prop_name: "score".into(),
+                }],
+                HashMap::new(),
+                dir.path().to_path_buf(),
+                OntologyMode::Exploratory,
+            ),
+            physical,
+        ));
+
+        for (plan, expected_name) in [
+            (delete, "GraphDeleteExec"),
+            (set, "GraphSetExec"),
+            (remove, "GraphRemoveExec"),
+        ] {
+            assert_eq!(plan.name(), expected_name);
+            assert!(
+                plan.as_any().is::<GraphDeleteExec>()
+                    || plan.as_any().is::<GraphSetExec>()
+                    || plan.as_any().is::<GraphRemoveExec>()
+            );
+            assert_eq!(plan.children().len(), 1);
+            assert_eq!(plan.properties().output_partitioning().partition_count(), 1);
+            assert!(format!("{plan:?}").contains(expected_name));
+            assert!(
+                datafusion::physical_plan::displayable(plan.as_ref())
+                    .one_line()
+                    .to_string()
+                    .contains(expected_name)
+            );
+            let missing_child = plan.clone().with_new_children(vec![]).unwrap_err();
+            assert!(missing_child.to_string().contains("needs one child"));
+            let invalid_partition = match plan.execute(1, SessionContext::new().task_ctx()) {
+                Ok(_) => panic!("{expected_name} accepted invalid partition 1"),
+                Err(error) => error,
+            };
+            assert!(
+                invalid_partition
+                    .to_string()
+                    .contains("only has partition 0")
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_write_execs_dispatch_and_report_zero_changes() {
+        let dir = TempDir::new().unwrap();
+        let (logical, physical) = empty_write_input();
+        let plans: Vec<Arc<dyn ExecutionPlan>> = vec![
+            Arc::new(GraphDeleteExec::new(
+                &GraphDeleteNode::new(
+                    logical.clone(),
+                    vec![],
+                    false,
+                    dir.path().to_path_buf(),
+                    OntologyMode::Exploratory,
+                ),
+                physical.clone(),
+            )),
+            Arc::new(GraphSetExec::new(
+                &GraphSetNode::new(
+                    logical.clone(),
+                    vec![],
+                    HashMap::new(),
+                    dir.path().to_path_buf(),
+                    OntologyMode::Exploratory,
+                ),
+                physical.clone(),
+            )),
+            Arc::new(GraphRemoveExec::new(
+                &GraphRemoveNode::new(
+                    logical,
+                    vec![],
+                    HashMap::new(),
+                    dir.path().to_path_buf(),
+                    OntologyMode::Exploratory,
+                ),
+                physical,
+            )),
+        ];
+
+        for plan in plans {
+            let batches =
+                datafusion::physical_plan::collect(plan, SessionContext::new().task_ctx())
+                    .await
+                    .unwrap();
+            assert_eq!(batches.len(), 1);
+            assert_eq!(batches[0].num_rows(), 1);
+            assert_eq!(
+                batches[0]
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<UInt64Array>()
+                    .unwrap()
+                    .value(0),
+                0
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn query_planner_dispatches_every_write_extension_to_its_physical_exec() {
+        let dir = TempDir::new().unwrap();
+        let (input, _) = empty_write_input();
+        let logical_nodes: Vec<(Arc<dyn UserDefinedLogicalNode>, &str)> = vec![
+            (
+                Arc::new(GraphCreateNode::new(
+                    input.clone(),
+                    vec![],
+                    vec![],
+                    dir.path().to_path_buf(),
+                    OntologyMode::Exploratory,
+                )),
+                "GraphCreateExec",
+            ),
+            (
+                Arc::new(GraphDeleteNode::new(
+                    input.clone(),
+                    vec![],
+                    false,
+                    dir.path().to_path_buf(),
+                    OntologyMode::Exploratory,
+                )),
+                "GraphDeleteExec",
+            ),
+            (
+                Arc::new(GraphSetNode::new(
+                    input.clone(),
+                    vec![],
+                    HashMap::new(),
+                    dir.path().to_path_buf(),
+                    OntologyMode::Exploratory,
+                )),
+                "GraphSetExec",
+            ),
+            (
+                Arc::new(GraphRemoveNode::new(
+                    input,
+                    vec![],
+                    HashMap::new(),
+                    dir.path().to_path_buf(),
+                    OntologyMode::Exploratory,
+                )),
+                "GraphRemoveExec",
+            ),
+        ];
+        let context = SessionContext::new();
+        let state = context.state();
+        let planner = GraphForgeQueryPlanner;
+
+        for (node, expected_name) in logical_nodes {
+            let logical = LogicalPlan::Extension(Extension { node });
+            let physical = planner
+                .create_physical_plan(&logical, &state)
+                .await
+                .unwrap();
+            assert_eq!(physical.name(), expected_name);
+        }
+    }
+
+    #[tokio::test]
+    async fn extension_planner_rejects_missing_write_inputs_and_declines_unknown_nodes() {
+        let dir = TempDir::new().unwrap();
+        let (input, _) = empty_write_input();
+        let nodes: Vec<Arc<dyn UserDefinedLogicalNode>> = vec![
+            Arc::new(GraphCreateNode::new(
+                input.clone(),
+                vec![],
+                vec![],
+                dir.path().to_path_buf(),
+                OntologyMode::Exploratory,
+            )),
+            Arc::new(GraphDeleteNode::new(
+                input.clone(),
+                vec![],
+                false,
+                dir.path().to_path_buf(),
+                OntologyMode::Exploratory,
+            )),
+            Arc::new(GraphSetNode::new(
+                input.clone(),
+                vec![],
+                HashMap::new(),
+                dir.path().to_path_buf(),
+                OntologyMode::Exploratory,
+            )),
+            Arc::new(GraphRemoveNode::new(
+                input,
+                vec![],
+                HashMap::new(),
+                dir.path().to_path_buf(),
+                OntologyMode::Exploratory,
+            )),
+        ];
+        let state = SessionContext::new().state();
+        let physical_planner = DefaultPhysicalPlanner::default();
+
+        for node in nodes {
+            let error = GraphForgeExtensionPlanner
+                .plan_extension(&physical_planner, node.as_ref(), &[], &[], &state)
+                .await
+                .unwrap_err();
+            assert!(error.to_string().contains("requires one physical input"));
+        }
+
+        let unknown = graphforge_plan::GraphMergeNode::new();
+        assert!(
+            GraphForgeExtensionPlanner
+                .plan_extension(&physical_planner, &unknown, &[], &[], &state)
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn deleted_entity_expression_walkers_cover_every_ir_container() {
+        let deleted_var = VarId(7);
+        let deleted = HashSet::from([deleted_var]);
+        let mut arena = ExprArena::new();
+        let var = arena.push(IrExpr::VarRef(deleted_var));
+        let literal = arena.push(IrExpr::Literal(IrLiteral::Int(1)));
+        let parameter = arena.push(IrExpr::Parameter("value".into()));
+        let property = arena.push(IrExpr::PropertyAccess {
+            base: var,
+            prop: graphforge_ir::PropId(0),
+        });
+        let binary = arena.push(IrExpr::BinaryOp {
+            op: graphforge_ir::BinaryOpKind::Add,
+            left: literal,
+            right: property,
+        });
+        let unary = arena.push(IrExpr::UnaryOp {
+            op: graphforge_ir::UnaryOpKind::Neg,
+            expr: property,
+        });
+        let function = arena.push(IrExpr::FunctionCall {
+            name: "properties".into(),
+            args: vec![var],
+        });
+        let type_function = arena.push(IrExpr::FunctionCall {
+            name: "type".into(),
+            args: vec![var],
+        });
+        let list = arena.push(IrExpr::ListLiteral(vec![literal, property]));
+        let map = arena.push(IrExpr::MapLiteral(vec![("key".into(), property)]));
+        let case = arena.push(IrExpr::Case {
+            operand: Some(literal),
+            arms: vec![graphforge_ir::CaseArm {
+                when: literal,
+                then: var,
+            }],
+            else_expr: Some(parameter),
+        });
+        let quantifier = arena.push(IrExpr::Quantifier {
+            kind: graphforge_ir::QuantifierKind::Any,
+            loop_var: VarId(8),
+            list,
+            predicate: var,
+        });
+        let comprehension = arena.push(IrExpr::ListComprehension {
+            loop_var: VarId(9),
+            list,
+            filter: Some(literal),
+            projection: Some(var),
+        });
+
+        for id in [
+            var,
+            property,
+            binary,
+            unary,
+            function,
+            list,
+            map,
+            case,
+            quantifier,
+            comprehension,
+        ] {
+            assert!(ExecutionSession::expr_references_vars(&arena, id, &deleted));
+        }
+        assert!(!ExecutionSession::expr_references_vars(
+            &arena, parameter, &deleted
+        ));
+        assert!(ExecutionSession::expr_accesses_deleted_vars(
+            &arena, property, &deleted
+        ));
+        assert!(ExecutionSession::expr_accesses_deleted_vars(
+            &arena, function, &deleted
+        ));
+        assert!(ExecutionSession::expr_accesses_deleted_vars(
+            &arena, binary, &deleted
+        ));
+        assert!(ExecutionSession::expr_accesses_deleted_vars(
+            &arena, unary, &deleted
+        ));
+        assert!(ExecutionSession::expr_accesses_deleted_vars(
+            &arena, list, &deleted
+        ));
+        assert!(ExecutionSession::expr_accesses_deleted_vars(
+            &arena, map, &deleted
+        ));
+        assert!(!ExecutionSession::expr_accesses_deleted_vars(
+            &arena,
+            type_function,
+            &deleted
+        ));
     }
 
     #[test]

--- a/crates/graphforge-ir/src/binder.rs
+++ b/crates/graphforge-ir/src/binder.rs
@@ -6563,6 +6563,63 @@ mod tests {
         (binder, catalog)
     }
 
+    fn parsed_return_expr(source: &str) -> Expr {
+        let ast =
+            parse(source).unwrap_or_else(|error| panic!("failed to parse {source:?}: {error}"));
+        let Some(AstClause::Return(clause)) = ast.clauses.last() else {
+            panic!("expected RETURN clause for {source:?}");
+        };
+        clause.items[0].expr.clone()
+    }
+
+    #[test]
+    fn expression_rewriters_traverse_every_public_ast_container() {
+        let expressions = [
+            "RETURN a + 1",
+            "RETURN NOT a",
+            "RETURN (a)",
+            "RETURN a.name",
+            "RETURN coalesce(a, 1)",
+            "RETURN [a, 1]",
+            "RETURN {k: a}",
+            "RETURN CASE a WHEN 1 THEN a ELSE 0 END",
+            "RETURN [x IN a WHERE x > 0 | x]",
+            "RETURN all(x IN a WHERE x > 0)",
+            "RETURN a IS NULL",
+            "RETURN a IN [1]",
+            "RETURN a STARTS WITH 'x'",
+            "RETURN a =~ 'x'",
+            "RETURN a:Person",
+            "RETURN [(a)-->(b) WHERE a.name = 'x' | a]",
+            "RETURN exists { (a)-->(b) WHERE a.name = 'x' }",
+        ]
+        .map(parsed_return_expr);
+        let alias_projection = ReturnItem {
+            expr: Expr::Literal(Literal::Int(7, Span::new(0, 1))),
+            alias: Some("a".into()),
+            display: None,
+            span: Span::new(0, 1),
+        };
+        let grouping = parsed_return_expr("RETURN a");
+        let bindings = [(grouping, "group_a".into(), VarId(0))];
+
+        for expression in expressions {
+            let mut refs = Vec::new();
+            collect_grouping_refs(&expression, &mut refs);
+            let alias_rewritten = rewrite_projection_alias_refs(
+                expression.clone(),
+                std::slice::from_ref(&alias_projection),
+            );
+            let grouping_rewritten = rewrite_grouping_refs(expression.clone(), &bindings);
+            assert_eq!(alias_rewritten.span(), expression.span());
+            assert_eq!(grouping_rewritten.span(), expression.span());
+            let _ = expr_contains_pattern_comprehension(&expression);
+            let _ = expr_contains_pattern_predicate(&expression);
+            let _ = expr_contains_volatile_function(&expression);
+            let _ = expr_contains_aggregate_inside_aggregate(&expression, false);
+        }
+    }
+
     fn catalog_entry(catalog: &RuntimeCatalog, kind: &str, name: &str) -> (u32, u64) {
         let batch = catalog.to_record_batch();
         let kinds = batch

--- a/crates/graphforge-plan/src/lib.rs
+++ b/crates/graphforge-plan/src/lib.rs
@@ -2143,6 +2143,70 @@ mod tests {
         assert_eq!(ha.finish(), hb.finish());
     }
 
+    #[test]
+    fn graph_create_hashes_every_literal_shape_deterministically() {
+        use std::collections::hash_map::DefaultHasher;
+
+        let literals = vec![
+            IrLiteral::Null,
+            IrLiteral::Bool(true),
+            IrLiteral::Int(7),
+            IrLiteral::Float(1.5),
+            IrLiteral::Str("value".into()),
+            IrLiteral::Uuid([1; 16]),
+            IrLiteral::Duration {
+                months: 1,
+                days: 2,
+                seconds: 3,
+                nanos: 4,
+            },
+            IrLiteral::DateTime(5),
+            IrLiteral::Date(6),
+            IrLiteral::LocalDateTime { days: 7, nanos: 8 },
+            IrLiteral::Time(9),
+            IrLiteral::ZonedTime {
+                nanos: 10,
+                offset: 3_600,
+            },
+            IrLiteral::ZonedDateTime {
+                days: 11,
+                nanos: 12,
+                offset: -3_600,
+                zone: Some("UTC".into()),
+            },
+            IrLiteral::List(vec![IrLiteral::Int(13)]),
+            IrLiteral::Map(vec![("key".into(), IrLiteral::Int(14))]),
+        ];
+        let make = || {
+            GraphCreateNode::new(
+                empty_plan(),
+                vec![ResolvedNodeSpec {
+                    var: 0,
+                    label_ids: vec![1],
+                    label_names: vec!["Person".into()],
+                    properties: literals
+                        .iter()
+                        .cloned()
+                        .enumerate()
+                        .map(|(index, literal)| (index.to_string(), literal))
+                        .collect(),
+                    computed_properties: vec![],
+                    is_reference: false,
+                }],
+                vec![],
+                PathBuf::from("/tmp/gf"),
+                OntologyMode::Strict,
+            )
+        };
+        let (first, second) = (make(), make());
+        let mut first_hash = DefaultHasher::new();
+        let mut second_hash = DefaultHasher::new();
+        first.hash(&mut first_hash);
+        second.hash(&mut second_hash);
+        assert_eq!(first, second);
+        assert_eq!(first_hash.finish(), second_hash.finish());
+    }
+
     fn set_node(value: Expr) -> GraphSetNode {
         GraphSetNode::new(
             empty_plan(),
@@ -2228,6 +2292,126 @@ mod tests {
         a.hash(&mut ha);
         b.hash(&mut hb);
         assert_eq!(ha.finish(), hb.finish());
+    }
+
+    #[test]
+    fn graph_create_rebuilds_computed_properties_and_preserves_emit_mode() {
+        use datafusion::logical_expr::lit;
+
+        let output_schema = Arc::new(DFSchema::empty());
+        let node = GraphCreateNode::new_emitting(
+            empty_plan(),
+            vec![ResolvedNodeSpec {
+                var: 0,
+                label_ids: vec![1],
+                label_names: vec!["Person".into()],
+                properties: vec![],
+                computed_properties: vec![("score".into(), lit(1_i64))],
+                is_reference: false,
+            }],
+            vec![ResolvedEdgeSpec {
+                var: 1,
+                src: 0,
+                dst: 2,
+                rel_type_id: Some(3),
+                rel_type_name: Some("KNOWS".into()),
+                direction: Direction::Out,
+                properties: vec![],
+                computed_properties: vec![("weight".into(), lit(2_i64))],
+            }],
+            PathBuf::from("/tmp/gf"),
+            OntologyMode::Strict,
+            output_schema.clone(),
+        );
+        assert!(node.emits_rows());
+        assert_eq!(UserDefinedLogicalNodeCore::expressions(&node).len(), 2);
+
+        let rebuilt = UserDefinedLogicalNodeCore::with_exprs_and_inputs(
+            &node,
+            vec![lit(10_i64), lit(20_i64)],
+            vec![(*empty_plan()).clone()],
+        )
+        .unwrap();
+        assert!(rebuilt.emits_rows());
+        assert_eq!(rebuilt.schema(), &output_schema);
+        assert_eq!(rebuilt.nodes[0].computed_properties[0].1, lit(10_i64));
+        assert_eq!(rebuilt.edges[0].computed_properties[0].1, lit(20_i64));
+
+        let short =
+            UserDefinedLogicalNodeCore::with_exprs_and_inputs(&node, vec![lit(99_i64)], vec![])
+                .unwrap();
+        assert_eq!(short.nodes[0].computed_properties[0].1, lit(1_i64));
+        assert_eq!(short.edges[0].computed_properties[0].1, lit(2_i64));
+    }
+
+    #[test]
+    fn graph_delete_contract_round_trips_and_distinguishes_detach() {
+        use std::collections::hash_map::DefaultHasher;
+
+        let node = GraphDeleteNode::new(
+            empty_plan(),
+            vec![DeleteTarget {
+                var: 7,
+                is_edge: false,
+            }],
+            true,
+            PathBuf::from("/tmp/gf"),
+            OntologyMode::Exploratory,
+        );
+        assert_eq!(UserDefinedLogicalNodeCore::name(&node), "GraphDelete");
+        assert_eq!(UserDefinedLogicalNodeCore::inputs(&node).len(), 1);
+        assert_eq!(UserDefinedLogicalNodeCore::schema(&node).fields().len(), 2);
+        assert!(UserDefinedLogicalNodeCore::expressions(&node).is_empty());
+
+        let rebuilt = UserDefinedLogicalNodeCore::with_exprs_and_inputs(
+            &node,
+            vec![],
+            vec![(*empty_plan()).clone()],
+        )
+        .unwrap();
+        assert_eq!(node, rebuilt);
+        assert_ne!(
+            node,
+            GraphDeleteNode::new(
+                empty_plan(),
+                node.targets.clone(),
+                false,
+                node.dir.clone(),
+                node.mode,
+            )
+        );
+        let mut first = DefaultHasher::new();
+        let mut second = DefaultHasher::new();
+        node.hash(&mut first);
+        rebuilt.hash(&mut second);
+        assert_eq!(first.finish(), second.finish());
+    }
+
+    #[test]
+    fn optimizer_nodes_are_intentionally_not_orderable() {
+        use datafusion::logical_expr::lit;
+
+        let set = set_node(lit(1_i64));
+        let remove = remove_node();
+        let create = GraphCreateNode::new(
+            empty_plan(),
+            vec![],
+            vec![],
+            PathBuf::from("/tmp/gf"),
+            OntologyMode::Strict,
+        );
+        let delete = GraphDeleteNode::new(
+            empty_plan(),
+            vec![],
+            false,
+            PathBuf::from("/tmp/gf"),
+            OntologyMode::Strict,
+        );
+
+        assert_eq!(create.partial_cmp(&create), None);
+        assert_eq!(delete.partial_cmp(&delete), None);
+        assert_eq!(set.partial_cmp(&set), None);
+        assert_eq!(remove.partial_cmp(&remove), None);
     }
 
     #[test]

--- a/crates/graphforge-rel/src/expr.rs
+++ b/crates/graphforge-rel/src/expr.rs
@@ -14630,6 +14630,108 @@ mod tests {
     }
 
     #[test]
+    fn scalar_to_ir_literal_normalizes_all_native_widths_and_rejects_overflow() {
+        let cases = [
+            (ScalarValue::Int8(Some(-8)), IrLiteral::Int(-8)),
+            (ScalarValue::Int16(Some(-16)), IrLiteral::Int(-16)),
+            (ScalarValue::UInt16(Some(16)), IrLiteral::Int(16)),
+            (ScalarValue::UInt32(Some(32)), IrLiteral::Int(32)),
+            (ScalarValue::UInt64(Some(64)), IrLiteral::Int(64)),
+            (ScalarValue::Float32(Some(1.25)), IrLiteral::Float(1.25)),
+            (
+                ScalarValue::LargeUtf8(Some("large".into())),
+                IrLiteral::Str("large".into()),
+            ),
+            (
+                ScalarValue::Utf8View(Some("view".into())),
+                IrLiteral::Str("view".into()),
+            ),
+            (
+                ScalarValue::TimestampSecond(Some(2), None),
+                IrLiteral::DateTime(2_000_000),
+            ),
+            (
+                ScalarValue::TimestampMillisecond(Some(3), None),
+                IrLiteral::DateTime(3_000),
+            ),
+            (
+                ScalarValue::TimestampNanosecond(Some(4_000), None),
+                IrLiteral::DateTime(4),
+            ),
+            (ScalarValue::Time64Nanosecond(Some(5)), IrLiteral::Time(5)),
+        ];
+        for (scalar, expected) in cases {
+            assert_eq!(scalar_to_ir_literal(&scalar).unwrap(), expected);
+        }
+        assert!(matches!(
+            scalar_to_ir_literal(&ScalarValue::UInt64(Some(u64::MAX))),
+            Err(LoweringError::UnsupportedExpr(message)) if message.contains("exceeds the i64 range")
+        ));
+        assert!(matches!(
+            scalar_to_ir_literal(&ScalarValue::Binary(Some(vec![1, 2]))),
+            Err(LoweringError::InvalidType(message)) if message.contains("invalid property type")
+        ));
+    }
+
+    #[test]
+    fn dynamic_access_helpers_cover_null_bounds_types_and_schema_errors() {
+        use datafusion::arrow::datatypes::{Field, Fields};
+
+        for (scalar, expected) in [
+            (ScalarValue::Int8(Some(-1)), Some(-1)),
+            (ScalarValue::Int16(Some(2)), Some(2)),
+            (ScalarValue::Int32(Some(3)), Some(3)),
+            (ScalarValue::Int64(Some(4)), Some(4)),
+            (ScalarValue::UInt8(Some(5)), Some(5)),
+            (ScalarValue::UInt16(Some(6)), Some(6)),
+            (ScalarValue::UInt32(Some(7)), Some(7)),
+            (ScalarValue::UInt64(Some(8)), Some(8)),
+            (ScalarValue::Null, None),
+        ] {
+            assert_eq!(scalar_list_index(&scalar).unwrap(), expected);
+        }
+        assert!(scalar_list_index(&ScalarValue::UInt64(Some(u64::MAX))).is_err());
+        assert!(scalar_list_index(&ScalarValue::Utf8(Some("one".into()))).is_err());
+        assert_eq!(scalar_access_key(&ScalarValue::Null).unwrap(), None);
+        assert_eq!(
+            scalar_access_key(&ScalarValue::LargeUtf8(Some("key".into()))).unwrap(),
+            Some("key".into())
+        );
+        assert!(scalar_access_key(&ScalarValue::Int64(Some(1))).is_err());
+
+        let homogeneous = Fields::from(vec![
+            Field::new("a", DataType::Null, true),
+            Field::new("b", DataType::Int64, true),
+            Field::new("c", DataType::Int64, false),
+        ]);
+        assert_eq!(
+            common_struct_field_type(&homogeneous).unwrap(),
+            DataType::Int64
+        );
+        let mixed = Fields::from(vec![
+            Field::new("a", DataType::Int64, true),
+            Field::new("b", DataType::Utf8, true),
+        ]);
+        assert!(common_struct_field_type(&mixed).is_err());
+
+        for dtype in [
+            DataType::Struct(Fields::empty()),
+            DataType::Struct(Fields::from(vec![Field::new(
+                "__het_map",
+                DataType::Utf8,
+                true,
+            )])),
+            DataType::Struct(Fields::from(vec![Field::new(
+                "__het_map",
+                DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
+                true,
+            )])),
+        ] {
+            assert!(het_value_access_return_type(&dtype).is_err());
+        }
+    }
+
+    #[test]
     fn scalar_to_ir_literal_round_trips_a_list() {
         // A homogeneous list now stores (#1006): scalar List → IrLiteral::List
         // and back, element-wise — including a list of typed temporals.

--- a/docs/engineering/TESTING.md
+++ b/docs/engineering/TESTING.md
@@ -177,11 +177,17 @@ artifacts.
 The run uses an isolated `CARGO_TARGET_DIR` (defaulting under its output tree),
 builds each native artifact once, and verifies that the loaded artifact hash
 matches the measured object.
-`build/coverage-rust/ledger.json` also binds the evidence to `HEAD` and the LLVM
-toolchain. Missing, empty, stale, wrong-artifact, or wrong-SHA adapter profiles
-fail before totals are accepted. Core has an 85% floor and each Rust binding
-adapter has an independent 80% floor; the merged workspace percentage cannot
-average away a failed surface.
+`build/coverage-rust/ledger.json` also binds the evidence to `HEAD`, the current
+`origin/main` merge base, and the LLVM toolchain. Missing, empty, malformed,
+stale, wrong-artifact, or wrong-SHA evidence fails before totals are accepted.
+Core has an interim 93.5% ratchet, every non-binding production crate has an
+independent 80% floor, and changed executable Rust lines have a 90% floor.
+Canonical issue #360 raises the aggregate ratchet to 95% after its remaining
+behavioral-test tranches land. Each Rust binding adapter also retains its
+independent 80% floor; neither the merged workspace percentage nor a strong
+crate can average away a failed surface. Patch coverage uses executable lines
+from the core LCOV report, so documentation, tests, blank lines, and non-Rust
+changes do not manufacture measured production coverage.
 
 | Experience / Requirement | Scenario (Given/When/Then) | Test / evidence |
 | ------------------------ | -------------------------- | ---- |

--- a/scripts/check-coverage-rust.sh
+++ b/scripts/check-coverage-rust.sh
@@ -8,6 +8,9 @@ LEDGER="${COVERAGE_RUST_LEDGER:-$ROOT/build/coverage-rust/ledger.json}"
 python3 "$ROOT/scripts/coverage_rust_ledger.py" \
   --root "$ROOT" \
   --ledger "$LEDGER" \
-  --core-floor "${COVERAGE_FAIL_UNDER_RUST:-85}" \
+  --core-floor "${COVERAGE_FAIL_UNDER_RUST:-93.5}" \
+  --crate-floor "${COVERAGE_FAIL_UNDER_RUST_CRATE:-80}" \
+  --patch-floor "${COVERAGE_FAIL_UNDER_RUST_PATCH:-90}" \
+  --patch-base "${COVERAGE_RUST_PATCH_BASE:-origin/main}" \
   --python-floor "${COVERAGE_FAIL_UNDER_RUST_PYTHON_ADAPTER:-80}" \
   --node-floor "${COVERAGE_FAIL_UNDER_RUST_NODE_ADAPTER:-80}"

--- a/scripts/ci/test-rust-coverage-ledger.py
+++ b/scripts/ci/test-rust-coverage-ledger.py
@@ -7,6 +7,7 @@ import importlib.util
 import json
 import os
 from pathlib import Path
+import subprocess
 import tempfile
 from types import SimpleNamespace
 
@@ -35,6 +36,32 @@ def main() -> None:
     with tempfile.TemporaryDirectory(prefix="gf-rust-coverage-ledger-") as directory:
         temp = Path(directory)
         expect_error("failed to resolve git HEAD", lambda: ledger_module.git_head(temp))
+        repository = temp / "repository"
+        repository.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=repository, check=True)
+        tracked = repository / "tracked.txt"
+        tracked.write_text("clean\n", encoding="utf-8")
+        subprocess.run(["git", "add", "tracked.txt"], cwd=repository, check=True)
+        subprocess.run(
+            [
+                "git",
+                "-c",
+                "user.name=GraphForge Test",
+                "-c",
+                "user.email=graphforge-test@example.invalid",
+                "commit",
+                "-qm",
+                "fixture",
+            ],
+            cwd=repository,
+            check=True,
+        )
+        ledger_module.validate_source_tree_clean(repository)
+        tracked.write_text("dirty\n", encoding="utf-8")
+        expect_error(
+            "uncommitted changes",
+            lambda: ledger_module.validate_source_tree_clean(repository),
+        )
         artifact = temp / "adapter.so"
         runtime = temp / "loaded.so"
         profile = temp / "adapter.profraw"
@@ -106,19 +133,39 @@ def main() -> None:
 
         args = SimpleNamespace(
             root=ROOT,
+            patch_base="HEAD",
             core_floor=85.0,
+            crate_floor=80.0,
+            patch_floor=90.0,
             python_floor=80.0,
             node_floor=80.0,
         )
         valid_ledger = {
-            "schema_version": 1,
+            "schema_version": 2,
             "source_sha": head,
+            "patch_base_sha": head,
             "surfaces": {
                 name: {"covered_lines": 90, "measured_lines": 100, "line_percent": 90.0}
                 for name in ("core", "python_adapter", "node_adapter", "workspace")
             },
+            "crates": {
+                crate: {
+                    "covered_lines": 90,
+                    "measured_lines": 100,
+                    "line_percent": 90.0,
+                }
+                for crate in ledger_module.expected_production_crates(ROOT)
+            },
+            "patch": {"covered_lines": 9, "measured_lines": 10, "line_percent": 90.0},
         }
         ledger_module.validate_floors(valid_ledger, args)
+
+        mutated = json.loads(json.dumps(valid_ledger))
+        mutated["patch_base_sha"] = "0" * 40
+        expect_error(
+            "stale for the current merge base",
+            lambda: ledger_module.validate_floors(mutated, args),
+        )
 
         mutated = json.loads(json.dumps(valid_ledger))
         mutated["surfaces"]["python_adapter"]["line_percent"] = 79.99
@@ -142,6 +189,38 @@ def main() -> None:
         mutated = json.loads(json.dumps(valid_ledger))
         mutated["surfaces"]["core"].pop("covered_lines")
         expect_error("malformed core", lambda: ledger_module.validate_floors(mutated, args))
+
+        mutated = json.loads(json.dumps(valid_ledger))
+        mutated["crates"]["graphforge-core"]["line_percent"] = 79.99
+        expect_error(
+            "graphforge-core Rust coverage below",
+            lambda: ledger_module.validate_floors(mutated, args),
+        )
+
+        mutated = json.loads(json.dumps(valid_ledger))
+        mutated["patch"]["line_percent"] = 89.99
+        expect_error(
+            "changed Rust coverage below", lambda: ledger_module.validate_floors(mutated, args)
+        )
+
+        mutated = json.loads(json.dumps(valid_ledger))
+        mutated.pop("crates")
+        expect_error("missing per-crate", lambda: ledger_module.validate_floors(mutated, args))
+
+        mutated = json.loads(json.dumps(valid_ledger))
+        mutated["crates"].pop(next(iter(mutated["crates"])))
+        expect_error(
+            "crate inventory mismatch",
+            lambda: ledger_module.validate_floors(mutated, args),
+        )
+
+        mutated = json.loads(json.dumps(valid_ledger))
+        mutated["patch"]["measured_lines"] = "ten"
+        expect_error("malformed patch", lambda: ledger_module.validate_floors(mutated, args))
+
+        mutated = json.loads(json.dumps(valid_ledger))
+        mutated["patch"]["line_percent"] = float("nan")
+        expect_error("malformed patch", lambda: ledger_module.validate_floors(mutated, args))
 
     print("rust coverage ledger mutation sentinels: ok")
 

--- a/scripts/coverage-rust.sh
+++ b/scripts/coverage-rust.sh
@@ -19,7 +19,10 @@ SUMMARY="$OUT_DIR/summary.txt"
 COVERAGE_RUST_ARGS="${COVERAGE_RUST_ARGS:---workspace}"
 PYTHON_FLOOR="${COVERAGE_FAIL_UNDER_RUST_PYTHON_ADAPTER:-80}"
 NODE_FLOOR="${COVERAGE_FAIL_UNDER_RUST_NODE_ADAPTER:-80}"
-CORE_FLOOR="${COVERAGE_FAIL_UNDER_RUST:-85}"
+CORE_FLOOR="${COVERAGE_FAIL_UNDER_RUST:-93.5}"
+CRATE_FLOOR="${COVERAGE_FAIL_UNDER_RUST_CRATE:-80}"
+PATCH_FLOOR="${COVERAGE_FAIL_UNDER_RUST_PATCH:-90}"
+PATCH_BASE="${COVERAGE_RUST_PATCH_BASE:-origin/main}"
 
 if ! cargo llvm-cov --version >/dev/null 2>&1; then
   echo "Rust coverage evidence error: cargo-llvm-cov is not installed" >&2
@@ -187,6 +190,9 @@ python3 scripts/coverage_rust_ledger.py \
   --workspace-lcov "$WORKSPACE_LCOV" \
   --evidence "$EVIDENCE" \
   --core-floor "$CORE_FLOOR" \
+  --crate-floor "$CRATE_FLOOR" \
+  --patch-floor "$PATCH_FLOOR" \
+  --patch-base "$PATCH_BASE" \
   --python-floor "$PYTHON_FLOOR" \
   --node-floor "$NODE_FLOOR" | tee "$SUMMARY"
 

--- a/scripts/coverage_rust_ledger.py
+++ b/scripts/coverage_rust_ledger.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import math
 from pathlib import Path
+import re
 import subprocess
 import sys
 from typing import Any
@@ -36,6 +38,32 @@ def git_head(root: Path) -> str:
         ).strip()
     except (subprocess.CalledProcessError, OSError) as error:
         raise LedgerError("failed to resolve git HEAD") from error
+
+
+def git_merge_base(root: Path, base_ref: str) -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "merge-base", "HEAD", base_ref],
+            cwd=root,
+            text=True,
+            stderr=subprocess.PIPE,
+        ).strip()
+    except (subprocess.CalledProcessError, OSError) as error:
+        raise LedgerError("failed to resolve Rust patch coverage base") from error
+
+
+def validate_source_tree_clean(root: Path) -> None:
+    try:
+        status = subprocess.check_output(
+            ["git", "status", "--porcelain", "--untracked-files=all"],
+            cwd=root,
+            text=True,
+            stderr=subprocess.PIPE,
+        )
+    except (subprocess.CalledProcessError, OSError) as error:
+        raise LedgerError("failed to inspect coverage source tree") from error
+    if status:
+        raise LedgerError("coverage source tree has uncommitted changes")
 
 
 def normalize_source(raw: str, root: Path) -> str | None:
@@ -110,6 +138,79 @@ def totals(records: dict[str, dict[int, int]]) -> dict[str, int | float]:
     }
 
 
+def crate_totals(records: dict[str, dict[int, int]]) -> dict[str, dict[str, int | float]]:
+    """Return deterministic totals for every non-binding production crate."""
+    crates: dict[str, dict[str, dict[int, int]]] = {}
+    for path, lines in records.items():
+        parts = path.split("/")
+        if len(parts) < 4 or parts[0] != "crates" or parts[2] != "src":
+            continue
+        crate = parts[1]
+        if crate.startswith("graphforge-bindings-"):
+            continue
+        crates.setdefault(crate, {})[path] = lines
+    if not crates:
+        raise LedgerError("core coverage contains no production Rust crates")
+    return {name: totals(crates[name]) for name in sorted(crates)}
+
+
+def expected_production_crates(root: Path) -> set[str]:
+    crates = {
+        path.parent.name
+        for path in (root / "crates").glob("*/Cargo.toml")
+        if not path.parent.name.startswith("graphforge-bindings-")
+        and any((path.parent / "src").rglob("*.rs"))
+    }
+    if not crates:
+        raise LedgerError("workspace contains no non-binding production Rust crates")
+    return crates
+
+
+def patch_totals(
+    records: dict[str, dict[int, int]], root: Path, base_ref: str
+) -> tuple[str, dict[str, int | float]]:
+    """Measure executable changed Rust lines against the merge base."""
+    try:
+        base_sha = git_merge_base(root, base_ref)
+        diff = subprocess.check_output(
+            ["git", "diff", "--unified=0", f"{base_sha}...HEAD", "--", "crates/**/*.rs"],
+            cwd=root,
+            text=True,
+            stderr=subprocess.PIPE,
+        )
+    except (subprocess.CalledProcessError, OSError) as error:
+        raise LedgerError("failed to resolve Rust patch coverage base") from error
+
+    changed: dict[str, set[int]] = {}
+    path: str | None = None
+    for line in diff.splitlines():
+        if line.startswith("+++ b/"):
+            path = line[6:]
+            continue
+        if not line.startswith("@@") or path is None:
+            continue
+        match = re.search(r"\+(\d+)(?:,(\d+))?", line)
+        if match is None:
+            raise LedgerError("malformed Rust patch hunk")
+        start = int(match.group(1))
+        count = int(match.group(2) or "1")
+        changed.setdefault(path, set()).update(range(start, start + count))
+
+    measured = covered = 0
+    for source, lines in records.items():
+        for line in changed.get(source, set()):
+            if line in lines:
+                measured += 1
+                covered += int(lines[line] > 0)
+    percent = 100.0 if measured == 0 else round(covered * 100 / measured, 2)
+    return base_sha, {
+        "covered_lines": covered,
+        "measured_lines": measured,
+        "line_percent": percent,
+        "source_files": sum(bool(changed.get(source)) for source in records),
+    }
+
+
 def write_lcov(records: dict[str, dict[int, int]], path: Path, root: Path) -> None:
     output: list[str] = []
     for source in sorted(records):
@@ -155,6 +256,7 @@ def validate_evidence(evidence: dict[str, Any], root: Path, expected_sha: str) -
 
 def build_ledger(args: argparse.Namespace) -> dict[str, Any]:
     root = args.root.resolve()
+    validate_source_tree_clean(root)
     expected_sha = git_head(root)
     evidence = json.loads(args.evidence.read_text(encoding="utf-8"))
     validate_evidence(evidence, root, expected_sha)
@@ -165,15 +267,18 @@ def build_ledger(args: argparse.Namespace) -> dict[str, Any]:
     merged = merge_records(core_report, python_report, node_report)
     if args.workspace_lcov is not None:
         write_lcov(merged, args.workspace_lcov, root)
+    core_records = select_surface(core_report, "core")
+    patch_base_sha, patch = patch_totals(core_records, root, args.patch_base)
     surfaces = {
-        "core": totals(select_surface(core_report, "core")),
+        "core": totals(core_records),
         "python_adapter": totals(select_surface(python_report, "python_adapter")),
         "node_adapter": totals(select_surface(node_report, "node_adapter")),
         "workspace": totals(merged),
     }
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "source_sha": expected_sha,
+        "patch_base_sha": patch_base_sha,
         "toolchain": {
             "rustc": evidence["rustc"],
             "cargo_llvm_cov": evidence["cargo_llvm_cov"],
@@ -186,15 +291,21 @@ def build_ledger(args: argparse.Namespace) -> dict[str, Any]:
             for name in ("python_adapter", "node_adapter")
         },
         "surfaces": surfaces,
+        "crates": crate_totals(core_records),
+        "patch": patch,
     }
 
 
 def validate_floors(ledger: dict[str, Any], args: argparse.Namespace) -> None:
-    expected_sha = git_head(args.root.resolve())
-    if ledger.get("schema_version") != 1:
+    root = args.root.resolve()
+    expected_sha = git_head(root)
+    if ledger.get("schema_version") != 2:
         raise LedgerError("unsupported or missing Rust coverage ledger schema")
     if ledger.get("source_sha") != expected_sha:
         raise LedgerError("Rust coverage ledger is stale for the current HEAD")
+    expected_patch_base = git_merge_base(root, args.patch_base)
+    if ledger.get("patch_base_sha") != expected_patch_base:
+        raise LedgerError("Rust patch coverage ledger is stale for the current merge base")
     floors: dict[str, float | None] = {
         "core": args.core_floor,
         "python_adapter": args.python_floor,
@@ -203,31 +314,71 @@ def validate_floors(ledger: dict[str, Any], args: argparse.Namespace) -> None:
     }
     for surface, floor in floors.items():
         data = ledger.get("surfaces", {}).get(surface)
-        if not isinstance(data, dict):
-            raise LedgerError(f"Rust coverage ledger is missing {surface}")
-        covered = data.get("covered_lines")
-        measured = data.get("measured_lines")
-        percent = data.get("line_percent")
-        if (
-            not isinstance(covered, int)
-            or covered < 0
-            or not isinstance(measured, int)
-            or measured <= 0
-            or covered > measured
-            or not isinstance(percent, (int, float))
-        ):
-            raise LedgerError(f"Rust coverage ledger has malformed {surface} totals")
+        validate_total(data, surface)
+        percent = data["line_percent"]
         if floor is not None and float(percent) < floor:
             raise LedgerError(
                 f"{surface} Rust coverage below {floor:.2f}% (got {float(percent):.2f}%)"
             )
+    crates = ledger.get("crates")
+    if not isinstance(crates, dict) or not crates:
+        raise LedgerError("Rust coverage ledger is missing per-crate totals")
+    expected_crates = expected_production_crates(root)
+    actual_crates = set(crates)
+    if actual_crates != expected_crates:
+        missing = sorted(expected_crates - actual_crates)
+        unexpected = sorted(actual_crates - expected_crates)
+        raise LedgerError(
+            "Rust coverage ledger crate inventory mismatch: "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+    for crate, data in sorted(crates.items()):
+        validate_total(data, f"crate {crate}")
+        if float(data["line_percent"]) < args.crate_floor:
+            raise LedgerError(
+                f"{crate} Rust coverage below {args.crate_floor:.2f}% "
+                f"(got {float(data['line_percent']):.2f}%)"
+            )
+    patch = ledger.get("patch")
+    validate_total(patch, "patch", allow_zero=True)
+    if float(patch["line_percent"]) < args.patch_floor:
+        raise LedgerError(
+            f"changed Rust coverage below {args.patch_floor:.2f}% "
+            f"(got {float(patch['line_percent']):.2f}%)"
+        )
+
+
+def validate_total(data: Any, name: str, *, allow_zero: bool = False) -> None:
+    if not isinstance(data, dict):
+        raise LedgerError(f"Rust coverage ledger is missing {name}")
+    covered = data.get("covered_lines")
+    measured = data.get("measured_lines")
+    percent = data.get("line_percent")
+    if (
+        isinstance(covered, bool)
+        or not isinstance(covered, int)
+        or covered < 0
+        or isinstance(measured, bool)
+        or not isinstance(measured, int)
+        or measured < int(not allow_zero)
+        or covered > measured
+        or isinstance(percent, bool)
+        or not isinstance(percent, (int, float))
+        or not math.isfinite(percent)
+        or percent < 0
+        or percent > 100
+    ):
+        raise LedgerError(f"Rust coverage ledger has malformed {name} totals")
 
 
 def parser() -> argparse.ArgumentParser:
     result = argparse.ArgumentParser()
     result.add_argument("--root", type=Path, required=True)
     result.add_argument("--ledger", type=Path, required=True)
-    result.add_argument("--core-floor", type=float, default=85.0)
+    result.add_argument("--core-floor", type=float, default=93.5)
+    result.add_argument("--crate-floor", type=float, default=80.0)
+    result.add_argument("--patch-floor", type=float, default=90.0)
+    result.add_argument("--patch-base", default="origin/main")
     result.add_argument("--python-floor", type=float, default=80.0)
     result.add_argument("--node-floor", type=float, default=80.0)
     result.add_argument("--build", action="store_true")
@@ -260,6 +411,8 @@ def main() -> int:
             (name, ledger["surfaces"][name])
             for name in ("core", "python_adapter", "node_adapter", "workspace")
         ]
+        crate_report = sorted(ledger["crates"].items())
+        patch_report = ledger["patch"]
     except (LedgerError, json.JSONDecodeError, KeyError, TypeError) as error:
         print(f"Rust coverage evidence error: {error}", file=sys.stderr)
         return 1
@@ -269,6 +422,15 @@ def main() -> int:
             f"{name}: {data['covered_lines']}/{data['measured_lines']} "
             f"lines ({data['line_percent']:.2f}%)"
         )
+    for name, data in crate_report:
+        print(
+            f"crate {name}: {data['covered_lines']}/{data['measured_lines']} "
+            f"lines ({data['line_percent']:.2f}%)"
+        )
+    print(
+        f"patch: {patch_report['covered_lines']}/{patch_report['measured_lines']} "
+        f"lines ({patch_report['line_percent']:.2f}%)"
+    )
     return 0
 
 


### PR DESCRIPTION
## Summary

- add a fail-closed Rust coverage ledger with exact HEAD and merge-base provenance, aggregate/core/per-crate/adapter/patch thresholds, and deterministic mutation sentinels
- cover foundational AST token/span, planner construction/reconstruction/hash/rejection, IR/rel expression, and executor write-extension dispatch contracts
- document the interim 93.5% core ratchet; the remaining #360 test tranches raise it to the final 95% goal

## Measured coverage

- core: 93.76%
- every production crate: above 80%
- graphforge-plan: 93.56%
- changed Rust lines: 99.67%
- Python adapter Rust: 84.40%
- Node adapter Rust: 86.22%

## Verification

- ledger sentinels under normal and optimized Python
- targeted `graphforge-ast`, `graphforge-plan`, `graphforge-ir`, `graphforge-rel`, and `graphforge-exec` suites
- `CARGO_TARGET_DIR=/tmp/graphforge-target-366 make pre-push`
  - Rust facade 463/463
  - Rust API BDD 97/97
  - openCypher TCK 3897/3897
  - Python native 215 passed, 21 tracked skips
  - Node native 219/219 and Node BDD 102/102
  - all coverage and mutation gates passed

Closes #366

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788371871&installation_model_id=20486&pr_number=378&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F378&signature=07b9749a11e6473ee403bb63cfba6356f0b2c0cc32e7d7370ceb7f9285ae0017"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce multi-tier Rust coverage ledger with per-crate, patch, and core thresholds
> - Raises the core Rust coverage floor from 85% to 93.5%, adds a per-crate floor of 80%, and adds a patch (changed-line) floor of 90%, all configurable via `COVERAGE_FAIL_UNDER_RUST_CRATE`, `COVERAGE_FAIL_UNDER_RUST_PATCH`, and `COVERAGE_FAIL_UNDER_RUST_CORE` in the [Makefile](https://github.com/CurateLabs/graphforge/pull/378/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52).
> - Upgrades [coverage_rust_ledger.py](https://github.com/CurateLabs/graphforge/pull/378/files#diff-9db9ac2da6eedb47b95536c78741bd2a5237220edc9ba178963230d42662a500) to schema v2: ledger builds now fail on a dirty working tree, compute per-crate totals, compute patch coverage via a git diff against a configurable merge base, and embed `patch_base_sha`.
> - Validation in `validate_floors` rejects ledgers that are not schema v2, have a stale patch base SHA, have a crate inventory mismatch, or fall below any floor.
> - Adds broad unit and contract tests across `graphforge-ast`, `graphforge-exec`, `graphforge-ir`, `graphforge-plan`, and `graphforge-rel` to bring coverage up to the new thresholds.
> - Risk: any PR with a dirty working tree or changed Rust lines below 90% coverage will now fail CI.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d41a6dc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Rust coverage reporting now includes core, per-crate, and patch-level metrics.
  - Coverage checks report detailed crate and patch results and support a configurable comparison branch.
- **Chores**
  - Coverage requirements have been raised to 93.5% overall, 80% per crate, and 90% for patches.
  - Validation now detects stale comparison points, incomplete coverage data, and unclean source trees.
- **Tests**
  - Expanded coverage for parsing, planning, execution, expression handling, and type conversion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->