### PR TITLE
test: speed make coverage-rust via profile align and parallel acceptance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ coverage:  ## Rust + Python + Node coverage with per-surface thresholds
 	@echo "━━━ Node JS surface coverage ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 	@$(MAKE) coverage-node
 	@echo "━━━ Coverage complete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-	@echo "Rust:   build/coverage-rust/ (ledger + merged lcov + core HTML + summary)"
+	@echo "Rust:   build/coverage-rust/ (ledger + merged lcov + summary; set COVERAGE_RUST_HTML=1 for core HTML)"
 	@echo "Python: coverage.xml + htmlcov/"
 	@echo "Node:   crates/graphforge-bindings-node/coverage/"
 	@echo "✅ All surfaces collected; thresholds enforced per surface"
@@ -215,6 +215,7 @@ pre-push-fast:  ## Run fast checks only — format, lint, type, security, docstr
 pre-push:  ## Run local policy checks plus multi-surface coverage thresholds
 	@$(MAKE) pre-push-fast
 	@uv run --no-sync python scripts/ci/test-rust-coverage-ledger.py
+	@bash scripts/ci/test-coverage-rust.sh
 	@echo "━━━ Coverage + thresholds (Rust + Python + Node) ━━━━━━━━━━━━━━━━━━━━━━━"
 	@$(MAKE) coverage
 	@echo "━━━ Public API BDD mutation sentinels ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
@@ -252,6 +253,8 @@ cargo-test:  ## Run all Rust workspace tests
 #   cargo install cargo-llvm-cov
 #   rustup component add llvm-tools-preview
 # Prefer an isolated CARGO_TARGET_DIR when other builds are running (AGENTS.md).
+# Set COVERAGE_RUST_HTML=1 to write the optional core HTML report. Set
+# COVERAGE_RUST_RESUME=1 only to reuse same-SHA phase stamps and valid outputs.
 coverage-rust:  ## Core + same-SHA Python/Node adapter Rust coverage ledger
 	@COVERAGE_FAIL_UNDER_RUST=$(COVERAGE_FAIL_UNDER_RUST) \
 		COVERAGE_FAIL_UNDER_RUST_CRATE=$(COVERAGE_FAIL_UNDER_RUST_CRATE) \

--- a/scripts/ci/test-coverage-rust.sh
+++ b/scripts/ci/test-coverage-rust.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="$ROOT/scripts/coverage-rust.sh"
+
+bash -n "$RUNNER"
+
+grep -Fq 'CORE_COVERAGE_ARGS="${COVERAGE_RUST_ARGS} --release"' "$RUNNER"
+grep -Fq 'cargo llvm-cov ${CORE_COVERAGE_ARGS} --no-report' "$RUNNER"
+grep -Fq 'if [[ "$HTML_REPORT" == "1" ]]; then' "$RUNNER"
+grep -Fq 'xargs -0 -n 1 -P "$PYTHON_BINDING_WORKERS"' "$RUNNER"
+grep -Fq 'run_python_acceptance' "$RUNNER"
+grep -Fq 'run_node_acceptance' "$RUNNER"
+grep -Fq 'wait "$python_pid"' "$RUNNER"
+grep -Fq 'wait "$node_pid"' "$RUNNER"
+grep -Fq 'stamp_matches()' "$RUNNER"
+grep -Fq 'write_stamp()' "$RUNNER"
+
+if rg -n --glob '*.{yml,yaml}' 'coverage-rust|make coverage|make pre-push' "$ROOT/.github"; then
+  echo "Rust coverage must remain outside PR CI" >&2
+  exit 1
+fi
+
+echo "rust coverage runner policy: ok"

--- a/scripts/coverage-rust.sh
+++ b/scripts/coverage-rust.sh
@@ -9,20 +9,37 @@ OUT_DIR="${COVERAGE_RUST_DIR:-build/coverage-rust}"
 mkdir -p "$OUT_DIR"
 OUT_DIR="$(cd "$OUT_DIR" && pwd)"
 PROFILE_DIR="$OUT_DIR/profiles"
