### PR TITLE
docs: dual-track CI objectives and speed as a first-class value

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,8 +2,17 @@
 
 GraphForge uses one stable required `CI Gate`. A deterministic classifier runs
 only the policy, language, and binding jobs relevant to the pull request.
-Release certification is manual and SHA-bound; `publish.yaml` consumes its
-retained candidate only after a GitHub Release is published.
+
+**Speed is a first-class value alongside honesty.** Surfaces shed work that is
+not required for their objective. PR CI does **not** run full `llvm-cov`.
+Frequent publishing uses the **publish-track** (Binding RC → tag →
+`publish.yaml` on retained bytes). M1 load, checkpoint, and m20/m21 remain
+**human-close / milestone** evidence and are not publish-track blockers.
+Wall-clock targets and the dual-track table live in
+[`docs/engineering/TESTING.md`](../../docs/engineering/TESTING.md).
+
+`publish.yaml` consumes a retained Binding RC candidate (no rebuild-on-write)
+after a GitHub Release / release identity exists for that SHA.
 
 Linux jobs run on the pinned `blacksmith-4vcpu-ubuntu-2404` image. Native PR
 jobs use Blacksmith sticky disks for job-isolated Cargo `target/` directories,
@@ -12,6 +21,9 @@ while registry and pnpm dependencies use the colocated cache through upstream
 sticky disks; inactive disks expire under Blacksmith's retention policy.
 The M1 host-native release load matrix also mounts a sticky `target/` so maturin, Cargo,
 and napi share one build volume instead of a second root-disk tree.
+Binding RC is expected to use the same Blacksmith-first sticky + colocated-cache
+model (see storage policy tests); put `target/` on sticky disks, not in
+`actions/cache` blobs.
 
 ## Pull-request contract
 
@@ -152,6 +164,13 @@ candidate manifest for 30 days. Credential preflight verifies the npm/crates.io
 secret projections without publishing. The release-event workflow consumes the
 retained candidate; ordinary PRs do not repeat that certification.
 
+**publish-track** (registry-honest publish, scheduled or on-demand): successful
+same-SHA Binding RC → tag / release identity → `publish.yaml` writes retained
+bytes only. Skip re-RC when a complete unexpired candidate for the current
+`main` tip already exists. Target wall-clock: Binding RC ≤20m p50 warm /
+≤35m cold; publish-track ≤35m p50 / ≤50m cold (see TESTING.md). M1,
+checkpoint, and m20/m21 are **not** required on this path.
+
 ### `clean-env-verify.yml`
 
 Maintainer `workflow_dispatch` after section 6 publication. Installs from **public**
@@ -166,6 +185,9 @@ Repository Policy — they never claim clean-env success against missing package
 See [`docs/development/clean-environment-verification.md`](../../docs/development/clean-environment-verification.md).
 
 ## Local equivalents
