### PR TITLE
ci: Binding RC Linux lanes consume Bazel-built natives

### DIFF
--- a/.github/workflows/binding-release-candidate.yml
+++ b/.github/workflows/binding-release-candidate.yml
@@ -49,9 +49,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: blacksmith-4vcpu-ubuntu-2404, target: python-ubuntu, sticky_target: "true" }
-          - { os: blacksmith-12vcpu-macos-15, target: python-macos, sticky_target: "false" }
-          - { os: blacksmith-8vcpu-windows-2025, target: python-windows, sticky_target: "false" }
+          # Linux: Bazel cdylib + assembler (no maturin recompile).
+          - { os: blacksmith-4vcpu-ubuntu-2404, target: python-ubuntu, native_builder: bazel, sticky_target: "false", wheel_tag: cp310-abi3-manylinux_2_17_x86_64 }
+          # Host maturin retained until macOS/Windows Binding RC Bazel cutover.
+          - { os: blacksmith-12vcpu-macos-15, target: python-macos, native_builder: maturin, sticky_target: "false" }
+          - { os: blacksmith-8vcpu-windows-2025, target: python-windows, native_builder: maturin, sticky_target: "false" }
     env:
       CARGO_INCREMENTAL: 0
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
@@ -72,15 +74,17 @@ jobs:
           python-version: "3.13"
 
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
       - name: Mount shared Linux Cargo build disk
         if: matrix.sticky_target == 'true'
         uses: useblacksmith/stickydisk@35ba2e331a80056a42af053ee54968511de2b7c7 # v1.5.0
         with:
-          # Python Ubuntu and Linux Node targets share compatible release products.
+          # Retained for maturin lanes that still compile into workspace target/.
           key: ${{ github.repository }}-binding-rc-linux-rust-1.96.0-${{ hashFiles('Cargo.lock') }}-release-target-v1
           path: target
 
       - name: Cache Cargo registry
+        if: matrix.native_builder == 'maturin'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
@@ -88,7 +92,30 @@ jobs:
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
 
+      - name: Install Bazelisk
+        if: matrix.native_builder == 'bazel'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo curl -fsSL \
+            "https://github.com/bazelbuild/bazelisk/releases/download/v1.26.0/bazelisk-linux-amd64" \
+            -o /usr/local/bin/bazelisk
+          sudo chmod +x /usr/local/bin/bazelisk
+          sudo ln -sf /usr/local/bin/bazelisk /usr/local/bin/bazel
+          bazelisk version
+
       - name: Build native abi3 wheel
+        if: matrix.native_builder == 'bazel'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          python3 scripts/ci/binding_rc_bazel_native.py python \
+            --out dist/graphforge-bazel.whl \
+            --wheel-tag "${{ matrix.wheel_tag }}"
+
+      - name: Build native abi3 wheel
+        if: matrix.native_builder == 'maturin'
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           command: build
@@ -99,7 +126,7 @@ jobs:
       # manylinux maturin writes into the mounted target as root; reclaim it
       # before the native contracts can launch Cargo on the host runner.
       - name: Reclaim sticky-disk ownership after maturin
-        if: matrix.sticky_target == 'true'
+        if: matrix.native_builder == 'maturin' && matrix.sticky_target == 'true'
         shell: bash
         run: |
           test "$CARGO_TARGET_DIR" = "$GITHUB_WORKSPACE/target"
@@ -112,6 +139,7 @@ jobs:
       # launch Cargo after that wrapper has left PATH, especially on containerized
       # Linux runners, so validate the inherited command before those contracts.
       - name: Prepare Rust compiler wrapper for native contracts
+        if: matrix.native_builder == 'maturin'
         shell: bash
         run: |
           python3 scripts/ci/prepare-rustc-wrapper.py \
@@ -119,6 +147,7 @@ jobs:
             --contract python-native-contracts
 
       - name: Verify writable Cargo target for native contracts
+        if: matrix.native_builder == 'maturin'
         shell: bash
         run: |
           test "$CARGO_TARGET_DIR" = "$GITHUB_WORKSPACE/target"
@@ -223,6 +252,7 @@ jobs:
             execution_mode: native
             cross_args: ""
             node_arch: x64
+            native_builder: napi
             sticky_target: "false"
           - os: blacksmith-12vcpu-macos-15
             target: aarch64-apple-darwin
@@ -230,6 +260,7 @@ jobs:
             execution_mode: native
             cross_args: ""
             node_arch: arm64
+            native_builder: napi
             sticky_target: "false"
           - os: blacksmith-4vcpu-ubuntu-2404
             target: x86_64-unknown-linux-gnu
