### PR TITLE
perf(exec): serial disposition for astar (#536)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_paths_astar.rs
+++ b/crates/graphforge-exec/src/algorithm_paths_astar.rs
@@ -1,3 +1,7 @@
+//! A* remains serial (#536). The accepted path is defined by one priority
+//! queue ordered by estimate, cost, path, and edge ID; each pop and relaxation
+//! mutates the best-path map consumed by the next pop.
+
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap};
 

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -723,6 +723,23 @@ The path still uses bounded Arrow output (#341), structured cancellation and
 resource checks, and never uses Rayon's process-global pool. Timing remains
 evidence only, not a CI threshold.
 
+## Serial paths(by="astar") (#536)
+
+`paths(by="astar")` has no parallel crossover. Its disposition is **serial
+priority-queue A*** for every `compute_threads` setting, including
+`1`/`2`/`4`/`8`/automatic policies.
+
+The Rust kernel consumes CSR-native weighted adjacency and graph-native
+heuristic values (#340), then drives one priority queue ordered by estimate,
+cost, path, and edge ID. Each pop validates and mutates the best-path map that
+subsequent relaxations observe. Parallel relaxations would need shared heap and
+best-map coordination and could change accepted ties, cancellation points, or
+fingerprints.
+
+The path still uses bounded Arrow output (#341), structured cancellation and
+resource checks, and no process-global Rayon pool. The M4 harness records
+`paths-astar` evidence and verifies one-thread parity; timing is report-only.
+
 ## Observability
 
 `GraphForge::resource_policy()` and `GraphForge::resource_diagnostics()` expose


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #536: serial disposition for astar.

Closes #536

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788957476&installation_model_id=20486&pr_number=660&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F660&signature=311ad38d552a9c18ee59c89ade4c017fe51d17835d34a3c8cc40a4db0701ed15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document serial disposition for A* path search in execution resource policy
> Adds documentation clarifying that the A* path search always runs serially, regardless of `compute_threads` settings. Covers the priority queue ordering (by estimate, cost, path, and edge ID), best-path map mutation semantics, bounded Arrow output, cancellation/resource checks, and evidence collection in [execution-resource-policy.md](https://github.com/CurateLabs/graphforge/pull/660/files#diff-978cd3c64399512fe02ce13768a045b47b2b98e5e672d553ee1bb69be7843971). Also adds a matching doc comment to [algorithm_paths_astar.rs](https://github.com/CurateLabs/graphforge/pull/660/files#diff-ca635733bac942abaa7c828013d0f267eac0565dcefd26038c22b45aa9502ede).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f36d3ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation clarifying A* pathfinding behavior, including serial execution, priority queue ordering, and best-path updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->