### PR TITLE
ci: accelerate Binding RC builds

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,4 +2,6 @@ self-hosted-runner:
   labels:
     - blacksmith-4vcpu-ubuntu-2404
     - blacksmith-4vcpu-windows-2025
+    - blacksmith-8vcpu-windows-2025
     - blacksmith-6vcpu-macos-15
+    - blacksmith-12vcpu-macos-15

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -94,6 +94,23 @@ npm, and crates.io surfaces, records four non-overlapping artifact groups, and
 reopens every archive with `graphforge-release-candidate-v2` completeness
 validation. A checksum-valid archive with missing entrypoints, types, native
 modules, dependency metadata, or legal files is rejected.
+Linux Binding RC build cells mount a shared release-profile `target/` sticky
+disk keyed by repository, RC Linux target family, Rust 1.96.0, and `Cargo.lock`;
+the Python Ubuntu and Linux Node cells share it because their Cargo artifacts
+are target-qualified. The release-assembly cell has its own equivalent sticky
+disk. Registry and git dependencies use colocated `actions/cache@v6` on every
+RC OS; no cache action transfers `target/`. macOS and Windows use larger
+Blacksmith runners (12-vCPU macOS, 8-vCPU Windows) rather than sticky disks.
+
+RC is intentionally slimmer than the PR suite: PR CI owns broad Linux binding
+acceptance, while RC runs only clean-install smoke plus publish-critical native
+parity/error contracts on every retained platform, then verifies the exact
+retained partitions offline. This keeps multi-OS native evidence, offline
+rehearsal, and same-SHA fail-closed packing intact. During the first three
+comparable dispatches after this change, record the Actions duration in the PR
+ledger: target p50 is ≤20 minutes warm and ≤35 minutes cold. Treat warm p50
+above 25 minutes as a failed speed acceptance criterion and open a bounded
+follow-up before declaring the change complete.
 After the maturin wheel build, the workflow verifies that any inherited Rust
 compiler wrapper is still executable before Python contracts may launch Cargo;
 an unavailable wrapper is cleared without printing the job environment or PATH.

--- a/.github/workflows/binding-release-candidate.yml
+++ b/.github/workflows/binding-release-candidate.yml
@@ -49,11 +49,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: blacksmith-4vcpu-ubuntu-2404, target: python-ubuntu }
-          - { os: blacksmith-6vcpu-macos-15, target: python-macos }
-          - { os: blacksmith-4vcpu-windows-2025, target: python-windows }
+          - { os: blacksmith-4vcpu-ubuntu-2404, target: python-ubuntu, sticky_target: "true" }
+          - { os: blacksmith-12vcpu-macos-15, target: python-macos, sticky_target: "false" }
+          - { os: blacksmith-8vcpu-windows-2025, target: python-windows, sticky_target: "false" }
     env:
       CARGO_INCREMENTAL: 0
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target
       EVIDENCE_SHA: ${{ needs.validate_source.outputs.evidence_sha }}
     steps:
       - uses: actions/checkout@v7
@@ -72,6 +73,22 @@ jobs:
 
       - uses: astral-sh/setup-uv@v9.0.0
 
+      - name: Mount shared Linux Cargo build disk
+        if: matrix.sticky_target == 'true'
+        uses: useblacksmith/stickydisk@v1
+        with:
+          # Python Ubuntu and Linux Node targets share compatible release products.
+          key: ${{ github.repository }}-binding-rc-linux-rust-1.96.0-${{ hashFiles('Cargo.lock') }}-release-target-v1
+          path: target
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
+
       - name: Build native abi3 wheel
         uses: PyO3/maturin-action@v1
         with:
@@ -79,6 +96,18 @@ jobs:
           args: --release --manifest-path crates/graphforge-bindings-py/Cargo.toml --out dist
           manylinux: auto
           sccache: "false"
