### PR TITLE
perf(exec): bounded Arrow shaping for analyst outputs (#341)

### DIFF
--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -2320,13 +2320,15 @@ impl GraphForge {
             .read()
             .expect("adjacency visibility lock poisoned");
         self.adjacency_provider.revalidate();
-        let batch = graphforge_exec::rank_algorithm(
+        let batch = graphforge_exec::rank_algorithm_with_limits(
             self.adjacency_provider.as_ref(),
             &self.dir,
             self.ontology_mode,
             label_id,
             std::slice::from_ref(&stem),
             &dispatch_options,
+            graphforge_exec::AlgorithmLimits::default()
+                .with_batch_size(self.resource_policy.batch_size),
         )?;
         self.write_algorithm_property(
             label,
@@ -2374,13 +2376,15 @@ impl GraphForge {
             .read()
             .expect("adjacency visibility lock poisoned");
         self.adjacency_provider.revalidate();
-        let batch = graphforge_exec::cluster_algorithm(
+        let batch = graphforge_exec::cluster_algorithm_with_limits(
             self.adjacency_provider.as_ref(),
             &self.dir,
             self.ontology_mode,
             label_id,
             std::slice::from_ref(&stem),
             &dispatch_options,
+            graphforge_exec::AlgorithmLimits::default()
+                .with_batch_size(self.resource_policy.batch_size),
         )?;
         self.write_algorithm_property(
             label,
@@ -2518,13 +2522,15 @@ impl GraphForge {
             .read()
             .expect("adjacency visibility lock poisoned");
         self.adjacency_provider.revalidate();
-        graphforge_exec::similar_algorithm(
+        graphforge_exec::similar_algorithm_with_limits(
             self.adjacency_provider.as_ref(),
             &self.dir,
             self.ontology_mode,
             label_id,
             std::slice::from_ref(&stem),
             options,
+            graphforge_exec::AlgorithmLimits::default()
+                .with_batch_size(self.resource_policy.batch_size),
         )
     }
 

--- a/crates/graphforge-exec/src/algorithm_analyze.rs
+++ b/crates/graphforge-exec/src/algorithm_analyze.rs
@@ -3971,7 +3971,8 @@ mod tests {
             output.schema,
             Algorithm::Analyze(AnalyzeAlgorithm::CountAutomorphisms).result_schema()
         );
-        let [row] = output.rows().as_slice() else {
+        let rows = output.rows();
+        let [row] = rows.as_slice() else {
             panic!("automorphism dispatch must return exactly one row");
         };
         let [AlgorithmValue::UInt64(count)] = row.as_slice() else {
@@ -4509,7 +4510,7 @@ mod tests {
             AlgorithmCancellation::default(),
         )
         .unwrap();
-        assert!(empty.rows.is_empty());
+        assert!(empty.rows().is_empty());
 
         let graph = AdjacencyGraph::with_test_undirected_multigraph(4, &[(1, 0, 1), (2, 2, 3)]);
         assert!(matches!(
@@ -4584,7 +4585,7 @@ mod tests {
             AlgorithmCancellation::default(),
         )
         .unwrap();
-        assert!(empty.rows.is_empty());
+        assert!(empty.rows().is_empty());
 
         let graph = AdjacencyGraph::with_test_undirected_multigraph(4, &[(1, 0, 1), (2, 2, 3)]);
         assert!(matches!(
@@ -4974,12 +4975,12 @@ mod tests {
         for algorithm in [AnalyzeAlgorithm::EulerCircuit, AnalyzeAlgorithm::EulerPath] {
             let empty = euler_output(&AdjacencyGraph::default(), algorithm, false).unwrap();
             assert_eq!(empty.schema, Algorithm::Analyze(algorithm).result_schema());
-            assert!(empty.rows.is_empty());
+            assert!(empty.rows().is_empty());
 
             let singleton =
                 euler_output(&AdjacencyGraph::with_test_edges(1, &[]), algorithm, false).unwrap();
             assert_eq!(
-                singleton.rows,
+                singleton.rows(),
                 [vec![
                     AlgorithmValue::UuidList(vec![uuid(0)]),
                     AlgorithmValue::UuidList(Vec::new()),
@@ -4995,7 +4996,7 @@ mod tests {
         assert_eq!(
             euler_output(&undirected_open, AnalyzeAlgorithm::EulerPath, false)
                 .unwrap()
-                .rows,
+                .rows(),
             [vec![
                 AlgorithmValue::UuidList(vec![uuid(0), uuid(1), uuid(2)]),
                 AlgorithmValue::UuidList(vec![uuid(10), uuid(11)]),
@@ -5010,7 +5011,7 @@ mod tests {
         assert_eq!(
             euler_output(&directed_open, AnalyzeAlgorithm::EulerPath, true)
                 .unwrap()
-                .rows,
+                .rows(),
             [vec![
                 AlgorithmValue::UuidList(vec![uuid(0), uuid(1), uuid(2)]),
                 AlgorithmValue::UuidList(vec![uuid(0), uuid(1)]),
@@ -5032,13 +5033,13 @@ mod tests {
             ),
         ] {
             let circuit = euler_output(&graph, AnalyzeAlgorithm::EulerCircuit, directed).unwrap();
-            assert_eq!(circuit.rows.len(), 1);
+            assert_eq!(circuit.rows().len(), 1);
             assert_eq!(
-                circuit.rows[0][0],
+                circuit.rows()[0][0],
                 AlgorithmValue::UuidList(vec![uuid(0), uuid(1), uuid(0)])
             );
             assert_eq!(
-                circuit.rows[0][1],
+                circuit.rows()[0][1],
                 AlgorithmValue::UuidList(if directed {
                     vec![uuid(0), uuid(1)]
                 } else {
@@ -5057,7 +5058,8 @@ mod tests {
         let first = euler_output(&graph, AnalyzeAlgorithm::EulerCircuit, false).unwrap();
         let second = euler_output(&graph, AnalyzeAlgorithm::EulerCircuit, false).unwrap();
         assert_eq!(first, second);
-        let [row] = first.rows.as_slice() else {
+        let rows = first.rows();
+        let [row] = rows.as_slice() else {
             panic!("Euler circuit must be one row");
         };
         let [
@@ -5212,7 +5214,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap()
-            .rows,
+            .rows(),
             Vec::<Vec<AlgorithmValue>>::new()
         );
         assert!(matches!(
@@ -5397,7 +5399,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap()
-            .rows,
+            .rows(),
             [vec![
                 AlgorithmValue::Float64(0.0),
                 AlgorithmValue::UuidList(Vec::new()),
@@ -5481,7 +5483,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap()
-            .rows,
+            .rows(),
             [vec![
                 AlgorithmValue::Float64(0.0),
                 AlgorithmValue::UuidList(Vec::new()),
@@ -5604,7 +5606,7 @@ mod tests {
                     AlgorithmCancellation::default(),
                 )
                 .unwrap()
-                .rows,
+                .rows(),
                 [vec![AlgorithmValue::Boolean(false)]]
             );
         }
@@ -5617,7 +5619,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap()
-            .rows,
+            .rows(),
             [vec![AlgorithmValue::Boolean(false)]]
         );
     }
@@ -5889,7 +5891,7 @@ mod tests {
                     AlgorithmCancellation::default(),
                 )
                 .unwrap()
-                .rows
+                .rows()
                 .is_empty()
             );
         }
@@ -6040,7 +6042,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap()
-            .rows,
+            .rows(),
             [
                 vec![AlgorithmValue::UuidList(
                     [0_u128, 1, 2].map(u128::to_be_bytes).to_vec()
@@ -6067,7 +6069,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap()
-            .rows,
+            .rows(),
             Vec::<Vec<AlgorithmValue>>::new()
         );
         let graph = AdjacencyGraph::with_test_directed_edges(3, &[(0, 1), (1, 2), (2, 0)]);
@@ -6561,7 +6563,7 @@ mod tests {
             AlgorithmCancellation::default(),
         )
         .unwrap();
-        assert_ne!(output.rows(), legacy.rows);
+        assert_ne!(output.rows(), legacy.rows());
         assert_ne!(
             output.schema,
             Algorithm::Analyze(AnalyzeAlgorithm::ChromaticNumber).result_schema()
@@ -6599,7 +6601,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap()
-            .rows
+            .rows()
             .is_empty()
         );
         assert!(matches!(

--- a/crates/graphforge-exec/src/algorithm_analyze.rs
+++ b/crates/graphforge-exec/src/algorithm_analyze.rs
@@ -208,7 +208,11 @@ impl RustAlgorithm for CountAutomorphisms {
         edges.dedup_by_key(|edge| edge.edge);
         let graph = AutomorphismGraph::try_new(&nodes, &edges, self.directed, control)?;
         let count = count_automorphisms(&graph, control)?;
-        AlgorithmOutput::from_rows(self.capability().algorithm, control, vec![vec![AlgorithmValue::UInt64(count)]])
+        AlgorithmOutput::from_rows(
+            self.capability().algorithm,
+            control,
+            vec![vec![AlgorithmValue::UInt64(count)]],
+        )
     }
 }
 
@@ -388,7 +392,11 @@ impl RustAlgorithm for Conductance {
             ]
         })
         .collect();
-        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::Conductance), control, rows)
+        AlgorithmOutput::from_rows(
+            Algorithm::Analyze(AnalyzeAlgorithm::Conductance),
+            control,
+            rows,
+        )
     }
 }
 
@@ -514,7 +522,11 @@ impl RustAlgorithm for MaxBipartiteMatching {
                 ]
             })
             .collect();
-        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::MaxBipartiteMatching), control, rows)
+        AlgorithmOutput::from_rows(
+            Algorithm::Analyze(AnalyzeAlgorithm::MaxBipartiteMatching),
+            control,
+            rows,
+        )
     }
 }
 
@@ -555,7 +567,11 @@ impl RustAlgorithm for ChromaticNumber {
             }
         }
         let value = exact_chromatic_number(&nodes, &edges, control)?;
-        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::ChromaticNumber), control, vec![vec![AlgorithmValue::UInt64(value)]])
+        AlgorithmOutput::from_rows(
+            Algorithm::Analyze(AnalyzeAlgorithm::ChromaticNumber),
+            control,
+            vec![vec![AlgorithmValue::UInt64(value)]],
+        )
     }
 }
 
@@ -604,7 +620,11 @@ impl RustAlgorithm for NodeColoring {
                 ]
             })
             .collect();
-        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::NodeColoring), control, rows)
+        AlgorithmOutput::from_rows(
+            Algorithm::Analyze(AnalyzeAlgorithm::NodeColoring),
+            control,
+            rows,
+        )
     }
 }
 
@@ -653,7 +673,11 @@ impl RustAlgorithm for K1Coloring {
                 ]
             })
             .collect();
-        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::K1Coloring), control, rows)
+        AlgorithmOutput::from_rows(
+            Algorithm::Analyze(AnalyzeAlgorithm::K1Coloring),
+            control,
+            rows,
+        )
     }
 }
 
@@ -702,7 +726,11 @@ impl RustAlgorithm for EdgeColoring {
                 ]
             })
             .collect();
-        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::EdgeColoring), control, rows)
+        AlgorithmOutput::from_rows(
+            Algorithm::Analyze(AnalyzeAlgorithm::EdgeColoring),
+            control,
+            rows,
+        )
     }
 }
 
@@ -830,7 +858,11 @@ impl RustAlgorithm for HasEulerPath {
             }
         }
         let value = has_euler_path(&nodes, &edges, self.directed, control)?;
-        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::HasEulerPath), control, vec![vec![AlgorithmValue::Boolean(value)]])
+        AlgorithmOutput::from_rows(
+            Algorithm::Analyze(AnalyzeAlgorithm::HasEulerPath),
+            control,
+            vec![vec![AlgorithmValue::Boolean(value)]],
+        )
     }
 }
 
@@ -871,7 +903,11 @@ impl RustAlgorithm for HasEulerCircuit {
             }
         }
         let value = has_euler_circuit(&nodes, &edges, self.directed, control)?;
-        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::HasEulerCircuit), control, vec![vec![AlgorithmValue::Boolean(value)]])
+        AlgorithmOutput::from_rows(
+            Algorithm::Analyze(AnalyzeAlgorithm::HasEulerCircuit),
+            control,
+            vec![vec![AlgorithmValue::Boolean(value)]],
+        )
     }
 }
 
@@ -915,7 +951,11 @@ impl RustAlgorithm for FindCycles {
             .into_iter()
             .map(|cycle| vec![AlgorithmValue::UuidList(cycle)])
             .collect();
-        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::FindCycles), control, rows)
+        AlgorithmOutput::from_rows(
+            Algorithm::Analyze(AnalyzeAlgorithm::FindCycles),
+            control,
+            rows,
+        )
     }
 }
 
@@ -956,10 +996,14 @@ impl RustAlgorithm for DagLongestPath {
             }
         }
         let result = dag_longest_path(&nodes, &edges, control)?;
-        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::DagLongestPath), control, vec![vec![
+        AlgorithmOutput::from_rows(
+            Algorithm::Analyze(AnalyzeAlgorithm::DagLongestPath),
+            control,
+            vec![vec![
                 AlgorithmValue::Float64(result.cost),
                 AlgorithmValue::UuidList(result.path),
-            ]])
+            ]],
+        )
     }
 }
 
@@ -1001,10 +1045,14 @@ impl RustAlgorithm for WeightedDagLongestPath {
             }
         }
         let result = weighted_dag_longest_path(&nodes, &edges, control)?;
-        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::DagLongestPathWeighted), control, vec![vec![
+        AlgorithmOutput::from_rows(
+            Algorithm::Analyze(AnalyzeAlgorithm::DagLongestPathWeighted),
+            control,
+            vec![vec![
                 AlgorithmValue::Float64(result.cost),
                 AlgorithmValue::UuidList(result.path),
-            ]])
+            ]],
+        )
     }
 }
 
@@ -1054,7 +1102,11 @@ impl RustAlgorithm for TriangleCount {
             }
         }
         let count = triangle_count(&nodes, &edges, control)?;
-        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::TriangleCount), control, vec![vec![AlgorithmValue::UInt64(count)]])
+        AlgorithmOutput::from_rows(
+            Algorithm::Analyze(AnalyzeAlgorithm::TriangleCount),
+            control,
+            vec![vec![AlgorithmValue::UInt64(count)]],
+        )
     }
 }
 
@@ -1104,7 +1156,11 @@ impl RustAlgorithm for Transitivity {
             }
         }
         let value = transitivity(&nodes, &edges, control)?;
-        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::Transitivity), control, vec![vec![AlgorithmValue::Float64(value)]])
+        AlgorithmOutput::from_rows(
+            Algorithm::Analyze(AnalyzeAlgorithm::Transitivity),
+            control,
+            vec![vec![AlgorithmValue::Float64(value)]],
+        )
     }
 }
 
@@ -1154,7 +1210,11 @@ impl RustAlgorithm for IsPlanar {
             }
         }
         let value = is_planar(&nodes, &edges, control)?;
-        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::IsPlanar), control, vec![vec![AlgorithmValue::Boolean(value)]])
+        AlgorithmOutput::from_rows(
+            Algorithm::Analyze(AnalyzeAlgorithm::IsPlanar),
+            control,
+            vec![vec![AlgorithmValue::Boolean(value)]],
+        )
     }
 }
 
@@ -1268,7 +1328,10 @@ impl RustAlgorithm for DyadCensus {
             }
         }
         let counts = dyad_census(&nodes, &edges, control)?;
-        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::DyadCensus), control, vec![
+        AlgorithmOutput::from_rows(
+            Algorithm::Analyze(AnalyzeAlgorithm::DyadCensus),
+            control,
+            vec![
                 vec![
                     AlgorithmValue::Utf8("mutual".into()),
                     AlgorithmValue::UInt64(counts.mutual),
@@ -1281,7 +1344,8 @@ impl RustAlgorithm for DyadCensus {
                     AlgorithmValue::Utf8("null".into()),
                     AlgorithmValue::UInt64(counts.null),
                 ],
-            ])
+            ],
+        )
     }
 }
 
@@ -1366,7 +1430,11 @@ impl RustAlgorithm for ArticulationPoints {
                     })
             })
             .collect::<Result<Vec<_>, _>>()?;
-        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::ArticulationPoints), control, rows)
+        AlgorithmOutput::from_rows(
+            Algorithm::Analyze(AnalyzeAlgorithm::ArticulationPoints),
+            control,
+            rows,
+        )
     }
 }
 
@@ -1507,7 +1575,11 @@ impl RustAlgorithm for IsDag {
         } else {
             false
         };
-        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::IsDag), control, vec![vec![AlgorithmValue::Boolean(is_dag)]])
+        AlgorithmOutput::from_rows(
+            Algorithm::Analyze(AnalyzeAlgorithm::IsDag),
+            control,
+            vec![vec![AlgorithmValue::Boolean(is_dag)]],
+        )
     }
 }
 
@@ -1538,7 +1610,11 @@ impl RustAlgorithm for TopologicalSort {
                 AlgorithmValue::UInt64(order),
             ]);
         }
-        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::TopologicalSort), control, rows)
+        AlgorithmOutput::from_rows(
+            Algorithm::Analyze(AnalyzeAlgorithm::TopologicalSort),
+            control,
+            rows,
+        )
     }
 }
 

--- a/crates/graphforge-exec/src/algorithm_analyze.rs
+++ b/crates/graphforge-exec/src/algorithm_analyze.rs
@@ -208,10 +208,7 @@ impl RustAlgorithm for CountAutomorphisms {
         edges.dedup_by_key(|edge| edge.edge);
         let graph = AutomorphismGraph::try_new(&nodes, &edges, self.directed, control)?;
         let count = count_automorphisms(&graph, control)?;
-        Ok(AlgorithmOutput {
-            schema: self.capability().algorithm.result_schema(),
-            rows: vec![vec![AlgorithmValue::UInt64(count)]],
-        })
+        AlgorithmOutput::from_rows(self.capability().algorithm, control, vec![vec![AlgorithmValue::UInt64(count)]])
     }
 }
 
@@ -263,7 +260,7 @@ impl RustAlgorithm for MaxCardinalityMatching {
                 });
             }
         }
-        let rows = maximum_cardinality_matching(&nodes, &edges, control)?
+        let rows: Vec<Vec<AlgorithmValue>> = maximum_cardinality_matching(&nodes, &edges, control)?
             .into_iter()
             .map(|edge| {
                 vec![
@@ -273,10 +270,7 @@ impl RustAlgorithm for MaxCardinalityMatching {
                 ]
             })
             .collect();
-        Ok(AlgorithmOutput {
-            schema: self.capability().algorithm.result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(self.capability().algorithm, control, rows)
     }
 }
 
@@ -316,7 +310,7 @@ impl RustAlgorithm for MaxWeightMatching {
             }
         }
         let graph = normalize_weighted_undirected(&nodes, &edges, control, &mut work)?;
-        let rows = solve_exact_matching(&graph, control)?
+        let rows: Vec<Vec<AlgorithmValue>> = solve_exact_matching(&graph, control)?
             .into_iter()
             .map(|edge| {
                 vec![
@@ -327,10 +321,7 @@ impl RustAlgorithm for MaxWeightMatching {
                 ]
             })
             .collect();
-        Ok(AlgorithmOutput {
-            schema: self.capability().algorithm.result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(self.capability().algorithm, control, rows)
     }
 }
 
@@ -382,7 +373,7 @@ impl RustAlgorithm for Conductance {
                 }
             }
         }
-        let rows = conductance(
+        let rows: Vec<Vec<AlgorithmValue>> = conductance(
             &nodes,
             &edges.into_values().collect::<Vec<_>>(),
             graph.is_directed(),
@@ -397,10 +388,7 @@ impl RustAlgorithm for Conductance {
             ]
         })
         .collect();
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Analyze(AnalyzeAlgorithm::Conductance).result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::Conductance), control, rows)
     }
 }
 
@@ -516,7 +504,7 @@ impl RustAlgorithm for MaxBipartiteMatching {
             self.partitions.as_ref(),
             control,
         )?;
-        let rows = maximum_bipartite_matching(&projection, control)?
+        let rows: Vec<Vec<AlgorithmValue>> = maximum_bipartite_matching(&projection, control)?
             .into_iter()
             .map(|edge| {
                 vec![
@@ -526,10 +514,7 @@ impl RustAlgorithm for MaxBipartiteMatching {
                 ]
             })
             .collect();
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Analyze(AnalyzeAlgorithm::MaxBipartiteMatching).result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::MaxBipartiteMatching), control, rows)
     }
 }
 
@@ -570,10 +555,7 @@ impl RustAlgorithm for ChromaticNumber {
             }
         }
         let value = exact_chromatic_number(&nodes, &edges, control)?;
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Analyze(AnalyzeAlgorithm::ChromaticNumber).result_schema(),
-            rows: vec![vec![AlgorithmValue::UInt64(value)]],
-        })
+        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::ChromaticNumber), control, vec![vec![AlgorithmValue::UInt64(value)]])
     }
 }
 
@@ -613,7 +595,7 @@ impl RustAlgorithm for NodeColoring {
                 });
             }
         }
-        let rows = greedy_node_coloring(&nodes, &edges, control)?
+        let rows: Vec<Vec<AlgorithmValue>> = greedy_node_coloring(&nodes, &edges, control)?
             .into_iter()
             .map(|entry| {
                 vec![
@@ -622,10 +604,7 @@ impl RustAlgorithm for NodeColoring {
                 ]
             })
             .collect();
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Analyze(AnalyzeAlgorithm::NodeColoring).result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::NodeColoring), control, rows)
     }
 }
 
@@ -665,7 +644,7 @@ impl RustAlgorithm for K1Coloring {
                 });
             }
         }
-        let rows = k1_coloring(&nodes, &edges, control)?
+        let rows: Vec<Vec<AlgorithmValue>> = k1_coloring(&nodes, &edges, control)?
             .into_iter()
             .map(|entry| {
                 vec![
@@ -674,10 +653,7 @@ impl RustAlgorithm for K1Coloring {
                 ]
             })
             .collect();
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Analyze(AnalyzeAlgorithm::K1Coloring).result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::K1Coloring), control, rows)
     }
 }
 
@@ -717,7 +693,7 @@ impl RustAlgorithm for EdgeColoring {
                 });
             }
         }
-        let rows = greedy_edge_coloring(&nodes, &edges, control)?
+        let rows: Vec<Vec<AlgorithmValue>> = greedy_edge_coloring(&nodes, &edges, control)?
             .into_iter()
             .map(|color| {
                 vec![
@@ -726,10 +702,7 @@ impl RustAlgorithm for EdgeColoring {
                 ]
             })
             .collect();
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Analyze(AnalyzeAlgorithm::EdgeColoring).result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::EdgeColoring), control, rows)
     }
 }
 
@@ -753,17 +726,14 @@ impl RustAlgorithm for EulerConstruction {
             AnalyzeAlgorithm::EulerPath => EulerTrailKind::Path,
             _ => unreachable!("Euler construction only registers Euler algorithms"),
         };
-        let rows = match projection.trail(kind, control)? {
+        let rows: Vec<Vec<AlgorithmValue>> = match projection.trail(kind, control)? {
             EulerTrailOutcome::EmptySelection => Vec::new(),
             EulerTrailOutcome::Trail(trail) => vec![vec![
                 AlgorithmValue::UuidList(trail.node_path),
                 AlgorithmValue::UuidList(trail.edge_path),
             ]],
         };
-        Ok(AlgorithmOutput {
-            schema: self.capability().algorithm.result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(self.capability().algorithm, control, rows)
     }
 }
 
@@ -860,10 +830,7 @@ impl RustAlgorithm for HasEulerPath {
             }
         }
         let value = has_euler_path(&nodes, &edges, self.directed, control)?;
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Analyze(AnalyzeAlgorithm::HasEulerPath).result_schema(),
-            rows: vec![vec![AlgorithmValue::Boolean(value)]],
-        })
+        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::HasEulerPath), control, vec![vec![AlgorithmValue::Boolean(value)]])
     }
 }
 
@@ -904,10 +871,7 @@ impl RustAlgorithm for HasEulerCircuit {
             }
         }
         let value = has_euler_circuit(&nodes, &edges, self.directed, control)?;
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Analyze(AnalyzeAlgorithm::HasEulerCircuit).result_schema(),
-            rows: vec![vec![AlgorithmValue::Boolean(value)]],
-        })
+        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::HasEulerCircuit), control, vec![vec![AlgorithmValue::Boolean(value)]])
     }
 }
 
