### PR TITLE
perf(exec): parallelize HITS authority on ComputePool (#509)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_rank.rs
+++ b/crates/graphforge-exec/src/algorithm_rank.rs
@@ -7,6 +7,9 @@
 //! PageRank (#343) and eigenvector (#507) may partition destination-owned score
 //! updates across the instance-owned private compute pool while preserving the
 //! serial contribution order, serial convergence reductions, and bit-identical
+//! PageRank (#343) and HITS hub (#510) may partition destination-owned score
+//! updates across the instance-owned private compute pool while preserving the
+//! serial contribution order, deterministic reductions, and bit-identical
 //! fingerprints.
 
 use std::collections::{HashMap, VecDeque};
@@ -133,6 +136,13 @@ const ARTICLE_RANK_ALPHA: f64 = 1.0 - ARTICLE_RANK_DAMPING;
 const ARTICLE_RANK_MAX_ITERATIONS: usize = 20;
 const ARTICLE_RANK_TOLERANCE: f64 = 1.0e-7;
 const HITS_ITERATIONS: usize = 20;
+/// Selected adjacency entries below which HITS stays on the serial path (#510).
+///
+/// HITS performs two full sparse matrix-vector phases per fixed iteration, so
+/// this keeps small invocations off the worker pool while large embedded
+/// workloads can partition independent dense-ordinal node updates.
+pub const HITS_PARALLEL_CROSSOVER_EDGES: u64 = 4_096;
+const HITS_CHECKPOINT_EDGES: usize = 4_096;
 const CELF_SIMULATIONS: u32 = 100;
 const CELF_LIVE_EDGE_THRESHOLD: u64 = u64::MAX / 10;
 
@@ -2477,6 +2487,26 @@ fn splitmix64(value: u64) -> u64 {
     mixed ^ (mixed >> 31)
 }
 
+#[derive(Clone, Debug, Default)]
+struct HitsCsr {
+    offsets: Vec<u32>,
+    neighbors: Vec<u32>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct PreparedHits {
+    outgoing: HitsCsr,
+    incoming: HitsCsr,
+    edge_count: u64,
+}
+
+/// Selected HITS execution path for observability and crossover tests (#510).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum HitsExecutionPath {
+    Serial,
+    Parallel { threads: usize, chunks: usize },
+}
+
 fn hits_scores(
     graph: &AdjacencyGraph,
     control: &AlgorithmControl,
@@ -2486,40 +2516,144 @@ fn hits_scores(
         return Ok((Vec::new(), Vec::new()));
     }
 
+    let prepared = prepare_hits(graph, control)?;
+    let path = select_hits_path(control, prepared.edge_count, node_ids.len());
+    let mut authorities = vec![1.0; node_ids.len()];
+    let mut hubs = vec![1.0; node_ids.len()];
+    for _ in 0..HITS_ITERATIONS {
+        control.checkpoint()?;
+        match path {
+            HitsExecutionPath::Serial => {
+                hits_pull_serial(&prepared.incoming, &hubs, &mut authorities, control)?;
+            }
+            HitsExecutionPath::Parallel { .. } => {
+                hits_pull_parallel(&prepared.incoming, &hubs, &mut authorities, control)?;
+            }
+        }
+        normalize_hits(&mut authorities, "authority")?;
+
+        control.checkpoint()?;
+        let mut next_hubs = vec![0.0; node_ids.len()];
+        match path {
+            HitsExecutionPath::Serial => {
+                hits_pull_serial(&prepared.outgoing, &authorities, &mut next_hubs, control)?;
+            }
+            HitsExecutionPath::Parallel { .. } => {
+                hits_pull_parallel(&prepared.outgoing, &authorities, &mut next_hubs, control)?;
+            }
+        }
+        normalize_hits(&mut next_hubs, "hub")?;
+        hubs = next_hubs;
+    }
+    Ok((authorities, hubs))
+}
+
+fn prepare_hits(
+    graph: &AdjacencyGraph,
+    control: &AlgorithmControl,
+) -> Result<PreparedHits, AlgorithmError> {
+    let node_ids = graph.node_ids();
     let indices: HashMap<u64, usize> = node_ids
         .iter()
         .enumerate()
         .map(|(index, &node)| (node, index))
         .collect();
-    let mut authorities = vec![1.0; node_ids.len()];
-    let mut hubs = vec![1.0; node_ids.len()];
-    for _ in 0..HITS_ITERATIONS {
-        control.checkpoint()?;
-        authorities.fill(0.0);
-        accumulate_hits_phase(
-            graph,
-            node_ids,
-            control,
-            |source, _| hubs[source],
-            |_, target, value| authorities[target] += value,
-            &indices,
-        )?;
-        normalize_hits(&mut authorities, "authority")?;
-
-        control.checkpoint()?;
-        let mut next_hubs = vec![0.0; node_ids.len()];
-        accumulate_hits_phase(
-            graph,
-            node_ids,
-            control,
-            |_, target| authorities[target],
-            |source, _, value| next_hubs[source] += value,
-            &indices,
-        )?;
-        normalize_hits(&mut next_hubs, "hub")?;
-        hubs = next_hubs;
+    let mut outgoing_offsets = Vec::with_capacity(node_ids.len() + 1);
+    let mut outgoing_neighbors = Vec::with_capacity(
+        usize::try_from(graph.edge_entry_count())
+            .map_err(|_| execution("HITS edge count exceeds supported range"))?,
+    );
+    let mut incoming_counts = vec![0_u32; node_ids.len()];
+    let mut edge_count = 0_u64;
+    outgoing_offsets.push(0_u32);
+    for &node in node_ids {
+        for edge in graph.neighbors(node) {
+            if edge_count > 0 && edge_count.is_multiple_of(1024) {
+                control.checkpoint()?;
+            }
+            let target = indices
+                .get(&edge.neighbor_id)
+                .copied()
+                .ok_or_else(|| execution("adjacency references an unselected node"))?;
+            incoming_counts[target] = incoming_counts[target]
+                .checked_add(1)
+                .ok_or_else(|| execution("HITS inbound degree exceeds supported range"))?;
+            outgoing_neighbors.push(exact_u32(target, "HITS target ordinal")?);
+            edge_count = edge_count
+                .checked_add(1)
+                .ok_or_else(|| execution("HITS edge count exceeds supported range"))?;
+        }
+        outgoing_offsets.push(exact_u32(
+            outgoing_neighbors.len(),
+            "HITS outgoing CSR length",
+        )?);
     }
-    Ok((authorities, hubs))
+
+    let mut incoming_offsets = Vec::with_capacity(node_ids.len() + 1);
+    incoming_offsets.push(0_u32);
+    for &count in &incoming_counts {
+        let next = incoming_offsets
+            .last()
+            .copied()
+            .unwrap_or(0)
+            .checked_add(count)
+            .ok_or_else(|| execution("HITS incoming CSR offsets exceed supported range"))?;
+        incoming_offsets.push(next);
+    }
+    let mut incoming_neighbors = vec![0_u32; outgoing_neighbors.len()];
+    let mut write_at = incoming_offsets[..node_ids.len()].to_vec();
+    for source in 0..node_ids.len() {
+        let source_u32 = exact_u32(source, "HITS source ordinal")?;
+        let start = usize::try_from(outgoing_offsets[source])
+            .map_err(|_| execution("HITS outgoing offset exceeds supported range"))?;
+        let end = usize::try_from(outgoing_offsets[source + 1])
+            .map_err(|_| execution("HITS outgoing offset exceeds supported range"))?;
+        for &target in &outgoing_neighbors[start..end] {
+            let target = usize::try_from(target)
+                .map_err(|_| execution("HITS target ordinal exceeds supported range"))?;
+            let slot = usize::try_from(write_at[target])
+                .map_err(|_| execution("HITS incoming write cursor exceeds supported range"))?;
+            incoming_neighbors[slot] = source_u32;
+            write_at[target] = write_at[target]
+                .checked_add(1)
+                .ok_or_else(|| execution("HITS incoming write cursor overflow"))?;
+        }
+    }
+
+    Ok(PreparedHits {
+        outgoing: HitsCsr {
+            offsets: outgoing_offsets,
+            neighbors: outgoing_neighbors,
+        },
+        incoming: HitsCsr {
+            offsets: incoming_offsets,
+            neighbors: incoming_neighbors,
+        },
+        edge_count,
+    })
+}
+
+/// Choose serial vs private-pool parallel execution for a HITS workload.
+pub(crate) fn select_hits_path(
+    control: &AlgorithmControl,
+    edge_count: u64,
+    nodes: usize,
+) -> HitsExecutionPath {
+    let threads = control.compute_threads();
+    if threads <= 1
+        || nodes <= 1
+        || edge_count < HITS_PARALLEL_CROSSOVER_EDGES
+        || control
+            .compute_pool()
+            .is_none_or(|pool| !pool.is_parallel())
+    {
+        return HitsExecutionPath::Serial;
+    }
+    let chunks = destination_chunks(nodes, threads).len();
+    if chunks <= 1 {
+        return HitsExecutionPath::Serial;
+    }
+    HitsExecutionPath::Parallel { threads, chunks }
 }
 
 fn rank_scores_output(
@@ -2538,29 +2672,89 @@ fn rank_scores_output(
     sink.finish()
 }
 
-fn accumulate_hits_phase(
-    graph: &AdjacencyGraph,
-    node_ids: &[u64],
+fn hits_pull_serial(
+    csr: &HitsCsr,
+    input: &[f64],
+    output: &mut [f64],
     control: &AlgorithmControl,
-    value: impl Fn(usize, usize) -> f64,
-    mut add: impl FnMut(usize, usize, f64),
-    indices: &HashMap<u64, usize>,
 ) -> Result<(), AlgorithmError> {
     let mut traversed_edges = 0_usize;
-    for (source, &node) in node_ids.iter().enumerate() {
-        for edge in graph.neighbors(node) {
+    for (node, score) in output.iter_mut().enumerate() {
+        *score = 0.0;
+        let start = usize::try_from(csr.offsets[node])
+            .map_err(|_| execution("HITS CSR offset exceeds supported range"))?;
+        let end = usize::try_from(csr.offsets[node + 1])
+            .map_err(|_| execution("HITS CSR offset exceeds supported range"))?;
+        for &neighbor in &csr.neighbors[start..end] {
             if traversed_edges > 0 && traversed_edges.is_multiple_of(1024) {
                 control.checkpoint()?;
             }
             traversed_edges += 1;
-            let target = indices
-                .get(&edge.neighbor_id)
-                .copied()
-                .ok_or_else(|| execution("adjacency references an unselected node"))?;
-            add(source, target, value(source, target));
+            let neighbor = usize::try_from(neighbor)
+                .map_err(|_| execution("HITS neighbor ordinal exceeds supported range"))?;
+            *score += input[neighbor];
         }
     }
     Ok(())
+}
+
+fn hits_pull_parallel(
+    csr: &HitsCsr,
+    input: &[f64],
+    output: &mut [f64],
+    control: &AlgorithmControl,
+) -> Result<(), AlgorithmError> {
+    let pool = control
+        .compute_pool()
+        .ok_or_else(|| execution("parallel HITS requires an instance-owned compute pool"))?;
+    let ranges = destination_chunks(output.len(), control.compute_threads());
+    let chunk_results = run_hits_on_pool(pool, || {
+        ranges
+            .par_iter()
+            .map(|&(start, end)| {
+                control.check_cancelled()?;
+                let mut local = Vec::with_capacity(end - start);
+                let mut traversed_edges = 0_usize;
+                for node in start..end {
+                    let edge_start = usize::try_from(csr.offsets[node])
+                        .map_err(|_| execution("HITS CSR offset exceeds supported range"))?;
+                    let edge_end = usize::try_from(csr.offsets[node + 1])
+                        .map_err(|_| execution("HITS CSR offset exceeds supported range"))?;
+                    let mut score = 0.0;
+                    for &neighbor in &csr.neighbors[edge_start..edge_end] {
+                        traversed_edges = traversed_edges.saturating_add(1);
+                        if traversed_edges.is_multiple_of(HITS_CHECKPOINT_EDGES) {
+                            control.check_cancelled()?;
+                        }
+                        let neighbor = usize::try_from(neighbor).map_err(|_| {
+                            execution("HITS neighbor ordinal exceeds supported range")
+                        })?;
+                        score += input[neighbor];
+                    }
+                    local.push(score);
+                }
+                Ok((start, local))
+            })
+            .collect::<Result<Vec<_>, AlgorithmError>>()
+    })?;
+    // Merge chunk outputs in ascending dense-ordinal range order (canonical).
+    for (start, local) in chunk_results {
+        output[start..start + local.len()].copy_from_slice(&local);
+    }
+    Ok(())
+}
+
+fn run_hits_on_pool<R>(
+    pool: &crate::ComputePool,
+    op: impl FnOnce() -> Result<R, AlgorithmError> + Send,
+) -> Result<R, AlgorithmError>
+where
+    R: Send,
+{
+    match catch_unwind(AssertUnwindSafe(|| pool.install(op))) {
+        Ok(result) => result,
+        Err(_) => Err(execution("HITS worker panicked")),
+    }
 }
 
 fn normalize_hits(scores: &mut [f64], kind: &str) -> Result<(), AlgorithmError> {
@@ -3108,6 +3302,22 @@ mod tests {
         )
     }
 
+    fn execute_hits_hub_with_pool(
+        graph: &AdjacencyGraph,
+        threads: usize,
+        cancellation: AlgorithmCancellation,
+    ) -> Result<AlgorithmOutput, AlgorithmError> {
+        let pool = Arc::new(crate::ComputePool::new(threads).unwrap());
+        let mut registry = AlgorithmRegistry::default();
+        register_rank_algorithms(&mut registry)?;
+        let control = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(threads),
+            cancellation,
+        )
+        .with_compute_pool(pool);
+        registry.execute(Algorithm::Rank(RankAlgorithm::HitsHub), graph, &control)
+    }
+
     fn hits_hub_scores(output: &AlgorithmOutput) -> Vec<f64> {
         output
             .rows()
@@ -3117,6 +3327,26 @@ mod tests {
                 _ => panic!("HITS hub score must be Float64"),
             })
             .collect()
+    }
+
+    fn hits_hub_bits(output: &AlgorithmOutput) -> Vec<u64> {
+        hits_hub_scores(output)
+            .into_iter()
+            .map(f64::to_bits)
+            .collect()
+    }
+
+    fn dense_hits_graph(nodes: usize) -> AdjacencyGraph {
+        let fanout = ((HITS_PARALLEL_CROSSOVER_EDGES as usize) / nodes.max(1)).saturating_add(3);
+        let edges = (0..nodes)
+            .flat_map(|source| {
+                (0..fanout).map(move |hop| {
+                    let target = (source + hop + usize::from(hop % 3 == 0)) % nodes;
+                    (source as u64, target as u64)
+                })
+            })
+            .collect::<Vec<_>>();
+        AdjacencyGraph::with_test_edges(nodes as u64, &edges)
     }
 
     fn execute_hits_authority(
@@ -5006,6 +5236,103 @@ mod tests {
             .find(|capability| capability.algorithm == Algorithm::Rank(RankAlgorithm::HitsHub))
             .unwrap();
         assert_eq!(capability.dependency, BUILTIN_REVIEW);
+    }
+
+    #[test]
+    fn hits_hub_path_selection_respects_crossover_and_one_thread() {
+        let serial_control = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(4),
+            AlgorithmCancellation::default(),
+        );
+        assert_eq!(
+            select_hits_path(&serial_control, HITS_PARALLEL_CROSSOVER_EDGES - 1, 64),
+            HitsExecutionPath::Serial
+        );
+        let one = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(1),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(Arc::new(crate::ComputePool::new(1).unwrap()));
+        assert_eq!(
+            select_hits_path(&one, HITS_PARALLEL_CROSSOVER_EDGES, 64),
+            HitsExecutionPath::Serial
+        );
+        let parallel = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(4),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(Arc::new(crate::ComputePool::new(4).unwrap()));
+        assert_eq!(
+            select_hits_path(&parallel, HITS_PARALLEL_CROSSOVER_EDGES, 64),
+            HitsExecutionPath::Parallel {
+                threads: 4,
+                chunks: 4
+            }
+        );
+    }
+
+    #[test]
+    fn hits_hub_thread_matrix_matches_one_thread_bits_and_ordering() {
+        let graph = dense_hits_graph(128);
+        assert!(graph.edge_entry_count() >= HITS_PARALLEL_CROSSOVER_EDGES);
+        let serial =
+            execute_hits_hub_with_pool(&graph, 1, AlgorithmCancellation::default()).unwrap();
+        let serial_bits = hits_hub_bits(&serial);
+        let serial_rows = serial.rows();
+        for threads in [2_usize, 4, 8] {
+            let parallel =
+                execute_hits_hub_with_pool(&graph, threads, AlgorithmCancellation::default())
+                    .unwrap();
+            assert_eq!(parallel.schema, serial.schema);
+            assert_eq!(parallel.rows(), serial_rows);
+            assert_eq!(hits_hub_bits(&parallel), serial_bits);
+        }
+    }
+
+    #[test]
+    fn hits_hub_parallel_preserves_multigraph_self_loop_and_disconnected_bits() {
+        let mut edges = Vec::new();
+        let nodes = 256_u64;
+        for source in 0..nodes {
+            edges.push((source, source));
+            edges.push((source, (source + 1) % nodes));
+            edges.push((source, (source + 1) % nodes));
+            for hop in 2..18 {
+                edges.push((source, (source + hop) % nodes));
+            }
+        }
+        let graph = AdjacencyGraph::with_test_edges(nodes, &edges);
+        assert!(graph.edge_entry_count() >= HITS_PARALLEL_CROSSOVER_EDGES);
+        let serial =
+            execute_hits_hub_with_pool(&graph, 1, AlgorithmCancellation::default()).unwrap();
+        for threads in [2_usize, 4, 8] {
+            let parallel =
+                execute_hits_hub_with_pool(&graph, threads, AlgorithmCancellation::default())
+                    .unwrap();
+            assert_eq!(hits_hub_bits(&parallel), hits_hub_bits(&serial));
+            assert_eq!(parallel.rows(), serial.rows());
+        }
+    }
+
+    #[test]
+    fn hits_hub_parallel_cancellation_and_worker_panic_are_structured() {
+        let graph = dense_hits_graph(128);
+        let cancellation = AlgorithmCancellation::default();
+        cancellation.cancel();
+        assert_eq!(
+            execute_hits_hub_with_pool(&graph, 4, cancellation),
+            Err(AlgorithmError::Cancelled)
+        );
+
+        let pool = crate::ComputePool::new(2).unwrap();
+        assert_eq!(
+            run_hits_on_pool(&pool, || -> Result<(), AlgorithmError> {
+                panic!("synthetic HITS worker panic");
+            }),
+            Err(AlgorithmError::Execution {
+                message: "HITS worker panicked".to_string()
+            })
+        );
     }
 
     #[test]

--- a/crates/graphforge-exec/src/algorithm_rank.rs
+++ b/crates/graphforge-exec/src/algorithm_rank.rs
@@ -11,6 +11,10 @@
 //! updates across the instance-owned private compute pool while preserving the
 //! serial contribution order, deterministic reductions, and bit-identical
 //! fingerprints.
+//! PageRank (#343), HITS hub (#510), and HITS authority (#509) may partition
+//! destination-owned score updates across the instance-owned private compute
+//! pool while preserving the serial contribution order, deterministic
+//! reductions, and bit-identical fingerprints.
 
 use std::collections::{HashMap, VecDeque};
 use std::panic::{AssertUnwindSafe, catch_unwind};
@@ -3363,6 +3367,26 @@ mod tests {
         )
     }
 
+    fn execute_hits_authority_with_pool(
+        graph: &AdjacencyGraph,
+        threads: usize,
+        cancellation: AlgorithmCancellation,
+    ) -> Result<AlgorithmOutput, AlgorithmError> {
+        let pool = Arc::new(crate::ComputePool::new(threads).unwrap());
+        let mut registry = AlgorithmRegistry::default();
+        register_rank_algorithms(&mut registry)?;
+        let control = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(threads),
+            cancellation,
+        )
+        .with_compute_pool(pool);
+        registry.execute(
+            Algorithm::Rank(RankAlgorithm::HitsAuthority),
+            graph,
+            &control,
+        )
+    }
+
     fn hits_authority_scores(output: &AlgorithmOutput) -> Vec<f64> {
         output
             .rows()
@@ -3371,6 +3395,13 @@ mod tests {
                 AlgorithmValue::Float64(score) => score,
                 _ => panic!("HITS authority score must be Float64"),
             })
+            .collect()
+    }
+
+    fn hits_authority_bits(output: &AlgorithmOutput) -> Vec<u64> {
+        hits_authority_scores(output)
+            .into_iter()
+            .map(f64::to_bits)
             .collect()
     }
 
@@ -5448,6 +5479,80 @@ mod tests {
             })
             .unwrap();
         assert_eq!(capability.dependency, BUILTIN_REVIEW);
