### PR TITLE
test(exec): prove write execution and dispatch boundaries

### DIFF
--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -5200,6 +5200,7 @@ const _: fn() = || {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow::datatypes::Schema;
     use datafusion::logical_expr::{Extension, LogicalPlanBuilder, lit};
     use datafusion::physical_plan::empty::EmptyExec;
     use graphforge_ir::RuntimeCatalog;
@@ -5223,9 +5224,131 @@ mod tests {
     }
 
     #[test]
+    fn write_summary_reads_named_counters_and_ignores_missing_or_empty_rows() {
+        let batch = RecordBatch::try_from_iter([
+            (
+                "properties_set",
+                Arc::new(UInt64Array::from(vec![7])) as ArrayRef,
+            ),
+            (
+                "nodes_created",
+                Arc::new(UInt64Array::from(vec![2])) as ArrayRef,
+            ),
+            (
+                "edges_deleted",
+                Arc::new(UInt64Array::from(vec![3])) as ArrayRef,
+            ),
+        ])
+        .unwrap();
+
+        assert_eq!(
+            SideEffects::from_summary(&[batch]),
+            SideEffects {
+                nodes_created: 2,
+                relationships_deleted: 3,
+                properties_set: 7,
+                ..SideEffects::default()
+            }
+        );
+        assert_eq!(SideEffects::from_summary(&[]), SideEffects::default());
+        assert_eq!(
+            SideEffects::from_summary(&[RecordBatch::new_empty(Arc::new(Schema::empty()))]),
+            SideEffects::default()
+        );
+    }
+
+    #[test]
+    fn referenced_node_columns_resolve_qualified_unqualified_and_struct_shapes() {
+        use datafusion::arrow::datatypes::{Field, Fields};
+        use datafusion::common::TableReference;
+
+        let qualified = DFSchema::new_with_metadata(
+            vec![
+                (
+                    Some(TableReference::bare("var_2")),
+                    Arc::new(Field::new(
+                        "node_uuid",
+                        DataType::FixedSizeBinary(16),
+                        false,
+                    )),
+                ),
+                (
+                    Some(TableReference::bare("var_2")),
+                    Arc::new(Field::new("node_id", DataType::UInt64, false)),
+                ),
+            ],
+            HashMap::new(),
+        )
+        .unwrap();
+        let resolved = RefNodeCols::resolve(&qualified, 2).unwrap();
+        assert_eq!(
+            (resolved.var, resolved.uuid_idx, resolved.node_id_idx),
+            (2, 0, Some(1))
+        );
+        assert_eq!(resolved.uuid_child_idx, None);
+
+        let unqualified = DFSchema::try_from(Schema::new(vec![
+            Field::new("node_uuid", DataType::FixedSizeBinary(16), false),
+            Field::new("node_id", DataType::UInt64, false),
+        ]))
+        .unwrap();
+        let resolved = RefNodeCols::resolve_with_alias(&unqualified, 4, "renamed").unwrap();
+        assert_eq!(
+            (resolved.var, resolved.uuid_idx, resolved.node_id_idx),
+            (4, 0, Some(1))
+        );
+
+        let node_fields = Fields::from(vec![Field::new(
+            "node_uuid",
+            DataType::FixedSizeBinary(16),
+            false,
+        )]);
+        let direct_struct = DFSchema::try_from(Schema::new(vec![Field::new(
+            "entity",
+            DataType::Struct(node_fields.clone()),
+            true,
+        )]))
+        .unwrap();
+        let resolved = RefNodeCols::resolve_with_alias(&direct_struct, 6, "entity").unwrap();
+        assert_eq!(
+            (
+                resolved.uuid_idx,
+                resolved.uuid_child_idx,
+                resolved.node_id_idx
+            ),
+            (0, Some(0), None)
+        );
+
+        let dynamic_struct = DFSchema::try_from(Schema::new(vec![Field::new(
+            "dynamic",
+            DataType::Struct(Fields::from(vec![Field::new(
+                "__het_value_8",
+                DataType::Struct(node_fields),
+                true,
+            )])),
+            true,
+        )]))
+        .unwrap();
+        let resolved = RefNodeCols::resolve_struct_at(&dynamic_struct, 8, 0).unwrap();
+        assert_eq!(resolved.uuid_child_idx, None);
+        assert!(RefNodeCols::resolve_struct_at(&unqualified, 9, 0).is_none());
+        assert!(RefNodeCols::resolve_with_alias(&direct_struct, 10, "missing").is_none());
+    }
+
+    #[test]
     fn write_execs_expose_stable_plan_contracts_and_reject_invalid_shape() {
         let dir = TempDir::new().unwrap();
         let (logical, physical) = empty_write_input();
+        let create: Arc<dyn ExecutionPlan> = Arc::new(GraphCreateExec::new(
+            &GraphCreateNode::new(
+                logical.clone(),
+                vec![],
+                vec![],
+                dir.path().to_path_buf(),
+                OntologyMode::Exploratory,
+            ),
+            physical.clone(),
+        ));
         let delete: Arc<dyn ExecutionPlan> = Arc::new(GraphDeleteExec::new(
             &GraphDeleteNode::new(
                 logical.clone(),
@@ -5270,13 +5393,15 @@ mod tests {
         ));
 
         for (plan, expected_name) in [
+            (create, "GraphCreateExec"),
             (delete, "GraphDeleteExec"),
             (set, "GraphSetExec"),
             (remove, "GraphRemoveExec"),
         ] {
             assert_eq!(plan.name(), expected_name);
             assert!(
-                plan.as_any().is::<GraphDeleteExec>()
+                plan.as_any().is::<GraphCreateExec>()
+                    || plan.as_any().is::<GraphDeleteExec>()
                     || plan.as_any().is::<GraphSetExec>()
                     || plan.as_any().is::<GraphRemoveExec>()
             );
@@ -5308,6 +5433,16 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let (logical, physical) = empty_write_input();
         let plans: Vec<Arc<dyn ExecutionPlan>> = vec![
+            Arc::new(GraphCreateExec::new(
+                &GraphCreateNode::new(
+                    logical.clone(),
+                    vec![],
+                    vec![],
+                    dir.path().to_path_buf(),
+                    OntologyMode::Exploratory,
+                ),
+                physical.clone(),
+            )),
             Arc::new(GraphDeleteExec::new(
                 &GraphDeleteNode::new(
                     logical.clone(),

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -5252,7 +5252,11 @@ mod tests {
         );
         assert_eq!(SideEffects::from_summary(&[]), SideEffects::default());
         assert_eq!(
-            SideEffects::from_summary(&[RecordBatch::new_empty(Arc::new(Schema::empty()))]),
+            SideEffects::from_summary(&[RecordBatch::try_from_iter([(
+                "nodes_created",
+                Arc::new(UInt64Array::from(Vec::<u64>::new())) as ArrayRef,
+            )])
+            .unwrap()]),
             SideEffects::default()
         );
     }
@@ -5482,15 +5486,16 @@ mod tests {
                     .unwrap();
             assert_eq!(batches.len(), 1);
             assert_eq!(batches[0].num_rows(), 1);
-            assert_eq!(
-                batches[0]
-                    .column(0)
-                    .as_any()
-                    .downcast_ref::<UInt64Array>()
-                    .unwrap()
-                    .value(0),
-                0
-            );
+            for column in batches[0].columns() {
+                assert_eq!(
+                    column
+                        .as_any()
+                        .downcast_ref::<UInt64Array>()
+                        .unwrap()
+                        .value(0),
+                    0
+                );
+            }
         }
     }
 

--- a/crates/graphforge-exec/src/write_driver.rs
+++ b/crates/graphforge-exec/src/write_driver.rs
@@ -3527,9 +3527,12 @@ pub(crate) fn statement_summary_batch(c: &WriteCounters) -> Result<RecordBatch, 
 
 #[cfg(test)]
 mod tests {
-    use arrow::array::{Array, Int64Array};
+    use arrow::array::{Array, FixedSizeBinaryBuilder, Int64Array, StringArray, UInt32Array};
     use datafusion::common::TableReference;
-    use graphforge_ir::{CreateEdgeSpec, CreateNodeSpec, CreatePattern, VarId};
+    use graphforge_ir::{
+        CreateEdgeSpec, CreateNodeSpec, CreatePattern, IrLiteral, PropId, RemovePropItem,
+        SetPropItem, VarId,
+    };
 
     use super::*;
 
@@ -3797,5 +3800,235 @@ mod tests {
         assert_eq!(input_schema, schema);
         assert_eq!(batches.len(), 1);
         assert_eq!(batches[0].num_rows(), 0);
+    }
+
+    fn nullable_uuids(values: &[Option<[u8; 16]>]) -> ArrayRef {
+        let mut builder = FixedSizeBinaryBuilder::with_capacity(values.len(), 16);
+        for value in values {
+            match value {
+                Some(value) => builder.append_value(value).unwrap(),
+                None => builder.append_null(),
+            }
+        }
+        Arc::new(builder.finish())
+    }
+
+    fn write_frontier(is_edge: bool) -> Frontier {
+        let uuid_name = if is_edge { "edge_uuid" } else { "node_uuid" };
+        let mut fields = vec![Field::new(uuid_name, DataType::FixedSizeBinary(16), true)];
+        let mut columns = vec![nullable_uuids(&[Some([7; 16]), Some([7; 16]), None])];
+        if is_edge {
+            fields.push(Field::new("rel_type_name", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec!["KNOWS"; 3])));
+        } else {
+            fields.push(Field::new("type_id", DataType::UInt32, false));
+            columns.push(Arc::new(UInt32Array::from(vec![3; 3])));
+        }
+        fields.push(Field::new("score", DataType::Int64, true));
+        columns.push(Arc::new(Int64Array::from(vec![Some(1), Some(1), Some(1)])));
+        let schema = Arc::new(Schema::new(fields.clone()));
+        let qualifier = TableReference::bare("var_1");
+        Frontier {
+            df_schema: DFSchema::new_with_metadata(
+                fields
+                    .into_iter()
+                    .map(|field| (Some(qualifier.clone()), Arc::new(field)))
+                    .collect(),
+                HashMap::new(),
+            )
+            .unwrap(),
+            batches: vec![RecordBatch::try_new(schema, columns).unwrap()],
+        }
+    }
+
+    fn phase_env<'a>(
+        lowerer: &'a GraphPlanLowerer<'a>,
+        exprs: &'a ExprArena,
+        dir: &'a Path,
+        params: &'a HashMap<String, IrLiteral>,
+    ) -> PhaseEnv<'a> {
+        PhaseEnv {
+            lowerer,
+            exprs,
+            dir,
+            mode: OntologyMode::Exploratory,
+            params,
+            type_map: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn set_accumulates_nodes_and_edges_once_across_duplicate_and_null_rows() {
+        for is_edge in [false, true] {
+            let dir = tempfile::tempdir().unwrap();
+            let lowerer =
+                GraphPlanLowerer::new_for_writes(None, None, dir.path(), OntologyMode::Exploratory);
+            let mut exprs = ExprArena::new();
+            let value = exprs.push(IrExpr::Literal(IrLiteral::Int(42)));
+            let params = HashMap::new();
+            let env = phase_env(&lowerer, &exprs, dir.path(), &params);
+            let mut frontier = write_frontier(is_edge);
+            let mut var_map = VarMap::new();
+            var_map.insert(VarId(1), "var_1");
+            let mut ctx =
+                StatementWriteContext::new(dir.path(), OntologyMode::Exploratory).unwrap();
+
+            run_set_phase(
+                &env,
+                &[SetPropItem {
+                    target: VarId(1),
+                    prop: PropId(9),
+                    prop_name: "score".into(),
+                    value,
+                }],
+                &mut frontier,
+                &var_map,
+                &mut ctx,
+            )
+            .unwrap();
+
+            let accumulated = if is_edge {
+                &ctx.set_acc.edges["KNOWS"]
+            } else {
+                &ctx.set_acc.nodes["_untyped"]
+            };
+            assert_eq!(
+                accumulated[&[7; 16]]["score"],
+                IrLiteral::Int(42),
+                "wrong accumulated value for is_edge={is_edge}"
+            );
+            assert_eq!(accumulated.len(), 1, "duplicate rows must coalesce");
+            assert_eq!(ctx.counters.properties_set, 1);
+            assert_eq!(ctx.counters.properties_removed, 1);
+        }
+    }
+
+    #[test]
+    fn remove_accumulates_nodes_and_edges_and_ignores_null_optional_rows() {
+        for is_edge in [false, true] {
+            let dir = tempfile::tempdir().unwrap();
+            let lowerer =
+                GraphPlanLowerer::new_for_writes(None, None, dir.path(), OntologyMode::Exploratory);
+            let exprs = ExprArena::new();
+            let params = HashMap::new();
+            let env = phase_env(&lowerer, &exprs, dir.path(), &params);
+            let mut frontier = write_frontier(is_edge);
+            frontier.batches[0] = RecordBatch::try_new(
+                Arc::clone(frontier.batches[0].schema_ref()),
+                vec![
+                    nullable_uuids(&[Some([7; 16]), Some([8; 16]), None]),
+                    Arc::clone(frontier.batches[0].column(1)),
+                    Arc::clone(frontier.batches[0].column(2)),
+                ],
+            )
+            .unwrap();
+            let mut ctx =
+                StatementWriteContext::new(dir.path(), OntologyMode::Exploratory).unwrap();
+
+            run_remove_phase(
+                &env,
+                &[RemovePropItem {
+                    target: VarId(1),
+                    prop: PropId(9),
+                    prop_name: "score".into(),
+                }],
+                &mut frontier,
+                &mut ctx,
+            )
+            .unwrap();
+
+            let accumulated = if is_edge {
+                &ctx.remove_acc.edges["KNOWS"]
+            } else {
+                &ctx.remove_acc.nodes["_untyped"]
+            };
+            assert_eq!(accumulated[&[7; 16]], HashSet::from(["score".into()]));
+            assert_eq!(accumulated[&[8; 16]], HashSet::from(["score".into()]));
+            assert_eq!(accumulated.len(), 2);
+            assert_eq!(ctx.counters.properties_removed, 2);
+        }
+    }
+
+    #[test]
+    fn set_and_remove_reject_malformed_identity_and_edge_routing_columns() {
+        let dir = tempfile::tempdir().unwrap();
+        let lowerer =
+            GraphPlanLowerer::new_for_writes(None, None, dir.path(), OntologyMode::Exploratory);
+        let mut exprs = ExprArena::new();
+        let value = exprs.push(IrExpr::Literal(IrLiteral::Int(42)));
+        let params = HashMap::new();
+        let env = phase_env(&lowerer, &exprs, dir.path(), &params);
+        let mut var_map = VarMap::new();
+        var_map.insert(VarId(1), "var_1");
+
+        let mut malformed_uuid = write_frontier(false);
+        malformed_uuid.batches[0] = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("node_uuid", DataType::Int64, false),
+                Field::new("type_id", DataType::UInt32, false),
+                Field::new("score", DataType::Int64, true),
+            ])),
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+                Arc::clone(malformed_uuid.batches[0].column(1)),
+                Arc::clone(malformed_uuid.batches[0].column(2)),
+            ],
+        )
+        .unwrap();
+        let mut ctx = StatementWriteContext::new(dir.path(), OntologyMode::Exploratory).unwrap();
+        let err = run_set_phase(
+            &env,
+            &[SetPropItem {
+                target: VarId(1),
+                prop: PropId(9),
+                prop_name: "score".into(),
+                value,
+            }],
+            &mut malformed_uuid,
+            &var_map,
+            &mut ctx,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "execution error: expected FixedSizeBinary(16) at column 0"
+        );
+        assert!(ctx.set_acc.nodes.is_empty());
+        assert!(ctx.set_acc.edges.is_empty());
+        assert_eq!(ctx.counters, WriteCounters::default());
+
+        let mut malformed_route = write_frontier(true);
+        malformed_route.batches[0] = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("edge_uuid", DataType::FixedSizeBinary(16), true),
+                Field::new("rel_type_name", DataType::Int64, false),
+                Field::new("score", DataType::Int64, true),
+            ])),
+            vec![
+                Arc::clone(malformed_route.batches[0].column(0)),
+                Arc::new(Int64Array::from(vec![1, 1, 1])),
+                Arc::clone(malformed_route.batches[0].column(2)),
+            ],
+        )
+        .unwrap();
+        let mut ctx = StatementWriteContext::new(dir.path(), OntologyMode::Exploratory).unwrap();
+        let err = run_remove_phase(
+            &env,
+            &[RemovePropItem {
+                target: VarId(1),
+                prop: PropId(9),
+                prop_name: "score".into(),
+            }],
+            &mut malformed_route,
+            &mut ctx,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "execution error: rel_type_name is not a string column"
+        );
+        assert!(ctx.remove_acc.nodes.is_empty());
+        assert!(ctx.remove_acc.edges.is_empty());
+        assert_eq!(ctx.counters, WriteCounters::default());
     }
 }