+STAMP_DIR="$OUT_DIR/stamps"
 CORE_LCOV="$OUT_DIR/core.lcov.info"
+CORE_HTML_INDEX="$OUT_DIR/core-html/index.html"
 PYTHON_LCOV="$OUT_DIR/python-adapter.lcov.info"
 NODE_LCOV="$OUT_DIR/node-adapter.lcov.info"
 WORKSPACE_LCOV="$OUT_DIR/lcov.info"
 LEDGER="$OUT_DIR/ledger.json"
 EVIDENCE="$OUT_DIR/evidence.json"
 SUMMARY="$OUT_DIR/summary.txt"
+COVERAGE_TIMING="$OUT_DIR/timing.log"
 COVERAGE_RUST_ARGS="${COVERAGE_RUST_ARGS:---workspace}"
+CORE_COVERAGE_ARGS="${COVERAGE_RUST_ARGS} --release"
+RESUME="${COVERAGE_RUST_RESUME:-0}"
+HTML_REPORT="${COVERAGE_RUST_HTML:-0}"
+PYTHON_BINDING_WORKERS="${PYTHON_BINDING_WORKERS:-4}"
 PYTHON_FLOOR="${COVERAGE_FAIL_UNDER_RUST_PYTHON_ADAPTER:-80}"
 NODE_FLOOR="${COVERAGE_FAIL_UNDER_RUST_NODE_ADAPTER:-80}"
 CORE_FLOOR="${COVERAGE_FAIL_UNDER_RUST:-95}"
 CRATE_FLOOR="${COVERAGE_FAIL_UNDER_RUST_CRATE:-80}"
 PATCH_FLOOR="${COVERAGE_FAIL_UNDER_RUST_PATCH:-90}"
 PATCH_BASE="${COVERAGE_RUST_PATCH_BASE:-origin/main}"
+SOURCE_SHA="$(git rev-parse HEAD)"
+
+if [[ "$RESUME" != "0" && "$RESUME" != "1" ]]; then
+  echo "Rust coverage evidence error: COVERAGE_RUST_RESUME must be 0 or 1" >&2
+  exit 1
+fi
+if [[ "$HTML_REPORT" != "0" && "$HTML_REPORT" != "1" ]]; then
+  echo "Rust coverage evidence error: COVERAGE_RUST_HTML must be 0 or 1" >&2
+  exit 1
+fi
 
 if ! cargo llvm-cov --version >/dev/null 2>&1; then
   echo "Rust coverage evidence error: cargo-llvm-cov is not installed" >&2
@@ -35,18 +52,78 @@ fi
 export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$OUT_DIR/native-target}"
 CORE_TARGET_DIR="$CARGO_TARGET_DIR/llvm-cov-target"
 