@@ -237,7 +268,9 @@ jobs:
             execution_mode: native
             cross_args: ""
             node_arch: x64
-            sticky_target: "true"
+            native_builder: bazel
+            platform_tag: linux-x64-gnu
+            sticky_target: "false"
           - os: blacksmith-4vcpu-ubuntu-2404
             target: aarch64-unknown-linux-gnu
             report_target: node-aarch64-unknown-linux-gnu
@@ -245,6 +278,7 @@ jobs:
             cross_args: --use-napi-cross
             arm_cflags: -D__ARM_ARCH=8
             node_arch: x64
+            native_builder: napi
             sticky_target: "true"
           - os: blacksmith-8vcpu-windows-2025
             target: x86_64-pc-windows-msvc
@@ -252,6 +286,7 @@ jobs:
             execution_mode: native
             cross_args: ""
             node_arch: x64
+            native_builder: napi
             sticky_target: "false"
             timeout_minutes: 90
     env:
@@ -276,6 +311,7 @@ jobs:
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master as of 2026-08-05
+        if: matrix.native_builder == 'napi'
         with:
           toolchain: "1.96.0"
           targets: ${{ matrix.target }}
@@ -284,11 +320,12 @@ jobs:
         if: matrix.sticky_target == 'true'
         uses: useblacksmith/stickydisk@35ba2e331a80056a42af053ee54968511de2b7c7 # v1.5.0
         with:
-          # Python Ubuntu and Linux Node targets share compatible release products.
+          # Retained for napi/cross lanes that still compile into workspace target/.
           key: ${{ github.repository }}-binding-rc-linux-rust-1.96.0-${{ hashFiles('Cargo.lock') }}-release-target-v1
           path: target
 
       - name: Cache Cargo registry
+        if: matrix.native_builder == 'napi'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
@@ -314,7 +351,29 @@ jobs:
             exit 1
           fi
 
+      - name: Install Bazelisk
+        if: matrix.native_builder == 'bazel'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo curl -fsSL \
+            "https://github.com/bazelbuild/bazelisk/releases/download/v1.26.0/bazelisk-linux-amd64" \
+            -o /usr/local/bin/bazelisk
+          sudo chmod +x /usr/local/bin/bazelisk
+          sudo ln -sf /usr/local/bin/bazelisk /usr/local/bin/bazel
+          bazelisk version
+
       - name: Build declared publish target
+        if: matrix.native_builder == 'bazel'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/binding_rc_bazel_native.py node \
+            --out-dir crates/graphforge-bindings-node \
+            --platform-tag "${{ matrix.platform_tag }}"
+
+      - name: Build declared publish target
+        if: matrix.native_builder == 'napi'
         shell: bash
         env:
           CFLAGS_aarch64_unknown_linux_gnu: ${{ matrix.arm_cflags || '' }}
