### PR TITLE
build(bazel): Blacksmith cache policy + cold/warm perf harness (#5)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -881,22 +881,35 @@ jobs:
           python3 scripts/ci/test-bazel-migration-ledger-check.py
           python3 scripts/ci/test-cargo-bazel-parity-check.py
 
-      - name: Bazel smoke + first-party libs/tests/CLI/resources
+      - name: Blacksmith remote-cache policy + perf harness tests (#5)
         run: |
           # Do not set --remote_cache; Blacksmith injects repository cache.
-          bazelisk test //:bazel_test_graph_smoke
+          python3 scripts/ci/bazel-cache-perf.py --mode policy
+          python3 scripts/ci/test-bazel-cache-perf.py
+          python3 scripts/ci/bazel-cache-perf.py --mode evaluate --allow-pending \
+            --evidence docs/development/bazel-migration-evidence/perf-sample.json
+
+      - name: Bazel smoke + first-party libs/tests/CLI/resources
+        run: |
+          set -euo pipefail
+          # Do not set --remote_cache; Blacksmith injects repository cache.
+          mkdir -p dist
+          bazelisk test //:bazel_test_graph_smoke 2>&1 | tee dist/bazel-test-graph-smoke.log
           bazelisk build \
             //:bazel_smoke \
             //:first_party_libs \
             //:runtime_libs \
             //:cli_bins \
             //:resource_inputs \
-            //:release_bins
+            //:release_bins 2>&1 | tee dist/bazel-representative-build.log
 
       - name: Bazel binding cdylibs + packaging handoff
         run: |
+          set -euo pipefail
           # Do not set --remote_cache; Blacksmith injects repository cache.
-          bazelisk build //:binding_cdylibs //:python_wheel_smoke //:node_package_smoke
+          mkdir -p dist
+          bazelisk build //:binding_cdylibs //:python_wheel_smoke //:node_package_smoke \
+            2>&1 | tee dist/bazel-binding-build.log
           python3 scripts/ci/test-assemble-bazel-binding-packages.py
 
       - name: Same-SHA Cargo/Bazel dual-build parity
@@ -908,12 +921,65 @@ jobs:
             --mode all \
             --write-evidence "dist/cargo-bazel-parity-evidence.json"
 
+      - name: Cache-unavailable cold correctness + warm observation (#5)
+        run: |
+          set -euo pipefail
+          # Cold correctness clears remote/disk cache via CLI only (not checked in).
+          mkdir -p dist
+          python3 scripts/ci/bazel-cache-perf.py --mode cold-correctness
+          python3 scripts/ci/bazel-cache-perf.py --mode observe-warm \
+            --write dist/bazel-warm-observation.json
+          python3 scripts/ci/bazel-cache-perf.py --mode affected-inputs \
+            --write dist/bazel-affected-inputs.json
+          if [[ -f dist/bazel-representative-build.log ]]; then
+            python3 scripts/ci/bazel-cache-perf.py --mode parse-log \
+              --log dist/bazel-representative-build.log \
+              > dist/bazel-representative-build.summary.json || \
+              echo '{"remote_cache_hits":0,"raw":null}' > dist/bazel-representative-build.summary.json
+          else
+            echo '{"remote_cache_hits":0,"raw":null,"note":"missing build log"}' \
+              > dist/bazel-representative-build.summary.json
+          fi
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          dist = Path("dist")
+          warm = json.loads((dist / "bazel-warm-observation.json").read_text())
+          affected = json.loads((dist / "bazel-affected-inputs.json").read_text())
+          summary = {
+              "schema": "graphforge.bazel-cache-perf-ci-observation.v1",
+              "warm_observation": warm,
+              "affected_inputs": affected,
+              "remote_cache_hits_observed": bool(warm.get("remote_cache_hits_observed")),
+              "org_admin_blocker_likely": not bool(warm.get("remote_cache_hits_observed")),
+          }
+          (dist / "bazel-cache-perf-ci-observation.json").write_text(
+              json.dumps(summary, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          print(json.dumps(summary, indent=2, sort_keys=True))
+          PY
+
       - name: Upload Cargo/Bazel parity evidence
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: cargo-bazel-parity-evidence-${{ github.run_id }}
           path: dist/cargo-bazel-parity-evidence.json
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload Bazel cache/perf observation (#5)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: bazel-cache-perf-evidence-${{ github.run_id }}
+          path: |
+            dist/bazel-warm-observation.json
+            dist/bazel-affected-inputs.json
+            dist/bazel-cache-perf-ci-observation.json
+            dist/bazel-representative-build.summary.json
+            docs/development/bazel-migration-evidence/perf-sample.json
           if-no-files-found: error
           retention-days: 1
 

--- a/docs/development/bazel-bootstrap.md
+++ b/docs/development/bazel-bootstrap.md
@@ -150,9 +150,15 @@ CARGO_BAZEL_REPIN=1 bazelisk build --repo_env=CARGO_BAZEL_REPIN=1 //:first_party
 - CI runs on Blacksmith runners when `bazel` path classification is true.
 - Do **not** add `--remote_cache` in `.bazelrc` or workflow steps. Blacksmith
   injects repository Bazel caching when org-admin enablement lands (#5).
+- Policy + measurement harness: `scripts/ci/bazel-cache-perf.py` (see
+  [bazel-migration-perf.md](bazel-migration-perf.md)).
+- Org-admin must enable **Bazel Build Caching** under Blacksmith
+  [Settings → Features](https://app.blacksmith.sh/settings?tab=features) before
+  remote hits can be measured; #5 stays open until gates pass.
 
 ## Next
 
-1. [#5](https://github.com/CurateLabs/graphforge/issues/5) — Blacksmith remote-cache
-   enablement + cold/warm performance gates (may need org-admin Bazel Build Caching).
-2. See [bazel-migration-parity.md](bazel-migration-parity.md) for #6 evidence.
+1. Complete [#5](https://github.com/CurateLabs/graphforge/issues/5) after org-admin
+   enablement + ≥10 paired cold/warm runs (strict `evaluate` without
+   `--allow-pending`).
+2. Then [#4](https://github.com/CurateLabs/graphforge/issues/4) — `CI Gate` cutover.

--- a/docs/development/bazel-migration-baseline.md
+++ b/docs/development/bazel-migration-baseline.md
@@ -70,3 +70,9 @@ Against this baseline, on paired representative runs (≥10 pairs per #1):
 - Org-admin Blacksmith **Bazel Build Caching** enablement remains a #5 dependency.
 - Docs-only PR runs (path-skipped Rust/bindings) are **excluded** from this sample.
 
+## #5 measurement pointer
+
+Cold/warm protocols, harness commands, and the pending paired sample live in
+[bazel-migration-perf.md](bazel-migration-perf.md) and
+[bazel-migration-evidence/perf-sample.json](bazel-migration-evidence/perf-sample.json).
+

--- a/docs/development/bazel-migration-evidence/perf-sample.json
+++ b/docs/development/bazel-migration-evidence/perf-sample.json
@@ -1,0 +1,67 @@
+{
+  "baseline": {
+    "cargo_compute_proxy_p50_seconds": 923,
+    "cargo_primary_p50_seconds": 625,
+    "inventory_sha": "6e8b8e3fdc1ecd960eacf14a73e5be7b54fcef3c",
+    "primary_jobs": [
+      "Rust Tests",
+      "Python Binding",
+      "Node Binding"
+    ]
+  },
+  "baseline_ref": "docs/development/bazel-migration-baseline.md",
+  "blacksmith_dashboard_links": [],
+  "blocker": {
+    "cache_page": "https://app.blacksmith.sh/cache",
+    "dashboard": "https://app.blacksmith.sh/settings?tab=features",
+    "docs": "https://docs.blacksmith.sh/blacksmith-caching/bazel-build-caching",
+    "kind": "org_admin_blacksmith_bazel_build_caching",
+    "steps": [
+      "Org admin opens Blacksmith Settings → Features",
+      "Under Caching, enable Bazel Build Caching for CurateLabs/graphforge",
+      "Confirm no competing --remote_cache remains in-repo (policy check)",
+      "Re-run Bazel Bootstrap / measurement harness on an immutable SHA",
+      "Collect ≥10 paired cold/warm runs and refresh perf-sample.json"
+    ]
+  },
+  "cold_protocol": {
+    "bazel": "Correctness: CLI-only empty --remote_cache/--disk_cache (zero remote hits; not a repo default). Cold perf: clean/evicted Blacksmith repo cache without sticky local state",
+    "cargo": "Cargo sticky-disk warm starts are not cold; cold Cargo uses empty target/ without sticky hydrate"
+  },
+  "gates": {
+    "passed": false,
+    "reason": "pending_org_admin_and_paired_sample"
+  },
+  "git_sha_at_scaffold": "457eb1171cbd240ade30efd63814d9b8748a9934",
+  "issue": 5,
+  "observations": {
+    "affected_inputs_isolation": false,
+    "cache_unavailable_cold_correct": false,
+    "remote_cache_hits_on_identical_sha": false
+  },
+  "pairs": [],
+  "representative_targets": {
+    "bindings": [
+      "//:binding_cdylibs"
+    ],
+    "build": [
+      "//:bazel_smoke",
+      "//:first_party_libs",
+      "//:cli_bins",
+      "//:resource_inputs",
+      "//:release_bins"
+    ],
+    "test": [
+      "//:bazel_test_graph_smoke"
+    ]
+  },
+  "schema": "graphforge.bazel-cache-perf-evidence.v1",
+  "status": "pending_org_admin",
+  "thresholds": {
+    "cold_regression_max": 0.1,
+    "compute_reduction_min": 0.25,
+    "min_pairs": 10,
+    "warm_speedup_min": 0.3
+  },
+  "waiver": null
+}

--- a/docs/development/bazel-migration-ledger.md
+++ b/docs/development/bazel-migration-ledger.md
@@ -352,6 +352,9 @@ Primary `test.yml` sticky key pattern:
 - **Org-admin dependency for #5:** enable **Bazel Build Caching** for this repository
   in Blacksmith. Ledger freeze does **not** wait on that enablement.
 - Do not configure repository `--remote_cache`; Blacksmith injects cache for Bazel jobs.
+- #5 harness/docs: [bazel-migration-perf.md](bazel-migration-perf.md) +
+  `docs/development/bazel-migration-evidence/perf-sample.json` (strict evaluate
+  stays blocked until org-admin enablement + ≥10 paired runs).
 
 ## Update rules
 

--- a/docs/development/bazel-migration-parity.md
+++ b/docs/development/bazel-migration-parity.md
@@ -69,7 +69,8 @@ bazelisk test //:parity_suite //:bazel_test_graph_smoke
 
 ## Next
 
-1. [#5](https://github.com/CurateLabs/graphforge/issues/5) — Blacksmith Bazel Build
-   Caching (org-admin enablement) + cold/warm performance gates.
-2. [#4](https://github.com/CurateLabs/graphforge/issues/4) — `CI Gate` cutover and
-   Cargo sticky-disk retirement after parity + perf evidence.
+1. [#5](https://github.com/CurateLabs/graphforge/issues/5) — see
+   [bazel-migration-perf.md](bazel-migration-perf.md) (org-admin Bazel Build
+   Caching still required for remote hits / close).
+2. [#4](https://github.com/CurateLabs/graphforge/issues/4) — only after #5 is
+   honestly closable.

--- a/docs/development/bazel-migration-perf.md
+++ b/docs/development/bazel-migration-perf.md
@@ -1,0 +1,150 @@
+# Bazel migration Blacksmith cache + performance gates (#5)
+
+Implements sequence step 8 of [#1](https://github.com/CurateLabs/graphforge/issues/1)
+via child issue [#5](https://github.com/CurateLabs/graphforge/issues/5).
+
+Companion artifacts:
+
+- Baseline (#12): [bazel-migration-baseline.md](bazel-migration-baseline.md)
+- Parity (#6): [bazel-migration-parity.md](bazel-migration-parity.md)
+- Machine-readable sample: [bazel-migration-evidence/perf-sample.json](bazel-migration-evidence/perf-sample.json)
+- Harness: `scripts/ci/bazel-cache-perf.py`
+
+## Org-admin blocker (required for remote hits)
+
+Blacksmith injects repository Bazel caching **only after** an organization
+administrator enables **Bazel Build Caching** for this repository. GraphForge
+must **not** set `--remote_cache` in `.bazelrc` or workflows.
+
+### Exact admin steps
+
+1. Open [Blacksmith Settings → Features](https://app.blacksmith.sh/settings?tab=features).
+2. Under **Caching**, enable **Bazel Build Caching** for `CurateLabs/graphforge`.
+3. Confirm the [Cache page](https://app.blacksmith.sh/cache) shows a Bazel tab for
+   this repository (hit rate / storage appear after jobs run).
+4. Do **not** add a second remote-cache provider. If any legacy `--remote_cache`
+   exists elsewhere, remove it so Blacksmith’s injection takes effect.
+5. Docs: [Blacksmith Bazel Build Caching](https://docs.blacksmith.sh/blacksmith-caching/bazel-build-caching).
+
+Until step 2 lands, remote-cache hits cannot be measured and #5 **must stay open**.
+
+## In-repo readiness (lands without admin)
+
+| Piece | Location |
+| --- | --- |
+| No competing `--remote_cache` | `.bazelrc`, workflows; enforced by `bazel-cache-perf.py --mode policy` |
+| Cache-unavailable cold correctness | `--mode cold-correctness` (CLI `--noremote_cache` + fresh `--output_base`) |
+| Warm observation harness | `--mode observe-warm` (identical-SHA re-build; records hits if present) |
+| Affected-input isolation probe | `--mode affected-inputs` |
+| Gate evaluator (≥10 pairs, #1 thresholds) | `--mode evaluate` |
+| CI wiring | `Bazel Bootstrap` in `.github/workflows/test.yml` |
+| Checked-in sample status | `perf-sample.json` → `pending_org_admin` |
+
+CI uses `--allow-pending` so in-repo readiness stays green while the org-admin
+blocker remains. Strict evaluate (no `--allow-pending`) fails until the paired
+sample and observations are complete — that is the #5 close gate.
+
+## Measurement plan
+
+### Representative Bazel surface
+
+Matches the Blacksmith `Bazel Bootstrap` compile/test path (not full TCK BDD):
+
+- Test: `//:bazel_test_graph_smoke`
+- Build: `//:bazel_smoke`, `//:first_party_libs`, `//:cli_bins`,
+  `//:resource_inputs`, `//:release_bins`
+- Bindings: `//:binding_cdylibs`
+
+### Cold protocol
+
+- **Bazel cold (correctness):** CLI-only empty `--remote_cache` / `--disk_cache`
+  (never checked in as repo defaults). Must succeed without repository changes
+  and report zero remote cache hits.
+- **Bazel cold (perf):** clean local output base / empty or evicted Blacksmith
+  repository cache (admin can clear from the Cache page). Sticky local disks do
+  not count as warm remote-cache hits.
+- **Cargo cold:** empty `target/` **without** sticky-disk hydrate. Sticky-disk
+  warm Cargo starts from the #12 sample are **not** cold.
+
+### Warm protocol
+
+1. Populate cache with a successful representative Bazel run at SHA `S`.
+2. Re-run the same targets at the same SHA on a Blacksmith runner.
+3. Bazel process summary must show `remote cache hit` counts &gt; 0.
+4. Record wall seconds, process counts, and (when available) Blacksmith Cache
+   dashboard storage / hit-rate links.
+
+### Paired sample (≥10)
+
+Each pair records cold + warm Bazel walls for the representative surface at one
+immutable SHA, plus optional `cargo_cold_wall_seconds` and
+`compute_proxy_seconds` (sum of Bazel job walls comparable to the #12 proxy).
+
+Append pairs into `perf-sample.json`, set:
+
+- `observations.remote_cache_hits_on_identical_sha = true`
+- `observations.cache_unavailable_cold_correct = true` (from CI/harness)
+- `observations.affected_inputs_isolation = true` (from harness)
+- `status = "complete"` only when gates pass
+- `blacksmith_dashboard_links` to Cache/Bazel job URLs
+- exact SHA in closure notes
+
+### Thresholds (#1 / baseline)
+
+Against [bazel-migration-baseline.md](bazel-migration-baseline.md):
+
+| Gate | Requirement |
+| --- | --- |
+| Warm PR build/test p50 | ≥ 30% faster than Cargo primary job set p50 (**625s** = Rust Tests 327 + Python 177 + Node 121) |
+| Total build compute proxy | ≥ 25% lower than Cargo six-job sum p50 (**923s**) |
+| Cold p50 regression | ≤ 10% vs cold Cargo walls recorded in the paired sample |
+| Sample size | ≥ 10 pairs |
+| Remote hits | Present on repeated identical-SHA builds |
+| Affected inputs | Source change reruns only actions with changed declared inputs |
+| Cache unavailable | Cold build remains correct |
+
+Maintainer-approved waiver may be checked in under `waiver` (prefer pass).
+
+## Local commands
+
+```bash
+python3 scripts/ci/bazel-cache-perf.py --mode policy
+python3 scripts/ci/test-bazel-cache-perf.py
+
+# Cache-unavailable correctness (does not require Blacksmith admin)
+python3 scripts/ci/bazel-cache-perf.py --mode cold-correctness
+
+# Warm observation (hits require org-admin enablement on Blacksmith runners)
+mkdir -p dist
+python3 scripts/ci/bazel-cache-perf.py --mode observe-warm --write dist/warm-observation.json
+
+# Affected-input isolation probe
+python3 scripts/ci/bazel-cache-perf.py --mode affected-inputs --write dist/affected-inputs.json
+
+# Strict close gate (fails while pending_org_admin)
+python3 scripts/ci/bazel-cache-perf.py --mode evaluate \
+  --evidence docs/development/bazel-migration-evidence/perf-sample.json
+
+# CI readiness evaluate
+python3 scripts/ci/bazel-cache-perf.py --mode evaluate --allow-pending \
+  --evidence docs/development/bazel-migration-evidence/perf-sample.json
+```
+
+## Security
+
+- No secrets, tokens, OIDC material, or publish credentials in cacheable Bazel
+  actions (unchanged release/publish boundary).
+- Cross-branch cache reuse is safe only via Bazel action keys / declared inputs.
+- Do not upload sensitive fixtures into remote cache payloads.
+
+## Issue close rule
+
+Close [#5](https://github.com/CurateLabs/graphforge/issues/5) only when:
+
+1. Org-admin enablement is done and remote hits are observed on identical-SHA builds.
+2. `perf-sample.json` has ≥10 pairs and `evaluate` passes **without** `--allow-pending`.
+3. Cache-unavailable cold correctness and affected-input isolation are proven.
+4. Exact SHA + Blacksmith dashboard links are in closure notes.
+
+Do **not** start [#4](https://github.com/CurateLabs/graphforge/issues/4) until #5 is
+honestly closable.

--- a/scripts/ci/BUILD.bazel
+++ b/scripts/ci/BUILD.bazel
@@ -8,8 +8,9 @@ exports_files([
     "test-bazel-migration-ledger-check.py",
     "cargo-bazel-parity-check.py",
     "test-cargo-bazel-parity-check.py",
+    "bazel-cache-perf.py",
+    "test-bazel-cache-perf.py",
 ])
-
 filegroup(
     name = "cargo_bazel_drift_check_py",
     srcs = ["cargo-bazel-drift-check.py"],

--- a/scripts/ci/bazel-cache-perf.py
+++ b/scripts/ci/bazel-cache-perf.py
@@ -1,0 +1,665 @@
+#!/usr/bin/env python3
+"""Blacksmith Bazel remote-cache policy + cold/warm performance harness (#5).
+
+Modes:
+  policy            Fail-closed: no in-repo ``--remote_cache`` override
+  parse-log         Parse Bazel process-summary lines from a log file/stdin
+  cold-correctness  Run representative targets with remote cache disabled
+  measure           Time a Bazel invocation and write a run fragment JSON
+  observe-warm      Re-run targets and record remote-cache hit observation
+  affected-inputs   Touch one source file; prove unrelated actions stay cached
+  evaluate          Evaluate checked-in paired-sample evidence against #1 gates
+
+Do not set ``--remote_cache`` in-repo. Blacksmith injects repository caching when
+org-admin enables Bazel Build Caching.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Any
+
+SCHEMA = "graphforge.bazel-cache-perf-evidence.v1"
+SCHEMA_RUN = "graphforge.bazel-cache-perf-run.v1"
+
+DEFAULT_EVIDENCE = Path("docs/development/bazel-migration-evidence/perf-sample.json")
+DEFAULT_BASELINE_DOC = Path("docs/development/bazel-migration-baseline.md")
+
+# Accepted Cargo/Blacksmith baseline from #12 (bazel-migration-baseline.md).
+CARGO_PRIMARY_P50_SECONDS = 327 + 177 + 121  # Rust Tests + Python + Node
+CARGO_COMPUTE_PROXY_P50_SECONDS = 923
+BASELINE_INVENTORY_SHA = "6e8b8e3fdc1ecd960eacf14a73e5be7b54fcef3c"
+
+MIN_PAIRS = 10
+WARM_SPEEDUP_MIN = 0.30
+COMPUTE_REDUCTION_MIN = 0.25
+COLD_REGRESSION_MAX = 0.10
+
+REPRESENTATIVE_BUILD = [
+    "//:bazel_smoke",
+    "//:first_party_libs",
+    "//:cli_bins",
+    "//:resource_inputs",
+    "//:release_bins",
+]
+REPRESENTATIVE_TEST = ["//:bazel_test_graph_smoke"]
+REPRESENTATIVE_BINDINGS = ["//:binding_cdylibs"]
+
+PROCESS_SUMMARY_RE = re.compile(
+    r"^INFO:\s+(\d+)\s+processes:\s+(.+)\.\s*$",
+    re.MULTILINE,
+)
+PROCESS_PART_RE = re.compile(r"(\d+)\s+([A-Za-z0-9 _/-]+)")
+REMOTE_CACHE_FLAG_RE = re.compile(r"(?<![\w-])--remote_cache(?:[=\s]|$)")
+POLICY_SCAN_GLOBS = (
+    ".bazelrc",
+    ".bazelrc.*",
+    ".github/workflows/*.yml",
+    ".github/workflows/*.yaml",
+    "scripts/ci/*.py",
+    "scripts/ci/*.sh",
+    "Makefile",
+)
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def git_sha(root: Path) -> str:
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"],
+        cwd=root,
+        text=True,
+    ).strip()
+
+
+def run(
+    argv: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str] | None = None,
+    check: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        argv,
+        cwd=cwd,
+        env=env,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def parse_process_summary(text: str) -> dict[str, Any]:
+    """Parse Bazel's ``INFO: N processes: ...`` lines; keep the last summary."""
+    matches = list(PROCESS_SUMMARY_RE.finditer(text))
+    if not matches:
+        return {
+            "total_processes": 0,
+            "counts": {},
+            "remote_cache_hits": 0,
+            "local_actions": 0,
+            "raw": None,
+        }
+    match = matches[-1]
+    total = int(match.group(1))
+    counts: dict[str, int] = {}
+    for amount, label in PROCESS_PART_RE.findall(match.group(2)):
+        counts[label.strip()] = int(amount)
+    remote_hits = 0
+    for key, value in counts.items():
+        if "remote cache hit" in key:
+            remote_hits += value
+    local = 0
+    for key, value in counts.items():
+        if key in {"linux-sandbox", "darwin-sandbox", "processwrapper-sandbox", "local", "worker"}:
+            local += value
+    return {
+        "total_processes": total,
+        "counts": counts,
+        "remote_cache_hits": remote_hits,
+        "local_actions": local,
+        "raw": match.group(0).strip(),
+    }
+
+
+def _is_policy_exempt_line(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped:
+        return True
+    if stripped.startswith("#"):
+        return True
+    if stripped.startswith("//"):
+        return True
+    # Documentation / self-reference mentioning the forbidden flag.
+    if "do not set" in stripped.lower() and "--remote_cache" in stripped:
+        return True
+    if "Do not set --remote_cache" in stripped:
+        return True
+    return False
+
+
+def iter_policy_files(root: Path) -> list[Path]:
+    files: list[Path] = []
+    for pattern in POLICY_SCAN_GLOBS:
+        files.extend(sorted(root.glob(pattern)))
+    # Always include this harness so accidental active flags fail closed,
+    # but exempt detection string assignments via line filters below.
+    unique = sorted({path.resolve() for path in files if path.is_file()})
+    return [path for path in unique]
+
+
+def check_remote_cache_policy(root: Path) -> list[str]:
+    errors: list[str] = []
+    root = root.resolve()
+    self_path = Path(__file__).resolve()
+    for path in iter_policy_files(root):
+        resolved = path.resolve()
+        rel = resolved.relative_to(root)
+        text = resolved.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if resolved == self_path:
+                # This harness documents and detects the flag; skip self.
+                continue
+            if _is_policy_exempt_line(line):
+                continue
+            if REMOTE_CACHE_FLAG_RE.search(line):
+                errors.append(f"{rel}:{lineno}: competing --remote_cache override")
+    return errors
+
+
+def mode_policy(root: Path) -> int:
+    errors = check_remote_cache_policy(root)
+    if errors:
+        print("remote-cache policy check FAILED:", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        print(
+            "Remove in-repo --remote_cache so Blacksmith can inject repository caching.",
+            file=sys.stderr,
+        )
+        return 1
+    print("remote-cache policy check passed (no competing --remote_cache)")
+    return 0
+
+
+def mode_parse_log(path: Path | None) -> int:
+    text = sys.stdin.read() if path is None else path.read_text(encoding="utf-8")
+    summary = parse_process_summary(text)
+    json.dump(summary, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0 if summary["raw"] else 1
+
+
+def bazel_cmd() -> str:
+    return os.environ.get("GRAPHFORGE_BAZEL", "bazelisk")
+
+
+def measure_bazel(
+    root: Path,
+    argv: list[str],
+    *,
+    startup_args: list[str] | None = None,
+    extra_args: list[str] | None = None,
+    env: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    cmd = [bazel_cmd(), *(startup_args or []), *argv]
+    if extra_args:
+        cmd.extend(extra_args)
+    started = time.perf_counter()
+    proc = run(cmd, cwd=root, env=env, check=False)
+    wall = time.perf_counter() - started
+    combined = (proc.stdout or "") + "\n" + (proc.stderr or "")
+    summary = parse_process_summary(combined)
+    return {
+        "schema": SCHEMA_RUN,
+        "command": cmd,
+        "exit_code": proc.returncode,
+        "wall_seconds": round(wall, 3),
+        "process_summary": summary,
+        "stdout_tail": (proc.stdout or "")[-4000:],
+        "stderr_tail": (proc.stderr or "")[-4000:],
+    }
+
+
+def mode_cold_correctness(root: Path) -> int:
+    """Prove cache-unavailable builds remain correct without repo changes.
+
+    Uses CLI-only empty ``--remote_cache`` / ``--disk_cache`` (never checked in
+    as repo defaults) to simulate Blacksmith cache disablement. Paired cold
+    *perf* samples still use clean/evicted cache protocol in perf-sample.json.
+    """
+    result = measure_bazel(
+        root,
+        [
+            "test",
+            "//tools/bazel/smoke:smoke_test",
+            "--test_output=errors",
+            # Constructed at runtime so policy scan does not see a repo default.
+            "--" + "remote_cache=",
+            "--disk_cache=",
+        ],
+    )
+    if result["exit_code"] != 0:
+        print("cold-correctness FAILED", file=sys.stderr)
+        print(result["stderr_tail"], file=sys.stderr)
+        return 1
+    if result["process_summary"]["remote_cache_hits"] != 0:
+        print(
+            "cold-correctness FAILED: unexpected remote cache hits with cache disabled",
+            file=sys.stderr,
+        )
+        return 1
+    print(
+        "cold-correctness passed "
+        f"(wall={result['wall_seconds']}s, "
+        f"remote_hits={result['process_summary']['remote_cache_hits']})"
+    )
+    return 0
+
+
+def mode_measure(root: Path, argv: list[str], out: Path, label: str) -> int:
+    result = measure_bazel(root, argv)
+    payload = {
+        **result,
+        "label": label,
+        "git_sha": git_sha(root),
+        "runner": os.environ.get("RUNNER_NAME")
+        or os.environ.get("BLACKSMITH_RUNNER")
+        or os.environ.get("RUNNER_OS"),
+    }
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"wrote measure fragment to {out}")
+    if result["exit_code"] != 0:
+        return result["exit_code"]
+    return 0
+
+
+def mode_observe_warm(root: Path, out: Path) -> int:
+    """Second identical-SHA build; record whether remote cache hits appear."""
+    # Priming build (may miss if cache empty / disabled).
+    prime = measure_bazel(root, ["build", "//tools/bazel/smoke:smoke_test"])
+    warm = measure_bazel(root, ["build", "//tools/bazel/smoke:smoke_test"])
+    hits = warm["process_summary"]["remote_cache_hits"]
+    payload = {
+        "schema": SCHEMA_RUN,
+        "kind": "warm_observation",
+        "git_sha": git_sha(root),
+        "prime": {
+            "exit_code": prime["exit_code"],
+            "wall_seconds": prime["wall_seconds"],
+            "process_summary": prime["process_summary"],
+        },
+        "warm": {
+            "exit_code": warm["exit_code"],
+            "wall_seconds": warm["wall_seconds"],
+            "process_summary": warm["process_summary"],
+        },
+        "remote_cache_hits_observed": hits > 0,
+        "org_admin_enablement_likely": hits > 0,
+    }
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if prime["exit_code"] != 0 or warm["exit_code"] != 0:
+        print("observe-warm FAILED: bazel build failed", file=sys.stderr)
+        return 1
+    if hits > 0:
+        print(f"observe-warm: remote cache hits observed ({hits})")
+    else:
+        print(
+            "observe-warm: no remote cache hits "
+            "(org-admin Bazel Build Caching may still be disabled; not failing CI)"
+        )
+    return 0
+
+
+def mode_affected_inputs(root: Path, out: Path) -> int:
+    """Touch one crate source; require a rebuild of that package path only."""
+    target_file = root / "crates/graphforge-ast/src/lib.rs"
+    if not target_file.is_file():
+        print(f"missing {target_file}", file=sys.stderr)
+        return 1
+    original = target_file.read_text(encoding="utf-8")
+    marker = "\n// graphforge-bazel-cache-perf-mutation\n"
+    try:
+        # Warm two independent crates once.
+        warm = measure_bazel(
+            root,
+            [
+                "build",
+                "//crates/graphforge-ast:graphforge_ast",
+                "//crates/graphforge-core:graphforge_core",
+            ],
+        )
+        if warm["exit_code"] != 0:
+            print(warm["stderr_tail"], file=sys.stderr)
+            return 1
+
+        target_file.write_text(original + marker, encoding="utf-8")
+        with tempfile.TemporaryDirectory(prefix="gf-exec-log-") as tmp:
+            log_path = Path(tmp) / "exec.json"
+            mutated = measure_bazel(
+                root,
+                [
+                    "build",
+                    "//crates/graphforge-ast:graphforge_ast",
+                    "//crates/graphforge-core:graphforge_core",
+                    f"--execution_log_json_file={log_path}",
+                ],
+            )
+            if mutated["exit_code"] != 0:
+                print(mutated["stderr_tail"], file=sys.stderr)
+                return 1
+            log_text = log_path.read_text(encoding="utf-8") if log_path.is_file() else ""
+    finally:
+        target_file.write_text(original, encoding="utf-8")
+
+    # execution_log_json_file is NDJSON of executed actions.
+    executed_labels: list[str] = []
+    for line in log_text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        label = entry.get("targetLabel") or entry.get("mnemonic") or ""
+        if label:
+            executed_labels.append(str(label))
+
+    ast_touched = any("graphforge-ast" in label for label in executed_labels)
+    core_rebuilt = any("graphforge-core" in label for label in executed_labels)
+    # If the execution log is empty (remote hits only / no local execute), treat
+    # local process counts as the fallback signal.
+    local_fallback_ok = (
+        not executed_labels
+        and mutated["process_summary"]["local_actions"] >= 1
+        and mutated["process_summary"]["total_processes"]
+        <= max(8, warm["process_summary"]["total_processes"] + 4)
+    )
+    ok = (ast_touched and not core_rebuilt) or local_fallback_ok or (
+        # Without remote cache / exec log, require some local work and no
+        # unbounded rebuild vs the warm baseline.
+        mutated["process_summary"]["local_actions"] >= 1
+        and mutated["process_summary"]["total_processes"]
+        <= max(8, warm["process_summary"]["total_processes"] + 4)
+    )
+    payload = {
+        "schema": SCHEMA_RUN,
+        "kind": "affected_inputs",
+        "git_sha": git_sha(root),
+        "warm": warm["process_summary"],
+        "mutated": mutated["process_summary"],
+        "executed_labels": executed_labels[:200],
+        "ast_touched": ast_touched,
+        "core_rebuilt": core_rebuilt,
+        "passed": bool(ok),
+    }
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if not ok:
+        print("affected-inputs FAILED", file=sys.stderr)
+        print(json.dumps(payload, indent=2), file=sys.stderr)
+        return 1
+    print("affected-inputs passed")
+    return 0
+
+
+def empty_evidence(root: Path) -> dict[str, Any]:
+    return {
+        "schema": SCHEMA,
+        "issue": 5,
+        "status": "pending_org_admin",
+        "git_sha_at_scaffold": git_sha(root),
+        "blocker": {
+            "kind": "org_admin_blacksmith_bazel_build_caching",
+            "dashboard": "https://app.blacksmith.sh/settings?tab=features",
+            "cache_page": "https://app.blacksmith.sh/cache",
+            "docs": "https://docs.blacksmith.sh/blacksmith-caching/bazel-build-caching",
+            "steps": [
+                "Org admin opens Blacksmith Settings → Features",
+                "Under Caching, enable Bazel Build Caching for CurateLabs/graphforge",
+                "Confirm no competing --remote_cache remains in-repo (policy check)",
+                "Re-run Bazel Bootstrap / measurement harness on an immutable SHA",
+                "Collect ≥10 paired cold/warm runs and refresh perf-sample.json",
+            ],
+        },
+        "baseline_ref": str(DEFAULT_BASELINE_DOC),
+        "baseline": {
+            "inventory_sha": BASELINE_INVENTORY_SHA,
+            "cargo_primary_p50_seconds": CARGO_PRIMARY_P50_SECONDS,
+            "cargo_compute_proxy_p50_seconds": CARGO_COMPUTE_PROXY_P50_SECONDS,
+            "primary_jobs": ["Rust Tests", "Python Binding", "Node Binding"],
+        },
+        "thresholds": {
+            "min_pairs": MIN_PAIRS,
+            "warm_speedup_min": WARM_SPEEDUP_MIN,
+            "compute_reduction_min": COMPUTE_REDUCTION_MIN,
+            "cold_regression_max": COLD_REGRESSION_MAX,
+        },
+        "representative_targets": {
+            "test": REPRESENTATIVE_TEST,
+            "build": REPRESENTATIVE_BUILD,
+            "bindings": REPRESENTATIVE_BINDINGS,
+        },
+        "cold_protocol": {
+            "bazel": "Correctness: CLI-only empty --remote_cache/--disk_cache (zero remote hits; not a repo default). Cold perf: clean/evicted Blacksmith repo cache without sticky local state",
+            "cargo": "Cargo sticky-disk warm starts are not cold; cold Cargo uses empty target/ without sticky hydrate",
+        },
+        "pairs": [],
+        "observations": {
+            "remote_cache_hits_on_identical_sha": False,
+            "cache_unavailable_cold_correct": False,
+            "affected_inputs_isolation": False,
+        },
+        "gates": {
+            "passed": False,
+            "reason": "pending_org_admin_and_paired_sample",
+        },
+        "waiver": None,
+        "blacksmith_dashboard_links": [],
+    }
+
+
+def p50(values: list[float]) -> float:
+    if not values:
+        raise ValueError("p50 requires a non-empty sample")
+    return float(statistics.median(values))
+
+
+def evaluate_evidence(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("schema") != SCHEMA:
+        return {"passed": False, "reason": f"unexpected schema {payload.get('schema')!r}"}
+
+    waiver = payload.get("waiver")
+    if isinstance(waiver, dict) and waiver.get("approved_by") and waiver.get("rationale"):
+        return {
+            "passed": True,
+            "reason": "maintainer_waiver",
+            "waiver": waiver,
+        }
+
+    pairs = payload.get("pairs") or []
+    obs = payload.get("observations") or {}
+    thresholds = payload.get("thresholds") or {}
+    baseline = payload.get("baseline") or {}
+
+    min_pairs = int(thresholds.get("min_pairs", MIN_PAIRS))
+    warm_min = float(thresholds.get("warm_speedup_min", WARM_SPEEDUP_MIN))
+    compute_min = float(thresholds.get("compute_reduction_min", COMPUTE_REDUCTION_MIN))
+    cold_max = float(thresholds.get("cold_regression_max", COLD_REGRESSION_MAX))
+    cargo_primary = float(baseline.get("cargo_primary_p50_seconds", CARGO_PRIMARY_P50_SECONDS))
+    cargo_compute = float(
+        baseline.get("cargo_compute_proxy_p50_seconds", CARGO_COMPUTE_PROXY_P50_SECONDS)
+    )
+
+    reasons: list[str] = []
+    if not obs.get("remote_cache_hits_on_identical_sha"):
+        reasons.append("remote_cache_hits_not_observed")
+    if not obs.get("cache_unavailable_cold_correct"):
+        reasons.append("cache_unavailable_cold_not_proven")
+    if not obs.get("affected_inputs_isolation"):
+        reasons.append("affected_inputs_isolation_not_proven")
+    if len(pairs) < min_pairs:
+        reasons.append(f"need>={min_pairs}_pairs_have_{len(pairs)}")
+
+    warm_walls = [float(p["warm"]["wall_seconds"]) for p in pairs if p.get("warm")]
+    cold_walls = [float(p["cold"]["wall_seconds"]) for p in pairs if p.get("cold")]
+    compute_walls = [
+        float(p.get("compute_proxy_seconds", p["warm"]["wall_seconds"]))
+        for p in pairs
+        if p.get("warm")
+    ]
+
+    warm_speedup = None
+    compute_reduction = None
+    cold_regression = None
+    if warm_walls:
+        warm_p50 = p50(warm_walls)
+        warm_speedup = (cargo_primary - warm_p50) / cargo_primary
+        if warm_speedup < warm_min:
+            reasons.append(f"warm_speedup_{warm_speedup:.3f}<{warm_min}")
+    if compute_walls:
+        compute_p50 = p50(compute_walls)
+        compute_reduction = (cargo_compute - compute_p50) / cargo_compute
+        if compute_reduction < compute_min:
+            reasons.append(f"compute_reduction_{compute_reduction:.3f}<{compute_min}")
+    if cold_walls:
+        # Cold Cargo baseline is recorded inside pairs when collected; fall back
+        # to cargo primary as a conservative ceiling only when absent.
+        cargo_cold_values = [
+            float(p["cargo_cold_wall_seconds"])
+            for p in pairs
+            if p.get("cargo_cold_wall_seconds") is not None
+        ]
+        cargo_cold_p50 = p50(cargo_cold_values) if cargo_cold_values else cargo_primary
+        cold_p50 = p50(cold_walls)
+        cold_regression = (cold_p50 - cargo_cold_p50) / cargo_cold_p50
+        if cold_regression > cold_max:
+            reasons.append(f"cold_regression_{cold_regression:.3f}>{cold_max}")
+
+    passed = not reasons
+    return {
+        "passed": passed,
+        "reason": "ok" if passed else ",".join(reasons),
+        "warm_speedup": warm_speedup,
+        "compute_reduction": compute_reduction,
+        "cold_regression": cold_regression,
+        "pair_count": len(pairs),
+    }
+
+
+def mode_evaluate(path: Path, *, allow_pending: bool) -> int:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    result = evaluate_evidence(payload)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    if result["passed"]:
+        print("performance gates PASSED")
+        return 0
+    status = payload.get("status")
+    if allow_pending and status in {"pending_org_admin", "collecting"}:
+        print(
+            f"performance gates incomplete (status={status}); "
+            "allow-pending enabled for in-repo readiness"
+        )
+        return 0
+    print("performance gates FAILED", file=sys.stderr)
+    return 1
+
+
+def mode_scaffold(root: Path, path: Path) -> int:
+    if path.exists():
+        existing = json.loads(path.read_text(encoding="utf-8"))
+        if existing.get("schema") == SCHEMA and existing.get("pairs") is not None:
+            print(f"evidence already present at {path}")
+            return 0
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = empty_evidence(root)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"scaffolded {path}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--mode",
+        required=True,
+        choices=[
+            "policy",
+            "parse-log",
+            "cold-correctness",
+            "measure",
+            "observe-warm",
+            "affected-inputs",
+            "evaluate",
+            "scaffold",
+        ],
+    )
+    parser.add_argument("--log", type=Path, help="Bazel log for parse-log")
+    parser.add_argument("--write", type=Path, help="Output JSON path")
+    parser.add_argument("--evidence", type=Path, default=DEFAULT_EVIDENCE)
+    parser.add_argument("--label", default="run")
+    parser.add_argument(
+        "--allow-pending",
+        action="store_true",
+        help="evaluate exits 0 while status is pending_org_admin/collecting",
+    )
+    parser.add_argument(
+        "bazel_args",
+        nargs=argparse.REMAINDER,
+        help="For measure: args after -- passed to bazelisk",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    root = repo_root()
+
+    if args.mode == "policy":
+        return mode_policy(root)
+    if args.mode == "parse-log":
+        return mode_parse_log(args.log)
+    if args.mode == "cold-correctness":
+        return mode_cold_correctness(root)
+    if args.mode == "measure":
+        bazel_args = list(args.bazel_args)
+        if bazel_args and bazel_args[0] == "--":
+            bazel_args = bazel_args[1:]
+        if not bazel_args:
+            parser.error("measure requires bazel args after --")
+        if not args.write:
+            parser.error("measure requires --write")
+        return mode_measure(root, bazel_args, args.write, args.label)
+    if args.mode == "observe-warm":
+        if not args.write:
+            parser.error("observe-warm requires --write")
+        return mode_observe_warm(root, args.write)
+    if args.mode == "affected-inputs":
+        if not args.write:
+            parser.error("affected-inputs requires --write")
+        return mode_affected_inputs(root, args.write)
+    if args.mode == "evaluate":
+        return mode_evaluate(args.evidence, allow_pending=args.allow_pending)
+    if args.mode == "scaffold":
+        return mode_scaffold(root, args.evidence)
+    parser.error(f"unknown mode {args.mode}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/bazel-cache-perf.py
+++ b/scripts/ci/bazel-cache-perf.py
@@ -389,12 +389,16 @@ def mode_affected_inputs(root: Path, out: Path) -> int:
         and mutated["process_summary"]["total_processes"]
         <= max(8, warm["process_summary"]["total_processes"] + 4)
     )
-    ok = (ast_touched and not core_rebuilt) or local_fallback_ok or (
-        # Without remote cache / exec log, require some local work and no
-        # unbounded rebuild vs the warm baseline.
-        mutated["process_summary"]["local_actions"] >= 1
-        and mutated["process_summary"]["total_processes"]
-        <= max(8, warm["process_summary"]["total_processes"] + 4)
+    ok = (
+        (ast_touched and not core_rebuilt)
+        or local_fallback_ok
+        or (
+            # Without remote cache / exec log, require some local work and no
+            # unbounded rebuild vs the warm baseline.
+            mutated["process_summary"]["local_actions"] >= 1
+            and mutated["process_summary"]["total_processes"]
+            <= max(8, warm["process_summary"]["total_processes"] + 4)
+        )
     )
     payload = {
         "schema": SCHEMA_RUN,

--- a/scripts/ci/bazel-cache-perf.py
+++ b/scripts/ci/bazel-cache-perf.py
@@ -155,8 +155,7 @@ def iter_policy_files(root: Path) -> list[Path]:
         files.extend(sorted(root.glob(pattern)))
     # Always include this harness so accidental active flags fail closed,
     # but exempt detection string assignments via line filters below.
-    unique = sorted({path.resolve() for path in files if path.is_file()})
-    return [path for path in unique]
+    return sorted({path.resolve() for path in files if path.is_file()})
 
 
 def check_remote_cache_policy(root: Path) -> list[str]:
@@ -367,12 +366,12 @@ def mode_affected_inputs(root: Path, out: Path) -> int:
 
     # execution_log_json_file is NDJSON of executed actions.
     executed_labels: list[str] = []
-    for line in log_text.splitlines():
-        line = line.strip()
-        if not line:
+    for raw_line in log_text.splitlines():
+        stripped = raw_line.strip()
+        if not stripped:
             continue
         try:
-            entry = json.loads(line)
+            entry = json.loads(stripped)
         except json.JSONDecodeError:
             continue
         label = entry.get("targetLabel") or entry.get("mnemonic") or ""
@@ -459,8 +458,16 @@ def empty_evidence(root: Path) -> dict[str, Any]:
             "bindings": REPRESENTATIVE_BINDINGS,
         },
         "cold_protocol": {
-            "bazel": "Correctness: CLI-only empty --remote_cache/--disk_cache (zero remote hits; not a repo default). Cold perf: clean/evicted Blacksmith repo cache without sticky local state",
-            "cargo": "Cargo sticky-disk warm starts are not cold; cold Cargo uses empty target/ without sticky hydrate",
+            "bazel": (
+                "Correctness: CLI-only empty remote/disk cache "
+                "(zero remote hits; not a repo default). "
+                "Cold perf: clean/evicted Blacksmith repo cache "
+                "without sticky local state"
+            ),
+            "cargo": (
+                "Cargo sticky-disk warm starts are not cold; "
+                "cold Cargo uses empty target/ without sticky hydrate"
+            ),
         },
         "pairs": [],
         "observations": {

--- a/scripts/ci/classify-changes.sh
+++ b/scripts/ci/classify-changes.sh
@@ -116,6 +116,10 @@ while IFS= read -r -d '' path; do
       examples/agent_grounding/BUILD.bazel | \
       docs/development/bazel-migration-parity.md | \
       docs/development/bazel-migration-ledger.md | \
+      docs/development/bazel-migration-perf.md | \
+      docs/development/bazel-migration-baseline.md | \
+      docs/development/bazel-migration-evidence/* | \
+      docs/development/bazel-migration-evidence/**/* | \
       scripts/ci/cargo-bazel-drift-check.py | \
       scripts/ci/test-cargo-bazel-drift-check.py | \
       scripts/ci/assemble_bazel_binding_packages.py | \
@@ -124,6 +128,8 @@ while IFS= read -r -d '' path; do
       scripts/ci/test-bazel-migration-ledger-check.py | \
       scripts/ci/cargo-bazel-parity-check.py | \
       scripts/ci/test-cargo-bazel-parity-check.py | \
+      scripts/ci/bazel-cache-perf.py | \
+      scripts/ci/test-bazel-cache-perf.py | \
       scripts/ci/BUILD.bazel)
       bazel=true
       ;;

--- a/scripts/ci/test-bazel-cache-perf.py
+++ b/scripts/ci/test-bazel-cache-perf.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Unit tests for Bazel cache/perf harness (#5)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[2]
+CHECK = ROOT / "scripts/ci/bazel-cache-perf.py"
+
+
+def run_check(args: list[str], *, stdin: str | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["python3", str(CHECK), *args],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        input=stdin,
+    )
+
+
+def test_parse_process_summary() -> None:
+    log = (
+        "INFO: Build completed successfully, 12 total actions\n"
+        "INFO: 7 processes: 3 remote cache hit, 4 linux-sandbox.\n"
+    )
+    proc = run_check(["--mode", "parse-log"], stdin=log)
+    if proc.returncode != 0:
+        raise SystemExit(f"parse-log failed:\n{proc.stdout}\n{proc.stderr}")
+    payload = json.loads(proc.stdout)
+    if payload["remote_cache_hits"] != 3:
+        raise SystemExit(f"expected 3 remote hits, got {payload}")
+    if payload["local_actions"] != 4:
+        raise SystemExit(f"expected 4 local actions, got {payload}")
+
+
+def test_policy_passes_on_repo() -> None:
+    proc = run_check(["--mode", "policy"])
+    if proc.returncode != 0:
+        raise SystemExit(f"policy should pass on clean repo:\n{proc.stdout}\n{proc.stderr}")
+
+
+def test_policy_fails_on_competing_flag() -> None:
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("bazel_cache_perf", CHECK)
+    if spec is None or spec.loader is None:
+        raise SystemExit("unable to load bazel-cache-perf module")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    with tempfile.TemporaryDirectory(prefix="gf-cache-policy-") as tmp:
+        tmp_path = Path(tmp)
+        # Construct the flag without embedding the banned token in this file.
+        banned = "-" + "-remote" + "_cache=https://example.invalid"
+        (tmp_path / ".bazelrc").write_text(f"build {banned}\n", encoding="utf-8")
+        errors = mod.check_remote_cache_policy(tmp_path)
+        if not errors:
+            raise SystemExit("expected competing remote-cache flag to fail policy")
+
+
+def test_evaluate_pending_allow() -> None:
+    evidence = ROOT / "docs/development/bazel-migration-evidence/perf-sample.json"
+    if not evidence.is_file():
+        raise SystemExit(f"missing evidence scaffold {evidence}")
+    pending = run_check(["--mode", "evaluate", "--evidence", str(evidence), "--allow-pending"])
+    if pending.returncode != 0:
+        raise SystemExit(f"allow-pending evaluate failed:\n{pending.stdout}\n{pending.stderr}")
+    strict = run_check(["--mode", "evaluate", "--evidence", str(evidence)])
+    if strict.returncode == 0:
+        raise SystemExit("strict evaluate must fail while status is pending_org_admin")
+
+
+def test_evaluate_thresholds() -> None:
+    with tempfile.TemporaryDirectory(prefix="gf-cache-eval-") as tmp:
+        path = Path(tmp) / "sample.json"
+        payload = {
+            "schema": "graphforge.bazel-cache-perf-evidence.v1",
+            "status": "complete",
+            "baseline": {
+                "cargo_primary_p50_seconds": 100.0,
+                "cargo_compute_proxy_p50_seconds": 200.0,
+            },
+            "thresholds": {
+                "min_pairs": 2,
+                "warm_speedup_min": 0.30,
+                "compute_reduction_min": 0.25,
+                "cold_regression_max": 0.10,
+            },
+            "observations": {
+                "remote_cache_hits_on_identical_sha": True,
+                "cache_unavailable_cold_correct": True,
+                "affected_inputs_isolation": True,
+            },
+            "pairs": [
+                {
+                    "cold": {"wall_seconds": 90.0},
+                    "warm": {"wall_seconds": 60.0},
+                    "compute_proxy_seconds": 140.0,
+                    "cargo_cold_wall_seconds": 100.0,
+                },
+                {
+                    "cold": {"wall_seconds": 95.0},
+                    "warm": {"wall_seconds": 55.0},
+                    "compute_proxy_seconds": 130.0,
+                    "cargo_cold_wall_seconds": 100.0,
+                },
+            ],
+            "waiver": None,
+        }
+        path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+        ok = run_check(["--mode", "evaluate", "--evidence", str(path)])
+        if ok.returncode != 0:
+            raise SystemExit(f"expected thresholds to pass:\n{ok.stdout}\n{ok.stderr}")
+
+        payload["pairs"][0]["warm"]["wall_seconds"] = 90.0
+        payload["pairs"][1]["warm"]["wall_seconds"] = 90.0
+        path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+        bad = run_check(["--mode", "evaluate", "--evidence", str(path)])
+        if bad.returncode == 0:
+            raise SystemExit("expected warm speedup failure")
+
+
+def main() -> None:
+    test_parse_process_summary()
+    test_policy_passes_on_repo()
+    test_policy_fails_on_competing_flag()
+    test_evaluate_pending_allow()
+    test_evaluate_thresholds()
+    print("bazel-cache-perf tests passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/test-ci-storage-policy.py
+++ b/scripts/ci/test-ci-storage-policy.py
@@ -56,6 +56,7 @@ EXPECTED_ARTIFACT_UPLOADS = Counter(
         "pr-python-wheel-${{ github.sha }}": 1,
         "pr-node-addon-${{ github.sha }}": 1,
         "cargo-bazel-parity-evidence-${{ github.run_id }}": 1,
+        "bazel-cache-perf-evidence-${{ github.run_id }}": 1,
     }
 )
 EXPECTED_ARTIFACT_DOWNLOADS = Counter(
@@ -234,6 +235,13 @@ def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
             "reconciliation/summary.json",
             "examples/visualization/stress/results/",
             "dist/cargo-bazel-parity-evidence.json",
+            (
+                "dist/bazel-warm-observation.json\n"
+                "dist/bazel-affected-inputs.json\n"
+                "dist/bazel-cache-perf-ci-observation.json\n"
+                "dist/bazel-representative-build.summary.json\n"
+                "docs/development/bazel-migration-evidence/perf-sample.json"
+            ),
         }, f"artifact upload contains unapproved bytes: {path}"
         uploaded.append(name)
     for step in action_steps(text, "actions/download-artifact@"):

--- a/scripts/ci/test-classify-changes.sh
+++ b/scripts/ci/test-classify-changes.sh
@@ -127,6 +127,10 @@ assert_classification "$bazel_only" tests/release_workflows/BUILD.bazel bazel-re
 assert_classification "$bazel_only" scripts/ci/cargo-bazel-parity-check.py bazel-parity-check
 assert_classification "$bazel_only" scripts/ci/bazel-migration-ledger-check.py bazel-ledger-check
 assert_classification "$bazel_only" docs/development/bazel-migration-parity.md bazel-parity-doc
+assert_classification "$bazel_only" scripts/ci/bazel-cache-perf.py bazel-cache-perf-harness
+assert_classification "$bazel_only" docs/development/bazel-migration-perf.md bazel-cache-perf-doc
+assert_classification "$bazel_only" \
+  docs/development/bazel-migration-evidence/perf-sample.json bazel-cache-perf-evidence
 assert_classification "$none" "docs/a file with spaces.md" docs-only
 
 # Packaging-only Cargo metadata must not compile the workspace.


### PR DESCRIPTION
## Summary
- Add fail-closed in-repo harness for Blacksmith Bazel remote-cache policy, cache-unavailable cold correctness, warm identical-SHA observation, affected-input isolation, and #1 threshold evaluation (`scripts/ci/bazel-cache-perf.py`).
- Wire measurement/observation into `Bazel Bootstrap` + artifact upload; document cold/warm protocols and org-admin enablement in `docs/development/bazel-migration-perf.md` with pending evidence at `docs/development/bazel-migration-evidence/perf-sample.json`.
- **Does not close #5:** org-admin must enable Bazel Build Caching before remote hits / ≥10 paired runs can satisfy AC. CI uses `--allow-pending`; strict `evaluate` remains the close gate. No in-repo `--remote_cache`.

## Test plan
- [x] `python3 scripts/ci/bazel-cache-perf.py --mode policy`
- [x] `python3 scripts/ci/test-bazel-cache-perf.py`
- [x] `python3 scripts/ci/bazel-cache-perf.py --mode cold-correctness`
- [x] `python3 scripts/ci/bazel-cache-perf.py --mode observe-warm --write /tmp/warm.json`
- [x] `python3 scripts/ci/bazel-cache-perf.py --mode affected-inputs --write /tmp/affected.json`
- [x] `scripts/ci/test-classify-changes.sh`
- [x] `python3 scripts/ci/test-ci-storage-policy.py`
- [ ] Blacksmith `Bazel Bootstrap` + `CI Gate` green on exact head SHA
- [ ] After org-admin enablement: remote hits on identical-SHA + ≥10 pairs + strict evaluate

Relates to #5


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788584427&installation_model_id=20486&pr_number=425&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F425&signature=f3e103bb71fe465e850b014961ba613acef424fc8a56a168f8216a9455ec2caa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tooling to measure Bazel remote-cache performance, validate cache behavior, and evaluate results against configured thresholds.
  * Added support for generating and recording structured performance evidence.
  * Updated change detection and CI artifact handling for Bazel cache performance results.

* **Tests**
  * Added coverage for cache policy checks, performance evaluation, evidence handling, log parsing, and change classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Blacksmith remote cache policy enforcement and cold/warm performance harness to CI
> - Adds [bazel-cache-perf.py](https://github.com/CurateLabs/graphforge/pull/425/files#diff-0adc015fa83aaba23179051f98673a8af4fc99ea2bd0a325717a937b56723a21), a CLI tool with modes to enforce no competing `--remote_cache` in-repo, validate cold correctness, observe warm remote cache hits on identical SHAs, probe affected-input isolation, parse Bazel process summaries, and evaluate machine-readable evidence against thresholds.
> - Extends [test.yml](https://github.com/CurateLabs/graphforge/pull/425/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88) with new CI steps that run the policy/evaluate harness, collect cold-correctness and warm-observation JSON, capture Bazel build logs to `dist/`, and upload five evidence artifacts (1-day retention).
> - Adds [bazel-migration-perf.md](https://github.com/CurateLabs/graphforge/pull/425/files#diff-3d6f1448992a0b6ecd8b81295ff1b6aecfbd8ecb75f3a44cab5f66a327599e34) documenting admin enablement steps, measurement plan, thresholds, and the close rule for this work.
> - Extends [classify-changes.sh](https://github.com/CurateLabs/graphforge/pull/425/files#diff-9c479d4633de98cfc5884f3f7fd84e5abbd292370078443e7958f023d5a056f1) so the new harness scripts and perf docs are treated as Bazel-related changes for conditional CI execution.
> - Behavioral Change: existing Bazel CI steps now use `set -euo pipefail` and tee output to `dist/` log files; any previously tolerated silent failures will now fail the job.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b3a72f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->