### PR TITLE
test(rel): prove expression and relational-lowering boundaries

### DIFF
--- a/crates/graphforge-rel/src/expr.rs
+++ b/crates/graphforge-rel/src/expr.rs
@@ -14732,6 +14732,127 @@ mod tests {
     }
 
     #[test]
+    fn heterogeneous_map_access_returns_exact_values_and_rejects_non_maps() {
+        use datafusion::arrow::array::{ArrayRef, StringArray};
+        use datafusion::scalar::ScalarValue as S;
+
+        let map = const_map_scalar(&[
+            ("answer".to_owned(), S::Int64(Some(42))),
+            ("empty".to_owned(), S::Int64(None)),
+        ])
+        .expect("map scalar");
+        let encoded = build_het_struct(&[map], 1).expect("tagged map");
+        let return_type =
+            het_value_access_return_type(encoded.data_type()).expect("map value type");
+        let null_value = S::try_from(&return_type).expect("typed null");
+        let keys = |key: Option<&str>| -> ArrayRef { Arc::new(StringArray::from(vec![key])) };
+
+        let found = het_map_access_value(&encoded, &keys(Some("answer")), 0, &null_value)
+            .expect("existing map key");
+        assert_eq!(decode_het(&found), Some(S::Int64(Some(42))));
+
+        let stored_null = het_map_access_value(&encoded, &keys(Some("empty")), 0, &null_value)
+            .expect("stored null");
+        assert_eq!(decode_het(&stored_null), Some(S::Null));
+        assert_eq!(
+            het_map_access_value(&encoded, &keys(Some("missing")), 0, &null_value)
+                .expect("missing key"),
+            null_value
+        );
+        assert_eq!(
+            het_map_access_value(&encoded, &keys(None), 0, &null_value).expect("null key"),
+            null_value
+        );
+
+        let non_map = build_het_struct(&[S::Int64(Some(7))], 0).expect("tagged integer");
+        let error = het_map_access_value(&non_map, &keys(Some("answer")), 0, &null_value)
+            .expect_err("a tagged integer is not dynamically property-readable");
+        assert_eq!(
+            error.to_string(),
+            "Execution error: invalid argument type: dynamic value access requires a map"
+        );
+    }
+
+    #[test]
+    fn dynamic_struct_access_observes_missing_null_type_and_row_null_semantics() {
+        use datafusion::arrow::array::{Array, ArrayRef, Int64Array, StringArray, StructArray};
+        use datafusion::arrow::buffer::NullBuffer;
+        use datafusion::arrow::datatypes::{Field, Fields};
+        use datafusion::config::ConfigOptions;
+
+        let values: ArrayRef = Arc::new(StructArray::new(
+            Fields::from(vec![Field::new("score", DataType::Int64, true)]),
+            vec![Arc::new(Int64Array::from(vec![Some(9), None, Some(11)]))],
+            Some(NullBuffer::from(vec![true, true, false])),
+        ));
+        let invoke = |keys: ArrayRef| -> datafusion::error::Result<ArrayRef> {
+            let udf = CypherValueAccess::new();
+            let result = udf.invoke_with_args(ScalarFunctionArgs {
+                args: vec![
+                    ColumnarValue::Array(Arc::clone(&values)),
+                    ColumnarValue::Array(keys),
+                ],
+                arg_fields: vec![
+                    Arc::new(Field::new("value", values.data_type().clone(), true)),
+                    Arc::new(Field::new("key", DataType::Utf8, true)),
+                ],
+                number_rows: 3,
+                return_field: Arc::new(Field::new("out", DataType::Int64, true)),
+                config_options: Arc::new(ConfigOptions::default()),
+            })?;
+            match result {
+                ColumnarValue::Array(array) => Ok(array),
+                ColumnarValue::Scalar(value) => value.to_array_of_size(3),
+            }
+        };
+
+        let result = invoke(Arc::new(StringArray::from(vec![
+            Some("score"),
+            Some("missing"),
+            Some("score"),
+        ])))
+        .expect("dynamic struct access");
+        let result = result.as_any().downcast_ref::<Int64Array>().expect("Int64");
+        assert_eq!(result.value(0), 9);
+        assert!(result.is_null(1), "an absent property is null");
+        assert!(result.is_null(2), "a null graph-element row is null");
+
+        let bad_keys: ArrayRef = Arc::new(Int64Array::from(vec![1, 2, 3]));
+        let error = invoke(bad_keys).expect_err("numeric property key");
+        assert!(
+            error
+                .to_string()
+                .contains("dynamic map/property access key must be a string"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn temporal_accessor_type_matrix_distinguishes_values_from_properties() {
+        // Date and duration dispatch through their dedicated lowering paths.
+        assert!(!temporal_accessor_valid(&DataType::Date32, "year"));
+        assert!(!temporal_accessor_valid(&DataType::Date32, "timezone"));
+        assert!(temporal_accessor_valid(
+            &ScalarValue::Time64Nanosecond(None).data_type(),
+            "nanosecond"
+        ));
+        assert!(!temporal_accessor_valid(
+            &duration_scalar(None).data_type(),
+            "monthsOfYear"
+        ));
+        assert!(temporal_accessor_valid(
+            &localdatetime_scalar(None).data_type(),
+            "year"
+        ));
+        assert!(temporal_accessor_valid(
+            &datetime_scalar(None).data_type(),
+            "offsetSeconds"
+        ));
+        assert!(!temporal_accessor_valid(&DataType::Utf8, "year"));
+        assert!(!temporal_accessor_valid(&DataType::Int64, "day"));
+    }
+
+    #[test]
     fn scalar_to_ir_literal_round_trips_a_list() {
         // A homogeneous list now stores (#1006): scalar List → IrLiteral::List
         // and back, element-wise — including a list of typed temporals.

--- a/crates/graphforge-rel/src/lowerer.rs
+++ b/crates/graphforge-rel/src/lowerer.rs
@@ -5153,6 +5153,161 @@ mod tests {
         );
     }
 
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn created_rows_schema_preserves_input_skips_references_and_types_minted_nodes() {
+        use std::collections::HashMap;
+
+        use datafusion::arrow::datatypes::{DataType, Field};
+        use datafusion::common::{DFSchema, TableReference};
+        use datafusion::logical_expr::{col, lit};
+        use graphforge_plan::ResolvedNodeSpec;
+
+        let input = Arc::new(
+            DFSchema::new_with_metadata(
+                vec![(
+                    Some(TableReference::bare("input")),
+                    Arc::new(Field::new("seed", DataType::Int64, false)),
+                )],
+                HashMap::new(),
+            )
+            .unwrap(),
+        );
+        let reference = ResolvedNodeSpec {
+            var: 1,
+            label_ids: vec![7],
+            label_names: vec!["Existing".into()],
+            properties: vec![("ignored".into(), IrLiteral::Int(1))],
+            computed_properties: vec![],
+            is_reference: true,
+        };
+        let minted = ResolvedNodeSpec {
+            var: 2,
+            label_ids: vec![8, 9],
+            label_names: vec!["New".into(), "Tagged".into()],
+            properties: vec![("active".into(), IrLiteral::Bool(true))],
+            computed_properties: vec![("copied_seed".into(), col("seed") + lit(1_i64))],
+            is_reference: false,
+        };
+
+        let schema = GraphPlanLowerer::created_rows_schema(&[reference, minted], &input).unwrap();
+        let fields: Vec<_> = schema
+            .iter()
+            .map(|(qualifier, field)| {
+                (
+                    qualifier.map(ToString::to_string),
+                    field.name().clone(),
+                    field.data_type().clone(),
+                    field.is_nullable(),
+                )
+            })
+            .collect();
+
+        assert_eq!(
+            fields.len(),
+            7,
+            "one input plus four identity and two property fields"
+        );
+        assert_eq!(
+            fields[0],
+            (Some("input".into()), "seed".into(), DataType::Int64, false)
+        );
+        assert_eq!(
+            fields[1..5]
+                .iter()
+                .map(|(q, name, ty, nullable)| { (q.clone(), name.clone(), ty.clone(), *nullable) })
+                .collect::<Vec<_>>(),
+            vec![
+                (
+                    Some("var_2".into()),
+                    "node_uuid".into(),
+                    DataType::FixedSizeBinary(16),
+                    false
+                ),
+                (
+                    Some("var_2".into()),
+                    "node_id".into(),
+                    DataType::UInt64,
+                    false,
+                ),
+                (
+                    Some("var_2".into()),
+                    "type_id".into(),
+                    DataType::UInt32,
+                    false,
+                ),
+                (
+                    Some("var_2".into()),
+                    "type_ids".into(),
+                    DataType::List(Arc::new(Field::new("item", DataType::UInt32, false))),
+                    false,
+                ),
+            ]
+        );
+        assert_eq!(
+            fields[5],
+            (
+                Some("var_2".into()),
+                "active".into(),
+                DataType::Boolean,
+                true
+            )
+        );
+        assert_eq!(
+            fields[6],
+            (
+                Some("var_2".into()),
+                "copied_seed".into(),
+                DataType::Int64,
+                true,
+            )
+        );
+        assert!(
+            fields
+                .iter()
+                .all(|(q, _, _, _)| q.as_deref() != Some("var_1")),
+            "reference nodes are passed through only and never duplicated"
+        );
+    }
+
+    #[test]
+    fn created_rows_schema_rejects_reserved_and_unbound_computed_properties() {
+        use graphforge_plan::ResolvedNodeSpec;
+
+        let input = Arc::new(datafusion::common::DFSchema::empty());
+        for reserved in ["node_uuid", "node_id", "type_id", "type_ids"] {
+            let spec = ResolvedNodeSpec {
+                var: 3,
+                label_ids: vec![],
+                label_names: vec![],
+                properties: vec![(reserved.into(), IrLiteral::Null)],
+                computed_properties: vec![],
+                is_reference: false,
+            };
+            let error = GraphPlanLowerer::created_rows_schema(&[spec], &input).unwrap_err();
+            assert_eq!(
+                error.to_string(),
+                format!(
+                    "unsupported expression: CREATE property `{reserved}` collides with a reserved node topology field"
+                )
+            );
+        }
+
+        let unbound = ResolvedNodeSpec {
+            var: 4,
+            label_ids: vec![],
+            label_names: vec![],
+            properties: vec![],
+            computed_properties: vec![("value".into(), datafusion::logical_expr::col("missing"))],
+            is_reference: false,
+        };
+        let error = GraphPlanLowerer::created_rows_schema(&[unbound], &input).unwrap_err();
+        assert!(
+            error.to_string().contains("No field named missing"),
+            "unbound computed properties must retain the DataFusion schema error: {error}"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // DELETE lowering (#740)
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- prove heterogeneous map and dynamic struct access across exact, null, missing, and wrong-type cases
- freeze temporal accessor dispatch boundaries
- prove created-row schema qualifiers, identity fields, reference omission, reserved-field rejection, and unresolved computed properties

## Verification

- `CARGO_TARGET_DIR=/tmp/graphforge-target-367-expr cargo test -p graphforge-rel expr::tests::` — 82 passed
- `CARGO_TARGET_DIR=/tmp/graphforge-target-367-expr cargo test -p graphforge-rel lowerer::tests::` — 43 passed
- `CARGO_TARGET_DIR=/tmp/graphforge-target-367-expr cargo clippy -p graphforge-rel -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/graphforge-target-367-expr make pre-push` — passed
- coverage: core 93.82%, graphforge-rel 91.90%, patch 99.52%
- Rust facade 463/463; Rust BDD 97/97; openCypher TCK 3897/3897
- Python native 215 passed with 21 tracked exclusions; Node native 219/219; Node BDD 102/102

Closes #367

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788375453&installation_model_id=20486&pr_number=379&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F379&signature=3bc1362c495c6f7fb790b2f398925a84b69f3aa5a7aecb38efc7030b15640d74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests for expression evaluation and relational-lowering boundaries in `graphforge-rel`
> - Adds tests for `het_map_access_value` in [expr.rs](https://github.com/CurateLabs/graphforge/pull/379/files#diff-84ebb88a746b913c23955a620f7ea54427485b8f7ad4b8a2bdb629731e5343ec) covering key lookup, null values, missing keys, and non-map inputs producing an execution error.
> - Adds tests for `CypherValueAccess` UDF covering struct field access, missing properties, row-level nulls, and non-string key errors.
> - Adds tests for `temporal_accessor_valid` verifying correct true/false results across date, duration, time-of-day, datetime, and non-temporal types.
> - Adds tests for `GraphPlanLowerer::created_rows_schema` in [lowerer.rs](https://github.com/CurateLabs/graphforge/pull/379/files#diff-99603ef95ae66a80dd1bb37d46c119e6f695cf833caa940f24a29bcf42ae9683) verifying schema output for minted vs reference nodes, reserved field collision rejection, and unbound computed property errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 916e456.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->