### PR TITLE
perf(exec): serial disposition for Louvain (#528)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_cluster.rs
+++ b/crates/graphforge-exec/src/algorithm_cluster.rs
@@ -5,6 +5,10 @@
 //! the accepted state from the previous step, so it keeps a serial execution
 //! disposition unless a future contract explicitly changes the numeric/tie
 //! semantics.
+//! Louvain (#528) is an order-sensitive multilevel modularity optimizer. Its
+//! local moves mutate community totals and accepted partitions one
+//! topology-ordered node at a time, so it keeps a serial execution disposition
+//! unless a future contract explicitly changes the numeric/tie semantics.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::panic::{AssertUnwindSafe, catch_unwind};
@@ -61,6 +65,13 @@ struct Leiden;
 pub(crate) enum LeidenExecutionPath {
     /// Local moves, refinement, and aggregation remain serial.
     SerialRefinement,
+}
+
+/// Selected Louvain execution path for #528 disposition evidence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum LouvainExecutionPath {
+    /// Topology-ordered local moves and condensation remain serial.
+    SerialLocalMoves,
 }
 
 struct LabelPropagation;
@@ -1000,6 +1011,9 @@ fn louvain_communities(
     graph: &AdjacencyGraph,
     control: &AlgorithmControl,
 ) -> Result<Vec<usize>, AlgorithmError> {
+    match select_louvain_path(control, graph.node_ids().len(), graph.edge_entry_count()) {
+        LouvainExecutionPath::SerialLocalMoves => {}
+    }
     let node_count = graph.node_ids().len();
     let (mut weights, mut members) = normalized_communities(graph, control)?;
 
@@ -1024,6 +1038,14 @@ fn louvain_communities(
         }
     }
     Ok(result)
