### PR TITLE
perf(storage): stream partitioned Parquet execution (#339)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2300,6 +2300,7 @@ dependencies = [
  "datafusion",
  "datafusion-catalog",
  "fs4 1.1.0",
+ "futures",
  "graphforge-core",
  "graphforge-ir",
  "graphforge-ontology",

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "ff07780c6da0c14fbccedd474016ead7caa83b11db8601da086498f55c659c48",
+  "checksum": "5f8f762b3ab87221b979d49753c6b9478b5e56e44789992a4423207cbd266d62",
   "crates": {
     "adler2 2.0.1": {
       "name": "adler2",
@@ -13081,6 +13081,10 @@
             {
               "id": "fs4 1.1.0",
               "target": "fs4"
+            },
+            {
+              "id": "futures 0.3.32",
+              "target": "futures"
             },
             {
               "id": "parquet 58.3.0",

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -642,6 +642,7 @@ impl GraphForge {
             spill_enabled: self.resource_policy.spill_enabled,
             spill_directory: self.resource_policy.spill_directory.clone(),
             spill_max_bytes: self.resource_policy.spill_max_bytes,
+            io_concurrency: self.resource_policy.io_concurrency,
         }
     }
 

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -1239,12 +1239,16 @@ impl GraphForge {
         ))
     }
 
-    /// Streaming query plus a [`RuntimeGuard`] that keeps the instance's runtime
-    /// alive for as long as the returned stream is held — for bindings that
-    /// detach the stream into a foreign, lazily-consumed reader (e.g. a
-    /// `pyarrow.RecordBatchReader`, #587). A bare runtime `Handle` does not keep
-    /// the runtime alive, so the guard holds an `Arc` to it; the runtime is shut
-    /// down only once both this `GraphForge` and every outstanding guard drop.
+    /// Streaming query plus a [`RuntimeGuard`] that keeps the instance's
+    /// runtime **and** on-disk graph workspace alive for as long as the returned
+    /// stream is held — for bindings that detach the stream into a foreign,
+    /// lazily-consumed reader (e.g. a `pyarrow.RecordBatchReader`, #587).
+    ///
+    /// A bare runtime `Handle` does not keep the runtime alive, and streaming
+    /// Parquet scans (#339) read fragment paths during consumer pull — so the
+    /// guard also pins the private workspace (and in-memory project tempdir)
+    /// that back those paths. Resources are released only once both this
+    /// `GraphForge` and every outstanding guard drop.
     ///
     /// Returns the (shaped) stream, its schema (advertised up front so a reader
     /// can expose `schema` before the first batch), and the guard.
@@ -1265,7 +1269,15 @@ impl GraphForge {
     > {
         let stream = self.execute_stream_with_params(cypher, params)?;
         let schema = stream.schema();
-        Ok((stream, schema, RuntimeGuard(Arc::clone(&self.runtime))))
+        Ok((
+            stream,
+            schema,
+            RuntimeGuard {
+                runtime: Arc::clone(&self.runtime),
+                workspace: Arc::clone(&self.workspace_guard),
+                tempdir: self.tempdir.clone(),
+            },
+        ))
     }
 
     /// Drive a future on the instance's runtime from a synchronous caller.
@@ -3053,13 +3065,23 @@ impl Drop for OwnedRuntime {
     }
 }
 
-/// An opaque guard that keeps a [`GraphForge`]'s Tokio runtime alive after the
-/// instance is dropped, so a detached [`execute_stream_owned`](GraphForge::execute_stream_owned)
-/// stream can still be driven to completion (e.g. a lazy
-/// `pyarrow.RecordBatchReader`, #587). Cheap to clone (an `Arc` bump); the
-/// runtime is shut down only once the `GraphForge` and all guards have dropped.
+/// An opaque guard that keeps a [`GraphForge`]'s Tokio runtime and on-disk graph
+/// workspace alive after the instance is dropped, so a detached
+/// [`execute_stream_owned`](GraphForge::execute_stream_owned) stream can still
+/// be driven to completion (e.g. a lazy `pyarrow.RecordBatchReader`, #587).
+///
+/// Cheap to clone (`Arc` bumps). The runtime shuts down and temp workspaces are
+/// removed only once the `GraphForge` and all guards have dropped. Streaming
+/// Parquet scans (#339) open fragment paths at pull time, so pinning the
+/// workspace is required for the same lifetime contract MemTable planning had.
 #[derive(Clone, Debug)]
-pub struct RuntimeGuard(Arc<OwnedRuntime>);
+pub struct RuntimeGuard {
+    runtime: Arc<OwnedRuntime>,
+    /// Private mutable graph workspace hydrated for this facade (`dir`).
+    workspace: Arc<tempfile::TempDir>,
+    /// In-memory project root, when the facade is not path-backed.
+    tempdir: Option<Arc<tempfile::TempDir>>,
+}
 
 impl RuntimeGuard {
     /// Drive a future to completion on the guarded runtime from a synchronous
@@ -3075,7 +3097,11 @@ impl RuntimeGuard {
         F: std::future::Future + Send,
         F::Output: Send,
     {
-        let handle = self.0.handle().clone();
+        // Keep workspace/tempdir referenced for the duration of the poll so a
+        // future that captures only `self.runtime` cannot outlive the pins.
+        let _workspace = &self.workspace;
+        let _tempdir = &self.tempdir;
+        let handle = self.runtime.handle().clone();
         if tokio::runtime::Handle::try_current().is_ok() {
             std::thread::scope(|s| {
                 s.spawn(|| handle.block_on(fut))

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -3078,8 +3078,11 @@ impl Drop for OwnedRuntime {
 pub struct RuntimeGuard {
     runtime: Arc<OwnedRuntime>,
     /// Private mutable graph workspace hydrated for this facade (`dir`).
+    /// Held solely so `TempDir` cleanup waits until stream consumers finish.
+    #[allow(dead_code)]
     workspace: Arc<tempfile::TempDir>,
     /// In-memory project root, when the facade is not path-backed.
+    #[allow(dead_code)]
     tempdir: Option<Arc<tempfile::TempDir>>,
 }
 
@@ -3097,10 +3100,6 @@ impl RuntimeGuard {
         F: std::future::Future + Send,
         F::Output: Send,
     {
-        // Keep workspace/tempdir referenced for the duration of the poll so a
-        // future that captures only `self.runtime` cannot outlive the pins.
-        let _workspace = &self.workspace;
-        let _tempdir = &self.tempdir;
         let handle = self.runtime.handle().clone();
         if tokio::runtime::Handle::try_current().is_ok() {
             std::thread::scope(|s| {

--- a/crates/graphforge-api/tests/e2e_baseline.rs
+++ b/crates/graphforge-api/tests/e2e_baseline.rs
@@ -3333,9 +3333,10 @@ fn execute_stream_owned_guard_outlives_dropped_forge() {
         &DataType::FixedSizeBinary(16),
     );
 
-    // Drop the GraphForge before consuming: the guard (an Arc to the runtime)
-    // must keep it alive so the detached stream still drives to completion — the
-    // lazy-reader lifetime contract the Python binding relies on (#587).
+    // Drop the GraphForge before consuming: the guard must keep the Tokio
+    // runtime and on-disk workspace alive so the detached stream still drives
+    // to completion — the lazy-reader lifetime contract the Python binding
+    // relies on (#587), including streaming Parquet fragment opens (#339).
     drop(gf);
 
     let mut rows = 0;

--- a/crates/graphforge-bindings-py/src/lib.rs
+++ b/crates/graphforge-bindings-py/src/lib.rs
@@ -1560,9 +1560,10 @@ fn bulk_edge_publication_error(py: Python<'_>, error: BulkEdgePublicationError) 
 /// query one batch per pull. Handed to PyArrow (via the Arrow C Stream
 /// Interface) so `execute_stream` returns a genuine `pyarrow.RecordBatchReader`.
 ///
-/// Owns a [`RuntimeGuard`] so the Tokio runtime outlives the parent
-/// `GraphForge`: the reader is lazy and `'static`, and a bare runtime handle
-/// would not keep the runtime (and the stream's worker threads) alive.
+/// Owns a [`RuntimeGuard`] so the Tokio runtime and on-disk graph workspace
+/// outlive the parent `GraphForge`: the reader is lazy and `'static`, and a bare
+/// runtime handle would not keep the runtime (and the stream's worker threads /
+/// Parquet fragment paths) alive.
 struct StreamReader {
     schema: SchemaRef,
     stream: SendableRecordBatchStream,

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -4323,6 +4323,8 @@ pub struct SessionResourceConfig {
     pub spill_directory: Option<PathBuf>,
     /// Optional spill byte cap.
     pub spill_max_bytes: Option<u64>,
+    /// Concurrent Parquet / I/O open budget (#337 / #339).
+    pub io_concurrency: usize,
 }
 
 impl Default for SessionResourceConfig {
@@ -4334,6 +4336,7 @@ impl Default for SessionResourceConfig {
             spill_enabled: false,
             spill_directory: None,
             spill_max_bytes: None,
+            io_concurrency: 2,
         }
     }
 }
@@ -4475,8 +4478,12 @@ impl ExecutionSession {
             },
         );
         let provider: Arc<dyn AdjacencyProvider> = Arc::clone(&adjacency_provider) as _;
+        let io_concurrency = resources.io_concurrency.max(1);
         let config = datafusion::prelude::SessionConfig::new()
             .with_extension(Arc::new(AdjacencyProviderExt(provider)))
+            .with_extension(Arc::new(graphforge_storage::IoConcurrencyExt(Arc::new(
+                tokio::sync::Semaphore::new(io_concurrency),
+            ))))
             .with_target_partitions(resources.target_partitions)
             .with_batch_size(resources.batch_size);
 

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -4478,12 +4478,11 @@ impl ExecutionSession {
             },
         );
         let provider: Arc<dyn AdjacencyProvider> = Arc::clone(&adjacency_provider) as _;
-        let io_concurrency = resources.io_concurrency.max(1);
         let config = datafusion::prelude::SessionConfig::new()
             .with_extension(Arc::new(AdjacencyProviderExt(provider)))
-            .with_extension(Arc::new(graphforge_storage::IoConcurrencyExt(Arc::new(
-                tokio::sync::Semaphore::new(io_concurrency),
-            ))))
+            .with_extension(Arc::new(graphforge_storage::IoConcurrencyExt::new(
+                resources.io_concurrency,
+            )))
             .with_target_partitions(resources.target_partitions)
             .with_batch_size(resources.batch_size);
 

--- a/crates/graphforge-exec/tests/explain_goldens/explain_snapshots__single_hop_index_absent_expand_exec.snap
+++ b/crates/graphforge-exec/tests/explain_goldens/explain_snapshots__single_hop_index_absent_expand_exec.snap
@@ -3,12 +3,12 @@ source: crates/graphforge-exec/tests/explain_snapshots.rs
 ---
 ProjectionExec: expr=[name@0 as bn]
   HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[name@1]
-    DataSourceExec: partitions=1, partition_sizes=[1]
+    GraphForgeParquetExec: fragments=1, batch_size=8192, limit=none
     FilterExec: array_has(type_ids@1, 0), projection=[node_uuid@0]
       RepartitionExec: partitioning=RoundRobinBatch(<N>), input_partitions=1
         ProjectionExec: expr=[node_uuid@15 as node_uuid, type_ids@18 as type_ids]
           ExpandExec: rel=KNOWS, dir=->, adjacency=building, fetch=all, demand_batch=all, cancel=none
             HashJoinExec: mode=CollectLeft, join_type=Left, on=[(node_uuid@0, node_uuid@0)], projection=[node_uuid@0, node_id@1, type_id@2, type_ids@3, created_at@4, updated_at@5, name@7]
               FilterExec: array_has(type_ids@3, 0)
-                DataSourceExec: partitions=1, partition_sizes=[1]
-              DataSourceExec: partitions=1, partition_sizes=[1]
+                GraphForgeParquetExec: fragments=1, batch_size=8192, limit=none
+              GraphForgeParquetExec: fragments=1, batch_size=8192, limit=none

--- a/crates/graphforge-exec/tests/explain_goldens/explain_snapshots__single_hop_index_present_expand_exec.snap
+++ b/crates/graphforge-exec/tests/explain_goldens/explain_snapshots__single_hop_index_present_expand_exec.snap
@@ -3,12 +3,12 @@ source: crates/graphforge-exec/tests/explain_snapshots.rs
 ---
 ProjectionExec: expr=[name@0 as bn]
   HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[name@1]
-    DataSourceExec: partitions=1, partition_sizes=[1]
+    GraphForgeParquetExec: fragments=1, batch_size=8192, limit=none
     FilterExec: array_has(type_ids@1, 0), projection=[node_uuid@0]
       RepartitionExec: partitioning=RoundRobinBatch(<N>), input_partitions=1
         ProjectionExec: expr=[node_uuid@15 as node_uuid, type_ids@18 as type_ids]
           ExpandExec: rel=KNOWS, dir=->, adjacency=hit, fetch=all, demand_batch=all, cancel=none
             HashJoinExec: mode=CollectLeft, join_type=Left, on=[(node_uuid@0, node_uuid@0)], projection=[node_uuid@0, node_id@1, type_id@2, type_ids@3, created_at@4, updated_at@5, name@7]
               FilterExec: array_has(type_ids@3, 0)
-                DataSourceExec: partitions=1, partition_sizes=[1]
-              DataSourceExec: partitions=1, partition_sizes=[1]
+                GraphForgeParquetExec: fragments=1, batch_size=8192, limit=none
+              GraphForgeParquetExec: fragments=1, batch_size=8192, limit=none

--- a/crates/graphforge-exec/tests/explain_goldens/explain_snapshots__var_len_index_absent.snap
+++ b/crates/graphforge-exec/tests/explain_goldens/explain_snapshots__var_len_index_absent.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/graphforge-exec/tests/explain_snapshots.rs
+assertion_line: 121
 ---
 ProjectionExec: expr=[1 as one]
   HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)]
-    DataSourceExec: partitions=1, partition_sizes=[1]
+    GraphForgeParquetExec: fragments=1, batch_size=8192, limit=none
     FilterExec: array_has(type_ids@1, 0), projection=[node_uuid@0]
       RepartitionExec: partitioning=RoundRobinBatch(<N>), input_partitions=1
         ProjectionExec: expr=[node_uuid@7 as node_uuid, type_ids@10 as type_ids]
@@ -12,5 +13,5 @@ ProjectionExec: expr=[1 as one]
               RepartitionExec: partitioning=RoundRobinBatch(<N>), input_partitions=1
                 HashJoinExec: mode=CollectLeft, join_type=Left, on=[(node_uuid@0, node_uuid@0)], projection=[node_uuid@0, node_id@1, type_id@2, type_ids@3, created_at@4, updated_at@5, name@7]
                   FilterExec: array_has(type_ids@3, 0)
-                    DataSourceExec: partitions=1, partition_sizes=[1]
-                  DataSourceExec: partitions=1, partition_sizes=[1]
+                    GraphForgeParquetExec: fragments=1, batch_size=8192, limit=none
+                  GraphForgeParquetExec: fragments=1, batch_size=8192, limit=none

--- a/crates/graphforge-exec/tests/explain_goldens/explain_snapshots__var_len_index_present.snap
+++ b/crates/graphforge-exec/tests/explain_goldens/explain_snapshots__var_len_index_present.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/graphforge-exec/tests/explain_snapshots.rs
+assertion_line: 141
 ---
 ProjectionExec: expr=[1 as one]
   HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)]
-    DataSourceExec: partitions=1, partition_sizes=[1]
+    GraphForgeParquetExec: fragments=1, batch_size=8192, limit=none
     FilterExec: array_has(type_ids@1, 0), projection=[node_uuid@0]
       RepartitionExec: partitioning=RoundRobinBatch(<N>), input_partitions=1
         ProjectionExec: expr=[node_uuid@7 as node_uuid, type_ids@10 as type_ids]
@@ -12,5 +13,5 @@ ProjectionExec: expr=[1 as one]
               RepartitionExec: partitioning=RoundRobinBatch(<N>), input_partitions=1
                 HashJoinExec: mode=CollectLeft, join_type=Left, on=[(node_uuid@0, node_uuid@0)], projection=[node_uuid@0, node_id@1, type_id@2, type_ids@3, created_at@4, updated_at@5, name@7]
                   FilterExec: array_has(type_ids@3, 0)
-                    DataSourceExec: partitions=1, partition_sizes=[1]
-                  DataSourceExec: partitions=1, partition_sizes=[1]
+                    GraphForgeParquetExec: fragments=1, batch_size=8192, limit=none
+                  GraphForgeParquetExec: fragments=1, batch_size=8192, limit=none

--- a/crates/graphforge-storage/Cargo.toml
+++ b/crates/graphforge-storage/Cargo.toml
@@ -23,6 +23,7 @@ atomicwrites = "0.4.4"
 datafusion = { workspace = true }
 datafusion-catalog = "54"
 fs4 = "1.1"
+futures = { workspace = true }
 parquet = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/graphforge-storage/src/catalog.rs
+++ b/crates/graphforge-storage/src/catalog.rs
@@ -1983,6 +1983,7 @@ mod tests {
     async fn query_providers_build_streaming_parquet_plan_not_memtable() {
         let dir = TempDir::new().unwrap();
         let nodes = dir.path().join("topology/nodes.parquet");
+        std::fs::create_dir_all(nodes.parent().unwrap()).unwrap();
         write_nodes_parquet(&nodes);
         let edges = dir.path().join("topology/edges/KNOWS.parquet");
         write_edge_parquet(&edges);
@@ -1990,10 +1991,7 @@ mod tests {
         let ctx = SessionContext::new();
         let state = ctx.state();
         let cases: Vec<(&str, Arc<dyn TableProvider>)> = vec![
-            (
-                "nodes",
-                Arc::new(TopologyNodeTable::new(nodes.clone())),
-            ),
+            ("nodes", Arc::new(TopologyNodeTable::new(nodes.clone()))),
             ("edges", Arc::new(TypedEdgeTable::open(dir.path(), "KNOWS"))),
             ("union", Arc::new(UnionEdgeTable::open(dir.path()))),
             (
@@ -2049,13 +2047,11 @@ mod tests {
             .join("KNOWS.parquet");
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         let n = 20usize;
-        let uuids = FixedSizeBinaryArray::try_from_iter(
-            (0..n).map(|i| {
-                let mut bytes = vec![0u8; 16];
-                bytes[15] = i as u8;
-                bytes
-            }),
-        )
+        let uuids = FixedSizeBinaryArray::try_from_iter((0..n).map(|i| {
+            let mut bytes = vec![0u8; 16];
+            bytes[15] = i as u8;
+            bytes
+        }))
         .unwrap();
         let src = FixedSizeBinaryArray::try_from_iter((0..n).map(|_| vec![1u8; 16])).unwrap();
         let dst = FixedSizeBinaryArray::try_from_iter((0..n).map(|_| vec![2u8; 16])).unwrap();

--- a/crates/graphforge-storage/src/catalog.rs
+++ b/crates/graphforge-storage/src/catalog.rs
@@ -13,10 +13,14 @@
 //!
 //! # Scan implementation
 //!
-//! Scans are implemented via DataFusion's [`MemTable`]: the Parquet file is read
-//! into memory at query time and wrapped in a `MemTable` which handles projection
-//! and filter application.  This is correct and simple for M12; lower-level
-//! pushdown can be added in a later milestone.
+//! Query-facing scans build a streaming [`GraphForgeParquetExec`](crate::parquet_scan::GraphForgeParquetExec)
+//! during `TableProvider::scan` without reading or concatenating Parquet payloads
+//! (#339). Decode happens in `ExecutionPlan::execute`, emitting bounded batches
+//! sized from the session batch size. Unsupported predicates stay DataFusion-owned
+//! (default filter pushdown is unsupported / non-exact).
+//!
+//! Direct readers (`read_edges`, `read_nodes`, …) used by ExpandExec and writers
+//! still eagerly materialize; they are outside the query-provider scan path.
 
 use std::collections::HashMap;
 use std::fmt;
@@ -29,7 +33,7 @@ use arrow::compute::concat_batches;
 use arrow::datatypes::{DataType, Field, SchemaRef};
 use async_trait::async_trait;
 use datafusion::catalog::{CatalogProvider, SchemaProvider};
-use datafusion::datasource::{MemTable, TableProvider, TableType};
+use datafusion::datasource::{TableProvider, TableType};
 use datafusion::error::DataFusionError;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::Expr;
@@ -40,6 +44,7 @@ use graphforge_core::OntologyMode;
 use graphforge_ir::RuntimeCatalog;
 use graphforge_ontology::OntologyHandle;
 
+use crate::parquet_scan::{ParquetFragment, scan_fragments};
 use crate::schemas::{
     EXPLORATORY_EDGE_SCHEMA, TOPOLOGY_NODES_SCHEMA, TYPED_EDGE_SCHEMA, property_schema,
 };
@@ -315,7 +320,10 @@ fn read_edges_union(
 /// Normalize a typed-edge batch to [`EXPLORATORY_EDGE_SCHEMA`] by appending a
 /// constant `rel_type_name = stem` column. A batch already carrying the column
 /// (an `_exploratory` file) is returned unchanged.
-fn tag_rel_type_name(batch: &RecordBatch, stem: &str) -> Result<RecordBatch, DataFusionError> {
+pub(crate) fn tag_rel_type_name(
+    batch: &RecordBatch,
+    stem: &str,
+) -> Result<RecordBatch, DataFusionError> {
     if batch.schema().field_with_name("rel_type_name").is_ok() {
         return Ok(batch.clone());
     }
@@ -1108,15 +1116,18 @@ impl TableProvider for TopologyNodeTable {
         &self,
         state: &dyn Session,
         projection: Option<&Vec<usize>>,
-        filters: &[Expr],
+        _filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-        let batches = normalize_topology_nodes(read_parquet_or_empty(
-            &self.path,
+        // Existence only — no Parquet decode during planning (#339).
+        let fragment = ParquetFragment::for_path(self.path.clone(), true);
+        scan_fragments(
             TOPOLOGY_NODES_SCHEMA.clone(),
-        )?)?;
-        let mem = MemTable::try_new(TOPOLOGY_NODES_SCHEMA.clone(), vec![batches])?;
-        mem.scan(state, projection, filters, limit).await
+            vec![fragment],
+            projection,
+            limit,
+            state.config().batch_size(),
+        )
     }
 }
 
@@ -1165,12 +1176,17 @@ impl TableProvider for TypedEdgeTable {
         &self,
         state: &dyn Session,
         projection: Option<&Vec<usize>>,
-        filters: &[Expr],
+        _filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-        let batches = read_parquet_or_empty(&self.path, self.schema.clone())?;
-        let mem = MemTable::try_new(self.schema.clone(), vec![batches])?;
-        mem.scan(state, projection, filters, limit).await
+        let fragment = ParquetFragment::for_path(self.path.clone(), false);
+        scan_fragments(
+            self.schema.clone(),
+            vec![fragment],
+            projection,
+            limit,
+            state.config().batch_size(),
+        )
     }
 }
 
@@ -1180,10 +1196,10 @@ impl TableProvider for TypedEdgeTable {
 
 /// [`TableProvider`] over the union of every relation's edge file (#823) — the
 /// scan source for an **untyped** single-hop pattern (`(a)-[]->(b)`) in a typed
-/// project, where the `_exploratory` table does not exist. Materializes
-/// [`read_edges_union`] into a [`MemTable`]; the schema is always
-/// [`EXPLORATORY_EDGE_SCHEMA`] (each row tagged with its source relation), so it
-/// is a drop-in for the exploratory edge scan the untyped lowering already uses.
+/// project, where the `_exploratory` table does not exist. Streams each
+/// relation file as a natural fragment via [`scan_fragments`] (stem order);
+/// the schema is always [`EXPLORATORY_EDGE_SCHEMA`] (each row tagged with its
+/// source relation).
 #[derive(Debug, Clone)]
 pub struct UnionEdgeTable {
     dir: PathBuf,
@@ -1213,12 +1229,31 @@ impl TableProvider for UnionEdgeTable {
         &self,
         state: &dyn Session,
         projection: Option<&Vec<usize>>,
-        filters: &[Expr],
+        _filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-        let batches = read_edges_union(&self.dir, None, None)?;
-        let mem = MemTable::try_new(EXPLORATORY_EDGE_SCHEMA.clone(), vec![batches])?;
-        mem.scan(state, projection, filters, limit).await
+        // Directory listing only — stem order matches `read_edges_union`.
+        let mut files = crate::mutator::parquet_files_in(&self.dir, "topology/edges")
+            .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+        files.sort();
+        let fragments: Vec<ParquetFragment> = files
+            .into_iter()
+            .map(|path| {
+                let stem = path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or_default()
+                    .to_owned();
+                ParquetFragment::for_union_edge(path, stem)
+            })
+            .collect();
+        scan_fragments(
+            EXPLORATORY_EDGE_SCHEMA.clone(),
+            fragments,
+            projection,
+            limit,
+            state.config().batch_size(),
+        )
     }
 }
 
@@ -1325,12 +1360,17 @@ impl TableProvider for EdgePropertyTable {
         &self,
         state: &dyn Session,
         projection: Option<&Vec<usize>>,
-        filters: &[Expr],
+        _filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-        let batches = read_parquet_or_empty(&self.path, self.schema.clone())?;
-        let mem = MemTable::try_new(self.schema.clone(), vec![batches])?;
-        mem.scan(state, projection, filters, limit).await
+        let fragment = ParquetFragment::for_path(self.path.clone(), false);
+        scan_fragments(
+            self.schema.clone(),
+            vec![fragment],
+            projection,
+            limit,
+            state.config().batch_size(),
+        )
     }
 }
 
@@ -1356,12 +1396,17 @@ impl TableProvider for PropertyTable {
         &self,
         state: &dyn Session,
         projection: Option<&Vec<usize>>,
-        filters: &[Expr],
+        _filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-        let batches = read_parquet_or_empty(&self.path, self.schema.clone())?;
-        let mem = MemTable::try_new(self.schema.clone(), vec![batches])?;
-        mem.scan(state, projection, filters, limit).await
+        let fragment = ParquetFragment::for_path(self.path.clone(), false);
+        scan_fragments(
+            self.schema.clone(),
+            vec![fragment],
+            projection,
+            limit,
+            state.config().batch_size(),
+        )
     }
 }
 
@@ -1932,6 +1977,142 @@ mod tests {
             let batches = frame.collect().await.unwrap();
             assert_eq!(row_count(&batches), 0);
         }
+    }
+
+    #[tokio::test]
+    async fn query_providers_build_streaming_parquet_plan_not_memtable() {
+        let dir = TempDir::new().unwrap();
+        let nodes = dir.path().join("topology/nodes.parquet");
+        write_nodes_parquet(&nodes);
+        let edges = dir.path().join("topology/edges/KNOWS.parquet");
+        write_edge_parquet(&edges);
+
+        let ctx = SessionContext::new();
+        let state = ctx.state();
+        let cases: Vec<(&str, Arc<dyn TableProvider>)> = vec![
+            (
+                "nodes",
+                Arc::new(TopologyNodeTable::new(nodes.clone())),
+            ),
+            ("edges", Arc::new(TypedEdgeTable::open(dir.path(), "KNOWS"))),
+            ("union", Arc::new(UnionEdgeTable::open(dir.path()))),
+            (
+                "props",
+                Arc::new(PropertyTable::open_discovered(dir.path(), "Person")),
+            ),
+            (
+                "edge_props",
+                Arc::new(EdgePropertyTable::open_discovered(dir.path(), "KNOWS")),
+            ),
+        ];
+        for (label, provider) in cases {
+            let plan = provider
+                .scan(&state as &dyn Session, None, &[], None)
+                .await
+                .unwrap();
+            let text = datafusion::physical_plan::displayable(plan.as_ref())
+                .indent(false)
+                .to_string();
+            assert!(
+                text.contains("GraphForgeParquetExec"),
+                "{label}: expected GraphForgeParquetExec, got:\n{text}"
+            );
+            assert!(
+                !text.contains("MemoryExec") && !text.contains("MemTable"),
+                "{label}: MemTable/MemoryExec must not appear:\n{text}"
+            );
+        }
+        // Corrupt after scan planning — execute must fail closed with a structured error.
+        let table = TypedEdgeTable::open(dir.path(), "KNOWS");
+        let plan = table
+            .scan(&state as &dyn Session, None, &[], None)
+            .await
+            .unwrap();
+        std::fs::write(&edges, b"not-parquet").unwrap();
+        let err = datafusion::physical_plan::collect(plan, ctx.task_ctx())
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().to_lowercase().contains("parquet")
+                || err.to_string().to_lowercase().contains("corrupt"),
+            "structured failure, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_scan_honors_session_batch_size_policy() {
+        let dir = TempDir::new().unwrap();
+        let path = dir
+            .path()
+            .join("topology")
+            .join("edges")
+            .join("KNOWS.parquet");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let n = 20usize;
+        let uuids = FixedSizeBinaryArray::try_from_iter(
+            (0..n).map(|i| {
+                let mut bytes = vec![0u8; 16];
+                bytes[15] = i as u8;
+                bytes
+            }),
+        )
+        .unwrap();
+        let src = FixedSizeBinaryArray::try_from_iter((0..n).map(|_| vec![1u8; 16])).unwrap();
+        let dst = FixedSizeBinaryArray::try_from_iter((0..n).map(|_| vec![2u8; 16])).unwrap();
+        let ts = TimestampMicrosecondArray::from(vec![0i64; n])
+            .with_timezone_opt(Some(Arc::from("UTC")));
+        let batch = RecordBatch::try_new(
+            TYPED_EDGE_SCHEMA.clone(),
+            vec![
+                Arc::new(uuids),
+                Arc::new(src),
+                Arc::new(dst),
+                Arc::new(UInt64Array::from((1..=n as u64).collect::<Vec<_>>())),
+                Arc::new(UInt64Array::from(vec![1u64; n])),
+                Arc::new(UInt64Array::from(vec![2u64; n])),
+                Arc::new(ts),
+            ],
+        )
+        .unwrap();
+        let file = File::create(&path).unwrap();
+        let mut writer = ArrowWriter::try_new(
+            file,
+            TYPED_EDGE_SCHEMA.clone(),
+            Some(WriterProperties::builder().build()),
+        )
+        .unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        let config = datafusion::prelude::SessionConfig::new().with_batch_size(5);
+        let state = datafusion::execution::SessionStateBuilder::new()
+            .with_default_features()
+            .with_config(config)
+            .build();
+        let ctx = SessionContext::new_with_state(state);
+        let table = TypedEdgeTable::open(dir.path(), "KNOWS");
+        let session = ctx.state();
+        let plan = table
+            .scan(&session as &dyn Session, None, &[], None)
+            .await
+            .unwrap();
+        let display = datafusion::physical_plan::displayable(plan.as_ref())
+            .one_line()
+            .to_string();
+        assert!(
+            display.contains("batch_size=5"),
+            "policy batch size must appear on plan: {display}"
+        );
+        let batches = datafusion::physical_plan::collect(plan, ctx.task_ctx())
+            .await
+            .unwrap();
+        assert!(
+            batches.len() >= 2,
+            "expected multiple batches, got {}",
+            batches.len()
+        );
+        assert!(batches.iter().all(|b| b.num_rows() <= 5));
+        assert_eq!(row_count(&batches), 20);
     }
 
     #[test]

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -178,6 +178,9 @@ pub use catalog::{
     read_nodes_filtered_observed, read_properties,
 };
 
+pub mod parquet_scan;
+pub use parquet_scan::{GraphForgeParquetExec, IoConcurrencyExt, ParquetFragment};
+
 pub mod schemas;
 pub use schemas::{
     ADJACENCY_CSR_SCHEMA, ADJACENCY_MANIFEST_SCHEMA, EDGE_PROPERTY_BASE_SCHEMA,

--- a/crates/graphforge-storage/src/parquet_scan.rs
+++ b/crates/graphforge-storage/src/parquet_scan.rs
@@ -1,0 +1,714 @@
+//! Streaming GraphForge Parquet [`ExecutionPlan`] (#339).
+//!
+//! Query-facing table providers build this plan during `TableProvider::scan`
+//! without reading or concatenating Parquet payloads. I/O happens in
+//! [`ExecutionPlan::execute`], which emits bounded batches sized from the
+//! session/`TaskContext` batch size and honors the optional I/O concurrency
+//! budget registered by #337.
+
+use std::fmt;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use arrow::array::RecordBatch;
+use arrow::datatypes::SchemaRef;
+use datafusion::error::DataFusionError;
+use datafusion::execution::TaskContext;
+use datafusion::physical_expr::EquivalenceProperties;
+use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, Partitioning,
+    PlanProperties, SendableRecordBatchStream,
+};
+use futures::stream::{self, StreamExt, TryStreamExt};
+use parquet::arrow::ProjectionMask;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
+use crate::catalog::{normalize_topology_nodes, tag_rel_type_name};
+
+/// One deterministic natural partition: a single Parquet path (file fragment).
+#[derive(Clone, Debug)]
+pub struct ParquetFragment {
+    /// Absolute or project-relative path to the Parquet file.
+    pub path: PathBuf,
+    /// When `false`, execute yields an empty batch without opening the file.
+    pub exists: bool,
+    /// Optional relation stem used by [`UnionEdgeTable`](crate::catalog::UnionEdgeTable)
+    /// to tag typed edge rows with `rel_type_name`.
+    pub rel_type_name: Option<String>,
+    /// Apply [`normalize_topology_nodes`] after decode (legacy `type_id` files).
+    pub normalize_topology: bool,
+}
+
+impl ParquetFragment {
+    /// Fragment for a single known path; `exists` is probed without reading bytes.
+    #[must_use]
+    pub fn for_path(path: PathBuf, normalize_topology: bool) -> Self {
+        let exists = path.exists();
+        Self {
+            path,
+            exists,
+            rel_type_name: None,
+            normalize_topology,
+        }
+    }
+
+    /// Union-edge fragment tagged with `rel_type_name` (file already listed).
+    #[must_use]
+    pub fn for_union_edge(path: PathBuf, rel_type_name: String) -> Self {
+        Self {
+            path,
+            exists: true,
+            rel_type_name: Some(rel_type_name),
+            normalize_topology: false,
+        }
+    }
+}
+
+/// Session extension carrying the #337 I/O concurrency semaphore.
+#[derive(Clone, Debug)]
+pub struct IoConcurrencyExt(pub Arc<tokio::sync::Semaphore>);
+
+/// Streaming Parquet scan over deterministic file fragments.
+#[derive(Clone)]
+pub struct GraphForgeParquetExec {
+    /// Provider / output schema after projection.
+    schema: SchemaRef,
+    /// Full table schema before projection (normalize / tag target).
+    base_schema: SchemaRef,
+    /// Arrow field indices into `base_schema`, when projected.
+    projection: Option<Vec<usize>>,
+    fragments: Vec<ParquetFragment>,
+    /// Remaining row cap across this plan (optional).
+    limit: Option<usize>,
+    /// Planning-time batch size hint (execute re-reads TaskContext).
+    batch_size: usize,
+    props: Arc<PlanProperties>,
+}
+
+impl fmt::Debug for GraphForgeParquetExec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GraphForgeParquetExec")
+            .field("fragments", &self.fragments.len())
+            .field("batch_size", &self.batch_size)
+            .field("limit", &self.limit)
+            .field("projection", &self.projection)
+            .finish()
+    }
+}
+
+impl GraphForgeParquetExec {
+    /// Build a streaming plan. Does not open Parquet footers or decode row groups.
+    ///
+    /// # Errors
+    /// Returns [`DataFusionError`] when the projection indices are invalid.
+    pub fn try_new(
+        base_schema: SchemaRef,
+        fragments: Vec<ParquetFragment>,
+        projection: Option<&Vec<usize>>,
+        limit: Option<usize>,
+        batch_size: usize,
+    ) -> Result<Self, DataFusionError> {
+        let projection = projection.cloned();
+        let schema = match projection.as_ref() {
+            Some(indices) => Arc::new(base_schema.project(indices).map_err(|e| {
+                DataFusionError::ArrowError(Box::new(e), Some("parquet projection".into()))
+            })?),
+            None => Arc::clone(&base_schema),
+        };
+        let partition_count = fragments.len().max(1);
+        let props = Arc::new(PlanProperties::new(
+            EquivalenceProperties::new(Arc::clone(&schema)),
+            Partitioning::UnknownPartitioning(partition_count),
+            EmissionType::Incremental,
+            Boundedness::Bounded,
+        ));
+        Ok(Self {
+            schema,
+            base_schema,
+            projection,
+            fragments,
+            limit,
+            batch_size: batch_size.max(1),
+            props,
+        })
+    }
+
+    /// Natural fragment count declared by this plan (at least one).
+    #[must_use]
+    pub fn fragment_count(&self) -> usize {
+        self.fragments.len().max(1)
+    }
+
+    /// Planning-time batch size captured from the session.
+    #[must_use]
+    pub fn batch_size(&self) -> usize {
+        self.batch_size
+    }
+
+    /// Wrap multi-fragment plans so consumers observe fragment order.
+    #[must_use]
+    pub fn into_ordered_plan(self) -> Arc<dyn ExecutionPlan> {
+        let inner: Arc<dyn ExecutionPlan> = Arc::new(self);
+        if inner.output_partitioning().partition_count() <= 1 {
+            return inner;
+        }
+        Arc::new(OrderedPartitionStreamExec::new(inner))
+    }
+}
+
+impl DisplayAs for GraphForgeParquetExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "GraphForgeParquetExec: fragments={}, batch_size={}, limit={}",
+            self.fragment_count(),
+            self.batch_size,
+            self.limit
+                .map_or_else(|| "none".to_owned(), |n| n.to_string())
+        )
+    }
+}
+
+impl ExecutionPlan for GraphForgeParquetExec {
+    fn name(&self) -> &str {
+        "GraphForgeParquetExec"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.props
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        if !children.is_empty() {
+            return Err(DataFusionError::Internal(
+                "GraphForgeParquetExec cannot have children".into(),
+            ));
+        }
+        Ok(self)
+    }
+
+    fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
+        let mut cloned = self.clone();
+        cloned.limit = match (cloned.limit, limit) {
+            (Some(a), Some(b)) => Some(a.min(b)),
+            (a, b) => a.or(b),
+        };
+        Some(Arc::new(cloned))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream, DataFusionError> {
+        let fragment = if self.fragments.is_empty() {
+            if partition != 0 {
+                return Err(DataFusionError::Internal(format!(
+                    "GraphForgeParquetExec partition {partition} out of range for empty fragments"
+                )));
+            }
+            None
+        } else {
+            Some(self.fragments.get(partition).ok_or_else(|| {
+                DataFusionError::Internal(format!(
+                    "GraphForgeParquetExec partition {partition} out of range ({})",
+                    self.fragments.len()
+                ))
+            })?)
+        };
+
+        let schema = Arc::clone(&self.schema);
+        let base_schema = Arc::clone(&self.base_schema);
+        let projection = self.projection.clone();
+        let limit = self.limit;
+        let batch_size = context.session_config().batch_size().max(1);
+        let io = context
+            .session_config()
+            .get_extension::<IoConcurrencyExt>()
+            .map(|ext| Arc::clone(&ext.0));
+        let fragment = fragment.cloned();
+
+        let stream = stream::once(async move {
+            let _permit = if let Some(sem) = io {
+                Some(sem.acquire_owned().await.map_err(|e| {
+                    DataFusionError::External(format!("io concurrency closed: {e}").into())
+                })?)
+            } else {
+                None
+            };
+            let batches = match fragment {
+                None => vec![RecordBatch::new_empty(Arc::clone(&schema))],
+                Some(frag) if !frag.exists => {
+                    vec![RecordBatch::new_empty(Arc::clone(&schema))]
+                }
+                Some(frag) => read_fragment_batches(
+                    &frag,
+                    &base_schema,
+                    projection.as_deref(),
+                    batch_size,
+                )?,
+            };
+            let batches = apply_limit(batches, limit);
+            Ok::<_, DataFusionError>(stream::iter(batches.into_iter().map(Ok)))
+        })
+        .try_flatten();
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+    }
+}
+
+fn apply_limit(batches: Vec<RecordBatch>, limit: Option<usize>) -> Vec<RecordBatch> {
+    let Some(mut remaining) = limit else {
+        return batches;
+    };
+    let mut out = Vec::new();
+    for batch in batches {
+        if remaining == 0 {
+            break;
+        }
+        if batch.num_rows() > remaining {
+            out.push(batch.slice(0, remaining));
+            break;
+        }
+        remaining -= batch.num_rows();
+        out.push(batch);
+    }
+    out
+}
+
+fn read_fragment_batches(
+    fragment: &ParquetFragment,
+    base_schema: &SchemaRef,
+    projection: Option<&[usize]>,
+    batch_size: usize,
+) -> Result<Vec<RecordBatch>, DataFusionError> {
+    let file = File::open(&fragment.path).map_err(|e| {
+        DataFusionError::External(format!("open parquet {}: {e}", path_label(&fragment.path)).into())
+    })?;
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file).map_err(|e| {
+        DataFusionError::External(format!("corrupt or unreadable parquet: {e}").into())
+    })?;
+
+    // Projection in the reader is only safe when we do not post-process columns
+    // (topology normalize / union rel_type_name tagging need the full row first).
+    let post_process = fragment.normalize_topology || fragment.rel_type_name.is_some();
+    let builder = if post_process {
+        builder.with_batch_size(batch_size)
+    } else if let Some(indices) = projection {
+        let mask = ProjectionMask::roots(builder.parquet_schema(), indices.iter().copied());
+        builder.with_batch_size(batch_size).with_projection(mask)
+    } else {
+        builder.with_batch_size(batch_size)
+    };
+
+    let reader = builder.build().map_err(|e| {
+        DataFusionError::External(format!("parquet reader build failed: {e}").into())
+    })?;
+
+    let mut out = Vec::new();
+    for batch in reader {
+        let mut batch = batch.map_err(|e| {
+            DataFusionError::External(format!("parquet decode failed: {e}").into())
+        })?;
+        if fragment.normalize_topology {
+            batch = normalize_topology_nodes(vec![batch])?
+                .into_iter()
+                .next()
+                .ok_or_else(|| {
+                    DataFusionError::Execution("normalize_topology_nodes returned no batch".into())
+                })?;
+        }
+        if let Some(stem) = fragment.rel_type_name.as_deref() {
+            batch = tag_rel_type_name(&batch, stem)?;
+        }
+        if post_process {
+            if let Some(indices) = projection {
+                batch = batch.project(indices).map_err(|e| {
+                    DataFusionError::ArrowError(Box::new(e), Some("post-process projection".into()))
+                })?;
+            }
+        }
+        // Ensure output schema matches the plan (field nullability / metadata).
+        let batch = align_schema(batch, base_schema, projection)?;
+        out.push(batch);
+    }
+    if out.is_empty() {
+        let empty = match projection {
+            Some(indices) => RecordBatch::new_empty(Arc::new(base_schema.project(indices).map_err(
+                |e| DataFusionError::ArrowError(Box::new(e), Some("empty projection".into())),
+            )?)),
+            None => RecordBatch::new_empty(Arc::clone(base_schema)),
+        };
+        out.push(empty);
+    }
+    Ok(out)
+}
+
+fn align_schema(
+    batch: RecordBatch,
+    base_schema: &SchemaRef,
+    projection: Option<&[usize]>,
+) -> Result<RecordBatch, DataFusionError> {
+    let target = match projection {
+        Some(indices) => Arc::new(base_schema.project(indices).map_err(|e| {
+            DataFusionError::ArrowError(Box::new(e), Some("align projection".into()))
+        })?),
+        None => Arc::clone(base_schema),
+    };
+    if batch.schema().as_ref() == target.as_ref() {
+        return Ok(batch);
+    }
+    // Rebuild with the canonical schema when field order/names match.
+    if batch.num_columns() != target.fields().len() {
+        return Err(DataFusionError::Plan(format!(
+            "parquet batch column count {} != schema {}",
+            batch.num_columns(),
+            target.fields().len()
+        )));
+    }
+    RecordBatch::try_new(target, batch.columns().to_vec())
+        .map_err(|e| DataFusionError::ArrowError(Box::new(e), Some("align schema".into())))
+}
+
+fn path_label(path: &Path) -> String {
+    path.file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("parquet")
+        .to_owned()
+}
+
+/// Serial merge that reads child partitions in index order (canonical fragment order).
+#[derive(Debug)]
+struct OrderedPartitionStreamExec {
+    input: Arc<dyn ExecutionPlan>,
+    props: Arc<PlanProperties>,
+}
+
+impl OrderedPartitionStreamExec {
+    fn new(input: Arc<dyn ExecutionPlan>) -> Self {
+        let schema = input.schema();
+        let props = Arc::new(PlanProperties::new(
+            EquivalenceProperties::new(schema),
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Incremental,
+            Boundedness::Bounded,
+        ));
+        Self { input, props }
+    }
+}
+
+impl DisplayAs for OrderedPartitionStreamExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "OrderedPartitionStreamExec: input_partitions={}",
+            self.input.output_partitioning().partition_count()
+        )
+    }
+}
+
+impl ExecutionPlan for OrderedPartitionStreamExec {
+    fn name(&self) -> &str {
+        "OrderedPartitionStreamExec"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.props
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn maintains_input_order(&self) -> Vec<bool> {
+        vec![true]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        let input = children.into_iter().next().ok_or_else(|| {
+            DataFusionError::Internal("OrderedPartitionStreamExec needs one child".into())
+        })?;
+        Ok(Arc::new(Self::new(input)))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream, DataFusionError> {
+        if partition != 0 {
+            return Err(DataFusionError::Internal(format!(
+                "OrderedPartitionStreamExec only has partition 0 (got {partition})"
+            )));
+        }
+        let input = Arc::clone(&self.input);
+        let schema = input.schema();
+        let n = input.output_partitioning().partition_count();
+        let stream = stream::iter(0..n)
+            .then(move |part| {
+                let input = Arc::clone(&input);
+                let context = Arc::clone(&context);
+                async move { input.execute(part, context) }
+            })
+            .try_flatten();
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+    }
+}
+
+/// Helper used by catalog providers to build the scan plan from session state.
+pub fn scan_fragments(
+    base_schema: SchemaRef,
+    fragments: Vec<ParquetFragment>,
+    projection: Option<&Vec<usize>>,
+    limit: Option<usize>,
+    batch_size: usize,
+) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+    let exec = GraphForgeParquetExec::try_new(base_schema, fragments, projection, limit, batch_size)?;
+    Ok(exec.into_ordered_plan())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{UInt64Array};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::physical_plan::collect;
+    use datafusion::prelude::SessionContext;
+    use parquet::arrow::ArrowWriter;
+    use parquet::file::properties::WriterProperties;
+    use tempfile::TempDir;
+
+    fn edge_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("edge_id", DataType::UInt64, false),
+            Field::new("src_id", DataType::UInt64, false),
+            Field::new("dst_id", DataType::UInt64, false),
+        ]))
+    }
+
+    fn write_edges(path: &Path, n: usize) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let schema = edge_schema();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(UInt64Array::from((1..=n as u64).collect::<Vec<_>>())),
+                Arc::new(UInt64Array::from(vec![1u64; n])),
+                Arc::new(UInt64Array::from(vec![2u64; n])),
+            ],
+        )
+        .unwrap();
+        let file = File::create(path).unwrap();
+        let mut writer =
+            ArrowWriter::try_new(file, schema, Some(WriterProperties::builder().build())).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+    }
+
+    #[tokio::test]
+    async fn scan_plan_does_not_require_readable_payload_until_execute() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("edges.parquet");
+        write_edges(&path, 8);
+        let table_schema = edge_schema();
+        let fragments = vec![ParquetFragment::for_path(path.clone(), false)];
+        let plan = GraphForgeParquetExec::try_new(
+            table_schema.clone(),
+            fragments,
+            None,
+            None,
+            4,
+        )
+        .unwrap()
+        .into_ordered_plan();
+        assert_eq!(plan.name(), "GraphForgeParquetExec");
+        // Corrupt after planning — proves scan did not consume the payload.
+        std::fs::write(&path, b"not-a-parquet-file").unwrap();
+        let ctx = SessionContext::new();
+        let task = ctx.task_ctx();
+        let err = collect(plan.execute(0, task).unwrap()).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("corrupt") || msg.contains("unreadable") || msg.contains("parquet"),
+            "structured parquet failure, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_emits_bounded_batches_honoring_batch_size() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("edges.parquet");
+        write_edges(&path, 10);
+        let plan = GraphForgeParquetExec::try_new(
+            edge_schema(),
+            vec![ParquetFragment::for_path(path, false)],
+            None,
+            None,
+            4,
+        )
+        .unwrap();
+        let config = datafusion::prelude::SessionConfig::new().with_batch_size(4);
+        let state = datafusion::execution::SessionStateBuilder::new()
+            .with_default_features()
+            .with_config(config)
+            .build();
+        let ctx = SessionContext::new_with_state(state);
+        let task = ctx.task_ctx();
+        let batches = collect(plan.execute(0, task).unwrap()).await.unwrap();
+        assert!(
+            batches.len() >= 2,
+            "expected multiple bounded batches, got {}",
+            batches.len()
+        );
+        assert!(
+            batches.iter().all(|b| b.num_rows() <= 4),
+            "batch_size 4 violated: {:?}",
+            batches.iter().map(RecordBatch::num_rows).collect::<Vec<_>>()
+        );
+        let total: usize = batches.iter().map(RecordBatch::num_rows).sum();
+        assert_eq!(total, 10);
+    }
+
+    #[tokio::test]
+    async fn projection_returns_selected_columns_only() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("edges.parquet");
+        write_edges(&path, 3);
+        let projection = vec![0usize, 2]; // edge_id, dst_id
+        let plan = GraphForgeParquetExec::try_new(
+            edge_schema(),
+            vec![ParquetFragment::for_path(path, false)],
+            Some(&projection),
+            None,
+            1024,
+        )
+        .unwrap();
+        assert_eq!(plan.schema().fields().len(), 2);
+        assert_eq!(plan.schema().field(0).name(), "edge_id");
+        assert_eq!(plan.schema().field(1).name(), "dst_id");
+        let ctx = SessionContext::new();
+        let batches = collect(plan.execute(0, ctx.task_ctx()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(batches[0].num_columns(), 2);
+        assert_eq!(batches[0].num_rows(), 3);
+    }
+
+    #[tokio::test]
+    async fn missing_fragment_yields_empty_schema_shaped_batch() {
+        let path = PathBuf::from("/nonexistent/graphforge-339.parquet");
+        let plan = GraphForgeParquetExec::try_new(
+            edge_schema(),
+            vec![ParquetFragment::for_path(path, false)],
+            None,
+            None,
+            8,
+        )
+        .unwrap();
+        let ctx = SessionContext::new();
+        let batches = collect(plan.execute(0, ctx.task_ctx()).unwrap())
+            .await
+            .unwrap();
+        let total: usize = batches.iter().map(RecordBatch::num_rows).sum();
+        assert_eq!(total, 0);
+        assert_eq!(batches[0].schema(), edge_schema());
+    }
+
+    #[test]
+    fn plan_shape_exposes_fragments_and_batch_size() {
+        let plan = GraphForgeParquetExec::try_new(
+            edge_schema(),
+            vec![ParquetFragment::for_path(PathBuf::from("a.parquet"), false)],
+            None,
+            Some(5),
+            128,
+        )
+        .unwrap();
+        assert_eq!(plan.fragment_count(), 1);
+        assert_eq!(plan.batch_size(), 128);
+        let display = format!("{}", datafusion::physical_plan::displayable(&plan).one_line());
+        assert!(display.contains("GraphForgeParquetExec"), "{display}");
+        assert!(display.contains("batch_size=128"), "{display}");
+    }
+
+    #[tokio::test]
+    async fn ordered_merge_preserves_fragment_order() {
+        let dir = TempDir::new().unwrap();
+        let a = dir.path().join("a.parquet");
+        let b = dir.path().join("b.parquet");
+        write_edges(&a, 2);
+        write_edges(&b, 2);
+        // Overwrite with distinct edge_ids via raw batches
+        let schema = edge_schema();
+        for (path, start) in [(&a, 10u64), (&b, 20u64)] {
+            let batch = RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(UInt64Array::from(vec![start, start + 1])),
+                    Arc::new(UInt64Array::from(vec![1u64, 1])),
+                    Arc::new(UInt64Array::from(vec![2u64, 2])),
+                ],
+            )
+            .unwrap();
+            let file = File::create(path).unwrap();
+            let mut writer =
+                ArrowWriter::try_new(file, schema.clone(), Some(WriterProperties::builder().build()))
+                    .unwrap();
+            writer.write(&batch).unwrap();
+            writer.close().unwrap();
+        }
+        let plan = GraphForgeParquetExec::try_new(
+            schema,
+            vec![
+                ParquetFragment::for_path(a, false),
+                ParquetFragment::for_path(b, false),
+            ],
+            None,
+            None,
+            1024,
+        )
+        .unwrap()
+        .into_ordered_plan();
+        assert_eq!(plan.name(), "OrderedPartitionStreamExec");
+        let ctx = SessionContext::new();
+        let batches = collect(plan.execute(0, ctx.task_ctx()).unwrap())
+            .await
+            .unwrap();
+        let ids = batches
+            .iter()
+            .flat_map(|b| {
+                b.column(0)
+                    .as_any()
+                    .downcast_ref::<UInt64Array>()
+                    .unwrap()
+                    .values()
+                    .iter()
+                    .copied()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(ids, vec![10, 11, 20, 21]);
+    }
+}

