### PR TITLE
ci: remove outage-era workflow_dispatch from Test Suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,6 @@ name: Test Suite
 on:
   pull_request:
     branches: ["main"]
-  # Temporary API trigger path while Actions webhooks are throttled (outage).
-  # Prefer pull_request events when they deliver; dispatch reads the branch ref.
-  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Remove temporary `workflow_dispatch` from Test Suite added during the Actions outage
- Required CI Gate must only run on pull_request merge refs

## Test plan
- [ ] Confirm `test.yml` has no `workflow_dispatch`
- [ ] CI Gate green on exact head

Closes #

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788711897&installation_model_id=20486&pr_number=435&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F435&signature=9fbc27a01e26bf090c4f2c12ebe608169798eff9dbef8b46cc07dc3885259422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `workflow_dispatch` trigger from CI test suite
> Removes the `workflow_dispatch` trigger added during an outage from [test.yml](.github/workflows/test.yml), so the test suite only runs on pull requests targeting `main`. Behavioral Change: the workflow can no longer be manually triggered from the GitHub Actions UI.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 05663ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->