### PR TITLE
perf(exec): parallelize dijkstra_all_pairs on ComputePool (#542)

### DIFF
--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -5649,7 +5649,14 @@ mod tests {
             hasher.update(column.null_count().to_le_bytes());
             hasher.update(format!("{column:?}").as_bytes());
         }
-        format!("{:x}", hasher.finalize())
+        let digest: [u8; 32] = hasher.finalize().into();
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let mut out = String::with_capacity(64);
+        for byte in digest {
+            out.push(HEX[(byte >> 4) as usize] as char);
+            out.push(HEX[(byte & 0xf) as usize] as char);
+        }
+        out
     }
 
     fn add_person(graph: &GraphForge, name: &str) -> NodeHandle {

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -3630,7 +3630,6 @@ mod tests {
         Int64Array, ListArray, StringArray, StructArray, UInt64Array,
     };
     use arrow::datatypes::DataType;
-    use sha2::Digest as _;
     use std::collections::HashSet;
 
     #[test]

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -3630,6 +3630,7 @@ mod tests {
         Int64Array, ListArray, StringArray, StructArray, UInt64Array,
     };
     use arrow::datatypes::DataType;
+    use sha2::Digest as _;
     use std::collections::HashSet;
 
     #[test]
@@ -5632,6 +5633,24 @@ mod tests {
                 )
             })
             .collect()
+    }
+
+    fn arrow_batch_fingerprint(batch: &arrow::record_batch::RecordBatch) -> String {
+        let mut hasher = sha2::Sha256::new();
+        for field in batch.schema().fields() {
+            hasher.update(field.name().as_bytes());
+            hasher.update([0]);
+            hasher.update(format!("{:?}", field.data_type()).as_bytes());
+            hasher.update([0]);
+            hasher.update([u8::from(field.is_nullable())]);
+        }
+        hasher.update(batch.num_rows().to_le_bytes());
+        for column in batch.columns() {
+            hasher.update(column.len().to_le_bytes());
+            hasher.update(column.null_count().to_le_bytes());
+            hasher.update(format!("{column:?}").as_bytes());
+        }
+        format!("{:x}", hasher.finalize())
     }
 
     fn add_person(graph: &GraphForge, name: &str) -> NodeHandle {
@@ -13780,6 +13799,123 @@ mod tests {
             ),
             Err(GfError::Validation(message)) if message.contains("k must be 1")
         ));
