### PR TITLE
perf(exec): serial disposition for bfs (#538)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_paths.rs
+++ b/crates/graphforge-exec/src/algorithm_paths.rs
@@ -2656,6 +2656,85 @@ mod tests {
     }
 
     #[test]
+    fn bfs_keeps_serial_fingerprint_under_thread_budgets() {
+        let graph = AdjacencyGraph::with_test_directed_edges(
+            8,
+            &[
+                (0, 2),
+                (0, 1),
+                (0, 1),
+                (1, 3),
+                (1, 4),
+                (2, 4),
+                (2, 5),
+                (3, 6),
+                (4, 6),
+                (5, 7),
+                (7, 7),
+            ],
+        );
+        let serial =
+            execute_path_with_compute_threads(&graph, PathAlgorithm::Bfs, 0, None, 1).unwrap();
+        assert_eq!(
+            serial.rows(),
+            vec![
+                vec![value(0), value(0), AlgorithmValue::Float64(0.0), path(&[0])],
+                vec![
+                    value(0),
+                    value(1),
+                    AlgorithmValue::Float64(1.0),
+                    path(&[0, 1]),
+                ],
+                vec![
+                    value(0),
+                    value(2),
+                    AlgorithmValue::Float64(1.0),
+                    path(&[0, 2]),
+                ],
+                vec![
+                    value(0),
+                    value(3),
+                    AlgorithmValue::Float64(2.0),
+                    path(&[0, 1, 3]),
+                ],
+                vec![
+                    value(0),
+                    value(4),
+                    AlgorithmValue::Float64(2.0),
+                    path(&[0, 1, 4]),
+                ],
+                vec![
+                    value(0),
+                    value(5),
+                    AlgorithmValue::Float64(2.0),
+                    path(&[0, 2, 5]),
+                ],
+                vec![
+                    value(0),
+                    value(6),
+                    AlgorithmValue::Float64(3.0),
+                    path(&[0, 1, 3, 6]),
+                ],
+                vec![
+                    value(0),
+                    value(7),
+                    AlgorithmValue::Float64(3.0),
+                    path(&[0, 2, 5, 7]),
+                ],
+            ]
+        );
+        let serial_fingerprint = output_fingerprint(&serial);
+
+        for threads in [2_usize, 4, 8] {
+            let output =
+                execute_path_with_compute_threads(&graph, PathAlgorithm::Bfs, 0, None, threads)
+                    .unwrap();
+            assert_eq!(output.schema, serial.schema);
+            assert_eq!(output_fingerprint(&output), serial_fingerprint);
+        }
+    }
+
+    #[test]
     fn dfs_dispatch_shapes_traversal_rows_and_preserves_boundaries() {
         let graph = AdjacencyGraph::with_test_directed_edges(5, &[(0, 2), (0, 1), (1, 3), (2, 3)]);
         let output = execute_dfs(

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -954,6 +954,19 @@ M4 entry harness records `paths-min-cut-edges` evidence and verifies parity
 against the one-thread oracle for supported resource-policy cells; timing is
 not a pass/fail gate.
 
+## Serial breadth-first search (#538)
+
+`paths(by="bfs")` is intentionally SERIAL. The public rows are ordered by hop
+count and stable node order, and predecessor choices for equal-length paths are
+defined by a single FIFO queue over sorted neighbor lists. Parallelizing frontier
+expansion would change those predecessor ties or require serial reassembly after
+each breadth layer.
+
+The handler uses Rust-owned adjacency projection and bounded Arrow output,
+does not use Rayon's global pool, and preserves shared cancellation and limits.
+A fingerprint test attaches private compute pools for `1`/`2`/`4`/`8`
+configured compute threads and requires identical schemas, row ordering, costs,
+and paths.
 ## Observability
 
 `GraphForge::resource_policy()` and `GraphForge::resource_diagnostics()` expose


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #538: serial disposition for bfs.

Closes #538

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788957477&installation_model_id=20486&pr_number=666&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F666&signature=264dddafe642eda37dd92e06a6716bdc947ed9b3ebdb9bf074d81fb5dd0fec08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce serial disposition for BFS path execution across thread budgets
> - Makes `paths(by="bfs")` intentionally serial by using a single FIFO queue over sorted neighbors, avoiding the Rayon global thread pool.
> - Adds a fingerprint test in [algorithm_paths.rs](https://github.com/CurateLabs/graphforge/pull/666/files#diff-902dfc5541c3cc8b6c0000163a583e2c00eb651f9f594079879b65e1a92962fa) that validates identical schema, ordering, costs, and paths across 1/2/4/8 compute threads.
> - Documents the serial BFS policy in [execution-resource-policy.md](https://github.com/CurateLabs/graphforge/pull/666/files#diff-978cd3c64399512fe02ce13768a045b47b2b98e5e672d553ee1bb69be7843971), including predecessor selection rules and cancellation/limit preservation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1251682.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->