### PR TITLE
perf(exec): parallelize total_neighbors on ComputePool (#514)

### DIFF
--- a/crates/graphforge-api/tests/m4_entry_baseline.rs
+++ b/crates/graphforge-api/tests/m4_entry_baseline.rs
@@ -17,9 +17,9 @@ use arrow::array::FixedSizeBinaryArray;
 use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
 use graphforge_api::{
-    AnalyzeOptions, CancellationToken, EmbeddingAnalyzeOptions, EmbeddingOptions,
-    ExecutionResourcePolicy, GraphForge, GraphForgeOptions, Node2VecOptions, NodeSelector,
-    PathsOptions, PropValue, RankOptions, ResourcePolicyMode, SimilarOptions, SpillPolicy,
+    CancellationToken, EmbeddingAnalyzeOptions, EmbeddingOptions, ExecutionResourcePolicy,
+    GraphForge, GraphForgeOptions, Node2VecOptions, NodeSelector, PathsOptions, PropValue,
+    RankOptions, ResourcePolicyMode, SimilarOptions, SpillPolicy,
 };
 use graphforge_core::algorithms::{
     AnalyzeAlgorithm, PathAlgorithm, RankAlgorithm, SimilarAlgorithm,

--- a/crates/graphforge-api/tests/m4_entry_baseline.rs
+++ b/crates/graphforge-api/tests/m4_entry_baseline.rs
@@ -17,9 +17,9 @@ use arrow::array::FixedSizeBinaryArray;
 use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
 use graphforge_api::{
-    CancellationToken, EmbeddingAnalyzeOptions, EmbeddingOptions, ExecutionResourcePolicy,
-    GraphForge, GraphForgeOptions, Node2VecOptions, NodeSelector, PathsOptions, PropValue,
-    RankOptions, ResourcePolicyMode, SimilarOptions, SpillPolicy,
+    AnalyzeOptions, CancellationToken, EmbeddingAnalyzeOptions, EmbeddingOptions,
+    ExecutionResourcePolicy, GraphForge, GraphForgeOptions, Node2VecOptions, NodeSelector,
+    PathsOptions, PropValue, RankOptions, ResourcePolicyMode, SimilarOptions, SpillPolicy,
 };
 use graphforge_core::algorithms::{
     AnalyzeAlgorithm, PathAlgorithm, RankAlgorithm, SimilarAlgorithm,

--- a/crates/graphforge-exec/src/algorithm_rank.rs
+++ b/crates/graphforge-exec/src/algorithm_rank.rs
@@ -22,6 +22,7 @@
 //! CELF (#502) remains intentionally serial under every compute_threads budget.
 //! Preferential attachment (#512) partitions independent source aggregates;
 //! each source keeps the accepted algebraic missing-link formula.
+//! Total-neighbors aggregates (#514) may partition independent work across the same private pool while preserving serial contribution order and checked arithmetic.
 
 use std::collections::{HashMap, VecDeque};
 use std::panic::{AssertUnwindSafe, catch_unwind};
@@ -159,6 +160,22 @@ const PREFERENTIAL_ATTACHMENT_CHECKPOINT_INTERVAL: usize = 1_024;
 /// exact counts remain identical on either path.
 pub const COMMON_NEIGHBORS_PARALLEL_CROSSOVER_WORK: u64 = 1_048_576;
 const COMMON_NEIGHBORS_CHECKPOINT_INTERVAL: usize = 1_024;
+/// Estimated pair/intersection work below which total-neighbors stays serial (#514).
+///
+/// Chosen from manual serial-vs-parallel timings on this M4 agent host
+/// (4x Xeon vCPU, directed ring-lattice fixtures, 4 private workers, debug
+/// test profile after a clean target-dir build; see
+/// ignored `measure_total_neighbors_parallel_crossover`):
+/// - ~230k estimated units: parallel still slower (~1.77x serial)
+/// - ~540k estimated units: parallel still slower (~1.16x serial)
+/// - ~1.2M estimated units: first clear win (~0.69x serial)
+/// - >=2.1M estimated units: >=1.7x speedup
+///
+/// `1_048_576` is the smallest power-of-two work estimate below that measured
+/// win boundary. Each source keeps serial candidate/intersection order, so
+/// exact union counts remain identical on either path.
+pub const TOTAL_NEIGHBORS_PARALLEL_CROSSOVER_WORK: u64 = 1_048_576;
+const TOTAL_NEIGHBORS_CHECKPOINT_INTERVAL: usize = 1_024;
 /// Estimated pair/intersection work below which Adamic-Adar stays serial (#499).
 ///
 /// Chosen from release-mode serial-vs-parallel timings on this M4 agent host
@@ -426,6 +443,13 @@ pub(crate) enum PageRankExecutionPath {
 /// Selected common-neighbors execution path for observability and crossover tests (#505).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum CommonNeighborsExecutionPath {
+    Serial,
+    Parallel { threads: usize, chunks: usize },
+}
+
+/// Selected total-neighbors execution path for observability and crossover tests (#514).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TotalNeighborsExecutionPath {
     Serial,
     Parallel { threads: usize, chunks: usize },
 }
@@ -3026,47 +3050,163 @@ fn total_neighbor_scores(
                 .map_err(|_| execution("total-neighbors degree exceeds supported range"))
         })
         .collect::<Result<_, _>>()?;
+    let estimated_work = estimated_total_neighbors_work(&neighbors);
+    match select_total_neighbors_path(control, neighbors.len(), estimated_work) {
+        TotalNeighborsExecutionPath::Serial => {
+            total_neighbor_scores_serial(&neighbors, &degrees, control)
+        }
+        TotalNeighborsExecutionPath::Parallel { .. } => {
+            total_neighbor_scores_parallel(&neighbors, &degrees, control)
+        }
+    }
+}
+
+fn total_neighbor_scores_serial(
+    neighbors: &[Vec<usize>],
+    degrees: &[u64],
+    control: &AlgorithmControl,
+) -> Result<Vec<f64>, AlgorithmError> {
     let mut visited = 0_usize;
     let mut scores = Vec::with_capacity(neighbors.len());
-    for (source, source_neighbors) in neighbors.iter().enumerate() {
-        let mut score = 0_u64;
-        for (candidate, candidate_neighbors) in neighbors.iter().enumerate() {
-            if visited.is_multiple_of(1024) {
-                control.checkpoint()?;
-            }
-            visited += 1;
-            if source == candidate || source_neighbors.binary_search(&candidate).is_ok() {
-                continue;
-            }
-            let mut union = degrees[source]
-                .checked_add(degrees[candidate])
-                .ok_or_else(|| execution("total-neighbors pair score exceeds supported range"))?;
-            let (mut left, mut right) = (0, 0);
-            while left < source_neighbors.len() && right < candidate_neighbors.len() {
-                if visited.is_multiple_of(1024) {
-                    control.checkpoint()?;
-                }
-                visited += 1;
-                match source_neighbors[left].cmp(&candidate_neighbors[right]) {
-                    std::cmp::Ordering::Less => left += 1,
-                    std::cmp::Ordering::Greater => right += 1,
-                    std::cmp::Ordering::Equal => {
-                        union = union
-                            .checked_sub(1)
-                            .ok_or_else(|| execution("total-neighbors pair score underflow"))?;
-                        left += 1;
-                        right += 1;
-                    }
-                }
-            }
-            score = score
-                .checked_add(union)
-                .ok_or_else(|| execution("total-neighbors score exceeds supported range"))?;
-        }
+    for source in 0..neighbors.len() {
+        let score = total_neighbor_source_score(neighbors, degrees, source, || {
+            total_neighbors_checkpoint(control, &mut visited)
+        })?;
         scores.push(exact_u64_as_f64(score, "total-neighbors score")?);
     }
     Ok(scores)
 }
+
+fn total_neighbor_scores_parallel(
+    neighbors: &[Vec<usize>],
+    degrees: &[u64],
+    control: &AlgorithmControl,
+) -> Result<Vec<f64>, AlgorithmError> {
+    let pool = control.compute_pool().ok_or_else(|| {
+        execution("parallel total-neighbors requires an instance-owned compute pool")
+    })?;
+    let ranges = source_chunks(neighbors.len(), control.compute_threads());
+    let chunk_results = run_total_neighbors_on_pool(pool, || {
+        let results = ranges
+            .par_iter()
+            .map(|&(start, end)| {
+                control.check_cancelled()?;
+                let mut work = 0_usize;
+                let mut local = Vec::with_capacity(end - start);
+                for source in start..end {
+                    let score = total_neighbor_source_score(neighbors, degrees, source, || {
+                        total_neighbors_checkpoint(control, &mut work)
+                    })?;
+                    local.push(exact_u64_as_f64(score, "total-neighbors score")?);
+                }
+                Ok((start, local))
+            })
+            .collect::<Vec<Result<_, AlgorithmError>>>();
+        first_chunk_error(results)
+    })?;
+
+    let mut scores = Vec::with_capacity(neighbors.len());
+    for (_start, local) in chunk_results {
+        scores.extend(local);
+    }
+    Ok(scores)
+}
+
+fn total_neighbor_source_score(
+    neighbors: &[Vec<usize>],
+    degrees: &[u64],
+    source: usize,
+    mut checkpoint: impl FnMut() -> Result<(), AlgorithmError>,
+) -> Result<u64, AlgorithmError> {
+    let source_neighbors = &neighbors[source];
+    let mut score = 0_u64;
+    for (candidate, candidate_neighbors) in neighbors.iter().enumerate() {
+        checkpoint()?;
+        if source == candidate || source_neighbors.binary_search(&candidate).is_ok() {
+            continue;
+        }
+        let mut union = degrees[source]
+            .checked_add(degrees[candidate])
+            .ok_or_else(|| execution("total-neighbors pair score exceeds supported range"))?;
+        let (mut left, mut right) = (0, 0);
+        while left < source_neighbors.len() && right < candidate_neighbors.len() {
+            checkpoint()?;
+            match source_neighbors[left].cmp(&candidate_neighbors[right]) {
+                std::cmp::Ordering::Less => left += 1,
+                std::cmp::Ordering::Greater => right += 1,
+                std::cmp::Ordering::Equal => {
+                    union = union
+                        .checked_sub(1)
+                        .ok_or_else(|| execution("total-neighbors pair score underflow"))?;
+                    left += 1;
+                    right += 1;
+                }
+            }
+        }
+        score = score
+            .checked_add(union)
+            .ok_or_else(|| execution("total-neighbors score exceeds supported range"))?;
+    }
+    Ok(score)
+}
+
+fn total_neighbors_checkpoint(
+    control: &AlgorithmControl,
+    visited: &mut usize,
+) -> Result<(), AlgorithmError> {
+    if (*visited).is_multiple_of(TOTAL_NEIGHBORS_CHECKPOINT_INTERVAL) {
+        control.checkpoint()?;
+    }
+    *visited = visited.saturating_add(1);
+    Ok(())
+}
+
+fn estimated_total_neighbors_work(neighbors: &[Vec<usize>]) -> u64 {
+    let sources = usize_to_u64_saturating(neighbors.len());
+    let degree_sum = neighbors.iter().fold(0_u64, |total, adjacent| {
+        total.saturating_add(usize_to_u64_saturating(adjacent.len()))
+    });
+    sources
+        .saturating_mul(sources)
+        .saturating_add(sources.saturating_mul(degree_sum).saturating_mul(2))
+}
+
+/// Choose serial vs private-pool parallel execution for a total-neighbors workload.
+pub(crate) fn select_total_neighbors_path(
+    control: &AlgorithmControl,
+    sources: usize,
+    estimated_work: u64,
+) -> TotalNeighborsExecutionPath {
+    let threads = control.compute_threads();
+    if threads <= 1
+        || sources <= 1
+        || estimated_work < TOTAL_NEIGHBORS_PARALLEL_CROSSOVER_WORK
+        || control
+            .compute_pool()
+            .is_none_or(|pool| !pool.is_parallel())
+    {
+        return TotalNeighborsExecutionPath::Serial;
+    }
+    let chunks = source_chunks(sources, threads).len();
+    if chunks <= 1 {
+        return TotalNeighborsExecutionPath::Serial;
+    }
+    TotalNeighborsExecutionPath::Parallel { threads, chunks }
+}
+
+fn run_total_neighbors_on_pool<R>(
+    pool: &crate::ComputePool,
+    op: impl FnOnce() -> Result<R, AlgorithmError> + Send,
+) -> Result<R, AlgorithmError>
+where
+    R: Send,
+{
+    match catch_unwind(AssertUnwindSafe(|| pool.install(op))) {
+        Ok(result) => result,
+        Err(_) => Err(execution("total-neighbors worker panicked")),
+    }
+}
+
 
 fn k_core_scores(
     graph: &AdjacencyGraph,
@@ -4846,6 +4986,49 @@ mod tests {
 
     fn total_neighbor_output_scores(output: &AlgorithmOutput) -> Vec<f64> {
         hits_hub_scores(output)
+    }
+
+    fn execute_total_neighbors_with_pool(
+        graph: &AdjacencyGraph,
+        threads: usize,
+        limits: AlgorithmLimits,
+        cancellation: AlgorithmCancellation,
+    ) -> Result<AlgorithmOutput, AlgorithmError> {
+        let pool = Arc::new(crate::ComputePool::new(threads).unwrap());
+        let mut registry = AlgorithmRegistry::default();
+        register_rank_algorithms(&mut registry)?;
+        let control = AlgorithmControl::new(limits.with_compute_threads(threads), cancellation)
+            .with_compute_pool(pool);
+        registry.execute(
+            Algorithm::Rank(RankAlgorithm::TotalNeighbors),
+            graph,
+            &control,
+        )
+    }
+
+    fn total_neighbor_bits(output: &AlgorithmOutput) -> Vec<u64> {
+        total_neighbor_output_scores(output)
+            .into_iter()
+            .map(f64::to_bits)
+            .collect()
+    }
+
+    fn total_neighbors_ring_graph(nodes: usize, fanout: usize) -> AdjacencyGraph {
+        let fanout = fanout.min(nodes.saturating_sub(1));
+        let edges = (0..nodes)
+            .flat_map(|node| {
+                (1..=fanout).map(move |hop| (node as u64, ((node + hop) % nodes) as u64))
+            })
+            .collect::<Vec<_>>();
+        AdjacencyGraph::with_test_edges(nodes as u64, &edges)
+    }
+
+    fn dense_total_neighbors_graph(nodes: usize) -> AdjacencyGraph {
+        let max_fanout = nodes.saturating_sub(1).max(1) / 2;
+        let fanout = ((TOTAL_NEIGHBORS_PARALLEL_CROSSOVER_WORK as usize)
+            / (nodes.max(1) * nodes.max(1)))
+        .clamp(4, max_fanout.max(1));
+        total_neighbors_ring_graph(nodes, fanout)
     }
 
     fn assert_scores_close(actual: &[f64], expected: &[f64]) {
@@ -9389,6 +9572,245 @@ mod tests {
                 message: "resource-allocation worker panicked".into()
             }
         );
+    }
+
+    #[test]
+    fn total_neighbors_path_selection_respects_crossover_pool_and_one_thread() {
+        let no_pool = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(4),
+            AlgorithmCancellation::default(),
+        );
+        assert_eq!(
+            select_total_neighbors_path(&no_pool, 64, TOTAL_NEIGHBORS_PARALLEL_CROSSOVER_WORK),
+            TotalNeighborsExecutionPath::Serial
+        );
+        let one = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(1),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(Arc::new(crate::ComputePool::new(1).unwrap()));
+        assert_eq!(
+            select_total_neighbors_path(&one, 64, TOTAL_NEIGHBORS_PARALLEL_CROSSOVER_WORK),
+            TotalNeighborsExecutionPath::Serial
+        );
+        let small = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(4),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(Arc::new(crate::ComputePool::new(4).unwrap()));
+        assert_eq!(
+            select_total_neighbors_path(&small, 64, TOTAL_NEIGHBORS_PARALLEL_CROSSOVER_WORK - 1),
+            TotalNeighborsExecutionPath::Serial
+        );
+        assert_eq!(
+            select_total_neighbors_path(&small, 64, TOTAL_NEIGHBORS_PARALLEL_CROSSOVER_WORK),
+            TotalNeighborsExecutionPath::Parallel {
+                threads: 4,
+                chunks: 4
+            }
+        );
+    }
+
+    #[test]
+    fn total_neighbors_thread_matrix_matches_one_thread_bits_and_ordering() {
+        let graph = dense_total_neighbors_graph(128);
+        let neighbors = simple_neighbors(
+            &graph,
+            &AlgorithmControl::new(AlgorithmLimits::default(), AlgorithmCancellation::default()),
+            false,
+        )
+        .unwrap();
+        assert!(
+            estimated_total_neighbors_work(&neighbors) >= TOTAL_NEIGHBORS_PARALLEL_CROSSOVER_WORK
+        );
+        let serial = execute_total_neighbors_with_pool(
+            &graph,
+            1,
+            AlgorithmLimits::default(),
+            AlgorithmCancellation::default(),
+        )
+        .unwrap();
+        let serial_rows = serial.rows();
+        let serial_bits = total_neighbor_bits(&serial);
+        for threads in [2_usize, 4, 8] {
+            let parallel = execute_total_neighbors_with_pool(
+                &graph,
+                threads,
+                AlgorithmLimits::default(),
+                AlgorithmCancellation::default(),
+            )
+            .unwrap();
+            assert_eq!(parallel.schema, serial.schema);
+            assert_eq!(parallel.rows(), serial_rows);
+            assert_eq!(total_neighbor_bits(&parallel), serial_bits);
+        }
+    }
+
+    #[test]
+    fn total_neighbors_parallel_preserves_boundary_bits() {
+        let multigraph = AdjacencyGraph::with_test_edges(
+            5,
+            &[
+                (0, 2),
+                (0, 2),
+                (0, 3),
+                (0, 0),
+                (1, 2),
+                (1, 3),
+                (2, 0),
+                (2, 4),
+                (3, 4),
+            ],
+        );
+        let directed = AdjacencyGraph::with_test_edges(2, &[(0, 1)]);
+        let undirected = AdjacencyGraph::with_test_edges(2, &[(0, 1), (1, 0)]);
+        let complete =
+            AdjacencyGraph::with_test_edges(3, &[(0, 1), (1, 0), (0, 2), (2, 0), (1, 2), (2, 1)]);
+        let empty = AdjacencyGraph::default();
+        let single = AdjacencyGraph::with_test_edges(1, &[]);
+        let disconnected = AdjacencyGraph::with_test_edges(4, &[(0, 1), (1, 0), (2, 3), (3, 2)]);
+        for graph in [
+            &multigraph,
+            &directed,
+            &undirected,
+            &complete,
+            &empty,
+            &single,
+            &disconnected,
+        ] {
+            let serial = execute_total_neighbors_with_pool(
+                graph,
+                1,
+                AlgorithmLimits::default(),
+                AlgorithmCancellation::default(),
+            )
+            .unwrap();
+            for threads in [2_usize, 4, 8] {
+                let parallel = execute_total_neighbors_with_pool(
+                    graph,
+                    threads,
+                    AlgorithmLimits::default(),
+                    AlgorithmCancellation::default(),
+                )
+                .unwrap();
+                assert_eq!(total_neighbor_bits(&parallel), total_neighbor_bits(&serial));
+                assert_eq!(parallel.rows(), serial.rows());
+            }
+        }
+    }
+
+    #[test]
+    fn total_neighbors_parallel_limits_and_cancellation_return_structured() {
+        let graph = dense_total_neighbors_graph(128);
+        let cancellation = AlgorithmCancellation::default();
+        cancellation.cancel();
+        assert_eq!(
+            execute_total_neighbors_with_pool(&graph, 4, AlgorithmLimits::default(), cancellation),
+            Err(AlgorithmError::Cancelled)
+        );
+        assert!(matches!(
+            execute_total_neighbors_with_pool(
+                &graph,
+                4,
+                AlgorithmLimits {
+                    iterations: 0,
+                    ..AlgorithmLimits::default()
+                },
+                AlgorithmCancellation::default()
+            ),
+            Err(AlgorithmError::IterationLimit { .. })
+        ));
+        assert!(matches!(
+            execute_total_neighbors_with_pool(
+                &graph,
+                4,
+                AlgorithmLimits {
+                    output_rows: 2,
+                    ..AlgorithmLimits::default()
+                },
+                AlgorithmCancellation::default()
+            ),
+            Err(AlgorithmError::OutputLimit { .. })
+        ));
+    }
+
+    #[test]
+    fn total_neighbors_source_chunks_cover_canonical_ranges() {
+        assert_eq!(source_chunks(0, 4), Vec::<(usize, usize)>::new());
+        assert_eq!(source_chunks(5, 1), vec![(0, 5)]);
+        assert_eq!(source_chunks(5, 2), vec![(0, 3), (3, 5)]);
+        assert_eq!(source_chunks(8, 4), vec![(0, 2), (2, 4), (4, 6), (6, 8)]);
+        assert_eq!(source_chunks(3, 8), vec![(0, 1), (1, 2), (2, 3)]);
+    }
+
+    #[test]
+    #[ignore = "manual crossover measurement; run with --ignored --nocapture"]
+    fn measure_total_neighbors_parallel_crossover() {
+        use std::time::Instant;
+
+        for (nodes, fanout) in [
+            (64_usize, 8_usize),
+            (96, 12),
+            (128, 16),
+            (192, 16),
+            (256, 16),
+            (512, 32),
+            (1024, 32),
+        ] {
+            let graph = total_neighbors_ring_graph(nodes, fanout);
+            let neighbors = simple_neighbors(
+                &graph,
+                &AlgorithmControl::new(
+                    AlgorithmLimits::default(),
+                    AlgorithmCancellation::default(),
+                ),
+                false,
+            )
+            .unwrap();
+            let degrees: Vec<u64> = neighbors
+                .iter()
+                .map(|adjacent| u64::try_from(adjacent.len()).unwrap())
+                .collect();
+            let work = estimated_total_neighbors_work(&neighbors);
+            let measurement_limits = AlgorithmLimits {
+                iterations: 1_000_000,
+                ..AlgorithmLimits::default()
+            };
+            let serial_ctl = AlgorithmControl::new(
+                measurement_limits.with_compute_threads(1),
+                AlgorithmCancellation::default(),
+            )
+            .with_compute_pool(Arc::new(crate::ComputePool::new(1).unwrap()));
+            let parallel_ctl = AlgorithmControl::new(
+                measurement_limits.with_compute_threads(4),
+                AlgorithmCancellation::default(),
+            )
+            .with_compute_pool(Arc::new(crate::ComputePool::new(4).unwrap()));
+            let mut serial_ns = u128::MAX;
+            let mut parallel_ns = u128::MAX;
+            for _ in 0..5 {
+                let t0 = Instant::now();
+                let serial =
+                    total_neighbor_scores_serial(&neighbors, &degrees, &serial_ctl).unwrap();
+                serial_ns = serial_ns.min(t0.elapsed().as_nanos());
+                let serial_bits = serial.iter().copied().map(f64::to_bits).collect::<Vec<_>>();
+
+                let t1 = Instant::now();
+                let parallel =
+                    total_neighbor_scores_parallel(&neighbors, &degrees, &parallel_ctl).unwrap();
+                parallel_ns = parallel_ns.min(t1.elapsed().as_nanos());
+                let parallel_bits = parallel
+                    .iter()
+                    .copied()
+                    .map(f64::to_bits)
+                    .collect::<Vec<_>>();
+                assert_eq!(parallel_bits, serial_bits);
+            }
+            println!(
+                "nodes={nodes} fanout={fanout} work={work} serial_ns={serial_ns} parallel_ns={parallel_ns} ratio={}",
+                parallel_ns as f64 / serial_ns as f64
+            );
+        }
     }
 
     #[test]

--- a/crates/graphforge-exec/src/algorithm_rank.rs
+++ b/crates/graphforge-exec/src/algorithm_rank.rs
@@ -166,10 +166,10 @@ const COMMON_NEIGHBORS_CHECKPOINT_INTERVAL: usize = 1_024;
 /// (4x Xeon vCPU, directed ring-lattice fixtures, 4 private workers, debug
 /// test profile after a clean target-dir build; see
 /// ignored `measure_total_neighbors_parallel_crossover`):
-/// - ~230k estimated units: parallel still slower (~1.77x serial)
-/// - ~540k estimated units: parallel still slower (~1.16x serial)
-/// - ~1.2M estimated units: first clear win (~0.69x serial)
-/// - >=2.1M estimated units: >=1.7x speedup
+/// - ~230k estimated units: parallel still slower (~1.06x serial)
+/// - ~540k estimated units: parallel still slower (~1.31x serial)
+/// - ~1.2M estimated units: first clear win (~0.84x serial)
+/// - >=2.1M estimated units: >=1.4x speedup
 ///
 /// `1_048_576` is the smallest power-of-two work estimate below that measured
 /// win boundary. Each source keeps serial candidate/intersection order, so

--- a/crates/graphforge-exec/src/algorithm_rank.rs
+++ b/crates/graphforge-exec/src/algorithm_rank.rs
@@ -3207,7 +3207,6 @@ where
     }
 }
 
