### PR TITLE
perf(exec): parallelize transitive_closure on ComputePool (#554)

### DIFF
--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -2450,13 +2450,17 @@ impl GraphForge {
             .read()
             .expect("adjacency visibility lock poisoned");
         self.adjacency_provider.revalidate();
-        graphforge_exec::paths_algorithm(
+        graphforge_exec::paths_algorithm_with_compute(
             self.adjacency_provider.as_ref(),
             &self.dir,
             self.ontology_mode,
             source.map(|uuid| *uuid.as_bytes()),
             target.map(|uuid| *uuid.as_bytes()),
             options,
+            graphforge_exec::AlgorithmLimits::default()
+                .with_batch_size(self.resource_policy.batch_size)
+                .with_compute_threads(self.resource_policy.compute_threads),
+            Some(self.compute_pool.clone()),
         )
     }
 

--- a/crates/graphforge-exec/src/algorithm_paths.rs
+++ b/crates/graphforge-exec/src/algorithm_paths.rs
@@ -12,8 +12,8 @@ use sha2::{Digest, Sha256};
 
 use crate::AdjacencyProvider;
 use crate::algorithm_dispatch::{
-    AlgorithmCapability, AlgorithmControl, AlgorithmError, AlgorithmOutput, AlgorithmRegistry,
-    AlgorithmValue, DependencyReview, RustAlgorithm,
+    AlgorithmCancellation, AlgorithmCapability, AlgorithmControl, AlgorithmError, AlgorithmLimits,
+    AlgorithmOutput, AlgorithmRegistry, AlgorithmValue, DependencyReview, RustAlgorithm,
 };
 use crate::algorithm_graph::{
     AdjacencyGraph, AdjacencySelection, export_adjacency, load_node_numeric_property,
@@ -1127,6 +1127,33 @@ pub fn paths_algorithm(
     target: Option<[u8; 16]>,
     options: PathsOptions,
 ) -> Result<RecordBatch, GfError> {
+    paths_algorithm_with_compute(
+        provider,
+        dir,
+        mode,
+        source,
+        target,
+        options,
+        AlgorithmLimits::default(),
+        None,
+    )
+}
+
+/// Execute path/flow algorithms with explicit limits and optional private compute pool (#554).
+#[allow(
+    clippy::too_many_arguments,
+    reason = "mirrors paths_algorithm plus resource-policy compute handles"
+)]
+pub fn paths_algorithm_with_compute(
+    provider: &dyn AdjacencyProvider,
+    dir: &Path,
+    mode: OntologyMode,
+    source: Option<[u8; 16]>,
+    target: Option<[u8; 16]>,
+    options: PathsOptions,
+    limits: AlgorithmLimits,
+    compute: Option<crate::SharedComputePool>,
+) -> Result<RecordBatch, GfError> {
     validate_path_options(source, target, &options)?;
     let via = options.via.as_deref().unwrap_or("*");
     let graph = export_adjacency(
@@ -1152,10 +1179,10 @@ pub fn paths_algorithm(
         },
     )?;
     let algorithm = Algorithm::Paths(options.by);
-    let control = AlgorithmControl::new(
-        crate::algorithm_dispatch::AlgorithmLimits::default(),
-        crate::algorithm_dispatch::AlgorithmCancellation::default(),
-    );
+    let mut control = AlgorithmControl::new(limits, AlgorithmCancellation::default());
+    if let Some(pool) = compute {
+        control = control.with_compute_pool(pool);
+    }
     if let Some(kind) = steiner_kind(options.by) {
         return execute_steiner(&graph, dir, source, target, &options, kind, &control);
     }

--- a/crates/graphforge-exec/src/algorithm_paths_transitive_closure.rs
+++ b/crates/graphforge-exec/src/algorithm_paths_transitive_closure.rs
@@ -1,9 +1,22 @@
 //! Deterministic positive-length transitive closure over shared adjacency.
 
 use std::collections::{HashSet, VecDeque};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use rayon::prelude::*;
 
 use crate::algorithm_dispatch::{AlgorithmControl, AlgorithmError};
 use crate::algorithm_graph::AdjacencyGraph;
+
+const TRANSITIVE_CLOSURE_PARALLEL_CROSSOVER_WORK: u64 = 65_536;
+const TRANSITIVE_CLOSURE_CHECKPOINT_EDGES: usize = 4_096;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TransitiveClosureExecutionPath {
+    Serial,
+    Parallel { threads: usize, chunks: usize },
+}
 
 /// One reachable ordered node pair.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -40,35 +53,37 @@ pub(crate) fn positive_transitive_closure(
         .collect::<Result<Vec<_>, _>>()?;
     sources.sort_unstable();
 
+    match select_transitive_closure_path(control, sources.len(), graph.edge_entry_count()) {
+        TransitiveClosureExecutionPath::Serial => {
+            positive_transitive_closure_serial(graph, &sources, control)
+        }
+        TransitiveClosureExecutionPath::Parallel { .. } => {
+            positive_transitive_closure_parallel(graph, &sources, control)
+        }
+    }
+}
+
+fn positive_transitive_closure_serial(
+    graph: &AdjacencyGraph,
+    sources: &[([u8; 16], u64)],
+    control: &AlgorithmControl,
+) -> Result<Vec<ClosurePair>, AlgorithmError> {
     let mut rows = Vec::new();
     let mut traversed_entries = 0_usize;
-    for (_, source) in sources {
+    for &(_, source) in sources {
         control.check_cancelled()?;
-        let mut reachable = HashSet::new();
-        let mut queue = VecDeque::from([source]);
-
-        while let Some(node) = queue.pop_front() {
-            for edge in graph.neighbors(node) {
-                if traversed_entries.is_multiple_of(4_096) {
+        let targets = transitive_closure_targets(
+            graph,
+            source,
+            control,
+            |control, traversed_entries| {
+                if traversed_entries.is_multiple_of(TRANSITIVE_CLOSURE_CHECKPOINT_EDGES) {
                     control.checkpoint()?;
                 }
-                traversed_entries = traversed_entries.saturating_add(1);
-                if reachable.insert(edge.neighbor_id) {
-                    queue.push_back(edge.neighbor_id);
-                }
-            }
-        }
-
-        let mut targets = reachable
-            .into_iter()
-            .map(|node| {
-                graph
-                    .node_uuid(node)
-                    .map(|uuid| (uuid, node))
-                    .ok_or_else(|| execution("transitive_closure target has no UUID identity"))
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        targets.sort_unstable();
+                Ok(())
+            },
+            &mut traversed_entries,
+        )?;
         let next_len = rows
             .len()
             .checked_add(targets.len())
@@ -84,6 +99,158 @@ pub(crate) fn positive_transitive_closure(
     Ok(rows)
 }
 
+fn positive_transitive_closure_parallel(
+    graph: &AdjacencyGraph,
+    sources: &[([u8; 16], u64)],
+    control: &AlgorithmControl,
+) -> Result<Vec<ClosurePair>, AlgorithmError> {
+    let pool = control.compute_pool().ok_or_else(|| {
+        execution("parallel transitive_closure requires an instance-owned compute pool")
+    })?;
+    let ranges = transitive_closure_source_chunks(sources.len(), control.compute_threads());
+    let traversed_entries = AtomicUsize::new(0);
+    let chunk_rows = run_transitive_closure_on_pool(pool, || {
+        ranges
+            .par_iter()
+            .map(|&(start, end)| {
+                control.check_cancelled()?;
+                let mut rows = Vec::new();
+                let mut local_edges = 0_usize;
+                for &(_, source) in &sources[start..end] {
+                    let targets = transitive_closure_targets(
+                        graph,
+                        source,
+                        control,
+                        |control, local_edges| {
+                            let observed = traversed_entries.fetch_add(1, Ordering::Relaxed);
+                            if observed.is_multiple_of(TRANSITIVE_CLOSURE_CHECKPOINT_EDGES)
+                                || local_edges.is_multiple_of(TRANSITIVE_CLOSURE_CHECKPOINT_EDGES)
+                            {
+                                control.check_cancelled()?;
+                            }
+                            Ok(())
+                        },
+                        &mut local_edges,
+                    )?;
+                    rows.extend(
+                        targets
+                            .into_iter()
+                            .map(|(_, target)| ClosurePair { source, target }),
+                    );
+                }
+                Ok(rows)
+            })
+            .collect::<Result<Vec<_>, AlgorithmError>>()
+    })?;
+
+    let total_rows = chunk_rows.iter().try_fold(0_usize, |total, rows| {
+        total
+            .checked_add(rows.len())
+            .ok_or_else(|| execution("transitive_closure output size exceeds platform range"))
+    })?;
+    control.check_output_rows(total_rows)?;
+
+    let mut rows = Vec::with_capacity(total_rows);
+    for chunk in chunk_rows {
+        rows.extend(chunk);
+    }
+    Ok(rows)
+}
+
+fn transitive_closure_targets<CHECKPOINT>(
+    graph: &AdjacencyGraph,
+    source: u64,
+    control: &AlgorithmControl,
+    mut checkpoint: CHECKPOINT,
+    traversed_entries: &mut usize,
+) -> Result<Vec<([u8; 16], u64)>, AlgorithmError>
+where
+    CHECKPOINT: FnMut(&AlgorithmControl, usize) -> Result<(), AlgorithmError>,
+{
+    control.check_cancelled()?;
+    let mut reachable = HashSet::new();
+    let mut queue = VecDeque::from([source]);
+
+    while let Some(node) = queue.pop_front() {
+        for edge in graph.neighbors(node) {
+            checkpoint(control, *traversed_entries)?;
+            *traversed_entries = traversed_entries.saturating_add(1);
+            if reachable.insert(edge.neighbor_id) {
+                queue.push_back(edge.neighbor_id);
+            }
+        }
+    }
+
+    let mut targets = reachable
+        .into_iter()
+        .map(|node| {
+            graph
+                .node_uuid(node)
+                .map(|uuid| (uuid, node))
+                .ok_or_else(|| execution("transitive_closure target has no UUID identity"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    targets.sort_unstable();
+    Ok(targets)
+}
+
+fn select_transitive_closure_path(
+    control: &AlgorithmControl,
+    sources: usize,
+    edge_entries: u64,
+) -> TransitiveClosureExecutionPath {
+    let threads = control.compute_threads();
+    let estimated_work = (sources as u64).saturating_mul(edge_entries);
+    if threads <= 1
+        || sources <= 1
+        || estimated_work < TRANSITIVE_CLOSURE_PARALLEL_CROSSOVER_WORK
+        || control
+            .compute_pool()
+            .is_none_or(|pool| !pool.is_parallel())
+    {
+        return TransitiveClosureExecutionPath::Serial;
+    }
+    let chunks = transitive_closure_source_chunks(sources, threads).len();
+    if chunks <= 1 {
+        TransitiveClosureExecutionPath::Serial
+    } else {
+        TransitiveClosureExecutionPath::Parallel { threads, chunks }
+    }
+}
+
+fn transitive_closure_source_chunks(sources: usize, threads: usize) -> Vec<(usize, usize)> {
+    if sources == 0 {
+        return Vec::new();
+    }
+    let workers = threads.clamp(1, sources);
+    let base = sources / workers;
+    let rem = sources % workers;
+    let mut ranges = Vec::with_capacity(workers);
+    let mut start = 0;
+    for index in 0..workers {
+        let len = base + usize::from(index < rem);
+        let end = start + len;
+        if start < end {
+            ranges.push((start, end));
+        }
+        start = end;
+    }
+    ranges
+}
+
+fn run_transitive_closure_on_pool<R>(
+    pool: &crate::ComputePool,
+    op: impl FnOnce() -> Result<R, AlgorithmError> + Send,
+) -> Result<R, AlgorithmError>
+where
+    R: Send,
+{
+    match catch_unwind(AssertUnwindSafe(|| pool.install(op))) {
+        Ok(result) => result,
+        Err(_) => Err(execution("transitive_closure worker panicked")),
+    }
+}
+
 fn execution(message: impl Into<String>) -> AlgorithmError {
     AlgorithmError::Execution {
         message: message.into(),
@@ -94,13 +261,32 @@ fn execution(message: impl Into<String>) -> AlgorithmError {
 mod tests {
     use super::*;
     use crate::algorithm_dispatch::{AlgorithmCancellation, AlgorithmLimits};
+    use std::sync::Arc;
 
     fn control() -> AlgorithmControl {
         AlgorithmControl::new(AlgorithmLimits::default(), AlgorithmCancellation::default())
     }
 
+    fn control_with_threads(threads: usize) -> AlgorithmControl {
+        AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(threads),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(Arc::new(crate::ComputePool::new(threads).unwrap()))
+    }
+
     fn pairs(rows: &[ClosurePair]) -> Vec<(u64, u64)> {
         rows.iter().map(|row| (row.source, row.target)).collect()
+    }
+
+    fn cyclic_graph(nodes: u64, fanout: u64) -> AdjacencyGraph {
+        let mut edges = Vec::new();
+        for source in 0..nodes {
+            for hop in 1..=fanout {
+                edges.push((source, (source + hop) % nodes));
+            }
+        }
+        AdjacencyGraph::with_test_directed_edges(nodes, &edges)
     }
 
     #[test]
@@ -193,6 +379,94 @@ mod tests {
         let cancellation = AlgorithmCancellation::default();
         cancellation.cancel();
         let cancelled = AlgorithmControl::new(AlgorithmLimits::default(), cancellation);
+        assert_eq!(
+            positive_transitive_closure(&graph, &cancelled),
+            Err(AlgorithmError::Cancelled)
+        );
+    }
+
+    #[test]
+    fn source_chunks_cover_canonical_ranges() {
+        assert_eq!(
+            transitive_closure_source_chunks(0, 4),
+            Vec::<(usize, usize)>::new()
+        );
+        assert_eq!(transitive_closure_source_chunks(5, 1), vec![(0, 5)]);
+        assert_eq!(transitive_closure_source_chunks(5, 2), vec![(0, 3), (3, 5)]);
+        assert_eq!(
+            transitive_closure_source_chunks(8, 4),
+            vec![(0, 2), (2, 4), (4, 6), (6, 8)]
+        );
+        assert_eq!(
+            transitive_closure_source_chunks(3, 8),
+            vec![(0, 1), (1, 2), (2, 3)]
+        );
+    }
+
+    #[test]
+    fn path_selection_requires_private_pool_and_crossover() {
+        let no_pool = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(4),
+            AlgorithmCancellation::default(),
+        );
+        assert_eq!(
+            select_transitive_closure_path(&no_pool, 64, 1_024),
+            TransitiveClosureExecutionPath::Serial
+        );
+
+        let one = control_with_threads(1);
+        assert_eq!(
+            select_transitive_closure_path(&one, 64, 1_024),
+            TransitiveClosureExecutionPath::Serial
+        );
+
+        let parallel = control_with_threads(4);
+        assert_eq!(
+            select_transitive_closure_path(&parallel, 64, 1),
+            TransitiveClosureExecutionPath::Serial
+        );
+        assert_eq!(
+            select_transitive_closure_path(
+                &parallel,
+                64,
+                TRANSITIVE_CLOSURE_PARALLEL_CROSSOVER_WORK / 64
+            ),
+            TransitiveClosureExecutionPath::Parallel {
+                threads: 4,
+                chunks: 4
+            }
+        );
+    }
+
+    #[test]
+    fn thread_matrix_matches_one_thread_output_order_and_fingerprint() {
+        let graph = cyclic_graph(128, 8);
+        assert!(
+            (graph.node_ids().len() as u64).saturating_mul(graph.edge_entry_count())
+                >= TRANSITIVE_CLOSURE_PARALLEL_CROSSOVER_WORK
+        );
+        let serial = positive_transitive_closure(&graph, &control_with_threads(1)).unwrap();
+        assert_eq!(serial.len(), 128 * 128);
+        let serial_pairs = pairs(&serial);
+
+        for threads in [2, 4, 8] {
+            let parallel =
+                positive_transitive_closure(&graph, &control_with_threads(threads)).unwrap();
+            assert_eq!(parallel, serial);
+            assert_eq!(pairs(&parallel), serial_pairs);
+        }
+    }
+
+    #[test]
+    fn parallel_path_honors_cancelled_control() {
+        let graph = cyclic_graph(128, 8);
+        let cancellation = AlgorithmCancellation::default();
+        cancellation.cancel();
+        let cancelled = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(4),
+            cancellation,
+        )
+        .with_compute_pool(Arc::new(crate::ComputePool::new(4).unwrap()));
         assert_eq!(
             positive_transitive_closure(&graph, &cancelled),
             Err(AlgorithmError::Cancelled)

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -208,7 +208,9 @@ pub use algorithm_embedding_invocation::{
     EmbeddingExecution, EmbeddingInvocationDescriptor, EmbeddingInvocationLimits,
     EmbeddingProjectionSelector, EmbeddingRngContract,
 };
-pub use algorithm_paths::{paths_algorithm, paths_projection_fingerprint};
+pub use algorithm_paths::{
+    paths_algorithm, paths_algorithm_with_compute, paths_projection_fingerprint,
+};
 pub use algorithm_rank::{
     rank_algorithm, rank_algorithm_with_compute, rank_algorithm_with_limits,
     rank_projection_fingerprint,

--- a/docs/book/architecture/algorithms.md
+++ b/docs/book/architecture/algorithms.md
@@ -2136,6 +2136,17 @@ Cancellation is checked before and during traversal. Limit, cancellation,
 projection, validation, execution, and Arrow-shaping failures return
 structured Rust errors without partial output.
 
+Per-source traversal may use the instance-owned private compute pool when
+`compute_threads > 1` and `sources * direction-expanded adjacency entries` is
+at least `TRANSITIVE_CLOSURE_PARALLEL_CROSSOVER_WORK` (`65,536`). Smaller
+workloads and one-thread policies stay serial. Parallel execution partitions
+only independent source traversals over the shared adjacency. Each worker
+preserves serial traversal inside its source range, sorts reachable targets by
+public UUID, and merges rows by ascending canonical source range. Schemas, row
+order, reachable pairs, and fingerprints match the one-thread oracle. There is
+no GPU, distributed, approximate, or user-visible transitive-closure
+concurrency option.
+
 Catalog registration, graph projection, execution, limits, cancellation,
 deduplication, ordering, and Arrow shaping are Rust-owned in `graphforge-exec`.
 Python and Node only adapt selectors/options and the native Arrow result; they

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -71,16 +71,17 @@ private Rayon pool on each `GraphForge` instance. Exact cosine KNN / similarity
 (#342), PageRank (#343), Node2Vec walk-corpus generation (#344), exact
 Jaccard node similarity (#535), local clustering coefficient (#504), triangle
 ranking (#515), Degree (#506), betweenness Brandes source searches (#501), and
-`cluster(by="components")` (#518) may partition independent work across that
-pool above documented crossovers; work never uses Rayon's process-global pool.
-Cosine dot products retain serial coordinate order, PageRank keeps canonical
-contribution order with serial dangling/delta reductions, Jaccard retains
-serial candidate order per source, clustering coefficient merges node-range
-scores in canonical dense-ordinal order, triangles merge node-owned counts by
-ascending dense ordinal, Degree merges node chunks in dense ordinal order,
-betweenness reduces per-source dependency arrays in canonical source order,
-Components merges worker-local forests in canonical source-range order, and
-Node2Vec skip-gram training stays serial, so fingerprints match the one-thread
+`cluster(by="components")` (#518), and transitive closure (#554) may partition
+independent work across that pool above documented crossovers; work never uses
+Rayon's process-global pool. Cosine dot products retain serial coordinate order,
+PageRank keeps canonical contribution order with serial dangling/delta
+reductions, Jaccard retains serial candidate order per source, clustering
+coefficient merges node-range scores in canonical dense-ordinal order, triangles
+merge node-owned counts by ascending dense ordinal, Degree merges node chunks in
+dense ordinal order, betweenness reduces per-source dependency arrays in
+canonical source order, Components merges worker-local forests in canonical
+source-range order, Node2Vec skip-gram training stays serial, and transitive
+closure merges source ranges canonically, so fingerprints match the one-thread
 path.
 
 ## Parallel cosine KNN (#342)
@@ -261,6 +262,23 @@ IDs are still assigned by canonical node order, so schemas, row order, labels,
 and fingerprints match the one-thread result at `1`/`2`/`4`/`8`/automatic
 configurations. Cancellation remains cooperative both before worker launch and
 inside chunk scans.
+
+## Parallel transitive closure (#554)
+
+`paths(by="transitive_closure")` partitions independent source-node traversals
+across the instance-owned private compute pool when:
+
+- `compute_threads > 1`, and
+- estimated traversal work (`sources × direction-expanded adjacency entries`) is
+  at least `TRANSITIVE_CLOSURE_PARALLEL_CROSSOVER_WORK` (`65_536`) in
+  `graphforge-exec`.
+
+Below that crossover, or when the policy provides one compute thread, the serial
+per-source breadth-first traversal runs with no pool scheduling tax. Parallel
+workers preserve the serial traversal inside each source, sort reachable targets
+by public UUID, and merge worker outputs by ascending canonical source range.
+Schemas, row order, reachable-pair sets, and fingerprints match the one-thread
+result at `1`/`2`/`4`/`8`/automatic configurations.
 
 ## Observability
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1859,6 +1859,13 @@ direction-expanded adjacency entries at 100,000,000, output rows at 10,000,000, 
 cooperative work checkpoints at 10,000. Cancellation and all failures abort without partial
 output.
 
+Above `TRANSITIVE_CLOSURE_PARALLEL_CROSSOVER_WORK` (`65,536` estimated
+`sources * direction-expanded adjacency entries` work units), multi-thread
+resource policies may run independent source traversals on the instance-owned
+private compute pool. Source ranges merge back in canonical UUID order before
+Arrow shaping, so schemas, row order, pairs, and fingerprints match the
+one-thread path. Small workloads and one-thread policies stay serial.
+
 Rust owns catalog dispatch, projection, validation, traversal, deduplication, ordering,
 limits, cancellation, and Arrow shaping. Python and Node only adapt arguments and the native
 Arrow result. Knowledge-layer presence cannot affect the topology-only result, preserving the topology-only knowledge isolation boundary. No external graph


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #554: parallel transitive_closure per-source on ComputePool.

Closes #554

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788956782&installation_model_id=20486&pr_number=622&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F622&signature=c40a5db4ae819e6b84770e4912e3b0bf84821a5950b6ab0d1863b7d96765cf74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parallelize `positive_transitive_closure` execution on the instance compute pool
> - Adds `paths_algorithm_with_compute` to accept explicit `AlgorithmLimits` and an optional compute pool, replacing the direct call to `paths_algorithm` in the API layer.
> - Introduces parallel execution for transitive closure in [algorithm_paths_transitive_closure.rs](https://github.com/CurateLabs/graphforge/pull/622/files#diff-686f54114ca1f150214840b5ec512183436b55a29d7d6c5f0ce632c82a5b665b): when `compute_threads > 1`, a private compute pool is present, and estimated work (sources × edges) exceeds `TRANSITIVE_CLOSURE_PARALLEL_CROSSOVER_WORK`, sources are partitioned into chunks and processed via Rayon on the pool.
> - Adds cooperative cancellation checkpoints and panic-catching in `run_transitive_closure_on_pool` to convert worker panics into structured `AlgorithmError::Execution` values.
> - Results are merged in canonical source-range order, preserving deterministic output and fingerprint equivalence with the serial path.
> - Behavioral Change: transitive closure now runs in parallel by default when resource policy configures multiple threads and work exceeds the crossover threshold; row order and fingerprints remain identical to single-threaded execution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d22a3be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->