+}
+
+pub(crate) fn select_louvain_path(
+    _control: &AlgorithmControl,
+    _node_count: usize,
+    _edge_count: u64,
+) -> LouvainExecutionPath {
+    LouvainExecutionPath::SerialLocalMoves
 }
 
 fn modularity_optimization_communities(
@@ -2330,6 +2352,23 @@ mod tests {
         execute_cluster(graph, Algorithm::Cluster(ClusterAlgorithm::Louvain), limits)
     }
 
+    fn execute_louvain_with_threads(
+        graph: &AdjacencyGraph,
+        threads: usize,
+        limits: AlgorithmLimits,
+        cancellation: AlgorithmCancellation,
+    ) -> Result<AlgorithmOutput, AlgorithmError> {
+        let mut registry = AlgorithmRegistry::default();
+        register_cluster_algorithms(&mut registry)?;
+        let control = AlgorithmControl::new(limits.with_compute_threads(threads), cancellation)
+            .with_compute_pool(Arc::new(crate::ComputePool::new(threads).unwrap()));
+        registry.execute(
+            Algorithm::Cluster(ClusterAlgorithm::Louvain),
+            graph,
+            &control,
+        )
+    }
+
     fn execute_leiden(
         graph: &AdjacencyGraph,
         limits: AlgorithmLimits,
@@ -2551,6 +2590,87 @@ mod tests {
 
     fn output_fingerprint(output: &AlgorithmOutput) -> String {
         format!("{:?}|{:?}", output.schema, output.rows())
+    }
+
+    #[test]
+    fn louvain_serial_disposition_holds_across_thread_budgets() {
+        let graph = AdjacencyGraph::with_test_edges(
+            8,
+            &[
+                (0, 1),
+                (1, 2),
+                (2, 0),
+                (3, 4),
+                (4, 5),
+                (5, 3),
+                (2, 3),
+                (6, 7),
+            ],
+        );
+        let control = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(8),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(Arc::new(crate::ComputePool::new(8).unwrap()));
+        assert_eq!(
+            select_louvain_path(&control, graph.node_ids().len(), graph.edge_entry_count()),
+            LouvainExecutionPath::SerialLocalMoves
+        );
+
+        let oracle = execute_louvain_with_threads(
+            &graph,
+            1,
+            AlgorithmLimits::default(),
+            AlgorithmCancellation::default(),
+        )
+        .unwrap();
+        for threads in [2_usize, 4, 8] {
+            let output = execute_louvain_with_threads(
+                &graph,
+                threads,
+                AlgorithmLimits::default(),
+                AlgorithmCancellation::default(),
+            )
+            .unwrap();
+            assert_eq!(output.schema, oracle.schema);
+            assert_eq!(output.rows(), oracle.rows());
+        }
+    }
+
+    #[test]
+    fn louvain_serial_path_preserves_limits_cancellation_and_arrow_shaping() {
+        let graph = AdjacencyGraph::with_test_edges(4, &[(0, 1), (1, 2), (2, 3)]);
+        assert!(matches!(
+            execute_louvain_with_threads(
+                &graph,
+                4,
+                AlgorithmLimits {
+                    output_rows: 1,
+                    ..AlgorithmLimits::default()
+                },
+                AlgorithmCancellation::default(),
+            ),
+            Err(AlgorithmError::OutputLimit { .. })
+        ));
+
+        let cancellation = AlgorithmCancellation::default();
+        cancellation.cancel();
+        assert_eq!(
+            execute_louvain_with_threads(&graph, 4, AlgorithmLimits::default(), cancellation),
+            Err(AlgorithmError::Cancelled)
+        );
+
+        let shaped = execute_louvain_with_threads(
+            &graph,
+            4,
+            AlgorithmLimits::default().with_batch_size(2),
+            AlgorithmCancellation::default(),
+        )
+        .unwrap();
+        assert_eq!(shaped.num_rows(), 4);
+        assert_eq!(shaped.record_batch().num_rows(), 4);
+        assert!(shaped.internal_batch_count > 1);
+        assert!(shaped.peak_builder_rows <= 2);
     }
 
     #[test]

--- a/docs/book/architecture/algorithms.md
+++ b/docs/book/architecture/algorithms.md
@@ -815,6 +815,14 @@ only after successful execution. Rust is the sole production owner; Python and
 Node only translate arguments and Arrow IPC and provide no backend, fallback,
 packaging dependency, or recovery path.
 
+M4 #528 disposition: Louvain remains serial. Each topology-ordered local move
+updates community totals before the next node evaluates its modularity gain, and
+each condensation level depends on the accepted partition from the previous
+level. GraphForge therefore does not claim a parallel crossover for
+`cluster(by="louvain")`; `1`/`2`/`4`/`8`/automatic thread policies preserve the
+one-thread schema, row order, community IDs, structured errors, and bounded
+Arrow shaping.
+
 ### Implemented Leiden contract
 
 `by="leiden"` is the Rust-owned classic Leiden implementation at modularity

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -1017,6 +1017,26 @@ The path still uses bounded Arrow output (#341), structured cancellation and
 resource checks, and no process-global Rayon pool. The M4 harness records
 `paths-floyd-warshall` evidence and verifies one-thread parity; timing is
 report-only.
+## Serial Louvain modularity optimization (#528)
+
+`cluster(by="louvain")` has no parallel crossover. Its performance disposition
+is **serial topology-ordered local moves** for every `compute_threads` setting,
+including `1`/`2`/`4`/`8`/automatic resource policies.
+
+Each Louvain level starts with the current partition and sweeps dense node
+ordinals in order. Moving one node immediately changes its source and target
+community totals, which changes the modularity gain and tie context seen by
+later nodes in the same sweep. Condensation then builds the next weighted
+supergraph from that accepted partition. Speculative worker moves would require
+a new conflict-resolution and reduction contract and could change community IDs,
+row ordering, or fingerprints.
+
+The #528 disposition therefore preserves the serial contract, CSR-native
+selected adjacency access, shared cancellation/checkpoint controls, structured
+resource errors, and bounded Arrow shaping. Schemas, row order, community IDs,
+projection fingerprints, cancellation, and limit behavior match the one-thread
+oracle at supported `1`/`2`/`4`/`8`/automatic configurations.
+
 ## Observability
 
 `GraphForge::resource_policy()` and `GraphForge::resource_diagnostics()` expose

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -638,6 +638,11 @@ limits, bounded cancellation checkpoints, and structured errors apply.
 Python and Node only translate arguments and Arrow IPC and contain no algorithm
 backend, fallback, packaging dependency, or recovery path.
 
+`louvain` has an explicit serial performance disposition (#528): topology-ordered
+local moves update community totals before later nodes are evaluated, and each
+condensation level depends on that accepted partition. No parallel crossover,
+GPU, or foreign-engine fallback is claimed.
+
 `by="leiden"` performs deterministic, unweighted classic Leiden in Rust at
 resolution `1.0`. Each level applies topology-ordered positive-gain local
 moves, refines coarse communities into connected subcommunities, and aggregates


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #528: serial disposition for Louvain.

Closes #528

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788956807&installation_model_id=20486&pr_number=633&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F633&signature=0eadcb4a4a717d6d034e10a763c2a8f1782b9977578c2721d5b655b4837ba634"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add serial disposition for Louvain community detection with topology-ordered local moves
> - Introduces `LouvainExecutionPath` enum and `select_louvain_path` function in [`algorithm_cluster.rs`](https://github.com/CurateLabs/graphforge/pull/633/files#diff-6dff1501420fc94f852063c9117e33b00e7855a33d11a109204fae38538e3fd9) to select the execution strategy based on control, node count, and edge count; currently always returns the serial path.
> - Local moves are topology-ordered and condensation depends on prior partitions, so no parallel crossover is claimed — thread count does not change output determinism.
> - Adds tests verifying output parity across 1/2/4/8 thread budgets, and that `OutputLimit` errors, cancellation, and Arrow batch shaping are preserved under the serial path.
> - Updates architecture, API reference, and execution-resource-policy docs to document the serial disposition.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9178a33.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Louvain clustering consistency across thread limits, output limits, and cancellation scenarios.
  * Preserved correct result ordering for order-sensitive processing.

* **Tests**
  * Added coverage for consistent results across execution settings.
  * Added validation for cancellation behavior and output batch formatting.

* **Documentation**
  * Documented Louvain’s serial execution requirements for reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->