--- a/crates/graphforge-exec/src/write_driver.rs
+++ b/crates/graphforge-exec/src/write_driver.rs
@@ -3306,13 +3306,13 @@ fn run_remove_phase(
                 ) {
                     continue;
                 }
+                let stem = col.stem_for_row(batch, row, env.mode, &env.type_map)?;
                 let keys = HashSet::from([item.prop_name.clone()]);
                 if is_edge && ctx.writer.contains_pending_edge(&uuid) {
                     ctx.writer.remove_pending_edge_props(&uuid, &keys);
                 } else if !is_edge && ctx.writer.contains_pending_node(&uuid) {
                     ctx.writer.remove_pending_node_props(&uuid, &keys);
                 } else {
-                    let stem = col.stem_for_row(batch, row, env.mode, &env.type_map)?;
                     ctx.set_acc.forget(is_edge, &stem, &uuid, &item.prop_name);
                     ctx.remove_acc
                         .record(is_edge, stem, uuid, item.prop_name.clone());
@@ -4030,5 +4030,44 @@ mod tests {
         assert!(ctx.remove_acc.nodes.is_empty());
         assert!(ctx.remove_acc.edges.is_empty());
         assert_eq!(ctx.counters, WriteCounters::default());
+
+        let mut pending_ctx =
+            StatementWriteContext::new(dir.path(), OntologyMode::Exploratory).unwrap();
+        let src = graphforge_core::uuid::new_v7();
+        let dst = graphforge_core::uuid::new_v7();
+        let edge = graphforge_core::uuid::Uuid::from_bytes([7; 16]);
+        pending_ctx
+            .writer
+            .create_node(src, graphforge_core::TypeId(1))
+            .unwrap();
+        pending_ctx
+            .writer
+            .create_node(dst, graphforge_core::TypeId(1))
+            .unwrap();
+        pending_ctx
+            .writer
+            .create_edge(edge, "KNOWS", &src, &dst)
+            .unwrap();
+        pending_ctx.writer.merge_pending_edge_props(
+            &[7; 16],
+            Some("KNOWS"),
+            HashMap::from([("score".into(), IrLiteral::Int(1))]),
+        );
+        let err = run_remove_phase(
+            &env,
+            &[RemovePropItem {
+                target: VarId(1),
+                prop: PropId(9),
+                prop_name: "score".into(),
+            }],
+            &mut malformed_route,
+            &mut pending_ctx,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "execution error: rel_type_name is not a string column"
+        );
+        assert_eq!(pending_ctx.counters, WriteCounters::default());
     }
 }


