### PR TITLE
perf(exec): serial disposition for k1_coloring (#579)

### DIFF
--- a/docs/development/m4-disposition-579-k1-coloring.md
+++ b/docs/development/m4-disposition-579-k1-coloring.md
@@ -1,0 +1,18 @@
+# M4 disposition: analyze(by="k1_coloring") (#579)
+
+Disposition: serial degree-ordered greedy coloring.
+
+`k1_coloring` first fixes a descending-degree, ascending-UUID node order and then
+assigns the first color not used by already-colored neighbors. Later colors
+depend on earlier assignments and on canonical post-normalization of color IDs,
+so parallel buckets are not trivially safe without extra repair logic.
+
+| Evidence item | Disposition |
+|---|---|
+| Path / threads | Serial for 1/2/4/8/automatic; no private-pool or process-global Rayon work is introduced. |
+| Work units | UUID indexing, simple-neighbor normalization, ordered greedy assignment, canonical color compaction. |
+| Determinism | Existing `graphforge-exec` tests cover graph-size/output limits, invalid endpoints, duplicate UUIDs, isolates, and repeatability. |
+| Resource shape | Uses selected adjacency only and the existing bounded Arrow node/color output. |
+
+No GPU, distributed, approximate, or foreign-engine fallback is implied, and
+hardware timing/RSS observations remain non-gating evidence only.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #579: serial disposition for k1_coloring.

Closes #579

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788956851&installation_model_id=20486&pr_number=659&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F659&signature=6b700dcfb692cc48a44432ac664635455d8f09a615cc593d5120e1b5d79ff388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document serial disposition for `analyze(by="k1_coloring")`
> Adds a development disposition document at [m4-disposition-579-k1-coloring.md](https://github.com/CurateLabs/graphforge/pull/659/files#diff-8f94b2a0827faafcb253755d3d54fd3a54945aeb7fd13d4dd17eee927ad6c2f1) describing the serial, degree-ordered greedy coloring approach used in `analyze(by="k1_coloring")`. Covers ordering and color assignment behavior, canonical color compaction, determinism evidence, and explicit constraints around parallelism and GPU/distributed fallbacks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c81418.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->