### PR TITLE
perf(exec): serial disposition for fastgreedy (#519)

### DIFF
--- a/docs/development/m4-disposition-519-fastgreedy.md
+++ b/docs/development/m4-disposition-519-fastgreedy.md
@@ -1,0 +1,18 @@
+# M4 disposition: cluster(by="fastgreedy") (#519)
+
+Disposition: serial greedy modularity merging.
+
+`fastgreedy` repeatedly chooses the next canonical community merge under the
+current modularity state. Each accepted merge rewrites the candidate frontier,
+so parallel merge proposals are not trivially safe without conflict resolution
+that could change merge order and final community IDs.
+
+| Evidence item | Disposition |
+|---|---|
+| Path / threads | Serial for 1/2/4/8/automatic; no private-pool or process-global Rayon work is introduced. |
+| Work units | Normalized community graph, best-merge search, modularity scoring, canonical partition output. |
+| Determinism | Existing `graphforge-exec` tests cover deterministic partitions, limits, cancellation, empty/isolate cases, and Rust registration. |
+| Resource shape | Uses selected Rust adjacency and bounded node/community output; no parallel-only graph copy is added. |
+
+No GPU, distributed, approximate, or foreign-engine fallback is implied, and
+hardware timing/RSS observations remain non-gating evidence only.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #519: serial disposition for fastgreedy.

Closes #519

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788956798&installation_model_id=20486&pr_number=629&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F629&signature=2321de72622a63cbee0acc9b91c854a1d5a78be8392a3b3d72b168df706d02e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document serial disposition for `cluster(by="fastgreedy")` execution
> Adds a development document ([m4-disposition-519-fastgreedy.md](https://github.com/CurateLabs/graphforge/pull/629/files#diff-3d22d1c6ae153d8d11f708b88bb8b5d7137f7b2f73a105d0c707742acc4a63a9)) describing the M4 execution disposition for the fastgreedy clustering algorithm. The document records that fastgreedy uses serial greedy modularity merging, explains why merges are serialized due to frontier rewrites, and covers evidence across path/threads, work units, determinism, and resource shape. No GPU, distributed, approximate, or foreign-engine fallbacks are present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ec1908.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->