+    }
+
+    #[test]
+    fn hits_authority_path_selection_reuses_shared_hits_crossover() {
+        let parallel = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(8),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(Arc::new(crate::ComputePool::new(8).unwrap()));
+        assert_eq!(
+            select_hits_path(&parallel, HITS_PARALLEL_CROSSOVER_EDGES, 128),
+            HitsExecutionPath::Parallel {
+                threads: 8,
+                chunks: 8
+            }
+        );
+        assert_eq!(
+            select_hits_path(&parallel, HITS_PARALLEL_CROSSOVER_EDGES - 1, 128),
+            HitsExecutionPath::Serial
+        );
+    }
+
+    #[test]
+    fn hits_authority_thread_matrix_matches_one_thread_bits_and_ordering() {
+        let graph = dense_hits_graph(128);
+        assert!(graph.edge_entry_count() >= HITS_PARALLEL_CROSSOVER_EDGES);
+        let serial =
+            execute_hits_authority_with_pool(&graph, 1, AlgorithmCancellation::default()).unwrap();
+        let serial_bits = hits_authority_bits(&serial);
+        let serial_rows = serial.rows();
+        for threads in [2_usize, 4, 8] {
+            let parallel =
+                execute_hits_authority_with_pool(&graph, threads, AlgorithmCancellation::default())
+                    .unwrap();
+            assert_eq!(parallel.schema, serial.schema);
+            assert_eq!(parallel.rows(), serial_rows);
+            assert_eq!(hits_authority_bits(&parallel), serial_bits);
+        }
+    }
+
+    #[test]
+    fn hits_authority_parallel_preserves_multigraph_self_loop_and_disconnected_bits() {
+        let mut edges = Vec::new();
+        let nodes = 256_u64;
+        for source in 0..nodes {
+            edges.push((source, source));
+            edges.push((source, (source + 1) % nodes));
+            edges.push((source, (source + 1) % nodes));
+            for hop in 2..18 {
+                edges.push((source, (source + hop) % nodes));
+            }
+        }
+        let graph = AdjacencyGraph::with_test_edges(nodes, &edges);
+        assert!(graph.edge_entry_count() >= HITS_PARALLEL_CROSSOVER_EDGES);
+        let serial =
+            execute_hits_authority_with_pool(&graph, 1, AlgorithmCancellation::default()).unwrap();
+        for threads in [2_usize, 4, 8] {
+            let parallel =
+                execute_hits_authority_with_pool(&graph, threads, AlgorithmCancellation::default())
+                    .unwrap();
+            assert_eq!(hits_authority_bits(&parallel), hits_authority_bits(&serial));
+            assert_eq!(parallel.rows(), serial.rows());
+        }
+    }
+
+    #[test]
+    fn hits_authority_parallel_cancellation_returns_structured_cancelled() {
+        let graph = dense_hits_graph(128);
+        let cancellation = AlgorithmCancellation::default();
+        cancellation.cancel();
+        assert_eq!(
+            execute_hits_authority_with_pool(&graph, 4, cancellation),
+            Err(AlgorithmError::Cancelled)
+        );
     }
 
     #[test]

