### PR TITLE
perf(exec): serial disposition for euler_circuit (#572)

### DIFF
--- a/docs/development/m4-disposition-572-euler-circuit.md
+++ b/docs/development/m4-disposition-572-euler-circuit.md
@@ -1,0 +1,19 @@
+# M4 disposition: analyze(by="euler_circuit") (#572)
+
+Disposition: serial deterministic Euler construction.
+
+`euler_circuit` uses one authoritative trail state: each consumed edge changes
+the next available edge frontier and the final canonical node/edge sequence.
+Parallel consumption is not trivially safe because it would need to merge partial
+circuits while preserving stored-edge UUID order, loop/parallel-edge handling,
+and structured undefined-circuit errors.
+
+| Evidence item | Disposition |
+|---|---|
+| Path / threads | Serial for 1/2/4/8/automatic; no private-pool or process-global Rayon work is introduced. |
+| Work units | Euler projection validation, degree/connectivity checks, trail stack updates, one-row path shaping. |
+| Determinism | Existing `graphforge-exec` tests cover empty/singleton cases, loops, parallel edges, UUID rename equivariance, repeatability, and registration. |
+| Resource shape | Uses selected Rust projection and bounded path output; no parallel-only graph copy is added. |
+
+No GPU, distributed, approximate, or foreign-engine fallback is implied, and
+hardware timing/RSS observations remain non-gating evidence only.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #572: serial disposition for euler_circuit.

Closes #572

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788956831&installation_model_id=20486&pr_number=650&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F650&signature=c3cb9ec86838b7625ddca726c2cb8a6dc7706f13d039c84568127ea6e85dd3dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document serial disposition for `analyze(by="euler_circuit")`
> Adds [m4-disposition-572-euler-circuit.md](https://github.com/CurateLabs/graphforge/pull/650/files#diff-d0e82df282f34c144f9702e6062a4ebb33f59b158f49ce4d2f1786f41f0c9f73) describing the chosen serial deterministic approach for Euler circuit construction. The document explains why parallel consumption is not trivially safe and includes a evidence table covering paths/threads, work units, determinism, and resource shape. It also clarifies that no GPU, distributed, approximate, or foreign-engine fallback is implied.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a763a94.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->