### PR TITLE
perf(exec): serial disposition for bridges (#564)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_analyze.rs
+++ b/crates/graphforge-exec/src/algorithm_analyze.rs
@@ -3981,6 +3981,26 @@ mod tests {
         )
     }
 
+    fn execute_with_compute_threads(
+        graph: &AdjacencyGraph,
+        algorithm: AnalyzeAlgorithm,
+        directed: bool,
+        threads: usize,
+    ) -> Result<AlgorithmOutput, AlgorithmError> {
+        let mut registry = AlgorithmRegistry::default();
+        register_analyze_algorithms(&mut registry, directed)?;
+        let control = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(threads),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(Arc::new(crate::ComputePool::new(threads).unwrap()));
+        registry.execute(Algorithm::Analyze(algorithm), graph, &control)
+    }
+
+    fn output_fingerprint(output: &AlgorithmOutput) -> String {
+        format!("{:?}|{:?}", output.schema, output.rows())
+    }
+
     fn execute_minimum_k_spanning_tree(
         graph: &AdjacencyGraph,
         k: usize,
@@ -6943,6 +6963,59 @@ mod tests {
             ),
             Err(AlgorithmError::Cancelled)
         );
+    }
+
+    #[test]
+    fn bridges_keeps_serial_fingerprint_under_thread_budgets() {
+        let graph = AdjacencyGraph::with_test_undirected_multigraph(
+            10,
+            &[
+                (10, 0, 1),
+                (11, 1, 2),
+                (12, 2, 0),
+                (13, 1, 3),
+                (14, 3, 4),
+                (15, 4, 5),
+                (16, 5, 3),
+                (17, 5, 6),
+                (18, 6, 7),
+                (19, 7, 5),
+                (20, 7, 8),
+                (21, 8, 9),
+                (22, 7, 8),
+            ],
+        );
+        let serial =
+            execute_with_compute_threads(&graph, AnalyzeAlgorithm::Bridges, false, 1).unwrap();
+        assert_eq!(
+            serial.rows(),
+            [
+                vec![
+                    AlgorithmValue::Uuid(13_u128.to_be_bytes()),
+                    AlgorithmValue::Uuid(1_u128.to_be_bytes()),
+                    AlgorithmValue::Uuid(3_u128.to_be_bytes()),
+                ],
+                vec![
+                    AlgorithmValue::Uuid(17_u128.to_be_bytes()),
+                    AlgorithmValue::Uuid(5_u128.to_be_bytes()),
+                    AlgorithmValue::Uuid(6_u128.to_be_bytes()),
+                ],
+                vec![
+                    AlgorithmValue::Uuid(21_u128.to_be_bytes()),
+                    AlgorithmValue::Uuid(8_u128.to_be_bytes()),
+                    AlgorithmValue::Uuid(9_u128.to_be_bytes()),
+                ],
+            ]
+        );
+        let serial_fingerprint = output_fingerprint(&serial);
+
+        for threads in [2_usize, 4, 8] {
+            let output =
+                execute_with_compute_threads(&graph, AnalyzeAlgorithm::Bridges, false, threads)
+                    .unwrap();
+            assert_eq!(output.schema, serial.schema);
+            assert_eq!(output_fingerprint(&output), serial_fingerprint);
+        }
     }
 
     #[test]

--- a/crates/graphforge-exec/src/algorithm_analyze.rs
+++ b/crates/graphforge-exec/src/algorithm_analyze.rs
@@ -6996,11 +6996,6 @@ mod tests {
                     AlgorithmValue::Uuid(3_u128.to_be_bytes()),
                 ],
                 vec![
-                    AlgorithmValue::Uuid(17_u128.to_be_bytes()),
-                    AlgorithmValue::Uuid(5_u128.to_be_bytes()),
-                    AlgorithmValue::Uuid(6_u128.to_be_bytes()),
-                ],
-                vec![
                     AlgorithmValue::Uuid(21_u128.to_be_bytes()),
                     AlgorithmValue::Uuid(8_u128.to_be_bytes()),
                     AlgorithmValue::Uuid(9_u128.to_be_bytes()),

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -262,6 +262,21 @@ and fingerprints match the one-thread result at `1`/`2`/`4`/`8`/automatic
 configurations. Cancellation remains cooperative both before worker launch and
 inside chunk scans.
 
+## Serial bridges (#564)
+
+`analyze(by="bridges")` is intentionally SERIAL. Bridge classification depends
+on the shared low-link DFS traversal: discovery order, parent-edge identity,
+multigraph parallel-edge handling, and low-link propagation determine whether an
+edge is a bridge. Parallelizing that state would change the canonical edge
+evidence or require synchronization around each DFS transition, so there is no
+safe independent kernel for the private compute pool.
+
+The handler keeps Rust-owned adjacency projection and bounded Arrow output,
+does not use Rayon's global pool, and preserves cancellation and shared resource
+limits. A fingerprint test attaches private compute pools for `1`/`2`/`4`/`8`
+configured compute threads and requires identical schemas, bridge ordering, and
+rows.
+
 ## Observability
 
 `GraphForge::resource_policy()` and `GraphForge::resource_diagnostics()` expose


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #564: serial disposition for bridges.

Closes #564

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788956819&installation_model_id=20486&pr_number=643&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F643&signature=237b1d1cb4af6a43eab121f17d9d5a3197eecfd36690d2f4251508b787c771a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make bridge analysis serial using a private compute pool
> - The `analyze(by="bridges")` algorithm is now explicitly serial due to DFS low-link traversal state, using a private compute pool instead of Rayon's global pool.
> - Adds a regression test in [`algorithm_analyze.rs`](https://github.com/CurateLabs/graphforge/pull/643/files#diff-e0fd28e19643ca53575d652fd8f79b67bc08d67c15d7e3f306d350887a4618e0) asserting identical schema and row ordering across 1, 2, 4, and 8 compute-thread configurations.
> - Documents the design decision in [`execution-resource-policy.md`](https://github.com/CurateLabs/graphforge/pull/643/files#diff-978cd3c64399512fe02ce13768a045b47b2b98e5e672d553ee1bb69be7843971), noting that cancellation and limits are preserved.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 37cc32d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added regression coverage for bridge analysis results across serial and multi-threaded execution modes.
  - Added validation helpers to compare analysis output schemas and rows under different compute-thread limits.
  - Helps ensure consistent analysis results regardless of the configured compute capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->