### PR TITLE
docs(bazel): documentation, observability, and #1 close-readiness evidence (#3)

### DIFF
--- a/docs/development/bazel-bootstrap.md
+++ b/docs/development/bazel-bootstrap.md
@@ -103,12 +103,12 @@ skills are declared via root `//:project_skills_bundle` / `//:project-skills/man
   for lint CI until a later slice).
 - Doctests are not separate Bazel targets (documented equivalent: coverage attaches
   to crate unit-test targets; same policy as #10/#9).
-- Blacksmith `Bazel Bootstrap` runs `//:bazel_test_graph_smoke`, release bins,
-  binding smokes, and the #6 dual-build parity gate. Full `//:integration_tests`
-  and `//:bdd_tests` remain executable under Bazel for local/full runs.
+- Blacksmith `Bazel Bootstrap` runs authoritative `//:ci_rust_tests`, release bins,
+  binding smokes, and diagnostic #6 dual-build parity (one release cycle after #4).
+  Full `//:integration_tests` and `//:bdd_tests` remain executable under Bazel for
+  local/full runs.
 - Cross-OS Binding RC still produces macOS/Windows natives on those runners;
   Bazel models every certified platform and builds host-native release artifacts.
-  Sole Bazel authority is #4 after #5 cache/perf.
 - Bazel storage always enables `test-failpoints` (env-gated no-ops); Cargo release
   builds keep the const no-op body — documented dual-build parity surface.
 
@@ -149,16 +149,14 @@ CARGO_BAZEL_REPIN=1 bazelisk build --repo_env=CARGO_BAZEL_REPIN=1 //:first_party
 
 - CI runs on Blacksmith runners when `bazel` path classification is true.
 - Do **not** add `--remote_cache` in `.bazelrc` or workflow steps. Blacksmith
