### PR TITLE
perf(exec): serial disposition for chromatic_number (#565)

### DIFF
--- a/docs/development/m4-disposition-565-chromatic-number.md
+++ b/docs/development/m4-disposition-565-chromatic-number.md
@@ -1,0 +1,20 @@
+# M4 disposition: analyze(by="chromatic_number") (#565)
+
+Disposition: serial exact search.
+
+`chromatic_number` keeps its Rust-owned branch-and-bound coloring search on one
+thread for every `compute_threads` setting. The next bound, incumbent color
+count, and UUID tie order are shared search state; speculative parallel branches
+would need extra merge policy and could change the exact witness ordering or
+limit/cancellation point. This branch therefore records an explicit serial
+disposition instead of claiming a crossover.
+
+| Evidence item | Disposition |
+|---|---|
+| Path / threads | Serial for 1/2/4/8/automatic; no private-pool or process-global Rayon work is introduced. |
+| Work units | Canonical node ordering, normalized edge projection, recursive color choices, and incumbent pruning. |
+| Determinism | Existing `graphforge-exec` tests cover schemas, exact color count, loop rejection, repeatability, and structured limits. |
+| Resource shape | No parallel-only graph copy; output is the existing one-row bounded Arrow shape. |
+
+No GPU, distributed, approximate, or foreign-engine fallback is implied, and
+hardware timing/RSS observations remain non-gating evidence only.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #565: serial disposition for chromatic_number.

Closes #565

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788956819&installation_model_id=20486&pr_number=646&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F646&signature=28789c498d3aa922596d0139e6e09aca0fd3e15e06aaf51826f94463520f7cd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document serial execution disposition for `analyze(by="chromatic_number")`
> Adds [m4-disposition-565-chromatic-number.md](https://github.com/CurateLabs/graphforge/pull/646/files#diff-c731dd7ccc77fcd397fbcb2df316398e5ba1ec4e0aa11e67d8d3971e30537f9b) describing how `chromatic_number` analysis runs: serial, exact search with no GPU, distributed, approximate, or foreign-engine fallback. Covers evidence on path/threads, work units, determinism, and resource shape.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d363643.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->