### PR TITLE
ci: split bazel diagnostics out of required CI Gate path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -794,8 +794,9 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: changes
     if: needs.changes.outputs.bazel == 'true'
-    # Authoritative //:ci_rust_tests + diagnostic parity + cache observation.
-    timeout-minutes: 120
+    # Authoritative drift/ledger/tests/binding smokes only. Diagnostics live in
+    # bazel-diagnostics (not required by CI Gate).
+    timeout-minutes: 90
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -827,14 +828,14 @@ jobs:
           python3 scripts/ci/test-bazel-migration-ledger-check.py
           python3 scripts/ci/test-cargo-bazel-parity-check.py
 
-      - name: Blacksmith remote-cache policy + perf harness tests (#5)
+      - name: Blacksmith remote-cache policy + harness unit tests
         run: |
           # Do not set --remote_cache; Blacksmith injects repository cache.
+          # Strict evaluate of checked-in perf-sample.json is one-shot M2
+          # evidence (see bazel-migration-perf.md), not a live regression gate;
+          # observation/collect lives in bazel-diagnostics.
           python3 scripts/ci/bazel-cache-perf.py --mode policy
           python3 scripts/ci/test-bazel-cache-perf.py
-          # Strict evaluate: #5 evidence is complete (no --allow-pending).
-          python3 scripts/ci/bazel-cache-perf.py --mode evaluate \
-            --evidence docs/development/bazel-migration-evidence/perf-sample.json
 
       - name: Authoritative Bazel Rust tests + first-party libs/CLI/resources
         run: |
@@ -859,6 +860,27 @@ jobs:
             2>&1 | tee dist/bazel-binding-build.log
           python3 scripts/ci/test-assemble-bazel-binding-packages.py
 
+  bazel-diagnostics:
+    # Non-required: dual-build parity + cache observe/collect. Must not be in
+    # ci-gate needs. Fail closed on harness crashes (no fabricated JSON).
+    name: Bazel Diagnostics
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: changes
+    if: needs.changes.outputs.bazel == 'true'
+    timeout-minutes: 120
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install Bazelisk
+        run: |
+          sudo curl -fsSL \
+            "https://github.com/bazelbuild/bazelisk/releases/download/v1.26.0/bazelisk-linux-amd64" \
+            -o /usr/local/bin/bazelisk
+          sudo chmod +x /usr/local/bin/bazelisk
+          sudo ln -sf /usr/local/bin/bazelisk /usr/local/bin/bazel
+          bazelisk version
+
       - name: Same-SHA Cargo/Bazel dual-build parity (diagnostic, one release cycle)
         run: |
           # Cargo is no longer authoritative under CI Gate (#4). Keep same-SHA
@@ -879,18 +901,21 @@ jobs:
             --write dist/bazel-warm-observation.json
           python3 scripts/ci/bazel-cache-perf.py --mode affected-inputs \
             --write dist/bazel-affected-inputs.json
-          if [[ -f dist/bazel-representative-build.log ]]; then
-            python3 scripts/ci/bazel-cache-perf.py --mode parse-log \
-              --log dist/bazel-representative-build.log \
-              > dist/bazel-representative-build.summary.json || \
-              echo '{"remote_cache_hits":0,"raw":null}' > dist/bazel-representative-build.summary.json
-          else
-            echo '{"remote_cache_hits":0,"raw":null,"note":"missing build log"}' \
-              > dist/bazel-representative-build.summary.json
-          fi
+          # Representative build for log parse (fail closed; no fabricated hits).
+          bazelisk build \
+            //:bazel_smoke \
+            //:first_party_libs \
+            //:runtime_libs \
+            //:cli_bins \
+            //:resource_inputs \
+            //:release_bins 2>&1 | tee dist/bazel-representative-build.log
+          python3 scripts/ci/bazel-cache-perf.py --mode parse-log \
+            --log dist/bazel-representative-build.log \
+            > dist/bazel-representative-build.summary.json
           # Collect ≥10 cold/warm pairs only when remote hits are observed and
           # checked-in evidence is still incomplete. Skip the long loop when the
-          # org-admin remote cache is still inactive.
+          # org-admin remote cache is still inactive. Checked-in perf-sample.json
+          # is one-shot M2 evidence, not a live regression gate.
           status="$(python3 - <<'PY'
           import json
           from pathlib import Path
@@ -947,6 +972,8 @@ jobs:
           mod = importlib.util.module_from_spec(spec)
           assert spec.loader is not None
           spec.loader.exec_module(mod)
+          # One-shot M2 evidence evaluation for observation rollup only; not a
+          # required CI Gate regression gate.
           eval_payload = mod.evaluate_evidence(evidence)
           evidence["gates"] = {
               "passed": bool(eval_payload.get("passed")),
@@ -972,6 +999,7 @@ jobs:
               "org_admin_blocker_likely": not hits,
               "evidence_status": evidence.get("status"),
               "evaluate": eval_payload,
+              "note": "perf-sample.json is one-shot M2 evidence; not a live CI Gate gate",
           }
           (dist / "bazel-cache-perf-ci-observation.json").write_text(
               json.dumps(summary, indent=2, sort_keys=True) + "\n",

--- a/docs/development/bazel-bootstrap.md
+++ b/docs/development/bazel-bootstrap.md
@@ -104,7 +104,8 @@ skills are declared via root `//:project_skills_bundle` / `//:project-skills/man
 - Doctests are not separate Bazel targets (documented equivalent: coverage attaches
   to crate unit-test targets; same policy as #10/#9).
 - Blacksmith `Bazel Bootstrap` runs authoritative `//:ci_rust_tests`, release bins,
-  binding smokes, and diagnostic #6 dual-build parity (one release cycle after #4).
+  and binding smokes under `CI Gate`. Diagnostic #6 dual-build parity and cache
+  observe/collect run in non-required `Bazel Diagnostics`.
   Full `//:integration_tests` and `//:bdd_tests` remain executable under Bazel for
   local/full runs.
 - Cross-OS Binding RC still produces macOS/Windows natives on those runners;

--- a/docs/development/bazel-migration-ac-evidence.md
+++ b/docs/development/bazel-migration-ac-evidence.md
@@ -68,8 +68,8 @@ Developer guide: [bazel.md](bazel.md).
 | Warm observation | `dist/bazel-warm-observation.json` |
 | Affected-input probe | `dist/bazel-affected-inputs.json` |
 | CI observation rollup | `dist/bazel-cache-perf-ci-observation.json` |
-| Checked-in ≥10-pair sample | [bazel-migration-evidence/perf-sample.json](bazel-migration-evidence/perf-sample.json) |
-| Diagnostic dual-build parity (one release cycle) | `dist/cargo-bazel-parity-evidence.json` |
+| Checked-in ≥10-pair sample (one-shot M2 evidence) | [bazel-migration-evidence/perf-sample.json](bazel-migration-evidence/perf-sample.json) |
+| Diagnostic dual-build parity (one release cycle; non-required) | `dist/cargo-bazel-parity-evidence.json` via `Bazel Diagnostics` |
 | Blacksmith Cache dashboard | https://app.blacksmith.sh/cache |
 | Authoritative Rust test log | `dist/bazel-ci-rust-tests.log` |
 

--- a/docs/development/bazel-migration-parity.md
+++ b/docs/development/bazel-migration-parity.md
@@ -20,7 +20,7 @@ Bootstrap: [bazel-bootstrap.md](bazel-bootstrap.md).
 | Representative suite | `tools/bazel/parity/parity_suite.json` / `//:parity_suite` |
 | Host release bins | `//:release_bins` (CLI + all 11 API examples) |
 | Packaging tags | `assemble_bazel_binding_packages.py --wheel-tag` / `--platform-tag` |
-| CI | `Bazel Bootstrap` (authoritative after #4) + diagnostic dual-build parity; required check remains `CI Gate` |
+| CI | `Bazel Bootstrap` (authoritative under `CI Gate`) + non-required `Bazel Diagnostics` dual-build parity |
 
 ## Acceptance mapping
 
@@ -36,8 +36,9 @@ Bootstrap: [bazel-bootstrap.md](bazel-bootstrap.md).
   `//:ci_rust_tests` is authoritative under `CI Gate`. Cargo `rust-test` is
   retired; see [bazel-migration-cutover.md](bazel-migration-cutover.md).
 - Bazel Bootstrap runs drift, ledger, release-platform inventory, authoritative
-  Rust tests, release bins, binding packaging, and diagnostic dual-build parity
-  for one release cycle.
+  Rust tests, release bins, and binding packaging.
+- Non-required `Bazel Diagnostics` runs dual-build parity for one release cycle
+  (not in `CI Gate` `needs`).
 - Required check name stays **`CI Gate`**.
 - Do **not** set `--remote_cache` (Blacksmith injects cache).
 

--- a/docs/development/bazel-migration-perf.md
+++ b/docs/development/bazel-migration-perf.md
@@ -37,11 +37,13 @@ hits regress:
 | Pair collector (≥10 cold/warm) | `--mode collect-pairs` (CI runs when hits observed + evidence incomplete) |
 | Affected-input isolation probe | `--mode affected-inputs` |
 | Gate evaluator (≥10 pairs, #1 thresholds) | `--mode evaluate` |
-| CI wiring | `Bazel Bootstrap` in `.github/workflows/test.yml` |
-| Checked-in sample status | `perf-sample.json` → `complete` (10 pairs; gates passed) |
+| CI wiring | Required: `Bazel Bootstrap` (policy + harness unit tests). Diagnostics: `Bazel Diagnostics` (observe/collect; **not** in `CI Gate` `needs`) |
+| Checked-in sample status | `perf-sample.json` → `complete` (10 pairs; **one-shot M2 evidence**) |
 
-CI may still pass `--allow-pending` for harness readiness. The #5 close gate is
-strict `evaluate` (no `--allow-pending`) against the checked-in complete sample.
+`perf-sample.json` is **one-shot M2 close evidence**, not a live PR regression
+gate. Required bootstrap runs `--mode policy` and harness unit tests only.
+`Bazel Diagnostics` may still observe/collect and roll up `evaluate` for
+dashboards; failures there do not fail `CI Gate`.
 
 ## Measurement plan
 

--- a/docs/development/bazel.md
+++ b/docs/development/bazel.md
@@ -169,10 +169,11 @@ Short form:
 | `dist/bazel-warm-observation.json` | Warm identical-SHA observation |
 | `dist/bazel-affected-inputs.json` | Affected-input isolation probe |
 | `dist/bazel-cache-perf-ci-observation.json` | CI rollup for cache/perf |
-| `docs/development/bazel-migration-evidence/perf-sample.json` | Checked-in ≥10-pair sample + gate results |
-| `dist/cargo-bazel-parity-evidence.json` | Diagnostic dual-build parity (one release cycle) |
+| `docs/development/bazel-migration-evidence/perf-sample.json` | One-shot M2 ≥10-pair evidence (not a live CI Gate regression gate) |
+| `dist/cargo-bazel-parity-evidence.json` | Diagnostic dual-build parity (`Bazel Diagnostics`, not required) |
 
-CI uploads the cache/perf set as `bazel-cache-perf-evidence-<run_id>`.
+`Bazel Diagnostics` uploads the cache/perf set as
+`bazel-cache-perf-evidence-<run_id>` (non-required).
 
 ### Common failures
 
@@ -191,7 +192,7 @@ CI uploads the cache/perf set as `bazel-cache-perf-evidence-<run_id>`.
 - After intentional dependency changes, always refresh Bazel lock/fingerprint
   (commands above).
 - For one release cycle after cutover, same-SHA dual-build parity remains a
-  **diagnostic** under `Bazel Bootstrap`.
+  **diagnostic** under non-required `Bazel Diagnostics` (not in `CI Gate`).
 - Temporary CI rollback to Cargo `rust-test` is documented in
   [bazel-migration-cutover.md](bazel-migration-cutover.md). Prefer fixing Bazel
   root causes.

--- a/scripts/ci/test-ci-storage-policy.py
+++ b/scripts/ci/test-ci-storage-policy.py
@@ -546,11 +546,28 @@ def validate_ci_gate_cutover(text: str) -> None:
         f"CI Gate must depend on authoritative Bazel job {auth_job!r} (needs={sorted(needed)})"
     )
     assert "rust-test" not in needed, "CI Gate must not aggregate the retired rust-test job"
+    assert "bazel-diagnostics" not in needed, (
+        "CI Gate must not require bazel-diagnostics (non-required diagnostic lane)"
+    )
     assert f"needs.{auth_job}.result" in gate_body, (
         f"CI Gate must require {auth_job}.result via require-gates.sh"
     )
     assert "needs.rust-test.result" not in gate_body, (
         "CI Gate must not reference needs.rust-test.result"
+    )
+    assert "needs.bazel-diagnostics.result" not in gate_body, (
+        "CI Gate must not reference needs.bazel-diagnostics.result"
+    )
+    assert "bazel-diagnostics" in jobs, "diagnostic dual-build/cache observe job must exist"
+    diag_body = jobs["bazel-diagnostics"]
+    assert job_runs_command(diag_body, "cargo-bazel-parity-check.py"), (
+        "bazel-diagnostics must run dual-build parity"
+    )
+    assert "|| echo" not in diag_body, (
+        "bazel-diagnostics must fail closed; no fabricated zero-hit JSON fallback"
+    )
+    assert not job_runs_command(jobs[auth_job], "cargo-bazel-parity-check.py --mode all"), (
+        "authoritative bazel-bootstrap must not run dual-build parity"
     )
 
 


### PR DESCRIPTION
## Summary
- Keep required `bazel-bootstrap` for drift, ledger/parity unit tests, `//:ci_rust_tests`, and binding smokes
- Move dual-build parity + cache observe/collect to non-required `bazel-diagnostics` (not in `ci-gate` needs)
- Remove fabricated zero-hit `|| echo` JSON fallback; fail closed on harness crashes
- Document `perf-sample.json` as one-shot M2 evidence

## Test plan
- [x] `python3 scripts/ci/test-ci-storage-policy.py`
- [ ] CI Gate green on exact head

Closes #446

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/452"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788714215&installation_model_id=20486&pr_number=452&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F452&signature=a28d8e1f09a21acebd6431bf67bbc2fc7262ac47e0b5eb65816bb86a09227e22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split bazel diagnostics into a non-required CI job separate from the CI Gate
> - Removes the perf gate evaluator from the `bazel-bootstrap` job and reduces its timeout from 120 to 90 minutes.
> - Adds a new `bazel-diagnostics` job that runs dual-build parity checks (`cargo-bazel-parity-check.py`), cache observe/collect flows, and log parsing — but is not in the CI Gate `needs` chain.
> - Updates [scripts/ci/test-ci-storage-policy.py](https://github.com/CurateLabs/graphforge/pull/452/files#diff-855ed98597547ac200b4015777e47aa99dda2b0ac141e95ffab9c0d96e87c1a0) to assert that `bazel-diagnostics` exists, is not required by the CI Gate, runs parity checks, and that the authoritative job does not run parity.
> - Updates developer docs to clarify that `bazel-bootstrap` covers authoritative tests under CI Gate while diagnostic results are informational only.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b8e9c0f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->