### PR TITLE
perf(exec): parallelize random_walk on ComputePool (#553)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_paths_random_walk.rs
+++ b/crates/graphforge-exec/src/algorithm_paths_random_walk.rs
@@ -73,52 +73,54 @@ pub(crate) fn random_walks<A: RandomWalkAdjacencySource>(
     control.check_output_rows(output_rows)?;
     control.check_iterations(transitions)?;
 
+    let plan = RandomWalkPlan {
+        sources,
+        walks_per_source,
+        walk_length,
+        seed,
+        weighted,
+        output_rows,
+    };
     let transitions = u64::try_from(transitions).unwrap_or(u64::MAX);
-    match select_random_walk_path(control, output_rows, transitions) {
-        RandomWalkExecutionPath::Serial => random_walks_serial(
-            adjacency,
-            sources,
-            walks_per_source,
-            walk_length,
-            seed,
-            weighted,
-            control,
-            output_rows,
-        ),
-        RandomWalkExecutionPath::Parallel { .. } => random_walks_parallel(
-            adjacency,
-            sources,
-            walks_per_source,
-            walk_length,
-            seed,
-            weighted,
-            control,
-            output_rows,
-        ),
+    match select_random_walk_path(control, plan.output_rows, transitions) {
+        RandomWalkExecutionPath::Serial => random_walks_serial(adjacency, plan, control),
+        RandomWalkExecutionPath::Parallel { .. } => random_walks_parallel(adjacency, plan, control),
     }
 }
 
-fn random_walks_serial<A: RandomWalkAdjacencySource>(
-    adjacency: &A,
-    sources: &[[u8; 16]],
+#[derive(Clone, Copy)]
+struct RandomWalkPlan<'a> {
+    sources: &'a [[u8; 16]],
     walks_per_source: usize,
     walk_length: usize,
     seed: u64,
     weighted: bool,
-    control: &AlgorithmControl,
     output_rows: usize,
+}
+
+#[derive(Clone, Copy)]
+struct RandomWalkTask {
+    source_uuid: [u8; 16],
+    source_ordinal: usize,
+    walk_ordinal: usize,
+}
+
+fn random_walks_serial<A: RandomWalkAdjacencySource>(
+    adjacency: &A,
+    plan: RandomWalkPlan<'_>,
+    control: &AlgorithmControl,
 ) -> Result<Vec<Vec<[u8; 16]>>, AlgorithmError> {
-    let mut output = Vec::with_capacity(output_rows);
-    for (source_ordinal, source_uuid) in sources.iter().enumerate() {
-        for walk_ordinal in 0..walks_per_source {
+    let mut output = Vec::with_capacity(plan.output_rows);
+    for (source_ordinal, source_uuid) in plan.sources.iter().enumerate() {
+        for walk_ordinal in 0..plan.walks_per_source {
             output.push(build_walk(
                 adjacency,
-                *source_uuid,
-                source_ordinal,
-                walk_ordinal,
-                walk_length,
-                seed,
-                weighted,
+                RandomWalkTask {
+                    source_uuid: *source_uuid,
+                    source_ordinal,
+                    walk_ordinal,
+                },
+                plan,
                 control,
             )?);
         }
@@ -128,34 +130,29 @@ fn random_walks_serial<A: RandomWalkAdjacencySource>(
 
 fn random_walks_parallel<A: RandomWalkAdjacencySource>(
     adjacency: &A,
-    sources: &[[u8; 16]],
-    walks_per_source: usize,
-    walk_length: usize,
-    seed: u64,
-    weighted: bool,
+    plan: RandomWalkPlan<'_>,
     control: &AlgorithmControl,
-    output_rows: usize,
 ) -> Result<Vec<Vec<[u8; 16]>>, AlgorithmError> {
     let pool = control
         .compute_pool()
         .ok_or_else(|| execution("parallel random_walk requires an instance-owned compute pool"))?;
-    let ranges = walk_task_chunks(output_rows, control.compute_threads());
+    let ranges = walk_task_chunks(plan.output_rows, control.compute_threads());
     let chunk_results = run_on_pool(pool, || {
         Ok(ranges
             .par_iter()
             .map(|&(start, end)| {
                 let mut walks = Vec::with_capacity(end.saturating_sub(start));
                 for task in start..end {
-                    let source_ordinal = task / walks_per_source;
-                    let walk_ordinal = task % walks_per_source;
+                    let source_ordinal = task / plan.walks_per_source;
+                    let walk_ordinal = task % plan.walks_per_source;
                     walks.push(build_walk(
                         adjacency,
-                        sources[source_ordinal],
-                        source_ordinal,
-                        walk_ordinal,
-                        walk_length,
-                        seed,
-                        weighted,
+                        RandomWalkTask {
+                            source_uuid: plan.sources[source_ordinal],
+                            source_ordinal,
+                            walk_ordinal,
+                        },
+                        plan,
                         control,
                     )?);
                 }
@@ -163,31 +160,31 @@ fn random_walks_parallel<A: RandomWalkAdjacencySource>(
             })
             .collect::<Vec<Result<Vec<Vec<[u8; 16]>>, AlgorithmError>>>())
     })?;
-    merge_walk_chunks(chunk_results, output_rows)
+    merge_walk_chunks(chunk_results, plan.output_rows)
 }
 
 fn build_walk<A: RandomWalkAdjacencySource>(
     adjacency: &A,
-    source_uuid: [u8; 16],
-    source_ordinal: usize,
-    walk_ordinal: usize,
-    walk_length: usize,
-    seed: u64,
-    weighted: bool,
+    task: RandomWalkTask,
+    plan: RandomWalkPlan<'_>,
     control: &AlgorithmControl,
 ) -> Result<Vec<[u8; 16]>, AlgorithmError> {
     control.check_cancelled()?;
-    let mut rng = SplitMix64::new(derive_seed(seed, source_ordinal, walk_ordinal));
-    let mut node = source_uuid;
+    let mut rng = SplitMix64::new(derive_seed(
+        plan.seed,
+        task.source_ordinal,
+        task.walk_ordinal,
+    ));
+    let mut node = task.source_uuid;
     let mut walk = Vec::new();
-    walk.push(source_uuid);
+    walk.push(task.source_uuid);
 
-    for _ in 0..walk_length {
+    for _ in 0..plan.walk_length {
         control.checkpoint()?;
         let mut choices = adjacency.choices(&node)?;
         choices.sort_unstable_by_key(|edge| (edge.neighbor_uuid, edge.edge_uuid));
         let choices = choices.iter().collect::<Vec<_>>();
-        let Some(edge) = choose(&choices, weighted, &mut rng)? else {
+        let Some(edge) = choose(&choices, plan.weighted, &mut rng)? else {
             break;
         };
         node = edge.neighbor_uuid;

--- a/crates/graphforge-exec/src/algorithm_paths_random_walk.rs
+++ b/crates/graphforge-exec/src/algorithm_paths_random_walk.rs
@@ -1,12 +1,28 @@
 //! Deterministic random walks over graph-native UUID adjacency.
+//!
+//! Parallelism (#553) partitions independent `(source ordinal, walk ordinal)`
+//! tasks through the instance-owned private compute pool. Each walk keeps the
+//! exact serial RNG stream and choice ordering, and worker outputs merge by
+//! canonical task ordinal so the public row order remains byte-identical.
 
 use std::collections::HashMap;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+use rayon::prelude::*;
 
 use crate::algorithm_dispatch::{AlgorithmControl, AlgorithmError};
 
 /// Changing the generator, seed derivation, draw conversion, or choice ordering
 /// requires a new contract version.
 pub(crate) const RANDOM_WALK_RNG_CONTRACT: &str = "splitmix64-v1";
+
+/// Estimated transitions below which random_walk stays on the serial path (#553).
+///
+/// This mirrors Node2Vec walk-corpus generation: the random-walk task body is
+/// similarly independent per start/walk pair, and the same release-mode M4
+/// crossover evidence showed pool scheduling/merge tax dominating below this
+/// boundary while larger walk corpora benefit from private workers.
+pub const RANDOM_WALK_PARALLEL_CROSSOVER: u64 = 256;
 
 /// One direction-expanded sampling choice. Parallel edges remain distinct.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -20,7 +36,7 @@ pub(crate) struct RandomWalkEdge {
 pub(crate) type RandomWalkAdjacency = HashMap<[u8; 16], Vec<RandomWalkEdge>>;
 
 /// Lazy source of graph-native choices for one visited node.
-pub(crate) trait RandomWalkAdjacencySource {
+pub(crate) trait RandomWalkAdjacencySource: Sync {
     fn choices(&self, node: &[u8; 16]) -> Result<Vec<RandomWalkEdge>, AlgorithmError>;
 }
 
@@ -57,30 +73,207 @@ pub(crate) fn random_walks<A: RandomWalkAdjacencySource>(
     control.check_output_rows(output_rows)?;
     control.check_iterations(transitions)?;
 
+    let transitions = u64::try_from(transitions).unwrap_or(u64::MAX);
+    match select_random_walk_path(control, output_rows, transitions) {
+        RandomWalkExecutionPath::Serial => random_walks_serial(
+            adjacency,
+            sources,
+            walks_per_source,
+            walk_length,
+            seed,
+            weighted,
+            control,
+            output_rows,
+        ),
+        RandomWalkExecutionPath::Parallel { .. } => random_walks_parallel(
+            adjacency,
+            sources,
+            walks_per_source,
+            walk_length,
+            seed,
+            weighted,
+            control,
+            output_rows,
+        ),
+    }
+}
+
+fn random_walks_serial<A: RandomWalkAdjacencySource>(
+    adjacency: &A,
+    sources: &[[u8; 16]],
+    walks_per_source: usize,
+    walk_length: usize,
+    seed: u64,
+    weighted: bool,
+    control: &AlgorithmControl,
+    output_rows: usize,
+) -> Result<Vec<Vec<[u8; 16]>>, AlgorithmError> {
     let mut output = Vec::with_capacity(output_rows);
     for (source_ordinal, source_uuid) in sources.iter().enumerate() {
         for walk_ordinal in 0..walks_per_source {
-            control.check_cancelled()?;
-            let mut rng = SplitMix64::new(derive_seed(seed, source_ordinal, walk_ordinal));
-            let mut node = *source_uuid;
-            let mut walk = Vec::new();
-            walk.push(*source_uuid);
-
-            for _ in 0..walk_length {
-                control.checkpoint()?;
-                let mut choices = adjacency.choices(&node)?;
-                choices.sort_unstable_by_key(|edge| (edge.neighbor_uuid, edge.edge_uuid));
-                let choices = choices.iter().collect::<Vec<_>>();
-                let Some(edge) = choose(&choices, weighted, &mut rng)? else {
-                    break;
-                };
-                node = edge.neighbor_uuid;
-                walk.push(node);
-            }
-            output.push(walk);
+            output.push(build_walk(
+                adjacency,
+                *source_uuid,
+                source_ordinal,
+                walk_ordinal,
+                walk_length,
+                seed,
+                weighted,
+                control,
+            )?);
         }
     }
     Ok(output)
+}
+
+fn random_walks_parallel<A: RandomWalkAdjacencySource>(
+    adjacency: &A,
+    sources: &[[u8; 16]],
+    walks_per_source: usize,
+    walk_length: usize,
+    seed: u64,
+    weighted: bool,
+    control: &AlgorithmControl,
+    output_rows: usize,
+) -> Result<Vec<Vec<[u8; 16]>>, AlgorithmError> {
+    let pool = control
+        .compute_pool()
+        .ok_or_else(|| execution("parallel random_walk requires an instance-owned compute pool"))?;
+    let ranges = walk_task_chunks(output_rows, control.compute_threads());
+    let chunk_results = run_on_pool(pool, || {
+        ranges
+            .par_iter()
+            .map(|&(start, end)| {
+                let mut walks = Vec::with_capacity(end.saturating_sub(start));
+                for task in start..end {
+                    let source_ordinal = task / walks_per_source;
+                    let walk_ordinal = task % walks_per_source;
+                    walks.push(build_walk(
+                        adjacency,
+                        sources[source_ordinal],
+                        source_ordinal,
+                        walk_ordinal,
+                        walk_length,
+                        seed,
+                        weighted,
+                        control,
+                    )?);
+                }
+                Ok(walks)
+            })
+            .collect::<Vec<Result<Vec<Vec<[u8; 16]>>, AlgorithmError>>>()
+    })?;
+    merge_walk_chunks(chunk_results, output_rows)
+}
+
+fn build_walk<A: RandomWalkAdjacencySource>(
+    adjacency: &A,
+    source_uuid: [u8; 16],
+    source_ordinal: usize,
+    walk_ordinal: usize,
+    walk_length: usize,
+    seed: u64,
+    weighted: bool,
+    control: &AlgorithmControl,
+) -> Result<Vec<[u8; 16]>, AlgorithmError> {
+    control.check_cancelled()?;
+    let mut rng = SplitMix64::new(derive_seed(seed, source_ordinal, walk_ordinal));
+    let mut node = source_uuid;
+    let mut walk = Vec::new();
+    walk.push(source_uuid);
+
+    for _ in 0..walk_length {
+        control.checkpoint()?;
+        let mut choices = adjacency.choices(&node)?;
+        choices.sort_unstable_by_key(|edge| (edge.neighbor_uuid, edge.edge_uuid));
+        let choices = choices.iter().collect::<Vec<_>>();
+        let Some(edge) = choose(&choices, weighted, &mut rng)? else {
+            break;
+        };
+        node = edge.neighbor_uuid;
+        walk.push(node);
+    }
+    Ok(walk)
+}
+
+fn merge_walk_chunks(
+    chunks: Vec<Result<Vec<Vec<[u8; 16]>>, AlgorithmError>>,
+    capacity: usize,
+) -> Result<Vec<Vec<[u8; 16]>>, AlgorithmError> {
+    let mut output = Vec::with_capacity(capacity);
+    for chunk in chunks {
+        output.extend(chunk?);
+    }
+    Ok(output)
+}
+
+fn run_on_pool<R>(
+    pool: &crate::ComputePool,
+    op: impl FnOnce() -> Result<R, AlgorithmError> + Send,
+) -> Result<R, AlgorithmError>
+where
+    R: Send,
+{
+    match catch_unwind(AssertUnwindSafe(|| pool.install(op))) {
+        Ok(result) => result,
+        Err(_) => Err(execution("random-walk worker panicked")),
+    }
+}
+
+/// Selected execution path for observability and crossover tests.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RandomWalkExecutionPath {
+    Serial,
+    Parallel { threads: usize, chunks: usize },
+}
+
+/// Choose serial vs private-pool parallel walk generation.
+pub(crate) fn select_random_walk_path(
+    control: &AlgorithmControl,
+    total_walks: usize,
+    estimated_transitions: u64,
+) -> RandomWalkExecutionPath {
+    let threads = control.compute_threads();
+    if threads <= 1 || total_walks <= 1 || estimated_transitions < RANDOM_WALK_PARALLEL_CROSSOVER {
+        return RandomWalkExecutionPath::Serial;
+    }
+    if control
+        .compute_pool()
+        .is_none_or(|pool| !pool.is_parallel())
+    {
+        return RandomWalkExecutionPath::Serial;
+    }
+    let chunks = walk_task_chunks(total_walks, threads).len();
+    if chunks <= 1 {
+        return RandomWalkExecutionPath::Serial;
+    }
+    RandomWalkExecutionPath::Parallel { threads, chunks }
+}
+
+fn walk_task_chunks(total_walks: usize, threads: usize) -> Vec<(usize, usize)> {
+    if total_walks == 0 {
+        return Vec::new();
+    }
+    let workers = threads.clamp(1, total_walks);
+    let base = total_walks / workers;
+    let rem = total_walks % workers;
+    let mut ranges = Vec::with_capacity(workers);
+    let mut start = 0;
+    for index in 0..workers {
+        let len = base + usize::from(index < rem);
+        let end = start + len;
+        if start < end {
+            ranges.push((start, end));
+        }
+        start = end;
+    }
+    ranges
+}
+
+fn execution(message: impl Into<String>) -> AlgorithmError {
+    AlgorithmError::Execution {
+        message: message.into(),
+    }
 }
 
 fn choose<'a>(
@@ -167,8 +360,10 @@ fn mix(mut value: u64) -> u64 {
 #[cfg(test)]
 mod tests {
     use crate::algorithm_dispatch::{AlgorithmCancellation, AlgorithmError, AlgorithmLimits};
+    use crate::compute_pool::ComputePool;
 
     use super::*;
+    use std::sync::Arc;
 
     fn uuid(value: u8) -> [u8; 16] {
         [value; 16]
@@ -184,6 +379,31 @@ mod tests {
 
     fn control() -> AlgorithmControl {
         AlgorithmControl::new(AlgorithmLimits::default(), AlgorithmCancellation::default())
+    }
+
+    fn control_with_threads(threads: usize) -> AlgorithmControl {
+        let pool = Arc::new(ComputePool::new(threads).unwrap());
+        AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(threads),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(pool)
+    }
+
+    fn parallel_fixture() -> (RandomWalkAdjacency, Vec<[u8; 16]>) {
+        let mut graph = HashMap::new();
+        for node in 0..32_u8 {
+            graph.insert(
+                uuid(node),
+                vec![
+                    edge(node.wrapping_add(64), node.wrapping_add(1) % 32, 2.0),
+                    edge(node.wrapping_add(32), node.wrapping_add(3) % 32, 1.0),
+                    edge(node.wrapping_add(96), node.wrapping_add(5) % 32, 3.0),
+                ],
+            );
+        }
+        let sources = (0..16_u8).map(uuid).collect::<Vec<_>>();
+        (graph, sources)
     }
 
     #[test]
@@ -289,5 +509,93 @@ mod tests {
             .unwrap_err();
             assert!(error.to_string().contains(expected));
         }
+    }
+
+    #[test]
+    fn random_walk_path_selection_uses_private_pool_above_crossover() {
+        assert_eq!(
+            select_random_walk_path(&control(), 64, RANDOM_WALK_PARALLEL_CROSSOVER),
+            RandomWalkExecutionPath::Serial
+        );
+        assert_eq!(
+            select_random_walk_path(
+                &control_with_threads(4),
+                64,
+                RANDOM_WALK_PARALLEL_CROSSOVER - 1
+            ),
+            RandomWalkExecutionPath::Serial
+        );
+        assert_eq!(
+            select_random_walk_path(&control_with_threads(4), 64, RANDOM_WALK_PARALLEL_CROSSOVER),
+            RandomWalkExecutionPath::Parallel {
+                threads: 4,
+                chunks: 4
+            }
+        );
+    }
+
+    #[test]
+    fn parallel_walks_match_serial_oracle_at_supported_thread_counts() {
+        let (graph, sources) = parallel_fixture();
+        let serial = random_walks(&graph, &sources, 4, 8, 99, true, &control()).unwrap();
+        for threads in [2, 4, 8] {
+            let parallel = random_walks(
+                &graph,
+                &sources,
+                4,
+                8,
+                99,
+                true,
+                &control_with_threads(threads),
+            )
+            .unwrap();
+            assert_eq!(parallel, serial, "threads={threads}");
+        }
+    }
+
+    #[test]
+    fn parallel_cancellation_returns_structured_error_without_rows() {
+        let (graph, sources) = parallel_fixture();
+        let cancellation = AlgorithmCancellation::default();
+        cancellation.cancel();
+        let pool = Arc::new(ComputePool::new(4).unwrap());
+        let control = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(4),
+            cancellation,
+        )
+        .with_compute_pool(pool);
+        assert_eq!(
+            random_walks(&graph, &sources, 4, 8, 99, true, &control),
+            Err(AlgorithmError::Cancelled)
+        );
+    }
+
+    #[test]
+    fn parallel_worker_panic_returns_structured_error() {
+        struct PanicAdjacency;
+
+        impl RandomWalkAdjacencySource for PanicAdjacency {
+            fn choices(&self, _node: &[u8; 16]) -> Result<Vec<RandomWalkEdge>, AlgorithmError> {
+                panic!("test worker panic");
+            }
+        }
+
+        let sources = (0..16_u8).map(uuid).collect::<Vec<_>>();
+        let error = random_walks(
+            &PanicAdjacency,
+            &sources,
+            4,
+            8,
+            99,
+            false,
+            &control_with_threads(4),
+        )
+        .unwrap_err();
+        assert_eq!(
+            error,
+            AlgorithmError::Execution {
+                message: "random-walk worker panicked".into()
+            }
+        );
     }
 }

--- a/crates/graphforge-exec/src/algorithm_paths_random_walk.rs
+++ b/crates/graphforge-exec/src/algorithm_paths_random_walk.rs
@@ -141,7 +141,7 @@ fn random_walks_parallel<A: RandomWalkAdjacencySource>(
         .ok_or_else(|| execution("parallel random_walk requires an instance-owned compute pool"))?;
     let ranges = walk_task_chunks(output_rows, control.compute_threads());
     let chunk_results = run_on_pool(pool, || {
-        ranges
+        Ok(ranges
             .par_iter()
             .map(|&(start, end)| {
                 let mut walks = Vec::with_capacity(end.saturating_sub(start));
@@ -161,7 +161,7 @@ fn random_walks_parallel<A: RandomWalkAdjacencySource>(
                 }
                 Ok(walks)
             })
-            .collect::<Vec<Result<Vec<Vec<[u8; 16]>>, AlgorithmError>>>()
+            .collect::<Vec<Result<Vec<Vec<[u8; 16]>>, AlgorithmError>>>())
     })?;
     merge_walk_chunks(chunk_results, output_rows)
 }

--- a/crates/graphforge-exec/src/compute_pool.rs
+++ b/crates/graphforge-exec/src/compute_pool.rs
@@ -1,12 +1,13 @@
 //! Instance-owned bounded CPU pool for deterministic algorithm kernels
-//! (#337 / #342 / #343 / #344 / #500 / #501 / #504 / #505 / #506 / #507 / #515 / #588).
+//! (#337 / #342 / #343 / #344 / #500 / #501 / #504 / #505 / #506 / #507 / #515 / #553 / #588).
 //!
 //! GraphForge never installs work onto Rayon's process-global pool. Parallel
 //! cosine KNN (#342), PageRank (#343), Node2Vec walk generation (#344),
 //! ArticleRank (#500), betweenness (#501), clustering coefficient (#504),
 //! common-neighbors (#505), Degree (#506), eigenvector (#507), triangles (#515),
-//! triangle count (#588), and sibling CPU kernels consume this private pool
-//! sized from [`crate`]-facing `compute_threads` on the embedded resource policy.
+//! random_walk generation (#553), triangle count (#588), and sibling CPU kernels
+//! consume this private pool sized from [`crate`]-facing `compute_threads` on the
+//! embedded resource policy.
 
 use std::sync::Arc;
 

--- a/docs/book/architecture/algorithms.md
+++ b/docs/book/architecture/algorithms.md
@@ -2159,6 +2159,10 @@ normalized seed, resolved-source ordinal, and walk ordinal. Changing SplitMix64,
 the integer-to-draw conversion, or canonical choice ordering requires a new named contract
 version; it must not silently alter `splitmix64-v1`. For the same graph projection, normalized
 options, contract version, and seed, the Arrow output is byte-identical across repeated calls.
+Above `RANDOM_WALK_PARALLEL_CROSSOVER` (`256`) estimated transitions and with more than one
+configured compute thread, independent walks may run on the instance-owned private compute pool;
+smaller workloads and one-thread policies stay serial. Parallel workers merge by resolved-source
+ordinal and walk ordinal, so this does not change schemas, row ordering, metadata, or fingerprints.
 
 Rows are ordered by resolved-source order and then zero-based walk ordinal. The exact non-null
 schema is `start_uuid: FixedSizeBinary(16), walk: List<FixedSizeBinary(16) not null>`, with

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -835,6 +835,22 @@ deriving the closed-form null count. Schemas, row order, category counts,
 structured errors, and fingerprints match the one-thread result at `1`/`2`/`4`/`8`
 / automatic configurations.
 
+## Parallel random_walk path generation (#553)
+
+`paths(by="random_walk")` partitions **independent `(resolved-source ordinal,
+walk ordinal)` tasks** across the instance-owned private compute pool when:
+
+- `compute_threads > 1`, and
+- estimated transitions (`resolved starts × k × walk_length`) are at least
+  `RANDOM_WALK_PARALLEL_CROSSOVER` (`256`) in `graphforge-exec`.
+
+Below that crossover, or when the policy provides one compute thread, the
+serial path runs with no pool scheduling tax. Each task derives the same
+`splitmix64-v1` stream as the one-thread path and still sorts choices by
+neighbor UUID then edge UUID before sampling. Worker outputs merge by contiguous
+source/walk task range, so schemas, row order, metadata, cancellation/limit
+outcomes, and fingerprints match the one-thread result at
+`1`/`2`/`4`/`8`/automatic configurations.
 ## Observability
 
 `GraphForge::resource_policy()` and `GraphForge::resource_diagnostics()` expose

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1638,7 +1638,10 @@ UUID, then each walk uses a stream deterministically derived from the normalized
 start ordinal, and walk ordinal. Changing the RNG, seed derivation, draw conversion, or choice
 ordering requires a new named contract version. Given the same resolved graph projection,
 normalized options, contract version, and seed, repeated calls return byte-identical Arrow
-output.
+output. Above `RANDOM_WALK_PARALLEL_CROSSOVER` (`256`) estimated transitions and with more than
+one configured compute thread, independent walks may run on the instance-owned private compute
+pool; smaller workloads and one-thread policies stay serial. Parallel workers merge by resolved
+start ordinal and walk ordinal, preserving schemas, row ordering, metadata, and fingerprints.
 
 Rows sort by resolved-start order and then walk ordinal. The exact non-null result is
 `start_uuid: FixedSizeBinary(16), walk: List<FixedSizeBinary(16) not null>`. Each list includes


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements #553: parallel `paths(by="random_walk")` independent walks on the instance-owned `ComputePool` with deterministic merge and fingerprint parity.

Closes #553

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788953938&installation_model_id=20486&pr_number=614&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F614&signature=62b8dbff2fc4aa9a77c33f185464b8d29c3c387f3b5db3d646fc4362bd18f1ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parallelize `random_walk` execution on the instance-owned ComputePool
> - Adds a parallel execution path to `random_walks` in [`algorithm_paths_random_walk.rs`](https://github.com/CurateLabs/graphforge/pull/614/files#diff-0da7bfa850f08c94948de240ff678b52e6ff25440af7cbf1d3341e307fcbbb74) using Rayon on the private compute pool when `compute_threads > 1`, total walks > 1, and estimated transitions ≥ 256 (new `RANDOM_WALK_PARALLEL_CROSSOVER` constant).
> - Partitions work into contiguous task ranges via `walk_task_chunks`, preserving deterministic RNG streams and row order across thread counts.
> - Extracts serial logic into `random_walks_serial` and adds `select_random_walk_path` to deterministically choose between `Serial` and `Parallel` execution paths.
> - Panics inside parallel workers are caught via `catch_unwind` and returned as a structured `AlgorithmError::Execution` instead of aborting.
> - Behavioral Change: `RandomWalkAdjacencySource` now requires a `Sync` supertrait bound; existing implementations must be thread-safe.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0f702cf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->