### PR TITLE
perf(exec): serial disposition for gomory_hu_tree (#544)

### DIFF
--- a/crates/graphforge-api/tests/m4_entry_baseline.rs
+++ b/crates/graphforge-api/tests/m4_entry_baseline.rs
@@ -17,10 +17,12 @@ use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
 use graphforge_api::{
     CancellationToken, EmbeddingAnalyzeOptions, EmbeddingOptions, ExecutionResourcePolicy,
-    GraphForge, GraphForgeOptions, Node2VecOptions, RankOptions, ResourcePolicyMode,
-    SimilarOptions, SpillPolicy,
+    GraphForge, GraphForgeOptions, Node2VecOptions, NodeSelector, PathsOptions, PropValue,
+    RankOptions, ResourcePolicyMode, SimilarOptions, SpillPolicy,
 };
-use graphforge_core::algorithms::{AnalyzeAlgorithm, RankAlgorithm, SimilarAlgorithm};
+use graphforge_core::algorithms::{
+    AnalyzeAlgorithm, PathAlgorithm, RankAlgorithm, SimilarAlgorithm,
+};
 use graphforge_exec::demand;
 use graphforge_storage::io_stats;
 use sha2::{Digest, Sha256};
@@ -48,16 +50,16 @@ const SCAN_COUNT: &str = "MATCH (n:Person) RETURN count(n) AS total";
 const AGGREGATE_TOP_N: &str =
     "MATCH (n:Person) RETURN n.name AS name, n.age AS age ORDER BY n.age DESC LIMIT 3";
 const CREATE_FIXTURE: &str = "CREATE \
-         (alice:Person {name:'Alice', age:30, embedding:[1.0, 0.0]}), \
-         (bob:Person {name:'Bob', age:25, embedding:[1.0, 0.0]}), \
-         (carol:Person {name:'Carol', age:35, embedding:[1.0, 1.0]}), \
-         (dave:Person {name:'Dave', age:28, embedding:[0.0, 1.0]}), \
-         (eve:Person {name:'Eve', age:22, embedding:[-1.0, 0.0]}), \
-         (alice)-[:KNOWS]->(bob), \
-         (bob)-[:KNOWS]->(carol), \
-         (carol)-[:KNOWS]->(dave), \
-         (alice)-[:KNOWS]->(carol), \
-         (dave)-[:LIKES]->(eve)";
+         (alice:Person {name:'Alice', age:30, embedding:[1.0, 0.0], heuristic:3.0, prize:5.0}), \
+         (bob:Person {name:'Bob', age:25, embedding:[1.0, 0.0], heuristic:2.0, prize:4.0}), \
+         (carol:Person {name:'Carol', age:35, embedding:[1.0, 1.0], heuristic:2.0, prize:3.0}), \
+         (dave:Person {name:'Dave', age:28, embedding:[0.0, 1.0], heuristic:0.0, prize:6.0}), \
+         (eve:Person {name:'Eve', age:22, embedding:[-1.0, 0.0], heuristic:1.0, prize:2.0}), \
+         (alice)-[:KNOWS {capacity:3.0, cost:1.0}]->(bob), \
+         (bob)-[:KNOWS {capacity:2.0, cost:1.0}]->(carol), \
+         (carol)-[:KNOWS {capacity:3.0, cost:2.0}]->(dave), \
+         (alice)-[:KNOWS {capacity:2.0, cost:2.0}]->(carol), \
+         (dave)-[:LIKES {capacity:1.0, cost:1.0}]->(eve)";
 
 fn load_contract_json() -> serde_json::Value {
     serde_json::from_str(CONTRACT_JSON).expect("parse m4-entry-matrix.json")
@@ -406,6 +408,11 @@ fn collect_workloads_for(gf: &GraphForge) -> Vec<WorkloadEvidence> {
             ev
         },
         {
+            let ev = run_paths_gomory_hu_tree(gf);
+            assert!(ev.output_rows > 0, "paths-gomory-hu-tree must produce rows");
+            ev
+        },
+        {
             let ev = run_knn(gf);
             assert!(ev.output_rows > 0, "knn must produce rows");
             ev
@@ -495,6 +502,65 @@ fn run_pagerank(gf: &GraphForge) -> WorkloadEvidence {
         wall_time_ms,
         peak_rss_bytes: peak_rss_bytes().or(before_rss),
         structural: BTreeMap::from([("surface", serde_json::json!("GraphForge::rank"))]),
+    }
+}
+
+fn person_selector(name: &str) -> NodeSelector {
+    NodeSelector::Match {
+        label: "Person".into(),
+        property: "name".into(),
+        value: PropValue::Str(name.to_owned()),
+    }
+}
+
+fn run_paths_gomory_hu_tree(gf: &GraphForge) -> WorkloadEvidence {
+    let options = PathsOptions {
+        by: PathAlgorithm::GomoryHuTree,
+        via: None,
+        directed: false,
+        k: 1,
+        weight: Some("capacity".into()),
+        capacity_property: None,
+        cost_property: None,
+        heuristic: None,
+        walk_length: None,
+        seed: None,
+        terminal_uuids: Vec::new(),
+        prize_property: None,
+    };
+    let before_rss = peak_rss_bytes();
+    let started = Instant::now();
+    let first = gf
+        .paths(Option::<&NodeSelector>::None, None, options.clone())
+        .expect("gomory_hu_tree");
+    let second = gf
+        .paths(Option::<&NodeSelector>::None, None, options)
+        .expect("gomory_hu_tree repeat");
+    let wall_time_ms = started.elapsed().as_secs_f64() * 1_000.0;
+    assert_logical_batch_equal(&first, &second, "gomory_hu_tree must be deterministic");
+    let fingerprint = batch_structural_fingerprint(std::slice::from_ref(&first));
+    WorkloadEvidence {
+        id: "paths-gomory-hu-tree",
+        schema_fields: schema_field_names(first.schema().as_ref()),
+        output_rows: first.num_rows() as u64,
+        fingerprint,
+        wall_time_ms,
+        peak_rss_bytes: peak_rss_bytes().or(before_rss),
+        structural: BTreeMap::from([
+            ("surface", serde_json::json!("GraphForge::paths")),
+            ("algorithm", serde_json::json!("gomory_hu_tree")),
+            (
+                "disposition",
+                serde_json::json!("serial_gomory_hu_parent_updates"),
+            ),
+            (
+                "work_units",
+                serde_json::json!("component_bfs_and_ordered_min_cut_parent_updates"),
+            ),
+            ("threads_path", serde_json::json!("serial_for_all_policies")),
+            ("csr_native_projection", serde_json::json!(true)),
+            ("bounded_arrow_sink", serde_json::json!(true)),
+        ]),
     }
 }
 
@@ -624,6 +690,11 @@ fn collect_short_matrix() -> (serde_json::Value, Vec<WorkloadEvidence>) {
             ev
         },
         {
+            let ev = run_paths_gomory_hu_tree(&gf);
+            assert!(ev.output_rows > 0, "paths-gomory-hu-tree must produce rows");
+            ev
+        },
+        {
             let ev = run_knn(&gf);
             assert!(ev.output_rows > 0, "knn must produce rows");
             ev
@@ -672,7 +743,7 @@ fn build_evidence(
 #[test]
 fn short_ci_matrix_runs_through_public_facade_under_fixed_two_workers() {
     let (contract, workloads) = collect_short_matrix();
-    assert_eq!(workloads.len(), 6);
+    assert_eq!(workloads.len(), 7);
     let ids: Vec<_> = workloads.iter().map(|w| w.id).collect();
     assert_eq!(
         ids,
@@ -681,6 +752,7 @@ fn short_ci_matrix_runs_through_public_facade_under_fixed_two_workers() {
             "scan-count",
             "aggregate-top-n",
             "pagerank",
+            "paths-gomory-hu-tree",
             "exact-cosine-knn",
             "node2vec"
         ]

--- a/crates/graphforge-exec/src/algorithm_paths_gomory_hu.rs
+++ b/crates/graphforge-exec/src/algorithm_paths_gomory_hu.rs
@@ -1,5 +1,9 @@
 //! Deterministic Gomory-Hu forests over undirected capacity multigraphs.
 
+//! The Gomory-Hu tree path remains serial (#544). Each component-local
+//! min-cut updates parent links that determine later source/sink pairs, so cut
+//! calls are ordered state transitions rather than independent tasks.
+
 use std::collections::VecDeque;
 
 use crate::algorithm_dispatch::{AlgorithmControl, AlgorithmError};

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -261,6 +261,22 @@ IDs are still assigned by canonical node order, so schemas, row order, labels,
 and fingerprints match the one-thread result at `1`/`2`/`4`/`8`/automatic
 configurations. Cancellation remains cooperative both before worker launch and
 inside chunk scans.
+## Serial paths(by="gomory_hu_tree") (#544)
+
+`paths(by="gomory_hu_tree")` has no parallel crossover. Its disposition is
+**serial Gomory-Hu parent updates** for every `compute_threads` setting,
+including `1`/`2`/`4`/`8`/automatic policies.
+
+The Rust kernel consumes CSR-native undirected capacity adjacency (#340), finds
+canonical connected components, and runs the classic parent-update sequence.
+Each min-cut result rewrites parent links that choose subsequent cut pairs and
+final forest rows. Launching those cuts independently would compute against the
+wrong parent state and could change cut values, row order, and fingerprints.
+
+The path still uses bounded Arrow output (#341), structured cancellation and
+resource checks, and no process-global Rayon pool. The M4 harness records
+`paths-gomory-hu-tree` evidence and verifies one-thread parity across supported
+resource-policy cells; timing remains evidence only.
 
 ## Observability
 

--- a/scripts/ci/m4-entry-matrix.py
+++ b/scripts/ci/m4-entry-matrix.py
@@ -18,6 +18,7 @@ REQUIRED_WORKLOAD_IDS = {
     "scan-count",
     "aggregate-top-n",
     "pagerank",
+    "paths-gomory-hu-tree",
     "exact-cosine-knn",
     "node2vec",
 }

--- a/tests/contracts/m4-entry-matrix.json
+++ b/tests/contracts/m4-entry-matrix.json
@@ -64,7 +64,7 @@
       "matrix": "short_ci",
       "nodes": 5,
       "edges": 5,
-      "density_note": "Person/KNOWS(+LIKES) e2e-shaped fixture with vector property for KNN",
+      "density_note": "Person/KNOWS(+LIKES) e2e-shaped fixture with vector, capacity, cost, heuristic, and prize properties",
       "opt_in": false
     },
     {
@@ -111,7 +111,11 @@
       "surface": "GraphForge::execute",
       "short_ci": true,
       "large_manual": true,
-      "structural_gates": ["schema", "row_count", "determinism"]
+      "structural_gates": [
+        "schema",
+        "row_count",
+        "determinism"
+      ]
     },
     {
       "id": "aggregate-top-n",
@@ -119,7 +123,12 @@
       "surface": "GraphForge::execute",
       "short_ci": true,
       "large_manual": true,
-      "structural_gates": ["schema", "row_count", "ordering", "determinism"]
+      "structural_gates": [
+        "schema",
+        "row_count",
+        "ordering",
+        "determinism"
+      ]
     },
     {
       "id": "pagerank",
@@ -127,7 +136,28 @@
       "surface": "GraphForge::rank",
       "short_ci": true,
       "large_manual": true,
-      "structural_gates": ["schema", "row_count", "determinism"]
+      "structural_gates": [
+        "schema",
+        "row_count",
+        "determinism"
+      ]
+    },
+    {
+      "id": "paths-gomory-hu-tree",
+      "class": "serial-cut-tree-graph-algorithm",
+      "surface": "GraphForge::paths",
+      "short_ci": true,
+      "large_manual": true,
+      "disposition": "serial_gomory_hu_parent_updates",
+      "structural_gates": [
+        "schema",
+        "row_count",
+        "ordering",
+        "result_fingerprint",
+        "csr_native_projection",
+        "bounded_arrow_sink",
+        "serial_disposition"
+      ]
     },
     {
       "id": "exact-cosine-knn",
@@ -135,7 +165,11 @@
       "surface": "GraphForge::similar",
       "short_ci": true,
       "large_manual": true,
-      "structural_gates": ["schema", "row_count", "determinism"]
+      "structural_gates": [
+        "schema",
+        "row_count",
+        "determinism"
+      ]
     },
     {
       "id": "node2vec",
@@ -143,7 +177,11 @@
       "surface": "GraphForge::analyze_embedding",
       "short_ci": true,
       "large_manual": true,
-      "structural_gates": ["schema", "row_count", "determinism"]
+      "structural_gates": [
+        "schema",
+        "row_count",
+        "determinism"
+      ]
     }
   ],
   "metrics": {
@@ -173,8 +211,14 @@
     "short_ci": {
       "fixture": "synthetic-small",
       "runtime": "policy-default-two-worker",
-      "pass_fail": ["structural_gates", "parity_assertions_on_supported_runtime"],
-      "report_only": ["wall_time_ms", "peak_rss_bytes"],
+      "pass_fail": [
+        "structural_gates",
+        "parity_assertions_on_supported_runtime"
+      ],
+      "report_only": [
+        "wall_time_ms",
+        "peak_rss_bytes"
+      ],
       "forbidden": [
         "timing_absolute_thresholds",
         "sleeps",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #544: serial disposition for gomory_hu_tree.

Closes #544

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788957476&installation_model_id=20486&pr_number=661&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F661&signature=eb5b0aec8f3a79d19b9cce9a358a408dbdb028351ddfadc7c412a65093d120bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add serial disposition for `PathAlgorithm::GomoryHuTree` in graph execution
> - Marks the Gomory-Hu tree path algorithm as serial across all compute threads, documenting that ordered parent link updates prevent parallel decomposition.
> - Adds a `run_paths_gomory_hu_tree` workload to the M4 baseline test suite, asserting determinism, capturing performance/memory stats, and computing a result fingerprint.
> - Updates the contract file [m4-entry-matrix.json](https://github.com/CurateLabs/graphforge/pull/661/files#diff-c7c779d06f868896c69a9da9fb4e4d4845e561b0809e8ece2e5a446efa038ab6) with a new `paths-gomory-hu-tree` entry and its structural gates (`serial_disposition`, `bounded_arrow_sink`, `csr_native_projection`).
> - Adds `paths-gomory-hu-tree` to the CI required workload set and extends test fixtures with capacity/cost edge properties and heuristic/prize node properties.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8d9dce6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->