### PR TITLE
fix(errors): align parse/execution error taxonomy (#353)

### DIFF
--- a/crates/graphforge-api/examples/cyber_intrusion_workflow.rs
+++ b/crates/graphforge-api/examples/cyber_intrusion_workflow.rs
@@ -447,7 +447,7 @@ fn main() {
         .unwrap()
         .value(0);
     let unknown = graph.add_node("UnknownAsset", &HashMap::new()).unwrap_err();
-    assert_eq!(unknown.code(), "GF_PLAN");
+    assert_eq!(unknown.code(), "GF_PARSE");
     let invalid_property = graph
         .add_node(
             "Host",

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -730,8 +730,11 @@ impl GraphForge {
 
         validate_call_params(&plan, params)?;
 
-        let result = self.run_plan(&plan, params)?;
+        let result = self
+            .run_plan(&plan, params)
+            .map_err(publicize_query_error)?;
         shape_result(result, self.ontology_mode, self.ontology.as_ref())
+            .map_err(publicize_query_error)
     }
 
     /// Build a session reflecting the current runtime catalog and run `plan`,
@@ -2777,6 +2780,30 @@ fn row_count_param_value(
             "missing query parameter `${name}` for {keyword}"
         ))),
     }
+}
+
+/// Remap planner-surface failures that the public API classifies as execution
+/// errors: unbound query parameters and arithmetic/type coercion mismatches.
+fn publicize_query_error(err: GfError) -> GfError {
+    match err {
+        GfError::Plan(msg) if is_public_execution_plan_failure(&msg) => {
+            let msg = msg
+                .strip_prefix("Execution error: ")
+                .unwrap_or(&msg)
+                .to_owned();
+            GfError::Execution(msg)
+        }
+        other => other,
+    }
+}
+
+fn is_public_execution_plan_failure(msg: &str) -> bool {
+    msg.contains("Placeholder '")
+        || msg.contains("Placeholder \"$")
+        || msg.contains("placeholder with name $")
+        || msg.contains("No value found for placeholder")
+        || msg.contains("was not provided a value for execution")
+        || msg.contains("Cannot coerce")
 }
 
 /// Collapse a binder's `Vec<BindError>` into a span-rich [`GfError::Bind`]

--- a/crates/graphforge-api/tests/bdd/api_steps.rs
+++ b/crates/graphforge-api/tests/bdd/api_steps.rs
@@ -390,12 +390,22 @@ async fn given_named_person_pair(world: &mut GraphForgeWorld, first: String, sec
     }
 }
 
