### PR TITLE
docs(release): v0.5.2 badges, roadmap, and retrospective (#188/#189)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,13 @@
 <p align="center">
   <a href="https://pypi.org/project/graphforge/"><img src="https://img.shields.io/pypi/v/graphforge.svg?label=PyPI&logo=pypi" alt="PyPI version" /></a>
   <a href="https://www.npmjs.com/package/@curatelabs/graphforge"><img src="https://img.shields.io/npm/v/%40curatelabs/graphforge.svg?label=npm&logo=npm" alt="npm version" /></a>
+  <a href="https://www.npmjs.com/package/@curatelabs/graphforge-cli"><img src="https://img.shields.io/npm/v/%40curatelabs%2Fgraphforge-cli.svg?label=CLI&logo=npm" alt="CLI npm version" /></a>
+  <a href="https://www.npmjs.com/package/@curatelabs/graphforge-agent-skills"><img src="https://img.shields.io/npm/v/%40curatelabs%2Fgraphforge-agent-skills.svg?label=skills&logo=npm" alt="agent-skills npm version" /></a>
+  <a href="https://github.com/CurateLabs/graphforge/releases/latest"><img src="https://img.shields.io/github/v/release/CurateLabs/graphforge?label=GitHub%20Release&logo=github" alt="GitHub Release" /></a>
   <a href="#installation"><img src="https://img.shields.io/badge/Python-3.10%2B-3776AB.svg?logo=python&logoColor=white" alt="Python 3.10 or newer" /></a>
   <a href="crates/graphforge-bindings-node"><img src="https://img.shields.io/badge/Node.js-20%2B-5FA04E.svg?logo=nodedotjs&logoColor=white" alt="Node.js 20 or newer" /></a>
   <a href="rust-toolchain.toml"><img src="https://img.shields.io/badge/Rust-1.96-000000.svg?logo=rust&logoColor=white" alt="Rust 1.96" /></a>
-  <a href="https://github.com/CurateLabs/graphforge/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/CurateLabs/graphforge/test.yml?branch=main&label=CI&logo=github" alt="Test Suite status" /></a>
+  <a href="https://github.com/CurateLabs/graphforge/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/CurateLabs/graphforge/test.yml?branch=main&label=CI%20Gate&logo=github" alt="CI Gate status" /></a>
   <a href="https://docs.graphforge.sh/"><img src="https://img.shields.io/badge/docs-online-0A66C2.svg" alt="Documentation" /></a>
   <a href="https://docs.graphforge.sh/reference/tck-compliance/"><img src="https://img.shields.io/badge/openCypher%20TCK-3897%2F3897-brightgreen.svg" alt="openCypher TCK" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="Apache License 2.0" /></a>
@@ -339,8 +342,8 @@ heads and stale commits before any platform matrix build starts.
 
 | Version | Focus | Status |
 |---------|-------|--------|
-| **v0.5.1** | Coordinated release across crates, PyPI, npm, CLI, and docs | **Current** |
-| v0.5.x | Swift + Kotlin bindings (UniFFI) and follow-on surfaces | Planned |
+| **v0.5.2** | Coordinated release across crates, PyPI, npm, CLI, skills, and docs | **Current** |
+| v0.5.x | Follow-on surfaces (mobile bindings abandoned for now) | Planned |
 | v1.0 | Long-term API stability commitment | Future |
 
 **Next steps:** [install](docs/guide/installation.md) → [quick start](docs/guide/quickstart.md)

--- a/docs/releases/roadmap.md
+++ b/docs/releases/roadmap.md
@@ -1,7 +1,7 @@
 # GraphForge Roadmap
 
-**Last Updated:** 2026-08-01
-**Current release line:** v0.5.1 (see [installation](../guide/installation.md))
+**Last Updated:** 2026-08-07
+**Current release line:** v0.5.2 (see [installation](../guide/installation.md))
 
 ---
 
@@ -9,27 +9,36 @@
 
 This roadmap describes **product surfaces and versions**, not internal delivery
 milestones. Where a GitHub milestone name appears elsewhere in operator docs
-(for example **M1** for the coordinated v0.5.1 publication), it is paired with
+(for example **M1** for the coordinated v0.5.x publication), it is paired with
 plain-language purpose there; this page stays version- and outcome-oriented.
 
 ---
 
-## v0.5.1 — Coordinated release (current)
+## v0.5.2 — Coordinated release (current)
 
-GraphForge **v0.5.1** is the current coordinated release across Rust crates,
+GraphForge **v0.5.2** is the current coordinated release across Rust crates,
 PyPI, npm bindings/CLI/skills, and public docs. Install from the published
-packages (see [installation](../guide/installation.md)). The incomplete v0.5.0
-registry publication remains documented historical incident evidence and is not
-the completion target.
+packages (see [installation](../guide/installation.md)).
+
+- GitHub Release: https://github.com/CurateLabs/graphforge/releases/tag/v0.5.2
+- PyPI: https://pypi.org/project/graphforge/0.5.2/
+- npm: `@curatelabs/graphforge`, `@curatelabs/graphforge-cli`,
+  `@curatelabs/graphforge-agent-skills` at `0.5.2`
+- Docs: https://docs.graphforge.sh/
 
 Capability surface matches the shipped v0.5 engine: openCypher, seven
 analyst-intent verbs, Parquet projects, and thin Python/Node bindings.
 
-Swift and Kotlin UniFFI bindings remain **planned** after this coordinated
-release; they are not part of the v0.5.1 core package set.
+Mobile bindings (Swift/Kotlin/UniFFI) are **not** part of the current core
+package set.
 
 See [Publishing](../engineering/PUBLISHING.md) for artifact destinations and
 [release process](../development/release-process.md) for operator sequence.
+
+### Prior coordinated line
+
+**v0.5.1** was the first complete coordinated registry publication after the
+incomplete v0.5.0 surface. Prefer v0.5.2 for new installs.
 
 ---
 

--- a/docs/releases/v0.5-retrospective.md
+++ b/docs/releases/v0.5-retrospective.md
@@ -1,0 +1,62 @@
+# v0.5.x release retrospective
+
+Short post-release notes for the GraphForge v0.5.0 → v0.5.2 publication and
+clean-environment verification track (#167 / #189). This is not an incident
+postmortem.
+
+## What worked
+
+- **Rust-owned behavior stayed the product boundary.** Python/Node remained thin
+  bindings; Binding RC and publication gates exercised real natives.
+- **Immutable candidate digests (`graphforge-release-candidate-v2`)** gave a
+  single checksum authority that clean-env verification could compare against
+  public registry digests (#187).
+- **Fail-closed clean-env harness** (`scripts/ci/clean-env-verify.py`) refused to
+  green-check unpublished surfaces; that prevented false closeouts during the
+  incomplete v0.5.0 publish.
+- **Corrective releases (v0.5.1, then v0.5.2)** recovered a full PyPI + npm
+  (node/CLI/skills) + crates.io surface without silently replacing v0.5.0 bytes.
+- **Apache-2.0 package metadata** on published surfaces names
+  `CurateLabs/graphforge` (#218 / #191).
+
+## What should change
+
+| Area | Observation | Follow-up |
+| --- | --- | --- |
+| Scope control | Issue titles and child ACs stayed pinned to `v0.5.0` while the complete public surface landed at `0.5.1`/`0.5.2`, creating verify ambiguity. | Prefer “current coordinated release” wording for post-release verify umbrellas; keep exact-version checks in the harness CLI. Existing: #167 children closed against `0.5.2` with disposition comments. |
+| Transaction / recovery | Publication recovery needed multiple corrective versions rather than one clean first publish. | Keep fail-closed registry observation + recovery planning (`release_registry.py`); do not weaken acceptance. No new issue — process already documented in `publication-order.md`. |
+| CI / release gates | Clean-env URL probes treated CDN-blocked human HTML pages as hard failures even when registry documents resolved. | Fixed in the clean-env URLs lane (#186 / PR for resilient probes). |
+| Registry publication | v0.5.0 shipped PyPI + npm node only; CLI/skills/crates arrived later. | Treat “coordinated surface complete” as the post-release verify gate, not the first tag alone. Declined as a separate issue — already encoded by M1 corrective releases. |
+
+## Release blockers vs optional improvements
+
+**Blockers that delayed honest clean-env closeout**
+
+- Incomplete v0.5.0 registry surface (missing CLI, skills, crates).
+- Need for a machine-readable release digest attached to the GitHub Release.
+- Bot/CDN friction on www.npmjs.com / crates.io HTML (mitigated by requiring
+  registry/API URLs).
+
+**Optional post-release improvements (not release blockers)**
+
+- External announcement in maintainer-selected channels (#188 AC3) — human-only.
+- Historical docs that still cite transferred `graphforge-legecy` PR numbers —
+  archive citations only; package metadata already canonical (#191).
+- Mobile / UniFFI bindings — explicitly out of current milestones.
+
+## Verification evidence pointer
+
+Clean-environment evidence for the current coordinated release `0.5.2` was
+produced with:
+
+```bash
+python3 scripts/ci/clean-env-verify.py run \
+  --version 0.5.2 \
+  --lane pip --lane npm --lane cli --lane skills --lane reopen \
+  --lane urls --lane checksums \
+  --release-record path/to/v0.5.2-digest.json \
+  --output build/clean-env-evidence-0.5.2.json
+```
+
+Lane outcomes: pip, npm, cli, skills, reopen, checksums, and urls succeeded
+against public registries (see issue comments on #180–#187 / #167).


### PR DESCRIPTION
## Summary
- Expand README badges to live PyPI, npm (node/CLI/skills), GitHub Release, docs, and Apache-2.0 links (no retired repo names).
- Mark **v0.5.2** as the current coordinated release on the product roadmap with canonical package URLs.
- Add `docs/releases/v0.5-retrospective.md` for #189 (what worked / what to change / blockers vs optional).

Closes #189.

## Partial notes for #188
Docs/badge AC covered here; **external announcement remains human-only** — do not close #188 until maintainer channels are posted.

## Test plan
- [x] Badge URLs resolve (PyPI/npm/GitHub Release/docs/LICENSE)
- [x] Retrospective links follow-ups to existing issues or explicit declines
- [ ] CI Gate green