### PR TITLE
fix(bdd): bulk add_nodes operation_uuid readback (#355)

### DIFF
--- a/crates/graphforge-api/tests/bdd/api_steps.rs
+++ b/crates/graphforge-api/tests/bdd/api_steps.rs
@@ -1392,6 +1392,61 @@ async fn when_load_ontology(world: &mut GraphForgeWorld) {
     }
 }
 
+#[when(regex = r#"^I bulk add nodes with label "Person" and 2 records$"#)]
+async fn when_bulk_add_nodes_list(world: &mut GraphForgeWorld) {
+    publish_bulk_person_nodes(world, &["Alice", "Bob"]);
+}
+
+#[when(regex = r#"^I bulk add nodes with label "Person" from an Arrow Table of 5 rows$"#)]
+async fn when_bulk_add_nodes_arrow(world: &mut GraphForgeWorld) {
+    publish_bulk_person_nodes(world, &["A", "B", "C", "D", "E"]);
+}
+
+fn publish_bulk_person_nodes(world: &mut GraphForgeWorld, names: &[&str]) {
+    use arrow::array::{FixedSizeBinaryBuilder, StringArray};
+    use arrow::datatypes::{DataType, Field};
+    use std::sync::Arc;
+
+    let rows = names.len();
+    let mut node_ids = FixedSizeBinaryBuilder::with_capacity(rows, 16);
+    for _ in 0..rows {
+        node_ids.append_null();
+    }
+    let schema = graphforge_api::bulk_node_input_schema(vec![Field::new(
+        "name",
+        DataType::Utf8,
+        false,
+    )])
+    .expect("bulk node schema");
+    let batch = arrow::record_batch::RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(node_ids.finish()),
+            Arc::new(StringArray::from(vec!["Person"; rows])),
+            Arc::new(StringArray::from(
+                names.iter().map(|name| (*name).to_owned()).collect::<Vec<_>>(),
+            )),
+        ],
+    )
+    .expect("bulk node batch");
+    match world
+        .forge
+        .as_ref()
+        .expect("bulk node forge")
+        .publish_bulk_nodes(graphforge_api::OperationId(uuid::Uuid::now_v7()), &[batch])
+    {
+        Ok(receipt) => {
+            world.last_algorithm_result = Some(receipt);
+            world.last_error = None;
+            world.last_error_code = None;
+        }
+        Err(error) => {
+            world.last_algorithm_result = None;
+            world.last_error = Some(error.to_string());
+        }
+    }
+}
+
 #[when(
     regex = r#"^I bulk add edges with type "([^"]+)" using source column "([^"]+)" and destination column "([^"]+)"$"#
 )]

--- a/crates/graphforge-api/tests/bdd/api_steps.rs
+++ b/crates/graphforge-api/tests/bdd/api_steps.rs
@@ -1412,19 +1412,19 @@ fn publish_bulk_person_nodes(world: &mut GraphForgeWorld, names: &[&str]) {
     for _ in 0..rows {
         node_ids.append_null();
     }
-    let schema = graphforge_api::bulk_node_input_schema(vec![Field::new(
-        "name",
-        DataType::Utf8,
-        false,
-    )])
-    .expect("bulk node schema");
+    let schema =
+        graphforge_api::bulk_node_input_schema(vec![Field::new("name", DataType::Utf8, false)])
+            .expect("bulk node schema");
     let batch = arrow::record_batch::RecordBatch::try_new(
         schema,
         vec![
             Arc::new(node_ids.finish()),
             Arc::new(StringArray::from(vec!["Person"; rows])),
             Arc::new(StringArray::from(
-                names.iter().map(|name| (*name).to_owned()).collect::<Vec<_>>(),
+                names
+                    .iter()
+                    .map(|name| (*name).to_owned())
+                    .collect::<Vec<_>>(),
             )),
         ],
     )

--- a/tests/contracts/api-bdd-exclusions.json
+++ b/tests/contracts/api-bdd-exclusions.json
@@ -43,18 +43,6 @@
       "scenario": "explain does not execute the query",
       "issue": 354,
       "languages": ["rust", "python", "node"]
-    },
-    {
-      "feature": "Graph Construction API",
-      "scenario": "bulk add_nodes with a list of records",
-      "issue": 355,
-      "languages": ["rust", "python", "node"]
-    },
-    {
-      "feature": "Graph Construction API",
-      "scenario": "bulk add_nodes with Arrow Table",
-      "issue": 355,
-      "languages": ["rust", "python", "node"]
     }
   ]
 }

--- a/tests/features/api/construction.feature
+++ b/tests/features/api/construction.feature
@@ -23,13 +23,11 @@ Feature: Graph Construction API
     Then execute readback returns the NodeHandle UUID and name "Alice"
 
   @construction