@@ -947,14 +911,11 @@ impl RustAlgorithm for FindCycles {
                 });
             }
         }
-        let rows = find_cycles(&nodes, &edges, self.directed, control)?
+        let rows: Vec<Vec<AlgorithmValue>> = find_cycles(&nodes, &edges, self.directed, control)?
             .into_iter()
             .map(|cycle| vec![AlgorithmValue::UuidList(cycle)])
             .collect();
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Analyze(AnalyzeAlgorithm::FindCycles).result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::FindCycles), control, rows)
     }
 }
 
@@ -995,13 +956,10 @@ impl RustAlgorithm for DagLongestPath {
             }
         }
         let result = dag_longest_path(&nodes, &edges, control)?;
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Analyze(AnalyzeAlgorithm::DagLongestPath).result_schema(),
-            rows: vec![vec![
+        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::DagLongestPath), control, vec![vec![
                 AlgorithmValue::Float64(result.cost),
                 AlgorithmValue::UuidList(result.path),
-            ]],
-        })
+            ]])
     }
 }
 
@@ -1043,13 +1001,10 @@ impl RustAlgorithm for WeightedDagLongestPath {
             }
         }
         let result = weighted_dag_longest_path(&nodes, &edges, control)?;
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Analyze(AnalyzeAlgorithm::DagLongestPathWeighted).result_schema(),
-            rows: vec![vec![
+        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::DagLongestPathWeighted), control, vec![vec![
                 AlgorithmValue::Float64(result.cost),
                 AlgorithmValue::UuidList(result.path),
-            ]],
-        })
+            ]])
     }
 }
 
@@ -1099,10 +1054,7 @@ impl RustAlgorithm for TriangleCount {
             }
         }
         let count = triangle_count(&nodes, &edges, control)?;
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Analyze(AnalyzeAlgorithm::TriangleCount).result_schema(),
-            rows: vec![vec![AlgorithmValue::UInt64(count)]],
-        })
+        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::TriangleCount), control, vec![vec![AlgorithmValue::UInt64(count)]])
     }
 }
 
@@ -1152,10 +1104,7 @@ impl RustAlgorithm for Transitivity {
             }
         }
         let value = transitivity(&nodes, &edges, control)?;
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Analyze(AnalyzeAlgorithm::Transitivity).result_schema(),
-            rows: vec![vec![AlgorithmValue::Float64(value)]],
-        })
+        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::Transitivity), control, vec![vec![AlgorithmValue::Float64(value)]])
     }
 }
 
@@ -1205,10 +1154,7 @@ impl RustAlgorithm for IsPlanar {
             }
         }
         let value = is_planar(&nodes, &edges, control)?;
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Analyze(AnalyzeAlgorithm::IsPlanar).result_schema(),
-            rows: vec![vec![AlgorithmValue::Boolean(value)]],
-        })
+        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::IsPlanar), control, vec![vec![AlgorithmValue::Boolean(value)]])
     }
 }
 
@@ -1258,19 +1204,21 @@ impl RustAlgorithm for TriadCensus {
             }
         }
         let counts = triad_census(&nodes, &edges, control)?;
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Analyze(AnalyzeAlgorithm::TriadCensus).result_schema(),
-            rows: TRIAD_NAMES
-                .iter()
-                .zip(counts)
-                .map(|(name, count)| {
-                    vec![
-                        AlgorithmValue::Utf8((*name).to_owned()),
-                        AlgorithmValue::UInt64(count),
-                    ]
-                })
-                .collect(),
-        })
+        let rows: Vec<Vec<AlgorithmValue>> = TRIAD_NAMES
+            .iter()
+            .zip(counts)
+            .map(|(name, count)| {
+                vec![
+                    AlgorithmValue::Utf8((*name).to_owned()),
+                    AlgorithmValue::UInt64(count),
+                ]
+            })
+            .collect();
+        AlgorithmOutput::from_rows(
+            Algorithm::Analyze(AnalyzeAlgorithm::TriadCensus),
+            control,
+            rows,
+        )
     }
 }
 
@@ -1320,9 +1268,7 @@ impl RustAlgorithm for DyadCensus {
             }
         }
         let counts = dyad_census(&nodes, &edges, control)?;
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Analyze(AnalyzeAlgorithm::DyadCensus).result_schema(),
-            rows: vec![
+        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::DyadCensus), control, vec![
                 vec![
                     AlgorithmValue::Utf8("mutual".into()),
                     AlgorithmValue::UInt64(counts.mutual),
@@ -1335,8 +1281,7 @@ impl RustAlgorithm for DyadCensus {
                     AlgorithmValue::Utf8("null".into()),
                     AlgorithmValue::UInt64(counts.null),
                 ],
-            ],
-        })
+            ])
     }
 }
 
@@ -1380,7 +1325,7 @@ impl RustAlgorithm for Bridges {
         edges.sort_unstable_by_key(|&(edge_uuid, source_uuid, target_uuid)| {
             (source_uuid, target_uuid, edge_uuid)
         });
-        let rows = edges
+        let rows: Vec<Vec<AlgorithmValue>> = edges
             .into_iter()
             .map(|(edge_uuid, source_uuid, target_uuid)| {
                 vec![
@@ -1390,10 +1335,7 @@ impl RustAlgorithm for Bridges {
                 ]
             })
             .collect();
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Analyze(AnalyzeAlgorithm::Bridges).result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::Bridges), control, rows)
     }
 }
 
@@ -1412,7 +1354,7 @@ impl RustAlgorithm for ArticulationPoints {
         control: &AlgorithmControl,
     ) -> Result<AlgorithmOutput, AlgorithmError> {
         let result = low_link(graph, control)?;
-        let rows = result
+        let rows: Vec<Vec<AlgorithmValue>> = result
             .articulation_nodes
             .into_iter()
             .map(|node| {
@@ -1424,10 +1366,7 @@ impl RustAlgorithm for ArticulationPoints {
                     })
             })
             .collect::<Result<Vec<_>, _>>()?;
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Analyze(AnalyzeAlgorithm::ArticulationPoints).result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::ArticulationPoints), control, rows)
     }
 }
 
@@ -1476,10 +1415,7 @@ impl RustAlgorithm for SpanningTree {
                 AlgorithmValue::Float64(edge.weight),
             ]);
         }
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Analyze(self.algorithm).result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(Algorithm::Analyze(self.algorithm), control, rows)
     }
 }
 
@@ -1548,10 +1484,7 @@ impl RustAlgorithm for MinimumKSpanningTree {
                 ]);
             }
         }
-        Ok(AlgorithmOutput {
-            schema: self.capability().algorithm.result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(self.capability().algorithm, control, rows)
     }
 }
 
@@ -1574,10 +1507,7 @@ impl RustAlgorithm for IsDag {
         } else {
             false
         };
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Analyze(AnalyzeAlgorithm::IsDag).result_schema(),
-            rows: vec![vec![AlgorithmValue::Boolean(is_dag)]],
-        })
+        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::IsDag), control, vec![vec![AlgorithmValue::Boolean(is_dag)]])
     }
 }
 
@@ -1608,10 +1538,7 @@ impl RustAlgorithm for TopologicalSort {
                 AlgorithmValue::UInt64(order),
             ]);
         }
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Analyze(AnalyzeAlgorithm::TopologicalSort).result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(Algorithm::Analyze(AnalyzeAlgorithm::TopologicalSort), control, rows)
     }
 }
 
@@ -3968,7 +3895,7 @@ mod tests {
             output.schema,
             Algorithm::Analyze(AnalyzeAlgorithm::CountAutomorphisms).result_schema()
         );
