### PR TITLE
perf(exec): serial disposition for speaker_listener (#530)

### DIFF
--- a/docs/development/m4-disposition-530-speaker-listener.md
+++ b/docs/development/m4-disposition-530-speaker-listener.md
@@ -1,0 +1,18 @@
+# M4 disposition: cluster(by="speaker_listener") (#530)
+
+Disposition: serial speaker-listener sweeps.
+
+`speaker_listener` advances a deterministic random stream while each listener
+samples neighbor memories and mutates its own memory. Parallel listener updates
+would consume randomness and expose memory snapshots differently, changing label
+selection and final community IDs.
+
+| Evidence item | Disposition |
+|---|---|
+| Path / threads | Serial for 1/2/4/8/automatic; no private-pool or process-global Rayon work is introduced. |
+| Work units | Normalized topology, seeded listener order, memory sampling/update, canonical label extraction, output. |
+| Determinism | Existing `graphforge-exec` tests cover repeatability, memory thresholds, limits, cancellation, empty/isolate cases, and Rust registration. |
+| Resource shape | Uses selected Rust adjacency and bounded node/community output; no parallel-only graph copy is added. |
+
+No GPU, distributed, approximate, or foreign-engine fallback is implied, and
+hardware timing/RSS observations remain non-gating evidence only.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #530: serial disposition for speaker_listener.

Closes #530

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788956807&installation_model_id=20486&pr_number=638&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F638&signature=76b7811a5ea5e073059e0ed8d9816e6cb7d1953cc088e1f3be4c2ee972a42074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add M4 disposition documentation for `cluster(by="speaker_listener")`
> Adds [m4-disposition-530-speaker-listener.md](https://github.com/CurateLabs/graphforge/pull/638/files#diff-ea29fb4c5d50a908f7bb45cf71f974a067efbfe8e7702c4f3c42e7c0071fbb98) documenting the serial execution strategy for `speaker_listener` clustering. The doc covers the serial speaker-listener sweep approach with deterministic randomness, evidence table (path/threads, work units, determinism, resource shape), and explicitly rules out GPU/distributed/approximate/foreign-engine fallbacks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ff4e30.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->