### PR TITLE
fix(recipes): neighbourhood hop-bound and schema contracts (#356)

### DIFF
--- a/crates/graphforge-api/tests/bdd/api_steps.rs
+++ b/crates/graphforge-api/tests/bdd/api_steps.rs
@@ -287,6 +287,15 @@ fn add_named_fixture_node(
         .expect("named fixture node")
 }
 
+fn is_cypher_identifier(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
 #[given("a graph with a directed cycle")]
 async fn given_directed_cycle(world: &mut GraphForgeWorld) {
     let forge = graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed");
@@ -470,28 +479,65 @@ fn set_ontology_fixture(world: &mut GraphForgeWorld, name: &str, contents: &str)
 
 #[given(regex = r#"^a graph with Person nodes connected by KNOWS edges up to 3 hops deep$"#)]
 async fn given_persons_3hops(world: &mut GraphForgeWorld) {
-    world.forge =
-        Some(graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed"));
+    let forge = graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed");
+    world.nodes.clear();
+    let names = ["Alice", "Bob", "Carol", "Dave"];
+    let mut handles = Vec::with_capacity(names.len());
+    for name in names {
+        let handle = add_named_fixture_node(&forge, name);
+        world.nodes.insert(name.into(), handle.clone());
+        handles.push(handle);
+    }
+    for window in handles.windows(2) {
+        forge
+            .add_edge(&window[0], "KNOWS", &window[1], &Default::default())
+            .expect("3-hop fixture edge");
+    }
+    world.forge = Some(forge);
 }
 
 #[given(
     regex = r#"^a graph where Alice knows Bob and Bob knows Charlie but Alice does not know Charlie$"#
 )]
 async fn given_alice_bob_charlie(world: &mut GraphForgeWorld) {
-    world.forge =
-        Some(graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed"));
+    let forge = graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed");
+    let alice = add_named_fixture_node(&forge, "Alice");
+    let bob = add_named_fixture_node(&forge, "Bob");
+    let charlie = add_named_fixture_node(&forge, "Charlie");
+    forge
+        .add_edge(&alice, "KNOWS", &bob, &Default::default())
+        .expect("Alice-Bob edge");
+    forge
+        .add_edge(&bob, "KNOWS", &charlie, &Default::default())
+        .expect("Bob-Charlie edge");
+    world.nodes.clear();
+    world.nodes.insert("Alice".into(), alice);
+    world.nodes.insert("Bob".into(), bob);
+    world.nodes.insert("Charlie".into(), charlie);
+    world.forge = Some(forge);
 }
 
 #[given(regex = r#"^a graph where Alice knows Bob$"#)]
 async fn given_alice_knows_bob(world: &mut GraphForgeWorld) {
-    world.forge =
-        Some(graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed"));
+    let forge = graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed");
+    let alice = add_named_fixture_node(&forge, "Alice");
+    let bob = add_named_fixture_node(&forge, "Bob");
+    forge
+        .add_edge(&alice, "KNOWS", &bob, &Default::default())
+        .expect("Alice-Bob edge");
+    world.nodes.clear();
+    world.nodes.insert("Alice".into(), alice);
+    world.nodes.insert("Bob".into(), bob);
+    world.forge = Some(forge);
 }
 
 #[given(regex = r#"^a graph with a single Person node named "Lone"$"#)]
 async fn given_lone_person(world: &mut GraphForgeWorld) {
-    world.forge =
-        Some(graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed"));
+    let forge = graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed");
+    let lone = add_named_fixture_node(&forge, "Lone");
+    world.nodes.clear();
+    world.nodes.insert("Lone".into(), lone);
+    world.forge = Some(forge);
 }
 
 #[given(
@@ -1211,6 +1257,60 @@ async fn when_node_count(world: &mut GraphForgeWorld, label: String) {
                 });
             }
             Err(error) => world.last_error = Some(error.to_string()),
+        }
+    }
+}
+
+#[when(
+    regex = r#"^I call neighbourhood for "([^"]*)" with hops (\d+) in label "([^"]*)" using canonical property "([^"]*)"$"#
+)]
+async fn when_neighbourhood(
+    world: &mut GraphForgeWorld,
+    canonical: String,
+    hops: u32,
+    label: String,
+    prop: String,
+) {
+    world.last_error = None;
+    world.last_error_code = None;
+    world.last_algorithm_result = None;
+    if !is_cypher_identifier(&label) || !is_cypher_identifier(&prop) {
+        world.last_error = Some("invalid neighbourhood identifier".into());
+        return;
+    }
+    let return_clause = if prop == "name" {
+        "RETURN DISTINCT neighbour.name AS name, labels(neighbour) AS labels".to_owned()
+    } else {
+        format!(
+            "RETURN DISTINCT neighbour.{prop} AS {prop}, neighbour.name AS name, labels(neighbour) AS labels"
+        )
+    };
+    let query = if hops == 0 {
+        format!("MATCH (neighbour:{label}) WHERE false {return_clause}")
+    } else {
+        format!(
+            "MATCH (seed:{label} {{{prop}: $canonical}})-[*1..{hops}]-(neighbour:{label}) \
+             WHERE neighbour.{prop} <> $canonical {return_clause}"
+        )
+    };
+    let params = std::collections::HashMap::from([(
+        "canonical".to_owned(),
+        graphforge_api::IrLiteral::Str(canonical),
+    )]);
+    match world
+        .forge
+        .as_ref()
+        .expect("neighbourhood fixture")
+        .execute_with_params(&query, &params)
+    {
+        Ok(result) => {
+            world.last_exec = Some(result);
+            world.last_error = None;
+        }
+        Err(error) => {
+            world.last_exec = None;
+            world.last_error_code = Some(error.code());
+            world.last_error = Some(error.to_string());
         }
     }
 }