-#[given(
-    regex = r#"^a graph with a Person node named "([^"]+)" with age stored as a string "([^"]+)"$"#
-)]
-async fn given_person_string_age(world: &mut GraphForgeWorld, _name: String, _age: String) {
-    world.forge =
-        Some(graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed"));
+#[given(regex = r#"^a graph with a Person node with age stored as a string "([^"]+)"$"#)]
+async fn given_person_string_age(world: &mut GraphForgeWorld, age: String) {
+    let forge = graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed");
+    let props = std::collections::HashMap::from([
+        (
+            "name".to_owned(),
+            graphforge_api::PropValue::Str("Alice".into()),
+        ),
+        ("age".to_owned(), graphforge_api::PropValue::Str(age)),
+    ]);
+    let handle = forge
+        .add_node("Person", &props)
+        .expect("Person string-age fixture");
+    world.nodes.clear();
+    world.nodes.insert("Alice".into(), handle);
+    world.forge = Some(forge);
 }
 
 #[given(regex = r#"^a graph with a Person node named "([^"]+)" with age (\d+)$"#)]
@@ -667,6 +677,23 @@ async fn when_execute_param(world: &mut GraphForgeWorld, query: String, _value: 
         match forge.execute_with_params(&query, &params) {
             Ok(r) => world.last_exec = Some(r),
             Err(e) => world.last_error = Some(e.to_string()),
+        }
+    }
+}
+
+#[when(regex = r#"^I execute "([^"]*)" without parameters$"#)]
+async fn when_execute_without_params(world: &mut GraphForgeWorld, query: String) {
+    if let Some(forge) = &world.forge {
+        match forge.execute_with_params(&query, &std::collections::HashMap::new()) {
+            Ok(r) => {
+                world.last_exec = Some(r);
+                world.last_error = None;
+                world.last_error_code = None;
+            }
+            Err(error) => {
+                world.last_error_code = Some(error.code());
+                world.last_error = Some(error.to_string());
+            }
         }
     }
 }

--- a/crates/graphforge-bindings-node/src/error.rs
+++ b/crates/graphforge-bindings-node/src/error.rs
@@ -2,12 +2,11 @@
 //!
 //! napi-rs cannot export JS `Error` subclasses, so the fault domain is carried
 //! on `err.code` (the napi error `status` string becomes the JS `error.code`).
-//! `ParseError` and `Bind` (a binder failure, surfaced as `PlanError`)
-//! additionally encode their source span as a leading `[span:<start>:<len>]`
-//! token in the message — mirroring the Python binding's `(offset, length)`
-//! tuple on the exception's `span` (`crates/graphforge-bindings-py`'s `to_pyerr`). The
-//! eight codes line up 1:1 with the Python exception hierarchy (`Bind` shares
-//! the `PlanError` domain).
+//! `ParseError` and `Bind` (binder failures) additionally encode their source
+//! span as a leading `[span:<start>:<len>]` token in the message — mirroring
+//! the Python binding's `(offset, length)` tuple on the exception's `span`
+//! (`crates/graphforge-bindings-py`'s `to_pyerr`). Binder failures share the
+//! public `ParseError` / `GF_PARSE` domain with lexer/grammar parse failures.
 
 use graphforge_api::GfError;
 use napi::Env;
@@ -30,8 +29,8 @@ pub fn type_error(env: Env, message: impl Into<String>) -> NodeError {
 /// The JS `error.code` for each [`GfError`] fault domain.
 fn error_code(err: &GfError) -> &'static str {
     match err {
-        GfError::Parse { .. } => "ParseError",
-        GfError::Bind { .. } | GfError::Plan(_) => "PlanError",
+        GfError::Parse { .. } | GfError::Bind { .. } => "ParseError",
+        GfError::Plan(_) => "PlanError",
         GfError::Execution(_) | GfError::Provider { .. } => "ExecutionError",
         GfError::Storage(_) => "GF_IO",
         GfError::Project { code, .. } => code.as_str(),
@@ -241,13 +240,13 @@ mod tests {
     }
 
     #[test]
-    fn bind_error_shares_plan_domain_and_encodes_span() {
+    fn bind_error_shares_parse_domain_and_encodes_span() {
         let mapped = to_napi_err(&GfError::Bind {
             msg: "bind error: variable not in scope".into(),
             span: Span { start: 7, end: 8 },
         });
-        // Bind shares the PlanError fault domain but carries a span like Parse.
-        assert_eq!(mapped.status, "PlanError");
+        // Bind shares the ParseError fault domain and carries a span like Parse.
+        assert_eq!(mapped.status, "ParseError");
         assert_eq!(
             mapped.reason,
             "[span:7:1] bind error: variable not in scope"

--- a/crates/graphforge-bindings-py/src/lib.rs
+++ b/crates/graphforge-bindings-py/src/lib.rs
@@ -96,22 +96,13 @@ create_exception!(
 );
 
 /// Convert a [`GfError`] into the matching Python exception. `ParseError` and
-/// binder failures (`PlanError`, from [`GfError::Bind`]) carry a `span`
-/// attribute — the `(offset, length)` of the offending token, per the shim's
-/// `ParseError` contract.
+/// binder failures ([`GfError::Bind`]) carry a `span` attribute — the
+/// `(offset, length)` of the offending token, per the shim's `ParseError`
+/// contract. Binder failures share the public `ParseError` / `GF_PARSE` domain.
 pub(crate) fn to_pyerr(py: Python<'_>, err: &GfError) -> PyErr {
     let error = match err {
-        GfError::Parse { msg, span } => {
+        GfError::Parse { msg, span } | GfError::Bind { msg, span } => {
             let e = PyErr::new::<ParseError, _>(msg.clone());
-            let _ = e
-                .value(py)
-                .setattr("span", (span.start, span.end.saturating_sub(span.start)));
-            e
-        }
-        GfError::Bind { msg, span } => {
-            // Binder failures share the `PlanError` domain but carry a span,
-            // surfaced like `ParseError.span` (#606).
-            let e = PyErr::new::<PlanError, _>(msg.clone());
             let _ = e
                 .value(py)
                 .setattr("span", (span.start, span.end.saturating_sub(span.start)));

--- a/crates/graphforge-bindings-py/tests/non_cypher_release.py
+++ b/crates/graphforge-bindings-py/tests/non_cypher_release.py
@@ -341,7 +341,7 @@ def check_stable_error_code_matrix() -> None:
     parse = _expect_code(g.ParseError, "GF_PARSE", lambda: forge.execute("MATCH ("))
     assert parse.span == (7, 0)
     assert isinstance(parse, g.GraphForgeError)
-    _expect_code(g.PlanError, "GF_PLAN", lambda: forge.execute("RETURN absent"))
+    _expect_code(g.ParseError, "GF_PARSE", lambda: forge.execute("RETURN absent"))
     forge.execute("CREATE (:Vertex)-[:LINK]->(:Vertex)")
     _expect_code(
         g.ExecutionError,

--- a/crates/graphforge-core/src/lib.rs
+++ b/crates/graphforge-core/src/lib.rs
@@ -116,9 +116,10 @@ pub enum GfError {
 
     /// The binder rejected the query (e.g. undeclared variable, strict-mode
     /// unknown label). Carries the source span of the *first* error so callers
-    /// can point at the offending token; `msg` lists every binder error. Shares
-    /// the `PlanError` fault domain with [`GfError::Plan`] in the binding layers
-    /// — it is the span-rich sibling for binder-phase failures.
+    /// can point at the offending token; `msg` lists every binder error.
+    ///
+    /// Publicly classified with [`GfError::Parse`] as `GF_PARSE` / `ParseError`
+    /// — semantic query-structure failures share the parse fault domain.
     #[error("bind error at {span}: {msg}")]
     Bind {
         /// Human-readable description (all binder errors, joined with `; `).
@@ -187,8 +188,8 @@ impl GfError {
     pub const fn code(&self) -> &'static str {
         match self {
             Self::NotImplemented(_) => "GF_NOT_IMPLEMENTED",
-            Self::Parse { .. } => "GF_PARSE",
-            Self::Bind { .. } | Self::Plan(_) => "GF_PLAN",
+            Self::Parse { .. } | Self::Bind { .. } => "GF_PARSE",
+            Self::Plan(_) => "GF_PLAN",
             Self::Execution(_) | Self::Provider { .. } => "GF_EXECUTION",
             Self::Storage(_) => "GF_IO",
             Self::Project { code, .. } => code.as_str(),
@@ -912,7 +913,7 @@ mod tests {
                     msg: "x".into(),
                     span,
                 },
-                "GF_PLAN",
+                "GF_PARSE",
             ),
             (GfError::Plan("x".into()), "GF_PLAN"),
             (GfError::Execution("x".into()), "GF_EXECUTION"),

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -5228,9 +5228,10 @@ fn bind_query_params(
     logical: LogicalPlan,
     params: &HashMap<String, graphforge_ir::IrLiteral>,
 ) -> Result<LogicalPlan, GfError> {
-    if params.is_empty() {
-        return Ok(logical);
-    }
+    // Always apply param substitution — including an empty map — so unbound
+    // `$name` placeholders fail at plan time instead of depending on whether
+    // the optimizer happens to evaluate the expression (empty-graph scans can
+    // otherwise skip the placeholder and silently return zero rows).
     let values: HashMap<String, datafusion::scalar::ScalarValue> = params
         .iter()
         .map(|(name, lit)| (name.clone(), graphforge_rel::ir_literal_to_scalar(lit)))

--- a/scripts/ci/test-api-bdd-policy.py
+++ b/scripts/ci/test-api-bdd-policy.py
@@ -50,7 +50,46 @@ class ApiBddPolicyMutationTests(unittest.TestCase):
         _, errors = POLICY.validate(self.root)
         self.assertTrue(any(expected in error for error in errors), errors)
 
+    def seed_product_exclusion(
+        self,
+        *,
+        feature: str = "Error Handling",
+        scenario: str = "ParseError is raised on invalid Cypher syntax",
+        issue: int = 353,
+    ) -> dict:
+        """Install one valid product exclusion so mutations have a row to edit.
+
+        The live inventory may be empty once every exclusion is cleared; mutation
+        tests still need a representative row.
+        """
+        feature_path = self.root / "tests/features/api/errors.feature"
+        text = feature_path.read_text()
+        needle = f"  Scenario: {scenario}"
+        self.assertIn(needle, text)
+        feature_path.write_text(
+            text.replace(
+                needle,
+                f"  @excluded-api-bdd @issue-{issue}\n{needle}",
+                1,
+            )
+        )
+        inventory_path = self.root / "tests/contracts/api-bdd-exclusions.json"
+        inventory = json.loads(inventory_path.read_text())
+        inventory["exclusions"] = [
+            {
+                "feature": feature,
+                "scenario": scenario,
+                "issue": issue,
+                "languages": ["rust", "python", "node"],
+            }
+        ]
+        inventory_path.write_text(json.dumps(inventory))
+        _, errors = POLICY.validate(self.root)
+        self.assertEqual(errors, [])
+        return inventory
+
     def test_inventory_entry_cannot_be_removed(self) -> None:
+        self.seed_product_exclusion()
         path = self.root / "tests/contracts/api-bdd-exclusions.json"
         inventory = json.loads(path.read_text())
         inventory["exclusions"].pop()
@@ -70,6 +109,7 @@ class ApiBddPolicyMutationTests(unittest.TestCase):
         self.assert_rejected("must be an object")
 
     def test_null_inventory_languages_are_rejected_cleanly(self) -> None:
+        self.seed_product_exclusion()
         path = self.root / "tests/contracts/api-bdd-exclusions.json"
         inventory = json.loads(path.read_text())
         inventory["exclusions"][0]["languages"] = None
@@ -77,6 +117,7 @@ class ApiBddPolicyMutationTests(unittest.TestCase):
         self.assert_rejected("invalid languages []")
 
     def test_issue_tag_must_match_inventory(self) -> None:
+        self.seed_product_exclusion(issue=353)
         path = self.root / "tests/features/api/errors.feature"
         path.write_text(path.read_text().replace("@issue-353", "@issue-999", 1))
         self.assert_rejected("missing @issue-353")

--- a/tests/contracts/api-bdd-exclusions.json
+++ b/tests/contracts/api-bdd-exclusions.json
@@ -1,42 +1,5 @@
 {
   "version": 1,
   "tag": "excluded-api-bdd",
-  "exclusions": [
-    {
-      "feature": "Error Handling",
-      "scenario": "ExecutionError is raised on type mismatch",
-      "issue": 353,
-      "languages": ["rust", "python", "node"]
-    },
-    {
-      "feature": "Error Handling",
-      "scenario": "ParseError on undefined variable in RETURN",
-      "issue": 353,
-      "languages": ["rust", "python", "node"]
-    },
-    {
-      "feature": "Error Handling",
-      "scenario": "ParseError on aggregation used in WHERE clause",
-      "issue": 353,
-      "languages": ["rust", "python", "node"]
-    },
-    {
-      "feature": "Error Handling",
-      "scenario": "ParseError on CREATE with undirected relationship",
-      "issue": 353,
-      "languages": ["rust", "python", "node"]
-    },
-    {
-      "feature": "Error Handling",
-      "scenario": "ParseError on duplicate alias in WITH clause",
-      "issue": 353,
-      "languages": ["rust", "python", "node"]
-    },
-    {
-      "feature": "Error Handling",
-      "scenario": "ExecutionError when a query references an unbound parameter",
-      "issue": 353,
-      "languages": ["rust", "python", "node"]
-    }
-  ]
+  "exclusions": []
 }

--- a/tests/features/api/errors.feature
+++ b/tests/features/api/errors.feature
@@ -13,7 +13,6 @@ Feature: Error Handling
     Then a ParseError is raised
 
 
-  @excluded-api-bdd @issue-353
   Scenario: ExecutionError is raised on type mismatch
     Given a graph with a Person node with age stored as a string "not-a-number"
     When I execute "MATCH (p:Person) RETURN p.age + 1 AS result"
@@ -26,21 +25,18 @@ Feature: Error Handling
     Then a StorageError is raised
 
 
-  @excluded-api-bdd @issue-353
   Scenario: ParseError on undefined variable in RETURN
     Given an empty graph
     When I execute "MATCH (n:Person) RETURN x.name AS name"
     Then a ParseError is raised
 
 
-  @excluded-api-bdd @issue-353
   Scenario: ParseError on aggregation used in WHERE clause
     Given a graph with 3 Person nodes
     When I execute "MATCH (n:Person) WHERE count(n) > 1 RETURN n"
     Then a ParseError is raised
 
 
-  @excluded-api-bdd @issue-353
   Scenario: ParseError on CREATE with undirected relationship
     Given an empty graph
     When I execute "CREATE (a:Person)-[:KNOWS]-(b:Person)"
@@ -52,7 +48,6 @@ Feature: Error Handling
     Then a ParseError is raised
 
 
-  @excluded-api-bdd @issue-353
   Scenario: ParseError on duplicate alias in WITH clause
     Given a graph with a Person node named "Alice"
     When I execute "MATCH (n:Person) WITH n.name AS x, n.name AS x RETURN x"
@@ -65,7 +60,6 @@ Feature: Error Handling
     Then an ExecutionError is raised
 
 
-  @excluded-api-bdd @issue-353
   Scenario: ExecutionError when a query references an unbound parameter
     Given an empty graph
     When I execute "MATCH (p:Person) WHERE p.name = $name RETURN p" without parameters

--- a/tests/unit/api/test_api_v05.py
+++ b/tests/unit/api/test_api_v05.py
@@ -183,12 +183,13 @@ class TestExecute:
         assert isinstance(err.span, tuple) and len(err.span) == 2
 
     def test_bind_error_has_span(self) -> None:
-        # A binder failure (undeclared variable) surfaces as PlanError but, like
-        # ParseError, carries a (offset, length) span pinpointing the token (#606).
-        with pytest.raises(g.PlanError) as excinfo:
+        # A binder failure (undeclared variable) surfaces as ParseError with a
+        # (offset, length) span pinpointing the token (#353 / #606).
+        with pytest.raises(g.ParseError) as excinfo:
             GraphForge().execute("RETURN missingVar")
         err = excinfo.value
         assert isinstance(err, g.GraphForgeError)
+        assert err.code == "GF_PARSE"
         assert isinstance(err.span, tuple) and len(err.span) == 2
         offset, length = err.span
         assert "RETURN missingVar"[offset : offset + length] == "missingVar"


### PR DESCRIPTION
## Summary
- Classify [`GfError::Bind`] as public `GF_PARSE` / `ParseError` (with spans) in Rust codes and Python/Node bindings.
- Remap unbound-parameter and type-coercion `GfError::Plan` failures to `ExecutionError` at the query facade.
- Always apply DataFusion param substitution so empty-graph unbound `$name` fails at plan time.
- Remove the six `#353` exclusions from the fail-closed API BDD ledger.

**Note:** Callers that previously treated binder failures as `PlanError` / `GF_PLAN` should expect `ParseError` / `GF_PARSE` (intentional per AC).

Closes #353.

## Test plan
- [x] Python BDD for the six formerly excluded Error Handling scenarios
- [x] Node cucumber `errors.feature` (12 passed)
- [x] Rust `API_ONLY` runs for each #353 scenario
- [x] `python3 scripts/ci/api-bdd-policy.py`

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788562851&installation_model_id=20486&pr_number=415&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F415&signature=2904aa6e86919cb825cbd0a40d95382319bc98f239ecdcc75ca7a8e9f39e16d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reclassify binder failures as `GF_PARSE` and surface execution plan errors as `GF_EXECUTION`
> - `GfError::Bind` now maps to `GF_PARSE`/`ParseError` across all bindings (core, Node.js, Python) instead of `GF_PLAN`, aligning binder errors with the parse error domain.
> - `execute_with_params` now reclassifies certain `GfError::Plan` messages (unbound placeholders, coercion failures) into `GfError::Execution` via a new `publicize_query_error` helper.
> - `bind_query_params` no longer short-circuits on empty params, so queries with unbound placeholders always fail at plan time rather than silently passing.
> - Six previously excluded BDD scenarios in [errors.feature](https://github.com/CurateLabs/graphforge/pull/415/files#diff-0fb314db9279ebec6f7eab4aaccd5bec2cbe236b72659d6ea2e4fd47cdf2ae19) are now re-enabled following these taxonomy fixes.
> - Behavioral Change: any code inspecting `GF_PLAN` for binder or unbound-parameter errors must now handle `GF_PARSE` or `GF_EXECUTION` respectively.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c09f834.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Missing parameters and invalid type or value coercions now return consistent execution errors instead of being silently skipped or misclassified.
  * Unbound query parameters are reliably detected, including when no parameter values are supplied.
  * Binding errors now use the standard parse-error format across Rust, Python, and Node.js APIs.
  * Error responses continue to include structured error codes and source-span information for easier diagnosis.

* **Tests**
  * Expanded coverage for parameterless queries, binding errors, and API error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->