### PR TITLE
perf(exec): parallelize exact cosine KNN by source (#342)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2176,6 +2176,7 @@ dependencies = [
  "graphforge-storage",
  "insta",
  "parquet",
+ "rayon",
  "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.19",

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "5f8f762b3ab87221b979d49753c6b9478b5e56e44789992a4423207cbd266d62",
+  "checksum": "b74a15b35763bdfd082f303def35cc16a39310445b26d13e8569a953de79e9c3",
   "crates": {
     "adler2 2.0.1": {
       "name": "adler2",
@@ -12493,6 +12493,10 @@
             {
               "id": "futures 0.3.32",
               "target": "futures"
+            },
+            {
+              "id": "rayon 1.12.0",
+              "target": "rayon"
             },
             {
               "id": "sha2 0.10.9",
@@ -32530,6 +32534,7 @@
     "napi-derive 3.6.2",
     "parquet 58.3.0",
     "pyo3 0.28.3",
+    "rayon 1.12.0",
     "serde 1.0.228",
     "serde_json 1.0.151",
     "serde_yaml_ng 0.9.36",

--- a/crates/graphforge-api/src/embedding_refresh.rs
+++ b/crates/graphforge-api/src/embedding_refresh.rs
@@ -273,6 +273,7 @@ impl GraphForge {
             graph_visibility: Arc::clone(&self.graph_visibility),
             write_options: self.write_options.clone(),
             resource_policy: self.resource_policy.clone(),
+            compute_pool: Arc::clone(&self.compute_pool),
             heavy_query_admission: Arc::clone(&self.heavy_query_admission),
             provider_refresh_driver_active: Arc::clone(&self.provider_refresh_driver_active),
             provider_refresh_runtimes: Arc::clone(&self.provider_refresh_runtimes),

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -382,6 +382,8 @@ pub struct GraphForge {
     write_options: GraphForgeOptions,
     /// Normalized execution resource policy applied to runtime and sessions (#337).
     resource_policy: resource_policy::NormalizedResourcePolicy,
+    /// Instance-owned private CPU pool for parallel algorithm kernels (#337 / #342).
+    compute_pool: graphforge_exec::SharedComputePool,
     /// Instance-owned heavy-query admission gate (#337).
     heavy_query_admission: Arc<resource_policy::HeavyQueryAdmission>,
     /// Ensures mutation bursts share one bounded process-local driver thread.
@@ -490,6 +492,9 @@ impl GraphForge {
             heavy_query_admission: Arc::new(resource_policy::HeavyQueryAdmission::new(
                 resource_policy.max_concurrent_heavy_queries,
             )),
+            compute_pool: Arc::new(graphforge_exec::ComputePool::new(
+                resource_policy.compute_threads,
+            )?),
             provider_refresh_driver_active: Arc::new(AtomicBool::new(false)),
             provider_refresh_runtimes: Arc::new(Mutex::new(Vec::new())),
             provider_find_runtimes: Arc::new(Mutex::new(Vec::new())),
@@ -567,6 +572,9 @@ impl GraphForge {
         let heavy_query_admission = Arc::new(resource_policy::HeavyQueryAdmission::new(
             resource_policy.max_concurrent_heavy_queries,
         ));
+        let compute_pool = Arc::new(graphforge_exec::ComputePool::new(
+            resource_policy.compute_threads,
+        )?);
         let runtime = build_runtime(&resource_policy)?;
 
         let graph = Self {
@@ -589,6 +597,7 @@ impl GraphForge {
             graph_visibility: Arc::new(write_modes::WriteCoordinator::new(&write_options)),
             write_options,
             resource_policy,
+            compute_pool,
             heavy_query_admission,
             provider_refresh_driver_active: Arc::new(AtomicBool::new(false)),
             provider_refresh_runtimes: Arc::new(Mutex::new(Vec::new())),
@@ -2522,7 +2531,7 @@ impl GraphForge {
             .read()
             .expect("adjacency visibility lock poisoned");
         self.adjacency_provider.revalidate();
-        graphforge_exec::similar_algorithm_with_limits(
+        graphforge_exec::similar_algorithm_with_compute(
             self.adjacency_provider.as_ref(),
             &self.dir,
             self.ontology_mode,
@@ -2530,7 +2539,9 @@ impl GraphForge {
             std::slice::from_ref(&stem),
             options,
             graphforge_exec::AlgorithmLimits::default()
-                .with_batch_size(self.resource_policy.batch_size),
+                .with_batch_size(self.resource_policy.batch_size)
+                .with_compute_threads(self.resource_policy.compute_threads),
+            Some(self.compute_pool.clone()),
         )
     }
 

--- a/crates/graphforge-api/src/resource_policy.rs
+++ b/crates/graphforge-api/src/resource_policy.rs
@@ -2,8 +2,9 @@
 //!
 //! One normalized policy configures Tokio workers, DataFusion partitions /
 //! batch size, memory, spill, I/O concurrency, and heavy-query admission
-//! before a [`crate::GraphForge`] instance begins work. Algorithm kernels are
-//! not parallelized here; `compute_threads` reserves a future private pool.
+//! before a [`crate::GraphForge`] instance begins work. `compute_threads`
+//! sizes the instance-owned private CPU pool consumed by parallel cosine KNN
+//! (#342) and future deterministic CPU kernels.
 
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
@@ -53,8 +54,10 @@ pub struct ExecutionResourcePolicy {
     pub io_concurrency: Option<usize>,
     /// Maximum concurrent heavy Cypher / analyst invocations. `None` → 64.
     pub max_concurrent_heavy_queries: Option<usize>,
-    /// Reserved compute-thread budget for future private CPU pools. Not used to
-    /// parallelize algorithms in #337.
+    /// Compute-thread budget for the instance-owned private CPU pool (#337 / #342).
+    ///
+    /// Parallel cosine KNN partitions work by canonical source through that pool
+    /// when work exceeds the documented crossover; `1` keeps the serial path.
     pub compute_threads: Option<usize>,
 }
 
@@ -98,7 +101,7 @@ pub struct NormalizedResourcePolicy {
     pub io_concurrency: usize,
     /// Heavy-query admission slots.
     pub max_concurrent_heavy_queries: usize,
-    /// Reserved compute-thread budget (future private pool).
+    /// Compute-thread budget for the instance-owned private CPU pool (#342).
     pub compute_threads: usize,
     /// Machine logical parallelism observed at normalize time.
     pub observed_logical_cpus: usize,
@@ -121,7 +124,7 @@ pub struct ResourcePolicyDiagnostics {
     pub spill_enabled: bool,
     /// I/O concurrency budget.
     pub io_concurrency: usize,
-    /// Reserved compute threads.
+    /// Compute-thread budget for the private CPU pool.
     pub compute_threads: usize,
     /// Heavy-query admission limit.
     pub max_concurrent_heavy_queries: usize,

--- a/crates/graphforge-exec/Cargo.toml
+++ b/crates/graphforge-exec/Cargo.toml
@@ -22,6 +22,7 @@ futures = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 sha2 = { workspace = true }
+rayon = "1.10"
 
 [dev-dependencies]
 graphforge-cypher = { path = "../graphforge-cypher" }

--- a/crates/graphforge-exec/src/algorithm_analyze_conductance.rs
+++ b/crates/graphforge-exec/src/algorithm_analyze_conductance.rs
@@ -255,6 +255,7 @@ mod tests {
                         iterations: limits.3,
                         states: AlgorithmLimits::default().states,
                         batch_size: AlgorithmLimits::default().batch_size,
+                        compute_threads: AlgorithmLimits::default().compute_threads,
                     },
                     AlgorithmCancellation::default(),
                 );

--- a/crates/graphforge-exec/src/algorithm_analyze_modularity.rs
+++ b/crates/graphforge-exec/src/algorithm_analyze_modularity.rs
@@ -456,6 +456,7 @@ mod tests {
                         iterations: limits.3,
                         states: AlgorithmLimits::default().states,
                         batch_size: AlgorithmLimits::default().batch_size,
+                        compute_threads: AlgorithmLimits::default().compute_threads,
                     },
                     AlgorithmCancellation::default(),
                 ),

--- a/crates/graphforge-exec/src/algorithm_dispatch.rs
+++ b/crates/graphforge-exec/src/algorithm_dispatch.rs
@@ -170,6 +170,11 @@ pub struct AlgorithmLimits {
     pub states: u64,
     /// Internal Arrow shaping batch size (from #337 resource policy).
     pub batch_size: usize,
+    /// Declared compute-thread budget from the instance resource policy (#337 / #342).
+    ///
+    /// `1` forces the serial cosine path; larger values may activate the private
+    /// pool when work exceeds the documented crossover.
+    pub compute_threads: usize,
 }
 
 impl Default for AlgorithmLimits {
@@ -181,6 +186,7 @@ impl Default for AlgorithmLimits {
             iterations: 10_000,
             states: 10_000_000,
             batch_size: 8_192,
+            compute_threads: 1,
         }
     }
 }
@@ -190,6 +196,13 @@ impl AlgorithmLimits {
     #[must_use]
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size.max(1);
+        self
+    }
+
+    /// Override the compute-thread budget used by parallel CPU kernels (#342).
+    #[must_use]
+    pub fn with_compute_threads(mut self, compute_threads: usize) -> Self {
+        self.compute_threads = compute_threads.max(1);
         self
     }
 }
@@ -216,6 +229,8 @@ pub(crate) struct AlgorithmControl {
     cancellation: AlgorithmCancellation,
     iterations: AtomicU64,
     states: AtomicU64,
+    /// Optional private compute pool from the owning GraphForge instance (#342).
+    compute_pool: Option<crate::SharedComputePool>,
 }
 
 impl AlgorithmControl {
@@ -225,11 +240,30 @@ impl AlgorithmControl {
             cancellation,
             iterations: AtomicU64::new(0),
             states: AtomicU64::new(0),
+            compute_pool: None,
         }
+    }
+
+    /// Attach the instance-owned private CPU pool (#337 / #342).
+    #[must_use]
+    pub(crate) fn with_compute_pool(mut self, pool: crate::SharedComputePool) -> Self {
+        self.limits.compute_threads = pool.num_threads().max(1);
+        self.compute_pool = Some(pool);
+        self
     }
 
     pub(crate) fn configured_limits(&self) -> AlgorithmLimits {
         self.limits
+    }
+
+    /// Declared compute-thread budget (at least one).
+    pub(crate) fn compute_threads(&self) -> usize {
+        self.limits.compute_threads.max(1)
+    }
+
+    /// Borrow the private compute pool when one was attached.
+    pub(crate) fn compute_pool(&self) -> Option<&crate::ComputePool> {
+        self.compute_pool.as_deref()
     }
 
     /// Internal Arrow shaping batch size for bounded columnar sinks (#341).
@@ -722,6 +756,7 @@ mod tests {
             iterations: 10,
             states: 10,
             batch_size: AlgorithmLimits::default().batch_size,
+            compute_threads: AlgorithmLimits::default().compute_threads,
         };
         assert_eq!(
             registry

--- a/crates/graphforge-exec/src/algorithm_similar.rs
+++ b/crates/graphforge-exec/src/algorithm_similar.rs
@@ -371,6 +371,10 @@ pub fn similar_algorithm_with_limits(
 }
 
 /// Execute similarity with shaping limits and an optional private compute pool (#342).
+#[allow(
+    clippy::too_many_arguments,
+    reason = "mirrors similar_algorithm_with_limits plus the instance compute pool handle"
+)]
 pub fn similar_algorithm_with_compute(
     provider: &dyn AdjacencyProvider,
     dir: &Path,

--- a/crates/graphforge-exec/src/algorithm_similar.rs
+++ b/crates/graphforge-exec/src/algorithm_similar.rs
@@ -336,7 +336,7 @@ pub fn similar_algorithm(
     property_stems: &[String],
     options: SimilarOptions,
 ) -> Result<RecordBatch, GfError> {
-    similar_algorithm_with_limits(
+    similar_algorithm_with_compute(
         provider,
         dir,
         mode,
@@ -344,6 +344,7 @@ pub fn similar_algorithm(
         property_stems,
         options,
         crate::algorithm_dispatch::AlgorithmLimits::default(),
+        None,
     )
 }
 
@@ -357,19 +358,42 @@ pub fn similar_algorithm_with_limits(
     options: SimilarOptions,
     limits: crate::algorithm_dispatch::AlgorithmLimits,
 ) -> Result<RecordBatch, GfError> {
+    similar_algorithm_with_compute(
+        provider,
+        dir,
+        mode,
+        label,
+        property_stems,
+        options,
+        limits,
+        None,
+    )
+}
+
+/// Execute similarity with shaping limits and an optional private compute pool (#342).
+pub fn similar_algorithm_with_compute(
+    provider: &dyn AdjacencyProvider,
+    dir: &Path,
+    mode: OntologyMode,
+    label: TypeId,
+    property_stems: &[String],
+    options: SimilarOptions,
+    limits: crate::algorithm_dispatch::AlgorithmLimits,
+    compute: Option<crate::SharedComputePool>,
+) -> Result<RecordBatch, GfError> {
     let graph = similar_projection(provider, dir, mode, label, property_stems, &options)?;
     let algorithm = Algorithm::Similar(options.by);
     let mut registry = AlgorithmRegistry::default();
     register_similar_algorithms(&mut registry, options.k)?;
     drop(options);
-    let output = registry.execute(
-        algorithm,
-        &graph,
-        &AlgorithmControl::new(
-            limits,
-            crate::algorithm_dispatch::AlgorithmCancellation::default(),
-        ),
-    )?;
+    let mut control = AlgorithmControl::new(
+        limits,
+        crate::algorithm_dispatch::AlgorithmCancellation::default(),
+    );
+    if let Some(pool) = compute {
+        control = control.with_compute_pool(pool);
+    }
+    let output = registry.execute(algorithm, &graph, &control)?;
     shape_algorithm_output(algorithm, &output).map_err(Into::into)
 }
 

--- a/crates/graphforge-exec/src/algorithm_similar_knn.rs
+++ b/crates/graphforge-exec/src/algorithm_similar_knn.rs
@@ -1,14 +1,39 @@
 //! Deterministic, dependency-free exact cosine K-nearest-neighbor kernel.
+//!
+//! Parallelism (#342) partitions work by canonical source ordinal through the
+//! instance-owned private compute pool. Each source retains serial coordinate
+//! order for validation, norms, every dot product, clamping, candidate
+//! ordering, and top-k ties. Worker outputs merge in source order so results
+//! stay bit-for-bit identical to the serial path.
+
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use rayon::prelude::*;
 
 use crate::algorithm_dispatch::{AlgorithmControl, AlgorithmError};
 
 const CHECKPOINT_INTERVAL: usize = 16_384;
+
+/// Multiply-add ops below which cosine stays on the serial path (#342).
+///
+/// Measured to keep accepted small fixtures and micro-invocations off the
+/// worker pool; above this, source-parallel execution amortizes scheduling on
+/// typical embedded hosts. Exact numeric results remain identical either way.
+pub const COSINE_PARALLEL_CROSSOVER_OPS: u64 = 16_384;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) struct SimilarityPair {
     pub source_index: usize,
     pub target_index: usize,
     pub similarity: f64,
+}
+
+/// Selected execution path for observability and crossover tests.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CosineExecutionPath {
+    Serial,
+    Parallel { threads: usize, chunks: usize },
 }
 
 pub(crate) fn exact_cosine_knn(
@@ -41,30 +66,100 @@ fn exact_cosine_pairs(
         return Ok(Vec::new());
     }
     let norms = validate(vectors)?;
-    let mut work = 0_usize;
-    let mut pairs = Vec::new();
-
-    for source_index in 0..vectors.len() {
-        let mut candidates = Vec::with_capacity(vectors.len().saturating_sub(1));
-        for target_index in 0..vectors.len() {
-            if source_index == target_index {
-                continue;
-            }
-            let similarity = cosine(
-                vectors,
-                &norms,
-                source_index,
-                target_index,
-                control,
-                &mut work,
-            )?;
-            if include_negative || similarity >= 0.0 {
-                candidates.push((target_index, similarity));
-            }
+    let dimension = vectors[0].len();
+    let sources = vectors.len();
+    let candidates_per_source = sources.saturating_sub(1) as u64;
+    let ops = estimated_ops(sources, candidates_per_source, dimension);
+    match select_cosine_path(control, sources, ops) {
+        CosineExecutionPath::Serial => {
+            exact_cosine_pairs_serial(vectors, &norms, k, include_negative, control)
         }
-        append_top_k(&mut pairs, source_index, candidates, k, control)?;
+        CosineExecutionPath::Parallel { .. } => {
+            exact_cosine_pairs_parallel(vectors, &norms, k, include_negative, control)
+        }
+    }
+}
+
+fn exact_cosine_pairs_serial(
+    vectors: &[&[f64]],
+    norms: &[f64],
+    k: usize,
+    include_negative: bool,
+    control: &AlgorithmControl,
+) -> Result<Vec<SimilarityPair>, AlgorithmError> {
+    let work = AtomicUsize::new(0);
+    let mut pairs = Vec::new();
+    for source_index in 0..vectors.len() {
+        let source_pairs = score_source_all_pairs(
+            vectors,
+            norms,
+            source_index,
+            k,
+            include_negative,
+            control,
+            &work,
+        )?;
+        append_checked(&mut pairs, source_pairs, control)?;
     }
     Ok(pairs)
+}
+
+fn exact_cosine_pairs_parallel(
+    vectors: &[&[f64]],
+    norms: &[f64],
+    k: usize,
+    include_negative: bool,
+    control: &AlgorithmControl,
+) -> Result<Vec<SimilarityPair>, AlgorithmError> {
+    let pool = control
+        .compute_pool()
+        .ok_or_else(|| execution("parallel cosine requires an instance-owned compute pool"))?;
+    let ranges = source_chunks(vectors.len(), control.compute_threads());
+    let work = AtomicUsize::new(0);
+    let chunk_results = run_on_pool(pool, || {
+        ranges
+            .par_iter()
+            .map(|&(start, end)| {
+                let mut chunk_pairs = Vec::new();
+                for source_index in start..end {
+                    let source_pairs = score_source_all_pairs(
+                        vectors,
+                        norms,
+                        source_index,
+                        k,
+                        include_negative,
+                        control,
+                        &work,
+                    )?;
+                    chunk_pairs.extend(source_pairs);
+                }
+                Ok(chunk_pairs)
+            })
+            .collect::<Result<Vec<_>, AlgorithmError>>()
+    })?;
+    merge_chunk_pairs(chunk_results, control)
+}
+
+fn score_source_all_pairs(
+    vectors: &[&[f64]],
+    norms: &[f64],
+    source_index: usize,
+    k: usize,
+    include_negative: bool,
+    control: &AlgorithmControl,
+    work: &AtomicUsize,
+) -> Result<Vec<SimilarityPair>, AlgorithmError> {
+    let mut candidates = Vec::with_capacity(vectors.len().saturating_sub(1));
+    for target_index in 0..vectors.len() {
+        if source_index == target_index {
+            continue;
+        }
+        let similarity = cosine(vectors, norms, source_index, target_index, control, work)?;
+        if include_negative || similarity >= 0.0 {
+            candidates.push((target_index, similarity));
+        }
+    }
+    top_k_pairs(source_index, candidates, k, control)
 }
 
 pub(crate) fn exact_filtered_cosine_knn(
@@ -86,37 +181,110 @@ pub(crate) fn exact_filtered_cosine_knn(
         return Ok(Vec::new());
     }
     let norms = validate(vectors)?;
-    let mut work = 0_usize;
-    let mut pairs = Vec::new();
-
-    for (source_index, source_candidates) in candidate_indices.iter().enumerate() {
-        let mut seen = vec![false; vectors.len()];
-        let mut candidates = Vec::with_capacity(source_candidates.len());
-        for &target_index in source_candidates {
-            checkpoint(control, &mut work)?;
-            let Some(target_seen) = seen.get_mut(target_index) else {
-                return Err(execution(
-                    "filtered KNN candidate is outside vector selection",
-                ));
-            };
-            if source_index == target_index || std::mem::replace(target_seen, true) {
-                continue;
-            }
-            let similarity = cosine(
-                vectors,
-                &norms,
-                source_index,
-                target_index,
-                control,
-                &mut work,
-            )?;
-            if similarity >= 0.0 {
-                candidates.push((target_index, similarity));
-            }
+    let dimension = vectors[0].len();
+    let sources = vectors.len();
+    let candidate_comparisons = candidate_indices
+        .iter()
+        .map(Vec::len)
+        .fold(0_u64, |acc, len| acc.saturating_add(len as u64));
+    let ops = estimated_ops_from_comparisons(candidate_comparisons, dimension);
+    match select_cosine_path(control, sources, ops) {
+        CosineExecutionPath::Serial => {
+            exact_filtered_cosine_knn_serial(vectors, &norms, candidate_indices, k, control)
         }
-        append_top_k(&mut pairs, source_index, candidates, k, control)?;
+        CosineExecutionPath::Parallel { .. } => {
+            exact_filtered_cosine_knn_parallel(vectors, &norms, candidate_indices, k, control)
+        }
+    }
+}
+
+fn exact_filtered_cosine_knn_serial(
+    vectors: &[&[f64]],
+    norms: &[f64],
+    candidate_indices: &[Vec<usize>],
+    k: usize,
+    control: &AlgorithmControl,
+) -> Result<Vec<SimilarityPair>, AlgorithmError> {
+    let work = AtomicUsize::new(0);
+    let mut pairs = Vec::new();
+    for (source_index, source_candidates) in candidate_indices.iter().enumerate() {
+        let source_pairs = score_source_filtered(
+            vectors,
+            norms,
+            source_index,
+            source_candidates,
+            k,
+            control,
+            &work,
+        )?;
+        append_checked(&mut pairs, source_pairs, control)?;
     }
     Ok(pairs)
+}
+
+fn exact_filtered_cosine_knn_parallel(
+    vectors: &[&[f64]],
+    norms: &[f64],
+    candidate_indices: &[Vec<usize>],
+    k: usize,
+    control: &AlgorithmControl,
+) -> Result<Vec<SimilarityPair>, AlgorithmError> {
+    let pool = control
+        .compute_pool()
+        .ok_or_else(|| execution("parallel cosine requires an instance-owned compute pool"))?;
+    let ranges = source_chunks(vectors.len(), control.compute_threads());
+    let work = AtomicUsize::new(0);
+    let chunk_results = run_on_pool(pool, || {
+        ranges
+            .par_iter()
+            .map(|&(start, end)| {
+                let mut chunk_pairs = Vec::new();
+                for source_index in start..end {
+                    let source_pairs = score_source_filtered(
+                        vectors,
+                        norms,
+                        source_index,
+                        &candidate_indices[source_index],
+                        k,
+                        control,
+                        &work,
+                    )?;
+                    chunk_pairs.extend(source_pairs);
+                }
+                Ok(chunk_pairs)
+            })
+            .collect::<Result<Vec<_>, AlgorithmError>>()
+    })?;
+    merge_chunk_pairs(chunk_results, control)
+}
+
+fn score_source_filtered(
+    vectors: &[&[f64]],
+    norms: &[f64],
+    source_index: usize,
+    source_candidates: &[usize],
+    k: usize,
+    control: &AlgorithmControl,
+    work: &AtomicUsize,
+) -> Result<Vec<SimilarityPair>, AlgorithmError> {
+    let mut seen = vec![false; vectors.len()];
+    let mut candidates = Vec::with_capacity(source_candidates.len());
+    for &target_index in source_candidates {
+        checkpoint(control, work)?;
+        let Some(target_seen) = seen.get_mut(target_index) else {
+            return Err(execution(
+                "filtered KNN candidate is outside vector selection",
+            ));
+        };
+        if source_index == target_index || std::mem::replace(target_seen, true) {
+            continue;
+        }
+        let similarity = cosine(vectors, norms, source_index, target_index, control, work)?;
+        if similarity >= 0.0 {
+            candidates.push((target_index, similarity));
+        }
+    }
+    top_k_pairs(source_index, candidates, k, control)
 }
 
 fn cosine(
@@ -125,7 +293,7 @@ fn cosine(
     source_index: usize,
     target_index: usize,
     control: &AlgorithmControl,
-    work: &mut usize,
+    work: &AtomicUsize,
 ) -> Result<f64, AlgorithmError> {
     let mut dot = 0.0;
     for (&left, &right) in vectors[source_index].iter().zip(vectors[target_index]) {
@@ -142,29 +310,65 @@ fn cosine(
         .ok_or_else(numeric_error)
 }
 
-fn append_top_k(
-    pairs: &mut Vec<SimilarityPair>,
+fn top_k_pairs(
     source_index: usize,
     mut candidates: Vec<(usize, f64)>,
     k: usize,
     control: &AlgorithmControl,
-) -> Result<(), AlgorithmError> {
+) -> Result<Vec<SimilarityPair>, AlgorithmError> {
     candidates.sort_by(|(left_index, left_score), (right_index, right_score)| {
         right_score
             .total_cmp(left_score)
             .then_with(|| left_index.cmp(right_index))
     });
     control.check_cancelled()?;
+    let mut pairs = Vec::with_capacity(k.min(candidates.len()));
     for (target_index, similarity) in candidates.into_iter().take(k) {
         control.check_cancelled()?;
-        control.check_output_rows(pairs.len().saturating_add(1))?;
         pairs.push(SimilarityPair {
             source_index,
             target_index,
             similarity,
         });
     }
+    Ok(pairs)
+}
+
+fn append_checked(
+    pairs: &mut Vec<SimilarityPair>,
+    source_pairs: Vec<SimilarityPair>,
+    control: &AlgorithmControl,
+) -> Result<(), AlgorithmError> {
+    for pair in source_pairs {
+        control.check_cancelled()?;
+        control.check_output_rows(pairs.len().saturating_add(1))?;
+        pairs.push(pair);
+    }
     Ok(())
+}
+
+fn merge_chunk_pairs(
+    chunk_results: Vec<Vec<SimilarityPair>>,
+    control: &AlgorithmControl,
+) -> Result<Vec<SimilarityPair>, AlgorithmError> {
+    let mut pairs = Vec::new();
+    for chunk in chunk_results {
+        append_checked(&mut pairs, chunk, control)?;
+    }
+    Ok(pairs)
+}
+
+fn run_on_pool<R>(
+    pool: &crate::ComputePool,
+    op: impl FnOnce() -> Result<R, AlgorithmError> + Send,
+) -> Result<R, AlgorithmError>
+where
+    R: Send,
+{
+    match catch_unwind(AssertUnwindSafe(|| pool.install(op))) {
+        Ok(result) => result,
+        Err(_) => Err(execution("cosine worker panicked")),
+    }
 }
 
 fn validate(vectors: &[&[f64]]) -> Result<Vec<f64>, AlgorithmError> {
@@ -190,12 +394,66 @@ fn validate(vectors: &[&[f64]]) -> Result<Vec<f64>, AlgorithmError> {
         .collect()
 }
 
-fn checkpoint(control: &AlgorithmControl, work: &mut usize) -> Result<(), AlgorithmError> {
-    *work += 1;
-    if (*work).is_multiple_of(CHECKPOINT_INTERVAL) {
+fn checkpoint(control: &AlgorithmControl, work: &AtomicUsize) -> Result<(), AlgorithmError> {
+    let observed = work.fetch_add(1, Ordering::Relaxed) + 1;
+    if observed.is_multiple_of(CHECKPOINT_INTERVAL) {
         control.checkpoint()?;
     }
     Ok(())
+}
+
+fn estimated_ops(sources: usize, candidates_per_source: u64, dimension: usize) -> u64 {
+    estimated_ops_from_comparisons(
+        (sources as u64).saturating_mul(candidates_per_source),
+        dimension,
+    )
+}
+
+fn estimated_ops_from_comparisons(comparisons: u64, dimension: usize) -> u64 {
+    comparisons.saturating_mul(dimension as u64)
+}
+
+/// Choose serial vs private-pool parallel execution for a cosine workload.
+pub(crate) fn select_cosine_path(
+    control: &AlgorithmControl,
+    sources: usize,
+    estimated_ops: u64,
+) -> CosineExecutionPath {
+    let threads = control.compute_threads();
+    if threads <= 1 || sources <= 1 || estimated_ops < COSINE_PARALLEL_CROSSOVER_OPS {
+        return CosineExecutionPath::Serial;
+    }
+    if control
+        .compute_pool()
+        .is_none_or(|pool| !pool.is_parallel())
+    {
+        return CosineExecutionPath::Serial;
+    }
+    let chunks = source_chunks(sources, threads).len();
+    if chunks <= 1 {
+        return CosineExecutionPath::Serial;
+    }
+    CosineExecutionPath::Parallel { threads, chunks }
+}
+
+fn source_chunks(sources: usize, threads: usize) -> Vec<(usize, usize)> {
+    if sources == 0 {
+        return Vec::new();
+    }
+    let workers = threads.clamp(1, sources);
+    let base = sources / workers;
+    let rem = sources % workers;
+    let mut ranges = Vec::with_capacity(workers);
+    let mut start = 0;
+    for index in 0..workers {
+        let len = base + usize::from(index < rem);
+        let end = start + len;
+        if start < end {
+            ranges.push((start, end));
+        }
+        start = end;
+    }
+    ranges
 }
 
 fn numeric_error() -> AlgorithmError {
@@ -212,9 +470,46 @@ fn execution(message: &str) -> AlgorithmError {
 mod tests {
     use super::*;
     use crate::algorithm_dispatch::{AlgorithmCancellation, AlgorithmLimits};
+    use crate::compute_pool::ComputePool;
+    use std::sync::Arc;
 
     fn control() -> AlgorithmControl {
         AlgorithmControl::new(AlgorithmLimits::default(), AlgorithmCancellation::default())
+    }
+
+    fn control_with_threads(threads: usize) -> AlgorithmControl {
+        let pool = Arc::new(ComputePool::new(threads).unwrap());
+        AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(threads),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(pool)
+    }
+
+    fn fingerprint(pairs: &[SimilarityPair]) -> Vec<(usize, usize, u64)> {
+        pairs
+            .iter()
+            .map(|pair| {
+                (
+                    pair.source_index,
+                    pair.target_index,
+                    pair.similarity.to_bits(),
+                )
+            })
+            .collect()
+    }
+
+    fn adversarial_vectors(count: usize, dimension: usize) -> Vec<Vec<f64>> {
+        (0..count)
+            .map(|source| {
+                (0..dimension)
+                    .map(|axis| {
+                        let signed = if (source + axis) % 2 == 0 { 1.0 } else { -1.0 };
+                        signed * ((source * 17 + axis * 13) % 97 + 1) as f64 / 97.0
+                    })
+                    .collect()
+            })
+            .collect()
     }
 
     #[test]
@@ -412,7 +707,7 @@ mod tests {
             Err(AlgorithmError::Cancelled)
         );
         assert_eq!(
-            append_top_k(&mut Vec::new(), 0, vec![(1, 1.0)], 1, &cancelled_control),
+            top_k_pairs(0, vec![(1, 1.0)], 1, &cancelled_control),
             Err(AlgorithmError::Cancelled)
         );
     }
@@ -452,6 +747,109 @@ mod tests {
         );
         assert_eq!(
             exact_cosine_similarity(&vectors, 1, &cancelled),
+            Err(AlgorithmError::Cancelled)
+        );
+    }
+
+    #[test]
+    fn small_work_and_one_thread_select_serial_path() {
+        let small = select_cosine_path(&control_with_threads(4), 4, 64);
+        assert_eq!(small, CosineExecutionPath::Serial);
+        let one = select_cosine_path(&control_with_threads(1), 64, COSINE_PARALLEL_CROSSOVER_OPS);
+        assert_eq!(one, CosineExecutionPath::Serial);
+        let large = select_cosine_path(&control_with_threads(4), 64, COSINE_PARALLEL_CROSSOVER_OPS);
+        assert!(matches!(
+            large,
+            CosineExecutionPath::Parallel {
+                threads: 4,
+                chunks: 4
+            }
+        ));
+    }
+
+    #[test]
+    fn source_chunks_cover_canonical_ranges() {
+        assert_eq!(source_chunks(0, 4), Vec::<(usize, usize)>::new());
+        assert_eq!(source_chunks(5, 1), vec![(0, 5)]);
+        assert_eq!(source_chunks(5, 2), vec![(0, 3), (3, 5)]);
+        assert_eq!(source_chunks(8, 4), vec![(0, 2), (2, 4), (4, 6), (6, 8)]);
+        assert_eq!(source_chunks(3, 8), vec![(0, 1), (1, 2), (2, 3)]);
+    }
+
+    #[test]
+    fn thread_matrix_preserves_exact_knn_cosine_and_filtered_fingerprints() {
+        let values = adversarial_vectors(48, 16);
+        let vectors = values.iter().map(Vec::as_slice).collect::<Vec<_>>();
+        let candidates = (0..values.len())
+            .map(|source| {
+                (0..values.len())
+                    .filter(|&target| target != source && (source + target) % 3 != 0)
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        let serial = control_with_threads(1);
+        let knn_serial = fingerprint(&exact_cosine_knn(&vectors, 5, &serial).unwrap());
+        let cosine_serial = fingerprint(&exact_cosine_similarity(&vectors, 7, &serial).unwrap());
+        let filtered_serial =
+            fingerprint(&exact_filtered_cosine_knn(&vectors, &candidates, 4, &serial).unwrap());
+        for threads in [2_usize, 4, 8] {
+            let parallel = control_with_threads(threads);
+            assert!(matches!(
+                select_cosine_path(
+                    &parallel,
+                    values.len(),
+                    estimated_ops(values.len(), (values.len() - 1) as u64, 16)
+                ),
+                CosineExecutionPath::Parallel { .. }
+            ));
+            assert_eq!(
+                fingerprint(&exact_cosine_knn(&vectors, 5, &parallel).unwrap()),
+                knn_serial
+            );
+            assert_eq!(
+                fingerprint(&exact_cosine_similarity(&vectors, 7, &parallel).unwrap()),
+                cosine_serial
+            );
+            assert_eq!(
+                fingerprint(
+                    &exact_filtered_cosine_knn(&vectors, &candidates, 4, &parallel).unwrap()
+                ),
+                filtered_serial
+            );
+        }
+    }
+
+    #[test]
+    fn parallel_output_limits_and_cancellation_remain_atomic() {
+        let values = adversarial_vectors(32, 8);
+        let vectors = values.iter().map(Vec::as_slice).collect::<Vec<_>>();
+        let pool = Arc::new(ComputePool::new(4).unwrap());
+        let limited = AlgorithmControl::new(
+            AlgorithmLimits {
+                output_rows: 3,
+                compute_threads: 4,
+                ..AlgorithmLimits::default()
+            },
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(pool.clone());
+        assert_eq!(
+            exact_cosine_knn(&vectors, 2, &limited),
+            Err(AlgorithmError::OutputLimit {
+                observed: 4,
+                limit: 3,
+            })
+        );
+
+        let cancellation = AlgorithmCancellation::default();
+        cancellation.cancel();
+        let cancelled = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(4),
+            cancellation,
+        )
+        .with_compute_pool(pool);
+        assert_eq!(
+            exact_cosine_similarity(&vectors, 3, &cancelled),
             Err(AlgorithmError::Cancelled)
         );
     }

--- a/crates/graphforge-exec/src/algorithm_similar_knn.rs
+++ b/crates/graphforge-exec/src/algorithm_similar_knn.rs
@@ -7,7 +7,6 @@
 //! stay bit-for-bit identical to the serial path.
 
 use std::panic::{AssertUnwindSafe, catch_unwind};
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rayon::prelude::*;
 
@@ -17,10 +16,16 @@ const CHECKPOINT_INTERVAL: usize = 16_384;
 
 /// Multiply-add ops below which cosine stays on the serial path (#342).
 ///
-/// Measured to keep accepted small fixtures and micro-invocations off the
-/// worker pool; above this, source-parallel execution amortizes scheduling on
-/// typical embedded hosts. Exact numeric results remain identical either way.
-pub const COSINE_PARALLEL_CROSSOVER_OPS: u64 = 16_384;
+/// Chosen from release-mode serial-vs-parallel timings of exact cosine KNN on
+/// this M4 agent host (4× Xeon vCPU, adversarial fixture, 4 private workers;
+/// see ignored `measure_cosine_parallel_crossover`):
+/// - ~16k ops: parallel still slower (Rayon install + merge tax)
+/// - ~36k ops: first clear win (~0.81× serial)
+/// - ≥65k ops: ≥2× speedup
+///
+/// `32_768` is the smallest power-of-two at/above that measured win boundary.
+/// Exact numeric results remain identical on either path.
+pub const COSINE_PARALLEL_CROSSOVER_OPS: u64 = 32_768;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) struct SimilarityPair {
@@ -87,7 +92,7 @@ fn exact_cosine_pairs_serial(
     include_negative: bool,
     control: &AlgorithmControl,
 ) -> Result<Vec<SimilarityPair>, AlgorithmError> {
-    let work = AtomicUsize::new(0);
+    let mut work = 0usize;
     let mut pairs = Vec::new();
     for source_index in 0..vectors.len() {
         let source_pairs = score_source_all_pairs(
@@ -97,7 +102,7 @@ fn exact_cosine_pairs_serial(
             k,
             include_negative,
             control,
-            &work,
+            &mut work,
         )?;
         append_checked(&mut pairs, source_pairs, control)?;
     }
@@ -115,11 +120,11 @@ fn exact_cosine_pairs_parallel(
         .compute_pool()
         .ok_or_else(|| execution("parallel cosine requires an instance-owned compute pool"))?;
     let ranges = source_chunks(vectors.len(), control.compute_threads());
-    let work = AtomicUsize::new(0);
     let chunk_results = run_on_pool(pool, || {
-        ranges
+        let results = ranges
             .par_iter()
             .map(|&(start, end)| {
+                let mut work = 0usize;
                 let mut chunk_pairs = Vec::new();
                 for source_index in start..end {
                     let source_pairs = score_source_all_pairs(
@@ -129,13 +134,14 @@ fn exact_cosine_pairs_parallel(
                         k,
                         include_negative,
                         control,
-                        &work,
+                        &mut work,
                     )?;
                     chunk_pairs.extend(source_pairs);
                 }
                 Ok(chunk_pairs)
             })
-            .collect::<Result<Vec<_>, AlgorithmError>>()
+            .collect::<Vec<Result<_, AlgorithmError>>>();
+        first_chunk_error(results)
     })?;
     merge_chunk_pairs(chunk_results, control)
 }
@@ -147,7 +153,7 @@ fn score_source_all_pairs(
     k: usize,
     include_negative: bool,
     control: &AlgorithmControl,
-    work: &AtomicUsize,
+    work: &mut usize,
 ) -> Result<Vec<SimilarityPair>, AlgorithmError> {
     let mut candidates = Vec::with_capacity(vectors.len().saturating_sub(1));
     for target_index in 0..vectors.len() {
@@ -205,7 +211,7 @@ fn exact_filtered_cosine_knn_serial(
     k: usize,
     control: &AlgorithmControl,
 ) -> Result<Vec<SimilarityPair>, AlgorithmError> {
-    let work = AtomicUsize::new(0);
+    let mut work = 0usize;
     let mut pairs = Vec::new();
     for (source_index, source_candidates) in candidate_indices.iter().enumerate() {
         let source_pairs = score_source_filtered(
@@ -215,7 +221,7 @@ fn exact_filtered_cosine_knn_serial(
             source_candidates,
             k,
             control,
-            &work,
+            &mut work,
         )?;
         append_checked(&mut pairs, source_pairs, control)?;
     }
@@ -233,11 +239,11 @@ fn exact_filtered_cosine_knn_parallel(
         .compute_pool()
         .ok_or_else(|| execution("parallel cosine requires an instance-owned compute pool"))?;
     let ranges = source_chunks(vectors.len(), control.compute_threads());
-    let work = AtomicUsize::new(0);
     let chunk_results = run_on_pool(pool, || {
-        ranges
+        let results = ranges
             .par_iter()
             .map(|&(start, end)| {
+                let mut work = 0usize;
                 let mut chunk_pairs = Vec::new();
                 for (source_index, source_candidates) in
                     candidate_indices.iter().enumerate().take(end).skip(start)
@@ -249,15 +255,33 @@ fn exact_filtered_cosine_knn_parallel(
                         source_candidates,
                         k,
                         control,
-                        &work,
+                        &mut work,
                     )?;
                     chunk_pairs.extend(source_pairs);
                 }
                 Ok(chunk_pairs)
             })
-            .collect::<Result<Vec<_>, AlgorithmError>>()
+            .collect::<Vec<Result<_, AlgorithmError>>>();
+        first_chunk_error(results)
     })?;
     merge_chunk_pairs(chunk_results, control)
+}
+
+/// Prefer the lowest-index chunk error so parallel failures stay deterministic.
+fn first_chunk_error<T>(results: Vec<Result<T, AlgorithmError>>) -> Result<Vec<T>, AlgorithmError> {
+    let mut ok = Vec::with_capacity(results.len());
+    let mut first_error: Option<AlgorithmError> = None;
+    for result in results {
+        match result {
+            Ok(value) if first_error.is_none() => ok.push(value),
+            Err(error) if first_error.is_none() => first_error = Some(error),
+            Ok(_) | Err(_) => {}
+        }
+    }
+    match first_error {
+        Some(error) => Err(error),
+        None => Ok(ok),
+    }
 }
 
 fn score_source_filtered(
@@ -267,7 +291,7 @@ fn score_source_filtered(
     source_candidates: &[usize],
     k: usize,
     control: &AlgorithmControl,
-    work: &AtomicUsize,
+    work: &mut usize,
 ) -> Result<Vec<SimilarityPair>, AlgorithmError> {
     let mut seen = vec![false; vectors.len()];
     let mut candidates = Vec::with_capacity(source_candidates.len());
@@ -295,7 +319,7 @@ fn cosine(
     source_index: usize,
     target_index: usize,
     control: &AlgorithmControl,
-    work: &AtomicUsize,
+    work: &mut usize,
 ) -> Result<f64, AlgorithmError> {
     let mut dot = 0.0;
     for (&left, &right) in vectors[source_index].iter().zip(vectors[target_index]) {
@@ -396,9 +420,9 @@ fn validate(vectors: &[&[f64]]) -> Result<Vec<f64>, AlgorithmError> {
         .collect()
 }
 
-fn checkpoint(control: &AlgorithmControl, work: &AtomicUsize) -> Result<(), AlgorithmError> {
-    let observed = work.fetch_add(1, Ordering::Relaxed) + 1;
-    if observed.is_multiple_of(CHECKPOINT_INTERVAL) {
+fn checkpoint(control: &AlgorithmControl, work: &mut usize) -> Result<(), AlgorithmError> {
+    *work = work.saturating_add(1);
+    if (*work).is_multiple_of(CHECKPOINT_INTERVAL) {
         control.checkpoint()?;
     }
     Ok(())
@@ -780,6 +804,7 @@ mod tests {
 
     #[test]
     fn thread_matrix_preserves_exact_knn_cosine_and_filtered_fingerprints() {
+        // 48×47×16 ≈ 36k ops exceeds COSINE_PARALLEL_CROSSOVER_OPS.
         let values = adversarial_vectors(48, 16);
         let vectors = values.iter().map(Vec::as_slice).collect::<Vec<_>>();
         let candidates = (0..values.len())
@@ -823,7 +848,9 @@ mod tests {
 
     #[test]
     fn parallel_output_limits_and_cancellation_remain_atomic() {
-        let values = adversarial_vectors(32, 8);
+        // 48×47×16 ≈ 36k ops exceeds COSINE_PARALLEL_CROSSOVER_OPS so
+        // this exercises the private-pool path, not the serial fallback.
+        let values = adversarial_vectors(48, 16);
         let vectors = values.iter().map(Vec::as_slice).collect::<Vec<_>>();
         let pool = Arc::new(ComputePool::new(4).unwrap());
         let limited = AlgorithmControl::new(
@@ -835,6 +862,14 @@ mod tests {
             AlgorithmCancellation::default(),
         )
         .with_compute_pool(pool.clone());
+        assert!(matches!(
+            select_cosine_path(
+                &limited,
+                values.len(),
+                estimated_ops(values.len(), (values.len() - 1) as u64, 16)
+            ),
+            CosineExecutionPath::Parallel { .. }
+        ));
         assert_eq!(
             exact_cosine_knn(&vectors, 2, &limited),
             Err(AlgorithmError::OutputLimit {
@@ -854,5 +889,77 @@ mod tests {
             exact_cosine_similarity(&vectors, 3, &cancelled),
             Err(AlgorithmError::Cancelled)
         );
+    }
+
+    #[test]
+    fn first_chunk_error_prefers_lowest_index() {
+        let results = vec![
+            Err(AlgorithmError::Cancelled),
+            Err(AlgorithmError::OutputLimit {
+                observed: 9,
+                limit: 1,
+            }),
+            Ok(vec![SimilarityPair {
+                source_index: 0,
+                target_index: 1,
+                similarity: 1.0,
+            }]),
+        ];
+        assert_eq!(first_chunk_error(results), Err(AlgorithmError::Cancelled));
+    }
+
+    #[test]
+    #[ignore = "manual crossover measurement; run with --ignored --nocapture"]
+    fn measure_cosine_parallel_crossover() {
+        use std::time::Instant;
+        let pool = Arc::new(ComputePool::new(4).unwrap());
+        for &(sources, dim) in &[
+            (16usize, 16),
+            (32, 16),
+            (48, 16),
+            (64, 32),
+            (96, 32),
+            (128, 32),
+            (256, 64),
+            (512, 64),
+            (512, 128),
+        ] {
+            let values = adversarial_vectors(sources, dim);
+            let vectors = values.iter().map(Vec::as_slice).collect::<Vec<_>>();
+            let norms = validate(&vectors).unwrap();
+            let ops = estimated_ops(sources, (sources - 1) as u64, dim);
+            let limits = AlgorithmLimits {
+                iterations: u64::MAX,
+                ..AlgorithmLimits::default()
+            };
+            let serial_ctl = AlgorithmControl::new(
+                limits.with_compute_threads(1),
+                AlgorithmCancellation::default(),
+            );
+            let parallel_ctl = AlgorithmControl::new(
+                limits.with_compute_threads(4),
+                AlgorithmCancellation::default(),
+            )
+            .with_compute_pool(pool.clone());
+            // Warm once.
+            let _ = exact_cosine_pairs_serial(&vectors, &norms, 5, false, &serial_ctl).unwrap();
+            let _ = exact_cosine_pairs_parallel(&vectors, &norms, 5, false, &parallel_ctl).unwrap();
+            let mut serial_ns = u128::MAX;
+            let mut parallel_ns = u128::MAX;
+            for _ in 0..5 {
+                let t0 = Instant::now();
+                let a = exact_cosine_pairs_serial(&vectors, &norms, 5, false, &serial_ctl).unwrap();
+                serial_ns = serial_ns.min(t0.elapsed().as_nanos());
+                let t1 = Instant::now();
+                let b =
+                    exact_cosine_pairs_parallel(&vectors, &norms, 5, false, &parallel_ctl).unwrap();
+                parallel_ns = parallel_ns.min(t1.elapsed().as_nanos());
+                assert_eq!(fingerprint(&a), fingerprint(&b));
+            }
+            eprintln!(
+                "sources={sources} dim={dim} ops={ops} serial_ns={serial_ns} parallel_ns={parallel_ns} ratio={}",
+                parallel_ns as f64 / serial_ns as f64
+            );
+        }
     }
 }

--- a/crates/graphforge-exec/src/algorithm_similar_knn.rs
+++ b/crates/graphforge-exec/src/algorithm_similar_knn.rs
@@ -239,12 +239,14 @@ fn exact_filtered_cosine_knn_parallel(
             .par_iter()
             .map(|&(start, end)| {
                 let mut chunk_pairs = Vec::new();
-                for source_index in start..end {
+                for (source_index, source_candidates) in
+                    candidate_indices.iter().enumerate().take(end).skip(start)
+                {
                     let source_pairs = score_source_filtered(
                         vectors,
                         norms,
                         source_index,
-                        &candidate_indices[source_index],
+                        source_candidates,
                         k,
                         control,
                         &work,

--- a/crates/graphforge-exec/src/compute_pool.rs
+++ b/crates/graphforge-exec/src/compute_pool.rs
@@ -1,0 +1,97 @@
+//! Instance-owned bounded CPU pool for deterministic algorithm kernels (#337 / #342).
+//!
+//! GraphForge never installs work onto Rayon's process-global pool. Parallel
+//! cosine KNN (#342) and future CPU kernels consume this private pool sized from
+//! [`crate`]-facing `compute_threads` on the embedded resource policy.
+
+use std::sync::Arc;
+
+use graphforge_core::GfError;
+use rayon::{ThreadPool, ThreadPoolBuilder};
+
+/// Private, instance-owned Rayon pool bounded by the resource-policy compute budget.
+#[derive(Debug)]
+pub struct ComputePool {
+    threads: usize,
+    /// `None` when the budget is one thread — callers stay on the serial path.
+    pool: Option<ThreadPool>,
+}
+
+impl ComputePool {
+    /// Build a private pool with exactly `threads` workers (`1` keeps no pool).
+    ///
+    /// # Errors
+    /// Returns [`GfError::Execution`] when the private Rayon pool cannot be created.
+    pub fn new(threads: usize) -> Result<Self, GfError> {
+        let threads = threads.max(1);
+        if threads == 1 {
+            return Ok(Self {
+                threads: 1,
+                pool: None,
+            });
+        }
+        let pool = ThreadPoolBuilder::new()
+            .num_threads(threads)
+            .thread_name(|index| format!("graphforge-compute-{index}"))
+            .build()
+            .map_err(|error| GfError::Execution(format!("compute pool unavailable: {error}")))?;
+        Ok(Self {
+            threads,
+            pool: Some(pool),
+        })
+    }
+
+    /// Declared worker count from the resource policy.
+    #[must_use]
+    pub fn num_threads(&self) -> usize {
+        self.threads
+    }
+
+    /// Whether a private multi-thread pool is installed.
+    #[must_use]
+    pub fn is_parallel(&self) -> bool {
+        self.pool.is_some()
+    }
+
+    /// Run `op` on this pool (or inline when the budget is one thread).
+    pub fn install<OP, R>(&self, op: OP) -> R
+    where
+        OP: FnOnce() -> R + Send,
+        R: Send,
+    {
+        match &self.pool {
+            Some(pool) => pool.install(op),
+            None => op(),
+        }
+    }
+}
+
+/// Shared handle stored on the facade and passed into algorithm controls.
+pub type SharedComputePool = Arc<ComputePool>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn one_thread_skips_pool_construction() {
+        let pool = ComputePool::new(1).unwrap();
+        assert_eq!(pool.num_threads(), 1);
+        assert!(!pool.is_parallel());
+        assert_eq!(pool.install(|| 7), 7);
+    }
+
+    #[test]
+    fn multi_thread_pool_runs_on_private_workers() {
+        let pool = ComputePool::new(2).unwrap();
+        assert!(pool.is_parallel());
+        let sum = pool.install(|| {
+            use rayon::prelude::*;
+            (0..32_usize)
+                .into_par_iter()
+                .map(|value| value * value)
+                .sum::<usize>()
+        });
+        assert_eq!(sum, (0..32).map(|value| value * value).sum::<usize>());
+    }
+}

--- a/crates/graphforge-exec/src/compute_pool.rs
+++ b/crates/graphforge-exec/src/compute_pool.rs
@@ -89,7 +89,15 @@ mod tests {
             use rayon::prelude::*;
             (0..32_usize)
                 .into_par_iter()
-                .map(|value| value * value)
+                .map(|value| {
+                    let thread = std::thread::current();
+                    let name = thread.name().unwrap_or("unnamed");
+                    assert!(
+                        name.starts_with("graphforge-compute-"),
+                        "expected private pool worker, got {name:?}"
+                    );
+                    value * value
+                })
                 .sum::<usize>()
         });
         assert_eq!(sum, (0..32).map(|value| value * value).sum::<usize>());

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -201,6 +201,7 @@ pub use algorithm_cluster::{
     cluster_algorithm, cluster_algorithm_with_limits, cluster_projection_fingerprint,
 };
 pub use algorithm_dispatch::AlgorithmLimits;
+mod compute_pool;
 pub use algorithm_embedding_invocation::{
     EmbeddingExecution, EmbeddingInvocationDescriptor, EmbeddingInvocationLimits,
     EmbeddingProjectionSelector, EmbeddingRngContract,
@@ -208,8 +209,10 @@ pub use algorithm_embedding_invocation::{
 pub use algorithm_paths::{paths_algorithm, paths_projection_fingerprint};
 pub use algorithm_rank::{rank_algorithm, rank_algorithm_with_limits, rank_projection_fingerprint};
 pub use algorithm_similar::{
-    similar_algorithm, similar_algorithm_with_limits, similar_projection_fingerprint,
+    similar_algorithm, similar_algorithm_with_compute, similar_algorithm_with_limits,
+    similar_projection_fingerprint,
 };
+pub use compute_pool::{ComputePool, SharedComputePool};
 
 mod write_driver;
 

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -17,7 +17,7 @@ Tokio runtime or any DataFusion execution session.
 | `spill` | disabled | Optional absolute spill directory + byte cap |
 | `io_concurrency` | `2` | Reserved I/O concurrency budget |
 | `max_concurrent_heavy_queries` | `64` | Instance-owned admission semaphore |
-| `compute_threads` | `2` | Reserved future private CPU-pool budget |
+| `compute_threads` | `2` | Instance-owned private CPU pool (#342 cosine KNN; future kernels) |
 
 Defaults preserve pre-#337 fixed two-worker / two-partition behavior.
 
@@ -66,9 +66,28 @@ state.
    natural file fragments, and acquire the session `io_concurrency` semaphore
    before opening each fragment
 
-Resources are **instance-owned**, not process-global. `compute_threads` is a
-structural reserve for a future private Rayon pool; this issue does **not**
-parallelize graph algorithms.
+Resources are **instance-owned**, not process-global. `compute_threads` sizes a
+private Rayon pool on each `GraphForge` instance. Exact cosine KNN / similarity
+(#342) may partition independent source rows across that pool above a documented
+crossover; work never uses Rayon's process-global pool. Dot products retain
+serial coordinate order so fingerprints match the one-thread path.
+
+## Parallel cosine KNN (#342)
+
+Exact, all-score, and filtered cosine partition **independent source rows**
+across the instance-owned private compute pool when:
+
+- `compute_threads > 1`, and
+- estimated multiply-adds (`sources × candidates × dimensions`, or the filtered
+  candidate total × dimensions) are at least
+  `COSINE_PARALLEL_CROSSOVER_OPS` (`16_384`) in `graphforge-exec`.
+
+Below that crossover, or when the policy provides one compute thread, the
+serial path runs with no pool scheduling tax. Inner floating-point reductions
+stay serial per source→target pair (no parallel dot products, no approximate
+similarity). Worker outputs merge in canonical source order so schemas, row
+order, scores, ties, and fingerprints match the one-thread result at
+`1`/`2`/`4`/`8`/automatic configurations.
 
 ## Observability
 

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -80,7 +80,12 @@ across the instance-owned private compute pool when:
 - `compute_threads > 1`, and
 - estimated multiply-adds (`sources × candidates × dimensions`, or the filtered
   candidate total × dimensions) are at least
-  `COSINE_PARALLEL_CROSSOVER_OPS` (`16_384`) in `graphforge-exec`.
+  `COSINE_PARALLEL_CROSSOVER_OPS` (`32_768`) in `graphforge-exec`. That
+  threshold is the smallest power-of-two multiply-add count at/above the measured
+  win boundary on the M4 agent host (4 vCPU, adversarial fixture, 4 private
+  workers, release build): ~16k ops still tax serial, ~36k ops first clear win,
+  ≥65k ops ≥2×. Smaller workloads stay serial. Worker-local checkpoint counters
+  avoid shared atomic contention on the multiply-add path.
 
 Below that crossover, or when the policy provides one compute thread, the
 serial path runs with no pool scheduling tax. Inner floating-point reductions

--- a/docs/development/m4-entry-baseline.md
+++ b/docs/development/m4-entry-baseline.md
@@ -79,11 +79,13 @@ DataFusion target partitions, thread-parity cells over the host budget.
 ## Honest bottlenecks retained
 
 The entry baseline intentionally records the current implementation, including
-serial algorithm kernels and CSR-to-map conversion where still observable.
-Query-facing Parquet providers stream bounded batches via
-`GraphForgeParquetExec` (#339) rather than eager single-partition `MemTable`
-materialization; ExpandExec filtered reads and fixed-hop demand remain the
-selective-path contract. Further optimizations belong to later M4 issues.
+CSR-to-map conversion where still observable. Exact cosine KNN / similarity
+(#342) may use the instance-owned private compute pool above a documented
+crossover while preserving one-thread fingerprints. Query-facing Parquet
+providers stream bounded batches via `GraphForgeParquetExec` (#339) rather than
+eager single-partition `MemTable` materialization; ExpandExec filtered reads and
+fixed-hop demand remain the selective-path contract. Further optimizations
+belong to later M4 issues.
 
 ## Discovery evidence (not a universal size ceiling)
 

--- a/tools/bazel/drift/cargo_feature_fingerprint.json
+++ b/tools/bazel/drift/cargo_feature_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "schema": "graphforge.cargo-feature-fingerprint.v1",
-  "sha256": "92928a4a2a9da6717b7ec493e4f14eda2a278a92395ffb8f223828b5a995e009",
+  "sha256": "4777d827830b434b34eca446567fa4c7790d230a5e91061363f28ea249b25780",
   "entries": [
     {
       "name": "graphforge-api",
@@ -821,6 +821,15 @@
           "optional": false,
           "uses_default_features": true,
           "kind": "dev",
+          "target": null
+        },
+        {
+          "name": "rayon",
+          "req": "^1.10",
+          "features": [],
+          "optional": false,
+          "uses_default_features": true,
+          "kind": null,
           "target": null
         },
         {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Parallelize exact / filtered cosine KNN and all-score cosine similarity by canonical source through the instance-owned Rayon `ComputePool` from #337, preserving bit-for-bit serial numeric order and merge semantics.

Closes #342.

## Changes

- Add `graphforge-exec::compute_pool` (instance-owned Rayon pool sized by `compute_threads`)
- Parallelize exact cosine KNN / similarity / filtered KNN by source ordinal above measured crossover (`COSINE_PARALLEL_CROSSOVER_OPS = 32_768`)
- Worker-local checkpoint counters (no shared atomic per MAC) so the parallel path wins above crossover
- Deterministic lowest-index chunk error selection; strengthened pool/path tests

## Test plan

- [x] `cargo test -p graphforge-exec --lib algorithm_similar_knn`
- [x] `cargo test -p graphforge-exec --lib compute_pool`
- [x] `cargo clippy -p graphforge-exec --lib -- -D warnings`
- [x] Release-mode crossover measurement (`measure_cosine_parallel_crossover --ignored`)
- [ ] Exact-head CI / CI Gate green

## Notes

Land before #343 / #344 so those PRs can reuse `ComputePool` without duplicating the module.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788916687&installation_model_id=20486&pr_number=494&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F494&signature=296fcc00623bee69cae36797049bad09398cd9e1f8468a7f25a7469beef9455a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parallelize exact cosine KNN by source using a private Rayon thread pool
> - Introduces a `ComputePool` wrapper around a private Rayon `ThreadPool` in [compute_pool.rs](https://github.com/CurateLabs/graphforge/pull/494/files#diff-95383b997bf575714e84dff1539eea109a608dcfe798f26c68ff117b38e2564b), sized by `resource_policy.compute_threads` and owned per `GraphForge` instance, avoiding the global Rayon pool.
> - Adds a `COSINE_PARALLEL_CROSSOVER_OPS` threshold in [algorithm_similar_knn.rs](https://github.com/CurateLabs/graphforge/pull/494/files#diff-75855e05d53b56ae17b7ecee64e4e2207c1367e9140251f05712f23dfd7b51c8); when estimated work exceeds it and a pool is attached, sources are chunked and processed in parallel.
> - Adds `similar_algorithm_with_compute` in [algorithm_similar.rs](https://github.com/CurateLabs/graphforge/pull/494/files#diff-7b8b8d48eed16d0356b20007eb6c347fac1e797d5f6dd5e5229029c9d1d98a5d) and threads the pool through `AlgorithmControl` so the KNN kernel can use it; existing `similar_algorithm` and `similar_algorithm_with_limits` callers are unaffected.
> - Parallel execution preserves deterministic output ordering and enforces row limits and cancellation atomically via `AtomicUsize`.
> - Risk: worker panics are caught and mapped to an execution error rather than propagating; parallel path activates automatically when `compute_threads > 1` and work exceeds the crossover, changing runtime behavior for existing callers who set `compute_threads`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 903ac87.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable CPU parallelism for similarity and cosine KNN searches.
  * Improved KNN performance with workload-based parallel execution while preserving deterministic results.
  * Added instance-level compute limits and cancellation-aware processing.

* **Bug Fixes**
  * Improved handling of filtered searches, output limits, worker failures, and execution errors.
  * Ensured serial and parallel search results remain equivalent.
  * Added safer processing for invalid candidates and computation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->