### PR TITLE
chore(release): freeze GraphForge surfaces at 0.5.2

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,7 +8,7 @@ on:
       release_tag:
         description: Existing immutable v2 release tag to resume
         required: true
-        default: v0.5.1
+        default: v0.5.2
         type: string
       recovery_reason:
         description: Public maintainer reason for the recovery dispatch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-api"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "arrow",
  "cucumber",
@@ -2048,7 +2048,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-ast"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "graphforge-core",
  "serde",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-bindings-node"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "arrow",
  "graphforge-api",
@@ -2072,7 +2072,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-bindings-py"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "arrow",
  "futures",
@@ -2085,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-cli"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "arrow",
  "clap",
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "serde",
  "serde_yaml_ng",
@@ -2109,7 +2109,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-cypher"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "graphforge-ast",
  "graphforge-core",
@@ -2121,7 +2121,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-exec"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2146,7 +2146,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-io"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "graphforge-core",
  "graphforge-storage",
@@ -2155,7 +2155,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-ir"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "arrow",
  "graphforge-ast",
@@ -2170,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-knowledge"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "arrow",
  "graphforge-core",
@@ -2183,7 +2183,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-ontology"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "arrow",
  "graphforge-core",
@@ -2198,7 +2198,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-plan"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "datafusion",
  "graphforge-core",
@@ -2208,7 +2208,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-provenance"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "arrow",
  "graphforge-core",
@@ -2219,7 +2219,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-rel"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "arrow-data",
  "chrono",
@@ -2239,7 +2239,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-search"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "arrow",
  "graphforge-core",
