### PR TITLE
release: npm trusted publishing + provenance

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -284,13 +284,14 @@ jobs:
     permissions:
       actions: read
       contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ needs.candidate-preflight.outputs.release_sha }}
       - uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: https://registry.npmjs.org
       - name: Download manifest and npm partition
         env:
@@ -332,12 +333,10 @@ jobs:
       - name: Publish one exact native tarball
         if: steps.authorize.outputs.publish == 'true'
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           RELEASE_SHA: ${{ needs.candidate-preflight.outputs.release_sha }}
           RELEASE_VERSION: ${{ needs.candidate-preflight.outputs.release_version }}
           MANIFEST_NAME: ${{ needs.candidate-preflight.outputs.manifest_name }}
         run: |
-          npm whoami
           python3 scripts/publish_npm_artifacts.py --release-record "candidate/$MANIFEST_NAME" --artifacts-dir candidate/release-artifacts --expected-sha "$RELEASE_SHA" --version "$RELEASE_VERSION" --package "@curatelabs/${{ matrix.package }}"
       - name: Observe native npm once after an accepted write
         if: steps.authorize.outputs.publish == 'true'
@@ -362,13 +361,14 @@ jobs:
     permissions:
       actions: read
       contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ needs.candidate-preflight.outputs.release_sha }}
       - uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: https://registry.npmjs.org
       - name: Download manifest and npm partition
         env:
@@ -408,12 +408,10 @@ jobs:
       - name: Publish exact npm main tarball once
         if: steps.authorize.outputs.publish == 'true'
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           RELEASE_SHA: ${{ needs.candidate-preflight.outputs.release_sha }}
           RELEASE_VERSION: ${{ needs.candidate-preflight.outputs.release_version }}
           MANIFEST_NAME: ${{ needs.candidate-preflight.outputs.manifest_name }}
         run: |
-          npm whoami
           python3 scripts/publish_npm_artifacts.py --release-record "candidate/$MANIFEST_NAME" --artifacts-dir candidate/release-artifacts --expected-sha "$RELEASE_SHA" --version "$RELEASE_VERSION" --package @curatelabs/graphforge
       - name: Observe npm main once after an accepted write
         if: steps.authorize.outputs.publish == 'true'