@@ -2026,4 +2126,51 @@ async fn then_arrow_at_least_1(world: &mut GraphForgeWorld) {
             .sum::<usize>()
             >= 1
     );
+}
+
+#[then(regex = r#"^the result contains a row for "([^"]*)"$"#)]
+async fn then_result_has_row_for(world: &mut GraphForgeWorld, name: String) {
+    assert!(
+        world.last_error.is_none(),
+        "unexpected error: {:?}",
+        world.last_error
+    );
+    let names = neighbourhood_names(world);
+    assert!(
+        names.iter().any(|value| value == &name),
+        "result omitted row for {name}; got {names:?}"
+    );
+}
+
+#[then(regex = r#"^the result does not contain a row for "([^"]*)"$"#)]
+async fn then_result_no_row_for(world: &mut GraphForgeWorld, name: String) {
+    assert!(
+        world.last_error.is_none(),
+        "unexpected error: {:?}",
+        world.last_error
+    );
+    let names = neighbourhood_names(world);
+    assert!(
+        names.iter().all(|value| value != &name),
+        "result unexpectedly included row for {name}; got {names:?}"
+    );
+}
+
+fn neighbourhood_names(world: &GraphForgeWorld) -> Vec<String> {
+    let mut names = Vec::new();
+    for batch in result_batches(world) {
+        let column = batch
+            .column_by_name("name")
+            .expect("neighbourhood result requires a name column");
+        let values = column
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .expect("Utf8 name column");
+        for index in 0..values.len() {
+            if !values.is_null(index) {
+                names.push(values.value(index).to_owned());
+            }
+        }
+    }
+    names
 }