@@ -488,6 +547,7 @@ jobs:
           python-version: "3.13"
 
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
@@ -548,10 +608,14 @@ jobs:
           cp candidate/release-artifacts/node-addons/*.node \
             crates/graphforge-bindings-node/artifacts/
           pushd crates/graphforge-bindings-node
-          # index.js / index.d.ts are gitignored NAPI-RS outputs. Generate them
-          # here before packing the main package; matrix jobs already retained
-          # the tested native addons that napi artifacts will distribute.
-          pnpm exec napi build --platform --release --target x86_64-unknown-linux-gnu
+          # index.js / index.d.ts are gitignored. Emit loaders from a retained
+          # Linux addon via the Bazel assembler — no second native recompile.
+          linux_addon="$(ls candidate/release-artifacts/node-addons/graphforge.linux-x64-gnu.node | head -n1)"
+          test -f "$linux_addon"
+          python3 "$GITHUB_WORKSPACE/scripts/ci/binding_rc_bazel_native.py" emit-node-loaders \
+            --addon "$linux_addon" \
+            --out-dir . \
+            --platform-tag linux-x64-gnu
           test -f index.js
           test -f index.d.ts
           pnpm exec napi create-npm-dirs

--- a/docs/development/bazel-migration-cutover.md
+++ b/docs/development/bazel-migration-cutover.md
@@ -17,9 +17,9 @@ Companion artifacts:
 | Required check name | Exactly **`CI Gate`** (unchanged) |
 | Authoritative Rust compile/test | `Bazel Bootstrap` → `bazelisk test //:ci_rust_tests` (+ libs/CLI/resources/bindings builds) |
 | Retired | Cargo `rust-test` workspace job; PR job-isolated Cargo `target/` sticky disks |
-| Retained Cargo diagnostics | `Rust Quality` (fmt/clippy); Windows `graphforge-storage` lock unit tests; PR maturin/napi binding assembly (no sticky); Binding RC / fuzz / M1 sticky packaging lanes |
+| Retained Cargo diagnostics | `Rust Quality` (fmt/clippy); Windows `graphforge-storage` lock unit tests; PR maturin/napi binding assembly (no sticky); Binding RC macOS/Windows/cross napi + fuzz / M1 sticky packaging lanes |
 | Path-classified skips | Remain neutral via `require-gates.sh` (`success` or `skipped`) |
-| Dual-build parity | Diagnostic under `Bazel Bootstrap` for **one release cycle** |
+| Dual-build parity | Diagnostic under non-required `Bazel Diagnostics` for **one release cycle** |
 
 Do **not** set `--remote_cache` in-repo. Blacksmith injects repository Bazel caching.
 
@@ -67,9 +67,16 @@ python3 scripts/ci/cargo-bazel-parity-check.py \
 
 ### Binding RC / publish sticky disks
 
-Not retired by #4. Linux Binding RC and M1 release-load sticky `target/` volumes
-remain for packaging/publish-track lanes (`RT-maturin-assemble` / `RT-napi-assemble`
-handoff). Fuzz retains its sticky disk as a justified retained tool.
+Linux Binding RC **host** lanes (Python Ubuntu + Node `x86_64-unknown-linux-gnu`)
+consume Bazel `//:binding_cdylibs` via
+`scripts/ci/binding_rc_bazel_native.py` +
+`assemble_bazel_binding_packages.py` — no maturin/napi native recompile and no
+Cargo `target/` sticky mount on those lanes. Remaining Binding RC platforms
+(macOS/Windows Python maturin; macOS/Windows Node napi; Linux aarch64
+napi-cross) and M1 release-load sticky `target/` volumes stay until follow-on
+cutover. Fuzz retains its sticky disk as a justified retained tool.
+`release_candidate` emits gitignored `index.js` / `index.d.ts` from a retained
+Linux addon (`emit-node-loaders`) instead of `napi build` recompile.
 
 ## Acceptance mapping
 

--- a/scripts/ci/binding_rc_bazel_native.py
+++ b/scripts/ci/binding_rc_bazel_native.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Build Binding RC natives with Bazel and assemble packages (no maturin/napi recompile).
+
+Used by binding-release-candidate.yml for hermetic Linux (and later host) lanes.
+Never shells out to ``maturin build``, ``napi build``, or ``cargo build``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[2]
+ASSEMBLE = ROOT / "scripts" / "ci" / "assemble_bazel_binding_packages.py"
+
+FORBIDDEN = ("maturin build", "napi build", "cargo build", "cargo rustc")
+
+
+def _die(message: str, code: int = 2) -> None:
+    print(f"binding_rc_bazel_native: {message}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def _run(cmd: list[str]) -> None:
+    print("+", " ".join(cmd), flush=True)
+    subprocess.run(cmd, cwd=ROOT, check=True)
+
+
+def _find_native(bazel_target: str, patterns: tuple[str, ...]) -> Path:
+    query = subprocess.check_output(
+        ["bazelisk", "cquery", bazel_target, "--output=files"],
+        cwd=ROOT,
+        text=True,
+    )
+    candidates: list[Path] = []
+    for line in query.splitlines():
+        path = Path(line.strip())
+        if not path.is_absolute():
+            path = ROOT / path
+        if path.is_file() and path.name.endswith(patterns):
+            candidates.append(path)
+    if not candidates:
+        # Fallback: walk bazel-bin for the target's package.
+        pkg = bazel_target.split(":", maxsplit=1)[0].removeprefix("//")
+        base = ROOT / "bazel-bin" / pkg
+        if base.is_dir():
+            for path in base.rglob("*"):
+                if path.is_file() and path.name.endswith(patterns):
+                    candidates.append(path)
+    if not candidates:
+        _die(f"no native library found for {bazel_target} (patterns={patterns})")
+    candidates.sort(key=lambda p: (len(p.parts), str(p)))
+    return candidates[0]
+
+
+def build_python(*, out: Path, wheel_tag: str | None) -> dict[str, str]:
+    target = "//crates/graphforge-bindings-py:graphforge_bindings_py"
+    _run(["bazelisk", "build", target])
+    native = _find_native(target, (".so", ".dylib", ".dll", ".pyd"))
+    out.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        sys.executable,
+        str(ASSEMBLE),
+        "--language",
+        "python",
+        "--native",
+        str(native),
+        "--package-root",
+        str(ROOT / "crates" / "graphforge-bindings-py"),
+        "--out",
+        str(out),
+    ]
+    if wheel_tag:
+        cmd.extend(["--wheel-tag", wheel_tag])
+    evidence_path = out.with_suffix(out.suffix + ".evidence.json")
+    cmd.extend(["--write-evidence", str(evidence_path)])
+    _run(cmd)
+    return json.loads(evidence_path.read_text(encoding="utf-8"))
+
+
+def build_node(*, out_dir: Path, platform_tag: str | None) -> dict[str, str]:
+    target = "//crates/graphforge-bindings-node:graphforge_bindings_node"
+    _run(["bazelisk", "build", target])
+    native = _find_native(target, (".so", ".dylib", ".dll", ".node"))
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="gf-binding-rc-node-") as tmp:
+        staging = Path(tmp) / "package"
+        cmd = [
+            sys.executable,
+            str(ASSEMBLE),
+            "--language",
+            "node",
+            "--native",
+            str(native),
+            "--package-root",
+            str(ROOT / "crates" / "graphforge-bindings-node"),
+            "--out",
+            str(staging),
+        ]
+        if platform_tag:
+            cmd.extend(["--platform-tag", platform_tag])
+        evidence_path = Path(tmp) / "evidence.json"
+        cmd.extend(["--write-evidence", str(evidence_path)])
+        _run(cmd)
+        evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+        for name in (evidence["addon"], "index.js", "index.d.ts"):
+            src = staging / name
+            if not src.is_file():
+                _die(f"assembler did not produce {name}")
+            shutil.copy2(src, out_dir / name)
+        shutil.copy2(evidence_path, out_dir / "bazel-native-evidence.json")
+    return evidence
+
+
+def emit_node_loaders(*, addon: Path, out_dir: Path, platform_tag: str | None) -> None:
+    """Emit index.js / index.d.ts from a retained addon without recompiling."""
+    if not addon.is_file():
+        _die(f"addon not found: {addon}")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="gf-emit-loaders-") as tmp:
+        staging = Path(tmp) / "package"
+        cmd = [
+            sys.executable,
+            str(ASSEMBLE),
+            "--language",
+            "node",
+            "--native",
+            str(addon),
+            "--package-root",
+            str(ROOT / "crates" / "graphforge-bindings-node"),
+            "--out",
+            str(staging),
+        ]
+        if platform_tag:
+            cmd.extend(["--platform-tag", platform_tag])
+        _run(cmd)
+        for name in ("index.js", "index.d.ts"):
+            shutil.copy2(staging / name, out_dir / name)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    joined = " ".join(argv).lower()
+    for token in FORBIDDEN:
+        if token in joined:
+            _die(f"refusing argv that looks like a silent native recompile ({token})")
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    py = sub.add_parser("python", help="Bazel-build + assemble an abi3 wheel")
+    py.add_argument("--out", type=Path, required=True)
+    py.add_argument("--wheel-tag", default=None)
+
+    node = sub.add_parser("node", help="Bazel-build + stage .node + loaders")
+    node.add_argument("--out-dir", type=Path, required=True)
+    node.add_argument("--platform-tag", default=None)
+
+    emit = sub.add_parser("emit-node-loaders", help="Emit index.js/d.ts from a retained addon")
+    emit.add_argument("--addon", type=Path, required=True)
+    emit.add_argument("--out-dir", type=Path, required=True)
+    emit.add_argument("--platform-tag", default=None)
+
+    args = parser.parse_args(argv)
+    if not shutil.which("bazelisk"):
+        _die("bazelisk is required on PATH; see docs/development/bazel.md")
+
+    if args.command == "python":
+        evidence = build_python(out=args.out.resolve(), wheel_tag=args.wheel_tag)
+    elif args.command == "node":
+        evidence = build_node(out_dir=args.out_dir.resolve(), platform_tag=args.platform_tag)
+    else:
+        emit_node_loaders(
+            addon=args.addon.resolve(),
+            out_dir=args.out_dir.resolve(),
+            platform_tag=args.platform_tag,
+        )
+        evidence = {"language": "node", "recompiled": "false", "loaders": "emitted"}
+    print(json.dumps(evidence, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test-binding-release-candidate.py
+++ b/scripts/ci/test-binding-release-candidate.py
@@ -105,14 +105,23 @@ def required_section(text: str, start: str, end: str) -> str:
 
 
 def assert_active_lines(section: str, *expected: str) -> None:
-    """Require exact, non-commented workflow lines."""
+    """Require exact, non-commented workflow lines.
+
+    Expectations ending in ``@`` match any SHA-pinned ``uses: …@<sha> # tag`` line
+    with that prefix (Dependabot-style action pins).
+    """
     active = {
         line.strip()
         for line in section.splitlines()
         if line.strip() and not line.lstrip().startswith("#")
     }
     for line in expected:
-        assert line in active, f"missing active workflow line: {line}"
+        if line.endswith("@"):
+            assert any(entry.startswith(line) for entry in active), (
+                f"missing active workflow line prefix: {line}"
+            )
+        else:
+            assert line in active, f"missing active workflow line: {line}"
 
 
 def workflow_step(section: str, marker: str) -> str:
@@ -132,7 +141,7 @@ def validate_python_evidence_policy(workflow_text: str) -> None:
     native_step = "Clean-install and execute native contract"
     write_step = "Write target evidence"
     stage_step = "Stage Python report for aggregate job"
-    transfer_step = "uses: actions/upload-artifact@v7"
+    transfer_step = "uses: actions/upload-artifact@"
     assert workflow_text.count(prepare_step) == 1
     python_job = required_section(workflow_text, "  python:\n", "  node:\n")
     assert (
@@ -237,10 +246,10 @@ def validate_windows_node_cold_start_policy(workflow_text: str) -> None:
     )
     assert_active_lines(node_job, "timeout-minutes: ${{ matrix.timeout_minutes || 60 }}")
 
-    assert node_job.count("actions/cache@v6") == 1
-    assert "actions/cache/restore@v6" not in node_job
-    assert "actions/cache/save@v6" not in node_job
-    assert node_job.count("actions/upload-artifact@v7") == 2
+    assert node_job.count("actions/cache@") == 1
+    assert "actions/cache/restore@" not in node_job
+    assert "actions/cache/save@" not in node_job
+    assert node_job.count("actions/upload-artifact@") == 2
     assert_active_lines(
         node_job,
         "name: binding-rc-report-${{ github.run_id }}-${{ matrix.report_target }}",
@@ -289,7 +298,7 @@ def validate_windows_node_cold_start_policy(workflow_text: str) -> None:
     )
     assert_active_lines(
         aggregate,
-        "uses: actions/download-artifact@v8",
+        "uses: actions/download-artifact@",
         "pattern: binding-rc-report-${{ github.run_id }}-*",
         "path: binding-rc-reports",
         "merge-multiple: true",
@@ -392,7 +401,7 @@ def main() -> None:
         "duplicate Windows matrix entry",
     )
     install_marker = "      - name: Install workspace dependencies"
-    for cache_action in ("actions/cache/restore@v6", "actions/cache/save@v6"):
+    for cache_action in ("actions/cache/restore@", "actions/cache/save@"):
         injected = (
             "      - name: Unapproved Windows cache transfer\n"
             f"        uses: {cache_action}\n"
@@ -465,7 +474,7 @@ def main() -> None:
     prepare_marker = "Prepare writable Python RC evidence directory"
     native_marker = "Clean-install and execute native contract"
     write_marker = "Write target evidence"
-    transfer_marker = "uses: actions/upload-artifact@v7"
+    transfer_marker = "uses: actions/upload-artifact@"
     for marker, active_line in (
         (
             prepare_marker,
@@ -521,7 +530,7 @@ def main() -> None:
         "Prepare writable Python RC evidence directory",
         "Clean-install and execute native contract",
         "Write target evidence",
-        "uses: actions/upload-artifact@v7",
+        "uses: actions/upload-artifact@",
     ):
         rejected_python_evidence_policy(rc_workflow_text.replace(marker, "", 1))
     wrapper_step = "Prepare Rust compiler wrapper for native contracts"
@@ -597,8 +606,8 @@ def main() -> None:
     assert "architecture: ${{ matrix.node_arch }}" in rc_workflow_text
     assert 'test "$(node -p \'process.arch\')" = "$EXPECTED_NODE_ARCH"' in rc_workflow_text
     assert "scripts/ci/prepare-rustc-wrapper.py" in rc_workflow_text
-    assert rc_workflow_text.count("uses: useblacksmith/stickydisk@v1") == 3
-    assert rc_workflow_text.count("uses: actions/cache@v6") == 3
+    assert rc_workflow_text.count("uses: useblacksmith/stickydisk@") == 3
+    assert rc_workflow_text.count("uses: actions/cache@") == 3
     shared_linux_key = (
         "${{ github.repository }}-binding-rc-linux-rust-1.96.0-"
         "${{ hashFiles('Cargo.lock') }}-release-target-v1"

--- a/scripts/ci/test-binding-release-candidate.py
+++ b/scripts/ci/test-binding-release-candidate.py
@@ -105,23 +105,14 @@ def required_section(text: str, start: str, end: str) -> str:
 
 
 def assert_active_lines(section: str, *expected: str) -> None:
-    """Require exact, non-commented workflow lines.
-
-    Expectations ending in ``@`` match any SHA-pinned ``uses: …@<sha> # tag`` line
-    with that prefix (Dependabot-style action pins).
-    """
+    """Require exact, non-commented workflow lines."""
     active = {
         line.strip()
         for line in section.splitlines()
         if line.strip() and not line.lstrip().startswith("#")
     }
     for line in expected:
-        if line.endswith("@"):
-            assert any(entry.startswith(line) for entry in active), (
-                f"missing active workflow line prefix: {line}"
-            )
-        else:
-            assert line in active, f"missing active workflow line: {line}"
+        assert line in active, f"missing active workflow line: {line}"
 
 
 def workflow_step(section: str, marker: str) -> str:
@@ -141,13 +132,16 @@ def validate_python_evidence_policy(workflow_text: str) -> None:
     native_step = "Clean-install and execute native contract"
     write_step = "Write target evidence"
     stage_step = "Stage Python report for aggregate job"
-    transfer_step = "uses: actions/upload-artifact@"
+    transfer_step = "uses: actions/upload-artifact@v7"
     assert workflow_text.count(prepare_step) == 1
     python_job = required_section(workflow_text, "  python:\n", "  node:\n")
     assert (
         python_job.count("PYTHON_RC_EVIDENCE_DIR: ${{ runner.temp }}/graphforge-python-rc-evidence")
         == 4
     )
+    assert "binding_rc_bazel_native.py python" in python_job
+    assert "native_builder: bazel" in python_job
+    assert "native_builder: maturin" in python_job
     _, maturin_found, post_maturin = python_job.partition("uses: PyO3/maturin-action@")
     assert maturin_found, "missing maturin build marker"
     assert (
@@ -243,10 +237,10 @@ def validate_windows_node_cold_start_policy(workflow_text: str) -> None:
     )
     assert_active_lines(node_job, "timeout-minutes: ${{ matrix.timeout_minutes || 60 }}")
 
-    assert node_job.count("actions/cache@") == 1
-    assert "actions/cache/restore@" not in node_job
-    assert "actions/cache/save@" not in node_job
-    assert node_job.count("actions/upload-artifact@") == 2
+    assert node_job.count("actions/cache@v6") == 1
+    assert "actions/cache/restore@v6" not in node_job
+    assert "actions/cache/save@v6" not in node_job
+    assert node_job.count("actions/upload-artifact@v7") == 2
     assert_active_lines(
         node_job,
         "name: binding-rc-report-${{ github.run_id }}-${{ matrix.report_target }}",
@@ -263,13 +257,17 @@ def validate_windows_node_cold_start_policy(workflow_text: str) -> None:
     )
     assert "path: target" not in workflow_step(node_job, "name: Cache Cargo registry")
     assert "key: ${{ runner.os }}-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}" in node_job
+    assert "binding_rc_bazel_native.py node" in node_job
+    assert "native_builder: bazel" in node_job
+    assert "native_builder: napi" in node_job
     assert node_job.index("uses: dtolnay/rust-toolchain@") < node_job.index(
-        "Build declared publish target"
+        "pnpm --filter @curatelabs/graphforge exec napi build --platform --release"
     )
 
     assert_active_lines(
         node_job,
         "pnpm --filter @curatelabs/graphforge exec napi build --platform --release",
+        "python3 scripts/ci/binding_rc_bazel_native.py node \\",
         "pnpm --filter @curatelabs/graphforge test:smoke",
         "tests/non-cypher-release-parity.test.mjs \\",
         "tests/async-errors.test.mjs",
@@ -291,7 +289,7 @@ def validate_windows_node_cold_start_policy(workflow_text: str) -> None:
     )
     assert_active_lines(
         aggregate,
-        "uses: actions/download-artifact@",
+        "uses: actions/download-artifact@v8",
         "pattern: binding-rc-report-${{ github.run_id }}-*",
         "path: binding-rc-reports",
         "merge-multiple: true",
@@ -394,7 +392,7 @@ def main() -> None:
         "duplicate Windows matrix entry",
     )
     install_marker = "      - name: Install workspace dependencies"
-    for cache_action in ("actions/cache/restore@", "actions/cache/save@"):
+    for cache_action in ("actions/cache/restore@v6", "actions/cache/save@v6"):
         injected = (
             "      - name: Unapproved Windows cache transfer\n"
             f"        uses: {cache_action}\n"
@@ -412,9 +410,12 @@ def main() -> None:
         ("pnpm --filter @curatelabs/graphforge test:smoke", "sleep 1"),
         ("pnpm --filter @curatelabs/graphforge test:smoke", "retry native-smoke"),
         (
-            "- name: Build declared publish target\n        shell: bash",
-            "- name: Build declared publish target\n"
-            "        if: false # disabled\n        shell: bash",
+            "pnpm --filter @curatelabs/graphforge exec napi build --platform --release",
+            "false # disabled napi build",
+        ),
+        (
+            "binding_rc_bazel_native.py node",
+            "false # disabled bazel node build",
         ),
         ("tests/non-cypher-release-parity.test.mjs", "tests/skipped-parity.test.mjs"),
         ("cmp built-addon.sha256 tested-addon.sha256", "true"),
@@ -464,7 +465,7 @@ def main() -> None:
     prepare_marker = "Prepare writable Python RC evidence directory"
     native_marker = "Clean-install and execute native contract"
     write_marker = "Write target evidence"
-    transfer_marker = "uses: actions/upload-artifact@"
+    transfer_marker = "uses: actions/upload-artifact@v7"
     for marker, active_line in (
         (
             prepare_marker,
@@ -516,10 +517,11 @@ def main() -> None:
         "  python:\n",
         "  node:\n",
         "uses: PyO3/maturin-action@",
+        "binding_rc_bazel_native.py python",
         "Prepare writable Python RC evidence directory",
         "Clean-install and execute native contract",
         "Write target evidence",
-        "uses: actions/upload-artifact@",
+        "uses: actions/upload-artifact@v7",
     ):
         rejected_python_evidence_policy(rc_workflow_text.replace(marker, "", 1))
     wrapper_step = "Prepare Rust compiler wrapper for native contracts"
@@ -533,19 +535,21 @@ def main() -> None:
         < rc_workflow_text.index(target_step)
         < rc_workflow_text.index(native_step)
     )
-    post_maturin_python = rc_workflow_text.split("uses: PyO3/maturin-action@", 1)[1].split(
-        "  node:", 1
-    )[0]
+    python_job_body = rc_workflow_text.split("  python:", 1)[1].split("  node:", 1)[0]
     assert "CARGO_TARGET_DIR: ${{ github.workspace }}/target" in rc_workflow_text
-    assert 'test "$CARGO_TARGET_DIR" = "$GITHUB_WORKSPACE/target"' in post_maturin_python
-    assert "cargo_target_state=unwritable" in post_maturin_python
-    assert "cargo_target_state=ready" in post_maturin_python
-    assert "chmod" not in post_maturin_python
-    assert post_maturin_python.count('sudo chown -R "$(id -u):$(id -g)" "$CARGO_TARGET_DIR"') == 1
-    assert "continue-on-error" not in post_maturin_python
-    assert "|| true" not in post_maturin_python
-    assert "retry" not in post_maturin_python.lower()
-    assert "if: false" not in post_maturin_python
+    assert 'test "$CARGO_TARGET_DIR" = "$GITHUB_WORKSPACE/target"' in python_job_body
+    assert "cargo_target_state=unwritable" in python_job_body
+    assert "cargo_target_state=ready" in python_job_body
+    # Bazelisk install uses chmod +x; forbid chmod on the Cargo sticky reclaim path.
+    maturin_lane = python_job_body.split("uses: PyO3/maturin-action@", 1)[1]
+    assert "chmod" not in maturin_lane
+    assert python_job_body.count('sudo chown -R "$(id -u):$(id -g)" "$CARGO_TARGET_DIR"') == 1
+    assert "continue-on-error" not in python_job_body
+    assert "|| true" not in python_job_body
+    assert "retry" not in python_job_body.lower()
+    assert "if: false" not in python_job_body
+    assert "if: matrix.native_builder == 'maturin'" in python_job_body
+    assert "if: matrix.native_builder == 'bazel'" in python_job_body
     strict_add_node_text = STRICT_ADD_NODE.read_text()
     cargo_invocation = strict_add_node_text.split('"cargo",', 1)[1].split("check=True,", 1)[0]
     assert "env=" not in cargo_invocation
@@ -561,6 +565,9 @@ def main() -> None:
     assert "project_generation::tests::" not in python_job
     assert "Clean-install and execute native contract" in python_job
     assert "uses: PyO3/maturin-action@" in python_job
+    assert "binding_rc_bazel_native.py python" in python_job
+    assert "native_builder: bazel" in python_job
+    assert "native_builder: maturin" in python_job
     test_workflow_text = (ROOT / ".github/workflows/test.yml").read_text()
     windows_locks_job = required_section(
         test_workflow_text,
@@ -590,8 +597,8 @@ def main() -> None:
     assert "architecture: ${{ matrix.node_arch }}" in rc_workflow_text
     assert 'test "$(node -p \'process.arch\')" = "$EXPECTED_NODE_ARCH"' in rc_workflow_text
     assert "scripts/ci/prepare-rustc-wrapper.py" in rc_workflow_text
-    assert rc_workflow_text.count("uses: useblacksmith/stickydisk@") == 3
-    assert rc_workflow_text.count("uses: actions/cache@") == 3
+    assert rc_workflow_text.count("uses: useblacksmith/stickydisk@v1") == 3
+    assert rc_workflow_text.count("uses: actions/cache@v6") == 3
     shared_linux_key = (
         "${{ github.repository }}-binding-rc-linux-rust-1.96.0-"
         "${{ hashFiles('Cargo.lock') }}-release-target-v1"
@@ -604,6 +611,9 @@ def main() -> None:
     assert 'sccache: "true"' not in rc_workflow_text
     assert "path: target\n          key: ${{ runner.os }}-cargo-registry" not in rc_workflow_text
     assert "Reclaim sticky-disk ownership after maturin" in rc_workflow_text
+    assert (
+        "matrix.native_builder == 'maturin' && matrix.sticky_target == 'true'" in rc_workflow_text
+    )
     package_validation_step = rc_workflow_text.split("- name: Validate cross-built package", 1)[
         1
     ].split("- name: Write target evidence", 1)[0]
@@ -625,8 +635,10 @@ def main() -> None:
     assert "scripts/ci/prepare-napi-packages.py" in release_candidate_job
     assert (
         "pnpm exec napi build --platform --release --target x86_64-unknown-linux-gnu"
-        in release_candidate_job
-    ), "assemble must generate gitignored index.js/index.d.ts before packing the main package"
+        not in release_candidate_job
+    ), "assemble must not recompile natives; emit loaders from retained addon"
+    assert "binding_rc_bazel_native.py" in release_candidate_job
+    assert "emit-node-loaders" in release_candidate_job
     assert "test -f index.js" in release_candidate_job
     assert "test -f index.d.ts" in release_candidate_job
     assert "package/index.js" in release_candidate_job


### PR DESCRIPTION
## Summary
- Linux Binding RC Python + Node x64 build Bazel cdylibs and assemble via `binding_rc_bazel_native.py` / `assemble_bazel_binding_packages.py`
- Stop maturin/napi recompile on those lanes; drop their Cargo `target/` sticky mounts
- `release_candidate` emits `index.js`/`index.d.ts` from a retained Linux addon (`emit-node-loaders`) instead of `napi build`
- Update `bazel-migration-cutover.md`; keep macOS/Windows/cross napi-maturin as follow-on

## Test plan
- [x] `python3 scripts/ci/test-binding-release-candidate.py`
- [x] `python3 scripts/ci/test-ci-storage-policy.py`
- [x] `python3 scripts/ci/test-assemble-bazel-binding-packages.py`
- [ ] CI Gate green on exact head
- [ ] Binding RC dispatch smoke on a non-prod SHA (optional)

Closes #450

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/456"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788714667&installation_model_id=20486&pr_number=456&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F456&signature=1bd1817d11394862646ca01c6416aff434e7ed772a0f5ea0ce7ec96d31fd6756"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch Linux RC lanes to consume Bazel-built native binaries
> - Linux Python RC builds now assemble the abi3 wheel from Bazel outputs via the new [`binding_rc_bazel_native.py`](https://github.com/CurateLabs/graphforge/pull/456/files#diff-752e5c8cfb5796340409bb721f27be816d91a15e3a98d422fab5ee6dda27379f) script instead of invoking maturin; macOS and Windows remain on maturin.
> - Linux Node x86_64 RC builds now stage the `.node` addon and loaders via Bazel instead of napi; other platforms remain on napi/napi-cross.
> - The release assembly job emits Node loaders via `emit-node-loaders` from the retained Linux addon rather than recompiling with `napi build`.
> - Cargo registry caching, sticky-disk mounts, and rustc-wrapper setup are skipped on Bazel lanes and retained only for maturin/napi lanes.
> - CI policy tests in [`test-binding-release-candidate.py`](https://github.com/CurateLabs/graphforge/pull/456/files#diff-0f46df0941bbc9d37e0287959e672d46800afacfe645b33a298b23229b1f366f) are updated to enforce presence of Bazel build paths and absence of recompiling `napi build` in release assembly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ecda605.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->