@@ -2254,7 +2254,7 @@ dependencies = [
 
 [[package]]
 name = "graphforge-storage"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "arrow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 license = "Apache-2.0"
 license-file = "LICENSE"

--- a/crates/graphforge-api/Cargo.toml
+++ b/crates/graphforge-api/Cargo.toml
@@ -8,16 +8,16 @@ license-file.workspace = true
 repository.workspace = true
 
 [dependencies]
-graphforge-core = { version = "0.5.1", path = "../graphforge-core" }
-graphforge-ir = { version = "0.5.1", path = "../graphforge-ir" }
-graphforge-ontology = { version = "0.5.1", path = "../graphforge-ontology" }
-graphforge-provenance = { version = "0.5.1", path = "../graphforge-provenance" }
-graphforge-knowledge = { version = "0.5.1", path = "../graphforge-knowledge" }
-graphforge-cypher = { version = "0.5.1", path = "../graphforge-cypher" }
-graphforge-rel = { version = "0.5.1", path = "../graphforge-rel" }
-graphforge-storage = { version = "0.5.1", path = "../graphforge-storage" }
-graphforge-exec = { version = "0.5.1", path = "../graphforge-exec" }
-graphforge-search = { version = "0.5.1", path = "../graphforge-search" }
+graphforge-core = { version = "0.5.2", path = "../graphforge-core" }
+graphforge-ir = { version = "0.5.2", path = "../graphforge-ir" }
+graphforge-ontology = { version = "0.5.2", path = "../graphforge-ontology" }
+graphforge-provenance = { version = "0.5.2", path = "../graphforge-provenance" }
+graphforge-knowledge = { version = "0.5.2", path = "../graphforge-knowledge" }
+graphforge-cypher = { version = "0.5.2", path = "../graphforge-cypher" }
+graphforge-rel = { version = "0.5.2", path = "../graphforge-rel" }
+graphforge-storage = { version = "0.5.2", path = "../graphforge-storage" }
+graphforge-exec = { version = "0.5.2", path = "../graphforge-exec" }
+graphforge-search = { version = "0.5.2", path = "../graphforge-search" }
 arrow = { workspace = true }
 datafusion = { workspace = true }
 futures = { workspace = true }

--- a/crates/graphforge-ast/Cargo.toml
+++ b/crates/graphforge-ast/Cargo.toml
@@ -8,7 +8,7 @@ license-file.workspace = true
 repository.workspace = true
 
 [dependencies]
-graphforge-core = { version = "0.5.1", path = "../graphforge-core" }
+graphforge-core = { version = "0.5.2", path = "../graphforge-core" }
 serde = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/graphforge-bindings-node/Cargo.toml
+++ b/crates/graphforge-bindings-node/Cargo.toml
@@ -12,8 +12,8 @@ repository.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-graphforge-api = { version = "0.5.1", path = "../graphforge-api" }
-graphforge-cli = { version = "0.5.1", path = "../graphforge-cli" }
+graphforge-api = { version = "0.5.2", path = "../graphforge-api" }
+graphforge-cli = { version = "0.5.2", path = "../graphforge-cli" }
 # `ipc` (default in arrow 58) serializes execute() results to an Arrow IPC
 # stream Buffer for the JS side to decode with apache-arrow.
 arrow = { workspace = true }

--- a/crates/graphforge-bindings-node/package.json
+++ b/crates/graphforge-bindings-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curatelabs/graphforge",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Native Node.js bindings for the GraphForge embedded graph engine",
   "license": "Apache-2.0",
   "homepage": "https://docs.graphforge.sh/",

--- a/crates/graphforge-bindings-py/Cargo.toml
+++ b/crates/graphforge-bindings-py/Cargo.toml
@@ -12,8 +12,8 @@ repository.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-graphforge-api = { version = "0.5.1", path = "../graphforge-api" }
-graphforge-cli = { version = "0.5.1", path = "../graphforge-cli" }
+graphforge-api = { version = "0.5.2", path = "../graphforge-api" }
+graphforge-cli = { version = "0.5.2", path = "../graphforge-cli" }
 # `StreamExt::next` drives the facade's async streaming query one batch per pull
 # in the synchronous RecordBatchReader adapter (execute_stream, #587).
 futures = { workspace = true }

--- a/crates/graphforge-bindings-py/pyproject.toml
+++ b/crates/graphforge-bindings-py/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "graphforge"
 description = "GraphForge native graph engine, bindings, and repository lifecycle CLI"
-version = "0.5.1"
+version = "0.5.2"
 readme = "README.md"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/crates/graphforge-cli/Cargo.toml
+++ b/crates/graphforge-cli/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 arrow = { workspace = true }
-graphforge-api = { version = "0.5.1", path = "../graphforge-api" }
+graphforge-api = { version = "0.5.2", path = "../graphforge-api" }
 clap = { workspace = true }
 uuid = { workspace = true }
 serde = { workspace = true }

--- a/crates/graphforge-cypher/Cargo.toml
+++ b/crates/graphforge-cypher/Cargo.toml
@@ -8,10 +8,10 @@ license-file.workspace = true
 repository.workspace = true
 
 [dependencies]
-graphforge-core = { version = "0.5.1", path = "../graphforge-core" }
-graphforge-ast = { version = "0.5.1", path = "../graphforge-ast" }
-graphforge-ir = { version = "0.5.1", path = "../graphforge-ir" }
-graphforge-rel = { version = "0.5.1", path = "../graphforge-rel" }
+graphforge-core = { version = "0.5.2", path = "../graphforge-core" }
+graphforge-ast = { version = "0.5.2", path = "../graphforge-ast" }
+graphforge-ir = { version = "0.5.2", path = "../graphforge-ir" }
+graphforge-rel = { version = "0.5.2", path = "../graphforge-rel" }
 thiserror = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/graphforge-exec/Cargo.toml
+++ b/crates/graphforge-exec/Cargo.toml
@@ -8,12 +8,12 @@ license-file.workspace = true
 repository.workspace = true
 
 [dependencies]
-graphforge-core = { version = "0.5.1", path = "../graphforge-core" }
-graphforge-ir = { version = "0.5.1", path = "../graphforge-ir" }
-graphforge-ontology = { version = "0.5.1", path = "../graphforge-ontology" }
-graphforge-plan = { version = "0.5.1", path = "../graphforge-plan" }
-graphforge-rel = { version = "0.5.1", path = "../graphforge-rel" }
-graphforge-storage = { version = "0.5.1", path = "../graphforge-storage" }
+graphforge-core = { version = "0.5.2", path = "../graphforge-core" }
+graphforge-ir = { version = "0.5.2", path = "../graphforge-ir" }
+graphforge-ontology = { version = "0.5.2", path = "../graphforge-ontology" }
+graphforge-plan = { version = "0.5.2", path = "../graphforge-plan" }
+graphforge-rel = { version = "0.5.2", path = "../graphforge-rel" }
+graphforge-storage = { version = "0.5.2", path = "../graphforge-storage" }
 arrow = { workspace = true }
 datafusion = { workspace = true }
 datafusion-datasource = { workspace = true }

--- a/crates/graphforge-io/Cargo.toml
+++ b/crates/graphforge-io/Cargo.toml
@@ -8,8 +8,8 @@ license-file.workspace = true
 repository.workspace = true
 
 [dependencies]
-graphforge-core = { version = "0.5.1", path = "../graphforge-core" }
-graphforge-storage = { version = "0.5.1", path = "../graphforge-storage" }
+graphforge-core = { version = "0.5.2", path = "../graphforge-core" }
+graphforge-storage = { version = "0.5.2", path = "../graphforge-storage" }
 thiserror = { workspace = true }
 
 [lints]

--- a/crates/graphforge-ir/Cargo.toml
+++ b/crates/graphforge-ir/Cargo.toml
@@ -8,9 +8,9 @@ license-file.workspace = true
 repository.workspace = true
 
 [dependencies]
-graphforge-core = { version = "0.5.1", path = "../graphforge-core" }
-graphforge-ast = { version = "0.5.1", path = "../graphforge-ast" }
-graphforge-ontology = { version = "0.5.1", path = "../graphforge-ontology" }
+graphforge-core = { version = "0.5.2", path = "../graphforge-core" }
+graphforge-ast = { version = "0.5.2", path = "../graphforge-ast" }
+graphforge-ontology = { version = "0.5.2", path = "../graphforge-ontology" }
 arrow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/graphforge-knowledge/Cargo.toml
+++ b/crates/graphforge-knowledge/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 
 [dependencies]
 arrow = { workspace = true }
-graphforge-core = { version = "0.5.1", path = "../graphforge-core" }
+graphforge-core = { version = "0.5.2", path = "../graphforge-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/graphforge-ontology/Cargo.toml
+++ b/crates/graphforge-ontology/Cargo.toml
@@ -8,7 +8,7 @@ license-file.workspace = true
 repository.workspace = true
 
 [dependencies]
-graphforge-core = { version = "0.5.1", path = "../graphforge-core" }
+graphforge-core = { version = "0.5.2", path = "../graphforge-core" }
 arrow = { workspace = true }
 parquet = { workspace = true }
 serde = { workspace = true }

--- a/crates/graphforge-plan/Cargo.toml
+++ b/crates/graphforge-plan/Cargo.toml
@@ -8,8 +8,8 @@ license-file.workspace = true
 repository.workspace = true
 
 [dependencies]
-graphforge-core = { version = "0.5.1", path = "../graphforge-core" }
-graphforge-ir = { version = "0.5.1", path = "../graphforge-ir" }
+graphforge-core = { version = "0.5.2", path = "../graphforge-core" }
+graphforge-ir = { version = "0.5.2", path = "../graphforge-ir" }
 datafusion = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/graphforge-provenance/Cargo.toml
+++ b/crates/graphforge-provenance/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 
 [dependencies]
 arrow = { workspace = true }
-graphforge-core = { version = "0.5.1", path = "../graphforge-core" }
+graphforge-core = { version = "0.5.2", path = "../graphforge-core" }
 serde = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }

--- a/crates/graphforge-rel/Cargo.toml
+++ b/crates/graphforge-rel/Cargo.toml
@@ -8,11 +8,11 @@ license-file.workspace = true
 repository.workspace = true
 
 [dependencies]
-graphforge-core = { version = "0.5.1", path = "../graphforge-core" }
-graphforge-ir = { version = "0.5.1", path = "../graphforge-ir" }
-graphforge-ontology = { version = "0.5.1", path = "../graphforge-ontology" }
-graphforge-plan = { version = "0.5.1", path = "../graphforge-plan" }
-graphforge-storage = { version = "0.5.1", path = "../graphforge-storage" }
+graphforge-core = { version = "0.5.2", path = "../graphforge-core" }
+graphforge-ir = { version = "0.5.2", path = "../graphforge-ir" }
+graphforge-ontology = { version = "0.5.2", path = "../graphforge-ontology" }
+graphforge-plan = { version = "0.5.2", path = "../graphforge-plan" }
+graphforge-storage = { version = "0.5.2", path = "../graphforge-storage" }
 datafusion = { workspace = true }
 arrow-data = { workspace = true }
 datafusion-functions-aggregate = "53"

--- a/crates/graphforge-search/Cargo.toml
+++ b/crates/graphforge-search/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 
 [dependencies]
 arrow = { workspace = true }
-graphforge-storage = { version = "0.5.1", path = "../graphforge-storage" }
+graphforge-storage = { version = "0.5.2", path = "../graphforge-storage" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tantivy = { workspace = true }

--- a/crates/graphforge-storage/Cargo.toml
+++ b/crates/graphforge-storage/Cargo.toml
@@ -14,9 +14,9 @@ default = []
 test-failpoints = []
 
 [dependencies]
-graphforge-core = { version = "0.5.1", path = "../graphforge-core" }
-graphforge-ir = { version = "0.5.1", path = "../graphforge-ir" }
-graphforge-ontology = { version = "0.5.1", path = "../graphforge-ontology" }
+graphforge-core = { version = "0.5.2", path = "../graphforge-core" }
+graphforge-ir = { version = "0.5.2", path = "../graphforge-ir" }
+graphforge-ontology = { version = "0.5.2", path = "../graphforge-ontology" }
 arrow = { workspace = true }
 async-trait = "0.1"
 atomicwrites = "0.4.4"

--- a/packages/agent-skills/compatibility.json
+++ b/packages/agent-skills/compatibility.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "package": "@curatelabs/graphforge-agent-skills",
-  "package_version": "0.5.1",
-  "graphforge_release": "0.5.1",
+  "package_version": "0.5.2",
+  "graphforge_release": "0.5.2",
   "graphforge_version_range": ">=0.5.0 <0.6.0",
   "security_contract": {
     "subprocess": "unsupported",

--- a/packages/agent-skills/package.json
+++ b/packages/agent-skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curatelabs/graphforge-agent-skills",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "NPX-distributed agent skills and adapters for GraphForge",
   "license": "Apache-2.0",
   "homepage": "https://docs.graphforge.sh/",
@@ -48,7 +48,7 @@
   },
   "graphforgeCompatibility": {
     "schemaVersion": 1,
-    "release": "0.5.1",
+    "release": "0.5.2",
     "range": ">=0.5.0 <0.6.0"
   },
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curatelabs/graphforge-cli",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "GraphForge repository lifecycle CLI",
   "license": "Apache-2.0",
   "homepage": "https://docs.graphforge.sh/",

--- a/scripts/ci/test-publish-crates.py
+++ b/scripts/ci/test-publish-crates.py
@@ -24,7 +24,7 @@ def load_module():
 
 
 mod = load_module()
-assert mod.VERSION == "0.5.1"
+assert mod.VERSION == "0.5.2"
 v = mod.VERSION
 
 assert mod.normalize_registry_token("  abc\n") == "abc"
@@ -98,7 +98,7 @@ finally:
     os.environ.update(original_environ)
 
 RATE_BODY = (
-    "error: failed to publish graphforge-plan v0.5.1 to registry at https://crates.io\n"
+    f"error: failed to publish graphforge-plan v{v} to registry at https://crates.io\n"
     "Caused by:\n"
     "  the remote server responded with an error (status 429 Too Many Requests): "
     "You have published too many new crates in a short period of time. "

--- a/scripts/ci/test-release-publish-preflight.py
+++ b/scripts/ci/test-release-publish-preflight.py
@@ -23,10 +23,10 @@ def load_module():
 
 mod = load_module()
 sha = "a" * 40
-versions = dict.fromkeys(("cargo", "python", "node", "cli", "skills"), "0.5.1")
+versions = dict.fromkeys(("cargo", "python", "node", "cli", "skills"), "0.5.2")
 assert (
     mod.validate(
-        tag="v0.5.1",
+        tag="v0.5.2",
         expected_sha=sha,
         actual_sha=sha,
         versions=versions,
@@ -34,14 +34,14 @@ assert (
     == []
 )
 assert mod.validate(
-    tag="v0.5.1",
+    tag="v0.5.2",
     expected_sha=sha,
     actual_sha=sha,
-    versions={**versions, "skills": "0.5.2"},
+    versions={**versions, "skills": "0.5.3"},
 )
 
 workflow = WORKFLOW.read_text(encoding="utf-8")
-assert "default: v0.5.1" in workflow
+assert "default: v0.5.2" in workflow
 assert 'test "$release_version" != 0.5.0' in workflow
 assert "candidate/v0.5.0-artifacts.json" not in workflow
 assert "v0.5.0-npm-amendment.json" not in workflow

--- a/tests/unit/test_set_release_version.py
+++ b/tests/unit/test_set_release_version.py
@@ -84,9 +84,7 @@ def test_check_aligned_rejects_stale_path_pin(
         lambda: [(path, dependency, stale)],
     )
     errors = set_release_version.check_aligned()
-    assert any(dependency in error and stale in error and root in error for error in errors), (
-        errors
-    )
+    assert any(dependency in error and stale in error and root in error for error in errors), errors
 
 
 def test_apply_version_rewrites_path_pins(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_set_release_version.py
+++ b/tests/unit/test_set_release_version.py
@@ -72,17 +72,19 @@ def test_check_aligned_rejects_stale_path_pin(
 ) -> None:
     """Stale path+version pins must fail --check before Binding RC rehearsal."""
     current = set_release_version.read_current()
-    assert current["cargo"] == "0.5.1"
+    root = current["cargo"]
+    assert root  # must be the live workspace root version
     pins = set_release_version.path_version_pins()
     assert pins
     path, dependency, _version = pins[0]
+    stale = "0.0.0"
     monkeypatch.setattr(
         set_release_version,
         "path_version_pins",
-        lambda: [(path, dependency, "0.5.0")],
+        lambda: [(path, dependency, stale)],
     )
     errors = set_release_version.check_aligned()
-    assert any(dependency in error and "0.5.0" in error and "0.5.1" in error for error in errors), (
+    assert any(dependency in error and stale in error and root in error for error in errors), (
         errors
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -324,7 +324,7 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "python-dateutil", specifier = ">=2.8.2" },
     { name = "pyyaml", specifier = ">=6.0.3" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.16.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.16.1" },
 ]
 provides-extras = ["pandas", "dev"]
 
@@ -343,7 +343,7 @@ dev = [
     { name = "pytest-bdd", specifier = ">=8.1.0" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "python-igraph", specifier = ">=1.0.0" },
-    { name = "ruff", specifier = "==0.16.0" },
+    { name = "ruff", specifier = "==0.16.1" },
     { name = "types-defusedxml", specifier = ">=0.7.0.20250822" },
     { name = "types-python-dateutil", specifier = ">=2.8" },
     { name = "types-pyyaml", specifier = ">=6.0" },
@@ -1913,27 +1913,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.16.0"
+version = "0.16.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/25/7113f6d5498888c5fb7db34081cba7d5971c4cb1bfb26819966eee68f003/ruff-0.16.1.tar.gz", hash = "sha256:fedad7c801dabd3fb9741d76aca39246e6ddd9ca446a015875207bf19f1e6bc7", size = 4877500, upload-time = "2026-07-30T19:37:01.379Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
-    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
-    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
-    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
-    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
-    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
-    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
-    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bd/694da69368e0973de65df2ddc73ab18d43c469d5963d9b150911de6bc513/ruff-0.16.1-py3-none-linux_armv6l.whl", hash = "sha256:58edb313b88f0c5460a26adf5f39a37a3be789494a15e3e411e35fa78b89f9a0", size = 10839126, upload-time = "2026-07-30T19:36:13.697Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/f0/b626e5d5bd0dd9576263658ef12885e2288afd1029a48e26ffed65ec1ac1/ruff-0.16.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fde5a99e2f97479af66edd6622c6d5a2a7592c77cf4153d9e4428f5eeb55b60c", size = 11070253, upload-time = "2026-07-30T19:36:17.14Z" },
+    { url = "https://files.pythonhosted.org/packages/83/63/f40acfb6b35b88623e71684942b552c3edd96035f5d98f313815f7b277de/ruff-0.16.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e0d4c20532fca4f7fa609369161d968dd28f65d83dabbd61d8e9c7edbf7001f6", size = 10561425, upload-time = "2026-07-30T19:36:20.04Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/dd/14ec0e9c2b4d315547dd38765004b4863e354e1b52cb308272215d9f6f6d/ruff-0.16.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30affbcedf59ad5703d9c91f82266e02b47739f797e1a7b6e158e5526a6dae38", size = 10948879, upload-time = "2026-07-30T19:36:22.476Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e9/9d870cbae575030fdef595f04b4b97573c525b5497cce4f4498cf2f85446/ruff-0.16.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:24e9c631573cbca9d20f1283f8f479b2afa4a8503504822bd71a293889f16743", size = 10643691, upload-time = "2026-07-30T19:36:24.914Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/09/12743d544e2173f53ecd27217c65f90d2bc0f8424a66a60339e56bbc0457/ruff-0.16.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b41bdd48fb420987a9b5212e4957c26ad4abce401fa9ea9d4d85843727945f4f", size = 11435354, upload-time = "2026-07-30T19:36:28.447Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/89/a1652b2daee52083c9554a6333b678a8b01d0400f976827bb87857f9449a/ruff-0.16.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b0d1e1393b7648079e13669de1c1f4fde06d4583e84d8fd5c1551e0a77a2aa75", size = 12259033, upload-time = "2026-07-30T19:36:31.326Z" },
+    { url = "https://files.pythonhosted.org/packages/16/96/ecdcb8c54ee7b123b487f807eb014e6e019155a0b81dfb669acd52f28ce3/ruff-0.16.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:07bf434b1c95f4e093be4532068ef4fcf00924eb2ade8796075980902d6fd54a", size = 11667981, upload-time = "2026-07-30T19:36:34.394Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/90/c52e12e0d862e9572f2a33aa227409143520abe53111e9a6babbac7b4af8/ruff-0.16.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39897739f112253ee4fdd2e8aa9a4f9ded99fb2be367d5f31dfa4ded6025584c", size = 11468183, upload-time = "2026-07-30T19:36:37.339Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6b/4ffb7ad1d83eb16cf8cbb3c8815d3f11c88460fd162d4b372a2059be1c2a/ruff-0.16.1-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:82ae3c0c0d74daf17b968a10b7b3bb3ef297ab7de0c1f749646b25e690ccb150", size = 11470071, upload-time = "2026-07-30T19:36:39.91Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/72/32ae7db4c0b5e32ab611787caa19d1546800676d79f7483b7100a3561bf4/ruff-0.16.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4d5f2ed10f8242d83fc08d521301089364e3375375705356f20c0e31606ef3ef", size = 10919503, upload-time = "2026-07-30T19:36:42.65Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ca/3d901ba6ad6fc38da39c3448fc6c59ac945679293a17c3ceb6d6c1cba13e/ruff-0.16.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a4665b309891f83f3e3c25447935f1213e9abbd4b5640af7a1f2def9f8d413c1", size = 10649861, upload-time = "2026-07-30T19:36:45.18Z" },
+    { url = "https://files.pythonhosted.org/packages/92/79/894ef1ced26552d5f8c9cf6d85b0687840e1128c55aeab7b9c2d54a0d880/ruff-0.16.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:26e9ca5c9bc3971f20d3cf18a957f52ffd6a5f6564ff15c4912a144dcac22494", size = 11148137, upload-time = "2026-07-30T19:36:47.936Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/69/3609a09fa1cb46cc28b762363e440a354204e5dff01bd0c8d7437874d6b9/ruff-0.16.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:67e1e1e3fa4f0c82f0e36d4cd61e661f6e7a6196cb1aa92fe0828fa7b8f257cd", size = 11559211, upload-time = "2026-07-30T19:36:50.448Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/8a/fb22af2fd78a736e241fabf67e30ce1799a64244026377a49e133af90762/ruff-0.16.1-py3-none-win32.whl", hash = "sha256:d31765e131295b8445caf301e3e8a85b34d1b9b211b4109b7ba457888b051806", size = 10838258, upload-time = "2026-07-30T19:36:53.298Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/35/e57fd9fb5d423961df087a00b12d42c0a830288dc2f3b45ecca299158b4f/ruff-0.16.1-py3-none-win_amd64.whl", hash = "sha256:09b05e8b90c2cb06ad63464350e7a45e8e44a2dfe52072ebfba6666ca8d3f596", size = 11961111, upload-time = "2026-07-30T19:36:56.107Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/46/240ea004bf6dc4feb40e9832f2205a476a47dd5b8a3f8211a5fc5f95e20e/ruff-0.16.1-py3-none-win_arm64.whl", hash = "sha256:dbaadaac38c70239f056d306b7476f246b0bf000fa6b3876402acbf5b227eaf8", size = 11309414, upload-time = "2026-07-30T19:36:58.79Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Freeze Cargo, Python, Node, CLI, and agent-skills package versions at `0.5.2`
- Keep path+version crate pins and lockfile entries aligned with the root version
- Make the stale path-pin `--check` regression assert against the live root version (not a hardcoded prior release)

Refs #396

This prepares the release candidate; it does not create the tag, GitHub Release, or publish registries. #336 remains deferred.

## Test plan
- [x] `python3 scripts/set_release_version.py --check`
- [x] `uv run pytest tests/unit/test_set_release_version.py -q`
- [ ] CI Gate green on exact PR head

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788456675&installation_model_id=20486&pr_number=397&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F397&signature=39b847ef62767713b597e3e6977d4a37e1841cd9d6ddd0f0885245cc431aa166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump GraphForge version to 0.5.2 across all crates and packages
> Updates version strings from `0.5.1` to `0.5.2` across all Rust crates, Node/Python bindings, and CLI packages. CI test scripts and version assertion logic are updated to reference `0.5.2`, with test helpers refactored to derive versions dynamically rather than using hardcoded literals.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 54fcb38.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated GraphForge and associated packages from version 0.5.1 to 0.5.2.
  * Aligned compatibility metadata across supported integrations with the 0.5.2 release.
* **Tests**
  * Improved release-version validation to use the current workspace version and provide clearer mismatch details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->