### PR TITLE
fix(ci): resilient clean-env URL probes for #186

### DIFF
--- a/docs/development/clean-environment-verification.md
+++ b/docs/development/clean-environment-verification.md
@@ -18,7 +18,7 @@ artifacts.
 | `skills` | #182 | Install `@curatelabs/graphforge-agent-skills@<version>` + offline `compatibility --json` |
 | `cargo` | #185 | Add all 15 `graphforge-*` crates at `<version>` and compile a clean consumer |
 | `reopen` | #184 | Create/close/reopen project; Arrow rows survive reopen |
-| `urls` | #186 | Published docs + package/registry URLs resolve |
+| `urls` | #186 | Published docs, licensing, and package/registry URLs resolve (human HTML pages optional when CDNs block bots) |
 | `checksums` | #187 | Registry digests match `graphforge-release-record-v1` |
 
 Close each child only with commands + outcomes (or an explicit disposition). The

--- a/scripts/ci/clean-env-verify.py
+++ b/scripts/ci/clean-env-verify.py
@@ -73,10 +73,38 @@ def utc_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
 
 
+# crates.io HTML pages reject the programmatic UA with 404; npmjs.com often
+# returns 403 to datacenter clients. Prefer registry/API URLs for package
+# identity, and use a browser-like UA only when probing human HTML hosts.
+BROWSER_LIKE_UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/120.0.0.0 Safari/537.36"
+)
+PROGRAMMATIC_UA = "graphforge-clean-env-verify/1.0"
+HTML_HOST_SUFFIXES = (
+    "crates.io",
+    "www.npmjs.com",
+    "docs.graphforge.sh",
+    "github.com",
+    "pypi.org",
+)
+
+
+def _user_agent_for(url: str) -> str:
+    host = urlparse(url).hostname or ""
+    if any(host == suffix or host.endswith("." + suffix) for suffix in HTML_HOST_SUFFIXES):
+        return BROWSER_LIKE_UA
+    return PROGRAMMATIC_UA
+
+
 def default_fetcher(url: str, timeout: float = 30.0) -> tuple[int, bytes, dict[str, str]]:
     request = urllib.request.Request(
         url,
-        headers={"User-Agent": "graphforge-clean-env-verify/1.0"},
+        headers={
+            "User-Agent": _user_agent_for(url),
+            "Accept": "*/*",
+        },
         method="GET",
     )
     try:
@@ -209,15 +237,21 @@ def registry_urls(version: str, crates: tuple[str, ...], docs_base: str) -> dict
     urls = {
         "pypi_json": f"https://pypi.org/pypi/graphforge/{version}/json",
         "pypi_project": f"https://pypi.org/project/graphforge/{version}/",
+        # Registry version documents are the anonymous, bot-reachable package
+        # links. www.npmjs.com often 403s datacenter clients even for published
+        # packages; human browsers still resolve the marketing pages.
         "npm_node": f"https://registry.npmjs.org/@curatelabs/graphforge/{version}",
         "npm_node_page": f"https://www.npmjs.com/package/@curatelabs/graphforge/v/{version}",
         "npm_cli": f"https://registry.npmjs.org/@curatelabs/graphforge-cli/{version}",
         "npm_cli_page": f"https://www.npmjs.com/package/@curatelabs/graphforge-cli/v/{version}",
         "npm_skills": f"https://registry.npmjs.org/@curatelabs/graphforge-agent-skills/{version}",
         "npm_skills_page": f"https://www.npmjs.com/package/@curatelabs/graphforge-agent-skills/v/{version}",
+        "docs_home": f"{docs}/",
         "docs_quickstart": f"{docs}/guide/quickstart/",
         "docs_installation": f"{docs}/guide/installation/",
+        "docs_licensing": f"{docs}/legal/licensing/",
         "github_release": (f"https://github.com/CurateLabs/graphforge/releases/tag/v{version}"),
+        "github_license": "https://github.com/CurateLabs/graphforge/blob/main/LICENSE",
     }
     for crate in crates:
         urls[f"crates_{crate}"] = f"https://crates.io/api/v1/crates/{crate}/{version}"
@@ -545,33 +579,63 @@ def lane_cargo(ctx: Context) -> LaneResult:
 
 
 def lane_urls(ctx: Context) -> LaneResult:
+    """Resolve anonymous docs + package links for the published version.
+
+    Required checks use bot-reachable endpoints (docs, PyPI project page,
+    npm registry version documents, crates.io API version documents, GitHub
+    Release, licensing). Optional human HTML pages (www.npmjs.com, crates.io
+    crate pages) are probed when reachable and recorded as notes when a CDN
+    blocks automation — they do not fail the lane when the registry document
+    for the same package already resolved.
+    """
     result = LaneResult(name="urls", issue=LANE_ISSUES["urls"], ok=False)
     urls = registry_urls(ctx.version, ctx.crates, ctx.docs_base)
