### PR TITLE
perf(exec): parallelize Adamic-Adar on ComputePool (#499)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_rank.rs
+++ b/crates/graphforge-exec/src/algorithm_rank.rs
@@ -138,6 +138,20 @@ pub const BETWEENNESS_PARALLEL_CROSSOVER_WORK: u64 = 65_536;
 /// exact counts remain identical on either path.
 pub const COMMON_NEIGHBORS_PARALLEL_CROSSOVER_WORK: u64 = 1_048_576;
 const COMMON_NEIGHBORS_CHECKPOINT_INTERVAL: usize = 1_024;
+/// Estimated pair/intersection work below which Adamic-Adar stays serial (#499).
+///
+/// Chosen from release-mode serial-vs-parallel timings on this M4 agent host
+/// (4x Xeon vCPU, directed ring-lattice fixtures, 4 private workers; see
+/// ignored `measure_adamic_adar_parallel_crossover`):
+/// - ~230k estimated units: parallel still neutral/slower (pool scheduling tax)
+/// - ~540k estimated units: first clear win (~0.61x serial)
+/// - >=2.1M estimated units: >=2.8x speedup
+///
+/// `524_288` is the smallest power-of-two work estimate below that measured win
+/// boundary. Each source keeps serial candidate/intersection order, so exact
+/// scores remain bit-identical on either path.
+pub const ADAMIC_ADAR_PARALLEL_CROSSOVER_WORK: u64 = 524_288;
+const ADAMIC_ADAR_CHECKPOINT_INTERVAL: usize = 1_024;
 const EIGENVECTOR_MAX_ITERATIONS: usize = 20;
 const EIGENVECTOR_TOLERANCE: f64 = 1.0e-7;
 /// Selected adjacency entries below which eigenvector stays on the serial path (#507).
@@ -362,6 +376,13 @@ pub(crate) enum PageRankExecutionPath {
 /// Selected common-neighbors execution path for observability and crossover tests (#505).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum CommonNeighborsExecutionPath {
+    Serial,
+    Parallel { threads: usize, chunks: usize },
+}
+
+/// Selected Adamic-Adar execution path for observability and crossover tests (#499).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AdamicAdarExecutionPath {
     Serial,
     Parallel { threads: usize, chunks: usize },
 }
