### PR TITLE
ci: harden publish concurrency, release env, recovery SHA

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,17 +6,25 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: Existing immutable v2 release tag to resume
+        description: Existing immutable v2 release tag to resume (no default; must match the tag)
         required: true
-        default: v0.5.2
         type: string
       recovery_reason:
         description: Public maintainer reason for the recovery dispatch
         required: true
         type: string
+      recovery_overlay_sha:
+        description: Reviewed commit SHA whose publisher/recovery scripts may overlay the tag checkout
+        required: true
+        type: string
 
 permissions:
   contents: read
+
+# One publish lane per tag; never cancel an in-flight registry write.
+concurrency:
+  group: publish-${{ github.event_name == 'release' && github.event.release.tag_name || inputs.release_tag }}
+  cancel-in-progress: false
 
 jobs:
   candidate-preflight:
@@ -45,6 +53,7 @@ jobs:
           RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.release_tag }}
           EVENT_SHA: ${{ github.sha }}
           RECOVERY_REASON: ${{ inputs.recovery_reason || '' }}
+          RECOVERY_OVERLAY_SHA: ${{ inputs.recovery_overlay_sha || '' }}
         run: |
           git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
           release_sha="$(git rev-parse "$RELEASE_TAG^{}")"
@@ -58,13 +67,19 @@ jobs:
             test "$(git rev-parse refs/remotes/origin/main)" = "$release_sha"
           else
             test -n "$RECOVERY_REASON"
+            test -n "$RECOVERY_OVERLAY_SHA"
+            test "${#RECOVERY_OVERLAY_SHA}" -eq 40
             gh release view "$RELEASE_TAG" >/dev/null
             git merge-base --is-ancestor "$release_sha" refs/remotes/origin/main
-            git show refs/remotes/origin/main:scripts/ci/release-publish-preflight.py \
+            git fetch --no-tags origin "$RECOVERY_OVERLAY_SHA"
+            git cat-file -e "$RECOVERY_OVERLAY_SHA^{commit}"
+            git merge-base --is-ancestor "$RECOVERY_OVERLAY_SHA" refs/remotes/origin/main
+            git show "$RECOVERY_OVERLAY_SHA:scripts/ci/release-publish-preflight.py" \
               > "$RUNNER_TEMP/release-publish-preflight.py"
             install -m 0755 "$RUNNER_TEMP/release-publish-preflight.py" \
               scripts/ci/release-publish-preflight.py
             printf 'Recovery reason: %s\n' "$RECOVERY_REASON"
+            printf 'Recovery overlay SHA: %s\n' "$RECOVERY_OVERLAY_SHA"
           fi
           python3 scripts/ci/release-publish-preflight.py \
             --tag "$RELEASE_TAG" \
@@ -206,6 +221,7 @@ jobs:
     name: PyPI node
     needs: candidate-preflight
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    environment: release
     permissions:
       actions: read
       contents: write
@@ -281,6 +297,7 @@ jobs:
           - graphforge-linux-x64-gnu
           - graphforge-win32-x64-msvc
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    environment: release
     permissions:
       actions: read
       contents: write
@@ -358,6 +375,7 @@ jobs:
     name: npm main fan-in
     needs: [candidate-preflight, npm-native]
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    environment: release
     permissions:
       actions: read
       contents: write
@@ -432,6 +450,7 @@ jobs:
     name: npm CLI after verified main
     needs: [candidate-preflight, npm-main]
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    environment: release
     permissions:
       actions: read
       contents: write
@@ -478,6 +497,7 @@ jobs:
     name: npm agent skills after verified CLI
     needs: [candidate-preflight, npm-cli]
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    environment: release
     permissions:
       actions: read
       contents: write
@@ -524,6 +544,7 @@ jobs:
     name: Dependency-ordered crates lane
     needs: candidate-preflight
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    environment: release
     # New-crate rate limits are ~10 minutes each; remaining surface may need ~90+ minutes.
     timeout-minutes: 180
     permissions:
@@ -534,25 +555,32 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.candidate-preflight.outputs.release_sha }}
-      - name: Use main-branch crates publisher for recovery
+      - name: Use reviewed recovery-overlay SHA crates publisher
         if: github.event_name == 'workflow_dispatch'
         shell: bash
+        env:
+          RECOVERY_OVERLAY_SHA: ${{ inputs.recovery_overlay_sha }}
         run: |
           # Recovery checkouts the immutable tag SHA for certified crate bytes.
