### PR TITLE
perf(exec): parallelize ArticleRank on ComputePool (#500)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_dispatch.rs
+++ b/crates/graphforge-exec/src/algorithm_dispatch.rs
@@ -172,8 +172,8 @@ pub struct AlgorithmLimits {
     pub batch_size: usize,
     /// Declared compute-thread budget from the instance resource policy (#337 / #342).
     ///
-    /// `1` forces the serial cosine path; larger values may activate the private
-    /// pool when work exceeds the documented crossover.
+    /// `1` forces serial CPU-kernel paths; larger values may activate the
+    /// private pool when work exceeds each documented crossover.
     pub compute_threads: usize,
 }
 

--- a/crates/graphforge-exec/src/algorithm_rank.rs
+++ b/crates/graphforge-exec/src/algorithm_rank.rs
@@ -184,10 +184,10 @@ const ARTICLE_RANK_MAX_ITERATIONS: usize = 20;
 const ARTICLE_RANK_TOLERANCE: f64 = 1.0e-7;
 /// Selected adjacency entries below which ArticleRank stays on the serial path (#500).
 ///
-/// ArticleRank shares PageRank's destination-owned pull shape and short fixed
-/// iteration cap, so the same measured edge-count crossover avoids worker-pool
-/// scheduling tax for small fixtures while keeping larger update rounds parallel.
-pub const ARTICLE_RANK_PARALLEL_CROSSOVER_EDGES: u64 = 4_096;
+/// Release-mode shared-pool timings on the M4 agent host first clear a parallel
+/// win at 131k selected entries; smaller fixtures stay serial to avoid worker
+/// scheduling tax.
+pub const ARTICLE_RANK_PARALLEL_CROSSOVER_EDGES: u64 = 131_072;
 const ARTICLE_RANK_CHECKPOINT_DESTINATIONS: usize = 4_096;
 const HITS_ITERATIONS: usize = 20;
 /// Selected adjacency entries below which HITS stays on the serial path (#510).

--- a/crates/graphforge-exec/src/algorithm_rank.rs
+++ b/crates/graphforge-exec/src/algorithm_rank.rs
@@ -16,6 +16,9 @@
 //! destination-owned score updates across the instance-owned private compute
 //! pool while preserving the serial contribution order, deterministic
 //! reductions, and bit-identical fingerprints.
+//! PageRank (#343) and ArticleRank (#500) may partition destination-owned score
+//! updates across the instance-owned private compute pool while preserving the
+//! serial contribution order, reductions, and bit-identical fingerprints.
 
 use std::collections::{HashMap, VecDeque};
 use std::panic::{AssertUnwindSafe, catch_unwind};
@@ -179,6 +182,13 @@ const ARTICLE_RANK_DAMPING: f64 = 0.85;
 const ARTICLE_RANK_ALPHA: f64 = 1.0 - ARTICLE_RANK_DAMPING;
 const ARTICLE_RANK_MAX_ITERATIONS: usize = 20;
 const ARTICLE_RANK_TOLERANCE: f64 = 1.0e-7;
+/// Selected adjacency entries below which ArticleRank stays on the serial path (#500).
+///
+/// ArticleRank shares PageRank's destination-owned pull shape and short fixed
+/// iteration cap, so the same measured edge-count crossover avoids worker-pool
+/// scheduling tax for small fixtures while keeping larger update rounds parallel.
+pub const ARTICLE_RANK_PARALLEL_CROSSOVER_EDGES: u64 = 4_096;
+const ARTICLE_RANK_CHECKPOINT_DESTINATIONS: usize = 4_096;
 const HITS_ITERATIONS: usize = 20;
 /// Selected adjacency entries below which HITS stays on the serial path (#510).
 ///
@@ -1584,46 +1594,39 @@ impl RustAlgorithm for ArticleRank {
     ) -> Result<AlgorithmOutput, AlgorithmError> {
         let algorithm = Algorithm::Rank(RankAlgorithm::ArticleRank);
         let node_ids = graph.node_ids();
-        if node_ids.is_empty() {
+        let node_len = node_ids.len();
+        if node_len == 0 {
             return AlgorithmOutput::empty(algorithm, control);
         }
 
-        let indices: HashMap<u64, usize> = node_ids
-            .iter()
-            .enumerate()
-            .map(|(index, &node)| (node, index))
-            .collect();
-        let edge_count = node_ids.iter().try_fold(0_usize, |total, &node| {
-            total
-                .checked_add(graph.neighbors(node).len())
-                .ok_or_else(|| execution("selected edge count exceeds supported score range"))
-        })?;
-        let average_degree = f64::from(exact_u32(edge_count, "selected edge count")?)
-            / f64::from(exact_u32(node_ids.len(), "node count")?);
-        let mut scores = vec![ARTICLE_RANK_ALPHA; node_ids.len()];
+        let prepared = prepare_article_rank(graph)?;
+        let mut scores = vec![ARTICLE_RANK_ALPHA; node_len];
         let mut deltas = scores.clone();
+        let path = select_article_rank_path(control, prepared.edge_count, node_len);
 
         for _ in 0..ARTICLE_RANK_MAX_ITERATIONS {
             control.checkpoint()?;
-            let mut next = vec![0.0; node_ids.len()];
-            let mut traversed_edges = 0_usize;
-            for (source_index, &source) in node_ids.iter().enumerate() {
-                let edges = graph.neighbors(source);
-                if edges.is_empty() {
-                    continue;
+            let mut next = vec![0.0; node_len];
+            match path {
+                ArticleRankExecutionPath::Serial => {
+                    article_rank_pull_serial(
+                        &prepared.inbound,
+                        &prepared.outdegrees,
+                        prepared.average_degree,
+                        &deltas,
+                        &mut next,
+                        control,
+                    )?;
                 }
-                let degree = f64::from(exact_u32(edges.len(), "node degree")?);
-                let message = deltas[source_index] / (degree + average_degree);
-                for edge in edges {
-                    if traversed_edges > 0 && traversed_edges.is_multiple_of(1024) {
-                        control.checkpoint()?;
-                    }
-                    traversed_edges += 1;
-                    let target = indices
-                        .get(&edge.neighbor_id)
-                        .copied()
-                        .ok_or_else(|| execution("adjacency references an unselected node"))?;
-                    next[target] += message;
+                ArticleRankExecutionPath::Parallel { .. } => {
+                    article_rank_pull_parallel(
+                        &prepared.inbound,
+                        &prepared.outdegrees,
+                        prepared.average_degree,
+                        &deltas,
+                        &mut next,
+                        control,
+                    )?;
                 }
             }
             let mut converged = true;
@@ -1658,6 +1661,209 @@ impl RustAlgorithm for ArticleRank {
             })
             .collect::<Result<Vec<_>, AlgorithmError>>()?;
         AlgorithmOutput::from_rows(algorithm, control, rows)
+    }
+}
+
+/// Selected ArticleRank execution path for observability and crossover tests (#500).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ArticleRankExecutionPath {
+    Serial,
+    Parallel { threads: usize, chunks: usize },
+}
+
+/// Dense inbound CSR: source ordinals in canonical source/edge order per destination.
+#[derive(Clone, Debug, Default)]
+struct ArticleRankInboundCsr {
+    offsets: Vec<u32>,
+    sources: Vec<u32>,
+}
+
+struct PreparedArticleRank {
+    outdegrees: Vec<f64>,
+    inbound: ArticleRankInboundCsr,
+    average_degree: f64,
+    edge_count: u64,
+}
+
+fn prepare_article_rank(graph: &AdjacencyGraph) -> Result<PreparedArticleRank, AlgorithmError> {
+    let node_ids = graph.node_ids();
+    let node_len = node_ids.len();
+    let node_count = exact_u32(node_len, "node count")?;
+    let indices: HashMap<u64, usize> = node_ids
+        .iter()
+        .enumerate()
+        .map(|(index, &node)| (node, index))
+        .collect();
+    let mut outdegrees = Vec::with_capacity(node_len);
+    let mut inbound_counts = vec![0_u32; node_len];
+    let mut edge_count = 0_u64;
+    for &source in node_ids {
+        let edges = graph.neighbors(source);
+        outdegrees.push(f64::from(exact_u32(edges.len(), "node degree")?));
+        for edge in edges {
+            let target = indices
+                .get(&edge.neighbor_id)
+                .copied()
+                .ok_or_else(|| execution("adjacency references an unselected node"))?;
+            inbound_counts[target] = inbound_counts[target]
+                .checked_add(1)
+                .ok_or_else(|| execution("inbound degree exceeds supported range"))?;
+            edge_count = edge_count
+                .checked_add(1)
+                .ok_or_else(|| execution("selected edge count exceeds supported score range"))?;
+        }
+    }
+
+    let mut offsets = Vec::with_capacity(node_len + 1);
+    offsets.push(0_u32);
+    for &count in &inbound_counts {
+        let next = offsets
+            .last()
+            .copied()
+            .unwrap_or(0)
+            .checked_add(count)
+            .ok_or_else(|| execution("inbound CSR offsets exceed supported range"))?;
+        offsets.push(next);
+    }
+    let total = usize::try_from(*offsets.last().unwrap_or(&0))
+        .map_err(|_| execution("inbound CSR length exceeds supported range"))?;
+    let mut sources = vec![0_u32; total];
+    let mut write_at = offsets[..node_len].to_vec();
+    for (source_index, &source) in node_ids.iter().enumerate() {
+        let source_u32 = exact_u32(source_index, "source ordinal")?;
+        for edge in graph.neighbors(source) {
+            let target = indices
+                .get(&edge.neighbor_id)
+                .copied()
+                .ok_or_else(|| execution("adjacency references an unselected node"))?;
+            let slot = usize::try_from(write_at[target])
+                .map_err(|_| execution("inbound write cursor exceeds supported range"))?;
+            sources[slot] = source_u32;
+            write_at[target] = write_at[target]
+                .checked_add(1)
+                .ok_or_else(|| execution("inbound write cursor overflow"))?;
+        }
+    }
+
+    let average_degree =
+        exact_u64_as_f64(edge_count, "selected edge count")? / f64::from(node_count);
+    Ok(PreparedArticleRank {
+        outdegrees,
+        inbound: ArticleRankInboundCsr { offsets, sources },
+        average_degree,
+        edge_count,
+    })
+}
+
+/// Choose serial vs private-pool parallel execution for an ArticleRank workload.
+pub(crate) fn select_article_rank_path(
+    control: &AlgorithmControl,
+    edge_count: u64,
+    nodes: usize,
+) -> ArticleRankExecutionPath {
+    let threads = control.compute_threads();
+    if threads <= 1
+        || nodes <= 1
+        || edge_count < ARTICLE_RANK_PARALLEL_CROSSOVER_EDGES
+        || control
+            .compute_pool()
+            .is_none_or(|pool| !pool.is_parallel())
+    {
+        return ArticleRankExecutionPath::Serial;
+    }
+    let chunks = destination_chunks(nodes, threads).len();
+    ArticleRankExecutionPath::Parallel { threads, chunks }
+}
+
+fn article_rank_pull_destination(
+    inbound: &ArticleRankInboundCsr,
+    outdegrees: &[f64],
+    average_degree: f64,
+    deltas: &[f64],
+    dest: usize,
+) -> f64 {
+    let start = usize::try_from(inbound.offsets[dest]).unwrap_or(0);
+    let end = usize::try_from(inbound.offsets[dest + 1]).unwrap_or(start);
+    let mut acc = 0.0;
+    for &source in &inbound.sources[start.min(end)..end.min(inbound.sources.len())] {
+        let source = usize::try_from(source).unwrap_or(usize::MAX);
+        if source < deltas.len() {
+            acc += deltas[source] / (outdegrees[source] + average_degree);
+        }
+    }
+    acc
+}
+
+fn article_rank_pull_serial(
+    inbound: &ArticleRankInboundCsr,
+    outdegrees: &[f64],
+    average_degree: f64,
+    deltas: &[f64],
+    next: &mut [f64],
+    control: &AlgorithmControl,
+) -> Result<(), AlgorithmError> {
+    for (dest, value) in next.iter_mut().enumerate() {
+        if dest > 0 && dest.is_multiple_of(ARTICLE_RANK_CHECKPOINT_DESTINATIONS) {
+            control.checkpoint()?;
+        }
+        *value = article_rank_pull_destination(inbound, outdegrees, average_degree, deltas, dest);
+    }
+    Ok(())
+}
+
+fn article_rank_pull_parallel(
+    inbound: &ArticleRankInboundCsr,
+    outdegrees: &[f64],
+    average_degree: f64,
+    deltas: &[f64],
+    next: &mut [f64],
+    control: &AlgorithmControl,
+) -> Result<(), AlgorithmError> {
+    let pool = control
+        .compute_pool()
+        .ok_or_else(|| execution("parallel ArticleRank requires an instance-owned compute pool"))?;
+    let ranges = destination_chunks(next.len(), control.compute_threads());
+    let work = AtomicUsize::new(0);
+    let chunk_results = run_article_rank_on_pool(pool, || {
+        ranges
+            .par_iter()
+            .map(|&(start, end)| {
+                control.check_cancelled()?;
+                let mut local = Vec::with_capacity(end - start);
+                for dest in start..end {
+                    let observed = work.fetch_add(1, Ordering::Relaxed) + 1;
+                    if observed.is_multiple_of(ARTICLE_RANK_CHECKPOINT_DESTINATIONS) {
+                        control.check_cancelled()?;
+                    }
+                    local.push(article_rank_pull_destination(
+                        inbound,
+                        outdegrees,
+                        average_degree,
+                        deltas,
+                        dest,
+                    ));
+                }
+                Ok((start, local))
+            })
+            .collect::<Result<Vec<_>, AlgorithmError>>()
+    })?;
+    // Merge chunk outputs in ascending destination-range order (canonical).
+    for (start, local) in chunk_results {
+        next[start..start + local.len()].copy_from_slice(&local);
+    }
+    Ok(())
+}
+
+fn run_article_rank_on_pool<R>(
+    pool: &crate::ComputePool,
+    op: impl FnOnce() -> Result<R, AlgorithmError> + Send,
+) -> Result<R, AlgorithmError>
+where
+    R: Send,
+{
+    match catch_unwind(AssertUnwindSafe(|| pool.install(op))) {
+        Ok(result) => result,
+        Err(_) => Err(execution("ArticleRank worker panicked")),
     }
 }
 
@@ -3819,6 +4025,22 @@ mod tests {
         )
     }
 
+    fn execute_article_rank_with_pool(
+        graph: &AdjacencyGraph,
+        threads: usize,
+        cancellation: AlgorithmCancellation,
+    ) -> Result<AlgorithmOutput, AlgorithmError> {
+        let pool = Arc::new(crate::ComputePool::new(threads).unwrap());
+        let mut registry = AlgorithmRegistry::default();
+        register_rank_algorithms(&mut registry)?;
+        let control = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(threads),
+            cancellation,
+        )
+        .with_compute_pool(pool);
+        registry.execute(Algorithm::Rank(RankAlgorithm::ArticleRank), graph, &control)
+    }
+
     fn article_rank_scores(output: &AlgorithmOutput) -> Vec<f64> {
         output
             .rows()
@@ -3828,6 +4050,44 @@ mod tests {
                 _ => panic!("ArticleRank score must be Float64"),
             })
             .collect()
+    }
+
+    fn article_rank_bits(output: &AlgorithmOutput) -> Vec<u64> {
+        article_rank_scores(output)
+            .into_iter()
+            .map(f64::to_bits)
+            .collect()
+    }
+
+    fn article_rank_fingerprint(output: &AlgorithmOutput) -> String {
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        hasher.update((output.rows().len() as u64).to_le_bytes());
+        for row in output.rows() {
+            match row.as_slice() {
+                [AlgorithmValue::Uuid(uuid), AlgorithmValue::Float64(score)] => {
+                    hasher.update(uuid);
+                    hasher.update(score.to_bits().to_le_bytes());
+                }
+                _ => panic!("ArticleRank output row must contain uuid and score"),
+            }
+        }
+        hasher
+            .finalize()
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect()
+    }
+
+    fn dense_article_rank_graph(nodes: usize) -> AdjacencyGraph {
+        let fanout =
+            ((ARTICLE_RANK_PARALLEL_CROSSOVER_EDGES as usize) / nodes.max(1)).saturating_add(2);
+        let edges = (0..nodes)
+            .flat_map(|node| {
+                (1..=fanout).map(move |hop| (node as u64, ((node + hop) % nodes) as u64))
+            })
+            .collect::<Vec<_>>();
+        AdjacencyGraph::with_test_edges(nodes as u64, &edges)
     }
 
     fn execute_hits_hub(
@@ -5879,6 +6139,188 @@ mod tests {
             .find(|capability| capability.algorithm == Algorithm::Rank(RankAlgorithm::ArticleRank))
             .unwrap();
         assert_eq!(capability.dependency, BUILTIN_REVIEW);
+    }
+
+    #[test]
+    fn article_rank_path_selection_respects_crossover_and_one_thread() {
+        let serial_control = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(4),
+            AlgorithmCancellation::default(),
+        );
+        assert_eq!(
+            select_article_rank_path(
+                &serial_control,
+                ARTICLE_RANK_PARALLEL_CROSSOVER_EDGES - 1,
+                64
+            ),
+            ArticleRankExecutionPath::Serial
+        );
+        let one = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(1),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(Arc::new(crate::ComputePool::new(1).unwrap()));
+        assert_eq!(
+            select_article_rank_path(&one, ARTICLE_RANK_PARALLEL_CROSSOVER_EDGES, 64),
+            ArticleRankExecutionPath::Serial
+        );
+        let parallel = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(4),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(Arc::new(crate::ComputePool::new(4).unwrap()));
+        assert_eq!(
+            select_article_rank_path(&parallel, ARTICLE_RANK_PARALLEL_CROSSOVER_EDGES, 64),
+            ArticleRankExecutionPath::Parallel {
+                threads: 4,
+                chunks: 4
+            }
+        );
+    }
+
+    #[test]
+    fn article_rank_thread_matrix_matches_one_thread_bits_and_ordering() {
+        let graph = dense_article_rank_graph(128);
+        assert!(graph.edge_entry_count() >= ARTICLE_RANK_PARALLEL_CROSSOVER_EDGES);
+        let serial =
+            execute_article_rank_with_pool(&graph, 1, AlgorithmCancellation::default()).unwrap();
+        let serial_bits = article_rank_bits(&serial);
+        let serial_rows = serial.rows();
+        for threads in [2_usize, 4, 8] {
+            let parallel =
+                execute_article_rank_with_pool(&graph, threads, AlgorithmCancellation::default())
+                    .unwrap();
+            assert_eq!(parallel.schema, serial.schema);
+            assert_eq!(parallel.rows(), serial_rows);
+            assert_eq!(article_rank_bits(&parallel), serial_bits);
+        }
+    }
+
+    #[test]
+    fn article_rank_parallel_preserves_multigraph_direction_and_disconnected_bits() {
+        let multigraph = AdjacencyGraph::with_test_edges(3, &[(0, 1), (0, 1), (0, 2), (1, 1)]);
+        let directed = AdjacencyGraph::with_test_edges(2, &[(0, 1)]);
+        let undirected = AdjacencyGraph::with_test_edges(2, &[(0, 1), (1, 0)]);
+        let empty = AdjacencyGraph::default();
+        let single = AdjacencyGraph::with_test_edges(1, &[]);
+        let disconnected = AdjacencyGraph::with_test_edges(4, &[(0, 1), (1, 0), (2, 3), (3, 2)]);
+        for graph in [
+            &multigraph,
+            &directed,
+            &undirected,
+            &empty,
+            &single,
+            &disconnected,
+        ] {
+            let serial =
+                execute_article_rank_with_pool(graph, 1, AlgorithmCancellation::default()).unwrap();
+            for threads in [2_usize, 4, 8] {
+                let parallel = execute_article_rank_with_pool(
+                    graph,
+                    threads,
+                    AlgorithmCancellation::default(),
+                )
+                .unwrap();
+                assert_eq!(article_rank_bits(&parallel), article_rank_bits(&serial));
+                assert_eq!(parallel.rows(), serial.rows());
+            }
+        }
+
+        let nodes = 512_u64;
+        let mut edges = Vec::new();
+        for source in 0..nodes {
+            let degree = 8 + (source % 13) as usize;
+            for hop in 0..degree {
+                edges.push((source, (source + hop as u64) % nodes));
+            }
+        }
+        let adversarial = AdjacencyGraph::with_test_edges(nodes, &edges);
+        assert!(adversarial.edge_entry_count() >= ARTICLE_RANK_PARALLEL_CROSSOVER_EDGES);
+        let serial =
+            execute_article_rank_with_pool(&adversarial, 1, AlgorithmCancellation::default())
+                .unwrap();
+        for threads in [2_usize, 4, 8] {
+            let parallel = execute_article_rank_with_pool(
+                &adversarial,
+                threads,
+                AlgorithmCancellation::default(),
+            )
+            .unwrap();
+            assert_eq!(article_rank_bits(&parallel), article_rank_bits(&serial));
+        }
+    }
+
+    #[test]
+    #[ignore = "manual crossover measurement; run with --ignored --nocapture"]
+    fn measure_article_rank_parallel_crossover() {
+        use std::time::Instant;
+
+        for &(nodes, fanout) in &[
+            (64usize, 16usize),
+            (64, 32),
+            (128, 32),
+            (128, 64),
+            (256, 64),
+            (512, 64),
+        ] {
+            let edges = (0..nodes)
+                .flat_map(|node| {
+                    (0..fanout).map(move |hop| (node as u64, ((node + hop) % nodes) as u64))
+                })
+                .collect::<Vec<_>>();
+            let graph = AdjacencyGraph::with_test_edges(nodes as u64, &edges);
+            let edge_count = graph.edge_entry_count();
+            let serial =
+                execute_article_rank_with_pool(&graph, 1, AlgorithmCancellation::default())
+                    .unwrap();
+            let expected = article_rank_fingerprint(&serial);
+            // Warm once so timings emphasize the kernel path over first-use setup.
+            let parallel =
+                execute_article_rank_with_pool(&graph, 4, AlgorithmCancellation::default())
+                    .unwrap();
+            assert_eq!(article_rank_fingerprint(&parallel), expected);
+
+            let mut serial_ns = u128::MAX;
+            let mut parallel_ns = u128::MAX;
+            for _ in 0..5 {
+                let t0 = Instant::now();
+                let serial =
+                    execute_article_rank_with_pool(&graph, 1, AlgorithmCancellation::default())
+                        .unwrap();
+                serial_ns = serial_ns.min(t0.elapsed().as_nanos());
+
+                let t1 = Instant::now();
+                let parallel =
+                    execute_article_rank_with_pool(&graph, 4, AlgorithmCancellation::default())
+                        .unwrap();
+                parallel_ns = parallel_ns.min(t1.elapsed().as_nanos());
+                assert_eq!(article_rank_fingerprint(&serial), expected);
+                assert_eq!(article_rank_fingerprint(&parallel), expected);
+            }
+            eprintln!(
+                "article_rank nodes={nodes} fanout={fanout} edges={edge_count} serial_ns={serial_ns} parallel_ns={parallel_ns} ratio={} fingerprint={expected}",
+                parallel_ns as f64 / serial_ns as f64
+            );
+        }
+    }
+
+    #[test]
+    fn article_rank_parallel_cancellation_and_worker_panic_are_structured() {
+        let graph = dense_article_rank_graph(128);
+        let cancellation = AlgorithmCancellation::default();
+        cancellation.cancel();
+        assert_eq!(
+            execute_article_rank_with_pool(&graph, 4, cancellation),
+            Err(AlgorithmError::Cancelled)
+        );
+
+        let pool = crate::ComputePool::new(2).unwrap();
+        assert_eq!(
+            run_article_rank_on_pool(&pool, || -> Result<(), AlgorithmError> {
+                panic!("synthetic ArticleRank worker panic")
+            }),
+            Err(execution("ArticleRank worker panicked"))
+        );
     }
 
     #[test]

