### PR TITLE
perf(exec): serial disposition for Tarjan SCC (#532)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_cluster_scc.rs
+++ b/crates/graphforge-exec/src/algorithm_cluster_scc.rs
@@ -20,35 +20,23 @@ pub(crate) fn strongly_connected_labels(
     control: &AlgorithmControl,
 ) -> Result<Vec<usize>, AlgorithmError> {
     control.check_cancelled()?;
-    let node_count = graph.node_ids().len();
-    let indices = graph
-        .node_ids()
+    let node_ids = graph.node_ids();
+    let node_count = node_ids.len();
+    let node_ordinals = node_ids
         .iter()
         .enumerate()
         .map(|(index, &node)| (node, index))
         .collect::<HashMap<_, _>>();
-    let mut adjacency = vec![Vec::new(); node_count];
-    let mut work = 0_usize;
-    for (source, &node) in graph.node_ids().iter().enumerate() {
-        for edge in graph.neighbors(node) {
-            checkpoint(control, &mut work)?;
-            adjacency[source].push(
-                indices
-                    .get(&edge.neighbor_id)
-                    .copied()
-                    .ok_or_else(|| execution("adjacency references an unselected node"))?,
-            );
-        }
-    }
 
     let mut discovery = vec![None; node_count];
     let mut lowlink = vec![0_usize; node_count];
     let mut on_stack = vec![false; node_count];
-    let mut component_stack = Vec::new();
-    let mut frames = Vec::new();
+    let mut component_stack = Vec::with_capacity(node_count);
+    let mut frames = Vec::with_capacity(node_count);
     let mut raw_labels = vec![usize::MAX; node_count];
     let mut next_discovery = 0_usize;
     let mut component_count = 0_usize;
+    let mut work = 0_usize;
 
     for root in 0..node_count {
         if discovery[root].is_some() {
@@ -68,8 +56,12 @@ pub(crate) fn strongly_connected_labels(
         while let Some(frame) = frames.last_mut() {
             checkpoint(control, &mut work)?;
             let node = frame.node;
-            if let Some(&neighbor) = adjacency[node].get(frame.next_neighbor) {
+            if let Some(edge) = graph.neighbors(node_ids[node]).get(frame.next_neighbor) {
                 frame.next_neighbor += 1;
+                let neighbor = node_ordinals
+                    .get(&edge.neighbor_id)
+                    .copied()
+                    .ok_or_else(|| execution("adjacency references an unselected node"))?;
                 if discovery[neighbor].is_none() {
                     discover(
                         neighbor,

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -856,6 +856,37 @@ records `paths-min-cost-max-flow` structural evidence and verifies parity
 against the one-thread oracle for supported resource-policy cells. Timing is
 hardware-specific evidence only.
 
+## Serial strongly connected components (#532)
+
+`cluster(by = "strongly_connected")` intentionally stays serial. The public
+algorithm is exact Tarjan SCC: discovery indices, low-link propagation,
+component-stack membership, component emission, and the final canonical label
+order all depend on one DFS traversal order. Forcing private-pool work into
+that state would require either shared mutable low-link/stack coordination or a
+different component algorithm, both of which would risk changing public row
+order, labels, fingerprints, cancellation points, and structured failure
+boundaries.
+
+The serial path still consumes #340 CSR-native adjacency: Tarjan walks
+`AdjacencyGraph::neighbors` slices directly in canonical edge order and keeps
+only the O(V) ordinal map plus Tarjan state (`discovery`, `lowlink`, stack
+flags, labels, and explicit DFS frames). It does not build a parallel-only graph
+copy and does not use Rayon's process-global pool. Checkpoints remain on the
+DFS edge/frame path so cancellation and limits return structured outcomes
+without partial public results.
+
+Evidence is carried by:
+
+- `graphforge-exec::algorithm_cluster_scc` unit coverage for exact labels,
+  duplicate/self-loop handling, exhaustive three-node digraph parity with
+  mutual reachability, deep iterative DFS, malformed adjacency errors, and
+  cancellation.
+- `graphforge-exec::algorithm_cluster` dispatch coverage for the public schema,
+  stable UUID-ordered output, one Rust owner, node/edge/output/iteration limits,
+  and cancellation.
+
+
+There is no crossover for SCC in M4: the documented disposition is `serial_tarjan`. Timing remains hardware-specific evidence, never a CI pass/fail gate.
 ## Observability
 
 `GraphForge::resource_policy()` and `GraphForge::resource_diagnostics()` expose
@@ -902,7 +933,5 @@ counts.
 | `spill` | disabled | Optional absolute spill directory + byte cap |
 | `io_concurrency` | `2` | Reserved I/O concurrency budget |
 | `max_concurrent_heavy_queries` | `64` | Instance-owned admission semaphore |
-| `compute_threads` | `2` | Instance-owned private CPU pool (#342 cosine KNN; #343 PageRank; #344 Node2Vec walks; #535 Jaccard similarity; #504 clustering coefficient; #515 triangles; #506 Degree; #501 betweenness; #518 Components; #503 closeness BFS) |
-| `compute_threads` | `2` | Instance-owned private CPU pool (#342 cosine KNN; #343 PageRank; #344 Node2Vec walks; #507 eigenvector) |
 
 ## Parallel closeness BFS (#503)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements #532: honest serial disposition for Tarjan `cluster(by="strongly_connected")` — DFS low-link order forbids safe parallel reduction. CSR-native neighbor walk polish + evidence/docs; no forced parallelism.

Closes #532

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788949511&installation_model_id=20486&pr_number=604&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F604&signature=e76a7b9c564e03769f2ce343dd7ad68ac9217edb3b2eb357fc7060e322a490df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Optimize SCC clustering in `strongly_connected_labels` with serial Tarjan traversal
> - Removes the explicit adjacency list prebuild phase; the DFS now walks `AdjacencyGraph::neighbors` directly and maps each neighbor to its ordinal on the fly using `node_ordinals`.
> - Pre-allocates `component_stack` and `frames` with `Vec::with_capacity(node_count)` to reduce allocations.
> - The 'unselected node' error is now raised during traversal rather than during a separate prebuild step, and cancellation checkpoints no longer occur in the prebuild phase.
> - Documents the serial Tarjan approach in [execution-resource-policy.md](https://github.com/CurateLabs/graphforge/pull/604/files#diff-978cd3c64399512fe02ce13768a045b47b2b98e5e672d553ee1bb69be7843971), noting it avoids building a parallel-only graph copy and global pools.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8dbcedf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved strongly connected component analysis for faster, more memory-efficient graph processing.
  * Preserved clear error handling when graphs contain unselected nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->