### PR TITLE
perf(exec): serial disposition for min_cut_edges (#550)

### DIFF
--- a/crates/graphforge-api/tests/m4_entry_baseline.rs
+++ b/crates/graphforge-api/tests/m4_entry_baseline.rs
@@ -426,6 +426,11 @@ fn collect_workloads_for(gf: &GraphForge) -> Vec<WorkloadEvidence> {
             ev
         },
         {
+            let ev = run_paths_min_cut_edges(gf);
+            assert!(ev.output_rows > 0, "paths-min-cut-edges must produce rows");
+            ev
+        },
+        {
             let ev = run_k_core(gf);
             assert_eq!(ev.output_rows, 5);
             ev
@@ -674,6 +679,59 @@ fn run_paths_max_flow(gf: &GraphForge) -> WorkloadEvidence {
             (
                 "work_units",
                 serde_json::json!("residual_bfs_augmentations"),
+            ),
+            ("threads_path", serde_json::json!("serial_for_all_policies")),
+            ("csr_native_projection", serde_json::json!(true)),
+            ("bounded_arrow_sink", serde_json::json!(true)),
+        ]),
+    }
+}
+
+fn run_paths_min_cut_edges(gf: &GraphForge) -> WorkloadEvidence {
+    let source = person_selector("Alice");
+    let target = person_selector("Dave");
+    let options = PathsOptions {
+        by: PathAlgorithm::MinCutEdges,
+        via: None,
+        directed: true,
+        k: 1,
+        weight: Some("capacity".into()),
+        capacity_property: None,
+        cost_property: None,
+        heuristic: None,
+        walk_length: None,
+        seed: None,
+        terminal_uuids: Vec::new(),
+        prize_property: None,
+    };
+    let before_rss = peak_rss_bytes();
+    let started = Instant::now();
+    let first = gf
+        .paths(&source, Some(&target), options.clone())
+        .expect("min_cut_edges");
+    let second = gf
+        .paths(&source, Some(&target), options)
+        .expect("min_cut_edges repeat");
+    let wall_time_ms = started.elapsed().as_secs_f64() * 1_000.0;
+    assert_logical_batch_equal(&first, &second, "min_cut_edges must be deterministic");
+    let fingerprint = batch_structural_fingerprint(std::slice::from_ref(&first));
+    WorkloadEvidence {
+        id: "paths-min-cut-edges",
+        schema_fields: schema_field_names(first.schema().as_ref()),
+        output_rows: first.num_rows() as u64,
+        fingerprint,
+        wall_time_ms,
+        peak_rss_bytes: peak_rss_bytes().or(before_rss),
+        structural: BTreeMap::from([
+            ("surface", serde_json::json!("GraphForge::paths")),
+            ("algorithm", serde_json::json!("min_cut_edges")),
+            (
+                "disposition",
+                serde_json::json!("serial_constrained_min_cut_edge_projection"),
+            ),
+            (
+                "work_units",
+                serde_json::json!("max_flow_oracles_partition_then_edge_projection"),
             ),
             ("threads_path", serde_json::json!("serial_for_all_policies")),
             ("csr_native_projection", serde_json::json!(true)),
@@ -1115,6 +1173,11 @@ fn collect_short_matrix() -> (serde_json::Value, Vec<WorkloadEvidence>) {
             ev
         },
         {
+            let ev = run_paths_min_cut_edges(&gf);
+            assert!(ev.output_rows > 0, "paths-min-cut-edges must produce rows");
+            ev
+        },
+        {
             let ev = run_k_core(&gf);
             assert_eq!(ev.output_rows, 5);
             ev
@@ -1202,7 +1265,7 @@ fn build_evidence(
 #[test]
 fn short_ci_matrix_runs_through_public_facade_under_fixed_two_workers() {
     let (contract, workloads) = collect_short_matrix();
-    assert_eq!(workloads.len(), 14);
+    assert_eq!(workloads.len(), 15);
     let ids: Vec<_> = workloads.iter().map(|w| w.id).collect();
     assert_eq!(
         ids,
@@ -1213,6 +1276,7 @@ fn short_ci_matrix_runs_through_public_facade_under_fixed_two_workers() {
             "pagerank",
             "paths-gomory-hu-tree",
             "paths-max-flow",
+            "paths-min-cut-edges",
             "rank-k-core",
             "analyze-maximum-spanning-tree",
             "paths-min-steiner-tree",
@@ -1220,7 +1284,7 @@ fn short_ci_matrix_runs_through_public_facade_under_fixed_two_workers() {
             "paths-min-cost-max-flow",
             "analyze-minimum-k-spanning-tree",
             "exact-cosine-knn",
-            "node2vec"
+            "node2vec",
         ]
     );
 

--- a/crates/graphforge-exec/src/algorithm_paths_min_cut.rs
+++ b/crates/graphforge-exec/src/algorithm_paths_min_cut.rs
@@ -1,3 +1,8 @@
+//! `min_cut_edges` shares the serial constrained-cut kernel (#550). Cut edges
+//! are emitted only after the canonical source-side partition is fixed, so edge
+//! projection is deterministic post-state rather than independent parallel
+//! work.
+
 //! `min_cut` intentionally remains serial (#549). The canonical source-side
 //! partition is built by a sequence of constrained max-flow oracle calls; each
 //! membership decision depends on the previously forced partition, so there are

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -914,6 +914,26 @@ time; RNG derivation, cumulative mass order, update arithmetic, schemas, row
 order, cancellation, work/output limits, and bounded Arrow shaping remain the
 one-thread oracle at `1`/`2`/`4`/`8`/automatic configurations. Walk generation
 continues to use the #344 private-pool crossover above.
+
+## Serial paths(by="min_cut_edges") (#550)
+
+`paths(by="min_cut_edges")` has no parallel crossover. Its disposition is
+**serial constrained min-cut edge projection** for every `compute_threads`
+setting, including `1`/`2`/`4`/`8`/automatic resource policies.
+
+The edge view shares the min-cut kernel: a serial max-flow oracle establishes
+the minimum value, then constrained oracle calls build the lexicographically
+canonical source-side partition. Only after that partition is final can the
+selected stored edges be projected in edge-UUID order. Parallel cut decisions or
+early edge projection would risk changing edge rows, capacities, and result
+fingerprints.
+
+The path still uses CSR-native adjacency (#340), bounded Arrow output (#341),
+structured cancellation/resource checks, and no process-global Rayon pool. The
+M4 entry harness records `paths-min-cut-edges` evidence and verifies parity
+against the one-thread oracle for supported resource-policy cells; timing is
+not a pass/fail gate.
+
 ## Observability
 
 `GraphForge::resource_policy()` and `GraphForge::resource_diagnostics()` expose

--- a/scripts/ci/m4-entry-matrix.py
+++ b/scripts/ci/m4-entry-matrix.py
@@ -20,6 +20,7 @@ REQUIRED_WORKLOAD_IDS = {
     "pagerank",
     "paths-gomory-hu-tree",
     "paths-max-flow",
+    "paths-min-cut-edges",
     "rank-k-core",
     "analyze-maximum-spanning-tree",
     "paths-min-steiner-tree",

--- a/tests/contracts/m4-entry-matrix.json
+++ b/tests/contracts/m4-entry-matrix.json
@@ -177,6 +177,23 @@
       ]
     },
     {
+      "id": "paths-min-cut-edges",
+      "class": "serial-cut-graph-algorithm",
+      "surface": "GraphForge::paths",
+      "short_ci": true,
+      "large_manual": true,
+      "disposition": "serial_constrained_min_cut_edge_projection",
+      "structural_gates": [
+        "schema",
+        "row_count",
+        "ordering",
+        "result_fingerprint",
+        "csr_native_projection",
+        "bounded_arrow_sink",
+        "serial_disposition"
+      ]
+    },
+    {
       "id": "rank-k-core",
       "class": "core-decomposition-peeling",
       "surface": "GraphForge::rank",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #550: serial disposition for min_cut_edges.

Closes #550

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788957489&installation_model_id=20486&pr_number=667&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F667&signature=a56f0f620318aab6a4be05b4187d451c25756a078585a1085fa716cee6388845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add serial disposition for `paths(by="min_cut_edges")` with determinism validation
> - Adds a serial constrained min-cut edge projection disposition for `GraphForge::paths` with `by=MinCutEdges`, enforcing serial execution regardless of `compute_threads` setting.
> - Adds a `run_paths_min_cut_edges` test helper in [m4_entry_baseline.rs](https://github.com/CurateLabs/graphforge/pull/667/files#diff-0552cbf7f10b2eb5e9d8a2fc9fd33329209500d28a521bbb4b07f497e48cbfb8) that validates determinism via `assert_logical_batch_equal` and captures timing, memory, schema, and a structural fingerprint.
> - Registers `paths-min-cut-edges` in the [m4-entry-matrix contract](https://github.com/CurateLabs/graphforge/pull/667/files#diff-c7c779d06f868896c69a9da9fb4e4d4845e561b0809e8ece2e5a446efa038ab6) and CI script, gating on schema, row count, ordering, fingerprint, CSR-native projection, and bounded Arrow sink.
> - Documents the serial disposition rationale in [execution-resource-policy.md](https://github.com/CurateLabs/graphforge/pull/667/files#diff-978cd3c64399512fe02ce13768a045b47b2b98e5e672d553ee1bb69be7843971): the shared min-cut kernel requires serial projection to guarantee determinism after fixing the canonical source-side partition.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bb6c305.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->