### PR TITLE
perf(exec): serial disposition for floyd_warshall (#543)

### DIFF
--- a/crates/graphforge-api/tests/m4_entry_baseline.rs
+++ b/crates/graphforge-api/tests/m4_entry_baseline.rs
@@ -470,6 +470,11 @@ fn collect_workloads_for(gf: &GraphForge) -> Vec<WorkloadEvidence> {
             ev
         },
         {
+            let ev = run_paths_floyd_warshall(gf);
+            assert!(ev.output_rows > 0, "paths-floyd-warshall must produce rows");
+            ev
+        },
+        {
             let ev = run_knn(gf);
             assert!(ev.output_rows > 0, "knn must produce rows");
             ev
@@ -1037,6 +1042,58 @@ fn run_analyze_minimum_k_spanning_tree(gf: &GraphForge) -> WorkloadEvidence {
     }
 }
 
+fn run_paths_floyd_warshall(gf: &GraphForge) -> WorkloadEvidence {
+    let source = person_selector("Alice");
+    let options = PathsOptions {
+        by: PathAlgorithm::FloydWarshall,
+        via: None,
+        directed: true,
+        k: 1,
+        weight: Some("cost".into()),
+        capacity_property: None,
+        cost_property: None,
+        heuristic: None,
+        walk_length: None,
+        seed: None,
+        terminal_uuids: Vec::new(),
+        prize_property: None,
+    };
+    let before_rss = peak_rss_bytes();
+    let started = Instant::now();
+    let first = gf
+        .paths(&source, None, options.clone())
+        .expect("floyd_warshall");
+    let second = gf
+        .paths(&source, None, options)
+        .expect("floyd_warshall repeat");
+    let wall_time_ms = started.elapsed().as_secs_f64() * 1_000.0;
+    assert_logical_batch_equal(&first, &second, "floyd_warshall must be deterministic");
+    let fingerprint = batch_structural_fingerprint(std::slice::from_ref(&first));
+    WorkloadEvidence {
+        id: "paths-floyd-warshall",
+        schema_fields: schema_field_names(first.schema().as_ref()),
+        output_rows: first.num_rows() as u64,
+        fingerprint,
+        wall_time_ms,
+        peak_rss_bytes: peak_rss_bytes().or(before_rss),
+        structural: BTreeMap::from([
+            ("surface", serde_json::json!("GraphForge::paths")),
+            ("algorithm", serde_json::json!("floyd_warshall")),
+            (
+                "disposition",
+                serde_json::json!("serial_floyd_warshall_dynamic_programming"),
+            ),
+            (
+                "work_units",
+                serde_json::json!("ordered_middle_source_target_updates"),
+            ),
+            ("threads_path", serde_json::json!("serial_for_all_policies")),
+            ("csr_native_projection", serde_json::json!(true)),
+            ("bounded_arrow_sink", serde_json::json!(true)),
+        ]),
+    }
+}
+
 fn run_knn(gf: &GraphForge) -> WorkloadEvidence {
     let options = SimilarOptions {
         by: SimilarAlgorithm::Knn,
@@ -1217,6 +1274,11 @@ fn collect_short_matrix() -> (serde_json::Value, Vec<WorkloadEvidence>) {
             ev
         },
         {
+            let ev = run_paths_floyd_warshall(&gf);
+            assert!(ev.output_rows > 0, "paths-floyd-warshall must produce rows");
+            ev
+        },
+        {
             let ev = run_knn(&gf);
             assert!(ev.output_rows > 0, "knn must produce rows");
             ev
@@ -1265,7 +1327,7 @@ fn build_evidence(
 #[test]
 fn short_ci_matrix_runs_through_public_facade_under_fixed_two_workers() {
     let (contract, workloads) = collect_short_matrix();
-    assert_eq!(workloads.len(), 15);
+    assert_eq!(workloads.len(), 16);
     let ids: Vec<_> = workloads.iter().map(|w| w.id).collect();
     assert_eq!(
         ids,
@@ -1283,6 +1345,7 @@ fn short_ci_matrix_runs_through_public_facade_under_fixed_two_workers() {
             "paths-bellman-ford",
             "paths-min-cost-max-flow",
             "analyze-minimum-k-spanning-tree",
+            "paths-floyd-warshall",
             "exact-cosine-knn",
             "node2vec",
         ]

--- a/crates/graphforge-exec/src/algorithm_paths_floyd_warshall.rs
+++ b/crates/graphforge-exec/src/algorithm_paths_floyd_warshall.rs
@@ -1,3 +1,7 @@
+//! Floyd-Warshall remains serial (#543). The dynamic-programming table is
+//! updated in canonical middle/source/target order, and each update can feed
+//! later updates and negative-cycle checks.
+
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -986,6 +986,21 @@ resource checks, and no process-global Rayon pool. Schemas, row order, costs,
 paths, structured errors, and fingerprints match the one-thread oracle at
 supported `1`/`2`/`4`/`8`/automatic configurations.
 
+## Serial paths(by="floyd_warshall") (#543)
+
+`paths(by="floyd_warshall")` has no parallel crossover. Its disposition is
+**serial Floyd-Warshall dynamic programming** for every `compute_threads`
+setting, including `1`/`2`/`4`/`8`/automatic policies.
+
+The Rust kernel consumes CSR-native weighted adjacency (#340), seeds a best-path
+table, and updates it in canonical `middle, source, target` order. Each update
+can feed later comparisons and negative-cycle checks, so changing update order
+would risk path ties, row ordering, or fingerprints.
+
+The path still uses bounded Arrow output (#341), structured cancellation and
+resource checks, and no process-global Rayon pool. The M4 harness records
+`paths-floyd-warshall` evidence and verifies one-thread parity; timing is
+report-only.
 ## Observability
 
 `GraphForge::resource_policy()` and `GraphForge::resource_diagnostics()` expose

--- a/scripts/ci/m4-entry-matrix.py
+++ b/scripts/ci/m4-entry-matrix.py
@@ -27,6 +27,7 @@ REQUIRED_WORKLOAD_IDS = {
     "paths-bellman-ford",
     "paths-min-cost-max-flow",
     "analyze-minimum-k-spanning-tree",
+    "paths-floyd-warshall",
     "exact-cosine-knn",
     "node2vec",
 }

--- a/tests/contracts/m4-entry-matrix.json
+++ b/tests/contracts/m4-entry-matrix.json
@@ -295,6 +295,23 @@
       ]
     },
     {
+      "id": "paths-floyd-warshall",
+      "class": "serial-all-pairs-shortest-path-graph-algorithm",
+      "surface": "GraphForge::paths",
+      "short_ci": true,
+      "large_manual": true,
+      "disposition": "serial_floyd_warshall_dynamic_programming",
+      "structural_gates": [
+        "schema",
+        "row_count",
+        "ordering",
+        "result_fingerprint",
+        "csr_native_projection",
+        "bounded_arrow_sink",
+        "serial_disposition"
+      ]
+    },
+    {
       "id": "exact-cosine-knn",
       "class": "exact-vector-search",
       "surface": "GraphForge::similar",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #543: serial disposition for floyd_warshall.

Closes #543

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788957477&installation_model_id=20486&pr_number=662&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F662&signature=dfe7bed62bbbedf1bbe5c0f25454bae96385957d470c8f7e0d8e01c311e19ee7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add serial Floyd-Warshall disposition to `GraphForge::paths` with M4 baseline coverage
> - Adds a serial execution disposition for the Floyd-Warshall all-pairs shortest path algorithm, documented in [execution-resource-policy.md](https://github.com/CurateLabs/graphforge/pull/662/files#diff-978cd3c64399512fe02ce13768a045b47b2b98e5e672d553ee1bb69be7843971) as always serial regardless of `compute_threads` policy.
> - Introduces a `run_paths_floyd_warshall` test helper that invokes `GraphForge::paths` twice to assert determinism and records `WorkloadEvidence` with id `paths-floyd-warshall`.
> - Adds the `paths-floyd-warshall` workload to the M4 entry baseline, CI matrix check, and [m4-entry-matrix.json](https://github.com/CurateLabs/graphforge/pull/662/files#diff-c7c779d06f868896c69a9da9fb4e4d4845e561b0809e8ece2e5a446efa038ab6) contract with structural gates including `serial_disposition`, `csr_native_projection`, and `bounded_arrow_sink`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a4587b5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added deterministic coverage for Floyd–Warshall all-pairs shortest-path workloads.
  * Expanded validation across short CI and large manual workload matrices.
  * Added checks for result structure, ordering, fingerprints, native projections, bounded output, and serial execution behavior.
* **Documentation**
  * Clarified Floyd–Warshall execution order, dynamic-programming updates, and negative-cycle handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->