### PR TITLE
perf(exec): serial disposition for dijkstra (#541)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_paths_dijkstra.rs
+++ b/crates/graphforge-exec/src/algorithm_paths_dijkstra.rs
@@ -1,3 +1,7 @@
+//! Dijkstra single-source and source-target execution remains serial for #541.
+//! Its heap, best-path map, and target early exit are one canonical state
+//! machine. The all-pairs variant has a separate #542 disposition.
+
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap};
 

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -262,6 +262,26 @@ and fingerprints match the one-thread result at `1`/`2`/`4`/`8`/automatic
 configurations. Cancellation remains cooperative both before worker launch and
 inside chunk scans.
 
+## Serial paths(by="dijkstra") (#541)
+
+`paths(by="dijkstra")` for one source, with or without one target, has no
+parallel crossover. Its disposition is **serial non-negative shortest-path
+relaxation** for every `compute_threads` setting. The all-pairs variant is
+tracked independently by #542.
+
+The Rust kernel validates non-negative finite weights, then repeatedly pops one
+canonical heap entry, compares it with the current best-path map, and relaxes
+stable outgoing edges. The public target early exit and equal-cost path-vector
+and edge-UUID ties depend on that exact pop order. Parallel relaxations would
+need to arbitrate competing predecessors and could alter paths, row order, or
+fingerprints.
+
+The path still uses CSR-native selected adjacency, bounded Arrow shaping,
+structured cancellation and limit checks, and no process-global Rayon pool.
+Costs, selected node sequences, unreachable-target behavior, structured errors,
+and cancellation behavior match the one-thread oracle across supported
+resource-policy cells.
+
 ## Observability
 
 `GraphForge::resource_policy()` and `GraphForge::resource_diagnostics()` expose


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #541: serial disposition for dijkstra SSSP.

Closes #541

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788957476&installation_model_id=20486&pr_number=664&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F664&signature=2cc76090cbe4e67fcab76a8c017e4c52429d3a7c2df9c970156d30d3b67394c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document serial execution policy for Dijkstra paths in graphforge-exec
> - Adds doc comments to [algorithm_paths_dijkstra.rs](https://github.com/CurateLabs/graphforge/pull/664/files#diff-ee775811d8035387bd4b12cd0461c3651fb6ea4683fe854809d6b62b5f6d4f54) clarifying that single-source and source-target Dijkstra execution is serial, describing the heap/best-path/early-exit state machine, and noting that all-pairs handling is tracked separately.
> - Adds a new section to [execution-resource-policy.md](https://github.com/CurateLabs/graphforge/pull/664/files#diff-978cd3c64399512fe02ce13768a045b47b2b98e5e672d553ee1bb69be7843971) specifying that `paths(by="dijkstra")` always runs serially regardless of `compute_threads`, with details on tie handling, target early exit, and behavioral parity with a one-thread oracle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8dedd23.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->