+    }
+
+    #[test]
+    fn dijkstra_all_pairs_public_fingerprint_matches_thread_configs() {
+        const NODE_COUNT: usize = 48;
+        const OFFSETS: [usize; 4] = [1, 5, 17, 31];
+
+        fn policy(workers: usize) -> ExecutionResourcePolicy {
+            ExecutionResourcePolicy {
+                mode: ResourcePolicyMode::Explicit,
+                tokio_worker_threads: Some(workers),
+                target_partitions: Some(workers),
+                batch_size: Some(8_192),
+                memory_budget_bytes: Some(512 * 1024 * 1024),
+                spill: SpillPolicy::default(),
+                io_concurrency: Some(workers),
+                max_concurrent_heavy_queries: Some(1),
+                compute_threads: Some(workers),
+            }
+        }
+
+        fn automatic_policy() -> ExecutionResourcePolicy {
+            ExecutionResourcePolicy {
+                mode: ResourcePolicyMode::Automatic,
+                tokio_worker_threads: None,
+                target_partitions: None,
+                batch_size: None,
+                memory_budget_bytes: None,
+                spill: SpillPolicy::default(),
+                io_concurrency: None,
+                max_concurrent_heavy_queries: None,
+                compute_threads: None,
+            }
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let source_uuid = {
+            let graph = GraphForge::new(Some(dir.path().to_str().unwrap())).unwrap();
+            let nodes = (0..NODE_COUNT)
+                .map(|index| add_person(&graph, &format!("n{index}")))
+                .collect::<Vec<_>>();
+            let match_clause = (0..NODE_COUNT)
+                .map(|index| format!("(n{index}:Person {{name:'n{index}'}})"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let create_clause = (0..NODE_COUNT)
+                .flat_map(|source| {
+                    OFFSETS.into_iter().map(move |offset| {
+                        let target = (source + offset) % NODE_COUNT;
+                        let cost = 1.0 + ((source + target) % 7) as f64 / 10.0;
+                        format!("(n{source})-[:ROAD {{cost:{cost:.1}}}]->(n{target})")
+                    })
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            graph
+                .execute(&format!("MATCH {match_clause} CREATE {create_clause}"))
+                .unwrap();
+            nodes[0].uuid
+        };
+
+        let configs = [
+            ("threads-1", policy(1)),
+            ("threads-2", policy(2)),
+            ("threads-4", policy(4)),
+            ("threads-8", policy(8)),
+            ("threads-automatic", automatic_policy()),
+        ];
+        let mut baseline: Option<(Vec<(String, String, bool)>, usize, String)> = None;
+        let mut executed = 0_usize;
+        for (id, resource) in configs {
+            let graph = match GraphForge::new_with_options(
+                Some(dir.path().to_str().unwrap()),
+                GraphForgeOptions {
+                    resource,
+                    ..GraphForgeOptions::default()
+                },
+            ) {
+                Ok(graph) => graph,
+                Err(error) => {
+                    eprintln!("{id}: unavailable resource policy: {error}");
+                    continue;
+                }
+            };
+            let batch = graph
+                .paths(
+                    &NodeSelector::Uuid(source_uuid),
+                    None,
+                    dijkstra_all_pairs_options(true, Some("ROAD"), Some("cost")),
+                )
+                .unwrap_or_else(|error| panic!("{id}: {error}"));
+            let schema = batch
+                .schema()
+                .fields()
+                .iter()
+                .map(|field| {
+                    (
+                        field.name().clone(),
+                        format!("{:?}", field.data_type()),
+                        field.is_nullable(),
+                    )
+                })
+                .collect::<Vec<_>>();
+            let fingerprint = arrow_batch_fingerprint(&batch);
+            let observed = (schema, batch.num_rows(), fingerprint);
+            if let Some(expected) = &baseline {
+                assert_eq!(&observed, expected, "{id}: dijkstra_all_pairs parity");
+            } else {
+                assert_eq!(batch.num_rows(), NODE_COUNT * (NODE_COUNT - 1));
+                baseline = Some(observed);
+            }
+            executed += 1;
+        }
+        assert!(
+            executed >= 2,
+            "expected at least threads-1 and one multi-thread/automatic dijkstra_all_pairs cell"
+        );
     }
 
     #[test]

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -13902,6 +13902,7 @@ mod tests {
                 })
                 .collect::<Vec<_>>();
             let fingerprint = arrow_batch_fingerprint(&batch);
+            eprintln!("{id}: rows={} fingerprint={fingerprint}", batch.num_rows());
             let observed = (schema, batch.num_rows(), fingerprint);
             if let Some(expected) = &baseline {
                 assert_eq!(&observed, expected, "{id}: dijkstra_all_pairs parity");

--- a/crates/graphforge-exec/src/algorithm_paths_dijkstra.rs
+++ b/crates/graphforge-exec/src/algorithm_paths_dijkstra.rs
@@ -4,11 +4,28 @@
 
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+use rayon::prelude::*;
 
 use crate::algorithm_dispatch::{AlgorithmControl, AlgorithmError};
 use crate::algorithm_graph::AdjacencyGraph;
 
 const CHECKPOINT_INTERVAL: usize = 4_096;
+/// Estimated source-edge inspections below which APSP Dijkstra stays serial (#542).
+///
+/// The estimate is `selected_nodes * CSR adjacency entries`. The threshold keeps
+/// small fixtures away from worker scheduling overhead while letting independent
+/// source searches use the instance-owned private compute pool.
+pub const DIJKSTRA_APSP_PARALLEL_CROSSOVER_WORK: u64 = 8_192;
+
+/// Selected all-pairs Dijkstra execution path for crossover and parity tests.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DijkstraAllPairsExecutionPath {
+    Serial,
+    Parallel { threads: usize, chunks: usize },
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct DijkstraPath {
     pub source: u64,
@@ -76,19 +93,64 @@ pub(crate) fn exact_dijkstra_all_pairs(
     control: &AlgorithmControl,
 ) -> Result<Vec<DijkstraPath>, AlgorithmError> {
     control.checkpoint()?;
-    let mut paths = Vec::new();
     let mut work = 0_usize;
     validate_weights(graph, control, &mut work)?;
+    match select_dijkstra_all_pairs_path(control, graph) {
+        DijkstraAllPairsExecutionPath::Serial => {
+            exact_dijkstra_all_pairs_serial(graph, control, &mut work)
+        }
+        DijkstraAllPairsExecutionPath::Parallel { .. } => {
+            exact_dijkstra_all_pairs_parallel(graph, control)
+        }
+    }
+}
+
+fn exact_dijkstra_all_pairs_serial(
+    graph: &AdjacencyGraph,
+    control: &AlgorithmControl,
+    work: &mut usize,
+) -> Result<Vec<DijkstraPath>, AlgorithmError> {
+    let mut paths = Vec::new();
     for &source in graph.node_ids() {
         checkpoint(control, &mut work)?;
         let source_paths = dijkstra_from(graph, source, None, control, &mut work)?
             .into_iter()
             .filter(|path| path.target != source)
             .collect::<Vec<_>>();
-        control.check_output_rows(paths.len().saturating_add(source_paths.len()))?;
-        paths.extend(source_paths);
+        append_paths(&mut paths, source_paths, control)?;
     }
     Ok(paths)
+}
+
+fn exact_dijkstra_all_pairs_parallel(
+    graph: &AdjacencyGraph,
+    control: &AlgorithmControl,
+) -> Result<Vec<DijkstraPath>, AlgorithmError> {
+    let pool = control.compute_pool().ok_or_else(|| {
+        execution("parallel dijkstra_all_pairs requires an instance-owned compute pool")
+    })?;
+    let sources = graph.node_ids();
+    let ranges = source_chunks(sources.len(), control.compute_threads());
+    let chunk_results = run_on_pool(pool, || {
+        let results = ranges
+            .par_iter()
+            .map(|&(start, end)| {
+                let mut work = 0_usize;
+                let mut chunk_paths = Vec::new();
+                for &source in &sources[start..end] {
+                    checkpoint(control, &mut work)?;
+                    let source_paths = dijkstra_from(graph, source, None, control, &mut work)?
+                        .into_iter()
+                        .filter(|path| path.target != source)
+                        .collect::<Vec<_>>();
+                    chunk_paths.extend(source_paths);
+                }
+                Ok(chunk_paths)
+            })
+            .collect::<Vec<Result<_, AlgorithmError>>>();
+        first_chunk_result(results)
+    })?;
+    merge_chunks(chunk_results, control)
 }
 
 fn dijkstra_from(
@@ -169,6 +231,95 @@ fn dijkstra_from(
         .collect())
 }
 
+fn append_paths(
+    paths: &mut Vec<DijkstraPath>,
+    source_paths: Vec<DijkstraPath>,
+    control: &AlgorithmControl,
+) -> Result<(), AlgorithmError> {
+    control.check_cancelled()?;
+    control.check_output_rows(paths.len().saturating_add(source_paths.len()))?;
+    paths.extend(source_paths);
+    Ok(())
+}
+
+fn merge_chunks(
+    chunk_results: Vec<Vec<DijkstraPath>>,
+    control: &AlgorithmControl,
+) -> Result<Vec<DijkstraPath>, AlgorithmError> {
+    let mut paths = Vec::new();
+    for chunk in chunk_results {
+        append_paths(&mut paths, chunk, control)?;
+    }
+    Ok(paths)
+}
+
+fn first_chunk_result(
+    results: Vec<Result<Vec<DijkstraPath>, AlgorithmError>>,
+) -> Result<Vec<Vec<DijkstraPath>>, AlgorithmError> {
+    let mut chunks = Vec::with_capacity(results.len());
+    for result in results {
+        chunks.push(result?);
+    }
+    Ok(chunks)
+}
+
+fn run_on_pool<R>(
+    pool: &crate::ComputePool,
+    op: impl FnOnce() -> Result<R, AlgorithmError> + Send,
+) -> Result<R, AlgorithmError>
+where
+    R: Send,
+{
+    match catch_unwind(AssertUnwindSafe(|| pool.install(op))) {
+        Ok(result) => result,
+        Err(_) => Err(execution("dijkstra_all_pairs worker panicked")),
+    }
+}
+
+/// Choose serial vs private-pool parallel source execution for APSP Dijkstra.
+pub(crate) fn select_dijkstra_all_pairs_path(
+    control: &AlgorithmControl,
+    graph: &AdjacencyGraph,
+) -> DijkstraAllPairsExecutionPath {
+    let sources = graph.node_ids().len();
+    let threads = control.compute_threads();
+    let estimated_work = (sources as u64).saturating_mul(graph.edge_entry_count());
+    if threads <= 1 || sources <= 1 || estimated_work < DIJKSTRA_APSP_PARALLEL_CROSSOVER_WORK {
+        return DijkstraAllPairsExecutionPath::Serial;
+    }
+    if control
+        .compute_pool()
+        .is_none_or(|pool| !pool.is_parallel())
+    {
+        return DijkstraAllPairsExecutionPath::Serial;
+    }
+    let chunks = source_chunks(sources, threads).len();
+    if chunks <= 1 {
+        return DijkstraAllPairsExecutionPath::Serial;
+    }
+    DijkstraAllPairsExecutionPath::Parallel { threads, chunks }
+}
+
+fn source_chunks(sources: usize, threads: usize) -> Vec<(usize, usize)> {
+    if sources == 0 {
+        return Vec::new();
+    }
+    let workers = threads.clamp(1, sources);
+    let base = sources / workers;
+    let rem = sources % workers;
+    let mut ranges = Vec::with_capacity(workers);
+    let mut start = 0;
+    for index in 0..workers {
+        let len = base + usize::from(index < rem);
+        let end = start + len;
+        if start < end {
+            ranges.push((start, end));
+        }
+        start = end;
+    }
+    ranges
+}
+
 fn validate_weights(
     graph: &AdjacencyGraph,
     control: &AlgorithmControl,
@@ -205,9 +356,56 @@ fn execution(message: impl Into<String>) -> AlgorithmError {
 mod tests {
     use super::*;
     use crate::algorithm_dispatch::{AlgorithmCancellation, AlgorithmLimits};
+    use crate::compute_pool::ComputePool;
+    use std::sync::Arc;
 
     fn control() -> AlgorithmControl {
         AlgorithmControl::new(AlgorithmLimits::default(), AlgorithmCancellation::default())
+    }
+
+    fn control_with_threads(threads: usize) -> AlgorithmControl {
+        let pool = Arc::new(ComputePool::new(threads).unwrap());
+        AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(threads),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(pool)
+    }
+
+    fn parallel_fixture(node_count: u64, weight: f64) -> AdjacencyGraph {
+        let offsets = [1_u64, 5, 17, 31];
+        let edges = (0..node_count)
+            .flat_map(|source| {
+                offsets
+                    .into_iter()
+                    .map(move |offset| (source, (source + offset) % node_count))
+            })
+            .collect::<Vec<_>>();
+        let weights = edges
+            .iter()
+            .map(|(source, target)| {
+                if weight == 1.0 {
+                    1.0 + ((source + target) % 7) as f64 / 10.0
+                } else {
+                    weight
+                }
+            })
+            .collect::<Vec<_>>();
+        AdjacencyGraph::with_test_edges(node_count, &edges).with_test_edge_weights(&weights)
+    }
+
+    fn path_fingerprint(paths: &[DijkstraPath]) -> Vec<(u64, u64, u64, Vec<u64>)> {
+        paths
+            .iter()
+            .map(|path| {
+                (
+                    path.source,
+                    path.target,
+                    path.cost.to_bits(),
+                    path.nodes.clone(),
+                )
+            })
+            .collect()
     }
 
     #[test]
@@ -303,6 +501,31 @@ mod tests {
     }
 
     #[test]
+    fn all_pairs_selects_parallel_only_above_private_pool_crossover() {
+        let small = AdjacencyGraph::with_test_edges(4, &[(0, 1), (1, 2), (2, 3)]);
+        assert_eq!(
+            select_dijkstra_all_pairs_path(&control_with_threads(4), &small),
+            DijkstraAllPairsExecutionPath::Serial
+        );
+        let large = parallel_fixture(48, 1.0);
+        assert_eq!(
+            select_dijkstra_all_pairs_path(&control(), &large),
+            DijkstraAllPairsExecutionPath::Serial
+        );
+        assert_eq!(
+            select_dijkstra_all_pairs_path(&control_with_threads(1), &large),
+            DijkstraAllPairsExecutionPath::Serial
+        );
+        assert_eq!(
+            select_dijkstra_all_pairs_path(&control_with_threads(4), &large),
+            DijkstraAllPairsExecutionPath::Parallel {
+                threads: 4,
+                chunks: 4
+            }
+        );
+    }
+
+    #[test]
     fn all_pairs_returns_exact_reachable_ordered_non_self_paths() {
         let graph =
             AdjacencyGraph::with_test_edges(5, &[(0, 2), (0, 1), (1, 3), (2, 3), (3, 0), (4, 4)])
@@ -331,6 +554,27 @@ mod tests {
         );
         assert_eq!(paths, exact_dijkstra_all_pairs(&graph, &control()).unwrap());
         assert!(paths.iter().all(|path| path.source != path.target));
+    }
+
+    #[test]
+    fn all_pairs_parallel_source_chunks_match_serial_fingerprint() {
+        let graph = parallel_fixture(48, 1.0);
+        let serial = exact_dijkstra_all_pairs(&graph, &control_with_threads(1)).unwrap();
+        assert_eq!(
+            serial.len(),
+            48 * 47,
+            "fixture should be strongly connected and omit self-pairs"
+        );
+        let serial_fingerprint = path_fingerprint(&serial);
+        for threads in [2, 4, 8] {
+            let parallel = exact_dijkstra_all_pairs(&graph, &control_with_threads(threads))
+                .unwrap_or_else(|error| panic!("threads={threads}: {error:?}"));
+            assert_eq!(
+                serial_fingerprint,
+                path_fingerprint(&parallel),
+                "threads={threads}: canonical source/target/cost/path fingerprint"
+            );
+        }
     }
 
     #[test]
@@ -413,6 +657,29 @@ mod tests {
             ),
             Err(AlgorithmError::Cancelled)
         );
+    }
+
+    #[test]
+    fn all_pairs_parallel_limits_and_worker_errors_are_structured() {
+        let graph = parallel_fixture(48, 1.0);
+        let limited = AlgorithmControl::new(
+            AlgorithmLimits {
+                output_rows: 10,
+                ..AlgorithmLimits::default().with_compute_threads(4)
+            },
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(Arc::new(ComputePool::new(4).unwrap()));
+        assert!(matches!(
+            exact_dijkstra_all_pairs(&graph, &limited),
+            Err(AlgorithmError::OutputLimit { .. })
+        ));
+
+        let overflow = parallel_fixture(48, f64::MAX);
+        assert!(matches!(
+            exact_dijkstra_all_pairs(&overflow, &control_with_threads(4)),
+            Err(AlgorithmError::Execution { .. })
+        ));
     }
 
     #[test]

--- a/crates/graphforge-exec/src/algorithm_paths_dijkstra.rs
+++ b/crates/graphforge-exec/src/algorithm_paths_dijkstra.rs
@@ -112,8 +112,8 @@ fn exact_dijkstra_all_pairs_serial(
 ) -> Result<Vec<DijkstraPath>, AlgorithmError> {
     let mut paths = Vec::new();
     for &source in graph.node_ids() {
-        checkpoint(control, &mut work)?;
-        let source_paths = dijkstra_from(graph, source, None, control, &mut work)?
+        checkpoint(control, work)?;
+        let source_paths = dijkstra_from(graph, source, None, control, work)?
             .into_iter()
             .filter(|path| path.target != source)
             .collect::<Vec<_>>();

--- a/docs/book/architecture/algorithms.md
+++ b/docs/book/architecture/algorithms.md
@@ -1555,6 +1555,13 @@ sequence and then edge topology order.
 batch. Shared node, edge, iteration, and output limits plus cooperative cancellation cover the
 complete invocation.
 
+Above the documented `DIJKSTRA_APSP_PARALLEL_CROSSOVER_WORK` source-edge estimate
+(`selected_nodes × CSR adjacency entries >= 8_192`) and with `compute_threads > 1`,
+the executor partitions independent source nodes across the instance-owned private
+`ComputePool`. Each source still runs the serial Dijkstra heap/tie algorithm, and
+worker chunks merge in canonical source order. Smaller workloads and one-thread
+policies retain the serial loop, so there is no universal pool scheduling tax.
+
 Projection, validation, execution, deterministic tie resolution, limits, and shaping are owned
 by Rust in `graphforge-exec`; Python and Node are thin argument/Arrow adapters. Results are independent
 of knowledge-layer presence. Official

--- a/docs/development/dijkstra-all-pairs-parallel-evidence.md
+++ b/docs/development/dijkstra-all-pairs-parallel-evidence.md
@@ -1,0 +1,47 @@
+# Dijkstra all-pairs source parallelism evidence (#542)
+
+`paths(by="dijkstra_all_pairs")` now parallelizes only independent source
+searches. Each source still runs the existing serial Dijkstra heap/tie logic, and
+worker chunks merge in canonical source-range order.
+
+## Structural disposition
+
+| Item | Before #542 | After #542 |
+|---|---|---|
+| Work unit | Whole all-pairs invocation looped sources serially | Contiguous canonical source ranges above crossover |
+| Crossover | None; always serial | `selected_nodes * CSR adjacency entries >= 8_192` and `compute_threads > 1` |
+| Threads/path | One thread for every source | Up to `compute_threads` private-pool workers; each source remains serial |
+| Graph representation | Existing CSR-native `AdjacencyGraph` | Same CSR-native graph; no parallel-only graph copy or O(E) edge map |
+| Output shaping | Existing bounded Arrow shaping | Same bounded Arrow shaping after deterministic merge |
+| Failure behavior | Structured cancellation/limits/execution errors | Same; worker errors/panics return structured errors without partial public output |
+
+## Local evidence
+
+Host policy rejected `threads-8` on this 4-vCPU agent because the explicit
+Tokio+DataFusion request exceeded the resource-policy budget. Executed cells
+shared schema, row count, ordering, and content fingerprint. Fingerprint values
+are UUID-sensitive and are compared within a run.
+
+```text
+CARGO_TARGET_DIR=/tmp/cargo-m4-542 cargo test -p graphforge-exec algorithm_paths_dijkstra --lib
+result: ok. 9 passed; 0 failed; 0 ignored; 717 filtered out.
+
+CARGO_TARGET_DIR=/tmp/cargo-m4-542 cargo test -p graphforge-api dijkstra_all_pairs --lib -- --nocapture
+threads-1: rows=2256 fingerprint=6ea5e53d27fcb1bf3813d4bbc6dab32a4c2c554a06ea26d554941c21ab2d8806
+threads-2: rows=2256 fingerprint=6ea5e53d27fcb1bf3813d4bbc6dab32a4c2c554a06ea26d554941c21ab2d8806
+threads-4: rows=2256 fingerprint=6ea5e53d27fcb1bf3813d4bbc6dab32a4c2c554a06ea26d554941c21ab2d8806
+threads-8: unavailable resource policy: validation error: combined tokio/partition concurrency 16 exceeds instance budget 8
+threads-automatic: rows=2256 fingerprint=6ea5e53d27fcb1bf3813d4bbc6dab32a4c2c554a06ea26d554941c21ab2d8806
+result: ok. 3 passed; 0 failed; 0 ignored; 543 filtered out.
+
+CARGO_TARGET_DIR=/tmp/cargo-m4-542 cargo clippy -p graphforge-exec -p graphforge-api -- -D warnings
+result: ok.
+
+CARGO_TARGET_DIR=/tmp/cargo-m4-542 cargo fmt --all -- --check
+result: ok.
+```
+
+Timing is hardware-specific and not a pass/fail gate. Shell keyword timing for
+the public parity cell on this agent reported `real 11.639 user 8.881 sys 2.914`
+including cargo/test harness overhead. `/usr/bin/time -v` is not installed on
+this VM, so local peak RSS was unavailable from the shell timing tool.

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -17,8 +17,7 @@ Tokio runtime or any DataFusion execution session.
 | `spill` | disabled | Optional absolute spill directory + byte cap |
 | `io_concurrency` | `2` | Reserved I/O concurrency budget |
 | `max_concurrent_heavy_queries` | `64` | Instance-owned admission semaphore |
-| `compute_threads` | `2` | Instance-owned private CPU pool (#342 cosine KNN; #343 PageRank; #344 Node2Vec walks; #501 betweenness; #503 closeness BFS; #504 clustering coefficient; #506 Degree; #510 HITS hub; #515 triangles; #518 Components; #535 Jaccard similarity; #513 resource allocation) |
-
+| `compute_threads` | `2` | Instance-owned private CPU pool (#342 cosine KNN; #343 PageRank; #344 Node2Vec walks; #501 betweenness; #503 closeness BFS; #504 clustering coefficient; #506 Degree; #510 HITS hub; #513 resource allocation; #515 triangles; #518 Components; #535 Jaccard similarity; #542 Dijkstra APSP sources) |
 
 Defaults preserve pre-#337 fixed two-worker / two-partition behavior.
 
@@ -72,20 +71,8 @@ private Rayon pool on each `GraphForge` instance. Exact cosine KNN / similarity
 (#342), PageRank (#343), Node2Vec walk-corpus generation (#344), exact
 Jaccard node similarity (#535), local clustering coefficient (#504), triangle
 ranking (#515), Degree (#506), betweenness Brandes source searches (#501), and
-`cluster(by="components")` (#518), and transitive closure (#554) may partition
-independent work across that pool above documented crossovers; work never uses
-Rayon's process-global pool. Cosine dot products retain serial coordinate order,
-PageRank keeps canonical contribution order with serial dangling/delta
-reductions, Jaccard retains serial candidate order per source, clustering
-coefficient merges node-range scores in canonical dense-ordinal order, triangles
-merge node-owned counts by ascending dense ordinal, Degree merges node chunks in
-dense ordinal order, betweenness reduces per-source dependency arrays in
-canonical source order, Components merges worker-local forests in canonical
-source-range order, Node2Vec skip-gram training stays serial, and transitive
-closure merges source ranges canonically, so fingerprints match the one-thread
-
 `cluster(by="components")` (#518) may partition independent work across that
-pool above documented crossovers; work never uses Rayon's process-global pool. Maximum-cardinality matching (#557) is explicitly dispositioned serial because blossom/primal-dual search mutates ordered matching state.
+pool above documented crossovers; work never uses Rayon's process-global pool.
 Cosine dot products retain serial coordinate order, PageRank keeps canonical
 contribution order with serial dangling/delta reductions, Jaccard retains
 serial candidate order per source, clustering coefficient merges node-range
@@ -94,94 +81,15 @@ ascending dense ordinal, Degree merges node chunks in dense ordinal order,
 betweenness reduces per-source dependency arrays in canonical source order,
 Components merges worker-local forests in canonical source-range order, and
 Node2Vec skip-gram training stays serial, so fingerprints match the one-thread
-
-(#342), PageRank (#343), and Node2Vec walk-corpus generation (#344) may partition
-independent work across that pool above documented crossovers; work never uses
-Rayon's process-global pool. GraphSAGE training (#560) is explicitly
-dispositioned serial because positive-pair replay, sampled computation graphs,
-gradient accumulation, Adam moment updates, and final full-neighborhood
-inference are one accepted state stream. Cosine dot products retain serial
-coordinate order, PageRank keeps canonical contribution order with serial
-dangling/delta reductions, Node2Vec skip-gram training stays serial, and
-GraphSAGE keeps one-thread training order, so fingerprints match the one-thread
-path.
-(#342), PageRank (#343), Node2Vec walk-corpus generation (#344), and
-eigenvector destination updates (#507) may partition independent work across
-that pool above documented crossovers; work never uses Rayon's process-global
-pool. Cosine dot products retain serial coordinate order, PageRank keeps
-canonical contribution order with serial dangling/delta reductions, eigenvector
-keeps per-destination incoming contribution order with serial norm/convergence
-reductions, and Node2Vec skip-gram training stays serial, so fingerprints match
-the one-thread path.
-
-(#342), PageRank (#343), Node2Vec walk-corpus generation (#344), and
-common-neighbors source aggregates (#505) may partition independent work across
-that pool above documented crossovers; work never uses Rayon's process-global
-pool. Cosine dot products retain serial coordinate order, PageRank keeps
-canonical contribution order with serial dangling/delta reductions, Node2Vec
-skip-gram training stays serial, and common-neighbors keeps serial
-candidate/intersection order per source, so fingerprints match the one-thread
 path.
 
-(#342), PageRank (#343), Node2Vec walk-corpus generation (#344), and triad census
-source-range enumeration (#587) may partition independent work across that pool
-above documented crossovers; work never uses Rayon's process-global pool. Cosine
-dot products retain serial coordinate order, PageRank keeps canonical
-contribution order with serial dangling/delta reductions, Node2Vec skip-gram
-training stays serial, and triad census merges integer class counts in canonical
-source-range order, so fingerprints match the one-thread path.
-
-(#342), PageRank (#343), and Node2Vec walk-corpus generation (#344) may partition
+(#342), PageRank (#343), Node2Vec walk-corpus generation (#344), and
+`paths(by="dijkstra_all_pairs")` source searches (#542) may partition
 independent work across that pool above documented crossovers; work never uses
-Rayon's process-global pool. Leiden (#527) is explicitly dispositioned serial
-because local moves, refinement, fixed random sampling, and aggregation consume
-the accepted state from the previous step. Cosine dot products retain serial
-coordinate order, PageRank keeps canonical contribution order with serial
-dangling/delta reductions, Node2Vec skip-gram training stays serial, and Leiden
-keeps one-thread refinement order, so fingerprints match the one-thread path.
-
-(#342), PageRank (#343), and Node2Vec walk-corpus generation (#344) may partition
-independent work across that pool above documented crossovers; work never uses
-Rayon's process-global pool. Maximum-weight matching (#558) is explicitly
-dispositioned serial because exact weighted blossom labels, dual arithmetic,
-contractions, expansions, and augmenting-path commits mutate one shared
-alternating forest. Cosine dot products retain serial coordinate order,
+Rayon's process-global pool. Cosine dot products retain serial coordinate order,
 PageRank keeps canonical contribution order with serial dangling/delta
-reductions, Node2Vec skip-gram training stays serial, and max-weight matching
-keeps one-thread weighted blossom state order, so fingerprints match the
-one-thread path.
-
-(#342), PageRank (#343), Node2Vec walk-corpus generation (#344), and transitivity
-triangle counting (#586) may partition independent work across that pool above
-documented crossovers; work never uses Rayon's process-global pool. Cosine dot
-products retain serial coordinate order, PageRank keeps canonical contribution
-order with serial dangling/delta reductions, Node2Vec skip-gram training stays
-serial, and transitivity merges integer triangle counts in canonical source-range
-order, so fingerprints match the one-thread path.
-
-(#342), PageRank (#343), Node2Vec walk-corpus generation (#344), and conductance
-row evaluation (#566) may partition independent work across that pool above
-documented crossovers; work never uses Rayon's process-global pool. Cosine dot
-products retain serial coordinate order, PageRank keeps canonical contribution
-order with serial dangling/delta reductions, Node2Vec skip-gram training stays
-serial, and conductance keeps weighted cut/volume accumulation serial, so
-fingerprints match the one-thread path.
-
-(#342), PageRank (#343), Node2Vec walk-corpus generation (#344), and
-Adamic-Adar source aggregates (#499) may partition independent work across that
-pool above documented crossovers; work never uses Rayon's process-global pool.
-Cosine dot products retain serial coordinate order, PageRank keeps canonical
-contribution order with serial dangling/delta reductions, Node2Vec skip-gram
-training stays serial, and Adamic-Adar keeps serial candidate/intersection order
-per source, so fingerprints match the one-thread path.
-
-(#342), PageRank (#343), Node2Vec walk-corpus generation (#344), and ArticleRank
-(#500) may partition independent work across that pool above documented
-crossovers; work never uses Rayon's process-global pool. Cosine dot products
-retain serial coordinate order, PageRank keeps canonical contribution order with
-serial dangling/delta reductions, ArticleRank keeps canonical per-destination
-message order with serial score/delta updates, and Node2Vec skip-gram training
-stays serial, so fingerprints match the one-thread path.
+reductions, Node2Vec skip-gram training stays serial, and each Dijkstra source
+search remains serial, so fingerprints match the one-thread path.
 
 (#342), PageRank (#343), Node2Vec walk-corpus generation (#344), and
 resource-allocation source aggregates (#513) may partition independent work
@@ -304,80 +212,7 @@ Below that crossover, or when the policy provides one compute thread, the
 serial path runs with no pool scheduling tax. Workers emit `(uuid, score)` rows
 for contiguous ordinal ranges; the sink merges them in ascending node order so
 schemas, row order, scores, and fingerprints match the one-thread result at
-
-## Parallel ArticleRank (#500)
-
-ArticleRank destination message sums run on the instance-owned private compute
-pool when:
-
-- `compute_threads > 1`, and
-- selected adjacency entries are at least
-  `ARTICLE_RANK_PARALLEL_CROSSOVER_EDGES` (`131_072`) in `graphforge-exec`.
-
-Below that crossover, or when the policy provides one compute thread, the serial
-destination-pull path runs with no pool scheduling tax. Parallel work is
-destination-owned: each worker owns a contiguous dense-ordinal destination range
-and applies inbound messages in the same canonical source/edge order as the
-one-thread recurrence. Score accumulation, delta damping, and convergence
-checks remain serial in dense node order, so schemas, row order, scores,
-iteration counts, and fingerprints match the one-thread result at
 `1`/`2`/`4`/`8`/automatic configurations.
-## Parallel eigenvector (#507)
-
-`rank(by="eigenvector")` shifted power-iteration destination updates may run on
-the instance-owned private compute pool when:
-
-- `compute_threads > 1`, and
-- selected adjacency entries are at least
-  `EIGENVECTOR_PARALLEL_CROSSOVER_EDGES` (`8_192`) in `graphforge-exec`.
-
-Release-mode local evidence on the 4-worker M4 agent host showed regular graphs
-that converge during warm-up avoid the pool, while irregular non-converged
-fixtures crossed over by ~8K selected adjacency entries:
-`8_689`, `24_440`, `65_505`, and `130_544` edge irregular fixtures repeatedly
-ran at roughly `0.4×–0.6×` of the one-thread time on four private workers.
-Those timings are hardware-specific evidence, not a CI gate.
-
-Below that crossover, or when the policy provides one compute thread, the
-serial source-scatter path runs with no pool scheduling tax. Above the
-crossover, the first two required power iterations also stay serial; if the
-workload converges there, no inbound CSR or worker scheduling tax is paid.
-Remaining non-converged work is destination-owned: each worker owns a
-contiguous dense-ordinal destination range and applies inbound contributions
-after the implicit identity term in the same canonical source/edge order as
-serial scatter. L2 normalization and component-wise convergence checks stay
-serial, so scores, iteration counts, and fingerprints match the one-thread
-result at `1`/`2`/`4`/`8`/automatic configurations.
-## Parallel HITS hub (#510)
-## Parallel HITS hub / authority (#510 / #509)
-
-The shared `hits_scores` kernel used by `rank(by="hits_hub")` prepares selected
-and `rank(by="hits_authority")` prepares selected adjacency once as
-dense-ordinal outgoing and incoming CSR, then partitions independent node-score
-updates across the instance-owned private compute pool when:
-
-- `compute_threads > 1`, and
-- selected adjacency entries are at least
-  `HITS_PARALLEL_CROSSOVER_EDGES` (`4_096`) in `graphforge-exec`.
-
-Below that crossover, or when the policy provides one compute thread, the
-serial path runs with no pool scheduling tax. Parallel work is node-owned: the
-authority phase owns contiguous target ranges over incoming CSR, and the hub
-phase owns contiguous source ranges over outgoing CSR. Each node's
-floating-point sum still walks its CSR slice in canonical source/edge order,
-and global L2 norms remain serial dense-ordinal reductions, so schemas, row
-order, scores, ties, and fingerprints match the one-thread result at
-`1`/`2`/`4`/`8`/automatic configurations. The crossover follows the same
-4 vCPU release-build structural benchmark regime used for adjacent M4 kernels:
-the parallel path avoids small-fixture tax and clears the worker-pool cost once
-20 fixed HITS iterations amortize two sparse matrix-vector phases per
-iteration. It is CPU-only; no GPU or universal scaling claim is made.
-
-The threshold is the first measured win on the M4 agent host using the ignored
-release harness (`measure_article_rank_parallel_crossover`) with a shared
-four-worker private pool: sizes through 32k selected entries stayed near parity
-within timing noise, while 131k and 262k selected entries were clear wins over
-the one-thread path.
 
 ## Parallel Node2Vec walk generation (#344)
 
@@ -443,250 +278,28 @@ IDs are still assigned by canonical node order, so schemas, row order, labels,
 and fingerprints match the one-thread result at `1`/`2`/`4`/`8`/automatic
 configurations. Cancellation remains cooperative both before worker launch and
 inside chunk scans.
-## Serial paths(by="gomory_hu_tree") (#544)
 
-`paths(by="gomory_hu_tree")` has no parallel crossover. Its disposition is
-**serial Gomory-Hu parent updates** for every `compute_threads` setting,
-including `1`/`2`/`4`/`8`/automatic policies.
+## Parallel Dijkstra all-pairs sources (#542)
 
-The Rust kernel consumes CSR-native undirected capacity adjacency (#340), finds
-canonical connected components, and runs the classic parent-update sequence.
-Each min-cut result rewrites parent links that choose subsequent cut pairs and
-final forest rows. Launching those cuts independently would compute against the
-wrong parent state and could change cut values, row order, and fingerprints.
-
-The path still uses bounded Arrow output (#341), structured cancellation and
-resource checks, and no process-global Rayon pool. The M4 harness records
-`paths-gomory-hu-tree` evidence and verifies one-thread parity across supported
-resource-policy cells; timing remains evidence only.
-
-## Parallel transitive closure (#554)
-
-`paths(by="transitive_closure")` partitions independent source-node traversals
-across the instance-owned private compute pool when:
-
-- `compute_threads > 1`, and
-- estimated traversal work (`sources × direction-expanded adjacency entries`) is
-  at least `TRANSITIVE_CLOSURE_PARALLEL_CROSSOVER_WORK` (`65_536`) in
-  `graphforge-exec`.
-
-Below that crossover, or when the policy provides one compute thread, the serial
-per-source breadth-first traversal runs with no pool scheduling tax. Parallel
-workers preserve the serial traversal inside each source, sort reachable targets
-by public UUID, and merge worker outputs by ascending canonical source range.
-Schemas, row order, reachable-pair sets, and fingerprints match the one-thread
-result at `1`/`2`/`4`/`8`/automatic configurations.
-
-## Parallel triad census source ranges (#587)
-
-`analyze(by="triad_census")` keeps UUID indexing and directed-neighbor
-normalization serial so duplicate-edge validation, self-loop elision, and
-canonical node ordering remain unchanged. The Batagelj-Mrvar enumeration then
-partitions independent source-ordinal ranges across the instance-owned private
-compute pool when:
-
-- `compute_threads > 1`, and
-- normalized weak dyads are at least
-  `TRIAD_CENSUS_PARALLEL_CROSSOVER_DYADS` (`4_096`) in `graphforge-exec`.
-
-Below that crossover, or when the policy provides one compute thread, triad
-census stays serial. Each worker builds the same per-dyad union sets as the
-serial path for its source range and returns worker-local `u64` counts for the 16
-MAN classes. Chunk results merge in ascending source-range order before deriving
-the closed-form `003` count and validating the `V choose 3` invariant. Schemas,
-row order, class counts, structured errors, and fingerprints match the one-thread
-result at `1`/`2`/`4`/`8`/automatic configurations.
-
-## Serial k-core decomposition (#523)
-
-`cluster(by="k_core_decomposition")` is intentionally SERIAL. The exact
-core-number peel mutates node degrees through a canonical min-heap; each removal
-changes later heap priorities and stale-entry rejection. Splitting that frontier
-across workers would either change tie order/core assignment evidence or add a
-global synchronization point around every peel, leaving no safe independent
-kernel for the private compute pool.
-
-The handler keeps the Rust-owned projection path and bounded Arrow sink, avoids
-the Rayon global pool, and observes shared graph/output/iteration limits. A
-fingerprint test attaches private compute pools for `1`/`2`/`4`/`8` configured
-compute threads and requires identical schemas, row ordering, core labels, and
-rows.
-
-## Serial Leiden modularity optimization (#527)
-
-`cluster(by="leiden")` has no parallel crossover. Its performance disposition is
-**serial local-move/refinement/aggregation** for every `compute_threads`
-setting, including `1`/`2`/`4`/`8`/automatic resource policies.
-
-Each Leiden level first runs topology-ordered positive-gain local moves, then
-refines coarse communities through connected subcommunities using the fixed
-Rust random stream and accepted membership state, then aggregates the refined
-partition while seeding the next level from the coarse partition. Reordering
-candidate moves, random draws, or aggregation updates would require a new
-numeric and tie contract and could change connected-community guarantees,
-community IDs, row ordering, or fingerprints.
-
-The #527 disposition therefore preserves the serial contract, CSR-native
-selected adjacency access, shared cancellation/checkpoint controls, structured
-resource errors, and bounded Arrow shaping. Schemas, row order, community IDs,
-projection fingerprints, cancellation, and limit behavior match the one-thread
-oracle at supported thread configurations. No GPU, distributed, approximate, or
-foreign-engine fallback is implied.
-
-## Serial bridges (#564)
-
-`analyze(by="bridges")` is intentionally SERIAL. Bridge classification depends
-on the shared low-link DFS traversal: discovery order, parent-edge identity,
-multigraph parallel-edge handling, and low-link propagation determine whether an
-edge is a bridge. Parallelizing that state would change the canonical edge
-evidence or require synchronization around each DFS transition, so there is no
-safe independent kernel for the private compute pool.
-
-The handler keeps Rust-owned adjacency projection and bounded Arrow output,
-does not use Rayon's global pool, and preserves cancellation and shared resource
-limits. A fingerprint test attaches private compute pools for `1`/`2`/`4`/`8`
-configured compute threads and requires identical schemas, bridge ordering, and
-rows.
-
-## Serial paths(by="dijkstra") (#541)
-
-`paths(by="dijkstra")` for one source, with or without one target, has no
-parallel crossover. Its disposition is **serial non-negative shortest-path
-relaxation** for every `compute_threads` setting. The all-pairs variant is
-tracked independently by #542.
-
-The Rust kernel validates non-negative finite weights, then repeatedly pops one
-canonical heap entry, compares it with the current best-path map, and relaxes
-stable outgoing edges. The public target early exit and equal-cost path-vector
-and edge-UUID ties depend on that exact pop order. Parallel relaxations would
-need to arbitrate competing predecessors and could alter paths, row order, or
-fingerprints.
-
-The path still uses CSR-native selected adjacency, bounded Arrow shaping,
-structured cancellation and limit checks, and no process-global Rayon pool.
-Costs, selected node sequences, unreachable-target behavior, structured errors,
-and cancellation behavior match the one-thread oracle across supported
-resource-policy cells.
-
-## Serial maximum-weight matching (#558)
-
-`analyze(by="max_weight_matching")` has no parallel crossover. Its performance
-disposition is **serial exact weighted blossom search** for every
-`compute_threads` setting.
-
-The weighted handler normalizes the selected undirected multigraph, validates
-finite weights, and uses the shared exact blossom/primal-dual core with summed
-Float64 weights as the primary objective, cardinality as a secondary objective,
-and canonical edge tuples for ties. Labels, root queues, exact-weight dual
-steps, blossom contractions/expansions, and augmenting-path commits all update
-one alternating forest. Parallel speculation would need conflict resolution
-across shared vertices/blossoms and could change the selected maximum-weight
-edge set or tie objective.
-
-The #558 disposition preserves CSR-native selected adjacency access before
-normalization, shared cancellation/checkpoint controls, structured resource
-errors, and bounded Arrow shaping. Schemas, row order, selected edge UUIDs and
-weights, projection fingerprints, cancellation, and limit behavior match the
-one-thread oracle at supported thread configurations. No GPU, distributed,
-approximate, or foreign-engine fallback is implied.
-
-## Parallel transitivity triangle counting (#586)
-
-`analyze(by="transitivity")` keeps UUID indexing, undirected simple-neighbor
-normalization, and the wedge denominator serial. Those steps validate duplicate
-edge UUIDs, self-loops, endpoint membership, and the zero-wedge early return
-before any pool scheduling. The triangle-closure scan then partitions independent
-source-ordinal ranges across the instance-owned private compute pool when:
-
-- `compute_threads > 1`, and
-- closed-wedge candidates are at least
-  `TRANSITIVITY_PARALLEL_CROSSOVER_WEDGES` (`32_768`) in `graphforge-exec`.
-
-Below that crossover, or when the policy provides one compute thread,
-transitivity stays serial. Parallel workers return local `u64` triangle counts;
-chunks merge in ascending source-range order before the single final `3T / wedge`
-floating-point division. Schemas, scalar row shape, ratio bits, structured
-errors, and fingerprints match the one-thread result at `1`/`2`/`4`/`8`/automatic
-configurations.
-
-## Parallel conductance row evaluation (#566)
-
-`analyze(by="conductance")` keeps weighted edge normalization, cut accumulation,
-and volume accumulation serial. Those stages contain floating-point additions
-whose order is part of the accepted bit-level contract. After the serial
-accumulators are complete, each partition row can be evaluated independently on
+`paths(by="dijkstra_all_pairs")` partitions **independent source nodes** across
 the instance-owned private compute pool when:
 
 - `compute_threads > 1`, and
-- normalized partitions are at least
-  `CONDUCTANCE_PARALLEL_CROSSOVER_PARTITIONS` (`128`) in `graphforge-exec`.
-
-Below that crossover, or when the policy provides one compute thread,
-conductance stays fully serial. Parallel workers evaluate canonical partition
-ranges; each row preserves the serial `BTreeMap` complement summation order, and
-chunks merge in ascending range order so row ordering and the first undefined
-partition error remain deterministic. Schemas, row order, conductance bits,
-structured errors, and fingerprints match the one-thread result at
-`1`/`2`/`4`/`8`/automatic configurations.
-## Serial depth-first search (#540)
-
-`paths(by="dfs")` is intentionally SERIAL. The public result is preorder with a
-stable discovery index and depth. That order is defined by a single stack over
-sorted neighbor lists; parallelizing frontier expansion would change discovery
-order, depth ties, or require serial reassembly of every stack mutation.
-
-The handler uses the Rust-owned adjacency projection and bounded Arrow sink,
-does not use Rayon's global pool, and preserves shared cancellation and limits.
-A fingerprint test attaches private compute pools for `1`/`2`/`4`/`8`
-configured compute threads and requires identical schemas, preorder rows,
-depths, and discovery ordinals.
-
-## Parallel common-neighbors aggregate (#505)
-
-`rank(by="common_neighbors")` partitions **independent source ordinals** across
-the instance-owned private compute pool when:
-
-- `compute_threads > 1`, and
-- the estimated pair/intersection work is at least
-  `COMMON_NEIGHBORS_PARALLEL_CROSSOVER_WORK` (`1_048_576`) in
+- estimated source-edge inspections (`selected_nodes × CSR adjacency entries`)
+  are at least `DIJKSTRA_APSP_PARALLEL_CROSSOVER_WORK` (`8_192`) in
   `graphforge-exec`.
-
-The estimate is `sources² + 2 × sources × distinct_adjacency_entries`, a
-conservative O(V + E) proxy for the serial pair loop and two-pointer
-intersection scans. The threshold is the smallest power-of-two work estimate
-below the measured win boundary on the M4 agent host (4 vCPU, directed
-ring-lattice fixture, 4 private workers, debug test profile after a clean
-target-dir build): ~230k units was still slower (~1.80x serial), ~540k units
-was still slower (~1.20x serial), ~1.2M units first won (~0.70x serial), and
->=2.1M units was >=1.8x faster.
-## Parallel Adamic-Adar aggregate (#499)
-
-`rank(by="adamic_adar")` partitions **independent source ordinals** across the
-instance-owned private compute pool when:
-
-- `compute_threads > 1`, and
-- the estimated pair/intersection work is at least
-  `ADAMIC_ADAR_PARALLEL_CROSSOVER_WORK` (`524_288`) in `graphforge-exec`.
-
-The estimate is `sources² + 2 × sources × distinct_adjacency_entries`, a
-conservative O(V + E) proxy for the serial pair loop and two-pointer
-intersection scans. The threshold is the smallest power-of-two work estimate
-below the measured win boundary on the M4 agent host (4 vCPU, directed
-ring-lattice fixture, 4 private workers, release build): ~230k units was still
-neutral/slower, ~540k units first won (~0.61x serial), and >=2.1M units was
->=2.8x faster.
 
 Below that crossover, or when the policy provides one compute thread, the
-serial path runs with no pool scheduling tax. Parallel workers only own source
-ranges. Candidate order, missing-link checks, two-pointer neighborhood
-intersection, and checked integer accumulation remain serial per source.
-Worker score chunks merge in canonical source order, so schemas, row order,
-scores, and fingerprints match the one-thread result at `1`/`2`/`4`/`8`/
-automatic configurations.
-intersection, logarithmic discounts, and compensated floating-point summation
-remain serial per source. Worker score chunks merge in canonical source order,
-so schemas, row order, scores, and fingerprints match the one-thread result at
-`1`/`2`/`4`/`8`/automatic configurations.
+existing serial source loop runs with no pool scheduling tax. Above the
+crossover, each worker runs the same single-source Dijkstra serially: heap
+ordering, equal-cost path ties, edge order, cost accumulation, cancellation
+checkpoints, and source-local allocations are unchanged. Worker outputs merge by
+canonical source range, and output limits are checked during that merge, so
+schemas, row order, costs, paths, structured errors, and fingerprints match the
+one-thread result at supported `1`/`2`/`4`/`8`/automatic configurations. The
+implementation consumes CSR-native adjacency and the existing bounded Arrow
+shaping path; it does not introduce a parallel-only graph copy or a global
+edge-index map.
 
 ## Parallel resource-allocation aggregate (#513)
 
@@ -929,7 +542,6 @@ Evidence is carried by:
 
 
 There is no crossover for SCC in M4: the documented disposition is `serial_tarjan`. Timing remains hardware-specific evidence, never a CI pass/fail gate.
-<<<<<<< HEAD
 ## Serial analyze(by="minimum_k_spanning_tree") (#581)
 
 `analyze(by="minimum_k_spanning_tree")` has no parallel crossover. Its
@@ -947,7 +559,7 @@ The path still uses bounded Arrow output (#341), structured cancellation and
 resource checks, and no process-global Rayon pool. The M4 harness records
 `analyze-minimum-k-spanning-tree` evidence and verifies one-thread parity;
 timing is report-only.
-=======
+
 ## Serial CELF influence maximization (#502)
 
 `rank(by="celf")` keeps the Cost-Effective Lazy Forward search serial under every
@@ -980,7 +592,6 @@ sink, avoids any Rayon global pool, and observes cancellation and shared
 iteration/output limits. The serial disposition is covered by a fingerprint test
 that attaches private compute pools for `1`/`2`/`4`/`8` configured compute
 threads and requires identical schemas, row ordering, labels, and rows.
-
 ## Observability
 
 `GraphForge::resource_policy()` and `GraphForge::resource_diagnostics()` expose
@@ -1017,15 +628,3 @@ counts.
 - [M4 Entry Baseline](m4-entry-baseline.md)
 - [Scale Limits](../reference/scale-limits.md)
 - Contract: [`tests/contracts/m4-entry-matrix.json`](../../tests/contracts/m4-entry-matrix.json)
-
-| Knob | Default (Explicit) | Applied to |
-|---|---|---|
-| `tokio_worker_threads` | `2` | Facade multi-thread Tokio runtime |
-| `target_partitions` | `2` | DataFusion `SessionConfig` |
-| `batch_size` | `8192` | DataFusion `SessionConfig`; analyst Arrow shaping / property enrichment (#341) |
-| `memory_budget_bytes` | `512 MiB` | DataFusion `RuntimeEnv` memory pool |
-| `spill` | disabled | Optional absolute spill directory + byte cap |
-| `io_concurrency` | `2` | Reserved I/O concurrency budget |
-| `max_concurrent_heavy_queries` | `64` | Instance-owned admission semaphore |
-
-## Parallel closeness BFS (#503)

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -626,5 +626,6 @@ counts.
 ## Related docs
 
 - [M4 Entry Baseline](m4-entry-baseline.md)
+- [Dijkstra all-pairs source parallelism evidence](dijkstra-all-pairs-parallel-evidence.md)
 - [Scale Limits](../reference/scale-limits.md)
 - Contract: [`tests/contracts/m4-entry-matrix.json`](../../tests/contracts/m4-entry-matrix.json)

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1715,8 +1715,13 @@ target topology/UUID. The non-null schema is `source_uuid: FixedSizeBinary(16)`,
 Unit-cost, strict named-weight, direction, relationship filtering, parallel-edge, and stable
 equal-cost tie semantics match `dijkstra`. `k` must be `1`. Empty or disconnected selections
 produce a valid empty Arrow table, and shared limits and cancellation apply to the whole
-invocation without partial output. Rust owns projection through Arrow shaping; Python and Node
-remain thin adapters, and knowledge-layer presence cannot change the result. The official
+invocation without partial output. Above the documented `8_192` source-edge
+inspection crossover and with a multi-thread resource policy, Rust may partition
+independent source nodes on the instance-owned private `ComputePool`; each source
+still runs serial Dijkstra and results merge in canonical source order. Smaller
+workloads and one-thread policies stay serial. Rust owns projection through Arrow
+shaping; Python and Node remain thin adapters, and knowledge-layer presence
+cannot change the result. The official
 [Neo4j GDS all-pairs shortest path documentation][gds-apsp] is a development reference only;
 there is no igraph, NetworkX, Neo4j, SciPy, external path service, fallback, packaging
 dependency, or recovery runtime.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements #542: parallel `paths(by="dijkstra_all_pairs")` by independent sources on ComputePool; each Dijkstra stays serial; deterministic merge and fingerprint parity.

Closes #542

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788951844&installation_model_id=20486&pr_number=608&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F608&signature=8732eb3fba87d68a1bf205e97968a4fa55f0bfce553782d5e0249a05723d2095"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parallelize `dijkstra_all_pairs` execution across a private ComputePool
> - Adds a parallel execution path to `exact_dijkstra_all_pairs` in [`algorithm_paths_dijkstra.rs`](https://github.com/CurateLabs/graphforge/pull/608/files#diff-ee775811d8035387bd4b12cd0461c3651fb6ea4683fe854809d6b62b5f6d4f54) that partitions source nodes into chunks and runs them concurrently via Rayon on the instance-owned compute pool.
> - Parallelism is selected when `compute_threads > 1`, a parallel-capable private pool is configured, and estimated work (sources × CSR edge entries) exceeds the new `DIJKSTRA_APSP_PARALLEL_CROSSOVER_WORK` constant (8,192); otherwise falls back to the existing serial loop.
> - Results are merged in canonical source order after parallel execution; output row limits and cancellation checks are enforced during merge via the new `append_paths` and `merge_chunks` helpers.
> - Worker panics in the parallel path are captured and returned as structured execution errors instead of unwinding.
> - Behavioral Change: `dijkstra_all_pairs` may now use multiple threads for large workloads, changing wall-clock timing and thread utilization profile.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 169eba8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->