### PR TITLE
ci: share PR artifacts with concurrency matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,8 +46,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
+      - name: Classify Repository Policy suites
+        id: policy-suites
+        shell: bash
+        run: |
+          scripts/ci/classify-policy-suites.sh \
+            "${{ github.event.pull_request.base.sha }}" \
+            "${{ github.sha }}" >> "$GITHUB_OUTPUT"
+
       - name: Test changed-path classifier
         run: scripts/ci/test-classify-changes.sh
+
+      - name: Test Repository Policy suite classifier
+        run: scripts/ci/test-classify-policy-suites.sh
 
       - name: Test text checkout byte policy
         run: python3 scripts/ci/test-text-checkout-policy.py
@@ -56,37 +67,47 @@ jobs:
         run: scripts/ci/test-require-gates.sh
 
       - name: Test M20 contract ledger
+        if: steps.policy-suites.outputs.contracts == 'true'
         run: python3 scripts/ci/test-m20-contract-gate.py
 
       - name: Test M21 contract ledger
+        if: steps.policy-suites.outputs.contracts == 'true'
         run: python3 scripts/ci/test-m21-contract-gate.py
 
       - name: Test checkpoint recovery ledger
+        if: steps.policy-suites.outputs.contracts == 'true'
         run: python3 scripts/ci/test-checkpoint-recovery-gate.py
 
       - name: Test concurrency and recovery ledger
+        if: steps.policy-suites.outputs.contracts == 'true'
         run: python3 scripts/ci/test-concurrency-recovery-gate.py
 
       - name: Test concurrency short matrix gate
+        if: steps.policy-suites.outputs.contracts == 'true'
         run: |
           python3 scripts/ci/concurrency-short-gate.py validate
           python3 scripts/ci/test-concurrency-short-gate.py
 
       - name: Test concurrency stress gate config
+        if: steps.policy-suites.outputs.contracts == 'true'
         run: |
           python3 scripts/ci/concurrency-stress-gate.py validate
           python3 scripts/ci/test-concurrency-stress-gate.py
 
       - name: Test Rust non-Cypher surface inventory
+        if: steps.policy-suites.outputs.contracts == 'true'
         run: python3 scripts/ci/test-non-cypher-surface-gate.py
 
       - name: Test Rust coverage ledger failure modes
+        if: steps.policy-suites.outputs.coverage_ledger == 'true'
         run: python3 scripts/ci/test-rust-coverage-ledger.py
 
       - name: Test Python and Node non-Cypher parity policy
+        if: steps.policy-suites.outputs.binding_parity == 'true'
         run: python3 scripts/ci/check-binding-parity-policy.py
 
       - name: Validate fail-closed public API BDD policy
+        if: steps.policy-suites.outputs.api_bdd == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -94,52 +115,69 @@ jobs:
           python3 scripts/ci/test-api-bdd-policy.py
 
       - uses: actions/setup-node@v6
+        if: >-
+          steps.policy-suites.outputs.release == 'true' ||
+          steps.policy-suites.outputs.cli_publish == 'true'
         with:
           node-version: "20"
 
       - uses: pnpm/action-setup@v4
+        if: >-
+          steps.policy-suites.outputs.release == 'true' ||
+          steps.policy-suites.outputs.cli_publish == 'true'
 
       - name: Install pinned napi CLI
+        if: >-
+          steps.policy-suites.outputs.release == 'true' ||
+          steps.policy-suites.outputs.cli_publish == 'true'
         run: pnpm install --frozen-lockfile --filter @curatelabs/graphforge...
 
       - name: Test binding release-candidate evidence validator
+        if: steps.policy-suites.outputs.release == 'true'
         run: python3 scripts/ci/test-binding-release-candidate.py
 
       - name: Test standardized release load matrix
+        if: steps.policy-suites.outputs.release == 'true'
         run: |
           python3 scripts/ci/test-release-load-matrix.py
           python3 scripts/ci/test-release-load-executor.py
 
       - name: Test final M1 release certification gate
+        if: steps.policy-suites.outputs.release == 'true'
         run: python3 scripts/ci/test-m1-release-certification.py
 
       - name: Test clean-environment verification harness
