### PR TITLE
style: drop unused ANN001 noqa in parity self-test

### DIFF
--- a/scripts/ci/test-cargo-bazel-parity-check.py
+++ b/scripts/ci/test-cargo-bazel-parity-check.py
@@ -101,7 +101,7 @@ def main() -> None:
 
         real_run = mod.run
 
-        def fake_run(cmd, cwd=None):  # noqa: ANN001
+        def fake_run(cmd, cwd=None):
             if len(cmd) >= 3 and cmd[0] == "bazelisk" and cmd[1] == "query":
                 # Empty suite → orphan label is missing.
                 return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")


### PR DESCRIPTION
## Summary
- Remove unused `# noqa: ANN001` that fails `ruff check` (RUF100) on every PR after #445.

## Test plan
- [x] `uv run ruff check scripts/ci/test-cargo-bazel-parity-check.py`
- [ ] CI Gate green


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788715660&installation_model_id=20486&pr_number=466&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F466&signature=45467d709170d354b4b5f2487b1d65f8d9725db737f85a6972962c5e5ab84aab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `# noqa: ANN001` comment from `fake_run` in parity self-test
> Drops a stale linter suppression comment from [test-cargo-bazel-parity-check.py](https://github.com/CurateLabs/graphforge/pull/466/files#diff-86514e0ee693236de6fa1be6734fece38654bda8016470c2203b738d7ff7232f) that is no longer needed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4941d27.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->