### PR TITLE
fix(storage): adapt checkpoint lock test helpers to fs4 1.x

### DIFF
--- a/crates/graphforge-api/src/repository.rs
+++ b/crates/graphforge-api/src/repository.rs
@@ -2547,11 +2547,15 @@ mod tests {
                 .truncate(false)
                 .open(&path)
                 .unwrap_or_else(|error| panic!("{phase}: open {name}: {error}"));
-            assert!(
-                FileExt::try_lock_exclusive(&file)
-                    .unwrap_or_else(|error| panic!("{phase}: try_lock {name}: {error}")),
-                "{phase}: {name} was still held (issue #275 probe)"
-            );
+            match FileExt::try_lock(&file) {
+                Ok(()) => {}
+                Err(fs4::TryLockError::WouldBlock) => {
+                    panic!("{phase}: {name} was still held (issue #275 probe)")
+                }
+                Err(fs4::TryLockError::Error(error)) => {
+                    panic!("{phase}: try_lock {name}: {error}")
+                }
+            }
             FileExt::unlock(&file)
                 .unwrap_or_else(|error| panic!("{phase}: unlock {name}: {error}"));
         }

--- a/crates/graphforge-storage/src/project_checkpoints.rs
+++ b/crates/graphforge-storage/src/project_checkpoints.rs
@@ -1848,8 +1848,10 @@ mod tests {
                 let acquired = match mode {
                     CheckpointLockMode::Shared => crate::file_lock::try_lock_shared(&checkpoint)
                         .expect("phase=holder acquire shared checkpoints.lock"),
-                    CheckpointLockMode::Exclusive => crate::file_lock::try_lock_exclusive(&checkpoint)
-                        .expect("phase=holder acquire exclusive checkpoints.lock"),
+                    CheckpointLockMode::Exclusive => {
+                        crate::file_lock::try_lock_exclusive(&checkpoint)
+                            .expect("phase=holder acquire exclusive checkpoints.lock")
+                    }
                 };
                 assert!(
                     acquired,
@@ -1857,7 +1859,8 @@ mod tests {
                 );
                 ready_sender.send(()).expect("phase=holder publish ready");
                 release_receiver.recv().expect("phase=holder await release");
-                crate::file_lock::unlock(&checkpoint).expect("phase=holder release checkpoints.lock");
+                crate::file_lock::unlock(&checkpoint)
+                    .expect("phase=holder release checkpoints.lock");
             })
             .expect("phase=holder spawn");
         let holder = WriterLockHolder {
@@ -1902,7 +1905,8 @@ mod tests {
                 let writer =
                     open_regular_lock(&worker_writer).expect("phase=holder open writer.lock");
                 assert!(
-                    crate::file_lock::try_lock_exclusive(&writer).expect("phase=holder acquire writer.lock"),
+                    crate::file_lock::try_lock_exclusive(&writer)
+                        .expect("phase=holder acquire writer.lock"),
                     "phase=holder writer.lock unexpectedly busy"
                 );
                 let checkpoint = open_regular_lock(&worker_checkpoint)
@@ -1915,7 +1919,8 @@ mod tests {
                 crate::file_lock::unlock(&writer).expect("phase=holder early release writer.lock");
                 ready_sender.send(()).expect("phase=holder publish ready");
                 release_receiver.recv().expect("phase=holder await release");
-                crate::file_lock::unlock(&checkpoint).expect("phase=holder release checkpoints.lock");
+                crate::file_lock::unlock(&checkpoint)
+                    .expect("phase=holder release checkpoints.lock");
             })
             .expect("phase=holder spawn");
         let holder = WriterLockHolder {

--- a/crates/graphforge-storage/src/project_checkpoints.rs
+++ b/crates/graphforge-storage/src/project_checkpoints.rs
@@ -1846,9 +1846,9 @@ mod tests {
                 let checkpoint =
                     open_regular_lock(&worker_path).expect("phase=holder open checkpoints.lock");
                 let acquired = match mode {
-                    CheckpointLockMode::Shared => FileExt::try_lock_shared(&checkpoint)
+                    CheckpointLockMode::Shared => crate::file_lock::try_lock_shared(&checkpoint)
                         .expect("phase=holder acquire shared checkpoints.lock"),
-                    CheckpointLockMode::Exclusive => FileExt::try_lock_exclusive(&checkpoint)
+                    CheckpointLockMode::Exclusive => crate::file_lock::try_lock_exclusive(&checkpoint)
                         .expect("phase=holder acquire exclusive checkpoints.lock"),
                 };
                 assert!(
@@ -1857,7 +1857,7 @@ mod tests {
                 );
                 ready_sender.send(()).expect("phase=holder publish ready");
                 release_receiver.recv().expect("phase=holder await release");
-                FileExt::unlock(&checkpoint).expect("phase=holder release checkpoints.lock");
+                crate::file_lock::unlock(&checkpoint).expect("phase=holder release checkpoints.lock");
             })
             .expect("phase=holder spawn");
         let holder = WriterLockHolder {
@@ -1902,20 +1902,20 @@ mod tests {
                 let writer =
                     open_regular_lock(&worker_writer).expect("phase=holder open writer.lock");
                 assert!(
-                    FileExt::try_lock_exclusive(&writer).expect("phase=holder acquire writer.lock"),
+                    crate::file_lock::try_lock_exclusive(&writer).expect("phase=holder acquire writer.lock"),
                     "phase=holder writer.lock unexpectedly busy"
                 );
                 let checkpoint = open_regular_lock(&worker_checkpoint)
                     .expect("phase=holder open checkpoints.lock");
                 assert!(
-                    FileExt::try_lock_exclusive(&checkpoint)
+                    crate::file_lock::try_lock_exclusive(&checkpoint)
                         .expect("phase=holder acquire checkpoints.lock"),
                     "phase=holder checkpoints.lock unexpectedly busy"
                 );
-                FileExt::unlock(&writer).expect("phase=holder early release writer.lock");
+                crate::file_lock::unlock(&writer).expect("phase=holder early release writer.lock");
                 ready_sender.send(()).expect("phase=holder publish ready");
                 release_receiver.recv().expect("phase=holder await release");
-                FileExt::unlock(&checkpoint).expect("phase=holder release checkpoints.lock");
+                crate::file_lock::unlock(&checkpoint).expect("phase=holder release checkpoints.lock");
             })
             .expect("phase=holder spawn");
         let holder = WriterLockHolder {
@@ -1948,10 +1948,10 @@ mod tests {
         for name in [WRITER_LOCK_FILE, CHECKPOINT_LOCK_FILE] {
             let lock = open_regular_lock(&lock_root.join(name)).unwrap();
             assert!(
-                FileExt::try_lock_exclusive(&lock).unwrap(),
+                crate::file_lock::try_lock_exclusive(&lock).unwrap(),
                 "{phase}: {name} leaked"
             );
-            FileExt::unlock(&lock).unwrap();
+            crate::file_lock::unlock(&lock).unwrap();
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace bare `FileExt::try_lock_*` / `unlock` in checkpoint contention test helpers with `crate::file_lock` bool-shaped wrappers
- Unblocks CI Gate after the fs4 1.1.0 bump (#465) broke helpers added in #469

## Test plan
- [x] `cargo test -p graphforge-storage --lib project_checkpoints::tests::` (35 passed, 1 ignored)
- [ ] CI Gate green on this head

Fixes #480

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/481"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788721366&installation_model_id=20486&pr_number=481&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F481&signature=566c241c0e455250cefc3bde3c71c1a225498932b77187d5bf7931f2dde1bb85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->