### PR TITLE
ci: classify Bazel-mapped crate test-data before binding globs

### DIFF
--- a/scripts/ci/classify-changes.sh
+++ b/scripts/ci/classify-changes.sh
@@ -166,6 +166,23 @@ while IFS= read -r -d '' path; do
       bindings=true
       ;;
 
+    # Bazel-mapped hermetic crate test data must win over the binding crate
+    # globs below. Without this ordering, e.g. graphforge-api fixtures only
+    # enable bindings and skip the authoritative Rust/Bazel suite.
+    crates/*/tests/*goldens/* | crates/*/tests/*goldens/**/* | \
+      crates/*/tests/**/*.snap | \
+      crates/*/tests/fixtures/* | crates/*/tests/fixtures/**/* | \
+      crates/*/tests/corpus/* | crates/*/tests/corpus/**/*)
+      rust=true
+      bazel=true
+      case "$path" in
+        crates/graphforge-api/* | crates/graphforge-bindings-py/* | \
+          crates/graphforge-bindings-node/*)
+          bindings=true
+          ;;
+      esac
+      ;;
+
     crates/graphforge-api/* | crates/graphforge-bindings-py/* | crates/graphforge-bindings-node/*)
       bindings=true
       [[ "$path" == *.rs ]] && rust=true
@@ -262,15 +279,11 @@ while IFS= read -r -d '' path; do
       terraform=true
       ;;
 
-    # Bazel-mapped hermetic test data (resource_inputs / filegroups). These are
-    # not *.rs, so they must be classified explicitly or they would fall through
-    # to the fail-closed default below.
+    # Bazel-mapped hermetic test data outside binding crate globs (crate
+    # goldens/fixtures/corpus/snaps are classified earlier so they win over
+    # crates/graphforge-api|bindings-* globs).
     tests/tck/* | tests/tck/**/* | \
       tests/release_workflows/* | tests/release_workflows/**/* | \
-      crates/*/tests/*goldens/* | crates/*/tests/*goldens/**/* | \
-      crates/*/tests/**/*.snap | \
-      crates/*/tests/fixtures/* | crates/*/tests/fixtures/**/* | \
-      crates/*/tests/corpus/* | crates/*/tests/corpus/**/* | \
       docs/contracts/examples/* | docs/contracts/examples/**/* | \
       docs/reference/* | docs/reference/**/*)
       rust=true

--- a/scripts/ci/test-classify-changes.sh
+++ b/scripts/ci/test-classify-changes.sh
@@ -144,6 +144,14 @@ assert_classification "$rust_only" \
   crates/graphforge-ontology/tests/fixtures/hr.json ontology-fixture
 assert_classification "$rust_only" \
   crates/graphforge-cypher/tests/corpus/valid.json cypher-corpus
+# Binding-crate fixtures must still enable authoritative Rust/Bazel (not
+# bindings-only from the later crate glob).
+assert_classification "$binding_rust" \
+  crates/graphforge-api/tests/fixtures/x.json api-fixture
+assert_classification "$binding_rust" \
+  crates/graphforge-bindings-py/tests/fixtures/sample.json py-binding-fixture
+assert_classification "$binding_rust" \
+  crates/graphforge-bindings-node/tests/fixtures/sample.json node-binding-fixture
 assert_classification "$binding_rust" \
   examples/agent_grounding/ecommerce_agent.ipynb grounding-notebook
 assert_classification "$rust_only" \


### PR DESCRIPTION
## Summary
- Evaluate Bazel-mapped crate goldens/fixtures/corpus/snaps before binding crate globs
- Keep `bindings=true` for api/bindings-py/bindings-node test data
- Add regressions for api and binding fixture paths

## Test plan
- [x] `bash scripts/ci/test-classify-changes.sh`
- [ ] CI Gate green on this head

Fixes #474

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788720497&installation_model_id=20486&pr_number=478&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F478&signature=092efc184dbdf4f8ec55df2d3cf2307afff43c143537cc44e8376e5ec703c793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI Improvements**
  - Improved change classification for crate test data, ensuring Rust and Bazel validation runs first.
  - Binding checks are now enabled selectively for applicable API, Python, and Node crates.
  - Added coverage to verify classification behavior across supported binding fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Classify Bazel-mapped crate test data before binding globs in CI change classifier
> - Adds a high-precedence case block in [classify-changes.sh](https://github.com/CurateLabs/graphforge/pull/478/files#diff-9c479d4633de98cfc5884f3f7fd84e5abbd292370078443e7958f023d5a056f1) that matches `crates/*/tests` paths (goldens, snaps, fixtures, corpus) and sets `rust=true` and `bazel=true`, ensuring these paths trigger Rust/Bazel suites rather than falling through to the bindings-only classification.
> - For binding crates (`graphforge-api`, `graphforge-bindings-py`, `graphforge-bindings-node`), the new block also sets `bindings=true`, so all three gates run.
> - Removes `crates/*/tests` globs from the later generic hermetic test data case, which now only covers `tests/tck`, `tests/release_workflows`, and docs paths.
> - Adds three assertions in [test-classify-changes.sh](https://github.com/CurateLabs/graphforge/pull/478/files#diff-b0cf9ea62c36d41efe27b93e7d80500212baff24baf9ff35652d79e540ee6c61) verifying fixture files in binding crates are classified as `binding_rust`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 09578c5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->