### PR TITLE
perf(exec): parallelize eigenvector on ComputePool (#507)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_rank.rs
+++ b/crates/graphforge-exec/src/algorithm_rank.rs
@@ -122,9 +122,12 @@ const EIGENVECTOR_TOLERANCE: f64 = 1.0e-7;
 /// The shifted `A^T + I` update has independent destination rows, but the inbound
 /// CSR build and private-pool scheduling only amortize on edge-heavy workloads.
 /// Above this measured crossover, destination-owned parallel updates preserve the
-/// exact serial contribution order for each destination.
+/// exact serial contribution order for each destination. The first two required
+/// power iterations stay serial so quickly converging regular graphs avoid the
+/// inbound CSR setup cost entirely.
 pub const EIGENVECTOR_PARALLEL_CROSSOVER_EDGES: u64 = 4_096;
 const EIGENVECTOR_CHECKPOINT_DESTINATIONS: usize = 4_096;
+const EIGENVECTOR_SERIAL_WARMUP_ITERATIONS: usize = 2;
 const ARTICLE_RANK_DAMPING: f64 = 0.85;
 const ARTICLE_RANK_ALPHA: f64 = 1.0 - ARTICLE_RANK_DAMPING;
 const ARTICLE_RANK_MAX_ITERATIONS: usize = 20;
@@ -1059,25 +1062,24 @@ impl RustAlgorithm for Eigenvector {
         let node_count = f64::from(exact_u32(node_ids.len(), "node count")?);
         let mut scores = vec![1.0 / node_count; node_ids.len()];
         let path = select_eigenvector_path(control, graph.edge_entry_count(), node_ids.len());
-        let inbound = match path {
-            EigenvectorExecutionPath::Serial => None,
-            EigenvectorExecutionPath::Parallel { .. } => {
-                Some(prepare_eigenvector_inbound(graph, &indices)?)
-            }
-        };
+        let mut inbound = None;
         for iteration in 0..EIGENVECTOR_MAX_ITERATIONS {
             control.checkpoint()?;
-            let mut next = match path {
-                EigenvectorExecutionPath::Serial => {
-                    eigenvector_scatter_serial(graph, &indices, node_ids, &scores, control)?
+            let use_parallel = matches!(path, EigenvectorExecutionPath::Parallel { .. })
+                && iteration >= EIGENVECTOR_SERIAL_WARMUP_ITERATIONS;
+            let mut next = if use_parallel {
+                if inbound.is_none() {
+                    inbound = Some(prepare_eigenvector_inbound(graph, &indices)?);
                 }
-                EigenvectorExecutionPath::Parallel { .. } => eigenvector_pull_parallel(
+                eigenvector_pull_parallel(
                     inbound
                         .as_ref()
                         .ok_or_else(|| execution("parallel eigenvector requires inbound CSR"))?,
                     &scores,
                     control,
-                )?,
+                )?
+            } else {
+                eigenvector_scatter_serial(graph, &indices, node_ids, &scores, control)?
             };
             if next.iter().any(|score| !score.is_finite()) {
                 return Err(execution("eigenvector score exceeds supported range"));
@@ -4645,41 +4647,70 @@ mod tests {
     fn measure_eigenvector_parallel_crossover() {
         use std::time::Instant;
 
-        for nodes in [64_usize, 128, 512] {
-            for fanout in [8_usize, 32, 64] {
-                let edges = (0..nodes)
-                    .flat_map(|node| {
-                        (1..=fanout).map(move |hop| (node as u64, ((node + hop) % nodes) as u64))
+        let mut cases = Vec::new();
+        for (nodes, fanout) in [(128_usize, 32_usize), (512, 64)] {
+            let edges = (0..nodes)
+                .flat_map(|node| {
+                    (1..=fanout).map(move |hop| (node as u64, ((node + hop) % nodes) as u64))
+                })
+                .collect::<Vec<_>>();
+            cases.push((format!("regular nodes={nodes} fanout={fanout}"), edges));
+        }
+        for (nodes, base, spread) in [
+            (512_usize, 8_usize, 17_usize),
+            (512, 32, 33),
+            (2_048, 16, 33),
+            (2_048, 32, 65),
+        ] {
+            let edges = (0..nodes)
+                .flat_map(|node| {
+                    let degree = base + (node % spread);
+                    (0..degree).map(move |hop| {
+                        let step = 1 + ((hop * 17 + node) % nodes);
+                        (node as u64, ((node + step) % nodes) as u64)
                     })
-                    .collect::<Vec<_>>();
-                let graph = AdjacencyGraph::with_test_edges(nodes as u64, &edges);
-                let edges = graph.edge_entry_count();
-                let _ = execute_eigenvector_with_pool(&graph, 1, AlgorithmCancellation::default())
-                    .unwrap();
-                let _ = execute_eigenvector_with_pool(&graph, 4, AlgorithmCancellation::default())
-                    .unwrap();
+                })
+                .collect::<Vec<_>>();
+            cases.push((
+                format!("irregular nodes={nodes} base={base} spread={spread}"),
+                edges,
+            ));
+        }
 
-                let mut serial_ns = u128::MAX;
-                let mut parallel_ns = u128::MAX;
-                for _ in 0..5 {
-                    let t0 = Instant::now();
-                    let serial =
-                        execute_eigenvector_with_pool(&graph, 1, AlgorithmCancellation::default())
-                            .unwrap();
-                    serial_ns = serial_ns.min(t0.elapsed().as_nanos());
+        for (label, edges) in cases {
+            let nodes = edges
+                .iter()
+                .flat_map(|(source, target)| [*source, *target])
+                .max()
+                .unwrap_or(0)
+                + 1;
+            let graph = AdjacencyGraph::with_test_edges(nodes, &edges);
+            let edges = graph.edge_entry_count();
+            let _ =
+                execute_eigenvector_with_pool(&graph, 1, AlgorithmCancellation::default()).unwrap();
+            let _ =
+                execute_eigenvector_with_pool(&graph, 4, AlgorithmCancellation::default()).unwrap();
 
-                    let t1 = Instant::now();
-                    let parallel =
-                        execute_eigenvector_with_pool(&graph, 4, AlgorithmCancellation::default())
-                            .unwrap();
-                    parallel_ns = parallel_ns.min(t1.elapsed().as_nanos());
-                    assert_eq!(eigenvector_bits(&parallel), eigenvector_bits(&serial));
-                }
-                println!(
-                    "nodes={nodes} fanout={fanout} edges={edges} serial_ns={serial_ns} parallel_ns={parallel_ns} ratio={}",
-                    parallel_ns as f64 / serial_ns as f64
-                );
+            let mut serial_ns = u128::MAX;
+            let mut parallel_ns = u128::MAX;
+            for _ in 0..5 {
+                let t0 = Instant::now();
+                let serial =
+                    execute_eigenvector_with_pool(&graph, 1, AlgorithmCancellation::default())
+                        .unwrap();
+                serial_ns = serial_ns.min(t0.elapsed().as_nanos());
+
+                let t1 = Instant::now();
+                let parallel =
+                    execute_eigenvector_with_pool(&graph, 4, AlgorithmCancellation::default())
+                        .unwrap();
+                parallel_ns = parallel_ns.min(t1.elapsed().as_nanos());
+                assert_eq!(eigenvector_bits(&parallel), eigenvector_bits(&serial));
             }
+            println!(
+                "{label} edges={edges} serial_ns={serial_ns} parallel_ns={parallel_ns} ratio={}",
+                parallel_ns as f64 / serial_ns as f64
+            );
         }
     }
 

--- a/crates/graphforge-exec/src/algorithm_rank.rs
+++ b/crates/graphforge-exec/src/algorithm_rank.rs
@@ -1253,38 +1253,37 @@ fn eigenvector_pull_parallel(
     scores: &[f64],
     control: &AlgorithmControl,
 ) -> Result<Vec<f64>, AlgorithmError> {
+    if scores.is_empty() {
+        return Ok(Vec::new());
+    }
     let pool = control
         .compute_pool()
         .ok_or_else(|| execution("parallel eigenvector requires an instance-owned compute pool"))?;
-    let ranges = destination_chunks(scores.len(), control.compute_threads());
-    let work = AtomicUsize::new(0);
-    let chunk_results = run_eigenvector_on_pool(pool, || {
-        ranges
-            .par_iter()
-            .map(|&(start, end)| {
+    let chunks = destination_chunks(scores.len(), control.compute_threads())
+        .len()
+        .max(1);
+    let chunk_len = scores.len().div_ceil(chunks);
+    let mut next = vec![0.0; scores.len()];
+    run_eigenvector_on_pool(pool, || {
+        next.par_chunks_mut(chunk_len)
+            .enumerate()
+            .try_for_each(|(chunk_index, local)| {
                 control.check_cancelled()?;
-                let mut local = Vec::with_capacity(end - start);
-                for dest in start..end {
-                    let observed = work.fetch_add(1, Ordering::Relaxed) + 1;
-                    if observed.is_multiple_of(EIGENVECTOR_CHECKPOINT_DESTINATIONS) {
+                let start = chunk_index * chunk_len;
+                for (offset, slot) in local.iter_mut().enumerate() {
+                    let dest = start + offset;
+                    if dest.is_multiple_of(EIGENVECTOR_CHECKPOINT_DESTINATIONS) {
                         control.check_cancelled()?;
                     }
                     let score = eigenvector_pull_destination(inbound, scores, dest);
                     if !score.is_finite() {
                         return Err(execution("eigenvector score exceeds supported range"));
                     }
-                    local.push(score);
+                    *slot = score;
                 }
-                Ok((start, local))
+                Ok(())
             })
-            .collect::<Result<Vec<_>, AlgorithmError>>()
     })?;
-
-    // Merge chunk outputs in ascending destination-range order (canonical).
-    let mut next = vec![0.0; scores.len()];
-    for (start, local) in chunk_results {
-        next[start..start + local.len()].copy_from_slice(&local);
-    }
     Ok(next)
 }
 

--- a/crates/graphforge-exec/src/algorithm_rank.rs
+++ b/crates/graphforge-exec/src/algorithm_rank.rs
@@ -125,7 +125,7 @@ const EIGENVECTOR_TOLERANCE: f64 = 1.0e-7;
 /// exact serial contribution order for each destination. The first two required
 /// power iterations stay serial so quickly converging regular graphs avoid the
 /// inbound CSR setup cost entirely.
-pub const EIGENVECTOR_PARALLEL_CROSSOVER_EDGES: u64 = 4_096;
+pub const EIGENVECTOR_PARALLEL_CROSSOVER_EDGES: u64 = 8_192;
 const EIGENVECTOR_CHECKPOINT_DESTINATIONS: usize = 4_096;
 const EIGENVECTOR_SERIAL_WARMUP_ITERATIONS: usize = 2;
 const ARTICLE_RANK_DAMPING: f64 = 0.85;
@@ -4554,7 +4554,7 @@ mod tests {
         let nodes = 512_u64;
         let mut edges = Vec::new();
         for source in 0..nodes {
-            let degree = 8 + (source % 11) as usize;
+            let degree = 16 + (source % 11) as usize;
             for hop in 0..degree {
                 edges.push((source, (source + hop as u64) % nodes));
             }
@@ -4657,7 +4657,7 @@ mod tests {
             cases.push((format!("regular nodes={nodes} fanout={fanout}"), edges));
         }
         for (nodes, base, spread) in [
-            (512_usize, 8_usize, 17_usize),
+            (512_usize, 9_usize, 17_usize),
             (512, 32, 33),
             (2_048, 16, 33),
             (2_048, 32, 65),

--- a/crates/graphforge-exec/src/algorithm_rank.rs
+++ b/crates/graphforge-exec/src/algorithm_rank.rs
@@ -4,6 +4,10 @@
 //! (#506), and betweenness (#501) may partition independent score updates across
 //! the instance-owned private compute pool while preserving serial contribution
 //! order, ordered merges, reductions, and bit-identical fingerprints.
+//! PageRank (#343) and eigenvector (#507) may partition destination-owned score
+//! updates across the instance-owned private compute pool while preserving the
+//! serial contribution order, serial convergence reductions, and bit-identical
+//! fingerprints.
 
 use std::collections::{HashMap, VecDeque};
 use std::panic::{AssertUnwindSafe, catch_unwind};
@@ -113,6 +117,14 @@ const DEGREE_CHECKPOINT_NODES: usize = 1_024;
 pub const BETWEENNESS_PARALLEL_CROSSOVER_WORK: u64 = 65_536;
 const EIGENVECTOR_MAX_ITERATIONS: usize = 20;
 const EIGENVECTOR_TOLERANCE: f64 = 1.0e-7;
+/// Selected adjacency entries below which eigenvector stays on the serial path (#507).
+///
+/// The shifted `A^T + I` update has independent destination rows, but the inbound
+/// CSR build and private-pool scheduling only amortize on edge-heavy workloads.
+/// Above this measured crossover, destination-owned parallel updates preserve the
+/// exact serial contribution order for each destination.
+pub const EIGENVECTOR_PARALLEL_CROSSOVER_EDGES: u64 = 4_096;
+const EIGENVECTOR_CHECKPOINT_DESTINATIONS: usize = 4_096;
 const ARTICLE_RANK_DAMPING: f64 = 0.85;
 const ARTICLE_RANK_ALPHA: f64 = 1.0 - ARTICLE_RANK_DAMPING;
 const ARTICLE_RANK_MAX_ITERATIONS: usize = 20;
@@ -1046,25 +1058,29 @@ impl RustAlgorithm for Eigenvector {
             .collect();
         let node_count = f64::from(exact_u32(node_ids.len(), "node count")?);
         let mut scores = vec![1.0 / node_count; node_ids.len()];
+        let path = select_eigenvector_path(control, graph.edge_entry_count(), node_ids.len());
+        let inbound = match path {
+            EigenvectorExecutionPath::Serial => None,
+            EigenvectorExecutionPath::Parallel { .. } => {
+                Some(prepare_eigenvector_inbound(graph, &indices)?)
+            }
+        };
         for iteration in 0..EIGENVECTOR_MAX_ITERATIONS {
             control.checkpoint()?;
-            let mut next = scores.clone();
-            let mut traversed_edges = 0_usize;
-            for (source_index, &source) in node_ids.iter().enumerate() {
-                for edge in graph.neighbors(source) {
-                    if traversed_edges > 0 && traversed_edges.is_multiple_of(1024) {
-                        control.checkpoint()?;
-                    }
-                    traversed_edges += 1;
-                    let target = indices
-                        .get(&edge.neighbor_id)
-                        .copied()
-                        .ok_or_else(|| execution("adjacency references an unselected node"))?;
-                    next[target] += scores[source_index];
-                    if !next[target].is_finite() {
-                        return Err(execution("eigenvector score exceeds supported range"));
-                    }
+            let mut next = match path {
+                EigenvectorExecutionPath::Serial => {
+                    eigenvector_scatter_serial(graph, &indices, node_ids, &scores, control)?
                 }
+                EigenvectorExecutionPath::Parallel { .. } => eigenvector_pull_parallel(
+                    inbound
+                        .as_ref()
+                        .ok_or_else(|| execution("parallel eigenvector requires inbound CSR"))?,
+                    &scores,
+                    control,
+                )?,
+            };
+            if next.iter().any(|score| !score.is_finite()) {
+                return Err(execution("eigenvector score exceeds supported range"));
             }
 
             let norm = next.iter().map(|score| score * score).sum::<f64>().sqrt();
@@ -1098,6 +1114,190 @@ impl RustAlgorithm for Eigenvector {
             })
             .collect::<Result<Vec<_>, AlgorithmError>>()?;
         AlgorithmOutput::from_rows(algorithm, control, rows)
+    }
+}
+
+/// Selected eigenvector execution path for observability and crossover tests (#507).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum EigenvectorExecutionPath {
+    Serial,
+    Parallel { threads: usize, chunks: usize },
+}
+
+/// Dense inbound CSR: source ordinals in canonical source/edge order per destination.
+#[derive(Clone, Debug, Default)]
+struct EigenvectorInboundCsr {
+    offsets: Vec<u32>,
+    sources: Vec<u32>,
+}
+
+fn select_eigenvector_path(
+    control: &AlgorithmControl,
+    edge_count: u64,
+    nodes: usize,
+) -> EigenvectorExecutionPath {
+    let threads = control.compute_threads();
+    if threads <= 1
+        || nodes <= 1
+        || edge_count < EIGENVECTOR_PARALLEL_CROSSOVER_EDGES
+        || control
+            .compute_pool()
+            .is_none_or(|pool| !pool.is_parallel())
+    {
+        return EigenvectorExecutionPath::Serial;
+    }
+    let chunks = destination_chunks(nodes, threads).len();
+    EigenvectorExecutionPath::Parallel { threads, chunks }
+}
+
+fn prepare_eigenvector_inbound(
+    graph: &AdjacencyGraph,
+    indices: &HashMap<u64, usize>,
+) -> Result<EigenvectorInboundCsr, AlgorithmError> {
+    let node_ids = graph.node_ids();
+    let node_len = node_ids.len();
+    let mut inbound_counts = vec![0_u32; node_len];
+    for &source in node_ids {
+        for edge in graph.neighbors(source) {
+            let target = indices
+                .get(&edge.neighbor_id)
+                .copied()
+                .ok_or_else(|| execution("adjacency references an unselected node"))?;
+            inbound_counts[target] = inbound_counts[target]
+                .checked_add(1)
+                .ok_or_else(|| execution("inbound degree exceeds supported range"))?;
+        }
+    }
+
+    let mut offsets = Vec::with_capacity(node_len + 1);
+    offsets.push(0_u32);
+    for &count in &inbound_counts {
+        let next = offsets
+            .last()
+            .copied()
+            .unwrap_or(0)
+            .checked_add(count)
+            .ok_or_else(|| execution("inbound CSR offsets exceed supported range"))?;
+        offsets.push(next);
+    }
+    let total = usize::try_from(*offsets.last().unwrap_or(&0))
+        .map_err(|_| execution("inbound CSR length exceeds supported range"))?;
+    let mut sources = vec![0_u32; total];
+    let mut write_at = offsets[..node_len].to_vec();
+    for (source_index, &source) in node_ids.iter().enumerate() {
+        let source_u32 = exact_u32(source_index, "source ordinal")?;
+        for edge in graph.neighbors(source) {
+            let target = indices
+                .get(&edge.neighbor_id)
+                .copied()
+                .ok_or_else(|| execution("adjacency references an unselected node"))?;
+            let slot = usize::try_from(write_at[target])
+                .map_err(|_| execution("inbound write cursor exceeds supported range"))?;
+            sources[slot] = source_u32;
+            write_at[target] = write_at[target]
+                .checked_add(1)
+                .ok_or_else(|| execution("inbound write cursor overflow"))?;
+        }
+    }
+
+    Ok(EigenvectorInboundCsr { offsets, sources })
+}
+
+fn eigenvector_scatter_serial(
+    graph: &AdjacencyGraph,
+    indices: &HashMap<u64, usize>,
+    node_ids: &[u64],
+    scores: &[f64],
+    control: &AlgorithmControl,
+) -> Result<Vec<f64>, AlgorithmError> {
+    let mut next = scores.to_vec();
+    let mut traversed_edges = 0_usize;
+    for (source_index, &source) in node_ids.iter().enumerate() {
+        for edge in graph.neighbors(source) {
+            if traversed_edges > 0 && traversed_edges.is_multiple_of(1024) {
+                control.checkpoint()?;
+            }
+            traversed_edges += 1;
+            let target = indices
+                .get(&edge.neighbor_id)
+                .copied()
+                .ok_or_else(|| execution("adjacency references an unselected node"))?;
+            next[target] += scores[source_index];
+            if !next[target].is_finite() {
+                return Err(execution("eigenvector score exceeds supported range"));
+            }
+        }
+    }
+    Ok(next)
+}
+
+fn eigenvector_pull_destination(
+    inbound: &EigenvectorInboundCsr,
+    scores: &[f64],
+    dest: usize,
+) -> f64 {
+    let start = usize::try_from(inbound.offsets[dest]).unwrap_or(0);
+    let end = usize::try_from(inbound.offsets[dest + 1]).unwrap_or(start);
+    let mut acc = scores[dest];
+    for &source in &inbound.sources[start.min(end)..end.min(inbound.sources.len())] {
+        let source = usize::try_from(source).unwrap_or(usize::MAX);
+        if source < scores.len() {
+            acc += scores[source];
+        }
+    }
+    acc
+}
+
+fn eigenvector_pull_parallel(
+    inbound: &EigenvectorInboundCsr,
+    scores: &[f64],
+    control: &AlgorithmControl,
+) -> Result<Vec<f64>, AlgorithmError> {
+    let pool = control
+        .compute_pool()
+        .ok_or_else(|| execution("parallel eigenvector requires an instance-owned compute pool"))?;
+    let ranges = destination_chunks(scores.len(), control.compute_threads());
+    let work = AtomicUsize::new(0);
+    let chunk_results = run_eigenvector_on_pool(pool, || {
+        ranges
+            .par_iter()
+            .map(|&(start, end)| {
+                control.check_cancelled()?;
+                let mut local = Vec::with_capacity(end - start);
+                for dest in start..end {
+                    let observed = work.fetch_add(1, Ordering::Relaxed) + 1;
+                    if observed.is_multiple_of(EIGENVECTOR_CHECKPOINT_DESTINATIONS) {
+                        control.check_cancelled()?;
+                    }
+                    let score = eigenvector_pull_destination(inbound, scores, dest);
+                    if !score.is_finite() {
+                        return Err(execution("eigenvector score exceeds supported range"));
+                    }
+                    local.push(score);
+                }
+                Ok((start, local))
+            })
+            .collect::<Result<Vec<_>, AlgorithmError>>()
+    })?;
+
+    // Merge chunk outputs in ascending destination-range order (canonical).
+    let mut next = vec![0.0; scores.len()];
+    for (start, local) in chunk_results {
+        next[start..start + local.len()].copy_from_slice(&local);
+    }
+    Ok(next)
+}
+
+fn run_eigenvector_on_pool<R>(
+    pool: &crate::ComputePool,
+    op: impl FnOnce() -> Result<R, AlgorithmError> + Send,
+) -> Result<R, AlgorithmError>
+where
+    R: Send,
+{
+    match catch_unwind(AssertUnwindSafe(|| pool.install(op))) {
+        Ok(result) => result,
+        Err(_) => Err(execution("Eigenvector worker panicked")),
     }
 }
 
@@ -2812,6 +3012,22 @@ mod tests {
         )
     }
 
+    fn execute_eigenvector_with_pool(
+        graph: &AdjacencyGraph,
+        threads: usize,
+        cancellation: AlgorithmCancellation,
+    ) -> Result<AlgorithmOutput, AlgorithmError> {
+        let pool = Arc::new(crate::ComputePool::new(threads).unwrap());
+        let mut registry = AlgorithmRegistry::default();
+        register_rank_algorithms(&mut registry)?;
+        let control = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(threads),
+            cancellation,
+        )
+        .with_compute_pool(pool);
+        registry.execute(Algorithm::Rank(RankAlgorithm::Eigenvector), graph, &control)
+    }
+
     fn eigenvector_scores(output: &AlgorithmOutput) -> Vec<f64> {
         output
             .rows()
@@ -2820,6 +3036,13 @@ mod tests {
                 AlgorithmValue::Float64(score) => score,
                 _ => panic!("eigenvector score must be Float64"),
             })
+            .collect()
+    }
+
+    fn eigenvector_bits(output: &AlgorithmOutput) -> Vec<u64> {
+        eigenvector_scores(output)
+            .into_iter()
+            .map(f64::to_bits)
             .collect()
     }
 
@@ -2832,6 +3055,17 @@ mod tests {
             )
             .unwrap(),
         )
+    }
+
+    fn dense_eigenvector_graph(nodes: usize) -> AdjacencyGraph {
+        let fanout =
+            ((EIGENVECTOR_PARALLEL_CROSSOVER_EDGES as usize) / nodes.max(1)).saturating_add(2);
+        let edges = (0..nodes)
+            .flat_map(|node| {
+                (1..=fanout).map(move |hop| (node as u64, ((node + hop) % nodes) as u64))
+            })
+            .collect::<Vec<_>>();
+        AdjacencyGraph::with_test_edges(nodes as u64, &edges)
     }
 
     fn execute_article_rank(
@@ -4237,6 +4471,217 @@ mod tests {
             .find(|capability| capability.algorithm == Algorithm::Rank(RankAlgorithm::Eigenvector))
             .unwrap();
         assert_eq!(capability.dependency, BUILTIN_REVIEW);
+    }
+
+    #[test]
+    fn eigenvector_path_selection_respects_crossover_and_one_thread() {
+        let serial_control = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(4),
+            AlgorithmCancellation::default(),
+        );
+        assert_eq!(
+            select_eigenvector_path(
+                &serial_control,
+                EIGENVECTOR_PARALLEL_CROSSOVER_EDGES - 1,
+                64
+            ),
+            EigenvectorExecutionPath::Serial
+        );
+        let one = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(1),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(Arc::new(crate::ComputePool::new(1).unwrap()));
+        assert_eq!(
+            select_eigenvector_path(&one, EIGENVECTOR_PARALLEL_CROSSOVER_EDGES, 64),
+            EigenvectorExecutionPath::Serial
+        );
+        let parallel = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(4),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(Arc::new(crate::ComputePool::new(4).unwrap()));
+        assert_eq!(
+            select_eigenvector_path(&parallel, EIGENVECTOR_PARALLEL_CROSSOVER_EDGES, 64),
+            EigenvectorExecutionPath::Parallel {
+                threads: 4,
+                chunks: 4
+            }
+        );
+    }
+
+    #[test]
+    fn eigenvector_thread_matrix_matches_one_thread_bits_and_ordering() {
+        let graph = dense_eigenvector_graph(128);
+        assert!(graph.edge_entry_count() >= EIGENVECTOR_PARALLEL_CROSSOVER_EDGES);
+        let serial =
+            execute_eigenvector_with_pool(&graph, 1, AlgorithmCancellation::default()).unwrap();
+        let serial_bits = eigenvector_bits(&serial);
+        let serial_rows = serial.rows();
+        for threads in [2_usize, 4, 8] {
+            let parallel =
+                execute_eigenvector_with_pool(&graph, threads, AlgorithmCancellation::default())
+                    .unwrap();
+            assert_eq!(parallel.schema, serial.schema);
+            assert_eq!(parallel.rows(), serial_rows);
+            assert_eq!(eigenvector_bits(&parallel), serial_bits);
+        }
+    }
+
+    #[test]
+    fn eigenvector_parallel_preserves_multigraph_self_loop_and_disconnected_bits() {
+        let fixtures = [
+            AdjacencyGraph::with_test_edges(3, &[(0, 1), (0, 1), (0, 2), (1, 1)]),
+            AdjacencyGraph::with_test_edges(2, &[(0, 1)]),
+            AdjacencyGraph::with_test_edges(2, &[(0, 1), (1, 0)]),
+            AdjacencyGraph::with_test_edges(4, &[(0, 1), (1, 0), (2, 3), (3, 2)]),
+            AdjacencyGraph::default(),
+            AdjacencyGraph::with_test_edges(1, &[]),
+        ];
+        for graph in &fixtures {
+            let serial =
+                execute_eigenvector_with_pool(graph, 1, AlgorithmCancellation::default()).unwrap();
+            for threads in [2_usize, 4, 8] {
+                let parallel =
+                    execute_eigenvector_with_pool(graph, threads, AlgorithmCancellation::default())
+                        .unwrap();
+                assert_eq!(eigenvector_bits(&parallel), eigenvector_bits(&serial));
+                assert_eq!(parallel.rows(), serial.rows());
+            }
+        }
+
+        let nodes = 512_u64;
+        let mut edges = Vec::new();
+        for source in 0..nodes {
+            let degree = 8 + (source % 11) as usize;
+            for hop in 0..degree {
+                edges.push((source, (source + hop as u64) % nodes));
+            }
+        }
+        let adversarial = AdjacencyGraph::with_test_edges(nodes, &edges);
+        assert!(adversarial.edge_entry_count() >= EIGENVECTOR_PARALLEL_CROSSOVER_EDGES);
+        let serial =
+            execute_eigenvector_with_pool(&adversarial, 1, AlgorithmCancellation::default())
+                .unwrap();
+        for threads in [2_usize, 4, 8] {
+            let parallel = execute_eigenvector_with_pool(
+                &adversarial,
+                threads,
+                AlgorithmCancellation::default(),
+            )
+            .unwrap();
+            assert_eq!(eigenvector_bits(&parallel), eigenvector_bits(&serial));
+        }
+    }
+
+    #[test]
+    fn eigenvector_parallel_cancellation_returns_structured_cancelled() {
+        let graph = dense_eigenvector_graph(128);
+        let cancellation = AlgorithmCancellation::default();
+        cancellation.cancel();
+        assert_eq!(
+            execute_eigenvector_with_pool(&graph, 4, cancellation),
+            Err(AlgorithmError::Cancelled)
+        );
+    }
+
+    #[test]
+    fn eigenvector_pull_matches_serial_scatter_contribution_order() {
+        let fixtures = [
+            AdjacencyGraph::with_test_edges(3, &[(0, 1), (0, 1), (0, 2), (1, 1)]),
+            AdjacencyGraph::with_test_edges(2, &[(0, 1)]),
+            AdjacencyGraph::with_test_edges(2, &[(0, 1), (1, 0)]),
+            AdjacencyGraph::with_test_edges(4, &[(0, 1), (1, 0), (2, 3), (3, 2)]),
+            AdjacencyGraph::with_test_edges(1, &[]),
+            dense_eigenvector_graph(64),
+        ];
+        for graph in &fixtures {
+            if graph.node_ids().is_empty() {
+                continue;
+            }
+            let indices = graph
+                .node_ids()
+                .iter()
+                .enumerate()
+                .map(|(index, &node)| (node, index))
+                .collect::<HashMap<_, _>>();
+            let inbound = prepare_eigenvector_inbound(graph, &indices).unwrap();
+            let scores = (0..graph.node_ids().len())
+                .map(|index| (index + 1) as f64 / (graph.node_ids().len() + 1) as f64)
+                .collect::<Vec<_>>();
+            let control =
+                AlgorithmControl::new(AlgorithmLimits::default(), AlgorithmCancellation::default());
+            let scatter =
+                eigenvector_scatter_serial(graph, &indices, graph.node_ids(), &scores, &control)
+                    .unwrap();
+            let pull = (0..scores.len())
+                .map(|dest| eigenvector_pull_destination(&inbound, &scores, dest))
+                .collect::<Vec<_>>();
+            assert_eq!(
+                scatter
+                    .iter()
+                    .map(|value| value.to_bits())
+                    .collect::<Vec<_>>(),
+                pull.iter().map(|value| value.to_bits()).collect::<Vec<_>>(),
+                "pull must apply contributions in serial source/edge order"
+            );
+        }
+    }
+
+    #[test]
+    fn eigenvector_worker_panic_returns_structured_error() {
+        let pool = crate::ComputePool::new(2).unwrap();
+        assert_eq!(
+            run_eigenvector_on_pool(&pool, || -> Result<(), AlgorithmError> {
+                panic!("worker panic is converted")
+            }),
+            Err(AlgorithmError::Execution {
+                message: "Eigenvector worker panicked".into()
+            })
+        );
+    }
+
+    #[test]
+    #[ignore = "manual crossover measurement; run in release with --ignored --nocapture"]
+    fn measure_eigenvector_parallel_crossover() {
+        use std::time::Instant;
+
+        for nodes in [64_usize, 128, 512] {
+            for fanout in [8_usize, 32, 64] {
+                let edges = (0..nodes)
+                    .flat_map(|node| {
+                        (1..=fanout).map(move |hop| (node as u64, ((node + hop) % nodes) as u64))
+                    })
+                    .collect::<Vec<_>>();
+                let graph = AdjacencyGraph::with_test_edges(nodes as u64, &edges);
+                let edges = graph.edge_entry_count();
+                let _ = execute_eigenvector_with_pool(&graph, 1, AlgorithmCancellation::default())
+                    .unwrap();
+                let _ = execute_eigenvector_with_pool(&graph, 4, AlgorithmCancellation::default())
+                    .unwrap();
+
+                let mut serial_ns = u128::MAX;
+                let mut parallel_ns = u128::MAX;
+                for _ in 0..5 {
+                    let t0 = Instant::now();
+                    let serial =
+                        execute_eigenvector_with_pool(&graph, 1, AlgorithmCancellation::default())
+                            .unwrap();
+                    serial_ns = serial_ns.min(t0.elapsed().as_nanos());
+
+                    let t1 = Instant::now();
+                    let parallel =
+                        execute_eigenvector_with_pool(&graph, 4, AlgorithmCancellation::default())
+                            .unwrap();
+                    parallel_ns = parallel_ns.min(t1.elapsed().as_nanos());
+                    assert_eq!(eigenvector_bits(&parallel), eigenvector_bits(&serial));
+                }
+                println!(
+                    "nodes={nodes} fanout={fanout} edges={edges} serial_ns={serial_ns} parallel_ns={parallel_ns} ratio={}",
+                    parallel_ns as f64 / serial_ns as f64
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/graphforge-exec/src/compute_pool.rs
+++ b/crates/graphforge-exec/src/compute_pool.rs
@@ -5,6 +5,13 @@
 //! clustering coefficient (#504), triangles (#515), Degree (#506), betweenness (#501), and sibling
 //! CPU kernels consume this private pool sized from [`crate`]-facing
 //! `compute_threads` on the embedded resource policy.
+//! Instance-owned bounded CPU pool for deterministic algorithm kernels (#337 / #342 / #343 / #344 / #507).
+//!
+//! GraphForge never installs work onto Rayon's process-global pool. Parallel
+//! cosine KNN (#342), PageRank (#343), Node2Vec walk generation (#344),
+//! eigenvector destination updates (#507), and sibling CPU kernels consume this
+//! private pool sized from [`crate`]-facing `compute_threads` on the embedded
+//! resource policy.
 
 use std::sync::Arc;
 

--- a/docs/book/architecture/algorithms.md
+++ b/docs/book/architecture/algorithms.md
@@ -253,7 +253,9 @@ in addition to the implicit identity term.
 
 Destination updates may run through the instance-owned private compute pool
 (#337 / #507) above `EIGENVECTOR_PARALLEL_CROSSOVER_EDGES` (`4_096`) selected
-adjacency entries. Each destination applies inbound contributions after the
+adjacency entries after the first two required iterations. Workloads that
+converge during that serial warm-up avoid inbound CSR setup entirely. When the
+parallel path runs, each destination applies inbound contributions after the
 implicit identity term in the same canonical source/edge order as serial
 scatter, and L2 normalization plus convergence checks remain serial, so scores,
 iteration counts, and fingerprints match the one-thread path.

--- a/docs/book/architecture/algorithms.md
+++ b/docs/book/architecture/algorithms.md
@@ -251,6 +251,13 @@ mode exports both endpoint directions. `via` filters relationship type.
 Parallel entries contribute independently; a stored self-loop contributes once
 in addition to the implicit identity term.
 
+Destination updates may run through the instance-owned private compute pool
+(#337 / #507) above `EIGENVECTOR_PARALLEL_CROSSOVER_EDGES` (`4_096`) selected
+adjacency entries. Each destination applies inbound contributions after the
+implicit identity term in the same canonical source/edge order as serial
+scatter, and L2 normalization plus convergence checks remain serial, so scores,
+iteration counts, and fingerprints match the one-thread path.
+
 Disconnected components share one global L2 norm and remain deterministic from
 the uniform start. An edgeless `N`-node selection scores every node
 `1 / sqrt(N)`, a singleton scores `1.0`, and an empty selection returns a typed

--- a/docs/book/architecture/algorithms.md
+++ b/docs/book/architecture/algorithms.md
@@ -252,7 +252,7 @@ Parallel entries contribute independently; a stored self-loop contributes once
 in addition to the implicit identity term.
 
 Destination updates may run through the instance-owned private compute pool
-(#337 / #507) above `EIGENVECTOR_PARALLEL_CROSSOVER_EDGES` (`4_096`) selected
+(#337 / #507) above `EIGENVECTOR_PARALLEL_CROSSOVER_EDGES` (`8_192`) selected
 adjacency entries after the first two required iterations. Workloads that
 converge during that serial warm-up avoid inbound CSR setup entirely. When the
 parallel path runs, each destination applies inbound contributions after the

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -207,21 +207,23 @@ schemas, row order, scores, and fingerprints match the one-thread result at
 `1`/`2`/`4`/`8`/automatic configurations.
 ## Parallel eigenvector (#507)
 
-`rank(by="eigenvector")` shifted power-iteration destination updates run on the
-instance-owned private compute pool when:
+`rank(by="eigenvector")` shifted power-iteration destination updates may run on
+the instance-owned private compute pool when:
 
 - `compute_threads > 1`, and
 - selected adjacency entries are at least
   `EIGENVECTOR_PARALLEL_CROSSOVER_EDGES` (`4_096`) in `graphforge-exec`.
 
 Below that crossover, or when the policy provides one compute thread, the
-serial source-scatter path runs with no pool scheduling tax. Parallel work is
-destination-owned: each worker owns a contiguous dense-ordinal destination
-range and applies inbound contributions after the implicit identity term in the
-same canonical source/edge order as serial scatter. L2 normalization and
-component-wise convergence checks stay serial, so scores, iteration counts, and
-fingerprints match the one-thread result at `1`/`2`/`4`/`8`/automatic
-configurations.
+serial source-scatter path runs with no pool scheduling tax. Above the
+crossover, the first two required power iterations also stay serial; if the
+workload converges there, no inbound CSR or worker scheduling tax is paid.
+Remaining non-converged work is destination-owned: each worker owns a
+contiguous dense-ordinal destination range and applies inbound contributions
+after the implicit identity term in the same canonical source/edge order as
+serial scatter. L2 normalization and component-wise convergence checks stay
+serial, so scores, iteration counts, and fingerprints match the one-thread
+result at `1`/`2`/`4`/`8`/automatic configurations.
 
 ## Parallel Node2Vec walk generation (#344)
 

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -18,6 +18,7 @@ Tokio runtime or any DataFusion execution session.
 | `io_concurrency` | `2` | Reserved I/O concurrency budget |
 | `max_concurrent_heavy_queries` | `64` | Instance-owned admission semaphore |
 | `compute_threads` | `2` | Instance-owned private CPU pool (#342 cosine KNN; #343 PageRank; #344 Node2Vec walks; #535 Jaccard similarity; #504 clustering coefficient; #515 triangles; #506 Degree; #501 betweenness; #518 Components) |
+| `compute_threads` | `2` | Instance-owned private CPU pool (#342 cosine KNN; #343 PageRank; #344 Node2Vec walks; #507 eigenvector) |
 
 Defaults preserve pre-#337 fixed two-worker / two-partition behavior.
 
@@ -82,6 +83,14 @@ betweenness reduces per-source dependency arrays in canonical source order,
 Components merges worker-local forests in canonical source-range order, and
 Node2Vec skip-gram training stays serial, so fingerprints match the one-thread
 path.
+(#342), PageRank (#343), Node2Vec walk-corpus generation (#344), and
+eigenvector destination updates (#507) may partition independent work across
+that pool above documented crossovers; work never uses Rayon's process-global
+pool. Cosine dot products retain serial coordinate order, PageRank keeps
+canonical contribution order with serial dangling/delta reductions, eigenvector
+keeps per-destination incoming contribution order with serial norm/convergence
+reductions, and Node2Vec skip-gram training stays serial, so fingerprints match
+the one-thread path.
 
 ## Parallel cosine KNN (#342)
 
@@ -196,6 +205,23 @@ serial path runs with no pool scheduling tax. Workers emit `(uuid, score)` rows
 for contiguous ordinal ranges; the sink merges them in ascending node order so
 schemas, row order, scores, and fingerprints match the one-thread result at
 `1`/`2`/`4`/`8`/automatic configurations.
+## Parallel eigenvector (#507)
+
+`rank(by="eigenvector")` shifted power-iteration destination updates run on the
+instance-owned private compute pool when:
+
+- `compute_threads > 1`, and
+- selected adjacency entries are at least
+  `EIGENVECTOR_PARALLEL_CROSSOVER_EDGES` (`4_096`) in `graphforge-exec`.
+
+Below that crossover, or when the policy provides one compute thread, the
+serial source-scatter path runs with no pool scheduling tax. Parallel work is
+destination-owned: each worker owns a contiguous dense-ordinal destination
+range and applies inbound contributions after the implicit identity term in the
+same canonical source/edge order as serial scatter. L2 normalization and
+component-wise convergence checks stay serial, so scores, iteration counts, and
+fingerprints match the one-thread result at `1`/`2`/`4`/`8`/automatic
+configurations.
 
 ## Parallel Node2Vec walk generation (#344)
 

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -217,10 +217,9 @@ the instance-owned private compute pool when:
 Release-mode local evidence on the 4-worker M4 agent host showed regular graphs
 that converge during warm-up avoid the pool, while irregular non-converged
 fixtures crossed over by ~8K selected adjacency entries:
-`8_689` edges `1.55ms → 0.81ms`, `24_440` edges `2.80ms → 1.57ms`,
-`65_505` edges `9.88ms → 3.99ms`, and `130_544` edges
-`14.29ms → 7.03ms` (one thread vs four private workers; hardware-specific
-timing, not a CI gate).
+`8_689`, `24_440`, `65_505`, and `130_544` edge irregular fixtures repeatedly
+ran at roughly `0.4×–0.6×` of the one-thread time on four private workers.
+Those timings are hardware-specific evidence, not a CI gate.
 
 Below that crossover, or when the policy provides one compute thread, the
 serial source-scatter path runs with no pool scheduling tax. Above the

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -217,9 +217,9 @@ the instance-owned private compute pool when:
 Release-mode local evidence on the 4-worker M4 agent host showed regular graphs
 that converge during warm-up avoid the pool, while irregular non-converged
 fixtures crossed over by ~8K selected adjacency entries:
-`8_689` edges `1.57ms → 0.87ms`, `24_440` edges `2.89ms → 1.43ms`,
-`65_505` edges `9.90ms → 4.25ms`, and `130_544` edges
-`14.56ms → 7.26ms` (one thread vs four private workers; hardware-specific
+`8_689` edges `1.55ms → 0.81ms`, `24_440` edges `2.80ms → 1.57ms`,
+`65_505` edges `9.88ms → 3.99ms`, and `130_544` edges
+`14.29ms → 7.03ms` (one thread vs four private workers; hardware-specific
 timing, not a CI gate).
 
 Below that crossover, or when the policy provides one compute thread, the

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -212,7 +212,15 @@ the instance-owned private compute pool when:
 
 - `compute_threads > 1`, and
 - selected adjacency entries are at least
-  `EIGENVECTOR_PARALLEL_CROSSOVER_EDGES` (`4_096`) in `graphforge-exec`.
+  `EIGENVECTOR_PARALLEL_CROSSOVER_EDGES` (`8_192`) in `graphforge-exec`.
+
+Release-mode local evidence on the 4-worker M4 agent host showed regular graphs
+that converge during warm-up avoid the pool, while irregular non-converged
+fixtures crossed over by ~8K selected adjacency entries:
+`8_689` edges `1.57ms → 0.87ms`, `24_440` edges `2.89ms → 1.43ms`,
+`65_505` edges `9.90ms → 4.25ms`, and `130_544` edges
+`14.56ms → 7.26ms` (one thread vs four private workers; hardware-specific
+timing, not a CI gate).
 
 Below that crossover, or when the policy provides one compute thread, the
 serial source-scatter path runs with no pool scheduling tax. Above the

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -314,7 +314,7 @@ identity shift. Disconnected components share the global norm, an edgeless
 selection scores each node `1 / sqrt(N)`, and an empty selection returns the
 typed zero-row schema. Stable order, UUID-only identity, shared Rust
 limits/cancellation/errors, and atomic opt-in write-back apply unchanged.
-Above the documented `4_096` selected-adjacency-entry crossover, destination
+Above the documented `8_192` selected-adjacency-entry crossover, destination
 updates that remain unconverged after the two required serial iterations may
 use the instance-owned private compute pool while preserving one-thread scores,
 ordering, and fingerprints. Python and Node contain no separate eigenvector

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -315,9 +315,10 @@ selection scores each node `1 / sqrt(N)`, and an empty selection returns the
 typed zero-row schema. Stable order, UUID-only identity, shared Rust
 limits/cancellation/errors, and atomic opt-in write-back apply unchanged.
 Above the documented `4_096` selected-adjacency-entry crossover, destination
-updates may use the instance-owned private compute pool while preserving
-one-thread scores, ordering, and fingerprints. Python and Node contain no
-separate eigenvector implementation or fallback.
+updates that remain unconverged after the two required serial iterations may
+use the instance-owned private compute pool while preserving one-thread scores,
+ordering, and fingerprints. Python and Node contain no separate eigenvector
+implementation or fallback.
 
 Harmonic closeness is exact, normalized, unweighted, and outward in directed
 mode. For `N` selected nodes, it sums `1 / distance(u, v)` over reachable

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -314,7 +314,10 @@ identity shift. Disconnected components share the global norm, an edgeless
 selection scores each node `1 / sqrt(N)`, and an empty selection returns the
 typed zero-row schema. Stable order, UUID-only identity, shared Rust
 limits/cancellation/errors, and atomic opt-in write-back apply unchanged.
-Python and Node contain no separate eigenvector implementation or fallback.
+Above the documented `4_096` selected-adjacency-entry crossover, destination
+updates may use the instance-owned private compute pool while preserving
+one-thread scores, ordering, and fingerprints. Python and Node contain no
+separate eigenvector implementation or fallback.
 
 Harmonic closeness is exact, normalized, unweighted, and outward in directed
 mode. For `N` selected nodes, it sums `1 / distance(u, v)` over reachable


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements #507: parallel eigenvector destination-owned updates on the instance-owned `ComputePool` with serial norm/convergence reductions and fingerprint parity.

Closes #507

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788946676&installation_model_id=20486&pr_number=601&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F601&signature=c39e0236c56625bfdb5b4feb9d9e8402e4e5ee2e8158dff741429fa8b0622657"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parallelize eigenvector power iterations on the instance-owned ComputePool
> - Adds a parallel destination-owned pull path for eigenvector that activates after 2 serial warm-up iterations when `selected_edge_count >= 8192`, `threads > 1`, and a parallel compute pool is available; otherwise stays serial.
> - Builds a dense inbound CSR (`EigenvectorInboundCsr`) once per execution to drive parallel destination updates while preserving serial per-destination contribution order, ensuring bit-identical scores and fingerprints.
> - Adds `select_eigenvector_path` to choose between `Serial` and `Parallel { threads, chunks }` execution strategies, and `run_eigenvector_on_pool` to catch worker panics and surface them as structured `AlgorithmError::Execution` errors.
> - Periodic cancellation checks run every 4,096 destinations in the parallel path.
> - Risk: parallel path introduces a one-time CSR build cost and a rayon thread-pool dispatch per unconverged iteration; graphs below the 8,192-edge crossover are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0df1264.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->