--- a/docs/book/architecture/algorithms.md
+++ b/docs/book/architecture/algorithms.md
@@ -376,6 +376,15 @@ contract, disconnected components share global norms, isolated nodes score
 `0.0`, an edgeless selection is all zero, and a self-loop singleton scores
 `1.0`. Empty selections return the same typed zero-row table.
 
+For selected adjacency at or above `HITS_PARALLEL_CROSSOVER_EDGES` (`4_096`)
+and a multi-thread private compute policy, the authority handler uses the same
+shared HITS CSR kernel as `hits_hub`. Authority updates own contiguous target
+ranges over incoming CSR, each target sums predecessor hub scores serially in
+canonical source/edge order, and the global L2 norm remains a serial
+dense-ordinal reduction. Smaller workloads and one-thread policies retain the
+serial path. This is the documented CPU-only crossover for #509, with no GPU or
+universal scaling claim.
+
 The public schema, UUID-only identity and order, materialized properties,
 atomic opt-in `write_property`, shared node/edge/output/iteration limits,
 edge-heavy cancellation checkpoints, finite-score validation, and structured

--- a/docs/book/architecture/algorithms.md
+++ b/docs/book/architecture/algorithms.md
@@ -335,6 +335,14 @@ components share global norms; isolated nodes score `0.0`, an edgeless selection
 scores every node `0.0`, a self-loop singleton scores `1.0`, and an empty
 selection returns the typed zero-row table.
 