@@ -1860,56 +1881,167 @@ fn adamic_adar_scores(
     control: &AlgorithmControl,
 ) -> Result<Vec<f64>, AlgorithmError> {
     let neighbors = simple_neighbors(graph, control, false)?;
+    let discount_degrees = adamic_adar_discount_degrees(&neighbors)?;
+    let estimated_work = estimated_adamic_adar_work(&neighbors);
+    match select_adamic_adar_path(control, neighbors.len(), estimated_work) {
+        AdamicAdarExecutionPath::Serial => {
+            adamic_adar_scores_serial(&neighbors, &discount_degrees, control)
+        }
+        AdamicAdarExecutionPath::Parallel { .. } => {
+            adamic_adar_scores_parallel(&neighbors, &discount_degrees, control)
+        }
+    }
+}
+fn adamic_adar_discount_degrees(neighbors: &[Vec<usize>]) -> Result<Vec<u64>, AlgorithmError> {
     let mut discount_degrees = vec![0_u64; neighbors.len()];
-    for adjacent in &neighbors {
+    for adjacent in neighbors {
         for &neighbor in adjacent {
             discount_degrees[neighbor] = discount_degrees[neighbor]
                 .checked_add(1)
                 .ok_or_else(|| execution("Adamic-Adar neighbor degree exceeds supported range"))?;
         }
     }
-
+    Ok(discount_degrees)
+}
+fn adamic_adar_scores_serial(
+    neighbors: &[Vec<usize>],
+    discount_degrees: &[u64],
+    control: &AlgorithmControl,
+) -> Result<Vec<f64>, AlgorithmError> {
     let mut visited = 0_usize;
     let mut scores = Vec::with_capacity(neighbors.len());
-    for (source, source_neighbors) in neighbors.iter().enumerate() {
-        let mut score = 0.0_f64;
-        let mut compensation = 0.0_f64;
-        for (candidate, candidate_neighbors) in neighbors.iter().enumerate() {
-            if visited.is_multiple_of(1024) {
-                control.checkpoint()?;
-            }
-            visited += 1;
-            if source == candidate || source_neighbors.binary_search(&candidate).is_ok() {
-                continue;
-            }
-            let (mut left, mut right) = (0, 0);
-            while left < source_neighbors.len() && right < candidate_neighbors.len() {
-                if visited.is_multiple_of(1024) {
-                    control.checkpoint()?;
-                }
-                visited += 1;
-                match source_neighbors[left].cmp(&candidate_neighbors[right]) {
-                    std::cmp::Ordering::Less => left += 1,
-                    std::cmp::Ordering::Greater => right += 1,
-                    std::cmp::Ordering::Equal => {
-                        let common = source_neighbors[left];
-                        let term = adamic_discount(discount_degrees[common])?;
-                        let adjusted = term - compensation;
-                        let updated = score + adjusted;
-                        compensation = (updated - score) - adjusted;
-                        score = updated;
-                        left += 1;
-                        right += 1;
-                    }
-                }
-            }
-        }
-        if !score.is_finite() {
-            return Err(execution("Adamic-Adar score is not finite"));
-        }
+    for source in 0..neighbors.len() {
+        let score = adamic_adar_source_score(neighbors, discount_degrees, source, || {
+            adamic_adar_serial_checkpoint(control, &mut visited)
+        })?;
         scores.push(score);
     }
     Ok(scores)
+}
+fn adamic_adar_scores_parallel(
+    neighbors: &[Vec<usize>],
+    discount_degrees: &[u64],
+    control: &AlgorithmControl,
+) -> Result<Vec<f64>, AlgorithmError> {
+    let pool = control
+        .compute_pool()
+        .ok_or_else(|| execution("parallel Adamic-Adar requires an instance-owned compute pool"))?;
+    let ranges = source_chunks(neighbors.len(), control.compute_threads());
+    let chunk_results = run_adamic_adar_on_pool(pool, || {
+        let results = ranges
+            .par_iter()
+            .map(|&(start, end)| {
+                control.check_cancelled()?;
+                let mut work = 0_usize;
+                let mut local = Vec::with_capacity(end - start);
+                for source in start..end {
+                    let score =
+                        adamic_adar_source_score(neighbors, discount_degrees, source, || {
+                            adamic_adar_serial_checkpoint(control, &mut work)
+                        })?;
+                    local.push(score);
+                }
+                Ok((start, local))
+            })
+            .collect::<Vec<Result<_, AlgorithmError>>>();
+        first_chunk_error(results)
+    })?;
+
+    let mut scores = Vec::with_capacity(neighbors.len());
+    for (_start, local) in chunk_results {
+        scores.extend(local);
+    }
+    Ok(scores)
+}
+fn adamic_adar_source_score(
+    neighbors: &[Vec<usize>],
+    discount_degrees: &[u64],
+    source: usize,
+    mut checkpoint: impl FnMut() -> Result<(), AlgorithmError>,
+) -> Result<f64, AlgorithmError> {
+    let source_neighbors = &neighbors[source];
+    let mut score = 0.0_f64;
+    let mut compensation = 0.0_f64;
+    for (candidate, candidate_neighbors) in neighbors.iter().enumerate() {
+        checkpoint()?;
+        if source == candidate || source_neighbors.binary_search(&candidate).is_ok() {
+            continue;
+        }
+        let (mut left, mut right) = (0, 0);
+        while left < source_neighbors.len() && right < candidate_neighbors.len() {
+            checkpoint()?;
+            match source_neighbors[left].cmp(&candidate_neighbors[right]) {
+                std::cmp::Ordering::Less => left += 1,
+                std::cmp::Ordering::Greater => right += 1,
+                std::cmp::Ordering::Equal => {
+                    let common = source_neighbors[left];
+                    let term = adamic_discount(discount_degrees[common])?;
+                    let adjusted = term - compensation;
+                    let updated = score + adjusted;
+                    compensation = (updated - score) - adjusted;
+                    score = updated;
+                    left += 1;
+                    right += 1;
+                }
+            }
+        }
+    }
+    if !score.is_finite() {
+        return Err(execution("Adamic-Adar score is not finite"));
+    }
+    Ok(score)
+}
+fn adamic_adar_serial_checkpoint(
+    control: &AlgorithmControl,
+    visited: &mut usize,
+) -> Result<(), AlgorithmError> {
+    if (*visited).is_multiple_of(ADAMIC_ADAR_CHECKPOINT_INTERVAL) {
+        control.checkpoint()?;
+    }
+    *visited = visited.saturating_add(1);
+    Ok(())
+}
+fn estimated_adamic_adar_work(neighbors: &[Vec<usize>]) -> u64 {
+    let sources = usize_to_u64_saturating(neighbors.len());
+    let degree_sum = neighbors.iter().fold(0_u64, |total, adjacent| {
+        total.saturating_add(usize_to_u64_saturating(adjacent.len()))
+    });
+    sources
+        .saturating_mul(sources)
+        .saturating_add(sources.saturating_mul(degree_sum).saturating_mul(2))
+}
+pub(crate) fn select_adamic_adar_path(
+    control: &AlgorithmControl,
+    sources: usize,
+    estimated_work: u64,
+) -> AdamicAdarExecutionPath {
+    let threads = control.compute_threads();
+    if threads <= 1
+        || sources <= 1
+        || estimated_work < ADAMIC_ADAR_PARALLEL_CROSSOVER_WORK
+        || control
+            .compute_pool()
+            .is_none_or(|pool| !pool.is_parallel())
+    {
+        return AdamicAdarExecutionPath::Serial;
+    }
+    let chunks = source_chunks(sources, threads).len();
+    if chunks <= 1 {
+        return AdamicAdarExecutionPath::Serial;
+    }
+    AdamicAdarExecutionPath::Parallel { threads, chunks }
+}
+fn run_adamic_adar_on_pool<R>(
+    pool: &crate::ComputePool,
+    op: impl FnOnce() -> Result<R, AlgorithmError> + Send,
+) -> Result<R, AlgorithmError>
+where
+    R: Send,
+{
+    match catch_unwind(AssertUnwindSafe(|| pool.install(op))) {
+        Ok(result) => result,
+        Err(_) => Err(execution("Adamic-Adar worker panicked")),
+    }
 }
 
 fn adamic_discount(degree: u64) -> Result<f64, AlgorithmError> {
@@ -3723,8 +3855,45 @@ mod tests {
         )
     }
 
+    fn execute_adamic_adar_with_pool(
+        graph: &AdjacencyGraph,
+        threads: usize,
+        limits: AlgorithmLimits,
+        cancellation: AlgorithmCancellation,
+    ) -> Result<AlgorithmOutput, AlgorithmError> {
+        let pool = Arc::new(crate::ComputePool::new(threads).unwrap());
+        let mut registry = AlgorithmRegistry::default();
+        register_rank_algorithms(&mut registry)?;
+        let control = AlgorithmControl::new(limits.with_compute_threads(threads), cancellation)
+            .with_compute_pool(pool);
+        registry.execute(Algorithm::Rank(RankAlgorithm::AdamicAdar), graph, &control)
+    }
+    fn dense_adamic_adar_graph(nodes: usize) -> AdjacencyGraph {
+        let max_fanout = nodes.saturating_sub(1).max(1) / 2;
+        let fanout = ((ADAMIC_ADAR_PARALLEL_CROSSOVER_WORK as usize)
+            / (nodes.max(1) * nodes.max(1)))
+        .clamp(4, max_fanout.max(1));
+        adamic_adar_ring_graph(nodes, fanout)
+    }
+
     fn adamic_adar_output_scores(output: &AlgorithmOutput) -> Vec<f64> {
         hits_hub_scores(output)
+    }
+
+    fn adamic_adar_bits(output: &AlgorithmOutput) -> Vec<u64> {
+        adamic_adar_output_scores(output)
+            .into_iter()
+            .map(f64::to_bits)
+            .collect()
+    }
+    fn adamic_adar_ring_graph(nodes: usize, fanout: usize) -> AdjacencyGraph {
+        let fanout = fanout.clamp(1, (nodes.saturating_sub(1) / 2).max(1));
+        let edges = (0..nodes)
+            .flat_map(|node| {
+                (1..=fanout).map(move |hop| (node as u64, ((node + hop) % nodes) as u64))
+            })
+            .collect::<Vec<_>>();
+        AdjacencyGraph::with_test_edges(nodes as u64, &edges)
     }
 
     fn execute_common_neighbors(
@@ -6667,6 +6836,232 @@ mod tests {
             .unwrap();
         assert_eq!(capability.dependency, BUILTIN_REVIEW);
         assert_eq!(capability.algorithm.as_str(), "adamic_adar");
+    }
+
+    #[test]
+    fn adamic_adar_path_selection_respects_crossover_and_one_thread() {
+        let no_pool = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(4),
+            AlgorithmCancellation::default(),
+        );
+        assert_eq!(
+            select_adamic_adar_path(&no_pool, 64, ADAMIC_ADAR_PARALLEL_CROSSOVER_WORK),
+            AdamicAdarExecutionPath::Serial
+        );
+        let one = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(1),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(Arc::new(crate::ComputePool::new(1).unwrap()));
+        assert_eq!(
+            select_adamic_adar_path(&one, 64, ADAMIC_ADAR_PARALLEL_CROSSOVER_WORK),
+            AdamicAdarExecutionPath::Serial
+        );
+        let small = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(4),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(Arc::new(crate::ComputePool::new(4).unwrap()));
+        assert_eq!(
+            select_adamic_adar_path(&small, 64, ADAMIC_ADAR_PARALLEL_CROSSOVER_WORK - 1),
+            AdamicAdarExecutionPath::Serial
+        );
+        assert_eq!(
+            select_adamic_adar_path(&small, 64, ADAMIC_ADAR_PARALLEL_CROSSOVER_WORK),
+            AdamicAdarExecutionPath::Parallel {
+                threads: 4,
+                chunks: 4
+            }
+        );
+    }
+    #[test]
+    fn adamic_adar_thread_matrix_matches_one_thread_bits_and_ordering() {
+        let graph = dense_adamic_adar_graph(128);
+        let neighbors = simple_neighbors(
+            &graph,
+            &AlgorithmControl::new(AlgorithmLimits::default(), AlgorithmCancellation::default()),
+            false,
+        )
+        .unwrap();
+        assert!(estimated_adamic_adar_work(&neighbors) >= ADAMIC_ADAR_PARALLEL_CROSSOVER_WORK);
+        let serial = execute_adamic_adar_with_pool(
+            &graph,
+            1,
+            AlgorithmLimits::default(),
+            AlgorithmCancellation::default(),
+        )
+        .unwrap();
+        let serial_rows = serial.rows();
+        let serial_bits = adamic_adar_bits(&serial);
+        for threads in [2_usize, 4, 8] {
+            let parallel = execute_adamic_adar_with_pool(
+                &graph,
+                threads,
+                AlgorithmLimits::default(),
+                AlgorithmCancellation::default(),
+            )
+            .unwrap();
+            assert_eq!(parallel.schema, serial.schema);
+            assert_eq!(parallel.rows(), serial_rows);
+            assert_eq!(adamic_adar_bits(&parallel), serial_bits);
+        }
+    }
+    #[test]
+    fn adamic_adar_parallel_preserves_boundary_bits() {
+        let multigraph = AdjacencyGraph::with_test_edges(
+            5,
+            &[
+                (0, 2),
+                (0, 2),
+                (0, 3),
+                (0, 0),
+                (1, 2),
+                (1, 3),
+                (2, 0),
+                (2, 4),
+                (3, 4),
+            ],
+        );
+        let directed = AdjacencyGraph::with_test_edges(2, &[(0, 1)]);
+        let undirected = AdjacencyGraph::with_test_edges(2, &[(0, 1), (1, 0)]);
+        let complete =
+            AdjacencyGraph::with_test_edges(3, &[(0, 1), (1, 0), (0, 2), (2, 0), (1, 2), (2, 1)]);
+        let empty = AdjacencyGraph::default();
+        let single = AdjacencyGraph::with_test_edges(1, &[]);
+        let disconnected = AdjacencyGraph::with_test_edges(4, &[(0, 1), (1, 0), (2, 3), (3, 2)]);
+        for graph in [
+            &multigraph,
+            &directed,
+            &undirected,
+            &complete,
+            &empty,
+            &single,
+            &disconnected,
+        ] {
+            let serial = execute_adamic_adar_with_pool(
+                graph,
+                1,
+                AlgorithmLimits::default(),
+                AlgorithmCancellation::default(),
+            )
+            .unwrap();
+            for threads in [2_usize, 4, 8] {
+                let parallel = execute_adamic_adar_with_pool(
+                    graph,
+                    threads,
+                    AlgorithmLimits::default(),
+                    AlgorithmCancellation::default(),
+                )
+                .unwrap();
+                assert_eq!(adamic_adar_bits(&parallel), adamic_adar_bits(&serial));
+                assert_eq!(parallel.rows(), serial.rows());
+            }
+        }
+    }
+    #[test]
+    fn adamic_adar_parallel_limits_and_cancellation_return_structured() {
+        let graph = dense_adamic_adar_graph(128);
+        let cancellation = AlgorithmCancellation::default();
+        cancellation.cancel();
+        assert_eq!(
+            execute_adamic_adar_with_pool(&graph, 4, AlgorithmLimits::default(), cancellation),
+            Err(AlgorithmError::Cancelled)
+        );
+        assert!(matches!(
+            execute_adamic_adar_with_pool(
+                &graph,
+                4,
+                AlgorithmLimits {
+                    iterations: 0,
+                    ..AlgorithmLimits::default()
+                },
+                AlgorithmCancellation::default()
+            ),
+            Err(AlgorithmError::IterationLimit { .. })
+        ));
+        assert!(matches!(
+            execute_adamic_adar_with_pool(
+                &graph,
+                4,
+                AlgorithmLimits {
+                    output_rows: 2,
+                    ..AlgorithmLimits::default()
+                },
+                AlgorithmCancellation::default()
+            ),
+            Err(AlgorithmError::OutputLimit { .. })
+        ));
+    }
+    #[test]
+    fn adamic_adar_source_chunks_cover_canonical_ranges() {
+        assert_eq!(source_chunks(0, 4), Vec::<(usize, usize)>::new());
+        assert_eq!(source_chunks(5, 1), vec![(0, 5)]);
+        assert_eq!(source_chunks(5, 2), vec![(0, 3), (3, 5)]);
+        assert_eq!(source_chunks(8, 4), vec![(0, 2), (2, 4), (4, 6), (6, 8)]);
+        assert_eq!(source_chunks(3, 8), vec![(0, 1), (1, 2), (2, 3)]);
+    }
+    #[test]
+    #[ignore = "manual crossover measurement; run with --ignored --nocapture"]
+    fn measure_adamic_adar_parallel_crossover() {
+        use std::time::Instant;
+
+        for (nodes, fanout) in [
+            (64_usize, 8_usize),
+            (96, 12),
+            (128, 16),
+            (192, 16),
+            (256, 16),
+            (512, 32),
+            (1024, 32),
+        ] {
+            let graph = adamic_adar_ring_graph(nodes, fanout);
+            let neighbors = simple_neighbors(
+                &graph,
+                &AlgorithmControl::new(
+                    AlgorithmLimits::default(),
+                    AlgorithmCancellation::default(),
+                ),
+                false,
+            )
+            .unwrap();
+            let work = estimated_adamic_adar_work(&neighbors);
+            let measurement_limits = AlgorithmLimits {
+                iterations: 1_000_000,
+                ..AlgorithmLimits::default()
+            };
+            let serial_ctl = AlgorithmControl::new(
+                measurement_limits.with_compute_threads(1),
+                AlgorithmCancellation::default(),
+            )
+            .with_compute_pool(Arc::new(crate::ComputePool::new(1).unwrap()));
+            let parallel_ctl = AlgorithmControl::new(
+                measurement_limits.with_compute_threads(4),
+                AlgorithmCancellation::default(),
+            )
+            .with_compute_pool(Arc::new(crate::ComputePool::new(4).unwrap()));
+            let mut serial_ns = u128::MAX;
+            let mut parallel_ns = u128::MAX;
+            for _ in 0..5 {
+                let t0 = Instant::now();
+                let serial = adamic_adar_scores(&graph, &serial_ctl).unwrap();
+                serial_ns = serial_ns.min(t0.elapsed().as_nanos());
+                let serial_bits = serial.iter().copied().map(f64::to_bits).collect::<Vec<_>>();
+
+                let t1 = Instant::now();
+                let parallel = adamic_adar_scores(&graph, &parallel_ctl).unwrap();
+                parallel_ns = parallel_ns.min(t1.elapsed().as_nanos());
+                let parallel_bits = parallel
+                    .iter()
+                    .copied()
+                    .map(f64::to_bits)
+                    .collect::<Vec<_>>();
+                assert_eq!(parallel_bits, serial_bits);
+            }
+            println!(
+                "nodes={nodes} fanout={fanout} work={work} serial_ns={serial_ns} parallel_ns={parallel_ns} ratio={}",
+                parallel_ns as f64 / serial_ns as f64
+            );
+        }
     }
 
     #[test]

--- a/docs/book/architecture/algorithms.md
+++ b/docs/book/architecture/algorithms.md
@@ -585,7 +585,14 @@ Stable topology and neighbor order drive pair intersections. Contributions and
 node aggregates use compensated `Float64` summation, and a non-finite
 contribution or result produces a structured execution error. Batched
 checkpoints enforce the shared selected-node, adjacency-entry, output-row,
-iteration, and cancellation limits.
+iteration, and cancellation limits. Above the documented
+`ADAMIC_ADAR_PARALLEL_CROSSOVER_WORK` (`524_288`) estimate, and only when the
+resource policy provides more than one compute thread, independent source
+ordinals may run on the instance-owned private compute pool (#337 / #499).
+Candidate order, missing-link checks, two-pointer intersections, logarithmic
+discounts, and compensated summation remain serial per source; worker score
+chunks merge in source order, so scores and fingerprints match the one-thread
+path.
 
 The public schema remains non-null `node_uuid: FixedSizeBinary(16)`, non-null
 `score: Float64`, then materialized node properties with Arrow NULLs for missing

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -20,6 +20,8 @@ Tokio runtime or any DataFusion execution session.
 | `compute_threads` | `2` | Instance-owned private CPU pool (#342 cosine KNN; #343 PageRank; #344 Node2Vec walks; #535 Jaccard similarity; #504 clustering coefficient; #515 triangles; #506 Degree; #501 betweenness; #518 Components) |
 | `compute_threads` | `2` | Instance-owned private CPU pool (#342 cosine KNN; #343 PageRank; #344 Node2Vec walks; #507 eigenvector) |
 
+| `compute_threads` | `2` | Instance-owned private CPU pool (#342 cosine KNN; #343 PageRank; #344 Node2Vec walks; #499 Adamic-Adar) |
+
 Defaults preserve pre-#337 fixed two-worker / two-partition behavior.
 
 ## Modes
@@ -145,6 +147,14 @@ products retain serial coordinate order, PageRank keeps canonical contribution
 order with serial dangling/delta reductions, Node2Vec skip-gram training stays
 serial, and conductance keeps weighted cut/volume accumulation serial, so
 fingerprints match the one-thread path.
+
+(#342), PageRank (#343), Node2Vec walk-corpus generation (#344), and
+Adamic-Adar source aggregates (#499) may partition independent work across that
+pool above documented crossovers; work never uses Rayon's process-global pool.
+Cosine dot products retain serial coordinate order, PageRank keeps canonical
+contribution order with serial dangling/delta reductions, Node2Vec skip-gram
+training stays serial, and Adamic-Adar keeps serial candidate/intersection order
+per source, so fingerprints match the one-thread path.
 
 ## Parallel cosine KNN (#342)
 
@@ -590,6 +600,22 @@ ring-lattice fixture, 4 private workers, debug test profile after a clean
 target-dir build): ~230k units was still slower (~1.80x serial), ~540k units
 was still slower (~1.20x serial), ~1.2M units first won (~0.70x serial), and
 >=2.1M units was >=1.8x faster.
+## Parallel Adamic-Adar aggregate (#499)
+
+`rank(by="adamic_adar")` partitions **independent source ordinals** across the
+instance-owned private compute pool when:
+
+- `compute_threads > 1`, and
+- the estimated pair/intersection work is at least
+  `ADAMIC_ADAR_PARALLEL_CROSSOVER_WORK` (`524_288`) in `graphforge-exec`.
+
+The estimate is `sources² + 2 × sources × distinct_adjacency_entries`, a
+conservative O(V + E) proxy for the serial pair loop and two-pointer
+intersection scans. The threshold is the smallest power-of-two work estimate
+below the measured win boundary on the M4 agent host (4 vCPU, directed
+ring-lattice fixture, 4 private workers, release build): ~230k units was still
+neutral/slower, ~540k units first won (~0.61x serial), and >=2.1M units was
+>=2.8x faster.
 
 Below that crossover, or when the policy provides one compute thread, the
 serial path runs with no pool scheduling tax. Parallel workers only own source
@@ -598,6 +624,10 @@ intersection, and checked integer accumulation remain serial per source.
 Worker score chunks merge in canonical source order, so schemas, row order,
 scores, and fingerprints match the one-thread result at `1`/`2`/`4`/`8`/
 automatic configurations.
+intersection, logarithmic discounts, and compensated floating-point summation
+remain serial per source. Worker score chunks merge in canonical source order,
+so schemas, row order, scores, and fingerprints match the one-thread result at
+`1`/`2`/`4`/`8`/automatic configurations.
 
 ## Observability
 

--- a/docs/development/m4-entry-baseline.md
+++ b/docs/development/m4-entry-baseline.md
@@ -85,6 +85,10 @@ common-neighbors source aggregates (#505) may use the instance-owned private
 compute pool above documented crossovers while preserving one-thread
 fingerprints. Query-facing Parquet providers stream bounded batches via
 `GraphForgeParquetExec` (#339) rather than eager
+Adamic-Adar source aggregates (#499) may use the instance-owned private compute
+pool above documented crossovers while preserving one-thread fingerprints.
+Query-facing Parquet providers stream bounded batches via `GraphForgeParquetExec`
+(#339) rather than eager
 single-partition `MemTable` materialization; ExpandExec filtered reads and
 fixed-hop demand remain the selective-path contract.
 

--- a/docs/development/m4-exit-evidence.md
+++ b/docs/development/m4-exit-evidence.md
@@ -32,7 +32,7 @@ ledger and does not block M4.
 | [`m4-exit-evidence.json`](m4-exit-evidence.json) | `graphforge-m4-entry-evidence/1` rerun on the final tree (short + thread-parity matrix) |
 | [`file-backed-oversize-evidence.json`](file-backed-oversize-evidence.json) | `graphforge-file-backed-oversize-evidence/1` public reopen past legacy 2 GiB envelope |
 | [`m4-entry-baseline.md`](m4-entry-baseline.md) | Entry contract narrative (updated for shipped M4) |
-| [`execution-resource-policy.md`](execution-resource-policy.md) | #337 policy + #342/#343/#344 crossovers |
+| [`execution-resource-policy.md`](execution-resource-policy.md) | #337 policy + #342/#343/#344/#499 crossovers |
 | [`../reference/scale-limits.md`](../reference/scale-limits.md) | Persistence / adjacency / CSR claim table |
 
 ## Final-tree reproduction
@@ -68,6 +68,9 @@ GF_FILE_BACKED_OVERSIZE_EVIDENCE_OUT=docs/development/file-backed-oversize-evide
 - **CPU kernels (#342–#344/#505):** exact cosine KNN, PageRank, Node2Vec walk
   generation, and common-neighbors source aggregates use the instance-owned
   private compute pool above documented crossovers; one-thread fingerprints are
+- **CPU kernels (#342–#344, #499):** exact cosine KNN, PageRank, Node2Vec walk
+  generation, and Adamic-Adar source aggregates use the instance-owned private
+  compute pool above documented crossovers; one-thread fingerprints are
   preserved. Thread cells that exceed the machine-relative concurrency budget
   are recorded `unavailable` (on this host `threads-8` is unavailable).
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -439,11 +439,17 @@ selections retain deterministic finite boundary behavior.
 
 Neighbor contributions and node aggregates use stable topology order and
 compensated `Float64` summation; any non-finite result is a structured execution
-error. Results expose only `node_uuid: FixedSizeBinary(16)`, `score: Float64`,
-then materialized node properties. Shared Rust limits and cancellation apply,
-and `write_property` atomically persists every score only after successful
-execution. Python and Node only translate arguments and Arrow IPC; neither
-contains an algorithm backend, fallback, packaging dependency, or recovery path.
+error. When the estimated pair/intersection work reaches
+`ADAMIC_ADAR_PARALLEL_CROSSOVER_WORK` (`524_288`) and the resource policy
+provides multiple compute threads, independent source ordinals may run on the
+instance-owned private compute pool. Candidate/intersection scoring stays serial
+per source and score chunks merge in source order, so results match the
+one-thread fingerprint. Results expose only `node_uuid: FixedSizeBinary(16)`,
+`score: Float64`, then materialized node properties. Shared Rust limits and
+cancellation apply, and `write_property` atomically persists every score only
+after successful execution. Python and Node only translate arguments and Arrow
+IPC; neither contains an algorithm backend, fallback, packaging dependency, or
+recovery path.
 
 Common neighbors is deterministic, unweighted, and Rust-owned. Its pair score
 is `CN(u, v) = |N(u) intersect N(v)|`. `rank()` returns one score per selected


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements #499: parallel `rank(by="adamic_adar")` by independent source chunks on the instance-owned `ComputePool`, serial pair scoring, ordered merge, measured crossover, and fingerprint parity.

Closes #499

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/595"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788943391&installation_model_id=20486&pr_number=595&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F595&signature=d3884605734c8b92f7b2173201350655f8451b674b1dc36a01ffb4ef9e74b28c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parallelize Adamic-Adar scoring on the private ComputePool
> - Adds a parallel execution path for Adamic-Adar in [`algorithm_rank.rs`](https://github.com/CurateLabs/graphforge/pull/595/files#diff-d42360b7ef75ce3112d55412fae040f54af2633f4b75d8609ca211a2702172b7) that splits sources into chunks and runs them via Rayon on the instance-owned private pool when estimated work exceeds `ADAMIC_ADAR_PARALLEL_CROSSOVER_WORK` (524,288).
> - Adds `select_adamic_adar_path` to dynamically choose serial vs. parallel at runtime based on thread count, pool availability, source count, and estimated work.
> - Extracts `adamic_adar_scores_serial`, `adamic_adar_scores_parallel`, and `adamic_adar_source_score` helpers to separate concerns; panics in worker threads are caught and converted to structured `AlgorithmError` values.
> - Results are guaranteed bit-identical to the single-threaded path via ordered chunk merging and serial per-source scoring.
> - Risk: parallel path adds overhead for small graphs; the crossover threshold was measured empirically and may not generalize to all hardware configurations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac20a7c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->