### PR TITLE
tooling: make pre-push validation resumable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,6 +219,9 @@ dist/
 crates/graphforge-bindings-node/coverage/
 target-py-cov/
 
+# Local pre-push validation evidence and reports (#376)
+.graphforge/validation/
+
 # Keep @curatelabs/graphforge first-party JS (root lib/ ignore is for Python venvs)
 !crates/graphforge-bindings-node/lib/
 !crates/graphforge-bindings-node/lib/**

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help lint format type-check security workflow-lint license-check third-party-notices third-party-notices-check cargo-deny-licenses test pre-push pre-push-fast clean test-tck docstring-coverage test-network benchmark test-perf test-perf-xs test-perf-slow test-perf-large coverage coverage-rust coverage-python coverage-node coverage-quick coverage-report coverage-diff coverage-strict check-coverage check-coverage-rust check-coverage-python check-coverage-node check-patch-coverage test-durations test-analytics docs-serve docs-build docs-clean cargo-build bench-traversal bench-fixed-hop-limit bench-fixed-hop-livejournal native-consumers release-load-matrix-check release-load-matrix bulk-construction-conformance-check bulk-construction-conformance cargo-test cargo-check cargo-clippy cargo-fmt cargo-fmt-check clean-builds clean-builds-all pnpm-install pnpm-build pnpm-test-bdd install build release-version-check package-license-verify publish-dry-run publish-dry-run-npm publish-dry-run-docs publish-dry-run-python publish-dry-run-cargo record-release-artifacts clean-env-verify-check clean-env-verify-preflight clean-env-verify
+.PHONY: help lint format type-check security workflow-lint license-check third-party-notices third-party-notices-check cargo-deny-licenses test pre-push pre-push-clean pre-push-preflight pre-push-fast clean test-tck docstring-coverage test-network benchmark test-perf test-perf-xs test-perf-slow test-perf-large coverage coverage-rust coverage-python coverage-node coverage-quick coverage-report coverage-diff coverage-strict check-coverage check-coverage-rust check-coverage-python check-coverage-node check-patch-coverage test-durations test-analytics docs-serve docs-build docs-clean cargo-build bench-traversal bench-fixed-hop-limit bench-fixed-hop-livejournal native-consumers release-load-matrix-check release-load-matrix bulk-construction-conformance-check bulk-construction-conformance cargo-test cargo-check cargo-clippy cargo-fmt cargo-fmt-check clean-builds clean-builds-all pnpm-install pnpm-build pnpm-test-bdd install build release-version-check package-license-verify publish-dry-run publish-dry-run-npm publish-dry-run-docs publish-dry-run-python publish-dry-run-cargo record-release-artifacts clean-env-verify-check clean-env-verify-preflight clean-env-verify
 
 help:  ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -212,14 +212,14 @@ pre-push-fast:  ## Run fast checks only — format, lint, type, security, docstr
 	@$(MAKE) docstring-coverage
 	@echo "✅ Fast checks passed! Run 'make pre-push' to include coverage."
 
-pre-push:  ## Run local policy checks plus multi-surface coverage thresholds
-	@$(MAKE) pre-push-fast
-	@uv run --no-sync python scripts/ci/test-rust-coverage-ledger.py
-	@echo "━━━ Coverage + thresholds (Rust + Python + Node) ━━━━━━━━━━━━━━━━━━━━━━━"
-	@$(MAKE) coverage
-	@echo "━━━ Public API BDD mutation sentinels ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-	@uv run --no-sync python scripts/ci/test-api-bdd-mutations.py
-	@echo "✅ All pre-push checks passed!"
+pre-push:  ## Run prerequisite-aware, resumable full local validation
+	@python3 scripts/pre_push_validation.py run
+
+pre-push-clean:  ## Discard local validation evidence and force a full revalidation
+	@python3 scripts/pre_push_validation.py run --force-clean
+
+pre-push-preflight:  ## Check local pre-push prerequisites and disk before compilation
+	@python3 scripts/pre_push_validation.py preflight
 
 clean:  ## Clean up cache files
 	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -209,6 +209,38 @@ make coverage-diff       # changed Python wrapper files only
 pytest tests/ -n auto
 ```
 
+## Resumable full validation
+
+`make pre-push` is the full local gate. It begins with a prerequisite and disk
+preflight, then records content-addressed evidence for policy checks, Rust
+tests and coverage, the instrumented native Python and Node builds consumed by
+acceptance, wrapper coverage, API BDD acceptance, and
+coverage thresholds. It never skips a gate: a compatible passed stage is reused
+only when its exact inputs, command contract, toolchain, dependency evidence,
+and required native artifact identity still match.
+
+The human-readable stage lines and machine-readable summary report elapsed time,
+evidence hit or miss, identity digest, invalidation reason, and disk budget.
+They are stored locally at `.graphforge/validation/v1/summary.json`; standalone
+preflight writes `preflight-summary.json` so it cannot replace the full-run
+outcome. These paths are ignored by Git and the evidence contains no command
+output or secrets. The instrumented Rust coverage run executes the full Rust
+corpus once and builds each native artifact once; later acceptance stages reuse
+those exact artifact identities.
+Compatible Cargo dependency compilation is shared beneath the common Git
+metadata directory, while evidence and native binding artifacts stay scoped to
+their individual worktree.
+
+Run `make pre-push-preflight` to check those prerequisites and disk budget
+without starting any heavy compilation.
+
+Use `make pre-push-clean` to discard only this local validation evidence and
+force every stage to rerun. If the preflight reports insufficient space, it does
+not start compilation. Review its reported safe options first: `make
+clean-builds` removes stale Rust artifacts when possible, while `make
+clean-builds-all` removes all Rust artifacts and forces future recompilation.
+Neither command is run automatically.
+
 ### Core Fixtures (`tests/conftest.py`)
 
 ```python

--- a/scripts/ci/test-pre-push-validation.py
+++ b/scripts/ci/test-pre-push-validation.py
@@ -127,6 +127,44 @@ class PrePushValidationTests(unittest.TestCase):
             self.assertEqual(calls, [("rust",), ("binding",)])
             self.assertEqual(rerun.results["binding"].status, "miss")
 
+    def test_evidence_missing_artifacts_key_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            self.make_root(root)
+            calls: list[tuple[str, ...]] = []
+            initial = self.coordinator(root, calls)
+            initial.run()
+            evidence_path = initial.evidence_path(
+                initial.stages["rust"], initial.results["rust"].digest
+            )
+            value = GATE.json.loads(evidence_path.read_text(encoding="utf-8"))
+            del value["artifacts"]
+            evidence_path.write_text(GATE.json.dumps(value), encoding="utf-8")
+            calls.clear()
+            rerun = self.coordinator(root, calls)
+            rerun.run()
+            self.assertEqual(calls, [("rust",), ("binding",)])
+            self.assertEqual(rerun.results["rust"].reason, "miss:malformed-evidence")
+
+    def test_cargo_cache_digest_excludes_first_party_sources(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            self.make_root(root)
+            (root / "rust-toolchain.toml").write_text("[toolchain]\n", encoding="utf-8")
+            crate = root / "crates" / "demo"
+            crate.mkdir(parents=True)
+            (crate / "Cargo.toml").write_text("[package]\nname='demo'\n", encoding="utf-8")
+            (crate / "lib.rs").write_text("fn first() {}\n", encoding="utf-8")
+            stage = GATE.Stage("heavy", commands=(("cargo",),), heavy=True)
+            coordinator = GATE.Coordinator(root, (), cache_stages=(stage,))
+            coordinator.command_versions = lambda _stage: {"tool": "test"}
+            before = coordinator.cargo_cache_digest(stage)
+            (crate / "lib.rs").write_text("fn changed() {}\n", encoding="utf-8")
+            after = coordinator.cargo_cache_digest(stage)
+            self.assertEqual(before, after)
+            (crate / "Cargo.toml").write_text("[package]\nname='demo2'\n", encoding="utf-8")
+            self.assertNotEqual(before, coordinator.cargo_cache_digest(stage))
+
     def test_missing_native_artifact_rejects_evidence(self) -> None:
         with tempfile.TemporaryDirectory() as raw:
             root = Path(raw)

--- a/scripts/ci/test-pre-push-validation.py
+++ b/scripts/ci/test-pre-push-validation.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Deterministic contract tests for resumable local pre-push validation."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+SCRIPT = Path(__file__).parents[1] / "pre_push_validation.py"
+SPEC = importlib.util.spec_from_file_location("pre_push_validation", SCRIPT)
+assert SPEC and SPEC.loader
+GATE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = GATE
+SPEC.loader.exec_module(GATE)
+
+
+class PrePushValidationTests(unittest.TestCase):
+    def make_root(self, directory: Path) -> None:
+        (directory / ".git").mkdir()
+        (directory / "Cargo.lock").write_text("first\n", encoding="utf-8")
+        (directory / "pyproject.toml").write_text("[project]\n", encoding="utf-8")
+
+    def coordinator(self, root: Path, calls: list[tuple[str, ...]]) -> object:
+        def runner(command: tuple[str, ...], _environment: object) -> None:
+            calls.append(command)
+
+        stages = (
+            GATE.Stage("preflight", inputs=("pyproject.toml",)),
+            GATE.Stage(
+                "rust", commands=(("rust",),), dependencies=("preflight",), inputs=("Cargo.lock",)
+            ),
+            GATE.Stage(
+                "binding",
+                commands=(("binding",),),
+                dependencies=("rust",),
+                inputs=("pyproject.toml",),
+            ),
+        )
+        coordinator = GATE.Coordinator(root, stages, runner=runner)
+        coordinator.run_preflight = lambda _environment: None
+        coordinator.command_versions = lambda _stage: {"tool": "test"}
+        return coordinator
+
+    def test_late_failure_resume_reuses_proven_upstream_stages(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            self.make_root(root)
+            calls: list[tuple[str, ...]] = []
+            first = self.coordinator(root, calls)
+            first.run()
+            self.assertEqual(calls, [("rust",), ("binding",)])
+            calls.clear()
+            second = self.coordinator(root, calls)
+            second.run()
+            self.assertEqual(calls, [])
+            self.assertEqual(
+                [item.status for item in second.results.values()], ["miss", "hit", "hit"]
+            )
+
+    def test_real_late_failure_publishes_only_complete_upstream_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            self.make_root(root)
+            calls: list[tuple[str, ...]] = []
+            first = self.coordinator(root, calls)
+
+            def fail_binding(command: tuple[str, ...], _environment: object) -> None:
+                calls.append(command)
+                if command == ("binding",):
+                    raise GATE.subprocess.CalledProcessError(1, command)
+
+            first.runner = fail_binding
+            with self.assertRaisesRegex(GATE.ValidationError, "stage binding failed"):
+                first.run()
+            self.assertIn("rust", first.results)
+            self.assertNotIn("binding", first.results)
+
+            calls.clear()
+            resumed = self.coordinator(root, calls)
+            resumed.run()
+            self.assertEqual(calls, [("binding",)])
+            self.assertEqual(resumed.results["rust"].status, "hit")
+
+    def test_input_change_invalidates_only_affected_stage_and_dependents(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            self.make_root(root)
+            calls: list[tuple[str, ...]] = []
+            self.coordinator(root, calls).run()
+            (root / "pyproject.toml").write_text("[project]\nname='changed'\n", encoding="utf-8")
+            calls.clear()
+            rerun = self.coordinator(root, calls)
+            rerun.run()
+            self.assertEqual(calls, [("binding",)])
+            self.assertEqual(rerun.results["rust"].status, "hit")
+
+    def test_unrelated_checked_in_change_does_not_invalidate_stages(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            self.make_root(root)
+            (root / "unrelated.md").write_text("first\n", encoding="utf-8")
+            calls: list[tuple[str, ...]] = []
+            self.coordinator(root, calls).run()
+            (root / "unrelated.md").write_text("changed\n", encoding="utf-8")
+            calls.clear()
+            rerun = self.coordinator(root, calls)
+            rerun.run()
+            self.assertEqual(calls, [])
+            self.assertEqual(rerun.results["rust"].status, "hit")
+
+    def test_corrupt_evidence_fails_closed_and_reruns_affected_stage(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            self.make_root(root)
+            calls: list[tuple[str, ...]] = []
+            initial = self.coordinator(root, calls)
+            initial.run()
+            evidence = initial.evidence_path(initial.stages["rust"], initial.results["rust"].digest)
+            evidence.write_text("not json", encoding="utf-8")
+            calls.clear()
+            rerun = self.coordinator(root, calls)
+            rerun.run()
+            self.assertEqual(calls, [("rust",), ("binding",)])
+            self.assertEqual(rerun.results["binding"].status, "miss")
+
+    def test_missing_native_artifact_rejects_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            self.make_root(root)
+            addon = root / "native.node"
+            addon.write_bytes(b"first")
+            calls: list[tuple[str, ...]] = []
+
+            def runner(command: tuple[str, ...], _environment: object) -> None:
+                calls.append(command)
+
+            stages = (
+                GATE.Stage("preflight", inputs=("pyproject.toml",)),
+                GATE.Stage(
+                    "native",
+                    commands=(("native",),),
+                    dependencies=("preflight",),
+                    artifacts=("*.node",),
+                ),
+            )
+            initial = GATE.Coordinator(root, stages, runner=runner)
+            initial.run_preflight = lambda _environment: None
+            initial.command_versions = lambda _stage: {"tool": "test"}
+            initial.run()
+            addon.unlink()
+            calls.clear()
+            rerun = GATE.Coordinator(root, stages, runner=runner)
+            rerun.run_preflight = lambda _environment: None
+            rerun.command_versions = lambda _stage: {"tool": "test"}
+            with self.assertRaisesRegex(GATE.ValidationError, "did not produce"):
+                rerun.run()
+            self.assertEqual(calls, [("native",)])
+
+    def test_force_clean_reruns_every_stage(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            self.make_root(root)
+            calls: list[tuple[str, ...]] = []
+            self.coordinator(root, calls).run()
+            calls.clear()
+            rerun = self.coordinator(root, calls)
+            rerun.force_clean = True
+            rerun.run()
+            self.assertEqual(calls, [("rust",), ("binding",)])
+            self.assertTrue(all(result.status == "miss" for result in rerun.results.values()))
+
+    def test_preflight_failure_occurs_before_heavy_runner(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            self.make_root(root)
+            calls: list[tuple[str, ...]] = []
+            coordinator = self.coordinator(root, calls)
+
+            def fail_preflight(_environment: object) -> None:
+                raise GATE.ValidationError("missing prerequisite: napi")
+
+            coordinator.run_preflight = fail_preflight
+            with self.assertRaisesRegex(GATE.ValidationError, "missing prerequisite"):
+                coordinator.run()
+            self.assertEqual(calls, [])
+            self.assertEqual(coordinator.results, {})
+
+    def test_command_contract_change_invalidates_stage_and_dependent(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            self.make_root(root)
+            calls: list[tuple[str, ...]] = []
+            initial = self.coordinator(root, calls)
+            initial.run()
+            calls.clear()
+            changed = self.coordinator(root, calls)
+            changed.stages["rust"] = GATE.Stage(
+                "rust",
+                commands=(("rust", "--new-contract"),),
+                dependencies=("preflight",),
+                inputs=("Cargo.lock",),
+            )
+            changed.run()
+            self.assertEqual(calls, [("rust", "--new-contract"), ("binding",)])
+
+    def test_evidence_publication_leaves_no_partial_file(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            self.make_root(root)
+            coordinator = self.coordinator(root, [])
+            coordinator.run()
+            evidence = coordinator.evidence_path(
+                coordinator.stages["rust"], coordinator.results["rust"].digest
+            )
+            self.assertEqual(evidence.stat().st_mode & 0o777, 0o600)
+            self.assertEqual(list(evidence.parent.glob("tmp*")), [])
+
+    def test_post_build_profiles_are_isolated_under_worktree_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            self.make_root(root)
+            stage = GATE.Stage("node-wrapper-coverage", profile_isolation=True)
+            coordinator = GATE.Coordinator(root, (stage,))
+            environment = coordinator.stage_environment(stage, "digest")
+            profile = Path(environment["LLVM_PROFILE_FILE"])
+            self.assertTrue(profile.parent.is_relative_to(coordinator.evidence_root))
+            self.assertEqual(profile.name, "%p-%m.profraw")
+            self.assertTrue(profile.parent.is_dir())
+
+    def test_disk_preflight_names_safe_cleanup(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            self.make_root(root)
+            coordinator = GATE.Coordinator(root, ())
+            usage = type("DiskUsage", (), {"free": 0})()
+            with (
+                patch.object(GATE.shutil, "disk_usage", return_value=usage),
+                self.assertRaisesRegex(GATE.ValidationError, "make clean-builds"),
+            ):
+                coordinator.run_preflight({"GF_VALIDATION_ROOT": str(root)})
+
+    def test_warm_compatible_cache_reduces_estimated_disk_need(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            self.make_root(root)
+            stage = GATE.Stage("heavy", commands=(("cargo",),), heavy=True)
+            coordinator = GATE.Coordinator(root, (), cache_stages=(stage,))
+            coordinator.command_versions = lambda _stage: {"tool": "test"}
+            cache = (
+                coordinator.shared_cache_root / "cargo" / coordinator.cargo_cache_digest(stage)[:24]
+            )
+            cache.mkdir(parents=True)
+            (cache / "fingerprint").write_text("warm", encoding="utf-8")
+            usage = type("DiskUsage", (), {"free": 30 * 1024**3})()
+
+            def successful_run(*_args: object, **_kwargs: object) -> object:
+                return type("Completed", (), {"returncode": 0})()
+
+            with (
+                patch.object(GATE.shutil, "which", return_value="/bin/tool"),
+                patch.object(GATE.shutil, "disk_usage", return_value=usage),
+                patch.object(GATE.subprocess, "run", side_effect=successful_run),
+                patch.object(
+                    GATE.subprocess,
+                    "check_output",
+                    return_value="llvm-tools-preview-aarch64 installed\n",
+                ),
+            ):
+                coordinator.run_preflight({"GF_VALIDATION_ROOT": str(root)})
+            self.assertEqual(coordinator.estimated_required_gib, 20)
+
+    def test_default_graph_executes_full_rust_corpus_once(self) -> None:
+        commands = [command for stage in GATE.stages() for command in stage.commands]
+        self.assertNotIn(("cargo", "test", "--workspace"), commands)
+        self.assertEqual(commands.count(("make", "coverage-rust")), 1)
+        coverage = next(
+            stage for stage in GATE.stages() if stage.name == "rust-tests-coverage-native"
+        )
+        self.assertEqual(coverage.dependencies, ("rust-quality",))
+        self.assertTrue(coverage.python_extension)
+        self.assertEqual(coverage.artifacts, ("crates/graphforge-bindings-node/*.node",))
+        self.assertFalse(any(command[0] == "uv" and "maturin" in command for command in commands))
+        self.assertFalse(any("napi" in command and "build" in command for command in commands))
+
+    def test_failure_summary_is_fail_closed_and_separate_from_preflight(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            self.make_root(root)
+            coordinator = self.coordinator(root, [])
+            coordinator.results["preflight"] = GATE.StageResult(
+                "preflight", "digest", "proof", "miss", "mandatory", 0.1
+            )
+            path = coordinator.write_summary(
+                list(coordinator.results.values()),
+                outcome="failed",
+                error="stage rust failed",
+                filename="preflight-summary.json",
+            )
+            value = GATE.json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual(path.name, "preflight-summary.json")
+            self.assertEqual(value["outcome"], "failed")
+            self.assertEqual(value["error"], "stage rust failed")
+            self.assertFalse((path.parent / "summary.json").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test-pre-push-validation.py
+++ b/scripts/ci/test-pre-push-validation.py
@@ -285,6 +285,10 @@ class PrePushValidationTests(unittest.TestCase):
         self.assertEqual(coverage.artifacts, ("crates/graphforge-bindings-node/*.node",))
         self.assertFalse(any(command[0] == "uv" and "maturin" in command for command in commands))
         self.assertFalse(any("napi" in command and "build" in command for command in commands))
+        final_thresholds = next(
+            stage for stage in GATE.stages() if stage.name == "final-thresholds"
+        )
+        self.assertTrue(final_thresholds.profile_isolation)
 
     def test_failure_summary_is_fail_closed_and_separate_from_preflight(self) -> None:
         with tempfile.TemporaryDirectory() as raw:

--- a/scripts/pre_push_validation.py
+++ b/scripts/pre_push_validation.py
@@ -651,6 +651,7 @@ def stages() -> tuple[Stage, ...]:
                 "api-bdd-acceptance",
             ),
             inputs=inputs("scripts/check-coverage-rust.sh"),
+            profile_isolation=True,
         ),
     )
 

--- a/scripts/pre_push_validation.py
+++ b/scripts/pre_push_validation.py
@@ -1,0 +1,700 @@
+#!/usr/bin/env python3
+"""Prerequisite-aware, resumable local validation for ``make pre-push``.
+
+Evidence is local to a worktree and is trusted only when its content-addressed
+identity, dependencies, and native artifacts still match. It deliberately does
+not transmit data or record command output, tokens, user names, or absolute paths.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+SCHEMA = "graphforge-pre-push-validation/v1"
+MIN_FREE_GIB = 80
+IGNORED_PARTS = {".git", ".graphforge", ".venv", "build", "target", "node_modules"}
+Command = tuple[str, ...]
+CommandRunner = Callable[[Command, Mapping[str, str]], None]
+
+
+@dataclass(frozen=True)
+class Stage:
+    """A fail-closed, content-addressed unit of local validation."""
+
+    name: str
+    commands: tuple[Command, ...] = ()
+    dependencies: tuple[str, ...] = ()
+    inputs: tuple[str, ...] = ()
+    environment: tuple[str, ...] = ()
+    artifacts: tuple[str, ...] = ()
+    python_extension: bool = False
+    heavy: bool = False
+    profile_isolation: bool = False
+
+
+@dataclass
+class StageResult:
+    name: str
+    digest: str
+    proof_digest: str
+    status: str
+    reason: str
+    elapsed_seconds: float
+    artifacts: list[dict[str, str]] = field(default_factory=list)
+
+
+class ValidationError(RuntimeError):
+    """A validation failure with an actionable, safe remediation."""
+
+
+def canonical(value: object) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def digest(value: object) -> str:
+    return hashlib.sha256(canonical(value)).hexdigest()
+
+
+def file_digest(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def default_runner(command: Command, environment: Mapping[str, str]) -> None:
+    print("$", " ".join(command), flush=True)
+    subprocess.run(
+        command, cwd=environment["GF_VALIDATION_ROOT"], env=dict(environment), check=True
+    )
+
+
+class Coordinator:
+    """Runs stages once per compatible identity and records atomic evidence."""
+
+    def __init__(
+        self,
+        root: Path,
+        stages: Iterable[Stage],
+        *,
+        runner: CommandRunner = default_runner,
+        minimum_free_gib: int = MIN_FREE_GIB,
+        force_clean: bool = False,
+        cache_stages: Iterable[Stage] | None = None,
+    ) -> None:
+        self.root = root.resolve()
+        selected_stages = tuple(stages)
+        self.stages = {stage.name: stage for stage in selected_stages}
+        self.cache_stages = tuple(cache_stages) if cache_stages is not None else selected_stages
+        self.runner = runner
+        self.minimum_free_gib = minimum_free_gib
+        self.force_clean = force_clean
+        self.evidence_root = self.root / ".graphforge" / "validation" / "v1"
+        self.shared_cache_root = self.common_git_dir() / "graphforge-validation-cache"
+        self.results: dict[str, StageResult] = {}
+        self.started_used_bytes = shutil.disk_usage(self.root).used
+        self.peak_used_bytes = self.started_used_bytes
+        self.estimated_required_gib = self.minimum_free_gib
+
+    def sample_disk(self) -> None:
+        """Record the largest observed filesystem use at stage boundaries."""
+        self.peak_used_bytes = max(self.peak_used_bytes, shutil.disk_usage(self.root).used)
+
+    def common_git_dir(self) -> Path:
+        try:
+            value = subprocess.check_output(
+                ("git", "rev-parse", "--git-common-dir"),
+                cwd=self.root,
+                text=True,
+                stderr=subprocess.DEVNULL,
+            ).strip()
+        except subprocess.CalledProcessError:
+            return self.root / ".graphforge" / "validation" / "shared-cache"
+        path = Path(value)
+        return (self.root / path).resolve() if not path.is_absolute() else path
+
+    def source_state(self, patterns: Sequence[str]) -> list[dict[str, str]]:
+        """Hash only stage-relevant checked-in inputs, including dirty content."""
+        paths: set[Path] = set()
+        for pattern in patterns:
+            paths.update(path for path in self.root.glob(pattern) if path.is_file())
+        records: list[dict[str, str]] = []
+        for path in sorted(paths):
+            relative = path.relative_to(self.root)
+            if any(part in IGNORED_PARTS for part in relative.parts):
+                continue
+            records.append({"path": relative.as_posix(), "sha256": file_digest(path)})
+        return records
+
+    def command_versions(self, stage: Stage) -> dict[str, str]:
+        executables = {command[0] for command in stage.commands if command}
+        if stage.name == "preflight":
+            executables.update({"cargo", "rustc", "rustup", "uv", "node", "pnpm"})
+        versions: dict[str, str] = {}
+        for executable in sorted(executables):
+            try:
+                completed = subprocess.run(
+                    (executable, "--version"),
+                    cwd=self.root,
+                    capture_output=True,
+                    check=False,
+                    text=True,
+                )
+            except OSError:
+                versions[executable] = "missing"
+                continue
+            versions[executable] = (completed.stdout or completed.stderr).strip().split("\n")[0]
+        return versions
+
+    def stage_digest(self, stage: Stage, dependencies: Mapping[str, str]) -> str:
+        environment = {key: os.environ.get(key, "") for key in stage.environment}
+        return digest(
+            {
+                "schema": SCHEMA,
+                "stage": stage.name,
+                "inputs": self.source_state(stage.inputs),
+                "execution_contract": {
+                    "commands": stage.commands,
+                    "artifacts": stage.artifacts,
+                    "python_extension": stage.python_extension,
+                    "heavy": stage.heavy,
+                    "profile_isolation": stage.profile_isolation,
+                },
+                "dependencies": dependencies,
+                "environment": environment,
+                "tool_versions": self.command_versions(stage),
+            }
+        )
+
+    def evidence_path(self, stage: Stage, stage_digest: str) -> Path:
+        return self.evidence_root / "stages" / stage.name / f"{stage_digest}.json"
+
+    def read_evidence(
+        self, stage: Stage, stage_digest: str, dependencies: Mapping[str, str]
+    ) -> tuple[dict[str, object] | None, str]:
+        path = self.evidence_path(stage, stage_digest)
+        try:
+            value = json.loads(path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return None, "miss:no-evidence"
+        except (OSError, json.JSONDecodeError):
+            return None, "miss:malformed-evidence"
+        if not isinstance(value, dict):
+            return None, "miss:malformed-evidence"
+        required = {
+            "schema": SCHEMA,
+            "stage": stage.name,
+            "digest": stage_digest,
+            "dependencies": dict(dependencies),
+            "outcome": "passed",
+        }
+        if any(value.get(key) != expected for key, expected in required.items()):
+            return None, "miss:incompatible-evidence"
+        if not isinstance(value.get("proof_digest"), str):
+            return None, "miss:malformed-evidence"
+        artifacts = value.get("artifacts", [])
+        if not isinstance(artifacts, list) or not self.artifacts_match(artifacts):
+            return None, "miss:artifact-identity-drift"
+        return value, "hit:compatible-evidence"
+
+    def python_extension_digest(self) -> str:
+        command: Command = (
+            "uv",
+            "run",
+            "python",
+            "-c",
+            "import graphforge, hashlib; from pathlib import Path; "
+            "p=Path(graphforge.__file__).resolve(); "
+            "print(hashlib.sha256(p.read_bytes()).hexdigest())",
+        )
+        completed = subprocess.run(
+            command, cwd=self.root, capture_output=True, check=True, text=True
+        )
+        value = completed.stdout.strip()
+        if len(value) != 64:
+            raise ValidationError("installed graphforge extension did not return a SHA-256 digest")
+        return value
+
+    def artifacts_match(self, artifacts: object) -> bool:
+        if not isinstance(artifacts, list):
+            return False
+        for artifact in artifacts:
+            if not isinstance(artifact, dict):
+                return False
+            relative, expected = artifact.get("path"), artifact.get("sha256")
+            if not isinstance(relative, str) or not isinstance(expected, str):
+                return False
+            if relative == "installed:graphforge-extension":
+                try:
+                    current = self.python_extension_digest()
+                except (OSError, subprocess.CalledProcessError, ValidationError):
+                    return False
+                if current != expected:
+                    return False
+                continue
+            path = self.root / relative
+            if not path.is_file() or file_digest(path) != expected:
+                return False
+        return True
+
+    def collect_artifacts(self, stage: Stage) -> list[dict[str, str]]:
+        artifacts: list[dict[str, str]] = []
+        for pattern in stage.artifacts:
+            for path in sorted(path for path in self.root.glob(pattern) if path.is_file()):
+                artifacts.append(
+                    {"path": path.relative_to(self.root).as_posix(), "sha256": file_digest(path)}
+                )
+        if stage.artifacts and not artifacts:
+            raise ValidationError(f"{stage.name} did not produce its required native artifact")
+        if stage.python_extension:
+            artifacts.append(
+                {"path": "installed:graphforge-extension", "sha256": self.python_extension_digest()}
+            )
+        return artifacts
+
+    def run_preflight(self, environment: Mapping[str, str]) -> None:
+        missing = [
+            name
+            for name in ("cargo", "rustc", "rustup", "uv", "node", "pnpm")
+            if not shutil.which(name)
+        ]
+        if missing:
+            raise ValidationError(
+                "missing prerequisite(s): "
+                + ", ".join(missing)
+                + ". Install the pinned toolchain described in docs/development/contributing.md."
+            )
+        heavy_stages = tuple(stage for stage in self.cache_stages if stage.heavy)
+        warm_cache = bool(heavy_stages) and all(
+            (
+                cache := self.shared_cache_root / "cargo" / self.cargo_cache_digest(stage)[:24]
+            ).is_dir()
+            and any(cache.iterdir())
+            for stage in heavy_stages
+        )
+        self.estimated_required_gib = (
+            min(self.minimum_free_gib, 20) if warm_cache else self.minimum_free_gib
+        )
+        available = shutil.disk_usage(self.root).free // (1024**3)
+        if available < self.estimated_required_gib:
+            raise ValidationError(
+                f"insufficient disk before compilation: {available} GiB available; "
+                f"{self.estimated_required_gib} GiB estimated need "
+                f"({'compatible cache present' if warm_cache else 'cold cache'}). "
+                "Safe cleanup options: "
+                "make clean-builds (stale artifacts) or make clean-builds-all (all Rust artifacts)."
+            )
+        llvm_cov = subprocess.run(
+            ("cargo", "llvm-cov", "--version"), cwd=self.root, capture_output=True, check=False
+        )
+        if llvm_cov.returncode:
+            raise ValidationError(
+                "cargo-llvm-cov is required; install it with: cargo install cargo-llvm-cov"
+            )
+        components = subprocess.check_output(
+            ("rustup", "component", "list", "--installed"), cwd=self.root, text=True
+        )
+        if not any(line.startswith("llvm-tools") for line in components.splitlines()):
+            raise ValidationError(
+                "llvm-tools-preview is required; install it with: "
+                "rustup component add llvm-tools-preview"
+            )
+        for command, remediation in (
+            (
+                ("uv", "sync", "--locked", "--all-extras", "--dry-run"),
+                "run: uv sync --locked --all-extras",
+            ),
+            (
+                (
+                    "uv",
+                    "run",
+                    "--no-sync",
+                    "python",
+                    "-c",
+                    "import coverage, hypothesis, pytest, xdist",
+                ),
+                "run: uv sync --locked --all-extras",
+            ),
+            (
+                (
+                    "pnpm",
+                    "install",
+                    "--frozen-lockfile",
+                    "--lockfile-only",
+                    "--offline",
+                    "--ignore-scripts",
+                ),
+                "run: pnpm install --frozen-lockfile",
+            ),
+            (("uv", "run", "maturin", "--version"), "run: uv sync --all-extras"),
+            (
+                ("pnpm", "--filter", "@curatelabs/graphforge", "exec", "napi", "--version"),
+                "run: pnpm install --frozen-lockfile",
+            ),
+        ):
+            completed = subprocess.run(command, cwd=self.root, env=dict(environment), check=False)
+            if completed.returncode:
+                raise ValidationError(
+                    "prerequisite check failed before compilation: "
+                    f"{' '.join(command)}. Remediation: {remediation}"
+                )
+
+    def stage_environment(self, stage: Stage, stage_digest: str) -> dict[str, str]:
+        environment = dict(os.environ)
+        environment["GF_VALIDATION_ROOT"] = str(self.root)
+        environment["GF_VALIDATION_STAGE"] = stage.name
+        environment["GF_VALIDATION_DIGEST"] = stage_digest
+        if stage.profile_isolation:
+            profile_root = self.evidence_root / "profiles" / stage.name
+            profile_root.mkdir(parents=True, exist_ok=True)
+            environment["LLVM_PROFILE_FILE"] = str(profile_root / "%p-%m.profraw")
+        # Cargo fingerprints individual units. This cache key scopes those units to compatible
+        # source, toolchain, profile, and build settings while native outputs remain local.
+        if stage.heavy:
+            environment["CARGO_TARGET_DIR"] = str(
+                self.shared_cache_root / "cargo" / self.cargo_cache_digest(stage)[:24]
+            )
+        return environment
+
+    def cargo_cache_digest(self, stage: Stage) -> str:
+        profile = "coverage" if stage.name == "rust-tests-coverage-native" else "release"
+        if stage.name == "rust-quality":
+            profile = "debug"
+        tool_stage = Stage("cargo-cache", commands=(("cargo",), ("rustc",)))
+        return digest(
+            {
+                "schema": SCHEMA,
+                "profile": profile,
+                "sources": self.source_state(
+                    (
+                        "Cargo.toml",
+                        "Cargo.lock",
+                        "rust-toolchain.toml",
+                        "crates/**/*.rs",
+                        "crates/**/Cargo.toml",
+                    )
+                ),
+                "tool_versions": self.command_versions(tool_stage),
+                "environment": {
+                    key: os.environ.get(key, "")
+                    for key in ("CARGO_BUILD_JOBS", "CARGO_FEATURES", "RUSTFLAGS")
+                },
+            }
+        )
+
+    @contextmanager
+    def heavy_lock(self) -> Iterable[None]:
+        """Serialise heavy compilation across worktrees (stricter than the two-build cap)."""
+        self.shared_cache_root.mkdir(parents=True, exist_ok=True)
+        lock_path = self.shared_cache_root / "heavy-build.lock"
+        with lock_path.open("w", encoding="utf-8") as lock:
+            fcntl.flock(lock, fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(lock, fcntl.LOCK_UN)
+
+    def write_evidence(self, stage: Stage, value: Mapping[str, object]) -> None:
+        path = self.evidence_path(stage, str(value["digest"]))
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(
+            "w", encoding="utf-8", dir=path.parent, delete=False
+        ) as handle:
+            json.dump(value, handle, sort_keys=True, indent=2)
+            handle.write("\n")
+            temporary = Path(handle.name)
+        temporary.chmod(0o600)
+        temporary.replace(path)
+
+    def run_stage(self, stage: Stage) -> StageResult:
+        # Preflight is deliberately mandatory on every invocation (disk pressure and installed
+        # tools are live conditions), but a fresh preflight should not invalidate unrelated
+        # successful stages. Each stage carries its own relevant toolchain and lockfile inputs.
+        dependencies = {
+            name: self.results[name].proof_digest
+            for name in stage.dependencies
+            if name != "preflight"
+        }
+        stage_digest = self.stage_digest(stage, dependencies)
+        if stage.name == "preflight":
+            evidence, reason = None, "miss:mandatory-preflight"
+        else:
+            evidence, reason = self.read_evidence(stage, stage_digest, dependencies)
+        if evidence is not None:
+            result = StageResult(
+                stage.name,
+                stage_digest,
+                str(evidence["proof_digest"]),
+                "hit",
+                reason,
+                0.0,
+                list(evidence["artifacts"]),
+            )
+            self.results[stage.name] = result
+            return result
+        self.sample_disk()
+        started = time.monotonic()
+        environment = self.stage_environment(stage, stage_digest)
+        try:
+            if stage.name == "preflight":
+                self.run_preflight(environment)
+            elif stage.heavy:
+                with self.heavy_lock():
+                    for command in stage.commands:
+                        self.runner(command, environment)
+            else:
+                for command in stage.commands:
+                    self.runner(command, environment)
+            artifacts = self.collect_artifacts(stage)
+        except (OSError, subprocess.CalledProcessError, ValidationError) as error:
+            raise ValidationError(f"stage {stage.name} failed: {error}") from error
+        elapsed = time.monotonic() - started
+        self.sample_disk()
+        evidence_value: dict[str, object] = {
+            "schema": SCHEMA,
+            "stage": stage.name,
+            "digest": stage_digest,
+            "dependencies": dependencies,
+            "outcome": "passed",
+            "proof_digest": digest({"identity": stage_digest, "recorded_at_ns": time.time_ns()}),
+            "elapsed_seconds": round(elapsed, 3),
+            "artifacts": artifacts,
+        }
+        self.write_evidence(stage, evidence_value)
+        result = StageResult(
+            stage.name,
+            stage_digest,
+            str(evidence_value["proof_digest"]),
+            "miss",
+            reason,
+            elapsed,
+            artifacts,
+        )
+        self.results[stage.name] = result
+        return result
+
+    def run(self) -> list[StageResult]:
+        if self.force_clean and self.evidence_root.exists():
+            shutil.rmtree(self.evidence_root)
+        ordered = list(self.stages.values())
+        for stage in ordered:
+            if any(dependency not in self.results for dependency in stage.dependencies):
+                raise ValidationError(f"stage {stage.name} has an unavailable dependency")
+            result = self.run_stage(stage)
+            print(
+                f"stage={result.name} evidence={result.status} "
+                f"reason={result.reason} digest={result.digest[:12]} "
+                f"elapsed={result.elapsed_seconds:.3f}s",
+                flush=True,
+            )
+        return [self.results[stage.name] for stage in ordered]
+
+    def write_summary(
+        self,
+        results: Sequence[StageResult],
+        *,
+        outcome: str = "passed",
+        error: str | None = None,
+        filename: str = "summary.json",
+    ) -> Path:
+        self.sample_disk()
+        usage = shutil.disk_usage(self.root)
+        summary = {
+            "schema": SCHEMA,
+            "outcome": outcome,
+            "disk": {
+                "available_gib": usage.free // (1024**3),
+                "estimated_required_gib": self.estimated_required_gib,
+                "start_used_bytes": self.started_used_bytes,
+                "peak_used_bytes": self.peak_used_bytes,
+            },
+            "stages": [result.__dict__ for result in results],
+        }
+        if error is not None:
+            summary["error"] = error
+        self.evidence_root.mkdir(parents=True, exist_ok=True)
+        path = self.evidence_root / filename
+        with tempfile.NamedTemporaryFile(
+            "w", encoding="utf-8", dir=path.parent, delete=False
+        ) as handle:
+            json.dump(summary, handle, sort_keys=True, indent=2)
+            handle.write("\n")
+            temporary = Path(handle.name)
+        temporary.chmod(0o600)
+        temporary.replace(path)
+        return path
+
+
+def stages() -> tuple[Stage, ...]:
+    common = ("Makefile", "rust-toolchain.toml")
+
+    def inputs(*paths: str) -> tuple[str, ...]:
+        return (*common, *paths)
+
+    return (
+        Stage(
+            "preflight",
+            inputs=inputs("pyproject.toml", "uv.lock", "package.json", "pnpm-lock.yaml"),
+        ),
+        Stage(
+            "policy-static",
+            commands=(
+                ("uv", "run", "--no-sync", "python", "scripts/ci/test-pre-push-validation.py"),
+                ("make", "pre-push-fast"),
+            ),
+            dependencies=("preflight",),
+            inputs=inputs(
+                "pyproject.toml",
+                "uv.lock",
+                "scripts/**/*.py",
+                "**/*.py",
+                ".github/**/*.yml",
+            ),
+        ),
+        Stage(
+            "rust-quality",
+            commands=(
+                ("cargo", "fmt", "--all", "--", "--check"),
+                ("cargo", "clippy", "--workspace", "--", "-D", "warnings"),
+            ),
+            dependencies=("preflight",),
+            environment=("CARGO_BUILD_JOBS", "CARGO_FEATURES", "RUSTFLAGS"),
+            inputs=inputs(
+                "Cargo.toml",
+                "Cargo.lock",
+                "crates/**/*.rs",
+                "crates/**/Cargo.toml",
+                "tests/**/*.rs",
+            ),
+            heavy=True,
+        ),
+        Stage(
+            "rust-tests-coverage-native",
+            commands=(
+                ("uv", "run", "--no-sync", "python", "scripts/ci/test-rust-coverage-ledger.py"),
+                ("make", "coverage-rust"),
+            ),
+            dependencies=("rust-quality",),
+            environment=("CARGO_BUILD_JOBS", "CARGO_FEATURES", "RUSTFLAGS"),
+            inputs=inputs(
+                "Cargo.toml",
+                "Cargo.lock",
+                "crates/**/*.rs",
+                "crates/**/Cargo.toml",
+                "tests/**/*.rs",
+                "scripts/ci/test-rust-coverage-ledger.py",
+            ),
+            artifacts=("crates/graphforge-bindings-node/*.node",),
+            python_extension=True,
+            heavy=True,
+        ),
+        Stage(
+            "python-wrapper-coverage",
+            commands=(("make", "coverage-python"),),
+            dependencies=("rust-tests-coverage-native",),
+            environment=("COVERAGE_FAIL_UNDER_PYTHON",),
+            inputs=inputs(
+                "pyproject.toml",
+                "uv.lock",
+                "crates/graphforge-bindings-py/**/*.py",
+                "tests/**/*.py",
+            ),
+            profile_isolation=True,
+        ),
+        Stage(
+            "node-wrapper-coverage",
+            commands=(("make", "coverage-node"),),
+            dependencies=("rust-tests-coverage-native",),
+            environment=("COVERAGE_FAIL_UNDER_NODE",),
+            inputs=inputs(
+                "package.json",
+                "pnpm-lock.yaml",
+                "crates/graphforge-bindings-node/**/*.mjs",
+                "crates/graphforge-bindings-node/package.json",
+            ),
+            profile_isolation=True,
+        ),
+        Stage(
+            "api-bdd-acceptance",
+            commands=(
+                ("uv", "run", "--no-sync", "python", "scripts/ci/test-api-bdd-mutations.py"),
+            ),
+            dependencies=("rust-tests-coverage-native", "policy-static"),
+            inputs=inputs(
+                "tests/**/*.py",
+                "tests/**/*.rs",
+                "tests/**/*.feature",
+                "scripts/ci/test-api-bdd-mutations.py",
+            ),
+            profile_isolation=True,
+        ),
+        Stage(
+            "final-thresholds",
+            commands=(("make", "check-coverage"),),
+            dependencies=(
+                "python-wrapper-coverage",
+                "node-wrapper-coverage",
+                "api-bdd-acceptance",
+            ),
+            inputs=inputs("scripts/check-coverage-rust.sh"),
+        ),
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("preflight", "run"))
+    parser.add_argument(
+        "--force-clean",
+        action="store_true",
+        help="discard only local validation evidence and rerun every stage",
+    )
+    parser.add_argument(
+        "--minimum-free-gib",
+        type=int,
+        default=int(os.environ.get("GF_PRE_PUSH_MIN_FREE_GIB", MIN_FREE_GIB)),
+    )
+    args = parser.parse_args(argv)
+    all_stages = stages()
+    selected_stages = all_stages[:1] if args.command == "preflight" else all_stages
+    coordinator = Coordinator(
+        Path.cwd(),
+        selected_stages,
+        force_clean=args.force_clean,
+        minimum_free_gib=args.minimum_free_gib,
+        cache_stages=all_stages,
+    )
+    try:
+        results = coordinator.run()
+        filename = "preflight-summary.json" if args.command == "preflight" else "summary.json"
+        coordinator.write_summary(results, filename=filename)
+    except ValidationError as error:
+        filename = "preflight-summary.json" if args.command == "preflight" else "summary.json"
+        coordinator.write_summary(
+            list(coordinator.results.values()),
+            outcome="failed",
+            error=str(error),
+            filename=filename,
+        )
+        print(f"pre-push validation failed: {error}", file=sys.stderr)
+        return 1
+    print(f"pre-push validation passed; summary=.graphforge/validation/v1/{filename}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pre_push_validation.py
+++ b/scripts/pre_push_validation.py
@@ -122,8 +122,16 @@ class Coordinator:
                 text=True,
                 stderr=subprocess.DEVNULL,
             ).strip()
+        except FileNotFoundError as error:
+            raise ValidationError(
+                "missing prerequisite(s): git. Install git so validation can "
+                "locate the shared compilation cache."
+            ) from error
         except subprocess.CalledProcessError:
+            # Non-repository trees (tests, unpackaged checkouts) keep a local cache.
             return self.root / ".graphforge" / "validation" / "shared-cache"
+        except OSError as error:
+            raise ValidationError(f"unable to resolve git common dir: {error}") from error
         path = Path(value)
         return (self.root / path).resolve() if not path.is_absolute() else path
 
@@ -206,7 +214,9 @@ class Coordinator:
             return None, "miss:incompatible-evidence"
         if not isinstance(value.get("proof_digest"), str):
             return None, "miss:malformed-evidence"
-        artifacts = value.get("artifacts", [])
+        if "artifacts" not in value:
+            return None, "miss:malformed-evidence"
+        artifacts = value["artifacts"]
         if not isinstance(artifacts, list) or not self.artifacts_match(artifacts):
             return None, "miss:artifact-identity-drift"
         return value, "hit:compatible-evidence"
@@ -215,10 +225,12 @@ class Coordinator:
         command: Command = (
             "uv",
             "run",
+            "--no-sync",
             "python",
             "-c",
-            "import graphforge, hashlib; from pathlib import Path; "
-            "p=Path(graphforge.__file__).resolve(); "
+            "import hashlib; from pathlib import Path; "
+            "from graphforge import _graphforge_rs; "
+            "p=Path(_graphforge_rs.__file__).resolve(); "
             "print(hashlib.sha256(p.read_bytes()).hexdigest())",
         )
         completed = subprocess.run(
@@ -362,8 +374,8 @@ class Coordinator:
             profile_root = self.evidence_root / "profiles" / stage.name
             profile_root.mkdir(parents=True, exist_ok=True)
             environment["LLVM_PROFILE_FILE"] = str(profile_root / "%p-%m.profraw")
-        # Cargo fingerprints individual units. This cache key scopes those units to compatible
-        # source, toolchain, profile, and build settings while native outputs remain local.
+        # Cargo fingerprints first-party units inside one target directory. Key only on
+        # toolchain/profile/manifest inputs that make a target directory incompatible.
         if stage.heavy:
             environment["CARGO_TARGET_DIR"] = str(
                 self.shared_cache_root / "cargo" / self.cargo_cache_digest(stage)[:24]
@@ -384,7 +396,6 @@ class Coordinator:
                         "Cargo.toml",
                         "Cargo.lock",
                         "rust-toolchain.toml",
-                        "crates/**/*.rs",
                         "crates/**/Cargo.toml",
                     )
                 ),
@@ -657,6 +668,15 @@ def stages() -> tuple[Stage, ...]:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
+    raw_minimum = os.environ.get("GF_PRE_PUSH_MIN_FREE_GIB")
+    try:
+        default_minimum = int(raw_minimum) if raw_minimum else MIN_FREE_GIB
+    except ValueError:
+        print(
+            f"GF_PRE_PUSH_MIN_FREE_GIB must be an integer number of GiB; got {raw_minimum!r}",
+            file=sys.stderr,
+        )
+        return 1
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("command", choices=("preflight", "run"))
     parser.add_argument(
@@ -667,7 +687,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument(
         "--minimum-free-gib",
         type=int,
-        default=int(os.environ.get("GF_PRE_PUSH_MIN_FREE_GIB", MIN_FREE_GIB)),
+        default=default_minimum,
     )
     args = parser.parse_args(argv)
     all_stages = stages()
@@ -679,21 +699,21 @@ def main(argv: Sequence[str] | None = None) -> int:
         minimum_free_gib=args.minimum_free_gib,
         cache_stages=all_stages,
     )
+    filename = "preflight-summary.json" if args.command == "preflight" else "summary.json"
     try:
         results = coordinator.run()
-        filename = "preflight-summary.json" if args.command == "preflight" else "summary.json"
-        coordinator.write_summary(results, filename=filename)
+        summary_path = coordinator.write_summary(results, filename=filename)
     except ValidationError as error:
-        filename = "preflight-summary.json" if args.command == "preflight" else "summary.json"
-        coordinator.write_summary(
+        summary_path = coordinator.write_summary(
             list(coordinator.results.values()),
             outcome="failed",
             error=str(error),
             filename=filename,
         )
         print(f"pre-push validation failed: {error}", file=sys.stderr)
+        print(f"summary={summary_path.relative_to(coordinator.root)}", file=sys.stderr)
         return 1
-    print(f"pre-push validation passed; summary=.graphforge/validation/v1/{filename}")
+    print(f"pre-push validation passed; summary={summary_path.relative_to(coordinator.root)}")
     return 0
 
 


### PR DESCRIPTION
Closes #376

## Summary
- replace the monolithic local pre-push gate with prerequisite-aware, content-addressed stages
- share compatible Cargo compilation while isolating worktree evidence and verifying native artifact identities
- fail closed on stale or malformed evidence, installation drift, disk pressure, and incomplete stages
- add force-clean, standalone preflight, machine-readable summaries, documentation, and deterministic contract tests

## BDD evidence
- missing prerequisite: installed dependency imports are verified before the heavy boundary with exact remediation
- safe resume: deterministic late-failure test reuses upstream proof; unchanged real run reused every non-preflight stage
- stale proof invalidation: source, command-contract, corrupt-evidence, dependency-proof, and artifact-drift tests pass
- disk pressure: cold/warm estimates and safe cleanup guidance are tested; no cleanup runs automatically
- worktree isolation: proof stays under each worktree while only compatible Cargo compilation is shared

## Verification
- `python3 scripts/ci/test-pre-push-validation.py` (13 tests)
- `make pre-push-preflight`
- exact-head `make pre-push` passed
- cold stage time: ~35.6 minutes; unchanged resume: 2.08 seconds
- peak additional disk observed by the exact-head run: ~2.6 GiB with compatible cache; cold exploratory run observed ~41.9 GiB additional
- Rust core 93.87%, Python adapter 84.40%, Node adapter 86.22%, workspace 93.54%
- Python wrapper 100%; Node wrapper 100%
- Rust BDD 97/97; openCypher TCK 3897/3897; Node BDD 102/102

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788385373&installation_model_id=20486&pr_number=381&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F381&signature=54c3be463f3295cfd46d0fcd6fa924d64613a5dd8f3361c88512d6ef05ed0c27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a coordinated pre-push validation workflow with resumable checks and reusable results.
  - Added preflight checks for required tools, prerequisites, and available disk space.
  - Added commands for forced-clean validation and preflight-only verification.
  - Improved validation failure reporting with actionable summaries.

- **Bug Fixes**
  - Invalid or corrupted validation results are now discarded automatically.
  - Validation results are handled securely and isolated appropriately.

- **Tests**
  - Added comprehensive automated coverage for validation, caching, preflight checks, artifact handling, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make pre-push validation resumable with stage-level evidence caching
> - Replaces the flat `make pre-push` recipe with a Python orchestrator ([pre_push_validation.py](https://github.com/CurateLabs/graphforge/pull/381/files#diff-4f8349090f985cfc4060322a0ec1e775a8b64c1a37e975aa9c51333b9d87af4b)) that tracks per-stage evidence under `.graphforge/validation/` and skips stages whose inputs, commands, and dependencies are unchanged.
> - Stages run in dependency order with fail-closed behavior; heavy builds are serialized via a file lock and coverage profiles are isolated under the evidence root.
> - Adds `make pre-push-clean` (discard evidence and rerun all stages) and `make pre-push-preflight` (prerequisite and disk checks only) targets.
> - A deterministic unittest suite ([test-pre-push-validation.py](https://github.com/CurateLabs/graphforge/pull/381/files#diff-28629704326758ef80e8f2dc01735c79659ced185d408dd0111fa5c79593c0d9)) covers evidence reuse, selective invalidation, corrupt evidence handling, atomicity, disk budgeting, and force-clean semantics.
> - Behavioral Change: `make pre-push` no longer runs checks directly; it delegates entirely to the orchestrator, which writes machine-readable `summary.json` output and exits non-zero on any failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac8cb12.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->