### PR TITLE
fix(node): preserve TypeError for binding coercion (#357)

### DIFF
--- a/crates/graphforge-bindings-node/src/error.rs
+++ b/crates/graphforge-bindings-node/src/error.rs
@@ -10,9 +10,22 @@
 //! the `PlanError` domain).
 
 use graphforge_api::GfError;
+use napi::Env;
 
 /// A napi error whose `status` string surfaces as the JS `error.code`.
 pub type NodeError = napi::Error<String>;
+
+/// Throw a real JavaScript `TypeError`, then return a `PendingException` sentinel
+/// so the `#[napi]` wrapper does not overwrite it with a generic `Error`.
+///
+/// Use this for binding coercion failures (bad handles, unsupported property
+/// types). Do **not** use it for Rust-owned [`GfError`] domains — those continue
+/// to go through [`to_napi_err`].
+pub fn type_error(env: &Env, message: impl Into<String>) -> NodeError {
+    let message = message.into();
+    let _ = env.throw_type_error(&message, Some("InvalidArg"));
+    napi::Error::new("PendingException".to_owned(), message)
+}
 
 /// The JS `error.code` for each [`GfError`] fault domain.
 fn error_code(err: &GfError) -> &'static str {

--- a/crates/graphforge-bindings-node/src/error.rs
+++ b/crates/graphforge-bindings-node/src/error.rs
@@ -21,7 +21,7 @@ pub type NodeError = napi::Error<String>;
 /// Use this for binding coercion failures (bad handles, unsupported property
 /// types). Do **not** use it for Rust-owned [`GfError`] domains — those continue
 /// to go through [`to_napi_err`].
-pub fn type_error(env: &Env, message: impl Into<String>) -> NodeError {
+pub fn type_error(env: Env, message: impl Into<String>) -> NodeError {
     let message = message.into();
     let _ = env.throw_type_error(&message, Some("InvalidArg"));
     napi::Error::new("PendingException".to_owned(), message)

--- a/crates/graphforge-bindings-node/src/lib.rs
+++ b/crates/graphforge-bindings-node/src/lib.rs
@@ -611,9 +611,12 @@ fn props_from_js_object(env: &Env, props: Option<Object>) -> Result<HashMap<Stri
     })?;
     let mut out = HashMap::with_capacity(keys.len());
     for key in keys {
-        let Some(value) = obj
-            .get::<Unknown>(&key)
-            .map_err(|error| type_error(env, format!("failed to read property `{key}`: {}", error.reason)))?
+        let Some(value) = obj.get::<Unknown>(&key).map_err(|error| {
+            type_error(
+                env,
+                format!("failed to read property `{key}`: {}", error.reason),
+            )
+        })?
         else {
             continue;
         };
@@ -703,9 +706,8 @@ fn node_handle_from_unknown<'env>(
     value: Unknown<'env>,
     role: &str,
 ) -> Result<ClassInstance<'env, NodeHandle>> {
-    unsafe { ClassInstance::<NodeHandle>::from_napi_value(env.raw(), value.raw()) }.map_err(
-        |_| type_error(env, format!("expected NodeHandle for addEdge {role}")),
-    )
+    unsafe { ClassInstance::<NodeHandle>::from_napi_value(env.raw(), value.raw()) }
+        .map_err(|_| type_error(env, format!("expected NodeHandle for addEdge {role}")))
 }
 
 type EmbeddingInput = HashMap<String, serde_json::Value>;