-  injects repository Bazel caching when org-admin enablement lands (#5).
+  injects repository Bazel caching (org-admin enablement complete; see #5).
 - Policy + measurement harness: `scripts/ci/bazel-cache-perf.py` (see
   [bazel-migration-perf.md](bazel-migration-perf.md)).
-- Org-admin must enable **Bazel Build Caching** under Blacksmith
-  [Settings → Features](https://app.blacksmith.sh/settings?tab=features) before
-  remote hits can be measured; #5 stays open until gates pass.
+- After [#4](https://github.com/CurateLabs/graphforge/issues/4), `Bazel Bootstrap`
+  is authoritative under `CI Gate` (`//:ci_rust_tests`).
 
-## Next
+## Developer entrypoint
 
-1. [#5](https://github.com/CurateLabs/graphforge/issues/5) cache/perf evidence —
-   see [bazel-migration-perf.md](bazel-migration-perf.md).
-2. [#4](https://github.com/CurateLabs/graphforge/issues/4) — `CI Gate` cutover;
-   see [bazel-migration-cutover.md](bazel-migration-cutover.md).
+Day-to-day install, extending targets, packaging handoff, troubleshooting, and
+CI/release runbooks: [bazel.md](bazel.md).
+#1 close-readiness evidence map: [bazel-migration-ac-evidence.md](bazel-migration-ac-evidence.md).

--- a/docs/development/bazel-migration-ac-evidence.md
+++ b/docs/development/bazel-migration-ac-evidence.md
@@ -1,0 +1,108 @@
+# #1 Bazel migration — close-readiness AC evidence map (#3)
+
+Checked-in map from canonical issue
+[#1](https://github.com/CurateLabs/graphforge/issues/1) acceptance criteria to
+M2 child-issue evidence (PR / merge SHA / artifact). Produced by
+[#3](https://github.com/CurateLabs/graphforge/issues/3) so M2 gate
+[#2](https://github.com/CurateLabs/graphforge/issues/2) can close when children
+are complete.
+
+Orchestration: [bazel-migration-orchestration.md](bazel-migration-orchestration.md).
+Developer guide: [bazel.md](bazel.md).
+
+**Cutover SHA (authoritative CI after #4):**
+`75a33e5cf6d9dab1407eba719e98740c95426d91` ([PR #427](https://github.com/CurateLabs/graphforge/pull/427)).
+
+## Child issue → merge evidence
+
+| Child | Title | PR(s) | Merge SHA |
+| --- | --- | --- | --- |
+| [#13](https://github.com/CurateLabs/graphforge/issues/13) | Sub-agent orchestration | [#417](https://github.com/CurateLabs/graphforge/pull/417) | `6e8b8e3fdc1ecd960eacf14a73e5be7b54fcef3c` |
+| [#12](https://github.com/CurateLabs/graphforge/issues/12) | Inventory + baseline freeze | [#418](https://github.com/CurateLabs/graphforge/pull/418) | `a8fa4298c51077c058b25b2e1d0b854597820cbf` |
+| [#11](https://github.com/CurateLabs/graphforge/issues/11) | Bazelisk / Bzlmod / drift | [#419](https://github.com/CurateLabs/graphforge/pull/419) | `9d5a10fb8078130745bcb41f2835b7298ee6bb77` |
+| [#10](https://github.com/CurateLabs/graphforge/issues/10) | Foundation / compiler libs | [#420](https://github.com/CurateLabs/graphforge/pull/420) | `ed96019e14ff5c7af28227c20f7195b7ceb7cd30` |
+| [#9](https://github.com/CurateLabs/graphforge/issues/9) | Runtime libs | [#421](https://github.com/CurateLabs/graphforge/pull/421) | `b8c217802dd7e7c0d15cdef10ad76d3cbe9f45f3` |
+| [#8](https://github.com/CurateLabs/graphforge/issues/8) | Tests / CLI / resources | [#423](https://github.com/CurateLabs/graphforge/pull/423) | `4d13fcdeb62386beed75e8aa2674432101e01904` |
+| [#7](https://github.com/CurateLabs/graphforge/issues/7) | PyO3 / napi packaging | [#422](https://github.com/CurateLabs/graphforge/pull/422) | `1c3a4068bebc2f6bb22a5f8be835b37474d99e12` |
+| [#6](https://github.com/CurateLabs/graphforge/issues/6) | Release platforms + parity | [#424](https://github.com/CurateLabs/graphforge/pull/424) | `457eb1171cbd240ade30efd63814d9b8748a9934` |
+| [#5](https://github.com/CurateLabs/graphforge/issues/5) | Blacksmith cache + perf | [#425](https://github.com/CurateLabs/graphforge/pull/425), [#426](https://github.com/CurateLabs/graphforge/pull/426) | `c52be21063ea3cc65d7d66c2ae91816c78bb3907`, `bad99f97bd1355b21702a20d464e8a342776353d` |
+| [#4](https://github.com/CurateLabs/graphforge/issues/4) | CI Gate cutover | [#427](https://github.com/CurateLabs/graphforge/pull/427) | `75a33e5cf6d9dab1407eba719e98740c95426d91` |
+| [#3](https://github.com/CurateLabs/graphforge/issues/3) | Docs / observability / this map | *(this PR)* | *(fill at merge)* |
+
+## #1 acceptance criteria → evidence
+
+| #1 AC | Status | Child | Evidence pointer |
+| --- | --- | --- | --- |
+| Checked-in migration ledger for all Cargo targets and every CI/release build command | Met | #12 (+ updates #11–#6) | [bazel-migration-ledger.md](bazel-migration-ledger.md); `tools/bazel/parity/migration_target_map.json`; `scripts/ci/bazel-migration-ledger-check.py` |
+| Bazel builds all 17 first-party packages without shelling out to Cargo for ordinary compilation or tests | Met | #11–#9, #8, #7 | [bazel-bootstrap.md](bazel-bootstrap.md); `//:first_party_libs`, `//:binding_cdylibs`, `//:ci_rust_tests`; merge SHAs above |
+| All 53 Rust integration tests, crate unit tests, doctest equivalents, BDD, snapshots, public-surface gates under mapped Bazel test graph | Met | #8, #6 | Ledger + `//:integration_tests` / `//:unit_tests` / `//:snapshot_tests` / `//:bdd_tests` / `//:ci_rust_tests`; [bazel-migration-parity.md](bazel-migration-parity.md) |
+| Bazel-built Python wheels and Node packages pass clean-install, no-fallback, parity, persistence/reopen, structured-error suites | Met | #7, #6 | `//:python_wheel_smoke` / `//:node_package_smoke`; `scripts/ci/assemble_bazel_binding_packages.py`; Binding RC still consumes natives (no silent Cargo recompile of a different graph) |
+| Linux, macOS, Windows, and supported Node cross-target release evidence remains complete | Met | #6 | `tools/bazel/release/release_platforms.json`; `//platforms:*`; Binding RC contract unchanged |
+| Cargo and Bazel dependency/feature graphs cannot drift silently | Met | #11 | `scripts/ci/cargo-bazel-drift-check.py`; `tools/bazel/drift/cargo_feature_fingerprint.json`; `cargo-bazel-lock.json` |
+| Repeated identical-SHA builds report remote cache hits; source change reruns only actions whose declared inputs changed | Met | #5 | [bazel-migration-perf.md](bazel-migration-perf.md); [perf-sample.json](bazel-migration-evidence/perf-sample.json); `affected-inputs` harness mode |
+| Blacksmith cache disablement or eviction produces a correct cold build without repository changes | Met | #5 | `bazel-cache-perf.py --mode cold-correctness`; observations in perf sample |
+| Across ≥10 paired runs: warm PR p50 ≥30% faster and compute ≥25% lower than Cargo baseline; cold p50 regression ≤10% | Met | #5 (#12 baseline) | [bazel-migration-baseline.md](bazel-migration-baseline.md); `perf-sample.json` `status=complete` + strict `evaluate` |
+| No secret, token, signing material, publish credential, or user data in a cacheable Bazel action or build log | Met | #7, #5, #3 | See [Security and supply chain](#security-and-supply-chain) below; publish OIDC/credentials stay in release workflows outside `Bazel Bootstrap` |
+| Required check context remains `CI Gate`; path-classified skips remain neutral | Met | #6, #4 | [bazel-migration-cutover.md](bazel-migration-cutover.md); `scripts/ci/require-gates.sh` |
+| Cargo CI compilation and sticky build disks removed only after same-SHA parity and performance gates | Met | #4 (after #6/#5) | PR sticky `target/` keys retired; Cargo `rust-test` removed; Binding RC / fuzz / M1 retained as justified |
+| Developer, architecture, build, release, troubleshooting, and cache-observability documentation is current | Met | #3 | [bazel.md](bazel.md) + companions listed there; this evidence map |
+
+## #1 Documentation checklist
+
+| #1 Documentation topic | Canonical doc |
+| --- | --- |
+| Build-system architecture and ownership | [bazel.md](bazel.md) § Architecture and ownership; [ARCHITECTURE.md](../engineering/ARCHITECTURE.md) |
+| Bazel/Bazelisk installation and local commands | [bazel.md](bazel.md) § Install; [bazel-bootstrap.md](bazel-bootstrap.md) |
+| Adding crates, dependencies, features, tests, fixtures, generated inputs | [bazel.md](bazel.md) § Extending the graph |
+| Python/Node packaging handoff | [bazel.md](bazel.md) § Packaging handoff; [bazel-bootstrap.md](bazel-bootstrap.md) |
+| Blacksmith Bazel cache enablement, metrics, eviction, troubleshooting | [bazel-migration-perf.md](bazel-migration-perf.md); [bazel.md](bazel.md) § Cache and troubleshooting |
+| Cargo compatibility and rollback | [bazel-migration-cutover.md](bazel-migration-cutover.md); [bazel.md](bazel.md) § Cargo compatibility |
+| CI and release runbooks | [bazel.md](bazel.md) § CI and release; [bazel-migration-cutover.md](bazel-migration-cutover.md); [release-process.md](release-process.md) |
+
+## Observability evidence paths
+
+| Signal | Path / artifact |
+| --- | --- |
+| Per-run representative build log | CI `dist/bazel-representative-build.log` (uploaded via cache/perf artifact when present) |
+| Per-run machine-readable process summary | `dist/bazel-representative-build.summary.json` |
+| Warm observation | `dist/bazel-warm-observation.json` |
+| Affected-input probe | `dist/bazel-affected-inputs.json` |
+| CI observation rollup | `dist/bazel-cache-perf-ci-observation.json` |
+| Checked-in ≥10-pair sample | [bazel-migration-evidence/perf-sample.json](bazel-migration-evidence/perf-sample.json) |
+| Diagnostic dual-build parity (one release cycle) | `dist/cargo-bazel-parity-evidence.json` |
+| Blacksmith Cache dashboard | https://app.blacksmith.sh/cache |
+| Authoritative Rust test log | `dist/bazel-ci-rust-tests.log` |
+
+See also [OBSERVABILITY.md](../engineering/OBSERVABILITY.md) (Bazel CI signals).
+
+## Security and supply chain
+
+Confirmed against the post-#4 tree (cutover SHA above):
+
+| Constraint | Evidence |
+| --- | --- |
+| Pin Bazel, rules, toolchains, external archives with integrity hashes | `.bazelversion` (`9.2.0`); `MODULE.bazel` (`rules_rust` `0.73.0`, Rust `1.96.0`); `MODULE.bazel.lock` `registryFileHashes` / archive `sha256` |
+| Third-party Rust deps from reviewed Cargo lock | `crate.from_cargo` + `Cargo.lock` + `cargo-bazel-lock.json` |
+| No `--remote_cache` in repo / workflow (Blacksmith injects) | `.bazelrc`; `Bazel Bootstrap` comments; `bazel-cache-perf.py --mode policy` |
+| OIDC / npm / PyPI / signing credentials outside cacheable Bazel actions | Publish/release workflows only; `Bazel Bootstrap` has no `NODE_AUTH_TOKEN` / PyPI / signing secrets; packaging smoke assembles from Bazel cdylibs without registry auth |
+| Network access restricted where practical | Ordinary `rules_rust` compile/test actions are sandboxed; crate_universe fetch is lockfile-bound; no in-repo remote-cache URL |
+| Cross-branch cache reuse only via action key + declared inputs | Bazel remote-cache semantics; documented in [bazel-migration-perf.md](bazel-migration-perf.md) |
+| No user data / sensitive fixtures uploaded as cache payloads | Test fixtures are hermetic source inputs; CI logs use `--test_output=errors` |
+
+## Explicit non-deliverables (M2)
+
+- **Mobile bindings** (Swift, Kotlin, UniFFI, XCFramework, JVM JAR/AAR) are
+  **abandoned for M2** — ledger row `RT-mobile` is `excluded`. Do not treat
+  product roadmap “planned UniFFI” notes as M2 Bazel migration deliverables.
+- M3 peer-extension and M4 embedded-performance epics are out of scope.
+
+## Gate close notes
+
+- Close [#3](https://github.com/CurateLabs/graphforge/issues/3) when this map and
+  [bazel.md](bazel.md) land with green CI on the docs PR and the table’s #3 merge
+  SHA is filled in (or linked from the closing PR).
+- Close [#2](https://github.com/CurateLabs/graphforge/issues/2) only when #13–#3
+  are closed with ordinary AGENTS.md evidence.
+- Close [#1](https://github.com/CurateLabs/graphforge/issues/1) when its AC
+  outcomes are met via this map (no release-gate cascade required for ordinary
+  close).

--- a/docs/development/bazel-migration-cutover.md
+++ b/docs/development/bazel-migration-cutover.md
@@ -83,5 +83,6 @@ handoff). Fuzz retains its sticky disk as a justified retained tool.
 
 ## Next
 
-[#3](https://github.com/CurateLabs/graphforge/issues/3) — docs/observability/#1
-close-readiness evidence map.
+[#3](https://github.com/CurateLabs/graphforge/issues/3) docs/observability/#1
+close-readiness: [bazel.md](bazel.md) and
+[bazel-migration-ac-evidence.md](bazel-migration-ac-evidence.md).

--- a/docs/development/bazel-migration-orchestration.md
+++ b/docs/development/bazel-migration-orchestration.md
@@ -213,7 +213,7 @@ canonical path).
 | Parity evidence | R7 / #6 | `docs/development/bazel-migration-parity.md` (+ CI artifacts linked from PR) | #5, #4, #3 |
 | Cache/perf benchmarks | R8 / #5 | `docs/development/bazel-migration-perf.md` + machine-readable files under `docs/development/bazel-migration-evidence/` | #4, #3, #1 close |
 | Cutover + Cargo rollback | R9 / #4 | `docs/development/bazel-migration-cutover.md` | #3, operators |
-| #1 AC evidence map | R10 / #3 | `docs/development/bazel-migration-ac-evidence.md` | #2, #1 close |
+| #1 AC evidence map | R10 / #3 | `docs/development/bazel-migration-ac-evidence.md` (+ developer guide `docs/development/bazel.md`) | #2, #1 close |
 
 PRs for modeling slices must update the migration ledger in the same change when
 they add, remap, or except targets.

--- a/docs/development/bazel-migration-parity.md
+++ b/docs/development/bazel-migration-parity.md
@@ -72,8 +72,7 @@ bazelisk test //:parity_suite //:bazel_test_graph_smoke
 
 ## Next
 
-1. [#4](https://github.com/CurateLabs/graphforge/issues/4) cutover — see
-   [bazel-migration-cutover.md](bazel-migration-cutover.md) (landed when #5
-   performance gates are complete).
-2. [#3](https://github.com/CurateLabs/graphforge/issues/3) — docs/observability
-   close-readiness.
+Cutover ([#4](https://github.com/CurateLabs/graphforge/issues/4)) and cache/perf
+([#5](https://github.com/CurateLabs/graphforge/issues/5)) are landed. Docs /
+#1 close-readiness: [bazel.md](bazel.md) and
+[bazel-migration-ac-evidence.md](bazel-migration-ac-evidence.md).

--- a/docs/development/bazel.md
+++ b/docs/development/bazel.md
@@ -1,0 +1,221 @@
+# Bazel build system (M2 / #1)
+
+GraphForge uses **Bazel** (via **Bazelisk**) as the authoritative incremental
+build and test engine for CI Rust compilation and mapped tests. Cargo manifests
+and `Cargo.lock` remain the Rust ecosystem source of truth for dependencies,
+local tooling, publishing metadata, and crate-universe generation.
+
+Canonical contract: [#1](https://github.com/CurateLabs/graphforge/issues/1).
+Close-readiness evidence map: [bazel-migration-ac-evidence.md](bazel-migration-ac-evidence.md).
+
+## Architecture and ownership
+
+| Concern | Owner | Notes |
+| --- | --- | --- |
+| Ordinary Rust compile + mapped tests in CI | Bazel (`rules_rust` / crate-universe) | Real targets — not `cargo` shell wrappers |
+| Dependency declaration / lockfile | `Cargo.toml` + `Cargo.lock` | Drift check fails closed |
+| Required PR merge check | **`CI Gate`** | Unchanged name through cutover |
+| Remote cache | Blacksmith repository Bazel cache | Do **not** set `--remote_cache` in-repo |
+| Python / Node package assembly | maturin / napi may assemble | Must consume Bazel-built natives; no silent recompile of a different graph |
+| Fmt / Clippy | Cargo (`Rust Quality`) | Workspace lint policy remains Cargo-owned for now |
+| Fuzz | `cargo-fuzz` (retained) | Justified exception `RT-fuzz` |
+| crates.io publish metadata | Cargo (retained) | Justified exception `RT-publish-crates` |
+| Binding RC / publish sticky disks | Packaging lanes | Not retired by M2 cutover |
+
+Mobile bindings (Swift / Kotlin / UniFFI / XCFramework / JVM) are **not** an M2
+Bazel deliverable. Product roadmap may still mention them as planned later work;
+they must not appear as required migration targets.
+
+Companion deep-dives:
+
+| Doc | Role |
+| --- | --- |
+| [bazel-migration-orchestration.md](bazel-migration-orchestration.md) | Sub-agent roles and DAG |
+| [bazel-migration-ledger.md](bazel-migration-ledger.md) | Target + CI command inventory |
+| [bazel-migration-baseline.md](bazel-migration-baseline.md) | Accepted Cargo/Blacksmith baseline |
+| [bazel-bootstrap.md](bazel-bootstrap.md) | Pins, labels, local smoke commands |
+| [bazel-migration-parity.md](bazel-migration-parity.md) | Same-SHA Cargo/Bazel parity |
+| [bazel-migration-perf.md](bazel-migration-perf.md) | Cache metrics, thresholds, troubleshooting |
+| [bazel-migration-cutover.md](bazel-migration-cutover.md) | CI Gate cutover + Cargo rollback |
+| [bazel-migration-ac-evidence.md](bazel-migration-ac-evidence.md) | #1 AC → child evidence |
+
+## Install
+
+1. Install [Bazelisk](https://github.com/bazelbuild/bazelisk) and ensure it is
+   on `PATH` as `bazelisk` (and optionally `bazel`).
+2. Repository pin: `.bazelversion` → **9.2.0** (do not override casually).
+3. First run downloads the pinned Bazel and module deps via Bzlmod
+   (`MODULE.bazel` / `MODULE.bazel.lock` carry integrity hashes).
+
+```bash
+bazelisk version   # must report 9.2.0 from .bazelversion
+```
+
+## Everyday local commands
+
+```bash
+# Authoritative CI-equivalent Rust test graph
+bazelisk test //:ci_rust_tests
+
+# Libraries, CLI, resources, release bins
+bazelisk build //:first_party_libs //:cli_bins //:resource_inputs //:release_bins
+
+# Binding cdylibs + packaging smoke (no maturin/napi native recompile)
+bazelisk build //:binding_cdylibs //:python_wheel_smoke //:node_package_smoke
+
+# Deterministic groups
+bazelisk test //:unit_tests //:integration_tests //:snapshot_tests //:cli_tests
+bazelisk test //:bdd_tests
+
+# Fail-closed inventory / drift / parity diagnostics
+python3 scripts/ci/cargo-bazel-drift-check.py
+python3 scripts/ci/bazel-migration-ledger-check.py
+python3 scripts/ci/cargo-bazel-parity-check.py --mode all \
+  --write-evidence dist/cargo-bazel-parity-evidence.json
+
+# Cache policy + cold correctness (no org-admin required)
+python3 scripts/ci/bazel-cache-perf.py --mode policy
+python3 scripts/ci/bazel-cache-perf.py --mode cold-correctness
+```
+
+Repo flags live in `.bazelrc` (Bzlmod on; **no** `--remote_cache`).
+
+## Extending the graph
+
+### New first-party crate
+
+1. Add the crate under `crates/` and wire it into the Cargo workspace
+   (`Cargo.toml` members + deps) as usual.
+2. Add a `BUILD.bazel` using `gf_rust_library` / `gf_rust_test` from
+   `tools/bazel/gf_rust.bzl` (see neighboring crates).
+3. Attach the library to the appropriate root aggregate
+   (`//:foundation_compiler_libs`, `//:runtime_libs`, or `//:first_party_libs`).
+4. Add/update a row in `tools/bazel/parity/migration_target_map.json` and the
+   human ledger ([bazel-migration-ledger.md](bazel-migration-ledger.md)).
+5. Refresh Cargo↔Bazel lock/fingerprint state:
+
+```bash
+python3 scripts/ci/cargo-bazel-drift-check.py --write
+CARGO_BAZEL_REPIN=1 bazelisk build --repo_env=CARGO_BAZEL_REPIN=1 //:first_party_libs
+python3 scripts/ci/bazel-migration-ledger-check.py
+```
+
+### Dependencies and features
+
+- Declare deps/features in Cargo manifests only; regenerate
+  `cargo-bazel-lock.json` / fingerprint via the commands above.
+- Do not hand-edit `@crates` labels to diverge from lock state — the drift
+  check must stay green.
+
+### Tests, fixtures, and generated inputs
+
+- Unit tests: `gf_rust_test` next to the library.
+- Integration binaries: follow `gf_rust_integration_test` patterns and attach to
+  `//:integration_tests`.
+- Snapshots / goldens / TCK / features / notebooks / contracts: declare as
+  `filegroup` inputs under `//:resource_inputs` (or the specific package
+  filegroup) so actions list hermetic inputs.
+- BDD: keep scenarios under the existing `//:bdd_tests` /
+  `//crates/graphforge-api:bdd` graph.
+- After adding targets, update the migration target map in the **same** PR.
+
+### CLI / build scripts
+
+- Prefer `gf_rust_binary` / `gf_cargo_build_script` (see `graphforge-cli`).
+- Skills and other non-source payloads stay declared filegroups — do not bury
+  undeclared reads in actions.
+
+## Packaging handoff (Python / Node)
+
+| Stage | Owner |
+| --- | --- |
+| Native `.so` / `.dylib` / `.node` | Bazel `//:binding_cdylibs` |
+| Wheel / npm package assembly smoke | `//:python_wheel_smoke`, `//:node_package_smoke` via `scripts/ci/assemble_bazel_binding_packages.py` |
+| Multi-OS Binding RC certification | Existing Binding RC workflows (consume Bazel-built or equivalent natives; no silent alternate native graph) |
+| Registry publish (OIDC / tokens) | Release workflows only — **never** cacheable Bazel actions |
+
+Credentials, signing material, and publish tokens must stay out of Bazel actions
+and remote-cache payloads.
+
+## Cache and troubleshooting
+
+### Enablement / metrics / eviction
+
+See [bazel-migration-perf.md](bazel-migration-perf.md) for the full protocol.
+Short form:
+
+1. Org admin: Blacksmith
+   [Settings → Features](https://app.blacksmith.sh/settings?tab=features) →
+   **Bazel Build Caching** for `CurateLabs/graphforge`.
+2. Confirm [Cache](https://app.blacksmith.sh/cache) shows a Bazel tab.
+3. Never add a competing `--remote_cache`.
+4. Eviction / empty cache: cold builds remain correct; only performance changes
+   (`--mode cold-correctness`).
+
+### Per-run observability paths
+
+| Artifact | Meaning |
+| --- | --- |
+| `dist/bazel-ci-rust-tests.log` | Authoritative `//:ci_rust_tests` log |
+| `dist/bazel-representative-build.log` | Representative libs/CLI/release build log |
+| `dist/bazel-representative-build.summary.json` | Parsed remote-hit / process summary |
+| `dist/bazel-warm-observation.json` | Warm identical-SHA observation |
+| `dist/bazel-affected-inputs.json` | Affected-input isolation probe |
+| `dist/bazel-cache-perf-ci-observation.json` | CI rollup for cache/perf |
+| `docs/development/bazel-migration-evidence/perf-sample.json` | Checked-in ≥10-pair sample + gate results |
+| `dist/cargo-bazel-parity-evidence.json` | Diagnostic dual-build parity (one release cycle) |
+
+CI uploads the cache/perf set as `bazel-cache-perf-evidence-<run_id>`.
+
+### Common failures
+
+| Symptom | What to check |
+| --- | --- |
+| Drift check red | Re-run `--write` + `CARGO_BAZEL_REPIN=1` after intentional Cargo changes; commit lock/fingerprint |
+| Ledger check red | Missing/unmapped row or `stub` retained exception — update map + justification |
+| No remote cache hits | Org-admin enablement; fresh `--output_base` for warm observe; no competing `--remote_cache` |
+| Cold build fails without cache | Bug — cache absence must not require repo/credential changes |
+| Binding packaging mismatch | Ensure assembly consumes Bazel cdylib outputs; do not `maturin build` / `napi build` a second native graph in the smoke path |
+| Need Cargo-only diagnosis | [bazel-migration-cutover.md](bazel-migration-cutover.md) rollback section |
+
+## Cargo compatibility and rollback
+
+- Keep using `cargo` locally for edit/build/test convenience; CI authority is Bazel.
+- After intentional dependency changes, always refresh Bazel lock/fingerprint
+  (commands above).
+- For one release cycle after cutover, same-SHA dual-build parity remains a
+  **diagnostic** under `Bazel Bootstrap`.
+- Temporary CI rollback to Cargo `rust-test` is documented in
+  [bazel-migration-cutover.md](bazel-migration-cutover.md). Prefer fixing Bazel
+  root causes.
+
+## CI and release runbooks
+
+### Pull requests
+
+1. Classifier: Rust changes enable `bazel=true` so `Bazel Bootstrap` runs.
+2. Authoritative Rust tests: `bazelisk test //:ci_rust_tests`.
+3. Also builds first-party libs, CLI, resources, release bins, binding smokes.
+4. Fail-closed: drift, ledger, release-platform inventory, cache policy, strict
+   perf `evaluate` against the checked-in sample.
+5. Required aggregate remains exactly **`CI Gate`**; path-classified skips stay
+   neutral.
+6. PR Cargo sticky `target/` disks are retired; do not re-add without a
+   documented rollback.
+
+### Release / Binding RC
+
+1. Prefer Bazel-built natives for packaging handoff; Binding RC still proves
+   clean-install on certified OS/arch matrices.
+2. Publish credentials and OIDC stay in release/publish workflows
+   ([release-process.md](release-process.md), [PUBLISHING.md](../engineering/PUBLISHING.md)).
+3. Do not claim M2 mobile-binding release surfaces.
+
+## Security summary
+
+- Pins + integrity: `.bazelversion`, `MODULE.bazel`, `MODULE.bazel.lock`.
+- No secrets in cacheable actions; no in-repo remote-cache URL.
+- Cross-branch cache reuse is safe only when Bazel action keys and declared
+  inputs match.
+- Details and AC pointers:
+  [bazel-migration-ac-evidence.md](bazel-migration-ac-evidence.md).

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -101,7 +101,7 @@ graphforge/
 │   ├── graphforge-knowledge/            # knowledge + epistemic record domains
 │   ├── graphforge-bindings-py/          # PyO3 Python binding
 │   ├── graphforge-bindings-node/        # napi-rs Node binding
-│   └── graphforge-bindings-uniffi/      # UniFFI shared binding (Swift + Kotlin)
+│   └── …                                # (Swift/Kotlin UniFFI not an M2 deliverable)
 ├── packages/                    # Node packaging and agent skills
 ├── docs/                        # Markdown sources (Starlight syncs an allowlist)
 ├── docs-site/                   # Astro Starlight site
@@ -251,9 +251,12 @@ When adding features, update:
 M2 Bazel migration work follows the sub-agent contracts in
 [bazel-migration-orchestration.md](bazel-migration-orchestration.md)
 (canonical issue [#1](https://github.com/CurateLabs/graphforge/issues/1)).
-The frozen inventory and Cargo/Blacksmith baseline live in
-[bazel-migration-ledger.md](bazel-migration-ledger.md) and
-[bazel-migration-baseline.md](bazel-migration-baseline.md).
+Start with the developer guide [bazel.md](bazel.md). The frozen inventory,
+baseline, and #1 close-readiness evidence map live in
+[bazel-migration-ledger.md](bazel-migration-ledger.md),
+[bazel-migration-baseline.md](bazel-migration-baseline.md), and
+[bazel-migration-ac-evidence.md](bazel-migration-ac-evidence.md).
+Mobile (Swift/Kotlin/UniFFI) bindings are not an M2 Bazel deliverable.
 
 ---
 

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -18,6 +18,13 @@ repository-maintained change history file.
 
 ## 2. Prove the candidate
 
+CI Rust compilation and the mapped test graph are Bazel-owned under required
+check **`CI Gate`** (see [bazel.md](bazel.md) and
+[bazel-migration-cutover.md](bazel-migration-cutover.md)). Binding RC and publish
+lanes must consume Bazel-built (or equivalent) natives rather than silently
+recompiling a different native graph. Publish credentials and OIDC stay in
+release workflows — never in cacheable Bazel actions.
+
 The Binding Release Candidate workflow must retain the manifest, Python, npm,
 crates, and evidence partitions for the same commit. Before any registry write,
 the exact retained bytes must pass:

--- a/docs/engineering/ARCHITECTURE.md
+++ b/docs/engineering/ARCHITECTURE.md
@@ -95,6 +95,11 @@ architecture deep-dives in [`../book/architecture/`](../book/architecture/overvi
   [`OBSERVABILITY.md`](OBSERVABILITY.md).
 - **Correctness bar:** TCK + non-Cypher surface inventories; wrapper/logical-plan tests
   alone are insufficient (`AGENTS.md`).
+- **Build system:** Bazel (Bazelisk) owns CI Rust compilation and the mapped test
+  graph; Cargo manifests remain ecosystem inputs. See
+  [`../development/bazel.md`](../development/bazel.md). Publish credentials stay
+  outside cacheable Bazel actions. Swift/Kotlin UniFFI bindings are not an M2
+  build-migration deliverable.
 
 ## Decisions
 

--- a/docs/engineering/OBSERVABILITY.md
+++ b/docs/engineering/OBSERVABILITY.md
@@ -22,6 +22,8 @@ provenance IDs, and structured errors ([`../releases/roadmap.md`](../releases/ro
 | Clean-install success | Quickstart smokes after publish | Manual/release verification | Pass from public registries | Release operator |
 | Docs usability | Docs build; link integrity | `docs.yml` / Starlight (`docs-site/`) | Green build | Docs owners |
 | Scale honesty | Fixed-hop LIMIT materialization ratios | Scale-limit CI gate | ≤3× rows on 10× edges for LIMIT 1000 shape | Maintainers |
+| Bazel CI correctness | Authoritative `//:ci_rust_tests` + drift/ledger | `Bazel Bootstrap` under `CI Gate` | Green on Rust-classified PRs | Maintainers |
+| Bazel remote-cache health | Remote hits, cold/warm walls, affected-input isolation | `dist/bazel-*-observation.json`, checked-in `perf-sample.json` | Hits on warm identical-SHA; cold correct without cache | Maintainers |
 
 ## Service health
 
@@ -60,8 +62,13 @@ aggregate CI signals.
 | Docs build failure | `docs.yml` / Starlight build red | Medium | Docs owners | Fix content or site config |
 | Publish dry-run failure | Registry reject | High | Release operator | Stop publication; recover per plan |
 | Scale-limit shape regression | Materialization ratio gate fail | Medium | Execution owners | Investigate adjacency/fetch path; update docs if limits change |
+| Bazel remote-cache regression | Warm identical-SHA hits disappear or cold correctness fails | High | Build owners | Confirm Blacksmith Bazel caching; never add competing `--remote_cache`; see [`../development/bazel-migration-perf.md`](../development/bazel-migration-perf.md) |
 
 There is no hosted ops dashboard product; CI and release artifacts are the shared “dashboard.”
+Bazel per-run summaries and machine-readable benchmark paths are listed in
+[`../development/bazel.md`](../development/bazel.md) and
+[`../development/bazel-migration-ac-evidence.md`](../development/bazel-migration-ac-evidence.md).
+Blacksmith Cache UI: https://app.blacksmith.sh/cache.
 
 ## Privacy and safety
 

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -28,10 +28,15 @@ flowchart LR
 | --- | --- |
 | [`../book/architecture/`](../book/architecture/overview.md) | Deep architecture notes, pipeline, storage, embedding contracts |
 | [`../development/`](../development/contributing.md) | Contributor workflow, testing detail, release process |
+| [`../development/bazel.md`](../development/bazel.md) | M2 / #1 Bazel developer guide (install, extend, cache, CI/release) |
+| [`../development/bazel-migration-ac-evidence.md`](../development/bazel-migration-ac-evidence.md) | M2 / #1 close-readiness AC → child evidence map |
 | [`../development/bazel-migration-orchestration.md`](../development/bazel-migration-orchestration.md) | M2 / #1 Bazel migration sub-agent roles, contracts, and handoffs |
 | [`../development/bazel-migration-ledger.md`](../development/bazel-migration-ledger.md) | M2 / #1 Cargo target + CI command migration ledger (freeze) |
 | [`../development/bazel-migration-baseline.md`](../development/bazel-migration-baseline.md) | M2 / #1 accepted Blacksmith/Cargo CI performance baseline |
 | [`../development/bazel-bootstrap.md`](../development/bazel-bootstrap.md) | M2 / #11 Bazelisk/Bzlmod bootstrap and Cargo drift check |
+| [`../development/bazel-migration-parity.md`](../development/bazel-migration-parity.md) | M2 / #6 same-SHA Cargo/Bazel parity |
+| [`../development/bazel-migration-perf.md`](../development/bazel-migration-perf.md) | M2 / #5 Blacksmith cache + performance gates |
+| [`../development/bazel-migration-cutover.md`](../development/bazel-migration-cutover.md) | M2 / #4 CI Gate cutover + Cargo rollback |
 | [`../contracts/`](https://github.com/CurateLabs/graphforge/tree/main/docs/contracts) | Frozen public API / fingerprint JSON contracts |
 | [`../reference/`](../reference/api.md) | Compatibility, TCK, scale limits, column naming |
 | Root `AGENTS.md` | Agent workflow and validation gates |


### PR DESCRIPTION
## Summary
- Add [bazel.md](docs/development/bazel.md) covering #1 Documentation topics (architecture/ownership, install, extending targets, packaging handoff, cache troubleshooting, Cargo rollback, CI/release).
- Add [bazel-migration-ac-evidence.md](docs/development/bazel-migration-ac-evidence.md) mapping every #1 AC to M2 child PR/SHA/artifact evidence, plus security/supply-chain confirmation and observability paths.
- Wire indexes (engineering README, contributing, ARCHITECTURE, OBSERVABILITY, release-process) and refresh stale #4/#5 “next” notes. Explicitly exclude mobile bindings as M2 deliverables.

Closes #3

## Test plan
- [x] Review AC evidence map covers all #1 checkboxes with child PR/SHA pointers
- [x] Confirm Bazel Bootstrap job has no publish/OIDC secrets (`secrets.` absent)
- [x] Confirm `.bazelrc` / docs forbid in-repo `--remote_cache`
- [ ] Docs-classified CI + `CI Gate` green on this PR head
- [ ] After merge, verify #3 closed and fill #3 merge SHA in evidence map if needed via follow-up comment


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788676592&installation_model_id=20486&pr_number=428&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F428&signature=c93c014da234ae66bac8a84eb4aef04c083b7018dc3fc3197420c62abfe1dbbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Bazel developer guide and #1 close-readiness evidence map to docs
> - Adds [bazel.md](https://github.com/CurateLabs/graphforge/pull/428/files#diff-a7e1adb0ba1fac3f10085902e4c8c3f553e3a5aa52386bbb43f61cb8743c7e3a) as the primary developer guide covering installation, local commands, extending the build graph, cache metrics, CI/release runbooks, and security constraints.
> - Adds [bazel-migration-ac-evidence.md](https://github.com/CurateLabs/graphforge/pull/428/files#diff-d4ad77f5c9eb6700d3196f42a1104a3f0803af6fd54c4d7d553cdecad1d63f9d) as a checked-in close-readiness map tying #1 acceptance criteria to child issues, PRs, and merge SHAs.
> - Updates [OBSERVABILITY.md](https://github.com/CurateLabs/graphforge/pull/428/files#diff-298b7b737ea1bb24f96071780f132a0653dc776c842bb489c00715534763cf97) with Bazel CI correctness and remote-cache health as observable outcomes, including dashboard/alert guidance.
> - Updates [release-process.md](https://github.com/CurateLabs/graphforge/pull/428/files#diff-9da68aeac1b6ee3aea9fb0e1673e7258280029d3ac7f8b30efbc5ad71abdd7ef) to explicitly state that Bazel owns CI Rust compilation and that publish credentials must never appear in cacheable Bazel actions.
> - Cross-links all existing migration docs (bootstrap, cutover, parity, orchestration) and [ARCHITECTURE.md](https://github.com/CurateLabs/graphforge/pull/428/files#diff-71cf9b9a44c354eb9240618a18231f96a5d1a344d1eced06b3d4f6d5db17fefc) to the new guides, replacing outdated 'Next' sections.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 35e31b4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->