### PR TITLE
perf(exec): serial disposition for max_bipartite_matching (#556)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_analyze_bipartite_matching.rs
+++ b/crates/graphforge-exec/src/algorithm_analyze_bipartite_matching.rs
@@ -3,6 +3,13 @@ use std::collections::{BTreeMap, VecDeque};
 use crate::algorithm_analyze_bipartite::{BipartiteEdge, BipartiteProjection};
 use crate::algorithm_dispatch::{AlgorithmControl, AlgorithmError};
 
+/// Selected bipartite matching execution path for #556 disposition evidence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum BipartiteMatchingExecutionPath {
+    /// BFS layers and augmenting-path commits stay serial.
+    SerialLayeredAugmentation,
+}
+
 /// Compute a deterministic maximum-cardinality matching.
 ///
 /// The projection has already established left/right orientation and retained
@@ -11,6 +18,14 @@ pub(crate) fn maximum_bipartite_matching(
     projection: &BipartiteProjection,
     control: &AlgorithmControl,
 ) -> Result<Vec<BipartiteEdge>, AlgorithmError> {
+    match select_bipartite_matching_path(
+        control,
+        projection.left_nodes.len(),
+        projection.right_nodes.len(),
+        projection.edges.len(),
+    ) {
+        BipartiteMatchingExecutionPath::SerialLayeredAugmentation => {}
+    }
     control.checkpoint()?;
     let left_index = projection
         .left_nodes
@@ -86,6 +101,16 @@ pub(crate) fn maximum_bipartite_matching(
     control.check_output_rows(result.len())?;
     Ok(result)
 }
+
+pub(crate) fn select_bipartite_matching_path(
+    _control: &AlgorithmControl,
+    _left_nodes: usize,
+    _right_nodes: usize,
+    _edge_count: usize,
+) -> BipartiteMatchingExecutionPath {
+    BipartiteMatchingExecutionPath::SerialLayeredAugmentation
+}
+
 fn find_layers(
     adjacency: &[Vec<usize>],
     left_match: &[Option<usize>],
@@ -169,6 +194,8 @@ fn invalid_projection(message: &str) -> AlgorithmError {
 mod tests {
     use super::*;
     use crate::algorithm_dispatch::{AlgorithmCancellation, AlgorithmLimits};
+    use crate::compute_pool::ComputePool;
+    use std::sync::Arc;
     fn uuid(value: u128) -> [u8; 16] {
         value.to_be_bytes()
     }
@@ -181,6 +208,14 @@ mod tests {
     }
     fn control() -> AlgorithmControl {
         AlgorithmControl::new(AlgorithmLimits::default(), AlgorithmCancellation::default())
+    }
+
+    fn control_with_threads(threads: usize) -> AlgorithmControl {
+        AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(threads),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(Arc::new(ComputePool::new(threads).unwrap()))
     }
     #[test]
     fn finds_maximum_cardinality_with_deterministic_ties() {
@@ -204,6 +239,40 @@ mod tests {
             maximum_bipartite_matching(&projection, &control()).unwrap(),
             expected
         );
+    }
+
+    #[test]
+    fn serial_disposition_holds_across_thread_budgets() {
+        let projection = BipartiteProjection {
+            left_nodes: vec![uuid(1), uuid(2), uuid(3), uuid(4)],
+            right_nodes: vec![uuid(5), uuid(6), uuid(7), uuid(8)],
+            edges: vec![
+                edge(9, 1, 5),
+                edge(8, 1, 6),
+                edge(7, 2, 5),
+                edge(6, 2, 7),
+                edge(5, 3, 6),
+                edge(4, 3, 8),
+                edge(3, 4, 7),
+            ],
+        };
+        let control = control_with_threads(8);
+        assert_eq!(
+            select_bipartite_matching_path(
+                &control,
+                projection.left_nodes.len(),
+                projection.right_nodes.len(),
+                projection.edges.len(),
+            ),
+            BipartiteMatchingExecutionPath::SerialLayeredAugmentation
+        );
+        let oracle = maximum_bipartite_matching(&projection, &control_with_threads(1)).unwrap();
+        for threads in [2_usize, 4, 8] {
+            assert_eq!(
+                maximum_bipartite_matching(&projection, &control_with_threads(threads)).unwrap(),
+                oracle
+            );
+        }
     }
     #[test]
     fn selects_lowest_parallel_edge_and_ignores_isolates() {

--- a/docs/book/architecture/algorithms.md
+++ b/docs/book/architecture/algorithms.md
@@ -3124,6 +3124,13 @@ entries, 10,000,000 output rows, and 10,000 cooperative work checkpoints.
 Projection, partition validation or inference, matching, output shaping, limit
 failures, and cancellation abort atomically without partial output.
 
+M4 #556 disposition: maximum bipartite matching remains serial. BFS layer
+construction and each augmenting-path commit mutate the left/right mate arrays
+consumed by later unmatched roots, so GraphForge does not claim a parallel
+crossover for `analyze(by="max_bipartite_matching")`. Thread policies at
+`1`/`2`/`4`/`8`/automatic preserve the one-thread selected edge set, row order,
+structured errors, and bounded Arrow shaping.
+
 Typed Rust owns graph-property resolution, the validated UUID mapping boundary,
 partition inference, matching, deterministic choices, controls, and Arrow
 shaping. The matching kernel consumes only graph-native topology and the

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -503,6 +503,26 @@ projection fingerprints, cancellation, and limit behavior match the one-thread
 oracle at supported thread configurations. No GPU, distributed, approximate, or
 foreign-engine fallback is implied.
 
+## Serial maximum bipartite matching (#556)
+
+`analyze(by="max_bipartite_matching")` has no parallel crossover. Its
+performance disposition is **serial layered augmentation** for every
+`compute_threads` setting.
+
+The Rust kernel resolves the selected bipartite projection, builds canonical
+left/right adjacency, computes BFS layers from unmatched left roots, and commits
+augmenting paths in left-node order. Each committed path immediately changes the
+left/right mate arrays and the later DFS frontier, so parallel augmentation
+would need conflict resolution for shared endpoints and could change the
+accepted edge set or row order.
+
+The #556 disposition preserves CSR-native selected adjacency access before
+projection, shared cancellation/checkpoint controls, structured output-limit
+errors, and bounded Arrow shaping. Schemas, row order, selected edge UUIDs,
+projection fingerprints, cancellation, and limit behavior match the one-thread
+oracle at supported thread configurations. No GPU, distributed, approximate, or
+foreign-engine fallback is implied.
+
 ## Serial paths(by="max_flow_edges") (#546)
 
 `paths(by="max_flow_edges")` has no parallel crossover. Its disposition is

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -2193,6 +2193,11 @@ consumes only graph-native topology and a validated UUID mapping: knowledge
 tables, confidence, provenance, assertions, evidence, belief state,
 hypotheses, and valid time cannot affect its options, result, or schema.
 
+`max_bipartite_matching` has an explicit serial performance disposition (#556):
+BFS layer construction and augmenting-path commits mutate shared mate arrays in
+the accepted left-node order. No parallel crossover, GPU, or foreign-engine
+fallback is claimed.
+
 **Eulerian** (`by=`):
 `euler_circuit`, `euler_path`, `has_euler_circuit`, `has_euler_path`
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #556: serial disposition for max_bipartite_matching.

Closes #556

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788956820&installation_model_id=20486&pr_number=642&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F642&signature=e9b057d69722c946c023f70a208892c0a06ae91942861cdaf2407b3de21ed663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add serial execution disposition for `max_bipartite_matching`
> - Introduces `BipartiteMatchingExecutionPath` enum and `select_bipartite_matching_path` in [`algorithm_analyze_bipartite_matching.rs`](https://github.com/CurateLabs/graphforge/pull/642/files#diff-7de9d0f0bd48c9a10a801da1b5b0be2cd89df913a0b59a5d4756f0c5ea3882c9) to formalize execution path selection at function entry.
> - The selector always returns `SerialLayeredAugmentation`, codifying that BFS layer construction and augmenting-path commits remain serial regardless of thread budget.
> - Adds a test (`serial_disposition_holds_across_thread_budgets`) that verifies results with 2, 4, and 8 threads match a 1-thread oracle.
> - Updates architecture and API docs to document the serial disposition and confirm no parallel, GPU, or foreign-engine fallback is used.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9adb471.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->