@@ -5735,8 +5737,7 @@ impl GraphForge {
         &self,
         env: Env,
         label: String,
-        #[napi(ts_arg_type = "Record<string, unknown> | null | undefined")]
-        props: Option<Object>,
+        #[napi(ts_arg_type = "Record<string, unknown> | null | undefined")] props: Option<Object>,
     ) -> Result<NodeHandle> {
         self.ensure_open()?;
         let props = props_from_js_object(&env, props)?;
@@ -5755,8 +5756,7 @@ impl GraphForge {
         #[napi(ts_arg_type = "NodeHandle")] src: Unknown,
         rel_type: String,
         #[napi(ts_arg_type = "NodeHandle")] dst: Unknown,
-        #[napi(ts_arg_type = "Record<string, unknown> | null | undefined")]
-        props: Option<Object>,
+        #[napi(ts_arg_type = "Record<string, unknown> | null | undefined")] props: Option<Object>,
     ) -> Result<EdgeHandle> {
         let src = node_handle_from_unknown(&env, src, "source")?;
         let dst = node_handle_from_unknown(&env, dst, "destination")?;

--- a/crates/graphforge-bindings-node/src/lib.rs
+++ b/crates/graphforge-bindings-node/src/lib.rs
@@ -599,7 +599,7 @@ const UNSUPPORTED_PROP_TYPE_MSG: &str =
 
 /// Convert a JS property bag, raising a real `TypeError` for unsupported values
 /// (functions, symbols, nested plain objects).
-fn props_from_js_object(env: &Env, props: Option<Object>) -> Result<HashMap<String, PropValue>> {
+fn props_from_js_object(env: Env, props: Option<Object>) -> Result<HashMap<String, PropValue>> {
     let Some(obj) = props else {
         return Ok(HashMap::new());
     };
@@ -628,7 +628,7 @@ fn props_from_js_object(env: &Env, props: Option<Object>) -> Result<HashMap<Stri
 // SAFETY: each `cast` / `from_napi_value` follows an explicit `ValueType`
 // check (or ClassInstance fallible coerce) so the napi value kind matches.
 #[allow(unsafe_code)]
-fn js_unknown_to_prop_value(env: &Env, value: Unknown<'_>) -> Result<PropValue> {
+fn js_unknown_to_prop_value(env: Env, value: Unknown<'_>) -> Result<PropValue> {
     match value.get_type().map_err(|error| {
         type_error(
             env,
@@ -647,8 +647,17 @@ fn js_unknown_to_prop_value(env: &Env, value: Unknown<'_>) -> Result<PropValue> 
                 type_error(env, format!("expected number property: {}", error.reason))
             })?;
             if number.is_finite() && number.fract() == 0.0 {
-                if number >= i64::MIN as f64 && number <= i64::MAX as f64 {
-                    return Ok(PropValue::Int(number as i64));
+                // JS numbers are IEEE-754; whole values in the exact integer
+                // range are stored as PropValue::Int.
+                #[allow(
+                    clippy::cast_precision_loss,
+                    clippy::cast_possible_truncation,
+                    reason = "JS Number is f64; whole values in i64 range are intentional"
+                )]
+                {
+                    if number >= i64::MIN as f64 && number <= i64::MAX as f64 {
+                        return Ok(PropValue::Int(number as i64));
+                    }
                 }
                 return Err(to_napi_err(&GfError::Validation(
                     "integer node property exceeds signed 64-bit range".into(),
@@ -702,7 +711,7 @@ fn js_unknown_to_prop_value(env: &Env, value: Unknown<'_>) -> Result<PropValue> 
 // TypeError rather than a generic napi Error.
 #[allow(unsafe_code)]
 fn node_handle_from_unknown<'env>(
-    env: &'env Env,
+    env: Env,
     value: Unknown<'env>,
     role: &str,
 ) -> Result<ClassInstance<'env, NodeHandle>> {
@@ -5740,7 +5749,7 @@ impl GraphForge {
         #[napi(ts_arg_type = "Record<string, unknown> | null | undefined")] props: Option<Object>,
     ) -> Result<NodeHandle> {
         self.ensure_open()?;
-        let props = props_from_js_object(&env, props)?;
+        let props = props_from_js_object(env, props)?;
         let graph = self.open_guard()?;
         graph
             .add_node(&label, &props)
@@ -5758,9 +5767,9 @@ impl GraphForge {
         #[napi(ts_arg_type = "NodeHandle")] dst: Unknown,
         #[napi(ts_arg_type = "Record<string, unknown> | null | undefined")] props: Option<Object>,
     ) -> Result<EdgeHandle> {
-        let src = node_handle_from_unknown(&env, src, "source")?;
-        let dst = node_handle_from_unknown(&env, dst, "destination")?;
-        let props = props_from_js_object(&env, props)?;
+        let src = node_handle_from_unknown(env, src, "source")?;
+        let dst = node_handle_from_unknown(env, dst, "destination")?;
+        let props = props_from_js_object(env, props)?;
         let graph = self.open_guard()?;
         graph
             .add_edge(&src.inner, &rel_type, &dst.inner, &props)

--- a/crates/graphforge-bindings-node/src/lib.rs
+++ b/crates/graphforge-bindings-node/src/lib.rs
@@ -7381,8 +7381,18 @@ mod tests {
     #[test]
     fn source_free_minimum_steiner_reaches_active_rust_handler() {
         let graph = GraphForge::new(None, None).unwrap();
-        let first = graph.add_node("Person".into(), None).unwrap();
-        let second = graph.add_node("Person".into(), None).unwrap();
+        // Construction methods require a napi Env for TypeError coercion; unit
+        // tests seed fixtures through the Rust facade instead.
+        let (first, second) = {
+            let engine = graph.open_guard().unwrap();
+            let first = engine
+                .add_node("Person", &Default::default())
+                .expect("fixture node");
+            let second = engine
+                .add_node("Person", &Default::default())
+                .expect("fixture node");
+            (first.uuid.to_string(), second.uuid.to_string())
+        };
 
         let result = graph.paths(
             None,
@@ -7395,7 +7405,7 @@ mod tests {
             None,
             None,
             None,
-            Some(vec![first.uuid(), second.uuid()]),
+            Some(vec![first, second]),
             None,
             None,
             None,

--- a/crates/graphforge-bindings-node/src/lib.rs
+++ b/crates/graphforge-bindings-node/src/lib.rs
@@ -40,15 +40,16 @@ use graphforge_api::{
     validate_embedding_options,
 };
 use napi::bindgen_prelude::{
-    AbortSignal, AsyncTask, BigInt, Buffer, ClassInstance, Either3, Function, JsObjectValue, Object,
+    AbortSignal, AsyncTask, BigInt, Buffer, ClassInstance, Either3, FromNapiValue, Function,
+    JsObjectValue, Object, Unknown,
 };
-use napi::{Env, Task};
+use napi::{Env, JsValue, Task, ValueType};
 use napi_derive::napi;
 
 mod composite;
 mod error;
 use composite::CompositeTransactionInput;
-use error::{NodeError, to_napi_err};
+use error::{NodeError, to_napi_err, type_error};
 
 /// Result alias whose error surfaces a typed JS `error.code` (see [`error`]).
 pub(crate) type Result<T> = std::result::Result<T, NodeError>;
@@ -572,6 +573,10 @@ fn json_to_prop_value(value: &serde_json::Value) -> Result<PropValue> {
                 .collect::<Result<Vec<_>>>()?,
         ),
         Value::Object(_) => {
+            // Nested plain objects are unsupported property values. Callers that
+            // need a JS `TypeError` (add_node / add_edge) must go through
+            // [`props_from_js_object`]; this serde path is used by composite
+            // JSON inputs and keeps a ValidationError for domain mapping.
             return Err(to_napi_err(&GfError::Validation(
                 "unsupported node property type (expected null/boolean/number/string/array)".into(),
             )));
@@ -587,6 +592,120 @@ pub(crate) fn props_from_map(
         .into_iter()
         .map(|(name, value)| Ok((name, json_to_prop_value(&value)?)))
         .collect()
+}
+
+const UNSUPPORTED_PROP_TYPE_MSG: &str =
+    "unsupported node property type (expected null/boolean/number/string/array)";
+
+/// Convert a JS property bag, raising a real `TypeError` for unsupported values
+/// (functions, symbols, nested plain objects).
+fn props_from_js_object(env: &Env, props: Option<Object>) -> Result<HashMap<String, PropValue>> {
+    let Some(obj) = props else {
+        return Ok(HashMap::new());
+    };
+    let keys = Object::keys(&obj).map_err(|error| {
+        type_error(
+            env,
+            format!("failed to read node property keys: {}", error.reason),
+        )
+    })?;
+    let mut out = HashMap::with_capacity(keys.len());
+    for key in keys {
+        let Some(value) = obj
+            .get::<Unknown>(&key)
+            .map_err(|error| type_error(env, format!("failed to read property `{key}`: {}", error.reason)))?
+        else {
+            continue;
+        };
+        out.insert(key, js_unknown_to_prop_value(env, value)?);
+    }
+    Ok(out)
+}
+
+// SAFETY: each `cast` / `from_napi_value` follows an explicit `ValueType`
+// check (or ClassInstance fallible coerce) so the napi value kind matches.
+#[allow(unsafe_code)]
+fn js_unknown_to_prop_value(env: &Env, value: Unknown<'_>) -> Result<PropValue> {
+    match value.get_type().map_err(|error| {
+        type_error(
+            env,
+            format!("failed to inspect property value type: {}", error.reason),
+        )
+    })? {
+        ValueType::Undefined | ValueType::Null => Ok(PropValue::Null),
+        ValueType::Boolean => {
+            let flag = unsafe { value.cast::<bool>() }.map_err(|error| {
+                type_error(env, format!("expected boolean property: {}", error.reason))
+            })?;
+            Ok(PropValue::Bool(flag))
+        }
+        ValueType::Number => {
+            let number = unsafe { value.cast::<f64>() }.map_err(|error| {
+                type_error(env, format!("expected number property: {}", error.reason))
+            })?;
+            if number.is_finite() && number.fract() == 0.0 {
+                if number >= i64::MIN as f64 && number <= i64::MAX as f64 {
+                    return Ok(PropValue::Int(number as i64));
+                }
+                return Err(to_napi_err(&GfError::Validation(
+                    "integer node property exceeds signed 64-bit range".into(),
+                )));
+            }
+            if !number.is_finite() {
+                return Err(to_napi_err(&GfError::Validation(
+                    "non-finite node property".into(),
+                )));
+            }
+            Ok(PropValue::Float(number))
+        }
+        ValueType::String => {
+            let text = unsafe { value.cast::<String>() }.map_err(|error| {
+                type_error(env, format!("expected string property: {}", error.reason))
+            })?;
+            Ok(PropValue::Str(text))
+        }
+        ValueType::Object => {
+            let object = unsafe { value.cast::<Object>() }.map_err(|error| {
+                type_error(env, format!("expected object property: {}", error.reason))
+            })?;
+            if !object.is_array().map_err(|error| {
+                type_error(
+                    env,
+                    format!("failed to inspect array property: {}", error.reason),
+                )
+            })? {
+                return Err(type_error(env, UNSUPPORTED_PROP_TYPE_MSG));
+            }
+            let json = unsafe {
+                <serde_json::Value as FromNapiValue>::from_napi_value(env.raw(), object.raw())
+            }
+            .map_err(|error| {
+                type_error(
+                    env,
+                    format!("failed to read array property: {}", error.reason),
+                )
+            })?;
+            json_to_prop_value(&json)
+        }
+        ValueType::Function
+        | ValueType::Symbol
+        | ValueType::External
+        | ValueType::Unknown
+        | ValueType::BigInt => Err(type_error(env, UNSUPPORTED_PROP_TYPE_MSG)),
+    }
+}
+
+// SAFETY: `from_napi_value` fallibly coerces a ClassInstance; failures become
+// TypeError rather than a generic napi Error.
+#[allow(unsafe_code)]
+fn node_handle_from_unknown<'env>(
+    env: &'env Env,
+    value: Unknown<'env>,
+    role: &str,
+) -> Result<ClassInstance<'env, NodeHandle>> {
+    unsafe { ClassInstance::<NodeHandle>::from_napi_value(env.raw(), value.raw()) }.map_err(
+        |_| type_error(env, format!("expected NodeHandle for addEdge {role}")),
+    )
 }
 
 type EmbeddingInput = HashMap<String, serde_json::Value>;
@@ -5614,11 +5733,13 @@ impl GraphForge {
     #[napi]
     pub fn add_node(
         &self,
+        env: Env,
         label: String,
-        props: Option<HashMap<String, serde_json::Value>>,
+        #[napi(ts_arg_type = "Record<string, unknown> | null | undefined")]
+        props: Option<Object>,
     ) -> Result<NodeHandle> {
         self.ensure_open()?;
-        let props = props_from_map(props)?;
+        let props = props_from_js_object(&env, props)?;
         let graph = self.open_guard()?;
         graph
             .add_node(&label, &props)
@@ -5630,12 +5751,16 @@ impl GraphForge {
     #[napi]
     pub fn add_edge(
         &self,
-        src: ClassInstance<'_, NodeHandle>,
+        env: Env,
+        #[napi(ts_arg_type = "NodeHandle")] src: Unknown,
         rel_type: String,
-        dst: ClassInstance<'_, NodeHandle>,
-        props: Option<HashMap<String, serde_json::Value>>,
+        #[napi(ts_arg_type = "NodeHandle")] dst: Unknown,
+        #[napi(ts_arg_type = "Record<string, unknown> | null | undefined")]
+        props: Option<Object>,
     ) -> Result<EdgeHandle> {
-        let props = props_from_map(props)?;
+        let src = node_handle_from_unknown(&env, src, "source")?;
+        let dst = node_handle_from_unknown(&env, dst, "destination")?;
+        let props = props_from_js_object(&env, props)?;
         let graph = self.open_guard()?;
         graph
             .add_edge(&src.inner, &rel_type, &dst.inner, &props)

--- a/crates/graphforge-bindings-node/tests/core.test.mjs
+++ b/crates/graphforge-bindings-node/tests/core.test.mjs
@@ -36,7 +36,7 @@ function checkAddNode() {
 
   assert.throws(
     () => forge.addNode("Person", { nested: { unsupported: true } }),
-    (error) => error.code === "ValidationError",
+    (error) => error instanceof TypeError,
   );
   assert.equal(
     tableFromIPC(forge.execute("MATCH (n:Person) RETURN n")).numRows,

--- a/crates/graphforge-bindings-node/tests/paths-shortest.test.mjs
+++ b/crates/graphforge-bindings-node/tests/paths-shortest.test.mjs
@@ -439,7 +439,8 @@ function checkAStarPaths() {
   assert.throws(
     () => new GraphForge().addNode("Person", { heuristic: Number.NaN }),
     (error) =>
-      error.code === "ValidationError" && /non-finite node property/.test(error.message),
+      error.code === "ValidationError" &&
+      /non-finite node property/.test(error.message),
   );
 
   for (const [name, literal, code] of [

--- a/crates/graphforge-bindings-node/tests/paths-shortest.test.mjs
+++ b/crates/graphforge-bindings-node/tests/paths-shortest.test.mjs
@@ -438,7 +438,8 @@ function checkAStarPaths() {
   }
   assert.throws(
     () => new GraphForge().addNode("Person", { heuristic: Number.NaN }),
-    /Failed to convert js number to serde_json::Number/,
+    (error) =>
+      error.code === "ValidationError" && /non-finite node property/.test(error.message),
   );
 
   for (const [name, literal, code] of [

--- a/tests/contracts/api-bdd-exclusions.json
+++ b/tests/contracts/api-bdd-exclusions.json
@@ -91,24 +91,6 @@
       "scenario": "neighbourhood with hops 0 returns empty Arrow Table",
       "issue": 356,
       "languages": ["rust", "python", "node"]
-    },
-    {
-      "feature": "Type Errors",
-      "scenario": "TypeError when add_edge source is not a NodeHandle",
-      "issue": 357,
-      "languages": ["node"]
-    },
-    {
-      "feature": "Type Errors",
-      "scenario": "TypeError when add_edge destination is not a NodeHandle",
-      "issue": 357,
-      "languages": ["node"]
-    },
-    {
-      "feature": "Type Errors",
-      "scenario": "TypeError on unsupported property value type",
-      "issue": 357,
-      "languages": ["node"]
     }
   ]
 }

--- a/tests/features/api/type_errors.feature
+++ b/tests/features/api/type_errors.feature
@@ -4,19 +4,19 @@ Feature: Type Errors
   Background:
     Given an empty graph
 
-  @binding-only @excluded-node-api-bdd @issue-357
+  @binding-only
   Scenario: TypeError when add_edge source is not a NodeHandle
     Given a Person node named "Alice"
     When I add a "KNOWS" edge from a raw integer to the node for "Alice"
     Then a TypeError is raised
 
-  @binding-only @excluded-node-api-bdd @issue-357
+  @binding-only
   Scenario: TypeError when add_edge destination is not a NodeHandle
     Given a Person node named "Alice"
     When I add a "KNOWS" edge from the node for "Alice" to a raw integer
     Then a TypeError is raised
 
-  @binding-only @excluded-node-api-bdd @issue-357
+  @binding-only
   Scenario: TypeError on unsupported property value type
     When I add a node with label "Person" with an unsupported property value
     Then a TypeError is raised


### PR DESCRIPTION
## Summary
- Convert napi handle-coercion failures and unsupported property value types to JavaScript `TypeError` via `env.throw_type_error` + `PendingException`.
- Keep Rust `GfError` domain codes unchanged for real validation/execution errors.
- Remove the three Node-only `@issue-357` exclusions from the fail-closed API BDD ledger.

Closes #357.

## Test plan
- [x] `cargo check -p graphforge-bindings-node`
- [x] `pnpm --filter @curatelabs/graphforge exec napi build --platform`
- [x] Node BDD: `cucumber-js ../api/type_errors.feature --tags @issue-357` (3 passed; tags since removed)
- [x] `python3 scripts/ci/api-bdd-policy.py`

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788558154&installation_model_id=20486&pr_number=411&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F411&signature=0318038e31cd250096ad63e35dd6554dc4a2bec7223017992bf3b0ec839b32ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Node binding coercion to throw real JS TypeError instead of generic napi errors
> - Adds a `type_error` helper in [error.rs](https://github.com/CurateLabs/graphforge/pull/411/files#diff-3896f86edbfb062334cdf867b60b707ad3bedd3a416a5e24260bf798320040b0) that throws a JS `TypeError` via `Env::throw_type_error` and returns a `PendingException` status so the `#[napi]` wrapper does not overwrite the exception.
> - Adds `js_unknown_to_prop_value` and `props_from_js_object` in [lib.rs](https://github.com/CurateLabs/graphforge/pull/411/files#diff-e4a29b53f79b655d232474d18c10ee7f1a9e7fe2fd2f1024a1d3ea783612ef7a) to type-check JS values at the binding boundary: unsupported types (functions, symbols, BigInt, non-array objects) throw `TypeError`; non-finite or out-of-range numbers produce `ValidationError`.
> - Changes `add_node` and `add_edge` signatures to accept `Env` and raw `Unknown`/`Object` arguments, replacing the previous serde-based `HashMap` coercion path.
> - `add_edge` now validates that `src` and `dst` are `NodeHandle` instances via `node_handle_from_unknown`, throwing `TypeError` when they are not.
> - Enables three previously excluded BDD scenarios in [type_errors.feature](https://github.com/CurateLabs/graphforge/pull/411/files#diff-da882caaaaab5d24acc5846c71f30da0795fc00a3883113f0259c5f89e2c5d4a) covering TypeError on bad `addEdge` source/destination and unsupported property value type.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c16a42.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JavaScript `TypeError` reporting for invalid node and edge handles.
  * Added clear validation for unsupported property values, including functions, symbols, BigInts, external values, and invalid nested objects.
  * Preserved numeric range and type validation during graph operations.

* **Tests**
  * Enabled Node API coverage for previously excluded type-error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->