### PR TITLE
perf(exec): serial disposition for articulation_points (#563)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_analyze.rs
+++ b/crates/graphforge-exec/src/algorithm_analyze.rs
@@ -6882,6 +6882,54 @@ mod tests {
     }
 
     #[test]
+    fn articulation_points_keeps_serial_fingerprint_under_thread_budgets() {
+        let graph = AdjacencyGraph::with_test_undirected_multigraph(
+            10,
+            &[
+                (10, 0, 1),
+                (11, 1, 2),
+                (12, 2, 0),
+                (13, 1, 3),
+                (14, 3, 4),
+                (15, 4, 5),
+                (16, 5, 3),
+                (17, 5, 6),
+                (18, 6, 7),
+                (19, 7, 5),
+                (20, 7, 8),
+                (21, 8, 9),
+                (22, 7, 8),
+            ],
+        );
+        let serial =
+            execute_with_compute_threads(&graph, AnalyzeAlgorithm::ArticulationPoints, false, 1)
+                .unwrap();
+        assert_eq!(
+            serial.rows(),
+            [
+                vec![AlgorithmValue::Uuid(1_u128.to_be_bytes())],
+                vec![AlgorithmValue::Uuid(3_u128.to_be_bytes())],
+                vec![AlgorithmValue::Uuid(5_u128.to_be_bytes())],
+                vec![AlgorithmValue::Uuid(7_u128.to_be_bytes())],
+                vec![AlgorithmValue::Uuid(8_u128.to_be_bytes())],
+            ]
+        );
+        let serial_fingerprint = output_fingerprint(&serial);
+
+        for threads in [2_usize, 4, 8] {
+            let output = execute_with_compute_threads(
+                &graph,
+                AnalyzeAlgorithm::ArticulationPoints,
+                false,
+                threads,
+            )
+            .unwrap();
+            assert_eq!(output.schema, serial.schema);
+            assert_eq!(output_fingerprint(&output), serial_fingerprint);
+        }
+    }
+
+    #[test]
     fn bridges_dispatches_canonical_uuid_rows_with_shared_controls() {
         let graph = AdjacencyGraph::with_test_undirected_multigraph(
             8,

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -599,6 +599,21 @@ Worker score chunks merge in canonical source order, so schemas, row order,
 scores, and fingerprints match the one-thread result at `1`/`2`/`4`/`8`/
 automatic configurations.
 
+## Serial articulation points (#563)
+
+`analyze(by="articulation_points")` is intentionally SERIAL. It shares the
+low-link DFS kernel used for cut-vertex and bridge classification; discovery
+indices, parent edges, root child counts, and low-link propagation are ordered
+state. Parallelizing those updates would change canonical cut-vertex evidence or
+require synchronization at each DFS step, which does not provide safe
+independent work for the private compute pool.
+
+The handler keeps Rust-owned adjacency projection and bounded Arrow output,
+does not use Rayon's global pool, and preserves shared cancellation and
+resource-limit behavior. A fingerprint test attaches private compute pools for
+`1`/`2`/`4`/`8` configured compute threads and requires identical schemas,
+cut-vertex ordering, and rows.
+
 ## Observability
 
 `GraphForge::resource_policy()` and `GraphForge::resource_diagnostics()` expose


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #563: serial disposition for articulation_points.

Closes #563

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788956820&installation_model_id=20486&pr_number=641&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F641&signature=a912598fbf429ea0205721f898835fd4cf5d93afd52ee3ba20c59604221ad369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce serial disposition for `ArticulationPoints` analyzer across thread configurations
> - The `ArticulationPoints` analyzer runs serially due to ordered DFS state, bypassing Rayon's global thread pool regardless of the configured compute thread count.
> - Adds a test in [algorithm_analyze.rs](https://github.com/CurateLabs/graphforge/pull/641/files#diff-e0fd28e19643ca53575d652fd8f79b67bc08d67c15d7e3f306d350887a4618e0) that asserts identical output schema and fingerprint across 1, 2, 4, and 8 compute thread configurations.
> - Documents the serial execution policy in [execution-resource-policy.md](https://github.com/CurateLabs/graphforge/pull/641/files#diff-978cd3c64399512fe02ce13768a045b47b2b98e5e672d553ee1bb69be7843971), including cancellation/resource limit behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b4db88. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->