### PR TITLE
perf(exec): serial disposition for has_euler_circuit (#575)

### DIFF
--- a/docs/development/m4-disposition-575-has-euler-circuit.md
+++ b/docs/development/m4-disposition-575-has-euler-circuit.md
@@ -1,0 +1,18 @@
+# M4 disposition: analyze(by="has_euler_circuit") (#575)
+
+Disposition: serial Euler feasibility predicate.
+
+`has_euler_circuit` validates one normalized projection, degree balance, and
+connectivity reachability before returning a single boolean. The scan and search
+share canonical validation and checkpoint order; introducing parallel fragments
+would add synchronization without a measured safe crossover for this predicate.
+
+| Evidence item | Disposition |
+|---|---|
+| Path / threads | Serial for 1/2/4/8/automatic; no private-pool or process-global Rayon work is introduced. |
+| Work units | Projection validation, degree/in-out balance, non-isolated connectivity, one-row boolean shaping. |
+| Determinism | Existing `graphforge-exec` tests cover directed/undirected cases, loops, parallel edges, disconnected graphs, cancellation, limits, and registration. |
+| Resource shape | Uses selected Rust projection and bounded one-row output; no parallel-only graph copy is added. |
+
+No GPU, distributed, approximate, or foreign-engine fallback is implied, and
+hardware timing/RSS observations remain non-gating evidence only.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #575: serial disposition for has_euler_circuit.

Closes #575

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/654"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788956832&installation_model_id=20486&pr_number=654&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F654&signature=59d2332226c38697e357c6b33a85f74532191d07e4e315b9e1c740268fc800b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add disposition documentation for `analyze(by="has_euler_circuit")` serial execution
> Adds [m4-disposition-575-has-euler-circuit.md](https://github.com/CurateLabs/graphforge/pull/654/files#diff-be583dded33e6509605e2a7fb838dc3859c69903db6f6aaf7da5ae163b0c4da8) documenting the serial predicate design for the `has_euler_circuit` analysis path. Covers validation steps (projection normalization, degree balance, connectivity), determinism evidence, resource shape, and the absence of parallel, GPU, or distributed fallbacks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ad827c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->