### PR TITLE
docs(bazel): freeze migration ledger and Cargo/Blacksmith baseline (#12)

### DIFF
--- a/docs/development/bazel-migration-baseline.md
+++ b/docs/development/bazel-migration-baseline.md
@@ -1,0 +1,72 @@
+# Bazel migration Cargo/Blacksmith baseline (freeze)
+
+Accepted Blacksmith + Cargo CI baseline for later [#1](https://github.com/CurateLabs/graphforge/issues/1)
+performance comparison ([#5](https://github.com/CurateLabs/graphforge/issues/5)).
+Owned by [#12](https://github.com/CurateLabs/graphforge/issues/12).
+
+Companion ledger: [bazel-migration-ledger.md](bazel-migration-ledger.md).
+
+## Freeze metadata
+
+| Field | Value |
+| --- | --- |
+| Baseline freeze date (UTC) | 2026-08-06 |
+| Inventory/document SHA | `6e8b8e3fdc1ecd960eacf14a73e5be7b54fcef3c` |
+| Runner family | Blacksmith (`test.yml` jobs) |
+| Build system | Cargo (+ maturin / napi packaging) |
+| Sample size | 5 successful full-matrix PR runs |
+| Metric | Job wall time seconds from GitHub Actions job `started_at`/`completed_at` |
+
+## Accepted sample runs
+
+| Run | SHA | Title | URL |
+| --- | --- | --- | --- |
+| `31065788285` | `f8d6ee50fa1185b4b7ffda62a8caedf650429500` | fix(explain): side-effect-free write planning (#354) | https://github.com/CurateLabs/graphforge/actions/runs/31065788285 |
+| `31065484762` | `0c28132251cdacb288e2ee80a556c03bc2dad9ae` | fix(bdd): bulk add_nodes operation_uuid readback (#355) | https://github.com/CurateLabs/graphforge/actions/runs/31065484762 |
+| `31065189044` | `11cc05b894b68b36db8f48395842021f7f4b5ffa` | fix(recipes): neighbourhood hop-bound and schema contracts (#356) | https://github.com/CurateLabs/graphforge/actions/runs/31065189044 |
+| `31064495388` | `2c16a425440319c84b539e2625826d221b9fd9e1` | fix(node): preserve TypeError for binding coercion (#357) | https://github.com/CurateLabs/graphforge/actions/runs/31064495388 |
+| `31058201474` | `b3cb50c9e8953d26a6cd3c34ac27b56f608dd4ff` | fix(search): align find empty and vector-query contracts (#352) | https://github.com/CurateLabs/graphforge/actions/runs/31058201474 |
+
+## Per-job wall times (seconds)
+
+| Job | `f8d6ee50` | `0c281322` | `11cc05b8` | `2c16a425` | `b3cb50c9` | **p50** |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Rust Quality | 42 | 42 | 41 | 44 | 57 | **42** |
+| Rust Tests | 327 | 308 | 293 | 356 | 386 | **327** |
+| Python Binding | 184 | 166 | 177 | 170 | 246 | **177** |
+| Node Binding | 120 | 120 | 132 | 121 | 143 | **121** |
+| Windows graphforge-storage Locks | 142 | 135 | 133 | 141 | 147 | **141** |
+| Concurrency Matrix | 108 | 103 | 110 | 133 | 132 | **110** |
+
+## Compute proxy
+
+GitHub Actions does not expose a single “CPU-seconds” field for all jobs here.
+For #1’s “total build compute” comparison, use the **sum of the six job wall times**
+above as the accepted Cargo/Blacksmith compute proxy for a representative PR run
+(jobs may overlap in wall-clock calendar time; the sum still tracks compile/test work).
+
+| Run SHA | Sum of six job walls (s) |
+| --- | ---: |
+| `f8d6ee50fa11` | 923 |
+| `0c28132251cd` | 874 |
+| `11cc05b894b6` | 886 |
+| `2c16a4254403` | 965 |
+| `b3cb50c9e895` | 1111 |
+| **p50** | **923** |
+
+## How #5 must compare
+
+Against this baseline, on paired representative runs (≥10 pairs per #1):
+
+- Warm PR build/test **p50** ≥ 30% faster than the Cargo path job set above
+  (primary: `Rust Tests` + binding jobs as defined in the #5 measurement plan).
+- Total build compute proxy ≥ 25% lower than the p50 sum above.
+- Cold p50 regression ≤ 10% vs cold Cargo/Blacksmith measurements recorded in #5
+  (cold Cargo sticky-disk warm starts are **not** cold; #5 must define cold protocol).
+
+## Explicit non-claims
+
+- This document does **not** claim Bazel modeling, remote-cache hits, or cutover.
+- Org-admin Blacksmith **Bazel Build Caching** enablement remains a #5 dependency.
+- Docs-only PR runs (path-skipped Rust/bindings) are **excluded** from this sample.
+

--- a/docs/development/bazel-migration-ledger.md
+++ b/docs/development/bazel-migration-ledger.md
@@ -1,0 +1,351 @@
+# Bazel migration ledger (freeze)
+
+Checked-in inventory for M2 issue [#12](https://github.com/CurateLabs/graphforge/issues/12) / canonical [#1](https://github.com/CurateLabs/graphforge/issues/1) step 1.
+
+Orchestration contract: [bazel-migration-orchestration.md](bazel-migration-orchestration.md).
+Performance baseline: [bazel-migration-baseline.md](bazel-migration-baseline.md).
+
+## Freeze metadata
+
+| Field | Value |
+| --- | --- |
+| Freeze date (UTC) | 2026-08-06 |
+| Inventory SHA | `6e8b8e3fdc1ecd960eacf14a73e5be7b54fcef3c` |
+| Authoritative source | `cargo metadata --format-version=1 --no-deps` |
+| Workspace packages | 17 |
+| Cargo metadata targets | **90** |
+| Bazel modeling claimed complete? | **No** — inventory/baseline only |
+
+Issue #1 historically cited ~71 Cargo targets / ~53 integration-test binaries.
+This freeze uses the **current authoritative** metadata count (**90** targets;
+**59** integration-test binaries). Later slices must update rows,
+not silently ignore new targets.
+
+## Target class summary
+
+| Class | Count | Notes |
+| --- | ---: | --- |
+| `lib` | 15 | First-party libraries (unit/doctest surface rides these targets under `cargo test --lib` / doctests) |
+| `integration-test` | 59 | `tests/*.rs` integration binaries |
+| `cdylib` | 2 | PyO3 + napi-rs native libs |
+| `bin` | 1 | CLI (`gf`) |
+| `custom-build` | 2 | `build.rs` scripts |
+| `example` | 11 | API examples (map or justify retained exception in later slices) |
+| **Total** | **90** | |
+
+### Unit tests and doctests
+
+Cargo metadata does **not** emit separate targets for `#[cfg(test)]` unit modules or
+doctests. For migration accounting:
+
+- **Unit tests** → owned with the package `lib` (or `bin`) row; prove under Bazel via
+  that crate's test configuration in #8/#10/#9.
+- **Doctests** → same attachment, or a documented equivalent if Bazel doctest support
+  differs (must not silently drop coverage).
+
+## Cargo target ledger
+
+Columns `bazel_label` and `status` are filled by later slices (#11–#7). At freeze,
+every row is `unmapped`.
+
+| Package | Target | Class | Source | Bazel label | Status | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| `graphforge-api` | `graphforge_api` | `lib` | `crates/graphforge-api/src/lib.rs` | — | `unmapped` | |
+| `graphforge-api` | `atomic_recovery_workflow` | `example` | `crates/graphforge-api/examples/atomic_recovery_workflow.rs` | — | `unmapped` | |
+| `graphforge-api` | `correction_churn_workflow` | `example` | `crates/graphforge-api/examples/correction_churn_workflow.rs` | — | `unmapped` | |
+| `graphforge-api` | `cyber_intrusion_workflow` | `example` | `crates/graphforge-api/examples/cyber_intrusion_workflow.rs` | — | `unmapped` | |
+| `graphforge-api` | `derived_state_freshness_workflow` | `example` | `crates/graphforge-api/examples/derived_state_freshness_workflow.rs` | — | `unmapped` | |
+| `graphforge-api` | `finance_fraud_workflow` | `example` | `crates/graphforge-api/examples/finance_fraud_workflow.rs` | — | `unmapped` | |
+| `graphforge-api` | `knowledge_evolution_workflow` | `example` | `crates/graphforge-api/examples/knowledge_evolution_workflow.rs` | — | `unmapped` | |
+| `graphforge-api` | `ontology_emergence_strict_handoff` | `example` | `crates/graphforge-api/examples/ontology_emergence_strict_handoff.rs` | — | `unmapped` | |
+| `graphforge-api` | `probate_genealogy_workflow` | `example` | `crates/graphforge-api/examples/probate_genealogy_workflow.rs` | — | `unmapped` | |
+| `graphforge-api` | `release_load_probe` | `example` | `crates/graphforge-api/examples/release_load_probe.rs` | — | `unmapped` | |
+| `graphforge-api` | `sna_intelligence_workflow` | `example` | `crates/graphforge-api/examples/sna_intelligence_workflow.rs` | — | `unmapped` | |
+| `graphforge-api` | `strict_add_node_fixture` | `example` | `crates/graphforge-api/examples/strict_add_node_fixture.rs` | — | `unmapped` | |
+| `graphforge-api` | `bdd` | `integration-test` | `crates/graphforge-api/tests/bdd/main.rs` | — | `unmapped` | |
+| `graphforge-api` | `bdd_timing` | `integration-test` | `crates/graphforge-api/tests/bdd_timing.rs` | — | `unmapped` | |
+| `graphforge-api` | `belief_subject_contract` | `integration-test` | `crates/graphforge-api/tests/belief_subject_contract.rs` | — | `unmapped` | |
+| `graphforge-api` | `bind_error_spans` | `integration-test` | `crates/graphforge-api/tests/bind_error_spans.rs` | — | `unmapped` | |
+| `graphforge-api` | `clear` | `integration-test` | `crates/graphforge-api/tests/clear.rs` | — | `unmapped` | |
+| `graphforge-api` | `conductance` | `integration-test` | `crates/graphforge-api/tests/conductance.rs` | — | `unmapped` | |
+| `graphforge-api` | `create_scaling` | `integration-test` | `crates/graphforge-api/tests/create_scaling.rs` | — | `unmapped` | |
+| `graphforge-api` | `e2e_baseline` | `integration-test` | `crates/graphforge-api/tests/e2e_baseline.rs` | — | `unmapped` | |
+| `graphforge-api` | `existential_subquery` | `integration-test` | `crates/graphforge-api/tests/existential_subquery.rs` | — | `unmapped` | |
+| `graphforge-api` | `facade_methods` | `integration-test` | `crates/graphforge-api/tests/facade_methods.rs` | — | `unmapped` | |
+| `graphforge-api` | `fixed_hop_limit` | `integration-test` | `crates/graphforge-api/tests/fixed_hop_limit.rs` | — | `unmapped` | |
+| `graphforge-api` | `graph_internal_metadata` | `integration-test` | `crates/graphforge-api/tests/graph_internal_metadata.rs` | — | `unmapped` | |
+| `graphforge-api` | `inference_provenance` | `integration-test` | `crates/graphforge-api/tests/inference_provenance.rs` | — | `unmapped` | |
+| `graphforge-api` | `knowledge_isolation` | `integration-test` | `crates/graphforge-api/tests/knowledge_isolation.rs` | — | `unmapped` | |
+| `graphforge-api` | `list_semantics` | `integration-test` | `crates/graphforge-api/tests/list_semantics.rs` | — | `unmapped` | |
+| `graphforge-api` | `m22_m18_public_surface` | `integration-test` | `crates/graphforge-api/tests/m22_m18_public_surface.rs` | — | `unmapped` | |
+| `graphforge-api` | `m22_m19_public_surface` | `integration-test` | `crates/graphforge-api/tests/m22_m19_public_surface.rs` | — | `unmapped` | |
+| `graphforge-api` | `m22_provider_public_surface` | `integration-test` | `crates/graphforge-api/tests/m22_provider_public_surface.rs` | — | `unmapped` | |
+| `graphforge-api` | `max_bipartite_matching` | `integration-test` | `crates/graphforge-api/tests/max_bipartite_matching.rs` | — | `unmapped` | |
+| `graphforge-api` | `max_cardinality_matching` | `integration-test` | `crates/graphforge-api/tests/max_cardinality_matching.rs` | — | `unmapped` | |
+| `graphforge-api` | `max_weight_matching` | `integration-test` | `crates/graphforge-api/tests/max_weight_matching.rs` | — | `unmapped` | |
+| `graphforge-api` | `minimum_k_spanning_tree` | `integration-test` | `crates/graphforge-api/tests/minimum_k_spanning_tree.rs` | — | `unmapped` | |
+| `graphforge-api` | `modularity` | `integration-test` | `crates/graphforge-api/tests/modularity.rs` | — | `unmapped` | |
+| `graphforge-api` | `multi_label_scaling` | `integration-test` | `crates/graphforge-api/tests/multi_label_scaling.rs` | — | `unmapped` | |
+| `graphforge-api` | `pattern_comprehension` | `integration-test` | `crates/graphforge-api/tests/pattern_comprehension.rs` | — | `unmapped` | |
+| `graphforge-api` | `percentile_aggregates` | `integration-test` | `crates/graphforge-api/tests/percentile_aggregates.rs` | — | `unmapped` | |
+| `graphforge-api` | `provider_session` | `integration-test` | `crates/graphforge-api/tests/provider_session.rs` | — | `unmapped` | |
+| `graphforge-api` | `public_facade_remaining_conformance` | `integration-test` | `crates/graphforge-api/tests/public_facade_remaining_conformance.rs` | — | `unmapped` | |
+| `graphforge-api` | `public_lifecycle_conformance` | `integration-test` | `crates/graphforge-api/tests/public_lifecycle_conformance.rs` | — | `unmapped` | |
+| `graphforge-api` | `release_load_construction` | `integration-test` | `crates/graphforge-api/tests/release_load_construction.rs` | — | `unmapped` | |
+| `graphforge-api` | `strict_runtime_properties` | `integration-test` | `crates/graphforge-api/tests/strict_runtime_properties.rs` | — | `unmapped` | |
+| `graphforge-api` | `value_access_semantics` | `integration-test` | `crates/graphforge-api/tests/value_access_semantics.rs` | — | `unmapped` | |
+| `graphforge-api` | `value_semantics` | `integration-test` | `crates/graphforge-api/tests/value_semantics.rs` | — | `unmapped` | |
+| `graphforge-api` | `with_aggregation` | `integration-test` | `crates/graphforge-api/tests/with_aggregation.rs` | — | `unmapped` | |
+| `graphforge-api` | `xor_scaling` | `integration-test` | `crates/graphforge-api/tests/xor_scaling.rs` | — | `unmapped` | |
+| `graphforge-ast` | `graphforge_ast` | `lib` | `crates/graphforge-ast/src/lib.rs` | — | `unmapped` | |
+| `graphforge-bindings-node` | `graphforge_bindings_node` | `cdylib` | `crates/graphforge-bindings-node/src/lib.rs` | — | `unmapped` | |
+| `graphforge-bindings-node` | `build-script-build` | `custom-build` | `crates/graphforge-bindings-node/build.rs` | — | `unmapped` | |
+| `graphforge-bindings-py` | `graphforge_bindings_py` | `cdylib` | `crates/graphforge-bindings-py/src/lib.rs` | — | `unmapped` | |
+| `graphforge-cli` | `graphforge_cli` | `lib` | `crates/graphforge-cli/src/lib.rs` | — | `unmapped` | |
+| `graphforge-cli` | `gf` | `bin` | `crates/graphforge-cli/src/main.rs` | — | `unmapped` | |
+| `graphforge-cli` | `checkpoints` | `integration-test` | `crates/graphforge-cli/tests/checkpoints.rs` | — | `unmapped` | |
+| `graphforge-cli` | `portable` | `integration-test` | `crates/graphforge-cli/tests/portable.rs` | — | `unmapped` | |
+| `graphforge-cli` | `repository` | `integration-test` | `crates/graphforge-cli/tests/repository.rs` | — | `unmapped` | |
+| `graphforge-cli` | `build-script-build` | `custom-build` | `crates/graphforge-cli/build.rs` | — | `unmapped` | |
+| `graphforge-core` | `graphforge_core` | `lib` | `crates/graphforge-core/src/lib.rs` | — | `unmapped` | |
+| `graphforge-cypher` | `graphforge_cypher` | `lib` | `crates/graphforge-cypher/src/lib.rs` | — | `unmapped` | |
+| `graphforge-cypher` | `corpus` | `integration-test` | `crates/graphforge-cypher/tests/corpus.rs` | — | `unmapped` | |
+| `graphforge-exec` | `graphforge_exec` | `lib` | `crates/graphforge-exec/src/lib.rs` | — | `unmapped` | |
+| `graphforge-exec` | `adjacency_expand` | `integration-test` | `crates/graphforge-exec/tests/adjacency_expand.rs` | — | `unmapped` | |
+| `graphforge-exec` | `bench_traversal_scaling` | `integration-test` | `crates/graphforge-exec/tests/bench_traversal_scaling.rs` | — | `unmapped` | |
+| `graphforge-exec` | `create_execution` | `integration-test` | `crates/graphforge-exec/tests/create_execution.rs` | — | `unmapped` | |
+| `graphforge-exec` | `create_input_driven` | `integration-test` | `crates/graphforge-exec/tests/create_input_driven.rs` | — | `unmapped` | |
+| `graphforge-exec` | `differential_traversal` | `integration-test` | `crates/graphforge-exec/tests/differential_traversal.rs` | — | `unmapped` | |
+| `graphforge-exec` | `explain_snapshots` | `integration-test` | `crates/graphforge-exec/tests/explain_snapshots.rs` | — | `unmapped` | |
+| `graphforge-exec` | `optional_match` | `integration-test` | `crates/graphforge-exec/tests/optional_match.rs` | — | `unmapped` | |
+| `graphforge-exec` | `persistent_adjacency` | `integration-test` | `crates/graphforge-exec/tests/persistent_adjacency.rs` | — | `unmapped` | |
+| `graphforge-exec` | `read_execution` | `integration-test` | `crates/graphforge-exec/tests/read_execution.rs` | — | `unmapped` | |
+| `graphforge-exec` | `unwind` | `integration-test` | `crates/graphforge-exec/tests/unwind.rs` | — | `unmapped` | |
+| `graphforge-exec` | `var_len_expand` | `integration-test` | `crates/graphforge-exec/tests/var_len_expand.rs` | — | `unmapped` | |
+| `graphforge-exec` | `write_statement` | `integration-test` | `crates/graphforge-exec/tests/write_statement.rs` | — | `unmapped` | |
+| `graphforge-io` | `graphforge_io` | `lib` | `crates/graphforge-io/src/lib.rs` | — | `unmapped` | |
+| `graphforge-ir` | `graphforge_ir` | `lib` | `crates/graphforge-ir/src/lib.rs` | — | `unmapped` | |
+| `graphforge-ir` | `golden` | `integration-test` | `crates/graphforge-ir/tests/golden.rs` | — | `unmapped` | |
+| `graphforge-knowledge` | `graphforge_knowledge` | `lib` | `crates/graphforge-knowledge/src/lib.rs` | — | `unmapped` | |
+| `graphforge-ontology` | `graphforge_ontology` | `lib` | `crates/graphforge-ontology/src/lib.rs` | — | `unmapped` | |
+| `graphforge-ontology` | `integration` | `integration-test` | `crates/graphforge-ontology/tests/integration.rs` | — | `unmapped` | |
+| `graphforge-plan` | `graphforge_plan` | `lib` | `crates/graphforge-plan/src/lib.rs` | — | `unmapped` | |
+| `graphforge-provenance` | `graphforge_provenance` | `lib` | `crates/graphforge-provenance/src/lib.rs` | — | `unmapped` | |
+| `graphforge-rel` | `graphforge_rel` | `lib` | `crates/graphforge-rel/src/lib.rs` | — | `unmapped` | |
+| `graphforge-rel` | `expression_lowering_matrix` | `integration-test` | `crates/graphforge-rel/tests/expression_lowering_matrix.rs` | — | `unmapped` | |
+| `graphforge-rel` | `logical_plan_golden` | `integration-test` | `crates/graphforge-rel/tests/logical_plan_golden.rs` | — | `unmapped` | |
+| `graphforge-search` | `graphforge_search` | `lib` | `crates/graphforge-search/src/lib.rs` | — | `unmapped` | |
+| `graphforge-storage` | `graphforge_storage` | `lib` | `crates/graphforge-storage/src/lib.rs` | — | `unmapped` | |
+| `graphforge-storage` | `adjacency_delta_write` | `integration-test` | `crates/graphforge-storage/tests/adjacency_delta_write.rs` | — | `unmapped` | |
+| `graphforge-storage` | `filtered_read` | `integration-test` | `crates/graphforge-storage/tests/filtered_read.rs` | — | `unmapped` | |
+| `graphforge-storage` | `graph_writer` | `integration-test` | `crates/graphforge-storage/tests/graph_writer.rs` | — | `unmapped` | |
+| `graphforge-storage` | `io_stats` | `integration-test` | `crates/graphforge-storage/tests/io_stats.rs` | — | `unmapped` | |
+
+## Retained-tool exception stubs
+
+These are **not** claimed as Bazel-complete at freeze. Each needs a justification
+before #6 parity can pass with the exception still open.
+
+| ID | Tool / surface | Why Bazel may not replace cleanly | Owning follow-up | Status |
+| --- | --- | --- | --- | --- |
+| RT-fuzz | `cargo fuzz` (`fuzz/` workspace, workflow `fuzz.yml`) | cargo-fuzz driver + corpus workflow outside ordinary `rules_rust` test graph | #8/#6 justify or map | stub |
+| RT-publish-crates | `cargo publish` / crates.io authorize flows | Ecosystem publication metadata and registry auth | keep Cargo; ledger must remain explicit | stub |
+| RT-maturin-assemble | `maturin build` / `maturin sdist` packaging assembly | May assemble/sign/publish wheels, but must consume Bazel-built natives after #7 | #7 handoff | stub |
+| RT-napi-assemble | `napi build` / `napi artifacts` / `napi pre-publish` | Package assembly + npm provenance; must not silently recompile a different Rust graph after #7 | #7 handoff | stub |
+| RT-examples | `graphforge-api` examples (11) | May be CI/release probes vs developer samples; map or except per #8/#6 | #8/#6 | stub |
+| RT-mobile | Swift / Kotlin / UniFFI / XCFramework / JVM AAR | **Abandoned for M2** — not a deliverable; do not inventory as required targets | excluded | excluded |
+
+## CI / release build command sites
+
+Frozen scan of `.github/workflows/`, `scripts/`, and `Makefile` for `cargo`,
+`maturin`, and `napi` build/test command invocations: **120** sites across
+**27** files. Representative required path is `CI Gate` via
+`.github/workflows/test.yml` on Blacksmith runners.
+
+### Sticky Cargo `target/` disks (retire only after #4 evidence)
+
+Workflows using `useblacksmith/stickydisk` at freeze:
+- `.github/workflows/binding-release-candidate.yml`
+- `.github/workflows/test.yml`
+- `.github/workflows/m1-release-certification.yml`
+- `.github/workflows/fuzz.yml`
+
+Primary `test.yml` sticky key pattern:
+`${{ github.repository }}-${{ github.job }}-${{ hashFiles('Cargo.lock') }}-target-v1` → `target/`.
+
+### Sites by file
+
+| File | Sites | Role |
+| --- | ---: | --- |
+| `.github/workflows/binding-release-candidate.yml` | 11 | Binding RC wheels/addons |
+| `.github/workflows/checkpoint-recovery-gate.yml` | 6 | Checkpoint recovery gate |
+| `.github/workflows/concurrency-stress-gate.yml` | 1 | Concurrency stress |
+| `.github/workflows/fuzz.yml` | 6 | cargo-fuzz (retained-tool candidate) |
+| `.github/workflows/m1-release-certification.yml` | 4 | Release load certification |
+| `.github/workflows/non-cypher-surface-gate.yml` | 4 | Non-Cypher surface gate |
+| `.github/workflows/test.yml` | 6 | Required CI Gate compile/test/bindings |
+| `.github/workflows/visualization-limits-stress.yml` | 1 | Visualization stress |
+| `Makefile` | 17 | Developer/CI mirrors |
+| `scripts/ci/clean-env-verify.py` | 1 | Build/test/package command site |
+| `scripts/ci/crate-publish-plan.py` | 4 | Build/test/package command site |
+| `scripts/ci/m1-release-certification.py` | 2 | Build/test/package command site |
+| `scripts/ci/test-binding-release-candidate.py` | 19 | Build/test/package command site |
+| `scripts/ci/test-checkpoint-recovery-gate.py` | 1 | Build/test/package command site |
+| `scripts/ci/test-ci-storage-policy.py` | 3 | Build/test/package command site |
+| `scripts/ci/test-crate-publish-plan.py` | 2 | Build/test/package command site |
+| `scripts/ci/test-m1-release-certification.py` | 10 | Build/test/package command site |
+| `scripts/ci/test-m20-contract-gate.py` | 1 | Build/test/package command site |
+| `scripts/ci/test-m21-contract-gate.py` | 1 | Build/test/package command site |
+| `scripts/ci/test-pre-push-validation.py` | 1 | Build/test/package command site |
+| `scripts/ci/test-publish-track.py` | 3 | Build/test/package command site |
+| `scripts/ci/test-release-publish-preflight.py` | 1 | Build/test/package command site |
+| `scripts/coverage-rust.sh` | 2 | Coverage builds (maturin/napi + cargo) |
+| `scripts/pre_push_validation.py` | 1 | Build/test/package command site |
+| `scripts/publish_crates.py` | 4 | Build/test/package command site |
+| `scripts/publish_dry_run.py` | 5 | Build/test/package command site |
+| `scripts/verify_package_licenses.py` | 3 | Build/test/package command site |
+
+<details>
+<summary>Full command-site listing (path:line)</summary>
+
+| Path | Line | Snippet |
+| --- | ---: | --- |
+| `.github/workflows/non-cypher-surface-gate.yml` | 41 | `cargo test -p graphforge-api --lib --no-fail-fast` |
+| `.github/workflows/non-cypher-surface-gate.yml` | 42 | `cargo test -p graphforge-api \` |
+| `.github/workflows/non-cypher-surface-gate.yml` | 135 | `"cargo test -p graphforge-api --lib --no-fail-fast",` |
+| `.github/workflows/non-cypher-surface-gate.yml` | 136 | `"cargo test -p graphforge-api --test knowledge_isolation --test public_lifecycle_conformance --test public_facade_remaining_conformance --test m22_m18_public_su` |
+| `.github/workflows/binding-release-candidate.yml` | 93 | `uses: PyO3/maturin-action@v1` |
+| `.github/workflows/binding-release-candidate.yml` | 102 | `- name: Reclaim sticky-disk ownership after maturin` |
+| `.github/workflows/binding-release-candidate.yml` | 324 | `pnpm --filter @curatelabs/graphforge exec napi build --platform --release` |
+| `.github/workflows/binding-release-candidate.yml` | 365 | `pnpm exec napi create-npm-dirs` |
+| `.github/workflows/binding-release-candidate.yml` | 366 | `pnpm exec napi artifacts --output-dir artifacts --npm-dir npm` |
+| `.github/workflows/binding-release-candidate.yml` | 543 | `uv run maturin sdist` |
+| `.github/workflows/binding-release-candidate.yml` | 558 | `pnpm exec napi build --platform --release --target x86_64-unknown-linux-gnu` |
+| `.github/workflows/binding-release-candidate.yml` | 561 | `pnpm exec napi create-npm-dirs` |
+| `.github/workflows/binding-release-candidate.yml` | 562 | `pnpm exec napi artifacts --output-dir artifacts --npm-dir npm` |
+| `.github/workflows/binding-release-candidate.yml` | 565 | `pnpm exec napi pre-publish -t npm --skip-optional-publish --no-gh-release` |
+| `.github/workflows/binding-release-candidate.yml` | 612 | `cargo package "${package_args[@]}" --allow-dirty --no-verify` |
+| `.github/workflows/test.yml` | 437 | `run: cargo fmt --all -- --check` |
+| `.github/workflows/test.yml` | 440 | `run: cargo clippy --workspace -- -D warnings` |
+| `.github/workflows/test.yml` | 477 | `run: cargo test --workspace --no-fail-fast` |
+| `.github/workflows/test.yml` | 529 | `uvx maturin build` |
+| `.github/workflows/test.yml` | 682 | `run: pnpm --filter @curatelabs/graphforge exec napi build --platform` |
+| `.github/workflows/test.yml` | 851 | `cargo test -p graphforge-storage project_generation::tests:: --lib` |
+| `.github/workflows/m1-release-certification.yml` | 137 | `uses: PyO3/maturin-action@v1` |
+| `.github/workflows/m1-release-certification.yml` | 145 | `- name: Reclaim sticky-disk ownership after maturin` |
+| `.github/workflows/m1-release-certification.yml` | 166 | `cargo build --release -p graphforge-api --example release_load_probe` |
+| `.github/workflows/m1-release-certification.yml` | 171 | `pnpm --filter @curatelabs/graphforge exec napi build --platform --release \` |
+| `.github/workflows/visualization-limits-stress.yml` | 59 | `uvx maturin build \` |
+| `.github/workflows/fuzz.yml` | 60 | `cargo fmt --check` |
+| `.github/workflows/fuzz.yml` | 61 | `cargo clippy --all-targets -- -D warnings` |
+| `.github/workflows/fuzz.yml` | 69 | `run: cargo fuzz run --target x86_64-unknown-linux-gnu fuzz_parse corpus/fuzz_parse seeds/queries -- -max_total_time=60 -rss_limit_mb=4096` |
+| `.github/workflows/fuzz.yml` | 73 | `run: cargo fuzz run --target x86_64-unknown-linux-gnu fuzz_bind corpus/fuzz_bind seeds/queries -- -max_total_time=60 -rss_limit_mb=4096` |
+| `.github/workflows/fuzz.yml` | 77 | `run: cargo fuzz run --target x86_64-unknown-linux-gnu fuzz_ontology corpus/fuzz_ontology seeds/ontology -- -max_total_time=60 -rss_limit_mb=4096` |
+| `.github/workflows/fuzz.yml` | 81 | `run: cargo fuzz run --target x86_64-unknown-linux-gnu fuzz_exec corpus/fuzz_exec seeds/queries -- -max_total_time=60 -rss_limit_mb=4096` |
+| `.github/workflows/concurrency-stress-gate.yml` | 54 | `uvx maturin build \` |
+| `.github/workflows/checkpoint-recovery-gate.yml` | 29 | `cargo test -p graphforge-storage --lib project_checkpoints::tests --no-fail-fast` |
+| `.github/workflows/checkpoint-recovery-gate.yml` | 30 | `cargo test -p graphforge-api --lib checkpoints::tests --no-fail-fast` |
+| `.github/workflows/checkpoint-recovery-gate.yml` | 31 | `cargo test -p graphforge-cli --no-fail-fast` |
+| `.github/workflows/checkpoint-recovery-gate.yml` | 32 | `cargo build -p graphforge-cli` |
+| `.github/workflows/checkpoint-recovery-gate.yml` | 84 | `uv run --with maturin maturin build --manifest-path crates/graphforge-bindings-py/Cargo.toml --out dist` |
+| `.github/workflows/checkpoint-recovery-gate.yml` | 127 | `pnpm --filter @curatelabs/graphforge exec napi build --platform` |
+| `scripts/coverage-rust.sh` | 139 | `uv run maturin develop --release -m crates/graphforge-bindings-py/Cargo.toml` |
+| `scripts/coverage-rust.sh` | 140 | `pnpm --filter @curatelabs/graphforge exec napi build --platform --release` |
+| `scripts/publish_crates.py` | 11 | `for every ``cargo publish`` attempt.` |
+| `scripts/publish_crates.py` | 13 | `The token is normalized before ``cargo publish``: leading/trailing whitespace` |
+| `scripts/publish_crates.py` | 207 | `"""Run ``cargo publish`` for one crate, sleeping through bounded 429 waits.` |
+| `scripts/publish_crates.py` | 314 | `raise RuntimeError(f"cargo package did not create {archive}")` |
+| `scripts/verify_package_licenses.py` | 6 | `- Cargo: ``cargo package --list`` includes LICENSE and NOTICE` |
+| `scripts/verify_package_licenses.py` | 8 | `- Python: maturin/pyproject ``license-files`` exist and declare Apache-2.0` |
+| `scripts/verify_package_licenses.py` | 88 | `errors.append(f"cargo package -p {name} --list failed: {detail}")` |
+| `scripts/pre_push_validation.py` | 355 | `(("uv", "run", "maturin", "--version"), "run: uv sync --all-extras"),` |
+| `scripts/publish_dry_run.py` | 5 | `- cargo-package: ``cargo package --list --no-verify`` per crates.io plan order` |
+| `scripts/publish_dry_run.py` | 6 | `- cargo-publish: ``cargo publish --dry-run`` (heavy; optional)` |
+| `scripts/publish_dry_run.py` | 9 | `- python: ``maturin sdist`` (local packaging; TestPyPI upload is separate/manual)` |
+| `scripts/publish_dry_run.py` | 206 | `"maturin",` |
+| `scripts/publish_dry_run.py` | 227 | `help="When surface=all, skip heavy cargo publish --dry-run",` |
+| `scripts/ci/test-checkpoint-recovery-gate.py` | 63 | `skipped["command_groups"]["rust-storage"] = "cargo test -- --ignored"` |
+| `scripts/ci/m1-release-certification.py` | 176 | `"cargo test -p graphforge-api --lib --no-fail-fast",` |
+| `scripts/ci/m1-release-certification.py` | 177 | `"cargo test -p graphforge-api --test knowledge_isolation "` |
+| `scripts/ci/test-crate-publish-plan.py` | 81 | `assert commands[0].startswith("cargo publish -p graphforge-core ")` |
+| `scripts/ci/test-crate-publish-plan.py` | 82 | `assert commands[-1].startswith("cargo publish -p graphforge-cli ")` |
+| `scripts/ci/test-m1-release-certification.py` | 112 | `self.assertNotIn("cargo build", validation_job)` |
+| `scripts/ci/test-m1-release-certification.py` | 113 | `self.assertNotIn("maturin-action", validation_job)` |
+| `scripts/ci/test-m1-release-certification.py` | 129 | `self.assertIn("Reclaim sticky-disk ownership after maturin", load_job)` |
+| `scripts/ci/test-m1-release-certification.py` | 138 | `reclaim_step = load_job.index("- name: Reclaim sticky-disk ownership after maturin")` |
+| `scripts/ci/test-m1-release-certification.py` | 147 | `self.assertNotIn("cargo build", load_job[wrapper_step:artifact_step])` |
+| `scripts/ci/test-m1-release-certification.py` | 151 | `rust_build = artifact_build.index("cargo build")` |
+| `scripts/ci/test-m1-release-certification.py` | 152 | `node_build = artifact_build.index("napi build")` |
+| `scripts/ci/test-m1-release-certification.py` | 219 | `"cargo test -p graphforge-api --lib --no-fail-fast",` |
+| `scripts/ci/test-m1-release-certification.py` | 220 | `"cargo test -p graphforge-api --test knowledge_isolation --test "` |
+| `scripts/ci/test-m1-release-certification.py` | 320 | `bad_rust_commands["commands"][0] = "cargo test --workspace"` |
+| `scripts/ci/test-pre-push-validation.py` | 324 | `self.assertFalse(any(command[0] == "uv" and "maturin" in command for command in commands))` |
+| `scripts/ci/clean-env-verify.py` | 540 | `result.commands.append("cargo check")` |
+| `scripts/ci/test-m21-contract-gate.py` | 60 | `forbidden["command_groups"]["rust"][0] = "cargo test -- --ignored"` |
+| `scripts/ci/test-ci-storage-policy.py` | 14 | `cache without GitHub-backed maturin sccache).` |
+| `scripts/ci/test-ci-storage-policy.py` | 373 | `for step in action_steps(text, "PyO3/maturin-action@"):` |
+| `scripts/ci/test-ci-storage-policy.py` | 374 | `assert field(step, "uses") == "PyO3/maturin-action@v1", "unapproved Maturin action"` |
+| `scripts/ci/test-release-publish-preflight.py` | 168 | `for forbidden in ("npm publish", "uv publish", "cargo publish", "release:\n"):` |
+| `scripts/ci/crate-publish-plan.py` | 100 | `"""Return crate → path deps that lack version= (blocks cargo publish)."""` |
+| `scripts/ci/crate-publish-plan.py` | 130 | `f"{name}: path dependencies missing version= for cargo publish: " + ", ".join(deps)` |
+| `scripts/ci/crate-publish-plan.py` | 152 | `print(f"cargo publish -p {name} --dry-run --locked")` |
+| `scripts/ci/crate-publish-plan.py` | 167 | `help="Print cargo publish --dry-run commands when unblocked",` |
+| `scripts/ci/test-publish-track.py` | 81 | `"cargo publish",` |
+| `scripts/ci/test-publish-track.py` | 92 | `assert "PyO3/maturin-action" not in publish` |
+| `scripts/ci/test-publish-track.py` | 93 | `assert "napi build" not in publish` |
+| `scripts/ci/test-m20-contract-gate.py` | 51 | `forbidden_command["command_groups"]["rust"][0] = "cargo test -- --ignored"` |
+| `scripts/ci/test-binding-release-candidate.py` | 27 | `ARTIFACT_COMMAND = "pnpm exec napi artifacts --output-dir artifacts --npm-dir npm"` |
+| `scripts/ci/test-binding-release-candidate.py` | 142 | `_, maturin_found, post_maturin = python_job.partition("uses: PyO3/maturin-action@v1")` |
+| `scripts/ci/test-binding-release-candidate.py` | 143 | `assert maturin_found, "missing maturin build marker"` |
+| `scripts/ci/test-binding-release-candidate.py` | 263 | `"pnpm --filter @curatelabs/graphforge exec napi build --platform --release",` |
+| `scripts/ci/test-binding-release-candidate.py` | 509 | `"uses: PyO3/maturin-action@v1",` |
+| `scripts/ci/test-binding-release-candidate.py` | 527 | `post_maturin_python = rc_workflow_text.split("uses: PyO3/maturin-action@v1", 1)[1].split(` |
+| `scripts/ci/test-binding-release-candidate.py` | 551 | `assert "cargo test --release -p graphforge-storage" not in python_job` |
+| `scripts/ci/test-binding-release-candidate.py` | 554 | `assert "uses: PyO3/maturin-action@v1" in python_job` |
+| `scripts/ci/test-binding-release-candidate.py` | 566 | `"cargo test -p graphforge-storage project_generation::tests:: --lib",` |
+| `scripts/ci/test-binding-release-candidate.py` | 597 | `assert "Reclaim sticky-disk ownership after maturin" in rc_workflow_text` |
+| `scripts/ci/test-binding-release-candidate.py` | 618 | `"pnpm exec napi build --platform --release --target x86_64-unknown-linux-gnu"` |
+| `scripts/ci/test-binding-release-candidate.py` | 628 | `assert 'cargo package "${package_args[@]}" --allow-dirty --no-verify' in (release_candidate_job)` |
+| `scripts/ci/test-binding-release-candidate.py` | 629 | `assert 'cargo package -p "$crate"' not in release_candidate_job` |
+| `scripts/ci/test-binding-release-candidate.py` | 654 | `assert "PyO3/maturin-action" not in publish_workflow_text` |
+| `scripts/ci/test-binding-release-candidate.py` | 655 | `assert "napi build" not in publish_workflow_text` |
+| `scripts/ci/test-binding-release-candidate.py` | 783 | `assert "exec napi build --platform --release" in workflow_text, (` |
+| `scripts/ci/test-binding-release-candidate.py` | 804 | `assert "napi artifacts --dir" not in workflow_text, (` |
+| `scripts/ci/test-binding-release-candidate.py` | 805 | `f"{workflow.name} uses the unsupported napi artifacts --dir option"` |
+| `scripts/ci/test-binding-release-candidate.py` | 809 | `assert "exec napi build --platform --release" not in publish_text` |
+| `Makefile` | 39 | `publish-dry-run-python:  ## Local maturin sdist packaging check (not TestPyPI upload)` |
+| `Makefile` | 41 | `publish-dry-run-cargo:  ## cargo package --list for all 15 crates.io packages in plan order` |
+| `Makefile` | 66 | `cargo test -p graphforge-core --test bdd` |
+| `Makefile` | 84 | `echo "   maturin develop --release -m crates/graphforge-bindings-py/Cargo.toml"; \` |
+| `Makefile` | 104 | `coverage-python:  ## Run unit tests with Python wrapper coverage (requires maturin develop)` |
+| `Makefile` | 250 | `cargo build --workspace` |
+| `Makefile` | 253 | `cargo test --workspace` |
+| `Makefile` | 271 | `cargo test -p graphforge-exec --release --test bench_traversal_scaling -- --ignored --nocapture --test-threads=1` |
+| `Makefile` | 274 | `cargo test -p graphforge-api --release --test fixed_hop_limit release_fixed_hop_limit_1m_10m -- --ignored --nocapture --test-threads=1` |
+| `Makefile` | 278 | `cargo test -p graphforge-api --release --test fixed_hop_limit release_livejournal_fixed_hop_limits -- --ignored --nocapture --test-threads=1` |
+| `Makefile` | 326 | `cargo check --workspace` |
+| `Makefile` | 329 | `cargo clippy --workspace -- -D warnings` |
+| `Makefile` | 332 | `cargo fmt --all` |
+| `Makefile` | 335 | `cargo fmt --all -- --check` |
+| `Makefile` | 362 | `echo "   Build first: pnpm --filter @curatelabs/graphforge exec napi build --platform --release"; \` |
+| `Makefile` | 385 | `cargo check --workspace` |
+| `Makefile` | 389 | `cargo build --workspace` |
+
+</details>
+
+## Blacksmith runner path
+
+- Required CI jobs use `blacksmith-*-ubuntu-*` / Blacksmith-hosted runners (see
+  `.github/workflows/test.yml` and related gates).
+- **Org-admin dependency for #5:** enable **Bazel Build Caching** for this repository
+  in Blacksmith. Ledger freeze does **not** wait on that enablement.
+- Do not configure repository `--remote_cache`; Blacksmith injects cache for Bazel jobs.
+
+## Update rules
+
+1. Modeling PRs (#11–#7) must update `bazel_label` / `status` for touched rows in the
+   same change.
+2. New Cargo targets require a new ledger row before #6 parity can pass.
+3. Unjustified retained exceptions fail the migration at #6.
+4. Mobile bindings stay `excluded` — never promote to required M2 targets.
+

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -251,6 +251,9 @@ When adding features, update:
 M2 Bazel migration work follows the sub-agent contracts in
 [bazel-migration-orchestration.md](bazel-migration-orchestration.md)
 (canonical issue [#1](https://github.com/CurateLabs/graphforge/issues/1)).
+The frozen inventory and Cargo/Blacksmith baseline live in
+[bazel-migration-ledger.md](bazel-migration-ledger.md) and
+[bazel-migration-baseline.md](bazel-migration-baseline.md).
 
 ---
 

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -29,6 +29,8 @@ flowchart LR
 | [`../book/architecture/`](../book/architecture/overview.md) | Deep architecture notes, pipeline, storage, embedding contracts |
 | [`../development/`](../development/contributing.md) | Contributor workflow, testing detail, release process |
 | [`../development/bazel-migration-orchestration.md`](../development/bazel-migration-orchestration.md) | M2 / #1 Bazel migration sub-agent roles, contracts, and handoffs |
+| [`../development/bazel-migration-ledger.md`](../development/bazel-migration-ledger.md) | M2 / #1 Cargo target + CI command migration ledger (freeze) |
+| [`../development/bazel-migration-baseline.md`](../development/bazel-migration-baseline.md) | M2 / #1 accepted Blacksmith/Cargo CI performance baseline |
 | [`../contracts/`](https://github.com/CurateLabs/graphforge/tree/main/docs/contracts) | Frozen public API / fingerprint JSON contracts |
 | [`../reference/`](../reference/api.md) | Compatibility, TCK, scale limits, column naming |
 | Root `AGENTS.md` | Agent workflow and validation gates |


### PR DESCRIPTION
## Summary
- Freeze an authoritative Cargo target ledger (90 metadata targets / 17 packages at SHA `6e8b8e3`) with unmapped Bazel columns for later slices.
- Inventory CI/release `cargo`/`maturin`/`napi` command sites, sticky-disk workflows, and retained-tool exception stubs (including explicit mobile exclusion).
- Record an accepted Blacksmith/Cargo baseline from five successful full-matrix PR runs for #5 performance comparison.

## Test plan
- [x] Regenerated ledger from `cargo metadata --format-version=1 --no-deps` on freeze SHA
- [x] Baseline timings pulled from GitHub Actions job timestamps (docs-only PRs excluded)
- [x] Docs-only change; no Bazel modeling claimed
- [ ] Confirm CI Gate / docs checks green on exact head SHA

Fixes #12

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/418"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788576088&installation_model_id=20486&pr_number=418&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F418&signature=1b07b8f65d0437c0c060335994d5b8da6134c3470ae1baf2a4b03aa565f12ab7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Freeze Bazel migration ledger and Cargo/Blacksmith CI performance baseline
> - Adds [bazel-migration-ledger.md](https://github.com/CurateLabs/graphforge/pull/418/files#diff-28cbdfbeb46f8803e51faefa92faf910255bc364d2f2e25631435114febc6af1) recording a frozen inventory of 90 Cargo targets (all unmapped at freeze), CI build command sites, Blacksmith runner notes, and update rules for future migration PRs.
> - Adds [bazel-migration-baseline.md](https://github.com/CurateLabs/graphforge/pull/418/files#diff-cc80dee4ecc9964d3b32a85e98cb7bb6f539021e3237e3ae8a17471472de0bee) recording the accepted Cargo/Blacksmith CI performance baseline: five sampled runs, per-job p50 wall times, compute proxy definition, and explicit comparison criteria that the Bazel migration PR must meet.
> - Updates [contributing.md](https://github.com/CurateLabs/graphforge/pull/418/files#diff-1111d51a0cac575359b0585ecfec1f7e88aef2c213989581db2dc909bfcbc635) and [engineering/README.md](https://github.com/CurateLabs/graphforge/pull/418/files#diff-e3474f2dac2c782a8a914751755200885802cf7dac8104ebf44011fa44eca155) to link to both new documents.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee78602.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->