+        if: steps.policy-suites.outputs.clean_env == 'true'
         run: python3 scripts/ci/test-clean-env-verify.py
 
       - name: Test GraphForge CLI publication contract
+        if: steps.policy-suites.outputs.cli_publish == 'true'
         run: python3 scripts/ci/test-publish-cli-contract.py
 
       - name: Enforce domain dependency directions
+        if: steps.policy-suites.outputs.domain_dependencies == 'true'
         run: |
           scripts/ci/check-domain-dependencies.py
           scripts/ci/test-domain-dependencies.py
 
       - name: Test crates.io publish plan helper
+        if: steps.policy-suites.outputs.crate_publish == 'true'
         run: |
           python3 scripts/ci/test-crate-publish-plan.py
           python3 scripts/ci/test-crate-authorize-refresh-nodes.py
           python3 scripts/ci/test-publish-crates.py
 
       - name: Test release publication preflight
+        if: steps.policy-suites.outputs.release == 'true'
         run: |
           python3 scripts/ci/test-release-publish-preflight.py
           python3 scripts/ci/test-release-candidate.py
           python3 scripts/ci/test-prepare-napi-packages.py
           python3 scripts/ci/test-publish-npm-artifacts.py
           python3 scripts/ci/test-amend-npm-main-artifact.py
-          python3 scripts/ci/test-publish-track.py
 
       - name: Test CI storage policy
+        if: steps.policy-suites.outputs.storage == 'true'
         run: python3 scripts/ci/test-ci-storage-policy.py
 
       - name: Validate GitHub Actions workflows
@@ -442,7 +480,9 @@ jobs:
     name: Python Binding
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: changes
-    if: needs.changes.outputs.bindings == 'true'
+    if: >-
+      needs.changes.outputs.bindings == 'true' ||
+      needs.changes.outputs.rust == 'true'
     timeout-minutes: 30
     steps:
       - name: Checkout code
