### PR TITLE
perf(exec): parallelize common_neighbors on ComputePool (#505)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_rank.rs
+++ b/crates/graphforge-exec/src/algorithm_rank.rs
@@ -119,17 +119,19 @@ pub const BETWEENNESS_PARALLEL_CROSSOVER_WORK: u64 = 65_536;
 =======
 /// Estimated pair/intersection work below which common-neighbors stays serial (#505).
 ///
-/// Chosen from release-mode serial-vs-parallel timings on this M4 agent host
-/// (4x Xeon vCPU, directed ring-lattice fixtures, 4 private workers; see
+/// Chosen from manual serial-vs-parallel timings on this M4 agent host
+/// (4x Xeon vCPU, directed ring-lattice fixtures, 4 private workers, debug
+/// test profile after a clean target-dir build; see
 /// ignored `measure_common_neighbors_parallel_crossover`):
 /// - ~230k estimated units: parallel still neutral/slower (pool scheduling tax)
-/// - ~540k estimated units: first clear win (~0.53x serial)
-/// - >=2.1M estimated units: >=3.0x speedup
+/// - ~540k estimated units: parallel still slower (~1.09x serial)
+/// - ~1.2M estimated units: first clear win (~0.81x serial)
+/// - >=2.1M estimated units: >=1.5x speedup
 ///
-/// `524_288` is the smallest power-of-two work estimate below that measured win
-/// boundary. Each source keeps serial candidate/intersection order, so exact
-/// counts remain identical on either path.
-pub const COMMON_NEIGHBORS_PARALLEL_CROSSOVER_WORK: u64 = 524_288;
+/// `1_048_576` is the smallest power-of-two work estimate below that measured
+/// win boundary. Each source keeps serial candidate/intersection order, so
+/// exact counts remain identical on either path.
+pub const COMMON_NEIGHBORS_PARALLEL_CROSSOVER_WORK: u64 = 1_048_576;
 const COMMON_NEIGHBORS_CHECKPOINT_INTERVAL: usize = 1_024;
 >>>>>>> ecfa5e4 (perf(exec): parallelize common neighbors rank)
 const EIGENVECTOR_MAX_ITERATIONS: usize = 20;

--- a/crates/graphforge-exec/src/algorithm_rank.rs
+++ b/crates/graphforge-exec/src/algorithm_rank.rs
@@ -88,6 +88,7 @@ const PAGERANK_TOLERANCE: f64 = 1.0e-10;
 /// embedded hosts. Numeric results remain identical either way.
 pub const PAGERANK_PARALLEL_CROSSOVER_EDGES: u64 = 4_096;
 const PAGERANK_CHECKPOINT_DESTINATIONS: usize = 4_096;
+<<<<<<< HEAD
 /// Estimated local neighbor-pair probes below which clustering coefficient stays serial (#504).
 ///
 /// Keeps small fixtures and sparse public invocations off the worker pool; above this,
@@ -115,6 +116,22 @@ const DEGREE_CHECKPOINT_NODES: usize = 1_024;
 /// The crossover keeps small fixtures off the private pool; parallel workers
 /// still run each source's Brandes BFS serially and reduce in source order.
 pub const BETWEENNESS_PARALLEL_CROSSOVER_WORK: u64 = 65_536;
+=======
+/// Estimated pair/intersection work below which common-neighbors stays serial (#505).
+///
+/// Chosen from release-mode serial-vs-parallel timings on this M4 agent host
+/// (4x Xeon vCPU, directed ring-lattice fixtures, 4 private workers; see
+/// ignored `measure_common_neighbors_parallel_crossover`):
+/// - ~230k estimated units: parallel still neutral/slower (pool scheduling tax)
+/// - ~540k estimated units: first clear win (~0.53x serial)
+/// - >=2.1M estimated units: >=3.0x speedup
+///
+/// `524_288` is the smallest power-of-two work estimate below that measured win
+/// boundary. Each source keeps serial candidate/intersection order, so exact
+/// counts remain identical on either path.
+pub const COMMON_NEIGHBORS_PARALLEL_CROSSOVER_WORK: u64 = 524_288;
+const COMMON_NEIGHBORS_CHECKPOINT_INTERVAL: usize = 1_024;
+>>>>>>> ecfa5e4 (perf(exec): parallelize common neighbors rank)
 const EIGENVECTOR_MAX_ITERATIONS: usize = 20;
 const EIGENVECTOR_TOLERANCE: f64 = 1.0e-7;
 /// Selected adjacency entries below which eigenvector stays on the serial path (#507).
@@ -329,6 +346,13 @@ pub(crate) enum PageRankExecutionPath {
     Parallel { threads: usize, chunks: usize },
 }
 
+/// Selected common-neighbors execution path for observability and crossover tests (#505).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CommonNeighborsExecutionPath {
+    Serial,
+    Parallel { threads: usize, chunks: usize },
+}
+
 /// Dense inbound CSR: source ordinals in canonical source/edge order per destination.
 #[derive(Clone, Debug, Default)]
 struct PageRankInboundCsr {
@@ -439,6 +463,7 @@ pub(crate) fn select_pagerank_path(
 }
 
 fn destination_chunks(nodes: usize, threads: usize) -> Vec<(usize, usize)> {
+<<<<<<< HEAD
     ordinal_chunks(nodes, threads)
 }
 
@@ -447,6 +472,12 @@ fn source_chunks(nodes: usize, threads: usize) -> Vec<(usize, usize)> {
 }
 
 fn ordinal_chunks(nodes: usize, threads: usize) -> Vec<(usize, usize)> {
+=======
+    source_chunks(nodes, threads)
+}
+
+fn source_chunks(nodes: usize, threads: usize) -> Vec<(usize, usize)> {
+>>>>>>> ecfa5e4 (perf(exec): parallelize common neighbors rank)
     if nodes == 0 {
         return Vec::new();
     }
@@ -1897,40 +1928,171 @@ fn common_neighbor_scores(
     control: &AlgorithmControl,
 ) -> Result<Vec<f64>, AlgorithmError> {
     let neighbors = simple_neighbors(graph, control, false)?;
+    let estimated_work = estimated_common_neighbors_work(&neighbors);
+    match select_common_neighbors_path(control, neighbors.len(), estimated_work) {
+        CommonNeighborsExecutionPath::Serial => common_neighbor_scores_serial(&neighbors, control),
+        CommonNeighborsExecutionPath::Parallel { .. } => {
+            common_neighbor_scores_parallel(&neighbors, control)
+        }
+    }
+}
+
+fn common_neighbor_scores_serial(
+    neighbors: &[Vec<usize>],
+    control: &AlgorithmControl,
+) -> Result<Vec<f64>, AlgorithmError> {
     let mut visited = 0_usize;
     let mut scores = Vec::with_capacity(neighbors.len());
-    for (source, source_neighbors) in neighbors.iter().enumerate() {
-        let mut score = 0_u64;
-        for (candidate, candidate_neighbors) in neighbors.iter().enumerate() {
-            if visited.is_multiple_of(1024) {
-                control.checkpoint()?;
-            }
-            visited += 1;
-            if source == candidate || source_neighbors.binary_search(&candidate).is_ok() {
-                continue;
-            }
-            let (mut left, mut right) = (0, 0);
-            while left < source_neighbors.len() && right < candidate_neighbors.len() {
-                if visited.is_multiple_of(1024) {
-                    control.checkpoint()?;
-                }
-                visited += 1;
-                match source_neighbors[left].cmp(&candidate_neighbors[right]) {
-                    std::cmp::Ordering::Less => left += 1,
-                    std::cmp::Ordering::Greater => right += 1,
-                    std::cmp::Ordering::Equal => {
-                        score = score.checked_add(1).ok_or_else(|| {
-                            execution("common-neighbors score exceeds supported range")
-                        })?;
-                        left += 1;
-                        right += 1;
-                    }
-                }
-            }
-        }
+    for source in 0..neighbors.len() {
+        let score = common_neighbor_source_score(neighbors, source, || {
+            common_neighbors_checkpoint(control, &mut visited)
+        })?;
         scores.push(exact_u64_as_f64(score, "common-neighbors score")?);
     }
     Ok(scores)
+}
+
+fn common_neighbor_scores_parallel(
+    neighbors: &[Vec<usize>],
+    control: &AlgorithmControl,
+) -> Result<Vec<f64>, AlgorithmError> {
+    let pool = control.compute_pool().ok_or_else(|| {
+        execution("parallel common-neighbors requires an instance-owned compute pool")
+    })?;
+    let ranges = source_chunks(neighbors.len(), control.compute_threads());
+    let chunk_results = run_common_neighbors_on_pool(pool, || {
+        let results = ranges
+            .par_iter()
+            .map(|&(start, end)| {
+                control.check_cancelled()?;
+                let mut work = 0_usize;
+                let mut local = Vec::with_capacity(end - start);
+                for source in start..end {
+                    let score = common_neighbor_source_score(neighbors, source, || {
+                        common_neighbors_checkpoint(control, &mut work)
+                    })?;
+                    local.push(exact_u64_as_f64(score, "common-neighbors score")?);
+                }
+                Ok((start, local))
+            })
+            .collect::<Vec<Result<_, AlgorithmError>>>();
+        first_chunk_error(results)
+    })?;
+
+    let mut scores = Vec::with_capacity(neighbors.len());
+    for (_start, local) in chunk_results {
+        scores.extend(local);
+    }
+    Ok(scores)
+}
+
+fn common_neighbor_source_score(
+    neighbors: &[Vec<usize>],
+    source: usize,
+    mut checkpoint: impl FnMut() -> Result<(), AlgorithmError>,
+) -> Result<u64, AlgorithmError> {
+    let source_neighbors = &neighbors[source];
+    let mut score = 0_u64;
+    for (candidate, candidate_neighbors) in neighbors.iter().enumerate() {
+        checkpoint()?;
+        if source == candidate || source_neighbors.binary_search(&candidate).is_ok() {
+            continue;
+        }
+        let (mut left, mut right) = (0, 0);
+        while left < source_neighbors.len() && right < candidate_neighbors.len() {
+            checkpoint()?;
+            match source_neighbors[left].cmp(&candidate_neighbors[right]) {
+                std::cmp::Ordering::Less => left += 1,
+                std::cmp::Ordering::Greater => right += 1,
+                std::cmp::Ordering::Equal => {
+                    score = score.checked_add(1).ok_or_else(|| {
+                        execution("common-neighbors score exceeds supported range")
+                    })?;
+                    left += 1;
+                    right += 1;
+                }
+            }
+        }
+    }
+    Ok(score)
+}
+
+fn common_neighbors_checkpoint(
+    control: &AlgorithmControl,
+    visited: &mut usize,
+) -> Result<(), AlgorithmError> {
+    if (*visited).is_multiple_of(COMMON_NEIGHBORS_CHECKPOINT_INTERVAL) {
+        control.checkpoint()?;
+    }
+    *visited = visited.saturating_add(1);
+    Ok(())
+}
+
+fn estimated_common_neighbors_work(neighbors: &[Vec<usize>]) -> u64 {
+    let sources = usize_to_u64_saturating(neighbors.len());
+    let degree_sum = neighbors.iter().fold(0_u64, |total, adjacent| {
+        total.saturating_add(usize_to_u64_saturating(adjacent.len()))
+    });
+    sources
+        .saturating_mul(sources)
+        .saturating_add(sources.saturating_mul(degree_sum).saturating_mul(2))
+}
+
+/// Choose serial vs private-pool parallel execution for a common-neighbors workload.
+pub(crate) fn select_common_neighbors_path(
+    control: &AlgorithmControl,
+    sources: usize,
+    estimated_work: u64,
+) -> CommonNeighborsExecutionPath {
+    let threads = control.compute_threads();
+    if threads <= 1
+        || sources <= 1
+        || estimated_work < COMMON_NEIGHBORS_PARALLEL_CROSSOVER_WORK
+        || control
+            .compute_pool()
+            .is_none_or(|pool| !pool.is_parallel())
+    {
+        return CommonNeighborsExecutionPath::Serial;
+    }
+    let chunks = source_chunks(sources, threads).len();
+    if chunks <= 1 {
+        return CommonNeighborsExecutionPath::Serial;
+    }
+    CommonNeighborsExecutionPath::Parallel { threads, chunks }
+}
+
+/// Prefer the lowest-index chunk error so parallel failures stay deterministic.
+fn first_chunk_error<T>(results: Vec<Result<T, AlgorithmError>>) -> Result<Vec<T>, AlgorithmError> {
+    let mut ok = Vec::with_capacity(results.len());
+    let mut first_error: Option<AlgorithmError> = None;
+    for result in results {
+        match result {
+            Ok(value) if first_error.is_none() => ok.push(value),
+            Err(error) if first_error.is_none() => first_error = Some(error),
+            Ok(_) | Err(_) => {}
+        }
+    }
+    match first_error {
+        Some(error) => Err(error),
+        None => Ok(ok),
+    }
+}
+
+fn run_common_neighbors_on_pool<R>(
+    pool: &crate::ComputePool,
+    op: impl FnOnce() -> Result<R, AlgorithmError> + Send,
+) -> Result<R, AlgorithmError>
+where
+    R: Send,
+{
+    match catch_unwind(AssertUnwindSafe(|| pool.install(op))) {
+        Ok(result) => result,
+        Err(_) => Err(execution("common-neighbors worker panicked")),
+    }
+}
+
+fn usize_to_u64_saturating(value: usize) -> u64 {
+    u64::try_from(value).unwrap_or(u64::MAX)
 }
 
 fn resource_allocation_scores(
@@ -3326,8 +3488,51 @@ mod tests {
         )
     }
 
+    fn execute_common_neighbors_with_pool(
+        graph: &AdjacencyGraph,
+        threads: usize,
+        limits: AlgorithmLimits,
+        cancellation: AlgorithmCancellation,
+    ) -> Result<AlgorithmOutput, AlgorithmError> {
+        let pool = Arc::new(crate::ComputePool::new(threads).unwrap());
+        let mut registry = AlgorithmRegistry::default();
+        register_rank_algorithms(&mut registry)?;
+        let control = AlgorithmControl::new(limits.with_compute_threads(threads), cancellation)
+            .with_compute_pool(pool);
+        registry.execute(
+            Algorithm::Rank(RankAlgorithm::CommonNeighbors),
+            graph,
+            &control,
+        )
+    }
+
     fn common_neighbor_output_scores(output: &AlgorithmOutput) -> Vec<f64> {
         hits_hub_scores(output)
+    }
+
+    fn common_neighbor_bits(output: &AlgorithmOutput) -> Vec<u64> {
+        common_neighbor_output_scores(output)
+            .into_iter()
+            .map(f64::to_bits)
+            .collect()
+    }
+
+    fn dense_common_neighbors_graph(nodes: usize) -> AdjacencyGraph {
+        let max_fanout = nodes.saturating_sub(1).max(1) / 2;
+        let fanout = ((COMMON_NEIGHBORS_PARALLEL_CROSSOVER_WORK as usize)
+            / (nodes.max(1) * nodes.max(1)))
+        .clamp(4, max_fanout.max(1));
+        common_neighbors_ring_graph(nodes, fanout)
+    }
+
+    fn common_neighbors_ring_graph(nodes: usize, fanout: usize) -> AdjacencyGraph {
+        let fanout = fanout.clamp(1, (nodes.saturating_sub(1) / 2).max(1));
+        let edges = (0..nodes)
+            .flat_map(|node| {
+                (1..=fanout).map(move |hop| (node as u64, ((node + hop) % nodes) as u64))
+            })
+            .collect::<Vec<_>>();
+        AdjacencyGraph::with_test_edges(nodes as u64, &edges)
     }
 
     fn execute_resource_allocation(
@@ -6183,6 +6388,229 @@ mod tests {
             .unwrap();
         assert_eq!(capability.dependency, BUILTIN_REVIEW);
         assert_eq!(capability.algorithm.as_str(), "common_neighbors");
+    }
+
+    #[test]
+    fn common_neighbors_path_selection_respects_crossover_and_one_thread() {
+        let no_pool = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(4),
+            AlgorithmCancellation::default(),
+        );
+        assert_eq!(
+            select_common_neighbors_path(&no_pool, 64, COMMON_NEIGHBORS_PARALLEL_CROSSOVER_WORK),
+            CommonNeighborsExecutionPath::Serial
+        );
+        let one = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(1),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(Arc::new(crate::ComputePool::new(1).unwrap()));
+        assert_eq!(
+            select_common_neighbors_path(&one, 64, COMMON_NEIGHBORS_PARALLEL_CROSSOVER_WORK),
+            CommonNeighborsExecutionPath::Serial
+        );
+        let small = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(4),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(Arc::new(crate::ComputePool::new(4).unwrap()));
+        assert_eq!(
+            select_common_neighbors_path(&small, 64, COMMON_NEIGHBORS_PARALLEL_CROSSOVER_WORK - 1),
+            CommonNeighborsExecutionPath::Serial
+        );
+        assert_eq!(
+            select_common_neighbors_path(&small, 64, COMMON_NEIGHBORS_PARALLEL_CROSSOVER_WORK),
+            CommonNeighborsExecutionPath::Parallel {
+                threads: 4,
+                chunks: 4
+            }
+        );
+    }
+
+    #[test]
+    fn common_neighbors_thread_matrix_matches_one_thread_bits_and_ordering() {
+        let graph = dense_common_neighbors_graph(128);
+        let neighbors = simple_neighbors(&graph, &control(), false).unwrap();
+        assert!(
+            estimated_common_neighbors_work(&neighbors) >= COMMON_NEIGHBORS_PARALLEL_CROSSOVER_WORK
+        );
+        let serial = execute_common_neighbors_with_pool(
+            &graph,
+            1,
+            AlgorithmLimits::default(),
+            AlgorithmCancellation::default(),
+        )
+        .unwrap();
+        let serial_rows = serial.rows();
+        let serial_bits = common_neighbor_bits(&serial);
+        for threads in [2_usize, 4, 8] {
+            let parallel = execute_common_neighbors_with_pool(
+                &graph,
+                threads,
+                AlgorithmLimits::default(),
+                AlgorithmCancellation::default(),
+            )
+            .unwrap();
+            assert_eq!(parallel.schema, serial.schema);
+            assert_eq!(parallel.rows(), serial_rows);
+            assert_eq!(common_neighbor_bits(&parallel), serial_bits);
+        }
+    }
+
+    #[test]
+    fn common_neighbors_parallel_preserves_boundary_bits() {
+        let multigraph = AdjacencyGraph::with_test_edges(
+            5,
+            &[
+                (0, 2),
+                (0, 2),
+                (0, 3),
+                (0, 0),
+                (1, 2),
+                (1, 3),
+                (2, 0),
+                (2, 4),
+                (3, 4),
+            ],
+        );
+        let directed = AdjacencyGraph::with_test_edges(2, &[(0, 1)]);
+        let undirected = AdjacencyGraph::with_test_edges(2, &[(0, 1), (1, 0)]);
+        let complete =
+            AdjacencyGraph::with_test_edges(3, &[(0, 1), (1, 0), (0, 2), (2, 0), (1, 2), (2, 1)]);
+        let empty = AdjacencyGraph::default();
+        let single = AdjacencyGraph::with_test_edges(1, &[]);
+        let disconnected = AdjacencyGraph::with_test_edges(4, &[(0, 1), (1, 0), (2, 3), (3, 2)]);
+        for graph in [
+            &multigraph,
+            &directed,
+            &undirected,
+            &complete,
+            &empty,
+            &single,
+            &disconnected,
+        ] {
+            let serial = execute_common_neighbors_with_pool(
+                graph,
+                1,
+                AlgorithmLimits::default(),
+                AlgorithmCancellation::default(),
+            )
+            .unwrap();
+            for threads in [2_usize, 4, 8] {
+                let parallel = execute_common_neighbors_with_pool(
+                    graph,
+                    threads,
+                    AlgorithmLimits::default(),
+                    AlgorithmCancellation::default(),
+                )
+                .unwrap();
+                assert_eq!(
+                    common_neighbor_bits(&parallel),
+                    common_neighbor_bits(&serial)
+                );
+                assert_eq!(parallel.rows(), serial.rows());
+            }
+        }
+    }
+
+    #[test]
+    fn common_neighbors_parallel_limits_and_cancellation_return_structured() {
+        let graph = dense_common_neighbors_graph(128);
+        let cancellation = AlgorithmCancellation::default();
+        cancellation.cancel();
+        assert_eq!(
+            execute_common_neighbors_with_pool(&graph, 4, AlgorithmLimits::default(), cancellation),
+            Err(AlgorithmError::Cancelled)
+        );
+        assert!(matches!(
+            execute_common_neighbors_with_pool(
+                &graph,
+                4,
+                AlgorithmLimits {
+                    iterations: 0,
+                    ..AlgorithmLimits::default()
+                },
+                AlgorithmCancellation::default()
+            ),
+            Err(AlgorithmError::IterationLimit { .. })
+        ));
+        assert!(matches!(
+            execute_common_neighbors_with_pool(
+                &graph,
+                4,
+                AlgorithmLimits {
+                    output_rows: 2,
+                    ..AlgorithmLimits::default()
+                },
+                AlgorithmCancellation::default()
+            ),
+            Err(AlgorithmError::OutputLimit { .. })
+        ));
+    }
+
+    #[test]
+    fn common_neighbors_source_chunks_cover_canonical_ranges() {
+        assert_eq!(source_chunks(0, 4), Vec::<(usize, usize)>::new());
+        assert_eq!(source_chunks(5, 1), vec![(0, 5)]);
+        assert_eq!(source_chunks(5, 2), vec![(0, 3), (3, 5)]);
+        assert_eq!(source_chunks(8, 4), vec![(0, 2), (2, 4), (4, 6), (6, 8)]);
+        assert_eq!(source_chunks(3, 8), vec![(0, 1), (1, 2), (2, 3)]);
+    }
+
+    #[test]
+    #[ignore = "manual crossover measurement; run with --ignored --nocapture"]
+    fn measure_common_neighbors_parallel_crossover() {
+        use std::time::Instant;
+
+        for (nodes, fanout) in [
+            (64_usize, 8_usize),
+            (96, 12),
+            (128, 16),
+            (192, 16),
+            (256, 16),
+            (512, 32),
+            (1024, 32),
+        ] {
+            let graph = common_neighbors_ring_graph(nodes, fanout);
+            let neighbors = simple_neighbors(&graph, &control(), false).unwrap();
+            let work = estimated_common_neighbors_work(&neighbors);
+            let measurement_limits = AlgorithmLimits {
+                iterations: 1_000_000,
+                ..AlgorithmLimits::default()
+            };
+            let serial_ctl = AlgorithmControl::new(
+                measurement_limits.with_compute_threads(1),
+                AlgorithmCancellation::default(),
+            )
+            .with_compute_pool(Arc::new(crate::ComputePool::new(1).unwrap()));
+            let parallel_ctl = AlgorithmControl::new(
+                measurement_limits.with_compute_threads(4),
+                AlgorithmCancellation::default(),
+            )
+            .with_compute_pool(Arc::new(crate::ComputePool::new(4).unwrap()));
+            let mut serial_ns = u128::MAX;
+            let mut parallel_ns = u128::MAX;
+            for _ in 0..5 {
+                let t0 = Instant::now();
+                let serial = common_neighbor_scores(&graph, &serial_ctl).unwrap();
+                serial_ns = serial_ns.min(t0.elapsed().as_nanos());
+                let serial_bits = serial.iter().copied().map(f64::to_bits).collect::<Vec<_>>();
+
+                let t1 = Instant::now();
+                let parallel = common_neighbor_scores(&graph, &parallel_ctl).unwrap();
+                parallel_ns = parallel_ns.min(t1.elapsed().as_nanos());
+                let parallel_bits = parallel
+                    .iter()
+                    .copied()
+                    .map(f64::to_bits)
+                    .collect::<Vec<_>>();
+                assert_eq!(parallel_bits, serial_bits);
+            }
+            println!(
+                "nodes={nodes} fanout={fanout} work={work} serial_ns={serial_ns} parallel_ns={parallel_ns} ratio={}",
+                parallel_ns as f64 / serial_ns as f64
+            );
+        }
     }
 
     #[test]

--- a/crates/graphforge-exec/src/algorithm_rank.rs
+++ b/crates/graphforge-exec/src/algorithm_rank.rs
@@ -6430,7 +6430,12 @@ mod tests {
     #[test]
     fn common_neighbors_thread_matrix_matches_one_thread_bits_and_ordering() {
         let graph = dense_common_neighbors_graph(128);
-        let neighbors = simple_neighbors(&graph, &control(), false).unwrap();
+        let neighbors = simple_neighbors(
+            &graph,
+            &AlgorithmControl::new(AlgorithmLimits::default(), AlgorithmCancellation::default()),
+            false,
+        )
+        .unwrap();
         assert!(
             estimated_common_neighbors_work(&neighbors) >= COMMON_NEIGHBORS_PARALLEL_CROSSOVER_WORK
         );
@@ -6572,7 +6577,15 @@ mod tests {
             (1024, 32),
         ] {
             let graph = common_neighbors_ring_graph(nodes, fanout);
-            let neighbors = simple_neighbors(&graph, &control(), false).unwrap();
+            let neighbors = simple_neighbors(
+                &graph,
+                &AlgorithmControl::new(
+                    AlgorithmLimits::default(),
+                    AlgorithmCancellation::default(),
+                ),
+                false,
+            )
+            .unwrap();
             let work = estimated_common_neighbors_work(&neighbors);
             let measurement_limits = AlgorithmLimits {
                 iterations: 1_000_000,

--- a/crates/graphforge-exec/src/algorithm_rank.rs
+++ b/crates/graphforge-exec/src/algorithm_rank.rs
@@ -6607,12 +6607,12 @@ mod tests {
             let mut parallel_ns = u128::MAX;
             for _ in 0..5 {
                 let t0 = Instant::now();
-                let serial = common_neighbor_scores(&graph, &serial_ctl).unwrap();
+                let serial = common_neighbor_scores_serial(&neighbors, &serial_ctl).unwrap();
                 serial_ns = serial_ns.min(t0.elapsed().as_nanos());
                 let serial_bits = serial.iter().copied().map(f64::to_bits).collect::<Vec<_>>();
 
                 let t1 = Instant::now();
-                let parallel = common_neighbor_scores(&graph, &parallel_ctl).unwrap();
+                let parallel = common_neighbor_scores_parallel(&neighbors, &parallel_ctl).unwrap();
                 parallel_ns = parallel_ns.min(t1.elapsed().as_nanos());
                 let parallel_bits = parallel
                     .iter()

--- a/crates/graphforge-exec/src/algorithm_rank.rs
+++ b/crates/graphforge-exec/src/algorithm_rank.rs
@@ -123,10 +123,10 @@ pub const BETWEENNESS_PARALLEL_CROSSOVER_WORK: u64 = 65_536;
 /// (4x Xeon vCPU, directed ring-lattice fixtures, 4 private workers, debug
 /// test profile after a clean target-dir build; see
 /// ignored `measure_common_neighbors_parallel_crossover`):
-/// - ~230k estimated units: parallel still neutral/slower (pool scheduling tax)
-/// - ~540k estimated units: parallel still slower (~1.09x serial)
-/// - ~1.2M estimated units: first clear win (~0.81x serial)
-/// - >=2.1M estimated units: >=1.5x speedup
+/// - ~230k estimated units: parallel still slower (~1.80x serial)
+/// - ~540k estimated units: parallel still slower (~1.20x serial)
+/// - ~1.2M estimated units: first clear win (~0.70x serial)
+/// - >=2.1M estimated units: >=1.8x speedup
 ///
 /// `1_048_576` is the smallest power-of-two work estimate below that measured
 /// win boundary. Each source keeps serial candidate/intersection order, so

--- a/crates/graphforge-exec/src/compute_pool.rs
+++ b/crates/graphforge-exec/src/compute_pool.rs
@@ -12,6 +12,9 @@
 //! eigenvector destination updates (#507), and sibling CPU kernels consume this
 //! private pool sized from [`crate`]-facing `compute_threads` on the embedded
 //! resource policy.
+//! common-neighbors source aggregates (#505), and sibling CPU kernels consume
+//! this private pool sized from [`crate`]-facing `compute_threads` on the
+//! embedded resource policy.
 
 use std::sync::Arc;
 

--- a/docs/book/architecture/algorithms.md
+++ b/docs/book/architecture/algorithms.md
@@ -600,7 +600,13 @@ Stable topology and neighbor order drive exact set intersections. Pair counts
 and node aggregates use checked integer arithmetic and convert to `Float64`
 only when exactly representable at or below `2^53`; larger results return a
 structured execution error. Shared selected-node, adjacency-entry, output-row,
-iteration, and cancellation limits apply with batched checkpoints.
+iteration, and cancellation limits apply with batched checkpoints. Above the
+documented `COMMON_NEIGHBORS_PARALLEL_CROSSOVER_WORK` (`524_288`) estimate, and
+only when the resource policy provides more than one compute thread,
+independent source ordinals may run on the instance-owned private compute pool
+(#337 / #505). Candidate order, missing-link checks, two-pointer intersections,
+and checked accumulation remain serial per source; worker score chunks merge in
+source order, so scores and fingerprints match the one-thread path.
 
 The public schema remains non-null `node_uuid: FixedSizeBinary(16)`, non-null
 `score: Float64`, then materialized node properties with Arrow NULLs for missing

--- a/docs/book/architecture/algorithms.md
+++ b/docs/book/architecture/algorithms.md
@@ -601,8 +601,8 @@ and node aggregates use checked integer arithmetic and convert to `Float64`
 only when exactly representable at or below `2^53`; larger results return a
 structured execution error. Shared selected-node, adjacency-entry, output-row,
 iteration, and cancellation limits apply with batched checkpoints. Above the
-documented `COMMON_NEIGHBORS_PARALLEL_CROSSOVER_WORK` (`524_288`) estimate, and
-only when the resource policy provides more than one compute thread,
+documented `COMMON_NEIGHBORS_PARALLEL_CROSSOVER_WORK` (`1_048_576`) estimate,
+and only when the resource policy provides more than one compute thread,
 independent source ordinals may run on the instance-owned private compute pool
 (#337 / #505). Candidate order, missing-link checks, two-pointer intersections,
 and checked accumulation remain serial per source; worker score chunks merge in

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -93,6 +93,15 @@ keeps per-destination incoming contribution order with serial norm/convergence
 reductions, and Node2Vec skip-gram training stays serial, so fingerprints match
 the one-thread path.
 
+(#342), PageRank (#343), Node2Vec walk-corpus generation (#344), and
+common-neighbors source aggregates (#505) may partition independent work across
+that pool above documented crossovers; work never uses Rayon's process-global
+pool. Cosine dot products retain serial coordinate order, PageRank keeps
+canonical contribution order with serial dangling/delta reductions, Node2Vec
+skip-gram training stays serial, and common-neighbors keeps serial
+candidate/intersection order per source, so fingerprints match the one-thread
+path.
+
 (#342), PageRank (#343), Node2Vec walk-corpus generation (#344), and triad census
 source-range enumeration (#587) may partition independent work across that pool
 above documented crossovers; work never uses Rayon's process-global pool. Cosine
@@ -538,6 +547,31 @@ does not use Rayon's global pool, and preserves shared cancellation and limits.
 A fingerprint test attaches private compute pools for `1`/`2`/`4`/`8`
 configured compute threads and requires identical schemas, preorder rows,
 depths, and discovery ordinals.
+
+## Parallel common-neighbors aggregate (#505)
+
+`rank(by="common_neighbors")` partitions **independent source ordinals** across
+the instance-owned private compute pool when:
+
+- `compute_threads > 1`, and
+- the estimated pair/intersection work is at least
+  `COMMON_NEIGHBORS_PARALLEL_CROSSOVER_WORK` (`524_288`) in `graphforge-exec`.
+
+The estimate is `sources² + 2 × sources × distinct_adjacency_entries`, a
+conservative O(V + E) proxy for the serial pair loop and two-pointer
+intersection scans. The threshold is the smallest power-of-two work estimate
+below the measured win boundary on the M4 agent host (4 vCPU, directed
+ring-lattice fixture, 4 private workers, release build): ~230k units was still
+neutral/slower, ~540k units first won (~0.53x serial), and >=2.1M units was
+>=3.0x faster.
+
+Below that crossover, or when the policy provides one compute thread, the
+serial path runs with no pool scheduling tax. Parallel workers only own source
+ranges. Candidate order, missing-link checks, two-pointer neighborhood
+intersection, and checked integer accumulation remain serial per source.
+Worker score chunks merge in canonical source order, so schemas, row order,
+scores, and fingerprints match the one-thread result at `1`/`2`/`4`/`8`/
+automatic configurations.
 
 ## Observability
 

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -563,9 +563,9 @@ conservative O(V + E) proxy for the serial pair loop and two-pointer
 intersection scans. The threshold is the smallest power-of-two work estimate
 below the measured win boundary on the M4 agent host (4 vCPU, directed
 ring-lattice fixture, 4 private workers, debug test profile after a clean
-target-dir build): ~230k units was neutral/slower, ~540k units was still slower
-(~1.09x serial), ~1.2M units first won (~0.81x serial), and >=2.1M units was
->=1.5x faster.
+target-dir build): ~230k units was still slower (~1.80x serial), ~540k units
+was still slower (~1.20x serial), ~1.2M units first won (~0.70x serial), and
+>=2.1M units was >=1.8x faster.
 
 Below that crossover, or when the policy provides one compute thread, the
 serial path runs with no pool scheduling tax. Parallel workers only own source

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -555,15 +555,17 @@ the instance-owned private compute pool when:
 
 - `compute_threads > 1`, and
 - the estimated pair/intersection work is at least
-  `COMMON_NEIGHBORS_PARALLEL_CROSSOVER_WORK` (`524_288`) in `graphforge-exec`.
+  `COMMON_NEIGHBORS_PARALLEL_CROSSOVER_WORK` (`1_048_576`) in
+  `graphforge-exec`.
 
 The estimate is `sources² + 2 × sources × distinct_adjacency_entries`, a
 conservative O(V + E) proxy for the serial pair loop and two-pointer
 intersection scans. The threshold is the smallest power-of-two work estimate
 below the measured win boundary on the M4 agent host (4 vCPU, directed
-ring-lattice fixture, 4 private workers, release build): ~230k units was still
-neutral/slower, ~540k units first won (~0.53x serial), and >=2.1M units was
->=3.0x faster.
+ring-lattice fixture, 4 private workers, debug test profile after a clean
+target-dir build): ~230k units was neutral/slower, ~540k units was still slower
+(~1.09x serial), ~1.2M units first won (~0.81x serial), and >=2.1M units was
+>=1.5x faster.
 
 Below that crossover, or when the policy provides one compute thread, the
 serial path runs with no pool scheduling tax. Parallel workers only own source

--- a/docs/development/m4-entry-baseline.md
+++ b/docs/development/m4-entry-baseline.md
@@ -80,10 +80,11 @@ DataFusion target partitions, thread-parity cells over the host budget.
 
 The entry baseline records structural gates on the public facade. Fresh CSR
 index hits no longer expand into an O(E) HashMap (#340). Exact cosine KNN /
-similarity (#342), PageRank (#343), and Node2Vec walk generation (#344) may use
-the instance-owned private compute pool above documented crossovers while
-preserving one-thread fingerprints. Query-facing Parquet providers stream
-bounded batches via `GraphForgeParquetExec` (#339) rather than eager
+similarity (#342), PageRank (#343), Node2Vec walk generation (#344), and
+common-neighbors source aggregates (#505) may use the instance-owned private
+compute pool above documented crossovers while preserving one-thread
+fingerprints. Query-facing Parquet providers stream bounded batches via
+`GraphForgeParquetExec` (#339) rather than eager
 single-partition `MemTable` materialization; ExpandExec filtered reads and
 fixed-hop demand remain the selective-path contract.
 

--- a/docs/development/m4-exit-evidence.md
+++ b/docs/development/m4-exit-evidence.md
@@ -65,11 +65,11 @@ GF_FILE_BACKED_OVERSIZE_EVIDENCE_OUT=docs/development/file-backed-oversize-evide
   via structural counters.
 - **Arrow shaping (#341):** analyst outputs are Arrow batches only (no retained
   `rows: Vec<Vec<…>>`).
-- **CPU kernels (#342–#344):** exact cosine KNN, PageRank, and Node2Vec walk
-  generation use the instance-owned private compute pool above documented
-  crossovers; one-thread fingerprints are preserved. Thread cells that exceed
-  the machine-relative concurrency budget are recorded `unavailable` (on this
-  host `threads-8` is unavailable).
+- **CPU kernels (#342–#344/#505):** exact cosine KNN, PageRank, Node2Vec walk
+  generation, and common-neighbors source aggregates use the instance-owned
+  private compute pool above documented crossovers; one-thread fingerprints are
+  preserved. Thread cells that exceed the machine-relative concurrency budget
+  are recorded `unavailable` (on this host `threads-8` is unavailable).
 
 ## Honest scale dispositions
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements #505: parallel `rank(by="common_neighbors")` source-partitioned on the instance-owned `ComputePool` with measured crossover and one-thread oracle parity.

Closes #505

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788946675&installation_model_id=20486&pr_number=599&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F599&signature=6b45fe336967533ec7e5c083baefce5888ac549d6340248ce4185c79490d89bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parallelize common-neighbors scoring on the private ComputePool
> - Adds a parallel execution path for `common_neighbor_scores` that partitions sources into chunks and runs them on the instance-owned compute pool when `compute_threads > 1`, a pool is present, `sources > 1`, and estimated work exceeds `COMMON_NEIGHBORS_PARALLEL_CROSSOVER_WORK` (1,048,576).
> - Introduces `estimated_common_neighbors_work` to estimate work as `sources² + 2 * sources * Σ(degrees)` and `select_common_neighbors_path` to choose between serial and parallel execution.
> - Extracts the former serial logic into `common_neighbor_scores_serial` and adds `common_neighbor_source_score` as a shared per-source helper used by both paths.
> - Parallel failures surface the lowest-index chunk error deterministically via `first_chunk_error`; panics inside workers are caught and returned as structured errors.
> - Behavioral Change: results and score fingerprints are guaranteed to match the one-thread serial path regardless of thread count.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3235ec8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved common-neighbors analysis with parallel execution for larger workloads.
  - Automatically selects an efficient execution strategy based on workload size.
  - Uses private compute resources to improve throughput while preserving deterministic result ordering.

- **Reliability**
  - Added support for cancellation and checkpointing during long-running computations.
  - Improved handling of worker failures and numeric overflow conditions.

- **Consistency**
  - Enhanced processing across source chunks while maintaining stable, predictable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->