### PR TITLE
perf(exec): serial disposition for max_flow_edges (#546)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_paths_max_flow.rs
+++ b/crates/graphforge-exec/src/algorithm_paths_max_flow.rs
@@ -1,3 +1,9 @@
+//! `max_flow_edges` shares the serial maximum-flow kernel (#546). The public
+//! edge assignment is read from the final residual state in canonical edge-UUID
+//! order, after every Edmonds-Karp augmentation has completed. Running
+//! augmentations concurrently would change residual visibility and edge-flow
+//! ties, so there is no private-pool crossover for this view.
+
 use std::collections::VecDeque;
 
 use crate::algorithm_dispatch::{AlgorithmControl, AlgorithmError};

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -19,7 +19,6 @@ Tokio runtime or any DataFusion execution session.
 | `max_concurrent_heavy_queries` | `64` | Instance-owned admission semaphore |
 | `compute_threads` | `2` | Instance-owned private CPU pool (#342 cosine KNN; #343 PageRank; #344 Node2Vec walks; #535 Jaccard similarity; #504 clustering coefficient; #515 triangles; #506 Degree; #501 betweenness; #518 Components) |
 
-| `compute_threads` | `2` | Instance-owned private CPU pool (#342 cosine KNN; #343 PageRank; #344 Node2Vec walks; #499 Adamic-Adar) |
 
 Defaults preserve pre-#337 fixed two-worker / two-partition behavior.
 
@@ -705,6 +704,24 @@ errors, and bounded Arrow shaping. Schemas, row order, selected edge UUIDs,
 projection fingerprints, cancellation, and limit behavior match the one-thread
 oracle at supported thread configurations. No GPU, distributed, approximate, or
 foreign-engine fallback is implied.
+
+## Serial paths(by="max_flow_edges") (#546)
+
+`paths(by="max_flow_edges")` has no parallel crossover. Its disposition is
+**serial Edmonds-Karp edge assignment** for every `compute_threads` setting,
+including `1`/`2`/`4`/`8`/automatic resource policies.
+
+The scalar and per-edge maximum-flow views share one Rust kernel. The kernel
+consumes the CSR-native projection (#340), sorts capacities by public edge UUID,
+then performs one canonical residual BFS and residual update at a time. The
+edge view is not independent post-processing: signed stored-orientation flow is
+updated during each augmentation and emitted only after the final residual state
+is known. Parallel augmentations would require shared residual coordination and
+would risk changing edge-flow ties, row ordering, and fingerprints.
+
+The path still uses bounded Arrow output (#341), structured cancellation and
+resource checks, and never uses Rayon's process-global pool. Timing remains
+evidence only, not a CI threshold.
 
 ## Observability
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #546: serial disposition for max_flow_edges.

Closes #546

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788956819&installation_model_id=20486&pr_number=644&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F644&signature=002b420770c5889437091136f3f2ee01d84d06d9aa650a6a5b035661ce4e6a10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document serial disposition for `paths(by="max_flow_edges")` using shared Edmonds–Karp kernel
> - Adds a module-level doc comment to [algorithm_paths_max_flow.rs](https://github.com/CurateLabs/graphforge/pull/644/files#diff-0b07323c963617c526e28cebc7295d713b4d9e23e648f587da05141254d64703) clarifying that `max_flow_edges` shares the serial Edmonds–Karp kernel with the scalar view, and that edge assignments are read from the final residual state in canonical edge-UUID order without parallel augmentation.
> - Updates [execution-resource-policy.md](https://github.com/CurateLabs/graphforge/pull/644/files#diff-978cd3c64399512fe02ce13768a045b47b2b98e5e672d553ee1bb69be7843971) to add a dedicated section for `paths(by="max_flow_edges")` covering residual BFS/update order, output timing, and resource bounds; also removes a duplicate `compute_threads` row.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7bfae21.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->