### PR TITLE
perf(exec): parallelize Node2Vec walk generation (#344)

### DIFF
--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -1694,13 +1694,17 @@ impl GraphForge {
             .read()
             .expect("adjacency visibility lock poisoned");
         self.adjacency_provider.revalidate();
-        let prepared = graphforge_exec::prepare_embedding_invocation_descriptor(
+        let prepared = graphforge_exec::prepare_embedding_invocation_descriptor_with_compute(
             self.adjacency_provider.as_ref(),
             &self.dir,
             self.ontology_mode,
             label_id,
             label,
             options,
+            graphforge_exec::AlgorithmLimits::default()
+                .with_batch_size(self.resource_policy.batch_size)
+                .with_compute_threads(self.resource_policy.compute_threads),
+            Some(self.compute_pool.clone()),
         )?;
         let mut parameters = std::collections::BTreeMap::from([
             (
@@ -2504,13 +2508,17 @@ impl GraphForge {
             .read()
             .expect("adjacency visibility lock poisoned");
         self.adjacency_provider.revalidate();
-        graphforge_exec::embedding_algorithm_execution(
+        graphforge_exec::embedding_algorithm_execution_with_compute(
             self.adjacency_provider.as_ref(),
             &self.dir,
             self.ontology_mode,
             label_id,
             label,
             options,
+            graphforge_exec::AlgorithmLimits::default()
+                .with_batch_size(self.resource_policy.batch_size)
+                .with_compute_threads(self.resource_policy.compute_threads),
+            Some(self.compute_pool.clone()),
         )
         .map(|execution| execution.result)
     }

--- a/crates/graphforge-api/src/resource_policy.rs
+++ b/crates/graphforge-api/src/resource_policy.rs
@@ -4,7 +4,8 @@
 //! batch size, memory, spill, I/O concurrency, and heavy-query admission
 //! before a [`crate::GraphForge`] instance begins work. `compute_threads`
 //! sizes the instance-owned private CPU pool consumed by parallel cosine KNN
-//! (#342), parallel PageRank (#343), and sibling deterministic CPU kernels.
+//! (#342), parallel PageRank (#343), Node2Vec walk generation (#344), and
+//! sibling deterministic CPU kernels.
 
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
@@ -54,11 +55,11 @@ pub struct ExecutionResourcePolicy {
     pub io_concurrency: Option<usize>,
     /// Maximum concurrent heavy Cypher / analyst invocations. `None` → 64.
     pub max_concurrent_heavy_queries: Option<usize>,
-    /// Compute-thread budget for the instance-owned private CPU pool (#337 / #342 / #343).
+    /// Compute-thread budget for the instance-owned private CPU pool (#337 / #342 / #343 / #344).
     ///
-    /// Parallel cosine KNN partitions work by canonical source, and parallel
-    /// PageRank partitions destination-owned updates, through that pool
-    /// when work exceeds the documented crossover; `1` keeps the serial path.
+    /// Parallel cosine KNN, PageRank destination updates, and Node2Vec walk
+    /// generation partition work through that pool above documented crossovers;
+    /// `1` keeps the serial path.
     pub compute_threads: Option<usize>,
 }
 
@@ -102,7 +103,7 @@ pub struct NormalizedResourcePolicy {
     pub io_concurrency: usize,
     /// Heavy-query admission slots.
     pub max_concurrent_heavy_queries: usize,
-    /// Compute-thread budget for the instance-owned private CPU pool (#342 / #343).
+    /// Compute-thread budget for the instance-owned private CPU pool (#342 / #343 / #344).
     pub compute_threads: usize,
     /// Machine logical parallelism observed at normalize time.
     pub observed_logical_cpus: usize,

--- a/crates/graphforge-exec/src/algorithm_analyze.rs
+++ b/crates/graphforge-exec/src/algorithm_analyze.rs
@@ -2020,7 +2020,35 @@ pub fn embedding_algorithm_execution(
     label_name: Option<&str>,
     invocation: &EmbeddingAnalyzeOptions,
 ) -> Result<EmbeddingExecution, GfError> {
-    let prepared = prepare_embedding_projection(provider, dir, mode, label, invocation)?;
+    embedding_algorithm_execution_with_compute(
+        provider,
+        dir,
+        mode,
+        label,
+        label_name,
+        invocation,
+        AlgorithmLimits::default(),
+        None,
+    )
+}
+
+/// Execute an embedding with shaping/compute limits and an optional private pool (#344).
+#[allow(
+    clippy::too_many_arguments,
+    reason = "mirrors embedding_algorithm_execution plus instance compute handles"
+)]
+pub fn embedding_algorithm_execution_with_compute(
+    provider: &dyn AdjacencyProvider,
+    dir: &Path,
+    mode: OntologyMode,
+    label: Option<TypeId>,
+    label_name: Option<&str>,
+    invocation: &EmbeddingAnalyzeOptions,
+    limits: AlgorithmLimits,
+    compute: Option<crate::SharedComputePool>,
+) -> Result<EmbeddingExecution, GfError> {
+    let prepared =
+        prepare_embedding_projection(provider, dir, mode, label, invocation, limits, compute)?;
     let invocation = &prepared.invocation;
     embedding_algorithm_execution_with_controls(
         &prepared.graph,
@@ -2051,6 +2079,8 @@ fn prepare_embedding_projection(
     mode: OntologyMode,
     label: Option<TypeId>,
     invocation: &EmbeddingAnalyzeOptions,
+    limits: AlgorithmLimits,
+    compute: Option<crate::SharedComputePool>,
 ) -> Result<PreparedEmbeddingProjection, GfError> {
     let invocation = normalize_embedding_options(invocation)?;
     let mut graph = export_adjacency(
@@ -2091,8 +2121,10 @@ fn prepare_embedding_projection(
         }
         _ => None,
     };
-    let algorithm_control =
-        AlgorithmControl::new(AlgorithmLimits::default(), AlgorithmCancellation::default());
+    let mut algorithm_control = AlgorithmControl::new(limits, AlgorithmCancellation::default());
+    if let Some(pool) = compute {
+        algorithm_control = algorithm_control.with_compute_pool(pool);
+    }
     let resource_limits = EmbeddingResourceLimits::default();
     if let EmbeddingOptions::HashGnn(options) = &invocation.options {
         let topology = TopologyResources {
@@ -2134,7 +2166,35 @@ pub fn prepare_embedding_invocation_descriptor(
     label_name: Option<&str>,
     invocation: &EmbeddingAnalyzeOptions,
 ) -> Result<EmbeddingInvocationDescriptor, GfError> {
-    let prepared = prepare_embedding_projection(provider, dir, mode, label, invocation)?;
+    prepare_embedding_invocation_descriptor_with_compute(
+        provider,
+        dir,
+        mode,
+        label,
+        label_name,
+        invocation,
+        AlgorithmLimits::default(),
+        None,
+    )
+}
+
+/// Prepare an embedding descriptor with the instance compute budget recorded (#344).
+#[allow(
+    clippy::too_many_arguments,
+    reason = "mirrors prepare_embedding_invocation_descriptor plus compute handles"
+)]
+pub fn prepare_embedding_invocation_descriptor_with_compute(
+    provider: &dyn AdjacencyProvider,
+    dir: &Path,
+    mode: OntologyMode,
+    label: Option<TypeId>,
+    label_name: Option<&str>,
+    invocation: &EmbeddingAnalyzeOptions,
+    limits: AlgorithmLimits,
+    compute: Option<crate::SharedComputePool>,
+) -> Result<EmbeddingInvocationDescriptor, GfError> {
+    let prepared =
+        prepare_embedding_projection(provider, dir, mode, label, invocation, limits, compute)?;
     let invocation = &prepared.invocation;
     let limits = prepared.algorithm_control.configured_limits();
     Ok(EmbeddingInvocationDescriptor {

--- a/crates/graphforge-exec/src/algorithm_embedding_control.rs
+++ b/crates/graphforge-exec/src/algorithm_embedding_control.rs
@@ -364,6 +364,16 @@ impl<'a> EmbeddingControl<'a> {
         self.algorithm.check_cancelled()?;
         Ok(())
     }
+
+    /// Declared compute-thread budget for parallel embedding kernels (#344).
+    pub(crate) fn compute_threads(&self) -> usize {
+        self.algorithm.compute_threads()
+    }
+
+    /// Borrow the instance-owned private compute pool when attached (#344).
+    pub(crate) fn compute_pool(&self) -> Option<&crate::ComputePool> {
+        self.algorithm.compute_pool()
+    }
 }
 
 #[cfg(test)]

--- a/crates/graphforge-exec/src/algorithm_embedding_node2vec.rs
+++ b/crates/graphforge-exec/src/algorithm_embedding_node2vec.rs
@@ -467,9 +467,12 @@ pub(crate) fn select_walk_corpus_path(
 }
 
 fn estimated_walk_transitions(starts: usize, walks_per_node: usize, walk_length: usize) -> u64 {
-    (starts as u64)
-        .saturating_mul(walks_per_node as u64)
-        .saturating_mul(walk_length as u64)
+    let starts = u64::try_from(starts).unwrap_or(u64::MAX);
+    let walks_per_node = u64::try_from(walks_per_node).unwrap_or(u64::MAX);
+    let walk_length = u64::try_from(walk_length).unwrap_or(u64::MAX);
+    starts
+        .saturating_mul(walks_per_node)
+        .saturating_mul(walk_length)
 }
 
 fn walk_task_chunks(total_walks: usize, threads: usize) -> Vec<(usize, usize)> {
@@ -663,16 +666,17 @@ mod tests {
     }
 
     fn adversarial_graph(nodes: usize) -> AdjacencyGraph {
-        let edges = (0..nodes)
+        let nodes_u64 = u64::try_from(nodes).expect("test node count fits u64");
+        let edges = (0..nodes_u64)
             .flat_map(|source| {
                 [
-                    (source, (source + 1) % nodes),
-                    (source, (source + 3) % nodes),
-                    (source, (source * 5 + 7) % nodes),
+                    (source, (source + 1) % nodes_u64),
+                    (source, (source + 3) % nodes_u64),
+                    (source, (source * 5 + 7) % nodes_u64),
                 ]
             })
             .collect::<Vec<_>>();
-        AdjacencyGraph::with_test_directed_edges(nodes, &edges)
+        AdjacencyGraph::with_test_directed_edges(nodes_u64, &edges)
     }
 
     #[test]

--- a/crates/graphforge-exec/src/algorithm_embedding_node2vec.rs
+++ b/crates/graphforge-exec/src/algorithm_embedding_node2vec.rs
@@ -1,13 +1,29 @@
-//! Deterministic Node2Vec walk-corpus generation.
+//! Deterministic Node2Vec walk-corpus generation and serial SGNS training.
+//!
+//! Walk-corpus construction (#344) may partition independent `(start ordinal,
+//! walk ordinal)` tasks across the instance-owned private compute pool above a
+//! documented crossover. Seed derivation, candidate ordering, transition-mass
+//! accumulation, sampling, and every generated walk remain identical to the
+//! serial path. Skip-gram / negative-sampling training stays serial and
+//! unchanged so embedding fingerprints are preserved.
 
 use std::collections::HashMap;
+use std::panic::{AssertUnwindSafe, catch_unwind};
 
 use graphforge_core::embedding_options::Node2VecOptions;
+use rayon::prelude::*;
 
 use crate::algorithm_embedding_control::{EmbeddingControl, EmbeddingResourceError};
 use crate::algorithm_embedding_output::EmbeddingOutputRow;
 use crate::algorithm_embedding_rng::{EmbeddingRng, EmbeddingRngField};
 use crate::algorithm_graph::{AdjacencyGraph, AlgorithmEdge};
+
+/// Estimated walk transitions below which corpus generation stays serial (#344).
+///
+/// Small fixtures and micro-invocations stay off the worker pool; above this,
+/// start/walk-parallel execution amortizes scheduling. Exact walks and token
+/// counts remain identical either way.
+pub const NODE2VEC_WALK_PARALLEL_CROSSOVER: u64 = 256;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct Node2VecCorpus {
@@ -16,6 +32,13 @@ pub(crate) struct Node2VecCorpus {
 }
 
 pub(crate) type Node2VecEmbeddingRow = EmbeddingOutputRow;
+
+/// Selected walk-corpus execution path for observability and crossover tests.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum WalkCorpusPath {
+    Serial,
+    Parallel { threads: usize, chunks: usize },
+}
 
 #[derive(Clone, Debug, PartialEq, thiserror::Error)]
 pub(crate) enum Node2VecWalkError {
@@ -27,6 +50,8 @@ pub(crate) enum Node2VecWalkError {
     TokenCountOverflow,
     #[error("node2vec training produced a non-finite embedding")]
     NonFiniteEmbedding,
+    #[error("node2vec walk worker panicked")]
+    WorkerPanic,
     #[error(transparent)]
     Resource(#[from] EmbeddingResourceError),
 }
@@ -260,10 +285,29 @@ pub(crate) fn build_walk_corpus(
         .len()
         .checked_mul(options.walks_per_node)
         .ok_or(Node2VecWalkError::TokenCountOverflow)?;
+    let estimated =
+        estimated_walk_transitions(starts.len(), options.walks_per_node, options.walk_length);
+    match select_walk_corpus_path(control, capacity, estimated) {
+        WalkCorpusPath::Serial => {
+            build_walk_corpus_serial(graph, options, control, &starts, capacity)
+        }
+        WalkCorpusPath::Parallel { .. } => {
+            build_walk_corpus_parallel(graph, options, control, &starts, capacity)
+        }
+    }
+}
+
+fn build_walk_corpus_serial(
+    graph: &AdjacencyGraph,
+    options: &Node2VecOptions,
+    control: &EmbeddingControl<'_>,
+    starts: &[([u8; 16], u64)],
+    capacity: usize,
+) -> Result<Node2VecCorpus, Node2VecWalkError> {
     let mut walks = Vec::with_capacity(capacity);
     let mut token_counts = HashMap::with_capacity(starts.len());
 
-    for &(start_uuid, start_id) in &starts {
+    for &(start_uuid, start_id) in starts {
         for walk_ordinal in 0..options.walks_per_node {
             control.checkpoint(1)?;
             let walk = build_walk(
@@ -274,12 +318,7 @@ pub(crate) fn build_walk_corpus(
                 start_id,
                 u64::try_from(walk_ordinal).map_err(|_| Node2VecWalkError::TokenCountOverflow)?,
             )?;
-            for &node_id in &walk {
-                let count = token_counts.entry(node_id).or_insert(0_u64);
-                *count = count
-                    .checked_add(1)
-                    .ok_or(Node2VecWalkError::TokenCountOverflow)?;
-            }
+            accumulate_tokens(&mut token_counts, &walk)?;
             walks.push(walk);
         }
     }
@@ -288,6 +327,176 @@ pub(crate) fn build_walk_corpus(
         walks,
         token_counts,
     })
+}
+
+fn build_walk_corpus_parallel(
+    graph: &AdjacencyGraph,
+    options: &Node2VecOptions,
+    control: &EmbeddingControl<'_>,
+    starts: &[([u8; 16], u64)],
+    capacity: usize,
+) -> Result<Node2VecCorpus, Node2VecWalkError> {
+    let pool = control.compute_pool().ok_or_else(|| {
+        Node2VecWalkError::Resource(EmbeddingResourceError::Algorithm(
+            crate::algorithm_dispatch::AlgorithmError::Execution {
+                message: "parallel node2vec walk corpus requires an instance-owned compute pool"
+                    .into(),
+            },
+        ))
+    })?;
+    let walks_per_node = options.walks_per_node;
+    let ranges = walk_task_chunks(capacity, control.compute_threads());
+    let chunk_results = run_on_pool(pool, || {
+        ranges
+            .par_iter()
+            .map(|&(start, end)| {
+                let mut walks = Vec::with_capacity(end.saturating_sub(start));
+                let mut token_counts = HashMap::new();
+                for task in start..end {
+                    let start_ordinal = task / walks_per_node;
+                    let walk_ordinal = task % walks_per_node;
+                    let (start_uuid, start_id) = starts[start_ordinal];
+                    control.checkpoint(1)?;
+                    let walk = build_walk(
+                        graph,
+                        options,
+                        control,
+                        start_uuid,
+                        start_id,
+                        u64::try_from(walk_ordinal)
+                            .map_err(|_| Node2VecWalkError::TokenCountOverflow)?,
+                    )?;
+                    accumulate_tokens(&mut token_counts, &walk)?;
+                    walks.push(walk);
+                }
+                Ok(WalkChunk {
+                    walks,
+                    token_counts,
+                })
+            })
+            .collect::<Result<Vec<_>, Node2VecWalkError>>()
+    })?;
+    merge_walk_chunks(chunk_results, starts.len())
+}
+
+#[derive(Debug)]
+struct WalkChunk {
+    walks: Vec<Vec<u64>>,
+    token_counts: HashMap<u64, u64>,
+}
+
+fn merge_walk_chunks(
+    chunks: Vec<WalkChunk>,
+    start_capacity: usize,
+) -> Result<Node2VecCorpus, Node2VecWalkError> {
+    let mut walks = Vec::new();
+    let mut token_counts = HashMap::with_capacity(start_capacity);
+    for chunk in chunks {
+        walks.extend(chunk.walks);
+        merge_token_counts(&mut token_counts, chunk.token_counts)?;
+    }
+    Ok(Node2VecCorpus {
+        walks,
+        token_counts,
+    })
+}
+
+fn accumulate_tokens(
+    token_counts: &mut HashMap<u64, u64>,
+    walk: &[u64],
+) -> Result<(), Node2VecWalkError> {
+    for &node_id in walk {
+        let count = token_counts.entry(node_id).or_insert(0_u64);
+        *count = count
+            .checked_add(1)
+            .ok_or(Node2VecWalkError::TokenCountOverflow)?;
+    }
+    Ok(())
+}
+
+fn merge_token_counts(
+    into: &mut HashMap<u64, u64>,
+    from: HashMap<u64, u64>,
+) -> Result<(), Node2VecWalkError> {
+    let mut entries = from.into_iter().collect::<Vec<_>>();
+    entries.sort_unstable_by_key(|(node_id, _)| *node_id);
+    for (node_id, count) in entries {
+        let entry = into.entry(node_id).or_insert(0_u64);
+        *entry = entry
+            .checked_add(count)
+            .ok_or(Node2VecWalkError::TokenCountOverflow)?;
+    }
+    Ok(())
+}
+
+fn run_on_pool<R>(
+    pool: &crate::ComputePool,
+    op: impl FnOnce() -> Result<R, Node2VecWalkError> + Send,
+) -> Result<R, Node2VecWalkError>
+where
+    R: Send,
+{
+    match catch_unwind(AssertUnwindSafe(|| pool.install(op))) {
+        Ok(result) => result,
+        Err(_) => Err(Node2VecWalkError::WorkerPanic),
+    }
+}
+
+/// Choose serial vs private-pool parallel walk-corpus generation.
+pub(crate) fn select_walk_corpus_path(
+    control: &EmbeddingControl<'_>,
+    total_walks: usize,
+    estimated_transitions: u64,
+) -> WalkCorpusPath {
+    let threads = control.compute_threads();
+    if threads <= 1 || total_walks <= 1 || estimated_transitions < NODE2VEC_WALK_PARALLEL_CROSSOVER
+    {
+        return WalkCorpusPath::Serial;
+    }
+    if control
+        .compute_pool()
+        .is_none_or(|pool| !pool.is_parallel())
+    {
+        return WalkCorpusPath::Serial;
+    }
+    let chunks = walk_task_chunks(total_walks, threads).len();
+    if chunks <= 1 {
+        return WalkCorpusPath::Serial;
+    }
+    WalkCorpusPath::Parallel { threads, chunks }
+}
+
+fn estimated_walk_transitions(starts: usize, walks_per_node: usize, walk_length: usize) -> u64 {
+    (starts as u64)
+        .saturating_mul(walks_per_node as u64)
+        .saturating_mul(walk_length as u64)
+}
+
+fn walk_task_chunks(total_walks: usize, threads: usize) -> Vec<(usize, usize)> {
+    if total_walks == 0 {
+        return Vec::new();
+    }
+    let workers = threads.clamp(1, total_walks);
+    let base = total_walks / workers;
+    let rem = total_walks % workers;
+    let mut ranges = Vec::with_capacity(workers);
+    let mut start = 0;
+    for index in 0..workers {
+        let len = base + usize::from(index < rem);
+        let end = start + len;
+        if start < end {
+            ranges.push((start, end));
+        }
+        start = end;
+    }
+    ranges
+}
+
+fn walk_task_ordinal(start_ordinal: usize, walk_ordinal: usize, walks_per_node: usize) -> usize {
+    start_ordinal
+        .checked_mul(walks_per_node)
+        .and_then(|value| value.checked_add(walk_ordinal))
+        .expect("validated walk task ordinals fit usize")
 }
 
 fn build_walk(
@@ -408,6 +617,8 @@ mod tests {
     use super::*;
     use crate::algorithm_dispatch::{AlgorithmCancellation, AlgorithmControl, AlgorithmLimits};
     use crate::algorithm_embedding_control::EmbeddingResourceLimits;
+    use crate::compute_pool::ComputePool;
+    use std::sync::Arc;
 
     fn controls(
         cancellation: AlgorithmCancellation,
@@ -422,12 +633,46 @@ mod tests {
         )
     }
 
+    fn control_with_threads(threads: usize) -> AlgorithmControl {
+        let pool = Arc::new(ComputePool::new(threads).unwrap());
+        AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(threads),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(pool)
+    }
+
+    fn embedding_control(algorithm: &AlgorithmControl) -> EmbeddingControl<'_> {
+        EmbeddingControl::new(algorithm, EmbeddingResourceLimits::default())
+    }
+
     fn corpus(
         graph: &AdjacencyGraph,
         options: &Node2VecOptions,
     ) -> Result<Node2VecCorpus, Node2VecWalkError> {
         let (algorithm, limits) = controls(AlgorithmCancellation::default(), u64::MAX);
         build_walk_corpus(graph, options, &EmbeddingControl::new(&algorithm, limits))
+    }
+
+    fn corpus_with_control(
+        graph: &AdjacencyGraph,
+        options: &Node2VecOptions,
+        algorithm: &AlgorithmControl,
+    ) -> Result<Node2VecCorpus, Node2VecWalkError> {
+        build_walk_corpus(graph, options, &embedding_control(algorithm))
+    }
+
+    fn adversarial_graph(nodes: usize) -> AdjacencyGraph {
+        let edges = (0..nodes)
+            .flat_map(|source| {
+                [
+                    (source, (source + 1) % nodes),
+                    (source, (source + 3) % nodes),
+                    (source, (source * 5 + 7) % nodes),
+                ]
+            })
+            .collect::<Vec<_>>();
+        AdjacencyGraph::with_test_directed_edges(nodes, &edges)
     }
 
     #[test]
@@ -703,6 +948,178 @@ mod tests {
             sample_negative(&nodes, &both, 0, 0, 0, 0_u128.to_be_bytes(), 0, 0, 1, 0).unwrap(),
             Some(1)
         );
+    }
+
+    #[test]
+    fn walk_task_ordinal_mapping_and_chunks_are_stable() {
+        assert_eq!(walk_task_ordinal(0, 0, 4), 0);
+        assert_eq!(walk_task_ordinal(2, 3, 4), 11);
+        assert_eq!(walk_task_chunks(0, 4), Vec::<(usize, usize)>::new());
+        assert_eq!(walk_task_chunks(5, 1), vec![(0, 5)]);
+        assert_eq!(walk_task_chunks(5, 2), vec![(0, 3), (3, 5)]);
+        assert_eq!(walk_task_chunks(8, 4), vec![(0, 2), (2, 4), (4, 6), (6, 8)]);
+        assert_eq!(walk_task_chunks(3, 8), vec![(0, 1), (1, 2), (2, 3)]);
+    }
+
+    #[test]
+    fn token_count_merge_is_canonical_and_overflow_checked() {
+        let mut into = HashMap::from([(2, 3_u64), (1, 1)]);
+        merge_token_counts(&mut into, HashMap::from([(1, 4), (3, 2)])).unwrap();
+        assert_eq!(into, HashMap::from([(1, 5), (2, 3), (3, 2)]));
+        let err = merge_token_counts(&mut into, HashMap::from([(1, u64::MAX)]));
+        assert_eq!(err, Err(Node2VecWalkError::TokenCountOverflow));
+    }
+
+    #[test]
+    fn small_work_and_one_thread_select_serial_walk_path() {
+        let small = select_walk_corpus_path(&embedding_control(&control_with_threads(4)), 8, 64);
+        assert_eq!(small, WalkCorpusPath::Serial);
+        let one = select_walk_corpus_path(
+            &embedding_control(&control_with_threads(1)),
+            64,
+            NODE2VEC_WALK_PARALLEL_CROSSOVER,
+        );
+        assert_eq!(one, WalkCorpusPath::Serial);
+        let large = select_walk_corpus_path(
+            &embedding_control(&control_with_threads(4)),
+            64,
+            NODE2VEC_WALK_PARALLEL_CROSSOVER,
+        );
+        assert!(matches!(
+            large,
+            WalkCorpusPath::Parallel {
+                threads: 4,
+                chunks: 4
+            }
+        ));
+    }
+
+    #[test]
+    fn thread_matrix_preserves_walk_corpus_and_embedding_fingerprints() {
+        let graph = adversarial_graph(24);
+        let options = Node2VecOptions {
+            dimensions: 4,
+            walk_length: 6,
+            walks_per_node: 4,
+            window_size: 2,
+            negative_samples: 2,
+            epochs: 1,
+            seed: 11,
+            ..Node2VecOptions::default()
+        };
+        let serial = control_with_threads(1);
+        let serial_corpus = corpus_with_control(&graph, &options, &serial).unwrap();
+        let serial_embedding =
+            train_node2vec(&graph, &options, &embedding_control(&serial)).unwrap();
+        let estimated = estimated_walk_transitions(24, options.walks_per_node, options.walk_length);
+        assert!(estimated >= NODE2VEC_WALK_PARALLEL_CROSSOVER);
+        for threads in [2_usize, 4, 8] {
+            let parallel = control_with_threads(threads);
+            assert!(matches!(
+                select_walk_corpus_path(
+                    &embedding_control(&parallel),
+                    24 * options.walks_per_node,
+                    estimated
+                ),
+                WalkCorpusPath::Parallel { .. }
+            ));
+            assert_eq!(
+                corpus_with_control(&graph, &options, &parallel).unwrap(),
+                serial_corpus
+            );
+            assert_eq!(
+                train_node2vec(&graph, &options, &embedding_control(&parallel)).unwrap(),
+                serial_embedding
+            );
+        }
+    }
+
+    #[test]
+    fn parallel_cancellation_and_work_limits_leave_no_partial_corpus() {
+        let graph = adversarial_graph(32);
+        let options = Node2VecOptions {
+            walk_length: 4,
+            walks_per_node: 4,
+            seed: 9,
+            ..Node2VecOptions::default()
+        };
+        let pool = Arc::new(ComputePool::new(4).unwrap());
+        let cancellation = AlgorithmCancellation::default();
+        cancellation.cancel();
+        let cancelled = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(4),
+            cancellation,
+        )
+        .with_compute_pool(pool.clone());
+        assert!(matches!(
+            corpus_with_control(&graph, &options, &cancelled),
+            Err(Node2VecWalkError::Resource(
+                EmbeddingResourceError::Algorithm(_)
+            ))
+        ));
+
+        let limited = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(4),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(pool);
+        let control = EmbeddingControl::new(
+            &limited,
+            EmbeddingResourceLimits {
+                work: 3,
+                ..EmbeddingResourceLimits::default()
+            },
+        );
+        assert!(matches!(
+            build_walk_corpus(&graph, &options, &control),
+            Err(Node2VecWalkError::Resource(
+                EmbeddingResourceError::WorkLimit { .. }
+            ))
+        ));
+    }
+
+    #[test]
+    fn weighted_and_parallel_edge_fixtures_match_across_thread_counts() {
+        let graph = AdjacencyGraph::with_test_directed_edges(
+            6,
+            &[
+                (0, 1),
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+                (4, 5),
+                (5, 0),
+                (1, 0),
+            ],
+        )
+        .with_test_edge_weights(&[1.0, 2.5, 0.5, 3.0, 1.25, 0.75, 4.0, 1.5]);
+        let options = Node2VecOptions {
+            walk_length: 8,
+            walks_per_node: 8,
+            p: 0.5,
+            q: 2.0,
+            seed: 13,
+            ..Node2VecOptions::default()
+        };
+        let estimated = estimated_walk_transitions(6, options.walks_per_node, options.walk_length);
+        assert!(estimated >= NODE2VEC_WALK_PARALLEL_CROSSOVER);
+        let serial = corpus_with_control(&graph, &options, &control_with_threads(1)).unwrap();
+        for threads in [2_usize, 4, 8] {
+            let parallel = control_with_threads(threads);
+            assert!(matches!(
+                select_walk_corpus_path(
+                    &embedding_control(&parallel),
+                    6 * options.walks_per_node,
+                    estimated
+                ),
+                WalkCorpusPath::Parallel { .. }
+            ));
+            assert_eq!(
+                corpus_with_control(&graph, &options, &parallel).unwrap(),
+                serial
+            );
+        }
     }
 
     fn corpus_training(

--- a/crates/graphforge-exec/src/compute_pool.rs
+++ b/crates/graphforge-exec/src/compute_pool.rs
@@ -1,9 +1,9 @@
-//! Instance-owned bounded CPU pool for deterministic algorithm kernels (#337 / #342 / #343).
+//! Instance-owned bounded CPU pool for deterministic algorithm kernels (#337 / #342 / #343 / #344).
 //!
 //! GraphForge never installs work onto Rayon's process-global pool. Parallel
-//! cosine KNN (#342), PageRank (#343), and sibling CPU kernels consume this
-//! private pool sized from [`crate`]-facing `compute_threads` on the embedded
-//! resource policy.
+//! cosine KNN (#342), PageRank (#343), Node2Vec walk generation (#344), and
+//! sibling CPU kernels consume this private pool sized from [`crate`]-facing
+//! `compute_threads` on the embedded resource policy.
 
 use std::sync::Arc;
 

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -195,7 +195,8 @@ pub use adjacency::{
 };
 pub use algorithm_analyze::{
     analyze_algorithm, analyze_projection_fingerprint, embedding_algorithm,
-    embedding_algorithm_execution, prepare_embedding_invocation_descriptor,
+    embedding_algorithm_execution, embedding_algorithm_execution_with_compute,
+    prepare_embedding_invocation_descriptor, prepare_embedding_invocation_descriptor_with_compute,
 };
 pub use algorithm_cluster::{
     cluster_algorithm, cluster_algorithm_with_limits, cluster_projection_fingerprint,

--- a/docs/book/architecture/embedding-v1.md
+++ b/docs/book/architecture/embedding-v1.md
@@ -163,7 +163,12 @@ mass in that order using `walk`
 terminates the walk; an isolate therefore contributes its start token only.
 
 The fixed corpus is generated once, independently of `epochs`, in start UUID,
-walk ordinal, then token-position order and replayed for every epoch. For every
+walk ordinal, then token-position order and replayed for every epoch.
+When `compute_threads > 1` and estimated walk transitions are at least
+`NODE2VEC_WALK_PARALLEL_CROSSOVER` (`256`), independent `(start ordinal, walk
+ordinal)` tasks may run on the instance-owned private CPU pool and merge in
+that same canonical order; seed derivation and every walk remain identical to
+the one-thread path. Skip-gram / negative-sampling training stays serial. For every
 center, contexts are positions in ascending order from
 `max(0,i-window_size)` to `min(length,i+window_size)`, excluding `i`; the window
 is not randomized. Token counts over that fixed corpus define

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -17,7 +17,7 @@ Tokio runtime or any DataFusion execution session.
 | `spill` | disabled | Optional absolute spill directory + byte cap |
 | `io_concurrency` | `2` | Reserved I/O concurrency budget |
 | `max_concurrent_heavy_queries` | `64` | Instance-owned admission semaphore |
-| `compute_threads` | `2` | Instance-owned private CPU pool (#342 cosine KNN; #343 PageRank; sibling kernels) |
+| `compute_threads` | `2` | Instance-owned private CPU pool (#342 cosine KNN; #343 PageRank; #344 Node2Vec walks) |
 
 Defaults preserve pre-#337 fixed two-worker / two-partition behavior.
 
@@ -68,10 +68,12 @@ state.
 
 Resources are **instance-owned**, not process-global. `compute_threads` sizes a
 private Rayon pool on each `GraphForge` instance. Exact cosine KNN / similarity
-(#342) and PageRank (#343) may partition work across that pool above documented
-crossovers; work never uses Rayon's process-global pool. Dot products retain
-serial coordinate order, and PageRank keeps canonical contribution order with
-serial dangling/delta reductions, so fingerprints match the one-thread path.
+(#342), PageRank (#343), and Node2Vec walk-corpus generation (#344) may partition
+independent work across that pool above documented crossovers; work never uses
+Rayon's process-global pool. Cosine dot products retain serial coordinate order,
+PageRank keeps canonical contribution order with serial dangling/delta
+reductions, and Node2Vec skip-gram training stays serial, so fingerprints match
+the one-thread path.
 
 ## Parallel cosine KNN (#342)
 
@@ -111,6 +113,21 @@ as serial scatter. Dangling-mass and L1 convergence reductions stay serial so
 IEEE accumulation order matches the accepted oracle. Schemas, row order,
 scores, iteration counts, and fingerprints match the one-thread result at
 `1`/`2`/`4`/`8`/automatic configurations.
+
+## Parallel Node2Vec walk generation (#344)
+
+Walk-corpus construction partitions **independent `(start ordinal, walk
+ordinal)` tasks** across the instance-owned private compute pool when:
+
+- `compute_threads > 1`, and
+- estimated transitions (`starts × walks_per_node × walk_length`) are at least
+  `NODE2VEC_WALK_PARALLEL_CROSSOVER` (`256`) in `graphforge-exec`.
+
+Below that crossover, or when the policy provides one compute thread, the
+serial path runs with no pool scheduling tax. Worker-local token counts merge
+by canonical node ordinal with checked addition. Training order and arithmetic
+are unchanged, so schemas, row order, metadata, and fingerprints match the
+one-thread result at `1`/`2`/`4`/`8`/automatic configurations.
 
 ## Observability
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Parallelize Node2Vec walk-corpus generation by `(start, walk)` through the shared `ComputePool`, keeping skip-gram training serial and embeddings bit-identical across thread counts.

Closes #344.

## Changes

- Parallel walk generation via shared pool; canonical merge of walks/token counts
- Training remains serial/unchanged
- Docs updated alongside #342/#343 pool consumers

## Test plan

- [x] `cargo test -p graphforge-exec --lib algorithm_embedding_node2vec` (13 passed)
- [x] `cargo clippy -p graphforge-exec --lib -- -D warnings`
- [ ] Exact-head CI / CI Gate green
- [ ] Squash-merge when `CLEAN`

## Notes

Rebased onto `main` after #492 (#343) merged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788916687&installation_model_id=20486&pr_number=493&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F493&signature=e777b37531ad1f077532bb643c6814f32e4ab8c4bac224f6089ddd42f1d72d6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parallelize Node2Vec walk-corpus generation using an instance compute pool
> - Walk-corpus generation in `algorithm_embedding_node2vec` now runs in parallel when `compute_threads > 1` and the estimated transition count exceeds a `NODE2VEC_WALK_PARALLEL_CROSSOVER` threshold; training remains serial.
> - New `embedding_algorithm_execution_with_compute` and `prepare_embedding_invocation_descriptor_with_compute` functions in `graphforge-exec` accept `AlgorithmLimits` and an optional `SharedComputePool`, propagated from `GraphForge` via `resource_policy`.
> - Workers accumulate walk corpora locally and merge results canonically, preserving determinism across thread counts.
> - A new `WorkerPanic` error variant is emitted if a pool worker panics.
> - Behavioral Change: callers using the new `_with_compute` API will execute eligible kernels in parallel; existing callers using the original API retain serial behavior via delegation to defaults.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5de8e9e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved Node2Vec performance by enabling parallel walk generation for larger workloads.
  - Preserved consistent results across serial and parallel execution.

- **Resource Management**
  - Embedding and Node2Vec workloads now better honor configured compute-thread and batch-size limits.
  - Shared compute resources are used more efficiently across supported operations.

- **Reliability**
  - Added safer handling for worker failures, cancellation, and workload limits during parallel processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->