### PR TITLE
ci: fail-closed change classifier for Bazel test data

### DIFF
--- a/scripts/ci/classify-changes.sh
+++ b/scripts/ci/classify-changes.sh
@@ -35,6 +35,25 @@ enable_all() {
   bazel=true
 }
 
+# Paths that do not affect CI Gate suites. Anything else unmatched must
+# fail closed via enable_all so Bazel-mapped test data cannot merge untested.
+is_inert_path() {
+  case "$1" in
+    *.md | *.mdx | *.txt | \
+      LICENSE | LICENSE-* | NOTICE | NOTICE-* | THIRD_PARTY* | AUTHORS | \
+      CHANGELOG* | CODE_OF_CONDUCT* | SECURITY.md | RELEASING.md | \
+      AGENTS.md | CONTRIBUTING.md | \
+      .github/*.md | .github/ISSUE_TEMPLATE/* | .github/PULL_REQUEST_TEMPLATE* | \
+      .github/CODEOWNERS | .editorconfig | .gitignore | .gitattributes | \
+      .mailmap)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 # Cargo package metadata does not affect compiled behavior. Treat a manifest
 # edit as metadata-only only when both revisions exist and every changed line is
 # a recognized packaging field. Dependency, feature, profile, or target edits
@@ -241,6 +260,34 @@ while IFS= read -r -d '' path; do
       bindings=true
       pulumi=true
       terraform=true
+      ;;
+
+    # Bazel-mapped hermetic test data (resource_inputs / filegroups). These are
+    # not *.rs, so they must be classified explicitly or they would fall through
+    # to the fail-closed default below.
+    tests/tck/* | tests/tck/**/* | \
+      tests/release_workflows/* | tests/release_workflows/**/* | \
+      crates/*/tests/*goldens/* | crates/*/tests/*goldens/**/* | \
+      crates/*/tests/**/*.snap | \
+      crates/*/tests/fixtures/* | crates/*/tests/fixtures/**/* | \
+      crates/*/tests/corpus/* | crates/*/tests/corpus/**/* | \
+      docs/contracts/examples/* | docs/contracts/examples/**/* | \
+      docs/reference/* | docs/reference/**/*)
+      rust=true
+      bazel=true
+      ;;
+
+    examples/agent_grounding/* | examples/agent_grounding/**/*)
+      rust=true
+      bazel=true
+      bindings=true
+      ;;
+
+    *)
+      if ! is_inert_path "$path"; then
+        # Unknown / unmapped path: fail closed toward full validation.
+        enable_all
+      fi
       ;;
   esac
 done <"$changed_files"

--- a/scripts/ci/classify-policy-suites.sh
+++ b/scripts/ci/classify-policy-suites.sh
@@ -29,6 +29,25 @@ enable_all() {
   storage=true
 }
 