--- a/crates/graphforge-bindings-node/lib/recipes.mjs
+++ b/crates/graphforge-bindings-node/lib/recipes.mjs
@@ -1,0 +1,51 @@
+/** Thin neighbourhood helper composing `forge.execute()`, mirroring Python recipes. */
+
+const IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function identifier(name, kind) {
+  if (typeof name !== "string" || !IDENTIFIER.test(name)) {
+    throw new TypeError(`${kind} must be a valid identifier, got ${JSON.stringify(name)}`);
+  }
+  return name;
+}
+
+function returnClause(canonicalProp) {
+  if (canonicalProp === "name") {
+    return "RETURN DISTINCT neighbour.name AS name, labels(neighbour) AS labels";
+  }
+  return (
+    `RETURN DISTINCT neighbour.${canonicalProp} AS ${canonicalProp}, ` +
+    "neighbour.name AS name, labels(neighbour) AS labels"
+  );
+}
+
+/**
+ * Return the n-hop neighbourhood of a seed node as an Arrow IPC Buffer.
+ *
+ * `hops === 0` returns a typed empty table with the same schema as a positive-hop
+ * result (no traversal).
+ */
+export function neighbourhood(
+  forge,
+  canonical,
+  hops = 2,
+  { label = "Entity", canonicalProp = "canonical" } = {},
+) {
+  label = identifier(label, "label");
+  canonicalProp = identifier(canonicalProp, "canonical_prop");
+  if (typeof hops !== "number" || !Number.isInteger(hops) || hops < 0) {
+    throw new TypeError(`hops must be an integer >= 0, got ${JSON.stringify(hops)}`);
+  }
+  if (hops === 0) {
+    return forge.execute(
+      `MATCH (neighbour:${label}) WHERE false ${returnClause(canonicalProp)}`,
+      { canonical },
+    );
+  }
+  const query =
+    `MATCH (seed:${label} {${canonicalProp}: $canonical})` +
+    `-[*1..${hops}]-(neighbour:${label}) ` +
+    `WHERE neighbour.${canonicalProp} <> $canonical ` +
+    returnClause(canonicalProp);
+  return forge.execute(query, { canonical });
+}

--- a/crates/graphforge-bindings-node/lib/recipes.mjs
+++ b/crates/graphforge-bindings-node/lib/recipes.mjs
@@ -4,7 +4,9 @@ const IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 function identifier(name, kind) {
   if (typeof name !== "string" || !IDENTIFIER.test(name)) {
-    throw new TypeError(`${kind} must be a valid identifier, got ${JSON.stringify(name)}`);
+    throw new TypeError(
+      `${kind} must be a valid identifier, got ${JSON.stringify(name)}`,
+    );
   }
   return name;
 }
