### PR TITLE
ci: add missing job timeouts on contract gates and Binding RC

### DIFF
--- a/.github/workflows/binding-release-candidate.yml
+++ b/.github/workflows/binding-release-candidate.yml
@@ -19,6 +19,7 @@ jobs:
   validate_source:
     name: Validate post-merge main SHA
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
     outputs:
       evidence_sha: ${{ steps.source.outputs.evidence_sha }}
     steps:
@@ -472,6 +473,7 @@ jobs:
     if: always() && needs.validate_source.result == 'success'
     needs: [validate_source, python, node]
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 20
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/m20-contract-gate.yml
+++ b/.github/workflows/m20-contract-gate.yml
@@ -79,6 +79,7 @@ jobs:
     if: always()
     needs: [rust, python, node]
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/m21-contract-gate.yml
+++ b/.github/workflows/m21-contract-gate.yml
@@ -79,6 +79,7 @@ jobs:
     if: always()
     needs: [rust, python, node]
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0


### PR DESCRIPTION
## Summary
- Add `timeout-minutes: 10` to m20/m21 `report` jobs
- Add `timeout-minutes: 15` to Binding RC `validate_source`
- Add `timeout-minutes: 20` to Binding RC `aggregate`

## Test plan
- [x] `python3 scripts/ci/test-binding-release-candidate.py`
- [ ] CI Gate green on this head

Fixes #475

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/479"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788720503&installation_model_id=20486&pr_number=479&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F479&signature=f3c32d75ddd8933cde3ff8b94bd629f97871af1b31ad0e1c06989baea4df45f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add missing job timeouts to contract gates and binding release candidate workflows
> Adds explicit `timeout-minutes` to jobs in three CI workflows that previously had no timeout, preventing hung jobs from blocking pipelines indefinitely.
>
> - `validate_source` in [binding-release-candidate.yml](.github/workflows/binding-release-candidate.yml) gets a 15-minute timeout; `aggregate` gets 20 minutes
> - `report` in both [m20-contract-gate.yml](.github/workflows/m20-contract-gate.yml) and [m21-contract-gate.yml](.github/workflows/m21-contract-gate.yml) gets a 10-minute timeout
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f6b000f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->