### PR DESCRIPTION
## Summary

- prove write-summary counter mapping and empty behavior
- cover referenced CREATE node identities across qualified, unqualified, direct-struct, and heterogeneous struct shapes
- extend CREATE physical-plan invariants and empty dispatch coverage
- prove node/edge SET and REMOVE accumulation, null optional rows, duplicate SET coalescing, and exact fail-closed malformed identity/routing errors

## Verification

- `CARGO_TARGET_DIR=/tmp/graphforge-target-368-exec cargo test -p graphforge-exec tests::` — 647 passed
- `CARGO_TARGET_DIR=/tmp/graphforge-target-368-exec cargo clippy -p graphforge-exec -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/graphforge-target-368-exec make pre-push` — passed
- coverage: core 93.87%, graphforge-exec 96.00%, patch 100.00%
- Rust facade 463/463; Rust BDD 97/97; openCypher TCK 3897/3897
- Python native 215 passed with 21 tracked exclusions; Node native 219/219; Node BDD 102/102

Closes #368

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788378018&installation_model_id=20486&pr_number=380&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F380&signature=74a7468f320faad9a5ad861d98ea8a6274be5d47c86ec34e1f639f7c24918ec2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests proving write execution and dispatch boundaries in graphforge-exec
> - Adds tests for `SideEffects::from_summary` to verify correct reading of named counters from `RecordBatch` and default handling of missing/empty rows in [lib.rs](https://github.com/CurateLabs/graphforge/pull/380/files#diff-c05ac8a70576f84c03650969ae57baef92f141cc398d6805778282ea615be398).
> - Extends write exec plan tests to include `GraphCreateExec`, asserting stable plan contracts and zero-change dispatch across all write exec types.
> - Adds tests for `run_set_phase` and `run_remove_phase` in [write_driver.rs](https://github.com/CurateLabs/graphforge/pull/380/files#diff-7ecd8095a72910882e8dba879e7ed25f2b87bbf9ed84ba3d7a8a40a25aefe9bc) covering duplicate/null UUID rows, accumulation correctness, and malformed identity/routing column errors.
> - Fixes `run_remove_phase` to compute the identity stem unconditionally per row, so malformed columns now produce an execution error rather than being silently skipped when a pending item exists.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 130cd6b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for graph creation, deletion, updates, and removal with empty inputs.
  - Added validation for qualified, unqualified, direct, and dynamic schema references.
  - Added checks for duplicate and NULL values during property updates.
  - Improved error handling coverage for malformed identity and edge-routing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->