### PR TITLE
build: add Bazelisk and drift checks to pre-push

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,15 @@ Use targeted checks while iterating; run gates appropriate to the changed surfac
 cargo fmt --all -- --check
 cargo clippy --workspace -- -D warnings
 cargo test --workspace
+make pre-push-fast   # includes bazelisk + Cargo/Bazel drift
 make pre-push
+make bazel-test      # optional: authoritative //:ci_rust_tests locally
 ```
+
+CI Rust compile/test authority is Bazel (`//:ci_rust_tests`); see
+`docs/development/bazel.md`. `make pre-push-fast` requires `bazelisk` on `PATH`
+and runs `cargo-bazel-drift-check.py`. Full `//:ci_rust_tests` is optional
+locally via `make bazel-test` (heavy).
 
 Run formatting after the final edit. Review intentional snapshot changes before accepting them. Keep native builds isolated with `CARGO_TARGET_DIR`; run at most two heavy builds concurrently and monitor disk.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,13 +22,16 @@ Agent-oriented workflow and architecture rules are in [AGENTS.md](AGENTS.md).
 ### Validation (summary)
 
 Before pushing, run the Rust gates appropriate to the changed surface, then the
-Python/workspace mirror:
+Python/workspace mirror. Install [Bazelisk](https://github.com/bazelbuild/bazelisk)
+(`bazelisk` on `PATH`); see [docs/development/bazel.md](docs/development/bazel.md).
 
 ```bash
 cargo fmt --all -- --check
 cargo clippy --workspace -- -D warnings
 cargo test --workspace
+make pre-push-fast   # bazelisk + Cargo/Bazel drift, then format/lint/…
 make pre-push
+make bazel-test      # optional local //:ci_rust_tests
 ```
 
 ## Getting help

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help lint format type-check security workflow-lint license-check third-party-notices third-party-notices-check cargo-deny-licenses test pre-push pre-push-clean pre-push-preflight pre-push-fast clean test-tck docstring-coverage test-network benchmark test-perf test-perf-xs test-perf-slow test-perf-large coverage coverage-rust coverage-python coverage-node coverage-quick coverage-report coverage-diff coverage-strict check-coverage check-coverage-rust check-coverage-python check-coverage-node check-patch-coverage test-durations test-analytics docs-serve docs-build docs-clean cargo-build bench-traversal bench-fixed-hop-limit bench-fixed-hop-livejournal native-consumers release-load-matrix-check release-load-matrix bulk-construction-conformance-check bulk-construction-conformance cargo-test cargo-check cargo-clippy cargo-fmt cargo-fmt-check clean-builds clean-builds-all pnpm-install pnpm-build pnpm-test-bdd install build release-version-check package-license-verify publish-dry-run publish-dry-run-npm publish-dry-run-docs publish-dry-run-python publish-dry-run-cargo record-release-artifacts clean-env-verify-check clean-env-verify-preflight clean-env-verify
+.PHONY: help lint format type-check security workflow-lint license-check third-party-notices third-party-notices-check cargo-deny-licenses test pre-push pre-push-clean pre-push-preflight pre-push-fast bazel-test clean test-tck docstring-coverage test-network benchmark test-perf test-perf-xs test-perf-slow test-perf-large coverage coverage-rust coverage-python coverage-node coverage-quick coverage-report coverage-diff coverage-strict check-coverage check-coverage-rust check-coverage-python check-coverage-node check-patch-coverage test-durations test-analytics docs-serve docs-build docs-clean cargo-build bench-traversal bench-fixed-hop-limit bench-fixed-hop-livejournal native-consumers release-load-matrix-check release-load-matrix bulk-construction-conformance-check bulk-construction-conformance cargo-test cargo-check cargo-clippy cargo-fmt cargo-fmt-check clean-builds clean-builds-all pnpm-install pnpm-build pnpm-test-bdd install build release-version-check package-license-verify publish-dry-run publish-dry-run-npm publish-dry-run-docs publish-dry-run-python publish-dry-run-cargo record-release-artifacts clean-env-verify-check clean-env-verify-preflight clean-env-verify
 
 help:  ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -196,7 +196,14 @@ check-patch-coverage:  ## Validate patch coverage for changed files (90% thresho
 		echo "✅ Patch coverage meets 90% threshold"; \
 	fi
 
+bazel-test:  ## Run authoritative Bazel Rust suite (//:ci_rust_tests); see docs/development/bazel.md
+	@command -v bazelisk >/dev/null || (echo "bazelisk is required on PATH; see docs/development/bazel.md"; exit 1)
+	bazelisk test //:ci_rust_tests
+
 pre-push-fast:  ## Run fast checks only — format, lint, type, security, docstrings (no coverage, ~30s)
+	@echo "━━━ Bazelisk preflight + Cargo/Bazel drift ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	@command -v bazelisk >/dev/null || (echo "bazelisk is required on PATH; see docs/development/bazel.md"; exit 1)
+	@python3 scripts/ci/cargo-bazel-drift-check.py
 	@echo "━━━ Public API BDD policy ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 	@python3 scripts/ci/api-bdd-policy.py --check-issues
 	@python3 scripts/ci/test-api-bdd-policy.py

--- a/docs/development/bazel.md
+++ b/docs/development/bazel.md
@@ -53,9 +53,13 @@ bazelisk version   # must report 9.2.0 from .bazelversion
 
 ## Everyday local commands
 
+`make pre-push-fast` requires `bazelisk` and runs the Cargo/Bazel drift check.
+`make bazel-test` wraps the authoritative suite below.
+
 ```bash
 # Authoritative CI-equivalent Rust test graph
-bazelisk test //:ci_rust_tests
+make bazel-test
+# equivalent: bazelisk test //:ci_rust_tests
 
 # Libraries, CLI, resources, release bins
 bazelisk build //:first_party_libs //:cli_bins //:resource_inputs //:release_bins

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -19,12 +19,18 @@ suite → open a focused PR against `main`. For release operators, start at
 
 ## Development Setup
 
-**Prerequisites:** Python 3.10+, Rust stable, [uv](https://github.com/astral-sh/uv), maturin
+**Prerequisites:** Python 3.10+, Rust stable (pinned by `rust-toolchain.toml`),
+[uv](https://github.com/astral-sh/uv), maturin, pnpm for the Node binding, and
+[Bazelisk](https://github.com/bazelbuild/bazelisk) (`bazelisk` on `PATH`).
+CI Rust compile/test authority is Bazel — start with [bazel.md](bazel.md).
 
 ```bash
 # Install Rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 rustup update stable
+
+# Install Bazelisk (example: macOS Homebrew)
+brew install bazelisk
 
 git clone https://github.com/CurateLabs/graphforge.git
 cd graphforge
@@ -38,6 +44,9 @@ maturin develop --release -m crates/graphforge-bindings-py/Cargo.toml
 # Verify
 cargo test --workspace
 python -c "import graphforge; print(graphforge.__version__)"
+make pre-push-fast   # requires bazelisk; runs Cargo/Bazel drift
+# Optional heavy local Bazel suite (mirrors CI authority):
+# make bazel-test
 ```
 
 See [Installation](../guide/installation.md) for the published-package path.
@@ -54,10 +63,15 @@ See [Installation](../guide/installation.md) for the published-package path.
 cargo fmt --all -- --check
 cargo clippy --workspace -- -D warnings
 cargo test --workspace
+make pre-push-fast   # bazelisk + drift, then format/lint/security/…
 make pre-push
+make bazel-test      # optional: bazelisk test //:ci_rust_tests
 ```
 
-`make pre-push` mirrors the CI gate for the changed surface.
+`make pre-push` mirrors the CI gate for the changed surface. Fast path requires
+`bazelisk` and fails closed on Cargo/Bazel feature drift
+(`scripts/ci/cargo-bazel-drift-check.py`). Full local Bazel suite:
+`make bazel-test` (see [bazel.md](bazel.md)).
 
 ### Running Tests
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -212,12 +212,16 @@ pytest tests/ -n auto
 ## Resumable full validation
 
 `make pre-push` is the full local gate. It begins with a prerequisite and disk
-preflight, then records content-addressed evidence for policy checks, Rust
-tests and coverage, the instrumented native Python and Node builds consumed by
-acceptance, wrapper coverage, API BDD acceptance, and
-coverage thresholds. It never skips a gate: a compatible passed stage is reused
-only when its exact inputs, command contract, toolchain, dependency evidence,
-and required native artifact identity still match.
+preflight (including `bazelisk` on `PATH`), then records content-addressed
+evidence for policy checks, Rust tests and coverage, the instrumented native
+Python and Node builds consumed by acceptance, wrapper coverage, API BDD
+acceptance, and coverage thresholds. `make pre-push-fast` (also invoked from the
+policy-static stage) runs bazelisk presence + `cargo-bazel-drift-check.py`
+before format/lint/security. Optional authoritative local Bazel suite:
+`make bazel-test` → `bazelisk test //:ci_rust_tests` (see [bazel.md](bazel.md)).
+It never skips a gate: a compatible passed stage is reused only when its exact
+inputs, command contract, toolchain, dependency evidence, and required native
+artifact identity still match.
 
 The human-readable stage lines and machine-readable summary report elapsed time,
 evidence hit or miss, identity digest, invalidation reason, and disk budget.

--- a/scripts/pre_push_validation.py
+++ b/scripts/pre_push_validation.py
@@ -281,14 +281,15 @@ class Coordinator:
     def run_preflight(self, environment: Mapping[str, str]) -> None:
         missing = [
             name
-            for name in ("cargo", "rustc", "rustup", "uv", "node", "pnpm")
+            for name in ("cargo", "rustc", "rustup", "uv", "node", "pnpm", "bazelisk")
             if not shutil.which(name)
         ]
         if missing:
             raise ValidationError(
                 "missing prerequisite(s): "
                 + ", ".join(missing)
-                + ". Install the pinned toolchain described in docs/development/contributing.md."
+                + ". Install the pinned toolchain described in docs/development/contributing.md "
+                "(Bazelisk: docs/development/bazel.md)."
             )
         heavy_stages = tuple(stage for stage in self.cache_stages if stage.heavy)
         warm_cache = bool(heavy_stages) and all(


### PR DESCRIPTION
## Summary
- Require `bazelisk` in `pre_push_validation` preflight and `make pre-push-fast`
- Run `cargo-bazel-drift-check.py` on the fast path
- Add `make bazel-test` for optional local `//:ci_rust_tests`
- Surface Bazel onboarding in AGENTS.md, CONTRIBUTING, contributing.md, testing.md, bazel.md

## Test plan
- [x] `python3 scripts/ci/cargo-bazel-drift-check.py`
- [x] `python3 scripts/ci/test-pre-push-validation.py`
- [x] `make -n bazel-test` / `make -n pre-push-fast`
- [ ] CI Gate green on exact head

Closes #447

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788714275&installation_model_id=20486&pr_number=453&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F453&signature=1bc4a9d7f5cf4a27eca9e7876f9856582c003e50db24c2319ed6323f63003ec6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Bazelisk presence check and Cargo/Bazel drift check to `pre-push-fast`
> - `make pre-push-fast` now checks for `bazelisk` on PATH and runs `scripts/ci/cargo-bazel-drift-check.py` before format/lint/security checks, failing fast if either prerequisite is not met.
> - Adds a new `make bazel-test` target that runs `bazelisk test //:ci_rust_tests`, the authoritative CI Rust test suite.
> - `scripts/pre_push_validation.py` preflight check is extended to require `bazelisk` on PATH, with error messages pointing to [bazel.md](https://github.com/CurateLabs/graphforge/pull/453/files#diff-a7e1adb0ba1fac3f10085902e4c8c3f553e3a5aa52386bbb43f61cb8743c7e3a).
> - Documentation in AGENTS.md, CONTRIBUTING.md, and the docs tree is updated to reflect these new requirements and commands.
> - Risk: developers without `bazelisk` installed will now see `make pre-push-fast` fail where it previously succeeded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e2f996d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->