@@ -34,7 +36,9 @@ export function neighbourhood(
   label = identifier(label, "label");
   canonicalProp = identifier(canonicalProp, "canonical_prop");
   if (typeof hops !== "number" || !Number.isInteger(hops) || hops < 0) {
-    throw new TypeError(`hops must be an integer >= 0, got ${JSON.stringify(hops)}`);
+    throw new TypeError(
+      `hops must be an integer >= 0, got ${JSON.stringify(hops)}`,
+    );
   }
   if (hops === 0) {
     return forge.execute(

--- a/crates/graphforge-bindings-node/tests/recipes.test.mjs
+++ b/crates/graphforge-bindings-node/tests/recipes.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { tableFromIPC } from "apache-arrow";
+
+import { neighbourhood } from "../lib/recipes.mjs";
+
+const { GraphForge } = await import("../index.js");
+
+test("neighbourhood returns distinct name rows without duplicate columns", () => {
+  const forge = new GraphForge();
+  const alice = forge.addNode("Person", { name: "Alice" });
+  const bob = forge.addNode("Person", { name: "Bob" });
+  const charlie = forge.addNode("Person", { name: "Charlie" });
+  forge.addEdge(alice, "KNOWS", bob);
+  forge.addEdge(bob, "KNOWS", charlie);
+
+  const table = tableFromIPC(
+    neighbourhood(forge, "Alice", 2, { label: "Person", canonicalProp: "name" }),
+  );
+  assert.deepEqual(
+    table.schema.fields.map((field) => field.name),
+    ["name", "labels"],
+  );
+  const names = [...(table.getChild("name")?.toArray() ?? [])].map(String).sort();
+  assert.deepEqual(names, ["Bob", "Charlie"]);
+});
+
+test("neighbourhood hops 0 returns typed empty Arrow table", () => {
+  const forge = new GraphForge();
+  forge.addNode("Person", { name: "Alice" });
+  const table = tableFromIPC(
+    neighbourhood(forge, "Alice", 0, { label: "Person", canonicalProp: "name" }),
+  );
+  assert.equal(table.numRows, 0);
+  assert.deepEqual(
+    table.schema.fields.map((field) => field.name),
+    ["name", "labels"],
+  );
+});

--- a/crates/graphforge-bindings-node/tests/recipes.test.mjs
+++ b/crates/graphforge-bindings-node/tests/recipes.test.mjs
@@ -15,13 +15,18 @@ test("neighbourhood returns distinct name rows without duplicate columns", () =>
   forge.addEdge(bob, "KNOWS", charlie);
 
   const table = tableFromIPC(
-    neighbourhood(forge, "Alice", 2, { label: "Person", canonicalProp: "name" }),
+    neighbourhood(forge, "Alice", 2, {
+      label: "Person",
+      canonicalProp: "name",
+    }),
   );
   assert.deepEqual(
     table.schema.fields.map((field) => field.name),
     ["name", "labels"],
   );
-  const names = [...(table.getChild("name")?.toArray() ?? [])].map(String).sort();
+  const names = [...(table.getChild("name")?.toArray() ?? [])]
+    .map(String)
+    .sort();
   assert.deepEqual(names, ["Bob", "Charlie"]);
 });
 
@@ -29,7 +34,10 @@ test("neighbourhood hops 0 returns typed empty Arrow table", () => {
   const forge = new GraphForge();
   forge.addNode("Person", { name: "Alice" });
   const table = tableFromIPC(
-    neighbourhood(forge, "Alice", 0, { label: "Person", canonicalProp: "name" }),
+    neighbourhood(forge, "Alice", 0, {
+      label: "Person",
+      canonicalProp: "name",
+    }),
   );
   assert.equal(table.numRows, 0);
   assert.deepEqual(

--- a/crates/graphforge-bindings-py/python/graphforge/recipes/__init__.py
+++ b/crates/graphforge-bindings-py/python/graphforge/recipes/__init__.py
@@ -28,6 +28,37 @@ def _identifier(name: str, kind: str) -> str:
     return name
 
 
+def _empty_neighbourhood_table(canonical_prop: str) -> pa.Table:
+    """Typed empty Arrow table matching the neighbourhood result schema."""
+    import pyarrow as pa
+
+    labels = pa.list_(pa.string())
+    if canonical_prop == "name":
+        schema = pa.schema([("name", pa.string()), ("labels", labels)])
+    else:
+        schema = pa.schema(
+            [
+                (canonical_prop, pa.string()),
+                ("name", pa.string()),
+                ("labels", labels),
+            ]
+        )
+    return pa.Table.from_pydict(
+        {field.name: [] for field in schema},
+        schema=schema,
+    )
+
+
+def _neighbourhood_return_clause(canonical_prop: str) -> str:
+    """Build RETURN columns without duplicating the canonical property as ``name``."""
+    if canonical_prop == "name":
+        return "RETURN DISTINCT neighbour.name AS name, labels(neighbour) AS labels"
+    return (
+        f"RETURN DISTINCT neighbour.{canonical_prop} AS {canonical_prop}, "
+        f"neighbour.name AS name, labels(neighbour) AS labels"
+    )
+
+
 def neighbourhood(
     forge: GraphForge,
     canonical: str,
@@ -36,16 +67,21 @@ def neighbourhood(
     label: str = "Entity",
     canonical_prop: str = "canonical",
 ) -> pa.Table:
-    """Return the n-hop neighbourhood of a seed node as a pyarrow.Table."""
+    """Return the n-hop neighbourhood of a seed node as a pyarrow.Table.
+
+    ``hops=0`` returns a typed empty table with the same schema as a positive-hop
+    result (no traversal). Negative hops and non-integers are rejected.
+    """
     label = _identifier(label, "label")
     canonical_prop = _identifier(canonical_prop, "canonical_prop")
-    if isinstance(hops, bool) or not isinstance(hops, int) or hops < 1:
-        raise ValueError(f"hops must be an integer >= 1, got {hops!r}")
+    if isinstance(hops, bool) or not isinstance(hops, int) or hops < 0:
+        raise ValueError(f"hops must be an integer >= 0, got {hops!r}")
+    if hops == 0:
+        return _empty_neighbourhood_table(canonical_prop)
     query = (
         f"MATCH (seed:{label} {{{canonical_prop}: $canonical}})"
         f"-[*1..{hops}]-(neighbour:{label}) "
         f"WHERE neighbour.{canonical_prop} <> $canonical "
-        f"RETURN DISTINCT neighbour.{canonical_prop} AS {canonical_prop}, "
-        f"neighbour.name AS name, labels(neighbour) AS labels"
+        f"{_neighbourhood_return_clause(canonical_prop)}"
     )
     return forge.execute(query, {"canonical": canonical})

--- a/tests/contracts/api-bdd-exclusions.json
+++ b/tests/contracts/api-bdd-exclusions.json
@@ -55,42 +55,6 @@
       "scenario": "bulk add_nodes with Arrow Table",
       "issue": 355,
       "languages": ["rust", "python", "node"]
-    },
-    {
-      "feature": "Recipes API",
-      "scenario": "neighbourhood returns an Arrow Table",
-      "issue": 356,
-      "languages": ["rust", "python", "node"]
-    },
-    {
-      "feature": "Recipes API",
-      "scenario": "neighbourhood with hops 1 returns only direct neighbours",
-      "issue": 356,
-      "languages": ["rust", "python", "node"]
-    },
-    {
-      "feature": "Recipes API",
-      "scenario": "neighbourhood with hops 2 reaches two-hop neighbours",
-      "issue": 356,
-      "languages": ["rust", "python", "node"]
-    },
-    {
-      "feature": "Recipes API",
-      "scenario": "neighbourhood on a node with no neighbours returns an empty Arrow Table",
-      "issue": 356,
-      "languages": ["rust", "python", "node"]
-    },
-    {
-      "feature": "Recipes API",
-      "scenario": "neighbourhood with non-existent canonical value returns empty Arrow Table",
-      "issue": 356,
-      "languages": ["rust", "python", "node"]
-    },
-    {
-      "feature": "Recipes API",
-      "scenario": "neighbourhood with hops 0 returns empty Arrow Table",
-      "issue": 356,
-      "languages": ["rust", "python", "node"]
     }
   ]
 }

--- a/tests/features/api/recipes.feature
+++ b/tests/features/api/recipes.feature
@@ -1,41 +1,35 @@
 @api @recipes
 Feature: Recipes API
 
-  @excluded-api-bdd @issue-356
   Scenario: neighbourhood returns an Arrow Table
     Given a graph with Person nodes connected by KNOWS edges up to 3 hops deep
     When I call neighbourhood for "Alice" with hops 2 in label "Person" using canonical property "name"
     Then the result is an Arrow Table
 
-  @excluded-api-bdd @issue-356
   Scenario: neighbourhood with hops 1 returns only direct neighbours
     Given a graph where Alice knows Bob and Bob knows Charlie but Alice does not know Charlie
     When I call neighbourhood for "Alice" with hops 1 in label "Person" using canonical property "name"
     Then the result contains a row for "Bob"
     And the result does not contain a row for "Charlie"
 
-  @excluded-api-bdd @issue-356
   Scenario: neighbourhood with hops 2 reaches two-hop neighbours
     Given a graph where Alice knows Bob and Bob knows Charlie but Alice does not know Charlie
     When I call neighbourhood for "Alice" with hops 2 in label "Person" using canonical property "name"
     Then the result contains a row for "Bob"
     And the result contains a row for "Charlie"
 
-  @excluded-api-bdd @issue-356
   Scenario: neighbourhood on a node with no neighbours returns an empty Arrow Table
     Given a graph with a single Person node named "Lone"
     When I call neighbourhood for "Lone" with hops 1 in label "Person" using canonical property "name"
     Then the result is an Arrow Table
     And the table has 0 rows
 
-  @excluded-api-bdd @issue-356
   Scenario: neighbourhood with non-existent canonical value returns empty Arrow Table
     Given a graph with Person nodes connected by KNOWS edges
     When I call neighbourhood for "NonExistent" with hops 2 in label "Person" using canonical property "name"
     Then the result is an Arrow Table
     And the table has 0 rows
 
-  @excluded-api-bdd @issue-356
   Scenario: neighbourhood with hops 0 returns empty Arrow Table
     Given a graph where Alice knows Bob
     When I call neighbourhood for "Alice" with hops 0 in label "Person" using canonical property "name"

--- a/tests/features/node/step_definitions/api_steps.ts
+++ b/tests/features/node/step_definitions/api_steps.ts
@@ -1096,6 +1096,25 @@ When(/^I analyze by "([^"]*)"$/, function (this: GraphForgeWorld, algorithm: str
   _catch(this, () => this.forge!.analyze(algorithm));
 });
 
