### PR TITLE
perf(exec): serial disposition for girvan_newman (#520)

### DIFF
--- a/docs/development/m4-disposition-520-girvan-newman.md
+++ b/docs/development/m4-disposition-520-girvan-newman.md
@@ -1,0 +1,18 @@
+# M4 disposition: cluster(by="girvan_newman") (#520)
+
+Disposition: serial edge-betweenness removal.
+
+`girvan_newman` repeatedly computes edge betweenness for the current graph and
+removes the single canonical best edge before recomputing partitions. Parallel
+removal is not safe because each deletion changes the next betweenness scores,
+modularity comparison, and final community IDs.
+
+| Evidence item | Disposition |
+|---|---|
+| Path / threads | Serial for 1/2/4/8/automatic; no private-pool or process-global Rayon work is introduced. |
+| Work units | Normalized community graph, edge-betweenness search, canonical edge removal, modularity tracking, output. |
+| Determinism | Existing `graphforge-exec` tests cover deterministic splits, limits, cancellation, empty/isolate cases, and Rust registration. |
+| Resource shape | Uses selected Rust adjacency and bounded node/community output; no parallel-only graph copy is added. |
+
+No GPU, distributed, approximate, or foreign-engine fallback is implied, and
+hardware timing/RSS observations remain non-gating evidence only.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #520: serial disposition for girvan_newman.

Closes #520

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788956797&installation_model_id=20486&pr_number=624&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F624&signature=9b99f6a8328af2cbf6cb08816edf483c1004fe2c14273d3c36e07fe911efa4ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add serial disposition documentation for `cluster(by="girvan_newman")`
> Adds a development doc at [m4-disposition-520-girvan-newman.md](https://github.com/CurateLabs/graphforge/pull/624/files#diff-5d1d3fc7aa3c12297f4332a928a40f0c655809f3f92690b2ba53ca47c9d187d6) capturing the execution disposition for the `girvan_newman` clustering algorithm. The doc outlines serial edge-betweenness removal as the chosen strategy and records evidence items covering path/threads, work units, determinism, and resource shape. No GPU, distributed, approximate, or foreign-engine fallback is planned.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9ed743e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->