### PR TITLE
fix(search): align find empty and vector-query contracts (#352)

### DIFF
--- a/crates/graphforge-api/src/search_find.rs
+++ b/crates/graphforge-api/src/search_find.rs
@@ -1,11 +1,14 @@
-//! Public graph-native text and complete-generation vector retrieval.
+//! Public graph-native text, index-store vector, and complete-generation retrieval.
 
 use graphforge_search::{
     EmbeddingGenerationQuery, EmbeddingVectorQuery, FindSearchLimits, FindSearchRequest,
-    FusedSearchHit, MatchedOn, SearchChannelHit, VectorLifecycleLimits, reciprocal_rank_fusion,
-    search_embedding_generation, search_graph_native,
+    FusedSearchHit, MatchedOn, SearchChannelHit, VectorIndexRequest, VectorLifecycleLimits,
+    reciprocal_rank_fusion, search_embedding_generation, search_graph_native, search_graph_vectors,
 };
-use graphforge_storage::{SearchArtifactError, generation::read_search_generation};
+use graphforge_storage::{
+    SearchArtifactError, SearchArtifactKey, VectorSearchHit, current_search_artifact,
+    generation::read_search_generation,
+};
 
 use super::search_output::shape_search_output;
 use super::{FindOptions, GfError, GraphForge};
@@ -16,15 +19,15 @@ enum VectorQuery {
 }
 
 impl GraphForge {
-    /// Search one required label by text, complete-generation vector, or RRF hybrid retrieval.
+    /// Search one required label by text, vector, or RRF hybrid retrieval.
     ///
-    /// Raw and existing-node vectors select one explicit complete embedding-space alias.
-    /// Substantially stale generations fail unless `force_stale` explicitly selects the last
-    /// otherwise-valid complete generation. Semantic queries resolve one exact process-local
-    /// provider runtime before outbound work.
+    /// Raw vectors prefer a published index-store space when one exists, then fall
+    /// back to a complete embedding-space generation. Existing-node vectors always
+    /// read the selected complete generation. Unknown labels and incompatible
+    /// query dimensions soft-miss as a typed empty Arrow table.
     ///
     /// # Errors
-    /// Returns structured option, label, selector, freshness, dimension, corruption, lifecycle,
+    /// Returns structured option, selector, freshness, corruption, lifecycle,
     /// cancellation, resource, storage, or Arrow-shaping errors without partial rows.
     pub fn find(&self, options: FindOptions) -> Result<arrow::record_batch::RecordBatch, GfError> {
         if options.semantic_query.is_some() {
@@ -41,7 +44,7 @@ impl GraphForge {
             force_stale,
         } = options;
         let label = label.ok_or_else(|| validation("find requires label"))?;
-        let label_id = self.search_label_id(&label)?;
+        let label_id = self.find_label_id(&label)?;
         let vector_forms = usize::from(vector.is_some()) + usize::from(similar_to.is_some());
         if vector_forms > 1 {
             return Err(validation("vector and similar_to are mutually exclusive"));
@@ -117,23 +120,7 @@ impl GraphForge {
             .transpose()?;
         let vector = vector_query
             .map(|vector_query| {
-                let prepared = self.prepare_embedding_space_read(space, force_stale)?;
-                let query = match vector_query {
-                    VectorQuery::Raw(vector) => EmbeddingVectorQuery::Raw(vector),
-                    VectorQuery::Node(node_uuid) => EmbeddingVectorQuery::Node(*node_uuid),
-                };
-                search_embedding_generation(
-                    &self.dir,
-                    EmbeddingGenerationQuery {
-                        prepared: &prepared,
-                        label_id,
-                        query,
-                        limit,
-                    },
-                    VectorLifecycleLimits::default(),
-                    || Ok(()),
-                )
-                .map_err(GfError::from)
+                self.retrieve_vector_hits(label, label_id, vector_query, space, force_stale, limit)
             })
             .transpose()?;
 
@@ -168,6 +155,77 @@ impl GraphForge {
             (None, None) => unreachable!("at least one retrieval channel validated"),
         }
     }
+
+    fn retrieve_vector_hits(
+        &self,
+        label: &str,
+        label_id: u32,
+        vector_query: &VectorQuery,
+        space: Option<&str>,
+        force_stale: bool,
+        limit: usize,
+    ) -> Result<Vec<VectorSearchHit>, GfError> {
+        let space = space.expect("vector query form requires space");
+        match vector_query {
+            VectorQuery::Raw(vector) => {
+                let key = SearchArtifactKey::vector(label, space)?;
+                if current_search_artifact(&self.dir, &key)?.is_some() {
+                    return soft_dimension_miss(search_graph_vectors(
+                        &self.dir,
+                        VectorIndexRequest {
+                            label,
+                            label_id,
+                            space,
+                        },
+                        vector,
+                        limit,
+                        VectorLifecycleLimits::default(),
+                        || Ok(()),
+                    ));
+                }
+                let prepared = self.prepare_embedding_space_read(Some(space), force_stale)?;
+                soft_dimension_miss(search_embedding_generation(
+                    &self.dir,
+                    EmbeddingGenerationQuery {
+                        prepared: &prepared,
+                        label_id,
+                        query: EmbeddingVectorQuery::Raw(vector),
+                        limit,
+                    },
+                    VectorLifecycleLimits::default(),
+                    || Ok(()),
+                ))
+            }
+            VectorQuery::Node(node_uuid) => {
+                let prepared = self.prepare_embedding_space_read(Some(space), force_stale)?;
+                soft_dimension_miss(search_embedding_generation(
+                    &self.dir,
+                    EmbeddingGenerationQuery {
+                        prepared: &prepared,
+                        label_id,
+                        query: EmbeddingVectorQuery::Node(*node_uuid),
+                        limit,
+                    },
+                    VectorLifecycleLimits::default(),
+                    || Ok(()),
+                ))
+            }
+        }
+    }
+}
+
+fn soft_dimension_miss(
+    result: Result<Vec<VectorSearchHit>, SearchArtifactError>,
+) -> Result<Vec<VectorSearchHit>, GfError> {
+    match result {
+        Ok(hits) => Ok(hits),
+        Err(SearchArtifactError::InvalidSelector { field, reason })
+            if field == "vector" && reason.contains("dimension") =>
+        {
+            Ok(Vec::new())
+        }
+        Err(error) => Err(error.into()),
+    }
 }
 
 fn validation(message: impl Into<String>) -> GfError {
@@ -183,7 +241,7 @@ mod tests {
     use super::*;
     use crate::{
         CallerEmbeddingBatchRequest, CallerEmbeddingBatchRow, CallerEmbeddingDistance,
-        CallerEmbeddingNormalization, NodeHandle, NodeSelector, PropValue,
+        CallerEmbeddingNormalization, NodeHandle, NodeSelector, PropValue, SearchIndexOptions,
     };
 
     fn node(graph: &GraphForge, title: &str) -> NodeHandle {
@@ -320,6 +378,72 @@ mod tests {
                 .collect::<Vec<_>>(),
             ["node_uuid", "title", "score", "matched_on"]
         );
+    }
+
+    #[test]
+    fn unknown_label_and_dimension_mismatch_soft_miss_as_empty() {
+        let graph = GraphForge::new(None).unwrap();
+        let empty = graph
+            .find(FindOptions {
+                query: Some("anything".to_owned()),
+                label: Some("Paper".to_owned()),
+                limit: 10,
+                ..FindOptions::default()
+            })
+            .unwrap();
+        assert_eq!(empty.num_rows(), 0);
+        assert!(empty.schema().field_with_name("score").is_ok());
+        assert!(empty.schema().field_with_name("matched_on").is_ok());
+
+        let paper = node(&graph, "stub");
+        graph
+            .index_search(
+                "Paper",
+                SearchIndexOptions::Vector {
+                    node: NodeSelector::Handle(paper),
+                    vector: vec![1.0; 128],
+                    space: "sbert".to_owned(),
+                },
+            )
+            .unwrap();
+        let mismatched = graph
+            .find(FindOptions {
+                label: Some("Paper".to_owned()),
+                vector: Some(vec![1.0; 64]),
+                space: Some("sbert".to_owned()),
+                limit: 10,
+                ..FindOptions::default()
+            })
+            .unwrap();
+        assert_eq!(mismatched.num_rows(), 0);
+    }
+
+    #[test]
+    fn index_upsert_raw_vector_find_returns_vector_channel() {
+        let graph = GraphForge::new(None).unwrap();
+        let paper = node(&graph, "Graph Neural Networks");
+        let vector = vec![1.0; 8];
+        graph
+            .index_search(
+                "Paper",
+                SearchIndexOptions::Vector {
+                    node: NodeSelector::Handle(paper.clone()),
+                    vector: vector.clone(),
+                    space: "sbert".to_owned(),
+                },
+            )
+            .unwrap();
+        let found = graph
+            .find(FindOptions {
+                label: Some("Paper".to_owned()),
+                vector: Some(vector),
+                space: Some("sbert".to_owned()),
+                limit: 10,
+                ..FindOptions::default()
+            })
+            .unwrap();
+        assert_eq!(uuids(&found), [*paper.uuid.as_bytes()]);
+        assert_eq!(channels(&found), ["vector"]);
     }
 
     #[test]

--- a/crates/graphforge-api/src/search_index.rs
+++ b/crates/graphforge-api/src/search_index.rs
@@ -365,6 +365,21 @@ impl GraphForge {
 
     pub(crate) fn search_label_id(&self, label: &str) -> Result<u32, GfError> {
         validate_label(label)?;
+        self.resolve_search_label_id(label)
+            .ok_or_else(|| validation(format!("unknown search label {label:?}")))
+    }
+
+    /// Resolve a find label, soft-missing unknown labels like analyst verbs.
+    ///
+    /// Invalid label spelling still fails validation. An absent catalog entry
+    /// becomes [`u32::MAX`] so retrieval and Arrow shaping return a typed empty
+    /// table instead of `GF_VALIDATION`.
+    pub(crate) fn find_label_id(&self, label: &str) -> Result<u32, GfError> {
+        validate_label(label)?;
+        Ok(self.resolve_search_label_id(label).unwrap_or(u32::MAX))
+    }
+
+    fn resolve_search_label_id(&self, label: &str) -> Option<u32> {
         self.ontology
             .as_ref()
             .and_then(|ontology| ontology.entity_type_id(label).map(|id| id.0))
@@ -375,7 +390,6 @@ impl GraphForge {
                     .entity_type_names_with_ids()
                     .find_map(|(id, name)| (name == label).then_some(id.0))
             })
-            .ok_or_else(|| validation(format!("unknown search label {label:?}")))
     }
 }
 

--- a/crates/graphforge-api/tests/bdd/api_steps.rs
+++ b/crates/graphforge-api/tests/bdd/api_steps.rs
@@ -78,16 +78,36 @@ async fn given_paper_node(world: &mut GraphForgeWorld, title: String) {
     let forge = graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed");
     let props = std::collections::HashMap::from([(
         "title".to_owned(),
-        graphforge_api::PropValue::Str(title),
+        graphforge_api::PropValue::Str(title.clone()),
     )]);
-    forge.add_node("Paper", &props).expect("Paper fixture");
+    let handle = forge.add_node("Paper", &props).expect("Paper fixture");
+    world.nodes.insert(title, handle);
     world.forge = Some(forge);
 }
 
 #[given(regex = r#"^a graph with a Paper node that has a stored vector embedding$"#)]
 async fn given_paper_with_vector(world: &mut GraphForgeWorld) {
-    world.forge =
-        Some(graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed"));
+    let forge = graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed");
+    let props = std::collections::HashMap::from([(
+        "title".to_owned(),
+        graphforge_api::PropValue::Str("Stub Paper".into()),
+    )]);
+    let handle = forge.add_node("Paper", &props).expect("Paper fixture");
+    let vector = vec![1.0_f32; 128];
+    forge
+        .index_search(
+            "Paper",
+            graphforge_api::SearchIndexOptions::Vector {
+                node: graphforge_api::NodeSelector::Handle(handle.clone()),
+                vector: vector.clone(),
+                space: "sbert".to_owned(),
+            },
+        )
+        .expect("vector upsert fixture");
+    world.nodes.insert("Stub Paper".into(), handle);
+    world.stored_vector = Some(vector);
+    world.stored_space = Some("sbert".into());
+    world.forge = Some(forge);
 }
 
 #[given(regex = r#"^a graph with (\d+) Paper nodes with similar titles$"#)]
@@ -129,14 +149,21 @@ fn create_papers(world: &mut GraphForgeWorld, count: u32, similar: bool) {
     for index in 0..count {
         let title = if similar {
             format!("Graph paper {index}")
+        } else if count == 1 {
+            "Stub Paper".to_owned()
         } else {
             format!("Paper {index}")
         };
         let props = std::collections::HashMap::from([(
             "title".to_owned(),
-            graphforge_api::PropValue::Str(title),
+            graphforge_api::PropValue::Str(title.clone()),
         )]);
-        forge.add_node("Paper", &props).expect("Paper fixture");
+        let handle = forge.add_node("Paper", &props).expect("Paper fixture");
+        if count == 1 {
+            world.nodes.insert("paper".into(), handle.clone());
+            world.stored_paper_id = Some(handle.uuid.to_string());
+        }
+        world.nodes.insert(title, handle);
     }
     world.forge = Some(forge);
 }
@@ -273,9 +300,28 @@ async fn given_directed_cycle(world: &mut GraphForgeWorld) {
 }
 
 #[given(regex = r#"^a graph with Paper nodes indexed with (\d+)-dimensional vectors$"#)]
-async fn given_papers_with_vectors(world: &mut GraphForgeWorld, _dims: u32) {
-    world.forge =
-        Some(graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed"));
+async fn given_papers_with_vectors(world: &mut GraphForgeWorld, dims: u32) {
+    let forge = graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed");
+    let props = std::collections::HashMap::from([(
+        "title".to_owned(),
+        graphforge_api::PropValue::Str("Stub".into()),
+    )]);
+    let handle = forge.add_node("Paper", &props).expect("Paper fixture");
+    let vector = vec![1.0_f32; dims as usize];
+    forge
+        .index_search(
+            "Paper",
+            graphforge_api::SearchIndexOptions::Vector {
+                node: graphforge_api::NodeSelector::Handle(handle.clone()),
+                vector: vector.clone(),
+                space: "sbert".to_owned(),
+            },
+        )
+        .expect("vector upsert fixture");
+    world.nodes.insert("paper".into(), handle);
+    world.stored_vector = Some(vector);
+    world.stored_space = Some("sbert".into());
+    world.forge = Some(forge);
 }
 
 #[given(regex = r#"^a path that does not exist on disk$"#)]
@@ -463,9 +509,28 @@ async fn given_second_component(_world: &mut GraphForgeWorld) {
 }
 
 #[given(regex = r#"^a graph with a Paper node titled "([^"]+)" and a stored vector embedding$"#)]
-async fn given_paper_with_title_and_vector(world: &mut GraphForgeWorld, _title: String) {
-    world.forge =
-        Some(graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed"));
+async fn given_paper_with_title_and_vector(world: &mut GraphForgeWorld, title: String) {
+    let forge = graphforge_api::GraphForge::new(None).expect("in-memory forge must succeed");
+    let props = std::collections::HashMap::from([(
+        "title".to_owned(),
+        graphforge_api::PropValue::Str(title.clone()),
+    )]);
+    let handle = forge.add_node("Paper", &props).expect("Paper fixture");
+    let vector = vec![1.0_f32; 128];
+    forge
+        .index_search(
+            "Paper",
+            graphforge_api::SearchIndexOptions::Vector {
+                node: graphforge_api::NodeSelector::Handle(handle.clone()),
+                vector: vector.clone(),
+                space: "sbert".to_owned(),
+            },
+        )
+        .expect("vector upsert fixture");
+    world.nodes.insert(title, handle);
+    world.stored_vector = Some(vector);
+    world.stored_space = Some("sbert".into());
+    world.forge = Some(forge);
 }
 
 #[given(regex = r#"^a graph with 2 Person nodes with ids in columns "src_id" and "dst_id"$"#)]
@@ -880,7 +945,7 @@ fn run_cluster(
 
 #[when(regex = r#"^I find "([^"]+)" in label "([^"]+)"$"#)]
 async fn when_find_text(world: &mut GraphForgeWorld, query: String, label: String) {
-    run_find(world, Some(query), label, 10, None);
+    run_find(world, Some(query), label, 10, None, None);
 }
 
 #[when(regex = r#"^I find "([^"]+)" in label "([^"]+)" with limit (\d+)$"#)]
@@ -890,7 +955,7 @@ async fn when_find_text_limit(
     label: String,
     limit: u32,
 ) {
-    run_find(world, Some(query), label, limit as usize, None);
+    run_find(world, Some(query), label, limit as usize, None, None);
 }
 
 fn run_find(
@@ -899,11 +964,13 @@ fn run_find(
     label: String,
     limit: usize,
     vector: Option<Vec<f32>>,
+    space: Option<String>,
 ) {
     let options = graphforge_api::FindOptions {
         query,
         label: Some(label),
         vector,
+        space,
         limit,
         ..Default::default()
     };
@@ -921,24 +988,144 @@ fn run_find(
     }
 }
 
+#[when(regex = r#"^I find by the stored vector in label "Paper"$"#)]
+async fn when_find_stored_vector(world: &mut GraphForgeWorld) {
+    let vector = world.stored_vector.clone().expect("stored vector fixture");
+    let space = world
+        .stored_space
+        .clone()
+        .unwrap_or_else(|| "sbert".to_owned());
+    run_find(world, None, "Paper".into(), 10, Some(vector), Some(space));
+}
+
+#[when(regex = r#"^I find by the stored embedding in label "([^"]+)" in space "([^"]+)"$"#)]
+async fn when_find_stored_embedding(world: &mut GraphForgeWorld, label: String, space: String) {
+    let vector = world
+        .stored_vector
+        .clone()
+        .expect("stored embedding fixture");
+    run_find(world, None, label, 10, Some(vector), Some(space));
+}
+
+#[when(regex = r#"^I find "([^"]+)" with the stored vector in label "([^"]+)"$"#)]
+async fn when_find_text_and_stored_vector(
+    world: &mut GraphForgeWorld,
+    query: String,
+    label: String,
+) {
+    let vector = world.stored_vector.clone().expect("stored vector fixture");
+    let space = world
+        .stored_space
+        .clone()
+        .unwrap_or_else(|| "sbert".to_owned());
+    run_find(world, Some(query), label, 10, Some(vector), Some(space));
+}
+
+#[when(regex = r#"^I find by a (\d+)-dimensional vector in label "([^"]+)"$"#)]
+async fn when_find_wrong_dim(world: &mut GraphForgeWorld, dims: u32, label: String) {
+    let space = world
+        .stored_space
+        .clone()
+        .unwrap_or_else(|| "sbert".to_owned());
+    run_find(
+        world,
+        None,
+        label,
+        10,
+        Some(vec![1.0_f32; dims as usize]),
+        Some(space),
+    );
+}
+
 #[when(regex = r#"^I find with no query and no vector in label "([^"]+)"$"#)]
 async fn when_find_no_args(world: &mut GraphForgeWorld, _label: String) {
-    run_find(world, None, _label, 10, None);
+    run_find(world, None, _label, 10, None, None);
 }
 
 #[when(regex = r#"^I find by an empty vector in label "([^"]+)"$"#)]
 async fn when_find_empty_vector(world: &mut GraphForgeWorld, _label: String) {
-    run_find(world, None, _label, 10, Some(Vec::new()));
+    run_find(world, None, _label, 10, Some(Vec::new()), None);
 }
 
 #[when(regex = r#"^I find by a vector containing NaN in label "([^"]+)"$"#)]
 async fn when_find_nan_vector(world: &mut GraphForgeWorld, _label: String) {
-    run_find(world, None, _label, 10, Some(vec![f32::NAN]));
+    run_find(world, None, _label, 10, Some(vec![f32::NAN]), None);
 }
 
 #[when(regex = r#"^I find by a vector containing infinity in label "([^"]+)"$"#)]
 async fn when_find_inf_vector(world: &mut GraphForgeWorld, _label: String) {
-    run_find(world, None, _label, 10, Some(vec![f32::INFINITY]));
+    run_find(world, None, _label, 10, Some(vec![f32::INFINITY]), None);
+}
+
+#[given(regex = r#"^I have stored the node id as "paper_id"$"#)]
+async fn given_store_paper_id(world: &mut GraphForgeWorld) {
+    let handle = world
+        .nodes
+        .get("paper")
+        .or_else(|| world.nodes.values().next())
+        .expect("paper fixture node");
+    world.stored_paper_id = Some(handle.uuid.to_string());
+}
+
+#[given(regex = r#"^I have an embedding vector stored as "embedding"$"#)]
+async fn given_store_embedding(world: &mut GraphForgeWorld) {
+    world.stored_vector = Some(vec![1.0_f32; 128]);
+}
+
+#[when(
+    regex = r#"^I index label "([^"]+)" storing the vector for node "([^"]+)" in space "([^"]+)"$"#
+)]
+async fn when_index_vector(
+    world: &mut GraphForgeWorld,
+    label: String,
+    node_key: String,
+    space: String,
+) {
+    let handle = world
+        .nodes
+        .get(&node_key)
+        .or_else(|| world.nodes.get("paper"))
+        .cloned()
+        .expect("indexed node fixture");
+    let vector = world
+        .stored_vector
+        .clone()
+        .expect("stored embedding fixture");
+    world.stored_space = Some(space.clone());
+    match world.forge.as_ref().expect("index fixture").index_search(
+        &label,
+        graphforge_api::SearchIndexOptions::Vector {
+            node: graphforge_api::NodeSelector::Handle(handle),
+            vector,
+            space,
+        },
+    ) {
+        Ok(_) => {
+            world.index_calls += 1;
+            world.last_error = None;
+        }
+        Err(error) => world.last_error = Some(error.to_string()),
+    }
+}
+
+#[when(regex = r#"^I add a node with label "Paper" titled "Deep Graph Learning"$"#)]
+async fn when_add_deep_graph_paper(world: &mut GraphForgeWorld) {
+    let props = std::collections::HashMap::from([(
+        "title".to_owned(),
+        graphforge_api::PropValue::Str("Deep Graph Learning".into()),
+    )]);
+    match world
+        .forge
+        .as_ref()
+        .expect("open forge")
+        .add_node("Paper", &props)
+    {
+        Ok(handle) => {
+            world.nodes.insert("Deep Graph Learning".into(), handle);
+            world.last_error = None;
+        }
+        Err(error) => world.last_error = Some(error.to_string()),
+    }
 }
 
 #[when(regex = r#"^I index label "([^"]+)" on properties "([^"]+)" and "([^"]+)"$"#)]
@@ -1526,6 +1713,61 @@ async fn then_nonempty_string(world: &mut GraphForgeWorld) {
         let error = world.last_error.as_deref().expect("selector error");
         assert!(error.contains("validation error"), "{error}");
     }
+}
+
+#[then(regex = r#"^the result contains that node$"#)]
+async fn then_result_contains_that_node(world: &mut GraphForgeWorld) {
+    assert!(
+        world.last_error.is_none(),
+        "unexpected error: {:?}",
+        world.last_error
+    );
+    let expected = world
+        .stored_paper_id
+        .clone()
+        .or_else(|| {
+            world
+                .nodes
+                .get("paper")
+                .map(|handle| handle.uuid.to_string())
+        })
+        .expect("paper_id fixture")
+        .replace('-', "")
+        .to_ascii_lowercase();
+    let batch = result_batch(world);
+    let uuids = batch
+        .column_by_name("node_uuid")
+        .expect("node_uuid column")
+        .as_any()
+        .downcast_ref::<arrow::array::FixedSizeBinaryArray>()
+        .expect("node_uuid FixedSizeBinary");
+    let found = (0..uuids.len()).any(|index| {
+        let actual = uuids
+            .value(index)
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+        actual == expected
+    });
+    assert!(found, "result omitted node {expected}");
+}
+
+#[then(regex = r#"^the result contains a row with title "([^"]+)"$"#)]
+async fn then_result_contains_title(world: &mut GraphForgeWorld, title: String) {
+    assert!(
+        world.last_error.is_none(),
+        "unexpected error: {:?}",
+        world.last_error
+    );
+    let batch = result_batch(world);
+    let titles = batch
+        .column_by_name("title")
+        .expect("title column")
+        .as_any()
+        .downcast_ref::<arrow::array::StringArray>()
+        .expect("title Utf8");
+    let found = (0..titles.len()).any(|index| titles.value(index) == title);
+    assert!(found, "result omitted title {title}");
 }
 
 #[then(regex = r#"^the result contains "([^"]+)"$"#)]

--- a/crates/graphforge-api/tests/bdd/main.rs
+++ b/crates/graphforge-api/tests/bdd/main.rs
@@ -57,6 +57,12 @@ pub struct GraphForgeWorld {
     pub last_edge_handle: Option<graphforge_api::EdgeHandle>,
     /// Number of explicit public index calls made in this scenario.
     pub index_calls: usize,
+    /// Stored query/index vector for find/index scenarios.
+    pub stored_vector: Option<Vec<f32>>,
+    /// Caller-defined vector space used by find/index fixtures.
+    pub stored_space: Option<String>,
+    /// Stored node UUID (hex or hyphenated) for index upsert scenarios.
+    pub stored_paper_id: Option<String>,
 }
 
 #[tokio::main]

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -3364,8 +3364,11 @@ exclusive forms:
 `space` is required for every vector form. Structural spaces that cannot embed
 arbitrary text reject `semantic_query`. Neither channel, conflicting vector
 forms, a space without a vector form, a vector form without a space, an empty
-text query, an unknown label/space, incompatible dimensions/identity, or
-`limit` outside `1..=10_000` is a structured validation error.
+text query, an unknown space, incompatible identity, or `limit` outside
+`1..=10_000` is a structured validation error. An unknown or unindexed label
+and a finite vector whose dimension does not match the selected space soft-miss
+as the typed empty Arrow table (same schema, zero rows) rather than
+`GF_VALIDATION`.
 
 Text indexing remains derived: a missing or stale matching text index triggers
 one coordinated lazy build from observed string properties. Vector data is

--- a/scripts/ci/test-api-bdd-policy.py
+++ b/scripts/ci/test-api-bdd-policy.py
@@ -77,9 +77,9 @@ class ApiBddPolicyMutationTests(unittest.TestCase):
         self.assert_rejected("invalid languages []")
 
     def test_issue_tag_must_match_inventory(self) -> None:
-        path = self.root / "tests/features/api/edge_cases.feature"
-        path.write_text(path.read_text().replace("@issue-352", "@issue-999", 1))
-        self.assert_rejected("missing @issue-352")
+        path = self.root / "tests/features/api/errors.feature"
+        path.write_text(path.read_text().replace("@issue-353", "@issue-999", 1))
+        self.assert_rejected("missing @issue-353")
 
     def test_stale_skip_tag_is_rejected(self) -> None:
         path = self.root / "tests/features/api/analyze.feature"

--- a/tests/contracts/api-bdd-exclusions.json
+++ b/tests/contracts/api-bdd-exclusions.json
@@ -3,18 +3,6 @@
   "tag": "excluded-api-bdd",
   "exclusions": [
     {
-      "feature": "Edge Cases and Graceful Empty Results",
-      "scenario": "find on a label with no indexed content returns empty Arrow Table",
-      "issue": 352,
-      "languages": ["rust", "python", "node"]
-    },
-    {
-      "feature": "Edge Cases and Graceful Empty Results",
-      "scenario": "find with vector dimension mismatch returns empty Arrow Table",
-      "issue": 352,
-      "languages": ["rust", "python", "node"]
-    },
-    {
       "feature": "Error Handling",
       "scenario": "ExecutionError is raised on type mismatch",
       "issue": 353,
@@ -57,18 +45,6 @@
       "languages": ["rust", "python", "node"]
     },
     {
-      "feature": "Find API",
-      "scenario": "find by vector returns score and matched_on set to vector",
-      "issue": 352,
-      "languages": ["rust", "python", "node"]
-    },
-    {
-      "feature": "Find API",
-      "scenario": "find with text and vector returns matched_on set to text+vector for fused results",
-      "issue": 352,
-      "languages": ["rust", "python", "node"]
-    },
-    {
       "feature": "Graph Construction API",
       "scenario": "bulk add_nodes with a list of records",
       "issue": 355,
@@ -78,18 +54,6 @@
       "feature": "Graph Construction API",
       "scenario": "bulk add_nodes with Arrow Table",
       "issue": 355,
-      "languages": ["rust", "python", "node"]
-    },
-    {
-      "feature": "Index API",
-      "scenario": "index vector upsert stores a vector for a node",
-      "issue": 352,
-      "languages": ["rust", "python", "node"]
-    },
-    {
-      "feature": "Index API",
-      "scenario": "find reflects nodes added after initial index build",
-      "issue": 352,
       "languages": ["rust", "python", "node"]
     },
     {

--- a/tests/features/api/edge_cases.feature
+++ b/tests/features/api/edge_cases.feature
@@ -23,14 +23,12 @@ Feature: Edge Cases and Graceful Empty Results
       | a label with no nodes  | a graph with Person nodes but no Paper nodes  | Paper       |
       | a non-existent label   | an empty graph                                | NonExistent |
 
-  @excluded-api-bdd @issue-352
   Scenario: find on a label with no indexed content returns empty Arrow Table
     Given an empty graph
     When I find "anything" in label "Paper"
     Then the result is an Arrow Table
     And the table has 0 rows
 
-  @excluded-api-bdd @issue-352
   Scenario: find with vector dimension mismatch returns empty Arrow Table
     Given a graph with Paper nodes indexed with 128-dimensional vectors
     When I find by a 64-dimensional vector in label "Paper"

--- a/tests/features/api/find.feature
+++ b/tests/features/api/find.feature
@@ -14,14 +14,12 @@ Feature: Find API
     And the table has column "matched_on"
     And the first row value for "matched_on" is "text"
 
-  @excluded-api-bdd @issue-352
   Scenario: find by vector returns score and matched_on set to vector
     Given a graph with a Paper node that has a stored vector embedding
     When I find by the stored vector in label "Paper"
     Then the table has column "score"
     And the first row value for "matched_on" is "vector"
 
-  @excluded-api-bdd @issue-352
   Scenario: find with text and vector returns matched_on set to text+vector for fused results
     Given a graph with a Paper node titled "Graph Neural Networks" and a stored vector embedding
     When I find "graph neural networks" with the stored vector in label "Paper"

--- a/tests/features/api/index.feature
+++ b/tests/features/api/index.feature
@@ -7,7 +7,6 @@ Feature: Index API
     And I find "neural networks" in label "Paper"
     Then the result is an Arrow Table with at least 1 row
 
-  @excluded-api-bdd @issue-352
   Scenario: index vector upsert stores a vector for a node
     Given a graph with a Paper node
     And I have stored the node id as "paper_id"
@@ -25,10 +24,9 @@ Feature: Index API
     Then no error is raised
     And find "paper" in label "Paper" returns the same results as after the first index call
 
-  @excluded-api-bdd @issue-352
   Scenario: find reflects nodes added after initial index build
     Given a graph with a Paper node titled "Graph Neural Networks"
-    And I index label "Paper" on property "title"
-    When I add a node with label "Paper" titled "Deep Graph Learning"
+    When I index label "Paper" on property "title"
+    And I add a node with label "Paper" titled "Deep Graph Learning"
     And I find "deep graph" in label "Paper"
     Then the result contains a row with title "Deep Graph Learning"

--- a/tests/features/node/step_definitions/api_steps.ts
+++ b/tests/features/node/step_definitions/api_steps.ts
@@ -311,7 +311,10 @@ Given(
     this.forge = new GraphForge();
     const h = this.forge.addNode("Paper", { title: "Stub Paper" });
     this.nodes["Stub Paper"] = h;
-    this.extra["vector"] = new Array(128).fill(1.0);
+    const vector = new Array(128).fill(1.0);
+    this.extra["vector"] = vector;
+    this.extra["space"] = "sbert";
+    this.forge.index("Paper", { node: h, vector, space: "sbert" });
   },
 );
 
@@ -321,7 +324,10 @@ Given(
     this.forge = new GraphForge();
     const h = this.forge.addNode("Paper", { title });
     this.nodes[title] = h;
-    this.extra["vector"] = new Array(128).fill(1.0);
+    const vector = new Array(128).fill(1.0);
+    this.extra["vector"] = vector;
+    this.extra["space"] = "sbert";
+    this.forge.index("Paper", { node: h, vector, space: "sbert" });
   },
 );
 
@@ -425,7 +431,11 @@ Given(
     this.forge = new GraphForge();
     const h = this.forge.addNode("Paper", { title: "Stub" });
     this.nodes["paper"] = h;
-    this.extra["vector_dim"] = parseInt(nStr, 10);
+    const dims = parseInt(nStr, 10);
+    const vector = new Array(dims).fill(1.0);
+    this.extra["vector_dim"] = dims;
+    this.extra["space"] = "sbert";
+    this.forge.index("Paper", { node: h, vector, space: "sbert" });
   },
 );
 
@@ -914,7 +924,10 @@ When(
 
 When('I find by the stored vector in label "Paper"', function (this: GraphForgeWorld) {
   const vec = this.extra["vector"] as number[];
-  _catch(this, () => this.forge!.find(undefined, "Paper", vec));
+  const space = (this.extra["space"] as string | undefined) ?? "sbert";
+  _catch(this, () =>
+    this.forge!.find(undefined, "Paper", vec, undefined, undefined, undefined, space),
+  );
 });
 
 When(
@@ -931,7 +944,10 @@ When(
   /^I find "([^"]*)" with the stored vector in label "([^"]*)"$/,
   function (this: GraphForgeWorld, query: string, label: string) {
     const vec = this.extra["vector"] as number[];
-    _catch(this, () => this.forge!.find(query, label, vec));
+    const space = (this.extra["space"] as string | undefined) ?? "sbert";
+    _catch(this, () =>
+      this.forge!.find(query, label, vec, undefined, undefined, undefined, space),
+    );
   },
 );
 
@@ -955,7 +971,10 @@ When(
   /^I find by a (\d+)-dimensional vector in label "([^"]*)"$/,
   function (this: GraphForgeWorld, nStr: string, label: string) {
     const vec = new Array(parseInt(nStr, 10)).fill(1.0);
-    _catch(this, () => this.forge!.find(undefined, label, vec));
+    const space = (this.extra["space"] as string | undefined) ?? "sbert";
+    _catch(this, () =>
+      this.forge!.find(undefined, label, vec, undefined, undefined, undefined, space),
+    );
   },
 );
 
@@ -984,9 +1003,13 @@ When(
   function (this: GraphForgeWorld, label: string, nodeKey: string, space: string) {
     const vec = this.extra["embedding"] as number[];
     _catch(this, () => {
-      const nodeId = this.nodes[nodeKey]?.uuid ?? (this.extra[nodeKey] as string | undefined);
-      if (!nodeId) throw new Error(`unknown stored node identifier: ${nodeKey}`);
-      return this.forge!.index(label, { nodeId, vector: vec, space });
+      const node =
+        this.nodes[nodeKey] ??
+        this.nodes["paper"] ??
+        (this.extra[nodeKey] as string | undefined) ??
+        (this.extra["paper_id"] as string | undefined);
+      if (!node) throw new Error(`unknown stored node identifier: ${nodeKey}`);
+      return this.forge!.index(label, { node, vector: vec, space });
     });
   },
 );

--- a/tests/features/steps/api_steps.py
+++ b/tests/features/steps/api_steps.py
@@ -205,7 +205,10 @@ def given_paper_with_vector():
     c.forge = GraphForge()
     h = c.forge.add_node("Paper", title="Stub Paper")
     c.nodes["Stub Paper"] = h
-    c.extra["vector"] = np.ones(128, dtype=float)
+    vector = np.ones(128, dtype=float)
+    c.extra["vector"] = vector
+    c.extra["space"] = "sbert"
+    c.forge.index("Paper", node=h, vector=vector.tolist(), space="sbert")
     return c
 
 
@@ -223,7 +226,10 @@ def given_paper_with_title_and_vector(title):
     c.forge = GraphForge()
     h = c.forge.add_node("Paper", title=title)
     c.nodes[title] = h
-    c.extra["vector"] = np.ones(128, dtype=float)
+    vector = np.ones(128, dtype=float)
+    c.extra["vector"] = vector
+    c.extra["space"] = "sbert"
+    c.forge.index("Paper", node=h, vector=vector.tolist(), space="sbert")
     return c
 
 
@@ -363,6 +369,7 @@ def given_persons_no_papers():
     target_fixture="ctx",
 )
 def given_paper_indexed_with_vectors(n):
+    import numpy as np
 
     c = _Ctx()
     c.nodes = {}
@@ -371,7 +378,10 @@ def given_paper_indexed_with_vectors(n):
     c.forge = GraphForge()
     h = c.forge.add_node("Paper", title="Stub")
     c.nodes["paper"] = h
+    vector = np.ones(n, dtype=float)
     c.extra["vector_dim"] = n
+    c.extra["space"] = "sbert"
+    c.forge.index("Paper", node=h, vector=vector.tolist(), space="sbert")
     return c
 
 
@@ -877,7 +887,8 @@ def when_find_text_limit(ctx, query_text, label, limit):
 @when('I find by the stored vector in label "Paper"')
 def when_find_vector(ctx):
     vec = ctx.extra.get("vector")
-    ctx.result, ctx.error = _catch(ctx.forge.find, label="Paper", vector=vec)
+    space = ctx.extra.get("space", "sbert")
+    ctx.result, ctx.error = _catch(ctx.forge.find, label="Paper", vector=vec, space=space)
 
 
 @when(parsers.parse('I find by the stored embedding in label "{label}" in space "{space}"'))
@@ -889,7 +900,10 @@ def when_find_embedding(ctx, label, space):
 @when(parsers.parse('I find "{query_text}" with the stored vector in label "{label}"'))
 def when_find_text_vector(ctx, query_text, label):
     vec = ctx.extra.get("vector")
-    ctx.result, ctx.error = _catch(ctx.forge.find, query_text, label=label, vector=vec)
+    space = ctx.extra.get("space", "sbert")
+    ctx.result, ctx.error = _catch(
+        ctx.forge.find, query_text, label=label, vector=vec, space=space
+    )
 
 
 @when('I find with no query and no vector in label "Paper"')
@@ -926,7 +940,10 @@ def when_find_inf_vector(ctx):
 def when_find_wrong_dim(ctx, n, label):
     import numpy as np
 
-    ctx.result, ctx.error = _catch(ctx.forge.find, label=label, vector=np.ones(n))
+    space = ctx.extra.get("space", "sbert")
+    ctx.result, ctx.error = _catch(
+        ctx.forge.find, label=label, vector=np.ones(n), space=space
+    )
 
 
 @when(parsers.parse('I index label "{label}" on properties "{p1}" and "{p2}"'))
@@ -954,9 +971,19 @@ def when_index_one_prop(ctx, label, prop):
     )
 )
 def when_index_vector(ctx, label, node_key, space):
-    node_id = ctx.extra.get("paper_id") or ctx.extra.get(node_key)
+    node = None
+    if node_key in ctx.nodes:
+        node = ctx.nodes[node_key]
+    elif "paper" in ctx.nodes:
+        node = ctx.nodes["paper"]
+    elif ctx.extra.get("paper_id") is not None:
+        node = ctx.extra["paper_id"]
+    elif ctx.extra.get(node_key) is not None:
+        node = ctx.extra[node_key]
+    elif ctx.nodes:
+        node = next(iter(ctx.nodes.values()))
     vec = ctx.extra.get("embedding")
-    ctx.result, ctx.error = _catch(ctx.forge.index, label, node_id=node_id, vector=vec, space=space)
+    ctx.result, ctx.error = _catch(ctx.forge.index, label, node=node, vector=vec, space=space)
 
 
 @when('I index label "Paper" on an empty properties list')
@@ -964,10 +991,10 @@ def when_index_empty_props(ctx):
     ctx.result, ctx.error = _catch(ctx.forge.index, "Paper", properties=[])
 
 
-@when('I add a node with label "Paper" titled "Deep Graph Learning"')
-def when_add_deep_graph_paper(ctx):
-    h = ctx.forge.add_node("Paper", title="Deep Graph Learning")
-    ctx.nodes["Deep Graph Learning"] = h
+@when(parsers.parse('I add a node with label "{label}" titled "{title}"'))
+def when_add_node_titled(ctx, label, title):
+    h = ctx.forge.add_node(label, title=title)
+    ctx.nodes[title] = h
 
 
 @when("I call schema")

--- a/tests/features/steps/api_steps.py
+++ b/tests/features/steps/api_steps.py
@@ -901,9 +901,7 @@ def when_find_embedding(ctx, label, space):
 def when_find_text_vector(ctx, query_text, label):
     vec = ctx.extra.get("vector")
     space = ctx.extra.get("space", "sbert")
-    ctx.result, ctx.error = _catch(
-        ctx.forge.find, query_text, label=label, vector=vec, space=space
-    )
+    ctx.result, ctx.error = _catch(ctx.forge.find, query_text, label=label, vector=vec, space=space)
 
 
 @when('I find with no query and no vector in label "Paper"')
@@ -941,9 +939,7 @@ def when_find_wrong_dim(ctx, n, label):
     import numpy as np
 
     space = ctx.extra.get("space", "sbert")
-    ctx.result, ctx.error = _catch(
-        ctx.forge.find, label=label, vector=np.ones(n), space=space
-    )
+    ctx.result, ctx.error = _catch(ctx.forge.find, label=label, vector=np.ones(n), space=space)
 
 
 @when(parsers.parse('I index label "{label}" on properties "{p1}" and "{p2}"'))


### PR DESCRIPTION
## Summary
- Soft-miss unknown/unindexed find labels and incompatible vector dimensions as typed empty Arrow tables (issue AC over older validation docs).
- Route raw `find(vector=…, space=…)` through published index-store vectors when present, keeping complete-generation embedding search as fallback.
- Complete Rust/Python/Node BDD fixtures for space-aware vector upsert/find and post-index text visibility; remove six `#352` exclusion rows.

Closes #352.

## Test plan
- [x] `cargo test -p graphforge-api --lib search_find`
- [x] Rust BDD: all six formerly excluded #352 scenarios (`API_ONLY=…`)
- [x] `uv run pytest tests/features/test_api_bdd.py -k "…"` (6 passed)
- [x] Node cucumber against `../api/**/*.feature` (6 passed)
- [x] `python3 scripts/ci/api-bdd-policy.py` + `test-api-bdd-policy.py`
- [x] `cargo fmt` / `cargo clippy -p graphforge-api --lib -- -D warnings`


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788566272&installation_model_id=20486&pr_number=416&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F416&signature=580435515263830aa31d0731cc0cb8482ca7950359ce14415a6d5da924125724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `find` to return empty results for unknown labels and vector dimension mismatches
> - Unknown labels in `GraphForge.find` now resolve to a sentinel id (`u32::MAX`) via the new `find_label_id` method, returning an empty typed Arrow table instead of a validation error.
> - Raw vector queries now prefer index-based search (`search_graph_vectors`) when a vector index artifact exists for the label+space, falling back to embedding generation otherwise.
> - Vector dimension mismatches are handled by the new `soft_dimension_miss` helper, which converts `InvalidSelector` errors on the `vector` field into empty result sets instead of propagating errors.
> - BDD scenarios previously excluded under `@issue-352` are re-enabled across Python and TypeScript test clients, with step definitions updated to pass vector space through `FindOptions`.
> - Behavioral Change: `find` no longer returns `GF_VALIDATION` for unknown labels or mismatched vector dimensions — callers that relied on these errors to detect invalid inputs will now receive empty results.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b3cb50c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->