-        let [row] = output.rows.as_slice() else {
+        let [row] = output.rows().as_slice() else {
             panic!("automorphism dispatch must return exactly one row");
         };
         let [AlgorithmValue::UInt64(count)] = row.as_slice() else {
@@ -4147,7 +4074,7 @@ mod tests {
             Algorithm::Analyze(AnalyzeAlgorithm::Conductance).result_schema()
         );
         assert_eq!(
-            output.rows,
+            output.rows(),
             [
                 vec![
                     AlgorithmValue::Utf8("alpha".into()),
@@ -4194,9 +4121,9 @@ mod tests {
             output.schema,
             Algorithm::Analyze(AnalyzeAlgorithm::Modularity).result_schema()
         );
-        assert_eq!(output.rows.len(), 1);
+        assert_eq!(output.rows().len(), 1);
         assert!(
-            matches!(output.rows[0].as_slice(), [AlgorithmValue::Float64(value)] if value.is_finite())
+            matches!(output.rows()[0].as_slice(), [AlgorithmValue::Float64(value)] if value.is_finite())
         );
         assert_eq!(
             shape_algorithm_output(Algorithm::Analyze(AnalyzeAlgorithm::Modularity), &output)
@@ -4383,7 +4310,7 @@ mod tests {
             Algorithm::Analyze(AnalyzeAlgorithm::MaxWeightMatching).result_schema()
         );
         assert_eq!(
-            output.rows,
+            output.rows(),
             [
                 vec![
                     AlgorithmValue::Uuid(u128::from(8_u8).to_be_bytes()),
@@ -4448,7 +4375,7 @@ mod tests {
             Algorithm::Analyze(AnalyzeAlgorithm::MaxCardinalityMatching).result_schema()
         );
         assert_eq!(
-            output.rows,
+            output.rows(),
             [
                 vec![
                     AlgorithmValue::Uuid(u128::from(4_u8).to_be_bytes()),
@@ -4679,7 +4606,7 @@ mod tests {
             Algorithm::Analyze(AnalyzeAlgorithm::MaxBipartiteMatching).result_schema()
         );
         assert_eq!(
-            output.rows,
+            output.rows(),
             [
                 vec![
                     AlgorithmValue::Uuid(u128::from(3_u8).to_be_bytes()),
@@ -4739,7 +4666,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            output.rows[0][1..],
+            output.rows()[0][1..],
             [
                 AlgorithmValue::Uuid(u128::from(1_u8).to_be_bytes()),
                 AlgorithmValue::Uuid(u128::from(0_u8).to_be_bytes())
@@ -4796,7 +4723,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap();
-            assert_eq!(output.rows, [vec![AlgorithmValue::Boolean(true)]]);
+            assert_eq!(output.rows(), [vec![AlgorithmValue::Boolean(true)]]);
             assert_eq!(
                 output.schema,
                 Algorithm::Analyze(AnalyzeAlgorithm::IsDag).result_schema()
@@ -4841,7 +4768,7 @@ mod tests {
                 output.schema,
                 Algorithm::Analyze(AnalyzeAlgorithm::HasEulerCircuit).result_schema()
             );
-            assert_eq!(output.rows, [vec![AlgorithmValue::Boolean(expected)]]);
+            assert_eq!(output.rows(), [vec![AlgorithmValue::Boolean(expected)]]);
         }
     }
 
@@ -4913,7 +4840,7 @@ mod tests {
                 output.schema,
                 Algorithm::Analyze(AnalyzeAlgorithm::HasEulerPath).result_schema()
             );
-            assert_eq!(output.rows, [vec![AlgorithmValue::Boolean(expected)]]);
+            assert_eq!(output.rows(), [vec![AlgorithmValue::Boolean(expected)]]);
         }
     }
 
@@ -5092,7 +5019,7 @@ mod tests {
             euler_output(&graph, AnalyzeAlgorithm::EulerPath, true).unwrap()
         );
         assert_eq!(
-            output.rows,
+            output.rows(),
             [vec![
                 AlgorithmValue::UuidList(vec![uuid(90), uuid(20), uuid(70)]),
                 AlgorithmValue::UuidList(vec![uuid(0), uuid(1)]),
@@ -5187,7 +5114,7 @@ mod tests {
             Algorithm::Analyze(AnalyzeAlgorithm::EdgeColoring).result_schema()
         );
         assert_eq!(
-            output.rows,
+            output.rows(),
             [(10_u64, 0_u64), (11, 1), (12, 2), (14, 3), (20, 0),]
                 .into_iter()
                 .map(|(edge, color)| vec![
@@ -5279,7 +5206,7 @@ mod tests {
                 output.schema,
                 Algorithm::Analyze(AnalyzeAlgorithm::ChromaticNumber).result_schema()
             );
-            assert_eq!(output.rows, [vec![AlgorithmValue::UInt64(expected)]]);
+            assert_eq!(output.rows(), [vec![AlgorithmValue::UInt64(expected)]]);
         }
     }
 
@@ -5343,7 +5270,7 @@ mod tests {
             Algorithm::Analyze(AnalyzeAlgorithm::TopologicalSort).result_schema()
         );
         assert_eq!(
-            output.rows,
+            output.rows(),
             [1_u64, 3, 2, 0, 4, 5]
                 .into_iter()
                 .enumerate()
@@ -5375,7 +5302,7 @@ mod tests {
             Algorithm::Analyze(AnalyzeAlgorithm::DagLongestPath).result_schema()
         );
         assert_eq!(
-            output.rows,
+            output.rows(),
             [vec![
                 AlgorithmValue::Float64(2.0),
                 AlgorithmValue::UuidList(vec![[10; 16], [20; 16], [40; 16]]),
@@ -5459,7 +5386,7 @@ mod tests {
             Algorithm::Analyze(AnalyzeAlgorithm::DagLongestPathWeighted).result_schema()
         );
         assert_eq!(
-            output.rows,
+            output.rows(),
             [vec![
                 AlgorithmValue::Float64(5.0),
                 AlgorithmValue::UuidList(vec![[10; 16], [20; 16], [40; 16]]),
@@ -5697,7 +5624,7 @@ mod tests {
             Algorithm::Analyze(AnalyzeAlgorithm::MinimumSpanningTree).result_schema()
         );
         assert_eq!(
-            output.rows,
+            output.rows(),
             [
                 vec![
                     AlgorithmValue::Uuid(5_u128.to_be_bytes()),
@@ -5793,7 +5720,7 @@ mod tests {
             Algorithm::Analyze(AnalyzeAlgorithm::MinimumKSpanningTree).result_schema()
         );
         assert_eq!(
-            output.rows,
+            output.rows(),
             [
                 vec![
                     AlgorithmValue::UInt64(0),
@@ -5932,7 +5859,7 @@ mod tests {
             Algorithm::Analyze(AnalyzeAlgorithm::MaximumSpanningTree).result_schema()
         );
         assert_eq!(
-            output.rows,
+            output.rows(),
             [
                 vec![
                     AlgorithmValue::Uuid(0_u128.to_be_bytes()),
@@ -6007,7 +5934,7 @@ mod tests {
             Algorithm::Analyze(AnalyzeAlgorithm::FindCycles).result_schema()
         );
         assert_eq!(
-            output.rows,
+            output.rows(),
             [
                 vec![AlgorithmValue::UuidList(vec![[10; 16], [20; 16], [30; 16]])],
                 vec![AlgorithmValue::UuidList(vec![[20; 16], [40; 16]])],
@@ -6122,7 +6049,7 @@ mod tests {
             output.schema,
             Algorithm::Analyze(AnalyzeAlgorithm::TriangleCount).result_schema()
         );
-        assert_eq!(output.rows, [vec![AlgorithmValue::UInt64(2)]]);
+        assert_eq!(output.rows(), [vec![AlgorithmValue::UInt64(2)]]);
 
         assert!(matches!(
             execute(
@@ -6166,10 +6093,10 @@ mod tests {
             output.schema,
             Algorithm::Analyze(AnalyzeAlgorithm::TriadCensus).result_schema()
         );
-        assert_eq!(output.rows.len(), 16);
+        assert_eq!(output.rows().len(), 16);
         for (index, name) in TRIAD_NAMES.iter().enumerate() {
             assert_eq!(
-                output.rows[index],
+                output.rows()[index],
                 [
                     AlgorithmValue::Utf8((*name).to_owned()),
                     AlgorithmValue::UInt64(u64::from(index == 9)),
@@ -6231,7 +6158,7 @@ mod tests {
             output.schema,
             Algorithm::Analyze(AnalyzeAlgorithm::Transitivity).result_schema()
         );
-        assert_eq!(output.rows, [vec![AlgorithmValue::Float64(0.75)]]);
+        assert_eq!(output.rows(), [vec![AlgorithmValue::Float64(0.75)]]);
 
         assert!(matches!(
             execute(
@@ -6303,7 +6230,7 @@ mod tests {
             output.schema,
             Algorithm::Analyze(AnalyzeAlgorithm::IsPlanar).result_schema()
         );
-        assert_eq!(output.rows, [vec![AlgorithmValue::Boolean(false)]]);
+        assert_eq!(output.rows(), [vec![AlgorithmValue::Boolean(false)]]);
 
         assert!(matches!(
             execute(
@@ -6351,7 +6278,7 @@ mod tests {
             Algorithm::Analyze(AnalyzeAlgorithm::DyadCensus).result_schema()
         );
         assert_eq!(
-            output.rows,
+            output.rows(),
             [
                 vec![
                     AlgorithmValue::Utf8("mutual".into()),
@@ -6455,7 +6382,7 @@ mod tests {
             Algorithm::Analyze(AnalyzeAlgorithm::NodeColoring).result_schema()
         );
         assert_eq!(
-            output.rows,
+            output.rows(),
             [
                 vec![
                     AlgorithmValue::Uuid(0_u128.to_be_bytes()),
@@ -6539,7 +6466,7 @@ mod tests {
             Algorithm::Analyze(AnalyzeAlgorithm::K1Coloring).result_schema()
         );
         assert_eq!(
-            output.rows,
+            output.rows(),
             [0_u64, 1, 0, 1, 0]
                 .into_iter()
                 .enumerate()
@@ -6558,7 +6485,7 @@ mod tests {
             AlgorithmCancellation::default(),
         )
         .unwrap();
-        assert_ne!(output.rows, legacy.rows);
+        assert_ne!(output.rows(), legacy.rows);
         assert_ne!(
             output.schema,
             Algorithm::Analyze(AnalyzeAlgorithm::ChromaticNumber).result_schema()
@@ -6748,7 +6675,7 @@ mod tests {
             Algorithm::Analyze(AnalyzeAlgorithm::ArticulationPoints).result_schema()
         );
         assert_eq!(
-            output.rows,
+            output.rows(),
             [
                 vec![AlgorithmValue::Uuid(1_u128.to_be_bytes())],
                 vec![AlgorithmValue::Uuid(3_u128.to_be_bytes())],
@@ -6824,7 +6751,7 @@ mod tests {
             Algorithm::Analyze(AnalyzeAlgorithm::Bridges).result_schema()
         );
         assert_eq!(
-            output.rows,
+            output.rows(),
             [
                 vec![
                     AlgorithmValue::Uuid(15_u128.to_be_bytes()),

--- a/crates/graphforge-exec/src/algorithm_analyze_conductance.rs
+++ b/crates/graphforge-exec/src/algorithm_analyze_conductance.rs
@@ -254,6 +254,7 @@ mod tests {
                         output_rows: limits.2,
                         iterations: limits.3,
                         states: AlgorithmLimits::default().states,
+                        batch_size: AlgorithmLimits::default().batch_size,
                     },
                     AlgorithmCancellation::default(),
                 );

--- a/crates/graphforge-exec/src/algorithm_analyze_euler.rs
+++ b/crates/graphforge-exec/src/algorithm_analyze_euler.rs
@@ -978,10 +978,7 @@ mod tests {
             let algorithm = Algorithm::Analyze(algorithm);
             let batch = shape_algorithm_output(
                 algorithm,
-                &AlgorithmOutput {
-                    schema: algorithm.result_schema(),
-                    rows: Vec::new(),
-                },
+                &AlgorithmOutput::empty(algorithm, &control()).unwrap(),
             )
             .unwrap();
             let schema = batch.schema();

--- a/crates/graphforge-exec/src/algorithm_analyze_modularity.rs
+++ b/crates/graphforge-exec/src/algorithm_analyze_modularity.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use graphforge_core::algorithms::{Algorithm, AnalyzeAlgorithm};
 
 use crate::algorithm_dispatch::{
-    AlgorithmControl, AlgorithmError, AlgorithmOutput, AlgorithmValue,
+    AlgorithmControl, AlgorithmError, AlgorithmLimits, AlgorithmOutput, AlgorithmValue,
 };
 use crate::algorithm_partition::ResolvedPartitionMap;
 
@@ -130,10 +130,12 @@ pub(crate) fn modularity(
 /// Shape the stable scalar result owned by the modularity contract.
 pub(crate) fn modularity_output(value: f64) -> Result<AlgorithmOutput, AlgorithmError> {
     let value = finite(value)?;
-    Ok(AlgorithmOutput {
-        schema: Algorithm::Analyze(AnalyzeAlgorithm::Modularity).result_schema(),
-        rows: vec![vec![AlgorithmValue::Float64(value)]],
-    })
+    crate::algorithm_output::shape_logical_rows(
+        Algorithm::Analyze(AnalyzeAlgorithm::Modularity),
+        [vec![AlgorithmValue::Float64(value)]],
+        AlgorithmLimits::default().batch_size,
+        AlgorithmLimits::default().output_rows,
+    )
 }
 
 fn canonical(mut edge: ModularityEdge) -> ModularityEdge {
@@ -350,7 +352,7 @@ mod tests {
         let algorithm = Algorithm::Analyze(AnalyzeAlgorithm::Modularity);
         let output = modularity_output(0.25).unwrap();
         assert_eq!(output.schema, algorithm.result_schema());
-        assert_eq!(output.rows, [vec![AlgorithmValue::Float64(0.25)]]);
+        assert_eq!(output.rows(), [vec![AlgorithmValue::Float64(0.25)]]);
         let batch = shape_algorithm_output(algorithm, &output).unwrap();
         assert_eq!(batch.num_rows(), 1);
         assert_eq!(batch.num_columns(), 1);
@@ -453,6 +455,7 @@ mod tests {
                         output_rows: limits.2,
                         iterations: limits.3,
                         states: AlgorithmLimits::default().states,
+                        batch_size: AlgorithmLimits::default().batch_size,
                     },
                     AlgorithmCancellation::default(),
                 ),

--- a/crates/graphforge-exec/src/algorithm_arrow_sink.rs
+++ b/crates/graphforge-exec/src/algorithm_arrow_sink.rs
@@ -24,7 +24,10 @@ const SCHEMA_VERSION: &str = "1";
 
 /// Typed, bounded Arrow builder set for one algorithm result schema.
 pub(crate) struct AlgorithmArrowSink {
-    #[allow(dead_code, reason = "retained for diagnostics and future observability")]
+    #[allow(
+        dead_code,
+        reason = "retained for diagnostics and future observability"
+    )]
     algorithm: Algorithm,
     schema: AlgorithmResultSchema,
     arrow_schema: Arc<Schema>,
@@ -82,7 +85,7 @@ impl AlgorithmArrowSink {
                 arrow_type(logical.data_type),
                 logical.nullable,
             ));
-            builders.push(ColumnBuilder::new(logical.data_type)?);
+            builders.push(ColumnBuilder::new(logical.data_type));
         }
         let metadata = HashMap::from([
             (
@@ -112,6 +115,7 @@ impl AlgorithmArrowSink {
         })
     }
 
+    #[allow(dead_code, reason = "diagnostics accessor")]
     pub(crate) fn algorithm(&self) -> Algorithm {
         self.algorithm
     }
@@ -121,11 +125,13 @@ impl AlgorithmArrowSink {
     }
 
     #[cfg(test)]
+    #[allow(dead_code, reason = "sink diagnostics reserved for direct sink tests")]
     pub(crate) fn peak_builder_rows(&self) -> usize {
         self.peak_builder_rows
     }
 
     #[cfg(test)]
+    #[allow(dead_code, reason = "sink diagnostics reserved for direct sink tests")]
     pub(crate) fn internal_batch_count(&self) -> usize {
         self.finished.len() + usize::from(self.current_rows > 0)
     }
@@ -180,8 +186,8 @@ impl AlgorithmArrowSink {
 }
 
 impl ColumnBuilder {
-    fn new(data_type: AlgorithmFieldType) -> Result<Self, AlgorithmError> {
-        Ok(match data_type {
+    fn new(data_type: AlgorithmFieldType) -> Self {
+        match data_type {
             AlgorithmFieldType::Uuid => Self::Uuid(FixedSizeBinaryBuilder::new(16)),
             AlgorithmFieldType::UuidList => {
                 Self::UuidList(
@@ -202,7 +208,7 @@ impl ColumnBuilder {
             AlgorithmFieldType::UInt64 => Self::UInt64(UInt64Builder::new()),
             AlgorithmFieldType::Int64 => Self::Int64(Int64Builder::new()),
             AlgorithmFieldType::Float64 => Self::Float64(Float64Builder::new()),
-        })
+        }
     }
 
     fn append(
@@ -306,7 +312,7 @@ impl AlgorithmArrowSink {
             .fields
             .iter()
             .map(|field| ColumnBuilder::new(field.data_type))
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect();
         let rows = self.current_rows;
         self.current_rows = 0;
         let batch = RecordBatch::try_new(self.arrow_schema.clone(), columns)
@@ -332,7 +338,7 @@ fn coalesce_batches(
     let total_rows = batches
         .iter()
         .map(RecordBatch::num_rows)
-        .try_fold(0_usize, |acc, rows| acc.checked_add(rows))
+        .try_fold(0_usize, usize::checked_add)
         .ok_or_else(|| shape_error("coalesced output row count overflows usize"))?;
     if total_rows > i32::MAX as usize {
         return Err(shape_error(
@@ -354,12 +360,12 @@ fn check_batch_capacity(batch: &RecordBatch) -> Result<(), AlgorithmError> {
         return Err(shape_error("Arrow batch exceeds checked i32 row capacity"));
     }
     for column in batch.columns() {
-        if let Some(list) = column.as_any().downcast_ref::<ListArray>() {
-            if list.values().len() > i32::MAX as usize {
-                return Err(shape_error(
-                    "Arrow list values exceed checked i32 offset capacity",
-                ));
-            }
+        if let Some(list) = column.as_any().downcast_ref::<ListArray>()
+            && list.values().len() > i32::MAX as usize
+        {
+            return Err(shape_error(
+                "Arrow list values exceed checked i32 offset capacity",
+            ));
         }
     }
     Ok(())

--- a/crates/graphforge-exec/src/algorithm_arrow_sink.rs
+++ b/crates/graphforge-exec/src/algorithm_arrow_sink.rs
@@ -24,6 +24,7 @@ const SCHEMA_VERSION: &str = "1";
 
 /// Typed, bounded Arrow builder set for one algorithm result schema.
 pub(crate) struct AlgorithmArrowSink {
+    #[allow(dead_code, reason = "retained for diagnostics and future observability")]
     algorithm: Algorithm,
     schema: AlgorithmResultSchema,
     arrow_schema: Arc<Schema>,
@@ -119,10 +120,12 @@ impl AlgorithmArrowSink {
         &self.schema
     }
 
+    #[cfg(test)]
     pub(crate) fn peak_builder_rows(&self) -> usize {
         self.peak_builder_rows
     }
 
+    #[cfg(test)]
     pub(crate) fn internal_batch_count(&self) -> usize {
         self.finished.len() + usize::from(self.current_rows > 0)
     }
@@ -180,13 +183,13 @@ impl ColumnBuilder {
     fn new(data_type: AlgorithmFieldType) -> Result<Self, AlgorithmError> {
         Ok(match data_type {
             AlgorithmFieldType::Uuid => Self::Uuid(FixedSizeBinaryBuilder::new(16)),
-            AlgorithmFieldType::UuidList => Self::UuidList(
-                ListBuilder::new(FixedSizeBinaryBuilder::new(16)).with_field(Arc::new(Field::new(
-                    "item",
-                    DataType::FixedSizeBinary(16),
-                    false,
-                ))),
-            ),
+            AlgorithmFieldType::UuidList => {
+                Self::UuidList(
+                    ListBuilder::new(FixedSizeBinaryBuilder::new(16)).with_field(Arc::new(
+                        Field::new("item", DataType::FixedSizeBinary(16), false),
+                    )),
+                )
+            }
             AlgorithmFieldType::Float32List => Self::Float32List(
                 ListBuilder::new(Float32Builder::new()).with_field(Arc::new(Field::new(
                     "item",
@@ -348,9 +351,7 @@ fn coalesce_batches(
 
 fn check_batch_capacity(batch: &RecordBatch) -> Result<(), AlgorithmError> {
     if batch.num_rows() > i32::MAX as usize {
-        return Err(shape_error(
-            "Arrow batch exceeds checked i32 row capacity",
-        ));
+        return Err(shape_error("Arrow batch exceeds checked i32 row capacity"));
     }
     for column in batch.columns() {
         if let Some(list) = column.as_any().downcast_ref::<ListArray>() {

--- a/crates/graphforge-exec/src/algorithm_arrow_sink.rs
+++ b/crates/graphforge-exec/src/algorithm_arrow_sink.rs
@@ -1,0 +1,533 @@
+//! Bounded columnar Arrow sinks for analyst-verb outputs (#341).
+//!
+//! Handlers append canonical field values directly into typed builders. Finished
+//! batches never retain a second complete `Vec<Vec<AlgorithmValue>>` copy.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arrow::array::{
+    Array, ArrayRef, BooleanArray, BooleanBuilder, FixedSizeBinaryArray, FixedSizeBinaryBuilder,
+    Float32Array, Float32Builder, Float64Array, Float64Builder, Int64Array, Int64Builder,
+    ListArray, ListBuilder, StringArray, StringBuilder, UInt64Array, UInt64Builder,
+};
+use arrow::compute::concat_batches;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use graphforge_core::algorithms::{Algorithm, AlgorithmFieldType, AlgorithmResultSchema};
+
+use crate::algorithm_dispatch::{
+    AlgorithmControl, AlgorithmError, AlgorithmOutput, AlgorithmValue,
+};
+
+const SCHEMA_VERSION: &str = "1";
+
+/// Typed, bounded Arrow builder set for one algorithm result schema.
+pub(crate) struct AlgorithmArrowSink {
+    algorithm: Algorithm,
+    schema: AlgorithmResultSchema,
+    arrow_schema: Arc<Schema>,
+    batch_size: usize,
+    output_limit: u64,
+    builders: Vec<ColumnBuilder>,
+    current_rows: usize,
+    total_rows: usize,
+    finished: Vec<RecordBatch>,
+    /// Peak logical rows retained in the active builder window (≤ batch_size).
+    peak_builder_rows: usize,
+}
+
+enum ColumnBuilder {
+    Uuid(FixedSizeBinaryBuilder),
+    UuidList(ListBuilder<FixedSizeBinaryBuilder>),
+    Float32List(ListBuilder<Float32Builder>),
+    Utf8(StringBuilder),
+    Boolean(BooleanBuilder),
+    UInt64(UInt64Builder),
+    Int64(Int64Builder),
+    Float64(Float64Builder),
+}
+
+impl AlgorithmArrowSink {
+    /// Start a sink for `algorithm` using the invocation's batch and row limits.
+    pub(crate) fn new(
+        algorithm: Algorithm,
+        control: &AlgorithmControl,
+    ) -> Result<Self, AlgorithmError> {
+        Self::with_limits(
+            algorithm,
+            control.batch_size(),
+            control.configured_limits().output_rows,
+        )
+    }
+
+    /// Start a sink with explicit batch size and output-row limit (tests / shaping).
+    pub(crate) fn with_limits(
+        algorithm: Algorithm,
+        batch_size: usize,
+        output_limit: u64,
+    ) -> Result<Self, AlgorithmError> {
+        let schema = algorithm.result_schema();
+        let mut fields = Vec::with_capacity(schema.fields.len());
+        let mut builders = Vec::with_capacity(schema.fields.len());
+        for logical in schema.fields {
+            if matches!(logical.name, "node_id" | "edge_id" | "src_id" | "dst_id") {
+                return Err(shape_error(
+                    "public algorithm schema contains a surrogate field",
+                ));
+            }
+            fields.push(Field::new(
+                logical.name,
+                arrow_type(logical.data_type),
+                logical.nullable,
+            ));
+            builders.push(ColumnBuilder::new(logical.data_type)?);
+        }
+        let metadata = HashMap::from([
+            (
+                "graphforge.algorithm".to_owned(),
+                algorithm.as_str().to_owned(),
+            ),
+            (
+                "graphforge.verb".to_owned(),
+                algorithm.verb().as_str().to_owned(),
+            ),
+            (
+                "graphforge.algorithm_schema_version".to_owned(),
+                SCHEMA_VERSION.to_owned(),
+            ),
+        ]);
+        Ok(Self {
+            algorithm,
+            schema,
+            arrow_schema: Arc::new(Schema::new_with_metadata(fields, metadata)),
+            batch_size: batch_size.max(1),
+            output_limit,
+            builders,
+            current_rows: 0,
+            total_rows: 0,
+            finished: Vec::new(),
+            peak_builder_rows: 0,
+        })
+    }
+
+    pub(crate) fn algorithm(&self) -> Algorithm {
+        self.algorithm
+    }
+
+    pub(crate) fn schema(&self) -> &AlgorithmResultSchema {
+        &self.schema
+    }
+
+    pub(crate) fn peak_builder_rows(&self) -> usize {
+        self.peak_builder_rows
+    }
+
+    pub(crate) fn internal_batch_count(&self) -> usize {
+        self.finished.len() + usize::from(self.current_rows > 0)
+    }
+
+    /// Append one canonical logical row into the active builders.
+    pub(crate) fn append_row(&mut self, row: &[AlgorithmValue]) -> Result<(), AlgorithmError> {
+        if row.len() != self.schema.fields.len() {
+            return Err(shape_error(format!(
+                "row has {} values but schema requires {}",
+                row.len(),
+                self.schema.fields.len()
+            )));
+        }
+        let next_total = self
+            .total_rows
+            .checked_add(1)
+            .ok_or_else(|| shape_error("output row count exceeds usize"))?;
+        let observed = u64::try_from(next_total).unwrap_or(u64::MAX);
+        if observed > self.output_limit {
+            return Err(AlgorithmError::OutputLimit {
+                observed,
+                limit: self.output_limit,
+            });
+        }
+        if self.current_rows >= self.batch_size {
+            self.flush_batch()?;
+        }
+        for (index, (field, value)) in self.schema.fields.iter().zip(row.iter()).enumerate() {
+            self.builders[index].append(field.name, field.nullable, value)?;
+        }
+        self.current_rows += 1;
+        self.total_rows = next_total;
+        self.peak_builder_rows = self.peak_builder_rows.max(self.current_rows);
+        Ok(())
+    }
+
+    /// Finish remaining builders and coalesce to the public single-batch contract.
+    pub(crate) fn finish(mut self) -> Result<AlgorithmOutput, AlgorithmError> {
+        if self.current_rows > 0 || self.finished.is_empty() {
+            self.flush_batch()?;
+        }
+        let internal_batch_count = self.finished.len().max(1);
+        let peak_builder_rows = self.peak_builder_rows;
+        let batch = coalesce_batches(&self.arrow_schema, &self.finished)?;
+        Ok(AlgorithmOutput {
+            schema: self.schema,
+            batch,
+            internal_batch_count,
+            peak_builder_rows,
+        })
+    }
+}
+
+impl ColumnBuilder {
+    fn new(data_type: AlgorithmFieldType) -> Result<Self, AlgorithmError> {
+        Ok(match data_type {
+            AlgorithmFieldType::Uuid => Self::Uuid(FixedSizeBinaryBuilder::new(16)),
+            AlgorithmFieldType::UuidList => Self::UuidList(
+                ListBuilder::new(FixedSizeBinaryBuilder::new(16)).with_field(Arc::new(Field::new(
+                    "item",
+                    DataType::FixedSizeBinary(16),
+                    false,
+                ))),
+            ),
+            AlgorithmFieldType::Float32List => Self::Float32List(
+                ListBuilder::new(Float32Builder::new()).with_field(Arc::new(Field::new(
+                    "item",
+                    DataType::Float32,
+                    false,
+                ))),
+            ),
+            AlgorithmFieldType::Utf8 => Self::Utf8(StringBuilder::new()),
+            AlgorithmFieldType::Boolean => Self::Boolean(BooleanBuilder::new()),
+            AlgorithmFieldType::UInt64 => Self::UInt64(UInt64Builder::new()),
+            AlgorithmFieldType::Int64 => Self::Int64(Int64Builder::new()),
+            AlgorithmFieldType::Float64 => Self::Float64(Float64Builder::new()),
+        })
+    }
+
+    fn append(
+        &mut self,
+        name: &str,
+        nullable: bool,
+        value: &AlgorithmValue,
+    ) -> Result<(), AlgorithmError> {
+        match (self, value) {
+            (Self::Uuid(builder), AlgorithmValue::Uuid(value)) => builder
+                .append_value(value)
+                .map_err(|error| shape_error(error.to_string()))?,
+            (Self::Uuid(builder), AlgorithmValue::Null) if nullable => builder.append_null(),
+            (Self::UuidList(builder), AlgorithmValue::UuidList(values)) => {
+                for value in values {
+                    builder
+                        .values()
+                        .append_value(value)
+                        .map_err(|error| shape_error(error.to_string()))?;
+                }
+                builder.append(true);
+            }
+            (Self::UuidList(builder), AlgorithmValue::Null) if nullable => builder.append(false),
+            (Self::Float32List(builder), AlgorithmValue::Float32List(values))
+                if values.iter().all(|value| value.is_finite()) =>
+            {
+                for value in values {
+                    builder.values().append_value(*value);
+                }
+                builder.append(true);
+            }
+            (Self::Float32List(_), AlgorithmValue::Float32List(_)) => {
+                return Err(shape_error(format!(
+                    "field {name:?} contains a non-finite Float32"
+                )));
+            }
+            (Self::Float32List(builder), AlgorithmValue::Null) if nullable => builder.append(false),
+            (Self::Utf8(builder), AlgorithmValue::Utf8(value)) => builder.append_value(value),
+            (Self::Utf8(builder), AlgorithmValue::Null) if nullable => builder.append_null(),
+            (Self::Boolean(builder), AlgorithmValue::Boolean(value)) => {
+                builder.append_value(*value);
+            }
+            (Self::Boolean(builder), AlgorithmValue::Null) if nullable => builder.append_null(),
+            (Self::UInt64(builder), AlgorithmValue::UInt64(value)) => builder.append_value(*value),
+            (Self::UInt64(builder), AlgorithmValue::Null) if nullable => builder.append_null(),
+            (Self::Int64(builder), AlgorithmValue::Int64(value)) => builder.append_value(*value),
+            (Self::Int64(builder), AlgorithmValue::Null) if nullable => builder.append_null(),
+            (Self::Float64(builder), AlgorithmValue::Float64(value)) if value.is_finite() => {
+                builder.append_value(*value);
+            }
+            (Self::Float64(_), AlgorithmValue::Float64(_)) => {
+                return Err(shape_error(format!(
+                    "field {name:?} contains a non-finite Float64"
+                )));
+            }
+            (Self::Float64(builder), AlgorithmValue::Null) if nullable => builder.append_null(),
+            (builder, other) => {
+                return Err(type_error(name, builder.expected(), other));
+            }
+        }
+        Ok(())
+    }
+
+    fn finish(&mut self) -> ArrayRef {
+        match self {
+            Self::Uuid(builder) => Arc::new(builder.finish()),
+            Self::UuidList(builder) => Arc::new(builder.finish()),
+            Self::Float32List(builder) => Arc::new(builder.finish()),
+            Self::Utf8(builder) => Arc::new(builder.finish()),
+            Self::Boolean(builder) => Arc::new(builder.finish()),
+            Self::UInt64(builder) => Arc::new(builder.finish()),
+            Self::Int64(builder) => Arc::new(builder.finish()),
+            Self::Float64(builder) => Arc::new(builder.finish()),
+        }
+    }
+
+    fn expected(&self) -> &'static str {
+        match self {
+            Self::Uuid(_) => "FixedSizeBinary(16)",
+            Self::UuidList(_) => "List<FixedSizeBinary(16)>",
+            Self::Float32List(_) => "List<Float32>",
+            Self::Utf8(_) => "Utf8",
+            Self::Boolean(_) => "Boolean",
+            Self::UInt64(_) => "UInt64",
+            Self::Int64(_) => "Int64",
+            Self::Float64(_) => "Float64",
+        }
+    }
+}
+
+impl AlgorithmArrowSink {
+    fn flush_batch(&mut self) -> Result<(), AlgorithmError> {
+        let columns = self
+            .builders
+            .iter_mut()
+            .map(ColumnBuilder::finish)
+            .collect::<Vec<_>>();
+        // Rebuild empty builders for the next window.
+        self.builders = self
+            .schema
+            .fields
+            .iter()
+            .map(|field| ColumnBuilder::new(field.data_type))
+            .collect::<Result<Vec<_>, _>>()?;
+        let rows = self.current_rows;
+        self.current_rows = 0;
+        let batch = RecordBatch::try_new(self.arrow_schema.clone(), columns)
+            .map_err(|error| shape_error(error.to_string()))?;
+        debug_assert_eq!(batch.num_rows(), rows);
+        // Checked Arrow capacity: reject batches that already overflow i32 list offsets.
+        check_batch_capacity(&batch)?;
+        self.finished.push(batch);
+        Ok(())
+    }
+}
+
+fn coalesce_batches(
+    schema: &Arc<Schema>,
+    batches: &[RecordBatch],
+) -> Result<RecordBatch, AlgorithmError> {
+    if batches.is_empty() {
+        return Ok(RecordBatch::new_empty(schema.clone()));
+    }
+    if batches.len() == 1 {
+        return Ok(batches[0].clone());
+    }
+    let total_rows = batches
+        .iter()
+        .map(RecordBatch::num_rows)
+        .try_fold(0_usize, |acc, rows| acc.checked_add(rows))
+        .ok_or_else(|| shape_error("coalesced output row count overflows usize"))?;
+    if total_rows > i32::MAX as usize {
+        return Err(shape_error(
+            "coalesced Arrow batch exceeds checked i32 row capacity",
+        ));
+    }
+    for batch in batches {
+        check_batch_capacity(batch)?;
+    }
+    concat_batches(schema, batches).map_err(|error| {
+        shape_error(format!(
+            "Arrow capacity exceeded while coalescing algorithm batches: {error}"
+        ))
+    })
+}
+
+fn check_batch_capacity(batch: &RecordBatch) -> Result<(), AlgorithmError> {
+    if batch.num_rows() > i32::MAX as usize {
+        return Err(shape_error(
+            "Arrow batch exceeds checked i32 row capacity",
+        ));
+    }
+    for column in batch.columns() {
+        if let Some(list) = column.as_any().downcast_ref::<ListArray>() {
+            if list.values().len() > i32::MAX as usize {
+                return Err(shape_error(
+                    "Arrow list values exceed checked i32 offset capacity",
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn arrow_type(logical: AlgorithmFieldType) -> DataType {
+    match logical {
+        AlgorithmFieldType::Uuid => DataType::FixedSizeBinary(16),
+        AlgorithmFieldType::UuidList => DataType::List(Arc::new(Field::new(
+            "item",
+            DataType::FixedSizeBinary(16),
+            false,
+        ))),
+        AlgorithmFieldType::Float32List => {
+            DataType::List(Arc::new(Field::new("item", DataType::Float32, false)))
+        }
+        AlgorithmFieldType::Utf8 => DataType::Utf8,
+        AlgorithmFieldType::Boolean => DataType::Boolean,
+        AlgorithmFieldType::UInt64 => DataType::UInt64,
+        AlgorithmFieldType::Int64 => DataType::Int64,
+        AlgorithmFieldType::Float64 => DataType::Float64,
+    }
+}
+
+pub(crate) const fn schema_version() -> &'static str {
+    SCHEMA_VERSION
+}
+
+/// Decode Arrow batches back to logical rows for test assertions only.
+pub(crate) fn decode_logical_rows(
+    schema: &AlgorithmResultSchema,
+    batch: &RecordBatch,
+) -> Result<Vec<Vec<AlgorithmValue>>, AlgorithmError> {
+    if batch.num_columns() != schema.fields.len() {
+        return Err(shape_error("batch width does not match logical schema"));
+    }
+    let mut rows = Vec::with_capacity(batch.num_rows());
+    for row in 0..batch.num_rows() {
+        let mut values = Vec::with_capacity(schema.fields.len());
+        for (column_index, field) in schema.fields.iter().enumerate() {
+            values.push(decode_value(
+                field.data_type,
+                field.nullable,
+                batch.column(column_index).as_ref(),
+                row,
+            )?);
+        }
+        rows.push(values);
+    }
+    Ok(rows)
+}
+
+fn decode_value(
+    data_type: AlgorithmFieldType,
+    nullable: bool,
+    column: &dyn Array,
+    row: usize,
+) -> Result<AlgorithmValue, AlgorithmError> {
+    if column.is_null(row) {
+        if nullable {
+            return Ok(AlgorithmValue::Null);
+        }
+        return Err(shape_error("unexpected null in non-nullable column"));
+    }
+    match data_type {
+        AlgorithmFieldType::Uuid => {
+            let array = column
+                .as_any()
+                .downcast_ref::<FixedSizeBinaryArray>()
+                .ok_or_else(|| shape_error("expected FixedSizeBinary(16)"))?;
+            let bytes: [u8; 16] = array
+                .value(row)
+                .try_into()
+                .map_err(|_| shape_error("malformed UUID width"))?;
+            Ok(AlgorithmValue::Uuid(bytes))
+        }
+        AlgorithmFieldType::UuidList => {
+            let array = column
+                .as_any()
+                .downcast_ref::<ListArray>()
+                .ok_or_else(|| shape_error("expected List<FixedSizeBinary(16)>"))?;
+            let values = array.value(row);
+            let uuids = values
+                .as_any()
+                .downcast_ref::<FixedSizeBinaryArray>()
+                .ok_or_else(|| shape_error("expected FixedSizeBinary(16) list items"))?;
+            let mut out = Vec::with_capacity(uuids.len());
+            for index in 0..uuids.len() {
+                let bytes: [u8; 16] = uuids
+                    .value(index)
+                    .try_into()
+                    .map_err(|_| shape_error("malformed UUID list item"))?;
+                out.push(bytes);
+            }
+            Ok(AlgorithmValue::UuidList(out))
+        }
+        AlgorithmFieldType::Float32List => {
+            let array = column
+                .as_any()
+                .downcast_ref::<ListArray>()
+                .ok_or_else(|| shape_error("expected List<Float32>"))?;
+            let values = array.value(row);
+            let floats = values
+                .as_any()
+                .downcast_ref::<Float32Array>()
+                .ok_or_else(|| shape_error("expected Float32 list items"))?;
+            Ok(AlgorithmValue::Float32List(floats.values().to_vec()))
+        }
+        AlgorithmFieldType::Utf8 => {
+            let array = column
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .ok_or_else(|| shape_error("expected Utf8"))?;
+            Ok(AlgorithmValue::Utf8(array.value(row).to_owned()))
+        }
+        AlgorithmFieldType::Boolean => {
+            let array = column
+                .as_any()
+                .downcast_ref::<BooleanArray>()
+                .ok_or_else(|| shape_error("expected Boolean"))?;
+            Ok(AlgorithmValue::Boolean(array.value(row)))
+        }
+        AlgorithmFieldType::UInt64 => {
+            let array = column
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .ok_or_else(|| shape_error("expected UInt64"))?;
+            Ok(AlgorithmValue::UInt64(array.value(row)))
+        }
+        AlgorithmFieldType::Int64 => {
+            let array = column
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .ok_or_else(|| shape_error("expected Int64"))?;
+            Ok(AlgorithmValue::Int64(array.value(row)))
+        }
+        AlgorithmFieldType::Float64 => {
+            let array = column
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .ok_or_else(|| shape_error("expected Float64"))?;
+            Ok(AlgorithmValue::Float64(array.value(row)))
+        }
+    }
+}
+
+fn type_error(name: &str, expected: &str, actual: &AlgorithmValue) -> AlgorithmError {
+    shape_error(format!(
+        "field {name:?} requires {expected}, received {}",
+        value_kind(actual)
+    ))
+}
+
+fn value_kind(value: &AlgorithmValue) -> &'static str {
+    match value {
+        AlgorithmValue::Null => "Null",
+        AlgorithmValue::Uuid(_) => "Uuid",
+        AlgorithmValue::UuidList(_) => "UuidList",
+        AlgorithmValue::Float32List(_) => "Float32List",
+        AlgorithmValue::Utf8(_) => "Utf8",
+        AlgorithmValue::Boolean(_) => "Boolean",
+        AlgorithmValue::UInt64(_) => "UInt64",
+        AlgorithmValue::Int64(_) => "Int64",
+        AlgorithmValue::Float64(_) => "Float64",
+    }
+}
+
+pub(crate) fn shape_error(message: impl Into<String>) -> AlgorithmError {
+    AlgorithmError::Execution {
+        message: format!("invalid algorithm output: {}", message.into()),
+    }
+}

--- a/crates/graphforge-exec/src/algorithm_cluster.rs
+++ b/crates/graphforge-exec/src/algorithm_cluster.rs
@@ -26,7 +26,7 @@ use crate::algorithm_graph::{
     AdjacencyGraph, AdjacencySelection, export_adjacency, load_node_vectors,
 };
 use crate::algorithm_k_core::k_core_numbers;
-use crate::algorithm_output::{materialize_node_properties, shape_algorithm_output};
+use crate::algorithm_output::shape_algorithm_output;
 
 const BUILTIN_REVIEW: DependencyReview = DependencyReview {
     implementation: "graphforge-exec built-in",
@@ -456,10 +456,7 @@ fn community_output(
             .ok_or_else(|| execution("selected node has no UUID identity"))?;
         let community = i64::try_from(communities[index])
             .map_err(|_| execution("community count exceeds Int64 result range"))?;
-        sink.append_row(&[
-            AlgorithmValue::Uuid(uuid),
-            AlgorithmValue::Int64(community),
-        ])?;
+        sink.append_row(&[AlgorithmValue::Uuid(uuid), AlgorithmValue::Int64(community)])?;
     }
     sink.finish()
 }
@@ -477,10 +474,7 @@ fn label_output(
         let uuid = graph
             .node_uuid(node_id)
             .ok_or_else(|| execution("selected node has no UUID identity"))?;
-        sink.append_row(&[
-            AlgorithmValue::Uuid(uuid),
-            AlgorithmValue::Int64(community),
-        ])?;
+        sink.append_row(&[AlgorithmValue::Uuid(uuid), AlgorithmValue::Int64(community)])?;
     }
     sink.finish()
 }
@@ -591,11 +585,38 @@ pub fn cluster_algorithm(
     property_stems: &[String],
     options: &ClusterOptions,
 ) -> Result<RecordBatch, GfError> {
+    cluster_algorithm_with_limits(
+        provider,
+        dir,
+        mode,
+        label,
+        property_stems,
+        options,
+        AlgorithmLimits::default(),
+    )
+}
+
+/// Execute clustering with an explicit output/memory shaping policy (#341).
+pub fn cluster_algorithm_with_limits(
+    provider: &dyn AdjacencyProvider,
+    dir: &Path,
+    mode: OntologyMode,
+    label: TypeId,
+    property_stems: &[String],
+    options: &ClusterOptions,
+    limits: AlgorithmLimits,
+) -> Result<RecordBatch, GfError> {
     let graph = cluster_projection(provider, dir, mode, label, property_stems, options)?;
     let algorithm = Algorithm::Cluster(options.by);
-    let output = execute_cluster(&graph, algorithm, AlgorithmLimits::default())?;
+    let output = execute_cluster(&graph, algorithm, limits)?;
     let batch = shape_algorithm_output(algorithm, &output)?;
-    materialize_node_properties(dir, property_stems, &batch).map_err(Into::into)
+    crate::algorithm_output::materialize_node_properties_with_batch_size(
+        dir,
+        property_stems,
+        &batch,
+        limits.batch_size,
+    )
+    .map_err(Into::into)
 }
 
 /// Fingerprint the exact topology and vector values consumed by clustering.
@@ -3543,7 +3564,10 @@ mod tests {
             first.schema,
             Algorithm::Cluster(ClusterAlgorithm::Louvain).result_schema()
         );
-        assert_eq!(first.rows()[0][0], AlgorithmValue::Uuid(0_u128.to_be_bytes()));
+        assert_eq!(
+            first.rows()[0][0],
+            AlgorithmValue::Uuid(0_u128.to_be_bytes())
+        );
     }
 
     #[test]

--- a/crates/graphforge-exec/src/algorithm_cluster.rs
+++ b/crates/graphforge-exec/src/algorithm_cluster.rs
@@ -447,7 +447,7 @@ fn community_output(
     algorithm: ClusterAlgorithm,
     control: &AlgorithmControl,
 ) -> Result<AlgorithmOutput, AlgorithmError> {
-    let mut rows = Vec::with_capacity(graph.node_ids().len());
+    let mut sink = control.output_sink(Algorithm::Cluster(algorithm))?;
     let mut work = 0_usize;
     for (index, &node_id) in graph.node_ids().iter().enumerate() {
         checkpoint_chunk(control, &mut work)?;
@@ -456,15 +456,12 @@ fn community_output(
             .ok_or_else(|| execution("selected node has no UUID identity"))?;
         let community = i64::try_from(communities[index])
             .map_err(|_| execution("community count exceeds Int64 result range"))?;
-        rows.push(vec![
+        sink.append_row(&[
             AlgorithmValue::Uuid(uuid),
             AlgorithmValue::Int64(community),
-        ]);
+        ])?;
     }
-    Ok(AlgorithmOutput {
-        schema: Algorithm::Cluster(algorithm).result_schema(),
-        rows,
-    })
+    sink.finish()
 }
 
 fn label_output(
@@ -473,22 +470,19 @@ fn label_output(
     algorithm: ClusterAlgorithm,
     control: &AlgorithmControl,
 ) -> Result<AlgorithmOutput, AlgorithmError> {
-    let mut rows = Vec::with_capacity(labels.len());
+    let mut sink = control.output_sink(Algorithm::Cluster(algorithm))?;
     let mut work = 0_usize;
     for (&node_id, &community) in graph.node_ids().iter().zip(labels) {
         checkpoint_chunk(control, &mut work)?;
         let uuid = graph
             .node_uuid(node_id)
             .ok_or_else(|| execution("selected node has no UUID identity"))?;
-        rows.push(vec![
+        sink.append_row(&[
             AlgorithmValue::Uuid(uuid),
             AlgorithmValue::Int64(community),
-        ]);
+        ])?;
     }
-    Ok(AlgorithmOutput {
-        schema: Algorithm::Cluster(algorithm).result_schema(),
-        rows,
-    })
+    sink.finish()
 }
 
 impl RustAlgorithm for Components {
@@ -530,7 +524,8 @@ impl RustAlgorithm for Components {
         }
 
         let mut ids = HashMap::new();
-        let mut rows = Vec::with_capacity(graph.node_ids().len());
+        let algorithm = Algorithm::Cluster(ClusterAlgorithm::Components);
+        let mut sink = control.output_sink(algorithm)?;
         for (index, &node_id) in graph.node_ids().iter().enumerate() {
             if index.is_multiple_of(16_384) {
                 control.checkpoint()?;
@@ -550,16 +545,12 @@ impl RustAlgorithm for Components {
                 .ok_or_else(|| AlgorithmError::Execution {
                     message: "selected node has no UUID identity".into(),
                 })?;
-            rows.push(vec![
+            sink.append_row(&[
                 AlgorithmValue::Uuid(uuid),
                 AlgorithmValue::Int64(community_id),
-            ]);
+            ])?;
         }
-
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Cluster(ClusterAlgorithm::Components).result_schema(),
-            rows,
-        })
+        sink.finish()
     }
 }
 
@@ -2193,7 +2184,7 @@ mod tests {
 
     fn community_ids(output: &AlgorithmOutput) -> Vec<i64> {
         output
-            .rows
+            .rows()
             .iter()
             .map(|row| match row[1] {
                 AlgorithmValue::Int64(value) => value,
@@ -2255,7 +2246,7 @@ mod tests {
         assert!(
             execute_leiden(&AdjacencyGraph::default(), AlgorithmLimits::default())
                 .unwrap()
-                .rows
+                .rows()
                 .is_empty()
         );
         assert_eq!(
@@ -2334,7 +2325,7 @@ mod tests {
         assert!(
             execute_label_propagation(&AdjacencyGraph::default(), AlgorithmLimits::default())
                 .unwrap()
-                .rows
+                .rows()
                 .is_empty()
         );
     }
@@ -2449,7 +2440,7 @@ mod tests {
         assert!(
             execute_speaker_listener(&AdjacencyGraph::default(), AlgorithmLimits::default())
                 .unwrap()
-                .rows
+                .rows()
                 .is_empty()
         );
     }
@@ -3437,7 +3428,7 @@ mod tests {
         let graph = AdjacencyGraph::with_test_edges(6, &[(0, 1), (2, 3), (2, 3), (3, 3)]);
         let output = execute_components(&graph, AlgorithmLimits::default()).unwrap();
         assert_eq!(
-            output.rows,
+            output.rows(),
             [0_i64, 0, 1, 1, 2, 3]
                 .into_iter()
                 .enumerate()
@@ -3462,7 +3453,7 @@ mod tests {
         assert!(
             execute_components(&AdjacencyGraph::default(), AlgorithmLimits::default())
                 .unwrap()
-                .rows
+                .rows()
                 .is_empty()
         );
         let graph = AdjacencyGraph::with_test_edges(3, &[(0, 1), (1, 2)]);
@@ -3552,7 +3543,7 @@ mod tests {
             first.schema,
             Algorithm::Cluster(ClusterAlgorithm::Louvain).result_schema()
         );
-        assert_eq!(first.rows[0][0], AlgorithmValue::Uuid(0_u128.to_be_bytes()));
+        assert_eq!(first.rows()[0][0], AlgorithmValue::Uuid(0_u128.to_be_bytes()));
     }
 
     #[test]
@@ -3596,7 +3587,7 @@ mod tests {
         assert!(
             execute_louvain(&AdjacencyGraph::default(), AlgorithmLimits::default())
                 .unwrap()
-                .rows
+                .rows()
                 .is_empty()
         );
     }

--- a/crates/graphforge-exec/src/algorithm_dispatch.rs
+++ b/crates/graphforge-exec/src/algorithm_dispatch.rs
@@ -758,7 +758,7 @@ mod tests {
                 )
                 .unwrap_err(),
             AlgorithmError::OutputLimit {
-                observed: 3,
+                observed: 2,
                 limit: 1
             }
         );

--- a/crates/graphforge-exec/src/algorithm_dispatch.rs
+++ b/crates/graphforge-exec/src/algorithm_dispatch.rs
@@ -580,7 +580,7 @@ mod tests {
                 }
                 Behavior::NonConverge(count) => {
                     for _ in 0..count {
-                        control.checkpoint();
+                        control.checkpoint()?;
                     }
                     Err(control.non_convergence())
                 }

--- a/crates/graphforge-exec/src/algorithm_dispatch.rs
+++ b/crates/graphforge-exec/src/algorithm_dispatch.rs
@@ -8,9 +8,11 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
+use arrow::record_batch::RecordBatch;
 use graphforge_core::GfError;
 use graphforge_core::algorithms::{Algorithm, AlgorithmResultSchema};
 
+use crate::algorithm_arrow_sink::{decode_logical_rows, AlgorithmArrowSink};
 use crate::algorithm_graph::AdjacencyGraph;
 
 /// Structured failures produced by Rust algorithm dispatch.
@@ -166,6 +168,8 @@ pub(crate) struct AlgorithmLimits {
     pub iterations: u64,
     /// Maximum aggregate exact-solver states retained or generated.
     pub states: u64,
+    /// Internal Arrow shaping batch size (from #337 resource policy).
+    pub batch_size: usize,
 }
 
 impl Default for AlgorithmLimits {
@@ -176,6 +180,7 @@ impl Default for AlgorithmLimits {
             output_rows: 10_000_000,
             iterations: 10_000,
             states: 10_000_000,
+            batch_size: 8_192,
         }
     }
 }
@@ -216,6 +221,19 @@ impl AlgorithmControl {
 
     pub(crate) fn configured_limits(&self) -> AlgorithmLimits {
         self.limits
+    }
+
+    /// Internal Arrow shaping batch size for bounded columnar sinks (#341).
+    pub(crate) fn batch_size(&self) -> usize {
+        self.limits.batch_size.max(1)
+    }
+
+    /// Open a columnar output sink for `algorithm`.
+    pub(crate) fn output_sink(
+        &self,
+        algorithm: Algorithm,
+    ) -> Result<AlgorithmArrowSink, AlgorithmError> {
+        AlgorithmArrowSink::new(algorithm, self)
     }
 
     /// Check cancellation and consume one cooperative iteration.
@@ -342,11 +360,56 @@ pub(crate) enum AlgorithmValue {
     Float64(f64),
 }
 
-/// Typed logical rows returned by one Rust handler.
+/// Columnar Arrow result produced by one Rust handler via [`AlgorithmArrowSink`].
+///
+/// Handlers append directly into the sink; this type retains the finished public
+/// `RecordBatch` only — never a second complete `Vec<Vec<AlgorithmValue>>`.
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct AlgorithmOutput {
     pub schema: AlgorithmResultSchema,
-    pub rows: Vec<Vec<AlgorithmValue>>,
+    pub(crate) batch: RecordBatch,
+    /// Number of internal batches before public coalesce.
+    pub(crate) internal_batch_count: usize,
+    /// Peak rows retained in the active builder window (≤ batch_size).
+    pub(crate) peak_builder_rows: usize,
+}
+
+impl AlgorithmOutput {
+    /// Number of public result rows.
+    pub(crate) fn num_rows(&self) -> usize {
+        self.batch.num_rows()
+    }
+
+    /// Borrow the canonical public Arrow batch.
+    pub(crate) fn record_batch(&self) -> &RecordBatch {
+        &self.batch
+    }
+
+    /// Decode logical rows for assertions. Does not store a retained row graph.
+    pub(crate) fn rows(&self) -> Vec<Vec<AlgorithmValue>> {
+        decode_logical_rows(&self.schema, &self.batch).unwrap_or_default()
+    }
+
+    /// Shape one or more logical rows through the shared columnar sink.
+    pub(crate) fn from_rows(
+        algorithm: Algorithm,
+        control: &AlgorithmControl,
+        rows: impl IntoIterator<Item = Vec<AlgorithmValue>>,
+    ) -> Result<Self, AlgorithmError> {
+        let mut sink = control.output_sink(algorithm)?;
+        for row in rows {
+            sink.append_row(&row)?;
+        }
+        sink.finish()
+    }
+
+    /// Empty canonical result for `algorithm`.
+    pub(crate) fn empty(
+        algorithm: Algorithm,
+        control: &AlgorithmControl,
+    ) -> Result<Self, AlgorithmError> {
+        control.output_sink(algorithm)?.finish()
+    }
 }
 
 /// Required dependency review attached to each registered capability.
@@ -439,7 +502,7 @@ impl AlgorithmRegistry {
                 algorithm: algorithm_name(algorithm),
             })?;
         let output = handler.execute(graph, control)?;
-        control.check_output_rows(output.rows.len())?;
+        control.check_output_rows(output.num_rows())?;
         control.check_cancelled()?;
         Ok(output)
     }
@@ -491,26 +554,48 @@ mod tests {
             _graph: &AdjacencyGraph,
             control: &AlgorithmControl,
         ) -> Result<AlgorithmOutput, AlgorithmError> {
-            let rows = match self.behavior {
-                Behavior::Rows(count) => vec![Vec::new(); count],
+            match self.behavior {
+                Behavior::Rows(count) => {
+                    let mut sink = control.output_sink(self.algorithm)?;
+                    let placeholders = placeholder_row(self.algorithm);
+                    for _ in 0..count {
+                        sink.append_row(&placeholders)?;
+                    }
+                    sink.finish()
+                }
                 Behavior::Checkpoints(count) => {
                     for _ in 0..count {
                         control.checkpoint()?;
                     }
-                    Vec::new()
+                    AlgorithmOutput::empty(self.algorithm, control)
                 }
                 Behavior::NonConverge(count) => {
                     for _ in 0..count {
-                        control.checkpoint()?;
+                        control.checkpoint();
                     }
-                    return Err(control.non_convergence());
+                    Err(control.non_convergence())
                 }
-            };
-            Ok(AlgorithmOutput {
-                schema: self.algorithm.result_schema(),
-                rows,
-            })
+            }
         }
+    }
+
+    fn placeholder_row(algorithm: Algorithm) -> Vec<AlgorithmValue> {
+        use graphforge_core::algorithms::AlgorithmFieldType;
+        algorithm
+            .result_schema()
+            .fields
+            .iter()
+            .map(|field| match field.data_type {
+                AlgorithmFieldType::Uuid => AlgorithmValue::Uuid([0; 16]),
+                AlgorithmFieldType::UuidList => AlgorithmValue::UuidList(Vec::new()),
+                AlgorithmFieldType::Float32List => AlgorithmValue::Float32List(Vec::new()),
+                AlgorithmFieldType::Utf8 => AlgorithmValue::Utf8(String::new()),
+                AlgorithmFieldType::Boolean => AlgorithmValue::Boolean(false),
+                AlgorithmFieldType::UInt64 => AlgorithmValue::UInt64(0),
+                AlgorithmFieldType::Int64 => AlgorithmValue::Int64(0),
+                AlgorithmFieldType::Float64 => AlgorithmValue::Float64(0.0),
+            })
+            .collect()
     }
 
     fn degree() -> Algorithm {
@@ -542,7 +627,7 @@ mod tests {
             )
             .unwrap();
         assert_eq!(output.schema, degree().result_schema());
-        assert_eq!(output.rows.len(), 1);
+        assert_eq!(output.num_rows(), 1);
         assert_eq!(registry.capabilities()[0].backend, "rust");
         assert_eq!(registry.capabilities()[0].dependency, REVIEW);
     }
@@ -627,6 +712,7 @@ mod tests {
             output_rows: 1,
             iterations: 10,
             states: 10,
+            batch_size: AlgorithmLimits::default().batch_size,
         };
         assert_eq!(
             registry

--- a/crates/graphforge-exec/src/algorithm_dispatch.rs
+++ b/crates/graphforge-exec/src/algorithm_dispatch.rs
@@ -12,7 +12,7 @@ use arrow::record_batch::RecordBatch;
 use graphforge_core::GfError;
 use graphforge_core::algorithms::{Algorithm, AlgorithmResultSchema};
 
-use crate::algorithm_arrow_sink::{decode_logical_rows, AlgorithmArrowSink};
+use crate::algorithm_arrow_sink::{AlgorithmArrowSink, decode_logical_rows};
 use crate::algorithm_graph::AdjacencyGraph;
 
 /// Structured failures produced by Rust algorithm dispatch.
@@ -157,7 +157,7 @@ impl From<AlgorithmError> for GfError {
 
 /// Hard limits shared by every Rust algorithm handler.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct AlgorithmLimits {
+pub struct AlgorithmLimits {
     /// Maximum selected nodes.
     pub nodes: u64,
     /// Maximum adjacency entries after direction and filtering.
@@ -182,6 +182,15 @@ impl Default for AlgorithmLimits {
             states: 10_000_000,
             batch_size: 8_192,
         }
+    }
+}
+
+impl AlgorithmLimits {
+    /// Override the internal Arrow shaping batch size (#337 / #341).
+    #[must_use]
+    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = batch_size.max(1);
+        self
     }
 }
 

--- a/crates/graphforge-exec/src/algorithm_output.rs
+++ b/crates/graphforge-exec/src/algorithm_output.rs
@@ -9,17 +9,17 @@ use std::path::Path;
 use std::sync::Arc;
 
 use arrow::array::{
-    Array, ArrayRef, BooleanBuilder, FixedSizeBinaryArray, FixedSizeBinaryBuilder, Float32Builder,
-    Float64Builder, Int64Builder, ListBuilder, StringBuilder, UInt32Array, UInt64Builder,
+    Array, ArrayRef, FixedSizeBinaryArray, Float64Array, Int64Array, StringArray, UInt32Array,
 };
-use arrow::compute::{concat_batches, take};
+use arrow::compute::take;
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use graphforge_core::algorithms::{Algorithm, AlgorithmFieldType};
 
+use crate::algorithm_arrow_sink::{schema_version, shape_error, AlgorithmArrowSink};
 use crate::algorithm_dispatch::{AlgorithmError, AlgorithmOutput, AlgorithmValue};
 
-const SCHEMA_VERSION: &str = "1";
+const SCHEMA_VERSION: &str = schema_version();
 
 /// Append node properties to a node-oriented algorithm batch by public UUID.
 ///
@@ -31,7 +31,21 @@ pub(crate) fn materialize_node_properties(
     batch: &RecordBatch,
 ) -> Result<RecordBatch, AlgorithmError> {
     materialize_node_properties_with(batch, stems, |stem| {
-        graphforge_storage::read_properties(dir, stem)
+        // Stream property tables as bounded batches; never concat the full table (#341).
+        graphforge_storage::read_properties_batched(dir, stem, 8_192)
+            .map_err(|error| materialization_error(error.to_string()))
+    })
+}
+
+/// Same as [`materialize_node_properties`] with an explicit property batch size.
+pub(crate) fn materialize_node_properties_with_batch_size(
+    dir: &Path,
+    stems: &[String],
+    batch: &RecordBatch,
+    batch_size: usize,
+) -> Result<RecordBatch, AlgorithmError> {
+    materialize_node_properties_with(batch, stems, |stem| {
+        graphforge_storage::read_properties_batched(dir, stem, batch_size.max(1))
             .map_err(|error| materialization_error(error.to_string()))
     })
 }
@@ -63,35 +77,47 @@ where
         .collect();
 
     for stem in ordered_stems {
-        let batches = load(&stem)?;
-        if batches.is_empty() {
+        let property_batches = load(&stem)?;
+        let property_batches: Vec<_> = property_batches
+            .into_iter()
+            .filter(|candidate| candidate.num_rows() > 0)
+            .collect();
+        if property_batches.is_empty() {
             continue;
         }
-        let schema = batches[0].schema();
-        if batches.iter().any(|candidate| candidate.schema() != schema) {
+        let schema = property_batches[0].schema();
+        if property_batches
+            .iter()
+            .any(|candidate| candidate.schema() != schema)
+        {
             return Err(materialization_error(format!(
                 "property table {stem:?} returned inconsistent batch schemas"
             )));
         }
-        let combined = concat_batches(&schema, &batches)
-            .map_err(|error| materialization_error(error.to_string()))?;
-        let property_uuids =
-            uuid_column(&combined, "node_uuid", &format!("property table {stem:?}"))?;
-        let mut row_by_uuid = HashMap::with_capacity(property_uuids.len());
-        for row in 0..property_uuids.len() {
-            if property_uuids.is_null(row) {
-                return Err(materialization_error(format!(
-                    "property table {stem:?} contains a NULL node_uuid"
-                )));
-            }
-            let uuid = uuid_at(property_uuids, row, &stem)?;
-            let row = u32::try_from(row).map_err(|_| {
-                materialization_error(format!("property table {stem:?} exceeds the row limit"))
-            })?;
-            if row_by_uuid.insert(uuid, row).is_some() {
-                return Err(materialization_error(format!(
-                    "property table {stem:?} contains duplicate rows for one node_uuid"
-                )));
+
+        let mut row_by_uuid: HashMap<[u8; 16], (usize, u32)> =
+            HashMap::with_capacity(property_batches.iter().map(RecordBatch::num_rows).sum());
+        for (batch_index, property_batch) in property_batches.iter().enumerate() {
+            let property_uuids = uuid_column(
+                property_batch,
+                "node_uuid",
+                &format!("property table {stem:?}"),
+            )?;
+            for row in 0..property_uuids.len() {
+                if property_uuids.is_null(row) {
+                    return Err(materialization_error(format!(
+                        "property table {stem:?} contains a NULL node_uuid"
+                    )));
+                }
+                let uuid = uuid_at(property_uuids, row, &stem)?;
+                let row = u32::try_from(row).map_err(|_| {
+                    materialization_error(format!("property table {stem:?} exceeds the row limit"))
+                })?;
+                if row_by_uuid.insert(uuid, (batch_index, row)).is_some() {
+                    return Err(materialization_error(format!(
+                        "property table {stem:?} contains duplicate rows for one node_uuid"
+                    )));
+                }
             }
         }
 
@@ -110,7 +136,8 @@ where
                 key,
                 (
                     field.clone(),
-                    combined.column(index).clone(),
+                    property_batches.clone(),
+                    index,
                     row_by_uuid.clone(),
                 ),
             );
@@ -119,22 +146,19 @@ where
 
     let mut fields: Vec<Arc<Field>> = batch.schema().fields().iter().cloned().collect();
     let mut columns = batch.columns().to_vec();
-    for ((_stem, _name), (field, values, row_by_uuid)) in properties {
-        let indices = UInt32Array::from(
-            (0..node_uuids.len())
-                .map(|row| {
-                    if node_uuids.is_null(row) {
-                        None
-                    } else {
-                        uuid_at(node_uuids, row, "algorithm result")
-                            .ok()
-                            .and_then(|uuid| row_by_uuid.get(&uuid).copied())
-                    }
-                })
-                .collect::<Vec<_>>(),
-        );
-        let gathered = take(values.as_ref(), &indices, None)
-            .map_err(|error| materialization_error(error.to_string()))?;
+    for ((_stem, _name), (field, property_batches, column_index, row_by_uuid)) in properties {
+        let locations: Vec<Option<(usize, u32)>> = (0..node_uuids.len())
+            .map(|row| {
+                if node_uuids.is_null(row) {
+                    None
+                } else {
+                    uuid_at(node_uuids, row, "algorithm result")
+                        .ok()
+                        .and_then(|uuid| row_by_uuid.get(&uuid).copied())
+                }
+            })
+            .collect();
+        let gathered = gather_property_column(&property_batches, column_index, &locations)?;
         fields.push(Arc::new(field.as_ref().clone().with_nullable(true)));
         columns.push(gathered);
     }
@@ -144,6 +168,43 @@ where
         batch.schema().metadata().clone(),
     ));
     RecordBatch::try_new(schema, columns).map_err(|error| materialization_error(error.to_string()))
+}
+
+fn gather_property_column(
+    batches: &[RecordBatch],
+    column_index: usize,
+    locations: &[Option<(usize, u32)>],
+) -> Result<ArrayRef, AlgorithmError> {
+    use arrow::compute::kernels::zip::zip;
+    use arrow::array::BooleanArray;
+
+    let mut merged: Option<ArrayRef> = None;
+    for (batch_index, batch) in batches.iter().enumerate() {
+        let indices = UInt32Array::from(
+            locations
+                .iter()
+                .map(|location| match location {
+                    Some((owned_batch, row)) if *owned_batch == batch_index => Some(*row),
+                    _ => None,
+                })
+                .collect::<Vec<_>>(),
+        );
+        let taken = take(batch.column(column_index).as_ref(), &indices, None)
+            .map_err(|error| materialization_error(error.to_string()))?;
+        merged = Some(match merged {
+            None => taken,
+            Some(base) => {
+                let use_overlay = BooleanArray::from(
+                    (0..taken.len())
+                        .map(|row| Some(!taken.is_null(row)))
+                        .collect::<Vec<_>>(),
+                );
+                zip(&use_overlay, &taken, &base)
+                    .map_err(|error| materialization_error(error.to_string()))?
+            }
+        });
+    }
+    merged.ok_or_else(|| materialization_error("property gather missing batches"))
 }
 
 fn uuid_column<'a>(
@@ -171,7 +232,7 @@ fn uuid_at(
         .map_err(|_| materialization_error(format!("{source} contains a malformed node_uuid")))
 }
 
-/// Convert typed logical handler rows into the canonical public Arrow batch.
+/// Return the canonical public Arrow batch already shaped by [`AlgorithmArrowSink`].
 pub(crate) fn shape_algorithm_output(
     algorithm: Algorithm,
     output: &AlgorithmOutput,
@@ -182,261 +243,33 @@ pub(crate) fn shape_algorithm_output(
             "handler returned a non-canonical logical schema",
         ));
     }
-    for (row_index, row) in output.rows.iter().enumerate() {
-        if row.len() != expected.fields.len() {
-            return Err(shape_error(format!(
-                "row {row_index} has {} values but schema requires {}",
-                row.len(),
-                expected.fields.len()
-            )));
-        }
+    if output.batch.schema().metadata().get("graphforge.algorithm")
+        != Some(&algorithm.as_str().to_owned())
+    {
+        return Err(shape_error("handler batch metadata is non-canonical"));
     }
+    Ok(output.batch.clone())
+}
 
-    let mut fields = Vec::with_capacity(expected.fields.len());
-    let mut columns = Vec::with_capacity(expected.fields.len());
-    for (column_index, logical) in expected.fields.iter().enumerate() {
-        if matches!(logical.name, "node_id" | "edge_id" | "src_id" | "dst_id") {
-            return Err(shape_error(
-                "public algorithm schema contains a surrogate field",
-            ));
-        }
-        fields.push(Field::new(
-            logical.name,
-            arrow_type(logical.data_type),
-            logical.nullable,
+/// Shape logical rows through the shared columnar sink (tests and tiny scalar outputs).
+pub(crate) fn shape_logical_rows(
+    algorithm: Algorithm,
+    rows: impl IntoIterator<Item = Vec<AlgorithmValue>>,
+    batch_size: usize,
+    output_limit: u64,
+) -> Result<AlgorithmOutput, AlgorithmError> {
+    let mut sink = AlgorithmArrowSink::with_limits(algorithm, batch_size, output_limit)?;
+    if sink.schema() != &algorithm.result_schema() {
+        return Err(shape_error(
+            "handler returned a non-canonical logical schema",
         ));
-        columns.push(build_column(
-            logical.data_type,
-            logical.nullable,
-            logical.name,
-            column_index,
-            &output.rows,
-        )?);
     }
-
-    let metadata = HashMap::from([
-        (
-            "graphforge.algorithm".to_owned(),
-            algorithm.as_str().to_owned(),
-        ),
-        (
-            "graphforge.verb".to_owned(),
-            algorithm.verb().as_str().to_owned(),
-        ),
-        (
-            "graphforge.algorithm_schema_version".to_owned(),
-            SCHEMA_VERSION.to_owned(),
-        ),
-    ]);
-    let schema = Arc::new(Schema::new_with_metadata(fields, metadata));
-    RecordBatch::try_new(schema, columns).map_err(|error| shape_error(error.to_string()))
-}
-
-fn arrow_type(logical: AlgorithmFieldType) -> DataType {
-    match logical {
-        AlgorithmFieldType::Uuid => DataType::FixedSizeBinary(16),
-        AlgorithmFieldType::UuidList => DataType::List(Arc::new(Field::new(
-            "item",
-            DataType::FixedSizeBinary(16),
-            false,
-        ))),
-        AlgorithmFieldType::Float32List => {
-            DataType::List(Arc::new(Field::new("item", DataType::Float32, false)))
-        }
-        AlgorithmFieldType::Utf8 => DataType::Utf8,
-        AlgorithmFieldType::Boolean => DataType::Boolean,
-        AlgorithmFieldType::UInt64 => DataType::UInt64,
-        AlgorithmFieldType::Int64 => DataType::Int64,
-        AlgorithmFieldType::Float64 => DataType::Float64,
+    for row in rows {
+        sink.append_row(&row)?;
     }
+    sink.finish()
 }
 
-fn build_column(
-    data_type: AlgorithmFieldType,
-    nullable: bool,
-    name: &str,
-    column_index: usize,
-    rows: &[Vec<AlgorithmValue>],
-) -> Result<ArrayRef, AlgorithmError> {
-    match data_type {
-        AlgorithmFieldType::Uuid => build_uuid(nullable, name, column_index, rows),
-        AlgorithmFieldType::UuidList => build_uuid_list(nullable, name, column_index, rows),
-        AlgorithmFieldType::Float32List => build_float32_list(nullable, name, column_index, rows),
-        AlgorithmFieldType::Utf8 => {
-            let mut builder = StringBuilder::new();
-            for value in column_values(rows, column_index) {
-                match value {
-                    AlgorithmValue::Utf8(value) => builder.append_value(value),
-                    AlgorithmValue::Null if nullable => builder.append_null(),
-                    other => return Err(type_error(name, "Utf8", other)),
-                }
-            }
-            Ok(Arc::new(builder.finish()))
-        }
-        AlgorithmFieldType::Boolean => {
-            let mut builder = BooleanBuilder::new();
-            for value in column_values(rows, column_index) {
-                match value {
-                    AlgorithmValue::Boolean(value) => builder.append_value(*value),
-                    AlgorithmValue::Null if nullable => builder.append_null(),
-                    other => return Err(type_error(name, "Boolean", other)),
-                }
-            }
-            Ok(Arc::new(builder.finish()))
-        }
-        AlgorithmFieldType::UInt64 => {
-            let mut builder = UInt64Builder::new();
-            for value in column_values(rows, column_index) {
-                match value {
-                    AlgorithmValue::UInt64(value) => builder.append_value(*value),
-                    AlgorithmValue::Null if nullable => builder.append_null(),
-                    other => return Err(type_error(name, "UInt64", other)),
-                }
-            }
-            Ok(Arc::new(builder.finish()))
-        }
-        AlgorithmFieldType::Int64 => {
-            let mut builder = Int64Builder::new();
-            for value in column_values(rows, column_index) {
-                match value {
-                    AlgorithmValue::Int64(value) => builder.append_value(*value),
-                    AlgorithmValue::Null if nullable => builder.append_null(),
-                    other => return Err(type_error(name, "Int64", other)),
-                }
-            }
-            Ok(Arc::new(builder.finish()))
-        }
-        AlgorithmFieldType::Float64 => {
-            let mut builder = Float64Builder::new();
-            for value in column_values(rows, column_index) {
-                match value {
-                    AlgorithmValue::Float64(value) if value.is_finite() => {
-                        builder.append_value(*value);
-                    }
-                    AlgorithmValue::Null if nullable => builder.append_null(),
-                    AlgorithmValue::Float64(_) => {
-                        return Err(shape_error(format!(
-                            "field {name:?} contains a non-finite Float64"
-                        )));
-                    }
-                    other => return Err(type_error(name, "Float64", other)),
-                }
-            }
-            Ok(Arc::new(builder.finish()))
-        }
-    }
-}
-
-fn build_uuid(
-    nullable: bool,
-    name: &str,
-    column_index: usize,
-    rows: &[Vec<AlgorithmValue>],
-) -> Result<ArrayRef, AlgorithmError> {
-    let mut builder = FixedSizeBinaryBuilder::new(16);
-    for value in column_values(rows, column_index) {
-        match value {
-            AlgorithmValue::Uuid(value) => builder
-                .append_value(value)
-                .map_err(|error| shape_error(error.to_string()))?,
-            AlgorithmValue::Null if nullable => builder.append_null(),
-            other => return Err(type_error(name, "FixedSizeBinary(16)", other)),
-        }
-    }
-    Ok(Arc::new(builder.finish()))
-}
-
-fn build_uuid_list(
-    nullable: bool,
-    name: &str,
-    column_index: usize,
-    rows: &[Vec<AlgorithmValue>],
-) -> Result<ArrayRef, AlgorithmError> {
-    let mut builder = ListBuilder::new(FixedSizeBinaryBuilder::new(16)).with_field(Arc::new(
-        Field::new("item", DataType::FixedSizeBinary(16), false),
-    ));
-    for value in column_values(rows, column_index) {
-        match value {
-            AlgorithmValue::UuidList(values) => {
-                for value in values {
-                    builder
-                        .values()
-                        .append_value(value)
-                        .map_err(|error| shape_error(error.to_string()))?;
-                }
-                builder.append(true);
-            }
-            AlgorithmValue::Null if nullable => builder.append(false),
-            other => return Err(type_error(name, "List<FixedSizeBinary(16)>", other)),
-        }
-    }
-    Ok(Arc::new(builder.finish()))
-}
-
-fn build_float32_list(
-    nullable: bool,
-    name: &str,
-    column_index: usize,
-    rows: &[Vec<AlgorithmValue>],
-) -> Result<ArrayRef, AlgorithmError> {
-    let mut builder = ListBuilder::new(Float32Builder::new()).with_field(Arc::new(Field::new(
-        "item",
-        DataType::Float32,
-        false,
-    )));
-    for value in column_values(rows, column_index) {
-        match value {
-            AlgorithmValue::Float32List(values) if values.iter().all(|value| value.is_finite()) => {
-                for value in values {
-                    builder.values().append_value(*value);
-                }
-                builder.append(true);
-            }
-            AlgorithmValue::Null if nullable => builder.append(false),
-            AlgorithmValue::Float32List(_) => {
-                return Err(shape_error(format!(
-                    "field {name:?} contains a non-finite Float32"
-                )));
-            }
-            other => return Err(type_error(name, "List<Float32>", other)),
-        }
-    }
-    Ok(Arc::new(builder.finish()))
-}
-
-fn column_values(
-    rows: &[Vec<AlgorithmValue>],
-    column_index: usize,
-) -> impl Iterator<Item = &AlgorithmValue> {
-    rows.iter().map(move |row| &row[column_index])
-}
-
-fn type_error(name: &str, expected: &str, actual: &AlgorithmValue) -> AlgorithmError {
-    shape_error(format!(
-        "field {name:?} requires {expected}, received {}",
-        value_kind(actual)
-    ))
-}
-
-fn value_kind(value: &AlgorithmValue) -> &'static str {
-    match value {
-        AlgorithmValue::Null => "Null",
-        AlgorithmValue::Uuid(_) => "Uuid",
-        AlgorithmValue::UuidList(_) => "UuidList",
-        AlgorithmValue::Float32List(_) => "Float32List",
-        AlgorithmValue::Utf8(_) => "Utf8",
-        AlgorithmValue::Boolean(_) => "Boolean",
-        AlgorithmValue::UInt64(_) => "UInt64",
-        AlgorithmValue::Int64(_) => "Int64",
-        AlgorithmValue::Float64(_) => "Float64",
-    }
-}
-
-fn shape_error(message: impl Into<String>) -> AlgorithmError {
-    AlgorithmError::Execution {
-        message: format!("invalid algorithm output: {}", message.into()),
-    }
-}
 
 fn materialization_error(message: impl Into<String>) -> AlgorithmError {
     AlgorithmError::Execution {
@@ -505,20 +338,34 @@ mod tests {
     }
 
     fn output(algorithm: Algorithm, populated: bool) -> AlgorithmOutput {
-        let schema = algorithm.result_schema();
-        AlgorithmOutput {
-            schema,
-            rows: populated
-                .then(|| {
-                    schema
-                        .fields
-                        .iter()
-                        .map(|field| value_for(field.data_type))
-                        .collect()
-                })
-                .into_iter()
-                .collect(),
-        }
+        let rows = populated
+            .then(|| {
+                algorithm
+                    .result_schema()
+                    .fields
+                    .iter()
+                    .map(|field| value_for(field.data_type))
+                    .collect::<Vec<_>>()
+            })
+            .into_iter()
+            .collect::<Vec<_>>();
+        shape_logical_rows(algorithm, rows, 8_192, u64::MAX).unwrap()
+    }
+
+    fn try_shape_row(
+        algorithm: Algorithm,
+        row: Vec<AlgorithmValue>,
+    ) -> Result<AlgorithmOutput, AlgorithmError> {
+        shape_logical_rows(algorithm, [row], 8_192, u64::MAX)
+    }
+
+    fn canonical_row(algorithm: Algorithm) -> Vec<AlgorithmValue> {
+        algorithm
+            .result_schema()
+            .fields
+            .iter()
+            .map(|field| value_for(field.data_type))
+            .collect()
     }
 
     #[test]
@@ -577,39 +424,40 @@ mod tests {
     #[test]
     fn nullable_weight_preserves_null() {
         let algorithm = Algorithm::Analyze(AnalyzeAlgorithm::MinimumSpanningTree);
-        let mut output = output(algorithm, true);
-        let weight = output
-            .schema
+        let weight = algorithm
+            .result_schema()
             .fields
             .iter()
             .position(|field| field.name == "weight")
             .unwrap();
-        output.rows[0][weight] = AlgorithmValue::Null;
-        let batch = shape_algorithm_output(algorithm, &output).unwrap();
+        let mut row = canonical_row(algorithm);
+        row[weight] = AlgorithmValue::Null;
+        let shaped = try_shape_row(algorithm, row).unwrap();
+        let batch = shape_algorithm_output(algorithm, &shaped).unwrap();
         assert_eq!(batch.column(weight).null_count(), 1);
     }
 
     #[test]
     fn row_width_type_and_nullability_mismatches_are_rejected() {
         let algorithm = Algorithm::Rank(RankAlgorithm::Degree);
-        let mut wrong_width = output(algorithm, true);
-        wrong_width.rows[0].pop();
+        let mut wrong_width = canonical_row(algorithm);
+        wrong_width.pop();
         assert!(matches!(
-            shape_algorithm_output(algorithm, &wrong_width),
+            try_shape_row(algorithm, wrong_width),
             Err(AlgorithmError::Execution { .. })
         ));
 
-        let mut wrong_type = output(algorithm, true);
-        wrong_type.rows[0][0] = AlgorithmValue::Utf8("not-a-uuid".into());
+        let mut wrong_type = canonical_row(algorithm);
+        wrong_type[0] = AlgorithmValue::Utf8("not-a-uuid".into());
         assert!(matches!(
-            shape_algorithm_output(algorithm, &wrong_type),
+            try_shape_row(algorithm, wrong_type),
             Err(AlgorithmError::Execution { .. })
         ));
 
-        let mut null_non_nullable = output(algorithm, true);
-        null_non_nullable.rows[0][0] = AlgorithmValue::Null;
+        let mut null_non_nullable = canonical_row(algorithm);
+        null_non_nullable[0] = AlgorithmValue::Null;
         assert!(matches!(
-            shape_algorithm_output(algorithm, &null_non_nullable),
+            try_shape_row(algorithm, null_non_nullable),
             Err(AlgorithmError::Execution { .. })
         ));
     }
@@ -624,10 +472,10 @@ mod tests {
             Err(AlgorithmError::Execution { .. })
         ));
 
-        let mut nonfinite = output(algorithm, true);
-        nonfinite.rows[0][1] = AlgorithmValue::Float64(f64::NAN);
+        let mut nonfinite = canonical_row(algorithm);
+        nonfinite[1] = AlgorithmValue::Float64(f64::NAN);
         assert!(matches!(
-            shape_algorithm_output(algorithm, &nonfinite),
+            try_shape_row(algorithm, nonfinite),
             Err(AlgorithmError::Execution { .. })
         ));
     }
@@ -825,23 +673,22 @@ mod tests {
             Algorithm::Analyze(AnalyzeAlgorithm::IsDag),
             Algorithm::Analyze(AnalyzeAlgorithm::NodeColoring),
         ] {
-            let canonical = output(algorithm, true);
-            for (index, field) in canonical.schema.fields.iter().enumerate() {
+            let canonical = canonical_row(algorithm);
+            for (index, field) in algorithm.result_schema().fields.iter().enumerate() {
                 let mut wrong_type = canonical.clone();
-                wrong_type.rows[0][index] = AlgorithmValue::Utf8("wrong-type".into());
+                wrong_type[index] = AlgorithmValue::Utf8("wrong-type".into());
                 if field.data_type == AlgorithmFieldType::Utf8 {
-                    wrong_type.rows[0][index] = AlgorithmValue::Boolean(false);
+                    wrong_type[index] = AlgorithmValue::Boolean(false);
                 }
-                let error = shape_algorithm_output(algorithm, &wrong_type)
-                    .expect_err("logical output type mismatch");
+                let error = try_shape_row(algorithm, wrong_type).expect_err("logical output type mismatch");
                 assert!(error.to_string().contains(field.name));
 
                 let mut null = canonical.clone();
-                null.rows[0][index] = AlgorithmValue::Null;
-                match shape_algorithm_output(algorithm, &null) {
+                null[index] = AlgorithmValue::Null;
+                match try_shape_row(algorithm, null) {
                     Ok(batch) => {
                         assert!(field.nullable);
-                        assert_eq!(batch.column(index).null_count(), 1);
+                        assert_eq!(batch.record_batch().column(index).null_count(), 1);
                     }
                     Err(error) => {
                         assert!(!field.nullable);
@@ -861,25 +708,75 @@ mod tests {
                 AlgorithmValue::Float64(f64::INFINITY),
             ),
         ] {
-            let mut malformed = output(algorithm, true);
+            let mut malformed = canonical_row(algorithm);
             let index = malformed
-                .schema
-                .fields
                 .iter()
-                .position(|field| {
+                .zip(algorithm.result_schema().fields.iter())
+                .position(|(_, field)| {
                     matches!(
                         field.data_type,
                         AlgorithmFieldType::Float32List | AlgorithmFieldType::Float64
                     )
                 })
                 .unwrap();
-            malformed.rows[0][index] = replacement;
+            malformed[index] = replacement;
             assert!(
-                shape_algorithm_output(algorithm, &malformed)
+                try_shape_row(algorithm, malformed)
                     .unwrap_err()
                     .to_string()
                     .contains("non-finite")
             );
         }
+    }
+
+    #[test]
+    fn bounded_batches_preserve_fingerprint_and_avoid_row_dup() {
+        let algorithm = Algorithm::Rank(RankAlgorithm::Degree);
+        let rows: Vec<Vec<AlgorithmValue>> = (0..17)
+            .map(|index| {
+                let mut uuid = [0_u8; 16];
+                uuid[15] = index as u8;
+                vec![
+                    AlgorithmValue::Uuid(uuid),
+                    AlgorithmValue::Float64(f64::from(index)),
+                ]
+            })
+            .collect();
+        let small = shape_logical_rows(algorithm, rows.clone(), 4, u64::MAX).unwrap();
+        let large = shape_logical_rows(algorithm, rows, 64, u64::MAX).unwrap();
+        assert!(small.internal_batch_count > 1, "small batch size must roll over");
+        assert_eq!(large.internal_batch_count, 1);
+        assert!(
+            small.peak_builder_rows <= 4,
+            "peak builder rows must stay within batch_size"
+        );
+        assert_eq!(
+            shape_algorithm_output(algorithm, &small).unwrap(),
+            shape_algorithm_output(algorithm, &large).unwrap()
+        );
+        assert_eq!(small.rows(), large.rows());
+    }
+
+    #[test]
+    fn property_enrichment_gathers_across_property_batches_without_concat() {
+        let one = [1; 16];
+        let two = [2; 16];
+        let input = node_result(&[two, one]);
+        let first = property_batch(&[two], "name", Arc::new(StringArray::from(vec![Some("Bob")])));
+        let second = property_batch(&[one], "name", Arc::new(StringArray::from(vec![Some("Ada")])));
+        let result = materialize_node_properties_with(&input, &["Person".into()], |_| {
+            Ok(vec![first.clone(), second.clone()])
+        })
+        .unwrap();
+        let name = result
+            .column_by_name("name")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(
+            name.iter().collect::<Vec<_>>(),
+            vec![Some("Bob"), Some("Ada")]
+        );
     }
 }

--- a/crates/graphforge-exec/src/algorithm_output.rs
+++ b/crates/graphforge-exec/src/algorithm_output.rs
@@ -16,7 +16,7 @@ use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use graphforge_core::algorithms::{Algorithm, AlgorithmFieldType};
 
-use crate::algorithm_arrow_sink::{schema_version, shape_error, AlgorithmArrowSink};
+use crate::algorithm_arrow_sink::{AlgorithmArrowSink, schema_version, shape_error};
 use crate::algorithm_dispatch::{AlgorithmError, AlgorithmOutput, AlgorithmValue};
 
 const SCHEMA_VERSION: &str = schema_version();
@@ -175,8 +175,8 @@ fn gather_property_column(
     column_index: usize,
     locations: &[Option<(usize, u32)>],
 ) -> Result<ArrayRef, AlgorithmError> {
-    use arrow::compute::kernels::zip::zip;
     use arrow::array::BooleanArray;
+    use arrow::compute::kernels::zip::zip;
 
     let mut merged: Option<ArrayRef> = None;
     for (batch_index, batch) in batches.iter().enumerate() {
@@ -269,7 +269,6 @@ pub(crate) fn shape_logical_rows(
     }
     sink.finish()
 }
-
 
 fn materialization_error(message: impl Into<String>) -> AlgorithmError {
     AlgorithmError::Execution {
@@ -680,7 +679,8 @@ mod tests {
                 if field.data_type == AlgorithmFieldType::Utf8 {
                     wrong_type[index] = AlgorithmValue::Boolean(false);
                 }
-                let error = try_shape_row(algorithm, wrong_type).expect_err("logical output type mismatch");
+                let error =
+                    try_shape_row(algorithm, wrong_type).expect_err("logical output type mismatch");
                 assert!(error.to_string().contains(field.name));
 
                 let mut null = canonical.clone();
@@ -744,7 +744,10 @@ mod tests {
             .collect();
         let small = shape_logical_rows(algorithm, rows.clone(), 4, u64::MAX).unwrap();
         let large = shape_logical_rows(algorithm, rows, 64, u64::MAX).unwrap();
-        assert!(small.internal_batch_count > 1, "small batch size must roll over");
+        assert!(
+            small.internal_batch_count > 1,
+            "small batch size must roll over"
+        );
         assert_eq!(large.internal_batch_count, 1);
         assert!(
             small.peak_builder_rows <= 4,
@@ -762,8 +765,16 @@ mod tests {
         let one = [1; 16];
         let two = [2; 16];
         let input = node_result(&[two, one]);
-        let first = property_batch(&[two], "name", Arc::new(StringArray::from(vec![Some("Bob")])));
-        let second = property_batch(&[one], "name", Arc::new(StringArray::from(vec![Some("Ada")])));
+        let first = property_batch(
+            &[two],
+            "name",
+            Arc::new(StringArray::from(vec![Some("Bob")])),
+        );
+        let second = property_batch(
+            &[one],
+            "name",
+            Arc::new(StringArray::from(vec![Some("Ada")])),
+        );
         let result = materialize_node_properties_with(&input, &["Person".into()], |_| {
             Ok(vec![first.clone(), second.clone()])
         })

--- a/crates/graphforge-exec/src/algorithm_output.rs
+++ b/crates/graphforge-exec/src/algorithm_output.rs
@@ -8,13 +8,11 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
 
-use arrow::array::{
-    Array, ArrayRef, FixedSizeBinaryArray, Float64Array, Int64Array, StringArray, UInt32Array,
-};
+use arrow::array::{Array, ArrayRef, FixedSizeBinaryArray, UInt32Array};
 use arrow::compute::take;
-use arrow::datatypes::{DataType, Field, Schema};
+use arrow::datatypes::{Field, Schema};
 use arrow::record_batch::RecordBatch;
-use graphforge_core::algorithms::{Algorithm, AlgorithmFieldType};
+use graphforge_core::algorithms::Algorithm;
 
 use crate::algorithm_arrow_sink::{AlgorithmArrowSink, schema_version, shape_error};
 use crate::algorithm_dispatch::{AlgorithmError, AlgorithmOutput, AlgorithmValue};
@@ -50,6 +48,10 @@ pub(crate) fn materialize_node_properties_with_batch_size(
     })
 }
 
+#[allow(
+    clippy::too_many_lines,
+    reason = "batchwise enrichment keeps one linear gather path"
+)]
 fn materialize_node_properties_with<F>(
     batch: &RecordBatch,
     stems: &[String],
@@ -282,8 +284,9 @@ fn materialization_error(message: impl Into<String>) -> AlgorithmError {
 #[cfg(test)]
 mod tests {
     use arrow::array::{Array, Float64Array, Int64Array, StringArray};
+    use arrow::datatypes::DataType;
     use graphforge_core::algorithms::{
-        AnalyzeAlgorithm, ClusterAlgorithm, PathAlgorithm, RankAlgorithm,
+        AlgorithmFieldType, AnalyzeAlgorithm, ClusterAlgorithm, PathAlgorithm, RankAlgorithm,
     };
 
     use super::*;

--- a/crates/graphforge-exec/src/algorithm_paths.rs
+++ b/crates/graphforge-exec/src/algorithm_paths.rs
@@ -111,7 +111,7 @@ impl RustAlgorithm for DeltaStepping {
                 })
             })
             .transpose()?;
-        let rows = exact_delta_stepping(graph, source, target, control)?
+        let rows: Vec<Vec<AlgorithmValue>> = exact_delta_stepping(graph, source, target, control)?
             .into_iter()
             .map(|result| {
                 Ok(vec![
@@ -127,11 +127,8 @@ impl RustAlgorithm for DeltaStepping {
                     ),
                 ])
             })
-            .collect::<Result<_, AlgorithmError>>()?;
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Paths(PathAlgorithm::DeltaStepping).result_schema(),
-            rows,
-        })
+            .collect::<Result<Vec<_>, AlgorithmError>>()?;
+        AlgorithmOutput::from_rows(Algorithm::Paths(PathAlgorithm::DeltaStepping), control, rows)
     }
 }
 
@@ -176,7 +173,7 @@ impl RustAlgorithm for GomoryHuTree {
         control: &AlgorithmControl,
     ) -> Result<AlgorithmOutput, AlgorithmError> {
         control.check_cancelled()?;
-        let rows = gomory_hu_forest(
+        let rows: Vec<Vec<AlgorithmValue>> = gomory_hu_forest(
             &graph.node_uuids().collect::<Vec<_>>(),
             &capacity_edges(graph)?,
             graph.is_directed(),
@@ -191,10 +188,7 @@ impl RustAlgorithm for GomoryHuTree {
             ]
         })
         .collect();
-        Ok(AlgorithmOutput {
-            schema: self.capability().algorithm.result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(self.capability().algorithm, control, rows)
     }
 }
 
@@ -247,7 +241,7 @@ impl RustAlgorithm for PrizeCollectingSteinerTree {
                 cost: ResolvedNumber::Float64(edge.capacity),
             })
             .collect::<Vec<_>>();
-        let rows = prize_collecting_steiner_tree(
+        let rows: Vec<Vec<AlgorithmValue>> = prize_collecting_steiner_tree(
             &nodes,
             &self.prizes,
             &edges,
@@ -265,10 +259,7 @@ impl RustAlgorithm for PrizeCollectingSteinerTree {
             ]
         })
         .collect();
-        Ok(AlgorithmOutput {
-            schema: self.capability().algorithm.result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(self.capability().algorithm, control, rows)
     }
 }
 
@@ -294,7 +285,7 @@ impl RustAlgorithm for MinSteinerTree {
             &self.terminals,
             control,
         )?;
-        let rows = solution
+        let rows: Vec<Vec<AlgorithmValue>> = solution
             .edges
             .into_iter()
             .map(|edge| {
@@ -306,10 +297,7 @@ impl RustAlgorithm for MinSteinerTree {
                 ]
             })
             .collect();
-        Ok(AlgorithmOutput {
-            schema: self.capability().algorithm.result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(self.capability().algorithm, control, rows)
     }
 }
 
@@ -353,7 +341,7 @@ impl RustAlgorithm for RandomWalk {
                 "random_walk source UUID is not in the selected graph",
             ));
         }
-        let rows = random_walks(
+        let rows: Vec<Vec<AlgorithmValue>> = random_walks(
             &GraphRandomWalkAdjacency(graph),
             &[self.source],
             self.k,
@@ -370,10 +358,7 @@ impl RustAlgorithm for RandomWalk {
             ]
         })
         .collect();
-        Ok(AlgorithmOutput {
-            schema: self.capability().algorithm.result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(self.capability().algorithm, control, rows)
     }
 }
 
@@ -407,7 +392,7 @@ impl RustAlgorithm for MaxFlow {
             graph.is_directed(),
             control,
         )?;
-        let rows = if self.edges {
+        let rows: Vec<Vec<AlgorithmValue>> = if self.edges {
             solution
                 .edge_flows
                 .into_iter()
@@ -427,10 +412,7 @@ impl RustAlgorithm for MaxFlow {
                 AlgorithmValue::Float64(solution.value),
             ]]
         };
-        Ok(AlgorithmOutput {
-            schema: algorithm.result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(algorithm, control, rows)
     }
 }
 
@@ -464,7 +446,7 @@ impl RustAlgorithm for MinCut {
             graph.is_directed(),
             control,
         )?;
-        let rows = if self.edges {
+        let rows: Vec<Vec<AlgorithmValue>> = if self.edges {
             solution
                 .cut_edges
                 .into_iter()
@@ -484,10 +466,7 @@ impl RustAlgorithm for MinCut {
                 AlgorithmValue::Float64(solution.value),
             ]]
         };
-        Ok(AlgorithmOutput {
-            schema: algorithm.result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(algorithm, control, rows)
     }
 }
 
@@ -640,7 +619,7 @@ impl RustAlgorithm for TransitiveClosure {
         graph: &AdjacencyGraph,
         control: &AlgorithmControl,
     ) -> Result<AlgorithmOutput, AlgorithmError> {
-        let rows = positive_transitive_closure(graph, control)?
+        let rows: Vec<Vec<AlgorithmValue>> = positive_transitive_closure(graph, control)?
             .into_iter()
             .map(|pair| {
                 Ok(vec![
@@ -648,11 +627,8 @@ impl RustAlgorithm for TransitiveClosure {
                     AlgorithmValue::Uuid(node_uuid(graph, pair.target)?),
                 ])
             })
-            .collect::<Result<_, AlgorithmError>>()?;
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Paths(PathAlgorithm::TransitiveClosure).result_schema(),
-            rows,
-        })
+            .collect::<Result<Vec<_>, AlgorithmError>>()?;
+        AlgorithmOutput::from_rows(Algorithm::Paths(PathAlgorithm::TransitiveClosure), control, rows)
     }
 }
 
@@ -679,7 +655,7 @@ impl RustAlgorithm for Yens {
         let target = graph
             .node_id(&target_uuid)
             .ok_or_else(|| execution("yens target UUID is not in the selected graph"))?;
-        let rows = exact_yens(graph, source, target, self.k, control)?
+        let rows: Vec<Vec<AlgorithmValue>> = exact_yens(graph, source, target, self.k, control)?
             .into_iter()
             .enumerate()
             .map(|(index, result)| {
@@ -699,11 +675,8 @@ impl RustAlgorithm for Yens {
                     ),
                 ])
             })
-            .collect::<Result<_, AlgorithmError>>()?;
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Paths(PathAlgorithm::Yens).result_schema(),
-            rows,
-        })
+            .collect::<Result<Vec<_>, AlgorithmError>>()?;
+        AlgorithmOutput::from_rows(Algorithm::Paths(PathAlgorithm::Yens), control, rows)
     }
 }
 
@@ -726,7 +699,7 @@ impl RustAlgorithm for FloydWarshall {
                 "floyd_warshall source UUID is not in the selected graph",
             ));
         }
-        let rows = exact_floyd_warshall(graph, control)?
+        let rows: Vec<Vec<AlgorithmValue>> = exact_floyd_warshall(graph, control)?
             .into_iter()
             .map(|result| {
                 Ok(vec![
@@ -742,11 +715,8 @@ impl RustAlgorithm for FloydWarshall {
                     ),
                 ])
             })
-            .collect::<Result<_, AlgorithmError>>()?;
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Paths(PathAlgorithm::FloydWarshall).result_schema(),
-            rows,
-        })
+            .collect::<Result<Vec<_>, AlgorithmError>>()?;
+        AlgorithmOutput::from_rows(Algorithm::Paths(PathAlgorithm::FloydWarshall), control, rows)
     }
 }
 
@@ -775,7 +745,7 @@ impl RustAlgorithm for BellmanFord {
                 })
             })
             .transpose()?;
-        let rows = exact_bellman_ford(graph, source, target, control)?
+        let rows: Vec<Vec<AlgorithmValue>> = exact_bellman_ford(graph, source, target, control)?
             .into_iter()
             .map(|result| {
                 Ok(vec![
@@ -791,11 +761,8 @@ impl RustAlgorithm for BellmanFord {
                     ),
                 ])
             })
-            .collect::<Result<_, AlgorithmError>>()?;
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Paths(PathAlgorithm::BellmanFord).result_schema(),
-            rows,
-        })
+            .collect::<Result<Vec<_>, AlgorithmError>>()?;
+        AlgorithmOutput::from_rows(Algorithm::Paths(PathAlgorithm::BellmanFord), control, rows)
     }
 }
 
@@ -822,7 +789,7 @@ impl RustAlgorithm for AStar {
         let target = graph
             .node_id(&target_uuid)
             .ok_or_else(|| execution("astar target UUID is not in the selected graph"))?;
-        let rows = exact_astar(graph, source, target, self.heuristic.as_ref(), control)?
+        let rows: Vec<Vec<AlgorithmValue>> = exact_astar(graph, source, target, self.heuristic.as_ref(), control)?
             .into_iter()
             .map(|result| {
                 Ok(vec![
@@ -838,11 +805,8 @@ impl RustAlgorithm for AStar {
                     ),
                 ])
             })
-            .collect::<Result<_, AlgorithmError>>()?;
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Paths(PathAlgorithm::AStar).result_schema(),
-            rows,
-        })
+            .collect::<Result<Vec<_>, AlgorithmError>>()?;
+        AlgorithmOutput::from_rows(Algorithm::Paths(PathAlgorithm::AStar), control, rows)
     }
 }
 
@@ -865,7 +829,7 @@ impl RustAlgorithm for DijkstraAllPairs {
                 "dijkstra_all_pairs source UUID is not in the selected graph",
             ));
         }
-        let rows = exact_dijkstra_all_pairs(graph, control)?
+        let rows: Vec<Vec<AlgorithmValue>> = exact_dijkstra_all_pairs(graph, control)?
             .into_iter()
             .map(|result| {
                 Ok(vec![
@@ -881,11 +845,8 @@ impl RustAlgorithm for DijkstraAllPairs {
                     ),
                 ])
             })
-            .collect::<Result<_, AlgorithmError>>()?;
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Paths(PathAlgorithm::DijkstraAllPairs).result_schema(),
-            rows,
-        })
+            .collect::<Result<Vec<_>, AlgorithmError>>()?;
+        AlgorithmOutput::from_rows(Algorithm::Paths(PathAlgorithm::DijkstraAllPairs), control, rows)
     }
 }
 
@@ -914,7 +875,7 @@ impl RustAlgorithm for Dijkstra {
                     .ok_or_else(|| execution("dijkstra target UUID is not in the selected graph"))
             })
             .transpose()?;
-        let rows = exact_dijkstra(graph, source, target, control)?
+        let rows: Vec<Vec<AlgorithmValue>> = exact_dijkstra(graph, source, target, control)?
             .into_iter()
             .map(|result| {
                 Ok(vec![
@@ -930,11 +891,8 @@ impl RustAlgorithm for Dijkstra {
                     ),
                 ])
             })
-            .collect::<Result<_, AlgorithmError>>()?;
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Paths(PathAlgorithm::Dijkstra).result_schema(),
-            rows,
-        })
+            .collect::<Result<Vec<_>, AlgorithmError>>()?;
+        AlgorithmOutput::from_rows(Algorithm::Paths(PathAlgorithm::Dijkstra), control, rows)
     }
 }
 
@@ -1020,10 +978,7 @@ impl RustAlgorithm for Bfs {
                 AlgorithmValue::UuidList(path_uuids(graph, source, target, &predecessor)?),
             ]);
         }
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Paths(PathAlgorithm::Bfs).result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(Algorithm::Paths(PathAlgorithm::Bfs), control, rows)
     }
 }
 
@@ -1044,7 +999,7 @@ impl RustAlgorithm for Dfs {
         let source = graph
             .node_id(&self.source)
             .ok_or_else(|| execution("dfs source UUID is not in the selected graph"))?;
-        let rows = depth_first_search(graph, source, control)?
+        let rows: Vec<Vec<AlgorithmValue>> = depth_first_search(graph, source, control)?
             .into_iter()
             .map(|visit| {
                 Ok(vec![
@@ -1053,11 +1008,8 @@ impl RustAlgorithm for Dfs {
                     AlgorithmValue::UInt64(visit.order),
                 ])
             })
-            .collect::<Result<_, AlgorithmError>>()?;
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Paths(PathAlgorithm::Dfs).result_schema(),
-            rows,
-        })
+            .collect::<Result<Vec<_>, AlgorithmError>>()?;
+        AlgorithmOutput::from_rows(Algorithm::Paths(PathAlgorithm::Dfs), control, rows)
     }
 }
 
@@ -1965,7 +1917,7 @@ mod tests {
             Algorithm::Paths(PathAlgorithm::GomoryHuTree).result_schema()
         );
         assert_eq!(
-            output.rows,
+            output.rows(),
             vec![
                 vec![value(0), value(1), AlgorithmValue::Float64(5.0),],
                 vec![value(1), value(2), AlgorithmValue::Float64(6.0),],
@@ -2038,7 +1990,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            scalar.rows,
+            scalar.rows(),
             vec![vec![
                 value(0),
                 value(2),
@@ -2063,7 +2015,7 @@ mod tests {
             AlgorithmLimits::default(),
         )
         .unwrap();
-        assert_eq!(edges.rows.len(), 3);
+        assert_eq!(edges.rows().len(), 3);
         assert_eq!(
             edges.schema,
             Algorithm::Paths(PathAlgorithm::MinCostMaxFlowEdges).result_schema()
@@ -2191,13 +2143,10 @@ mod tests {
         .unwrap();
         assert_eq!(
             scalar,
-            AlgorithmOutput {
-                schema: Algorithm::Paths(PathAlgorithm::MaxFlow).result_schema(),
-                rows: vec![vec![value(0), value(3), AlgorithmValue::Float64(5.0)]],
-            }
+            crate::algorithm_output::shape_logical_rows(Algorithm::Paths(PathAlgorithm::MaxFlow), vec![vec![value(0), value(3), AlgorithmValue::Float64(5.0)]], 8192, u64::MAX)
         );
         assert_eq!(
-            edges.rows.iter().map(|row| &row[3]).collect::<Vec<_>>(),
+            edges.rows().iter().map(|row| &row[3]).collect::<Vec<_>>(),
             vec![
                 &AlgorithmValue::Float64(3.0),
                 &AlgorithmValue::Float64(2.0),
@@ -2250,23 +2199,15 @@ mod tests {
 
         assert_eq!(
             scalar,
-            AlgorithmOutput {
-                schema: Algorithm::Paths(PathAlgorithm::MinCut).result_schema(),
-                rows: vec![vec![value(0), value(3), AlgorithmValue::Float64(5.0)]],
-            }
+            crate::algorithm_output::shape_logical_rows(Algorithm::Paths(PathAlgorithm::MinCut), vec![vec![value(0), value(3), AlgorithmValue::Float64(5.0)]], 8192, u64::MAX)
         );
         assert_eq!(
             edges,
-            AlgorithmOutput {
-                schema: Algorithm::Paths(PathAlgorithm::MinCutEdges).result_schema(),
-                rows: vec![
-                    vec![value(0), value(0), value(1), AlgorithmValue::Float64(3.0)],
-                    vec![value(1), value(0), value(2), AlgorithmValue::Float64(2.0)],
-                ],
-            }
+            crate::algorithm_output::shape_logical_rows(Algorithm::Paths(PathAlgorithm::MinCutEdges), vec![
+                    vec![value(0), value(0), value(1), AlgorithmValue::Float64(3.0)], vec![value(1), value(0), value(2), AlgorithmValue::Float64(2.0)], ], 8192, u64::MAX)
         );
         assert_eq!(
-            scalar.rows[0][2],
+            scalar.rows()[0][2],
             AlgorithmValue::Float64(
                 edges
                     .rows
@@ -2438,7 +2379,7 @@ mod tests {
             &[(10, 1, 0), (11, 2, 1), (12, 3, 2)],
         )
         .with_test_edge_weights(&[2.0, 2.0, 2.0, 2.0, 2.0, 2.0]);
-        let rows = execute_flow(
+        let rows: Vec<Vec<AlgorithmValue>> = execute_flow(
             &graph,
             PathAlgorithm::MaxFlowEdges,
             3,
@@ -2471,7 +2412,7 @@ mod tests {
             Algorithm::Paths(PathAlgorithm::TransitiveClosure).result_schema()
         );
         assert_eq!(
-            output.rows,
+            output.rows(),
             vec![
                 vec![value(0), value(0)],
                 vec![value(0), value(1)],
@@ -2520,7 +2461,7 @@ mod tests {
             Algorithm::Paths(PathAlgorithm::Yens).result_schema()
         );
         assert_eq!(
-            output.rows,
+            output.rows(),
             vec![
                 vec![
                     value(0),
@@ -2581,7 +2522,7 @@ mod tests {
         let schema = Algorithm::Paths(PathAlgorithm::Bfs).result_schema();
         assert_eq!(all.schema, schema);
         assert_eq!(
-            all.rows,
+            all.rows(),
             vec![
                 vec![value(0), value(0), AlgorithmValue::Float64(0.0), path(&[0])],
                 vec![
@@ -2644,7 +2585,7 @@ mod tests {
             Algorithm::Paths(PathAlgorithm::Dfs).result_schema()
         );
         assert_eq!(
-            output.rows,
+            output.rows(),
             vec![
                 traversal(0, 0, 0),
                 traversal(1, 1, 1),
@@ -3041,9 +2982,9 @@ mod tests {
             AlgorithmCancellation::default(),
         )
         .unwrap();
-        assert_eq!(output.rows.len(), 2);
+        assert_eq!(output.rows().len(), 2);
         assert_eq!(
-            output.rows.iter().map(|row| &row[0]).collect::<Vec<_>>(),
+            output.rows().iter().map(|row| &row[0]).collect::<Vec<_>>(),
             [&value(6), &value(7)]
         );
 
@@ -3077,7 +3018,7 @@ mod tests {
             )
             .unwrap()
             .rows,
-            output.rows
+            output.rows()
         );
     }
 
@@ -3097,7 +3038,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            output.rows,
+            output.rows(),
             vec![vec![
                 value(8),
                 value(0),
@@ -3149,7 +3090,7 @@ mod tests {
             )
             .unwrap()
             .rows,
-            output.rows
+            output.rows()
         );
     }
 

--- a/crates/graphforge-exec/src/algorithm_paths.rs
+++ b/crates/graphforge-exec/src/algorithm_paths.rs
@@ -128,7 +128,11 @@ impl RustAlgorithm for DeltaStepping {
                 ])
             })
             .collect::<Result<Vec<_>, AlgorithmError>>()?;
-        AlgorithmOutput::from_rows(Algorithm::Paths(PathAlgorithm::DeltaStepping), control, rows)
+        AlgorithmOutput::from_rows(
+            Algorithm::Paths(PathAlgorithm::DeltaStepping),
+            control,
+            rows,
+        )
     }
 }
 
@@ -628,7 +632,11 @@ impl RustAlgorithm for TransitiveClosure {
                 ])
             })
             .collect::<Result<Vec<_>, AlgorithmError>>()?;
-        AlgorithmOutput::from_rows(Algorithm::Paths(PathAlgorithm::TransitiveClosure), control, rows)
+        AlgorithmOutput::from_rows(
+            Algorithm::Paths(PathAlgorithm::TransitiveClosure),
+            control,
+            rows,
+        )
     }
 }
 
@@ -716,7 +724,11 @@ impl RustAlgorithm for FloydWarshall {
                 ])
             })
             .collect::<Result<Vec<_>, AlgorithmError>>()?;
-        AlgorithmOutput::from_rows(Algorithm::Paths(PathAlgorithm::FloydWarshall), control, rows)
+        AlgorithmOutput::from_rows(
+            Algorithm::Paths(PathAlgorithm::FloydWarshall),
+            control,
+            rows,
+        )
     }
 }
 
@@ -789,23 +801,24 @@ impl RustAlgorithm for AStar {
         let target = graph
             .node_id(&target_uuid)
             .ok_or_else(|| execution("astar target UUID is not in the selected graph"))?;
-        let rows: Vec<Vec<AlgorithmValue>> = exact_astar(graph, source, target, self.heuristic.as_ref(), control)?
-            .into_iter()
-            .map(|result| {
-                Ok(vec![
-                    AlgorithmValue::Uuid(self.source),
-                    AlgorithmValue::Uuid(target_uuid),
-                    AlgorithmValue::Float64(result.cost),
-                    AlgorithmValue::UuidList(
-                        result
-                            .nodes
-                            .into_iter()
-                            .map(|node| node_uuid(graph, node))
-                            .collect::<Result<_, _>>()?,
-                    ),
-                ])
-            })
-            .collect::<Result<Vec<_>, AlgorithmError>>()?;
+        let rows: Vec<Vec<AlgorithmValue>> =
+            exact_astar(graph, source, target, self.heuristic.as_ref(), control)?
+                .into_iter()
+                .map(|result| {
+                    Ok(vec![
+                        AlgorithmValue::Uuid(self.source),
+                        AlgorithmValue::Uuid(target_uuid),
+                        AlgorithmValue::Float64(result.cost),
+                        AlgorithmValue::UuidList(
+                            result
+                                .nodes
+                                .into_iter()
+                                .map(|node| node_uuid(graph, node))
+                                .collect::<Result<_, _>>()?,
+                        ),
+                    ])
+                })
+                .collect::<Result<Vec<_>, AlgorithmError>>()?;
         AlgorithmOutput::from_rows(Algorithm::Paths(PathAlgorithm::AStar), control, rows)
     }
 }
@@ -846,7 +859,11 @@ impl RustAlgorithm for DijkstraAllPairs {
                 ])
             })
             .collect::<Result<Vec<_>, AlgorithmError>>()?;
-        AlgorithmOutput::from_rows(Algorithm::Paths(PathAlgorithm::DijkstraAllPairs), control, rows)
+        AlgorithmOutput::from_rows(
+            Algorithm::Paths(PathAlgorithm::DijkstraAllPairs),
+            control,
+            rows,
+        )
     }
 }
 
@@ -2143,7 +2160,12 @@ mod tests {
         .unwrap();
         assert_eq!(
             scalar,
-            crate::algorithm_output::shape_logical_rows(Algorithm::Paths(PathAlgorithm::MaxFlow), vec![vec![value(0), value(3), AlgorithmValue::Float64(5.0)]], 8192, u64::MAX)
+            crate::algorithm_output::shape_logical_rows(
+                Algorithm::Paths(PathAlgorithm::MaxFlow),
+                vec![vec![value(0), value(3), AlgorithmValue::Float64(5.0)]],
+                8192,
+                u64::MAX
+            )
         );
         assert_eq!(
             edges.rows().iter().map(|row| &row[3]).collect::<Vec<_>>(),
@@ -2199,12 +2221,24 @@ mod tests {
 
         assert_eq!(
             scalar,
-            crate::algorithm_output::shape_logical_rows(Algorithm::Paths(PathAlgorithm::MinCut), vec![vec![value(0), value(3), AlgorithmValue::Float64(5.0)]], 8192, u64::MAX)
+            crate::algorithm_output::shape_logical_rows(
+                Algorithm::Paths(PathAlgorithm::MinCut),
+                vec![vec![value(0), value(3), AlgorithmValue::Float64(5.0)]],
+                8192,
+                u64::MAX
+            )
         );
         assert_eq!(
             edges,
-            crate::algorithm_output::shape_logical_rows(Algorithm::Paths(PathAlgorithm::MinCutEdges), vec![
-                    vec![value(0), value(0), value(1), AlgorithmValue::Float64(3.0)], vec![value(1), value(0), value(2), AlgorithmValue::Float64(2.0)], ], 8192, u64::MAX)
+            crate::algorithm_output::shape_logical_rows(
+                Algorithm::Paths(PathAlgorithm::MinCutEdges),
+                vec![
+                    vec![value(0), value(0), value(1), AlgorithmValue::Float64(3.0)],
+                    vec![value(1), value(0), value(2), AlgorithmValue::Float64(2.0)],
+                ],
+                8192,
+                u64::MAX
+            )
         );
         assert_eq!(
             scalar.rows()[0][2],

--- a/crates/graphforge-exec/src/algorithm_paths.rs
+++ b/crates/graphforge-exec/src/algorithm_paths.rs
@@ -1914,7 +1914,7 @@ mod tests {
                     AlgorithmCancellation::default(),
                 )
                 .unwrap()
-                .rows
+                .rows()
                 .is_empty()
             );
         }
@@ -1966,7 +1966,7 @@ mod tests {
         assert_eq!(
             execute_random_walk(&directed, 0, 2, 3, 42, false)
                 .unwrap()
-                .rows,
+                .rows(),
             vec![
                 vec![value(0), path(&[0, 2])],
                 vec![value(0), path(&[0, 1, 3])],
@@ -1975,7 +1975,7 @@ mod tests {
         assert_eq!(
             execute_random_walk(&directed, 2, 1, 3, 42, false)
                 .unwrap()
-                .rows,
+                .rows(),
             vec![vec![value(2), path(&[2])]]
         );
 
@@ -1983,7 +1983,7 @@ mod tests {
         assert_eq!(
             execute_random_walk(&undirected, 1, 1, 1, 0, false)
                 .unwrap()
-                .rows,
+                .rows(),
             vec![vec![value(1), path(&[1, 0])]]
         );
 
@@ -1992,7 +1992,7 @@ mod tests {
         assert_eq!(
             execute_random_walk(&weighted, 0, 1, 1, 0, true)
                 .unwrap()
-                .rows,
+                .rows(),
             vec![vec![value(0), path(&[0, 2])]]
         );
     }
@@ -2166,6 +2166,7 @@ mod tests {
                 8192,
                 u64::MAX
             )
+            .unwrap()
         );
         assert_eq!(
             edges.rows().iter().map(|row| &row[3]).collect::<Vec<_>>(),
@@ -2227,6 +2228,7 @@ mod tests {
                 8192,
                 u64::MAX
             )
+            .unwrap()
         );
         assert_eq!(
             edges,
@@ -2239,12 +2241,13 @@ mod tests {
                 8192,
                 u64::MAX
             )
+            .unwrap()
         );
         assert_eq!(
             scalar.rows()[0][2],
             AlgorithmValue::Float64(
                 edges
-                    .rows
+                    .rows()
                     .iter()
                     .map(|row| match &row[3] {
                         AlgorithmValue::Float64(capacity) => *capacity,
@@ -2307,7 +2310,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap()
-            .rows,
+            .rows(),
             vec![vec![
                 value(10),
                 value(0),
@@ -2327,7 +2330,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap()
-            .rows,
+            .rows(),
             vec![vec![value(0), value(2), AlgorithmValue::Float64(0.0)]]
         );
         assert!(
@@ -2340,7 +2343,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap()
-            .rows
+            .rows()
             .is_empty()
         );
     }
@@ -2421,7 +2424,7 @@ mod tests {
             AlgorithmLimits::default(),
         )
         .unwrap()
-        .rows;
+        .rows();
         assert_eq!(
             rows,
             vec![
@@ -2594,7 +2597,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap()
-            .rows,
+            .rows(),
             vec![vec![
                 value(0),
                 value(4),
@@ -3051,7 +3054,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap()
-            .rows,
+            .rows(),
             output.rows()
         );
     }
@@ -3123,7 +3126,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap()
-            .rows,
+            .rows(),
             output.rows()
         );
     }
@@ -3140,7 +3143,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap()
-            .rows,
+            .rows(),
             Vec::<Vec<AlgorithmValue>>::new()
         );
         assert!(matches!(

--- a/crates/graphforge-exec/src/algorithm_paths.rs
+++ b/crates/graphforge-exec/src/algorithm_paths.rs
@@ -2190,7 +2190,7 @@ mod tests {
                 },
             ),
             Err(AlgorithmError::OutputLimit {
-                observed: 5,
+                observed: 2,
                 limit: 1
             })
         ));
@@ -2651,7 +2651,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             ),
             Err(AlgorithmError::OutputLimit {
-                observed: 4,
+                observed: 3,
                 limit: 2
             })
         ));

--- a/crates/graphforge-exec/src/algorithm_paths_min_cost_flow.rs
+++ b/crates/graphforge-exec/src/algorithm_paths_min_cost_flow.rs
@@ -245,9 +245,8 @@ pub(crate) fn shape_min_cost_flow_output(
     });
     let output_rows = if edges { solution.edge_flows.len() } else { 1 };
     control.check_output_rows(output_rows)?;
-    let mut rows = Vec::new();
-    reserve_vec(&mut rows, output_rows, "output rows")?;
-    let rows = if edges {
+    let mut output = control.output_sink(algorithm)?;
+    if edges {
         for row in solution.edge_flows {
             let mut values = Vec::new();
             reserve_vec(&mut values, 6, "edge output values")?;
@@ -259,9 +258,8 @@ pub(crate) fn shape_min_cost_flow_output(
                 AlgorithmValue::Float64(row.edge.unit_cost),
                 AlgorithmValue::Float64(row.flow_cost),
             ]);
-            rows.push(values);
+            output.append_row(&values)?;
         }
-        rows
     } else {
         let mut values = Vec::new();
         reserve_vec(&mut values, 4, "scalar output values")?;
@@ -271,13 +269,9 @@ pub(crate) fn shape_min_cost_flow_output(
             AlgorithmValue::Float64(solution.flow),
             AlgorithmValue::Float64(solution.cost),
         ]);
-        rows.push(values);
-        rows
-    };
-    Ok(AlgorithmOutput {
-        schema: algorithm.result_schema(),
-        rows,
-    })
+        output.append_row(&values)?;
+    }
+    output.finish()
 }
 
 fn refine_lexicographic_ties(
@@ -820,8 +814,8 @@ mod tests {
             scalar.schema,
             Algorithm::Paths(PathAlgorithm::MinCostMaxFlow).result_schema()
         );
-        assert_eq!(scalar.rows.len(), 1);
-        assert_eq!(scalar.rows[0].len(), 4);
+        assert_eq!(scalar.rows().len(), 1);
+        assert_eq!(scalar.rows()[0].len(), 4);
 
         let edges =
             shape_min_cost_flow_output(solution, uuid(1), uuid(2), true, &control()).unwrap();
@@ -829,8 +823,8 @@ mod tests {
             edges.schema,
             Algorithm::Paths(PathAlgorithm::MinCostMaxFlowEdges).result_schema()
         );
-        assert_eq!(edges.rows.len(), 1);
-        assert_eq!(edges.rows[0].len(), 6);
+        assert_eq!(edges.rows().len(), 1);
+        assert_eq!(edges.rows()[0].len(), 6);
     }
 
     #[test]

--- a/crates/graphforge-exec/src/algorithm_rank.rs
+++ b/crates/graphforge-exec/src/algorithm_rank.rs
@@ -95,7 +95,8 @@ impl RustAlgorithm for Degree {
             graph.node_ids().len().saturating_sub(1).max(1),
             "node count",
         )?;
-        let mut rows = Vec::with_capacity(graph.node_ids().len());
+        let algorithm = Algorithm::Rank(RankAlgorithm::Degree);
+        let mut sink = control.output_sink(algorithm)?;
         for (index, &node_id) in graph.node_ids().iter().enumerate() {
             if index % 1024 == 0 {
                 control.checkpoint()?;
@@ -104,15 +105,12 @@ impl RustAlgorithm for Degree {
                 .node_uuid(node_id)
                 .ok_or_else(|| execution("selected node has no UUID identity"))?;
             let degree = exact_u32(graph.neighbors(node_id).len(), "node degree")?;
-            rows.push(vec![
+            sink.append_row(&[
                 AlgorithmValue::Uuid(uuid),
                 AlgorithmValue::Float64(f64::from(degree) / f64::from(denominator)),
-            ]);
+            ])?;
         }
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Rank(RankAlgorithm::Degree).result_schema(),
-            rows,
-        })
+        sink.finish()
     }
 }
 
@@ -133,10 +131,7 @@ impl RustAlgorithm for PageRank {
         let algorithm = Algorithm::Rank(RankAlgorithm::PageRank);
         let node_count = graph.node_ids().len();
         if node_count == 0 {
-            return Ok(AlgorithmOutput {
-                schema: algorithm.result_schema(),
-                rows: Vec::new(),
-            });
+            return AlgorithmOutput::empty(algorithm, control);
         }
 
         let indices: HashMap<u64, usize> = graph
@@ -199,10 +194,7 @@ impl RustAlgorithm for PageRank {
                 ])
             })
             .collect::<Result<Vec<_>, AlgorithmError>>()?;
-        Ok(AlgorithmOutput {
-            schema: algorithm.result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(algorithm, control, rows)
     }
 }
 
@@ -223,10 +215,7 @@ impl RustAlgorithm for Betweenness {
         let algorithm = Algorithm::Rank(RankAlgorithm::Betweenness);
         let node_ids = graph.node_ids();
         if node_ids.is_empty() {
-            return Ok(AlgorithmOutput {
-                schema: algorithm.result_schema(),
-                rows: Vec::new(),
-            });
+            return AlgorithmOutput::empty(algorithm, control);
         }
 
         let indices: HashMap<u64, usize> = node_ids
@@ -319,10 +308,7 @@ impl RustAlgorithm for Betweenness {
                 ])
             })
             .collect::<Result<Vec<_>, AlgorithmError>>()?;
-        Ok(AlgorithmOutput {
-            schema: algorithm.result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(algorithm, control, rows)
     }
 }
 
@@ -343,10 +329,7 @@ impl RustAlgorithm for Closeness {
         let algorithm = Algorithm::Rank(RankAlgorithm::Closeness);
         let node_ids = graph.node_ids();
         if node_ids.is_empty() {
-            return Ok(AlgorithmOutput {
-                schema: algorithm.result_schema(),
-                rows: Vec::new(),
-            });
+            return AlgorithmOutput::empty(algorithm, control);
         }
 
         let indices: HashMap<u64, usize> = node_ids
@@ -414,10 +397,7 @@ impl RustAlgorithm for Closeness {
                 ])
             })
             .collect::<Result<Vec<_>, AlgorithmError>>()?;
-        Ok(AlgorithmOutput {
-            schema: algorithm.result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(algorithm, control, rows)
     }
 }
 
@@ -438,10 +418,7 @@ impl RustAlgorithm for HarmonicCloseness {
         let algorithm = Algorithm::Rank(RankAlgorithm::HarmonicCloseness);
         let node_ids = graph.node_ids();
         if node_ids.is_empty() {
-            return Ok(AlgorithmOutput {
-                schema: algorithm.result_schema(),
-                rows: Vec::new(),
-            });
+            return AlgorithmOutput::empty(algorithm, control);
         }
 
         let indices: HashMap<u64, usize> = node_ids
@@ -507,10 +484,7 @@ impl RustAlgorithm for HarmonicCloseness {
                 ])
             })
             .collect::<Result<Vec<_>, AlgorithmError>>()?;
-        Ok(AlgorithmOutput {
-            schema: algorithm.result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(algorithm, control, rows)
     }
 }
 
@@ -531,10 +505,7 @@ impl RustAlgorithm for Eigenvector {
         let algorithm = Algorithm::Rank(RankAlgorithm::Eigenvector);
         let node_ids = graph.node_ids();
         if node_ids.is_empty() {
-            return Ok(AlgorithmOutput {
-                schema: algorithm.result_schema(),
-                rows: Vec::new(),
-            });
+            return AlgorithmOutput::empty(algorithm, control);
         }
 
         let indices: HashMap<u64, usize> = node_ids
@@ -595,10 +566,7 @@ impl RustAlgorithm for Eigenvector {
                 ])
             })
             .collect::<Result<Vec<_>, AlgorithmError>>()?;
-        Ok(AlgorithmOutput {
-            schema: algorithm.result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(algorithm, control, rows)
     }
 }
 
@@ -619,10 +587,7 @@ impl RustAlgorithm for ArticleRank {
         let algorithm = Algorithm::Rank(RankAlgorithm::ArticleRank);
         let node_ids = graph.node_ids();
         if node_ids.is_empty() {
-            return Ok(AlgorithmOutput {
-                schema: algorithm.result_schema(),
-                rows: Vec::new(),
-            });
+            return AlgorithmOutput::empty(algorithm, control);
         }
 
         let indices: HashMap<u64, usize> = node_ids
@@ -694,10 +659,7 @@ impl RustAlgorithm for ArticleRank {
                 ])
             })
             .collect::<Result<Vec<_>, AlgorithmError>>()?;
-        Ok(AlgorithmOutput {
-            schema: algorithm.result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(algorithm, control, rows)
     }
 }
 
@@ -717,7 +679,7 @@ impl RustAlgorithm for HitsHub {
     ) -> Result<AlgorithmOutput, AlgorithmError> {
         let algorithm = Algorithm::Rank(RankAlgorithm::HitsHub);
         let (_, hubs) = hits_scores(graph, control)?;
-        rank_scores_output(algorithm, graph, hubs)
+        rank_scores_output(algorithm, graph, hubs, control)
     }
 }
 
@@ -737,7 +699,7 @@ impl RustAlgorithm for HitsAuthority {
     ) -> Result<AlgorithmOutput, AlgorithmError> {
         let algorithm = Algorithm::Rank(RankAlgorithm::HitsAuthority);
         let (authorities, _) = hits_scores(graph, control)?;
-        rank_scores_output(algorithm, graph, authorities)
+        rank_scores_output(algorithm, graph, authorities, control)
     }
 }
 
@@ -756,7 +718,7 @@ impl RustAlgorithm for Celf {
         control: &AlgorithmControl,
     ) -> Result<AlgorithmOutput, AlgorithmError> {
         let algorithm = Algorithm::Rank(RankAlgorithm::Celf);
-        rank_scores_output(algorithm, graph, celf_scores(graph, control)?)
+        rank_scores_output(algorithm, graph, celf_scores(graph, control)?, control)
     }
 }
 
@@ -775,11 +737,7 @@ impl RustAlgorithm for ClusteringCoefficient {
         control: &AlgorithmControl,
     ) -> Result<AlgorithmOutput, AlgorithmError> {
         let algorithm = Algorithm::Rank(RankAlgorithm::ClusteringCoefficient);
-        rank_scores_output(
-            algorithm,
-            graph,
-            clustering_coefficient_scores(graph, control)?,
-        )
+        rank_scores_output(algorithm, graph, clustering_coefficient_scores(graph, control)?, control)
     }
 }
 
@@ -798,7 +756,7 @@ impl RustAlgorithm for Triangles {
         control: &AlgorithmControl,
     ) -> Result<AlgorithmOutput, AlgorithmError> {
         let algorithm = Algorithm::Rank(RankAlgorithm::Triangles);
-        rank_scores_output(algorithm, graph, triangle_scores(graph, control)?)
+        rank_scores_output(algorithm, graph, triangle_scores(graph, control)?, control)
     }
 }
 
@@ -817,7 +775,7 @@ impl RustAlgorithm for KCore {
         control: &AlgorithmControl,
     ) -> Result<AlgorithmOutput, AlgorithmError> {
         let algorithm = Algorithm::Rank(RankAlgorithm::KCore);
-        rank_scores_output(algorithm, graph, k_core_scores(graph, control)?)
+        rank_scores_output(algorithm, graph, k_core_scores(graph, control)?, control)
     }
 }
 
@@ -836,11 +794,7 @@ impl RustAlgorithm for PreferentialAttachment {
         control: &AlgorithmControl,
     ) -> Result<AlgorithmOutput, AlgorithmError> {
         let algorithm = Algorithm::Rank(RankAlgorithm::PreferentialAttachment);
-        rank_scores_output(
-            algorithm,
-            graph,
-            preferential_attachment_scores(graph, control)?,
-        )
+        rank_scores_output(algorithm, graph, preferential_attachment_scores(graph, control)?, control)
     }
 }
 
@@ -859,7 +813,7 @@ impl RustAlgorithm for AdamicAdar {
         control: &AlgorithmControl,
     ) -> Result<AlgorithmOutput, AlgorithmError> {
         let algorithm = Algorithm::Rank(RankAlgorithm::AdamicAdar);
-        rank_scores_output(algorithm, graph, adamic_adar_scores(graph, control)?)
+        rank_scores_output(algorithm, graph, adamic_adar_scores(graph, control)?, control)
     }
 }
 
@@ -878,7 +832,7 @@ impl RustAlgorithm for CommonNeighbors {
         control: &AlgorithmControl,
     ) -> Result<AlgorithmOutput, AlgorithmError> {
         let algorithm = Algorithm::Rank(RankAlgorithm::CommonNeighbors);
-        rank_scores_output(algorithm, graph, common_neighbor_scores(graph, control)?)
+        rank_scores_output(algorithm, graph, common_neighbor_scores(graph, control)?, control)
     }
 }
 
@@ -897,11 +851,7 @@ impl RustAlgorithm for ResourceAllocation {
         control: &AlgorithmControl,
     ) -> Result<AlgorithmOutput, AlgorithmError> {
         let algorithm = Algorithm::Rank(RankAlgorithm::ResourceAllocation);
-        rank_scores_output(
-            algorithm,
-            graph,
-            resource_allocation_scores(graph, control)?,
-        )
+        rank_scores_output(algorithm, graph, resource_allocation_scores(graph, control)?, control)
     }
 }
 
@@ -920,7 +870,7 @@ impl RustAlgorithm for TotalNeighbors {
         control: &AlgorithmControl,
     ) -> Result<AlgorithmOutput, AlgorithmError> {
         let algorithm = Algorithm::Rank(RankAlgorithm::TotalNeighbors);
-        rank_scores_output(algorithm, graph, total_neighbor_scores(graph, control)?)
+        rank_scores_output(algorithm, graph, total_neighbor_scores(graph, control)?, control)
     }
 }
 
@@ -1554,25 +1504,19 @@ fn rank_scores_output(
     algorithm: Algorithm,
     graph: &AdjacencyGraph,
     scores: Vec<f64>,
+    control: &AlgorithmControl,
 ) -> Result<AlgorithmOutput, AlgorithmError> {
-    let rows = graph
-        .node_ids()
-        .iter()
-        .zip(scores)
-        .map(|(&node, score)| {
-            let uuid = graph
-                .node_uuid(node)
-                .ok_or_else(|| execution("selected node has no UUID identity"))?;
-            Ok(vec![
-                AlgorithmValue::Uuid(uuid),
-                AlgorithmValue::Float64(score),
-            ])
-        })
-        .collect::<Result<Vec<_>, AlgorithmError>>()?;
-    Ok(AlgorithmOutput {
-        schema: algorithm.result_schema(),
-        rows,
-    })
+    let mut sink = control.output_sink(algorithm)?;
+    for (&node, score) in graph.node_ids().iter().zip(scores) {
+        let uuid = graph
+            .node_uuid(node)
+            .ok_or_else(|| execution("selected node has no UUID identity"))?;
+        sink.append_row(&[
+            AlgorithmValue::Uuid(uuid),
+            AlgorithmValue::Float64(score),
+        ])?;
+    }
+    sink.finish()
 }
 
 fn accumulate_hits_phase(
@@ -1770,7 +1714,7 @@ mod tests {
 
     fn pagerank_scores(output: &AlgorithmOutput) -> Vec<f64> {
         output
-            .rows
+            .rows()
             .iter()
             .map(|row| match row[1] {
                 AlgorithmValue::Float64(score) => score,
@@ -1795,7 +1739,7 @@ mod tests {
 
     fn betweenness_scores(output: &AlgorithmOutput) -> Vec<f64> {
         output
-            .rows
+            .rows()
             .iter()
             .map(|row| match row[1] {
                 AlgorithmValue::Float64(score) => score,
@@ -1820,7 +1764,7 @@ mod tests {
 
     fn closeness_scores(output: &AlgorithmOutput) -> Vec<f64> {
         output
-            .rows
+            .rows()
             .iter()
             .map(|row| match row[1] {
                 AlgorithmValue::Float64(score) => score,
@@ -1845,7 +1789,7 @@ mod tests {
 
     fn harmonic_closeness_scores(output: &AlgorithmOutput) -> Vec<f64> {
         output
-            .rows
+            .rows()
             .iter()
             .map(|row| match row[1] {
                 AlgorithmValue::Float64(score) => score,
@@ -1870,7 +1814,7 @@ mod tests {
 
     fn eigenvector_scores(output: &AlgorithmOutput) -> Vec<f64> {
         output
-            .rows
+            .rows()
             .iter()
             .map(|row| match row[1] {
                 AlgorithmValue::Float64(score) => score,
@@ -1906,7 +1850,7 @@ mod tests {
 
     fn article_rank_scores(output: &AlgorithmOutput) -> Vec<f64> {
         output
-            .rows
+            .rows()
             .iter()
             .map(|row| match row[1] {
                 AlgorithmValue::Float64(score) => score,
@@ -1931,7 +1875,7 @@ mod tests {
 
     fn hits_hub_scores(output: &AlgorithmOutput) -> Vec<f64> {
         output
-            .rows
+            .rows()
             .iter()
             .map(|row| match row[1] {
                 AlgorithmValue::Float64(score) => score,
@@ -1956,7 +1900,7 @@ mod tests {
 
     fn hits_authority_scores(output: &AlgorithmOutput) -> Vec<f64> {
         output
-            .rows
+            .rows()
             .iter()
             .map(|row| match row[1] {
                 AlgorithmValue::Float64(score) => score,
@@ -2155,7 +2099,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            output.rows,
+            output.rows(),
             vec![
                 vec![AlgorithmValue::Uuid([0; 16]), AlgorithmValue::Float64(2.0)],
                 vec![
@@ -2178,7 +2122,7 @@ mod tests {
         assert!(
             execute_degree(&AdjacencyGraph::default(), AlgorithmLimits::default())
                 .unwrap()
-                .rows
+                .rows()
                 .is_empty()
         );
         let limits = AlgorithmLimits {
@@ -2237,7 +2181,7 @@ mod tests {
             AlgorithmCancellation::default(),
         )
         .unwrap();
-        assert!(empty.rows.is_empty());
+        assert!(empty.rows().is_empty());
     }
 
     #[test]
@@ -2397,7 +2341,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap()
-            .rows
+            .rows()
             .is_empty()
         );
     }
@@ -2531,7 +2475,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap()
-            .rows
+            .rows()
             .is_empty()
         );
         assert_eq!(
@@ -2676,7 +2620,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap()
-            .rows
+            .rows()
             .is_empty()
         );
         assert_eq!(
@@ -2839,7 +2783,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap()
-            .rows
+            .rows()
             .is_empty()
         );
     }
@@ -3002,7 +2946,7 @@ mod tests {
                 AlgorithmCancellation::default()
             )
             .unwrap()
-            .rows
+            .rows()
             .is_empty()
         );
     }
@@ -3147,7 +3091,7 @@ mod tests {
                 AlgorithmCancellation::default()
             )
             .unwrap()
-            .rows
+            .rows()
             .is_empty()
         );
     }
@@ -3283,7 +3227,7 @@ mod tests {
                 AlgorithmCancellation::default()
             )
             .unwrap()
-            .rows
+            .rows()
             .is_empty()
         );
     }
@@ -3482,7 +3426,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap()
-            .rows
+            .rows()
             .is_empty()
         );
     }
@@ -3573,7 +3517,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap()
-            .rows
+            .rows()
             .is_empty()
         );
     }
@@ -3674,7 +3618,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap()
-            .rows
+            .rows()
             .is_empty()
         );
     }
@@ -3825,7 +3769,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap()
-            .rows
+            .rows()
             .is_empty()
         );
     }
@@ -3974,7 +3918,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap()
-            .rows
+            .rows()
             .is_empty()
         );
     }
@@ -4117,7 +4061,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap()
-            .rows
+            .rows()
             .is_empty()
         );
     }
@@ -4262,7 +4206,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap()
-            .rows
+            .rows()
             .is_empty()
         );
     }
@@ -4428,7 +4372,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap()
-            .rows
+            .rows()
             .is_empty()
         );
     }

--- a/crates/graphforge-exec/src/algorithm_rank.rs
+++ b/crates/graphforge-exec/src/algorithm_rank.rs
@@ -17,7 +17,9 @@ use crate::algorithm_dispatch::{
 use crate::algorithm_graph::{AdjacencyGraph, AdjacencySelection, export_adjacency};
 use crate::algorithm_k_core::k_core_numbers;
 use crate::algorithm_neighbors::{simple_neighbors, simple_undirected_neighbors};
-use crate::algorithm_output::{materialize_node_properties, shape_algorithm_output};
+use crate::algorithm_output::{
+    materialize_node_properties_with_batch_size, shape_algorithm_output,
+};
 
 const BUILTIN_REVIEW: DependencyReview = DependencyReview {
     implementation: "graphforge-exec built-in",
@@ -737,7 +739,12 @@ impl RustAlgorithm for ClusteringCoefficient {
         control: &AlgorithmControl,
     ) -> Result<AlgorithmOutput, AlgorithmError> {
         let algorithm = Algorithm::Rank(RankAlgorithm::ClusteringCoefficient);
-        rank_scores_output(algorithm, graph, clustering_coefficient_scores(graph, control)?, control)
+        rank_scores_output(
+            algorithm,
+            graph,
+            clustering_coefficient_scores(graph, control)?,
+            control,
+        )
     }
 }
 
@@ -794,7 +801,12 @@ impl RustAlgorithm for PreferentialAttachment {
         control: &AlgorithmControl,
     ) -> Result<AlgorithmOutput, AlgorithmError> {
         let algorithm = Algorithm::Rank(RankAlgorithm::PreferentialAttachment);
-        rank_scores_output(algorithm, graph, preferential_attachment_scores(graph, control)?, control)
+        rank_scores_output(
+            algorithm,
+            graph,
+            preferential_attachment_scores(graph, control)?,
+            control,
+        )
     }
 }
 
@@ -813,7 +825,12 @@ impl RustAlgorithm for AdamicAdar {
         control: &AlgorithmControl,
     ) -> Result<AlgorithmOutput, AlgorithmError> {
         let algorithm = Algorithm::Rank(RankAlgorithm::AdamicAdar);
-        rank_scores_output(algorithm, graph, adamic_adar_scores(graph, control)?, control)
+        rank_scores_output(
+            algorithm,
+            graph,
+            adamic_adar_scores(graph, control)?,
+            control,
+        )
     }
 }
 
@@ -832,7 +849,12 @@ impl RustAlgorithm for CommonNeighbors {
         control: &AlgorithmControl,
     ) -> Result<AlgorithmOutput, AlgorithmError> {
         let algorithm = Algorithm::Rank(RankAlgorithm::CommonNeighbors);
-        rank_scores_output(algorithm, graph, common_neighbor_scores(graph, control)?, control)
+        rank_scores_output(
+            algorithm,
+            graph,
+            common_neighbor_scores(graph, control)?,
+            control,
+        )
     }
 }
 
@@ -851,7 +873,12 @@ impl RustAlgorithm for ResourceAllocation {
         control: &AlgorithmControl,
     ) -> Result<AlgorithmOutput, AlgorithmError> {
         let algorithm = Algorithm::Rank(RankAlgorithm::ResourceAllocation);
-        rank_scores_output(algorithm, graph, resource_allocation_scores(graph, control)?, control)
+        rank_scores_output(
+            algorithm,
+            graph,
+            resource_allocation_scores(graph, control)?,
+            control,
+        )
     }
 }
 
@@ -870,7 +897,12 @@ impl RustAlgorithm for TotalNeighbors {
         control: &AlgorithmControl,
     ) -> Result<AlgorithmOutput, AlgorithmError> {
         let algorithm = Algorithm::Rank(RankAlgorithm::TotalNeighbors);
-        rank_scores_output(algorithm, graph, total_neighbor_scores(graph, control)?, control)
+        rank_scores_output(
+            algorithm,
+            graph,
+            total_neighbor_scores(graph, control)?,
+            control,
+        )
     }
 }
 
@@ -1511,10 +1543,7 @@ fn rank_scores_output(
         let uuid = graph
             .node_uuid(node)
             .ok_or_else(|| execution("selected node has no UUID identity"))?;
-        sink.append_row(&[
-            AlgorithmValue::Uuid(uuid),
-            AlgorithmValue::Float64(score),
-        ])?;
+        sink.append_row(&[AlgorithmValue::Uuid(uuid), AlgorithmValue::Float64(score)])?;
     }
     sink.finish()
 }
@@ -1598,11 +1627,33 @@ pub fn rank_algorithm(
     property_stems: &[String],
     options: &RankOptions,
 ) -> Result<RecordBatch, GfError> {
+    rank_algorithm_with_limits(
+        provider,
+        dir,
+        mode,
+        label,
+        property_stems,
+        options,
+        AlgorithmLimits::default(),
+    )
+}
+
+/// Execute rank with an explicit output/memory shaping policy (#341).
+pub fn rank_algorithm_with_limits(
+    provider: &dyn AdjacencyProvider,
+    dir: &Path,
+    mode: OntologyMode,
+    label: TypeId,
+    property_stems: &[String],
+    options: &RankOptions,
+    limits: AlgorithmLimits,
+) -> Result<RecordBatch, GfError> {
     let graph = rank_projection(provider, dir, mode, label, options)?;
     let algorithm = Algorithm::Rank(options.by);
-    let output = execute_rank(&graph, algorithm, AlgorithmLimits::default())?;
+    let output = execute_rank(&graph, algorithm, limits)?;
     let batch = shape_algorithm_output(algorithm, &output)?;
-    materialize_node_properties(dir, property_stems, &batch).map_err(Into::into)
+    materialize_node_properties_with_batch_size(dir, property_stems, &batch, limits.batch_size)
+        .map_err(Into::into)
 }
 
 /// Fingerprint the exact logical topology consumed by a rank invocation.

--- a/crates/graphforge-exec/src/algorithm_similar.rs
+++ b/crates/graphforge-exec/src/algorithm_similar.rs
@@ -222,7 +222,11 @@ impl RustAlgorithm for NodeSimilarity {
                 ])
             })
             .collect::<Result<Vec<_>, AlgorithmError>>()?;
-        AlgorithmOutput::from_rows(Algorithm::Similar(SimilarAlgorithm::NodeSimilarity), control, rows)
+        AlgorithmOutput::from_rows(
+            Algorithm::Similar(SimilarAlgorithm::NodeSimilarity),
+            control,
+            rows,
+        )
     }
 }
 
@@ -258,7 +262,11 @@ impl RustAlgorithm for FilteredNodeSimilarity {
                 ])
             })
             .collect::<Result<Vec<_>, AlgorithmError>>()?;
-        AlgorithmOutput::from_rows(Algorithm::Similar(SimilarAlgorithm::FilteredNodeSimilarity), control, rows)
+        AlgorithmOutput::from_rows(
+            Algorithm::Similar(SimilarAlgorithm::FilteredNodeSimilarity),
+            control,
+            rows,
+        )
     }
 }
 
@@ -328,6 +336,27 @@ pub fn similar_algorithm(
     property_stems: &[String],
     options: SimilarOptions,
 ) -> Result<RecordBatch, GfError> {
+    similar_algorithm_with_limits(
+        provider,
+        dir,
+        mode,
+        label,
+        property_stems,
+        options,
+        crate::algorithm_dispatch::AlgorithmLimits::default(),
+    )
+}
+
+/// Execute similarity with an explicit output/memory shaping policy (#341).
+pub fn similar_algorithm_with_limits(
+    provider: &dyn AdjacencyProvider,
+    dir: &Path,
+    mode: OntologyMode,
+    label: TypeId,
+    property_stems: &[String],
+    options: SimilarOptions,
+    limits: crate::algorithm_dispatch::AlgorithmLimits,
+) -> Result<RecordBatch, GfError> {
     let graph = similar_projection(provider, dir, mode, label, property_stems, &options)?;
     let algorithm = Algorithm::Similar(options.by);
     let mut registry = AlgorithmRegistry::default();
@@ -337,7 +366,7 @@ pub fn similar_algorithm(
         algorithm,
         &graph,
         &AlgorithmControl::new(
-            crate::algorithm_dispatch::AlgorithmLimits::default(),
+            limits,
             crate::algorithm_dispatch::AlgorithmCancellation::default(),
         ),
     )?;

--- a/crates/graphforge-exec/src/algorithm_similar.rs
+++ b/crates/graphforge-exec/src/algorithm_similar.rs
@@ -602,7 +602,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap()
-            .rows,
+            .rows(),
             vec![
                 vec![uuid(0), uuid(1), AlgorithmValue::Float64(1.0)],
                 vec![uuid(1), uuid(0), AlgorithmValue::Float64(1.0)],
@@ -617,7 +617,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap()
-            .rows
+            .rows()
             .is_empty()
         );
         assert!(
@@ -628,7 +628,7 @@ mod tests {
                 AlgorithmCancellation::default(),
             )
             .unwrap()
-            .rows
+            .rows()
             .is_empty()
         );
         assert!(matches!(

--- a/crates/graphforge-exec/src/algorithm_similar.rs
+++ b/crates/graphforge-exec/src/algorithm_similar.rs
@@ -76,7 +76,7 @@ impl RustAlgorithm for Knn {
                     .ok_or_else(|| execution("validated KNN vector is missing"))
             })
             .collect::<Result<Vec<_>, _>>()?;
-        let rows = exact_cosine_knn(&vectors, self.k, control)?
+        let rows: Vec<Vec<AlgorithmValue>> = exact_cosine_knn(&vectors, self.k, control)?
             .into_iter()
             .map(|pair| {
                 let source = graph.node_ids()[pair.source_index];
@@ -96,10 +96,7 @@ impl RustAlgorithm for Knn {
                 ])
             })
             .collect::<Result<Vec<_>, AlgorithmError>>()?;
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Similar(SimilarAlgorithm::Knn).result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(Algorithm::Similar(SimilarAlgorithm::Knn), control, rows)
     }
 }
 
@@ -118,7 +115,7 @@ impl RustAlgorithm for Cosine {
         control: &AlgorithmControl,
     ) -> Result<AlgorithmOutput, AlgorithmError> {
         let pairs = exact_cosine_similarity(&selected_vectors(graph)?, self.k, control)?;
-        knn_output(graph, SimilarAlgorithm::Cosine, pairs)
+        knn_output(graph, SimilarAlgorithm::Cosine, pairs, control)
     }
 }
 
@@ -139,7 +136,7 @@ impl RustAlgorithm for FilteredKnn {
         let candidates = neighbor_indices(graph, "filtered KNN")?;
         let pairs =
             exact_filtered_cosine_knn(&selected_vectors(graph)?, &candidates, self.k, control)?;
-        knn_output(graph, SimilarAlgorithm::FilteredKnn, pairs)
+        knn_output(graph, SimilarAlgorithm::FilteredKnn, pairs, control)
     }
 }
 
@@ -159,8 +156,9 @@ fn knn_output(
     graph: &AdjacencyGraph,
     algorithm: SimilarAlgorithm,
     pairs: Vec<SimilarityPair>,
+    control: &AlgorithmControl,
 ) -> Result<AlgorithmOutput, AlgorithmError> {
-    let rows = pairs
+    let rows: Vec<Vec<AlgorithmValue>> = pairs
         .into_iter()
         .map(|pair| {
             let source = graph.node_ids()[pair.source_index];
@@ -180,10 +178,7 @@ fn knn_output(
             ])
         })
         .collect::<Result<Vec<_>, AlgorithmError>>()?;
-    Ok(AlgorithmOutput {
-        schema: Algorithm::Similar(algorithm).result_schema(),
-        rows,
-    })
+    AlgorithmOutput::from_rows(Algorithm::Similar(algorithm), control, rows)
 }
 
 impl RustAlgorithm for NodeSimilarity {
@@ -211,7 +206,7 @@ impl RustAlgorithm for NodeSimilarity {
                     .collect()
             })
             .collect();
-        let rows = exact_jaccard(&neighborhoods, None, self.k, control)?
+        let rows: Vec<Vec<AlgorithmValue>> = exact_jaccard(&neighborhoods, None, self.k, control)?
             .into_iter()
             .map(|pair| {
                 let source_uuid = graph
@@ -227,10 +222,7 @@ impl RustAlgorithm for NodeSimilarity {
                 ])
             })
             .collect::<Result<Vec<_>, AlgorithmError>>()?;
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Similar(SimilarAlgorithm::NodeSimilarity).result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(Algorithm::Similar(SimilarAlgorithm::NodeSimilarity), control, rows)
     }
 }
 
@@ -250,7 +242,7 @@ impl RustAlgorithm for FilteredNodeSimilarity {
     ) -> Result<AlgorithmOutput, AlgorithmError> {
         let candidates = neighbor_indices(graph, "filtered node similarity")?;
         let pairs = exact_jaccard(&neighborhoods(graph), Some(&candidates), self.k, control)?;
-        let rows = pairs
+        let rows: Vec<Vec<AlgorithmValue>> = pairs
             .into_iter()
             .map(|pair| {
                 let source_uuid = graph
@@ -266,10 +258,7 @@ impl RustAlgorithm for FilteredNodeSimilarity {
                 ])
             })
             .collect::<Result<Vec<_>, AlgorithmError>>()?;
-        Ok(AlgorithmOutput {
-            schema: Algorithm::Similar(SimilarAlgorithm::FilteredNodeSimilarity).result_schema(),
-            rows,
-        })
+        AlgorithmOutput::from_rows(Algorithm::Similar(SimilarAlgorithm::FilteredNodeSimilarity), control, rows)
     }
 }
 
@@ -541,7 +530,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            output.rows,
+            output.rows(),
             vec![
                 vec![uuid(0), uuid(1), AlgorithmValue::Float64(1.0)],
                 vec![uuid(0), uuid(2), AlgorithmValue::Float64(0.5)],
@@ -564,7 +553,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            top_one.rows,
+            top_one.rows(),
             vec![
                 vec![uuid(0), uuid(1), AlgorithmValue::Float64(1.0)],
                 vec![uuid(1), uuid(0), AlgorithmValue::Float64(1.0)],

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -113,6 +113,7 @@ mod algorithm_embedding_invocation;
 pub(crate) mod algorithm_embedding_options;
 pub use algorithm_embedding_options::validate_embedding_options;
 pub use algorithm_graph::AlgorithmProjectionFingerprint;
+pub(crate) mod algorithm_arrow_sink;
 #[allow(
     dead_code,
     reason = "Node2Vec activation consumes the deterministic walk corpus"
@@ -133,7 +134,6 @@ pub(crate) mod algorithm_k_core;
 pub(crate) mod algorithm_matching_blossom;
 pub(crate) mod algorithm_matching_state;
 pub(crate) mod algorithm_neighbors;
-pub(crate) mod algorithm_arrow_sink;
 pub(crate) mod algorithm_output;
 #[allow(
     dead_code,
@@ -197,14 +197,19 @@ pub use algorithm_analyze::{
     analyze_algorithm, analyze_projection_fingerprint, embedding_algorithm,
     embedding_algorithm_execution, prepare_embedding_invocation_descriptor,
 };
-pub use algorithm_cluster::{cluster_algorithm, cluster_projection_fingerprint};
+pub use algorithm_cluster::{
+    cluster_algorithm, cluster_algorithm_with_limits, cluster_projection_fingerprint,
+};
+pub use algorithm_dispatch::AlgorithmLimits;
 pub use algorithm_embedding_invocation::{
     EmbeddingExecution, EmbeddingInvocationDescriptor, EmbeddingInvocationLimits,
     EmbeddingProjectionSelector, EmbeddingRngContract,
 };
 pub use algorithm_paths::{paths_algorithm, paths_projection_fingerprint};
-pub use algorithm_rank::{rank_algorithm, rank_projection_fingerprint};
-pub use algorithm_similar::{similar_algorithm, similar_projection_fingerprint};
+pub use algorithm_rank::{rank_algorithm, rank_algorithm_with_limits, rank_projection_fingerprint};
+pub use algorithm_similar::{
+    similar_algorithm, similar_algorithm_with_limits, similar_projection_fingerprint,
+};
 
 mod write_driver;
 

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -133,6 +133,7 @@ pub(crate) mod algorithm_k_core;
 pub(crate) mod algorithm_matching_blossom;
 pub(crate) mod algorithm_matching_state;
 pub(crate) mod algorithm_neighbors;
+pub(crate) mod algorithm_arrow_sink;
 pub(crate) mod algorithm_output;
 #[allow(
     dead_code,

--- a/crates/graphforge-storage/src/catalog.rs
+++ b/crates/graphforge-storage/src/catalog.rs
@@ -1035,6 +1035,31 @@ pub fn read_properties(dir: &Path, stem: &str) -> Result<Vec<RecordBatch>, DataF
     }
 }
 
+/// Stream `properties/<stem>.parquet` as bounded batches without concatenating
+/// the complete property table into one `RecordBatch` (#341 enrichment).
+///
+/// Returns an empty `Vec` when the file is absent. When present, batches honor
+/// `batch_size` (clamped to at least 1) and retain natural Parquet row-group
+/// boundaries subject to that cap.
+///
+/// # Errors
+/// Propagates Parquet / Arrow errors encountered while reading.
+pub fn read_properties_batched(
+    dir: &Path,
+    stem: &str,
+    batch_size: usize,
+) -> Result<Vec<RecordBatch>, DataFusionError> {
+    let path = dir.join("properties").join(format!("{stem}.parquet"));
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let file = File::open(&path).map_err(|e| io_err(&e))?;
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file).map_err(parquet_err)?;
+    let builder = builder.with_batch_size(batch_size.max(1));
+    let reader = builder.build().map_err(parquet_err)?;
+    reader.collect::<Result<Vec<_>, _>>().map_err(parquet_err)
+}
+
 /// Edge analogue of [`read_properties`]: read `edge_properties/<stem>.parquet`
 /// (keyed by `edge_uuid`), discovering its dynamic schema from the file. Returns
 /// an **empty `Vec`** when the file is absent.

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -175,7 +175,7 @@ pub use catalog::{
     EdgePropertyTable, GraphCatalog, PropertyTable, TopologyNodeTable, TypedEdgeTable,
     UnionEdgeTable, list_edge_property_stems, list_property_stems, read_edge_properties,
     read_edges, read_edges_filtered, read_edges_filtered_observed, read_nodes, read_nodes_filtered,
-    read_nodes_filtered_observed, read_properties,
+    read_nodes_filtered_observed, read_properties, read_properties_batched,
 };
 
 pub mod parquet_scan;

--- a/docs/book/architecture/algorithms.md
+++ b/docs/book/architecture/algorithms.md
@@ -40,7 +40,12 @@ semijoins) are added as needed without breaking the verb design.
 
 Production algorithms register one `RustAlgorithm` handler per typed catalog value in
 `graphforge-exec`. Dispatch, limits, cancellation, and Arrow result shaping are shared across the
-five verbs. igraph and NetworkX are optional development parity oracles only: they are not
+five verbs. Handlers append canonical values into a shared columnar
+`AlgorithmArrowSink` (#341) that builds bounded Arrow batches under the
+invocation `batch_size` from the [embedded resource policy](../../development/execution-resource-policy.md);
+they do not retain a second complete `Vec<Vec<AlgorithmValue>>` beside the final
+Arrow buffers. Property enrichment streams selected property tables by batch
+rather than concatenating them before UUID gather. igraph and NetworkX are optional development parity oracles only: they are not
 runtime backends, fallbacks, packaging dependencies, or recovery paths.
 
 ### Invocation and knowledge-layer boundary

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -12,7 +12,7 @@ Tokio runtime or any DataFusion execution session.
 |---|---|---|
 | `tokio_worker_threads` | `2` | Facade multi-thread Tokio runtime |
 | `target_partitions` | `2` | DataFusion `SessionConfig` |
-| `batch_size` | `8192` | DataFusion `SessionConfig` |
+| `batch_size` | `8192` | DataFusion `SessionConfig`; analyst Arrow shaping / property enrichment (#341) |
 | `memory_budget_bytes` | `512 MiB` | DataFusion `RuntimeEnv` memory pool |
 | `spill` | disabled | Optional absolute spill directory + byte cap |
 | `io_concurrency` | `2` | Reserved I/O concurrency budget |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Shape analyst-verb results directly into typed bounded Arrow builders/batches, removing the retained `AlgorithmOutput.rows: Vec<Vec<AlgorithmValue>>` second representation.

Rebased onto `main` after #339 merged.

## Changes

- `AlgorithmArrowSink` with batch rollover, schema enforcement, and coalesce-to-public-batch
- `AlgorithmOutput` holds Arrow batch (+ stats) only
- Property enrichment via batchwise gather (no full-table concat)
- Thread #337 `batch_size` into public rank/cluster/similar shaping

## Testing

```bash
cargo test -p graphforge-api --lib -- rank cluster similar
cargo test -p graphforge-exec --lib -- algorithm_output::
cargo clippy -p graphforge-api -p graphforge-exec -- -D warnings
```

Closes #341

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788912649&installation_model_id=20486&pr_number=491&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F491&signature=d98388acf3aa6abc7beec07fa33bdc02110ff6a2a288952c5c0d2a0282eb18df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route all analyst algorithm outputs through a bounded Arrow sink with configurable batch size
> - Introduces `AlgorithmArrowSink` in [algorithm_arrow_sink.rs](https://github.com/CurateLabs/graphforge/pull/491/files#diff-65c8e51ed7c3583923e5d4231e1dd93516ee34a077bbeff9f4e25fe8d13388cc), a columnar Arrow sink that appends `AlgorithmValue` rows into typed builders, flushing into `RecordBatch` chunks at a configurable `batch_size` and enforcing an output row limit.
> - Replaces manual `Vec<Vec<AlgorithmValue>>` accumulation and inline `AlgorithmOutput` construction across all algorithm families (rank, cluster, similar, paths, analyze) with sink-based `append_row`/`finish` calls or the `AlgorithmOutput::from_rows` helper.
> - `AlgorithmOutput` now holds a canonical Arrow `RecordBatch` internally; the `rows()` accessor decodes it on demand, removing the previously retained full in-memory row vector.
> - Exposes `rank_algorithm_with_limits`, `cluster_algorithm_with_limits`, and `similar_algorithm_with_limits` so callers can pass an explicit `AlgorithmLimits` (including `batch_size`). The `GraphForge` API wires these to `resource_policy.batch_size`.
> - Property enrichment in `materialize_node_properties` now streams parquet files as bounded `RecordBatch` chunks via `read_properties_batched` instead of concatenating the full table into memory.
> - Behavioral Change: `AlgorithmOutput` construction can now return errors at row-append or finish time (e.g. output limit exceeded, type mismatch), whereas previously it always succeeded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ae473c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->