### PR TITLE
ci: live suite-membership inventory on bazel-bootstrap

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -858,6 +858,13 @@ jobs:
           python3 scripts/ci/test-bazel-migration-ledger-check.py
           python3 scripts/ci/test-cargo-bazel-parity-check.py
 
+      # Live suite-membership gate: every mapped integration-test label must be
+      # reachable from tests(//:ci_rust_tests). Required path must exercise the
+      # live bazelisk query (unit-test harness may skip it).
+      - name: Live suite-membership inventory (fail-closed)
+        run: |
+          python3 scripts/ci/cargo-bazel-parity-check.py --mode inventory
+
       - name: Blacksmith remote-cache policy + harness unit tests
         run: |
           # Do not set --remote_cache; Blacksmith injects repository cache.

--- a/scripts/ci/test-ci-storage-policy.py
+++ b/scripts/ci/test-ci-storage-policy.py
@@ -570,6 +570,18 @@ def validate_ci_gate_cutover(text: str) -> None:
     assert not job_runs_command(jobs[auth_job], "cargo-bazel-parity-check.py --mode all"), (
         "authoritative bazel-bootstrap must not run dual-build parity"
     )
+    assert job_runs_command(jobs[auth_job], "cargo-bazel-parity-check.py --mode inventory"), (
+        "authoritative bazel-bootstrap must run live suite-membership inventory"
+    )
+    inventory_lines = [
+        line
+        for line in jobs[auth_job].splitlines()
+        if "cargo-bazel-parity-check.py --mode inventory" in line
+    ]
+    assert inventory_lines, "live inventory command line must be present in bazel-bootstrap"
+    assert all("--skip-label-query" not in line for line in inventory_lines), (
+        "authoritative bazel-bootstrap inventory must not skip bazelisk label query"
+    )
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- Run `cargo-bazel-parity-check.py --mode inventory` (with live bazelisk query) on required `bazel-bootstrap`
- Add storage-policy regression so CI Gate authority cannot skip suite-membership again
- Closes the residual gap from #440 after doctest/helper work landed earlier

## Test plan
- [x] `python3 scripts/ci/test-ci-storage-policy.py`
- [x] `ruff format --check` / `ruff check` on touched Python
- [ ] CI Gate green on this head

Fixes #440

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788720345&installation_model_id=20486&pr_number=476&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F476&signature=7df019b982b3b2a0f33d27bc4eb57acae57c01abf5ede36f247435cabcf59d59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened CI validation to ensure the authoritative build job uses the live suite-membership inventory.
  * Added checks that the required inventory command is configured.
  * Prevented bypassing label-query validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add live suite-membership inventory step to bazel-bootstrap CI workflow
> - Adds a new CI step in [test.yml](.github/workflows/test.yml) that runs `cargo-bazel-parity-check.py --mode inventory` via a live bazelisk query, failing closed if the command fails.
> - Extends `validate_ci_gate_cutover` in [test-ci-storage-policy.py](scripts/ci/test-ci-storage-policy.py) to assert the inventory command is present in the authoritative job and that `--skip-label-query` is not used.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 939fed3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->