### PR TITLE
build(bazel): model unit, integration, snapshot, BDD, CLI, and resource targets (#8)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -875,11 +875,16 @@ jobs:
           python3 scripts/ci/cargo-bazel-drift-check.py
           python3 scripts/ci/test-cargo-bazel-drift-check.py
 
-      - name: Bazel smoke + first-party library targets
+      - name: Bazel smoke + first-party libs/tests/CLI/resources
         run: |
           # Do not set --remote_cache; Blacksmith injects repository cache.
-          bazelisk test //tools/bazel/smoke:smoke_test //:first_party_lib_tests
-          bazelisk build //:bazel_smoke //:first_party_libs //:runtime_libs
+          bazelisk test //:bazel_test_graph_smoke
+          bazelisk build \
+            //:bazel_smoke \
+            //:first_party_libs \
+            //:runtime_libs \
+            //:cli_bins \
+            //:resource_inputs
 
       - name: Bazel binding cdylibs + packaging handoff
         run: |

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,4 @@
-"""Root Bazel package for GraphForge (#10/#9 libs + #7 binding cdylibs)."""
+"""Root Bazel package for GraphForge (#10/#9/#7 libs+cdylibs + #8 tests/CLI/resources)."""
 
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
@@ -11,7 +11,7 @@ exports_files([
     "project-skills/manifest.json",
 ])
 
-# Canonical skill bundle for CLI embedding (#7). Kept at the workspace root so
+# Canonical skill bundle for CLI embedding (#7/#8). Kept at the workspace root so
 # `project-skills/` stays a pure distribution tree (no BUILD.bazel payload).
 filegroup(
     name = "project_skills_bundle",
@@ -106,12 +106,13 @@ test_suite(
     ],
 )
 
-# All first-party library targets modeled so far (#10 + #9).
+# All first-party library targets (#10 + #9 + #8 CLI lib).
 build_test(
     name = "first_party_libs",
     targets = [
         "//crates/graphforge-api:graphforge_api",
         "//crates/graphforge-ast:graphforge_ast",
+        "//crates/graphforge-cli:graphforge_cli",
         "//crates/graphforge-core:graphforge_core",
         "//crates/graphforge-cypher:graphforge_cypher",
         "//crates/graphforge-exec:graphforge_exec",
@@ -132,6 +133,7 @@ test_suite(
     tests = [
         "//crates/graphforge-api:graphforge_api_test",
         "//crates/graphforge-ast:graphforge_ast_test",
+        "//crates/graphforge-cli:graphforge_cli_test",
         "//crates/graphforge-core:graphforge_core_test",
         "//crates/graphforge-cypher:graphforge_cypher_test",
         "//crates/graphforge-exec:graphforge_exec_test",
@@ -144,5 +146,92 @@ test_suite(
         "//crates/graphforge-rel:graphforge_rel_test",
         "//crates/graphforge-search:graphforge_search_test",
         "//crates/graphforge-storage:graphforge_storage_test",
+    ],
+)
+
+# CLI binary build surface (#8).
+build_test(
+    name = "cli_bins",
+    targets = ["//crates/graphforge-cli:gf"],
+)
+
+# Deterministic CI target groups (#8 / #1 step 5).
+test_suite(
+    name = "unit_tests",
+    tests = [":first_party_lib_tests"],
+)
+
+test_suite(
+    name = "integration_tests",
+    tests = [
+        "//crates/graphforge-api:api_integration_tests",
+        "//crates/graphforge-cli:checkpoints",
+        "//crates/graphforge-cli:portable",
+        "//crates/graphforge-cli:repository",
+        "//crates/graphforge-cypher:corpus",
+        "//crates/graphforge-exec:exec_integration_tests",
+        "//crates/graphforge-ir:golden",
+        "//crates/graphforge-ontology:integration",
+        "//crates/graphforge-rel:expression_lowering_matrix",
+        "//crates/graphforge-rel:logical_plan_golden",
+        "//crates/graphforge-storage:storage_integration_tests",
+    ],
+)
+
+test_suite(
+    name = "snapshot_tests",
+    tests = [
+        "//crates/graphforge-exec:snapshot_tests",
+        "//crates/graphforge-ir:snapshot_tests",
+        "//crates/graphforge-rel:snapshot_tests",
+    ],
+)
+
+test_suite(
+    name = "bdd_tests",
+    tests = ["//crates/graphforge-api:bdd_tests"],
+)
+
+test_suite(
+    name = "cli_tests",
+    tests = ["//crates/graphforge-cli:cli_tests"],
+)
+
+# Non-source inputs declared as precise filegroups (#8).
+build_test(
+    name = "resource_inputs",
+    targets = [
+        "//:project_skills_bundle",
+        "//docs/contracts/examples:fixtures",
+        "//docs/reference:schema_inventory_fixtures",
+        "//examples/agent_grounding:notebooks",
+        "//tests/features:api_features",
+        "//tests/tck:corpus",
+        "//crates/graphforge-cypher:corpus_data",
+        "//crates/graphforge-exec:explain_goldens",
+        "//crates/graphforge-ir:ir_goldens",
+        "//crates/graphforge-ontology:test_fixtures",
+        "//crates/graphforge-rel:logical_plan_goldens",
+    ],
+)
+
+# Representative #8 surface for Blacksmith Bazel Bootstrap (excludes full TCK BDD
+# wall-time; BDD remains in //:bdd_tests for explicit/full runs).
+test_suite(
+    name = "bazel_test_graph_smoke",
+    tests = [
+        "//tools/bazel/smoke:smoke_test",
+        ":unit_tests",
+        "//crates/graphforge-cli:cli_tests",
+        "//crates/graphforge-cypher:corpus",
+        "//crates/graphforge-ir:golden",
+        "//crates/graphforge-ontology:integration",
+        "//crates/graphforge-rel:expression_lowering_matrix",
+        "//crates/graphforge-rel:logical_plan_golden",
+        "//crates/graphforge-exec:explain_snapshots",
+        "//crates/graphforge-storage:storage_integration_tests",
+        # One mid-size API integration binary as the public-facade probe.
+        "//crates/graphforge-api:clear",
+        "//crates/graphforge-api:value_semantics",
     ],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,9 +1,9 @@
-"""GraphForge Bazel module (M2 / #10/#9 libs + #7 binding cdylibs).
+"""GraphForge Bazel module (M2 / #10–#7 libs+cdylibs + #8 tests/CLI).
 
 Canonical build-system contract: GitHub issue #1.
 Activates crate_universe `from_cargo` against the frozen Cargo workspace and
-models first-party libraries and PyO3/napi cdylibs as real rules_rust targets
-(no Cargo shell-out for ordinary compilation).
+models first-party libraries, tests, CLI, resources, and PyO3/napi cdylibs as
+real rules_rust targets (no Cargo shell-out for ordinary compilation or tests).
 """
 
 module(

--- a/crates/BUILD.bazel
+++ b/crates/BUILD.bazel
@@ -1,3 +1,3 @@
-"""First-party crate packages live in crates/*/BUILD.bazel (#10/#9+)."""
+"""First-party crate packages live in crates/*/BUILD.bazel (#10/#9/#8)."""
 
 package(default_visibility = ["//visibility:public"])

--- a/crates/graphforge-api/BUILD.bazel
+++ b/crates/graphforge-api/BUILD.bazel
@@ -1,6 +1,6 @@
-"""Bazel targets for graphforge-api (#9 runtime)."""
+"""Bazel targets for graphforge-api (#9 runtime + #8 integration/BDD)."""
 
-load("//tools/bazel:gf_rust.bzl", "gf_rust_library", "gf_rust_test")
+load("//tools/bazel:gf_rust.bzl", "gf_rust_integration_test", "gf_rust_library", "gf_rust_test")
 
 exports_files(["Cargo.toml"])
 
@@ -11,21 +11,23 @@ _API_COMPILE_DATA = [
     "//docs/contracts/examples:fixtures",
 ]
 
+_API_DEPS = [
+    "//crates/graphforge-core:graphforge_core",
+    "//crates/graphforge-cypher:graphforge_cypher",
+    "//crates/graphforge-exec:graphforge_exec",
+    "//crates/graphforge-ir:graphforge_ir",
+    "//crates/graphforge-knowledge:graphforge_knowledge",
+    "//crates/graphforge-ontology:graphforge_ontology",
+    "//crates/graphforge-provenance:graphforge_provenance",
+    "//crates/graphforge-rel:graphforge_rel",
+    "//crates/graphforge-search:graphforge_search",
+    "//crates/graphforge-storage:graphforge_storage",
+]
+
 gf_rust_library(
     name = "graphforge_api",
     compile_data = _API_COMPILE_DATA,
-    deps = [
-        "//crates/graphforge-core:graphforge_core",
-        "//crates/graphforge-cypher:graphforge_cypher",
-        "//crates/graphforge-exec:graphforge_exec",
-        "//crates/graphforge-ir:graphforge_ir",
-        "//crates/graphforge-knowledge:graphforge_knowledge",
-        "//crates/graphforge-ontology:graphforge_ontology",
-        "//crates/graphforge-provenance:graphforge_provenance",
-        "//crates/graphforge-rel:graphforge_rel",
-        "//crates/graphforge-search:graphforge_search",
-        "//crates/graphforge-storage:graphforge_storage",
-    ],
+    deps = _API_DEPS,
 )
 
 gf_rust_test(
@@ -41,16 +43,401 @@ gf_rust_test(
     # Large public-facade unit suite with filesystem/async paths.
     size = "large",
     timeout = "long",
-    deps = [
-        "//crates/graphforge-core:graphforge_core",
-        "//crates/graphforge-cypher:graphforge_cypher",
-        "//crates/graphforge-exec:graphforge_exec",
-        "//crates/graphforge-ir:graphforge_ir",
-        "//crates/graphforge-knowledge:graphforge_knowledge",
-        "//crates/graphforge-ontology:graphforge_ontology",
-        "//crates/graphforge-provenance:graphforge_provenance",
-        "//crates/graphforge-rel:graphforge_rel",
-        "//crates/graphforge-search:graphforge_search",
-        "//crates/graphforge-storage:graphforge_storage",
+    deps = _API_DEPS,
+)
+
+_API_TEST_DATA = [
+    "//docs/contracts/examples:fixtures",
+    "//docs/reference:schema_inventory_fixtures",
+    "//crates/graphforge-ontology:test_fixtures",
+]
+
+
+gf_rust_integration_test(
+    name = "bdd_timing",
+    srcs = ["tests/bdd_timing.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "large",
+    timeout = "long",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "belief_subject_contract",
+    srcs = ["tests/belief_subject_contract.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "medium",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "bind_error_spans",
+    srcs = ["tests/bind_error_spans.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "medium",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "clear",
+    srcs = ["tests/clear.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "medium",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "conductance",
+    srcs = ["tests/conductance.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "medium",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "create_scaling",
+    srcs = ["tests/create_scaling.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "large",
+    timeout = "long",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "e2e_baseline",
+    srcs = ["tests/e2e_baseline.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "large",
+    timeout = "long",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "existential_subquery",
+    srcs = ["tests/existential_subquery.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "medium",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "facade_methods",
+    srcs = ["tests/facade_methods.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "medium",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "fixed_hop_limit",
+    srcs = ["tests/fixed_hop_limit.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "large",
+    timeout = "long",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "graph_internal_metadata",
+    srcs = ["tests/graph_internal_metadata.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "medium",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "inference_provenance",
+    srcs = ["tests/inference_provenance.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "medium",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "knowledge_isolation",
+    srcs = ["tests/knowledge_isolation.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "large",
+    timeout = "long",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "list_semantics",
+    srcs = ["tests/list_semantics.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "medium",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "m22_m18_public_surface",
+    srcs = ["tests/m22_m18_public_surface.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "medium",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "m22_m19_public_surface",
+    srcs = ["tests/m22_m19_public_surface.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "medium",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "m22_provider_public_surface",
+    srcs = ["tests/m22_provider_public_surface.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "medium",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "max_bipartite_matching",
+    srcs = ["tests/max_bipartite_matching.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "medium",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "max_cardinality_matching",
+    srcs = ["tests/max_cardinality_matching.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "medium",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "max_weight_matching",
+    srcs = ["tests/max_weight_matching.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "medium",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "minimum_k_spanning_tree",
+    srcs = ["tests/minimum_k_spanning_tree.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "medium",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "modularity",
+    srcs = ["tests/modularity.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "medium",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "multi_label_scaling",
+    srcs = ["tests/multi_label_scaling.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "large",
+    timeout = "long",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "pattern_comprehension",
+    srcs = ["tests/pattern_comprehension.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "medium",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "percentile_aggregates",
+    srcs = ["tests/percentile_aggregates.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "medium",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "provider_session",
+    srcs = ["tests/provider_session.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "medium",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "public_facade_remaining_conformance",
+    srcs = ["tests/public_facade_remaining_conformance.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "large",
+    timeout = "long",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "public_lifecycle_conformance",
+    srcs = ["tests/public_lifecycle_conformance.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "large",
+    timeout = "long",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "release_load_construction",
+    srcs = ["tests/release_load_construction.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "large",
+    timeout = "long",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "strict_runtime_properties",
+    srcs = ["tests/strict_runtime_properties.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "medium",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "value_access_semantics",
+    srcs = ["tests/value_access_semantics.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "medium",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "value_semantics",
+    srcs = ["tests/value_semantics.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "medium",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "with_aggregation",
+    srcs = ["tests/with_aggregation.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "medium",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "xor_scaling",
+    srcs = ["tests/xor_scaling.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    size = "large",
+    timeout = "long",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "bdd",
+    srcs = glob(["tests/bdd/**/*.rs"]),
+    crate = ":graphforge_api",
+    crate_root = "tests/bdd/main.rs",
+    data = _API_TEST_DATA + [
+        "//tests/features:api_features",
+        "//tests/tck:corpus",
+    ],
+    # Runtime path resolution (std::env::var), not rustc env!().
+    env = {
+        "CARGO_MANIFEST_DIR": "crates/graphforge-api",
+    },
+    size = "enormous",
+    timeout = "eternal",
+    use_libtest_harness = False,
+    deps = _API_DEPS,
+)
+
+test_suite(
+    name = "api_integration_tests",
+    tests = [
+        ":bdd_timing",
+        ":belief_subject_contract",
+        ":bind_error_spans",
+        ":clear",
+        ":conductance",
+        ":create_scaling",
+        ":e2e_baseline",
+        ":existential_subquery",
+        ":facade_methods",
+        ":fixed_hop_limit",
+        ":graph_internal_metadata",
+        ":inference_provenance",
+        ":knowledge_isolation",
+        ":list_semantics",
+        ":m22_m18_public_surface",
+        ":m22_m19_public_surface",
+        ":m22_provider_public_surface",
+        ":max_bipartite_matching",
+        ":max_cardinality_matching",
+        ":max_weight_matching",
+        ":minimum_k_spanning_tree",
+        ":modularity",
+        ":multi_label_scaling",
+        ":pattern_comprehension",
+        ":percentile_aggregates",
+        ":provider_session",
+        ":public_facade_remaining_conformance",
+        ":public_lifecycle_conformance",
+        ":release_load_construction",
+        ":strict_runtime_properties",
+        ":value_access_semantics",
+        ":value_semantics",
+        ":with_aggregation",
+        ":xor_scaling",
+    ],
+)
+
+test_suite(
+    name = "bdd_tests",
+    tests = [":bdd"],
+)
+
+test_suite(
+    name = "api_tests",
+    tests = [
+        ":api_integration_tests",
+        ":bdd",
+        ":graphforge_api_test",
     ],
 )

--- a/crates/graphforge-cli/BUILD.bazel
+++ b/crates/graphforge-cli/BUILD.bazel
@@ -1,15 +1,32 @@
-"""Bazel targets for graphforge-cli library (link dep for #7 bindings).
+"""Bazel targets for graphforge-cli (#8): lib + build.rs + gf bin + tests.
 
-Bin / integration tests remain #8. This package models the `lib` + `build.rs`
-surface required to link PyO3/napi cdylibs (RT-cli-build-script partial).
+Lib + build script were first modeled in #7 as a binding link dep; this package
+owns the remaining bin/unit/integration surface and closes RT-cli-build-script.
 """
 
-load("//tools/bazel:gf_rust.bzl", "gf_cargo_build_script", "gf_rust_library")
+load(
+    "//tools/bazel:gf_rust.bzl",
+    "gf_cargo_build_script",
+    "gf_rust_binary",
+    "gf_rust_integration_test",
+    "gf_rust_library",
+    "gf_rust_test",
+)
 
 exports_files(["Cargo.toml"])
 
 package(default_visibility = ["//visibility:public"])
 
+_CLI_DEPS = [
+    "//crates/graphforge-api:graphforge_api",
+]
+
+_CONTRACT_FIXTURES = [
+    "//docs/contracts/examples:fixtures",
+]
+
+# Skill bundle stays at the workspace root (`//:project_skills_bundle`) so
+# `project-skills/` remains a pure distribution tree (#7 packaging contract).
 gf_cargo_build_script(
     name = "graphforge_cli_build_script",
     build_script_env = {
@@ -31,8 +48,69 @@ gf_rust_library(
         ["src/**/*.rs"],
         exclude = ["src/main.rs"],
     ),
-    deps = [
-        ":graphforge_cli_build_script",
-        "//crates/graphforge-api:graphforge_api",
+    deps = _CLI_DEPS + [":graphforge_cli_build_script"],
+)
+
+gf_rust_test(
+    name = "graphforge_cli_test",
+    crate = ":graphforge_cli",
+    compile_data = _CONTRACT_FIXTURES,
+    size = "medium",
+    deps = _CLI_DEPS,
+)
+
+gf_rust_binary(
+    name = "gf",
+    srcs = ["src/main.rs"],
+    deps = _CLI_DEPS + [":graphforge_cli"],
+)
+
+_CLI_TEST_DATA = [":gf"] + _CONTRACT_FIXTURES
+
+_CLI_BIN_ENV = {
+    "CARGO_BIN_EXE_gf": "$(rootpath :gf)",
+}
+
+gf_rust_integration_test(
+    name = "checkpoints",
+    srcs = ["tests/checkpoints.rs"],
+    crate = ":graphforge_cli",
+    data = _CLI_TEST_DATA,
+    rustc_env = _CLI_BIN_ENV,
+    size = "large",
+    timeout = "long",
+    deps = _CLI_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "portable",
+    srcs = ["tests/portable.rs"],
+    crate = ":graphforge_cli",
+    data = _CLI_TEST_DATA,
+    rustc_env = _CLI_BIN_ENV,
+    size = "large",
+    timeout = "long",
+    deps = _CLI_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "repository",
+    srcs = ["tests/repository.rs"],
+    crate = ":graphforge_cli",
+    compile_data = _CONTRACT_FIXTURES,
+    data = _CLI_TEST_DATA,
+    rustc_env = _CLI_BIN_ENV,
+    size = "large",
+    timeout = "long",
+    deps = _CLI_DEPS,
+)
+
+test_suite(
+    name = "cli_tests",
+    tests = [
+        ":checkpoints",
+        ":graphforge_cli_test",
+        ":portable",
+        ":repository",
     ],
 )

--- a/crates/graphforge-cypher/BUILD.bazel
+++ b/crates/graphforge-cypher/BUILD.bazel
@@ -1,10 +1,15 @@
-"""Bazel targets for graphforge-cypher (#10 compiler)."""
+"""Bazel targets for graphforge-cypher (#10 compiler + #8 corpus)."""
 
-load("//tools/bazel:gf_rust.bzl", "gf_rust_library", "gf_rust_test")
+load("//tools/bazel:gf_rust.bzl", "gf_rust_integration_test", "gf_rust_library", "gf_rust_test")
 
 exports_files(["Cargo.toml"])
 
 package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "corpus_data",
+    srcs = glob(["tests/corpus/**/*"]),
+)
 
 gf_rust_library(
     name = "graphforge_cypher",
@@ -16,13 +21,35 @@ gf_rust_library(
     ],
 )
 
+_CYPHER_DEPS = [
+    "//crates/graphforge-ast:graphforge_ast",
+    "//crates/graphforge-core:graphforge_core",
+    "//crates/graphforge-ir:graphforge_ir",
+    "//crates/graphforge-rel:graphforge_rel",
+]
+
 gf_rust_test(
     name = "graphforge_cypher_test",
     crate = ":graphforge_cypher",
-    deps = [
-        "//crates/graphforge-ast:graphforge_ast",
-        "//crates/graphforge-core:graphforge_core",
-        "//crates/graphforge-ir:graphforge_ir",
-        "//crates/graphforge-rel:graphforge_rel",
+    deps = _CYPHER_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "corpus",
+    srcs = ["tests/corpus.rs"],
+    crate = ":graphforge_cypher",
+    data = [
+        ":corpus_data",
+        "//tests/tck:features",
+    ],
+    size = "large",
+    deps = _CYPHER_DEPS,
+)
+
+test_suite(
+    name = "cypher_tests",
+    tests = [
+        ":corpus",
+        ":graphforge_cypher_test",
     ],
 )

--- a/crates/graphforge-exec/BUILD.bazel
+++ b/crates/graphforge-exec/BUILD.bazel
@@ -1,21 +1,28 @@
-"""Bazel targets for graphforge-exec (#9 runtime)."""
+"""Bazel targets for graphforge-exec (#9 runtime + #8 integration/snapshots)."""
 
-load("//tools/bazel:gf_rust.bzl", "gf_rust_library", "gf_rust_test")
+load("//tools/bazel:gf_rust.bzl", "gf_rust_integration_test", "gf_rust_library", "gf_rust_test")
 
 exports_files(["Cargo.toml"])
 
 package(default_visibility = ["//visibility:public"])
 
+filegroup(
+    name = "explain_goldens",
+    srcs = glob(["tests/explain_goldens/**/*"]),
+)
+
+_EXEC_DEPS = [
+    "//crates/graphforge-core:graphforge_core",
+    "//crates/graphforge-ir:graphforge_ir",
+    "//crates/graphforge-ontology:graphforge_ontology",
+    "//crates/graphforge-plan:graphforge_plan",
+    "//crates/graphforge-rel:graphforge_rel",
+    "//crates/graphforge-storage:graphforge_storage",
+]
+
 gf_rust_library(
     name = "graphforge_exec",
-    deps = [
-        "//crates/graphforge-core:graphforge_core",
-        "//crates/graphforge-ir:graphforge_ir",
-        "//crates/graphforge-ontology:graphforge_ontology",
-        "//crates/graphforge-plan:graphforge_plan",
-        "//crates/graphforge-rel:graphforge_rel",
-        "//crates/graphforge-storage:graphforge_storage",
-    ],
+    deps = _EXEC_DEPS,
 )
 
 gf_rust_test(
@@ -23,13 +30,156 @@ gf_rust_test(
     crate = ":graphforge_exec",
     # Algorithm + execution unit suite; default "small" is too tight.
     size = "medium",
-    deps = [
-        "//crates/graphforge-core:graphforge_core",
+    deps = _EXEC_DEPS + [
         "//crates/graphforge-cypher:graphforge_cypher",
-        "//crates/graphforge-ir:graphforge_ir",
-        "//crates/graphforge-ontology:graphforge_ontology",
-        "//crates/graphforge-plan:graphforge_plan",
-        "//crates/graphforge-rel:graphforge_rel",
-        "//crates/graphforge-storage:graphforge_storage",
     ],
+)
+
+_EXEC_TEST_DEPS = _EXEC_DEPS + [
+    "//crates/graphforge-cypher:graphforge_cypher",
+]
+
+_EXEC_TEST_DATA = [
+    "//crates/graphforge-ontology:test_fixtures",
+]
+
+
+gf_rust_integration_test(
+    name = "adjacency_expand",
+    srcs = ["tests/adjacency_expand.rs"],
+    crate = ":graphforge_exec",
+    data = _EXEC_TEST_DATA,
+    size = "medium",
+    deps = _EXEC_TEST_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "bench_traversal_scaling",
+    srcs = ["tests/bench_traversal_scaling.rs"],
+    crate = ":graphforge_exec",
+    data = _EXEC_TEST_DATA,
+    size = "large",
+    timeout = "long",
+    deps = _EXEC_TEST_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "create_execution",
+    srcs = ["tests/create_execution.rs"],
+    crate = ":graphforge_exec",
+    data = _EXEC_TEST_DATA,
+    size = "medium",
+    deps = _EXEC_TEST_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "create_input_driven",
+    srcs = ["tests/create_input_driven.rs"],
+    crate = ":graphforge_exec",
+    data = _EXEC_TEST_DATA,
+    size = "medium",
+    deps = _EXEC_TEST_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "differential_traversal",
+    srcs = ["tests/differential_traversal.rs"],
+    crate = ":graphforge_exec",
+    data = _EXEC_TEST_DATA,
+    size = "medium",
+    deps = _EXEC_TEST_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "explain_snapshots",
+    srcs = ["tests/explain_snapshots.rs"],
+    crate = ":graphforge_exec",
+    data = _EXEC_TEST_DATA + [":explain_goldens"],
+    size = "medium",
+    deps = _EXEC_TEST_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "optional_match",
+    srcs = ["tests/optional_match.rs"],
+    crate = ":graphforge_exec",
+    data = _EXEC_TEST_DATA,
+    size = "medium",
+    deps = _EXEC_TEST_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "persistent_adjacency",
+    srcs = ["tests/persistent_adjacency.rs"],
+    crate = ":graphforge_exec",
+    data = _EXEC_TEST_DATA,
+    size = "medium",
+    deps = _EXEC_TEST_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "read_execution",
+    srcs = ["tests/read_execution.rs"],
+    crate = ":graphforge_exec",
+    data = _EXEC_TEST_DATA,
+    size = "medium",
+    deps = _EXEC_TEST_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "unwind",
+    srcs = ["tests/unwind.rs"],
+    crate = ":graphforge_exec",
+    data = _EXEC_TEST_DATA,
+    size = "medium",
+    deps = _EXEC_TEST_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "var_len_expand",
+    srcs = ["tests/var_len_expand.rs"],
+    crate = ":graphforge_exec",
+    data = _EXEC_TEST_DATA,
+    size = "medium",
+    deps = _EXEC_TEST_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "write_statement",
+    srcs = ["tests/write_statement.rs"],
+    crate = ":graphforge_exec",
+    data = _EXEC_TEST_DATA,
+    size = "medium",
+    deps = _EXEC_TEST_DEPS,
+)
+
+test_suite(
+    name = "exec_integration_tests",
+    tests = [
+        ":adjacency_expand",
+        ":bench_traversal_scaling",
+        ":create_execution",
+        ":create_input_driven",
+        ":differential_traversal",
+        ":explain_snapshots",
+        ":optional_match",
+        ":persistent_adjacency",
+        ":read_execution",
+        ":unwind",
+        ":var_len_expand",
+        ":write_statement",
+    ],
+)
+
+test_suite(
+    name = "exec_tests",
+    tests = [
+        ":exec_integration_tests",
+        ":graphforge_exec_test",
+    ],
+)
+
+test_suite(
+    name = "snapshot_tests",
+    tests = [":explain_snapshots"],
 )

--- a/crates/graphforge-exec/tests/explain_snapshots.rs
+++ b/crates/graphforge-exec/tests/explain_snapshots.rs
@@ -69,13 +69,19 @@ fn escape_for_regex(s: &str) -> String {
 
 /// Snapshot settings: goldens directory + filters normalizing the TempDir
 /// path and any partition/byte-size noise DataFusion embeds in scan nodes.
+fn manifest_dir() -> std::path::PathBuf {
+    let raw = Path::new(env!("CARGO_MANIFEST_DIR"));
+    if raw.is_absolute() {
+        return raw.to_path_buf();
+    }
+    std::env::current_dir()
+        .map(|cwd| cwd.join(raw))
+        .unwrap_or_else(|_| raw.to_path_buf())
+}
+
 fn golden_settings(dir: &Path) -> insta::Settings {
     let mut settings = insta::Settings::clone_current();
-    settings.set_snapshot_path(
-        Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("tests")
-            .join("explain_goldens"),
-    );
+    settings.set_snapshot_path(manifest_dir().join("tests").join("explain_goldens"));
     settings.set_omit_expression(true);
     settings.add_filter(&escape_for_regex(&dir.display().to_string()), "<DIR>");
     // Parquet scan lines embed file sizes / row-group offsets that vary with

--- a/crates/graphforge-ir/BUILD.bazel
+++ b/crates/graphforge-ir/BUILD.bazel
@@ -1,10 +1,15 @@
-"""Bazel targets for graphforge-ir (#10 compiler)."""
+"""Bazel targets for graphforge-ir (#10 compiler + #8 golden/snapshots)."""
 
-load("//tools/bazel:gf_rust.bzl", "gf_rust_library", "gf_rust_test")
+load("//tools/bazel:gf_rust.bzl", "gf_rust_integration_test", "gf_rust_library", "gf_rust_test")
 
 exports_files(["Cargo.toml"])
 
 package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "ir_goldens",
+    srcs = glob(["tests/ir_goldens/**/*"]),
+)
 
 gf_rust_library(
     name = "graphforge_ir",
@@ -25,4 +30,33 @@ gf_rust_test(
         "//crates/graphforge-cypher:graphforge_cypher",
         "//crates/graphforge-ontology:graphforge_ontology",
     ],
+)
+
+gf_rust_integration_test(
+    name = "golden",
+    srcs = ["tests/golden.rs"],
+    crate = ":graphforge_ir",
+    data = [
+        ":ir_goldens",
+        "//crates/graphforge-ontology:test_fixtures",
+    ],
+    deps = [
+        "//crates/graphforge-ast:graphforge_ast",
+        "//crates/graphforge-core:graphforge_core",
+        "//crates/graphforge-cypher:graphforge_cypher",
+        "//crates/graphforge-ontology:graphforge_ontology",
+    ],
+)
+
+test_suite(
+    name = "ir_tests",
+    tests = [
+        ":golden",
+        ":graphforge_ir_test",
+    ],
+)
+
+test_suite(
+    name = "snapshot_tests",
+    tests = [":golden"],
 )

--- a/crates/graphforge-ir/tests/golden.rs
+++ b/crates/graphforge-ir/tests/golden.rs
@@ -18,10 +18,26 @@ use graphforge_ontology::{OntologyCompiler, OntologyHandle, OntologyLoader};
 // Setup helpers
 // ---------------------------------------------------------------------------
 
+/// Resolve `CARGO_MANIFEST_DIR` to an absolute path.
+///
+/// Cargo bakes an absolute path; Bazel may bake a workspace-relative path.
+/// Insta falls back to the manifest directory when `cargo metadata` is
+/// unavailable and will double-prefix relative snapshot paths unless this is
+/// absolute.
+fn manifest_dir() -> std::path::PathBuf {
+    let raw = Path::new(env!("CARGO_MANIFEST_DIR"));
+    if raw.is_absolute() {
+        return raw.to_path_buf();
+    }
+    std::env::current_dir()
+        .map(|cwd| cwd.join(raw))
+        .unwrap_or_else(|_| raw.to_path_buf())
+}
+
 /// Path to the shared HR ontology fixture.
 fn hr_fixture() -> std::path::PathBuf {
     // The HR fixture lives in graphforge-ontology's test fixtures directory.
-    Path::new(env!("CARGO_MANIFEST_DIR"))
+    manifest_dir()
         .parent() // crates/
         .unwrap()
         .join("graphforge-ontology")
@@ -62,11 +78,7 @@ fn bind_query(query: &str) -> graphforge_ir::GraphPlan {
 /// Must be called at the start of every `#[test]` in this file.
 fn golden_settings() -> insta::Settings {
     let mut settings = insta::Settings::clone_current();
-    settings.set_snapshot_path(
-        Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("tests")
-            .join("ir_goldens"),
-    );
+    settings.set_snapshot_path(manifest_dir().join("tests").join("ir_goldens"));
     // Omit the module path prefix from snapshot names for cleaner file names.
     settings.set_omit_expression(true);
     settings

--- a/crates/graphforge-ontology/BUILD.bazel
+++ b/crates/graphforge-ontology/BUILD.bazel
@@ -1,10 +1,15 @@
-"""Bazel targets for graphforge-ontology (#10 foundation)."""
+"""Bazel targets for graphforge-ontology (#10 foundation + #8 integration)."""
 
-load("//tools/bazel:gf_rust.bzl", "gf_rust_library", "gf_rust_test")
+load("//tools/bazel:gf_rust.bzl", "gf_rust_integration_test", "gf_rust_library", "gf_rust_test")
 
 exports_files(["Cargo.toml"])
 
 package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "test_fixtures",
+    srcs = glob(["tests/fixtures/**/*"]),
+)
 
 gf_rust_library(
     name = "graphforge_ontology",
@@ -18,5 +23,23 @@ gf_rust_test(
     crate = ":graphforge_ontology",
     deps = [
         "//crates/graphforge-core:graphforge_core",
+    ],
+)
+
+gf_rust_integration_test(
+    name = "integration",
+    srcs = ["tests/integration.rs"],
+    crate = ":graphforge_ontology",
+    data = [":test_fixtures"],
+    deps = [
+        "//crates/graphforge-core:graphforge_core",
+    ],
+)
+
+test_suite(
+    name = "ontology_tests",
+    tests = [
+        ":graphforge_ontology_test",
+        ":integration",
     ],
 )

--- a/crates/graphforge-rel/BUILD.bazel
+++ b/crates/graphforge-rel/BUILD.bazel
@@ -1,30 +1,67 @@
-"""Bazel targets for graphforge-rel (#10 compiler)."""
+"""Bazel targets for graphforge-rel (#10 compiler + #8 integration/snapshots)."""
 
-load("//tools/bazel:gf_rust.bzl", "gf_rust_library", "gf_rust_test")
+load("//tools/bazel:gf_rust.bzl", "gf_rust_integration_test", "gf_rust_library", "gf_rust_test")
 
 exports_files(["Cargo.toml"])
 
 package(default_visibility = ["//visibility:public"])
 
+filegroup(
+    name = "logical_plan_goldens",
+    srcs = glob(["tests/logical_plan_goldens/**/*"]),
+)
+
+_REL_DEPS = [
+    "//crates/graphforge-core:graphforge_core",
+    "//crates/graphforge-ir:graphforge_ir",
+    "//crates/graphforge-ontology:graphforge_ontology",
+    "//crates/graphforge-plan:graphforge_plan",
+    "//crates/graphforge-storage:graphforge_storage",
+]
+
 gf_rust_library(
     name = "graphforge_rel",
-    deps = [
-        "//crates/graphforge-core:graphforge_core",
-        "//crates/graphforge-ir:graphforge_ir",
-        "//crates/graphforge-ontology:graphforge_ontology",
-        "//crates/graphforge-plan:graphforge_plan",
-        "//crates/graphforge-storage:graphforge_storage",
-    ],
+    deps = _REL_DEPS,
 )
 
 gf_rust_test(
     name = "graphforge_rel_test",
     crate = ":graphforge_rel",
-    deps = [
-        "//crates/graphforge-core:graphforge_core",
-        "//crates/graphforge-ir:graphforge_ir",
-        "//crates/graphforge-ontology:graphforge_ontology",
-        "//crates/graphforge-plan:graphforge_plan",
-        "//crates/graphforge-storage:graphforge_storage",
+    deps = _REL_DEPS,
+)
+
+_REL_TEST_DEPS = _REL_DEPS + [
+    "//crates/graphforge-cypher:graphforge_cypher",
+]
+
+gf_rust_integration_test(
+    name = "expression_lowering_matrix",
+    srcs = ["tests/expression_lowering_matrix.rs"],
+    crate = ":graphforge_rel",
+    deps = _REL_TEST_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "logical_plan_golden",
+    srcs = ["tests/logical_plan_golden.rs"],
+    crate = ":graphforge_rel",
+    data = [
+        ":logical_plan_goldens",
+        "//crates/graphforge-ontology:test_fixtures",
     ],
+    deps = _REL_TEST_DEPS,
+)
+
+test_suite(
+    name = "rel_tests",
+    tests = [
+        ":expression_lowering_matrix",
+        ":graphforge_rel_test",
+        ":logical_plan_golden",
+    ],
+)
+
+test_suite(
+    name = "snapshot_tests",
+    tests = [":logical_plan_golden"],
 )

--- a/crates/graphforge-rel/tests/logical_plan_golden.rs
+++ b/crates/graphforge-rel/tests/logical_plan_golden.rs
@@ -44,9 +44,20 @@ use graphforge_ontology::{OntologyCompiler, OntologyHandle, OntologyLoader};
 // Setup helpers (mirrors crates/graphforge-ir/tests/golden.rs)
 // ---------------------------------------------------------------------------
 
+/// Resolve `CARGO_MANIFEST_DIR` to an absolute path (see graphforge-ir golden).
+fn manifest_dir() -> std::path::PathBuf {
+    let raw = Path::new(env!("CARGO_MANIFEST_DIR"));
+    if raw.is_absolute() {
+        return raw.to_path_buf();
+    }
+    std::env::current_dir()
+        .map(|cwd| cwd.join(raw))
+        .unwrap_or_else(|_| raw.to_path_buf())
+}
+
 /// Path to the shared HR ontology fixture.
 fn hr_fixture() -> std::path::PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
+    manifest_dir()
         .parent() // crates/
         .unwrap()
         .join("graphforge-ontology")
@@ -161,11 +172,7 @@ fn render_property_read(query: &str) -> String {
 /// insta settings with the snapshot path set to `tests/logical_plan_goldens/`.
 fn golden_settings() -> insta::Settings {
     let mut settings = insta::Settings::clone_current();
-    settings.set_snapshot_path(
-        Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("tests")
-            .join("logical_plan_goldens"),
-    );
+    settings.set_snapshot_path(manifest_dir().join("tests").join("logical_plan_goldens"));
     settings.set_omit_expression(true);
     settings
 }

--- a/crates/graphforge-storage/BUILD.bazel
+++ b/crates/graphforge-storage/BUILD.bazel
@@ -1,14 +1,16 @@
-"""Bazel targets for graphforge-storage.
+"""Bazel targets for graphforge-storage (#10/#9 + #8 integration)."""
 
-Modeled in #10 because graphforge-rel (compiler lowering) depends on it.
-Runtime peers (exec/search/knowledge/api/io) are modeled in #9.
-"""
-
-load("//tools/bazel:gf_rust.bzl", "gf_rust_library", "gf_rust_test")
+load("//tools/bazel:gf_rust.bzl", "gf_rust_integration_test", "gf_rust_library", "gf_rust_test")
 
 exports_files(["Cargo.toml"])
 
 package(default_visibility = ["//visibility:public"])
+
+_STORAGE_DEPS = [
+    "//crates/graphforge-core:graphforge_core",
+    "//crates/graphforge-ir:graphforge_ir",
+    "//crates/graphforge-ontology:graphforge_ontology",
+]
 
 gf_rust_library(
     name = "graphforge_storage",
@@ -18,11 +20,7 @@ gf_rust_library(
     # unification). Residual vs Cargo release builds: Bazel links the env-gated
     # bodies instead of the const no-op; document for #6 parity.
     crate_features = ["test-failpoints"],
-    deps = [
-        "//crates/graphforge-core:graphforge_core",
-        "//crates/graphforge-ir:graphforge_ir",
-        "//crates/graphforge-ontology:graphforge_ontology",
-    ],
+    deps = _STORAGE_DEPS,
 )
 
 gf_rust_test(
@@ -31,9 +29,60 @@ gf_rust_test(
     crate_features = ["test-failpoints"],
     # Unit suite exercises filesystem/async paths; default "small" is too tight.
     size = "medium",
-    deps = [
-        "//crates/graphforge-core:graphforge_core",
-        "//crates/graphforge-ir:graphforge_ir",
-        "//crates/graphforge-ontology:graphforge_ontology",
+    deps = _STORAGE_DEPS,
+)
+
+
+gf_rust_integration_test(
+    name = "adjacency_delta_write",
+    srcs = ["tests/adjacency_delta_write.rs"],
+    crate = ":graphforge_storage",
+    crate_features = ["test-failpoints"],
+    size = "medium",
+    deps = _STORAGE_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "filtered_read",
+    srcs = ["tests/filtered_read.rs"],
+    crate = ":graphforge_storage",
+    crate_features = ["test-failpoints"],
+    size = "medium",
+    deps = _STORAGE_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "graph_writer",
+    srcs = ["tests/graph_writer.rs"],
+    crate = ":graphforge_storage",
+    crate_features = ["test-failpoints"],
+    size = "medium",
+    deps = _STORAGE_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "io_stats",
+    srcs = ["tests/io_stats.rs"],
+    crate = ":graphforge_storage",
+    crate_features = ["test-failpoints"],
+    size = "medium",
+    deps = _STORAGE_DEPS,
+)
+
+test_suite(
+    name = "storage_integration_tests",
+    tests = [
+        ":adjacency_delta_write",
+        ":filtered_read",
+        ":graph_writer",
+        ":io_stats",
+    ],
+)
+
+test_suite(
+    name = "storage_tests",
+    tests = [
+        ":graphforge_storage_test",
+        ":storage_integration_tests",
     ],
 )

--- a/docs/development/bazel-bootstrap.md
+++ b/docs/development/bazel-bootstrap.md
@@ -1,12 +1,9 @@
-# Bazelisk / Bzlmod bootstrap (#11–#9, #7 bindings)
+# Bazelisk / Bzlmod bootstrap (#11–#8, #7 bindings)
 
 Minimal Bazel workspace for M2 issues
-[#11](https://github.com/CurateLabs/graphforge/issues/11),
-[#10](https://github.com/CurateLabs/graphforge/issues/10),
-[#9](https://github.com/CurateLabs/graphforge/issues/9), and
-[#7](https://github.com/CurateLabs/graphforge/issues/7). Canonical contract:
-[#1](https://github.com/CurateLabs/graphforge/issues/1). Orchestration:
-[bazel-migration-orchestration.md](bazel-migration-orchestration.md).
+[#11](https://github.com/CurateLabs/graphforge/issues/11)–[#7](https://github.com/CurateLabs/graphforge/issues/7).
+Canonical contract: [#1](https://github.com/CurateLabs/graphforge/issues/1).
+Orchestration: [bazel-migration-orchestration.md](bazel-migration-orchestration.md).
 
 ## What landed
 
@@ -19,10 +16,13 @@ Minimal Bazel workspace for M2 issues
 | Smoke library/test | `//tools/bazel/smoke:smoke` / `:smoke_test` |
 | Foundation/compiler libs | `//:foundation_compiler_libs` / `//:foundation_compiler_tests` |
 | Runtime libs | `//:runtime_libs` / `//:runtime_lib_tests` |
-| All modeled libs | `//:first_party_libs` / `//:first_party_lib_tests` |
+| All modeled libs (incl. CLI) | `//:first_party_libs` / `//:first_party_lib_tests` |
 | Binding cdylibs | `//:binding_cdylibs` (`graphforge_bindings_py` / `graphforge_bindings_node`) |
 | Packaging handoff | `//:python_wheel_smoke` / `//:node_package_smoke` |
-| Shared rust macros | `tools/bazel/gf_rust.bzl` (`gf_rust_library` / `gf_rust_test` / `gf_rust_shared_library` / `gf_cargo_build_script`) |
+| CI target groups | `//:unit_tests`, `//:integration_tests`, `//:snapshot_tests`, `//:bdd_tests`, `//:cli_tests` |
+| Resource filegroups | `//:resource_inputs` (skills via `//:project_skills_bundle`, TCK, features, goldens, notebooks, contracts) |
+| Bootstrap smoke suite | `//:bazel_test_graph_smoke` |
+| Shared rust macros | `tools/bazel/gf_rust.bzl` (`gf_rust_library` / `gf_rust_test` / `gf_rust_integration_test` / `gf_rust_binary` / `gf_rust_shared_library` / `gf_cargo_build_script`) |
 | Cargo feature fingerprint | `tools/bazel/drift/cargo_feature_fingerprint.json` |
 | Drift check | `scripts/ci/cargo-bazel-drift-check.py` |
 | Fail-closed drift test | `scripts/ci/test-cargo-bazel-drift-check.py` |
@@ -64,28 +64,48 @@ see the same env-gated hooks Cargo gets via feature unification.
 | --- | --- | --- |
 | PyO3 cdylib | `//crates/graphforge-bindings-py:graphforge_bindings_py` | abi3-py310 / extension-module via crate_universe |
 | napi-rs cdylib | `//crates/graphforge-bindings-node:graphforge_bindings_node` | includes `napi-build` build script |
-| CLI lib (link dep) | `//crates/graphforge-cli:graphforge_cli` | lib + skill-bundle `build.rs` only; bin/tests → #8 |
 | Python wheel smoke | `//:python_wheel_smoke` | assembles wheel from Bazel `.so`/`.dylib`; no `maturin build` |
 | Node package smoke | `//:node_package_smoke` | assembles zip from Bazel cdylib; no `napi build` |
 
 Credentials / OIDC stay outside cacheable Bazel actions (publish workflows unchanged).
 
+## Test / CLI / resource slice (#8)
+
+| Surface | Labels |
+| --- | --- |
+| CLI lib + `build.rs` + `gf` bin | `//crates/graphforge-cli:graphforge_cli`, `:graphforge_cli_build_script`, `:gf` |
+| CLI tests | `//crates/graphforge-cli:cli_tests` |
+| Integration suite | `//:integration_tests` (59 Cargo integration binaries) |
+| Snapshot / golden | `//:snapshot_tests` (IR, logical plan, explain) |
+| BDD (API + TCK) | `//:bdd_tests` → `//crates/graphforge-api:bdd` |
+| Resources | `//:resource_inputs` (`//:project_skills_bundle`, TCK, features, goldens, notebooks, contracts) |
+
+`project-skills/` remains a pure distribution tree (no `BUILD.bazel` payload);
+skills are declared via root `//:project_skills_bundle` / `//:project-skills/manifest.json`.
+
 ### Package coverage (17 workspace members)
 
-| Class | Count | Status after #7 |
+| Class | Count | Status after #8 |
 | --- | ---: | --- |
-| Ordinary `lib` mapped | 15 | foundation + runtime + CLI lib (link dep) |
-| Binding cdylibs mapped | 2 | PyO3 + napi-rs |
-| Remaining for #8 | bin + integration/BDD/CLI tests + resources | |
+| Ordinary `lib` mapped | 15 | foundation + runtime + CLI |
+| Binding cdylibs mapped | 2 | PyO3 + napi-rs (#7) |
+| Integration-test mapped | 59 | `//:integration_tests` (+ BDD harness) |
+| CLI `bin` mapped | 1 | `//crates/graphforge-cli:gf` |
+| CLI `custom-build` mapped | 1 | `cargo_build_script` + `//:project_skills_bundle` |
+| Explicit retained exception | 1 | API examples (`RT-examples` → #6) |
+| Justified Cargo tool | 1 | `RT-fuzz` (cargo-fuzz workflow; keep until #6) |
 
 ### Residual gaps (justified)
 
 - Workspace Clippy/lint policy from `Cargo.toml` `[workspace.lints]` is not yet
   mirrored as Bazel `rustc_flags` / Clippy aspects (Cargo remains authoritative
   for lint CI until a later slice).
-- Doctests are not separate Bazel targets yet (same attachment note as the
-  ledger unit-test policy).
-- Integration / snapshot / BDD / CLI tests and the `gf` binary are out of scope (#8).
+- Doctests are not separate Bazel targets (documented equivalent: coverage attaches
+  to crate unit-test targets; same policy as #10/#9).
+- API `example` binaries are `RT-examples` for #6 (not required to close #8).
+- Blacksmith `Bazel Bootstrap` runs `//:bazel_test_graph_smoke` (unit + CLI +
+  representative integration/snapshot probes). Full `//:integration_tests` and
+  `//:bdd_tests` remain executable under Bazel for parity (#6) and local runs.
 - Full cross-platform binding/release matrix remains #6.
 - Bazel storage always enables `test-failpoints` (env-gated no-ops); Cargo release
   builds keep the const no-op body — track under #6 parity if needed.
@@ -96,13 +116,17 @@ Credentials / OIDC stay outside cacheable Bazel actions (publish workflows uncha
 # Pin via Bazelisk
 bazelisk version   # must report 9.2.0 from .bazelversion
 
-# Smoke + all modeled first-party libraries (rules_rust; no Cargo shell-out)
-bazelisk test //tools/bazel/smoke:smoke_test //:first_party_lib_tests
-bazelisk build //:bazel_smoke //:first_party_libs //:runtime_libs
+# Smoke + modeled first-party libraries/tests/CLI/resources
+bazelisk test //:bazel_test_graph_smoke
+bazelisk build //:first_party_libs //:cli_bins //:resource_inputs
 
 # Binding cdylibs + packaging handoff (no maturin/napi recompile)
 bazelisk build //:binding_cdylibs //:python_wheel_smoke //:node_package_smoke
 python3 scripts/ci/test-assemble-bazel-binding-packages.py
+
+# Full mapped suites (longer)
+bazelisk test //:unit_tests //:integration_tests //:snapshot_tests //:cli_tests
+bazelisk test //:bdd_tests
 
 # Cargo ↔ fingerprint drift (host cargo metadata; fail-closed)
 python3 scripts/ci/cargo-bazel-drift-check.py
@@ -121,7 +145,5 @@ CARGO_BAZEL_REPIN=1 bazelisk build --repo_env=CARGO_BAZEL_REPIN=1 //:first_party
 
 ## Next
 
-1. [#8](https://github.com/CurateLabs/graphforge/issues/8) — test/BDD/CLI/resource
-   graph (CLI bin + tests; may extend the CLI lib row already mapped for #7).
-2. [#6](https://github.com/CurateLabs/graphforge/issues/6) — cross-platform release
-   targets and Cargo/Bazel parity evidence (blocked by #7 and #8).
+1. [#6](https://github.com/CurateLabs/graphforge/issues/6) — cross-platform release
+   targets and same-SHA Cargo/Bazel parity (blocked by #7 and #8).

--- a/docs/development/bazel-migration-ledger.md
+++ b/docs/development/bazel-migration-ledger.md
@@ -14,8 +14,8 @@ Performance baseline: [bazel-migration-baseline.md](bazel-migration-baseline.md)
 | Authoritative source | `cargo metadata --format-version=1 --no-deps` |
 | Workspace packages | 17 |
 | Cargo metadata targets | **90** |
-| Bazel modeling claimed complete? | **No** — #10/#9/#7 libs+cdylibs mapped (15/15 lib rows + 2 cdylibs); CLI bin + tests/resources remain (#8) |
-| Bootstrap note | See [bazel-bootstrap.md](bazel-bootstrap.md); crate_universe + foundation/runtime/binding labels from #10/#9/#7 |
+| Bazel modeling claimed complete? | **No** — #10/#9/#7/#8 libs+cdylibs+tests+CLI mapped; examples (`RT-examples`) remain for #6 |
+| Bootstrap note | See [bazel-bootstrap.md](bazel-bootstrap.md); crate_universe + library/test/CLI/cdylib labels from #10/#9/#8/#7 |
 
 Issue #1 historically cited ~71 Cargo targets / ~53 integration-test binaries.
 This freeze uses the **current authoritative** metadata count (**90** targets;
@@ -47,7 +47,7 @@ doctests. For migration accounting:
 ## Cargo target ledger
 
 Columns `bazel_label` and `status` are filled by modeling slices (#10–#7).
-Integration-test / example / cdylib / bin rows stay `unmapped` until #8/#7/#9.
+Example rows stay `unmapped` until #6; libs/tests/CLI/cdylibs mapped through #8/#7.
 
 | Package | Target | Class | Source | Bazel label | Status | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -63,84 +63,84 @@ Integration-test / example / cdylib / bin rows stay `unmapped` until #8/#7/#9.
 | `graphforge-api` | `release_load_probe` | `example` | `crates/graphforge-api/examples/release_load_probe.rs` | — | `unmapped` | |
 | `graphforge-api` | `sna_intelligence_workflow` | `example` | `crates/graphforge-api/examples/sna_intelligence_workflow.rs` | — | `unmapped` | |
 | `graphforge-api` | `strict_add_node_fixture` | `example` | `crates/graphforge-api/examples/strict_add_node_fixture.rs` | — | `unmapped` | |
-| `graphforge-api` | `bdd` | `integration-test` | `crates/graphforge-api/tests/bdd/main.rs` | — | `unmapped` | |
-| `graphforge-api` | `bdd_timing` | `integration-test` | `crates/graphforge-api/tests/bdd_timing.rs` | — | `unmapped` | |
-| `graphforge-api` | `belief_subject_contract` | `integration-test` | `crates/graphforge-api/tests/belief_subject_contract.rs` | — | `unmapped` | |
-| `graphforge-api` | `bind_error_spans` | `integration-test` | `crates/graphforge-api/tests/bind_error_spans.rs` | — | `unmapped` | |
-| `graphforge-api` | `clear` | `integration-test` | `crates/graphforge-api/tests/clear.rs` | — | `unmapped` | |
-| `graphforge-api` | `conductance` | `integration-test` | `crates/graphforge-api/tests/conductance.rs` | — | `unmapped` | |
-| `graphforge-api` | `create_scaling` | `integration-test` | `crates/graphforge-api/tests/create_scaling.rs` | — | `unmapped` | |
-| `graphforge-api` | `e2e_baseline` | `integration-test` | `crates/graphforge-api/tests/e2e_baseline.rs` | — | `unmapped` | |
-| `graphforge-api` | `existential_subquery` | `integration-test` | `crates/graphforge-api/tests/existential_subquery.rs` | — | `unmapped` | |
-| `graphforge-api` | `facade_methods` | `integration-test` | `crates/graphforge-api/tests/facade_methods.rs` | — | `unmapped` | |
-| `graphforge-api` | `fixed_hop_limit` | `integration-test` | `crates/graphforge-api/tests/fixed_hop_limit.rs` | — | `unmapped` | |
-| `graphforge-api` | `graph_internal_metadata` | `integration-test` | `crates/graphforge-api/tests/graph_internal_metadata.rs` | — | `unmapped` | |
-| `graphforge-api` | `inference_provenance` | `integration-test` | `crates/graphforge-api/tests/inference_provenance.rs` | — | `unmapped` | |
-| `graphforge-api` | `knowledge_isolation` | `integration-test` | `crates/graphforge-api/tests/knowledge_isolation.rs` | — | `unmapped` | |
-| `graphforge-api` | `list_semantics` | `integration-test` | `crates/graphforge-api/tests/list_semantics.rs` | — | `unmapped` | |
-| `graphforge-api` | `m22_m18_public_surface` | `integration-test` | `crates/graphforge-api/tests/m22_m18_public_surface.rs` | — | `unmapped` | |
-| `graphforge-api` | `m22_m19_public_surface` | `integration-test` | `crates/graphforge-api/tests/m22_m19_public_surface.rs` | — | `unmapped` | |
-| `graphforge-api` | `m22_provider_public_surface` | `integration-test` | `crates/graphforge-api/tests/m22_provider_public_surface.rs` | — | `unmapped` | |
-| `graphforge-api` | `max_bipartite_matching` | `integration-test` | `crates/graphforge-api/tests/max_bipartite_matching.rs` | — | `unmapped` | |
-| `graphforge-api` | `max_cardinality_matching` | `integration-test` | `crates/graphforge-api/tests/max_cardinality_matching.rs` | — | `unmapped` | |
-| `graphforge-api` | `max_weight_matching` | `integration-test` | `crates/graphforge-api/tests/max_weight_matching.rs` | — | `unmapped` | |
-| `graphforge-api` | `minimum_k_spanning_tree` | `integration-test` | `crates/graphforge-api/tests/minimum_k_spanning_tree.rs` | — | `unmapped` | |
-| `graphforge-api` | `modularity` | `integration-test` | `crates/graphforge-api/tests/modularity.rs` | — | `unmapped` | |
-| `graphforge-api` | `multi_label_scaling` | `integration-test` | `crates/graphforge-api/tests/multi_label_scaling.rs` | — | `unmapped` | |
-| `graphforge-api` | `pattern_comprehension` | `integration-test` | `crates/graphforge-api/tests/pattern_comprehension.rs` | — | `unmapped` | |
-| `graphforge-api` | `percentile_aggregates` | `integration-test` | `crates/graphforge-api/tests/percentile_aggregates.rs` | — | `unmapped` | |
-| `graphforge-api` | `provider_session` | `integration-test` | `crates/graphforge-api/tests/provider_session.rs` | — | `unmapped` | |
-| `graphforge-api` | `public_facade_remaining_conformance` | `integration-test` | `crates/graphforge-api/tests/public_facade_remaining_conformance.rs` | — | `unmapped` | |
-| `graphforge-api` | `public_lifecycle_conformance` | `integration-test` | `crates/graphforge-api/tests/public_lifecycle_conformance.rs` | — | `unmapped` | |
-| `graphforge-api` | `release_load_construction` | `integration-test` | `crates/graphforge-api/tests/release_load_construction.rs` | — | `unmapped` | |
-| `graphforge-api` | `strict_runtime_properties` | `integration-test` | `crates/graphforge-api/tests/strict_runtime_properties.rs` | — | `unmapped` | |
-| `graphforge-api` | `value_access_semantics` | `integration-test` | `crates/graphforge-api/tests/value_access_semantics.rs` | — | `unmapped` | |
-| `graphforge-api` | `value_semantics` | `integration-test` | `crates/graphforge-api/tests/value_semantics.rs` | — | `unmapped` | |
-| `graphforge-api` | `with_aggregation` | `integration-test` | `crates/graphforge-api/tests/with_aggregation.rs` | — | `unmapped` | |
-| `graphforge-api` | `xor_scaling` | `integration-test` | `crates/graphforge-api/tests/xor_scaling.rs` | — | `unmapped` | |
+| `graphforge-api` | `bdd` | `integration-test` | `crates/graphforge-api/tests/bdd/main.rs` | `//crates/graphforge-api:bdd` | `mapped` | #8 |
+| `graphforge-api` | `bdd_timing` | `integration-test` | `crates/graphforge-api/tests/bdd_timing.rs` | `//crates/graphforge-api:bdd_timing` | `mapped` | #8 |
+| `graphforge-api` | `belief_subject_contract` | `integration-test` | `crates/graphforge-api/tests/belief_subject_contract.rs` | `//crates/graphforge-api:belief_subject_contract` | `mapped` | #8 |
+| `graphforge-api` | `bind_error_spans` | `integration-test` | `crates/graphforge-api/tests/bind_error_spans.rs` | `//crates/graphforge-api:bind_error_spans` | `mapped` | #8 |
+| `graphforge-api` | `clear` | `integration-test` | `crates/graphforge-api/tests/clear.rs` | `//crates/graphforge-api:clear` | `mapped` | #8 |
+| `graphforge-api` | `conductance` | `integration-test` | `crates/graphforge-api/tests/conductance.rs` | `//crates/graphforge-api:conductance` | `mapped` | #8 |
+| `graphforge-api` | `create_scaling` | `integration-test` | `crates/graphforge-api/tests/create_scaling.rs` | `//crates/graphforge-api:create_scaling` | `mapped` | #8 |
+| `graphforge-api` | `e2e_baseline` | `integration-test` | `crates/graphforge-api/tests/e2e_baseline.rs` | `//crates/graphforge-api:e2e_baseline` | `mapped` | #8 |
+| `graphforge-api` | `existential_subquery` | `integration-test` | `crates/graphforge-api/tests/existential_subquery.rs` | `//crates/graphforge-api:existential_subquery` | `mapped` | #8 |
+| `graphforge-api` | `facade_methods` | `integration-test` | `crates/graphforge-api/tests/facade_methods.rs` | `//crates/graphforge-api:facade_methods` | `mapped` | #8 |
+| `graphforge-api` | `fixed_hop_limit` | `integration-test` | `crates/graphforge-api/tests/fixed_hop_limit.rs` | `//crates/graphforge-api:fixed_hop_limit` | `mapped` | #8 |
+| `graphforge-api` | `graph_internal_metadata` | `integration-test` | `crates/graphforge-api/tests/graph_internal_metadata.rs` | `//crates/graphforge-api:graph_internal_metadata` | `mapped` | #8 |
+| `graphforge-api` | `inference_provenance` | `integration-test` | `crates/graphforge-api/tests/inference_provenance.rs` | `//crates/graphforge-api:inference_provenance` | `mapped` | #8 |
+| `graphforge-api` | `knowledge_isolation` | `integration-test` | `crates/graphforge-api/tests/knowledge_isolation.rs` | `//crates/graphforge-api:knowledge_isolation` | `mapped` | #8 |
+| `graphforge-api` | `list_semantics` | `integration-test` | `crates/graphforge-api/tests/list_semantics.rs` | `//crates/graphforge-api:list_semantics` | `mapped` | #8 |
+| `graphforge-api` | `m22_m18_public_surface` | `integration-test` | `crates/graphforge-api/tests/m22_m18_public_surface.rs` | `//crates/graphforge-api:m22_m18_public_surface` | `mapped` | #8 |
+| `graphforge-api` | `m22_m19_public_surface` | `integration-test` | `crates/graphforge-api/tests/m22_m19_public_surface.rs` | `//crates/graphforge-api:m22_m19_public_surface` | `mapped` | #8 |
+| `graphforge-api` | `m22_provider_public_surface` | `integration-test` | `crates/graphforge-api/tests/m22_provider_public_surface.rs` | `//crates/graphforge-api:m22_provider_public_surface` | `mapped` | #8 |
+| `graphforge-api` | `max_bipartite_matching` | `integration-test` | `crates/graphforge-api/tests/max_bipartite_matching.rs` | `//crates/graphforge-api:max_bipartite_matching` | `mapped` | #8 |
+| `graphforge-api` | `max_cardinality_matching` | `integration-test` | `crates/graphforge-api/tests/max_cardinality_matching.rs` | `//crates/graphforge-api:max_cardinality_matching` | `mapped` | #8 |
+| `graphforge-api` | `max_weight_matching` | `integration-test` | `crates/graphforge-api/tests/max_weight_matching.rs` | `//crates/graphforge-api:max_weight_matching` | `mapped` | #8 |
+| `graphforge-api` | `minimum_k_spanning_tree` | `integration-test` | `crates/graphforge-api/tests/minimum_k_spanning_tree.rs` | `//crates/graphforge-api:minimum_k_spanning_tree` | `mapped` | #8 |
+| `graphforge-api` | `modularity` | `integration-test` | `crates/graphforge-api/tests/modularity.rs` | `//crates/graphforge-api:modularity` | `mapped` | #8 |
+| `graphforge-api` | `multi_label_scaling` | `integration-test` | `crates/graphforge-api/tests/multi_label_scaling.rs` | `//crates/graphforge-api:multi_label_scaling` | `mapped` | #8 |
+| `graphforge-api` | `pattern_comprehension` | `integration-test` | `crates/graphforge-api/tests/pattern_comprehension.rs` | `//crates/graphforge-api:pattern_comprehension` | `mapped` | #8 |
+| `graphforge-api` | `percentile_aggregates` | `integration-test` | `crates/graphforge-api/tests/percentile_aggregates.rs` | `//crates/graphforge-api:percentile_aggregates` | `mapped` | #8 |
+| `graphforge-api` | `provider_session` | `integration-test` | `crates/graphforge-api/tests/provider_session.rs` | `//crates/graphforge-api:provider_session` | `mapped` | #8 |
+| `graphforge-api` | `public_facade_remaining_conformance` | `integration-test` | `crates/graphforge-api/tests/public_facade_remaining_conformance.rs` | `//crates/graphforge-api:public_facade_remaining_conformance` | `mapped` | #8 |
+| `graphforge-api` | `public_lifecycle_conformance` | `integration-test` | `crates/graphforge-api/tests/public_lifecycle_conformance.rs` | `//crates/graphforge-api:public_lifecycle_conformance` | `mapped` | #8 |
+| `graphforge-api` | `release_load_construction` | `integration-test` | `crates/graphforge-api/tests/release_load_construction.rs` | `//crates/graphforge-api:release_load_construction` | `mapped` | #8 |
+| `graphforge-api` | `strict_runtime_properties` | `integration-test` | `crates/graphforge-api/tests/strict_runtime_properties.rs` | `//crates/graphforge-api:strict_runtime_properties` | `mapped` | #8 |
+| `graphforge-api` | `value_access_semantics` | `integration-test` | `crates/graphforge-api/tests/value_access_semantics.rs` | `//crates/graphforge-api:value_access_semantics` | `mapped` | #8 |
+| `graphforge-api` | `value_semantics` | `integration-test` | `crates/graphforge-api/tests/value_semantics.rs` | `//crates/graphforge-api:value_semantics` | `mapped` | #8 |
+| `graphforge-api` | `with_aggregation` | `integration-test` | `crates/graphforge-api/tests/with_aggregation.rs` | `//crates/graphforge-api:with_aggregation` | `mapped` | #8 |
+| `graphforge-api` | `xor_scaling` | `integration-test` | `crates/graphforge-api/tests/xor_scaling.rs` | `//crates/graphforge-api:xor_scaling` | `mapped` | #8 |
 | `graphforge-ast` | `graphforge_ast` | `lib` | `crates/graphforge-ast/src/lib.rs` | `//crates/graphforge-ast:graphforge_ast` | `mapped` | #10; unit tests `//crates/graphforge-ast:graphforge_ast_test` |
 | `graphforge-bindings-node` | `graphforge_bindings_node` | `cdylib` | `crates/graphforge-bindings-node/src/lib.rs` | `//crates/graphforge-bindings-node:graphforge_bindings_node` | `mapped` | #7; packaging `//:node_package_smoke` |
 | `graphforge-bindings-node` | `build-script-build` | `custom-build` | `crates/graphforge-bindings-node/build.rs` | `//crates/graphforge-bindings-node:graphforge_bindings_node_build_script` | `mapped` | #7; `napi-build` via `gf_cargo_build_script` |
 | `graphforge-bindings-py` | `graphforge_bindings_py` | `cdylib` | `crates/graphforge-bindings-py/src/lib.rs` | `//crates/graphforge-bindings-py:graphforge_bindings_py` | `mapped` | #7; packaging `//:python_wheel_smoke` |
-| `graphforge-cli` | `graphforge_cli` | `lib` | `crates/graphforge-cli/src/lib.rs` | `//crates/graphforge-cli:graphforge_cli` | `mapped` | #7 link dep for bindings; bin/tests remain #8 |
-| `graphforge-cli` | `gf` | `bin` | `crates/graphforge-cli/src/main.rs` | — | `unmapped` | #8 |
-| `graphforge-cli` | `checkpoints` | `integration-test` | `crates/graphforge-cli/tests/checkpoints.rs` | — | `unmapped` | #8 |
-| `graphforge-cli` | `portable` | `integration-test` | `crates/graphforge-cli/tests/portable.rs` | — | `unmapped` | #8 |
-| `graphforge-cli` | `repository` | `integration-test` | `crates/graphforge-cli/tests/repository.rs` | — | `unmapped` | #8 |
-| `graphforge-cli` | `build-script-build` | `custom-build` | `crates/graphforge-cli/build.rs` | `//crates/graphforge-cli:graphforge_cli_build_script` | `mapped` | #7 (embeds `project-skills`); #8 owns bin/tests |
+| `graphforge-cli` | `graphforge_cli` | `lib` | `crates/graphforge-cli/src/lib.rs` | `//crates/graphforge-cli:graphforge_cli` | `mapped` | #7/#8; unit `//crates/graphforge-cli:graphforge_cli_test` |
+| `graphforge-cli` | `gf` | `bin` | `crates/graphforge-cli/src/main.rs` | `//crates/graphforge-cli:gf` | `mapped` | #8 |
+| `graphforge-cli` | `checkpoints` | `integration-test` | `crates/graphforge-cli/tests/checkpoints.rs` | `//crates/graphforge-cli:checkpoints` | `mapped` | #8 |
+| `graphforge-cli` | `portable` | `integration-test` | `crates/graphforge-cli/tests/portable.rs` | `//crates/graphforge-cli:portable` | `mapped` | #8 |
+| `graphforge-cli` | `repository` | `integration-test` | `crates/graphforge-cli/tests/repository.rs` | `//crates/graphforge-cli:repository` | `mapped` | #8 |
+| `graphforge-cli` | `build-script-build` | `custom-build` | `crates/graphforge-cli/build.rs` | `//crates/graphforge-cli:graphforge_cli_build_script` | `mapped` | #7/#8; RT-cli-build-script closed |
 | `graphforge-core` | `graphforge_core` | `lib` | `crates/graphforge-core/src/lib.rs` | `//crates/graphforge-core:graphforge_core` | `mapped` | #10; unit tests `//crates/graphforge-core:graphforge_core_test` |
 | `graphforge-cypher` | `graphforge_cypher` | `lib` | `crates/graphforge-cypher/src/lib.rs` | `//crates/graphforge-cypher:graphforge_cypher` | `mapped` | #10; unit tests `//crates/graphforge-cypher:graphforge_cypher_test` |
-| `graphforge-cypher` | `corpus` | `integration-test` | `crates/graphforge-cypher/tests/corpus.rs` | — | `unmapped` | #8 |
+| `graphforge-cypher` | `corpus` | `integration-test` | `crates/graphforge-cypher/tests/corpus.rs` | `//crates/graphforge-cypher:corpus` | `mapped` | #8 |
 | `graphforge-exec` | `graphforge_exec` | `lib` | `crates/graphforge-exec/src/lib.rs` | `//crates/graphforge-exec:graphforge_exec` | `mapped` | #9; unit tests `//crates/graphforge-exec:graphforge_exec_test` |
-| `graphforge-exec` | `adjacency_expand` | `integration-test` | `crates/graphforge-exec/tests/adjacency_expand.rs` | — | `unmapped` | |
-| `graphforge-exec` | `bench_traversal_scaling` | `integration-test` | `crates/graphforge-exec/tests/bench_traversal_scaling.rs` | — | `unmapped` | |
-| `graphforge-exec` | `create_execution` | `integration-test` | `crates/graphforge-exec/tests/create_execution.rs` | — | `unmapped` | |
-| `graphforge-exec` | `create_input_driven` | `integration-test` | `crates/graphforge-exec/tests/create_input_driven.rs` | — | `unmapped` | |
-| `graphforge-exec` | `differential_traversal` | `integration-test` | `crates/graphforge-exec/tests/differential_traversal.rs` | — | `unmapped` | |
-| `graphforge-exec` | `explain_snapshots` | `integration-test` | `crates/graphforge-exec/tests/explain_snapshots.rs` | — | `unmapped` | |
-| `graphforge-exec` | `optional_match` | `integration-test` | `crates/graphforge-exec/tests/optional_match.rs` | — | `unmapped` | |
-| `graphforge-exec` | `persistent_adjacency` | `integration-test` | `crates/graphforge-exec/tests/persistent_adjacency.rs` | — | `unmapped` | |
-| `graphforge-exec` | `read_execution` | `integration-test` | `crates/graphforge-exec/tests/read_execution.rs` | — | `unmapped` | |
-| `graphforge-exec` | `unwind` | `integration-test` | `crates/graphforge-exec/tests/unwind.rs` | — | `unmapped` | |
-| `graphforge-exec` | `var_len_expand` | `integration-test` | `crates/graphforge-exec/tests/var_len_expand.rs` | — | `unmapped` | |
-| `graphforge-exec` | `write_statement` | `integration-test` | `crates/graphforge-exec/tests/write_statement.rs` | — | `unmapped` | |
+| `graphforge-exec` | `adjacency_expand` | `integration-test` | `crates/graphforge-exec/tests/adjacency_expand.rs` | `//crates/graphforge-exec:adjacency_expand` | `mapped` | #8 |
+| `graphforge-exec` | `bench_traversal_scaling` | `integration-test` | `crates/graphforge-exec/tests/bench_traversal_scaling.rs` | `//crates/graphforge-exec:bench_traversal_scaling` | `mapped` | #8 |
+| `graphforge-exec` | `create_execution` | `integration-test` | `crates/graphforge-exec/tests/create_execution.rs` | `//crates/graphforge-exec:create_execution` | `mapped` | #8 |
+| `graphforge-exec` | `create_input_driven` | `integration-test` | `crates/graphforge-exec/tests/create_input_driven.rs` | `//crates/graphforge-exec:create_input_driven` | `mapped` | #8 |
+| `graphforge-exec` | `differential_traversal` | `integration-test` | `crates/graphforge-exec/tests/differential_traversal.rs` | `//crates/graphforge-exec:differential_traversal` | `mapped` | #8 |
+| `graphforge-exec` | `explain_snapshots` | `integration-test` | `crates/graphforge-exec/tests/explain_snapshots.rs` | `//crates/graphforge-exec:explain_snapshots` | `mapped` | #8 |
+| `graphforge-exec` | `optional_match` | `integration-test` | `crates/graphforge-exec/tests/optional_match.rs` | `//crates/graphforge-exec:optional_match` | `mapped` | #8 |
+| `graphforge-exec` | `persistent_adjacency` | `integration-test` | `crates/graphforge-exec/tests/persistent_adjacency.rs` | `//crates/graphforge-exec:persistent_adjacency` | `mapped` | #8 |
+| `graphforge-exec` | `read_execution` | `integration-test` | `crates/graphforge-exec/tests/read_execution.rs` | `//crates/graphforge-exec:read_execution` | `mapped` | #8 |
+| `graphforge-exec` | `unwind` | `integration-test` | `crates/graphforge-exec/tests/unwind.rs` | `//crates/graphforge-exec:unwind` | `mapped` | #8 |
+| `graphforge-exec` | `var_len_expand` | `integration-test` | `crates/graphforge-exec/tests/var_len_expand.rs` | `//crates/graphforge-exec:var_len_expand` | `mapped` | #8 |
+| `graphforge-exec` | `write_statement` | `integration-test` | `crates/graphforge-exec/tests/write_statement.rs` | `//crates/graphforge-exec:write_statement` | `mapped` | #8 |
 | `graphforge-io` | `graphforge_io` | `lib` | `crates/graphforge-io/src/lib.rs` | `//crates/graphforge-io:graphforge_io` | `mapped` | #9; unit tests `//crates/graphforge-io:graphforge_io_test` |
 | `graphforge-ir` | `graphforge_ir` | `lib` | `crates/graphforge-ir/src/lib.rs` | `//crates/graphforge-ir:graphforge_ir` | `mapped` | #10; unit tests `//crates/graphforge-ir:graphforge_ir_test` |
-| `graphforge-ir` | `golden` | `integration-test` | `crates/graphforge-ir/tests/golden.rs` | — | `unmapped` | #8 |
+| `graphforge-ir` | `golden` | `integration-test` | `crates/graphforge-ir/tests/golden.rs` | `//crates/graphforge-ir:golden` | `mapped` | #8 |
 | `graphforge-knowledge` | `graphforge_knowledge` | `lib` | `crates/graphforge-knowledge/src/lib.rs` | `//crates/graphforge-knowledge:graphforge_knowledge` | `mapped` | #9; unit tests `//crates/graphforge-knowledge:graphforge_knowledge_test` |
 | `graphforge-ontology` | `graphforge_ontology` | `lib` | `crates/graphforge-ontology/src/lib.rs` | `//crates/graphforge-ontology:graphforge_ontology` | `mapped` | #10; unit tests `//crates/graphforge-ontology:graphforge_ontology_test` |
-| `graphforge-ontology` | `integration` | `integration-test` | `crates/graphforge-ontology/tests/integration.rs` | — | `unmapped` | #8 |
+| `graphforge-ontology` | `integration` | `integration-test` | `crates/graphforge-ontology/tests/integration.rs` | `//crates/graphforge-ontology:integration` | `mapped` | #8 |
 | `graphforge-plan` | `graphforge_plan` | `lib` | `crates/graphforge-plan/src/lib.rs` | `//crates/graphforge-plan:graphforge_plan` | `mapped` | #10; unit tests `//crates/graphforge-plan:graphforge_plan_test` |
 | `graphforge-provenance` | `graphforge_provenance` | `lib` | `crates/graphforge-provenance/src/lib.rs` | `//crates/graphforge-provenance:graphforge_provenance` | `mapped` | #10; unit tests `//crates/graphforge-provenance:graphforge_provenance_test` |
 | `graphforge-rel` | `graphforge_rel` | `lib` | `crates/graphforge-rel/src/lib.rs` | `//crates/graphforge-rel:graphforge_rel` | `mapped` | #10; unit tests `//crates/graphforge-rel:graphforge_rel_test` |
-| `graphforge-rel` | `expression_lowering_matrix` | `integration-test` | `crates/graphforge-rel/tests/expression_lowering_matrix.rs` | — | `unmapped` | #8 |
-| `graphforge-rel` | `logical_plan_golden` | `integration-test` | `crates/graphforge-rel/tests/logical_plan_golden.rs` | — | `unmapped` | #8 |
+| `graphforge-rel` | `expression_lowering_matrix` | `integration-test` | `crates/graphforge-rel/tests/expression_lowering_matrix.rs` | `//crates/graphforge-rel:expression_lowering_matrix` | `mapped` | #8 |
+| `graphforge-rel` | `logical_plan_golden` | `integration-test` | `crates/graphforge-rel/tests/logical_plan_golden.rs` | `//crates/graphforge-rel:logical_plan_golden` | `mapped` | #8 |
 | `graphforge-search` | `graphforge_search` | `lib` | `crates/graphforge-search/src/lib.rs` | `//crates/graphforge-search:graphforge_search` | `mapped` | #9; unit tests `//crates/graphforge-search:graphforge_search_test` |
 | `graphforge-storage` | `graphforge_storage` | `lib` | `crates/graphforge-storage/src/lib.rs` | `//crates/graphforge-storage:graphforge_storage` | `mapped` | #10 early / #9; Bazel enables `test-failpoints` for api subprocess unification; unit tests `//crates/graphforge-storage:graphforge_storage_test` |
-| `graphforge-storage` | `adjacency_delta_write` | `integration-test` | `crates/graphforge-storage/tests/adjacency_delta_write.rs` | — | `unmapped` | |
-| `graphforge-storage` | `filtered_read` | `integration-test` | `crates/graphforge-storage/tests/filtered_read.rs` | — | `unmapped` | |
-| `graphforge-storage` | `graph_writer` | `integration-test` | `crates/graphforge-storage/tests/graph_writer.rs` | — | `unmapped` | |
-| `graphforge-storage` | `io_stats` | `integration-test` | `crates/graphforge-storage/tests/io_stats.rs` | — | `unmapped` | |
+| `graphforge-storage` | `adjacency_delta_write` | `integration-test` | `crates/graphforge-storage/tests/adjacency_delta_write.rs` | `//crates/graphforge-storage:adjacency_delta_write` | `mapped` | #8 |
+| `graphforge-storage` | `filtered_read` | `integration-test` | `crates/graphforge-storage/tests/filtered_read.rs` | `//crates/graphforge-storage:filtered_read` | `mapped` | #8 |
+| `graphforge-storage` | `graph_writer` | `integration-test` | `crates/graphforge-storage/tests/graph_writer.rs` | `//crates/graphforge-storage:graph_writer` | `mapped` | #8 |
+| `graphforge-storage` | `io_stats` | `integration-test` | `crates/graphforge-storage/tests/io_stats.rs` | `//crates/graphforge-storage:io_stats` | `mapped` | #8 |
 
 ## Retained-tool exception stubs
 
@@ -149,13 +149,13 @@ before #6 parity can pass with the exception still open.
 
 | ID | Tool / surface | Why Bazel may not replace cleanly | Owning follow-up | Status |
 | --- | --- | --- | --- | --- |
-| RT-fuzz | `cargo fuzz` (`fuzz/` workspace, workflow `fuzz.yml`) | cargo-fuzz driver + corpus workflow outside ordinary `rules_rust` test graph | #8/#6 justify or map | stub |
+| RT-fuzz | `cargo fuzz` (`fuzz/` workspace, workflow `fuzz.yml`) | cargo-fuzz driver + corpus workflow outside ordinary `rules_rust` test graph | #6 parity may keep Cargo; justified retained tool | explicit |
 | RT-publish-crates | `cargo publish` / crates.io authorize flows | Ecosystem publication metadata and registry auth | keep Cargo; ledger must remain explicit | stub |
 | RT-maturin-assemble | `maturin build` / `maturin sdist` packaging assembly | Bazel handoff: `//:python_wheel_smoke` + `assemble_bazel_binding_packages.py` consume Bazel cdylibs (no silent `maturin build` recompile). Maturin may still sign/publish later. | #7 handoff | handoff |
 | RT-napi-assemble | `napi build` / `napi artifacts` / `napi pre-publish` | Bazel handoff: `//:node_package_smoke` consumes Bazel cdylib (no silent `napi build` recompile). napi may still assemble/sign/publish later. | #7 handoff | handoff |
-| RT-cli-build-script | `graphforge-cli` lib (`build.rs` → embedded `project-skills`) | Lib + build script mapped for #7 binding link; bin/tests still #8 | #8 bin/tests; #7 mapped lib | partial |
+| RT-cli-build-script | `graphforge-cli` lib (`build.rs` → embedded `project-skills`) | Mapped via `cargo_build_script` + `//:project_skills_bundle`; bin/tests mapped | #8 complete | closed |
 | RT-bindings-cdylib | `graphforge-bindings-py` / `graphforge-bindings-node` packages | Mapped as `rust_shared_library` cdylibs + packaging smoke targets | #7 | mapped |
-| RT-examples | `graphforge-api` examples (11) | May be CI/release probes vs developer samples; map or except per #8/#6 | #8/#6 | stub |
+| RT-examples | `graphforge-api` examples (11) | Developer samples + release-load probes; not required for #8 test graph; map under #6 if parity demands binaries | #6 | explicit |
 | RT-mobile | Swift / Kotlin / UniFFI / XCFramework / JVM AAR | **Abandoned for M2** — not a deliverable; do not inventory as required targets | excluded | excluded |
 
 ## CI / release build command sites

--- a/examples/agent_grounding/BUILD.bazel
+++ b/examples/agent_grounding/BUILD.bazel
@@ -1,0 +1,8 @@
+"""Notebook resources inventoried for the Bazel test/resource graph (#8)."""
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "notebooks",
+    srcs = glob(["**/*.ipynb"]),
+)

--- a/scripts/ci/classify-changes.sh
+++ b/scripts/ci/classify-changes.sh
@@ -110,6 +110,8 @@ while IFS= read -r -d '' path; do
       cargo-bazel-lock.json | tools/bazel/* | tools/bazel/**/* | \
       crates/BUILD.bazel | crates/*/BUILD.bazel | \
       docs/contracts/examples/BUILD.bazel | docs/reference/BUILD.bazel | \
+      tests/features/BUILD.bazel | tests/tck/BUILD.bazel | \
+      examples/agent_grounding/BUILD.bazel | \
       scripts/ci/cargo-bazel-drift-check.py | \
       scripts/ci/test-cargo-bazel-drift-check.py | \
       scripts/ci/assemble_bazel_binding_packages.py | \

--- a/scripts/ci/test-classify-changes.sh
+++ b/scripts/ci/test-classify-changes.sh
@@ -119,6 +119,9 @@ assert_classification "$bazel_only" docs/reference/BUILD.bazel bazel-docs-refere
 assert_classification "$bazel_only" docs/contracts/examples/BUILD.bazel bazel-docs-contracts-build
 assert_classification "$bazel_only" scripts/ci/assemble_bazel_binding_packages.py bazel-binding-packaging
 assert_classification "$bazel_only" tools/bazel/bindings/BUILD.bazel bazel-bindings-handoff
+assert_classification "$bazel_only" tests/features/BUILD.bazel bazel-features-build
+assert_classification "$bazel_only" tests/tck/BUILD.bazel bazel-tck-build
+assert_classification "$bazel_only" examples/agent_grounding/BUILD.bazel bazel-notebook-build
 assert_classification "$none" "docs/a file with spaces.md" docs-only
 
 # Packaging-only Cargo metadata must not compile the workspace.

--- a/tests/features/BUILD.bazel
+++ b/tests/features/BUILD.bazel
@@ -1,0 +1,20 @@
+"""Public-API Gherkin features consumed by graphforge-api BDD (#8)."""
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "api_features",
+    srcs = glob(["api/**/*.feature"]),
+)
+
+filegroup(
+    name = "all_features",
+    srcs = glob(
+        ["**/*"],
+        exclude = [
+            "BUILD.bazel",
+            "**/__pycache__/**",
+            "**/*.pyc",
+        ],
+    ),
+)

--- a/tests/tck/BUILD.bazel
+++ b/tests/tck/BUILD.bazel
@@ -1,0 +1,29 @@
+"""Vendored openCypher TCK corpus + baselines for Rust BDD (#8)."""
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "features",
+    srcs = glob(["features/**/*"]),
+)
+
+filegroup(
+    name = "baselines",
+    srcs = [
+        "passing_baseline.txt",
+        "performance_baseline.json",
+        "performance_policy.json",
+        "coverage_matrix.json",
+    ],
+)
+
+filegroup(
+    name = "corpus",
+    srcs = [
+        ":baselines",
+        ":features",
+        "LICENSE",
+        "NOTICE",
+        "README.md",
+    ],
+)

--- a/tools/bazel/gf_rust.bzl
+++ b/tools/bazel/gf_rust.bzl
@@ -1,8 +1,8 @@
-"""Shared macros for first-party GraphForge rust_library / rust_test / cdylib targets."""
+"""Shared macros for first-party GraphForge rust_library / rust_test / binary / cdylib targets."""
 
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
 load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
-load("@rules_rust//rust:defs.bzl", "rust_library", "rust_shared_library", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_shared_library", "rust_test")
 
 def gf_rust_library(name, deps = [], compile_data = [], crate_features = [], **kwargs):
     """rust_library wired to crate_universe deps for this package's Cargo.toml."""
@@ -35,6 +35,48 @@ def gf_rust_test(name, crate, deps = [], crate_features = [], **kwargs):
         **kwargs
     )
 
+def gf_rust_integration_test(
+        name,
+        srcs,
+        crate,
+        deps = [],
+        data = [],
+        crate_features = [],
+        rustc_env = {},
+        env = {},
+        size = "medium",
+        timeout = None,
+        use_libtest_harness = True,
+        crate_root = None,
+        **kwargs):
+    """Cargo-style integration test (`tests/*.rs`) with hermetic CARGO_MANIFEST_DIR."""
+    package_name = native.package_name()
+    merged_rustc_env = {"CARGO_MANIFEST_DIR": package_name}
+    merged_rustc_env.update(rustc_env)
+    test_kwargs = dict(kwargs)
+    if timeout != None:
+        test_kwargs["timeout"] = timeout
+    if crate_root != None:
+        test_kwargs["crate_root"] = crate_root
+    rust_test(
+        name = name,
+        srcs = srcs,
+        aliases = aliases(
+            normal_dev = True,
+            proc_macro_dev = True,
+        ),
+        crate_features = crate_features,
+        data = data,
+        edition = "2024",
+        env = env,
+        proc_macro_deps = all_crate_deps(proc_macro = True) + all_crate_deps(proc_macro_dev = True),
+        rustc_env = merged_rustc_env,
+        size = size,
+        use_libtest_harness = use_libtest_harness,
+        deps = all_crate_deps(normal = True) + all_crate_deps(normal_dev = True) + [crate] + deps,
+        **test_kwargs
+    )
+
 def gf_cargo_build_script(name, deps = [], data = [], crate_features = [], **kwargs):
     """cargo_build_script wired to crate_universe build-deps for this package."""
     cargo_build_script(
@@ -47,6 +89,21 @@ def gf_cargo_build_script(name, deps = [], data = [], crate_features = [], **kwa
         proc_macro_deps = all_crate_deps(build_proc_macro = True),
         visibility = kwargs.pop("visibility", ["//visibility:private"]),
         deps = all_crate_deps(build = True) + deps,
+        **kwargs
+    )
+
+def gf_rust_binary(name, deps = [], data = [], crate_features = [], **kwargs):
+    """rust_binary wired to crate_universe deps for this package's Cargo.toml."""
+    rust_binary(
+        name = name,
+        srcs = kwargs.pop("srcs", native.glob(["src/**/*.rs"])),
+        aliases = aliases(),
+        crate_features = crate_features,
+        data = data,
+        edition = "2024",
+        proc_macro_deps = all_crate_deps(proc_macro = True),
+        visibility = kwargs.pop("visibility", ["//visibility:public"]),
+        deps = all_crate_deps(normal = True) + deps,
         **kwargs
     )
 


### PR DESCRIPTION
## Summary
- Map all 59 integration-test binaries, CLI lib/`gf`/build.rs, snapshot/golden suites, BDD harness, and non-source resource filegroups as real `rules_rust` targets (no Cargo shell-out).
- Add deterministic CI groups (`//:unit_tests`, `//:integration_tests`, `//:snapshot_tests`, `//:bdd_tests`, `//:cli_tests`, `//:resource_inputs`) and Blacksmith smoke suite `//:bazel_test_graph_smoke`.
- Close `RT-cli-build-script` via hermetic `cargo_build_script` + OUT_DIR skill embedding; justify `RT-examples`/`RT-fuzz` for #6; update ledger and bootstrap docs.

## Test plan
- [x] `scripts/ci/test-classify-changes.sh`
- [x] `python3 scripts/ci/cargo-bazel-drift-check.py` + `test-cargo-bazel-drift-check.py`
- [x] `bazelisk build //:first_party_libs //:cli_bins //:resource_inputs`
- [x] `bazelisk test //:bazel_test_graph_smoke` (31/31 pass locally)
- [ ] Blacksmith `Bazel Bootstrap` + `CI Gate` green on exact head SHA

Fixes #8

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788580717&installation_model_id=20486&pr_number=423&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F423&signature=d7fe252717fa0c3416d022486699bc9c847545990529a90af541656e588903ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Bazel targets for unit, integration, snapshot, BDD, CLI, and resource test suites
> - Adds `gf_rust_integration_test` and `gf_rust_binary` macros to [gf_rust.bzl](https://github.com/CurateLabs/graphforge/pull/423/files#diff-8da64aca68331f8f3ba3a0b8333b86d412e721700301f72a2d618cd7cec73b39), setting `CARGO_MANIFEST_DIR` hermetically so integration tests resolve fixtures correctly under Bazel.
> - Extends `BUILD.bazel` files across all crates (`graphforge-api`, `graphforge-cli`, `graphforge-exec`, `graphforge-ir`, `graphforge-rel`, `graphforge-storage`, etc.) with discrete integration, snapshot, and BDD test targets grouped into suites.
> - Adds a root `bazel_test_graph_smoke` test suite and `cli_bins`/`resource_inputs` build targets to the top-level [BUILD.bazel](https://github.com/CurateLabs/graphforge/pull/423/files#diff-7fc57714ef13c3325ce2a1130202edced92fcccc0c6db34a72f7b57f60d552a3), and wires these into CI via [test.yml](https://github.com/CurateLabs/graphforge/pull/423/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88).
> - Adds filegroup targets for BDD feature files, TCK corpus, and example notebooks so they are addressable as Bazel data dependencies.
> - Fixes snapshot/golden test helpers in `explain_snapshots.rs`, `golden.rs`, and `logical_plan_golden.rs` to resolve `CARGO_MANIFEST_DIR` as an absolute path, preventing path errors when run under Bazel.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8277005.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->