--- a/crates/graphforge-storage/src/parquet_scan.rs
+++ b/crates/graphforge-storage/src/parquet_scan.rs
@@ -365,17 +365,40 @@ fn apply_limit(batches: Vec<RecordBatch>, limit: Option<usize>) -> Vec<RecordBat
     out
 }
 
+fn empty_projected_batch(
+    base_schema: &SchemaRef,
+    projection: Option<&[usize]>,
+) -> Result<RecordBatch, DataFusionError> {
+    match projection {
+        Some(indices) => Ok(RecordBatch::new_empty(Arc::new(
+            base_schema.project(indices).map_err(|e| {
+                DataFusionError::ArrowError(Box::new(e), Some("empty projection".into()))
+            })?,
+        ))),
+        None => Ok(RecordBatch::new_empty(Arc::clone(base_schema))),
+    }
+}
+
 fn read_fragment_batches(
     fragment: &ParquetFragment,
     base_schema: &SchemaRef,
     projection: Option<&[usize]>,
     batch_size: usize,
 ) -> Result<Vec<RecordBatch>, DataFusionError> {
-    let file = File::open(&fragment.path).map_err(|e| {
-        DataFusionError::External(
-            format!("open parquet {}: {e}", path_label(&fragment.path)).into(),
-        )
-    })?;
+    // Match `read_parquet_or_empty`: a missing path is an empty schema-shaped
+    // batch, never a hard error — including TOCTOU where planning saw the file
+    // and execute does not (clear / workspace teardown races).
+    let file = match File::open(&fragment.path) {
+        Ok(file) => file,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(vec![empty_projected_batch(base_schema, projection)?]);
+        }
+        Err(e) => {
+            return Err(DataFusionError::External(
+                format!("open parquet {}: {e}", path_label(&fragment.path)).into(),
+            ));
+        }
+    };
     let builder = ParquetRecordBatchReaderBuilder::try_new(file).map_err(|e| {
         DataFusionError::External(format!("corrupt or unreadable parquet: {e}").into())
     })?;
