### PR TITLE
perf(exec): GraphSAGE performance disposition (#560)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_embedding_graphsage.rs
+++ b/crates/graphforge-exec/src/algorithm_embedding_graphsage.rs
@@ -1,4 +1,10 @@
 //! Deterministic GraphSAGE-v1 projection and neighborhood-sampling kernel.
+//!
+//! GraphSAGE training remains serial for #560: positive-pair replay, sampled
+//! computation graphs, gradient accumulation, Adam moment updates, and final
+//! full-neighborhood inference all feed the next accepted state in canonical
+//! order. The implementation therefore avoids a private-pool crossover and
+//! keeps the order-sensitive path explicit for evidence.
 
 use std::collections::{BTreeMap, HashMap};
 use std::mem::size_of;
@@ -126,6 +132,13 @@ pub(crate) enum GraphSageKernelError {
     IndexOverflow,
     #[error(transparent)]
     Resource(#[from] EmbeddingResourceError),
+}
+
+/// Selected GraphSAGE execution path for #560 disposition evidence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum GraphSageExecutionPath {
+    /// Training and inference keep one canonical state stream.
+    SerialOrderedTraining,
 }
 
 /// Validate public identity and features, then canonicalize an undirected graph.
@@ -364,6 +377,9 @@ pub(crate) fn train_graphsage(
     options: &GraphSageOptions,
     control: &EmbeddingControl<'_>,
 ) -> Result<Vec<GraphSageEmbeddingRow>, GraphSageKernelError> {
+    match select_graphsage_path(control, projection.nodes.len()) {
+        GraphSageExecutionPath::SerialOrderedTraining => {}
+    }
     validate_graphsage_options(options)?;
     if projection.nodes.is_empty() {
         return Err(GraphSageKernelError::UndefinedTraining);
@@ -409,6 +425,13 @@ pub(crate) fn train_graphsage(
     }
 
     infer_full_neighborhood(projection, options, &parameters.weights, control)
+}
+
+pub(crate) fn select_graphsage_path(
+    _control: &EmbeddingControl<'_>,
+    _node_count: usize,
+) -> GraphSageExecutionPath {
+    GraphSageExecutionPath::SerialOrderedTraining
 }
 
 fn validate_graphsage_options(options: &GraphSageOptions) -> Result<(), GraphSageKernelError> {
@@ -1375,6 +1398,8 @@ mod tests {
         AlgorithmCancellation, AlgorithmControl, AlgorithmError, AlgorithmLimits,
     };
     use crate::algorithm_embedding_control::EmbeddingResourceLimits;
+    use crate::compute_pool::ComputePool;
+    use std::sync::Arc;
 
     fn uuid(value: u128) -> [u8; 16] {
         value.to_be_bytes()
@@ -1423,6 +1448,20 @@ mod tests {
         }
     }
 
+    fn control_with_threads(threads: usize) -> (AlgorithmControl, EmbeddingResourceLimits) {
+        (
+            AlgorithmControl::new(
+                AlgorithmLimits::default().with_compute_threads(threads),
+                AlgorithmCancellation::default(),
+            )
+            .with_compute_pool(Arc::new(ComputePool::new(threads).unwrap())),
+            EmbeddingResourceLimits {
+                memory_bytes: u64::MAX,
+                work: u64::MAX,
+            },
+        )
+    }
+
     #[test]
     fn projection_is_uuid_ordered_and_validates_feature_shape_and_finiteness() {
         let projection = validate_graphsage_projection(
@@ -1450,6 +1489,72 @@ mod tests {
         assert_eq!(
             validate_graphsage_projection(vec![node(1, &[])], vec![]),
             Err(GraphSageKernelError::EmptyFeatures)
+        );
+    }
+
+    #[test]
+    fn serial_disposition_holds_across_thread_budgets() {
+        let graph = validate_graphsage_projection(
+            vec![
+                node(4, &[4.0, 40.0]),
+                node(1, &[1.0, 10.0]),
+                node(3, &[3.0, 30.0]),
+                node(2, &[2.0, 20.0]),
+            ],
+            vec![
+                edge(11, 1, 2),
+                edge(12, 2, 3),
+                edge(13, 3, 4),
+                edge(14, 4, 1),
+                edge(15, 1, 3),
+            ],
+        )
+        .unwrap();
+        let options = GraphSageOptions {
+            dimensions: 2,
+            hidden_dimensions: 2,
+            layers: 1,
+            sample_sizes: vec![1],
+            epochs: 1,
+            negative_samples: 1,
+            learning_rate: 0.000_002,
+            feature_properties: vec!["feature".into()],
+            seed: 23,
+            ..GraphSageOptions::default()
+        };
+        let (algorithm, limits) = control_with_threads(1);
+        let oracle_control = EmbeddingControl::new(&algorithm, limits);
+        assert_eq!(
+            select_graphsage_path(&oracle_control, graph.nodes.len()),
+            GraphSageExecutionPath::SerialOrderedTraining
+        );
+        let oracle = train_graphsage(&graph, &options, &oracle_control).unwrap();
+
+        for threads in [2_usize, 4, 8] {
+            let (algorithm, limits) = control_with_threads(threads);
+            let control = EmbeddingControl::new(&algorithm, limits);
+            assert_eq!(
+                select_graphsage_path(&control, graph.nodes.len()),
+                GraphSageExecutionPath::SerialOrderedTraining
+            );
+            assert_eq!(train_graphsage(&graph, &options, &control).unwrap(), oracle);
+        }
+    }
+
+    #[test]
+    fn negative_distribution_follows_projection_uuid_order() {
+        let graph = validate_graphsage_projection(
+            vec![node(3, &[3.0]), node(1, &[1.0]), node(2, &[2.0])],
+            vec![edge(11, 3, 1), edge(12, 2, 1)],
+        )
+        .unwrap();
+        assert_eq!(
+            negative_distribution(&graph)
+                .unwrap()
+                .into_iter()
+                .map(|(node, _)| graph.nodes[node].uuid)
+                .collect::<Vec<_>>(),
+            vec![uuid(1), uuid(2), uuid(3)]
         );
     }
 

--- a/docs/book/architecture/algorithms.md
+++ b/docs/book/architecture/algorithms.md
@@ -3834,6 +3834,13 @@ That operation preserves the algorithm/version and graph projection in the
 space compatibility identity. Multiple spaces may contain the same UUID, and
 neither search freshness nor knowledge/epistemic run state changes the algorithm result.
 
+M4 #560 disposition: GraphSAGE-v1 training remains serial. Positive-pair replay,
+sampled role-path computation graphs, gradient accumulation, Adam updates, and
+full-neighborhood inference are an order-sensitive state stream, so GraphForge
+does not claim a parallel crossover for `analyze_embedding(by="graphsage")`.
+Thread policies at `1`/`2`/`4`/`8`/automatic preserve the one-thread schema, row
+order, embeddings, structured errors, and bounded Arrow shaping.
+
 ---
 
 ## `forge.similar()` — Pairwise Similarity

--- a/docs/book/architecture/embedding-v1.md
+++ b/docs/book/architecture/embedding-v1.md
@@ -330,6 +330,13 @@ candidate, and coordinate orders. Xavier initialization uses
 `graphsage-xavier`
 (`U64(layer), U64(output coordinate), U64(input coordinate)`).
 
+GraphSAGE-v1 training has an explicit serial performance disposition (#560) and
+no private-pool crossover. Positive-pair replay, sampled role-path computation
+graphs, gradient accumulation, Adam moment updates, and final inference are one
+canonical state stream; reordering examples or reducing gradients across workers
+would define a different numeric contract. Multi-thread resource policies must
+therefore preserve the one-thread output rather than parallelize this path.
+
 After training, output is one deterministic full-neighborhood forward pass,
 an explicit GraphForge v1 choice rather than a paper requirement:
 each mean uses all canonical incident candidates, not a sample, and rows are

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -18,7 +18,6 @@ Tokio runtime or any DataFusion execution session.
 | `io_concurrency` | `2` | Reserved I/O concurrency budget |
 | `max_concurrent_heavy_queries` | `64` | Instance-owned admission semaphore |
 | `compute_threads` | `2` | Instance-owned private CPU pool (#342 cosine KNN; #343 PageRank; #344 Node2Vec walks; #535 Jaccard similarity; #504 clustering coefficient; #515 triangles; #506 Degree; #501 betweenness; #518 Components) |
-| `compute_threads` | `2` | Instance-owned private CPU pool (#342 cosine KNN; #343 PageRank; #344 Node2Vec walks; #507 eigenvector) |
 
 Defaults preserve pre-#337 fixed two-worker / two-partition behavior.
 
@@ -83,6 +82,27 @@ dense ordinal order, betweenness reduces per-source dependency arrays in
 canonical source order, Components merges worker-local forests in canonical
 source-range order, Node2Vec skip-gram training stays serial, and transitive
 closure merges source ranges canonically, so fingerprints match the one-thread
+
+`cluster(by="components")` (#518) may partition independent work across that
+pool above documented crossovers; work never uses Rayon's process-global pool.
+Cosine dot products retain serial coordinate order, PageRank keeps canonical
+contribution order with serial dangling/delta reductions, Jaccard retains
+serial candidate order per source, clustering coefficient merges node-range
+scores in canonical dense-ordinal order, triangles merge node-owned counts by
+ascending dense ordinal, Degree merges node chunks in dense ordinal order,
+betweenness reduces per-source dependency arrays in canonical source order,
+Components merges worker-local forests in canonical source-range order, and
+Node2Vec skip-gram training stays serial, so fingerprints match the one-thread
+
+(#342), PageRank (#343), and Node2Vec walk-corpus generation (#344) may partition
+independent work across that pool above documented crossovers; work never uses
+Rayon's process-global pool. GraphSAGE training (#560) is explicitly
+dispositioned serial because positive-pair replay, sampled computation graphs,
+gradient accumulation, Adam moment updates, and final full-neighborhood
+inference are one accepted state stream. Cosine dot products retain serial
+coordinate order, PageRank keeps canonical contribution order with serial
+dangling/delta reductions, Node2Vec skip-gram training stays serial, and
+GraphSAGE keeps one-thread training order, so fingerprints match the one-thread
 path.
 (#342), PageRank (#343), Node2Vec walk-corpus generation (#344), and
 eigenvector destination updates (#507) may partition independent work across
@@ -598,6 +618,27 @@ intersection, and checked integer accumulation remain serial per source.
 Worker score chunks merge in canonical source order, so schemas, row order,
 scores, and fingerprints match the one-thread result at `1`/`2`/`4`/`8`/
 automatic configurations.
+
+## Serial GraphSAGE training (#560)
+
+`analyze_embedding(by="graphsage")` keeps the GraphSAGE-v1 training and final
+inference path serial under every `compute_threads` setting. The operation
+replays positive pairs in start UUID / walk / transition order, builds sampled
+role-path computation graphs for the center, positive, and negative examples,
+accumulates one binary64 gradient tensor, and updates Adam moments in layer /
+output-coordinate / input-coordinate order. Each accepted pair changes the
+parameter and moment state consumed by the next pair, so private-pool
+speculation would require a new reduction contract and could change binary64
+Adam state, final Float32 embeddings, and fingerprints.
+
+The #560 disposition therefore preserves the serial numeric contract and records
+thread-policy parity rather than claiming a crossover. The Rust path consumes
+the normalized projection, shared resource preflight, cooperative cancellation,
+structured work/output errors, and bounded Arrow shaping already used by the
+embedding surface. Schemas, row order, fingerprints, cancellation, and limit
+behavior match the one-thread oracle at `1`/`2`/`4`/`8`/automatic
+configurations. No GPU, distributed, approximate, or foreign-engine fallback is
+implied.
 
 ## Observability
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -3203,6 +3203,12 @@ Embedding items are non-null. Metadata includes
 `graphforge.rng_derivation`. Embedding analysis is read-only: it has no
 `write_property` behavior and does not publish or refresh an embedding space.
 
+`by="graphsage"` has an explicit serial performance disposition (#560). The
+training examples, sampled computation graphs, gradient accumulation, Adam
+updates, and final inference preserve one canonical order under every
+`compute_threads` policy; no parallel training crossover, GPU, or foreign-engine
+fallback is claimed.
+
 ---
 
 ### `similar(label, *, by, k=10, vector_property=None, via=None)` → `pyarrow.Table`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #560: GraphSAGE performance disposition.

Closes #560

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788956808&installation_model_id=20486&pr_number=636&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F636&signature=184657b7499cad9f534747b0243e278e8acf0084856de0bf2f6a1d70a2b3f614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document and codify GraphSAGE-v1 training as serial across all thread budgets
> - Introduces a `GraphSageExecutionPath` enum and `select_graphsage_path` function in [`algorithm_embedding_graphsage.rs`](https://github.com/CurateLabs/graphforge/pull/636/files#diff-4dafa4bea5ca0faa516b03e24a0c9b9bfa3ef37f8683901415c875380de46953) that unconditionally returns `SerialOrderedTraining`, making the serial disposition explicit in code.
> - Adds tests verifying that `select_graphsage_path` returns `SerialOrderedTraining` for thread budgets 1/2/4/8 and that `train_graphsage` output is identical across all budgets.
> - Updates architecture and API docs to state that `analyze_embedding(by="graphsage")` is serial under all `compute_threads` settings due to order-sensitive positive-pair replay, gradient accumulation, Adam updates, and full-neighborhood inference.
> - Behavioral Change: multi-thread policies for GraphSAGE do not parallelize training; all thread budgets produce one-thread output with no parallel, GPU, or distributed fallback.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3123a2c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->