+
+Default maintainer loop is `make pre-push-fast` (~30s). Run `make coverage-rust`
+when claiming coverage floors; PR CI does not enforce full llvm-cov.
 
 ```bash
 make pre-push-fast

--- a/docs/development/publication-order.md
+++ b/docs/development/publication-order.md
@@ -11,14 +11,27 @@ This document describes the executable order in
 `.github/workflows/publish.yaml`. It does not authorize a tag, GitHub Release,
 or registry write.
 
+## Tracks
+
+| Track | Path | Required before registry write | Deferred |
+| --- | --- | --- | --- |
+| **publish-track** | Binding RC → tag / release identity → `publish.yaml` | Same-SHA retained candidate + offline rehearsal; no rebuild-on-write | M1 load, checkpoint, m20/m21, full clean-env |
+| **Human release close** | publish-track **plus** milestone evidence | Whatever the active runbook requires (may include M1 / surface gates) | — |
+
+M1, checkpoint recovery, and m20/m21 assemble human-close / milestone confidence.
+They are **not** registry-honesty inputs for `publish.yaml` and must not block
+every publish-track run. See [`../engineering/TESTING.md`](../engineering/TESTING.md)
+dual-track table and wall-clock targets.
+
 ## Candidate preconditions
 
-Before a maintainer authorizes publication:
+Before a maintainer authorizes publication (publish-track or human close):
 
 1. The intended tag resolves to the current reviewed `main` commit and the root
    version is aligned across Cargo, PyPI, Node/native npm, CLI, and agent skills.
 2. A successful same-SHA Binding Release Candidate run retains five 30-day
    artifacts: `manifest`, `python`, `npm`, `crates`, and `evidence`.
+   Skip re-RC when a complete unexpired candidate for that SHA already exists.
 3. The v2 manifest validates the complete file inventory and dependency graph.
    A matching checksum alone is not sufficient.
 4. `evidence/offline-rehearsal.json` proves the exact partitions passed clean
@@ -27,9 +40,9 @@ Before a maintainer authorizes publication:
 5. PyPI and crates.io trusted publishing are configured for
    `CurateLabs/graphforge` and `publish.yaml`; the npm token has scoped
    public-package write access and Bypass 2FA.
-6. The maintainer explicitly decides to create the immutable v0.5.1 tag and
-   GitHub Release. Implementation CI and ordinary issue close do not run a
-   release-certification cascade.
+6. The maintainer (or publish-track automation) creates the immutable tag and
+   GitHub Release identity that `publish.yaml` consumes. Implementation CI and
+   ordinary issue close do not run Binding RC or the human-close cascade.
 
 ## Planner-driven execution
 

--- a/docs/engineering/PUBLISHING.md
+++ b/docs/engineering/PUBLISHING.md
@@ -9,6 +9,17 @@ multi-tenant service. Operational detail:
 [`../development/release-workflows.md`](../development/release-workflows.md), and
 `.github/workflows/publish.yaml`.
 
+**Speed is a first-class value alongside registry honesty.** Prefer the
+**publish-track** for frequent publishes (scheduled or on-demand): Binding RC →
+tag / release identity → `publish.yaml` on retained bytes (no rebuild-on-write).
+Wall-clock targets: Binding RC ≤20m p50 warm / ≤35m cold; publish-track
+≤35m p50 / ≤50m cold; unchanged-SHA publish-only ≤15m. Dual-track table:
+[`TESTING.md`](TESTING.md).
+
+**Human release close** (milestone / coordinated GA) adds optional evidence gates
+(M1 load, checkpoint, m20/m21 surface aggregates) on top of publish-track honesty.
+Those gates must not block every publish-track run.
+
 ## Artifacts and destinations
 
 | Artifact | Destination | Versioned by | Owner |
@@ -71,9 +82,10 @@ must be green on the **same SHA** that is tagged for publication.
 
 | From | To | Required evidence / approval |
 | --- | --- | --- |
-| PR branch | `main` | Focused PR, green CI Gate, clean review threads |
-| `main` SHA | Release candidate | Complete v0.5.1 candidate manifest and offline rehearsal (tracker [#192](https://github.com/CurateLabs/graphforge/issues/192)) |
-| Release candidate | Registries + GitHub Release | Dry-runs, checksums/SBOM where configured, human release execution |
+| PR branch | `main` | Focused PR, green CI Gate, clean review threads (not Binding RC / M1) |
+| `main` SHA | Binding RC candidate | Same-SHA multi-OS retained partitions + offline rehearsal |
+| Binding RC candidate | Registries (publish-track) | Tag / release identity + `publish.yaml` retained bytes; M1/checkpoint/m20/m21 **not** required |
+| publish-track success | Human release close (optional) | Documented M1 / surface gates when the milestone runbook requires them |
 | Published artifacts | Clean-install verification | Fresh pip/npm/Cargo consumers use only public registries |
 | `main` docs | Public docs site | Green `docs.yml` / Starlight build for the deployed commit |
 

--- a/docs/engineering/TESTING.md
+++ b/docs/engineering/TESTING.md
@@ -2,15 +2,39 @@
 
 GraphForge proves shippable behavior with deterministic Rust and binding tests,
 the openCypher TCK as the language oracle, and contract inventories for non-Cypher
-surfaces. Correctness beats performance; skips, sleeps, retries-as-green, and
-weakened assertions do not satisfy gates (`AGENTS.md`,
+surfaces. Correctness and registry honesty are non-negotiable; skips, sleeps,
+retries-as-green, and weakened assertions do not satisfy gates (`AGENTS.md`,
 [`../development/testing.md`](../development/testing.md)).
+
+**Speed is a first-class engineering value alongside honesty.** Every surface
+has a wall-clock target, sheds work that is not required for its objective, and
+parallelizes the rest. Frequent publishing uses the **publish-track**, not a
+separately named “nightly” product. Full `llvm-cov` / `make coverage-rust` is a
+local (or coverage-sensitive) honesty tool — **PR CI does not run full coverage**.
 
 This page is the **v0.5.0 / release-prep testing strategy** that shipped on
 `main`: how layers compose, what each gate proves, and what does not count as
 end-to-end evidence. Command recipes and historical suite layout live in
 [`../development/testing.md`](../development/testing.md). Workflow mechanics live
 in [`.github/workflows/README.md`](../../.github/workflows/README.md).
+
+## Dual-track objectives (PR / publish-track / human close)
+
+| Surface | Objective | Required when | Wall-clock target | Must keep | Shed / defer |
+| --- | --- | --- | --- | --- | --- |
+| `pre-push-fast` | Policy/format | Local habit | ~30s | lint/license/workflow | Full coverage |
+| PR Test Suite + CI Gate | Changed-surface correctness | Every PR → `main` | ≤10m p50 / ≤12m p95 | Classifier, same-SHA Linux bindings, workspace tests, Gate | Multi-OS, load, llvm-cov, Binding RC |
+| `make coverage-rust` | Honest floors | Coverage-sensitive changes / floor claims | ≤20m p50 local | Hash/runtime/ledger; real acceptance | HTML by default; CI enforcement |
+| Binding RC | Multi-OS publish bytes + offline rehearsal | publish-track and human close | ≤20m p50 warm / ≤35m cold | Retained multi-OS artifacts, same-SHA, offline rehearsal | Full PR suite re-run; cold builds when sticky hits |
+| **publish-track** | Registry-honest publish certification | Whenever we publish (scheduled or on-demand) | ≤35m p50 / ≤50m cold (RC + tag + publish) | Binding RC bytes + `publish.yaml` no-rebuild | M1, checkpoint, m20/m21, full clean-env |
+| **Human release close** | Milestone / coordinated GA confidence | Human publication close | publish-track + optional gates | publish-track honesty **plus** M1 / surface gates as documented | — |
+| Unchanged-SHA reuse | Skip redundant RC | Same `main` tip + unexpired candidate | RC ~0; publish-only ≤15m | Candidate completeness checks | Rebuilding identical bytes |
+| Fuzz / stress / viz | Diagnostic | Schedule/manual | N/A | Not merge or publish-track blockers | — |
+
+**publish-track** is Binding RC → tag / release identity → `publish.yaml` on
+retained bytes. M1 load, checkpoint recovery, and m20/m21 surface aggregates remain
+**human-close / milestone** evidence — they are not registry-honesty inputs and
+must not block every publish.
 
 ## Ownership
 
@@ -70,15 +94,15 @@ layers are SHA-bound release certification.
 | Unit + workspace | Rust (or classified) changes | Crate logic and `cargo test --workspace` pass with Clippy `-D warnings` |
 | Binding acceptance (PR) | Binding / classified changes | One same-SHA Linux Python wheel and Node addon; native contracts; short concurrency matrix |
 | Language oracle | Workspace / TCK entrypoints | openCypher TCK runnable scenarios pass (currently **3897/3897**) |
-| Binding release candidate | Manual, exact `main` SHA | Clean-install native proof on Linux, macOS, and Windows; fail-closed aggregate |
-| Surface / recovery / load certification | Manual, exact SHA | Non-Cypher inventory + facade matrix, checkpoint recovery, XS–XL load ledger as publication evidence |
-| Publication | Human release path | `publish.yaml` / registry artifacts for the certified SHA |
+| Binding release candidate | publish-track and human close; exact `main` SHA | Clean-install multi-OS natives + offline rehearsal; fail-closed aggregate; retained publish bytes |
+| publish-track publication | Scheduled or on-demand publish | Binding RC retained bytes → tag → `publish.yaml` (no rebuild-on-write) |
+| Surface / recovery / load certification | Human release close (optional / milestone) | Non-Cypher inventory, checkpoint recovery, XS–XL load ledger — **not** publish-track blockers |
+| Human publication close | Coordinated GA / milestone | publish-track honesty **plus** documented human-close gates |
 
 Ordinary implementation issues close on acceptance-criteria outcomes and green
-checks for the **changed surface**. They do **not** require the full
-release-certification cascade (Binding RC → surface aggregate → publish). Exact
-SHA pairing and downloadable artifacts are publication evidence — see
-`AGENTS.md` § Issue close.
+checks for the **changed surface**. They do **not** require Binding RC,
+publish-track, or the human-close cascade. Exact SHA pairing and downloadable
+artifacts are publication evidence — see `AGENTS.md` § Issue close.
 
 ### Pull-request contract (Test Suite + CI Gate)
 
@@ -143,7 +167,8 @@ docs surfaces; it does not prove runtime behavior.
 | Persistence / reopen | Facade lifecycle + kill-reopen / recovery suites | “Wrote Parquet files” without reopen readback |
 | Binding parity | Same-SHA clean-install wheel/addon; Arrow/IPC and error-code equality | Import smoke or stubbed natives |
 | Concurrency contract | Frozen short matrix in PR CI; stress lane is diagnostic | Stress retries used as the merge gate |
-| Release publication | Exact SHA + same-SHA Binding RC / surface artifacts + publish path | Green PR CI on an unrelated SHA |
+| publish-track publication | Exact SHA + same-SHA Binding RC retained bytes + `publish.yaml` no-rebuild | Green PR CI on an unrelated SHA; M1/checkpoint alone |
+| Human release close | publish-track honesty **plus** documented M1 / surface gates when required | Treating every human-close gate as a publish-track blocker |
 
 Failure handling for matrix or RC failures: let safe lanes finish, census
 symptoms, group by root cause, fix with earlier regression coverage, freeze a
@@ -164,6 +189,11 @@ weakened assertions (`AGENTS.md`).
 | Policy / docs | Format, lint, license, docs build | `make pre-push`, `.github/workflows/docs.yml` |
 
 ## Behavior coverage
+
+PR CI does **not** enforce full `llvm-cov` floors. Use `make coverage-rust`
+locally (or when claiming floor changes). Default maintainer loop is
+`make pre-push-fast`; run full `make coverage` / `make pre-push` when the changed
+surface needs coverage honesty.
 
 ### Rust coverage evidence
 
@@ -232,11 +262,18 @@ unfiltered because their functional runtime suites are the measured surface.
 ## Running the tests
 
 ```bash