-  @excluded-api-bdd @issue-355
   Scenario: bulk add_nodes with a list of records
     When I bulk add nodes with label "Person" and 2 records
     Then execute "MATCH (p:Person) RETURN p.name" returns 2 rows
 
   @construction
-  @excluded-api-bdd @issue-355
   Scenario: bulk add_nodes with Arrow Table
     When I bulk add nodes with label "Person" from an Arrow Table of 5 rows
     Then execute "MATCH (p:Person) RETURN p.name" returns 5 rows

--- a/tests/features/steps/api_steps.py
+++ b/tests/features/steps/api_steps.py
@@ -797,13 +797,17 @@ def when_add_edge_bad_dst(ctx):
 @when('I bulk add nodes with label "Person" and 2 records')
 def when_bulk_add_nodes_list(ctx):
     records = [{"name": "Alice"}, {"name": "Bob"}]
-    ctx.result, ctx.error = _catch(ctx.forge.add_nodes, "Person", records)
+    ctx.result, ctx.error = _catch(
+        ctx.forge.add_nodes, "Person", records, operation_uuid=_uuid7()
+    )
 
 
 @when('I bulk add nodes with label "Person" from an Arrow Table of 5 rows')
 def when_bulk_add_nodes_arrow(ctx):
     table = pa.table({"name": ["A", "B", "C", "D", "E"]})
-    ctx.result, ctx.error = _catch(ctx.forge.add_nodes, "Person", table)
+    ctx.result, ctx.error = _catch(
+        ctx.forge.add_nodes, "Person", table, operation_uuid=_uuid7()
+    )
 
 
 @when(

--- a/tests/features/steps/api_steps.py
+++ b/tests/features/steps/api_steps.py
@@ -797,17 +797,13 @@ def when_add_edge_bad_dst(ctx):
 @when('I bulk add nodes with label "Person" and 2 records')
 def when_bulk_add_nodes_list(ctx):
     records = [{"name": "Alice"}, {"name": "Bob"}]
-    ctx.result, ctx.error = _catch(
-        ctx.forge.add_nodes, "Person", records, operation_uuid=_uuid7()
-    )
+    ctx.result, ctx.error = _catch(ctx.forge.add_nodes, "Person", records, operation_uuid=_uuid7())
 
 
 @when('I bulk add nodes with label "Person" from an Arrow Table of 5 rows')
 def when_bulk_add_nodes_arrow(ctx):
     table = pa.table({"name": ["A", "B", "C", "D", "E"]})
-    ctx.result, ctx.error = _catch(
-        ctx.forge.add_nodes, "Person", table, operation_uuid=_uuid7()
-    )
+    ctx.result, ctx.error = _catch(ctx.forge.add_nodes, "Person", table, operation_uuid=_uuid7())
 
 
 @when(


### PR DESCRIPTION
## Summary
- Pass required `operation_uuid` into Python `add_nodes` BDD steps (list and Arrow inputs).
- Add Rust BDD steps that publish via `publish_bulk_nodes` with the same readback contract.
- Remove the two `#355` exclusions from the fail-closed API BDD ledger.

Closes #355.

## Test plan
- [x] Python BDD: `bulk_add_nodes` (2 passed)
- [x] Node cucumber `--name \"bulk add_nodes\"` (2 passed)
- [x] `API_ONLY='bulk add_nodes' cargo test -p graphforge-api --test bdd` (2 passed)
- [x] `python3 scripts/ci/api-bdd-policy.py`

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788559776&installation_model_id=20486&pr_number=413&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F413&signature=8538d7e2a6fd5c4e2d6a3fac0dc6655c6833af4576a7bd9d2523eaba5c000066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix bulk `add_nodes` operation UUID readback in BDD tests
> - Adds explicit `operation_uuid` argument (via `_uuid7()`) to `add_nodes` calls in the Python BDD steps for bulk node creation.
> - Adds Rust BDD step handlers and a `publish_bulk_person_nodes` helper that builds Arrow `RecordBatch` payloads and calls `publish_bulk_nodes` with a v7 UUID-based `OperationId`.
> - Removes exclusion entries for the two bulk `add_nodes` scenarios from [api-bdd-exclusions.json](https://github.com/CurateLabs/graphforge/pull/413/files#diff-0c0a4463cb04df8d80ed405eb1b57bbcd80a642abe625e354c2c57eae3adffa0) and drops `@excluded-api-bdd` tags from [construction.feature](https://github.com/CurateLabs/graphforge/pull/413/files#diff-c3fd5adf4251e231b37b31d1ecd4778ea6a6b9fe78e48da04ba91147c3c363de) so these scenarios now run across all runtimes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c28132.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled end-to-end coverage for bulk node insertion using both record-based and Arrow Table inputs.
  * Added test coverage for inserting batches of two or five person nodes.
  * Updated bulk insertion scenarios to include operation identifiers and verify resulting receipts or errors.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->