+# Policy suites only care about gate scripts/workflows. Docs and similar
+# prose stay inert; anything else unmatched fails closed.
+is_inert_path() {
+  case "$1" in
+    *.md | *.mdx | *.txt | \
+      LICENSE | LICENSE-* | NOTICE | NOTICE-* | THIRD_PARTY* | AUTHORS | \
+      CHANGELOG* | CODE_OF_CONDUCT* | SECURITY.md | RELEASING.md | \
+      AGENTS.md | CONTRIBUTING.md | \
+      .github/*.md | .github/ISSUE_TEMPLATE/* | .github/PULL_REQUEST_TEMPLATE* | \
+      .github/CODEOWNERS | .editorconfig | .gitignore | .gitattributes | \
+      .mailmap)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 emit() {
   printf 'contracts=%s\n' "$contracts"
   printf 'coverage_ledger=%s\n' "$coverage_ledger"
@@ -124,6 +143,11 @@ while IFS= read -r -d '' path; do
       ;;
     scripts/ci/test-ci-storage-policy.py | .github/workflows/*.yml | .github/workflows/*.yaml)
       storage=true
+      ;;
+    *)
+      if ! is_inert_path "$path"; then
+        enable_all
+      fi
       ;;
   esac
 done <"$changed_files"

--- a/scripts/ci/test-classify-changes.sh
+++ b/scripts/ci/test-classify-changes.sh
@@ -135,6 +135,22 @@ assert_classification "$bazel_only" \
   docs/development/bazel-migration-evidence/perf-sample.json bazel-cache-perf-evidence
 assert_classification "$none" "docs/a file with spaces.md" docs-only
 
+# Fail-closed: formerly inert Bazel-mapped test data must enable Rust+Bazel.
+assert_classification "$rust_only" \
+  tests/tck/features/clauses/match/Match1.feature tck-feature
+assert_classification "$rust_only" \
+  crates/graphforge-ir/tests/ir_goldens/golden__parameter.snap ir-golden-snap
+assert_classification "$rust_only" \
+  crates/graphforge-ontology/tests/fixtures/hr.json ontology-fixture
+assert_classification "$rust_only" \
+  crates/graphforge-cypher/tests/corpus/valid.json cypher-corpus
+assert_classification "$binding_rust" \
+  examples/agent_grounding/ecommerce_agent.ipynb grounding-notebook
+assert_classification "$rust_only" \
+  tests/release_workflows/atomic-recovery/workflow.feature release-workflow-feature
+# Unknown paths must fail closed toward full validation.
+assert_classification "$all" totally/unknown/path.xyz unknown-path
+
 # Packaging-only Cargo metadata must not compile the workspace.
 perl -0pi -e 's/license = "MIT"/license = "Apache-2.0"/' "$fixture/Cargo.toml"
 git -C "$fixture" add Cargo.toml

--- a/scripts/ci/test-classify-policy-suites.sh
+++ b/scripts/ci/test-classify-policy-suites.sh
@@ -43,6 +43,8 @@ assert_classification "$contracts" tests/contracts/m20-contract-matrix.json
 assert_classification "$coverage_ledger" scripts/coverage_rust_ledger.py
 assert_classification "$storage" .github/workflows/docs.yml
 assert_classification "$all" .github/workflows/test.yml
+# Unknown paths must fail closed toward full policy validation.
+assert_classification "$all" totally/unknown/path.xyz
 
 missing=$(cd "$fixture" && "$classifier" deadbeef HEAD)
 [[ "$missing" == "$all" ]] || {


### PR DESCRIPTION
## Summary
- Invert the path classifier so unmatched non-allowlisted paths fail closed (`enable_all`)
- Explicitly classify Bazel-mapped test data (TCK, goldens/snaps, fixtures, corpus, notebooks, release workflows)
- Mirror the same fail-closed default in the Repository Policy suite classifier
- Add regression coverage for formerly inert families and unknown paths

## Test plan
- [x] `scripts/ci/test-classify-changes.sh`
- [x] `scripts/ci/test-classify-policy-suites.sh`
- [ ] CI Gate green on exact head

Closes #432

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788711877&installation_model_id=20486&pr_number=433&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F433&signature=62b1a4afdd860ab8cbe0831969cabe1e8047f7bbcbb4d2c6e48dcbff18a1b43d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add fail-closed behavior to CI change classifiers for Bazel test data paths
> - Unknown, non-inert paths in [`classify-changes.sh`](https://github.com/CurateLabs/graphforge/pull/433/files#diff-9c479d4633de98cfc5884f3f7fd84e5abbd292370078443e7958f023d5a056f1) and [`classify-policy-suites.sh`](https://github.com/CurateLabs/graphforge/pull/433/files#diff-f7e796d328a74a8873c6ae99c9836e8f9dbd11b8dfc2663b5ca3567c62093ab3) now call `enable_all`, forcing full validation instead of silently skipping.
> - A new `is_inert_path` helper identifies non-code paths (docs, licenses, templates, git config) so they are excluded from the fail-closed fallback.
> - Bazel-mapped hermetic test data paths (`tests/tck`, `*.snap`, `fixtures`, `corpus`, etc.) are now explicitly classified as `rust=true` and `bazel=true`.
> - `examples/agent_grounding/*` paths additionally enable `bindings=true`.
> - Tests in [`test-classify-changes.sh`](https://github.com/CurateLabs/graphforge/pull/433/files#diff-b0cf9ea62c36d41efe27b93e7d80500212baff24baf9ff35652d79e540ee6c61) and [`test-classify-policy-suites.sh`](https://github.com/CurateLabs/graphforge/pull/433/files#diff-8aa354f3da8e15d3810ef012fd5f93dca65118a36455cb01e97b7b7165d5ab86) verify the new fail-closed and classification behavior.
> - Behavioral Change: any previously unclassified non-inert path now triggers all CI validation suites instead of none.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 41f7ed0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->