### PR TITLE
ci: fix Publish Track Binding RC dispatch without git checkout

### DIFF
--- a/.github/workflows/publish-track.yml
+++ b/.github/workflows/publish-track.yml
@@ -192,7 +192,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_SHA: ${{ needs.resolve_source.outputs.release_sha }}
         run: |
+          # --repo avoids gh inferring the repository from a local .git
+          # (this job has no checkout).
           gh workflow run binding-release-candidate.yml \
+            --repo "$GITHUB_REPOSITORY" \
             --ref main \
             -f "commit_sha=$RELEASE_SHA"
 

--- a/scripts/ci/test-publish-track.py
+++ b/scripts/ci/test-publish-track.py
@@ -59,6 +59,8 @@ assert "needs.locate_candidate.result == 'success'" in dispatch
 assert "needs.validate_candidate.result != 'success'" in dispatch
 assert "inputs.create_release" in dispatch
 assert "gh workflow run binding-release-candidate.yml" in dispatch
+assert '--repo "$GITHUB_REPOSITORY"' in dispatch
+assert "--ref main" in dispatch
 
 release = workflow.split("  create_release:\n", 1)[1]
 assert "inputs.create_release" in release


### PR DESCRIPTION
## Summary
- Pass `--repo "$GITHUB_REPOSITORY"` to `gh workflow run` in `dispatch_binding_rc`
- Contract-test the durable dispatch form

## Test plan
- [x] `python3 scripts/ci/test-publish-track.py`
- [ ] CI Gate green on this head

Fixes #483

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788725484&installation_model_id=20486&pr_number=484&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F484&signature=f701b120dae70ba14ce161e1011cb055f45292be665305c5690ef8844fc306ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `gh workflow run` dispatch in publish-track CI by adding explicit `--repo` flag
> The `gh` CLI requires a local `.git` directory to infer the repository, which is unavailable at the dispatch step. Adding `--repo "$GITHUB_REPOSITORY"` to the `gh workflow run binding-release-candidate.yml` command in [publish-track.yml](.github/workflows/publish-track.yml) makes the target repository explicit. A test in [test-publish-track.py](scripts/ci/test-publish-track.py) now asserts both `--repo` and `--ref main` are present in the dispatch command.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 80010ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->