+When(
+  /^I call neighbourhood for "([^"]*)" with hops (\d+) in label "([^"]*)" using canonical property "([^"]*)"$/,
+  function (
+    this: GraphForgeWorld,
+    canonical: string,
+    hopsStr: string,
+    label: string,
+    prop: string,
+  ) {
+    const { neighbourhood } = require("../../../../crates/graphforge-bindings-node/lib/recipes.mjs");
+    _catch(this, () =>
+      neighbourhood(this.forge!, canonical, parseInt(hopsStr, 10), {
+        label,
+        canonicalProp: prop,
+      }),
+    );
+  },
+);
+
 // ---------------------------------------------------------------------------
 // THEN steps
 // ---------------------------------------------------------------------------

--- a/tests/unit/recipes/test_neighbourhood.py
+++ b/tests/unit/recipes/test_neighbourhood.py
@@ -35,6 +35,19 @@ def test_neighbourhood_returns_arrow_table() -> None:
     assert table.num_rows >= 1
     assert "canonical" in table.column_names
     assert "name" in table.column_names
+    assert len(table.column_names) == len(set(table.column_names))
+
+
+def test_neighbourhood_name_canonical_prop_has_no_duplicate_columns() -> None:
+    forge = GraphForge()
+    forge.execute(
+        "CREATE (:Person {name: 'Alice'})-[:KNOWS]->(:Person {name: 'Bob'})"
+    )
+    table = neighbourhood(
+        forge, "Alice", hops=1, label="Person", canonical_prop="name"
+    )
+    assert table.column_names == ["name", "labels"]
+    assert table.column("name").to_pylist() == ["Bob"]
 
 
 def test_neighbourhood_hops_1_direct_only() -> None:
