### PR TITLE
fix(explain): side-effect-free write planning (#354)

### DIFF
--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -2517,12 +2517,36 @@ impl GraphForge {
         // lower in the dir-backed physical stage, so the dir-less logical
         // renderer errors on them. Don't fail the whole EXPLAIN — the physical
         // section still shows the plan, including the inference rule_id (#605).
-        let logical = graphforge_rel::explain_logical_with_catalog(
-            &plan,
-            Some(&catalog),
-            self.ontology.as_ref(),
-        )
-        .unwrap_or_else(|e| format!("(logical plan unavailable: {e})"));
+        // Write terminals need `new_for_writes` so CREATE/MERGE/DELETE/SET/
+        // REMOVE render instead of failing as "requires a write target".
+        let logical = {
+            let needs_writes = plan.ops.iter().any(|op| {
+                matches!(
+                    op,
+                    GraphOp::Create { .. }
+                        | GraphOp::Merge { .. }
+                        | GraphOp::Delete { .. }
+                        | GraphOp::Set { .. }
+                        | GraphOp::Remove { .. }
+                )
+            });
+            let explained = if needs_writes {
+                graphforge_rel::explain_logical_for_writes(
+                    &plan,
+                    Some(&catalog),
+                    self.ontology.as_ref(),
+                    &self.dir,
+                    self.ontology_mode,
+                )
+            } else {
+                graphforge_rel::explain_logical_with_catalog(
+                    &plan,
+                    Some(&catalog),
+                    self.ontology.as_ref(),
+                )
+            };
+            explained.unwrap_or_else(|e| format!("(logical plan unavailable: {e})"))
+        };
 
         let session = graphforge_exec::ExecutionSession::new_with_target_and_provider(
             catalog,

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -466,6 +466,25 @@ fn plan_reads_persisted_data(plan: &GraphPlan) -> bool {
     })
 }
 
+/// True when `plan` contains a write terminal that must lower via
+/// [`GraphPlanLowerer::new_for_writes`].
+fn plan_requires_writes(plan: &GraphPlan) -> bool {
+    use graphforge_ir::GraphOp;
+    plan.ops.iter().any(|op| match op {
+        GraphOp::Create { .. }
+        | GraphOp::Merge { .. }
+        | GraphOp::Delete { .. }
+        | GraphOp::Set { .. }
+        | GraphOp::Remove { .. } => true,
+        GraphOp::Optional { child }
+        | GraphOp::Exists { child, .. }
+        | GraphOp::PatternComprehension { child, .. }
+        | GraphOp::ListElementPatternComprehension { child, .. } => plan_requires_writes(child),
+        GraphOp::Union { inputs, .. } => inputs.iter().any(plan_requires_writes),
+        _ => false,
+    })
+}
+
 // ---------------------------------------------------------------------------
 // GraphCreateExec — physical node for CREATE
 // ---------------------------------------------------------------------------
@@ -5048,8 +5067,13 @@ impl ExecutionSession {
             .map_err(|e| GfError::Execution(e.to_string()))
     }
 
-    /// Render the physical plan for a read [`GraphPlan`] (indented, one line
-    /// per node) without executing it.
+    /// Render the physical plan for a [`GraphPlan`] (indented, one line per
+    /// node) without executing it.
+    ///
+    /// Write plans (`CREATE` / `MERGE` / `DELETE` / `SET` / `REMOVE`) lower via
+    /// [`GraphPlanLowerer::new_for_writes`] and stop after
+    /// `create_physical_plan` — never `collect` — so EXPLAIN shows the write
+    /// path without publishing mutations. Read plans reuse [`Self::plan_physical`].
     ///
     /// This is the physical-plan inspection surface: node lines carry
     /// execution detail the logical stages cannot show, such as
@@ -5058,6 +5082,31 @@ impl ExecutionSession {
     /// # Errors
     /// Returns [`GfError`] if lowering or physical planning fails.
     pub async fn explain_physical(&self, plan: &GraphPlan) -> Result<String, GfError> {
+        if plan_requires_writes(plan) {
+            if self.dir.as_os_str().is_empty() {
+                return Err(GfError::Execution(
+                    "explain of a write plan requires a write target; \
+                     build the session with new_with_target"
+                        .into(),
+                ));
+            }
+            let lowerer = GraphPlanLowerer::new_for_writes(
+                Some(&self.catalog),
+                self.ontology.as_ref(),
+                &self.dir,
+                self.mode,
+            );
+            let logical = lowerer.lower_plan(plan)?;
+            let physical = self
+                .ctx
+                .state()
+                .create_physical_plan(&logical)
+                .await
+                .map_err(|e| GfError::Plan(e.to_string()))?;
+            return Ok(datafusion::physical_plan::displayable(physical.as_ref())
+                .indent(false)
+                .to_string());
+        }
         let (physical, _) = self.plan_physical(plan, &HashMap::new()).await?;
         Ok(datafusion::physical_plan::displayable(physical.as_ref())
             .indent(false)

--- a/crates/graphforge-rel/src/lib.rs
+++ b/crates/graphforge-rel/src/lib.rs
@@ -115,3 +115,23 @@ pub fn explain_logical_with_catalog(
     let final_plan = ctx.state().optimize(&lowered).unwrap_or(lowered);
     Ok(final_plan.display_indent_schema().to_string())
 }
+
+/// Like [`explain_logical_with_catalog`] but lowers write terminals through
+/// [`GraphPlanLowerer::new_for_writes`] so EXPLAIN can render `CREATE` / `MERGE`
+/// / `DELETE` / `SET` / `REMOVE` without executing them.
+///
+/// # Errors
+///
+/// Returns [`GfError`] if the plan cannot be lowered.
+pub fn explain_logical_for_writes(
+    plan: &GraphPlan,
+    catalog: Option<&graphforge_storage::GraphCatalog>,
+    ontology: Option<&OntologyHandle>,
+    dir: &std::path::Path,
+    mode: graphforge_core::OntologyMode,
+) -> Result<String, GfError> {
+    let lowered = GraphPlanLowerer::new_for_writes(catalog, ontology, dir, mode).lower_plan(plan)?;
+    let ctx = datafusion::prelude::SessionContext::new();
+    let final_plan = ctx.state().optimize(&lowered).unwrap_or(lowered);
+    Ok(final_plan.display_indent_schema().to_string())
+}

--- a/crates/graphforge-rel/src/lib.rs
+++ b/crates/graphforge-rel/src/lib.rs
@@ -130,7 +130,8 @@ pub fn explain_logical_for_writes(
     dir: &std::path::Path,
     mode: graphforge_core::OntologyMode,
 ) -> Result<String, GfError> {
-    let lowered = GraphPlanLowerer::new_for_writes(catalog, ontology, dir, mode).lower_plan(plan)?;
+    let lowered =
+        GraphPlanLowerer::new_for_writes(catalog, ontology, dir, mode).lower_plan(plan)?;
     let ctx = datafusion::prelude::SessionContext::new();
     let final_plan = ctx.state().optimize(&lowered).unwrap_or(lowered);
     Ok(final_plan.display_indent_schema().to_string())

--- a/tests/contracts/api-bdd-exclusions.json
+++ b/tests/contracts/api-bdd-exclusions.json
@@ -37,12 +37,6 @@
       "scenario": "ExecutionError when a query references an unbound parameter",
       "issue": 353,
       "languages": ["rust", "python", "node"]
-    },
-    {
-      "feature": "Explain API",
-      "scenario": "explain does not execute the query",
-      "issue": 354,
-      "languages": ["rust", "python", "node"]
     }
   ]
 }

--- a/tests/features/api/explain.feature
+++ b/tests/features/api/explain.feature
@@ -12,7 +12,6 @@ Feature: Explain API
     Then the result contains "AST"
     And the result contains "GraphIR"
 
-  @excluded-api-bdd @issue-354
   Scenario: explain does not execute the query
     Given an empty graph
     When I call explain on "CREATE (:Person {name: 'Ghost'})"


### PR DESCRIPTION
## Summary
- `explain_physical` lowers write terminals via `GraphPlanLowerer::new_for_writes` and stops after `create_physical_plan` (no collect/publish).
- Logical EXPLAIN uses the matching write lowerer so CREATE no longer surfaces as \"requires a write target\".
- Remove the `#354` exclusion from the fail-closed API BDD ledger.

Closes #354.

## Test plan
- [x] `API_ONLY='explain does not execute' cargo test -p graphforge-api --test bdd`
- [x] Python BDD `explain_does_not_execute`
- [x] Node cucumber `--name \"explain does not execute\"`
- [x] `python3 scripts/ci/api-bdd-policy.py`

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788560759&installation_model_id=20486&pr_number=414&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F414&signature=3c3f10a64cfbda528a3882a2358805d1f371ad3799f0ef368ff251a2a35f3cee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix EXPLAIN for write queries to plan without executing mutations
> - Adds `explain_logical_for_writes` in [`crates/graphforge-rel/src/lib.rs`](https://github.com/CurateLabs/graphforge/pull/414/files#diff-4a9512210877fca1d5d0a145f0a6fe554b9087d4282be047ca4e91877c65c5f2) that lowers write plans (CREATE/MERGE/DELETE/SET/REMOVE) via `GraphPlanLowerer::new_for_writes` without executing them.
> - Updates `GraphForge.explain` in [`crates/graphforge-api/src/lib.rs`](https://github.com/CurateLabs/graphforge/pull/414/files#diff-976dbde8422857ff05859bd8c109a35cf2362a405a454253560568397dc4653b) to detect write ops and route to the new write-aware lowering path instead of the read-only path that previously failed with 'requires a write target'.
> - Updates `ExecutionSession.explain_physical` in [`crates/graphforge-exec/src/lib.rs`](https://github.com/CurateLabs/graphforge/pull/414/files#diff-c05ac8a70576f84c03650969ae57baef92f141cc398d6805778282ea615be398) to build a physical plan for write queries using `GraphPlanLowerer::new_for_writes` without collecting or executing mutations.
> - Re-enables the previously excluded BDD scenario 'explain does not execute the query' in [`tests/features/api/explain.feature`](https://github.com/CurateLabs/graphforge/pull/414/files#diff-aee55a30771ed32697a7d1e1b7588911509f5d48e77d5b96e2bda2338451f705).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f8d6ee5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->