### PR TITLE
perf(exec): serial disposition for biconnected (#517)

### DIFF
--- a/crates/graphforge-api/tests/m4_entry_baseline.rs
+++ b/crates/graphforge-api/tests/m4_entry_baseline.rs
@@ -21,7 +21,6 @@ use graphforge_api::{
     ExecutionResourcePolicy, GraphForge, GraphForgeOptions, Node2VecOptions, NodeSelector,
     PathsOptions, PropValue, RankOptions, ResourcePolicyMode, SimilarOptions, SpillPolicy,
 };
-use graphforge_core::AnalyzeOptions;
 use graphforge_core::algorithms::{
     AnalyzeAlgorithm, PathAlgorithm, RankAlgorithm, SimilarAlgorithm,
 };
@@ -1087,7 +1086,7 @@ fn build_evidence(
 #[test]
 fn short_ci_matrix_runs_through_public_facade_under_fixed_two_workers() {
     let (contract, workloads) = collect_short_matrix();
-    assert_eq!(workloads.len(), 11);
+    assert_eq!(workloads.len(), 12);
     let ids: Vec<_> = workloads.iter().map(|w| w.id).collect();
     assert_eq!(
         ids,

--- a/crates/graphforge-exec/src/algorithm_cluster.rs
+++ b/crates/graphforge-exec/src/algorithm_cluster.rs
@@ -4284,4 +4284,53 @@ mod tests {
         assert_eq!(result_rx.recv().unwrap(), Err(AlgorithmError::Cancelled));
         worker.join().unwrap();
     }
+    fn execute_biconnected_with_compute_threads(
+        graph: &AdjacencyGraph,
+        threads: usize,
+    ) -> Result<AlgorithmOutput, AlgorithmError> {
+        let mut registry = AlgorithmRegistry::default();
+        register_cluster_algorithms(&mut registry)?;
+        let control = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(threads),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(Arc::new(crate::ComputePool::new(threads).unwrap()));
+        registry.execute(
+            Algorithm::Cluster(ClusterAlgorithm::Biconnected),
+            graph,
+            &control,
+        )
+    }
+    #[test]
+    fn biconnected_keeps_serial_fingerprint_under_thread_budgets() {
+        let graph = AdjacencyGraph::with_test_directed_edges(
+            9,
+            &[
+                (0, 1),
+                (1, 2),
+                (2, 0),
+                (2, 3),
+                (3, 4),
+                (4, 2),
+                (4, 5),
+                (5, 6),
+                (6, 7),
+                (7, 5),
+                (7, 8),
+                (8, 8),
+                (1, 0),
+                (0, 1),
+            ],
+        );
+        let serial = execute_biconnected_with_compute_threads(&graph, 1).unwrap();
+        assert_eq!(community_ids(&serial), [0, 0, 0, 1, 1, 2, 3, 3, 4]);
+        let serial_fingerprint = output_fingerprint(&serial);
+
+        for threads in [2_usize, 4, 8] {
+            let output = execute_biconnected_with_compute_threads(&graph, threads).unwrap();
+            assert_eq!(output.schema, serial.schema);
+            assert_eq!(output_fingerprint(&output), serial_fingerprint);
+        }
+    }
+
 }

--- a/crates/graphforge-exec/src/algorithm_cluster.rs
+++ b/crates/graphforge-exec/src/algorithm_cluster.rs
@@ -4332,5 +4332,4 @@ mod tests {
             assert_eq!(output_fingerprint(&output), serial_fingerprint);
         }
     }
-
 }

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -967,6 +967,20 @@ at `1`/`2`/`4`/`8`/automatic configurations. No GPU, distributed, approximate, o
 foreign-engine fallback is implied.
 >>>>>>> dced88e (perf(exec): serial disposition for CELF (#502))
 
+## Serial biconnected components (#517)
+
+`cluster(by="biconnected")` is intentionally SERIAL. The implementation is an
+iterative Tarjan-style low-link traversal whose discovery indices, edge stack,
+and block-pop boundaries are sequential state; parallelizing those steps would
+either change the canonical primary-block labels or add synchronization that
+does not expose independent work to the private compute pool.
+
+The handler still uses Rust-owned adjacency projection and the bounded Arrow
+sink, avoids any Rayon global pool, and observes cancellation and shared
+iteration/output limits. The serial disposition is covered by a fingerprint test
+that attaches private compute pools for `1`/`2`/`4`/`8` configured compute
+threads and requires identical schemas, row ordering, labels, and rows.
+
 ## Observability
 
 `GraphForge::resource_policy()` and `GraphForge::resource_diagnostics()` expose


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #517: honest serial disposition for biconnected components (DFS order-dependent).

Closes #517

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788956782&installation_model_id=20486&pr_number=616&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F616&signature=ae8831d6e57c46c5d98b31acccef0d330ca955643e5f51a703913057ffacb022"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce serial disposition for biconnected component clustering
> - Makes `cluster(by="biconnected")` explicitly serial due to the inherently sequential nature of Tarjan-style graph traversal, ensuring consistent output regardless of the compute thread budget.
> - Adds `biconnected_keeps_serial_fingerprint_under_thread_budgets` test in [algorithm_cluster.rs](https://github.com/CurateLabs/graphforge/pull/616/files#diff-6dff1501420fc94f852063c9117e33b00e7855a33d11a109204fae38538e3fd9) that verifies identical schema and fingerprint across 1/2/4/8 thread configurations.
> - Documents the serial disposition and its rationale in [execution-resource-policy.md](https://github.com/CurateLabs/graphforge/pull/616/files#diff-978cd3c64399512fe02ce13768a045b47b2b98e5e672d553ee1bb69be7843971).
> - Updates the workload assertion in [m4_entry_baseline.rs](https://github.com/CurateLabs/graphforge/pull/616/files#diff-0552cbf7f10b2eb5e9d8a2fc9fd33329209500d28a521bbb4b07f497e48cbfb8) from 11 to 12 to match the current short CI matrix size.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9471889.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->