-rm -rf "$PROFILE_DIR" "$OUT_DIR/core-html"
-rm -f "$CORE_LCOV" "$PYTHON_LCOV" "$NODE_LCOV" "$WORKSPACE_LCOV" \
-  "$LEDGER" "$EVIDENCE" "$SUMMARY" "$OUT_DIR/python.profdata" "$OUT_DIR/node.profdata"
-mkdir -p "$PROFILE_DIR"
+if [[ "$RESUME" != "1" ]]; then
+  rm -rf "$PROFILE_DIR" "$STAMP_DIR" "$OUT_DIR/core-html"
+  rm -f "$CORE_LCOV" "$PYTHON_LCOV" "$NODE_LCOV" "$WORKSPACE_LCOV" \
+    "$LEDGER" "$EVIDENCE" "$SUMMARY" "$COVERAGE_TIMING" \
+    "$OUT_DIR/python.profdata" "$OUT_DIR/node.profdata"
+fi
+mkdir -p "$PROFILE_DIR" "$STAMP_DIR"
+
+hash_file() {
+  python3 -c 'import hashlib, pathlib, sys; print(hashlib.sha256(pathlib.Path(sys.argv[1]).read_bytes()).hexdigest())' "$1"
+}
+
+stamp_payload() {
+  local phase="$1"
+  local input="$2"
+  shift 2
+  printf 'source_sha=%s\nphase=%s\ninput=%s\n' "$SOURCE_SHA" "$phase" "$input"
+  for output in "$@"; do
+    printf 'output_sha256=%s path=%s\n' "$(hash_file "$output")" "$output"
+  done
+}
+
+stamp_matches() {
+  local phase="$1"
+  local input="$2"
+  shift 2
+  local stamp="$STAMP_DIR/$phase.stamp"
+  [[ "$RESUME" == "1" && -f "$stamp" ]] || return 1
+  for required in "$@"; do
+    [[ -s "$required" ]] || return 1
+  done
+  cmp -s <(stamp_payload "$phase" "$input" "$@") "$stamp"
+}
+
+write_stamp() {
+  local phase="$1"
+  local input="$2"
+  shift 2
+  local stamp="$STAMP_DIR/$phase.stamp"
+  local temporary="$stamp.tmp.$$"
+  stamp_payload "$phase" "$input" "$@" >"$temporary"
+  mv "$temporary" "$stamp"
+}
+
+record_timing() {
+  local phase="$1"
+  local started="$2"
+  printf 'source_sha=%s phase=%s seconds=%s\n' \
+    "$SOURCE_SHA" "$phase" "$((SECONDS - started))" >>"$COVERAGE_TIMING"
+}
 
 echo "━━━ Core Rust coverage ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-# shellcheck disable=SC2086
-cargo llvm-cov clean ${COVERAGE_RUST_ARGS}
-# shellcheck disable=SC2086
-cargo llvm-cov ${COVERAGE_RUST_ARGS} --no-report
-cargo llvm-cov report --lcov --output-path "$CORE_LCOV"
-cargo llvm-cov report --html --output-dir "$OUT_DIR/core-html"
+core_input="${CORE_COVERAGE_ARGS} html=${HTML_REPORT}"
+core_outputs=("$CORE_LCOV")
+if [[ "$HTML_REPORT" == "1" ]]; then
+  core_outputs+=("$CORE_HTML_INDEX")
+fi
+if stamp_matches core "$core_input" "${core_outputs[@]}"; then
+  echo "Resuming verified core coverage from $CORE_LCOV"
+else
+  phase_started=$SECONDS
+  # shellcheck disable=SC2086
+  cargo llvm-cov clean ${COVERAGE_RUST_ARGS}
+  # shellcheck disable=SC2086
+  cargo llvm-cov ${CORE_COVERAGE_ARGS} --no-report
+  cargo llvm-cov report --release --lcov --output-path "$CORE_LCOV"
+  if [[ "$HTML_REPORT" == "1" ]]; then
+    cargo llvm-cov report --release --html --output-dir "$OUT_DIR/core-html"
+  fi
+  write_stamp core "$core_input" "${core_outputs[@]}"
+  record_timing core "$phase_started"
+fi
 
 # Export the exact instrumentation environment used by cargo-llvm-cov. Native
 # artifacts are built once, sequentially, and then reused by all acceptance.
@@ -54,8 +131,16 @@ COVERAGE_ENV="$(cargo llvm-cov show-env --sh)"
 eval "$COVERAGE_ENV"
 
 echo "━━━ Instrumented native artifacts ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-uv run maturin develop --release -m crates/graphforge-bindings-py/Cargo.toml
