### PR TITLE
perf(exec): serial disposition for bellman_ford (#537)

### DIFF
--- a/crates/graphforge-api/tests/m4_entry_baseline.rs
+++ b/crates/graphforge-api/tests/m4_entry_baseline.rs
@@ -422,6 +422,11 @@ fn collect_workloads_for(gf: &GraphForge) -> Vec<WorkloadEvidence> {
             ev
         },
         {
+            let ev = run_paths_bellman_ford(gf);
+            assert!(ev.output_rows > 0, "paths-bellman-ford must produce rows");
+            ev
+        },
+        {
             let ev = run_knn(gf);
             assert!(ev.output_rows > 0, "knn must produce rows");
             ev
@@ -641,6 +646,58 @@ fn run_paths_min_steiner_tree(gf: &GraphForge) -> WorkloadEvidence {
     }
 }
 
+fn run_paths_bellman_ford(gf: &GraphForge) -> WorkloadEvidence {
+    let source = person_selector("Alice");
+    let options = PathsOptions {
+        by: PathAlgorithm::BellmanFord,
+        via: None,
+        directed: true,
+        k: 1,
+        weight: Some("cost".into()),
+        capacity_property: None,
+        cost_property: None,
+        heuristic: None,
+        walk_length: None,
+        seed: None,
+        terminal_uuids: Vec::new(),
+        prize_property: None,
+    };
+    let before_rss = peak_rss_bytes();
+    let started = Instant::now();
+    let first = gf
+        .paths(&source, None, options.clone())
+        .expect("bellman_ford");
+    let second = gf
+        .paths(&source, None, options)
+        .expect("bellman_ford repeat");
+    let wall_time_ms = started.elapsed().as_secs_f64() * 1_000.0;
+    assert_logical_batch_equal(&first, &second, "bellman_ford must be deterministic");
+    let fingerprint = batch_structural_fingerprint(std::slice::from_ref(&first));
+    WorkloadEvidence {
+        id: "paths-bellman-ford",
+        schema_fields: schema_field_names(first.schema().as_ref()),
+        output_rows: first.num_rows() as u64,
+        fingerprint,
+        wall_time_ms,
+        peak_rss_bytes: peak_rss_bytes().or(before_rss),
+        structural: BTreeMap::from([
+            ("surface", serde_json::json!("GraphForge::paths")),
+            ("algorithm", serde_json::json!("bellman_ford")),
+            (
+                "disposition",
+                serde_json::json!("serial_ordered_bellman_ford_relaxation"),
+            ),
+            (
+                "work_units",
+                serde_json::json!("ordered_relaxation_rounds_and_negative_cycle_scan"),
+            ),
+            ("threads_path", serde_json::json!("serial_for_all_policies")),
+            ("csr_native_projection", serde_json::json!(true)),
+            ("bounded_arrow_sink", serde_json::json!(true)),
+        ]),
+    }
+}
+
 fn run_knn(gf: &GraphForge) -> WorkloadEvidence {
     let options = SimilarOptions {
         by: SimilarAlgorithm::Knn,
@@ -780,6 +837,11 @@ fn collect_short_matrix() -> (serde_json::Value, Vec<WorkloadEvidence>) {
             ev
         },
         {
+            let ev = run_paths_bellman_ford(&gf);
+            assert!(ev.output_rows > 0, "paths-bellman-ford must produce rows");
+            ev
+        },
+        {
             let ev = run_knn(&gf);
             assert!(ev.output_rows > 0, "knn must produce rows");
             ev
@@ -828,7 +890,7 @@ fn build_evidence(
 #[test]
 fn short_ci_matrix_runs_through_public_facade_under_fixed_two_workers() {
     let (contract, workloads) = collect_short_matrix();
-    assert_eq!(workloads.len(), 8);
+    assert_eq!(workloads.len(), 9);
     let ids: Vec<_> = workloads.iter().map(|w| w.id).collect();
     assert_eq!(
         ids,
@@ -839,6 +901,7 @@ fn short_ci_matrix_runs_through_public_facade_under_fixed_two_workers() {
             "pagerank",
             "paths-gomory-hu-tree",
             "paths-min-steiner-tree",
+            "paths-bellman-ford",
             "exact-cosine-knn",
             "node2vec"
         ]

--- a/crates/graphforge-exec/src/algorithm_paths_bellman_ford.rs
+++ b/crates/graphforge-exec/src/algorithm_paths_bellman_ford.rs
@@ -1,3 +1,7 @@
+//! Bellman-Ford remains serial (#537). Relaxation rounds walk nodes and edges
+//! in canonical order, mutating a best-path map whose state determines later
+//! relaxations and negative-cycle detection.
+
 use std::cmp::Ordering;
 use std::collections::HashMap;
 

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -789,6 +789,23 @@ Acceptance for #551 is documented here and covered by the short CI matrix
 `paths-min-steiner-tree` evidence with one-thread parity across supported worker
 counts.
 
+## Serial paths(by="bellman_ford") (#537)
+
+`paths(by="bellman_ford")` has no parallel crossover. Its disposition is
+**serial ordered Bellman-Ford relaxation** for every `compute_threads` setting,
+including `1`/`2`/`4`/`8`/automatic policies.
+
+The Rust kernel consumes CSR-native weighted adjacency (#340) and applies
+relaxation rounds in canonical node and edge order. Each successful relaxation
+mutates the best-path map used by later relaxations, tie comparisons, and the
+reachable negative-cycle scan. Parallel relaxations would require shared map
+coordination and could alter accepted paths, row order, or fingerprints.
+
+The path still uses bounded Arrow output (#341), structured cancellation and
+resource checks, and no process-global Rayon pool. The M4 harness records
+`paths-bellman-ford` evidence and verifies one-thread parity; timing is
+report-only.
+
 ## Observability
 
 `GraphForge::resource_policy()` and `GraphForge::resource_diagnostics()` expose

--- a/scripts/ci/m4-entry-matrix.py
+++ b/scripts/ci/m4-entry-matrix.py
@@ -20,6 +20,7 @@ REQUIRED_WORKLOAD_IDS = {
     "pagerank",
     "paths-gomory-hu-tree",
     "paths-min-steiner-tree",
+    "paths-bellman-ford",
     "exact-cosine-knn",
     "node2vec",
 }

--- a/tests/contracts/m4-entry-matrix.json
+++ b/tests/contracts/m4-entry-matrix.json
@@ -177,6 +177,23 @@
       ]
     },
     {
+      "id": "paths-bellman-ford",
+      "class": "serial-shortest-path-graph-algorithm",
+      "surface": "GraphForge::paths",
+      "short_ci": true,
+      "large_manual": true,
+      "disposition": "serial_ordered_bellman_ford_relaxation",
+      "structural_gates": [
+        "schema",
+        "row_count",
+        "ordering",
+        "result_fingerprint",
+        "csr_native_projection",
+        "bounded_arrow_sink",
+        "serial_disposition"
+      ]
+    },
+    {
       "id": "exact-cosine-knn",
       "class": "exact-vector-search",
       "surface": "GraphForge::similar",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #537: serial disposition for bellman_ford.

Closes #537

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788957476&installation_model_id=20486&pr_number=663&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F663&signature=03587ff0fa3b0a145e2f7e2b0a4abb9d03884c32a3844ecf73fc426d57544a08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add serial disposition for Bellman-Ford shortest-path execution
> - Registers `paths-bellman-ford` as a formal workload in the M4 baseline harness, including determinism checks, fingerprinting, and RSS measurement.
> - Documents that Bellman-Ford uses serial ordered relaxation rounds with no parallel crossover, recorded in [execution-resource-policy.md](https://github.com/CurateLabs/graphforge/pull/663/files#diff-978cd3c64399512fe02ce13768a045b47b2b98e5e672d553ee1bb69be7843971).
> - Adds `paths-bellman-ford` to CI matrix validation in [m4-entry-matrix.py](https://github.com/CurateLabs/graphforge/pull/663/files#diff-14765eed7a3cbfb23798132678b054ff062659e92f67eb92f4dd5c833863a6f5) and the contract file, so runs missing this workload will fail CI.
> - Updates the short CI matrix test to expect 8 workloads, including `paths-bellman-ford`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 75c82ce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->