### PR TITLE
ci: rewrite storage policy for Blacksmith sticky disks and colocated cache

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -25,6 +25,37 @@ Binding RC is expected to use the same Blacksmith-first sticky + colocated-cache
 model (see storage policy tests); put `target/` on sticky disks, not in
 `actions/cache` blobs.
 
+### Blacksmith-first CI storage policy
+
+`scripts/ci/test-ci-storage-policy.py` encodes these rules (not the GitHub
+Actions cache-era bans that blocked RC speed):
+
+| Allowed | Purpose |
+| --- | --- |
+| `useblacksmith/stickydisk` for `target/`, optional `.sccache`, large trees | Persist compile products across RC/publish-track runs (~3s mount) |
+| Upstream `actions/cache@v6` for `~/.cargo/registry` + git (and pnpm/uv) | Colocated Blacksmith cache; exact lockfile keys |
+| Local `sccache` with `SCCACHE_DIR` on a sticky disk | Cross-crate compile cache without GHA-backend maturin sccache |
+| Bigger Blacksmith runners for RC cells | Linux 8/16 vCPU; larger macOS/Windows when needed |
+
+| Still forbidden | Why |
+| --- | --- |
+| Putting `target/` into `actions/cache` blobs | Wrong tool — use sticky disks |
+| Maturin-action `sccache: true` (GHA-integrated) | Prefer sticky `SCCACHE_DIR` / sticky `target/` |
+| Unbounded artifact uploads | Keep consumer-driven retention for candidate partitions |
+
+**Expected Binding RC Linux sticky keys** (release profile; shared across
+Python-ubuntu and Node-linux when safe):
+
+```text
+${{ github.repository }}-binding-rc-linux-rust-<toolchain>-${{ hashFiles('Cargo.lock') }}-release-target-v1
+${{ github.repository }}-release_candidate-rust-<toolchain>-${{ hashFiles('Cargo.lock') }}-release-target-v1
+```
+
+PR sticky keys stay job-isolated:
+`${{ github.repository }}-${{ github.job }}-${{ hashFiles('Cargo.lock') }}-target-v1`.
+macOS/Windows RC cells use larger Blacksmith runners + colocated registry cache;
+use sticky disks there only when the platform supports them.
+
 ## Pull-request contract
 
 - A newer commit cancels obsolete Test Suite, Documentation, and auto-label

--- a/scripts/ci/test-ci-storage-policy.py
+++ b/scripts/ci/test-ci-storage-policy.py
@@ -1,5 +1,34 @@
 #!/usr/bin/env python3
-"""Enforce bounded, consumer-driven CI transfer storage."""
+"""Enforce Blacksmith-first, consumer-driven CI transfer storage.
+
+Speed and honesty share one storage model on Blacksmith runners:
+
+Allowed
+-------
+- ``useblacksmith/stickydisk`` for ``target/``, optional ``.sccache``, and other
+  large build trees (persist compile products across RC/publish-track runs;
+  ~3s hydrate vs multi-minute cache blobs).
+- Upstream ``actions/cache@v6`` for ``~/.cargo/registry`` + git (and pnpm/uv)
+  with exact lockfile keys — Blacksmith colocates this cache.
+- Local ``sccache`` with ``SCCACHE_DIR`` on a sticky disk (cross-crate compile
+  cache without GitHub-backed maturin sccache).
+- Larger Blacksmith runners for Binding RC cells when wall-clock requires them.
+
+Still forbidden
+---------------
+- Putting ``target/`` (or other large build trees) into ``actions/cache`` blobs —
+  wrong tool; use sticky disks.
+- Maturin-action ``sccache: true`` (GHA-integrated backend) — prefer sticky
+  ``SCCACHE_DIR`` / sticky ``target/`` we control.
+- Unbounded artifact uploads — keep consumer-driven retention for candidate
+  partitions (1-day transfer vs 30-day publication groups).
+
+Expected Binding RC Linux sticky keys use repository + lane + rustc +
+Cargo.lock hash + ``release-target-v1``. PR sticky keys stay job-isolated with
+``${{ github.job }}`` and ``target-v1``.
+
+This module inventories workflow storage steps and fails closed on drift.
+"""
 
 from __future__ import annotations
 
@@ -278,7 +307,9 @@ def dependency_contracts(text: str) -> list[str]:
         key = field(step, "key")
         assert key is not None, "dependency cache has no exact key"
         rendered = "\n".join(step)
-        assert "target" not in rendered, f"large build tree stored in actions/cache: {key}"
+        assert "target" not in rendered, (
+            f"large build tree stored in actions/cache (use stickydisk): {key}"
+        )
         assert "crates/**/*.rs" not in key and "crates/**" not in key, (
             f"dependency cache is keyed by source files: {key}"
         )
@@ -309,7 +340,9 @@ def validate_maturin_storage(text: str) -> None:
         assert field(step, "uses") == "PyO3/maturin-action@v1", "unapproved Maturin action"
         sccache = field(step, "sccache")
         assert sccache is None or sccache.lower() == "false", (
-            f"Maturin sccache uses GitHub storage: {sccache}"
+            "Maturin-action sccache:true uses the GitHub-integrated backend; "
+            "use sticky SCCACHE_DIR / sticky target/ instead "
+            f"(got sccache={sccache!r})"
         )
 
 


### PR DESCRIPTION
## Summary
- Rewrite `test-ci-storage-policy.py` as Blacksmith-first (sticky disks, colocated `actions/cache@v6`, sticky `SCCACHE_DIR`; forbid `target/` in cache blobs and maturin GHA sccache).
- Document allowed/forbidden table and expected Binding RC sticky key shapes in workflows README.
- Prefer policy/docs in this PR; Binding RC sticky mounts land in #387 / PR #392.

Closes #385.

## Test plan
- [x] `python3 scripts/ci/test-ci-storage-policy.py`
- [ ] CI Gate green

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788452298&installation_model_id=20486&pr_number=395&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F395&signature=500f3e43cca633574c8fa4f3608f1afb74ca3a3112fd31d50d43ba6abc9800ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update CI storage policy script and docs for Blacksmith sticky disks
> - Expands the [README.md](.github/workflows/README.md) with a new section documenting allowed and forbidden CI storage patterns, expected sticky-disk keys, and notes on PR/macOS/Windows behavior.
> - Updates error messages in [test-ci-storage-policy.py](scripts/ci/test-ci-storage-policy.py) to give actionable guidance: the `actions/cache` violation now names `stickydisk` as the correct alternative, and the Maturin `sccache:true` violation now explains the GitHub-integrated backend and recommends sticky `SCCACHE_DIR/target`.
> - No logic or detection changes — only message text and documentation are updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f286bd4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->