@@ -59,6 +72,13 @@ def test_neighbourhood_empty_for_isolated_node() -> None:
     assert table.num_rows == 0
 
 
+def test_neighbourhood_hops_0_returns_typed_empty_table() -> None:
+    forge = _person_graph()
+    table = neighbourhood(forge, "Alice", hops=0, label="Person")
+    assert table.num_rows == 0
+    assert table.column_names == ["canonical", "name", "labels"]
+
+
 def test_neighbourhood_rejects_invalid_label() -> None:
     forge = GraphForge()
     with pytest.raises(ValueError, match="label must be a valid identifier"):
@@ -71,9 +91,9 @@ def test_neighbourhood_rejects_invalid_canonical_prop() -> None:
         neighbourhood(forge, "Alice", label="Person", canonical_prop="name`")
 
 
-def test_neighbourhood_rejects_non_positive_hops() -> None:
+def test_neighbourhood_rejects_negative_and_bool_hops() -> None:
     forge = GraphForge()
-    with pytest.raises(ValueError, match="hops must be an integer >= 1"):
-        neighbourhood(forge, "Alice", hops=0, label="Person")
-    with pytest.raises(ValueError, match="hops must be an integer >= 1"):
+    with pytest.raises(ValueError, match="hops must be an integer >= 0"):
+        neighbourhood(forge, "Alice", hops=-1, label="Person")
+    with pytest.raises(ValueError, match="hops must be an integer >= 0"):
         neighbourhood(forge, "Alice", hops=True, label="Person")  # type: ignore[arg-type]

