### PR TITLE
build(bazel): model runtime library targets (#9)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -875,11 +875,11 @@ jobs:
           python3 scripts/ci/cargo-bazel-drift-check.py
           python3 scripts/ci/test-cargo-bazel-drift-check.py
 
-      - name: Bazel smoke + foundation/compiler libs
+      - name: Bazel smoke + first-party library targets
         run: |
           # Do not set --remote_cache; Blacksmith injects repository cache.
-          bazelisk test //tools/bazel/smoke:smoke_test //:foundation_compiler_tests
-          bazelisk build //:bazel_smoke //:foundation_compiler_libs
+          bazelisk test //tools/bazel/smoke:smoke_test //:first_party_lib_tests
+          bazelisk build //:bazel_smoke //:first_party_libs //:runtime_libs
 
   ci-gate:
     name: CI Gate

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,4 @@
-"""Root Bazel package for GraphForge (#10 foundation/compiler libs)."""
+"""Root Bazel package for GraphForge (#10 foundation + #9 runtime libs)."""
 
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
@@ -23,7 +23,7 @@ alias(
 )
 
 # Foundation + compiler-layer libraries modeled in #10 (plus storage, required
-# by graphforge-rel). Runtime peers remain for #9.
+# by graphforge-rel).
 build_test(
     name = "foundation_compiler_libs",
     targets = [
@@ -50,6 +50,72 @@ test_suite(
         "//crates/graphforge-plan:graphforge_plan_test",
         "//crates/graphforge-provenance:graphforge_provenance_test",
         "//crates/graphforge-rel:graphforge_rel_test",
+        "//crates/graphforge-storage:graphforge_storage_test",
+    ],
+)
+
+# Runtime libraries modeled in #9 (storage already in foundation aggregate).
+build_test(
+    name = "runtime_libs",
+    targets = [
+        "//crates/graphforge-api:graphforge_api",
+        "//crates/graphforge-exec:graphforge_exec",
+        "//crates/graphforge-io:graphforge_io",
+        "//crates/graphforge-knowledge:graphforge_knowledge",
+        "//crates/graphforge-search:graphforge_search",
+        "//crates/graphforge-storage:graphforge_storage",
+    ],
+)
+
+test_suite(
+    name = "runtime_lib_tests",
+    tests = [
+        "//crates/graphforge-api:graphforge_api_test",
+        "//crates/graphforge-exec:graphforge_exec_test",
+        "//crates/graphforge-io:graphforge_io_test",
+        "//crates/graphforge-knowledge:graphforge_knowledge_test",
+        "//crates/graphforge-search:graphforge_search_test",
+        "//crates/graphforge-storage:graphforge_storage_test",
+    ],
+)
+
+# All first-party library targets modeled so far (#10 + #9).
+build_test(
+    name = "first_party_libs",
+    targets = [
+        "//crates/graphforge-api:graphforge_api",
+        "//crates/graphforge-ast:graphforge_ast",
+        "//crates/graphforge-core:graphforge_core",
+        "//crates/graphforge-cypher:graphforge_cypher",
+        "//crates/graphforge-exec:graphforge_exec",
+        "//crates/graphforge-io:graphforge_io",
+        "//crates/graphforge-ir:graphforge_ir",
+        "//crates/graphforge-knowledge:graphforge_knowledge",
+        "//crates/graphforge-ontology:graphforge_ontology",
+        "//crates/graphforge-plan:graphforge_plan",
+        "//crates/graphforge-provenance:graphforge_provenance",
+        "//crates/graphforge-rel:graphforge_rel",
+        "//crates/graphforge-search:graphforge_search",
+        "//crates/graphforge-storage:graphforge_storage",
+    ],
+)
+
+test_suite(
+    name = "first_party_lib_tests",
+    tests = [
+        "//crates/graphforge-api:graphforge_api_test",
+        "//crates/graphforge-ast:graphforge_ast_test",
+        "//crates/graphforge-core:graphforge_core_test",
+        "//crates/graphforge-cypher:graphforge_cypher_test",
+        "//crates/graphforge-exec:graphforge_exec_test",
+        "//crates/graphforge-io:graphforge_io_test",
+        "//crates/graphforge-ir:graphforge_ir_test",
+        "//crates/graphforge-knowledge:graphforge_knowledge_test",
+        "//crates/graphforge-ontology:graphforge_ontology_test",
+        "//crates/graphforge-plan:graphforge_plan_test",
+        "//crates/graphforge-provenance:graphforge_provenance_test",
+        "//crates/graphforge-rel:graphforge_rel_test",
+        "//crates/graphforge-search:graphforge_search_test",
         "//crates/graphforge-storage:graphforge_storage_test",
     ],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,9 +1,9 @@
-"""GraphForge Bazel module (M2 / #10 foundation + compiler libs).
+"""GraphForge Bazel module (M2 / #10 foundation + #9 runtime libs).
 
 Canonical build-system contract: GitHub issue #1.
 Activates crate_universe `from_cargo` against the frozen Cargo workspace and
-models foundation/compiler-layer first-party libraries as real rules_rust
-targets (no Cargo shell-out for ordinary compilation).
+models first-party libraries as real rules_rust targets (no Cargo shell-out
+for ordinary compilation).
 """
 
 module(

--- a/crates/BUILD.bazel
+++ b/crates/BUILD.bazel
@@ -1,3 +1,3 @@
-"""First-party crate packages live in crates/*/BUILD.bazel (#10+)."""
+"""First-party crate packages live in crates/*/BUILD.bazel (#10/#9+)."""
 
 package(default_visibility = ["//visibility:public"])

--- a/crates/graphforge-api/BUILD.bazel
+++ b/crates/graphforge-api/BUILD.bazel
@@ -1,5 +1,56 @@
-"""Scaffolding for crate_universe manifests; library modeling deferred (#9/#7/#8)."""
+"""Bazel targets for graphforge-api (#9 runtime)."""
+
+load("//tools/bazel:gf_rust.bzl", "gf_rust_library", "gf_rust_test")
 
 exports_files(["Cargo.toml"])
 
 package(default_visibility = ["//visibility:public"])
+
+# Unit tests include_str! contract fixtures from docs/contracts/examples.
+_API_COMPILE_DATA = [
+    "//docs/contracts/examples:fixtures",
+]
+
+gf_rust_library(
+    name = "graphforge_api",
+    compile_data = _API_COMPILE_DATA,
+    deps = [
+        "//crates/graphforge-core:graphforge_core",
+        "//crates/graphforge-cypher:graphforge_cypher",
+        "//crates/graphforge-exec:graphforge_exec",
+        "//crates/graphforge-ir:graphforge_ir",
+        "//crates/graphforge-knowledge:graphforge_knowledge",
+        "//crates/graphforge-ontology:graphforge_ontology",
+        "//crates/graphforge-provenance:graphforge_provenance",
+        "//crates/graphforge-rel:graphforge_rel",
+        "//crates/graphforge-search:graphforge_search",
+        "//crates/graphforge-storage:graphforge_storage",
+    ],
+)
+
+gf_rust_test(
+    name = "graphforge_api_test",
+    crate = ":graphforge_api",
+    compile_data = _API_COMPILE_DATA,
+    # Runtime reads via env!("CARGO_MANIFEST_DIR")/../../docs/reference/...
+    # Bake a workspace-relative manifest dir so runfiles layout resolves.
+    data = ["//docs/reference:schema_inventory_fixtures"],
+    rustc_env = {
+        "CARGO_MANIFEST_DIR": "crates/graphforge-api",
+    },
+    # Large public-facade unit suite with filesystem/async paths.
+    size = "large",
+    timeout = "long",
+    deps = [
+        "//crates/graphforge-core:graphforge_core",
+        "//crates/graphforge-cypher:graphforge_cypher",
+        "//crates/graphforge-exec:graphforge_exec",
+        "//crates/graphforge-ir:graphforge_ir",
+        "//crates/graphforge-knowledge:graphforge_knowledge",
+        "//crates/graphforge-ontology:graphforge_ontology",
+        "//crates/graphforge-provenance:graphforge_provenance",
+        "//crates/graphforge-rel:graphforge_rel",
+        "//crates/graphforge-search:graphforge_search",
+        "//crates/graphforge-storage:graphforge_storage",
+    ],
+)

--- a/crates/graphforge-exec/BUILD.bazel
+++ b/crates/graphforge-exec/BUILD.bazel
@@ -1,5 +1,35 @@
-"""Scaffolding for crate_universe manifests; library modeling deferred (#9/#7/#8)."""
+"""Bazel targets for graphforge-exec (#9 runtime)."""
+
+load("//tools/bazel:gf_rust.bzl", "gf_rust_library", "gf_rust_test")
 
 exports_files(["Cargo.toml"])
 
 package(default_visibility = ["//visibility:public"])
+
+gf_rust_library(
+    name = "graphforge_exec",
+    deps = [
+        "//crates/graphforge-core:graphforge_core",
+        "//crates/graphforge-ir:graphforge_ir",
+        "//crates/graphforge-ontology:graphforge_ontology",
+        "//crates/graphforge-plan:graphforge_plan",
+        "//crates/graphforge-rel:graphforge_rel",
+        "//crates/graphforge-storage:graphforge_storage",
+    ],
+)
+
+gf_rust_test(
+    name = "graphforge_exec_test",
+    crate = ":graphforge_exec",
+    # Algorithm + execution unit suite; default "small" is too tight.
+    size = "medium",
+    deps = [
+        "//crates/graphforge-core:graphforge_core",
+        "//crates/graphforge-cypher:graphforge_cypher",
+        "//crates/graphforge-ir:graphforge_ir",
+        "//crates/graphforge-ontology:graphforge_ontology",
+        "//crates/graphforge-plan:graphforge_plan",
+        "//crates/graphforge-rel:graphforge_rel",
+        "//crates/graphforge-storage:graphforge_storage",
+    ],
+)

--- a/crates/graphforge-io/BUILD.bazel
+++ b/crates/graphforge-io/BUILD.bazel
@@ -1,5 +1,24 @@
-"""Scaffolding for crate_universe manifests; library modeling deferred (#9/#7/#8)."""
+"""Bazel targets for graphforge-io (#9 runtime)."""
+
+load("//tools/bazel:gf_rust.bzl", "gf_rust_library", "gf_rust_test")
 
 exports_files(["Cargo.toml"])
 
 package(default_visibility = ["//visibility:public"])
+
+gf_rust_library(
+    name = "graphforge_io",
+    deps = [
+        "//crates/graphforge-core:graphforge_core",
+        "//crates/graphforge-storage:graphforge_storage",
+    ],
+)
+
+gf_rust_test(
+    name = "graphforge_io_test",
+    crate = ":graphforge_io",
+    deps = [
+        "//crates/graphforge-core:graphforge_core",
+        "//crates/graphforge-storage:graphforge_storage",
+    ],
+)

--- a/crates/graphforge-knowledge/BUILD.bazel
+++ b/crates/graphforge-knowledge/BUILD.bazel
@@ -1,5 +1,22 @@
-"""Scaffolding for crate_universe manifests; library modeling deferred (#9/#7/#8)."""
+"""Bazel targets for graphforge-knowledge (#9 runtime)."""
+
+load("//tools/bazel:gf_rust.bzl", "gf_rust_library", "gf_rust_test")
 
 exports_files(["Cargo.toml"])
 
 package(default_visibility = ["//visibility:public"])
+
+gf_rust_library(
+    name = "graphforge_knowledge",
+    deps = [
+        "//crates/graphforge-core:graphforge_core",
+    ],
+)
+
+gf_rust_test(
+    name = "graphforge_knowledge_test",
+    crate = ":graphforge_knowledge",
+    deps = [
+        "//crates/graphforge-core:graphforge_core",
+    ],
+)

--- a/crates/graphforge-search/BUILD.bazel
+++ b/crates/graphforge-search/BUILD.bazel
@@ -1,5 +1,26 @@
-"""Scaffolding for crate_universe manifests; library modeling deferred (#9/#7/#8)."""
+"""Bazel targets for graphforge-search (#9 runtime)."""
+
+load("//tools/bazel:gf_rust.bzl", "gf_rust_library", "gf_rust_test")
 
 exports_files(["Cargo.toml"])
 
 package(default_visibility = ["//visibility:public"])
+
+gf_rust_library(
+    name = "graphforge_search",
+    deps = [
+        "//crates/graphforge-storage:graphforge_storage",
+    ],
+)
+
+gf_rust_test(
+    name = "graphforge_search_test",
+    crate = ":graphforge_search",
+    # Indexing / tempfile paths; default "small" is too tight.
+    size = "medium",
+    deps = [
+        "//crates/graphforge-core:graphforge_core",
+        "//crates/graphforge-ir:graphforge_ir",
+        "//crates/graphforge-storage:graphforge_storage",
+    ],
+)

--- a/crates/graphforge-storage/BUILD.bazel
+++ b/crates/graphforge-storage/BUILD.bazel
@@ -1,7 +1,7 @@
 """Bazel targets for graphforge-storage.
 
 Modeled in #10 because graphforge-rel (compiler lowering) depends on it.
-Issue #9 still owns the remaining runtime libraries (exec/search/knowledge/api/io).
+Runtime peers (exec/search/knowledge/api/io) are modeled in #9.
 """
 
 load("//tools/bazel:gf_rust.bzl", "gf_rust_library", "gf_rust_test")
@@ -12,6 +12,12 @@ package(default_visibility = ["//visibility:public"])
 
 gf_rust_library(
     name = "graphforge_storage",
+    # Enable failpoint hooks so api/cli unit tests that spawn subprocesses can
+    # inject protocol faults. Hooks remain no-ops unless the exact env cookie is
+    # set (same as Cargo `[dev-dependencies] features = ["test-failpoints"]`
+    # unification). Residual vs Cargo release builds: Bazel links the env-gated
+    # bodies instead of the const no-op; document for #6 parity.
+    crate_features = ["test-failpoints"],
     deps = [
         "//crates/graphforge-core:graphforge_core",
         "//crates/graphforge-ir:graphforge_ir",
@@ -22,6 +28,7 @@ gf_rust_library(
 gf_rust_test(
     name = "graphforge_storage_test",
     crate = ":graphforge_storage",
+    crate_features = ["test-failpoints"],
     # Unit suite exercises filesystem/async paths; default "small" is too tight.
     size = "medium",
     deps = [

--- a/docs/contracts/examples/BUILD.bazel
+++ b/docs/contracts/examples/BUILD.bazel
@@ -1,0 +1,10 @@
+"""Contract example fixtures compiled into graphforge-api unit tests (#9)."""
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files(glob(["*"]))
+
+filegroup(
+    name = "fixtures",
+    srcs = glob(["*"]),
+)

--- a/docs/development/bazel-bootstrap.md
+++ b/docs/development/bazel-bootstrap.md
@@ -1,8 +1,9 @@
-# Bazelisk / Bzlmod bootstrap (#11) and foundation libs (#10)
+# Bazelisk / Bzlmod bootstrap (#11), foundation (#10), runtime libs (#9)
 
 Minimal Bazel workspace for M2 issues
-[#11](https://github.com/CurateLabs/graphforge/issues/11) and
-[#10](https://github.com/CurateLabs/graphforge/issues/10). Canonical contract:
+[#11](https://github.com/CurateLabs/graphforge/issues/11),
+[#10](https://github.com/CurateLabs/graphforge/issues/10), and
+[#9](https://github.com/CurateLabs/graphforge/issues/9). Canonical contract:
 [#1](https://github.com/CurateLabs/graphforge/issues/1). Orchestration:
 [bazel-migration-orchestration.md](bazel-migration-orchestration.md).
 
@@ -16,6 +17,8 @@ Minimal Bazel workspace for M2 issues
 | Repo flags | `.bazelrc` (Bzlmod on; **no** `--remote_cache`) |
 | Smoke library/test | `//tools/bazel/smoke:smoke` / `:smoke_test` |
 | Foundation/compiler libs | `//:foundation_compiler_libs` / `//:foundation_compiler_tests` |
+| Runtime libs | `//:runtime_libs` / `//:runtime_lib_tests` |
+| All modeled libs | `//:first_party_libs` / `//:first_party_lib_tests` |
 | Shared rust macros | `tools/bazel/gf_rust.bzl` (`gf_rust_library` / `gf_rust_test`) |
 | Cargo feature fingerprint | `tools/bazel/drift/cargo_feature_fingerprint.json` |
 | Drift check | `scripts/ci/cargo-bazel-drift-check.py` |
@@ -23,9 +26,6 @@ Minimal Bazel workspace for M2 issues
 | CI | `Bazel Bootstrap` job in `.github/workflows/test.yml` (path-classified) |
 
 ## Foundation / compiler slice (#10)
-
-Modeled first-party libraries (ordinary compilation via rules_rust; no Cargo
-shell-out):
 
 | Crate | Library label | Unit-test label |
 | --- | --- | --- |
@@ -39,10 +39,27 @@ shell-out):
 | `graphforge-rel` | `//crates/graphforge-rel:graphforge_rel` | `:graphforge_rel_test` |
 | `graphforge-cypher` | `//crates/graphforge-cypher:graphforge_cypher` | `:graphforge_cypher_test` |
 
-`graphforge-storage` is modeled in #10 because `graphforge-rel` depends on it.
-Issue [#9](https://github.com/CurateLabs/graphforge/issues/9) still owns exec,
-search, knowledge, API, and io libraries. Integration-test binaries remain for
-[#8](https://github.com/CurateLabs/graphforge/issues/8).
+## Runtime slice (#9)
+
+| Crate | Library label | Unit-test label |
+| --- | --- | --- |
+| `graphforge-exec` | `//crates/graphforge-exec:graphforge_exec` | `:graphforge_exec_test` |
+| `graphforge-search` | `//crates/graphforge-search:graphforge_search` | `:graphforge_search_test` |
+| `graphforge-knowledge` | `//crates/graphforge-knowledge:graphforge_knowledge` | `:graphforge_knowledge_test` |
+| `graphforge-api` | `//crates/graphforge-api:graphforge_api` | `:graphforge_api_test` |
+| `graphforge-io` | `//crates/graphforge-io:graphforge_io` | `:graphforge_io_test` |
+
+`graphforge-storage` remains under the foundation aggregate (modeled in #10) and is
+also listed in `//:runtime_libs` for the runtime slice view. Bazel enables the
+`test-failpoints` crate feature on storage so api subprocess recovery unit tests
+see the same env-gated hooks Cargo gets via feature unification.
+
+### Package coverage (17 workspace members)
+
+| Class | Count | Status after #9 |
+| --- | ---: | --- |
+| Ordinary `lib` mapped | 14 | foundation + runtime above |
+| Explicit retained exception | 3 | CLI lib (`RT-cli-build-script` → #8); bindings cdylibs (`RT-bindings-cdylib` → #7) |
 
 ### Residual gaps (justified)
 
@@ -51,7 +68,11 @@ search, knowledge, API, and io libraries. Integration-test binaries remain for
   for lint CI until a later slice).
 - Doctests are not separate Bazel targets yet (same attachment note as the
   ledger unit-test policy).
-- Integration / snapshot / BDD / CLI tests are out of scope for #10.
+- Integration / snapshot / BDD / CLI tests are out of scope (#8).
+- CLI library `build.rs` skill-bundle embedding is `RT-cli-build-script` (#8).
+- Binding cdylib packaging is #7.
+- Bazel storage always enables `test-failpoints` (env-gated no-ops); Cargo release
+  builds keep the const no-op body — track under #6 parity if needed.
 
 ## Local commands
 
@@ -59,9 +80,9 @@ search, knowledge, API, and io libraries. Integration-test binaries remain for
 # Pin via Bazelisk
 bazelisk version   # must report 9.2.0 from .bazelversion
 
-# Smoke + foundation/compiler libraries (rules_rust; no Cargo shell-out)
-bazelisk test //tools/bazel/smoke:smoke_test //:foundation_compiler_tests
-bazelisk build //:bazel_smoke //:foundation_compiler_libs
+# Smoke + all modeled first-party libraries (rules_rust; no Cargo shell-out)
+bazelisk test //tools/bazel/smoke:smoke_test //:first_party_lib_tests
+bazelisk build //:bazel_smoke //:first_party_libs //:runtime_libs
 
 # Cargo ↔ fingerprint drift (host cargo metadata; fail-closed)
 python3 scripts/ci/cargo-bazel-drift-check.py
@@ -69,7 +90,7 @@ python3 scripts/ci/test-cargo-bazel-drift-check.py
 
 # After intentional Cargo dependency/feature changes:
 python3 scripts/ci/cargo-bazel-drift-check.py --write
-CARGO_BAZEL_REPIN=1 bazelisk build --repo_env=CARGO_BAZEL_REPIN=1 //:foundation_compiler_libs
+CARGO_BAZEL_REPIN=1 bazelisk build --repo_env=CARGO_BAZEL_REPIN=1 //:first_party_libs
 ```
 
 ## Blacksmith / cache
@@ -78,8 +99,9 @@ CARGO_BAZEL_REPIN=1 bazelisk build --repo_env=CARGO_BAZEL_REPIN=1 //:foundation_
 - Do **not** add `--remote_cache` in `.bazelrc` or workflow steps. Blacksmith
   injects repository Bazel caching when org-admin enablement lands (#5).
 
-## Next (#9)
+## Next (#8 / #7, parallel)
 
-1. Model remaining first-party libraries (exec, search, knowledge, api, io).
-2. Keep drift check + `cargo-bazel-lock.json` green across new deps/features.
-3. Update [bazel-migration-ledger.md](bazel-migration-ledger.md) labels/status.
+1. [#8](https://github.com/CurateLabs/graphforge/issues/8) — test/BDD/CLI/resource
+   graph (includes CLI lib + `build.rs`).
+2. [#7](https://github.com/CurateLabs/graphforge/issues/7) — PyO3/napi cdylibs and
+   packaging handoff.

--- a/docs/development/bazel-migration-ledger.md
+++ b/docs/development/bazel-migration-ledger.md
@@ -14,8 +14,8 @@ Performance baseline: [bazel-migration-baseline.md](bazel-migration-baseline.md)
 | Authoritative source | `cargo metadata --format-version=1 --no-deps` |
 | Workspace packages | 17 |
 | Cargo metadata targets | **90** |
-| Bazel modeling claimed complete? | **No** — #10 foundation/compiler libs mapped; runtime/bindings/tests remain |
-| Bootstrap note | See [bazel-bootstrap.md](bazel-bootstrap.md); crate_universe + foundation/compiler labels from #10 |
+| Bazel modeling claimed complete? | **No** — #10/#9 first-party libs mapped (14/15 lib rows); CLI lib + bindings/tests remain |
+| Bootstrap note | See [bazel-bootstrap.md](bazel-bootstrap.md); crate_universe + foundation/runtime library labels from #10/#9 |
 
 Issue #1 historically cited ~71 Cargo targets / ~53 integration-test binaries.
 This freeze uses the **current authoritative** metadata count (**90** targets;
@@ -51,7 +51,7 @@ Integration-test / example / cdylib / bin rows stay `unmapped` until #8/#7/#9.
 
 | Package | Target | Class | Source | Bazel label | Status | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
-| `graphforge-api` | `graphforge_api` | `lib` | `crates/graphforge-api/src/lib.rs` | — | `unmapped` | #9 |
+| `graphforge-api` | `graphforge_api` | `lib` | `crates/graphforge-api/src/lib.rs` | `//crates/graphforge-api:graphforge_api` | `mapped` | #9; unit tests `//crates/graphforge-api:graphforge_api_test` |
 | `graphforge-api` | `atomic_recovery_workflow` | `example` | `crates/graphforge-api/examples/atomic_recovery_workflow.rs` | — | `unmapped` | |
 | `graphforge-api` | `correction_churn_workflow` | `example` | `crates/graphforge-api/examples/correction_churn_workflow.rs` | — | `unmapped` | |
 | `graphforge-api` | `cyber_intrusion_workflow` | `example` | `crates/graphforge-api/examples/cyber_intrusion_workflow.rs` | — | `unmapped` | |
@@ -102,7 +102,7 @@ Integration-test / example / cdylib / bin rows stay `unmapped` until #8/#7/#9.
 | `graphforge-bindings-node` | `graphforge_bindings_node` | `cdylib` | `crates/graphforge-bindings-node/src/lib.rs` | — | `unmapped` | #7 |
 | `graphforge-bindings-node` | `build-script-build` | `custom-build` | `crates/graphforge-bindings-node/build.rs` | — | `unmapped` | #7 |
 | `graphforge-bindings-py` | `graphforge_bindings_py` | `cdylib` | `crates/graphforge-bindings-py/src/lib.rs` | — | `unmapped` | #7 |
-| `graphforge-cli` | `graphforge_cli` | `lib` | `crates/graphforge-cli/src/lib.rs` | — | `unmapped` | #8/#9 peer |
+| `graphforge-cli` | `graphforge_cli` | `lib` | `crates/graphforge-cli/src/lib.rs` | — | `unmapped` | #8; `build.rs` embeds `project-skills` (RT-cli-build-script) |
 | `graphforge-cli` | `gf` | `bin` | `crates/graphforge-cli/src/main.rs` | — | `unmapped` | #8 |
 | `graphforge-cli` | `checkpoints` | `integration-test` | `crates/graphforge-cli/tests/checkpoints.rs` | — | `unmapped` | #8 |
 | `graphforge-cli` | `portable` | `integration-test` | `crates/graphforge-cli/tests/portable.rs` | — | `unmapped` | #8 |
@@ -111,7 +111,7 @@ Integration-test / example / cdylib / bin rows stay `unmapped` until #8/#7/#9.
 | `graphforge-core` | `graphforge_core` | `lib` | `crates/graphforge-core/src/lib.rs` | `//crates/graphforge-core:graphforge_core` | `mapped` | #10; unit tests `//crates/graphforge-core:graphforge_core_test` |
 | `graphforge-cypher` | `graphforge_cypher` | `lib` | `crates/graphforge-cypher/src/lib.rs` | `//crates/graphforge-cypher:graphforge_cypher` | `mapped` | #10; unit tests `//crates/graphforge-cypher:graphforge_cypher_test` |
 | `graphforge-cypher` | `corpus` | `integration-test` | `crates/graphforge-cypher/tests/corpus.rs` | — | `unmapped` | #8 |
-| `graphforge-exec` | `graphforge_exec` | `lib` | `crates/graphforge-exec/src/lib.rs` | — | `unmapped` | #9 |
+| `graphforge-exec` | `graphforge_exec` | `lib` | `crates/graphforge-exec/src/lib.rs` | `//crates/graphforge-exec:graphforge_exec` | `mapped` | #9; unit tests `//crates/graphforge-exec:graphforge_exec_test` |
 | `graphforge-exec` | `adjacency_expand` | `integration-test` | `crates/graphforge-exec/tests/adjacency_expand.rs` | — | `unmapped` | |
 | `graphforge-exec` | `bench_traversal_scaling` | `integration-test` | `crates/graphforge-exec/tests/bench_traversal_scaling.rs` | — | `unmapped` | |
 | `graphforge-exec` | `create_execution` | `integration-test` | `crates/graphforge-exec/tests/create_execution.rs` | — | `unmapped` | |
@@ -124,10 +124,10 @@ Integration-test / example / cdylib / bin rows stay `unmapped` until #8/#7/#9.
 | `graphforge-exec` | `unwind` | `integration-test` | `crates/graphforge-exec/tests/unwind.rs` | — | `unmapped` | |
 | `graphforge-exec` | `var_len_expand` | `integration-test` | `crates/graphforge-exec/tests/var_len_expand.rs` | — | `unmapped` | |
 | `graphforge-exec` | `write_statement` | `integration-test` | `crates/graphforge-exec/tests/write_statement.rs` | — | `unmapped` | |
-| `graphforge-io` | `graphforge_io` | `lib` | `crates/graphforge-io/src/lib.rs` | — | `unmapped` | #9 |
+| `graphforge-io` | `graphforge_io` | `lib` | `crates/graphforge-io/src/lib.rs` | `//crates/graphforge-io:graphforge_io` | `mapped` | #9; unit tests `//crates/graphforge-io:graphforge_io_test` |
 | `graphforge-ir` | `graphforge_ir` | `lib` | `crates/graphforge-ir/src/lib.rs` | `//crates/graphforge-ir:graphforge_ir` | `mapped` | #10; unit tests `//crates/graphforge-ir:graphforge_ir_test` |
 | `graphforge-ir` | `golden` | `integration-test` | `crates/graphforge-ir/tests/golden.rs` | — | `unmapped` | #8 |
-| `graphforge-knowledge` | `graphforge_knowledge` | `lib` | `crates/graphforge-knowledge/src/lib.rs` | — | `unmapped` | #9 |
+| `graphforge-knowledge` | `graphforge_knowledge` | `lib` | `crates/graphforge-knowledge/src/lib.rs` | `//crates/graphforge-knowledge:graphforge_knowledge` | `mapped` | #9; unit tests `//crates/graphforge-knowledge:graphforge_knowledge_test` |
 | `graphforge-ontology` | `graphforge_ontology` | `lib` | `crates/graphforge-ontology/src/lib.rs` | `//crates/graphforge-ontology:graphforge_ontology` | `mapped` | #10; unit tests `//crates/graphforge-ontology:graphforge_ontology_test` |
 | `graphforge-ontology` | `integration` | `integration-test` | `crates/graphforge-ontology/tests/integration.rs` | — | `unmapped` | #8 |
 | `graphforge-plan` | `graphforge_plan` | `lib` | `crates/graphforge-plan/src/lib.rs` | `//crates/graphforge-plan:graphforge_plan` | `mapped` | #10; unit tests `//crates/graphforge-plan:graphforge_plan_test` |
@@ -135,8 +135,8 @@ Integration-test / example / cdylib / bin rows stay `unmapped` until #8/#7/#9.
 | `graphforge-rel` | `graphforge_rel` | `lib` | `crates/graphforge-rel/src/lib.rs` | `//crates/graphforge-rel:graphforge_rel` | `mapped` | #10; unit tests `//crates/graphforge-rel:graphforge_rel_test` |
 | `graphforge-rel` | `expression_lowering_matrix` | `integration-test` | `crates/graphforge-rel/tests/expression_lowering_matrix.rs` | — | `unmapped` | #8 |
 | `graphforge-rel` | `logical_plan_golden` | `integration-test` | `crates/graphforge-rel/tests/logical_plan_golden.rs` | — | `unmapped` | #8 |
-| `graphforge-search` | `graphforge_search` | `lib` | `crates/graphforge-search/src/lib.rs` | — | `unmapped` | #9 |
-| `graphforge-storage` | `graphforge_storage` | `lib` | `crates/graphforge-storage/src/lib.rs` | `//crates/graphforge-storage:graphforge_storage` | `mapped` | #10 early (required by `graphforge-rel`); unit tests `//crates/graphforge-storage:graphforge_storage_test` |
+| `graphforge-search` | `graphforge_search` | `lib` | `crates/graphforge-search/src/lib.rs` | `//crates/graphforge-search:graphforge_search` | `mapped` | #9; unit tests `//crates/graphforge-search:graphforge_search_test` |
+| `graphforge-storage` | `graphforge_storage` | `lib` | `crates/graphforge-storage/src/lib.rs` | `//crates/graphforge-storage:graphforge_storage` | `mapped` | #10 early / #9; Bazel enables `test-failpoints` for api subprocess unification; unit tests `//crates/graphforge-storage:graphforge_storage_test` |
 | `graphforge-storage` | `adjacency_delta_write` | `integration-test` | `crates/graphforge-storage/tests/adjacency_delta_write.rs` | — | `unmapped` | |
 | `graphforge-storage` | `filtered_read` | `integration-test` | `crates/graphforge-storage/tests/filtered_read.rs` | — | `unmapped` | |
 | `graphforge-storage` | `graph_writer` | `integration-test` | `crates/graphforge-storage/tests/graph_writer.rs` | — | `unmapped` | |
@@ -153,6 +153,8 @@ before #6 parity can pass with the exception still open.
 | RT-publish-crates | `cargo publish` / crates.io authorize flows | Ecosystem publication metadata and registry auth | keep Cargo; ledger must remain explicit | stub |
 | RT-maturin-assemble | `maturin build` / `maturin sdist` packaging assembly | May assemble/sign/publish wheels, but must consume Bazel-built natives after #7 | #7 handoff | stub |
 | RT-napi-assemble | `napi build` / `napi artifacts` / `napi pre-publish` | Package assembly + npm provenance; must not silently recompile a different Rust graph after #7 | #7 handoff | stub |
+| RT-cli-build-script | `graphforge-cli` lib (`build.rs` → embedded `project-skills`) | `cargo_build_script` + `include_bytes!` skill bundle; bin/tests owned with CLI surface | #8 map with build script | explicit |
+| RT-bindings-cdylib | `graphforge-bindings-py` / `graphforge-bindings-node` packages | cdylib packages have no ordinary `lib` row; native packaging is #7 | #7 | explicit |
 | RT-examples | `graphforge-api` examples (11) | May be CI/release probes vs developer samples; map or except per #8/#6 | #8/#6 | stub |
 | RT-mobile | Swift / Kotlin / UniFFI / XCFramework / JVM AAR | **Abandoned for M2** — not a deliverable; do not inventory as required targets | excluded | excluded |
 

--- a/docs/reference/BUILD.bazel
+++ b/docs/reference/BUILD.bazel
@@ -1,0 +1,15 @@
+"""Checked-in schema inventory contracts used by graphforge-api unit tests (#9)."""
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files(glob(["*"]))
+
+filegroup(
+    name = "schema_inventory_fixtures",
+    srcs = [
+        "m20-schema-inventory.json",
+        "m20-schema-inventory.sha256",
+        "m21-schema-inventory.json",
+        "m21-schema-inventory.sha256",
+    ],
+)

--- a/scripts/ci/classify-changes.sh
+++ b/scripts/ci/classify-changes.sh
@@ -109,6 +109,7 @@ while IFS= read -r -d '' path; do
     MODULE.bazel | MODULE.bazel.lock | BUILD.bazel | .bazelrc | .bazelversion | \
       cargo-bazel-lock.json | tools/bazel/* | tools/bazel/**/* | \
       crates/BUILD.bazel | crates/*/BUILD.bazel | \
+      docs/contracts/examples/BUILD.bazel | docs/reference/BUILD.bazel | \
       scripts/ci/cargo-bazel-drift-check.py | \
       scripts/ci/test-cargo-bazel-drift-check.py | \
       scripts/ci/BUILD.bazel)

--- a/scripts/ci/test-classify-changes.sh
+++ b/scripts/ci/test-classify-changes.sh
@@ -115,6 +115,8 @@ assert_classification "$bazel_only" tools/bazel/smoke/src/lib.rs bazel-smoke
 assert_classification "$bazel_only" scripts/ci/cargo-bazel-drift-check.py bazel-drift-check
 assert_classification "$bazel_only" cargo-bazel-lock.json bazel-crate-universe-lock
 assert_classification "$bazel_only" crates/graphforge-core/BUILD.bazel bazel-crate-build
+assert_classification "$bazel_only" docs/reference/BUILD.bazel bazel-docs-reference-build
+assert_classification "$bazel_only" docs/contracts/examples/BUILD.bazel bazel-docs-contracts-build
 assert_classification "$none" "docs/a file with spaces.md" docs-only
 
 # Packaging-only Cargo metadata must not compile the workspace.

--- a/tools/bazel/crate_universe.MODULE.bazel.fragment
+++ b/tools/bazel/crate_universe.MODULE.bazel.fragment
@@ -12,4 +12,4 @@
 # use_repo(crate, "crates")
 #
 # After Cargo.toml / Cargo.lock dependency changes:
-#   CARGO_BAZEL_REPIN=1 bazelisk build --repo_env=CARGO_BAZEL_REPIN=1 //:foundation_compiler_libs
+#   CARGO_BAZEL_REPIN=1 bazelisk build --repo_env=CARGO_BAZEL_REPIN=1 //:first_party_libs


### PR DESCRIPTION
## Summary
- Model remaining first-party runtime libraries under rules_rust: `graphforge-exec`, `graphforge-search`, `graphforge-knowledge`, `graphforge-api`, `graphforge-io` (storage already from #10).
- Add aggregates `//:runtime_libs` / `//:runtime_lib_tests` and `//:first_party_libs` / `//:first_party_lib_tests`; wire Blacksmith `Bazel Bootstrap` to the full first-party surface.
- Update migration ledger + bootstrap docs; explicit retained exceptions for CLI lib (`RT-cli-build-script` → #8) and bindings cdylibs (`RT-bindings-cdylib` → #7).

## Test plan
- [x] `bazelisk build //:first_party_libs //:runtime_libs` (local)
- [x] `bazelisk test //tools/bazel/smoke:smoke_test //:first_party_lib_tests` (local; 15/15 pass)
- [x] `python3 scripts/ci/cargo-bazel-drift-check.py` + `test-cargo-bazel-drift-check.py`
- [x] `scripts/ci/test-classify-changes.sh` + `scripts/ci/test-require-gates.sh`
- [ ] Blacksmith `Bazel Bootstrap` + `CI Gate` green on exact head SHA

Fixes #9


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788579419&installation_model_id=20486&pr_number=421&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F421&signature=7cdab217880b30b8d96c9aecd2a018969aec37ee6ff0062e39e8576f350211a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Bazel library and test targets for runtime crates
> - Adds concrete `gf_rust_library` and `gf_rust_test` targets for `graphforge-api`, `graphforge-exec`, `graphforge-io`, `graphforge-knowledge`, and `graphforge-search` in their respective [BUILD.bazel](https://github.com/CurateLabs/graphforge/pull/421/files#diff-90130fa991d9c9ab0c765dae8b2578371dff5fc0261f70c0ad791b701b84b89d) files, replacing scaffolding placeholders.
> - Enables the `test-failpoints` crate feature on the `graphforge-storage` library and test targets in [BUILD.bazel](https://github.com/CurateLabs/graphforge/pull/421/files#diff-a3b24230bafb8890947bb6dd4c3d3b36d659280cb867133c2f17f46d5e189490).
> - Adds `//:runtime_libs`, `//:runtime_lib_tests`, `//:first_party_libs`, and `//:first_party_lib_tests` aggregate targets to the root [BUILD.bazel](https://github.com/CurateLabs/graphforge/pull/421/files#diff-7fc57714ef13c3325ce2a1130202edced92fcccc0c6db34a72f7b57f60d552a3).
> - Updates the CI workflow to build and test these new aggregates instead of the previous `foundation_compiler` targets.
> - Adds `fixtures` and `schema_inventory_fixtures` filegroups under `docs/` for use as `compile_data` and `runtime_data` in the `graphforge-api` targets.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 171b4f6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->