### PR TITLE
perf(exec): Node2Vec training serial disposition (#562)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_embedding_node2vec.rs
+++ b/crates/graphforge-exec/src/algorithm_embedding_node2vec.rs
@@ -5,7 +5,9 @@
 //! documented crossover. Seed derivation, candidate ordering, transition-mass
 //! accumulation, sampling, and every generated walk remain identical to the
 //! serial path. Skip-gram / negative-sampling training stays serial and
-//! unchanged so embedding fingerprints are preserved.
+//! preserves embedding fingerprints; #562 precomputes canonical negative
+//! sampling masses once per corpus so the serial trainer avoids per-sample mass
+//! vector allocation without changing RNG keys or draw order.
 
 use std::collections::HashMap;
 use std::panic::{AssertUnwindSafe, catch_unwind};
@@ -68,6 +70,7 @@ pub(crate) fn train_node2vec(
         .enumerate()
         .map(|(index, &(_, node_id))| (node_id, index))
         .collect::<HashMap<_, _>>();
+    let negative_table = NegativeSamplingTable::new(&nodes, &corpus.token_counts)?;
     let mut input = initialize_input(&nodes, options);
     let mut output = vec![vec![0.0_f32; options.dimensions]; nodes.len()];
     let learning_rate = f64_to_f32(options.learning_rate);
@@ -108,8 +111,7 @@ pub(crate) fn train_node2vec(
 
                     for negative_ordinal in 0..options.negative_samples {
                         let Some(negative_id) = sample_negative(
-                            &nodes,
-                            &corpus.token_counts,
+                            &negative_table,
                             context_id,
                             options.seed,
                             epoch,
@@ -183,10 +185,42 @@ fn initialize_input(nodes: &[([u8; 16], u64)], options: &Node2VecOptions) -> Vec
         .collect()
 }
 
+#[derive(Clone, Debug, PartialEq)]
+struct NegativeSamplingTable {
+    masses: Vec<(u64, f64)>,
+    total: f64,
+}
+
+impl NegativeSamplingTable {
+    fn new(
+        nodes: &[([u8; 16], u64)],
+        token_counts: &HashMap<u64, u64>,
+    ) -> Result<Self, Node2VecWalkError> {
+        let masses = nodes
+            .iter()
+            .map(|&(_, node_id)| {
+                let count = token_counts.get(&node_id).copied().unwrap_or(0);
+                (node_id, u64_to_f64(count).powf(0.75))
+            })
+            .collect::<Vec<_>>();
+        let total = masses.iter().map(|(_, mass)| mass).sum::<f64>();
+        if !total.is_finite() {
+            return Err(Node2VecWalkError::InvalidTransitionMass);
+        }
+        Ok(Self { masses, total })
+    }
+
+    fn context_mass(&self, context_id: u64) -> f64 {
+        self.masses
+            .iter()
+            .find_map(|&(node_id, mass)| (node_id == context_id).then_some(mass))
+            .unwrap_or(0.0)
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn sample_negative(
-    nodes: &[([u8; 16], u64)],
-    token_counts: &HashMap<u64, u64>,
+    table: &NegativeSamplingTable,
     context_id: u64,
     seed: u64,
     epoch: u64,
@@ -196,19 +230,7 @@ fn sample_negative(
     context_position: u64,
     negative_ordinal: u64,
 ) -> Result<Option<u64>, Node2VecWalkError> {
-    let masses = nodes
-        .iter()
-        .map(|&(_, node_id)| {
-            let count = token_counts.get(&node_id).copied().unwrap_or(0);
-            let mass = if node_id == context_id {
-                0.0
-            } else {
-                u64_to_f64(count).powf(0.75)
-            };
-            (node_id, mass)
-        })
-        .collect::<Vec<_>>();
-    let total = masses.iter().map(|(_, mass)| mass).sum::<f64>();
+    let total = table.total - table.context_mass(context_id);
     if total == 0.0 {
         return Ok(None);
     }
@@ -230,7 +252,10 @@ fn sample_negative(
     );
     let draw = rng.unit_f64() * total;
     let mut cumulative = 0.0;
-    Ok(masses.into_iter().find_map(|(node_id, mass)| {
+    Ok(table.masses.iter().find_map(|&(node_id, mass)| {
+        if node_id == context_id {
+            return None;
+        }
         cumulative += mass;
         (draw < cumulative).then_some(node_id)
     }))
@@ -931,26 +956,46 @@ mod tests {
         let graph = AdjacencyGraph::with_test_directed_edges(2, &[]);
         let nodes = canonical_nodes(&graph);
         let only_context = HashMap::from([(0, 4)]);
+        let only_context = NegativeSamplingTable::new(&nodes, &only_context).unwrap();
         assert_eq!(
-            sample_negative(
-                &nodes,
-                &only_context,
-                0,
-                0,
-                0,
-                0_u128.to_be_bytes(),
-                0,
-                0,
-                1,
-                0,
-            )
-            .unwrap(),
+            sample_negative(&only_context, 0, 0, 0, 0_u128.to_be_bytes(), 0, 0, 1, 0,).unwrap(),
             None
         );
         let both = HashMap::from([(0, 4), (1, 1)]);
+        let both = NegativeSamplingTable::new(&nodes, &both).unwrap();
         assert_eq!(
-            sample_negative(&nodes, &both, 0, 0, 0, 0_u128.to_be_bytes(), 0, 0, 1, 0).unwrap(),
+            sample_negative(&both, 0, 0, 0, 0_u128.to_be_bytes(), 0, 0, 1, 0).unwrap(),
             Some(1)
+        );
+    }
+
+    #[test]
+    fn negative_sampling_table_reuses_canonical_masses_without_context() {
+        let graph = AdjacencyGraph::with_test_directed_edges_and_uuids(
+            &[
+                3_u128.to_be_bytes(),
+                1_u128.to_be_bytes(),
+                2_u128.to_be_bytes(),
+            ],
+            &[],
+        );
+        let nodes = canonical_nodes(&graph);
+        let table =
+            NegativeSamplingTable::new(&nodes, &HashMap::from([(0, 8), (1, 1), (2, 27)])).unwrap();
+        assert_eq!(
+            table
+                .masses
+                .iter()
+                .map(|(node, _)| *node)
+                .collect::<Vec<_>>(),
+            [1, 2, 0]
+        );
+        assert!(table.context_mass(2) > 0.0);
+        assert_eq!(table.context_mass(99), 0.0);
+        assert!(
+            sample_negative(&table, 1, 7, 0, 3_u128.to_be_bytes(), 0, 0, 1, 0)
+                .unwrap()
+                .is_some()
         );
     }
 

--- a/docs/book/architecture/algorithms.md
+++ b/docs/book/architecture/algorithms.md
@@ -3920,6 +3920,13 @@ does not claim a parallel crossover for `analyze_embedding(by="graphsage")`.
 Thread policies at `1`/`2`/`4`/`8`/automatic preserve the one-thread schema, row
 order, embeddings, structured errors, and bounded Arrow shaping.
 
+M4 #562 disposition: Node2Vec walk generation may use the documented private-pool
+crossover, but SGNS / negative-sampling training remains serial. The trainer now
+precomputes the canonical negative-sampling mass table once per corpus and
+excludes the current context at draw time; update order, RNG keys, Float32
+arithmetic, schemas, row order, fingerprints, structured errors, and bounded
+Arrow shaping stay on the one-thread contract.
+
 ---
 
 ## `forge.similar()` — Pairwise Similarity

--- a/docs/book/architecture/embedding-v1.md
+++ b/docs/book/architecture/embedding-v1.md
@@ -168,8 +168,10 @@ When `compute_threads > 1` and estimated walk transitions are at least
 `NODE2VEC_WALK_PARALLEL_CROSSOVER` (`256`), independent `(start ordinal, walk
 ordinal)` tasks may run on the instance-owned private CPU pool and merge in
 that same canonical order; seed derivation and every walk remain identical to
-the one-thread path. Skip-gram / negative-sampling training stays serial. For every
-center, contexts are positions in ascending order from
+the one-thread path. Skip-gram / negative-sampling training stays serial with
+no parallel crossover (#562): each accepted update mutates shared input/output
+vectors in corpus order, so reordering would change the public Float32
+fingerprint contract. For every center, contexts are positions in ascending order from
 `max(0,i-window_size)` to `min(length,i+window_size)`, excluding `i`; the window
 is not randomized. Token counts over that fixed corpus define
 
@@ -183,7 +185,10 @@ from `negative` (`U64(epoch), UUID(start), U64(walk ordinal),
 U64(center position), U64(context position), U64(negative ordinal)`). If no
 mass remains, the negative set for the example is empty. This conditioned
 distribution makes the classic context exclusion total without a
-probability-dependent redraw loop.
+probability-dependent redraw loop. GraphForge precomputes the canonical
+`count(v)^0.75` mass table once per corpus and excludes the current context at
+draw time; this is an allocation/representation optimization only and does not
+change the RNG keys, cumulative scan order, or sampled negatives.
 
 The input matrix is initialized coordinate-wise from
 `Uniform[-0.5/dimensions, 0.5/dimensions)` using `node2vec-init-input`

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -895,6 +895,25 @@ hardware-specific timing) and verifies fingerprint parity against the
 one-thread oracle for every supported resource-policy cell. Timing remains
 evidence only, not a CI threshold.
 
+
+## Serial Node2Vec SGNS training (#562)
+
+`analyze_embedding(by="node2vec")` has no parallel crossover for the skip-gram
+with negative sampling (SGNS) training phase. The accepted public embedding is
+the result of replaying the canonical walk corpus in `(epoch, walk, center,
+context, negative ordinal)` order. Each sample reads a center vector, mutates one
+or more output vectors, accumulates a center delta, then writes that delta back
+to the input vector. Reordering or sharding those updates would require a new
+conflict-resolution contract and could change Float32 bits, row fingerprints,
+and tie behavior.
+
+The #562 polish therefore keeps SGNS serial while removing avoidable
+per-negative-sample allocation. The trainer now builds a canonical negative-mass
+table once from corpus token counts and excludes the current context at draw
+time; RNG derivation, cumulative mass order, update arithmetic, schemas, row
+order, cancellation, work/output limits, and bounded Arrow shaping remain the
+one-thread oracle at `1`/`2`/`4`/`8`/automatic configurations. Walk generation
+continues to use the #344 private-pool crossover above.
 ## Observability
 
 `GraphForge::resource_policy()` and `GraphForge::resource_diagnostics()` expose

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -3254,6 +3254,12 @@ updates, and final inference preserve one canonical order under every
 `compute_threads` policy; no parallel training crossover, GPU, or foreign-engine
 fallback is claimed.
 
+`by="node2vec"` uses the documented private-pool crossover only for walk-corpus
+generation. SGNS / negative-sampling training has an explicit serial disposition
+(#562): GraphForge preserves corpus-order updates and instead precomputes the
+canonical negative-sampling mass table once per corpus. No parallel training,
+GPU, or foreign-engine fallback is claimed.
+
 ---
 
 ### `similar(label, *, by, k=10, vector_property=None, via=None)` → `pyarrow.Table`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #562: Node2Vec SGNS training serial disposition (walks already parallel #344).

Closes #562

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788956782&installation_model_id=20486&pr_number=618&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F618&signature=f5945fc4ad53fab87f0ad1b5a80b9df1be4de17b21e739768d9ea9cc72124c42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Precompute Node2Vec negative-sampling mass table once per corpus in serial training
> - Introduces `NegativeSamplingTable`, a struct that builds canonical node-id mass entries (`count^0.75`) once per corpus instead of allocating a new mass vector on every negative sample draw.
> - Updates `sample_negative` to accept `&NegativeSamplingTable` and exclude the context node at draw time by subtracting its mass from the total, preserving RNG keys and scan order.
> - Documents in architecture and API reference that SGNS/negative-sampling training remains strictly serial while walk-corpus generation may still use the private-pool crossover.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e33ea14.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->