--- a/tests/unit/recipes/test_neighbourhood.py
+++ b/tests/unit/recipes/test_neighbourhood.py
@@ -40,12 +40,8 @@ def test_neighbourhood_returns_arrow_table() -> None:
 
 def test_neighbourhood_name_canonical_prop_has_no_duplicate_columns() -> None:
     forge = GraphForge()
-    forge.execute(
-        "CREATE (:Person {name: 'Alice'})-[:KNOWS]->(:Person {name: 'Bob'})"
-    )
-    table = neighbourhood(
-        forge, "Alice", hops=1, label="Person", canonical_prop="name"
-    )
+    forge.execute("CREATE (:Person {name: 'Alice'})-[:KNOWS]->(:Person {name: 'Bob'})")
+    table = neighbourhood(forge, "Alice", hops=1, label="Person", canonical_prop="name")
     assert table.column_names == ["name", "labels"]
     assert table.column("name").to_pylist() == ["Bob"]
 


### PR DESCRIPTION
## Summary
- Fix Python `neighbourhood` so `canonical_prop=\"name\"` no longer emits duplicate columns, and `hops=0` returns a typed empty Arrow table.
- Add a matching Node `lib/recipes.mjs` helper plus Rust/Node BDD steps and real Rust recipe fixtures.
- Remove the six `#356` rows from the fail-closed API BDD exclusions ledger.

Closes #356.

## Test plan
- [x] `pytest tests/unit/recipes/test_neighbourhood.py` and Python Recipes BDD
- [x] Node cucumber `recipes.feature` (6 passed)
- [x] `API_ONLY=neighbourhood cargo test -p graphforge-api --test bdd` (6 passed)
- [x] `node --test tests/recipes.test.mjs`
- [x] `python3 scripts/ci/api-bdd-policy.py`

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/412"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788559345&installation_model_id=20486&pr_number=412&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F412&signature=bfa0a223db71016a949be66e235aeb0c6d2f91a4ce62745522e0b222aba54522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix neighbourhood recipe to handle hops=0 and avoid duplicate columns in results
> - The `neighbourhood` recipe in the Python, Node, and API bindings now accepts `hops=0`, returning a typed empty Arrow table with the correct schema instead of raising an error.
> - A new `returnClause` helper (Python and Node) avoids duplicate columns when `canonical_prop` is `'name'`, returning `['name', 'labels']` instead of `['name', 'name', 'labels']`.
> - Identifier validation is added in both Node ([recipes.mjs](https://github.com/CurateLabs/graphforge/pull/412/files#diff-c3ff0036efb7d4f93a15e2866f7f1031f5db3fa78ddbf0037c0619ba8ffcdeb5)) and Rust BDD steps ([api_steps.rs](https://github.com/CurateLabs/graphforge/pull/412/files#diff-c9185be2d752dff4a7a8049611e8c1a1e636ecf4ad8eb61b754c15777aa34bcd)) to reject invalid Cypher label or property names before query construction.
> - Six previously excluded neighbourhood BDD scenarios in [recipes.feature](https://github.com/CurateLabs/graphforge/pull/412/files#diff-0824d6ee1303840fae83b90f7f8d1eaf773cb489e2cf6154fe6423d194e8b2b7) are now active, with supporting step definitions added for Node and Rust.
> - Behavioral Change: `hops=0` previously raised `ValueError`; it now returns an empty typed table.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 11cc05b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->