### PR TITLE
perf(exec): serial disposition for has_euler_path (#576)

### DIFF
--- a/docs/development/m4-disposition-576-has-euler-path.md
+++ b/docs/development/m4-disposition-576-has-euler-path.md
@@ -1,0 +1,18 @@
+# M4 disposition: analyze(by="has_euler_path") (#576)
+
+Disposition: serial Euler feasibility predicate.
+
+`has_euler_path` validates one normalized projection, open-trail endpoint counts,
+degree balance, and reachability before returning a single boolean. The accepted
+kernel is already bounded and deterministic; no independent parallel frontier is
+introduced for this predicate without a measured crossover.
+
+| Evidence item | Disposition |
+|---|---|
+| Path / threads | Serial for 1/2/4/8/automatic; no private-pool or process-global Rayon work is introduced. |
+| Work units | Projection validation, endpoint/degree checks, non-isolated connectivity, one-row boolean shaping. |
+| Determinism | Existing `graphforge-exec` tests cover directed/undirected cases, open trails, loops, parallel edges, disconnected graphs, cancellation, limits, and registration. |
+| Resource shape | Uses selected Rust projection and bounded one-row output; no parallel-only graph copy is added. |
+
+No GPU, distributed, approximate, or foreign-engine fallback is implied, and
+hardware timing/RSS observations remain non-gating evidence only.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #576: serial disposition for has_euler_path.

Closes #576

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788956831&installation_model_id=20486&pr_number=649&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F649&signature=6b1e5cc6e20ac4f66a142c99ff560bb2fc5e5ace8bc34035f9f31d14ac5c4977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add M4 disposition documentation for `analyze(by="has_euler_path")` serial execution
> Adds a development doc at [m4-disposition-576-has-euler-path.md](https://github.com/CurateLabs/graphforge/pull/649/files#diff-3707921a53310ef216451a513f47268cbd39a4b0ac33fb9a8599a430f251f20a) capturing the serial disposition decision for the `has_euler_path` predicate. The document covers the validation steps (projection, endpoint/degree balance, reachability), an evidence table for path/threads, work units, and determinism coverage, and explicitly notes no GPU/distributed/approximate/foreign-engine fallback.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f36aaa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->