### PR TITLE
test(performance): reconcile M4 exit evidence and scale claims (#345)

### DIFF
--- a/benchmarks/m4_entry_baseline.md
+++ b/benchmarks/m4_entry_baseline.md
@@ -18,11 +18,16 @@ make bench-m4-entry
 
 ## Accepted entry posture
 
-- **Supported runtime:** fixed two-worker Tokio facade; DataFusion default partitions as observed.
-- **Deferred runtime matrix:** `1` / `2` / `4` / `8` / `automatic` → owned by **#337** with parity assertions named in `tests/contracts/m4-entry-matrix.json`.
+- **Supported runtime:** Explicit `ExecutionResourcePolicy` default remains fixed
+  two-worker / two-partition; callers may request `1` / `2` / `4` / `8` /
+  `automatic` (#337).
+- **Thread-parity matrix:** every cell in `deferred_runtime_configurations` is
+  policy-supported; hosts may still record a cell `unavailable` when the request
+  exceeds the machine-relative concurrency budget (no fabricated results).
 - **CI gates:** schema, row counts, determinism / fingerprint stability, fixed-hop demand integrity (no eager `RoundRobinBatch` side effect).
 - **Not CI gates:** absolute wall-clock thresholds.
-- **8M/128M:** discovery-class measured fixture; public persistence beyond the legacy 2 GiB snapshot envelope is accepted via file-backed `graph`/`files` (#338 oversize evidence). Full 8M/128M public-facade reruns remain optional for #345 under local resource stops.
+- **8M/128M:** discovery-class measured fixture; public persistence beyond the legacy 2 GiB snapshot envelope is accepted via file-backed `graph`/`files` (#338 oversize evidence). Full densified 8M/128M public-facade reruns remain optional scale-host evidence under local resource stops (#345).
+- **Exit ledger:** [`docs/development/m4-exit-evidence.md`](../docs/development/m4-exit-evidence.md).
 
 ## Workload classes
 

--- a/docs/development/file-backed-oversize-evidence.json
+++ b/docs/development/file-backed-oversize-evidence.json
@@ -17,24 +17,24 @@
     "strategy": "PrivateMaterialize"
   },
   "publication": {
-    "generation_uuid": "019fe8b7-97a4-73a3-b3a8-f12f681e2cb4",
+    "generation_uuid": "019fe9b5-3dee-7cb1-81f8-ccb7e8146cf5",
     "path": "stage_project_generation_with_graph_tree + publish (same path as GraphForge)"
   },
   "query": {
     "cypher": "MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN a.name AS from, b.name AS to",
     "rows_produced": 1
   },
-  "recorded_at_unix_secs": 1786316053,
+  "recorded_at_unix_secs": 1786332669,
   "resources": {
     "honest_limits": [
       "Padding is sparse on supporting filesystems; validated/copied byte lengths are logical sizes.",
       "Writable GraphForge::new materializes file-by-file (PrivateMaterialize); checkpoint/RO uses PinnedInPlace.",
       "This proves public persistence beyond the 2 GiB snapshot envelope; full 8M/128M (~15 GiB) remains optional measured evidence under local resource stops."
     ],
-    "peak_rss_bytes_after_query": 99725312,
-    "peak_rss_bytes_before_open": 98304000
+    "peak_rss_bytes_after_query": 98455552,
+    "peak_rss_bytes_before_open": 97193984
   },
   "schema": "graphforge-file-backed-oversize-evidence/1",
-  "source_sha": "7a36f549abeb5a630a151aaf2383a8b2dbc693ae",
+  "source_sha": "2b1bfda8145c7f9fe125a75faf695792fc6bbfcb",
   "strategy": "sparse_padding_beside_queryable_graph"
 }

--- a/docs/development/m4-entry-baseline.md
+++ b/docs/development/m4-entry-baseline.md
@@ -78,14 +78,17 @@ DataFusion target partitions, thread-parity cells over the host budget.
 
 ## Honest bottlenecks retained
 
-The entry baseline intentionally records the current implementation, including
-CSR-to-map conversion where still observable. Exact cosine KNN / similarity
-(#342) and PageRank (#343) may use the instance-owned private compute pool above
-documented crossovers while preserving one-thread fingerprints. Query-facing
-Parquet providers stream bounded batches via `GraphForgeParquetExec` (#339)
-rather than eager single-partition `MemTable` materialization; ExpandExec
-filtered reads and fixed-hop demand remain the selective-path contract. Further
-optimizations belong to later M4 issues.
+The entry baseline records structural gates on the public facade. Fresh CSR
+index hits no longer expand into an O(E) HashMap (#340). Exact cosine KNN /
+similarity (#342), PageRank (#343), and Node2Vec walk generation (#344) may use
+the instance-owned private compute pool above documented crossovers while
+preserving one-thread fingerprints. Query-facing Parquet providers stream
+bounded batches via `GraphForgeParquetExec` (#339) rather than eager
+single-partition `MemTable` materialization; ExpandExec filtered reads and
+fixed-hop demand remain the selective-path contract.
+
+Exit reconciliation for the final M4 tree lives in
+[`m4-exit-evidence.md`](m4-exit-evidence.md).
 
 ## Discovery evidence (not a universal size ceiling)
 
@@ -110,5 +113,7 @@ Before/after evidence source:
   and [`benchmarks/m4_entry_baseline.md`](../benchmarks/m4_entry_baseline.md)
 - Harness: `crates/graphforge-api/tests/m4_entry_baseline.rs`
 
-Every M4 child (#336–#344) should compare against this gate’s structural
-contract. #345 reruns it as exit evidence on the final tree.
+Every M4 child (#336–#344) compared against this gate’s structural contract.
+#345 reruns it as exit evidence on the final tree
+([`m4-exit-evidence.md`](m4-exit-evidence.md) /
+[`m4-exit-evidence.json`](m4-exit-evidence.json)).

--- a/docs/development/m4-exit-evidence.json
+++ b/docs/development/m4-exit-evidence.json
@@ -1,0 +1,349 @@
+{
+  "build_profile": "debug",
+  "contract_schema": "graphforge-m4-entry-matrix/1",
+  "dataset": {
+    "edges": 5,
+    "fixture_id": "synthetic-small",
+    "nodes": 5,
+    "opt_in": false
+  },
+  "deferred_configurations": [
+    {
+      "cancellation_outcome": "token_cancelled",
+      "executed": true,
+      "fingerprints": {
+        "aggregate-top-n": "8e9605bf74fce66b022b9c84825c76e27953477671417b4e480e5cde982db509",
+        "exact-cosine-knn": "6b12e00c540da6f7b3d7cf4546eb17e6fabf88cbaa7a1cc2c17e41bd1dff6dd5",
+        "fixed-hop-limit": "22668ddcd8294f761fac18f5404884234d9ba5b4a438aade7eb2fb1d95a2d8e4",
+        "node2vec": "98c429c3d4d89f132d5310124657c585118afee786489abe577f90889c47e445",
+        "pagerank": "e3fe6b40aaca585441c2335c857b79ca47b2b3ff9cd8779752d5c18b82c3e88f",
+        "scan-count": "ca521a363e7458a148aba59c43483a2a3d7b0abb5d21cfe3731f07ca9dfe69bc"
+      },
+      "id": "threads-1",
+      "normalized": {
+        "mode": "Explicit",
+        "observed_logical_cpus": 4,
+        "target_partitions": 1,
+        "tokio_worker_threads": 1
+      },
+      "owner_issue": 337,
+      "parity_assertions": [
+        "canonical_arrow_schema",
+        "row_ordering",
+        "result_fingerprint",
+        "structured_errors",
+        "cancellation_outcome",
+        "resource_limit_behavior"
+      ],
+      "requested_workers": 1,
+      "resource_limit_rows": 3,
+      "status": "supported",
+      "structured_error_code": "GF_VALIDATION"
+    },
+    {
+      "cancellation_outcome": "token_cancelled",
+      "executed": true,
+      "fingerprints": {
+        "aggregate-top-n": "8e9605bf74fce66b022b9c84825c76e27953477671417b4e480e5cde982db509",
+        "exact-cosine-knn": "6b12e00c540da6f7b3d7cf4546eb17e6fabf88cbaa7a1cc2c17e41bd1dff6dd5",
+        "fixed-hop-limit": "22668ddcd8294f761fac18f5404884234d9ba5b4a438aade7eb2fb1d95a2d8e4",
+        "node2vec": "98c429c3d4d89f132d5310124657c585118afee786489abe577f90889c47e445",
+        "pagerank": "e3fe6b40aaca585441c2335c857b79ca47b2b3ff9cd8779752d5c18b82c3e88f",
+        "scan-count": "ca521a363e7458a148aba59c43483a2a3d7b0abb5d21cfe3731f07ca9dfe69bc"
+      },
+      "id": "threads-2",
+      "normalized": {
+        "mode": "Explicit",
+        "observed_logical_cpus": 4,
+        "target_partitions": 2,
+        "tokio_worker_threads": 2
+      },
+      "owner_issue": 337,
+      "parity_assertions": [
+        "canonical_arrow_schema",
+        "row_ordering",
+        "result_fingerprint",
+        "structured_errors",
+        "cancellation_outcome",
+        "resource_limit_behavior"
+      ],
+      "requested_workers": 2,
+      "resource_limit_rows": 3,
+      "status": "supported",
+      "structured_error_code": "GF_VALIDATION"
+    },
+    {
+      "cancellation_outcome": "token_cancelled",
+      "executed": true,
+      "fingerprints": {
+        "aggregate-top-n": "8e9605bf74fce66b022b9c84825c76e27953477671417b4e480e5cde982db509",
+        "exact-cosine-knn": "6b12e00c540da6f7b3d7cf4546eb17e6fabf88cbaa7a1cc2c17e41bd1dff6dd5",
+        "fixed-hop-limit": "22668ddcd8294f761fac18f5404884234d9ba5b4a438aade7eb2fb1d95a2d8e4",
+        "node2vec": "98c429c3d4d89f132d5310124657c585118afee786489abe577f90889c47e445",
+        "pagerank": "e3fe6b40aaca585441c2335c857b79ca47b2b3ff9cd8779752d5c18b82c3e88f",
+        "scan-count": "ca521a363e7458a148aba59c43483a2a3d7b0abb5d21cfe3731f07ca9dfe69bc"
+      },
+      "id": "threads-4",
+      "normalized": {
+        "mode": "Explicit",
+        "observed_logical_cpus": 4,
+        "target_partitions": 4,
+        "tokio_worker_threads": 4
+      },
+      "owner_issue": 337,
+      "parity_assertions": [
+        "canonical_arrow_schema",
+        "row_ordering",
+        "result_fingerprint",
+        "structured_errors",
+        "cancellation_outcome",
+        "resource_limit_behavior"
+      ],
+      "requested_workers": 4,
+      "resource_limit_rows": 3,
+      "status": "supported",
+      "structured_error_code": "GF_VALIDATION"
+    },
+    {
+      "executed": false,
+      "id": "threads-8",
+      "owner_issue": 337,
+      "parity_assertions": [
+        "canonical_arrow_schema",
+        "row_ordering",
+        "result_fingerprint",
+        "structured_errors",
+        "cancellation_outcome",
+        "resource_limit_behavior"
+      ],
+      "reason": "validation error: combined tokio/partition concurrency 16 exceeds instance budget 8",
+      "requested_workers": 8,
+      "status": "unavailable"
+    },
+    {
+      "cancellation_outcome": "token_cancelled",
+      "executed": true,
+      "fingerprints": {
+        "aggregate-top-n": "8e9605bf74fce66b022b9c84825c76e27953477671417b4e480e5cde982db509",
+        "exact-cosine-knn": "6b12e00c540da6f7b3d7cf4546eb17e6fabf88cbaa7a1cc2c17e41bd1dff6dd5",
+        "fixed-hop-limit": "22668ddcd8294f761fac18f5404884234d9ba5b4a438aade7eb2fb1d95a2d8e4",
+        "node2vec": "98c429c3d4d89f132d5310124657c585118afee786489abe577f90889c47e445",
+        "pagerank": "e3fe6b40aaca585441c2335c857b79ca47b2b3ff9cd8779752d5c18b82c3e88f",
+        "scan-count": "ca521a363e7458a148aba59c43483a2a3d7b0abb5d21cfe3731f07ca9dfe69bc"
+      },
+      "id": "threads-automatic",
+      "normalized": {
+        "mode": "Automatic",
+        "observed_logical_cpus": 4,
+        "target_partitions": 2,
+        "tokio_worker_threads": 2
+      },
+      "owner_issue": 337,
+      "parity_assertions": [
+        "canonical_arrow_schema",
+        "row_ordering",
+        "result_fingerprint",
+        "structured_errors",
+        "cancellation_outcome",
+        "resource_limit_behavior"
+      ],
+      "requested_workers": "automatic",
+      "resource_limit_rows": 3,
+      "status": "supported",
+      "structured_error_code": "GF_VALIDATION"
+    }
+  ],
+  "discovery_evidence": [
+    {
+      "approx_edges": 128000000,
+      "approx_nodes": 8000000,
+      "classification": "discovery_not_public_facade_baseline",
+      "id": "lower-level-8m-128m",
+      "notes": "Retain as qualified discovery evidence. Public persistence beyond the legacy 2 GiB snapshot envelope is accepted via file-backed graph/files (#338 oversize evidence). Full 8M/128M public-facade reruns remain optional measured evidence under local resource stops for #345.",
+      "path": "lower-level Rust construction/execution (not GraphForge::new public snapshot path)",
+      "public_facade_owner_issue": 338
+    },
+    {
+      "classification": "public_facade_persistence_proof",
+      "evidence_artifact": "docs/development/file-backed-oversize-evidence.json",
+      "id": "file-backed-oversize-beyond-snapshot-envelope",
+      "notes": "Deterministic sparse multi-file generation whose validated bytes exceed 2 GiB; published and reopened through the public GraphForge path without Arrow snapshot hydrate. CI keeps the small fixture only; regenerate via the ignored oversize test into build/.",
+      "owner_issue": 338,
+      "path": "crates/graphforge-api/tests/file_backed_graph_generation.rs::oversize_file_backed_generation_exceeds_legacy_snapshot_envelope"
+    }
+  ],
+  "hardware": {
+    "accelerator_identity": null,
+    "arch": "x86_64",
+    "cpu_model": ": Intel(R) Xeon(R) Processor",
+    "logical_cpus": 4,
+    "memory_bytes": 16791945216,
+    "os": "linux",
+    "peak_rss_bytes_process": 104755200
+  },
+  "known_limitations": [
+    "Fresh CSR index hits no longer expand the base CSR into an O(E) HashMap (#340); scan-build / missing / stale / corrupt paths may still use the historical hash-map oracle.",
+    "Exact cosine KNN, PageRank, and Node2Vec walk generation may use the instance-owned private compute pool above documented crossovers (#342-#344); one-thread fingerprints remain authoritative.",
+    "Portable interchange does not yet encode file-backed graph/files trees (structured GF_UNSUPPORTED_PROJECT_FORMAT); copy the project directory instead (#338).",
+    "Full 8M-node/128M-edge densified public-facade reruns and >200M-edge adjacency RSS remain optional scale-host evidence under local resource stops (#345); do not treat them as a universal product ceiling.",
+    "Wall-clock numbers are hardware-specific and never CI pass/fail gates.",
+    "Thread-parity cells that exceed the machine-relative concurrency budget are recorded unavailable without fabricating results.",
+    "GPU / accelerator backends are intentionally out of scope for M4."
+  ],
+  "matrix": "large_manual",
+  "opt_in_fixtures": [
+    {
+      "command": "make bench-fixed-hop-limit",
+      "downloaded_by_ci": false,
+      "id": "synthetic-1m-edges"
+    },
+    {
+      "command": "make bench-fixed-hop-limit",
+      "downloaded_by_ci": false,
+      "id": "synthetic-10m-edges"
+    },
+    {
+      "command": "GF_LIVEJOURNAL_PROJECT=/path/to/project make bench-fixed-hop-livejournal",
+      "downloaded_by_ci": false,
+      "env": "GF_LIVEJOURNAL_PROJECT",
+      "id": "livejournal-cached"
+    }
+  ],
+  "reproduction": {
+    "contract_validate": "make m4-entry-matrix-check",
+    "large_manual": "make bench-m4-entry",
+    "short_ci": "cargo test -p graphforge-api --test m4_entry_baseline -- --nocapture",
+    "thread_parity": "cargo test -p graphforge-api --test m4_entry_baseline thread_parity_matrix_executes_under_resource_policy -- --nocapture"
+  },
+  "runtime_configuration": {
+    "datafusion_partitions": 2,
+    "id": "policy-default-two-worker",
+    "notes": "Default Explicit ExecutionResourcePolicy preserves pre-#337 two-worker / two-partition semantics.",
+    "public_resource_policy": true,
+    "status": "supported",
+    "tokio_worker_threads": 2
+  },
+  "schema": "graphforge-m4-entry-evidence/1",
+  "source_sha": "2b1bfda8145c7f9fe125a75faf695792fc6bbfcb",
+  "spill_bytes": null,
+  "workloads": [
+    {
+      "id": "fixed-hop-limit",
+      "structural_gates": {
+        "details": {
+          "limit": 3,
+          "surface": "GraphForge::execute"
+        },
+        "output_rows": 3,
+        "result_fingerprint": "e22a3c912008994478ce05204cd8c6a2e9df7e35e67d9e16a5cba75625255fd0",
+        "schema_fields": [
+          "id"
+        ]
+      },
+      "timing_is_pass_fail": false,
+      "timing_observation": {
+        "peak_rss_bytes": 99954688,
+        "wall_time_ms": 29.499494000000002
+      }
+    },
+    {
+      "id": "scan-count",
+      "structural_gates": {
+        "details": {
+          "expected_count": 5,
+          "surface": "GraphForge::execute"
+        },
+        "output_rows": 1,
+        "result_fingerprint": "ca521a363e7458a148aba59c43483a2a3d7b0abb5d21cfe3731f07ca9dfe69bc",
+        "schema_fields": [
+          "total"
+        ]
+      },
+      "timing_is_pass_fail": false,
+      "timing_observation": {
+        "peak_rss_bytes": 102318080,
+        "wall_time_ms": 20.526748
+      }
+    },
+    {
+      "id": "aggregate-top-n",
+      "structural_gates": {
+        "details": {
+          "surface": "GraphForge::execute"
+        },
+        "output_rows": 3,
+        "result_fingerprint": "8e9605bf74fce66b022b9c84825c76e27953477671417b4e480e5cde982db509",
+        "schema_fields": [
+          "name",
+          "age"
+        ]
+      },
+      "timing_is_pass_fail": false,
+      "timing_observation": {
+        "peak_rss_bytes": 102850560,
+        "wall_time_ms": 20.620441
+      }
+    },
+    {
+      "id": "pagerank",
+      "structural_gates": {
+        "details": {
+          "surface": "GraphForge::rank"
+        },
+        "output_rows": 5,
+        "result_fingerprint": "eb80085f870e7505865f4ef1f63d76915ca11506f6d0852c85dcf495601e6b3a",
+        "schema_fields": [
+          "node_uuid",
+          "score",
+          "age",
+          "embedding",
+          "name"
+        ]
+      },
+      "timing_is_pass_fail": false,
+      "timing_observation": {
+        "peak_rss_bytes": 103190528,
+        "wall_time_ms": 3.564849
+      }
+    },
+    {
+      "id": "exact-cosine-knn",
+      "structural_gates": {
+        "details": {
+          "surface": "GraphForge::similar"
+        },
+        "output_rows": 9,
+        "result_fingerprint": "974bd515cffe9bfec2ff1bf3f22c40ae4bcce49d559a03b467e243af84d2d816",
+        "schema_fields": [
+          "node1_uuid",
+          "node2_uuid",
+          "similarity"
+        ]
+      },
+      "timing_is_pass_fail": false,
+      "timing_observation": {
+        "peak_rss_bytes": 103530496,
+        "wall_time_ms": 1.818031
+      }
+    },
+    {
+      "id": "node2vec",
+      "structural_gates": {
+        "details": {
+          "surface": "GraphForge::analyze_embedding"
+        },
+        "output_rows": 5,
+        "result_fingerprint": "f5b1d3d52ed75ef0a44057d553c4e526dbadf8ea5a3117711b9da2c7b5d9d220",
+        "schema_fields": [
+          "node_uuid",
+          "embedding"
+        ]
+      },
+      "timing_is_pass_fail": false,
+      "timing_observation": {
+        "peak_rss_bytes": 103530496,
+        "wall_time_ms": 2.87057
+      }
+    }
+  ]
+}

--- a/docs/development/m4-exit-evidence.md
+++ b/docs/development/m4-exit-evidence.md
@@ -1,0 +1,95 @@
+# M4 Exit Evidence Reconciliation (#345)
+
+Final accepted M4 tree: `2b1bfda8145c7f9fe125a75faf695792fc6bbfcb`
+(`perf(exec): parallelize Node2Vec walk generation (#344) (#493)`).
+
+This page is the exit ledger for epic **#335**. It performs no new optimization.
+GPU acceleration remains intentionally out of scope; CPU-only embedded operation
+satisfies M4 closure.
+
+## Child disposition (live blocked-by of #345)
+
+| Issue | Disposition | Exact-head PR |
+|---|---|---|
+| #334 | Merged — entry contract / harness | [#485](https://github.com/CurateLabs/graphforge/pull/485) |
+| #337 | Merged — embedded resource policy | [#486](https://github.com/CurateLabs/graphforge/pull/486) |
+| #338 | Merged — file-backed generations | [#487](https://github.com/CurateLabs/graphforge/pull/487) |
+| #336 | Merged — streamed adjacency past Arrow 134M | [#488](https://github.com/CurateLabs/graphforge/pull/488) |
+| #339 | Merged — streaming partitioned Parquet | [#489](https://github.com/CurateLabs/graphforge/pull/489) |
+| #340 | Merged — CSR-native adjacency | [#490](https://github.com/CurateLabs/graphforge/pull/490) |
+| #341 | Merged — bounded Arrow shaping | [#491](https://github.com/CurateLabs/graphforge/pull/491) |
+| #342 | Merged — parallel exact cosine KNN | [#494](https://github.com/CurateLabs/graphforge/pull/494) |
+| #343 | Merged — parallel PageRank | [#492](https://github.com/CurateLabs/graphforge/pull/492) |
+| #344 | Merged — parallel Node2Vec walks | [#493](https://github.com/CurateLabs/graphforge/pull/493) |
+
+Optional milestone side track **#398** (GSI profiler) is not on the #335 close
+ledger and does not block M4.
+
+## Exit evidence artifacts
+
+| Artifact | Schema / role |
+|---|---|
+| [`m4-exit-evidence.json`](m4-exit-evidence.json) | `graphforge-m4-entry-evidence/1` rerun on the final tree (short + thread-parity matrix) |
+| [`file-backed-oversize-evidence.json`](file-backed-oversize-evidence.json) | `graphforge-file-backed-oversize-evidence/1` public reopen past legacy 2 GiB envelope |
+| [`m4-entry-baseline.md`](m4-entry-baseline.md) | Entry contract narrative (updated for shipped M4) |
+| [`execution-resource-policy.md`](execution-resource-policy.md) | #337 policy + #342/#343/#344 crossovers |
+| [`../reference/scale-limits.md`](../reference/scale-limits.md) | Persistence / adjacency / CSR claim table |
+
+## Final-tree reproduction
+
+```bash
+make m4-entry-matrix-check
+cargo test -p graphforge-api --test m4_entry_baseline -- --nocapture --test-threads=1
+cargo test -p graphforge-api --test file_backed_graph_generation -- --test-threads=1
+GF_M4_ENTRY_EVIDENCE_OUT=docs/development/m4-exit-evidence.json \
+  cargo test -p graphforge-api --test m4_entry_baseline \
+  large_manual_matrix_emits_hardware_dataset_evidence -- --ignored --nocapture
+GF_FILE_BACKED_OVERSIZE_EVIDENCE_OUT=docs/development/file-backed-oversize-evidence.json \
+  cargo test -p graphforge-api --test file_backed_graph_generation \
+  oversize_file_backed_generation_exceeds_legacy_snapshot_envelope -- --ignored --nocapture
+```
+
+## Structural outcomes (not wall-clock)
+
+- **File-backed persistence (#338):** public `GraphForge::new` reopens past the
+  legacy 1 GiB/file · 2 GiB snapshot envelope (sparse oversize evidence). No
+  universal GiB product ceiling. Full **8M-node / 128M-edge** densified
+  public-facade reruns remain an optional scale-host measurement under local
+  resource stops — not mislabeled as CI-accepted product max.
+- **Adjacency (#336):** streamed projected Parquet build removes the
+  134,217,727-edge Arrow concat ceiling. Full **>200M-edge** RSS evidence stays
+  scale-host / scheduled (accepted blocker on this 4 vCPU / ~15 GiB agent).
+- **Streaming Parquet (#339):** query path uses `GraphForgeParquetExec` with
+  execution-time I/O and bounded batches.
+- **CSR-native (#340):** fresh index hits report zero base-CSR HashMap expansion
+  via structural counters.
+- **Arrow shaping (#341):** analyst outputs are Arrow batches only (no retained
+  `rows: Vec<Vec<…>>`).
+- **CPU kernels (#342–#344):** exact cosine KNN, PageRank, and Node2Vec walk
+  generation use the instance-owned private compute pool above documented
+  crossovers; one-thread fingerprints are preserved. Thread cells that exceed
+  the machine-relative concurrency budget are recorded `unavailable` (on this
+  host `threads-8` is unavailable).
+
+## Honest scale dispositions
+
+| Claim | Exit disposition |
+|---|---|
+| Legacy 1 GiB/file · 2 GiB snapshot | Historical envelope only; still readable; not raised |
+| Public reopen >2 GiB validated bytes | Proven via oversize file-backed evidence |
+| 8M/128M (~15 GiB) densified public facade | Optional measured evidence / accepted blocker on agent hosts — not a universal product claim |
+| >200M-edge adjacency index | Accepted pending scale-host evidence; 134M Arrow boundary no longer governs the public build path |
+| GPU / accelerator | Out of scope for M4; no shipped capability or claim |
+| Universal graph-size / SLO / cross-machine timing | Explicitly rejected |
+
+## Exact-head CI
+
+Each child PR above carried required Test Suite + CI Gate at its merge SHA.
+This exit reconciliation does not rerun unchanged historical trees solely to
+attach duplicate badges to the squash commits.
+
+## Closing #335
+
+After this issue merges and closes, #335 has no remaining required open child
+other than itself (optional #398 excluded). Post this ledger on #335 and close
+the epic when the live parent/blocked-by graph matches.

--- a/docs/reference/scale-limits.md
+++ b/docs/reference/scale-limits.md
@@ -83,7 +83,7 @@ policy; thread configurations `1`/`2`/`4`/`8`/automatic are executed under
 | Path | What it stores | Open behavior | Size guidance |
 |---|---|---|---|
 | Legacy `graph`/`snapshot` (Arrow IPC) | Whole workspace bytes in one participant | Hydrates every file into a private workspace | Historical envelope: 1 GiB/file and 2 GiB total. Still readable. Do not raise these constants. |
-| File-backed `graph`/`files` + generation `graph/` tree | Canonical inventory participant; graph files remain on disk | Validates inventory; read-only opens may pin the generation tree; writers materialize file-by-file | No universal GiB ceiling. Measured 8M/128M (~15 GiB) is accepted evidence for the public path once published through this contract; CI uses a small multi-file fixture. |
+| File-backed `graph`/`files` + generation `graph/` tree | Canonical inventory participant; graph files remain on disk | Validates inventory; read-only opens may pin the generation tree; writers materialize file-by-file | No universal GiB ceiling. Public reopen past the legacy 2 GiB snapshot envelope is proven by oversize file-backed evidence (#338 / #345). Full 8M/128M densified public-facade reruns remain optional scale-host measurements under local resource stops — not a CI product max. CI uses a small multi-file fixture. |
 
 New publications use the file-backed path. Portable interchange currently returns a
 structured unsupported error for file-backed trees (copy the project directory
@@ -135,7 +135,7 @@ boundary as a GraphForge maximum graph size.
 | No full-file UUID concat during adjacency build/validate/inspect | Covered by CI streaming seam |
 | CSR bytes match scan-build semantics under spill | Covered by tiny-chunk golden tests |
 | Cancel/failure leaves prior index or absent/stale | Covered by cancel + spill-cap tests |
-| >200M edges indexes on a supported machine | Pending reproducible M4 scale evidence |
+| >200M edges indexes on a supported machine | Accepted disposition: pending scale-host / scheduled evidence (#345). Not a product claim on agent hosts. |
 
 Manual/scheduled 8M/128M reproduction (not CI): build or point at the measured
 fixture, publish through `GraphForge`, reopen, and record RSS/storage/fingerprint
@@ -167,7 +167,7 @@ heap vectors for every graph edge.
 | Out / in / undirected / typed / wildcard semantics preserved | Covered by adjacency + persistent provider tests |
 | Bounded delta overlay without full base copy | Covered by storage overlay parity tests |
 | Selected-subgraph projection bounded by selection | Covered by export path iterating selected node ids |
-| Peak RSS / cold-warm first-use on #334 fixtures | Pending M4 scale evidence (timing remains hardware-specific) |
+| Peak RSS / cold-warm first-use on #334 fixtures | Hardware-specific observation only; recorded in [`m4-exit-evidence.json`](../development/m4-exit-evidence.json). Never a CI pass/fail gate. |
 ---
 
 ## Why Edge Count, Not Node Count

--- a/tests/contracts/m4-entry-matrix.json
+++ b/tests/contracts/m4-entry-matrix.json
@@ -19,7 +19,8 @@
       "id": "threads-1",
       "requested_workers": 1,
       "status": "supported",
-      "owner_issue": 337
+      "owner_issue": 337,
+      "notes": "Field name is historical (#334); #337 made every listed cell executable. Hosts may still record a cell unavailable when the request exceeds the machine-relative concurrency budget."
     },
     {
       "id": "threads-2",
@@ -38,7 +39,8 @@
       "id": "threads-8",
       "requested_workers": 8,
       "status": "supported",
-      "owner_issue": 337
+      "owner_issue": 337,
+      "notes": "Supported by policy; on hosts where workers+partitions exceed the machine budget the harness records unavailable rather than fabricating results."
     },
     {
       "id": "threads-automatic",
@@ -234,10 +236,12 @@
     ]
   },
   "known_limitations": [
-    "CSR-to-hash-map expansion remains on analyst/traversal paths (#340).",
-    "Algorithm kernels remain serial (#342-#344).",
+    "Fresh CSR index hits no longer expand the base CSR into an O(E) HashMap (#340); scan-build / missing / stale / corrupt paths may still use the historical hash-map oracle.",
+    "Exact cosine KNN, PageRank, and Node2Vec walk generation may use the instance-owned private compute pool above documented crossovers (#342-#344); one-thread fingerprints remain authoritative.",
     "Portable interchange does not yet encode file-backed graph/files trees (structured GF_UNSUPPORTED_PROJECT_FORMAT); copy the project directory instead (#338).",
+    "Full 8M-node/128M-edge densified public-facade reruns and >200M-edge adjacency RSS remain optional scale-host evidence under local resource stops (#345); do not treat them as a universal product ceiling.",
     "Wall-clock numbers are hardware-specific and never CI pass/fail gates.",
-    "Thread-parity cells that exceed the machine-relative concurrency budget are recorded unavailable without fabricating results."
+    "Thread-parity cells that exceed the machine-relative concurrency budget are recorded unavailable without fabricating results.",
+    "GPU / accelerator backends are intentionally out of scope for M4."
   ]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Final M4 exit evidence reconciliation on tree `2b1bfda` after #342–#344. No new optimizations. Documents honest scale dispositions and refreshes the #334 evidence emitter + oversize file-backed proof.

Closes #345.

## Changes

- Emit `docs/development/m4-exit-evidence.json` (`graphforge-m4-entry-evidence/1`) on the final SHA
- Add `docs/development/m4-exit-evidence.md` ledger (child PRs, dispositions, reproduction)
- Refresh `file-backed-oversize-evidence.json` on the final SHA
- Update `m4-entry-matrix.json` known limitations (CSR/kernels shipped; scale-host blockers; GPU OOS)
- Soft-correct `scale-limits.md`, entry baseline docs, and benchmark methodology

## Honest dispositions

- **8M/128M densified public facade:** optional scale-host measurement — not a universal product claim (agent hosts keep sparse >2 GiB oversize proof)
- **>200M adjacency RSS:** accepted pending scale-host evidence; 134M Arrow boundary no longer governs the public build path
- **GPU:** out of scope for M4
- **`threads-8`:** policy-supported; unavailable on hosts under the machine concurrency budget

## Test plan

- [x] `make m4-entry-matrix-check`
- [x] `cargo test -p graphforge-api --test m4_entry_baseline -- --test-threads=1`
- [x] `cargo test -p graphforge-api --test file_backed_graph_generation -- --test-threads=1`
- [x] Ignored evidence emitters for exit JSON + oversize proof
- [ ] Exact-head CI / CI Gate green
- [ ] After merge: post ledger on #335 and close the epic (optional #398 excluded)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788924756&installation_model_id=20486&pr_number=496&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F496&signature=80378a78b9de44250391668e5db81fb26d2a472527884dc585ad27dab03b6ae3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reconcile M4 exit evidence and scale claims across docs and test contracts
> - Adds new exit ledger artifacts ([m4-exit-evidence.md](https://github.com/CurateLabs/graphforge/pull/496/files#diff-b49c415196d8d7a64cc8a1be0a7b427669ba2e20f6fc37ba6b6ec2f503eb8885) and [m4-exit-evidence.json](https://github.com/CurateLabs/graphforge/pull/496/files#diff-a0ed0fec5bb1859a6a3867ad461a94285871f2061ba4b5ea9e910711d25c9f65)) documenting M4 milestone disposition, reproduction commands, structural outcomes, and policy normalization for thread configurations.
> - Updates [scale-limits.md](https://github.com/CurateLabs/graphforge/pull/496/files#diff-49eadbd251ef299f5f8b5dc91af98e33ce55231d0f03d8dfebab5faf324e2106) to mark >200M edge scale claims as accepted-pending-scale-host-evidence and clarify that 8M/128M densified reruns are optional, not a CI product maximum.
> - Refreshes [file-backed-oversize-evidence.json](https://github.com/CurateLabs/graphforge/pull/496/files#diff-124ac82bc8867bbe5268cab0c64cb28ea1c84e32fa7f2a88f922187001e4546f) fields (UUID, timestamps, peak RSS, source SHA) to match current recorded state.
> - Adds `notes` fields to [m4-entry-matrix.json](https://github.com/CurateLabs/graphforge/pull/496/files#diff-c7c779d06f868896c69a9da9fb4e4d4845e561b0809e8ece2e5a446efa038ab6) clarifying unavailable thread-parity cells and GPU/accelerator out-of-scope scope boundary.
> - Cross-links entry and exit evidence documents in [m4-entry-baseline.md](https://github.com/CurateLabs/graphforge/pull/496/files#diff-0fc545eb9e584396164a8b77188aaf7c05a061a4eaab938b50a5c29f54ab3794) and [benchmarks/m4_entry_baseline.md](https://github.com/CurateLabs/graphforge/pull/496/files#diff-f42e75d0dc788b15cf5dc6c748748b27cab62b6737f230a47dd3fc5476682bbd).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d915820.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated runtime configuration guidance for 1-worker and 8-worker setups.
  - Clarified executable support and when host-relative configurations are unavailable.
  - Documented current limitations around fresh CSR indexes, private compute resources, optional large-scale reruns, and GPU support.
  - Removed outdated statements regarding CSR expansion and serial algorithm execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->