### PR TITLE
perf(exec): serial disposition for Leiden (#527)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_cluster.rs
+++ b/crates/graphforge-exec/src/algorithm_cluster.rs
@@ -1,4 +1,10 @@
 //! Rust-owned cluster handlers registered under the shared algorithm dispatch contract.
+//!
+//! Leiden (#527) is an order-sensitive multilevel modularity optimizer. Its
+//! local moves, refinement, fixed random stream, and seeded aggregation consume
+//! the accepted state from the previous step, so it keeps a serial execution
+//! disposition unless a future contract explicitly changes the numeric/tie
+//! semantics.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::panic::{AssertUnwindSafe, catch_unwind};
@@ -49,6 +55,13 @@ struct Components;
 struct Louvain;
 
 struct Leiden;
+
+/// Selected Leiden execution path for #527 disposition evidence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum LeidenExecutionPath {
+    /// Local moves, refinement, and aggregation remain serial.
+    SerialRefinement,
+}
 
 struct LabelPropagation;
 
@@ -1697,6 +1710,9 @@ fn leiden_communities(
     graph: &AdjacencyGraph,
     control: &AlgorithmControl,
 ) -> Result<Vec<usize>, AlgorithmError> {
+    match select_leiden_path(control, graph.node_ids().len(), graph.edge_entry_count()) {
+        LeidenExecutionPath::SerialRefinement => {}
+    }
     let (mut weights, mut members) = normalized_communities(graph, control)?;
     let mut seed = None;
     let mut random = 0x4c45_4944_454e_u64;
@@ -1718,6 +1734,14 @@ fn leiden_communities(
         (weights, members) = condense(&weights, &members, &refined, count, control)?;
         seed = Some(next_seed);
     }
+}
+
+pub(crate) fn select_leiden_path(
+    _control: &AlgorithmControl,
+    _node_count: usize,
+    _edge_count: u64,
+) -> LeidenExecutionPath {
+    LeidenExecutionPath::SerialRefinement
 }
 
 fn label_propagation_communities(
@@ -2312,6 +2336,23 @@ mod tests {
         execute_cluster(graph, Algorithm::Cluster(ClusterAlgorithm::Leiden), limits)
     }
 
+    fn execute_leiden_with_threads(
+        graph: &AdjacencyGraph,
+        threads: usize,
+        limits: AlgorithmLimits,
+        cancellation: AlgorithmCancellation,
+    ) -> Result<AlgorithmOutput, AlgorithmError> {
+        let mut registry = AlgorithmRegistry::default();
+        register_cluster_algorithms(&mut registry)?;
+        let control = AlgorithmControl::new(limits.with_compute_threads(threads), cancellation)
+            .with_compute_pool(Arc::new(crate::ComputePool::new(threads).unwrap()));
+        registry.execute(
+            Algorithm::Cluster(ClusterAlgorithm::Leiden),
+            graph,
+            &control,
+        )
+    }
+
     fn execute_label_propagation(
         graph: &AdjacencyGraph,
         limits: AlgorithmLimits,
@@ -2487,6 +2528,88 @@ mod tests {
             }
         }
         AdjacencyGraph::with_test_edges(nodes, &edges)
+    }
+
+    #[test]
+    fn leiden_serial_disposition_holds_across_thread_budgets() {
+        let graph = AdjacencyGraph::with_test_edges(
+            8,
+            &[
+                (0, 4),
+                (0, 6),
+                (1, 2),
+                (1, 5),
+                (1, 6),
+                (2, 6),
+                (3, 6),
+                (4, 6),
+                (5, 6),
+            ],
+        );
+        let control = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(8),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(Arc::new(crate::ComputePool::new(8).unwrap()));
+        assert_eq!(
+            select_leiden_path(&control, graph.node_ids().len(), graph.edge_entry_count()),
+            LeidenExecutionPath::SerialRefinement
+        );
+
+        let oracle = execute_leiden_with_threads(
+            &graph,
+            1,
+            AlgorithmLimits::default(),
+            AlgorithmCancellation::default(),
+        )
+        .unwrap();
+        for threads in [2_usize, 4, 8] {
+            let output = execute_leiden_with_threads(
+                &graph,
+                threads,
+                AlgorithmLimits::default(),
+                AlgorithmCancellation::default(),
+            )
+            .unwrap();
+            assert_eq!(output.schema, oracle.schema);
+            assert_eq!(output.rows(), oracle.rows());
+        }
+    }
+
+    #[test]
+    fn leiden_serial_path_preserves_limits_cancellation_and_arrow_shaping() {
+        let graph = AdjacencyGraph::with_test_edges(4, &[(0, 1), (1, 2), (2, 3)]);
+        assert!(matches!(
+            execute_leiden_with_threads(
+                &graph,
+                4,
+                AlgorithmLimits {
+                    output_rows: 1,
+                    ..AlgorithmLimits::default()
+                },
+                AlgorithmCancellation::default(),
+            ),
+            Err(AlgorithmError::OutputLimit { .. })
+        ));
+
+        let cancellation = AlgorithmCancellation::default();
+        cancellation.cancel();
+        assert_eq!(
+            execute_leiden_with_threads(&graph, 4, AlgorithmLimits::default(), cancellation),
+            Err(AlgorithmError::Cancelled)
+        );
+
+        let shaped = execute_leiden_with_threads(
+            &graph,
+            4,
+            AlgorithmLimits::default().with_batch_size(2),
+            AlgorithmCancellation::default(),
+        )
+        .unwrap();
+        assert_eq!(shaped.num_rows(), 4);
+        assert_eq!(shaped.record_batch().num_rows(), 4);
+        assert!(shaped.internal_batch_count > 1);
+        assert!(shaped.peak_builder_rows <= 2);
     }
 
     #[test]

