### PR TITLE
ci: pin Diagnostics checkout + checksum bazelisk

### DIFF
--- a/.github/workflows/binding-release-candidate.yml
+++ b/.github/workflows/binding-release-candidate.yml
@@ -97,10 +97,18 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          sudo curl -fsSL \
-            "https://github.com/bazelbuild/bazelisk/releases/download/v1.26.0/bazelisk-linux-amd64" \
-            -o /usr/local/bin/bazelisk
-          sudo chmod +x /usr/local/bin/bazelisk
+          version=1.26.0
+          # SHA-256 of bazelisk-linux-amd64 from
+          # https://github.com/bazelbuild/bazelisk/releases/tag/v1.26.0
+          # Computed locally: curl -fsSL … | shasum -a 256
+          checksum=6539c12842ad76966f3d493e8f80d67caa84ec4a000e220d5459833c967c12bc
+          tmp=$(mktemp)
+          curl -fsSL \
+            "https://github.com/bazelbuild/bazelisk/releases/download/v${version}/bazelisk-linux-amd64" \
+            -o "$tmp"
+          printf '%s  %s\n' "$checksum" "$tmp" | shasum -a 256 --check
+          sudo install -m 0755 "$tmp" /usr/local/bin/bazelisk
+          rm -f "$tmp"
           sudo ln -sf /usr/local/bin/bazelisk /usr/local/bin/bazel
           bazelisk version
 
@@ -356,10 +364,18 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          sudo curl -fsSL \
-            "https://github.com/bazelbuild/bazelisk/releases/download/v1.26.0/bazelisk-linux-amd64" \
-            -o /usr/local/bin/bazelisk
-          sudo chmod +x /usr/local/bin/bazelisk
+          version=1.26.0
+          # SHA-256 of bazelisk-linux-amd64 from
+          # https://github.com/bazelbuild/bazelisk/releases/tag/v1.26.0
+          # Computed locally: curl -fsSL … | shasum -a 256
+          checksum=6539c12842ad76966f3d493e8f80d67caa84ec4a000e220d5459833c967c12bc
+          tmp=$(mktemp)
+          curl -fsSL \
+            "https://github.com/bazelbuild/bazelisk/releases/download/v${version}/bazelisk-linux-amd64" \
+            -o "$tmp"
+          printf '%s  %s\n' "$checksum" "$tmp" | shasum -a 256 --check
+          sudo install -m 0755 "$tmp" /usr/local/bin/bazelisk
+          rm -f "$tmp"
           sudo ln -sf /usr/local/bin/bazelisk /usr/local/bin/bazel
           bazelisk version
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -900,14 +900,22 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Bazelisk
         run: |
-          sudo curl -fsSL \
-            "https://github.com/bazelbuild/bazelisk/releases/download/v1.26.0/bazelisk-linux-amd64" \
-            -o /usr/local/bin/bazelisk
-          sudo chmod +x /usr/local/bin/bazelisk
+          version=1.26.0
+          # SHA-256 of bazelisk-linux-amd64 from
+          # https://github.com/bazelbuild/bazelisk/releases/tag/v1.26.0
+          # Computed locally: curl -fsSL … | shasum -a 256
+          checksum=6539c12842ad76966f3d493e8f80d67caa84ec4a000e220d5459833c967c12bc
+          tmp=$(mktemp)
+          curl -fsSL \
+            "https://github.com/bazelbuild/bazelisk/releases/download/v${version}/bazelisk-linux-amd64" \
+            -o "$tmp"
+          printf '%s  %s\n' "$checksum" "$tmp" | shasum -a 256 --check
+          sudo install -m 0755 "$tmp" /usr/local/bin/bazelisk
+          rm -f "$tmp"
           sudo ln -sf /usr/local/bin/bazelisk /usr/local/bin/bazel
           bazelisk version
 

--- a/scripts/ci/test-binding-release-candidate.py
+++ b/scripts/ci/test-binding-release-candidate.py
@@ -549,7 +549,7 @@ def main() -> None:
     assert 'test "$CARGO_TARGET_DIR" = "$GITHUB_WORKSPACE/target"' in python_job_body
     assert "cargo_target_state=unwritable" in python_job_body
     assert "cargo_target_state=ready" in python_job_body
-    # Bazelisk install uses chmod +x; forbid chmod on the Cargo sticky reclaim path.
+    # Bazelisk install uses sudo install -m 0755; forbid chmod on the Cargo sticky reclaim path.
     maturin_lane = python_job_body.split("uses: PyO3/maturin-action@", 1)[1]
     assert "chmod" not in maturin_lane
     assert python_job_body.count('sudo chown -R "$(id -u):$(id -g)" "$CARGO_TARGET_DIR"') == 1


### PR DESCRIPTION
## Summary
- Pin `bazel-diagnostics` `actions/checkout` to the same SHA as bootstrap
- Verify bazelisk SHA-256 on Diagnostics and Binding RC Linux Bazel lanes
- Refresh Binding RC contract comment for the install pattern

## Test plan
- [x] `python3 scripts/ci/test-ci-storage-policy.py`
- [x] `python3 scripts/ci/test-binding-release-candidate.py`
- [ ] CI Gate green on this head

Fixes #473

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788720408&installation_model_id=20486&pr_number=477&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F477&signature=25f40d96b4b31361cec831c7464d72610792295cc8e778c53d4f29503dcc2cc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin Diagnostics checkout and add checksum verification for Bazelisk install in CI
> - Pins the `actions/checkout` step in the `bazel-diagnostics` job to a specific commit SHA (v7.0.1) instead of the floating `@v7` tag.
> - Replaces the direct curl-and-chmod Bazelisk install with a verified install: downloads to a temp path, checks a hardcoded SHA-256 for v1.26.0, then installs with `sudo install -m 0755`. Applied to all affected CI jobs in [binding-release-candidate.yml](.github/workflows/binding-release-candidate.yml) and [test.yml](.github/workflows/test.yml).
> - Behavioral Change: CI jobs now fail if the Bazelisk binary checksum does not match, rather than silently proceeding with an unverified binary.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 298e8ea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->