### PR TITLE
perf(exec): parallelize FastRP on ComputePool (#559)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_embedding_fastrp.rs
+++ b/crates/graphforge-exec/src/algorithm_embedding_fastrp.rs
@@ -1339,12 +1339,13 @@ mod tests {
         ));
 
         let pool = ComputePool::new(2).unwrap();
-        assert_eq!(
-            run_on_pool(&pool, || -> Result<(), FastRpError> {
-                panic!("test FastRP worker panic");
-            }),
-            Err(FastRpError::WorkerPanic)
-        );
+        let previous_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let worker_result = run_on_pool(&pool, || -> Result<(), FastRpError> {
+            panic!("test FastRP worker panic");
+        });
+        std::panic::set_hook(previous_hook);
+        assert_eq!(worker_result, Err(FastRpError::WorkerPanic));
     }
 
     #[test]

--- a/crates/graphforge-exec/src/algorithm_embedding_fastrp.rs
+++ b/crates/graphforge-exec/src/algorithm_embedding_fastrp.rs
@@ -377,9 +377,9 @@ fn initial_projection_parallel(
             .par_iter()
             .map(|&(start, end)| {
                 let mut rows = Vec::with_capacity(end - start);
-                for node_index in start..end {
+                for (node_index, node) in nodes.iter().enumerate().take(end).skip(start) {
                     rows.push(initial_projection_row(
-                        &nodes[node_index],
+                        node,
                         node_index,
                         strengths,
                         total_strength,
@@ -486,9 +486,9 @@ fn mix_features(
                     .par_iter()
                     .map(|&(start, end)| {
                         let mut rows = Vec::with_capacity(end - start);
-                        for index in start..end {
-                            let mut row = current[index].clone();
-                            mix_feature_row(&mut row, &nodes[index], &projection, options);
+                        for (row, node) in current.iter().zip(nodes).take(end).skip(start) {
+                            let mut row = row.clone();
+                            mix_feature_row(&mut row, node, &projection, options);
                             rows.push(row);
                         }
                         Ok((start, rows))
@@ -574,10 +574,10 @@ fn propagate_serial(
     control: &EmbeddingControl<'_>,
 ) -> Result<Vec<Vec<f64>>, FastRpError> {
     let mut next = Vec::with_capacity(adjacency.len());
-    for source in 0..adjacency.len() {
+    for (neighbors, &strength) in adjacency.iter().zip(strengths) {
         next.push(propagate_row(
-            &adjacency[source],
-            strengths[source],
+            neighbors,
+            strength,
             current,
             dimensions,
             dimensions_u64,
@@ -602,9 +602,9 @@ fn propagate_parallel(
             .par_iter()
             .map(|&(start, end)| {
                 let mut rows = Vec::with_capacity(end - start);
-                for source in start..end {
+                for (source, neighbors) in adjacency.iter().enumerate().take(end).skip(start) {
                     rows.push(propagate_row(
-                        &adjacency[source],
+                        neighbors,
                         strengths[source],
                         current,
                         dimensions,

--- a/crates/graphforge-exec/src/algorithm_embedding_fastrp.rs
+++ b/crates/graphforge-exec/src/algorithm_embedding_fastrp.rs
@@ -1,15 +1,36 @@
 //! Deterministic FastRP mathematical kernel.
+//!
+//! Row-owned FastRP work (#559) may use the instance-owned private compute pool
+//! above a documented crossover. Each source row retains serial neighbor and
+//! coordinate order; worker chunks merge by canonical node ordinal so embeddings
+//! remain bit-for-bit identical to the one-thread path.
 
 use std::collections::{HashMap, HashSet};
+use std::panic::{AssertUnwindSafe, catch_unwind};
 
 use graphforge_core::embedding_options::FastRpOptions;
+use rayon::prelude::*;
 
 use crate::algorithm_embedding_control::{EmbeddingControl, EmbeddingResourceError};
 use crate::algorithm_embedding_output::EmbeddingOutputRow;
 use crate::algorithm_embedding_rng::{EmbeddingRng, EmbeddingRngField};
 use crate::algorithm_graph::AdjacencyGraph;
 
+/// Estimated FastRP row/coordinate ops below which execution stays serial (#559).
+///
+/// Keeps small fixtures and micro-invocations off the worker pool. At or above
+/// this boundary, row-owned projection, accumulation, and sparse matvec work
+/// amortize scheduling while preserving each row's serial arithmetic order.
+pub const FASTRP_PARALLEL_CROSSOVER_OPS: u64 = 65_536;
+
 pub(crate) type FastRpEmbeddingRow = EmbeddingOutputRow;
+
+/// Selected FastRP execution path for observability and crossover tests.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum FastRpExecutionPath {
+    Serial,
+    Parallel { threads: usize, chunks: usize },
+}
 
 #[derive(Clone, Debug, PartialEq, thiserror::Error)]
 pub(crate) enum FastRpError {
@@ -25,6 +46,8 @@ pub(crate) enum FastRpError {
     NonFiniteEmbedding,
     #[error("fastrp dimensions exceed UInt64 range")]
     DimensionOverflow,
+    #[error("fastrp worker panicked")]
+    WorkerPanic,
     #[error(transparent)]
     Resource(#[from] EmbeddingResourceError),
 }
@@ -136,6 +159,14 @@ fn run_fastrp(
 
     let dimensions =
         u64::try_from(options.dimensions).map_err(|_| FastRpError::DimensionOverflow)?;
+    let work_units = estimated_fastrp_ops(
+        input.nodes.len(),
+        adjacency_entries(&adjacency),
+        options.dimensions,
+        options.iteration_weights.len(),
+        options.feature_properties.len(),
+    );
+    let path = select_fastrp_path(control, input.nodes.len(), work_units);
     let mut current = initial_projection(
         &input.nodes,
         &strengths,
@@ -143,8 +174,16 @@ fn run_fastrp(
         options,
         control,
         dimensions,
+        path,
     )?;
-    mix_features(&mut current, &input.nodes, options, control, dimensions)?;
+    mix_features(
+        &mut current,
+        &input.nodes,
+        options,
+        control,
+        dimensions,
+        path,
+    )?;
 
     let mut accumulator = vec![vec![0.0; options.dimensions]; input.nodes.len()];
     accumulate(
@@ -152,27 +191,20 @@ fn run_fastrp(
         &current,
         options.iteration_weights[0],
         control,
+        path,
     )?;
     for &iteration_weight in options.iteration_weights.iter().skip(1) {
-        let mut next = vec![vec![0.0; options.dimensions]; input.nodes.len()];
-        for (source, neighbors) in adjacency.iter().enumerate() {
-            let adjacency_work = u64::try_from(neighbors.len())
-                .ok()
-                .and_then(|entries| entries.checked_mul(dimensions))
-                .ok_or(EmbeddingResourceError::Overflow)?;
-            control.checkpoint(adjacency_work)?;
-            if strengths[source] == 0.0 {
-                continue;
-            }
-            for &(target, weight) in neighbors {
-                let probability = weight / strengths[source];
-                for coordinate in 0..options.dimensions {
-                    next[source][coordinate] += probability * current[target][coordinate];
-                }
-            }
-        }
+        let next = propagate(
+            &adjacency,
+            &strengths,
+            &current,
+            options.dimensions,
+            dimensions,
+            control,
+            path,
+        )?;
         current = next;
-        accumulate(&mut accumulator, &current, iteration_weight, control)?;
+        accumulate(&mut accumulator, &current, iteration_weight, control, path)?;
     }
 
     control.before_publish()?;
@@ -220,7 +252,89 @@ fn build_adjacency(
     Ok(adjacency)
 }
 
+/// Choose serial vs private-pool parallel FastRP execution.
+pub(crate) fn select_fastrp_path(
+    control: &EmbeddingControl<'_>,
+    rows: usize,
+    estimated_ops: u64,
+) -> FastRpExecutionPath {
+    let threads = control.compute_threads();
+    if threads <= 1 || rows <= 1 || estimated_ops < FASTRP_PARALLEL_CROSSOVER_OPS {
+        return FastRpExecutionPath::Serial;
+    }
+    if control
+        .compute_pool()
+        .is_none_or(|pool| !pool.is_parallel())
+    {
+        return FastRpExecutionPath::Serial;
+    }
+    let chunks = row_chunks(rows, threads).len();
+    if chunks <= 1 {
+        return FastRpExecutionPath::Serial;
+    }
+    FastRpExecutionPath::Parallel { threads, chunks }
+}
+
+fn estimated_fastrp_ops(
+    nodes: usize,
+    adjacency_entries: usize,
+    dimensions: usize,
+    iteration_weights: usize,
+    properties: usize,
+) -> u64 {
+    let nodes = u64::try_from(nodes).unwrap_or(u64::MAX);
+    let adjacency_entries = u64::try_from(adjacency_entries).unwrap_or(u64::MAX);
+    let dimensions = u64::try_from(dimensions).unwrap_or(u64::MAX);
+    let iteration_weights = u64::try_from(iteration_weights).unwrap_or(u64::MAX);
+    let properties = u64::try_from(properties).unwrap_or(u64::MAX);
+    let propagated_iterations = iteration_weights.saturating_sub(1);
+    adjacency_entries
+        .saturating_mul(propagated_iterations)
+        .saturating_mul(dimensions)
+        .saturating_add(nodes.saturating_mul(dimensions))
+        .saturating_add(
+            nodes
+                .saturating_mul(iteration_weights)
+                .saturating_mul(dimensions),
+        )
+        .saturating_add(properties.saturating_mul(dimensions))
+        .saturating_add(nodes.saturating_mul(properties).saturating_mul(dimensions))
+}
+
+fn adjacency_entries(adjacency: &[Vec<(usize, f64)>]) -> usize {
+    adjacency.iter().map(Vec::len).sum()
+}
+
 fn initial_projection(
+    nodes: &[FastRpNode],
+    strengths: &[f64],
+    total_strength: f64,
+    options: &FastRpOptions,
+    control: &EmbeddingControl<'_>,
+    dimensions: u64,
+    path: FastRpExecutionPath,
+) -> Result<Vec<Vec<f64>>, FastRpError> {
+    match path {
+        FastRpExecutionPath::Serial => initial_projection_serial(
+            nodes,
+            strengths,
+            total_strength,
+            options,
+            control,
+            dimensions,
+        ),
+        FastRpExecutionPath::Parallel { .. } => initial_projection_parallel(
+            nodes,
+            strengths,
+            total_strength,
+            options,
+            control,
+            dimensions,
+        ),
+    }
+}
+
+fn initial_projection_serial(
     nodes: &[FastRpNode],
     strengths: &[f64],
     total_strength: f64,
@@ -233,31 +347,89 @@ fn initial_projection(
         .iter()
         .enumerate()
         .map(|(node_index, node)| {
-            control.checkpoint(dimensions)?;
-            let level = if options.normalization_strength == 0.0 {
-                1.0
-            } else if strengths[node_index] == 0.0 {
-                0.0
-            } else {
-                (strengths[node_index] / total_strength).powf(options.normalization_strength)
-            };
-            let mut row = vec![0.0; options.dimensions];
-            for (coordinate, value) in row.iter_mut().enumerate() {
-                *value = level
-                    * sparse_projection(
-                        "node-projection",
-                        options.seed,
-                        &[
-                            EmbeddingRngField::Uuid(node.uuid),
-                            EmbeddingRngField::U64(to_u64(coordinate)?),
-                        ],
-                        node_q,
-                    );
-            }
-            unit_l2(&mut row);
-            Ok(row)
+            initial_projection_row(
+                node,
+                node_index,
+                strengths,
+                total_strength,
+                options,
+                control,
+                dimensions,
+                node_q,
+            )
         })
         .collect()
+}
+
+fn initial_projection_parallel(
+    nodes: &[FastRpNode],
+    strengths: &[f64],
+    total_strength: f64,
+    options: &FastRpOptions,
+    control: &EmbeddingControl<'_>,
+    dimensions: u64,
+) -> Result<Vec<Vec<f64>>, FastRpError> {
+    let pool = fastrp_pool(control)?;
+    let node_q = usize_to_f64(nodes.len()).sqrt().max(1.0);
+    let ranges = row_chunks(nodes.len(), control.compute_threads());
+    let chunks = run_on_pool(pool, || {
+        ranges
+            .par_iter()
+            .map(|&(start, end)| {
+                let mut rows = Vec::with_capacity(end - start);
+                for node_index in start..end {
+                    rows.push(initial_projection_row(
+                        &nodes[node_index],
+                        node_index,
+                        strengths,
+                        total_strength,
+                        options,
+                        control,
+                        dimensions,
+                        node_q,
+                    )?);
+                }
+                Ok((start, rows))
+            })
+            .collect::<Result<Vec<_>, FastRpError>>()
+    })?;
+    Ok(merge_row_chunks(nodes.len(), chunks))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn initial_projection_row(
+    node: &FastRpNode,
+    node_index: usize,
+    strengths: &[f64],
+    total_strength: f64,
+    options: &FastRpOptions,
+    control: &EmbeddingControl<'_>,
+    dimensions: u64,
+    node_q: f64,
+) -> Result<Vec<f64>, FastRpError> {
+    control.checkpoint(dimensions)?;
+    let level = if options.normalization_strength == 0.0 {
+        1.0
+    } else if strengths[node_index] == 0.0 {
+        0.0
+    } else {
+        (strengths[node_index] / total_strength).powf(options.normalization_strength)
+    };
+    let mut row = vec![0.0; options.dimensions];
+    for (coordinate, value) in row.iter_mut().enumerate() {
+        *value = level
+            * sparse_projection(
+                "node-projection",
+                options.seed,
+                &[
+                    EmbeddingRngField::Uuid(node.uuid),
+                    EmbeddingRngField::U64(to_u64(coordinate)?),
+                ],
+                node_q,
+            );
+    }
+    unit_l2(&mut row);
+    Ok(row)
 }
 
 fn mix_features(
@@ -266,6 +438,7 @@ fn mix_features(
     options: &FastRpOptions,
     control: &EmbeddingControl<'_>,
     dimensions: u64,
+    path: FastRpExecutionPath,
 ) -> Result<(), FastRpError> {
     if options.feature_properties.is_empty() {
         return Ok(());
@@ -299,19 +472,55 @@ fn mix_features(
             );
         }
     }
-    for (row, node) in current.iter_mut().zip(nodes) {
-        let mut features = vec![0.0; options.dimensions];
-        for (property_ordinal, value) in node.features.iter().enumerate() {
-            for (coordinate, coordinate_value) in features.iter_mut().enumerate() {
-                *coordinate_value += value * projection[property_ordinal][coordinate];
+    match path {
+        FastRpExecutionPath::Serial => {
+            for (row, node) in current.iter_mut().zip(nodes) {
+                mix_feature_row(row, node, &projection, options);
             }
         }
-        unit_l2(&mut features);
-        for (coordinate, value) in row.iter_mut().enumerate() {
-            *value += options.feature_weight * features[coordinate];
+        FastRpExecutionPath::Parallel { .. } => {
+            let pool = fastrp_pool(control)?;
+            let ranges = row_chunks(current.len(), control.compute_threads());
+            let chunks = run_on_pool(pool, || {
+                ranges
+                    .par_iter()
+                    .map(|&(start, end)| {
+                        let mut rows = Vec::with_capacity(end - start);
+                        for index in start..end {
+                            let mut row = current[index].clone();
+                            mix_feature_row(&mut row, &nodes[index], &projection, options);
+                            rows.push(row);
+                        }
+                        Ok((start, rows))
+                    })
+                    .collect::<Result<Vec<_>, FastRpError>>()
+            })?;
+            for (start, rows) in chunks {
+                for (offset, row) in rows.into_iter().enumerate() {
+                    current[start + offset] = row;
+                }
+            }
         }
     }
     Ok(())
+}
+
+fn mix_feature_row(
+    row: &mut [f64],
+    node: &FastRpNode,
+    projection: &[Vec<f64>],
+    options: &FastRpOptions,
+) {
+    let mut features = vec![0.0; options.dimensions];
+    for (property_ordinal, value) in node.features.iter().enumerate() {
+        for (coordinate, coordinate_value) in features.iter_mut().enumerate() {
+            *coordinate_value += value * projection[property_ordinal][coordinate];
+        }
+    }
+    unit_l2(&mut features);
+    for (coordinate, value) in row.iter_mut().enumerate() {
+        *value += options.feature_weight * features[coordinate];
+    }
 }
 
 fn sparse_projection(phase: &str, seed: u64, fields: &[EmbeddingRngField<'_>], q: f64) -> f64 {
@@ -327,21 +536,237 @@ fn sparse_projection(phase: &str, seed: u64, fields: &[EmbeddingRngField<'_>], q
     }
 }
 
+fn propagate(
+    adjacency: &[Vec<(usize, f64)>],
+    strengths: &[f64],
+    current: &[Vec<f64>],
+    dimensions: usize,
+    dimensions_u64: u64,
+    control: &EmbeddingControl<'_>,
+    path: FastRpExecutionPath,
+) -> Result<Vec<Vec<f64>>, FastRpError> {
+    match path {
+        FastRpExecutionPath::Serial => propagate_serial(
+            adjacency,
+            strengths,
+            current,
+            dimensions,
+            dimensions_u64,
+            control,
+        ),
+        FastRpExecutionPath::Parallel { .. } => propagate_parallel(
+            adjacency,
+            strengths,
+            current,
+            dimensions,
+            dimensions_u64,
+            control,
+        ),
+    }
+}
+
+fn propagate_serial(
+    adjacency: &[Vec<(usize, f64)>],
+    strengths: &[f64],
+    current: &[Vec<f64>],
+    dimensions: usize,
+    dimensions_u64: u64,
+    control: &EmbeddingControl<'_>,
+) -> Result<Vec<Vec<f64>>, FastRpError> {
+    let mut next = Vec::with_capacity(adjacency.len());
+    for source in 0..adjacency.len() {
+        next.push(propagate_row(
+            &adjacency[source],
+            strengths[source],
+            current,
+            dimensions,
+            dimensions_u64,
+            control,
+        )?);
+    }
+    Ok(next)
+}
+
+fn propagate_parallel(
+    adjacency: &[Vec<(usize, f64)>],
+    strengths: &[f64],
+    current: &[Vec<f64>],
+    dimensions: usize,
+    dimensions_u64: u64,
+    control: &EmbeddingControl<'_>,
+) -> Result<Vec<Vec<f64>>, FastRpError> {
+    let pool = fastrp_pool(control)?;
+    let ranges = row_chunks(adjacency.len(), control.compute_threads());
+    let chunks = run_on_pool(pool, || {
+        ranges
+            .par_iter()
+            .map(|&(start, end)| {
+                let mut rows = Vec::with_capacity(end - start);
+                for source in start..end {
+                    rows.push(propagate_row(
+                        &adjacency[source],
+                        strengths[source],
+                        current,
+                        dimensions,
+                        dimensions_u64,
+                        control,
+                    )?);
+                }
+                Ok((start, rows))
+            })
+            .collect::<Result<Vec<_>, FastRpError>>()
+    })?;
+    Ok(merge_row_chunks(adjacency.len(), chunks))
+}
+
+fn propagate_row(
+    neighbors: &[(usize, f64)],
+    strength: f64,
+    current: &[Vec<f64>],
+    dimensions: usize,
+    dimensions_u64: u64,
+    control: &EmbeddingControl<'_>,
+) -> Result<Vec<f64>, FastRpError> {
+    let adjacency_work = u64::try_from(neighbors.len())
+        .ok()
+        .and_then(|entries| entries.checked_mul(dimensions_u64))
+        .ok_or(EmbeddingResourceError::Overflow)?;
+    control.checkpoint(adjacency_work)?;
+    let mut row = vec![0.0; dimensions];
+    if strength == 0.0 {
+        return Ok(row);
+    }
+    for &(target, weight) in neighbors {
+        let probability = weight / strength;
+        for (coordinate, value) in row.iter_mut().enumerate() {
+            *value += probability * current[target][coordinate];
+        }
+    }
+    Ok(row)
+}
+
 fn accumulate(
+    accumulator: &mut [Vec<f64>],
+    matrix: &[Vec<f64>],
+    weight: f64,
+    control: &EmbeddingControl<'_>,
+    path: FastRpExecutionPath,
+) -> Result<(), FastRpError> {
+    match path {
+        FastRpExecutionPath::Serial => accumulate_serial(accumulator, matrix, weight, control),
+        FastRpExecutionPath::Parallel { .. } => {
+            accumulate_parallel(accumulator, matrix, weight, control)
+        }
+    }
+}
+
+fn accumulate_serial(
     accumulator: &mut [Vec<f64>],
     matrix: &[Vec<f64>],
     weight: f64,
     control: &EmbeddingControl<'_>,
 ) -> Result<(), FastRpError> {
     for (output, row) in accumulator.iter_mut().zip(matrix) {
-        control.checkpoint(to_u64(row.len())?)?;
-        let mut normalized = row.clone();
-        unit_l2(&mut normalized);
+        let normalized = normalized_accumulation_row(row, control)?;
         for (coordinate, value) in normalized.into_iter().enumerate() {
             output[coordinate] += weight * value;
         }
     }
     Ok(())
+}
+
+fn accumulate_parallel(
+    accumulator: &mut [Vec<f64>],
+    matrix: &[Vec<f64>],
+    weight: f64,
+    control: &EmbeddingControl<'_>,
+) -> Result<(), FastRpError> {
+    let pool = fastrp_pool(control)?;
+    let ranges = row_chunks(matrix.len(), control.compute_threads());
+    let chunks = run_on_pool(pool, || {
+        ranges
+            .par_iter()
+            .map(|&(start, end)| {
+                let mut rows = Vec::with_capacity(end - start);
+                for row in &matrix[start..end] {
+                    rows.push(normalized_accumulation_row(row, control)?);
+                }
+                Ok((start, rows))
+            })
+            .collect::<Result<Vec<_>, FastRpError>>()
+    })?;
+    for (start, rows) in chunks {
+        for (offset, row) in rows.into_iter().enumerate() {
+            let output = &mut accumulator[start + offset];
+            for (coordinate, value) in row.into_iter().enumerate() {
+                output[coordinate] += weight * value;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn normalized_accumulation_row(
+    row: &[f64],
+    control: &EmbeddingControl<'_>,
+) -> Result<Vec<f64>, FastRpError> {
+    control.checkpoint(to_u64(row.len())?)?;
+    let mut normalized = row.to_vec();
+    unit_l2(&mut normalized);
+    Ok(normalized)
+}
+
+fn row_chunks(rows: usize, threads: usize) -> Vec<(usize, usize)> {
+    if rows == 0 {
+        return Vec::new();
+    }
+    let workers = threads.clamp(1, rows);
+    let base = rows / workers;
+    let rem = rows % workers;
+    let mut ranges = Vec::with_capacity(workers);
+    let mut start = 0;
+    for index in 0..workers {
+        let len = base + usize::from(index < rem);
+        let end = start + len;
+        if start < end {
+            ranges.push((start, end));
+        }
+        start = end;
+    }
+    ranges
+}
+
+fn merge_row_chunks(rows: usize, chunks: Vec<(usize, Vec<Vec<f64>>)>) -> Vec<Vec<f64>> {
+    let mut output = vec![Vec::new(); rows];
+    for (start, chunk_rows) in chunks {
+        for (offset, row) in chunk_rows.into_iter().enumerate() {
+            output[start + offset] = row;
+        }
+    }
+    output
+}
+
+fn fastrp_pool(control: &EmbeddingControl<'_>) -> Result<&crate::ComputePool, FastRpError> {
+    control.compute_pool().ok_or_else(|| {
+        FastRpError::Resource(EmbeddingResourceError::Algorithm(
+            crate::algorithm_dispatch::AlgorithmError::Execution {
+                message: "parallel FastRP requires an instance-owned compute pool".into(),
+            },
+        ))
+    })
+}
+
+fn run_on_pool<R>(
+    pool: &crate::ComputePool,
+    op: impl FnOnce() -> Result<R, FastRpError> + Send,
+) -> Result<R, FastRpError>
+where
+    R: Send,
+{
+    match catch_unwind(AssertUnwindSafe(|| pool.install(op))) {
+        Ok(result) => result,
+        Err(_) => Err(FastRpError::WorkerPanic),
+    }
 }
 
 fn unit_l2(row: &mut [f64]) {
@@ -379,6 +804,9 @@ mod tests {
     use super::*;
     use crate::algorithm_dispatch::{AlgorithmCancellation, AlgorithmControl, AlgorithmLimits};
     use crate::algorithm_embedding_control::EmbeddingResourceLimits;
+    use crate::compute_pool::ComputePool;
+    use std::sync::Arc;
+    use std::time::Instant;
 
     fn uuid(value: u8) -> [u8; 16] {
         [value; 16]
@@ -400,6 +828,16 @@ mod tests {
         }
     }
 
+    fn uuid_from_usize(value: usize) -> [u8; 16] {
+        let mut uuid = [0_u8; 16];
+        uuid[8..].copy_from_slice(
+            &u64::try_from(value)
+                .expect("test UUID ordinal fits in u64")
+                .to_be_bytes(),
+        );
+        uuid
+    }
+
     fn options(seed: u64) -> FastRpOptions {
         FastRpOptions {
             dimensions: 8,
@@ -408,6 +846,52 @@ mod tests {
             feature_weight: 0.0,
             feature_properties: Vec::new(),
             seed,
+        }
+    }
+
+    fn parallel_options() -> FastRpOptions {
+        FastRpOptions {
+            dimensions: 16,
+            iteration_weights: vec![0.5, 1.0, 0.25, 0.75],
+            normalization_strength: 0.5,
+            feature_weight: 0.35,
+            feature_properties: vec!["x".into(), "y".into()],
+            seed: 17,
+        }
+    }
+
+    fn parallel_input(nodes: usize, degree: usize, features: bool) -> FastRpInput {
+        let node_rows = (0..nodes)
+            .map(|index| FastRpNode {
+                uuid: uuid_from_usize(index),
+                features: if features {
+                    vec![
+                        ((index * 17) % 23) as f64 / 23.0,
+                        ((index * 29 + 3) % 31) as f64 / 31.0,
+                    ]
+                } else {
+                    Vec::new()
+                },
+            })
+            .collect::<Vec<_>>();
+        let mut edges = Vec::with_capacity(nodes.saturating_mul(degree));
+        let mut edge_ordinal = 0_usize;
+        for source in 0..nodes {
+            for hop in 1..=degree {
+                let target = (source + hop) % nodes;
+                edges.push(FastRpEdge {
+                    uuid: uuid_from_usize(nodes + edge_ordinal),
+                    source: uuid_from_usize(source),
+                    target: uuid_from_usize(target),
+                    weight: 0.5 + ((source + hop) % 11) as f64 / 7.0,
+                });
+                edge_ordinal += 1;
+            }
+        }
+        FastRpInput {
+            directed: true,
+            nodes: node_rows,
+            edges,
         }
     }
 
@@ -427,6 +911,47 @@ mod tests {
     ) -> Result<Vec<FastRpEmbeddingRow>, FastRpError> {
         with_control(EmbeddingResourceLimits::default(), |control| {
             run_fastrp(input, options, control)
+        })
+    }
+
+    fn control_with_threads(threads: usize) -> AlgorithmControl {
+        let pool = Arc::new(ComputePool::new(threads).unwrap());
+        AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(threads),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(pool)
+    }
+
+    fn embedding_control<'a>(algorithm: &'a AlgorithmControl) -> EmbeddingControl<'a> {
+        EmbeddingControl::new(algorithm, EmbeddingResourceLimits::default())
+    }
+
+    fn run_with_threads(
+        input: FastRpInput,
+        options: &FastRpOptions,
+        threads: usize,
+    ) -> Result<Vec<FastRpEmbeddingRow>, FastRpError> {
+        let algorithm = control_with_threads(threads);
+        run_fastrp(input, options, &embedding_control(&algorithm))
+    }
+
+    fn fingerprint(rows: &[FastRpEmbeddingRow]) -> Vec<([u8; 16], Vec<u32>)> {
+        rows.iter()
+            .map(|row| {
+                (
+                    row.node_uuid,
+                    row.embedding.iter().map(|value| value.to_bits()).collect(),
+                )
+            })
+            .collect()
+    }
+
+    fn peak_rss_kib() -> Option<u64> {
+        let status = std::fs::read_to_string("/proc/self/status").ok()?;
+        status.lines().find_map(|line| {
+            let value = line.strip_prefix("VmHWM:")?.trim();
+            value.split_whitespace().next()?.parse().ok()
         })
     }
 
@@ -708,5 +1233,155 @@ mod tests {
             run_fastrp(input, &options(0), &control),
             Err(FastRpError::Resource(_))
         ));
+    }
+
+    #[test]
+    fn small_work_and_one_thread_select_serial_fastrp_path() {
+        let small_algorithm = control_with_threads(4);
+        let small = embedding_control(&small_algorithm);
+        assert_eq!(
+            select_fastrp_path(&small, 64, FASTRP_PARALLEL_CROSSOVER_OPS - 1),
+            FastRpExecutionPath::Serial
+        );
+
+        let one_algorithm = control_with_threads(1);
+        let one = embedding_control(&one_algorithm);
+        assert_eq!(
+            select_fastrp_path(&one, 64, FASTRP_PARALLEL_CROSSOVER_OPS),
+            FastRpExecutionPath::Serial
+        );
+
+        let large_algorithm = control_with_threads(4);
+        let large = embedding_control(&large_algorithm);
+        assert_eq!(
+            select_fastrp_path(&large, 64, FASTRP_PARALLEL_CROSSOVER_OPS),
+            FastRpExecutionPath::Parallel {
+                threads: 4,
+                chunks: 4
+            }
+        );
+    }
+
+    #[test]
+    fn row_chunks_cover_canonical_ranges() {
+        assert_eq!(row_chunks(0, 4), Vec::<(usize, usize)>::new());
+        assert_eq!(row_chunks(5, 1), vec![(0, 5)]);
+        assert_eq!(row_chunks(5, 2), vec![(0, 3), (3, 5)]);
+        assert_eq!(row_chunks(8, 4), vec![(0, 2), (2, 4), (4, 6), (6, 8)]);
+        assert_eq!(row_chunks(3, 8), vec![(0, 1), (1, 2), (2, 3)]);
+    }
+
+    #[test]
+    fn thread_matrix_preserves_parallel_fastrp_fingerprints() {
+        let input = parallel_input(96, 24, true);
+        let options = parallel_options();
+        let estimated = estimated_fastrp_ops(
+            input.nodes.len(),
+            input.edges.len(),
+            options.dimensions,
+            options.iteration_weights.len(),
+            options.feature_properties.len(),
+        );
+        assert!(estimated >= FASTRP_PARALLEL_CROSSOVER_OPS);
+
+        let serial = run_with_threads(input.clone(), &options, 1).unwrap();
+        let serial_fingerprint = fingerprint(&serial);
+        for threads in [2_usize, 4, 8] {
+            let algorithm = control_with_threads(threads);
+            let control = embedding_control(&algorithm);
+            assert!(matches!(
+                select_fastrp_path(&control, input.nodes.len(), estimated),
+                FastRpExecutionPath::Parallel { .. }
+            ));
+            let parallel = run_fastrp(input.clone(), &options, &control).unwrap();
+            assert_eq!(parallel, serial);
+            assert_eq!(fingerprint(&parallel), serial_fingerprint);
+        }
+    }
+
+    #[test]
+    fn parallel_cancellation_work_limits_and_worker_panic_are_structured() {
+        let input = parallel_input(96, 24, false);
+        let mut options = parallel_options();
+        options.feature_properties.clear();
+        options.feature_weight = 0.0;
+
+        let pool = Arc::new(ComputePool::new(4).unwrap());
+        let cancellation = AlgorithmCancellation::default();
+        cancellation.cancel();
+        let cancelled = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(4),
+            cancellation,
+        )
+        .with_compute_pool(pool.clone());
+        assert!(matches!(
+            run_fastrp(input.clone(), &options, &embedding_control(&cancelled)),
+            Err(FastRpError::Resource(EmbeddingResourceError::Algorithm(_)))
+        ));
+
+        let limited = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(4),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(pool);
+        let control = EmbeddingControl::new(
+            &limited,
+            EmbeddingResourceLimits {
+                work: 3,
+                ..EmbeddingResourceLimits::default()
+            },
+        );
+        assert!(matches!(
+            run_fastrp(input, &options, &control),
+            Err(FastRpError::Resource(
+                EmbeddingResourceError::WorkLimit { .. }
+            ))
+        ));
+
+        let pool = ComputePool::new(2).unwrap();
+        assert_eq!(
+            run_on_pool(&pool, || -> Result<(), FastRpError> {
+                panic!("test FastRP worker panic");
+            }),
+            Err(FastRpError::WorkerPanic)
+        );
+    }
+
+    #[test]
+    #[ignore = "manual crossover measurement; run with --ignored --nocapture"]
+    fn measure_fastrp_parallel_crossover() {
+        for (nodes, degree, dimensions) in [(64, 16, 8), (96, 24, 8), (96, 24, 16), (160, 32, 16)] {
+            let input = parallel_input(nodes, degree, true);
+            let mut options = parallel_options();
+            options.dimensions = dimensions;
+            let estimated = estimated_fastrp_ops(
+                input.nodes.len(),
+                input.edges.len(),
+                options.dimensions,
+                options.iteration_weights.len(),
+                options.feature_properties.len(),
+            );
+
+            let serial_start = Instant::now();
+            let serial = run_with_threads(input.clone(), &options, 1).unwrap();
+            let serial_elapsed = serial_start.elapsed();
+
+            let parallel_algorithm = control_with_threads(4);
+            let parallel_control = embedding_control(&parallel_algorithm);
+            let path = select_fastrp_path(&parallel_control, input.nodes.len(), estimated);
+            let parallel_start = Instant::now();
+            let parallel = run_fastrp(input.clone(), &options, &parallel_control).unwrap();
+            let parallel_elapsed = parallel_start.elapsed();
+            assert_eq!(fingerprint(&parallel), fingerprint(&serial));
+
+            println!(
+                "fastrp_measure nodes={nodes} edges={} dimensions={dimensions} ops={estimated} path={path:?} threads=4 serial_ms={} parallel_ms={} peak_rss_kib={:?} fingerprint_head={:?}",
+                input.edges.len(),
+                serial_elapsed.as_millis(),
+                parallel_elapsed.as_millis(),
+                peak_rss_kib(),
+                fingerprint(&serial).first()
+            );
+        }
     }
 }

--- a/crates/graphforge-exec/src/algorithm_embedding_fastrp.rs
+++ b/crates/graphforge-exec/src/algorithm_embedding_fastrp.rs
@@ -746,7 +746,9 @@ fn merge_row_chunks(rows: usize, chunks: Vec<(usize, Vec<Vec<f64>>)>) -> Vec<Vec
     output
 }
 
-fn fastrp_pool(control: &EmbeddingControl<'_>) -> Result<&crate::ComputePool, FastRpError> {
+fn fastrp_pool<'a>(
+    control: &'a EmbeddingControl<'a>,
+) -> Result<&'a crate::ComputePool, FastRpError> {
     control.compute_pool().ok_or_else(|| {
         FastRpError::Resource(EmbeddingResourceError::Algorithm(
             crate::algorithm_dispatch::AlgorithmError::Execution {

--- a/docs/book/architecture/embedding-v1.md
+++ b/docs/book/architecture/embedding-v1.md
@@ -430,6 +430,15 @@ embedding(v) = sum_t iteration_weights[t] * unit_l2(H_t[v]).
 canonical adjacency, iteration, and coordinate order, followed by a checked
 Float32 cast. An isolate has `H_t=0` for `t>=1`.
 
+FastRP may use the instance-owned private compute pool when estimated
+row/coordinate work is at least `FASTRP_PARALLEL_CROSSOVER_OPS` (`65_536`) and
+the resource policy supplies more than one compute thread. Parallel work is
+source-row owned: initial projection, feature mixing, accumulation, and sparse
+matvec rows run independently, but every row still visits neighbors and
+coordinates in the serial order above. Chunks merge by canonical node ordinal, so
+schemas, row ordering, and f32 embedding fingerprints match the one-thread
+oracle. Smaller workloads and one-thread policies stay on the serial path.
+
 Memory includes output, two `nodes * dimensions` binary64 iteration buffers, a
 binary64 accumulator, UUID projection state, normalized adjacency, and the
 `properties * dimensions` feature projection. Checked arithmetic covers each

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -673,6 +673,28 @@ peak RSS, result fingerprint, and hardware-specific timing) and verifies that
 executed thread configurations match the one-thread oracle. Timing remains
 evidence only, not a CI threshold.
 
+## Parallel FastRP row kernels (#559)
+
+`analyze_embedding(by="fast_random_projection")` partitions **independent
+source rows** across the instance-owned private compute pool when:
+
+- `compute_threads > 1`, and
+- estimated row/coordinate operations are at least
+  `FASTRP_PARALLEL_CROSSOVER_OPS` (`65_536`) in `graphforge-exec`.
+
+The estimate covers sparse propagation
+(`adjacency_entries × propagated_iterations × dimensions`), initial projection,
+feature projection/mixing, and per-iteration accumulation. Below that crossover,
+or when the policy provides one compute thread, FastRP stays serial with no pool
+scheduling tax.
+
+Parallel FastRP never parallelizes a row's floating-point reduction. Initial
+projection, feature mixing, accumulation, and sparse matvec work are row-owned;
+each source row visits neighbors and coordinates in the same order as the
+one-thread oracle, and worker chunks merge by canonical node ordinal. Schemas,
+row order, f32 embedding bits, cancellation, and work-limit errors are covered at
+`1`/`2`/`4`/`8` thread configurations.
+
 ## Observability
 
 `GraphForge::resource_policy()` and `GraphForge::resource_diagnostics()` expose


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements #559: parallel FastRP row-owned work on the instance-owned `ComputePool` above measured crossover with serial fallback and fingerprint parity.

Closes #559

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788953938&installation_model_id=20486&pr_number=613&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F613&signature=de261b0618e0dc1acf3db7227e2ba043b1f40201a6089293561a8438556b407f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parallelize FastRP embedding on ComputePool for large workloads
> - Adds a parallel execution path for FastRP in [`algorithm_embedding_fastrp.rs`](https://github.com/CurateLabs/graphforge/pull/613/files#diff-70456c647f9d122ce51e2edc3864b1cb9b13e2404bdf00c67535f7f00ffbec4b) that activates when `compute_threads > 1` and estimated operations ≥ `FASTRP_PARALLEL_CROSSOVER_OPS` (65,536); smaller workloads remain serial.
> - Parallelizes all four phases (initial projection, feature mixing, propagation, accumulation) using rayon and the instance-owned `ComputePool`, partitioning work by row chunks and merging in canonical order.
> - Adds `FastRpError::WorkerPanic` to surface panics from parallel workers instead of unwinding the calling thread.
> - Output order and numeric values are deterministic and identical between serial and parallel paths.
> - Risk: parallel path introduces rayon scheduling overhead and a `catch_unwind` boundary; panics in worker closures are now returned as errors rather than propagating normally.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dfd4649.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->