-pnpm --filter @curatelabs/graphforge exec napi build --platform --release
+native_input="$(printf '%s\n' "$CORE_COVERAGE_ARGS" "$COVERAGE_ENV" | shasum -a 256)"
+if stamp_matches native-artifacts "$native_input"; then
+  echo "Resuming verified native artifact build"
+else
+  phase_started=$SECONDS
+  uv run maturin develop --release -m crates/graphforge-bindings-py/Cargo.toml
+  pnpm --filter @curatelabs/graphforge exec napi build --platform --release
+  write_stamp native-artifacts "$native_input"
+  record_timing native-artifacts "$phase_started"
+fi
 
 find_one() {
   local description="$1"
@@ -83,9 +168,6 @@ for artifact in "$PYTHON_OBJECT" "$NODE_OBJECT" "$PYTHON_RUNTIME" "$NODE_RUNTIME
   fi
 done
 
-hash_file() {
-  python3 -c 'import hashlib, pathlib, sys; print(hashlib.sha256(pathlib.Path(sys.argv[1]).read_bytes()).hexdigest())' "$1"
-}
 python_hash="$(hash_file "$PYTHON_OBJECT")"
 node_hash="$(hash_file "$NODE_OBJECT")"
 if [[ "$(hash_file "$PYTHON_RUNTIME")" != "$python_hash" ]]; then
@@ -97,27 +179,72 @@ if [[ "$(hash_file "$NODE_RUNTIME")" != "$node_hash" ]]; then
   exit 1
 fi
 
-echo "━━━ Python native acceptance ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-export LLVM_PROFILE_FILE="$PROFILE_DIR/python-%p-%10m.profraw"
-for test_file in crates/graphforge-bindings-py/tests/*.py; do
-  CARGO_TARGET_DIR="$CORE_TARGET_DIR" uv run --no-sync python "$test_file"
-done
-uv run --no-sync pytest tests/unit tests/integration tests/features \
-  -n "${PYTEST_WORKERS:-4}" --tb=short
+run_python_acceptance() {
+  export LLVM_PROFILE_FILE="$PROFILE_DIR/python-%p-%10m.profraw"
+  shopt -s nullglob
+  local test_files=(crates/graphforge-bindings-py/tests/*.py)
+  if [[ "${#test_files[@]}" -eq 0 ]]; then
+    echo "Rust coverage evidence error: no Python binding acceptance tests found" >&2
+    return 1
+  fi
+  printf '%s\0' "${test_files[@]}" | xargs -0 -n 1 -P "$PYTHON_BINDING_WORKERS" \
+    env CARGO_TARGET_DIR="$CORE_TARGET_DIR" uv run --no-sync python
+  uv run --no-sync pytest tests/unit tests/integration tests/features \
+    -n "${PYTEST_WORKERS:-4}" --tb=short
+}
 
-echo "━━━ Node native acceptance ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-export LLVM_PROFILE_FILE="$PROFILE_DIR/node-%p-%10m.profraw"
-pnpm --filter @curatelabs/graphforge test:smoke
-pnpm --filter @curatelabs/graphforge test
-(
-  cd tests/features/node
-  node node_modules/@cucumber/cucumber/bin/cucumber.js \
-    "../api/**/*.feature" \
-    --require-module ts-node/register \
-    --require "step_definitions/**/*.ts" \
-    --tags "not @excluded-api-bdd and not @excluded-node-api-bdd" \
-    --format summary
-)
+run_node_acceptance() {
+  export LLVM_PROFILE_FILE="$PROFILE_DIR/node-%p-%10m.profraw"
+  pnpm --filter @curatelabs/graphforge test:smoke
+  pnpm --filter @curatelabs/graphforge test
+  (
+    cd tests/features/node
+    node node_modules/@cucumber/cucumber/bin/cucumber.js \
+      "../api/**/*.feature" \
+      --require-module ts-node/register \
+      --require "step_definitions/**/*.ts" \
+      --tags "not @excluded-api-bdd and not @excluded-node-api-bdd" \
+      --format summary
+  )
+}
+
+python_input="artifact_sha256=$python_hash"
+node_input="artifact_sha256=$node_hash"
+echo "━━━ Parallel native acceptance ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+if stamp_matches python-acceptance "$python_input" "${PROFILE_DIR}"/python-*.profraw; then
+  echo "Resuming verified Python native acceptance"
+else
+  (
+    phase_started=$SECONDS
+    run_python_acceptance
+    write_stamp python-acceptance "$python_input" "${PROFILE_DIR}"/python-*.profraw
+    record_timing python-acceptance "$phase_started"
+  ) &
+  python_pid=$!
+fi
+if stamp_matches node-acceptance "$node_input" "${PROFILE_DIR}"/node-*.profraw; then
+  echo "Resuming verified Node native acceptance"
+else
+  (
+    phase_started=$SECONDS
+    run_node_acceptance
+    write_stamp node-acceptance "$node_input" "${PROFILE_DIR}"/node-*.profraw
+    record_timing node-acceptance "$phase_started"
+  ) &
+  node_pid=$!
+fi
+
+acceptance_status=0
+if [[ -n "${python_pid:-}" ]] && ! wait "$python_pid"; then
+  acceptance_status=1
+fi
+if [[ -n "${node_pid:-}" ]] && ! wait "$node_pid"; then
+  acceptance_status=1
+fi
+if [[ "$acceptance_status" -ne 0 ]]; then
+  echo "Rust coverage evidence error: native acceptance failed" >&2
+  exit 1
+fi
 
 TOOLS_DIR="$(rustc --print sysroot)/lib/rustlib/$(rustc -vV | sed -n 's/^host: //p')/bin"
 shopt -s nullglob