--- a/crates/graphforge-exec/src/algorithm_rank.rs
+++ b/crates/graphforge-exec/src/algorithm_rank.rs
@@ -184,9 +184,9 @@ const ARTICLE_RANK_MAX_ITERATIONS: usize = 20;
 const ARTICLE_RANK_TOLERANCE: f64 = 1.0e-7;
 /// Selected adjacency entries below which ArticleRank stays on the serial path (#500).
 ///
-/// Release-mode shared-pool timings on the M4 agent host first clear a parallel
-/// win at 131k selected entries; smaller fixtures stay serial to avoid worker
-/// scheduling tax.
+/// Release-mode shared-pool timings on the M4 agent host first show a clear
+/// parallel win at 131k selected entries; smaller fixtures stay serial because
+/// their tiny deltas are within timing noise.
 pub const ARTICLE_RANK_PARALLEL_CROSSOVER_EDGES: u64 = 131_072;
 const ARTICLE_RANK_CHECKPOINT_DESTINATIONS: usize = 4_096;
 const HITS_ITERATIONS: usize = 20;

--- a/crates/graphforge-exec/src/algorithm_rank.rs
+++ b/crates/graphforge-exec/src/algorithm_rank.rs
@@ -4031,6 +4031,15 @@ mod tests {
         cancellation: AlgorithmCancellation,
     ) -> Result<AlgorithmOutput, AlgorithmError> {
         let pool = Arc::new(crate::ComputePool::new(threads).unwrap());
+        execute_article_rank_with_shared_pool(graph, pool, cancellation)
+    }
+
+    fn execute_article_rank_with_shared_pool(
+        graph: &AdjacencyGraph,
+        pool: Arc<crate::ComputePool>,
+        cancellation: AlgorithmCancellation,
+    ) -> Result<AlgorithmOutput, AlgorithmError> {
+        let threads = pool.num_threads();
         let mut registry = AlgorithmRegistry::default();
         register_rank_algorithms(&mut registry)?;
         let control = AlgorithmControl::new(
@@ -6255,6 +6264,8 @@ mod tests {
     fn measure_article_rank_parallel_crossover() {
         use std::time::Instant;
 
+        let serial_pool = Arc::new(crate::ComputePool::new(1).unwrap());
+        let parallel_pool = Arc::new(crate::ComputePool::new(4).unwrap());
         for &(nodes, fanout) in &[
             (64usize, 16usize),
             (64, 32),
@@ -6262,6 +6273,8 @@ mod tests {
             (128, 64),
             (256, 64),
             (512, 64),
+            (1024, 128),
+            (2048, 128),
         ] {
             let edges = (0..nodes)
                 .flat_map(|node| {
@@ -6270,29 +6283,41 @@ mod tests {
                 .collect::<Vec<_>>();
             let graph = AdjacencyGraph::with_test_edges(nodes as u64, &edges);
             let edge_count = graph.edge_entry_count();
-            let serial =
-                execute_article_rank_with_pool(&graph, 1, AlgorithmCancellation::default())
-                    .unwrap();
+            let serial = execute_article_rank_with_shared_pool(
+                &graph,
+                serial_pool.clone(),
+                AlgorithmCancellation::default(),
+            )
+            .unwrap();
             let expected = article_rank_fingerprint(&serial);
             // Warm once so timings emphasize the kernel path over first-use setup.
-            let parallel =
-                execute_article_rank_with_pool(&graph, 4, AlgorithmCancellation::default())
-                    .unwrap();
+            let parallel = execute_article_rank_with_shared_pool(
+                &graph,
+                parallel_pool.clone(),
+                AlgorithmCancellation::default(),
+            )
+            .unwrap();
             assert_eq!(article_rank_fingerprint(&parallel), expected);
 
             let mut serial_ns = u128::MAX;
             let mut parallel_ns = u128::MAX;
             for _ in 0..5 {
                 let t0 = Instant::now();
-                let serial =
-                    execute_article_rank_with_pool(&graph, 1, AlgorithmCancellation::default())
-                        .unwrap();
+                let serial = execute_article_rank_with_shared_pool(
+                    &graph,
+                    serial_pool.clone(),
+                    AlgorithmCancellation::default(),
+                )
+                .unwrap();
                 serial_ns = serial_ns.min(t0.elapsed().as_nanos());
 
                 let t1 = Instant::now();
-                let parallel =
-                    execute_article_rank_with_pool(&graph, 4, AlgorithmCancellation::default())
-                        .unwrap();
+                let parallel = execute_article_rank_with_shared_pool(
+                    &graph,
+                    parallel_pool.clone(),
+                    AlgorithmCancellation::default(),
+                )
+                .unwrap();
                 parallel_ns = parallel_ns.min(t1.elapsed().as_nanos());
                 assert_eq!(article_rank_fingerprint(&serial), expected);
                 assert_eq!(article_rank_fingerprint(&parallel), expected);

--- a/crates/graphforge-exec/src/algorithm_rank.rs
+++ b/crates/graphforge-exec/src/algorithm_rank.rs
@@ -6238,7 +6238,7 @@ mod tests {
         let nodes = 512_u64;
         let mut edges = Vec::new();
         for source in 0..nodes {
-            let degree = 8 + (source % 13) as usize;
+            let degree = 256 + (source % 13) as usize;
             for hop in 0..degree {
                 edges.push((source, (source + hop as u64) % nodes));
             }

--- a/crates/graphforge-exec/src/compute_pool.rs
+++ b/crates/graphforge-exec/src/compute_pool.rs
@@ -15,6 +15,12 @@
 //! common-neighbors source aggregates (#505), and sibling CPU kernels consume
 //! this private pool sized from [`crate`]-facing `compute_threads` on the
 //! embedded resource policy.
+//! Instance-owned bounded CPU pool for deterministic algorithm kernels (#337 / #342 / #343 / #344 / #500).
+//!
+//! GraphForge never installs work onto Rayon's process-global pool. Parallel
+//! cosine KNN (#342), PageRank (#343), Node2Vec walk generation (#344),
+//! ArticleRank (#500), and sibling CPU kernels consume this private pool sized
+//! from [`crate`]-facing `compute_threads` on the embedded resource policy.
 
 use std::sync::Arc;
 

--- a/docs/book/architecture/algorithms.md
+++ b/docs/book/architecture/algorithms.md
@@ -300,7 +300,7 @@ adapter's directed/undirected export contract.
 
 Destination message sums may run through the instance-owned private compute
 pool (#337 / #500) above the documented
-`ARTICLE_RANK_PARALLEL_CROSSOVER_EDGES` (`4_096`) threshold. Each worker owns a
+`ARTICLE_RANK_PARALLEL_CROSSOVER_EDGES` (`131_072`) threshold. Each worker owns a
 contiguous dense-ordinal destination range and applies inbound source messages
 in the same canonical source/edge order as the one-thread recurrence; damping,
 score accumulation, and convergence checks remain serial in dense node order, so

--- a/docs/book/architecture/algorithms.md
+++ b/docs/book/architecture/algorithms.md
@@ -298,6 +298,15 @@ before degree, average-degree, and score computation. Parallel adjacency entries
 contribute independently, and stored self-loops follow the shared adjacency
 adapter's directed/undirected export contract.
 
+Destination message sums may run through the instance-owned private compute
+pool (#337 / #500) above the documented
+`ARTICLE_RANK_PARALLEL_CROSSOVER_EDGES` (`4_096`) threshold. Each worker owns a
+contiguous dense-ordinal destination range and applies inbound source messages
+in the same canonical source/edge order as the one-thread recurrence; damping,
+score accumulation, and convergence checks remain serial in dense node order, so
+scores, iteration counts, schemas, row order, and fingerprints match the
+one-thread path.
+
 Disconnected components share only the graph-wide average-degree denominator.
 An edgeless non-empty selection scores every node `0.15`; a singleton does the
 same, and an empty selection returns the typed zero-row table. The public schema
@@ -308,7 +317,7 @@ score only after successful execution and is otherwise read-only.
 
 ArticleRank uses the shared hard caps of 10,000,000 selected nodes, 100,000,000
 selected adjacency entries, 10,000,000 output rows, and 10,000 cooperative
-iteration checkpoints, including edge-heavy checkpoints during propagation.
+iteration checkpoints, including checkpoints during propagation.
 Invalid selectors or unavailable catalog values, resource limits, cancellation,
 non-finite scores, and adjacency/storage/shaping/write-back failures remain
 structured Rust errors. Python and Node only translate arguments and Arrow IPC

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -303,7 +303,7 @@ pool when:
 
 - `compute_threads > 1`, and
 - selected adjacency entries are at least
-  `ARTICLE_RANK_PARALLEL_CROSSOVER_EDGES` (`4_096`) in `graphforge-exec`.
+  `ARTICLE_RANK_PARALLEL_CROSSOVER_EDGES` (`131_072`) in `graphforge-exec`.
 
 Below that crossover, or when the policy provides one compute thread, the serial
 destination-pull path runs with no pool scheduling tax. Parallel work is
@@ -363,6 +363,11 @@ order, scores, ties, and fingerprints match the one-thread result at
 the parallel path avoids small-fixture tax and clears the worker-pool cost once
 20 fixed HITS iterations amortize two sparse matrix-vector phases per
 iteration. It is CPU-only; no GPU or universal scaling claim is made.
+
+The threshold is the first measured win on the M4 agent host using the ignored
+release harness (`measure_article_rank_parallel_crossover`) with a shared
+four-worker private pool: 32k selected entries still carried scheduling overhead,
+while 131k and 262k selected entries were faster than the one-thread path.
 
 ## Parallel Node2Vec walk generation (#344)
 

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -366,8 +366,9 @@ iteration. It is CPU-only; no GPU or universal scaling claim is made.
 
 The threshold is the first measured win on the M4 agent host using the ignored
 release harness (`measure_article_rank_parallel_crossover`) with a shared
-four-worker private pool: 32k selected entries still carried scheduling overhead,
-while 131k and 262k selected entries were faster than the one-thread path.
+four-worker private pool: sizes through 32k selected entries stayed near parity
+within timing noise, while 131k and 262k selected entries were clear wins over
+the one-thread path.
 
 ## Parallel Node2Vec walk generation (#344)
 

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -175,6 +175,14 @@ contribution order with serial dangling/delta reductions, Node2Vec skip-gram
 training stays serial, and Adamic-Adar keeps serial candidate/intersection order
 per source, so fingerprints match the one-thread path.
 
+(#342), PageRank (#343), Node2Vec walk-corpus generation (#344), and ArticleRank
+(#500) may partition independent work across that pool above documented
+crossovers; work never uses Rayon's process-global pool. Cosine dot products
+retain serial coordinate order, PageRank keeps canonical contribution order with
+serial dangling/delta reductions, ArticleRank keeps canonical per-destination
+message order with serial score/delta updates, and Node2Vec skip-gram training
+stays serial, so fingerprints match the one-thread path.
+
 ## Parallel cosine KNN (#342)
 
 Exact, all-score, and filtered cosine partition **independent source rows**
@@ -287,6 +295,23 @@ Below that crossover, or when the policy provides one compute thread, the
 serial path runs with no pool scheduling tax. Workers emit `(uuid, score)` rows
 for contiguous ordinal ranges; the sink merges them in ascending node order so
 schemas, row order, scores, and fingerprints match the one-thread result at
+
+## Parallel ArticleRank (#500)
+
+ArticleRank destination message sums run on the instance-owned private compute
+pool when:
+
+- `compute_threads > 1`, and
+- selected adjacency entries are at least
+  `ARTICLE_RANK_PARALLEL_CROSSOVER_EDGES` (`4_096`) in `graphforge-exec`.
+
+Below that crossover, or when the policy provides one compute thread, the serial
+destination-pull path runs with no pool scheduling tax. Parallel work is
+destination-owned: each worker owns a contiguous dense-ordinal destination range
+and applies inbound messages in the same canonical source/edge order as the
+one-thread recurrence. Score accumulation, delta damping, and convergence
+checks remain serial in dense node order, so schemas, row order, scores,
+iteration counts, and fingerprints match the one-thread result at
 `1`/`2`/`4`/`8`/automatic configurations.
 ## Parallel eigenvector (#507)
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -300,8 +300,12 @@ are at most `1e-7` or after 20 rounds. Directed mode sends over outgoing selecte
 edges; undirected mode exports both endpoint directions. `via`, parallel edges,
 self-loops, dangling/disconnected/edgeless/empty behavior, stable UUID-only
 schema/order, shared Rust limits/cancellation/errors, and atomic opt-in
-write-back follow the documented architecture contract. Python and Node contain
-no separate ArticleRank implementation or fallback.
+write-back follow the documented architecture contract. Above
+`ARTICLE_RANK_PARALLEL_CROSSOVER_EDGES` (`4_096`) selected adjacency entries,
+ArticleRank may compute destination-owned message sums on the instance-owned
+private compute pool; inbound messages still apply in canonical source/edge
+order and serial score updates preserve one-thread fingerprints. Python and Node
+contain no separate ArticleRank implementation or fallback.
 
 Eigenvector centrality is unweighted and uses deterministic shifted power
 iteration over `Aᵀ + I`. Every selected node starts at `1 / N`; each iteration

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -301,7 +301,7 @@ edges; undirected mode exports both endpoint directions. `via`, parallel edges,
 self-loops, dangling/disconnected/edgeless/empty behavior, stable UUID-only
 schema/order, shared Rust limits/cancellation/errors, and atomic opt-in
 write-back follow the documented architecture contract. Above
-`ARTICLE_RANK_PARALLEL_CROSSOVER_EDGES` (`4_096`) selected adjacency entries,
+`ARTICLE_RANK_PARALLEL_CROSSOVER_EDGES` (`131_072`) selected adjacency entries,
 ArticleRank may compute destination-owned message sums on the instance-owned
 private compute pool; inbound messages still apply in canonical source/edge
 order and serial score updates preserve one-thread fingerprints. Python and Node


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements #500: parallel ArticleRank destination-owned updates on the instance-owned `ComputePool` with measured crossover and bit-identical fingerprints.

Closes #500

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788949511&installation_model_id=20486&pr_number=603&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F603&signature=f97d397d16b001ed870f361284f96ea1564d3da9ce8f43db01481dc1bd63ea43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parallelize ArticleRank execution on the instance-owned compute pool
> - Adds a destination-owned pull accumulation path for ArticleRank using a prebuilt inbound CSR, replacing the previous push-based source iteration.
> - Selects the parallel path when `compute_threads > 1`, a compute pool is present, and the graph has ≥131,072 edges; otherwise falls back to serial.
> - Serial path checkpoints every 4,096 destinations (previously every 1,024 edges); parallel path uses a shared `AtomicUsize` for periodic cancellation checks.
> - Worker panics in the parallel path are caught via `catch_unwind` and surfaced as a structured `AlgorithmError` with a stable message.
> - Behavioral Change: serial cancellation checkpoint cadence changes from edge-count-based (1,024 edges) to destination-count-based (4,096 destinations).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b399e4a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->