@@ -421,15 +444,7 @@ fn read_fragment_batches(
         out.push(batch);
     }
     if out.is_empty() {
-        let empty = match projection {
-            Some(indices) => {
-                RecordBatch::new_empty(Arc::new(base_schema.project(indices).map_err(|e| {
-                    DataFusionError::ArrowError(Box::new(e), Some("empty projection".into()))
-                })?))
-            }
-            None => RecordBatch::new_empty(Arc::clone(base_schema)),
-        };
-        out.push(empty);
+        out.push(empty_projected_batch(base_schema, projection)?);
     }
     Ok(out)
 }
@@ -707,6 +722,29 @@ mod tests {
         let batches = collect(Arc::new(plan) as Arc<dyn ExecutionPlan>, ctx.task_ctx())
             .await
             .unwrap();
+        let total: usize = batches.iter().map(RecordBatch::num_rows).sum();
+        assert_eq!(total, 0);
+        assert_eq!(batches[0].schema(), edge_schema());
+    }
+
+    #[tokio::test]
+    async fn stale_exists_flag_missing_file_yields_empty_not_error() {
+        // Planning-time `exists: true` must still match `read_parquet_or_empty`
+        // when the path is gone by execute (TOCTOU / clear).
+        let path = PathBuf::from("/nonexistent/graphforge-339-stale.parquet");
+        let fragment = ParquetFragment {
+            path,
+            exists: true,
+            rel_type_name: None,
+            normalize_topology: false,
+            exact_rows: None,
+        };
+        let plan = GraphForgeParquetExec::try_new(edge_schema(), vec![fragment], None, None, 8)
+            .unwrap();
+        let ctx = SessionContext::new();
+        let batches = collect(Arc::new(plan) as Arc<dyn ExecutionPlan>, ctx.task_ctx())
+            .await
+            .expect("missing path must not hard-error");
         let total: usize = batches.iter().map(RecordBatch::num_rows).sum();
         assert_eq!(total, 0);
         assert_eq!(batches[0].schema(), edge_schema());

--- a/crates/graphforge-storage/src/parquet_scan.rs
+++ b/crates/graphforge-storage/src/parquet_scan.rs
@@ -739,8 +739,8 @@ mod tests {
             normalize_topology: false,
             exact_rows: None,
         };
-        let plan = GraphForgeParquetExec::try_new(edge_schema(), vec![fragment], None, None, 8)
-            .unwrap();
+        let plan =
+            GraphForgeParquetExec::try_new(edge_schema(), vec![fragment], None, None, 8).unwrap();
         let ctx = SessionContext::new();
         let batches = collect(Arc::new(plan) as Arc<dyn ExecutionPlan>, ctx.task_ctx())
             .await

--- a/crates/graphforge-storage/src/parquet_scan.rs
+++ b/crates/graphforge-storage/src/parquet_scan.rs
@@ -71,6 +71,14 @@ impl ParquetFragment {
 #[derive(Clone, Debug)]
 pub struct IoConcurrencyExt(pub Arc<tokio::sync::Semaphore>);
 
+impl IoConcurrencyExt {
+    /// Build a semaphore with at least one permit.
+    #[must_use]
+    pub fn new(permits: usize) -> Self {
+        Self(Arc::new(tokio::sync::Semaphore::new(permits.max(1))))
+    }
+}
+
 /// Streaming Parquet scan over deterministic file fragments.
 #[derive(Clone)]
 pub struct GraphForgeParquetExec {
@@ -177,10 +185,6 @@ impl ExecutionPlan for GraphForgeParquetExec {
         "GraphForgeParquetExec"
     }
 
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn properties(&self) -> &Arc<PlanProperties> {
         &self.props
     }
@@ -232,6 +236,7 @@ impl ExecutionPlan for GraphForgeParquetExec {
         };
 
         let schema = Arc::clone(&self.schema);
+        let stream_schema = Arc::clone(&schema);
         let base_schema = Arc::clone(&self.base_schema);
         let projection = self.projection.clone();
         let limit = self.limit;
@@ -255,19 +260,19 @@ impl ExecutionPlan for GraphForgeParquetExec {
                 Some(frag) if !frag.exists => {
                     vec![RecordBatch::new_empty(Arc::clone(&schema))]
                 }
-                Some(frag) => read_fragment_batches(
-                    &frag,
-                    &base_schema,
-                    projection.as_deref(),
-                    batch_size,
-                )?,
+                Some(frag) => {
+                    read_fragment_batches(&frag, &base_schema, projection.as_deref(), batch_size)?
+                }
             };
             let batches = apply_limit(batches, limit);
             Ok::<_, DataFusionError>(stream::iter(batches.into_iter().map(Ok)))
         })
         .try_flatten();
 
-        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            stream_schema,
+            stream,
+        )))
     }
 }
 