### PR DESCRIPTION
## Summary
- Align core `cargo llvm-cov` with instrumented release profile.
- Parallelize Python ‖ Node acceptance and binding `tests/*.py` after hash checks.
- HTML opt-in (`COVERAGE_RUST_HTML=1`); fail-closed resume stamps (`COVERAGE_RUST_RESUME=1`).
- Add coverage-rust script policy sentinel; do not put full coverage into PR CI.

Closes #388.

## Test plan
- [x] `make pre-push-fast`
- [x] `bash scripts/ci/test-coverage-rust.sh`
- [x] `uv run --no-sync python scripts/ci/test-rust-coverage-ledger.py`
- [ ] CI Gate green
- [ ] Wall-clock evidence when a full local run is feasible (isolated target vanished mid-compile in one attempt; floors unchanged)

## BDD evidence
- Profile align: core llvm-cov uses `--release`; ledger floors still enforced by existing ledger tests.
- Parallel acceptance: Python/Node and binding `*.py` parallelized in `scripts/coverage-rust.sh`.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788451801&installation_model_id=20486&pr_number=391&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F391&signature=b04c7df8b9347b1809a996e81aef68c6c9820ce3182c387cb7258208aad35fac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Speed up Rust coverage via parallel acceptance, resume stamps, and profile alignment
> - [scripts/coverage-rust.sh](https://github.com/CurateLabs/graphforge/pull/391/files#diff-ba8f769c5f416a174372d309110af994b61b2ab4c2d033b4d6aac34ba43c5674) now runs Python and Node acceptance phases in parallel, with per-phase stamp files enabling resume (`COVERAGE_RUST_RESUME=1`) to skip already-completed phases when outputs match.
> - Core coverage runs with `--release` by default; the HTML report is opt-in via `COVERAGE_RUST_HTML=1` to avoid unnecessary output.
> - Per-phase timing is recorded to `build/coverage-rust/timing.log`; Python binding tests run per-file in parallel via `xargs -P` with a configurable `PYTHON_BINDING_WORKERS` count, and the phase fails fast if no binding tests are found.
> - A new CI policy script [scripts/ci/test-coverage-rust.sh](https://github.com/CurateLabs/graphforge/pull/391/files#diff-d5f68e121dbc31491412d682ef7560ffc7ef7c0cfe0689d38382869c5fec811b) is added and wired into the `pre-push` Makefile target; it validates that `coverage-rust.sh` contains required commands and that GitHub workflows do not invoke Rust coverage directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 32654a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resumable Rust coverage runs with configurable HTML reporting, release mode, worker count, and timing options.
  * Improved coverage artifact validation and phase progress reporting.
  * Added concurrent Python and Node acceptance-test coverage.

* **Bug Fixes**
  * Improved failure handling when acceptance tests or coverage steps fail.

* **Tests**
  * Added automated validation for Rust coverage workflow policies.
  * Rust coverage checks now run during pre-push validation.

* **Documentation**
  * Documented Rust coverage resume and HTML-report configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->