@@ -521,12 +561,26 @@ jobs:
           uv sync --all-extras
           uv pip install dist/*.whl
 
-      - name: Run Python unit, integration, and BDD tests
+      - name: Restore SNAP ego-Facebook fixture
+        id: snap-fixture
+        uses: actions/cache@v6
+        with:
+          path: ~/.graphforge/datasets/snap-ego-facebook.txt.gz
+          key: ${{ runner.os }}-snap-ego-facebook-v1
+
+      - name: Download SNAP ego-Facebook fixture
+        if: steps.snap-fixture.outputs.cache-hit != 'true'
         shell: bash
         run: |
           mkdir -p ~/.graphforge/datasets
-          curl -L -o ~/.graphforge/datasets/snap-ego-facebook.txt.gz \
+          curl --fail --location \
+            --output ~/.graphforge/datasets/snap-ego-facebook.txt.gz \
             https://snap.stanford.edu/data/facebook_combined.txt.gz
+
+      - name: Run Python unit, integration, and BDD tests
+        shell: bash
+        run: |
+          test -s ~/.graphforge/datasets/snap-ego-facebook.txt.gz
           uv run --no-sync pytest tests/unit tests/integration tests/features \
             -n auto --tb=short
 
@@ -567,11 +621,21 @@ jobs:
             --case check_m20_m21_native_projection \
             --output dist/python-binding-parity-evidence.json
 
+      - name: Upload same-SHA wheel for concurrency matrix
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-python-wheel-${{ github.sha }}
+          path: dist/*.whl
+          if-no-files-found: error
+          retention-days: 1
+
   node-binding:
     name: Node Binding
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: changes
-    if: needs.changes.outputs.bindings == 'true'
+    if: >-
+      needs.changes.outputs.bindings == 'true' ||
+      needs.changes.outputs.rust == 'true'
     timeout-minutes: 30
     env:
       CARGO_INCREMENTAL: 0
@@ -654,13 +718,27 @@ jobs:
             --case "a future project format fails structurally without mutating the project" \
             --output crates/graphforge-bindings-node/node-binding-parity-evidence.json
 
+      - name: Upload same-SHA addon for concurrency matrix
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-node-addon-${{ github.sha }}
+          path: |
+            crates/graphforge-bindings-node/*.node
+            crates/graphforge-bindings-node/index.js
+            crates/graphforge-bindings-node/index.d.ts
+          if-no-files-found: error
+          retention-days: 1
+
   concurrency-matrix:
     name: Concurrency Matrix
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: changes
+    needs: [changes, python-binding, node-binding]
     if: >-
-      needs.changes.outputs.rust == 'true' ||
-      needs.changes.outputs.bindings == 'true'
+      always() &&
+      (needs.changes.outputs.rust == 'true' ||
+      needs.changes.outputs.bindings == 'true') &&
+      needs.python-binding.result == 'success' &&
+      needs.node-binding.result == 'success'
     timeout-minutes: 25
     env:
       CARGO_INCREMENTAL: 0
@@ -709,17 +787,28 @@ jobs:
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
 
-      - name: Build Python wheel and Node addon
+      - name: Download same-SHA Python wheel
+        uses: actions/download-artifact@v8
+        with:
+          name: pr-python-wheel-${{ github.sha }}
+          path: dist
+
+      - name: Download same-SHA Node addon
+        uses: actions/download-artifact@v8
+        with:
+          name: pr-node-addon-${{ github.sha }}
+          path: crates/graphforge-bindings-node
+
+      - name: Install shared native artifacts
         shell: bash
         run: |
-          uvx maturin build \
-            --manifest-path crates/graphforge-bindings-py/Cargo.toml \
-            --profile dev \
-            --out dist
+          wheels=(dist/*.whl)
+          test "${#wheels[@]}" -eq 1
+          addons=(crates/graphforge-bindings-node/*.node)
+          test "${#addons[@]}" -eq 1
           uv venv /tmp/gf-concurrency --python 3.13
-          uv pip install --python /tmp/gf-concurrency/bin/python dist/*.whl
+          uv pip install --python /tmp/gf-concurrency/bin/python "${wheels[0]}"
           pnpm install --frozen-lockfile
-          pnpm --filter @curatelabs/graphforge exec napi build --platform
 
       - name: Run required short concurrency matrix
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,10 @@ _ensure-graphforge:  ## Fail fast unless the native graphforge package is import
 		 echo "   maturin develop --release -m crates/graphforge-bindings-py/Cargo.toml"; \
 		 exit 1)
 
+# Default maintainer loop: make pre-push-fast (~30s). Use this full coverage
+# gate for coverage-sensitive changes or floor claims.
+# Rust adapter acceptance is not pytest-cov/c8 evidence, so wrapper reports
+# remain separate fail-closed measurements rather than being silently skipped.
 coverage:  ## Rust + Python + Node coverage with per-surface thresholds
 	@echo "━━━ Rust coverage ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 	@$(MAKE) coverage-rust

--- a/scripts/ci/classify-policy-suites.sh
+++ b/scripts/ci/classify-policy-suites.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Emit fail-closed Repository Policy suite selectors for a PR range.
+set -euo pipefail
+
+base_sha=${1:-}
+head_sha=${2:-HEAD}
+
+contracts=false
+coverage_ledger=false
+binding_parity=false
+api_bdd=false
+release=false
+clean_env=false
+cli_publish=false
+domain_dependencies=false
+crate_publish=false
+storage=false
+
+enable_all() {
+  contracts=true
+  coverage_ledger=true
+  binding_parity=true
+  api_bdd=true
+  release=true
+  clean_env=true
+  cli_publish=true
+  domain_dependencies=true
+  crate_publish=true
+  storage=true
+}
+
+emit() {
+  printf 'contracts=%s\n' "$contracts"
+  printf 'coverage_ledger=%s\n' "$coverage_ledger"
+  printf 'binding_parity=%s\n' "$binding_parity"
+  printf 'api_bdd=%s\n' "$api_bdd"
+  printf 'release=%s\n' "$release"
+  printf 'clean_env=%s\n' "$clean_env"
+  printf 'cli_publish=%s\n' "$cli_publish"
+  printf 'domain_dependencies=%s\n' "$domain_dependencies"
+  printf 'crate_publish=%s\n' "$crate_publish"
+  printf 'storage=%s\n' "$storage"
+}
+
+if [[ -z "$base_sha" ]] || ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
+  enable_all
+  emit
+  exit 0
+fi
+
+changed_files=$(mktemp)
+trap 'rm -f "$changed_files"' EXIT
+if ! git diff --name-only -z "${base_sha}...${head_sha}" >"$changed_files"; then
+  enable_all
+  emit
+  exit 0
+fi
+
+while IFS= read -r -d '' path; do
+  case "$path" in
+    .github/workflows/test.yml | scripts/ci/classify-policy-suites.sh | \
+      scripts/ci/test-classify-policy-suites.sh)
+      enable_all
+      ;;
+    scripts/ci/m20-contract-gate.py | scripts/ci/test-m20-contract-gate.py | \
+      tests/contracts/m20-contract-matrix.json | \
+      scripts/ci/m21-contract-gate.py | scripts/ci/test-m21-contract-gate.py | \
+      tests/contracts/m21-contract-matrix.json | \
+      scripts/ci/checkpoint-recovery-gate.py | scripts/ci/test-checkpoint-recovery-gate.py | \
+      tests/contracts/checkpoint-recovery-matrix.json | \
+      scripts/ci/concurrency-short-gate.py | scripts/ci/test-concurrency-short-gate.py | \
+      scripts/ci/concurrency-stress-gate.py | scripts/ci/test-concurrency-stress-gate.py | \
+      scripts/ci/test-concurrency-recovery-gate.py | \
+      tests/contracts/concurrency-short-matrix.json | \
+      tests/contracts/concurrency-recovery-matrix.json | \
+      scripts/ci/non-cypher-surface-gate.py | scripts/ci/test-non-cypher-surface-gate.py | \
+      tests/contracts/non-cypher-rust-surface.json)
+      contracts=true
+      ;;
+    scripts/coverage_rust_ledger.py | scripts/check-coverage-rust.sh | \
+      scripts/ci/test-rust-coverage-ledger.py)
+      coverage_ledger=true
+      ;;
+    scripts/ci/check-binding-parity-policy.py)
+      binding_parity=true
+      ;;
+    scripts/ci/api-bdd-policy.py | scripts/ci/test-api-bdd-policy.py | \
+      tests/features/api/* | tests/features/api/**/* | \
+      tests/contracts/api-bdd-exclusions.json)
+      api_bdd=true
+      ;;
+    scripts/ci/test-binding-release-candidate.py | \
+      scripts/ci/test-release-load-matrix.py | scripts/ci/test-release-load-executor.py | \
+      scripts/ci/test-m1-release-certification.py | \
+      .github/workflows/binding-release-candidate.yml | \
+      .github/workflows/m1-release-certification.yml)
+      release=true
+      ;;
+    scripts/ci/test-clean-env-verify.py | scripts/ci/clean-env-verify.py | \
+      .github/workflows/clean-env-verify.yml)
+      clean_env=true
+      ;;
+    scripts/ci/test-publish-cli-contract.py | scripts/ci/verify-node-cli-release-package.mjs | \
+      packages/cli/* | packages/cli/**/*)
+      cli_publish=true
+      ;;
+    scripts/ci/check-domain-dependencies.py | scripts/ci/test-domain-dependencies.py | \
+      docs/adr/0014-* | Cargo.toml | crates/*/Cargo.toml)
+      domain_dependencies=true
+      ;;
+    scripts/ci/test-crate-publish-plan.py | \
+      scripts/ci/test-crate-authorize-refresh-nodes.py | scripts/ci/test-publish-crates.py | \
+      scripts/ci/crate-publish-plan.py | scripts/ci/publish-crates.py | \
+      .github/workflows/publish.yaml)
+      crate_publish=true
+      ;;
+    scripts/ci/test-release-publish-preflight.py | scripts/ci/test-release-candidate.py | \
+      scripts/ci/test-prepare-napi-packages.py | scripts/ci/test-publish-npm-artifacts.py | \
+      scripts/ci/test-amend-npm-main-artifact.py | scripts/ci/release-publish-preflight.py | \
+      scripts/ci/release-candidate.py | scripts/ci/prepare-napi-packages.py | \
+      scripts/ci/publish-npm-artifacts.py | scripts/ci/amend-npm-main-artifact.py | \
+      .github/workflows/publish.yaml)
+      release=true
+      ;;
+    scripts/ci/test-ci-storage-policy.py | .github/workflows/*.yml | .github/workflows/*.yaml)
+      storage=true
+      ;;
+  esac
+done <"$changed_files"
+
+emit

--- a/scripts/ci/test-ci-storage-policy.py
+++ b/scripts/ci/test-ci-storage-policy.py
@@ -53,6 +53,8 @@ EXPECTED_ARTIFACT_UPLOADS = Counter(
         "M1-Release-Candidate-evidence-${{ needs.validate_source.outputs.evidence_sha }}": 1,
         "M1-Release-Reconciliation-${{ github.run_id }}": 1,
         "visualization-limits-stress-${{ github.sha }}": 1,
+        "pr-python-wheel-${{ github.sha }}": 1,
+        "pr-node-addon-${{ github.sha }}": 1,
     }
 )
 EXPECTED_ARTIFACT_DOWNLOADS = Counter(
@@ -73,11 +75,14 @@ EXPECTED_ARTIFACT_DOWNLOADS = Counter(
         "M1-Release-Candidate-npm-${{ needs.resolve_source.outputs.release_sha }}": 1,
         "M1-Release-Candidate-crates-${{ needs.resolve_source.outputs.release_sha }}": 1,
         "M1-Release-Candidate-evidence-${{ needs.resolve_source.outputs.release_sha }}": 1,
+        "pr-python-wheel-${{ github.sha }}": 1,
+        "pr-node-addon-${{ github.sha }}": 1,
     }
 )
 EXPECTED_DEPENDENCY_KEYS = Counter(
     {
         "${{ runner.os }}-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}": 10,
+        "${{ runner.os }}-snap-ego-facebook-v1": 1,
         "${{ runner.os }}-fuzz-${{ hashFiles('fuzz/Cargo.toml', '**/Cargo.lock') }}": 1,
     }
 )
