### PR TITLE
perf(exec): parallelize delta-stepping proposals on ComputePool (#539)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_paths_delta_stepping.rs
+++ b/crates/graphforge-exec/src/algorithm_paths_delta_stepping.rs
@@ -15,10 +15,10 @@ const CHECKPOINT_INTERVAL: usize = 4_096;
 ///
 /// The parallel path partitions the current bucket's source set, not adjacency
 /// rows globally, so single-source buckets remain serial. On this agent host the
-/// private-pool path first won consistently once a relaxation wave scanned at
-/// least about 8k edges; 8,192 keeps small public calls off the pool while large
-/// bucket waves can use available compute threads.
-pub(crate) const DELTA_STEPPING_PARALLEL_CROSSOVER_EDGE_SCANS: u64 = 8_192;
+/// private-pool path did not win consistently at 132k edge entries, but 2/4/8
+/// workers all beat one thread at 395k edge entries. 262,144 keeps smaller
+/// public calls off the pool while large bucket waves can use compute threads.
+pub(crate) const DELTA_STEPPING_PARALLEL_CROSSOVER_EDGE_SCANS: u64 = 262_144;
 
 type BestPath = (f64, Vec<u64>, Vec<u64>);
 type Buckets = BTreeMap<BucketIndex, BTreeSet<u64>>;
@@ -557,7 +557,7 @@ mod tests {
 
     #[test]
     fn parallel_proposals_match_one_thread_oracle_across_thread_counts() {
-        let graph = parallel_wave_fixture(96, 96);
+        let graph = parallel_wave_fixture(1024, 384);
         let oracle = exact_delta_stepping(&graph, 0, None, &control_with_threads(1)).unwrap();
 
         for threads in [2, 4, 8] {
@@ -569,9 +569,9 @@ mod tests {
 
     #[test]
     fn parallel_limit_failure_is_structured_without_partial_results() {
-        let graph = parallel_wave_fixture(160, 128);
+        let graph = parallel_wave_fixture(1024, 384);
         let limited = AlgorithmLimits {
-            iterations: 8,
+            iterations: 100,
             ..AlgorithmLimits::default()
         };
         assert!(matches!(

--- a/crates/graphforge-exec/src/algorithm_paths_delta_stepping.rs
+++ b/crates/graphforge-exec/src/algorithm_paths_delta_stepping.rs
@@ -1,5 +1,8 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+use rayon::prelude::*;
 
 use crate::algorithm_dispatch::{AlgorithmControl, AlgorithmError};
 use crate::algorithm_graph::{AdjacencyGraph, AlgorithmEdge};
@@ -7,9 +10,26 @@ use crate::algorithm_paths_dijkstra::DijkstraPath;
 
 const DELTA: f64 = 1.0;
 const CHECKPOINT_INTERVAL: usize = 4_096;
+/// Direction-expanded edge scans below which delta-stepping proposal collection
+/// stays serial (#539).
+///
+/// The parallel path partitions the current bucket's source set, not adjacency
+/// rows globally, so single-source buckets remain serial. On this agent host the
+/// private-pool path first won consistently once a relaxation wave scanned at
+/// least about 8k edges; 8,192 keeps small public calls off the pool while large
+/// bucket waves can use available compute threads.
+pub(crate) const DELTA_STEPPING_PARALLEL_CROSSOVER_EDGE_SCANS: u64 = 8_192;
 
 type BestPath = (f64, Vec<u64>, Vec<u64>);
 type Buckets = BTreeMap<BucketIndex, BTreeSet<u64>>;
+type Proposal = (u64, BestPath);
+
+/// Selected execution path for observability and crossover tests.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DeltaSteppingExecutionPath {
+    Serial,
+    Parallel { threads: usize, chunks: usize },
+}
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 struct BucketIndex(f64);
@@ -111,6 +131,45 @@ fn relax_edges(
     control: &AlgorithmControl,
     work: &mut usize,
 ) -> Result<(), AlgorithmError> {
+    let mut proposals = collect_relaxation_proposals(graph, sources, light, best, control, work)?;
+    sort_proposals(&mut proposals);
+    for (node, candidate) in proposals {
+        if improves(&candidate, best.get(&node)) {
+            let index = bucket_index(candidate.0);
+            best.insert(node, candidate);
+            buckets.entry(index).or_default().insert(node);
+        }
+    }
+    Ok(())
+}
+
+fn collect_relaxation_proposals(
+    graph: &AdjacencyGraph,
+    sources: &BTreeSet<u64>,
+    light: bool,
+    best: &HashMap<u64, BestPath>,
+    control: &AlgorithmControl,
+    work: &mut usize,
+) -> Result<Vec<Proposal>, AlgorithmError> {
+    let edge_scans = relaxation_edge_scans(graph, sources);
+    match select_delta_stepping_path(control, sources.len(), edge_scans) {
+        DeltaSteppingExecutionPath::Serial => {
+            collect_relaxation_proposals_serial(graph, sources, light, best, control, work)
+        }
+        DeltaSteppingExecutionPath::Parallel { .. } => {
+            collect_relaxation_proposals_parallel(graph, sources, light, best, control)
+        }
+    }
+}
+
+fn collect_relaxation_proposals_serial(
+    graph: &AdjacencyGraph,
+    sources: &BTreeSet<u64>,
+    light: bool,
+    best: &HashMap<u64, BestPath>,
+    control: &AlgorithmControl,
+    work: &mut usize,
+) -> Result<Vec<Proposal>, AlgorithmError> {
     let mut proposals = Vec::new();
     for &source in sources {
         let Some(current) = best.get(&source).cloned() else {
@@ -124,19 +183,126 @@ fn relax_edges(
             proposals.push((edge.neighbor_id, candidate(&current, edge)?));
         }
     }
+    Ok(proposals)
+}
+
+fn collect_relaxation_proposals_parallel(
+    graph: &AdjacencyGraph,
+    sources: &BTreeSet<u64>,
+    light: bool,
+    best: &HashMap<u64, BestPath>,
+    control: &AlgorithmControl,
+) -> Result<Vec<Proposal>, AlgorithmError> {
+    let pool = control.compute_pool().ok_or_else(|| {
+        execution("parallel delta_stepping requires an instance-owned compute pool")
+    })?;
+    let source_ids = sources.iter().copied().collect::<Vec<_>>();
+    let ranges = source_chunks(source_ids.len(), control.compute_threads());
+    let chunk_results = run_delta_on_pool(pool, || {
+        ranges
+            .par_iter()
+            .map(|&(start, end)| {
+                let mut work = 0_usize;
+                let mut proposals = Vec::new();
+                for &source in &source_ids[start..end] {
+                    let Some(current) = best.get(&source).cloned() else {
+                        continue;
+                    };
+                    for edge in graph.neighbors(source) {
+                        checkpoint(control, &mut work)?;
+                        if (edge.weight <= DELTA) != light || current.1.contains(&edge.neighbor_id)
+                        {
+                            continue;
+                        }
+                        proposals.push((edge.neighbor_id, candidate(&current, edge)?));
+                    }
+                }
+                Ok(proposals)
+            })
+            .collect::<Vec<Result<_, AlgorithmError>>>()
+    })?;
+    merge_chunk_proposals(chunk_results)
+}
+
+fn merge_chunk_proposals(
+    chunk_results: Vec<Result<Vec<Proposal>, AlgorithmError>>,
+) -> Result<Vec<Proposal>, AlgorithmError> {
+    let mut proposals = Vec::new();
+    for chunk in chunk_results {
+        proposals.extend(chunk?);
+    }
+    Ok(proposals)
+}
+
+fn sort_proposals(proposals: &mut [Proposal]) {
     proposals.sort_by(|left, right| {
         left.0
             .cmp(&right.0)
             .then_with(|| compare_paths(&left.1, &right.1))
     });
-    for (node, candidate) in proposals {
-        if improves(&candidate, best.get(&node)) {
-            let index = bucket_index(candidate.0);
-            best.insert(node, candidate);
-            buckets.entry(index).or_default().insert(node);
-        }
+}
+
+fn relaxation_edge_scans(graph: &AdjacencyGraph, sources: &BTreeSet<u64>) -> u64 {
+    sources.iter().fold(0_u64, |acc, source| {
+        acc.saturating_add(u64::try_from(graph.neighbors(*source).len()).unwrap_or(u64::MAX))
+    })
+}
+
+/// Choose serial vs private-pool parallel proposal collection for one bucket wave.
+pub(crate) fn select_delta_stepping_path(
+    control: &AlgorithmControl,
+    sources: usize,
+    edge_scans: u64,
+) -> DeltaSteppingExecutionPath {
+    let threads = control.compute_threads();
+    if threads <= 1
+        || sources <= 1
+        || edge_scans < DELTA_STEPPING_PARALLEL_CROSSOVER_EDGE_SCANS
+        || control
+            .compute_pool()
+            .is_none_or(|pool| !pool.is_parallel())
+    {
+        return DeltaSteppingExecutionPath::Serial;
     }
-    Ok(())
+    let chunks = source_chunks(sources, threads).len();
+    if chunks <= 1 {
+        DeltaSteppingExecutionPath::Serial
+    } else {
+        DeltaSteppingExecutionPath::Parallel { threads, chunks }
+    }
+}
+
+fn source_chunks(sources: usize, threads: usize) -> Vec<(usize, usize)> {
+    if sources == 0 {
+        return Vec::new();
+    }
+    let workers = threads.clamp(1, sources);
+    let base = sources / workers;
+    let rem = sources % workers;
+    let mut ranges = Vec::with_capacity(workers);
+    let mut start = 0;
+    for index in 0..workers {
+        let len = base + usize::from(index < rem);
+        let end = start + len;
+        if start < end {
+            ranges.push((start, end));
+        }
+        start = end;
+    }
+    ranges
+}
+
+fn run_delta_on_pool<R>(
+    pool: &crate::ComputePool,
+    op: impl FnOnce() -> Result<R, AlgorithmError> + Send,
+) -> Result<R, AlgorithmError>
+where
+    R: Send,
+{
+    match catch_unwind(AssertUnwindSafe(|| pool.install(op))) {
+        Ok(result) => result,
+        Err(_) => Err(execution("delta_stepping worker panicked")),
+    }
 }
 
 fn validate_endpoint(graph: &AdjacencyGraph, node: u64, role: &str) -> Result<(), AlgorithmError> {
@@ -217,9 +383,56 @@ fn execution(message: impl Into<String>) -> AlgorithmError {
 mod tests {
     use super::*;
     use crate::algorithm_dispatch::{AlgorithmCancellation, AlgorithmLimits};
+    use crate::compute_pool::ComputePool;
+    use std::sync::Arc;
+    use std::time::Instant;
 
     fn control() -> AlgorithmControl {
         AlgorithmControl::new(AlgorithmLimits::default(), AlgorithmCancellation::default())
+    }
+
+    fn control_with_threads(threads: usize) -> AlgorithmControl {
+        let pool = Arc::new(ComputePool::new(threads).unwrap());
+        AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(threads),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(pool)
+    }
+
+    fn control_with_threads_and_limits(
+        threads: usize,
+        limits: AlgorithmLimits,
+    ) -> AlgorithmControl {
+        let pool = Arc::new(ComputePool::new(threads).unwrap());
+        AlgorithmControl::new(
+            limits.with_compute_threads(threads),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(pool)
+    }
+
+    fn parallel_wave_fixture(middles: u64, fanout: u64) -> AdjacencyGraph {
+        let common = 1 + middles;
+        let targets = (0..fanout)
+            .map(|target| common + target)
+            .collect::<Vec<_>>();
+        let mut edges = Vec::new();
+        let mut weights = Vec::new();
+        for middle in 1..=middles {
+            edges.push((0, middle));
+            weights.push(0.5);
+        }
+        for middle in 1..=middles {
+            edges.push((middle, common));
+            weights.push(0.5);
+            for &target in &targets {
+                edges.push((middle, target));
+                weights.push(0.5);
+            }
+        }
+        AdjacencyGraph::with_test_directed_edges(common + fanout + 1, &edges)
+            .with_test_edge_weights(&weights)
     }
 
     #[test]
@@ -307,6 +520,72 @@ mod tests {
     }
 
     #[test]
+    fn select_delta_stepping_path_respects_pool_and_crossover() {
+        let serial = control();
+        assert_eq!(
+            select_delta_stepping_path(&serial, 64, DELTA_STEPPING_PARALLEL_CROSSOVER_EDGE_SCANS),
+            DeltaSteppingExecutionPath::Serial
+        );
+
+        let one = control_with_threads(1);
+        assert_eq!(
+            select_delta_stepping_path(&one, 64, DELTA_STEPPING_PARALLEL_CROSSOVER_EDGE_SCANS),
+            DeltaSteppingExecutionPath::Serial
+        );
+
+        let small = control_with_threads(4);
+        assert_eq!(
+            select_delta_stepping_path(
+                &small,
+                64,
+                DELTA_STEPPING_PARALLEL_CROSSOVER_EDGE_SCANS - 1
+            ),
+            DeltaSteppingExecutionPath::Serial
+        );
+        assert_eq!(
+            select_delta_stepping_path(&small, 1, DELTA_STEPPING_PARALLEL_CROSSOVER_EDGE_SCANS),
+            DeltaSteppingExecutionPath::Serial
+        );
+        assert_eq!(
+            select_delta_stepping_path(&small, 64, DELTA_STEPPING_PARALLEL_CROSSOVER_EDGE_SCANS),
+            DeltaSteppingExecutionPath::Parallel {
+                threads: 4,
+                chunks: 4
+            }
+        );
+    }
+
+    #[test]
+    fn parallel_proposals_match_one_thread_oracle_across_thread_counts() {
+        let graph = parallel_wave_fixture(96, 96);
+        let oracle = exact_delta_stepping(&graph, 0, None, &control_with_threads(1)).unwrap();
+
+        for threads in [2, 4, 8] {
+            let parallel =
+                exact_delta_stepping(&graph, 0, None, &control_with_threads(threads)).unwrap();
+            assert_eq!(parallel, oracle, "threads={threads}");
+        }
+    }
+
+    #[test]
+    fn parallel_limit_failure_is_structured_without_partial_results() {
+        let graph = parallel_wave_fixture(160, 128);
+        let limited = AlgorithmLimits {
+            iterations: 8,
+            ..AlgorithmLimits::default()
+        };
+        assert!(matches!(
+            exact_delta_stepping(
+                &graph,
+                0,
+                None,
+                &control_with_threads_and_limits(4, limited)
+            ),
+            Err(AlgorithmError::IterationLimit { .. })
+        ));
+    }
+
+    #[test]
     fn weights_endpoints_limits_and_cancellation_are_structured() {
         let negative =
             AdjacencyGraph::with_test_edges(2, &[(0, 1)]).with_test_edge_weights(&[-1.0]);
@@ -355,5 +634,27 @@ mod tests {
             exact_delta_stepping(&graph, 0, None, &cancelled),
             Err(AlgorithmError::Cancelled)
         ));
+    }
+
+    #[test]
+    #[ignore = "manual crossover evidence; timing is hardware-specific"]
+    fn measure_delta_stepping_parallel_crossover() {
+        let graph = parallel_wave_fixture(192, 96);
+        let oracle = exact_delta_stepping(&graph, 0, None, &control_with_threads(1)).unwrap();
+        eprintln!(
+            "delta_stepping fixture: nodes={} edge_entries={} rows={} crossover_edge_scans={}",
+            graph.node_ids().len(),
+            graph.edge_entry_count(),
+            oracle.len(),
+            DELTA_STEPPING_PARALLEL_CROSSOVER_EDGE_SCANS
+        );
+        for threads in [1, 2, 4, 8] {
+            let control = control_with_threads(threads);
+            let started = Instant::now();
+            let paths = exact_delta_stepping(&graph, 0, None, &control).unwrap();
+            let elapsed = started.elapsed();
+            assert_eq!(paths, oracle);
+            eprintln!("threads={threads} elapsed={elapsed:?}");
+        }
     }
 }

--- a/crates/graphforge-exec/src/algorithm_paths_delta_stepping.rs
+++ b/crates/graphforge-exec/src/algorithm_paths_delta_stepping.rs
@@ -658,5 +658,24 @@ mod tests {
                 eprintln!("threads={threads} elapsed={elapsed:?}");
             }
         }
+        if let Some(peak_rss_kib) = peak_rss_kib() {
+            eprintln!("peak_rss_kib={peak_rss_kib}");
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn peak_rss_kib() -> Option<u64> {
+        std::fs::read_to_string("/proc/self/status")
+            .ok()?
+            .lines()
+            .find_map(|line| {
+                let value = line.strip_prefix("VmHWM:")?.trim();
+                value.split_whitespace().next()?.parse().ok()
+            })
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn peak_rss_kib() -> Option<u64> {
+        None
     }
 }

--- a/crates/graphforge-exec/src/algorithm_paths_delta_stepping.rs
+++ b/crates/graphforge-exec/src/algorithm_paths_delta_stepping.rs
@@ -639,22 +639,24 @@ mod tests {
     #[test]
     #[ignore = "manual crossover evidence; timing is hardware-specific"]
     fn measure_delta_stepping_parallel_crossover() {
-        let graph = parallel_wave_fixture(192, 96);
-        let oracle = exact_delta_stepping(&graph, 0, None, &control_with_threads(1)).unwrap();
-        eprintln!(
-            "delta_stepping fixture: nodes={} edge_entries={} rows={} crossover_edge_scans={}",
-            graph.node_ids().len(),
-            graph.edge_entry_count(),
-            oracle.len(),
-            DELTA_STEPPING_PARALLEL_CROSSOVER_EDGE_SCANS
-        );
-        for threads in [1, 2, 4, 8] {
-            let control = control_with_threads(threads);
-            let started = Instant::now();
-            let paths = exact_delta_stepping(&graph, 0, None, &control).unwrap();
-            let elapsed = started.elapsed();
-            assert_eq!(paths, oracle);
-            eprintln!("threads={threads} elapsed={elapsed:?}");
+        for (middles, fanout) in [(192, 96), (512, 256), (1024, 384)] {
+            let graph = parallel_wave_fixture(middles, fanout);
+            let oracle = exact_delta_stepping(&graph, 0, None, &control_with_threads(1)).unwrap();
+            eprintln!(
+                "delta_stepping fixture: middles={middles} fanout={fanout} nodes={} edge_entries={} rows={} crossover_edge_scans={}",
+                graph.node_ids().len(),
+                graph.edge_entry_count(),
+                oracle.len(),
+                DELTA_STEPPING_PARALLEL_CROSSOVER_EDGE_SCANS
+            );
+            for threads in [1, 2, 4, 8] {
+                let control = control_with_threads(threads);
+                let started = Instant::now();
+                let paths = exact_delta_stepping(&graph, 0, None, &control).unwrap();
+                let elapsed = started.elapsed();
+                assert_eq!(paths, oracle);
+                eprintln!("threads={threads} elapsed={elapsed:?}");
+            }
         }
     }
 }

--- a/crates/graphforge-exec/src/algorithm_paths_delta_stepping.rs
+++ b/crates/graphforge-exec/src/algorithm_paths_delta_stepping.rs
@@ -199,7 +199,7 @@ fn collect_relaxation_proposals_parallel(
     let source_ids = sources.iter().copied().collect::<Vec<_>>();
     let ranges = source_chunks(source_ids.len(), control.compute_threads());
     let chunk_results = run_delta_on_pool(pool, || {
-        ranges
+        Ok(ranges
             .par_iter()
             .map(|&(start, end)| {
                 let mut work = 0_usize;
@@ -219,7 +219,7 @@ fn collect_relaxation_proposals_parallel(
                 }
                 Ok(proposals)
             })
-            .collect::<Vec<Result<_, AlgorithmError>>>()
+            .collect::<Vec<Result<_, AlgorithmError>>>())
     })?;
     merge_chunk_proposals(chunk_results)
 }

--- a/docs/book/architecture/algorithms.md
+++ b/docs/book/architecture/algorithms.md
@@ -1689,6 +1689,13 @@ Projection errors, invalid selectors or options, strict-weight failures, accumul
 overflow, limit violations, cancellation, execution errors, and Arrow shaping failures abort
 the invocation without partial output.
 
+Proposal collection for bucket waves with at least 8,192 direction-expanded edge scans and
+more than one current source may run on the instance-owned private `ComputePool`; one-thread,
+single-source, missing-pool, and smaller waves stay serial. Workers only produce candidate
+proposals from CSR neighbor slices. Bucket mutation, distance updates, final sorting, and
+tie resolution remain canonical, so supported thread configurations must match the one-thread
+oracle bit-for-bit. No process-global Rayon pool is used.
+
 Projection, validation, bucket execution, deterministic tie resolution, limits, cancellation,
 and Arrow shaping are Rust-owned in `graphforge-exec`. Python and Node are argument/Arrow adapters
 only. Exploratory operation without a knowledge layer produces the same graph result,

--- a/docs/book/architecture/algorithms.md
+++ b/docs/book/architecture/algorithms.md
@@ -1689,7 +1689,7 @@ Projection errors, invalid selectors or options, strict-weight failures, accumul
 overflow, limit violations, cancellation, execution errors, and Arrow shaping failures abort
 the invocation without partial output.
 
-Proposal collection for bucket waves with at least 8,192 direction-expanded edge scans and
+Proposal collection for bucket waves with at least 262,144 direction-expanded edge scans and
 more than one current source may run on the instance-owned private `ComputePool`; one-thread,
 single-source, missing-pool, and smaller waves stay serial. Workers only produce candidate
 proposals from CSR neighbor slices. Bucket mutation, distance updates, final sorting, and

--- a/docs/development/perf-delta-stepping-539.md
+++ b/docs/development/perf-delta-stepping-539.md
@@ -1,0 +1,48 @@
+# Delta-stepping #539 performance disposition
+
+**Date:** 2026-08-10  
+**Branch:** `cursor/539-parallel-delta-stepping-9e9f`  
+**Machine:** Cursor Cloud Linux 6.12.94+ x86_64  
+**Command:** `CARGO_TARGET_DIR=/tmp/cargo-m4-539 cargo test --release -p graphforge-exec --lib algorithm_paths_delta_stepping::tests::measure_delta_stepping_parallel_crossover -- --ignored --nocapture`
+
+## Disposition
+
+`paths(by="delta_stepping")` now uses the instance-owned private `ComputePool`
+for deterministic proposal collection when a bucket wave has at least **262,144
+direction-expanded edge scans** and more than one current source. Smaller waves,
+single-source waves, one-thread policies, and missing-pool controls stay serial.
+
+Workers read CSR neighbor slices and emit local candidate proposals only. Bucket
+mutation, best-distance updates, stale-bucket filtering, final proposal sorting,
+and public row ordering remain canonical on the caller thread, so multi-thread
+results must match the one-thread oracle.
+
+## Release-mode crossover evidence
+
+Synthetic fixtures create one source, a light-edge middle bucket, and repeated
+middle-to-target relaxations so the second bucket wave is eligible for
+parallel proposal generation. All thread counts below matched the one-thread
+oracle exactly.
+
+| Middle nodes | Fanout | Edge entries | Rows | 1 thread | 2 threads | 4 threads | 8 threads |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| 192 | 96 | 18,816 | 289 | 12.005 ms | 15.840 ms | 11.871 ms | 18.963 ms |
+| 512 | 256 | 132,096 | 769 | 63.214 ms | 105.937 ms | 87.360 ms | 59.756 ms |
+| 1,024 | 384 | 395,264 | 1,409 | 271.509 ms | 154.973 ms | 130.093 ms | 108.390 ms |
+
+The first two fixtures do not consistently justify the pool tax across supported
+thread counts. The 395k-edge-entry fixture is the first measured wave where
+2/4/8 workers all beat one thread, so the implementation uses the conservative
+power-of-two threshold below that fixture and above the inconsistent 132k
+fixture: `262_144`.
+
+## Structural gates
+
+- No process-global Rayon pool; parallel work is installed only on the
+  `AlgorithmControl` compute pool.
+- No parallel-only graph copy and no O(E) hash map expansion; workers borrow
+  CSR neighbor slices from `AdjacencyGraph`.
+- Canonical merge sorts all proposals by target, complete node path, then edge
+  path before applying improvements.
+- Tests cover serial crossover selection, one-thread vs 2/4/8-thread equality,
+  and structured iteration-limit failure without partial results.

--- a/docs/development/perf-delta-stepping-539.md
+++ b/docs/development/perf-delta-stepping-539.md
@@ -22,17 +22,24 @@ results must match the one-thread oracle.
 Synthetic fixtures create one source, a light-edge middle bucket, and repeated
 middle-to-target relaxations so the second bucket wave is eligible for
 parallel proposal generation. All thread counts below matched the one-thread
-oracle exactly.
+oracle exactly. Rows below the 262,144 crossover stay on the serial path even
+when the control carries a multi-thread pool, so those columns reflect serial
+noise under different controls rather than parallel speedups.
 
 | Middle nodes | Fanout | Edge entries | Rows | 1 thread | 2 threads | 4 threads | 8 threads |
 |---:|---:|---:|---:|---:|---:|---:|---:|
-| 192 | 96 | 18,816 | 289 | 12.005 ms | 15.840 ms | 11.871 ms | 18.963 ms |
-| 512 | 256 | 132,096 | 769 | 63.214 ms | 105.937 ms | 87.360 ms | 59.756 ms |
-| 1,024 | 384 | 395,264 | 1,409 | 271.509 ms | 154.973 ms | 130.093 ms | 108.390 ms |
+| 192 | 96 | 18,816 | 289 | 4.851 ms | 3.916 ms | 3.971 ms | 3.561 ms |
+| 512 | 256 | 132,096 | 769 | 40.090 ms | 46.920 ms | 34.302 ms | 41.604 ms |
+| 1,024 | 384 | 395,264 | 1,409 | 139.790 ms | 137.109 ms | 120.984 ms | 102.622 ms |
 
-The first two fixtures do not consistently justify the pool tax across supported
-thread counts. The 395k-edge-entry fixture is the first measured wave where
-2/4/8 workers all beat one thread, so the implementation uses the conservative
+Peak resident set reported by `/proc/self/status` `VmHWM` for the evidence test
+process: **276,480 KiB**.
+
+An exploratory release-mode run with the provisional 8,192 threshold showed that
+the 132k-edge-entry fixture did not consistently justify the pool tax (2 and 4
+threads were slower while 8 threads was only slightly faster). The 395k fixture
+is the first measured wave where 2/4/8 workers beat one thread in the repeat
+production-threshold run above, so the implementation uses the conservative
 power-of-two threshold below that fixture and above the inconsistent 132k
 fixture: `262_144`.
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1815,6 +1815,12 @@ cooperative iteration checkpoints at 10,000. Selector, option, projection, weigh
 limit, cancellation, execution, or shaping failures return structured errors without partial
 output.
 
+For bucket waves with at least 8,192 direction-expanded edge scans and more than one current
+source, proposal collection may use the instance-owned private `ComputePool`; one-thread,
+single-source, missing-pool, and smaller waves remain serial. Distance updates and public
+ordering are still merged canonically against the same one-thread oracle, and no process-global
+Rayon pool is used.
+
 Rust owns projection, validation, execution, ordering, limits, cancellation, and Arrow
 shaping. Python and Node are thin adapters. Results are independent of the graph/knowledge boundary
 knowledge-layer presence. External libraries and documentation are development parity

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1815,7 +1815,7 @@ cooperative iteration checkpoints at 10,000. Selector, option, projection, weigh
 limit, cancellation, execution, or shaping failures return structured errors without partial
 output.
 
-For bucket waves with at least 8,192 direction-expanded edge scans and more than one current
+For bucket waves with at least 262,144 direction-expanded edge scans and more than one current
 source, proposal collection may use the instance-owned private `ComputePool`; one-thread,
 single-source, missing-pool, and smaller waves remain serial. Distance updates and public
 ordering are still merged canonically against the same one-thread oracle, and no process-global


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements #539: parallelize deterministic proposal collection for `paths(by="delta_stepping")` on the instance-owned `ComputePool` above a measured crossover, keeping bucket mutation and tie resolution serial for bit-identical results.

Closes #539

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788946703&installation_model_id=20486&pr_number=602&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F602&signature=cd3b8ee68e37d06cb6d5735cd3c07b0e4c5452313f6fd0d8f53e5d9fc219db6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parallelize delta-stepping proposal collection on a private ComputePool
> - Adds a parallel proposal collection path in `relax_edges` that dispatches bucket-wave work across threads via a private Rayon pool when edge scans exceed 262,144 and more than one source is present.
> - Introduces `select_delta_stepping_path` to choose between `Serial` and `Parallel` execution; falls back to serial when the pool is absent, thread count is ≤1, or workload is below the crossover threshold.
> - Sources are partitioned into contiguous chunks via `source_chunks`; each chunk runs a serial scan, and results are merged by `merge_chunk_proposals`. Ordering and bucket-update semantics are unchanged.
> - Panics inside pool-installed work are caught via `catch_unwind(AssertUnwindSafe)` in `run_delta_on_pool` and returned as execution errors.
> - Behavioral Change: proposal collection now runs on the instance-owned pool rather than the caller's thread when selection criteria are met; no process-global Rayon pool is used.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0dcf582.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->