### PR TITLE
perf(exec): serial disposition for dfs (#540)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_paths.rs
+++ b/crates/graphforge-exec/src/algorithm_paths.rs
@@ -1726,6 +1726,27 @@ mod tests {
         )
     }
 
+    fn execute_path_with_compute_threads(
+        graph: &AdjacencyGraph,
+        algorithm: PathAlgorithm,
+        source: u64,
+        target: Option<u64>,
+        threads: usize,
+    ) -> Result<AlgorithmOutput, AlgorithmError> {
+        let mut registry = AlgorithmRegistry::default();
+        register_path_algorithms(&mut registry, uuid(source), target.map(uuid), 1, None, None)?;
+        let control = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(threads),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(Arc::new(crate::ComputePool::new(threads).unwrap()));
+        registry.execute(Algorithm::Paths(algorithm), graph, &control)
+    }
+
+    fn output_fingerprint(output: &AlgorithmOutput) -> String {
+        format!("{:?}|{:?}", output.schema, output.rows())
+    }
+
     fn execute_gomory_hu(
         graph: &AdjacencyGraph,
         limits: AlgorithmLimits,
@@ -2740,6 +2761,49 @@ mod tests {
             ),
         ] {
             assert!(matches!(result, Err(GfError::Validation(_))));
+        }
+    }
+
+    #[test]
+    fn dfs_keeps_serial_fingerprint_under_thread_budgets() {
+        let graph = AdjacencyGraph::with_test_directed_edges(
+            8,
+            &[
+                (0, 2),
+                (0, 1),
+                (0, 1),
+                (1, 3),
+                (1, 4),
+                (3, 6),
+                (6, 1),
+                (2, 5),
+                (5, 7),
+                (7, 7),
+            ],
+        );
+        let serial =
+            execute_path_with_compute_threads(&graph, PathAlgorithm::Dfs, 0, None, 1).unwrap();
+        assert_eq!(
+            serial.rows(),
+            vec![
+                traversal(0, 0, 0),
+                traversal(1, 1, 1),
+                traversal(3, 2, 2),
+                traversal(6, 3, 3),
+                traversal(4, 2, 4),
+                traversal(2, 1, 5),
+                traversal(5, 2, 6),
+                traversal(7, 3, 7),
+            ]
+        );
+        let serial_fingerprint = output_fingerprint(&serial);
+
+        for threads in [2_usize, 4, 8] {
+            let output =
+                execute_path_with_compute_threads(&graph, PathAlgorithm::Dfs, 0, None, threads)
+                    .unwrap();
+            assert_eq!(output.schema, serial.schema);
+            assert_eq!(output_fingerprint(&output), serial_fingerprint);
         }
     }
 

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -526,6 +526,18 @@ chunks merge in ascending range order so row ordering and the first undefined
 partition error remain deterministic. Schemas, row order, conductance bits,
 structured errors, and fingerprints match the one-thread result at
 `1`/`2`/`4`/`8`/automatic configurations.
+## Serial depth-first search (#540)
+
+`paths(by="dfs")` is intentionally SERIAL. The public result is preorder with a
+stable discovery index and depth. That order is defined by a single stack over
+sorted neighbor lists; parallelizing frontier expansion would change discovery
+order, depth ties, or require serial reassembly of every stack mutation.
+
+The handler uses the Rust-owned adjacency projection and bounded Arrow sink,
+does not use Rayon's global pool, and preserves shared cancellation and limits.
+A fingerprint test attaches private compute pools for `1`/`2`/`4`/`8`
+configured compute threads and requires identical schemas, preorder rows,
+depths, and discovery ordinals.
 
 ## Observability
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #540: serial disposition for dfs.

Closes #540

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788957477&installation_model_id=20486&pr_number=665&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F665&signature=456cd64d7f1b751c36167fccb8a29728c33672cdb1fcc0a93f05632ae205e0fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce serial execution for DFS path algorithm across all compute thread counts
> - Adds a test in [algorithm_paths.rs](https://github.com/CurateLabs/graphforge/pull/665/files#diff-902dfc5541c3cc8b6c0000163a583e2c00eb651f9f594079879b65e1a92962fa) that runs DFS with 1 thread to capture a reference output fingerprint (preorder, depth, ordinal), then re-runs with 2, 4, and 8 threads using private compute pools and asserts identical fingerprints.
> - DFS must execute serially because parallelization would alter discovery order and depth assignments, making results non-deterministic.
> - Adds a documentation section in [execution-resource-policy.md](https://github.com/CurateLabs/graphforge/pull/665/files#diff-978cd3c64399512fe02ce13768a045b47b2b98e5e672d553ee1bb69be7843971) explaining the serial disposition policy for `paths(by="dfs")`.
> - Behavioral Change: DFS is now explicitly required to produce the same output regardless of available compute threads.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 21c16fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->