-    keys = [
+    required = [
+        "docs_home",
         "docs_quickstart",
         "docs_installation",
+        "docs_licensing",
         "pypi_project",
+        "npm_node",
+        "npm_cli",
+        "npm_skills",
+        "github_release",
+        "github_license",
+        *[f"crates_{crate}" for crate in ctx.crates],
+    ]
+    optional_html = [
         "npm_node_page",
         "npm_cli_page",
         "npm_skills_page",
-        "github_release",
         *[f"crates_page_{crate}" for crate in ctx.crates],
     ]
     resolved: dict[str, int] = {}
     failures: list[str] = []
-    for key in keys:
+    optional_blocked: list[str] = []
+    for key in required + optional_html:
         url = urls[key]
         status, _, _ = ctx.fetch(url)
         resolved[key] = status
         result.commands.append(f"GET {url}")
-        if status >= 400:
+        if key in required and status >= 400:
             failures.append(f"{key} -> {status}")
+        elif key in optional_html and status >= 400:
+            optional_blocked.append(f"{key} -> {status}")
     result.artifacts["statuses"] = resolved
+    if optional_blocked:
+        result.notes.append(
+            "optional human HTML pages blocked for this client (CDN/bot policy); "
+            "registry/API counterparts already required: " + ", ".join(optional_blocked)
+        )
     if failures:
         result.error = "URL resolve failures: " + ", ".join(failures)
         return result
     result.ok = True
-    result.notes.append(f"resolved {len(keys)} docs/package URLs")
+    optional_ok = len(optional_html) - len(optional_blocked)
+    note = f"resolved {len(required)} required docs/package URLs"
+    if optional_html:
+        note += f"; {optional_ok} optional HTML ok"
+    result.notes.append(note)
     return result
 
 

--- a/scripts/ci/test-clean-env-verify.py
+++ b/scripts/ci/test-clean-env-verify.py
@@ -184,6 +184,31 @@ def test_urls_lane_reports_failures() -> None:
         assert result.error and "docs_quickstart" in result.error
 
 
+def test_urls_lane_tolerates_optional_html_cdn_blocks() -> None:
+    def fetch(url: str) -> tuple[int, bytes, dict[str, str]]:
+        if "www.npmjs.com" in url or url.startswith("https://crates.io/crates/"):
+            return 403, b"blocked", {}
+        return 200, b"ok", {}
+
+    with tempfile.TemporaryDirectory() as tmp:
+        ctx = cev.Context(
+            version="0.5.2",
+            work_root=Path(tmp),
+            docs_base=cev.DEFAULT_DOCS_BASE,
+            crates=("graphforge-api",),
+            release_record=None,
+            fetch=fetch,
+            run_cmd=cev.run_subprocess,
+            allow_network_install=False,
+        )
+        result = cev.lane_urls(ctx)
+        assert result.ok is True
+        assert any("optional human HTML" in note for note in result.notes)
+        assert result.artifacts["statuses"]["npm_node"] == 200
+        assert result.artifacts["statuses"]["crates_graphforge-api"] == 200
+        assert result.artifacts["statuses"]["docs_licensing"] == 200
+
+
 def test_checksums_match_release_record() -> None:
     record = sample_record()
 


### PR DESCRIPTION
## Summary
- Make the clean-env `urls` lane require bot-reachable docs, licensing, PyPI, npm registry, crates.io API, and GitHub Release/License URLs.
- Treat www.npmjs.com / crates.io HTML pages as optional when CDNs block automation; record blocked optional pages as notes instead of failing closed.
- Use a browser-like User-Agent for human HTML hosts; add a unit test for optional CDN blocks.

Closes none directly (evidence comments on #186 follow after merge + re-verify). Supports #186 / #167.

## Test plan
- [x] `python3 scripts/ci/test-clean-env-verify.py`
- [x] `python3 scripts/ci/clean-env-verify.py run --version 0.5.2 --lane urls` → `ok: true`
- [ ] CI Gate green on this PR

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788709319&installation_model_id=20486&pr_number=429&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F429&signature=05efcaf1ec7cbcef1819b43509556d159063e44c13b0db5a390c99080171fff2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved URL verification by using browser-like or programmatic request behavior based on the destination.
  - Added checks for registry, API, documentation, and licensing endpoints.
  - Verification now succeeds when optional human-facing pages are blocked, while recording their status and notes.

- **Tests**
  - Added coverage for blocked HTML pages to ensure required service checks remain reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make URL probes in the CI `urls` lane resilient to CDN bot-blocking
> - Splits probed URLs into `required` (registry/API endpoints, docs home, licensing, GitHub release/license) and `optional_html` (www.npmjs.com and crates.io HTML pages that CDNs may block).
> - Adds `_user_agent_for` in [clean-env-verify.py](https://github.com/CurateLabs/graphforge/pull/429/files#diff-e3d9e60251ea05fe4384401a204098ca35bef1d9b322b0fd3a0039637ae0df81) to send a browser-like UA for known human HTML hosts and a programmatic UA for API/registry endpoints; also adds `Accept: */*` to all requests.
> - Failures on optional HTML URLs are recorded as notes rather than lane failures, so the `urls` lane passes when CDN/bot blocks return 4xx.
> - Adds `docs_home`, `docs_licensing`, and `github_license` as newly required URLs in the probe set.
> - Behavioral Change: the `urls` lane now passes in environments where npmjs.com or crates.io HTML pages return 403, provided all required API/registry URLs resolve.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e97f22c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->