### PR TITLE
perf(exec): parallelize PageRank updates deterministically (#343)

### DIFF
--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -382,7 +382,7 @@ pub struct GraphForge {
     write_options: GraphForgeOptions,
     /// Normalized execution resource policy applied to runtime and sessions (#337).
     resource_policy: resource_policy::NormalizedResourcePolicy,
-    /// Instance-owned private CPU pool for parallel algorithm kernels (#337 / #342).
+    /// Instance-owned private CPU pool for parallel algorithm kernels (#337 / #342 / #343).
     compute_pool: graphforge_exec::SharedComputePool,
     /// Instance-owned heavy-query admission gate (#337).
     heavy_query_admission: Arc<resource_policy::HeavyQueryAdmission>,
@@ -2329,7 +2329,7 @@ impl GraphForge {
             .read()
             .expect("adjacency visibility lock poisoned");
         self.adjacency_provider.revalidate();
-        let batch = graphforge_exec::rank_algorithm_with_limits(
+        let batch = graphforge_exec::rank_algorithm_with_compute(
             self.adjacency_provider.as_ref(),
             &self.dir,
             self.ontology_mode,
@@ -2337,7 +2337,9 @@ impl GraphForge {
             std::slice::from_ref(&stem),
             &dispatch_options,
             graphforge_exec::AlgorithmLimits::default()
-                .with_batch_size(self.resource_policy.batch_size),
+                .with_batch_size(self.resource_policy.batch_size)
+                .with_compute_threads(self.resource_policy.compute_threads),
+            Some(self.compute_pool.clone()),
         )?;
         self.write_algorithm_property(
             label,

--- a/crates/graphforge-api/src/resource_policy.rs
+++ b/crates/graphforge-api/src/resource_policy.rs
@@ -4,7 +4,7 @@
 //! batch size, memory, spill, I/O concurrency, and heavy-query admission
 //! before a [`crate::GraphForge`] instance begins work. `compute_threads`
 //! sizes the instance-owned private CPU pool consumed by parallel cosine KNN
-//! (#342) and future deterministic CPU kernels.
+//! (#342), parallel PageRank (#343), and sibling deterministic CPU kernels.
 
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
@@ -54,9 +54,10 @@ pub struct ExecutionResourcePolicy {
     pub io_concurrency: Option<usize>,
     /// Maximum concurrent heavy Cypher / analyst invocations. `None` → 64.
     pub max_concurrent_heavy_queries: Option<usize>,
-    /// Compute-thread budget for the instance-owned private CPU pool (#337 / #342).
+    /// Compute-thread budget for the instance-owned private CPU pool (#337 / #342 / #343).
     ///
-    /// Parallel cosine KNN partitions work by canonical source through that pool
+    /// Parallel cosine KNN partitions work by canonical source, and parallel
+    /// PageRank partitions destination-owned updates, through that pool
     /// when work exceeds the documented crossover; `1` keeps the serial path.
     pub compute_threads: Option<usize>,
 }
@@ -101,7 +102,7 @@ pub struct NormalizedResourcePolicy {
     pub io_concurrency: usize,
     /// Heavy-query admission slots.
     pub max_concurrent_heavy_queries: usize,
-    /// Compute-thread budget for the instance-owned private CPU pool (#342).
+    /// Compute-thread budget for the instance-owned private CPU pool (#342 / #343).
     pub compute_threads: usize,
     /// Machine logical parallelism observed at normalize time.
     pub observed_logical_cpus: usize,

--- a/crates/graphforge-exec/src/algorithm_rank.rs
+++ b/crates/graphforge-exec/src/algorithm_rank.rs
@@ -1,13 +1,20 @@
 //! Rust-owned rank handlers registered under the shared M18 dispatch contract.
+//!
+//! PageRank (#343) may partition destination-owned score updates across the
+//! instance-owned private compute pool while preserving the serial contribution
+//! order, dangling/delta reductions, and bit-identical fingerprints.
 
 use std::collections::{HashMap, VecDeque};
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::path::Path;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use arrow::record_batch::RecordBatch;
 use graphforge_core::algorithms::{Algorithm, RankAlgorithm};
 use graphforge_core::{GfError, OntologyMode, RankOptions, TypeId};
 use graphforge_ir::Direction;
+use rayon::prelude::*;
 
 use crate::AdjacencyProvider;
 use crate::algorithm_dispatch::{
@@ -69,6 +76,13 @@ struct TotalNeighbors;
 
 const PAGERANK_DAMPING: f64 = 0.85;
 const PAGERANK_TOLERANCE: f64 = 1.0e-10;
+/// Selected adjacency entries below which PageRank stays on the serial path (#343).
+///
+/// Keeps accepted small fixtures and micro-invocations off the worker pool; above
+/// this, destination-owned parallel updates amortize scheduling on typical
+/// embedded hosts. Numeric results remain identical either way.
+pub const PAGERANK_PARALLEL_CROSSOVER_EDGES: u64 = 4_096;
+const PAGERANK_CHECKPOINT_DESTINATIONS: usize = 4_096;
 const EIGENVECTOR_MAX_ITERATIONS: usize = 20;
 const EIGENVECTOR_TOLERANCE: f64 = 1.0e-7;
 const ARTICLE_RANK_DAMPING: f64 = 0.85;
@@ -131,46 +145,38 @@ impl RustAlgorithm for PageRank {
         control: &AlgorithmControl,
     ) -> Result<AlgorithmOutput, AlgorithmError> {
         let algorithm = Algorithm::Rank(RankAlgorithm::PageRank);
-        let node_count = graph.node_ids().len();
-        if node_count == 0 {
+        let node_len = graph.node_ids().len();
+        if node_len == 0 {
             return AlgorithmOutput::empty(algorithm, control);
         }
 
-        let indices: HashMap<u64, usize> = graph
-            .node_ids()
-            .iter()
-            .enumerate()
-            .map(|(index, &node)| (node, index))
-            .collect();
-        let node_count = f64::from(exact_u32(node_count, "node count")?);
-        let mut scores = vec![1.0 / node_count; graph.node_ids().len()];
+        let prepared = prepare_pagerank(graph)?;
+        let node_count = f64::from(exact_u32(node_len, "node count")?);
+        let mut scores = vec![1.0 / node_count; node_len];
+        let path = select_pagerank_path(control, prepared.edge_count, node_len);
         loop {
             control.checkpoint()?;
-            let dangling: f64 = graph
-                .node_ids()
-                .iter()
-                .enumerate()
-                .filter(|(_, node)| graph.neighbors(**node).is_empty())
-                .map(|(index, _)| scores[index])
-                .sum();
+            // Serial dangling reduction in dense ordinal order (accepted oracle).
+            let dangling: f64 = prepared.dangling.iter().map(|&index| scores[index]).sum();
             let base =
                 (1.0 - PAGERANK_DAMPING) / node_count + PAGERANK_DAMPING * dangling / node_count;
-            let mut next = vec![base; scores.len()];
-            for (source_index, &source) in graph.node_ids().iter().enumerate() {
-                let edges = graph.neighbors(source);
-                if edges.is_empty() {
-                    continue;
+            let mut next = vec![base; node_len];
+            match path {
+                PageRankExecutionPath::Serial => {
+                    pagerank_scatter_serial(graph, &prepared.indices, &scores, &mut next)?;
                 }
-                let outdegree = f64::from(exact_u32(edges.len(), "node degree")?);
-                let contribution = PAGERANK_DAMPING * scores[source_index] / outdegree;
-                for edge in edges {
-                    let target = indices
-                        .get(&edge.neighbor_id)
-                        .copied()
-                        .ok_or_else(|| execution("adjacency references an unselected node"))?;
-                    next[target] += contribution;
+                PageRankExecutionPath::Parallel { .. } => {
+                    pagerank_pull_parallel(
+                        &prepared.inbound,
+                        &prepared.outdegrees,
+                        &scores,
+                        base,
+                        &mut next,
+                        control,
+                    )?;
                 }
             }
+            // Serial L1 delta in dense ordinal order (accepted oracle).
             let delta: f64 = scores
                 .iter()
                 .zip(&next)
@@ -182,21 +188,251 @@ impl RustAlgorithm for PageRank {
             }
         }
 
-        let rows = graph
-            .node_ids()
-            .iter()
-            .enumerate()
-            .map(|(index, &node)| {
-                let uuid = graph
-                    .node_uuid(node)
-                    .ok_or_else(|| execution("selected node has no UUID identity"))?;
-                Ok(vec![
-                    AlgorithmValue::Uuid(uuid),
-                    AlgorithmValue::Float64(scores[index]),
-                ])
+        let mut sink = control.output_sink(algorithm)?;
+        for (index, &node) in graph.node_ids().iter().enumerate() {
+            if index % 1024 == 0 {
+                control.checkpoint()?;
+            }
+            let uuid = graph
+                .node_uuid(node)
+                .ok_or_else(|| execution("selected node has no UUID identity"))?;
+            sink.append_row(&[
+                AlgorithmValue::Uuid(uuid),
+                AlgorithmValue::Float64(scores[index]),
+            ])?;
+        }
+        sink.finish()
+    }
+}
+
+/// Selected PageRank execution path for observability and crossover tests (#343).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PageRankExecutionPath {
+    Serial,
+    Parallel { threads: usize, chunks: usize },
+}
+
+/// Dense inbound CSR: source ordinals in canonical source/edge order per destination.
+#[derive(Clone, Debug, Default)]
+struct PageRankInboundCsr {
+    offsets: Vec<u32>,
+    sources: Vec<u32>,
+}
+
+struct PreparedPageRank {
+    indices: HashMap<u64, usize>,
+    outdegrees: Vec<f64>,
+    dangling: Vec<usize>,
+    inbound: PageRankInboundCsr,
+    edge_count: u64,
+}
+
+fn prepare_pagerank(graph: &AdjacencyGraph) -> Result<PreparedPageRank, AlgorithmError> {
+    let node_ids = graph.node_ids();
+    let node_len = node_ids.len();
+    let indices: HashMap<u64, usize> = node_ids
+        .iter()
+        .enumerate()
+        .map(|(index, &node)| (node, index))
+        .collect();
+    let mut outdegrees = Vec::with_capacity(node_len);
+    let mut dangling = Vec::new();
+    let mut inbound_counts = vec![0_u32; node_len];
+    let mut edge_count = 0_u64;
+    for (source_index, &source) in node_ids.iter().enumerate() {
+        let edges = graph.neighbors(source);
+        let degree = exact_u32(edges.len(), "node degree")?;
+        outdegrees.push(f64::from(degree));
+        if edges.is_empty() {
+            dangling.push(source_index);
+            continue;
+        }
+        for edge in edges {
+            let target = indices
+                .get(&edge.neighbor_id)
+                .copied()
+                .ok_or_else(|| execution("adjacency references an unselected node"))?;
+            inbound_counts[target] = inbound_counts[target]
+                .checked_add(1)
+                .ok_or_else(|| execution("inbound degree exceeds supported range"))?;
+            edge_count = edge_count
+                .checked_add(1)
+                .ok_or_else(|| execution("edge count exceeds supported range"))?;
+        }
+    }
+
+    let mut offsets = Vec::with_capacity(node_len + 1);
+    offsets.push(0_u32);
+    for &count in &inbound_counts {
+        let next = offsets
+            .last()
+            .copied()
+            .unwrap_or(0)
+            .checked_add(count)
+            .ok_or_else(|| execution("inbound CSR offsets exceed supported range"))?;
+        offsets.push(next);
+    }
+    let total = usize::try_from(*offsets.last().unwrap_or(&0))
+        .map_err(|_| execution("inbound CSR length exceeds supported range"))?;
+    let mut sources = vec![0_u32; total];
+    let mut write_at = offsets[..node_len].to_vec();
+    for (source_index, &source) in node_ids.iter().enumerate() {
+        let source_u32 = exact_u32(source_index, "source ordinal")?;
+        for edge in graph.neighbors(source) {
+            let target = indices
+                .get(&edge.neighbor_id)
+                .copied()
+                .ok_or_else(|| execution("adjacency references an unselected node"))?;
+            let slot = usize::try_from(write_at[target])
+                .map_err(|_| execution("inbound write cursor exceeds supported range"))?;
+            sources[slot] = source_u32;
+            write_at[target] = write_at[target]
+                .checked_add(1)
+                .ok_or_else(|| execution("inbound write cursor overflow"))?;
+        }
+    }
+
+    Ok(PreparedPageRank {
+        indices,
+        outdegrees,
+        dangling,
+        inbound: PageRankInboundCsr { offsets, sources },
+        edge_count,
+    })
+}
+
+/// Choose serial vs private-pool parallel execution for a PageRank workload.
+pub(crate) fn select_pagerank_path(
+    control: &AlgorithmControl,
+    edge_count: u64,
+    nodes: usize,
+) -> PageRankExecutionPath {
+    let threads = control.compute_threads();
+    if threads <= 1
+        || nodes <= 1
+        || edge_count < PAGERANK_PARALLEL_CROSSOVER_EDGES
+        || control
+            .compute_pool()
+            .is_none_or(|pool| !pool.is_parallel())
+    {
+        return PageRankExecutionPath::Serial;
+    }
+    let chunks = destination_chunks(nodes, threads).len();
+    PageRankExecutionPath::Parallel { threads, chunks }
+}
+
+fn destination_chunks(nodes: usize, threads: usize) -> Vec<(usize, usize)> {
+    if nodes == 0 {
+        return Vec::new();
+    }
+    let workers = threads.clamp(1, nodes);
+    let base = nodes / workers;
+    let rem = nodes % workers;
+    let mut ranges = Vec::with_capacity(workers);
+    let mut start = 0;
+    for index in 0..workers {
+        let len = base + usize::from(index < rem);
+        let end = start + len;
+        if start < end {
+            ranges.push((start, end));
+        }
+        start = end;
+    }
+    ranges
+}
+
+fn pagerank_scatter_serial(
+    graph: &AdjacencyGraph,
+    indices: &HashMap<u64, usize>,
+    scores: &[f64],
+    next: &mut [f64],
+) -> Result<(), AlgorithmError> {
+    for (source_index, &source) in graph.node_ids().iter().enumerate() {
+        let edges = graph.neighbors(source);
+        if edges.is_empty() {
+            continue;
+        }
+        let outdegree = f64::from(exact_u32(edges.len(), "node degree")?);
+        let contribution = PAGERANK_DAMPING * scores[source_index] / outdegree;
+        for edge in edges {
+            let target = indices
+                .get(&edge.neighbor_id)
+                .copied()
+                .ok_or_else(|| execution("adjacency references an unselected node"))?;
+            next[target] += contribution;
+        }
+    }
+    Ok(())
+}
+
+fn pagerank_pull_destination(
+    inbound: &PageRankInboundCsr,
+    outdegrees: &[f64],
+    scores: &[f64],
+    base: f64,
+    dest: usize,
+) -> f64 {
+    let start = usize::try_from(inbound.offsets[dest]).unwrap_or(0);
+    let end = usize::try_from(inbound.offsets[dest + 1]).unwrap_or(start);
+    let mut acc = base;
+    for &source in &inbound.sources[start.min(end)..end.min(inbound.sources.len())] {
+        let source = usize::try_from(source).unwrap_or(usize::MAX);
+        if source < scores.len() {
+            acc += PAGERANK_DAMPING * scores[source] / outdegrees[source];
+        }
+    }
+    acc
+}
+
+fn pagerank_pull_parallel(
+    inbound: &PageRankInboundCsr,
+    outdegrees: &[f64],
+    scores: &[f64],
+    base: f64,
+    next: &mut [f64],
+    control: &AlgorithmControl,
+) -> Result<(), AlgorithmError> {
+    let pool = control
+        .compute_pool()
+        .ok_or_else(|| execution("parallel PageRank requires an instance-owned compute pool"))?;
+    let ranges = destination_chunks(next.len(), control.compute_threads());
+    let work = AtomicUsize::new(0);
+    let chunk_results = run_pagerank_on_pool(pool, || {
+        ranges
+            .par_iter()
+            .map(|&(start, end)| {
+                control.check_cancelled()?;
+                let mut local = Vec::with_capacity(end - start);
+                for dest in start..end {
+                    let observed = work.fetch_add(1, Ordering::Relaxed) + 1;
+                    if observed.is_multiple_of(PAGERANK_CHECKPOINT_DESTINATIONS) {
+                        control.check_cancelled()?;
+                    }
+                    local.push(pagerank_pull_destination(
+                        inbound, outdegrees, scores, base, dest,
+                    ));
+                }
+                Ok((start, local))
             })
-            .collect::<Result<Vec<_>, AlgorithmError>>()?;
-        AlgorithmOutput::from_rows(algorithm, control, rows)
+            .collect::<Result<Vec<_>, AlgorithmError>>()
+    })?;
+    // Merge chunk outputs in ascending destination-range order (canonical).
+    for (start, local) in chunk_results {
+        next[start..start + local.len()].copy_from_slice(&local);
+    }
+    Ok(())
+}
+
+fn run_pagerank_on_pool<R>(
+    pool: &crate::ComputePool,
+    op: impl FnOnce() -> Result<R, AlgorithmError> + Send,
+) -> Result<R, AlgorithmError>
+where
+    R: Send,
+{
+    match catch_unwind(AssertUnwindSafe(|| pool.install(op))) {
+        Ok(result) => result,
+        Err(_) => Err(execution("PageRank worker panicked")),
     }
 }
 
@@ -1648,9 +1884,36 @@ pub fn rank_algorithm_with_limits(
     options: &RankOptions,
     limits: AlgorithmLimits,
 ) -> Result<RecordBatch, GfError> {
+    rank_algorithm_with_compute(
+        provider,
+        dir,
+        mode,
+        label,
+        property_stems,
+        options,
+        limits,
+        None,
+    )
+}
+
+/// Execute rank with shaping limits and an optional private compute pool (#343).
+#[allow(
+    clippy::too_many_arguments,
+    reason = "mirrors rank_algorithm_with_limits plus the instance compute pool handle"
+)]
+pub fn rank_algorithm_with_compute(
+    provider: &dyn AdjacencyProvider,
+    dir: &Path,
+    mode: OntologyMode,
+    label: TypeId,
+    property_stems: &[String],
+    options: &RankOptions,
+    limits: AlgorithmLimits,
+    compute: Option<crate::SharedComputePool>,
+) -> Result<RecordBatch, GfError> {
     let graph = rank_projection(provider, dir, mode, label, options)?;
     let algorithm = Algorithm::Rank(options.by);
-    let output = execute_rank(&graph, algorithm, limits)?;
+    let output = execute_rank_with_compute(&graph, algorithm, limits, compute)?;
     let batch = shape_algorithm_output(algorithm, &output)?;
     materialize_node_properties_with_batch_size(dir, property_stems, &batch, limits.batch_size)
         .map_err(Into::into)
@@ -1703,18 +1966,19 @@ fn rank_projection(
     )
 }
 
-fn execute_rank(
+fn execute_rank_with_compute(
     graph: &AdjacencyGraph,
     algorithm: Algorithm,
     limits: AlgorithmLimits,
+    compute: Option<crate::SharedComputePool>,
 ) -> Result<AlgorithmOutput, AlgorithmError> {
     let mut registry = AlgorithmRegistry::default();
     register_rank_algorithms(&mut registry)?;
-    registry.execute(
-        algorithm,
-        graph,
-        &AlgorithmControl::new(limits, AlgorithmCancellation::default()),
-    )
+    let mut control = AlgorithmControl::new(limits, AlgorithmCancellation::default());
+    if let Some(pool) = compute {
+        control = control.with_compute_pool(pool);
+    }
+    registry.execute(algorithm, graph, &control)
 }
 
 fn exact_u32(value: usize, kind: &str) -> Result<u32, AlgorithmError> {
@@ -1746,7 +2010,7 @@ mod tests {
         graph: &AdjacencyGraph,
         limits: AlgorithmLimits,
     ) -> Result<AlgorithmOutput, AlgorithmError> {
-        execute_rank(graph, Algorithm::Rank(RankAlgorithm::Degree), limits)
+        execute_rank_with_compute(graph, Algorithm::Rank(RankAlgorithm::Degree), limits, None)
     }
 
     fn execute_pagerank(
@@ -1763,6 +2027,22 @@ mod tests {
         )
     }
 
+    fn execute_pagerank_with_pool(
+        graph: &AdjacencyGraph,
+        threads: usize,
+        cancellation: AlgorithmCancellation,
+    ) -> Result<AlgorithmOutput, AlgorithmError> {
+        let pool = Arc::new(crate::ComputePool::new(threads).unwrap());
+        let mut registry = AlgorithmRegistry::default();
+        register_rank_algorithms(&mut registry)?;
+        let control = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(threads),
+            cancellation,
+        )
+        .with_compute_pool(pool);
+        registry.execute(Algorithm::Rank(RankAlgorithm::PageRank), graph, &control)
+    }
+
     fn pagerank_scores(output: &AlgorithmOutput) -> Vec<f64> {
         output
             .rows()
@@ -1772,6 +2052,21 @@ mod tests {
                 _ => panic!("pagerank score must be Float64"),
             })
             .collect()
+    }
+
+    fn pagerank_bits(output: &AlgorithmOutput) -> Vec<u64> {
+        pagerank_scores(output)
+            .into_iter()
+            .map(f64::to_bits)
+            .collect()
+    }
+
+    fn dense_cycle_graph(nodes: usize) -> AdjacencyGraph {
+        let edges = (0..nodes)
+            .map(|node| (node as u64, ((node + 1) % nodes) as u64))
+            .chain((0..nodes).map(|node| (node as u64, ((node + 3) % nodes) as u64)))
+            .collect::<Vec<_>>();
+        AdjacencyGraph::with_test_edges(nodes as u64, &edges)
     }
 
     fn execute_betweenness(
@@ -2317,6 +2612,171 @@ mod tests {
             .find(|capability| capability.algorithm == Algorithm::Rank(RankAlgorithm::PageRank))
             .unwrap();
         assert_eq!(capability.dependency, BUILTIN_REVIEW);
+    }
+
+    #[test]
+    fn pagerank_path_selection_respects_crossover_and_one_thread() {
+        let serial_control = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(4),
+            AlgorithmCancellation::default(),
+        );
+        assert_eq!(
+            select_pagerank_path(&serial_control, PAGERANK_PARALLEL_CROSSOVER_EDGES - 1, 64),
+            PageRankExecutionPath::Serial
+        );
+        let one = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(1),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(Arc::new(crate::ComputePool::new(1).unwrap()));
+        assert_eq!(
+            select_pagerank_path(&one, PAGERANK_PARALLEL_CROSSOVER_EDGES, 64),
+            PageRankExecutionPath::Serial
+        );
+        let parallel = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(4),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(Arc::new(crate::ComputePool::new(4).unwrap()));
+        assert_eq!(
+            select_pagerank_path(&parallel, PAGERANK_PARALLEL_CROSSOVER_EDGES, 64),
+            PageRankExecutionPath::Parallel {
+                threads: 4,
+                chunks: 4
+            }
+        );
+    }
+
+    #[test]
+    fn pagerank_thread_matrix_matches_one_thread_bits_and_ordering() {
+        // Above crossover so multi-thread policies exercise the parallel path.
+        let graph = dense_cycle_graph(128);
+        assert!(graph.edge_entry_count() >= PAGERANK_PARALLEL_CROSSOVER_EDGES);
+        let serial =
+            execute_pagerank_with_pool(&graph, 1, AlgorithmCancellation::default()).unwrap();
+        let serial_bits = pagerank_bits(&serial);
+        let serial_rows = serial.rows();
+        for threads in [2_usize, 4, 8] {
+            let parallel =
+                execute_pagerank_with_pool(&graph, threads, AlgorithmCancellation::default())
+                    .unwrap();
+            assert_eq!(parallel.schema, serial.schema);
+            assert_eq!(parallel.rows(), serial_rows);
+            assert_eq!(pagerank_bits(&parallel), serial_bits);
+        }
+    }
+
+    #[test]
+    fn pagerank_parallel_preserves_dangling_parallel_self_loop_and_direction_bits() {
+        let multigraph = AdjacencyGraph::with_test_edges(3, &[(0, 1), (0, 1), (0, 2), (1, 1)]);
+        let directed = AdjacencyGraph::with_test_edges(2, &[(0, 1)]);
+        let undirected = AdjacencyGraph::with_test_edges(2, &[(0, 1), (1, 0)]);
+        let empty = AdjacencyGraph::default();
+        let single = AdjacencyGraph::with_test_edges(1, &[]);
+        let disconnected = AdjacencyGraph::with_test_edges(4, &[(0, 1), (1, 0), (2, 3), (3, 2)]);
+        for graph in [
+            &multigraph,
+            &directed,
+            &undirected,
+            &empty,
+            &single,
+            &disconnected,
+        ] {
+            let serial =
+                execute_pagerank_with_pool(graph, 1, AlgorithmCancellation::default()).unwrap();
+            for threads in [2_usize, 4, 8] {
+                // Force parallel path selection by attaching a multi-thread pool even
+                // when edge counts are below the crossover: call pull through registry
+                // with an oversized synthetic control only when edges meet crossover,
+                // otherwise verify serial path still matches across thread budgets.
+                let parallel =
+                    execute_pagerank_with_pool(graph, threads, AlgorithmCancellation::default())
+                        .unwrap();
+                assert_eq!(pagerank_bits(&parallel), pagerank_bits(&serial));
+                assert_eq!(parallel.rows(), serial.rows());
+            }
+        }
+
+        // Adversarial magnitudes: force parallel on a graph above crossover with
+        // dangling nodes and uneven outdegrees.
+        let mut edges = Vec::new();
+        for source in 0..96_u64 {
+            let degree = 1 + (source % 7) as usize;
+            for hop in 0..degree {
+                edges.push((source, (source + 1 + hop as u64) % 96));
+            }
+        }
+        // Leave high-index nodes dangling.
+        let adversarial = AdjacencyGraph::with_test_edges(128, &edges);
+        assert!(adversarial.edge_entry_count() >= PAGERANK_PARALLEL_CROSSOVER_EDGES);
+        let serial =
+            execute_pagerank_with_pool(&adversarial, 1, AlgorithmCancellation::default()).unwrap();
+        for threads in [2_usize, 4, 8] {
+            let parallel =
+                execute_pagerank_with_pool(&adversarial, threads, AlgorithmCancellation::default())
+                    .unwrap();
+            assert_eq!(pagerank_bits(&parallel), pagerank_bits(&serial));
+        }
+    }
+
+    #[test]
+    fn pagerank_parallel_cancellation_returns_structured_cancelled() {
+        let graph = dense_cycle_graph(128);
+        let cancellation = AlgorithmCancellation::default();
+        cancellation.cancel();
+        assert_eq!(
+            execute_pagerank_with_pool(&graph, 4, cancellation),
+            Err(AlgorithmError::Cancelled)
+        );
+    }
+
+    #[test]
+    fn pagerank_destination_chunks_cover_canonical_ranges() {
+        assert_eq!(destination_chunks(0, 4), Vec::<(usize, usize)>::new());
+        assert_eq!(destination_chunks(5, 1), vec![(0, 5)]);
+        assert_eq!(destination_chunks(5, 2), vec![(0, 3), (3, 5)]);
+        assert_eq!(
+            destination_chunks(8, 4),
+            vec![(0, 2), (2, 4), (4, 6), (6, 8)]
+        );
+        assert_eq!(destination_chunks(3, 8), vec![(0, 1), (1, 2), (2, 3)]);
+    }
+
+    #[test]
+    fn pagerank_pull_matches_serial_scatter_contribution_order() {
+        let fixtures = [
+            AdjacencyGraph::with_test_edges(3, &[(0, 1), (0, 1), (0, 2), (1, 1)]),
+            AdjacencyGraph::with_test_edges(2, &[(0, 1)]),
+            AdjacencyGraph::with_test_edges(2, &[(0, 1), (1, 0)]),
+            AdjacencyGraph::with_test_edges(4, &[(0, 1), (1, 0), (2, 3), (3, 2)]),
+            AdjacencyGraph::with_test_edges(1, &[]),
+            dense_cycle_graph(64),
+        ];
+        for graph in &fixtures {
+            if graph.node_ids().is_empty() {
+                continue;
+            }
+            let prepared = prepare_pagerank(graph).unwrap();
+            let scores = vec![1.0 / graph.node_ids().len() as f64; graph.node_ids().len()];
+            let base = 0.15 / graph.node_ids().len() as f64;
+            let mut scatter = vec![base; scores.len()];
+            pagerank_scatter_serial(graph, &prepared.indices, &scores, &mut scatter).unwrap();
+            let mut pull = vec![0.0; scores.len()];
+            for dest in 0..scores.len() {
+                pull[dest] = pagerank_pull_destination(
+                    &prepared.inbound,
+                    &prepared.outdegrees,
+                    &scores,
+                    base,
+                    dest,
+                );
+            }
+            assert_eq!(
+                scatter.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+                pull.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+                "pull must apply contributions in serial source/edge order"
+            );
+        }
     }
 
     #[test]

--- a/crates/graphforge-exec/src/algorithm_rank.rs
+++ b/crates/graphforge-exec/src/algorithm_rank.rs
@@ -2062,9 +2062,14 @@ mod tests {
     }
 
     fn dense_cycle_graph(nodes: usize) -> AdjacencyGraph {
+        // Enough parallel edges per source to clear the documented crossover on
+        // modest node counts while keeping the fixture deterministic.
+        let fanout =
+            ((PAGERANK_PARALLEL_CROSSOVER_EDGES as usize) / nodes.max(1)).saturating_add(2);
         let edges = (0..nodes)
-            .map(|node| (node as u64, ((node + 1) % nodes) as u64))
-            .chain((0..nodes).map(|node| (node as u64, ((node + 3) % nodes) as u64)))
+            .flat_map(|node| {
+                (1..=fanout).map(move |hop| (node as u64, ((node + hop) % nodes) as u64))
+            })
             .collect::<Vec<_>>();
         AdjacencyGraph::with_test_edges(nodes as u64, &edges)
     }
@@ -2699,15 +2704,16 @@ mod tests {
 
         // Adversarial magnitudes: force parallel on a graph above crossover with
         // dangling nodes and uneven outdegrees.
+        let nodes = 512_u64;
         let mut edges = Vec::new();
-        for source in 0..96_u64 {
-            let degree = 1 + (source % 7) as usize;
+        for source in 0..(nodes - 64) {
+            let degree = 12 + (source % 17) as usize;
             for hop in 0..degree {
-                edges.push((source, (source + 1 + hop as u64) % 96));
+                edges.push((source, (source + 1 + hop as u64) % nodes));
             }
         }
         // Leave high-index nodes dangling.
-        let adversarial = AdjacencyGraph::with_test_edges(128, &edges);
+        let adversarial = AdjacencyGraph::with_test_edges(nodes, &edges);
         assert!(adversarial.edge_entry_count() >= PAGERANK_PARALLEL_CROSSOVER_EDGES);
         let serial =
             execute_pagerank_with_pool(&adversarial, 1, AlgorithmCancellation::default()).unwrap();

--- a/crates/graphforge-exec/src/compute_pool.rs
+++ b/crates/graphforge-exec/src/compute_pool.rs
@@ -1,8 +1,9 @@
-//! Instance-owned bounded CPU pool for deterministic algorithm kernels (#337 / #342).
+//! Instance-owned bounded CPU pool for deterministic algorithm kernels (#337 / #342 / #343).
 //!
 //! GraphForge never installs work onto Rayon's process-global pool. Parallel
-//! cosine KNN (#342) and future CPU kernels consume this private pool sized from
-//! [`crate`]-facing `compute_threads` on the embedded resource policy.
+//! cosine KNN (#342), PageRank (#343), and sibling CPU kernels consume this
+//! private pool sized from [`crate`]-facing `compute_threads` on the embedded
+//! resource policy.
 
 use std::sync::Arc;
 

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -207,7 +207,10 @@ pub use algorithm_embedding_invocation::{
     EmbeddingProjectionSelector, EmbeddingRngContract,
 };
 pub use algorithm_paths::{paths_algorithm, paths_projection_fingerprint};
-pub use algorithm_rank::{rank_algorithm, rank_algorithm_with_limits, rank_projection_fingerprint};
+pub use algorithm_rank::{
+    rank_algorithm, rank_algorithm_with_compute, rank_algorithm_with_limits,
+    rank_projection_fingerprint,
+};
 pub use algorithm_similar::{
     similar_algorithm, similar_algorithm_with_compute, similar_algorithm_with_limits,
     similar_projection_fingerprint,

--- a/docs/book/architecture/algorithms.md
+++ b/docs/book/architecture/algorithms.md
@@ -119,7 +119,11 @@ the transition distribution.
 The implementation uses damping `0.85`, uniform initial scores, uniform teleportation, and
 uniform redistribution of dangling-node mass. Iteration stops when the L1 score delta is at
 most `selected_node_count * 1e-10`. Rows and floating-point accumulation follow stable
-topology order, so identical graph state and options produce identical results. Disconnected
+topology order, so identical graph state and options produce identical results. Destination
+updates may run through the instance-owned private compute pool (#337 / #343) above a
+documented edge-count crossover; each destination still applies inbound contributions in the
+same canonical source/edge order as serial scatter, and dangling/delta reductions remain
+serial, so scores, iteration counts, and fingerprints match the one-thread path. Disconnected
 graphs retain every selected node and normalized mass; an empty selection returns a typed
 zero-row table.
 

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -17,7 +17,7 @@ Tokio runtime or any DataFusion execution session.
 | `spill` | disabled | Optional absolute spill directory + byte cap |
 | `io_concurrency` | `2` | Reserved I/O concurrency budget |
 | `max_concurrent_heavy_queries` | `64` | Instance-owned admission semaphore |
-| `compute_threads` | `2` | Instance-owned private CPU pool (#342 cosine KNN; future kernels) |
+| `compute_threads` | `2` | Instance-owned private CPU pool (#342 cosine KNN; #343 PageRank; sibling kernels) |
 
 Defaults preserve pre-#337 fixed two-worker / two-partition behavior.
 
@@ -68,9 +68,10 @@ state.
 
 Resources are **instance-owned**, not process-global. `compute_threads` sizes a
 private Rayon pool on each `GraphForge` instance. Exact cosine KNN / similarity
-(#342) may partition independent source rows across that pool above a documented
-crossover; work never uses Rayon's process-global pool. Dot products retain
-serial coordinate order so fingerprints match the one-thread path.
+(#342) and PageRank (#343) may partition work across that pool above documented
+crossovers; work never uses Rayon's process-global pool. Dot products retain
+serial coordinate order, and PageRank keeps canonical contribution order with
+serial dangling/delta reductions, so fingerprints match the one-thread path.
 
 ## Parallel cosine KNN (#342)
 
@@ -92,6 +93,23 @@ serial path runs with no pool scheduling tax. Inner floating-point reductions
 stay serial per source→target pair (no parallel dot products, no approximate
 similarity). Worker outputs merge in canonical source order so schemas, row
 order, scores, ties, and fingerprints match the one-thread result at
+`1`/`2`/`4`/`8`/automatic configurations.
+
+## Parallel PageRank (#343)
+
+PageRank destination updates run on the instance-owned private compute pool when:
+
+- `compute_threads > 1`, and
+- selected adjacency entries are at least
+  `PAGERANK_PARALLEL_CROSSOVER_EDGES` (`4_096`) in `graphforge-exec`.
+
+Below that crossover, or when the policy provides one compute thread, the
+serial source-scatter path runs with no pool scheduling tax. Parallel work is
+destination-owned: each worker owns a contiguous dense-ordinal destination
+range and applies inbound contributions in the same canonical source/edge order
+as serial scatter. Dangling-mass and L1 convergence reductions stay serial so
+IEEE accumulation order matches the accepted oracle. Schemas, row order,
+scores, iteration counts, and fingerprints match the one-thread result at
 `1`/`2`/`4`/`8`/automatic configurations.
 
 ## Observability

--- a/docs/development/m4-entry-baseline.md
+++ b/docs/development/m4-entry-baseline.md
@@ -80,12 +80,12 @@ DataFusion target partitions, thread-parity cells over the host budget.
 
 The entry baseline intentionally records the current implementation, including
 CSR-to-map conversion where still observable. Exact cosine KNN / similarity
-(#342) may use the instance-owned private compute pool above a documented
-crossover while preserving one-thread fingerprints. Query-facing Parquet
-providers stream bounded batches via `GraphForgeParquetExec` (#339) rather than
-eager single-partition `MemTable` materialization; ExpandExec filtered reads and
-fixed-hop demand remain the selective-path contract. Further optimizations
-belong to later M4 issues.
+(#342) and PageRank (#343) may use the instance-owned private compute pool above
+documented crossovers while preserving one-thread fingerprints. Query-facing
+Parquet providers stream bounded batches via `GraphForgeParquetExec` (#339)
+rather than eager single-partition `MemTable` materialization; ExpandExec
+filtered reads and fixed-hop demand remain the selective-path contract. Further
+optimizations belong to later M4 issues.
 
 ## Discovery evidence (not a universal size ceiling)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Deterministic parallel PageRank destination updates via the shared instance-owned `ComputePool` (#337/#342), preserving bit-for-bit scores, convergence, and fingerprints vs the one-thread path.

Closes #343.

## Changes

- Parallel destination-owned PageRank updates with canonical contribution order
- Serial path for one thread / below crossover; enlarged fixtures past crossover
- Reuses shared `compute_pool` from #342 (now on `main`)

## Test plan

- [x] `cargo test -p graphforge-exec --lib algorithm_rank`
- [x] `cargo clippy -p graphforge-exec --lib -- -D warnings`
- [ ] Exact-head CI green, then squash-merge

## Notes

Rebased onto `main` after #494 (#342) merged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788916687&installation_model_id=20486&pr_number=492&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F492&signature=03449558b86a5b53d7cc92835daec449eb0d8b4b0eba43fa4e8baf34783e7824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parallelize PageRank updates deterministically using a private Rayon compute pool
> - Adds a private instance-owned `ComputePool` (wrapping a Rayon `ThreadPool`) to `GraphForge`, sized by `resource_policy.compute_threads`, and passes it into `rank` and `similar` algorithm execution paths.
> - PageRank switches from serial scatter to pull-based parallel accumulation (`pagerank_pull_parallel`) when edge count exceeds `PAGERANK_PARALLEL_CROSSOVER_EDGES` and a multi-thread pool is available; cosine KNN similarly parallelizes above `COSINE_PARALLEL_CROSSOVER_OPS`.
> - Both parallel paths use destination/source chunking with ordered merge to preserve bitwise-identical scores and fingerprints vs. the single-thread path.
> - Worker panics in parallel chunks are caught via `catch_unwind` and returned as structured `AlgorithmError::Execution` rather than unwinding across the pool boundary.
> - Risk: `GraphForge::new_with_options` now returns an error if compute pool initialization fails, which is a new failure mode for constructors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b239feb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PageRank calculations can now use parallel processing for larger graphs, improving performance while preserving consistent, bit-identical results.
  * Execution automatically selects between serial and parallel processing based on graph size and available resources.
  * PageRank now supports cancellation and handles worker interruptions safely.
* **Documentation**
  * Updated resource and compute-pool documentation to describe parallel PageRank support alongside existing CPU kernels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->