### PR TITLE
perf(exec): serial disposition for k_core peeling (#511)

### DIFF
--- a/crates/graphforge-api/tests/m4_entry_baseline.rs
+++ b/crates/graphforge-api/tests/m4_entry_baseline.rs
@@ -266,6 +266,10 @@ fn supported_runtime_configuration() -> serde_json::Value {
     })
 }
 
+#[allow(
+    clippy::too_many_lines,
+    reason = "matrix assembly keeps assertions and emitted evidence together"
+)]
 fn parity_configurations(
     contract: &serde_json::Value,
     fixture: &std::path::Path,
@@ -414,6 +418,11 @@ fn collect_workloads_for(gf: &GraphForge) -> Vec<WorkloadEvidence> {
         {
             let ev = run_paths_gomory_hu_tree(gf);
             assert!(ev.output_rows > 0, "paths-gomory-hu-tree must produce rows");
+            ev
+        },
+        {
+            let ev = run_k_core(gf);
+            assert_eq!(ev.output_rows, 5);
             ev
         },
         {
@@ -607,6 +616,45 @@ fn run_paths_gomory_hu_tree(gf: &GraphForge) -> WorkloadEvidence {
             (
                 "work_units",
                 serde_json::json!("component_bfs_and_ordered_min_cut_parent_updates"),
+            ),
+            ("threads_path", serde_json::json!("serial_for_all_policies")),
+            ("csr_native_projection", serde_json::json!(true)),
+            ("bounded_arrow_sink", serde_json::json!(true)),
+        ]),
+    }
+}
+
+fn run_k_core(gf: &GraphForge) -> WorkloadEvidence {
+    let options = RankOptions {
+        by: RankAlgorithm::KCore,
+        via: Some("KNOWS".into()),
+        directed: true,
+        ..RankOptions::default()
+    };
+    let before_rss = peak_rss_bytes();
+    let started = Instant::now();
+    let first = gf.rank("Person", options.clone()).expect("k_core");
+    let second = gf.rank("Person", options).expect("k_core repeat");
+    let wall_time_ms = started.elapsed().as_secs_f64() * 1_000.0;
+    assert_logical_batch_equal(&first, &second, "k_core must be deterministic");
+    let fingerprint = batch_structural_fingerprint(std::slice::from_ref(&first));
+    WorkloadEvidence {
+        id: "rank-k-core",
+        schema_fields: schema_field_names(first.schema().as_ref()),
+        output_rows: first.num_rows() as u64,
+        fingerprint,
+        wall_time_ms,
+        peak_rss_bytes: peak_rss_bytes().or(before_rss),
+        structural: BTreeMap::from([
+            ("surface", serde_json::json!("GraphForge::rank")),
+            ("algorithm", serde_json::json!("k_core")),
+            (
+                "disposition",
+                serde_json::json!("serial_priority_queue_peeling"),
+            ),
+            (
+                "work_units",
+                serde_json::json!("heap_pops_and_live_neighbor_decrements"),
             ),
             ("threads_path", serde_json::json!("serial_for_all_policies")),
             ("csr_native_projection", serde_json::json!(true)),
@@ -1004,6 +1052,11 @@ fn collect_short_matrix() -> (serde_json::Value, Vec<WorkloadEvidence>) {
             ev
         },
         {
+            let ev = run_k_core(&gf);
+            assert_eq!(ev.output_rows, 5);
+            ev
+        },
+        {
             let ev = run_analyze_maximum_spanning_tree(&gf);
             assert!(
                 ev.output_rows > 0,
@@ -1086,7 +1139,7 @@ fn build_evidence(
 #[test]
 fn short_ci_matrix_runs_through_public_facade_under_fixed_two_workers() {
     let (contract, workloads) = collect_short_matrix();
-    assert_eq!(workloads.len(), 12);
+    assert_eq!(workloads.len(), 13);
     let ids: Vec<_> = workloads.iter().map(|w| w.id).collect();
     assert_eq!(
         ids,
@@ -1096,6 +1149,7 @@ fn short_ci_matrix_runs_through_public_facade_under_fixed_two_workers() {
             "aggregate-top-n",
             "pagerank",
             "paths-gomory-hu-tree",
+            "rank-k-core",
             "analyze-maximum-spanning-tree",
             "paths-min-steiner-tree",
             "paths-bellman-ford",
@@ -1203,11 +1257,9 @@ fn contract_classifies_thread_parity_configurations_for_337() {
             "resource_limit_behavior"
         ])
     );
-    assert!(
-        contract["current_runtime"]["public_resource_policy"]
-            .as_bool()
-            .unwrap()
-    );
+    assert!(contract["current_runtime"]["public_resource_policy"]
+        .as_bool()
+        .unwrap());
 }
 
 #[test]
@@ -1289,12 +1341,10 @@ fn evidence_distinguishes_structural_gates_from_timing_observations() {
         assert_eq!(workload["timing_is_pass_fail"], false);
         assert!(workload["timing_observation"].get("wall_time_ms").is_some());
         // Peak RSS may be unavailable on non-Linux hosts; presence of the field is required.
-        assert!(
-            workload["timing_observation"]
-                .as_object()
-                .expect("timing object")
-                .contains_key("peak_rss_bytes")
-        );
+        assert!(workload["timing_observation"]
+            .as_object()
+            .expect("timing object")
+            .contains_key("peak_rss_bytes"));
     }
     assert!(evidence.get("spill_bytes").is_some());
 }

--- a/crates/graphforge-api/tests/m4_entry_baseline.rs
+++ b/crates/graphforge-api/tests/m4_entry_baseline.rs
@@ -1257,9 +1257,11 @@ fn contract_classifies_thread_parity_configurations_for_337() {
             "resource_limit_behavior"
         ])
     );
-    assert!(contract["current_runtime"]["public_resource_policy"]
-        .as_bool()
-        .unwrap());
+    assert!(
+        contract["current_runtime"]["public_resource_policy"]
+            .as_bool()
+            .unwrap()
+    );
 }
 
 #[test]
@@ -1341,10 +1343,12 @@ fn evidence_distinguishes_structural_gates_from_timing_observations() {
         assert_eq!(workload["timing_is_pass_fail"], false);
         assert!(workload["timing_observation"].get("wall_time_ms").is_some());
         // Peak RSS may be unavailable on non-Linux hosts; presence of the field is required.
-        assert!(workload["timing_observation"]
-            .as_object()
-            .expect("timing object")
-            .contains_key("peak_rss_bytes"));
+        assert!(
+            workload["timing_observation"]
+                .as_object()
+                .expect("timing object")
+                .contains_key("peak_rss_bytes")
+        );
     }
     assert!(evidence.get("spill_bytes").is_some());
 }

--- a/crates/graphforge-exec/src/algorithm_k_core.rs
+++ b/crates/graphforge-exec/src/algorithm_k_core.rs
@@ -1,4 +1,11 @@
 //! Exact deterministic core numbers shared by Rust rank and cluster handlers.
+//!
+//! K-core peeling intentionally remains serial (#511). The accepted public
+//! contract follows a min-priority queue keyed by `(current degree, dense node
+//! ordinal)`: each pop decides which live neighbors are decremented and which
+//! stale heap entries will later be ignored. That frontier is order-dependent,
+//! so there are no independent work units to send to the private compute pool
+//! without changing fingerprints or tie behavior.
 
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;

--- a/crates/graphforge-exec/src/algorithm_rank.rs
+++ b/crates/graphforge-exec/src/algorithm_rank.rs
@@ -7704,6 +7704,20 @@ mod tests {
             execute_k_core(&graph, AlgorithmLimits::default(), cancellation),
             Err(AlgorithmError::Cancelled)
         );
+        assert!(matches!(
+            execute_k_core(
+                &graph,
+                AlgorithmLimits {
+                    output_rows: 2,
+                    ..AlgorithmLimits::default()
+                },
+                AlgorithmCancellation::default(),
+            ),
+            Err(AlgorithmError::OutputLimit {
+                observed: 3,
+                limit: 2
+            })
+        ));
         let mut registry = AlgorithmRegistry::default();
         register_rank_algorithms(&mut registry).unwrap();
         let capability = registry
@@ -7713,6 +7727,54 @@ mod tests {
             .unwrap();
         assert_eq!(capability.dependency, BUILTIN_REVIEW);
         assert_eq!(capability.algorithm.as_str(), "k_core");
+    }
+
+    #[test]
+    fn k_core_serial_disposition_matches_across_compute_thread_budgets() {
+        let graph = AdjacencyGraph::with_test_edges(
+            10,
+            &[
+                (0, 1),
+                (0, 2),
+                (0, 3),
+                (1, 2),
+                (1, 3),
+                (2, 3),
+                (0, 4),
+                (4, 5),
+                (7, 8),
+                (8, 9),
+                (9, 7),
+            ],
+        );
+        let limits = AlgorithmLimits {
+            batch_size: 2,
+            ..AlgorithmLimits::default()
+        };
+        let algorithm = Algorithm::Rank(RankAlgorithm::KCore);
+        let oracle = execute_rank_with_compute(
+            &graph,
+            algorithm,
+            limits.with_compute_threads(1),
+            Some(Arc::new(crate::ComputePool::new(1).unwrap())),
+        )
+        .unwrap();
+        assert_eq!(oracle.peak_builder_rows, 2);
+        assert_eq!(oracle.internal_batch_count, 5);
+
+        for threads in [2, 4, 8] {
+            let candidate = execute_rank_with_compute(
+                &graph,
+                algorithm,
+                limits.with_compute_threads(threads),
+                Some(Arc::new(crate::ComputePool::new(threads).unwrap())),
+            )
+            .unwrap();
+            assert_eq!(
+                candidate, oracle,
+                "serial k-core disposition must match one-thread oracle at {threads} threads"
+            );
+        }
     }
 
     #[test]

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -213,6 +213,64 @@ serial path runs with no pool scheduling tax. Workers emit `(uuid, score)` rows
 for contiguous ordinal ranges; the sink merges them in ascending node order so
 schemas, row order, scores, and fingerprints match the one-thread result at
 `1`/`2`/`4`/`8`/automatic configurations.
+<<<<<<< HEAD
+=======
+## Parallel eigenvector (#507)
+
+`rank(by="eigenvector")` shifted power-iteration destination updates may run on
+the instance-owned private compute pool when:
+
+- `compute_threads > 1`, and
+- selected adjacency entries are at least
+  `EIGENVECTOR_PARALLEL_CROSSOVER_EDGES` (`8_192`) in `graphforge-exec`.
+
+Release-mode local evidence on the 4-worker M4 agent host showed regular graphs
+that converge during warm-up avoid the pool, while irregular non-converged
+fixtures crossed over by ~8K selected adjacency entries:
+`8_689`, `24_440`, `65_505`, and `130_544` edge irregular fixtures repeatedly
+ran at roughly `0.4×–0.6×` of the one-thread time on four private workers.
+Those timings are hardware-specific evidence, not a CI gate.
+
+Below that crossover, or when the policy provides one compute thread, the
+serial source-scatter path runs with no pool scheduling tax. Above the
+crossover, the first two required power iterations also stay serial; if the
+workload converges there, no inbound CSR or worker scheduling tax is paid.
+Remaining non-converged work is destination-owned: each worker owns a
+contiguous dense-ordinal destination range and applies inbound contributions
+after the implicit identity term in the same canonical source/edge order as
+serial scatter. L2 normalization and component-wise convergence checks stay
+serial, so scores, iteration counts, and fingerprints match the one-thread
+result at `1`/`2`/`4`/`8`/automatic configurations.
+## Parallel HITS hub / authority (#510 / #509)
+
+The shared `hits_scores` kernel used by `rank(by="hits_hub")` prepares selected
+and `rank(by="hits_authority")` prepares selected adjacency once as
+dense-ordinal outgoing and incoming CSR, then partitions independent node-score
+updates across the instance-owned private compute pool when:
+
+- `compute_threads > 1`, and
+- selected adjacency entries are at least
+  `HITS_PARALLEL_CROSSOVER_EDGES` (`4_096`) in `graphforge-exec`.
+
+Below that crossover, or when the policy provides one compute thread, the
+serial path runs with no pool scheduling tax. Parallel work is node-owned: the
+authority phase owns contiguous target ranges over incoming CSR, and the hub
+phase owns contiguous source ranges over outgoing CSR. Each node's
+floating-point sum still walks its CSR slice in canonical source/edge order,
+and global L2 norms remain serial dense-ordinal reductions, so schemas, row
+order, scores, ties, and fingerprints match the one-thread result at
+`1`/`2`/`4`/`8`/automatic configurations. The crossover follows the same
+4 vCPU release-build structural benchmark regime used for adjacent M4 kernels:
+the parallel path avoids small-fixture tax and clears the worker-pool cost once
+20 fixed HITS iterations amortize two sparse matrix-vector phases per
+iteration. It is CPU-only; no GPU or universal scaling claim is made.
+
+The threshold is the first measured win on the M4 agent host using the ignored
+release harness (`measure_article_rank_parallel_crossover`) with a shared
+four-worker private pool: sizes through 32k selected entries stayed near parity
+within timing noise, while 131k and 262k selected entries were clear wins over
+the one-thread path.
+>>>>>>> 1d5f6e2 (perf(exec): serial disposition for k_core peeling (#511))
 
 ## Parallel Node2Vec walk generation (#344)
 
@@ -577,7 +635,6 @@ Schemas, row order, marginal scores, projection fingerprints, structured
 limit/cancellation errors, and write-back atomicity match the one-thread oracle
 at `1`/`2`/`4`/`8`/automatic configurations. No GPU, distributed, approximate, or
 foreign-engine fallback is implied.
->>>>>>> dced88e (perf(exec): serial disposition for CELF (#502))
 
 ## Serial biconnected components (#517)
 
@@ -592,6 +649,34 @@ sink, avoids any Rayon global pool, and observes cancellation and shared
 iteration/output limits. The serial disposition is covered by a fingerprint test
 that attaches private compute pools for `1`/`2`/`4`/`8` configured compute
 threads and requires identical schemas, row ordering, labels, and rows.
+<<<<<<< HEAD
+=======
+
+## Serial k-core peeling (#511)
+
+`rank(by="k_core")` has no parallel crossover. Its performance disposition is
+**serial priority-queue peeling** for every `compute_threads` setting, including
+`1`/`2`/`4`/`8`/automatic resource policies.
+
+The Rust kernel consumes the CSR-native `AdjacencyGraph` projection (#340),
+normalizes simple undirected neighbor ordinals for the exact core-decomposition
+contract, then peels through a min-priority queue keyed by
+`(current degree, dense node ordinal)`. Each heap pop decides which live
+neighbors are decremented and which stale entries will later be ignored, so the
+frontier is order-dependent rather than a set of independent work units. Using
+the private compute pool here would require concurrent decrease-key/tie
+coordination and would risk changing accepted row ordering, ties, and
+fingerprints.
+
+The path still uses shared cancellation/checkpoint controls, structured
+resource errors, and the bounded Arrow sink (#341); it never creates a
+parallel-only graph copy or uses Rayon's process-global pool. The M4 entry
+harness records `rank-k-core` structural evidence (work units, serial path,
+peak RSS, result fingerprint, and hardware-specific timing) and verifies that
+executed thread configurations match the one-thread oracle. Timing remains
+evidence only, not a CI threshold.
+
+>>>>>>> 1d5f6e2 (perf(exec): serial disposition for k_core peeling (#511))
 ## Observability
 
 `GraphForge::resource_policy()` and `GraphForge::resource_diagnostics()` expose

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -213,8 +213,6 @@ serial path runs with no pool scheduling tax. Workers emit `(uuid, score)` rows
 for contiguous ordinal ranges; the sink merges them in ascending node order so
 schemas, row order, scores, and fingerprints match the one-thread result at
 `1`/`2`/`4`/`8`/automatic configurations.
-<<<<<<< HEAD
-=======
 ## Parallel eigenvector (#507)
 
 `rank(by="eigenvector")` shifted power-iteration destination updates may run on
@@ -270,7 +268,6 @@ release harness (`measure_article_rank_parallel_crossover`) with a shared
 four-worker private pool: sizes through 32k selected entries stayed near parity
 within timing noise, while 131k and 262k selected entries were clear wins over
 the one-thread path.
->>>>>>> 1d5f6e2 (perf(exec): serial disposition for k_core peeling (#511))
 
 ## Parallel Node2Vec walk generation (#344)
 
@@ -649,8 +646,6 @@ sink, avoids any Rayon global pool, and observes cancellation and shared
 iteration/output limits. The serial disposition is covered by a fingerprint test
 that attaches private compute pools for `1`/`2`/`4`/`8` configured compute
 threads and requires identical schemas, row ordering, labels, and rows.
-<<<<<<< HEAD
-=======
 
 ## Serial k-core peeling (#511)
 
@@ -676,7 +671,6 @@ peak RSS, result fingerprint, and hardware-specific timing) and verifies that
 executed thread configurations match the one-thread oracle. Timing remains
 evidence only, not a CI threshold.
 
->>>>>>> 1d5f6e2 (perf(exec): serial disposition for k_core peeling (#511))
 ## Observability
 
 `GraphForge::resource_policy()` and `GraphForge::resource_diagnostics()` expose

--- a/scripts/ci/m4-entry-matrix.py
+++ b/scripts/ci/m4-entry-matrix.py
@@ -19,6 +19,7 @@ REQUIRED_WORKLOAD_IDS = {
     "aggregate-top-n",
     "pagerank",
     "paths-gomory-hu-tree",
+    "rank-k-core",
     "analyze-maximum-spanning-tree",
     "paths-min-steiner-tree",
     "paths-bellman-ford",

--- a/tests/contracts/m4-entry-matrix.json
+++ b/tests/contracts/m4-entry-matrix.json
@@ -160,6 +160,22 @@
       ]
     },
     {
+      "id": "rank-k-core",
+      "class": "core-decomposition-peeling",
+      "surface": "GraphForge::rank",
+      "short_ci": true,
+      "large_manual": true,
+      "disposition": "serial_priority_queue_peeling",
+      "structural_gates": [
+        "schema",
+        "row_count",
+        "ordering",
+        "result_fingerprint",
+        "csr_native_projection",
+        "bounded_arrow_sink"
+      ]
+    },
+    {
       "id": "analyze-maximum-spanning-tree",
       "class": "serial-spanning-tree-graph-algorithm",
       "surface": "GraphForge::analyze",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements #511: honest serial disposition for `rank(by="k_core")` priority-queue peeling (order-dependent). CSR-native/evidence docs; no forced parallelism.

Closes #511

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788951844&installation_model_id=20486&pr_number=611&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F611&signature=fc67434dacf4ab17111965362eaf3e5d4a1f47f63d5c0f1fc30ac8592b392ceb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add serial disposition for k-core peeling to `GraphForge::rank`
> - Establishes k-core peeling as explicitly serial (priority-queue frontier, no parallel work units dispatched), documented in [execution-resource-policy.md](https://github.com/CurateLabs/graphforge/pull/611/files#diff-978cd3c64399512fe02ce13768a045b47b2b98e5e672d553ee1bb69be7843971) and the [algorithm_k_core.rs](https://github.com/CurateLabs/graphforge/pull/611/files#diff-ffc6235be021b763626c18ef7effef594c613b2416c1e2b9a2605a058e3e7f2d) module docs.
> - Adds a regression test confirming k-core output and internal metrics (`peak_builder_rows`, `internal_batch_count`) are identical across 1, 2, 4, and 8 compute threads.
> - Registers `rank-k-core` as a required workload in the M4 entry CI matrix, with a contract entry specifying `serial_priority_queue_peeling` disposition and structural gates (fingerprint, CSR projection, Arrow sink).
> - Extends baseline tests to include the k-core workload, asserting 5 output rows and emitting `WorkloadEvidence` with resource metrics.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized abf38de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->