@@ -297,7 +302,9 @@ fn read_fragment_batches(
     batch_size: usize,
 ) -> Result<Vec<RecordBatch>, DataFusionError> {
     let file = File::open(&fragment.path).map_err(|e| {
-        DataFusionError::External(format!("open parquet {}: {e}", path_label(&fragment.path)).into())
+        DataFusionError::External(
+            format!("open parquet {}: {e}", path_label(&fragment.path)).into(),
+        )
     })?;
     let builder = ParquetRecordBatchReaderBuilder::try_new(file).map_err(|e| {
         DataFusionError::External(format!("corrupt or unreadable parquet: {e}").into())
@@ -321,9 +328,8 @@ fn read_fragment_batches(
 
     let mut out = Vec::new();
     for batch in reader {
-        let mut batch = batch.map_err(|e| {
-            DataFusionError::External(format!("parquet decode failed: {e}").into())
-        })?;
+        let mut batch = batch
+            .map_err(|e| DataFusionError::External(format!("parquet decode failed: {e}").into()))?;
         if fragment.normalize_topology {
             batch = normalize_topology_nodes(vec![batch])?
                 .into_iter()
@@ -348,9 +354,11 @@ fn read_fragment_batches(
     }
     if out.is_empty() {
         let empty = match projection {
-            Some(indices) => RecordBatch::new_empty(Arc::new(base_schema.project(indices).map_err(
-                |e| DataFusionError::ArrowError(Box::new(e), Some("empty projection".into())),
-            )?)),
+            Some(indices) => {
+                RecordBatch::new_empty(Arc::new(base_schema.project(indices).map_err(|e| {
+                    DataFusionError::ArrowError(Box::new(e), Some("empty projection".into()))
+                })?))
+            }
             None => RecordBatch::new_empty(Arc::clone(base_schema)),
         };
         out.push(empty);
@@ -426,10 +434,6 @@ impl ExecutionPlan for OrderedPartitionStreamExec {
         "OrderedPartitionStreamExec"
     }
 
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn properties(&self) -> &Arc<PlanProperties> {
         &self.props
     }
@@ -484,14 +488,15 @@ pub fn scan_fragments(
     limit: Option<usize>,
     batch_size: usize,
 ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-    let exec = GraphForgeParquetExec::try_new(base_schema, fragments, projection, limit, batch_size)?;
+    let exec =
+        GraphForgeParquetExec::try_new(base_schema, fragments, projection, limit, batch_size)?;
     Ok(exec.into_ordered_plan())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{UInt64Array};
+    use arrow::array::UInt64Array;
     use arrow::datatypes::{DataType, Field, Schema};
     use datafusion::physical_plan::collect;
     use datafusion::prelude::SessionContext;
@@ -535,21 +540,15 @@ mod tests {
         write_edges(&path, 8);
         let table_schema = edge_schema();
         let fragments = vec![ParquetFragment::for_path(path.clone(), false)];
-        let plan = GraphForgeParquetExec::try_new(
-            table_schema.clone(),
-            fragments,
-            None,
-            None,
-            4,
-        )
-        .unwrap()
-        .into_ordered_plan();
+        let plan = GraphForgeParquetExec::try_new(table_schema.clone(), fragments, None, None, 4)
+            .unwrap()
+            .into_ordered_plan();
         assert_eq!(plan.name(), "GraphForgeParquetExec");
         // Corrupt after planning — proves scan did not consume the payload.
         std::fs::write(&path, b"not-a-parquet-file").unwrap();
         let ctx = SessionContext::new();
         let task = ctx.task_ctx();
-        let err = collect(plan.execute(0, task).unwrap()).await.unwrap_err();
+        let err = collect(plan, task).await.unwrap_err();
         let msg = err.to_string();
         assert!(
             msg.contains("corrupt") || msg.contains("unreadable") || msg.contains("parquet"),
@@ -577,7 +576,9 @@ mod tests {
             .build();
         let ctx = SessionContext::new_with_state(state);
         let task = ctx.task_ctx();
-        let batches = collect(plan.execute(0, task).unwrap()).await.unwrap();
+        let batches = collect(Arc::new(plan) as Arc<dyn ExecutionPlan>, task)
+            .await
+            .unwrap();
         assert!(
             batches.len() >= 2,
             "expected multiple bounded batches, got {}",
@@ -586,7 +587,10 @@ mod tests {
         assert!(
             batches.iter().all(|b| b.num_rows() <= 4),
             "batch_size 4 violated: {:?}",
-            batches.iter().map(RecordBatch::num_rows).collect::<Vec<_>>()
+            batches
+                .iter()
+                .map(RecordBatch::num_rows)
+                .collect::<Vec<_>>()
         );
         let total: usize = batches.iter().map(RecordBatch::num_rows).sum();
         assert_eq!(total, 10);
@@ -610,7 +614,7 @@ mod tests {
         assert_eq!(plan.schema().field(0).name(), "edge_id");
         assert_eq!(plan.schema().field(1).name(), "dst_id");
         let ctx = SessionContext::new();
-        let batches = collect(plan.execute(0, ctx.task_ctx()).unwrap())
+        let batches = collect(Arc::new(plan) as Arc<dyn ExecutionPlan>, ctx.task_ctx())
             .await
             .unwrap();
         assert_eq!(batches[0].num_columns(), 2);
@@ -629,7 +633,7 @@ mod tests {
         )
         .unwrap();
         let ctx = SessionContext::new();
-        let batches = collect(plan.execute(0, ctx.task_ctx()).unwrap())
+        let batches = collect(Arc::new(plan) as Arc<dyn ExecutionPlan>, ctx.task_ctx())
             .await
             .unwrap();
         let total: usize = batches.iter().map(RecordBatch::num_rows).sum();
@@ -649,7 +653,10 @@ mod tests {
         .unwrap();
         assert_eq!(plan.fragment_count(), 1);
         assert_eq!(plan.batch_size(), 128);
-        let display = format!("{}", datafusion::physical_plan::displayable(&plan).one_line());
+        let display = format!(
+            "{}",
+            datafusion::physical_plan::displayable(&plan).one_line()
+        );
         assert!(display.contains("GraphForgeParquetExec"), "{display}");
         assert!(display.contains("batch_size=128"), "{display}");
     }
@@ -674,9 +681,12 @@ mod tests {
             )
             .unwrap();
             let file = File::create(path).unwrap();
-            let mut writer =
-                ArrowWriter::try_new(file, schema.clone(), Some(WriterProperties::builder().build()))
-                    .unwrap();
+            let mut writer = ArrowWriter::try_new(
+                file,
+                schema.clone(),
+                Some(WriterProperties::builder().build()),
+            )
+            .unwrap();
             writer.write(&batch).unwrap();
             writer.close().unwrap();
         }
@@ -694,9 +704,7 @@ mod tests {
         .into_ordered_plan();
         assert_eq!(plan.name(), "OrderedPartitionStreamExec");
         let ctx = SessionContext::new();
-        let batches = collect(plan.execute(0, ctx.task_ctx()).unwrap())
-            .await
-            .unwrap();
+        let batches = collect(plan, ctx.task_ctx()).await.unwrap();
         let ids = batches
             .iter()
             .flat_map(|b| {

--- a/crates/graphforge-storage/src/parquet_scan.rs
+++ b/crates/graphforge-storage/src/parquet_scan.rs
@@ -13,10 +13,12 @@ use std::sync::Arc;
 
 use arrow::array::RecordBatch;
 use arrow::datatypes::SchemaRef;
+use datafusion::common::stats::Precision;
+use datafusion::common::{ColumnStatistics, Statistics};
 use datafusion::error::DataFusionError;
 use datafusion::execution::TaskContext;
 use datafusion::physical_expr::EquivalenceProperties;
-use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType, SchedulingType};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, Partitioning,
@@ -40,31 +42,51 @@ pub struct ParquetFragment {
     pub rel_type_name: Option<String>,
     /// Apply [`normalize_topology_nodes`] after decode (legacy `type_id` files).
     pub normalize_topology: bool,
+    /// Footer-only row count when known (no row-group decode).
+    pub exact_rows: Option<usize>,
 }
 
 impl ParquetFragment {
     /// Fragment for a single known path; `exists` is probed without reading bytes.
+    ///
+    /// When the file exists, the Parquet footer is opened for an exact row count
+    /// so DataFusion can keep CollectLeft joins (MemTable parity). Row groups are
+    /// not decoded.
     #[must_use]
     pub fn for_path(path: PathBuf, normalize_topology: bool) -> Self {
         let exists = path.exists();
+        let exact_rows = if exists {
+            footer_num_rows(&path)
+        } else {
+            Some(0)
+        };
         Self {
             path,
             exists,
             rel_type_name: None,
             normalize_topology,
+            exact_rows,
         }
     }
 
     /// Union-edge fragment tagged with `rel_type_name` (file already listed).
     #[must_use]
     pub fn for_union_edge(path: PathBuf, rel_type_name: String) -> Self {
+        let exact_rows = footer_num_rows(&path);
         Self {
             path,
             exists: true,
             rel_type_name: Some(rel_type_name),
             normalize_topology: false,
+            exact_rows,
         }
     }
+}
+
+fn footer_num_rows(path: &Path) -> Option<usize> {
+    let file = File::open(path).ok()?;
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file).ok()?;
+    usize::try_from(builder.metadata().file_metadata().num_rows()).ok()
 }
 
 /// Session extension carrying the #337 I/O concurrency semaphore.
@@ -103,12 +125,16 @@ impl fmt::Debug for GraphForgeParquetExec {
             .field("batch_size", &self.batch_size)
             .field("limit", &self.limit)
             .field("projection", &self.projection)
-            .finish()
+            .field("schema", &self.schema)
+            .finish_non_exhaustive()
     }
 }
 
 impl GraphForgeParquetExec {
-    /// Build a streaming plan. Does not open Parquet footers or decode row groups.
+    /// Build a streaming plan. Does not decode Parquet row groups.
+    ///
+    /// Fragments may already carry footer-only row counts for DataFusion
+    /// statistics; this constructor itself performs no I/O.
     ///
     /// # Errors
     /// Returns [`DataFusionError`] when the projection indices are invalid.
@@ -127,12 +153,17 @@ impl GraphForgeParquetExec {
             None => Arc::clone(&base_schema),
         };
         let partition_count = fragments.len().max(1);
-        let props = Arc::new(PlanProperties::new(
-            EquivalenceProperties::new(Arc::clone(&schema)),
-            Partitioning::UnknownPartitioning(partition_count),
-            EmissionType::Incremental,
-            Boundedness::Bounded,
-        ));
+        let props = Arc::new(
+            PlanProperties::new(
+                EquivalenceProperties::new(Arc::clone(&schema)),
+                Partitioning::UnknownPartitioning(partition_count),
+                EmissionType::Incremental,
+                Boundedness::Bounded,
+            )
+            // Match MemTable / MemorySourceConfig so DF keeps CollectLeft joins
+            // and does not insert eager RoundRobinBatch exchanges (#339 / #1269).
+            .with_scheduling_type(SchedulingType::Cooperative),
+        );
         Ok(Self {
             schema,
             base_schema,
@@ -181,7 +212,7 @@ impl DisplayAs for GraphForgeParquetExec {
 }
 
 impl ExecutionPlan for GraphForgeParquetExec {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "GraphForgeParquetExec"
     }
 
@@ -212,6 +243,45 @@ impl ExecutionPlan for GraphForgeParquetExec {
             (a, b) => a.or(b),
         };
         Some(Arc::new(cloned))
+    }
+
+    fn partition_statistics(
+        &self,
+        partition: Option<usize>,
+    ) -> Result<Arc<Statistics>, DataFusionError> {
+        let column_statistics = self
+            .schema
+            .fields()
+            .iter()
+            .map(|_| ColumnStatistics::new_unknown())
+            .collect();
+        let num_rows = match partition {
+            None => {
+                if self.fragments.is_empty() {
+                    Some(0usize)
+                } else {
+                    self.fragments
+                        .iter()
+                        .map(|f| f.exact_rows)
+                        .try_fold(0usize, |acc, rows| Some(acc.saturating_add(rows?)))
+                }
+            }
+            Some(idx) => {
+                if self.fragments.is_empty() {
+                    (idx == 0).then_some(0usize)
+                } else {
+                    self.fragments.get(idx).and_then(|f| f.exact_rows)
+                }
+            }
+        };
+        Ok(Arc::new(Statistics {
+            num_rows: match num_rows {
+                Some(n) => Precision::Exact(n),
+                None => Precision::Absent,
+            },
+            total_byte_size: Precision::Absent,
+            column_statistics,
+        }))
     }
 
     fn execute(
@@ -341,12 +411,10 @@ fn read_fragment_batches(
         if let Some(stem) = fragment.rel_type_name.as_deref() {
             batch = tag_rel_type_name(&batch, stem)?;
         }
-        if post_process {
-            if let Some(indices) = projection {
-                batch = batch.project(indices).map_err(|e| {
-                    DataFusionError::ArrowError(Box::new(e), Some("post-process projection".into()))
-                })?;
-            }
+        if post_process && let Some(indices) = projection {
+            batch = batch.project(indices).map_err(|e| {
+                DataFusionError::ArrowError(Box::new(e), Some("post-process projection".into()))
+            })?;
         }
         // Ensure output schema matches the plan (field nullability / metadata).
         let batch = align_schema(batch, base_schema, projection)?;
@@ -409,12 +477,15 @@ struct OrderedPartitionStreamExec {
 impl OrderedPartitionStreamExec {
     fn new(input: Arc<dyn ExecutionPlan>) -> Self {
         let schema = input.schema();
-        let props = Arc::new(PlanProperties::new(
-            EquivalenceProperties::new(schema),
-            Partitioning::UnknownPartitioning(1),
-            EmissionType::Incremental,
-            Boundedness::Bounded,
-        ));
+        let props = Arc::new(
+            PlanProperties::new(
+                EquivalenceProperties::new(schema),
+                Partitioning::UnknownPartitioning(1),
+                EmissionType::Incremental,
+                Boundedness::Bounded,
+            )
+            .with_scheduling_type(SchedulingType::Cooperative),
+        );
         Self { input, props }
     }
 }
@@ -430,7 +501,7 @@ impl DisplayAs for OrderedPartitionStreamExec {
 }
 
 impl ExecutionPlan for OrderedPartitionStreamExec {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "OrderedPartitionStreamExec"
     }
 

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -58,9 +58,13 @@ state.
 3. `build_runtime(&policy)` sets Tokio worker threads
 4. Every DataFusion `ExecutionSession` receives a
    [`SessionResourceConfig`](../../crates/graphforge-exec/src/lib.rs) with
-   partitions, batch size, memory, and optional spill
+   partitions, batch size, memory, optional spill, and `io_concurrency`
 5. Heavy ops (`run_query`, streams construction, `rank`, `similar`,
    `analyze_embedding`) take an admission permit
+6. Query-facing Parquet scans (`GraphForgeParquetExec`, #339) defer file I/O to
+   `ExecutionPlan::execute`, emit batches sized from `batch_size`, declare
+   natural file fragments, and acquire the session `io_concurrency` semaphore
+   before opening each fragment
 
 Resources are **instance-owned**, not process-global. `compute_threads` is a
 structural reserve for a future private Rayon pool; this issue does **not**

--- a/docs/development/m4-entry-baseline.md
+++ b/docs/development/m4-entry-baseline.md
@@ -79,9 +79,11 @@ DataFusion target partitions, thread-parity cells over the host budget.
 ## Honest bottlenecks retained
 
 The entry baseline intentionally records the current implementation, including
-eager Parquet materialization, single-partition custom plans, serial algorithm
-kernels, and CSR-to-map conversion where still observable. Optimizations belong
-to later M4 issues.
+serial algorithm kernels and CSR-to-map conversion where still observable.
+Query-facing Parquet providers stream bounded batches via
+`GraphForgeParquetExec` (#339) rather than eager single-partition `MemTable`
+materialization; ExpandExec filtered reads and fixed-hop demand remain the
+selective-path contract. Further optimizations belong to later M4 issues.
 
 ## Discovery evidence (not a universal size ceiling)
 

--- a/tests/contracts/m4-entry-matrix.json
+++ b/tests/contracts/m4-entry-matrix.json
@@ -234,7 +234,6 @@
     ]
   },
   "known_limitations": [
-    "Eager Parquet materialization into single-partition MemTable remains observable.",
     "CSR-to-hash-map expansion remains on analyst/traversal paths (#340).",
     "Algorithm kernels remain serial (#342-#344).",
     "Portable interchange does not yet encode file-backed graph/files trees (structured GF_UNSUPPORTED_PROJECT_FORMAT); copy the project directory instead (#338).",

--- a/tools/bazel/drift/cargo_feature_fingerprint.json
+++ b/tools/bazel/drift/cargo_feature_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "schema": "graphforge.cargo-feature-fingerprint.v1",
-  "sha256": "5bf6ceb145c5f44c9489528cf177a8cbfb5efd8575c91096e62760f9e6e4886b",
+  "sha256": "92928a4a2a9da6717b7ec493e4f14eda2a278a92395ffb8f223828b5a995e009",
   "entries": [
     {
       "name": "graphforge-api",
@@ -1570,6 +1570,15 @@
         {
           "name": "fs4",
           "req": "^1.1",
+          "features": [],
+          "optional": false,
+          "uses_default_features": true,
+          "kind": null,
+          "target": null
+        },
+        {
+          "name": "futures",
+          "req": "^0.3",
           "features": [],
           "optional": false,
           "uses_default_features": true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replace eager MemTable Parquet scans with `GraphForgeParquetExec` so query-facing topology/property providers stream bounded batches at execute time under the #337 resource policy.

Rebased onto `main` after #336+#338.

## Changes

- Shared streaming Parquet execution plan with file-fragment partitions, batch sizing, and `io_concurrency`
- Wire TopologyNode / TypedEdge / UnionEdge / Property / EdgeProperty providers
- Preserve fixed-hop demand contract; RuntimeGuard keeps workspace alive for streams after drop
- Missing parquet paths return empty schema-shaped batches
- Bazel crate_index repin so storage links `futures`

## Testing

```bash
python3 scripts/ci/cargo-bazel-drift-check.py
cargo test -p graphforge-storage --lib parquet_scan
cargo test -p graphforge-storage --lib catalog::
cargo test -p graphforge-api --test fixed_hop_limit
cargo test -p graphforge-api --test m4_entry_baseline
```

Closes #339

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788910781&installation_model_id=20486&pr_number=489&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F489&signature=60b7bca211fb60d022777bcf27f9782bd43c81429a3a80f3498cfeac0f4a315a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stream partitioned Parquet execution across all storage catalog providers
> - Replaces eager `MemTable` materialization in all catalog `TableProvider::scan` implementations (`TopologyNodeTable`, `TypedEdgeTable`, `UnionEdgeTable`, `EdgePropertyTable`, `PropertyTable`) with a new streaming `GraphForgeParquetExec` plan defined in [`parquet_scan.rs`](https://github.com/CurateLabs/graphforge/pull/489/files#diff-fcf822b84f343633ae6d12e4f8fd8288a4900b5b8abf387a84f816f499811bef).
> - `GraphForgeParquetExec` defers Parquet file I/O to execute time, emits bounded batches sized by the session's `batch_size`, and uses an `OrderedPartitionStreamExec` wrapper to preserve deterministic fragment order across a single output partition.
> - An `IoConcurrencyExt` session extension (default: 2 permits) gates concurrent fragment opens via a Tokio semaphore; this value is now propagated from `GraphForge`'s resource policy through `SessionResourceConfig`.
> - Behavioral Change: Parquet I/O previously occurred at planning time; it now occurs at execution time, and scans will fail closed on corrupt or missing files discovered after planning rather than at scan build time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized beebdb0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streaming Parquet scanning with support for projections, limits, batching, ordering, and structured read errors.
  * Added configurable I/O concurrency, defaulting to two concurrent operations.
* **Bug Fixes**
  * Streaming results now remain functional after the parent graph session is dropped.
  * Missing or corrupted files are handled more reliably during scans.
* **Documentation**
  * Clarified streaming resource ownership and lifetime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->