-
 fn k_core_scores(
     graph: &AdjacencyGraph,
     control: &AlgorithmControl,

--- a/docs/book/architecture/algorithms.md
+++ b/docs/book/architecture/algorithms.md
@@ -720,8 +720,15 @@ selections, and empty selections retain deterministic zero/boundary behavior.
 Stable topology and neighbor order drive exact union counts. Pair counts and
 node aggregates use checked integer arithmetic and convert to `Float64` only
 when exactly representable at or below `2^53`; larger results return a
-structured execution error. Shared selected-node, adjacency-entry, output-row,
-iteration, and cancellation limits apply with batched checkpoints.
+structured execution error. Above the documented
+`TOTAL_NEIGHBORS_PARALLEL_CROSSOVER_WORK` (`1_048_576`) estimate and with more
+than one compute thread, independent source ordinals may run on the
+instance-owned private compute pool. Each source retains the serial candidate,
+missing-link, two-pointer union, checked-addition, and conversion order, and
+worker chunks merge by canonical source ordinal, so schemas, row order, scores,
+and fingerprints match the one-thread oracle. Smaller workloads remain serial
+to avoid pool scheduling tax. Shared selected-node, adjacency-entry,
+output-row, iteration, and cancellation limits apply with batched checkpoints.
 
 The public schema remains non-null `node_uuid: FixedSizeBinary(16)`, non-null
 `score: Float64`, then materialized node properties with Arrow NULLs for missing

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -17,7 +17,7 @@ Tokio runtime or any DataFusion execution session.
 | `spill` | disabled | Optional absolute spill directory + byte cap |
 | `io_concurrency` | `2` | Reserved I/O concurrency budget |
 | `max_concurrent_heavy_queries` | `64` | Instance-owned admission semaphore |
-| `compute_threads` | `2` | Instance-owned private CPU pool (#342 cosine KNN; #343 PageRank; #344 Node2Vec walks; #501 betweenness; #503 closeness BFS; #504 clustering coefficient; #506 Degree; #510 HITS hub; #513 resource allocation; #515 triangles; #518 Components; #534 filtered Jaccard; #535 Jaccard similarity; #542 Dijkstra APSP sources) |
+| `compute_threads` | `2` | Instance-owned private CPU pool (#342 cosine KNN; #343 PageRank; #344 Node2Vec walks; #501 betweenness; #503 closeness BFS; #504 clustering coefficient; #506 Degree; #510 HITS hub; #513 resource allocation; #514 total-neighbors aggregate; #515 triangles; #518 Components; #534 filtered Jaccard; #535 Jaccard similarity; #542 Dijkstra APSP sources) |
 
 Defaults preserve pre-#337 fixed two-worker / two-partition behavior.
 
@@ -634,6 +634,31 @@ Schemas, row order, marginal scores, projection fingerprints, structured
 limit/cancellation errors, and write-back atomicity match the one-thread oracle
 at `1`/`2`/`4`/`8`/automatic configurations. No GPU, distributed, approximate, or
 foreign-engine fallback is implied.
+
+## Parallel total-neighbors aggregate (#514)
+
+`rank(by="total_neighbors")` partitions **independent source ordinals** across
+the instance-owned private compute pool when:
+
+- `compute_threads > 1`, and
+- estimated pair/intersection work is at least
+  `TOTAL_NEIGHBORS_PARALLEL_CROSSOVER_WORK` (`1_048_576`) in
+  `graphforge-exec`.
+
+The estimate is `sources^2 + 2 * sources * selected_degree_sum`. Manual
+serial-vs-parallel timing on the M4 agent host (4x Xeon vCPU, directed
+ring-lattice fixtures, 4 private workers, debug test profile after a clean
+target-dir build; see ignored `measure_total_neighbors_parallel_crossover`)
+showed ~230k units still slower (~1.77x serial), ~540k still slower (~1.16x),
+~1.2M first clear win (~0.69x), and >=2.1M at least 1.7x faster.
+
+Below that crossover, or when the policy provides one compute thread, the
+serial path runs with no pool scheduling tax. Parallel workers own only source
+ranges. Candidate order, missing-link checks, two-pointer neighborhood
+intersections, checked integer union arithmetic, and exact `Float64` conversion
+remain serial within each source; worker scores merge in canonical source
+order. Schemas, row order, scores, structured errors, and fingerprints match the
+one-thread result at `1`/`2`/`4`/`8`/automatic configurations.
 
 ## Serial biconnected components (#517)
 

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -649,8 +649,8 @@ The estimate is `sources^2 + 2 * sources * selected_degree_sum`. Manual
 serial-vs-parallel timing on the M4 agent host (4x Xeon vCPU, directed
 ring-lattice fixtures, 4 private workers, debug test profile after a clean
 target-dir build; see ignored `measure_total_neighbors_parallel_crossover`)
-showed ~230k units still slower (~1.77x serial), ~540k still slower (~1.16x),
-~1.2M first clear win (~0.69x), and >=2.1M at least 1.7x faster.
+showed ~230k units still slower (~1.06x serial), ~540k still slower (~1.31x),
+~1.2M first clear win (~0.84x), and >=2.1M at least 1.4x faster.
 
 Below that crossover, or when the policy provides one compute thread, the
 serial path runs with no pool scheduling tax. Parallel workers own only source

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -529,7 +529,12 @@ zero/boundary behavior.
 
 Union counts and aggregates use checked integer arithmetic and become `Float64`
 only when exactly representable at or below `2^53`; larger results produce a
-structured execution error. Results expose only
+structured execution error. Above the documented
+`TOTAL_NEIGHBORS_PARALLEL_CROSSOVER_WORK` (`1_048_576`) estimate and with a
+multi-thread compute policy, independent source ordinals may run on the
+instance-owned private compute pool; each source retains serial candidate and
+union order, and worker chunks merge in canonical source order. Smaller
+workloads remain serial to avoid pool scheduling tax. Results expose only
 `node_uuid: FixedSizeBinary(16)`, `score: Float64`, then materialized node
 properties. Shared Rust limits and cancellation apply, and `write_property`
 atomically persists every score only after successful execution. Python and


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements #514: parallel total_neighbors on ComputePool with measured crossover and fingerprint parity.

Closes #514

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788951844&installation_model_id=20486&pr_number=610&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F610&signature=6f3f97ca1b956bfdb53242f641b1f08dc4e9c9f668cbf32568ad79a7b7b9c0ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parallelize `total_neighbors` scoring across the instance-owned compute pool
> - Adds a parallel execution path for `total_neighbor_scores` in [algorithm_rank.rs](https://github.com/CurateLabs/graphforge/pull/610/files#diff-d42360b7ef75ce3112d55412fae040f54af2633f4b75d8609ca211a2702172b7): when `compute_threads > 1`, a private pool is present, `sources > 1`, and estimated work meets `TOTAL_NEIGHBORS_PARALLEL_CROSSOVER_WORK` (1,048,576), sources are partitioned into chunks and processed concurrently.
> - Introduces `estimated_total_neighbors_work` (heuristic: `sources² + 2 * sources * degree_sum`) and `select_total_neighbors_path` to choose serial vs. parallel at runtime.
> - Extracts shared helpers `total_neighbor_source_score`, `total_neighbors_checkpoint`, and `run_total_neighbors_on_pool`; serial behavior is preserved for sub-threshold workloads.
> - Worker panics are caught and surfaced as a structured `AlgorithmError` with message `"total-neighbors worker panicked"`.
> - Behavioral Change: requests that previously always ran serially may now run in parallel, consuming more CPU and pool threads for large graphs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c0ec8b7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved total-neighbors processing by automatically selecting serial or parallel execution based on workload and available resources.
  * Preserved deterministic results while supporting cancellation, limits, and clearer handling of worker failures.

* **Testing**
  * Expanded coverage across thread counts, graph boundaries, execution paths, cancellation, and workload limits.
  * Updated CI workload expectations to include the existing node2vec workload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->