### PR TITLE
perf(exec): serial disposition for dag_longest_path_weighted (#569)

### DIFF
--- a/docs/development/m4-disposition-569-dag-longest-path-weighted.md
+++ b/docs/development/m4-disposition-569-dag-longest-path-weighted.md
@@ -1,0 +1,18 @@
+# M4 disposition: analyze(by="dag_longest_path_weighted") (#569)
+
+Disposition: serial weighted topological dynamic programming.
+
+`dag_longest_path_weighted` combines stable Kahn ordering with weighted edge
+relaxation and exact deterministic tie-breaking. Floating-point accumulation,
+invalid-weight validation, and predecessor-state updates remain serial so the
+public best path and error ordering match the one-thread oracle.
+
+| Evidence item | Disposition |
+|---|---|
+| Path / threads | Serial for 1/2/4/8/automatic; no private-pool or process-global Rayon work is introduced. |
+| Work units | UUID/weight projection, stable topological order, weighted relaxation, best-path tie resolution, one-row path output. |
+| Determinism | Existing `graphforge-exec` tests cover disconnected DAGs, equal-weight ties, cycles, invalid weights, empty graphs, cancellation, limits, and registration. |
+| Resource shape | Uses selected Rust projection and bounded one-row output; no parallel-only graph copy is added. |
+
+No GPU, distributed, approximate, or foreign-engine fallback is implied, and
+hardware timing/RSS observations remain non-gating evidence only.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #569: serial disposition for dag_longest_path_weighted.

Closes #569

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/653"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788956832&installation_model_id=20486&pr_number=653&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F653&signature=bdb7bcffa40d9d75ab6c64dbcb9f9eadd40e138604e3ff7c95e2fb1d847e47cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add disposition documentation for `analyze(by="dag_longest_path_weighted")`
> Adds a [development doc](https://github.com/CurateLabs/graphforge/pull/653/files#diff-6720b31d8e89061d7a8aeb7fb6a14eaca0d7638603264796d4439c5f53e584ee) describing the serial weighted topological dynamic programming approach used for `dag_longest_path_weighted`. Covers determinism guarantees (stable Kahn ordering, weighted relaxation, tie-breaking) and clarifies that no GPU, distributed, or approximate fallback is used.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e308728.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->