-          # Overlay the durable publisher (429 Retry-After waits) and authorize
-          # diagnostics from main without moving the tag. Never print secrets.
+          # Overlay durable publisher scripts from an explicit reviewed SHA
+          # (not floating origin/main tip). Never print secrets.
+          test -n "$RECOVERY_OVERLAY_SHA"
+          test "${#RECOVERY_OVERLAY_SHA}" -eq 40
           git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
-          git show refs/remotes/origin/main:scripts/publish_crates.py \
+          git fetch --no-tags origin "$RECOVERY_OVERLAY_SHA"
+          git cat-file -e "$RECOVERY_OVERLAY_SHA^{commit}"
+          git merge-base --is-ancestor "$RECOVERY_OVERLAY_SHA" refs/remotes/origin/main
+          git show "$RECOVERY_OVERLAY_SHA:scripts/publish_crates.py" \
             > "$RUNNER_TEMP/publish_crates.py"
           install -m 0755 "$RUNNER_TEMP/publish_crates.py" scripts/publish_crates.py
-          git show refs/remotes/origin/main:scripts/ci/release_action.py \
+          git show "$RECOVERY_OVERLAY_SHA:scripts/ci/release_action.py" \
             > "$RUNNER_TEMP/release_action.py"
           install -m 0755 "$RUNNER_TEMP/release_action.py" scripts/ci/release_action.py
-          git show refs/remotes/origin/main:scripts/ci/crate-authorize-refresh-nodes.py \
+          git show "$RECOVERY_OVERLAY_SHA:scripts/ci/crate-authorize-refresh-nodes.py" \
             > "$RUNNER_TEMP/crate-authorize-refresh-nodes.py"
           install -m 0755 "$RUNNER_TEMP/crate-authorize-refresh-nodes.py" \
             scripts/ci/crate-authorize-refresh-nodes.py
-          git show refs/remotes/origin/main:scripts/ci/release_registry.py \
+          git show "$RECOVERY_OVERLAY_SHA:scripts/ci/release_registry.py" \
             > "$RUNNER_TEMP/release_registry.py"
           install -m 0755 "$RUNNER_TEMP/release_registry.py" scripts/ci/release_registry.py
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master as of 2026-08-05

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,7 +13,10 @@ are in
 - PyPI, crates.io, and npm trusted publishing are configured for
   `publish.yaml` (OIDC; no long-lived `NPM_TOKEN`).
 - A maintainer has explicitly authorized the immutable tag, GitHub Release, and
-  registry writes.
+  registry writes (GitHub Environment `release` reviewers on `publish.yaml`
+  registry jobs).
+- Recovery dispatches must pass `release_tag`, `recovery_reason`, and an
+  explicit reviewed `recovery_overlay_sha` (not floating `main`).
 
 ## Release
 

--- a/docs/development/publication-order.md
+++ b/docs/development/publication-order.md
@@ -158,10 +158,15 @@ headers, cookies, tokens, or raw registry bodies.
 
 ## Recovery and stop conditions
 