+For selected adjacency at or above `HITS_PARALLEL_CROSSOVER_EDGES` (`4_096`)
+and a multi-thread private compute policy, the hub handler uses the shared HITS
+CSR kernel to partition independent node updates over the instance-owned
+compute pool. Each node still sums its canonical CSR slice serially, and the
+global L2 norm remains a serial dense-ordinal reduction; smaller workloads and
+one-thread policies retain the serial path. This is the documented CPU-only
+crossover for #510, with no GPU or universal scaling claim.
+
 The public schema is non-null `node_uuid: FixedSizeBinary(16)`, non-null
 `score: Float64`, then materialized node properties with Arrow NULLs for missing
 values. Numeric execution surrogates never escape. `write_property` atomically

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -276,6 +276,29 @@ after the implicit identity term in the same canonical source/edge order as
 serial scatter. L2 normalization and component-wise convergence checks stay
 serial, so scores, iteration counts, and fingerprints match the one-thread
 result at `1`/`2`/`4`/`8`/automatic configurations.
+## Parallel HITS hub (#510)
+
+The shared `hits_scores` kernel used by `rank(by="hits_hub")` prepares selected
+adjacency once as dense-ordinal outgoing and incoming CSR, then partitions
+independent node-score updates across the instance-owned private compute pool
+when:
+
+- `compute_threads > 1`, and
+- selected adjacency entries are at least
+  `HITS_PARALLEL_CROSSOVER_EDGES` (`4_096`) in `graphforge-exec`.
+
+Below that crossover, or when the policy provides one compute thread, the
+serial path runs with no pool scheduling tax. Parallel work is node-owned: the
+authority phase owns contiguous target ranges over incoming CSR, and the hub
+phase owns contiguous source ranges over outgoing CSR. Each node's
+floating-point sum still walks its CSR slice in canonical source/edge order,
+and global L2 norms remain serial dense-ordinal reductions, so schemas, row
+order, scores, ties, and fingerprints match the one-thread result at
+`1`/`2`/`4`/`8`/automatic configurations. The crossover follows the same
+4 vCPU release-build structural benchmark regime used for adjacent M4 kernels:
+the parallel path avoids small-fixture tax and clears the worker-pool cost once
+20 fixed HITS iterations amortize two sparse matrix-vector phases per
+iteration. It is CPU-only; no GPU or universal scaling claim is made.
 
 ## Parallel Node2Vec walk generation (#344)
 

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -277,11 +277,12 @@ serial scatter. L2 normalization and component-wise convergence checks stay
 serial, so scores, iteration counts, and fingerprints match the one-thread
 result at `1`/`2`/`4`/`8`/automatic configurations.
 ## Parallel HITS hub (#510)