@@ -212,6 +217,11 @@ def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
             "binding-rc-reports/${{ matrix.report_target }}.json",
             "dist/*.whl",
             "crates/graphforge-bindings-node/*.node",
+            (
+                "crates/graphforge-bindings-node/*.node\n"
+                "crates/graphforge-bindings-node/index.js\n"
+                "crates/graphforge-bindings-node/index.d.ts"
+            ),
             "non-cypher-evidence/",
             "binding-rc-aggregate/report.json",
             "m1-release-load-evidence",
@@ -243,6 +253,8 @@ def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
             "candidate/release-artifacts/npm",
             "candidate/release-artifacts/crates",
             "candidate/release-artifacts",
+            "dist",
+            "crates/graphforge-bindings-node",
         }, f"artifact download path drift: {selector}"
         if pattern is not None:
             assert field(step, "merge-multiple") == "true", (
@@ -255,7 +267,9 @@ def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
             assert field(step, "merge-multiple") is None, (
                 f"single artifact unexpectedly merged: {name}"
             )
-            cross_run = name != "M1-Release-Load-${{ github.run_id }}"
+            cross_run = name != "M1-Release-Load-${{ github.run_id }}" and not name.startswith(
+                "pr-"
+            )
             if cross_run:
                 assert field(step, "github-token") == "${{ github.token }}", (
                     f"cross-run artifact has no token: {name}"

--- a/scripts/ci/test-classify-policy-suites.sh
+++ b/scripts/ci/test-classify-policy-suites.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+classifier=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/classify-policy-suites.sh
+fixture=$(mktemp -d)
+trap 'rm -rf "$fixture"' EXIT
+
+git -C "$fixture" init -q
+git -C "$fixture" config user.name "GraphForge CI"
+git -C "$fixture" config user.email "ci@graphforge.invalid"
+printf 'baseline\n' >"$fixture/README.md"
+git -C "$fixture" add README.md
+git -C "$fixture" commit -qm baseline
+base=$(git -C "$fixture" rev-parse HEAD)
+
+none=$'contracts=false\ncoverage_ledger=false\nbinding_parity=false\napi_bdd=false\nrelease=false\nclean_env=false\ncli_publish=false\ndomain_dependencies=false\ncrate_publish=false\nstorage=false'
+contracts=$'contracts=true\ncoverage_ledger=false\nbinding_parity=false\napi_bdd=false\nrelease=false\nclean_env=false\ncli_publish=false\ndomain_dependencies=false\ncrate_publish=false\nstorage=false'
+coverage_ledger=$'contracts=false\ncoverage_ledger=true\nbinding_parity=false\napi_bdd=false\nrelease=false\nclean_env=false\ncli_publish=false\ndomain_dependencies=false\ncrate_publish=false\nstorage=false'
+storage=$'contracts=false\ncoverage_ledger=false\nbinding_parity=false\napi_bdd=false\nrelease=false\nclean_env=false\ncli_publish=false\ndomain_dependencies=false\ncrate_publish=false\nstorage=true'
+all=$'contracts=true\ncoverage_ledger=true\nbinding_parity=true\napi_bdd=true\nrelease=true\nclean_env=true\ncli_publish=true\ndomain_dependencies=true\ncrate_publish=true\nstorage=true'
+
+assert_classification() {
+  local expected=$1
+  local path=$2
+
+  mkdir -p "$fixture/$(dirname "$path")"
+  printf 'change\n' >"$fixture/$path"
+  git -C "$fixture" add "$path"
+  git -C "$fixture" commit -qm "change $path"
+
+  local actual
+  actual=$(cd "$fixture" && "$classifier" "$base" HEAD)
+  [[ "$actual" == "$expected" ]] || {
+    printf 'unexpected classification for %s\nexpected:\n%s\nactual:\n%s\n' \
+      "$path" "$expected" "$actual" >&2
+    exit 1
+  }
+  git -C "$fixture" reset --hard -q "$base"
+}
+
+assert_classification "$none" docs/guide.md
+assert_classification "$contracts" tests/contracts/m20-contract-matrix.json
+assert_classification "$coverage_ledger" scripts/coverage_rust_ledger.py
+assert_classification "$storage" .github/workflows/docs.yml
+assert_classification "$all" .github/workflows/test.yml
+
+missing=$(cd "$fixture" && "$classifier" deadbeef HEAD)
+[[ "$missing" == "$all" ]] || {
+  printf 'missing base must fail safe, got:\n%s\n' "$missing" >&2
+  exit 1
+}
+
+echo "Repository Policy suite classifier tests passed"


### PR DESCRIPTION
## Summary
- share the tested same-SHA Python wheel and Node addon with the PR concurrency matrix, eliminating its native rebuild
- path-gate infrequently changing Repository Policy suites while retaining classifier, merge-gate, workflow, and license checks on every PR
- cache the immutable SNAP fixture and keep artifact/cache storage policy fail-closed

## Test plan
- [x] `scripts/ci/test-classify-policy-suites.sh`
- [x] `scripts/ci/test-classify-changes.sh`
- [x] `python3 scripts/ci/test-ci-storage-policy.py`
- [x] `scripts/check-workflows.sh`
- [x] `cargo fmt --all -- --check`

Closes #389

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788452263&installation_model_id=20486&pr_number=394&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F394&signature=39dfdf6ece8160e1ec1af5fe5e61267783fed71f71cf7ad6894c1812d40707c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Share Python wheel and Node addon artifacts between CI binding and concurrency matrix jobs
> - Adds a [`classify-policy-suites.sh`](https://github.com/CurateLabs/graphforge/pull/394/files#diff-f7e796d328a74a8873c6ae99c9836e8f9dbd11b8dfc2663b5ca3567c62093ab3) script that emits boolean flags based on changed files, allowing the CI workflow to gate policy/test steps to only relevant suites.
> - Python and Node binding jobs now also trigger on Rust changes and upload same-SHA artifacts (`pr-python-wheel-${{ github.sha }}` and `pr-node-addon-${{ github.sha }}`) instead of building inline in the concurrency matrix.
> - The concurrency matrix job downloads these artifacts rather than building them, and is gated on both binding jobs succeeding.
> - Updates [`test-ci-storage-policy.py`](https://github.com/CurateLabs/graphforge/pull/394/files#diff-855ed98597547ac200b4015777e47aa99dda2b0ac141e95ffab9c0d96e87c1a0) to require the new artifacts and SNAP dataset cache key, and exempts `pr-*` artifacts from cross-run validations.
> - Behavioral Change: the concurrency matrix no longer runs unless both binding jobs succeed; previously it built its own artifacts independently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b92232.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->