-Re-run `publish.yaml` only for the same immutable v0.5.1 tag and provide a
-public recovery reason. The new run re-observes the registries, skips verified
-nodes without downloading unrelated partitions, and schedules only eligible
-absent work.
+Re-run `publish.yaml` only for the same immutable tag via `workflow_dispatch`
+and provide: the exact `release_tag` (no stale default), a public
+`recovery_reason`, and a reviewed `recovery_overlay_sha` (40-char commit on
+`main`) whose publisher/recovery scripts may overlay the tag checkout. Do not
+overlay floating `origin/main` tip. Concurrent runs for the same tag share
+concurrency group `publish-<tag>` with `cancel-in-progress: false`. Registry
+write jobs require the GitHub Environment `release`. The new run re-observes
+the registries, skips verified nodes without downloading unrelated partitions,
+and schedules only eligible absent work.
 
 Stop and require a human decision when:
 

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -52,7 +52,11 @@ gh release create vX.Y.Z --title "GraphForge vX.Y.Z" --generate-notes
 ```
 
 Publishing is triggered only by the authorized GitHub Release or an authorized
-recovery dispatch for the same immutable release identity.
+recovery dispatch for the same immutable release identity. Recovery
+`workflow_dispatch` requires `release_tag`, `recovery_reason`, and a reviewed
+`recovery_overlay_sha` (publisher scripts overlay that SHA, not floating
+`main`). Registry write jobs use GitHub Environment `release`; concurrency
+group `publish-<tag>` sets `cancel-in-progress: false`.
 
 ## 4. Publish and reconcile
 

--- a/scripts/ci/test-release-publish-preflight.py
+++ b/scripts/ci/test-release-publish-preflight.py
@@ -41,7 +41,10 @@ assert mod.validate(
 )
 
 workflow = WORKFLOW.read_text(encoding="utf-8")
-assert "default: v0.5.2" in workflow
+assert "default: v0.5.2" not in workflow
+assert "recovery_overlay_sha:" in workflow
+assert "cancel-in-progress: false" in workflow
+assert "group: publish-${{ github.event_name == 'release' && github.event.release.tag_name || inputs.release_tag }}" in workflow
 assert 'test "$release_version" != 0.5.0' in workflow
 assert "candidate/v0.5.0-artifacts.json" not in workflow
 assert "v0.5.0-npm-amendment.json" not in workflow
@@ -76,6 +79,7 @@ crates = workflow.split("  publish-crates:\n", 1)[1].split("\n  reconcile:", 1)[
 summary = workflow.split("  reconcile:\n", 1)[1]
 
 assert "needs: candidate-preflight" in pypi
+assert "environment: release" in pypi
 assert "id-token: write" in pypi
 assert "uv publish candidate/release-artifacts/python/*" in pypi
 assert "secrets.NPM_TOKEN" not in pypi
@@ -84,6 +88,7 @@ assert "secrets.CARGO_REGISTRY_TOKEN" not in pypi
 assert "fail-fast: false" in native
 assert native.count("- graphforge-") == 5
 assert "needs: candidate-preflight" in native
+assert "environment: release" in native
 assert '--package "@curatelabs/${{ matrix.package }}"' in native
 assert "id-token: write" in native
 assert "secrets.NPM_TOKEN" not in native
@@ -91,29 +96,37 @@ assert "NODE_AUTH_TOKEN" not in native
 assert "secrets.CARGO_REGISTRY_TOKEN" not in native
 
 assert "needs: [candidate-preflight, npm-native]" in main
+assert "environment: release" in main
 assert "Require verified native fan-in and authorize main" in main
 assert "--node npm:@curatelabs/graphforge" in main
 assert "id-token: write" in main
 assert "secrets.NPM_TOKEN" not in main
 assert "NODE_AUTH_TOKEN" not in main
 assert "needs: [candidate-preflight, npm-main]" in cli
+assert "environment: release" in cli
 assert "--node npm:@curatelabs/graphforge-cli" in cli
 assert "id-token: write" in cli
 assert "secrets.NPM_TOKEN" not in cli
 assert "NODE_AUTH_TOKEN" not in cli
 assert "needs: [candidate-preflight, npm-cli]" in skills
+assert "environment: release" in skills
 assert "--node npm:@curatelabs/graphforge-agent-skills" in skills
 assert "id-token: write" in skills
 assert "secrets.NPM_TOKEN" not in skills
 assert "NODE_AUTH_TOKEN" not in skills
 
 assert "needs: candidate-preflight" in crates
+assert "environment: release" in crates
 assert "timeout-minutes: 180" in crates
-assert "Use main-branch crates publisher for recovery" in crates
-assert "refs/remotes/origin/main:scripts/publish_crates.py" in crates
-assert "refs/remotes/origin/main:scripts/ci/release_action.py" in crates
-assert "refs/remotes/origin/main:scripts/ci/crate-authorize-refresh-nodes.py" in crates
-assert "refs/remotes/origin/main:scripts/ci/release_registry.py" in crates
+assert "Use reviewed recovery-overlay SHA crates publisher" in crates
+assert "RECOVERY_OVERLAY_SHA" in crates
+assert 'git show "$RECOVERY_OVERLAY_SHA:scripts/publish_crates.py"' in crates
+assert 'git show "$RECOVERY_OVERLAY_SHA:scripts/ci/release_action.py"' in crates
+assert 'git show "$RECOVERY_OVERLAY_SHA:scripts/ci/crate-authorize-refresh-nodes.py"' in crates
+assert 'git show "$RECOVERY_OVERLAY_SHA:scripts/ci/release_registry.py"' in crates
+assert "refs/remotes/origin/main:scripts/publish_crates.py" not in crates
+assert "RECOVERY_OVERLAY_SHA" in preflight
+assert 'git show "$RECOVERY_OVERLAY_SHA:scripts/ci/release-publish-preflight.py"' in preflight
 assert "scripts/ci/crate-publish-plan.py list" in crates
 assert "scripts/publish_crates.py" in crates
 assert '--crate "$crate"' in crates

--- a/scripts/ci/test-release-publish-preflight.py
+++ b/scripts/ci/test-release-publish-preflight.py
@@ -44,7 +44,10 @@ workflow = WORKFLOW.read_text(encoding="utf-8")
 assert "default: v0.5.2" not in workflow
 assert "recovery_overlay_sha:" in workflow
 assert "cancel-in-progress: false" in workflow
-assert "group: publish-${{ github.event_name == 'release' && github.event.release.tag_name || inputs.release_tag }}" in workflow
+assert (
+    "group: publish-${{ github.event_name == 'release' && github.event.release.tag_name || inputs.release_tag }}"
+    in workflow
+)
 assert 'test "$release_version" != 0.5.0' in workflow
 assert "candidate/v0.5.0-artifacts.json" not in workflow
 assert "v0.5.0-npm-amendment.json" not in workflow

--- a/scripts/ci/test-release-publish-preflight.py
+++ b/scripts/ci/test-release-publish-preflight.py
@@ -44,10 +44,11 @@ workflow = WORKFLOW.read_text(encoding="utf-8")
 assert "default: v0.5.2" not in workflow
 assert "recovery_overlay_sha:" in workflow
 assert "cancel-in-progress: false" in workflow
-assert (
-    "group: publish-${{ github.event_name == 'release' && github.event.release.tag_name || inputs.release_tag }}"
-    in workflow
+group = (
+    "group: publish-${{ github.event_name == 'release' && "
+    "github.event.release.tag_name || inputs.release_tag }}"
 )
+assert group in workflow
 assert 'test "$release_version" != 0.5.0' in workflow
 assert "candidate/v0.5.0-artifacts.json" not in workflow
 assert "v0.5.0-npm-amendment.json" not in workflow


### PR DESCRIPTION
## Summary
- Add `concurrency` group `publish-<tag>` with `cancel-in-progress: false`
- Put registry-writing jobs in GitHub Environment `release`
- Remove stale `release_tag` default `v0.5.2`
- Pin recovery script overlays to required `recovery_overlay_sha` input
- Update publication-order / RELEASING / release-process runbooks + contract tests

## Test plan
- [x] `python3 scripts/ci/test-release-publish-preflight.py`
- [x] `python3 scripts/ci/test-publish-track.py`
- [ ] CI Gate green on exact head
- [ ] Human: configure `release` environment reviewers in GitHub settings

Closes #449

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788714366&installation_model_id=20486&pr_number=455&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F455&signature=131702fa25ede97f43926b3066de9572eccd1ab7fa3283fabee10d1038504155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden publish workflow with concurrency control, release environment, and reviewed recovery SHA
> - Adds a top-level concurrency group `publish-<tag>` with `cancel-in-progress: false` so concurrent runs for the same tag are serialized rather than cancelled.
> - Adds `environment: release` to all registry write jobs (`publish-pypi`, `npm-*`, `publish-crates`), requiring GitHub Environment reviewers to authorize registry writes.
> - Adds a required `recovery_overlay_sha` input to `workflow_dispatch`; recovery runs must supply a reviewed 40-char commit SHA on `main` instead of floating `origin/main`.
> - Both the preflight script and crates publisher/recovery scripts are sourced from the reviewed SHA after verifying it exists and is an ancestor of `origin/main`.
> - Updates [RELEASING.md](https://github.com/CurateLabs/graphforge/pull/455/files#diff-87d6a57a759f2386bf9caf5309b9aa0b9ff0ca70f5e38696e114a1ccdb0e785d) and docs to document the new recovery dispatch requirements and environment reviewer gate.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 114ac87.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened release preflight checks to validate publishing environments, recovery procedures, and workflow concurrency settings.
  * Added safeguards to ensure release and authorization steps use the reviewed recovery configuration.

* **Chores**
  * Cleaned up test helper annotations without changing behavior.
  * Improved release workflow reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->