+
+      # manylinux maturin writes into the mounted target as root; reclaim it
+      # before the native contracts can launch Cargo on the host runner.
+      - name: Reclaim sticky-disk ownership after maturin
+        if: matrix.sticky_target == 'true'
+        shell: bash
+        run: |
+          test "$CARGO_TARGET_DIR" = "$GITHUB_WORKSPACE/target"
+          sudo chown -R "$(id -u):$(id -g)" "$CARGO_TARGET_DIR"
+          mkdir -p "$CARGO_TARGET_DIR/release"
+          touch "$CARGO_TARGET_DIR/release/.cargo-build-lock"
+          rm -f "$CARGO_TARGET_DIR/release/.cargo-build-lock"
 
       # The maturin action owns its build wrapper. Later Python contracts may
       # launch Cargo after that wrapper has left PATH, especially on containerized
@@ -90,18 +119,17 @@ jobs:
             --platform "${{ matrix.target }}" \
             --contract python-native-contracts
 
-      - name: Prepare writable Cargo target for native contracts
+      - name: Verify writable Cargo target for native contracts
         shell: bash
         run: |
-          cargo_target_dir="$RUNNER_TEMP/graphforge-python-native-target"
-          if ! mkdir -p "$cargo_target_dir" || \
-             ! touch "$cargo_target_dir/.graphforge-write-probe" || \
-             ! rm "$cargo_target_dir/.graphforge-write-probe"; then
-            printf 'cargo_target_state=unwritable target=runner-temp/graphforge-python-native-target\n' >&2
+          test "$CARGO_TARGET_DIR" = "$GITHUB_WORKSPACE/target"
+          if ! mkdir -p "$CARGO_TARGET_DIR" || \
+             ! touch "$CARGO_TARGET_DIR/.graphforge-write-probe" || \
+             ! rm "$CARGO_TARGET_DIR/.graphforge-write-probe"; then
+            printf 'cargo_target_state=unwritable target=workspace/target\n' >&2
             exit 1
           fi
-          printf 'CARGO_TARGET_DIR=%s\n' "$cargo_target_dir" >> "$GITHUB_ENV"
-          printf 'cargo_target_state=ready target=runner-temp/graphforge-python-native-target\n'
+          printf 'cargo_target_state=ready target=workspace/target\n'
 
       - name: Prepare writable Python RC evidence directory
         shell: bash
