### PR TITLE
style: ruff-format suite-membership parity check files

### DIFF
--- a/scripts/ci/cargo-bazel-parity-check.py
+++ b/scripts/ci/cargo-bazel-parity-check.py
@@ -168,17 +168,14 @@ def check_suite_membership(root: Path, map_path: Path) -> list[str]:
     )
     if result.returncode != 0:
         return [
-            "bazelisk query tests(//:ci_rust_tests) failed:\n"
-            + (result.stderr or result.stdout)
+            "bazelisk query tests(//:ci_rust_tests) failed:\n" + (result.stderr or result.stdout)
         ]
 
     suite = {line.strip() for line in result.stdout.splitlines() if line.strip()}
     errors: list[str] = []
     for label in mapped_tests:
         if label not in suite:
-            errors.append(
-                f"mapped integration-test not reachable from //:ci_rust_tests: {label}"
-            )
+            errors.append(f"mapped integration-test not reachable from //:ci_rust_tests: {label}")
     return errors
 
 

--- a/scripts/ci/test-cargo-bazel-parity-check.py
+++ b/scripts/ci/test-cargo-bazel-parity-check.py
@@ -115,8 +115,7 @@ def main() -> None:
 
         if not suite_errors or "orphan_test" not in suite_errors[0]:
             raise SystemExit(
-                "expected suite-membership check to report orphan_test, got:\n"
-                + repr(suite_errors)
+                "expected suite-membership check to report orphan_test, got:\n" + repr(suite_errors)
             )
 
     print("cargo-bazel parity check tests passed")


### PR DESCRIPTION
## Summary
- Format `cargo-bazel-parity-check.py` and its self-test after #445 landed with ruff-format debt that breaks Python Quality on every subsequent PR.

## Test plan
- [x] `uv run ruff format --check` on the two files
- [ ] CI Gate green


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788714886&installation_model_id=20486&pr_number=458&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F458&signature=3f76057277a4dc8dfdce6b45fbb1c78f08047bc1af5d06b601a73258c385e634"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Apply ruff formatting to suite-membership parity check scripts
> Collapses multi-line string concatenations into single-line expressions in [cargo-bazel-parity-check.py](https://github.com/CurateLabs/graphforge/pull/458/files#diff-744af0fb1eaac01ee3da0e7b2ef3ec7afb49d27d717706f539f8ab1075535dfc) and [test-cargo-bazel-parity-check.py](https://github.com/CurateLabs/graphforge/pull/458/files#diff-86514e0ee693236de6fa1be6734fece38654bda8016470c2203b738d7ff7232f). No logic, control flow, or test behavior is changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0b61834.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->