### PR TITLE
perf(exec): serial disposition for max_flow (#545)

### DIFF
--- a/crates/graphforge-api/tests/m4_entry_baseline.rs
+++ b/crates/graphforge-api/tests/m4_entry_baseline.rs
@@ -421,6 +421,11 @@ fn collect_workloads_for(gf: &GraphForge) -> Vec<WorkloadEvidence> {
             ev
         },
         {
+            let ev = run_paths_max_flow(gf);
+            assert!(ev.output_rows > 0, "paths-max-flow must produce rows");
+            ev
+        },
+        {
             let ev = run_k_core(gf);
             assert_eq!(ev.output_rows, 5);
             ev
@@ -616,6 +621,59 @@ fn run_paths_gomory_hu_tree(gf: &GraphForge) -> WorkloadEvidence {
             (
                 "work_units",
                 serde_json::json!("component_bfs_and_ordered_min_cut_parent_updates"),
+            ),
+            ("threads_path", serde_json::json!("serial_for_all_policies")),
+            ("csr_native_projection", serde_json::json!(true)),
+            ("bounded_arrow_sink", serde_json::json!(true)),
+        ]),
+    }
+}
+
+fn run_paths_max_flow(gf: &GraphForge) -> WorkloadEvidence {
+    let source = person_selector("Alice");
+    let target = person_selector("Dave");
+    let options = PathsOptions {
+        by: PathAlgorithm::MaxFlow,
+        via: None,
+        directed: true,
+        k: 1,
+        weight: Some("capacity".into()),
+        capacity_property: None,
+        cost_property: None,
+        heuristic: None,
+        walk_length: None,
+        seed: None,
+        terminal_uuids: Vec::new(),
+        prize_property: None,
+    };
+    let before_rss = peak_rss_bytes();
+    let started = Instant::now();
+    let first = gf
+        .paths(&source, Some(&target), options.clone())
+        .expect("max_flow");
+    let second = gf
+        .paths(&source, Some(&target), options)
+        .expect("max_flow repeat");
+    let wall_time_ms = started.elapsed().as_secs_f64() * 1_000.0;
+    assert_logical_batch_equal(&first, &second, "max_flow must be deterministic");
+    let fingerprint = batch_structural_fingerprint(std::slice::from_ref(&first));
+    WorkloadEvidence {
+        id: "paths-max-flow",
+        schema_fields: schema_field_names(first.schema().as_ref()),
+        output_rows: first.num_rows() as u64,
+        fingerprint,
+        wall_time_ms,
+        peak_rss_bytes: peak_rss_bytes().or(before_rss),
+        structural: BTreeMap::from([
+            ("surface", serde_json::json!("GraphForge::paths")),
+            ("algorithm", serde_json::json!("max_flow")),
+            (
+                "disposition",
+                serde_json::json!("serial_edmonds_karp_augmenting_paths"),
+            ),
+            (
+                "work_units",
+                serde_json::json!("residual_bfs_augmentations"),
             ),
             ("threads_path", serde_json::json!("serial_for_all_policies")),
             ("csr_native_projection", serde_json::json!(true)),
@@ -1052,6 +1110,11 @@ fn collect_short_matrix() -> (serde_json::Value, Vec<WorkloadEvidence>) {
             ev
         },
         {
+            let ev = run_paths_max_flow(&gf);
+            assert!(ev.output_rows > 0, "paths-max-flow must produce rows");
+            ev
+        },
+        {
             let ev = run_k_core(&gf);
             assert_eq!(ev.output_rows, 5);
             ev
@@ -1139,7 +1202,7 @@ fn build_evidence(
 #[test]
 fn short_ci_matrix_runs_through_public_facade_under_fixed_two_workers() {
     let (contract, workloads) = collect_short_matrix();
-    assert_eq!(workloads.len(), 13);
+    assert_eq!(workloads.len(), 14);
     let ids: Vec<_> = workloads.iter().map(|w| w.id).collect();
     assert_eq!(
         ids,
@@ -1149,6 +1212,7 @@ fn short_ci_matrix_runs_through_public_facade_under_fixed_two_workers() {
             "aggregate-top-n",
             "pagerank",
             "paths-gomory-hu-tree",
+            "paths-max-flow",
             "rank-k-core",
             "analyze-maximum-spanning-tree",
             "paths-min-steiner-tree",

--- a/crates/graphforge-exec/src/algorithm_paths_max_flow.rs
+++ b/crates/graphforge-exec/src/algorithm_paths_max_flow.rs
@@ -1,8 +1,8 @@
-//! `max_flow_edges` shares the serial maximum-flow kernel (#546). The public
-//! edge assignment is read from the final residual state in canonical edge-UUID
-//! order, after every Edmonds-Karp augmentation has completed. Running
-//! augmentations concurrently would change residual visibility and edge-flow
-//! ties, so there is no private-pool crossover for this view.
+//! Maximum-flow views intentionally remain serial (#545/#546). Edmonds-Karp
+//! augmentation mutates one residual graph after each canonical BFS path, and
+//! each update determines the next path, edge-flow assignment, and tie order.
+//! Parallel augmentations would need shared residual coordination and could
+//! change public flow fingerprints, so no private-pool crossover is claimed.
 
 use std::collections::VecDeque;
 

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -870,6 +870,31 @@ Arrow output remain serial, so schemas, row order, community IDs, and
 fingerprints match the one-thread result at `1`/`2`/`4`/`8`/automatic
 configurations.
 
+
+## Serial paths(by="max_flow") (#545)
+
+`paths(by="max_flow")` has no parallel crossover. Its disposition is
+**serial Edmonds-Karp residual augmentation** for every `compute_threads`
+setting, including `1`/`2`/`4`/`8`/automatic resource policies.
+
+The Rust kernel consumes the CSR-native adjacency projection (#340), shapes
+graph-native capacities into canonical UUID-ordered residual arcs, and then
+repeats one shortest residual BFS plus one residual-capacity update at a time.
+Each augmentation changes the residual graph that the next BFS observes and
+updates the signed stored-edge flow assignment, so the work is a sequential
+state machine rather than independent tasks for the private compute pool.
+Forcing concurrent augmentations would require shared residual coordination and
+would risk changing accepted flow values, edge assignment ties, row ordering,
+and fingerprints.
+
+The path still uses bounded Arrow output (#341), structured cancellation and
+resource checks, and never uses Rayon's process-global pool. The M4 entry
+harness records `paths-max-flow` structural evidence (work units, serial path,
+CSR projection, bounded Arrow sink, result fingerprint, peak RSS, and
+hardware-specific timing) and verifies fingerprint parity against the
+one-thread oracle for every supported resource-policy cell. Timing remains
+evidence only, not a CI threshold.
+
 ## Observability
 
 `GraphForge::resource_policy()` and `GraphForge::resource_diagnostics()` expose

--- a/scripts/ci/m4-entry-matrix.py
+++ b/scripts/ci/m4-entry-matrix.py
@@ -19,6 +19,7 @@ REQUIRED_WORKLOAD_IDS = {
     "aggregate-top-n",
     "pagerank",
     "paths-gomory-hu-tree",
+    "paths-max-flow",
     "rank-k-core",
     "analyze-maximum-spanning-tree",
     "paths-min-steiner-tree",

--- a/tests/contracts/m4-entry-matrix.json
+++ b/tests/contracts/m4-entry-matrix.json
@@ -160,6 +160,23 @@
       ]
     },
     {
+      "id": "paths-max-flow",
+      "class": "serial-flow-graph-algorithm",
+      "surface": "GraphForge::paths",
+      "short_ci": true,
+      "large_manual": true,
+      "disposition": "serial_edmonds_karp_augmenting_paths",
+      "structural_gates": [
+        "schema",
+        "row_count",
+        "ordering",
+        "result_fingerprint",
+        "csr_native_projection",
+        "bounded_arrow_sink",
+        "serial_disposition"
+      ]
+    },
+    {
       "id": "rank-k-core",
       "class": "core-decomposition-peeling",
       "surface": "GraphForge::rank",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #545: serial disposition for max_flow.

Closes #545

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788956809&installation_model_id=20486&pr_number=639&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F639&signature=1cc040436afe4c9a01e47f275ae6df545afffe8d02ab926fe6c0bbf35257f693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add serial disposition for `paths(by="max_flow")` to the M4 entry baseline
> - Adds a `run_paths_max_flow` workload to the M4 entry harness that runs `GraphForge::paths` with `PathAlgorithm::MaxFlow`, asserts determinism across two runs, and records fingerprint evidence.
> - Documents in [execution-resource-policy.md](https://github.com/CurateLabs/graphforge/pull/639/files#diff-978cd3c64399512fe02ce13768a045b47b2b98e5e672d553ee1bb69be7843971) that max-flow uses serial Edmonds–Karp augmentations across all thread configurations due to residual graph mutation and fingerprint stability concerns.
> - Registers `"paths-max-flow"` in the CI matrix script and contract JSON with `disposition: serial_edmonds_karp_augmenting_paths` and `short_ci: true`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1679ecc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a deterministic maximum-flow workload for validating directed, capacity-weighted paths from Alice to Dave.
  - Included evidence metadata and repeatability checks for consistent results.

- **Bug Fixes**
  - Updated the GraphForge paths contract to use the Edmonds–Karp maximum-flow algorithm.

- **Tests**
  - Added the workload to short continuous-integration and manual coverage matrices.
  - Added checks for expected workload ordering, registration, and deterministic execution.
  - Documented that maximum-flow views remain serial for stable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->