-# Default maintainer loop
+# Default maintainer loop (policy/format; ~30s)
+make pre-push-fast
+
+# Changed-surface validation
 cargo fmt --all -- --check
 cargo clippy --workspace -- -D warnings
 cargo test --workspace
 make test-tck
+
+# Coverage-sensitive changes / floor claims (local; not PR CI)
+make coverage-rust
+# Full local gate when needed
 make pre-push
 
 # Non-Cypher surface (Rust)
@@ -265,15 +302,15 @@ identifiers; they are not product milestone labels.
 
 | Workflow surface | Role |
 | --- | --- |
-| `.github/workflows/test.yml` (Test Suite + CI Gate) | Classified PR/`main` policy, Rust, bindings, concurrency short matrix |
-| `.github/workflows/binding-release-candidate.yml` | Manual multi-OS clean-install Binding RC for an exact SHA |
-| Non-Cypher / recovery / load gate workflows | SHA-bound publication evidence (inventory, recovery, XS–XL load) |
+| `.github/workflows/test.yml` (Test Suite + CI Gate) | Classified PR/`main` policy, Rust, bindings, concurrency short matrix (not full llvm-cov) |
+| `.github/workflows/binding-release-candidate.yml` | Multi-OS Binding RC for publish-track and human close (exact SHA) |
+| Non-Cypher / recovery / load gate workflows | Human-close / milestone publication evidence (not publish-track blockers) |
 | `.github/workflows/docs.yml` | Starlight `pnpm docs:build` |