+## Parallel HITS hub / authority (#510 / #509)
 
 The shared `hits_scores` kernel used by `rank(by="hits_hub")` prepares selected
-adjacency once as dense-ordinal outgoing and incoming CSR, then partitions
-independent node-score updates across the instance-owned private compute pool
-when:
+and `rank(by="hits_authority")` prepares selected adjacency once as
+dense-ordinal outgoing and incoming CSR, then partitions independent node-score
+updates across the instance-owned private compute pool when:
 
 - `compute_threads > 1`, and
 - selected adjacency entries are at least


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements #509: parallel HITS authority scoring on the instance-owned `ComputePool` (shared hits kernel with authority-focused evidence), fingerprint parity preserved.

Closes #509

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788949511&installation_model_id=20486&pr_number=605&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F605&signature=f9b6bda7822641706acdfbcd58a189505e3f1e767c741af30410403db11b91d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parallelize HITS authority and hub score computation on a compute pool
> - Adds a parallel execution path for HITS hub and authority iterations in [`algorithm_rank.rs`](https://github.com/CurateLabs/graphforge/pull/605/files#diff-d42360b7ef75ce3112d55412fae040f54af2633f4b75d8609ca211a2702172b7), activated when `compute_threads > 1` and `edge_count >= HITS_PARALLEL_CROSSOVER_EDGES` (4,096).
> - Introduces CSR precomputation via `prepare_hits`, replacing the previous closure-based `accumulate_hits_phase` traversal; nodes are partitioned into contiguous ranges and processed concurrently on the compute pool.
> - Per-node sums and global L2 norms remain serial; parallel results are merged in dense-ordinal order and produce bit-identical scores to the single-thread path.
> - Worker panics are caught and surfaced as structured `AlgorithmError::Execution` via `run_hits_on_pool`; cancellation tokens are checked every 4,096 traversed edges within workers.
> - Risk: the serial path now operates over a precomputed CSR rather than the original `AdjacencyGraph` traversal, which changes internal memory layout and adds structured error conditions for count overflows and out-of-range adjacency references.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 003de24.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->