### PR TITLE
perf(exec): parallelize k-means assignment on ComputePool (#524)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_cluster.rs
+++ b/crates/graphforge-exec/src/algorithm_cluster.rs
@@ -823,6 +823,7 @@ pub fn cluster_algorithm_with_limits(
 }
 
 /// Execute clustering with shaping limits and an optional private compute pool (#518).
+/// Execute clustering with shaping limits and an optional private compute pool (#524).
 #[allow(
     clippy::too_many_arguments,
     reason = "mirrors cluster_algorithm_with_limits plus the instance compute pool handle"

--- a/crates/graphforge-exec/src/algorithm_cluster_kmeans.rs
+++ b/crates/graphforge-exec/src/algorithm_cluster_kmeans.rs
@@ -1,9 +1,32 @@
 //! Deterministic, dependency-free K-means kernel for vector clustering.
+//!
+//! Assignment (#524) may partition independent point-to-centroid searches across
+//! the instance-owned private compute pool above a documented crossover.
+//! Farthest-first initialization and centroid updates remain serial, preserving
+//! topology ties and floating-point accumulation order.
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+use rayon::prelude::*;
+
 use crate::algorithm_dispatch::{AlgorithmControl, AlgorithmError};
 
 pub(crate) const CLUSTER_COUNT: usize = 10;
 const MAX_ITERATIONS: usize = 100;
 const CHECKPOINT_INTERVAL: usize = 64;
+
+/// Distance-coordinate evaluations below which assignment stays serial (#524).
+///
+/// The unit is `points * CLUSTER_COUNT * dimensions`; below this threshold,
+/// private-pool scheduling and merge overhead dominate the independent assign
+/// work. Distance coordinates remain serial for each point/centroid pair.
+pub const KMEANS_ASSIGN_PARALLEL_CROSSOVER_OPS: u64 = 32_768;
+
+/// Selected assignment execution path for observability and crossover tests.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum KMeansAssignPath {
+    Serial,
+    Parallel { threads: usize, chunks: usize },
+}
 
 pub(crate) fn stable_labels(
     vectors: &[&[f64]],
@@ -103,6 +126,19 @@ fn assign(
     control: &AlgorithmControl,
     work: &mut usize,
 ) -> Result<Vec<usize>, AlgorithmError> {
+    let dimension = vectors.first().map_or(0, |vector| vector.len());
+    match select_kmeans_assign_path(control, vectors.len(), dimension) {
+        KMeansAssignPath::Serial => assign_serial(vectors, centroids, control, work),
+        KMeansAssignPath::Parallel { .. } => assign_parallel(vectors, centroids, control),
+    }
+}
+
+fn assign_serial(
+    vectors: &[&[f64]],
+    centroids: &[Vec<f64>],
+    control: &AlgorithmControl,
+    work: &mut usize,
+) -> Result<Vec<usize>, AlgorithmError> {
     vectors
         .iter()
         .map(|vector| {
@@ -120,6 +156,51 @@ fn assign(
                 .ok_or_else(|| execution("K-means has no centroid"))
         })
         .collect()
+}
+
+fn assign_parallel(
+    vectors: &[&[f64]],
+    centroids: &[Vec<f64>],
+    control: &AlgorithmControl,
+) -> Result<Vec<usize>, AlgorithmError> {
+    let pool = control.compute_pool().ok_or_else(|| {
+        execution("parallel K-means assignment requires an instance-owned compute pool")
+    })?;
+    let ranges = point_chunks(vectors.len(), control.compute_threads());
+    let chunk_results = run_on_pool(pool, || {
+        let results = ranges
+            .par_iter()
+            .map(|&(start, end)| {
+                let mut work = 0_usize;
+                let mut chunk = Vec::with_capacity(end.saturating_sub(start));
+                for vector in &vectors[start..end] {
+                    chunk.push(assign_one(vector, centroids, control, &mut work)?);
+                }
+                Ok(chunk)
+            })
+            .collect::<Vec<Result<Vec<usize>, AlgorithmError>>>();
+        first_chunk_error(results)
+    })?;
+    Ok(chunk_results.into_iter().flatten().collect())
+}
+
+fn assign_one(
+    vector: &[f64],
+    centroids: &[Vec<f64>],
+    control: &AlgorithmControl,
+    work: &mut usize,
+) -> Result<usize, AlgorithmError> {
+    centroids
+        .iter()
+        .enumerate()
+        .map(|(index, centroid)| {
+            squared_distance(vector, centroid, control, work).map(|distance| (distance, index))
+        })
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .min_by(|left, right| left.0.total_cmp(&right.0).then(left.1.cmp(&right.1)))
+        .map(|(_, index)| index)
+        .ok_or_else(|| execution("K-means has no centroid"))
 }
 
 fn update(
@@ -200,6 +281,76 @@ fn checkpoint(control: &AlgorithmControl, work: &mut usize) -> Result<(), Algori
     }
     Ok(())
 }
+
+fn run_on_pool<R>(
+    pool: &crate::ComputePool,
+    op: impl FnOnce() -> Result<R, AlgorithmError> + Send,
+) -> Result<R, AlgorithmError>
+where
+    R: Send,
+{
+    match catch_unwind(AssertUnwindSafe(|| pool.install(op))) {
+        Ok(result) => result,
+        Err(_) => Err(execution("K-means assignment worker panicked")),
+    }
+}
+
+fn first_chunk_error<T>(results: Vec<Result<T, AlgorithmError>>) -> Result<Vec<T>, AlgorithmError> {
+    results.into_iter().collect()
+}
+
+/// Choose serial vs private-pool parallel assignment for a K-means workload.
+pub(crate) fn select_kmeans_assign_path(
+    control: &AlgorithmControl,
+    points: usize,
+    dimension: usize,
+) -> KMeansAssignPath {
+    let threads = control.compute_threads();
+    let estimated_ops = estimated_assign_ops(points, dimension);
+    if threads <= 1 || points <= 1 || estimated_ops < KMEANS_ASSIGN_PARALLEL_CROSSOVER_OPS {
+        return KMeansAssignPath::Serial;
+    }
+    if control
+        .compute_pool()
+        .is_none_or(|pool| !pool.is_parallel())
+    {
+        return KMeansAssignPath::Serial;
+    }
+    let chunks = point_chunks(points, threads).len();
+    if chunks <= 1 {
+        return KMeansAssignPath::Serial;
+    }
+    KMeansAssignPath::Parallel { threads, chunks }
+}
+
+fn estimated_assign_ops(points: usize, dimension: usize) -> u64 {
+    let points = u64::try_from(points).unwrap_or(u64::MAX);
+    let dimension = u64::try_from(dimension).unwrap_or(u64::MAX);
+    points
+        .saturating_mul(CLUSTER_COUNT as u64)
+        .saturating_mul(dimension)
+}
+
+fn point_chunks(points: usize, threads: usize) -> Vec<(usize, usize)> {
+    if points == 0 {
+        return Vec::new();
+    }
+    let workers = threads.clamp(1, points);
+    let base = points / workers;
+    let rem = points % workers;
+    let mut ranges = Vec::with_capacity(workers);
+    let mut start = 0;
+    for index in 0..workers {
+        let len = base + usize::from(index < rem);
+        let end = start + len;
+        if start < end {
+            ranges.push((start, end));
+        }
+        start = end;
+    }
+    ranges
+}
+
 fn numeric_error() -> AlgorithmError {
     execution("K-means numeric state is NaN or infinite")
 }
@@ -214,9 +365,43 @@ fn execution(message: &str) -> AlgorithmError {
 mod tests {
     use super::*;
     use crate::algorithm_dispatch::{AlgorithmCancellation, AlgorithmLimits};
+    use crate::compute_pool::ComputePool;
+    use std::sync::Arc;
 
     fn control() -> AlgorithmControl {
         AlgorithmControl::new(AlgorithmLimits::default(), AlgorithmCancellation::default())
+    }
+
+    fn control_with_threads(threads: usize) -> AlgorithmControl {
+        let pool = Arc::new(ComputePool::new(threads).unwrap());
+        AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(threads),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(pool)
+    }
+
+    fn broad_fixture() -> Vec<Vec<f64>> {
+        (0..300)
+            .map(|point| {
+                let group = point % CLUSTER_COUNT;
+                let member = point / CLUSTER_COUNT;
+                vec![
+                    group as f64 * 1_000.0 + member as f64 * 0.01,
+                    group as f64 * 10.0,
+                    member as f64,
+                    (group * group) as f64,
+                    (point % 7) as f64,
+                    (point % 11) as f64,
+                    (point % 13) as f64,
+                    (point % 17) as f64,
+                    (point % 19) as f64,
+                    (point % 23) as f64,
+                    (point % 29) as f64,
+                    (point % 31) as f64,
+                ]
+            })
+            .collect()
     }
 
     #[test]
@@ -230,6 +415,41 @@ mod tests {
             .collect::<Vec<i64>>();
         assert_eq!(fit(&vectors, &control(), MAX_ITERATIONS).unwrap(), expected);
         assert_eq!(fit(&vectors, &control(), MAX_ITERATIONS).unwrap(), expected);
+    }
+
+    #[test]
+    fn assign_path_respects_crossover_threads_and_pool() {
+        assert_eq!(
+            select_kmeans_assign_path(&control(), 512, 16),
+            KMeansAssignPath::Serial
+        );
+
+        let parallel = control_with_threads(4);
+        assert_eq!(
+            select_kmeans_assign_path(&parallel, 204, 16),
+            KMeansAssignPath::Serial
+        );
+        assert_eq!(
+            select_kmeans_assign_path(&parallel, 205, 16),
+            KMeansAssignPath::Parallel {
+                threads: 4,
+                chunks: 4
+            }
+        );
+    }
+
+    #[test]
+    fn thread_matrix_preserves_kmeans_assignment_fingerprint() {
+        let values = broad_fixture();
+        let vectors = values.iter().map(Vec::as_slice).collect::<Vec<_>>();
+        let serial = stable_labels(&vectors, &control_with_threads(1)).unwrap();
+        for threads in [2, 4, 8] {
+            assert_eq!(
+                stable_labels(&vectors, &control_with_threads(threads)).unwrap(),
+                serial,
+                "threads={threads}"
+            );
+        }
     }
 
     #[test]

--- a/docs/book/architecture/algorithms.md
+++ b/docs/book/architecture/algorithms.md
@@ -1239,6 +1239,17 @@ consecutive `Int64` values ordered by the first topology point assigned to each
 observed community. Duplicate vectors are valid and may collapse multiple
 centroids into fewer returned communities.
 
+The assignment pass may use the instance-owned private compute pool when
+`compute_threads > 1` and `points * 10 * dimensions` is at least
+`KMEANS_ASSIGN_PARALLEL_CROSSOVER_OPS` (`32,768`). Smaller workloads and
+one-thread policies stay serial. Parallel execution only partitions independent
+point assignment; each point still evaluates centroid distances in the serial
+coordinate and centroid order above. Initialization, centroid mean reductions,
+empty-cluster retention, convergence comparison, label canonicalization, and
+Arrow publication remain serial, so schemas, row order, community IDs, and
+fingerprints match the one-thread oracle. There is no GPU, approximate, or
+user-visible K-means concurrency option.
+
 Empty selections preserve the typed zero-row result; non-empty selections with
 fewer than ten nodes are rejected. The schema is non-null
 `node_uuid: FixedSizeBinary(16)`, non-null `community_id: Int64`, then

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -851,6 +851,25 @@ neighbor UUID then edge UUID before sampling. Worker outputs merge by contiguous
 source/walk task range, so schemas, row order, metadata, cancellation/limit
 outcomes, and fingerprints match the one-thread result at
 `1`/`2`/`4`/`8`/automatic configurations.
+## Parallel K-means assignment (#524)
+
+K-means assignment partitions **independent point-to-centroid searches** across
+the instance-owned private compute pool when:
+
+- `compute_threads > 1`, and
+- estimated distance-coordinate evaluations
+  (`points * CLUSTER_COUNT * dimensions`) are at least
+  `KMEANS_ASSIGN_PARALLEL_CROSSOVER_OPS` (`32_768`) in `graphforge-exec`.
+
+Below that crossover, or when the policy provides one compute thread, the
+serial path runs with no pool scheduling tax. Each point still computes squared
+Euclidean distances to centroids in centroid-index order and applies the same
+lower-index tie-break. Farthest-first initialization, centroid mean reductions,
+empty-centroid retention, convergence checks, canonical label assignment, and
+Arrow output remain serial, so schemas, row order, community IDs, and
+fingerprints match the one-thread result at `1`/`2`/`4`/`8`/automatic
+configurations.
+
 ## Observability
 
 `GraphForge::resource_policy()` and `GraphForge::resource_diagnostics()` expose


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #524: parallel k-means assignment on ComputePool.

Closes #524

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/621"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788956783&installation_model_id=20486&pr_number=621&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F621&signature=888eb7097dfb4618d903261bec08e12e192abb3a43ae1472182a127ad294d656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parallelize k-means assignment on `ComputePool` with a 32,768-operation crossover threshold
> - Adds a parallel assignment path in [`algorithm_cluster_kmeans.rs`](https://github.com/CurateLabs/graphforge/pull/621/files#diff-a0ce86f4b57877644805136c1909322c3b6943f3c60b1521c46447461d9daa04) that splits points into chunks and runs them concurrently via the instance-owned `ComputePool` using rayon.
> - Introduces `select_kmeans_assign_path` to choose between `Serial` and `Parallel` based on estimated ops (`points × clusters × dimensions`), thread count, and pool availability; falls back to serial for small workloads or single-thread policies.
> - Panics inside assignment workers are caught via `catch_unwind` and converted to `AlgorithmError::Execution` rather than unwinding to the caller.
> - Parallel output is verified to produce bit-identical labels to the serial path across thread counts.
> - Behavioral Change: assignment now returns an error (instead of running serially) if the parallel path is selected but no `ComputePool` is present at invocation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d8ef02d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->