### PR TITLE
perf(exec): serial disposition for euler_path (#573)

### DIFF
--- a/docs/development/m4-disposition-573-euler-path.md
+++ b/docs/development/m4-disposition-573-euler-path.md
@@ -1,0 +1,19 @@
+# M4 disposition: analyze(by="euler_path") (#573)
+
+Disposition: serial deterministic Euler trail construction.
+
+`euler_path` has a single mutable trail frontier. Each stored edge consumed by
+the current stack determines the next edge choice and the final public node/edge
+sequence. A parallel path would need non-trivial partial-trail splicing and could
+alter UUID tie order, open-trail endpoint selection, or structured undefined-path
+errors.
+
+| Evidence item | Disposition |
+|---|---|
+| Path / threads | Serial for 1/2/4/8/automatic; no private-pool or process-global Rayon work is introduced. |
+| Work units | Euler projection validation, endpoint/degree checks, trail stack updates, one-row path shaping. |
+| Determinism | Existing `graphforge-exec` tests cover empty/singleton cases, open trails, loops, parallel edges, UUID rename equivariance, repeatability, and registration. |
+| Resource shape | Uses selected Rust projection and bounded path output; no parallel-only graph copy is added. |
+
+No GPU, distributed, approximate, or foreign-engine fallback is implied, and
+hardware timing/RSS observations remain non-gating evidence only.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #573: serial disposition for euler_path.

Closes #573

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788956831&installation_model_id=20486&pr_number=652&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F652&signature=a213dbd99faf5b7105f40795bdd64fe0103ad3eb9cf60455fd5d1aa10055c2e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document serial disposition for `analyze(by="euler_path")`
> Adds a documentation page at [m4-disposition-573-euler-path.md](https://github.com/CurateLabs/graphforge/pull/652/files#diff-8017032d8f9912b744e68d03fdff67f8bd06a1c197e5ad99a653aa9f35349a7f) describing the execution model for `analyze(by="euler_path")`. The page records that the implementation uses a serial, deterministic Euler trail construction with a single mutable trail frontier, and explicitly notes that no GPU, distributed, approximate, or foreign-engine fallback is implied.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 81c1294.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->