### PR TITLE
perf(exec): serial disposition for dag_longest_path (#568)

### DIFF
--- a/docs/development/m4-disposition-568-dag-longest-path.md
+++ b/docs/development/m4-disposition-568-dag-longest-path.md
@@ -1,0 +1,18 @@
+# M4 disposition: analyze(by="dag_longest_path") (#568)
+
+Disposition: serial topological dynamic programming.
+
+`dag_longest_path` first consumes the shared deterministic Kahn topology, then
+relaxes edges in that order with canonical tie-breaking for the single public
+best path. Parallel relaxation would require synchronization across predecessor
+state and could change equal-hop tie outcomes or structured cycle errors.
+
+| Evidence item | Disposition |
+|---|---|
+| Path / threads | Serial for 1/2/4/8/automatic; no private-pool or process-global Rayon work is introduced. |
+| Work units | UUID projection, stable topological order, edge relaxation, best-path tie resolution, one-row path output. |
+| Determinism | Existing `graphforge-exec` tests cover disconnected DAGs, tie-breaking, cycles, empty graphs, cancellation, limits, and registration. |
+| Resource shape | Uses selected Rust projection and bounded one-row output; no parallel-only graph copy is added. |
+
+No GPU, distributed, approximate, or foreign-engine fallback is implied, and
+hardware timing/RSS observations remain non-gating evidence only.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #568: serial disposition for dag_longest_path.

Closes #568

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788956820&installation_model_id=20486&pr_number=647&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F647&signature=63fe09223129d17bb7add45e2f7b9b07416327191a13ed082e84b549c5109a0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add disposition doc for serial `dag_longest_path` execution approach
> Adds [m4-disposition-568-dag-longest-path.md](https://github.com/CurateLabs/graphforge/pull/647/files#diff-185231ea0ee60ded4ec00737244b77ed905e7a1f01319d775f0f5956452616d9) describing the planned serial implementation for `analyze(by="dag_longest_path")`. The approach uses deterministic Kahn topological ordering with edge relaxation and canonical tie-breaking, explicitly ruling out parallel work pools or alternative execution backends.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b49e75a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->