@@ -123,8 +151,13 @@ jobs:
         run: |
           wheels=(dist/*.whl)
           test "${#wheels[@]}" -eq 1
+          test -f crates/graphforge-bindings-py/tests/smoke.py
           test -f crates/graphforge-bindings-py/tests/gil_release.py
-          for test_file in crates/graphforge-bindings-py/tests/*.py; do
+          # Broad Python acceptance belongs to PR CI. RC retains the installed
+          # package smoke, GIL, and non-Cypher contracts required before publish.
+          for test_file in \
+            crates/graphforge-bindings-py/tests/smoke.py \
+            crates/graphforge-bindings-py/tests/gil_release.py; do
             uv run --isolated --no-project --with "${wheels[0]}" python "$test_file"
           done
           GRAPHFORGE_PYTHON_PARITY_REPORT="$PYTHON_RC_EVIDENCE_DIR/python-classification.json" \
@@ -185,24 +218,27 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: blacksmith-6vcpu-macos-15
+          - os: blacksmith-12vcpu-macos-15
             target: x86_64-apple-darwin
             report_target: node-x86_64-apple-darwin
             execution_mode: native
             cross_args: ""
             node_arch: x64
-          - os: blacksmith-6vcpu-macos-15
+            sticky_target: "false"
+          - os: blacksmith-12vcpu-macos-15
             target: aarch64-apple-darwin
             report_target: node-aarch64-apple-darwin
             execution_mode: native
             cross_args: ""
             node_arch: arm64
+            sticky_target: "false"
           - os: blacksmith-4vcpu-ubuntu-2404
             target: x86_64-unknown-linux-gnu
             report_target: node-x86_64-unknown-linux-gnu
             execution_mode: native
             cross_args: ""
             node_arch: x64
+            sticky_target: "true"
           - os: blacksmith-4vcpu-ubuntu-2404
             target: aarch64-unknown-linux-gnu
             report_target: node-aarch64-unknown-linux-gnu
@@ -210,15 +246,18 @@ jobs:
             cross_args: --use-napi-cross
             arm_cflags: -D__ARM_ARCH=8
             node_arch: x64
-          - os: blacksmith-4vcpu-windows-2025
+            sticky_target: "true"
+          - os: blacksmith-8vcpu-windows-2025
             target: x86_64-pc-windows-msvc
             report_target: node-x86_64-pc-windows-msvc
             execution_mode: native
             cross_args: ""
             node_arch: x64
+            sticky_target: "false"
             timeout_minutes: 90
     env:
       CARGO_INCREMENTAL: 0
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target
       EVIDENCE_SHA: ${{ needs.validate_source.outputs.evidence_sha }}
     steps:
       - uses: actions/checkout@v7
@@ -242,6 +281,22 @@ jobs:
         with:
           toolchain: "1.96.0"
           targets: ${{ matrix.target }}
+
+      - name: Mount shared Linux Cargo build disk
+        if: matrix.sticky_target == 'true'
+        uses: useblacksmith/stickydisk@v1
+        with:
+          # Python Ubuntu and Linux Node targets share compatible release products.
+          key: ${{ github.repository }}-binding-rc-linux-rust-1.96.0-${{ hashFiles('Cargo.lock') }}-release-target-v1
+          path: target
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
 
       - name: Install workspace dependencies
         run: pnpm install
@@ -399,7 +454,7 @@ jobs:
     env:
       EVIDENCE_SHA: ${{ needs.validate_source.outputs.evidence_sha }}
       CARGO_INCREMENTAL: 0
-      CARGO_TARGET_DIR: ${{ github.workspace }}/target/release-candidate
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target
     steps:
       - uses: actions/checkout@v7
         with:
@@ -445,6 +500,20 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.96.0"
+
+      - name: Mount release assembly Cargo build disk
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-release_candidate-rust-1.96.0-${{ hashFiles('Cargo.lock') }}-release-target-v1
+          path: target
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
 
       - name: Download exact-run tested wheels
         uses: actions/download-artifact@v8
@@ -496,6 +565,14 @@ jobs:
           pnpm exec napi pre-publish -t npm --skip-optional-publish --no-gh-release
           python3 "$GITHUB_WORKSPACE/scripts/ci/prepare-napi-packages.py" \
             --npm-dir npm --legal-dir .
+          # CLI and agent-skills packs have no dependency on NAPI package
+          # generation, so overlap them with the package loop below.
+          pnpm --dir "$GITHUB_WORKSPACE/packages/cli" pack \
+            --pack-destination "$GITHUB_WORKSPACE/candidate/release-artifacts/npm" &
+          cli_pack_pid=$!
+          pnpm --dir "$GITHUB_WORKSPACE/packages/agent-skills" pack \
+            --pack-destination "$GITHUB_WORKSPACE/candidate/release-artifacts/npm" &
+          agent_skills_pack_pid=$!
           for package_dir in npm/*; do
             npm pack "./$package_dir" --ignore-scripts \
               --pack-destination "$GITHUB_WORKSPACE/candidate/release-artifacts/npm"
@@ -518,10 +595,8 @@ jobs:
           assert not missing, f"{packs[0].name} missing {sorted(missing)}"
           PY
           popd
-          pnpm --dir packages/cli pack \
-            --pack-destination "$GITHUB_WORKSPACE/candidate/release-artifacts/npm"
-          pnpm --dir packages/agent-skills pack \
-            --pack-destination "$GITHUB_WORKSPACE/candidate/release-artifacts/npm"
+          wait "$cli_pack_pid"
+          wait "$agent_skills_pack_pid"
 
       - name: Package the complete Rust surface
         shell: bash
@@ -536,7 +611,7 @@ jobs:
           done < <(python3 scripts/ci/crate-publish-plan.py list)
           cargo package "${package_args[@]}" --allow-dirty --no-verify
           for crate in "${crates[@]}"; do
-            cp "target/release-candidate/package/${crate}-${RELEASE_VERSION}.crate" \
+            cp "target/package/${crate}-${RELEASE_VERSION}.crate" \
               candidate/release-artifacts/crates/
           done
 

--- a/scripts/ci/test-binding-release-candidate.py
+++ b/scripts/ci/test-binding-release-candidate.py
@@ -171,11 +171,14 @@ def validate_python_evidence_policy(workflow_text: str) -> None:
     assert_active_lines(
         native,
         "PYTHON_RC_EVIDENCE_DIR: ${{ runner.temp }}/graphforge-python-rc-evidence",
+        "test -f crates/graphforge-bindings-py/tests/smoke.py",
+        "test -f crates/graphforge-bindings-py/tests/gil_release.py",
         f"GRAPHFORGE_PYTHON_PARITY_REPORT={report} \\",
         'uv run --isolated --no-project --with "${wheels[0]}" \\',
         "python crates/graphforge-bindings-py/tests/non_cypher_release.py \\",
         "--classification-only",
     )
+    assert "crates/graphforge-bindings-py/tests/*.py" not in native
     assert "GRAPHFORGE_PYTHON_PARITY_REPORT=dist/" not in native
     write = required_section(
         post_maturin, f"- name: {write_step}", "- name: Stage Python report for aggregate job"
@@ -200,7 +203,7 @@ def validate_python_evidence_policy(workflow_text: str) -> None:
         "if-no-files-found: error",
         "retention-days: 1",
     )
-    for forbidden in ("chmod", "chown", "continue-on-error", "|| true", "retry"):
+    for forbidden in ("chmod", "continue-on-error", "|| true", "retry"):
         assert forbidden not in post_maturin.lower()
     assert not re.search(r"(?mi)^\s*if:\s*(?:false|\$\{\{\s*false\s*\}\})\s*$", post_maturin)
 
@@ -231,7 +234,7 @@ def validate_windows_node_cold_start_policy(workflow_text: str) -> None:
     )
     assert_active_lines(node_job, "timeout-minutes: ${{ matrix.timeout_minutes || 60 }}")
 
-    assert "actions/cache@v6" not in node_job
+    assert node_job.count("actions/cache@v6") == 1
     assert "actions/cache/restore@v6" not in node_job
     assert "actions/cache/save@v6" not in node_job
     assert node_job.count("actions/upload-artifact@v7") == 2
@@ -249,7 +252,8 @@ def validate_windows_node_cold_start_policy(workflow_text: str) -> None:
         "if-no-files-found: error",
         "retention-days: 1",
     )
-    assert "Restore Windows Node Cargo build state" not in node_job
+    assert "path: target" not in workflow_step(node_job, "name: Cache Cargo registry")
+    assert "key: ${{ runner.os }}-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}" in node_job
     assert node_job.index("uses: dtolnay/rust-toolchain@master") < node_job.index(
         "Build declared publish target"
     )
@@ -510,7 +514,7 @@ def main() -> None:
     ):
         rejected_python_evidence_policy(rc_workflow_text.replace(marker, "", 1))
     wrapper_step = "Prepare Rust compiler wrapper for native contracts"
-    target_step = "Prepare writable Cargo target for native contracts"
+    target_step = "Verify writable Cargo target for native contracts"
     native_step = "Clean-install and execute native contract"
     assert rc_workflow_text.count(wrapper_step) == 1
     assert rc_workflow_text.count(target_step) == 1
@@ -523,12 +527,12 @@ def main() -> None:
     post_maturin_python = rc_workflow_text.split("uses: PyO3/maturin-action@v1", 1)[1].split(
         "  node:", 1
     )[0]
-    assert 'cargo_target_dir="$RUNNER_TEMP/graphforge-python-native-target"' in post_maturin_python
-    assert "printf 'CARGO_TARGET_DIR=%s\\n'" in post_maturin_python
+    assert "CARGO_TARGET_DIR: ${{ github.workspace }}/target" in rc_workflow_text
+    assert 'test "$CARGO_TARGET_DIR" = "$GITHUB_WORKSPACE/target"' in post_maturin_python
     assert "cargo_target_state=unwritable" in post_maturin_python
     assert "cargo_target_state=ready" in post_maturin_python
     assert "chmod" not in post_maturin_python
-    assert "chown" not in post_maturin_python
+    assert post_maturin_python.count('sudo chown -R "$(id -u):$(id -g)" "$CARGO_TARGET_DIR"') == 1
     assert "continue-on-error" not in post_maturin_python
     assert "|| true" not in post_maturin_python
     assert "retry" not in post_maturin_python.lower()
@@ -572,11 +576,25 @@ def main() -> None:
     assert "macos-latest" not in rc_workflow_text
     assert "macos-15-intel" not in rc_workflow_text
     assert "windows-latest" not in rc_workflow_text
-    assert rc_workflow_text.count("os: blacksmith-6vcpu-macos-15") == 3
-    assert rc_workflow_text.count("os: blacksmith-4vcpu-windows-2025") == 2
+    assert rc_workflow_text.count("os: blacksmith-12vcpu-macos-15") == 3
+    assert rc_workflow_text.count("os: blacksmith-8vcpu-windows-2025") == 2
     assert "architecture: ${{ matrix.node_arch }}" in rc_workflow_text
     assert 'test "$(node -p \'process.arch\')" = "$EXPECTED_NODE_ARCH"' in rc_workflow_text
     assert "scripts/ci/prepare-rustc-wrapper.py" in rc_workflow_text
+    assert rc_workflow_text.count("uses: useblacksmith/stickydisk@v1") == 3
+    assert rc_workflow_text.count("uses: actions/cache@v6") == 3
+    shared_linux_key = (
+        "${{ github.repository }}-binding-rc-linux-rust-1.96.0-"
+        "${{ hashFiles('Cargo.lock') }}-release-target-v1"
+    )
+    assert rc_workflow_text.count(shared_linux_key) == 2
+    assert (
+        "${{ github.repository }}-release_candidate-rust-1.96.0-"
+        "${{ hashFiles('Cargo.lock') }}-release-target-v1"
+    ) in rc_workflow_text
+    assert 'sccache: "true"' not in rc_workflow_text
+    assert "path: target\n          key: ${{ runner.os }}-cargo-registry" not in rc_workflow_text
+    assert "Reclaim sticky-disk ownership after maturin" in rc_workflow_text
     package_validation_step = rc_workflow_text.split("- name: Validate cross-built package", 1)[
         1
     ].split("- name: Write target evidence", 1)[0]
@@ -603,8 +621,10 @@ def main() -> None:
     assert "test -f index.js" in release_candidate_job
     assert "test -f index.d.ts" in release_candidate_job
     assert "package/index.js" in release_candidate_job
-    assert "pnpm --dir packages/cli pack" in release_candidate_job
-    assert "pnpm --dir packages/agent-skills pack" in release_candidate_job
+    assert 'pnpm --dir "$GITHUB_WORKSPACE/packages/cli" pack' in release_candidate_job
+    assert 'pnpm --dir "$GITHUB_WORKSPACE/packages/agent-skills" pack' in release_candidate_job
+    assert 'wait "$cli_pack_pid"' in release_candidate_job
+    assert 'wait "$agent_skills_pack_pid"' in release_candidate_job
     assert 'cargo package "${package_args[@]}" --allow-dirty --no-verify' in (release_candidate_job)
     assert 'cargo package -p "$crate"' not in release_candidate_job
     assert "scripts/set_release_version.py --check" in release_candidate_job

--- a/scripts/ci/test-ci-storage-policy.py
+++ b/scripts/ci/test-ci-storage-policy.py
@@ -43,13 +43,21 @@ EXPECTED_ARTIFACT_DOWNLOADS = Counter(
 )
 EXPECTED_DEPENDENCY_KEYS = Counter(
     {
-        "${{ runner.os }}-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}": 7,
+        "${{ runner.os }}-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}": 10,
         "${{ runner.os }}-fuzz-${{ hashFiles('fuzz/Cargo.toml', '**/Cargo.lock') }}": 1,
     }
 )
 EXPECTED_STICKY_KEYS = Counter(
     {
         "${{ github.repository }}-${{ github.job }}-${{ hashFiles('Cargo.lock') }}-target-v1": 5,
+        (
+            "${{ github.repository }}-binding-rc-linux-rust-1.96.0-"
+            "${{ hashFiles('Cargo.lock') }}-release-target-v1"
+        ): 2,
+        (
+            "${{ github.repository }}-release_candidate-rust-1.96.0-"
+            "${{ hashFiles('Cargo.lock') }}-release-target-v1"
+        ): 1,
         (
             "${{ github.repository }}-daily-fuzz-"
             "${{ hashFiles('fuzz/Cargo.toml', '**/Cargo.lock') }}-target-v1"


### PR DESCRIPTION
## Summary
- Mount release-profile sticky Cargo targets for Linux Binding RC builds, sharing the compatible Python Ubuntu and Node Linux target disk; use colocated Cargo registry caches and larger macOS/Windows runners.
- Point maturin and napi at the mounted target, reclaim ownership after manylinux maturin, and overlap independent CLI and agent-skills packs during assembly.
- Slim RC to installed-package smoke plus publish-critical GIL/non-Cypher and Node parity/error contracts; retain multi-OS natives, offline rehearsal, same-SHA fail-closed packing, and storage-policy enforcement.

## Measurement plan
- Dispatch three comparable Binding RCs after merge and record Actions wall-clock as cold/warm in the PR ledger.
- Acceptance target is p50 ≤20 minutes warm and ≤35 minutes cold. Treat warm p50 >25 minutes as a hard failure of #387 and open a bounded follow-up before declaring the speed objective complete.

## Test plan
- [x] `python3 scripts/ci/test-binding-release-candidate.py`
- [x] `python3 scripts/ci/test-ci-storage-policy.py`
- [x] `make workflow-lint`
- [x] `uv run ruff check scripts/ci/test-binding-release-candidate.py scripts/ci/test-ci-storage-policy.py`
- [x] `uv run ruff format --check scripts/ci/test-binding-release-candidate.py scripts/ci/test-ci-storage-policy.py`

Closes #387.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788452010&installation_model_id=20486&pr_number=392&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F392&signature=d90dfe762c2d6cd78d91e300cf22e817f72a87f36d1363451bdebb6059417eef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Accelerate Binding RC builds with sticky disks, Cargo caching, and larger runners
> - Mounts shared sticky Cargo `target` disks for Linux Python and Node RC builds, keyed by repo/Rust version/`Cargo.lock`, to reuse incremental build artifacts across runs.
> - Adds `actions/cache@v6` for Cargo registry and git directories on all RC platforms.
> - Upgrades macOS runners to 12-vCPU (`blacksmith-12vcpu-macos-15`) and Windows to 8-vCPU (`blacksmith-8vcpu-windows-2025`).
> - Parallelizes `pnpm pack` for `packages/cli` and `packages/agent-skills` in the release assembly job using background processes.
> - Restricts Python RC tests to `smoke.py` and `gil_release.py` instead of globbing all tests, and reclaims sticky-disk ownership after manylinux (`maturin`) builds via `sudo chown`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 48d8880.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->