### PR TITLE
perf(exec): serial disposition for k_core_decomposition (#523)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_cluster.rs
+++ b/crates/graphforge-exec/src/algorithm_cluster.rs
@@ -2451,6 +2451,24 @@ mod tests {
         )
     }
 
+    fn execute_k_core_decomposition_with_compute_threads(
+        graph: &AdjacencyGraph,
+        threads: usize,
+    ) -> Result<AlgorithmOutput, AlgorithmError> {
+        let mut registry = AlgorithmRegistry::default();
+        register_cluster_algorithms(&mut registry)?;
+        let control = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(threads),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(Arc::new(crate::ComputePool::new(threads).unwrap()));
+        registry.execute(
+            Algorithm::Cluster(ClusterAlgorithm::KCoreDecomposition),
+            graph,
+            &control,
+        )
+    }
+
     fn community_ids(output: &AlgorithmOutput) -> Vec<i64> {
         output
             .rows()
@@ -2487,6 +2505,10 @@ mod tests {
             }
         }
         AdjacencyGraph::with_test_edges(nodes, &edges)
+    }
+
+    fn output_fingerprint(output: &AlgorithmOutput) -> String {
+        format!("{:?}|{:?}", output.schema, output.rows())
     }
 
     #[test]
@@ -3717,6 +3739,42 @@ mod tests {
             ),
             Err(AlgorithmError::Cancelled)
         );
+    }
+
+    #[test]
+    fn k_core_decomposition_keeps_serial_fingerprint_under_thread_budgets() {
+        let graph = AdjacencyGraph::with_test_edges(
+            12,
+            &[
+                (0, 1),
+                (0, 2),
+                (0, 3),
+                (1, 2),
+                (1, 3),
+                (2, 3),
+                (3, 4),
+                (4, 5),
+                (5, 6),
+                (6, 4),
+                (7, 8),
+                (8, 9),
+                (9, 10),
+                (10, 7),
+                (10, 11),
+                (0, 1),
+                (2, 2),
+            ],
+        );
+        let serial = execute_k_core_decomposition_with_compute_threads(&graph, 1).unwrap();
+        assert_eq!(community_ids(&serial), [3, 3, 3, 3, 2, 2, 2, 2, 2, 2, 2, 1]);
+        let serial_fingerprint = output_fingerprint(&serial);
+
+        for threads in [2_usize, 4, 8] {
+            let output =
+                execute_k_core_decomposition_with_compute_threads(&graph, threads).unwrap();
+            assert_eq!(output.schema, serial.schema);
+            assert_eq!(output_fingerprint(&output), serial_fingerprint);
+        }
     }
 
     #[test]

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -262,6 +262,21 @@ and fingerprints match the one-thread result at `1`/`2`/`4`/`8`/automatic
 configurations. Cancellation remains cooperative both before worker launch and
 inside chunk scans.
 
+## Serial k-core decomposition (#523)
+
+`cluster(by="k_core_decomposition")` is intentionally SERIAL. The exact
+core-number peel mutates node degrees through a canonical min-heap; each removal
+changes later heap priorities and stale-entry rejection. Splitting that frontier
+across workers would either change tie order/core assignment evidence or add a
+global synchronization point around every peel, leaving no safe independent
+kernel for the private compute pool.
+
+The handler keeps the Rust-owned projection path and bounded Arrow sink, avoids
+the Rayon global pool, and observes shared graph/output/iteration limits. A
+fingerprint test attaches private compute pools for `1`/`2`/`4`/`8` configured
+compute threads and requires identical schemas, row ordering, core labels, and
+rows.
+
 ## Observability
 
 `GraphForge::resource_policy()` and `GraphForge::resource_diagnostics()` expose


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #523: serial disposition for k_core_decomposition.

Closes #523

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788956802&installation_model_id=20486&pr_number=627&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F627&signature=d6f0f9dbaead90854c1615074849ea4236aa07440c54df19d565baeed707175c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce serial disposition for `k_core_decomposition` cluster algorithm
> - The `k_core_decomposition` handler is made intentionally serial because the canonical peel process depends on heap mutation ordering, which is non-deterministic under parallelism.
> - The handler uses a private compute pool instead of the Rayon global pool, isolating it from thread-count-driven ordering differences.
> - A new fingerprint test in [algorithm_cluster.rs](https://github.com/CurateLabs/graphforge/pull/627/files#diff-6dff1501420fc94f852063c9117e33b00e7855a33d11a109204fae38538e3fd9) builds a 12-node graph and asserts identical schema, row order, and community labels across 1, 2, 4, and 8 thread configurations.
> - Documents the design decision in [execution-resource-policy.md](https://github.com/CurateLabs/graphforge/pull/627/files#diff-978cd3c64399512fe02ce13768a045b47b2b98e5e672d553ee1bb69be7843971) under a dedicated 'Serial k-core decomposition' section.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8df9016.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for K-core decomposition across 1, 2, 4, and 8 execution threads.
  * Verified consistent schemas and serialized results across different thread counts.
  * Confirmed expected community identifiers for serial execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->