### PR TITLE
perf(exec): serial disposition for max_cardinality_matching (#557)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_analyze_max_cardinality_matching.rs
+++ b/crates/graphforge-exec/src/algorithm_analyze_max_cardinality_matching.rs
@@ -10,6 +10,13 @@ pub(crate) struct MatchingEdge {
     pub target: [u8; 16],
 }
 
+/// Selected max-cardinality matching path for #557 disposition evidence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum MaxCardinalityMatchingExecutionPath {
+    /// Exact blossom state and tie objective remain serial.
+    SerialBlossomSearch,
+}
+
 /// Returns the canonical maximum-cardinality matching of an undirected multigraph.
 ///
 /// A zero primary weight makes the shared exact blossom solver compare cardinality
@@ -21,6 +28,9 @@ pub(crate) fn maximum_cardinality_matching(
     edges: &[MatchingEdge],
     control: &AlgorithmControl,
 ) -> Result<Vec<MatchingEdge>, AlgorithmError> {
+    match select_max_cardinality_matching_path(control, nodes.len(), edges.len()) {
+        MaxCardinalityMatchingExecutionPath::SerialBlossomSearch => {}
+    }
     let weighted = edges
         .iter()
         .map(|edge| WeightedEdge {
@@ -44,10 +54,20 @@ pub(crate) fn maximum_cardinality_matching(
     })
 }
 
+pub(crate) fn select_max_cardinality_matching_path(
+    _control: &AlgorithmControl,
+    _node_count: usize,
+    _edge_count: usize,
+) -> MaxCardinalityMatchingExecutionPath {
+    MaxCardinalityMatchingExecutionPath::SerialBlossomSearch
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::algorithm_dispatch::{AlgorithmCancellation, AlgorithmLimits};
+    use crate::compute_pool::ComputePool;
+    use std::sync::Arc;
 
     fn uuid(value: u8) -> [u8; 16] {
         [value; 16]
@@ -63,6 +83,14 @@ mod tests {
 
     fn control() -> AlgorithmControl {
         AlgorithmControl::new(AlgorithmLimits::default(), AlgorithmCancellation::default())
+    }
+
+    fn control_with_threads(threads: usize) -> AlgorithmControl {
+        AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(threads),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(Arc::new(ComputePool::new(threads).unwrap()))
     }
 
     fn selected(nodes: &[[u8; 16]], edges: &[MatchingEdge]) -> Vec<[u8; 16]> {
@@ -141,6 +169,35 @@ mod tests {
         let mut reversed = edges;
         reversed.reverse();
         assert_eq!(selected(&nodes, &reversed), expected);
+    }
+
+    #[test]
+    fn serial_disposition_holds_across_thread_budgets() {
+        let nodes = (0..8).map(uuid).collect::<Vec<_>>();
+        let edges = [
+            edge(9, 0, 1),
+            edge(8, 1, 2),
+            edge(7, 2, 0),
+            edge(6, 1, 3),
+            edge(5, 2, 4),
+            edge(4, 5, 6),
+            edge(3, 6, 5),
+            edge(2, 7, 7),
+        ];
+        let control = control_with_threads(8);
+        assert_eq!(
+            select_max_cardinality_matching_path(&control, nodes.len(), edges.len()),
+            MaxCardinalityMatchingExecutionPath::SerialBlossomSearch
+        );
+        let oracle =
+            maximum_cardinality_matching(&nodes, &edges, &control_with_threads(1)).unwrap();
+        for threads in [2_usize, 4, 8] {
+            assert_eq!(
+                maximum_cardinality_matching(&nodes, &edges, &control_with_threads(threads))
+                    .unwrap(),
+                oracle
+            );
+        }
     }
 
     #[test]

--- a/docs/book/architecture/algorithms.md
+++ b/docs/book/architecture/algorithms.md
@@ -2985,6 +2985,14 @@ normalization, blossom search, optimum tie resolution, checked arithmetic,
 output shaping, limit failures, and cancellation abort atomically without
 partial output.
 
+M4 #557 disposition: maximum-cardinality matching remains serial. The exact
+blossom/primal-dual core mutates labels, root queues, blossom contractions,
+dual state, and augmenting paths in one alternating forest, so GraphForge does
+not claim a parallel crossover for
+`analyze(by="max_cardinality_matching")`. Thread policies at
+`1`/`2`/`4`/`8`/automatic preserve the one-thread selected edge set, raw-edge
+UUID tie order, structured errors, and bounded Arrow shaping.
+
 Typed, dependency-free Rust in `graphforge-exec` owns projection, exact matching,
 deterministic choices, controls, and Arrow shaping. It may reuse the private
 shared matching/blossom core used by other exact matching handlers, but that

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -86,7 +86,7 @@ source-range order, Node2Vec skip-gram training stays serial, and transitive
 closure merges source ranges canonically, so fingerprints match the one-thread
 
 `cluster(by="components")` (#518) may partition independent work across that
-pool above documented crossovers; work never uses Rayon's process-global pool.
+pool above documented crossovers; work never uses Rayon's process-global pool. Maximum-cardinality matching (#557) is explicitly dispositioned serial because blossom/primal-dual search mutates ordered matching state.
 Cosine dot products retain serial coordinate order, PageRank keeps canonical
 contribution order with serial dangling/delta reductions, Jaccard retains
 serial candidate order per source, clustering coefficient merges node-range
@@ -684,6 +684,27 @@ embedding surface. Schemas, row order, fingerprints, cancellation, and limit
 behavior match the one-thread oracle at `1`/`2`/`4`/`8`/automatic
 configurations. No GPU, distributed, approximate, or foreign-engine fallback is
 implied.
+
+## Serial maximum-cardinality matching (#557)
+
+`analyze(by="max_cardinality_matching")` has no parallel crossover. Its
+performance disposition is **serial exact blossom search** for every
+`compute_threads` setting.
+
+The unweighted wrapper normalizes the selected undirected multigraph, then uses
+the shared exact blossom/primal-dual core with cardinality as the primary
+objective and raw edge UUIDs as the deterministic tie order. Labels, root
+queues, blossom contractions/expansions, dual steps, and augmenting-path commits
+all update one alternating forest. Parallel speculation would need conflict
+resolution across shared vertices/blossoms and could change the chosen maximum
+matching or raw-edge UUID tie objective.
+
+The #557 disposition preserves CSR-native selected adjacency access before
+normalization, shared cancellation/checkpoint controls, structured resource
+errors, and bounded Arrow shaping. Schemas, row order, selected edge UUIDs,
+projection fingerprints, cancellation, and limit behavior match the one-thread
+oracle at supported thread configurations. No GPU, distributed, approximate, or
+foreign-engine fallback is implied.
 
 ## Observability
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -2130,6 +2130,11 @@ projection fingerprint, normalized `label` and `via` selectors,
 version `1`. The shipped knowledge run API can persist the descriptor and
 `algorithm_run_uuid` without changing this result.
 
+`max_cardinality_matching` has an explicit serial performance disposition
+(#557): exact blossom labels, contractions, dual updates, and augmenting paths
+mutate one alternating forest and raw-edge UUID tie objective. No parallel
+crossover, GPU, or foreign-engine fallback is claimed.
+
 For `by="max_bipartite_matching"`, pass `directed=False`; the operation is
 unweighted and rejects `weight`. Supply `partition_property="side"` to resolve
 an explicit partition from every selected node's non-null scalar string or


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #557: serial disposition for max_cardinality_matching.

Closes #557

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/645"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788956819&installation_model_id=20486&pr_number=645&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F645&signature=68f139361bb40860b1b89f062409711e45a9d01b26d6b9171cf06be10d8032c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add serial execution disposition for `max_cardinality_matching`
> - Introduces `MaxCardinalityMatchingExecutionPath` enum and `select_max_cardinality_matching_path` in [`algorithm_analyze_max_cardinality_matching.rs`](https://github.com/CurateLabs/graphforge/pull/645/files#diff-53f84ded45ae23fc54af5055a432f511ac492b3f6b2fdd4736a09a339b3cdda0), always returning `SerialBlossomSearch` since blossom/primal-dual search mutates a single alternating forest.
> - Adds a test asserting the serial path is selected regardless of thread budget (1/2/4/8 threads) and that results are identical across configurations.
> - Documents the serial disposition in architecture, execution-resource-policy, and API reference docs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b47a497.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved maximum-cardinality matching reliability by explicitly selecting the serial matching path.
  - Ensured consistent matching results across different compute-resource settings.

- **Tests**
  - Added coverage verifying serial execution behavior and identical results across thread budgets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->