-| `.github/workflows/publish.yaml` | Human publication path |
+| `.github/workflows/publish.yaml` | publish-track and human publication path (retained Binding RC bytes; no rebuild) |
 
-Merge requires green required checks and CI Gate at the exact head SHA. Manual
-SHA-bound release workflows certify publication; they are not close rituals for
-ordinary implementation issues. Details:
+Merge requires green required checks and CI Gate at the exact head SHA.
+publish-track and human-close workflows certify registry publication; they are
+not close rituals for ordinary implementation issues. Details:
 [`.github/workflows/README.md`](../../.github/workflows/README.md).
 
 ## Test data & environments


### PR DESCRIPTION
## Summary
- Document dual-track objectives (PR / publish-track / human close) with wall-clock targets in TESTING.md, workflows README, PUBLISHING.md, and publication-order.md.
- Call out speed as a first-class value alongside honesty; clarify PR CI does not run full llvm-cov.
- Defer M1/checkpoint/m20/m21 from publish-track blockers.

Closes #384.

## Test plan
- [x] Doc review against #384 AC / BDD
- [ ] CI Gate green on docs PR

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788450799&installation_model_id=20486&pr_number=390&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F390&signature=936c9fecb6c1c3c2fa31f8fc2039dc1ccda7cd4863e7f715f1bfde6b3f9eaeda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document dual-track CI model with speed as a first-class value
> - Introduces a dual-track CI model across [TESTING.md](https://github.com/CurateLabs/graphforge/pull/390/files#diff-04262e531b0f3eccbfa8ec6d251c3c0dd036246c2617555db11f35f2b007d18c), [PUBLISHING.md](https://github.com/CurateLabs/graphforge/pull/390/files#diff-8cf3f6c59229d9eee8062f78e5abbefcbee7cd160305b7fa7e5f70f1aca1d97c), [publication-order.md](https://github.com/CurateLabs/graphforge/pull/390/files#diff-829f9cf32a204fa61ff3101e12637e9b28447ce45883a6487b3756e5ea5e3114), and the [CI README](https://github.com/CurateLabs/graphforge/pull/390/files#diff-636942e0afa55e1aea027fb857aa2c6046858fb317c0b9a4f12ff3ca17e64ffb): a fast publish-track (Binding RC → tag/release identity → publish without rebuild) and a Human release close track (publish-track plus milestone evidence).
> - Establishes wall-clock targets for Binding RC, publish-track, and unchanged-SHA publish-only runs; M1/checkpoint/m20/m21 are deferred to human close and are not blockers for publishing.
> - Clarifies that PR CI does not run full `llvm-cov`; full coverage is a local tool for claiming coverage floors, with `make pre-push-fast` as the local maintainer loop.
> - Specifies that publish-track relies on Blacksmith sticky disks and colocated caches (retained Binding RC bytes) rather than `actions/cache`, and that a complete unexpired candidate for the same SHA can skip re-running RC.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31f7e27.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->