--- a/docs/book/architecture/algorithms.md
+++ b/docs/book/architecture/algorithms.md
@@ -780,6 +780,13 @@ is the sole production owner; Python and Node only translate arguments and
 Arrow IPC and provide no backend, fallback, packaging dependency, or recovery
 path.
 
+M4 #527 disposition: Leiden remains serial. Topology-ordered local moves,
+connected refinement, fixed-stream sampled refinement choices, and seeded
+aggregation each consume the accepted state from the previous step. GraphForge
+therefore does not claim a parallel crossover for `cluster(by="leiden")`;
+`1`/`2`/`4`/`8`/automatic thread policies preserve the one-thread schema, row
+order, connected community IDs, structured errors, and bounded Arrow shaping.
+
 ### Implemented label-propagation contract
 
 `by="label_propagation"` is the Rust-owned classic asynchronous algorithm of

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -83,6 +83,15 @@ Components merges worker-local forests in canonical source-range order, and
 Node2Vec skip-gram training stays serial, so fingerprints match the one-thread
 path.
 
+(#342), PageRank (#343), and Node2Vec walk-corpus generation (#344) may partition
+independent work across that pool above documented crossovers; work never uses
+Rayon's process-global pool. Leiden (#527) is explicitly dispositioned serial
+because local moves, refinement, fixed random sampling, and aggregation consume
+the accepted state from the previous step. Cosine dot products retain serial
+coordinate order, PageRank keeps canonical contribution order with serial
+dangling/delta reductions, Node2Vec skip-gram training stays serial, and Leiden
+keeps one-thread refinement order, so fingerprints match the one-thread path.
+
 ## Parallel cosine KNN (#342)
 
 Exact, all-score, and filtered cosine partition **independent source rows**
@@ -261,6 +270,27 @@ IDs are still assigned by canonical node order, so schemas, row order, labels,
 and fingerprints match the one-thread result at `1`/`2`/`4`/`8`/automatic
 configurations. Cancellation remains cooperative both before worker launch and
 inside chunk scans.
+
+## Serial Leiden modularity optimization (#527)
+
+`cluster(by="leiden")` has no parallel crossover. Its performance disposition is
+**serial local-move/refinement/aggregation** for every `compute_threads`
+setting, including `1`/`2`/`4`/`8`/automatic resource policies.
+
+Each Leiden level first runs topology-ordered positive-gain local moves, then
+refines coarse communities through connected subcommunities using the fixed
+Rust random stream and accepted membership state, then aggregates the refined
+partition while seeding the next level from the coarse partition. Reordering
+candidate moves, random draws, or aggregation updates would require a new
+numeric and tie contract and could change connected-community guarantees,
+community IDs, row ordering, or fingerprints.
+
+The #527 disposition therefore preserves the serial contract, CSR-native
+selected adjacency access, shared cancellation/checkpoint controls, structured
+resource errors, and bounded Arrow shaping. Schemas, row order, community IDs,
+projection fingerprints, cancellation, and limit behavior match the one-thread
+oracle at supported thread configurations. No GPU, distributed, approximate, or
+foreign-engine fallback is implied.
 
 ## Observability
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -637,6 +637,11 @@ checkpoints, structured numeric errors, UUID-only identity, and atomic opt-in
 `write_property` apply. Python and Node remain thin Arrow IPC bindings with no
 algorithm backend, fallback, packaging dependency, or recovery path.
 
+`leiden` has an explicit serial performance disposition (#527): local moves,
+connected refinement, fixed random-stream choices, and seeded aggregation
+consume the accepted state from the previous step. No parallel crossover, GPU,
+or foreign-engine fallback is claimed.
+
 `by="girvan_newman"` performs the deterministic, unweighted algorithm of
 [Girvan and Newman](https://doi.org/10.1073/pnas.122653799) in Rust. It computes
 all-shortest-path edge betweenness, removes one highest-scoring edge, and


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #527: serial disposition for Leiden.

Closes #527

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788956807&installation_model_id=20486&pr_number=635&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F635&signature=bf4c70f9e48cc29ca12560771b60175334fb336e9abd336d25aff4e5ad2f5b66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add serial disposition for Leiden community detection with path selection and tests
> - Introduces `LeidenExecutionPath` enum and `select_leiden_path` function in [`algorithm_cluster.rs`](https://github.com/CurateLabs/graphforge/pull/635/files#diff-6dff1501420fc94f852063c9117e33b00e7855a33d11a109204fae38538e3fd9) to formally document that Leiden is order-sensitive and must remain serial.
> - `select_leiden_path` unconditionally returns `SerialRefinement`; the `leiden_communities` function now matches on this path before proceeding with existing logic.
> - Adds tests verifying that `select_leiden_path` returns `SerialRefinement` across thread budgets (1, 2, 4, 8) and that output limits, cancellation, and Arrow batch shaping behave correctly.
> - Updates architecture and API docs to record the serial disposition and clarify that no parallel crossover, GPU, or foreign engine fallback exists for Leiden.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b0a412.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Leiden clustering consistency across different compute-thread settings and graph sizes.
  * Preserved output limits, cancellation behavior, and result formatting.
* **Tests**
  * Added coverage confirming deterministic clustering results and reliable Arrow batch output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->