@@ -437,18 +435,18 @@ jobs:
     permissions:
       actions: read
       contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ needs.candidate-preflight.outputs.release_sha }}
       - uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: https://registry.npmjs.org
       - name: Download, authorize, and publish CLI if absent
         env:
           GH_TOKEN: ${{ github.token }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           RUN_ID: ${{ needs.candidate-preflight.outputs.candidate_run_id }}
           RELEASE_SHA: ${{ needs.candidate-preflight.outputs.release_sha }}
           RELEASE_VERSION: ${{ needs.candidate-preflight.outputs.release_version }}
@@ -467,7 +465,6 @@ jobs:
             attempt="v$RELEASE_VERSION-attempt-npm-graphforge-cli.json"
             python3 scripts/ci/release_action.py attempt --manifest "candidate/$MANIFEST_NAME" --node npm:@curatelabs/graphforge-cli --started-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --out "$attempt"
             gh release upload "$RELEASE_TAG" "$attempt" --clobber
-            npm whoami
             python3 scripts/publish_npm_artifacts.py --release-record "candidate/$MANIFEST_NAME" --artifacts-dir candidate/release-artifacts --expected-sha "$RELEASE_SHA" --version "$RELEASE_VERSION" --package @curatelabs/graphforge-cli
             accepted_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
             receipt="v$RELEASE_VERSION-accepted-npm-graphforge-cli.json"
@@ -484,18 +481,18 @@ jobs:
     permissions:
       actions: read
       contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ needs.candidate-preflight.outputs.release_sha }}
       - uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: https://registry.npmjs.org
       - name: Download, authorize, and publish skills if absent
         env:
           GH_TOKEN: ${{ github.token }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           RUN_ID: ${{ needs.candidate-preflight.outputs.candidate_run_id }}
           RELEASE_SHA: ${{ needs.candidate-preflight.outputs.release_sha }}
           RELEASE_VERSION: ${{ needs.candidate-preflight.outputs.release_version }}
@@ -514,7 +511,6 @@ jobs:
             attempt="v$RELEASE_VERSION-attempt-npm-graphforge-agent-skills.json"
             python3 scripts/ci/release_action.py attempt --manifest "candidate/$MANIFEST_NAME" --node npm:@curatelabs/graphforge-agent-skills --started-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --out "$attempt"
             gh release upload "$RELEASE_TAG" "$attempt" --clobber
-            npm whoami
             python3 scripts/publish_npm_artifacts.py --release-record "candidate/$MANIFEST_NAME" --artifacts-dir candidate/release-artifacts --expected-sha "$RELEASE_SHA" --version "$RELEASE_VERSION" --package @curatelabs/graphforge-agent-skills
             accepted_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
             receipt="v$RELEASE_VERSION-accepted-npm-graphforge-agent-skills.json"

--- a/.github/workflows/release-credential-preflight.yml
+++ b/.github/workflows/release-credential-preflight.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   credentials:
-    name: Verify projected npm credential
+    name: Verify npm trusted-publishing contract
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v7
@@ -32,15 +32,41 @@ jobs:
           test "$REQUESTED_SHA" = "$(git rev-parse refs/remotes/origin/main)"
           test "$REQUESTED_SHA" = "$(git rev-parse HEAD)"
 
-      - uses: actions/setup-node@v7
-        with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
+      - name: Require npm OIDC jobs and no long-lived npm token
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
 
-      - name: Verify npm token identity
-        run: npm whoami
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          workflow = Path(".github/workflows/publish.yaml").read_text(encoding="utf-8")
+          publisher = Path("scripts/publish_npm_artifacts.py").read_text(encoding="utf-8")
+          markers = {
+              "npm-native": ("  npm-native:\n", "\n  npm-main:\n"),
+              "npm-main": ("  npm-main:\n", "\n  npm-cli:\n"),
+              "npm-cli": ("  npm-cli:\n", "\n  npm-skills:\n"),
+              "npm-skills": ("  npm-skills:\n", "\n  publish-crates:\n"),
+          }
+          # Avoid embedding retired secret/env names as contiguous literals in this file.
+          retired_secret = "secrets." + "NPM" + "_TOKEN"
+          retired_env = "NODE_" + "AUTH" + "_TOKEN"
+          for job, (start, end) in markers.items():
+              body = workflow.split(start, 1)[1].split(end, 1)[0]
+              if "id-token: write" not in body:
+                  raise SystemExit(f"{job}: missing id-token: write")
+              if retired_secret in body or retired_env in body:
+                  raise SystemExit(f"{job}: must not project a long-lived npm token")
+              if 'node-version: "24"' not in body:
+                  raise SystemExit(f"{job}: trusted publishing requires Node 24 (npm >= 11.5.1)")
+              print(f"{job}: OIDC trusted-publishing contract ok")
+          if "--provenance" not in publisher:
+              raise SystemExit("publish_npm_artifacts.py must publish with --provenance")
+          if retired_env + " is required" in publisher:
+              raise SystemExit("publish_npm_artifacts.py must not require a long-lived npm token")
+          print("publisher: provenance OIDC path ok")
+          PY
 
       - name: Record non-publishing result
-        run: echo "npm credential projection succeeded; crates.io Trusted Publishing is verified in publish.yaml."
+        run: |
+          echo "npm trusted publishing is configured like PyPI/crates.io;"
+          echo "OIDC exchange and provenance are verified only when publish.yaml writes."
+          echo "Do not keep a long-lived npm registry token after the trusted-publisher cutover."

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,7 +10,8 @@ are in
 - The release version is aligned across every public package surface.
 - Normal PR CI is green on the intended `main` commit.
 - The retained partitioned candidate and offline rehearsal are complete.
-- The npm token and PyPI/crates.io trusted publishing are configured.
+- PyPI, crates.io, and npm trusted publishing are configured for
+  `publish.yaml` (OIDC; no long-lived `NPM_TOKEN`).
 - A maintainer has explicitly authorized the immutable tag, GitHub Release, and
   registry writes.
 

--- a/docs/development/publication-order.md
+++ b/docs/development/publication-order.md
@@ -37,9 +37,10 @@ Before a maintainer authorizes publication (publish-track or human close):
 4. `evidence/offline-rehearsal.json` proves the exact partitions passed clean
    Python, Node/native, CLI, and skills consumers and crate/dependency checks
    with zero registry writes.
-5. PyPI and crates.io trusted publishing are configured for
-   `CurateLabs/graphforge` and `publish.yaml`; the npm token has scoped
-   public-package write access and Bypass 2FA.
+5. PyPI, crates.io, and npm trusted publishing are configured for
+   `CurateLabs/graphforge` and `publish.yaml` (OIDC; no long-lived
+   `NPM_TOKEN`). Each of the eight `@curatelabs` npm packages must list that
+   workflow as a trusted publisher.
 6. The maintainer explicitly enables the immutable tag and GitHub Release
    identity. Implementation CI and ordinary issue close do not run Binding RC
    or the human-close cascade.
@@ -88,8 +89,8 @@ The independent work is:
 - PyPI may run independently with OIDC and the Python partition.
 - crates.io may run independently with its short-lived trusted-publishing token
   and the crates partition; crates remain in the checked topological order below.
-- the five native npm packages run as a fail-slow parallel matrix with only the
-  npm token and npm partition.
+- the five native npm packages run as a fail-slow parallel matrix with npm
+  trusted publishing (OIDC + provenance) and the npm partition.
 
 The npm dependency fan-in is strict:
 

--- a/docs/development/v0.5.0-release-operator-runbook.md
+++ b/docs/development/v0.5.0-release-operator-runbook.md
@@ -35,13 +35,17 @@ These account-level actions cannot be completed from repository automation:
 1. Confirm the publishing maintainer can create public packages in the owned
    npm organization `@curatelabs`. Do not publish the retired `@graphforge/*`
    candidate names.
-2. Create a granular npm token with read/write package and scope access to
-   `@curatelabs` and **Bypass 2FA** enabled. Store it without putting the value
-   on the command line:
+2. Configure an npm trusted publisher for **each** of the eight `@curatelabs`
+   packages (five natives, main, CLI, agent-skills), matching PyPI/crates:
 
-   ```bash
-   gh secret set NPM_TOKEN --repo CurateLabs/graphforge
-   ```
+   - owner: `CurateLabs`
+   - repository: `graphforge`
+   - workflow: `publish.yaml`
+   - environment: leave blank
+
+   After the first successful OIDC publish, delete any retired repo secret
+   `NPM_TOKEN` (`gh secret delete NPM_TOKEN --repo CurateLabs/graphforge`).
+   Do not create Bypass-2FA granular tokens for publication.
 
 3. Configure a PyPI pending trusted publisher for the not-yet-created
    `graphforge` project:
@@ -55,7 +59,8 @@ These account-level actions cannot be completed from repository automation:
    `CurateLabs/graphforge` and `publish.yaml`. The publication workflow obtains
    only short-lived tokens from GitHub Actions OIDC.
 
-The npm secret projection can then be tested without publishing:
+The in-repo npm trusted-publishing contract (OIDC permissions, no
+`NPM_TOKEN` projection) can be checked without publishing:
 
 ```bash
 RC_SHA="$(git rev-parse origin/main)"
@@ -65,9 +70,9 @@ gh workflow run release-credential-preflight.yml \
   -f commit_sha="$RC_SHA"
 ```
 
-Wait for `Release Credential Preflight` to pass. PyPI and crates.io validate
-their OIDC configurations only when the release publication job requests a
-token; either failure is a hard stop.
+Wait for `Release Credential Preflight` to pass. PyPI, crates.io, and npm
+validate their OIDC / trusted-publisher configurations only when the release
+publication job requests a token; any failure is a hard stop.
 
 ## 2. Freeze and certify one current-main SHA (automated, non-publishing)
 
@@ -166,8 +171,9 @@ gh release create v0.5.0 \
 
 Publishing the GitHub Release triggers `Publish to PyPI, npm, and crates.io`.
 Its preflight must resolve the successful, unexpired same-SHA candidate,
-revalidate every byte, verify npm identity, and attach
-`v0.5.0-artifacts.json` before the first registry write.
+revalidate every byte, and attach `v0.5.0-artifacts.json` before the first
+registry write. npm lanes authenticate with trusted publishing (OIDC) and
+publish provenance; they do not use `npm whoami` or `NPM_TOKEN`.
 
 Record the release URL and publication run URL on #194. Do not close registry
 issues merely because the workflow started.

--- a/docs/engineering/PUBLISHING.md
+++ b/docs/engineering/PUBLISHING.md
@@ -82,8 +82,8 @@ The release-event workflow runs `release-publish-preflight.py`, validates the
 complete partitioned candidate and offline rehearsal, and obtains fresh public
 registry truth before any registry write. The release tag must resolve to the
 reviewed `main` SHA, and Cargo, Python, Node, CLI, and skills versions must match
-the tag. `npm whoami` runs only in an npm write step so registry credentials
-remain isolated.
+the tag. npm write steps use trusted publishing (GitHub Actions OIDC) with
+provenance and do not project a long-lived `NPM_TOKEN`.
 
 Required TESTING.md gates (TCK, contract gates applicable to the release, binding RC evidence)
 must be green on the **same SHA** that is tagged for publication.

--- a/scripts/ci/test-publish-cli-contract.py
+++ b/scripts/ci/test-publish-cli-contract.py
@@ -33,7 +33,10 @@ def main() -> None:
         assert "--registry npm" in job
         assert job.count("release_action.py authorize") == 1
         assert job.count("scripts/publish_npm_artifacts.py") == 1
-        assert "secrets.NPM_TOKEN" in job
+        assert "id-token: write" in job
+        assert "secrets.NPM_TOKEN" not in job
+        assert "NODE_AUTH_TOKEN" not in job
+        assert 'node-version: "24"' in job
         assert not re.search(r"(?m)(?:^|\s|[;&|])sleep(?:\s|$)", job)
     print("publish CLI contract tests passed")
 

--- a/scripts/ci/test-publish-npm-artifacts.py
+++ b/scripts/ci/test-publish-npm-artifacts.py
@@ -59,4 +59,10 @@ assert publisher.GROUPS["skills"] == slice(7, 8)
 source = SCRIPT.read_text(encoding="utf-8")
 assert "time.sleep" not in source
 assert "while " not in source
+assert "--provenance" in source
+assert "NODE_AUTH_TOKEN is required" not in source
+# --package and --group both resume through publish_one (no direct publish_archive bypass).
+assert "for name in names:" in source
+assert "publish_one(by_name[name], args.artifacts_dir)" in source
+assert "if args.package:" not in source or "publish_archive(args.artifacts_dir" not in source
 print("publish npm artifact tests passed")

--- a/scripts/ci/test-release-publish-preflight.py
+++ b/scripts/ci/test-release-publish-preflight.py
@@ -85,16 +85,27 @@ assert "fail-fast: false" in native
 assert native.count("- graphforge-") == 5
 assert "needs: candidate-preflight" in native
 assert '--package "@curatelabs/${{ matrix.package }}"' in native
-assert "secrets.NPM_TOKEN" in native
+assert "id-token: write" in native
+assert "secrets.NPM_TOKEN" not in native
+assert "NODE_AUTH_TOKEN" not in native
 assert "secrets.CARGO_REGISTRY_TOKEN" not in native
 
 assert "needs: [candidate-preflight, npm-native]" in main
 assert "Require verified native fan-in and authorize main" in main
 assert "--node npm:@curatelabs/graphforge" in main
+assert "id-token: write" in main
+assert "secrets.NPM_TOKEN" not in main
+assert "NODE_AUTH_TOKEN" not in main
 assert "needs: [candidate-preflight, npm-main]" in cli
 assert "--node npm:@curatelabs/graphforge-cli" in cli
+assert "id-token: write" in cli
+assert "secrets.NPM_TOKEN" not in cli
+assert "NODE_AUTH_TOKEN" not in cli
 assert "needs: [candidate-preflight, npm-cli]" in skills
 assert "--node npm:@curatelabs/graphforge-agent-skills" in skills
+assert "id-token: write" in skills
+assert "secrets.NPM_TOKEN" not in skills
+assert "NODE_AUTH_TOKEN" not in skills
 
 assert "needs: candidate-preflight" in crates
 assert "timeout-minutes: 180" in crates
@@ -161,8 +172,11 @@ assert "gh release download" in write_evidence
 assert "sleep" not in write_evidence
 
 credential_workflow = CREDENTIAL_WORKFLOW.read_text(encoding="utf-8")
-assert "npm whoami" in credential_workflow
-assert "secrets.NPM_TOKEN" in credential_workflow
+assert "id-token: write" in credential_workflow
+assert "${{ secrets.NPM_TOKEN }}" not in credential_workflow
+assert "NODE_AUTH_TOKEN:" not in credential_workflow
+assert "npm whoami" not in credential_workflow
+assert "trusted-publishing" in credential_workflow
 assert "secrets.CARGO_REGISTRY_TOKEN" not in credential_workflow
 assert "crates-io-auth-action" not in credential_workflow
 for forbidden in ("npm publish", "uv publish", "cargo publish", "release:\n"):

--- a/scripts/publish_npm_artifacts.py
+++ b/scripts/publish_npm_artifacts.py
@@ -87,8 +87,9 @@ def archive_matches_integrity(path: Path, integrity: str) -> bool:
 
 
 def publish_archive(path: Path) -> None:
+    """Publish one retained tarball via npm trusted publishing (OIDC) + provenance."""
     subprocess.run(
-        ["npm", "publish", str(path), "--access", "public"],
+        ["npm", "publish", str(path), "--access", "public", "--provenance"],
         cwd=ROOT,
         check=True,
         env=os.environ.copy(),
@@ -125,9 +126,6 @@ def main(argv: list[str] | None = None) -> int:
     selection.add_argument("--group", choices=tuple(GROUPS))
     selection.add_argument("--package")
     args = parser.parse_args(argv)
-    if not os.environ.get("NODE_AUTH_TOKEN", "").strip():
-        print("NODE_AUTH_TOKEN is required", file=sys.stderr)
-        return 2
 
     candidate = load_candidate_module()
     try:
@@ -149,11 +147,7 @@ def main(argv: list[str] | None = None) -> int:
         print("requested npm package is outside the candidate", file=sys.stderr)
         return 2
     for name in names:
-        if args.package:
-            publish_archive(args.artifacts_dir / by_name[name]["path"])
-            print(f"{name}@{args.version}: accepted; public verification required")
-        else:
-            publish_one(by_name[name], args.artifacts_dir)
+        publish_one(by_name[name], args.artifacts_dir)
     return 0
 
 


### PR DESCRIPTION
## Summary
- Migrate `publish.yaml` npm jobs to OIDC trusted publishing (`id-token: write`, Node 24 for npm ≥ 11.5.1) and drop `NODE_AUTH_TOKEN` / `NPM_TOKEN` / `npm whoami`
- Publish retained tarballs with `--provenance` and route `--package` through integrity-resume (`publish_one`) so publish-once / attempt-receipt semantics stay intact
- Update credential preflight, contract tests, and release docs to document npm trusted publishing like PyPI/crates (no Bypass-2FA token)

Closes #438

## Human console steps (required before first OIDC npm publish)

On npmjs.com, add a GitHub Actions trusted publisher for **each** of these 8 packages → `CurateLabs` / `graphforge` / `publish.yaml` / environment blank:

1. `@curatelabs/graphforge-darwin-arm64`
2. `@curatelabs/graphforge-darwin-x64`
3. `@curatelabs/graphforge-linux-arm64-gnu`
4. `@curatelabs/graphforge-linux-x64-gnu`
5. `@curatelabs/graphforge-win32-x64-msvc`
6. `@curatelabs/graphforge`
7. `@curatelabs/graphforge-cli`
8. `@curatelabs/graphforge-agent-skills`

After a successful OIDC publish:

```bash
gh secret delete NPM_TOKEN --repo CurateLabs/graphforge
```

## Test plan
- [x] `python3 scripts/ci/test-publish-npm-artifacts.py`
- [x] `python3 scripts/ci/test-publish-cli-contract.py`
- [x] `python3 scripts/ci/test-release-publish-preflight.py`
- [ ] CI green on exact head SHA
- [ ] Maintainer configures the 8 npm trusted publishers before next publish-track run


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788712262&installation_model_id=20486&pr_number=441&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F441&signature=a28c74e2f81cd504675eb37b5fa9f3feb2ba12a8f269c20bc498818e3777890d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch npm publishing to OIDC trusted publishing with provenance
> - Replaces long-lived `NPM_TOKEN` / `NODE_AUTH_TOKEN` credentials with OIDC-based trusted publishing across all npm publish jobs in [publish.yaml](.github/workflows/publish.yaml).
> - Adds `--provenance` flag to `npm publish` in [publish_npm_artifacts.py](scripts/publish_npm_artifacts.py) and removes the `NODE_AUTH_TOKEN` requirement check from the script's `main` function.
> - Updates the credential preflight workflow to enforce the new contract: `id-token: write` permission, Node 24, no long-lived token references, and presence of `--provenance`.
> - Updates runbook and documentation to require npm trusted publisher configuration per `@curatelabs` package and to delete any stored `NPM_TOKEN` secret.
> - Behavioral Change: npm publish jobs no longer authenticate with a stored secret; OIDC exchange happens at publish time, so each package must be registered as a trusted publisher on npmjs.com or publishing will fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0a1c2d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->