### PR TITLE
perf(exec): serial disposition for max_weight_matching (#558)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_weighted_undirected.rs
+++ b/crates/graphforge-exec/src/algorithm_weighted_undirected.rs
@@ -30,6 +30,13 @@ pub(crate) struct WeightedUndirectedGraph {
     pub matching_state: AlternatingDualState,
 }
 
+/// Selected weighted matching execution path for #558 disposition evidence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum WeightedMatchingExecutionPath {
+    /// Exact weighted blossom state remains serial.
+    SerialWeightedBlossom,
+}
+
 pub(crate) fn normalize_weighted_undirected(
     nodes: &[[u8; 16]],
     edges: &[WeightedEdge],
@@ -98,6 +105,9 @@ pub(crate) fn solve_exact_matching(
     graph: &WeightedUndirectedGraph,
     control: &AlgorithmControl,
 ) -> Result<Vec<WeightedEdge>, AlgorithmError> {
+    match select_weighted_matching_path(control, graph.node_index.len(), graph.edges.len()) {
+        WeightedMatchingExecutionPath::SerialWeightedBlossom => {}
+    }
     let indexed = graph
         .edges
         .iter()
@@ -114,6 +124,14 @@ pub(crate) fn solve_exact_matching(
     let selected = state.solve_exact(&indexed, control)?;
     control.check_output_rows(selected.len())?;
     Ok(selected.into_iter().map(|edge| graph.edges[edge]).collect())
+}
+
+pub(crate) fn select_weighted_matching_path(
+    _control: &AlgorithmControl,
+    _node_count: usize,
+    _edge_count: usize,
+) -> WeightedMatchingExecutionPath {
+    WeightedMatchingExecutionPath::SerialWeightedBlossom
 }
 
 /// Solves with raw edge UUIDs as the canonical identity order.
@@ -177,6 +195,8 @@ fn execution(message: impl Into<String>) -> AlgorithmError {
 mod tests {
     use super::*;
     use crate::algorithm_dispatch::{AlgorithmCancellation, AlgorithmLimits};
+    use crate::compute_pool::ComputePool;
+    use std::sync::Arc;
 
     fn uuid(value: u8) -> [u8; 16] {
         [value; 16]
@@ -193,6 +213,14 @@ mod tests {
 
     fn control() -> AlgorithmControl {
         AlgorithmControl::new(AlgorithmLimits::default(), AlgorithmCancellation::default())
+    }
+
+    fn control_with_threads(threads: usize) -> AlgorithmControl {
+        AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(threads),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(Arc::new(ComputePool::new(threads).unwrap()))
     }
 
     fn normalize(
@@ -364,6 +392,33 @@ mod tests {
         permuted_edges.reverse();
         permuted_edges[0] = permuted_edges[0].canonical();
         assert_eq!(selected(&permuted_nodes, &permuted_edges), expected);
+    }
+
+    #[test]
+    fn serial_disposition_holds_across_thread_budgets() {
+        let nodes = (0..6).map(uuid).collect::<Vec<_>>();
+        let edges = [
+            edge(9, 0, 1, 2.0),
+            edge(8, 0, 1, 2.0),
+            edge(7, 1, 2, 4.0),
+            edge(6, 2, 3, 1.0),
+            edge(5, 3, 4, 3.0),
+            edge(4, 4, 5, 3.0),
+            edge(3, 5, 0, -1.0),
+        ];
+        let graph = normalize(&nodes, &edges).unwrap();
+        let control = control_with_threads(8);
+        assert_eq!(
+            select_weighted_matching_path(&control, graph.node_index.len(), graph.edges.len()),
+            WeightedMatchingExecutionPath::SerialWeightedBlossom
+        );
+        let oracle = solve_exact_matching(&graph, &control_with_threads(1)).unwrap();
+        for threads in [2_usize, 4, 8] {
+            assert_eq!(
+                solve_exact_matching(&graph, &control_with_threads(threads)).unwrap(),
+                oracle
+            );
+        }
     }
 
     #[test]

--- a/docs/book/architecture/algorithms.md
+++ b/docs/book/architecture/algorithms.md
@@ -2860,6 +2860,14 @@ A deterministic blossom/primal-dual implementation runs in `O(V^3)` time and
 weight validation, blossom search, optimum tie resolution, output shaping,
 limit failures, and cancellation abort atomically without partial output.
 
+M4 #558 disposition: maximum-weight matching remains serial. The exact weighted
+blossom/primal-dual core mutates labels, root queues, exact-weight dual state,
+blossom contractions, and augmenting paths in one alternating forest, so
+GraphForge does not claim a parallel crossover for
+`analyze(by="max_weight_matching")`. Thread policies at `1`/`2`/`4`/`8`/automatic
+preserve the one-thread selected edge set, weights, canonical tuple tie order,
+structured errors, and bounded Arrow shaping.
+
 Typed, dependency-free Rust in `graphforge-exec` owns projection, validation,
 blossom/primal-dual execution, deterministic choices, controls, and Arrow
 shaping. Python and Node only adapt arguments and native Arrow/Arrow IPC.

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -83,6 +83,17 @@ Components merges worker-local forests in canonical source-range order, and
 Node2Vec skip-gram training stays serial, so fingerprints match the one-thread
 path.
 
+(#342), PageRank (#343), and Node2Vec walk-corpus generation (#344) may partition
+independent work across that pool above documented crossovers; work never uses
+Rayon's process-global pool. Maximum-weight matching (#558) is explicitly
+dispositioned serial because exact weighted blossom labels, dual arithmetic,
+contractions, expansions, and augmenting-path commits mutate one shared
+alternating forest. Cosine dot products retain serial coordinate order,
+PageRank keeps canonical contribution order with serial dangling/delta
+reductions, Node2Vec skip-gram training stays serial, and max-weight matching
+keeps one-thread weighted blossom state order, so fingerprints match the
+one-thread path.
+
 ## Parallel cosine KNN (#342)
 
 Exact, all-score, and filtered cosine partition **independent source rows**
@@ -261,6 +272,28 @@ IDs are still assigned by canonical node order, so schemas, row order, labels,
 and fingerprints match the one-thread result at `1`/`2`/`4`/`8`/automatic
 configurations. Cancellation remains cooperative both before worker launch and
 inside chunk scans.
+
+## Serial maximum-weight matching (#558)
+
+`analyze(by="max_weight_matching")` has no parallel crossover. Its performance
+disposition is **serial exact weighted blossom search** for every
+`compute_threads` setting.
+
+The weighted handler normalizes the selected undirected multigraph, validates
+finite weights, and uses the shared exact blossom/primal-dual core with summed
+Float64 weights as the primary objective, cardinality as a secondary objective,
+and canonical edge tuples for ties. Labels, root queues, exact-weight dual
+steps, blossom contractions/expansions, and augmenting-path commits all update
+one alternating forest. Parallel speculation would need conflict resolution
+across shared vertices/blossoms and could change the selected maximum-weight
+edge set or tie objective.
+
+The #558 disposition preserves CSR-native selected adjacency access before
+normalization, shared cancellation/checkpoint controls, structured resource
+errors, and bounded Arrow shaping. Schemas, row order, selected edge UUIDs and
+weights, projection fingerprints, cancellation, and limit behavior match the
+one-thread oracle at supported thread configurations. No GPU, distributed,
+approximate, or foreign-engine fallback is implied.
 
 ## Observability
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -2067,6 +2067,11 @@ columns. Empty and no-match selections return the same typed zero-row table.
 Limit failures, cancellation, invalid selectors or weights, storage failures,
 and Arrow-shaping failures are atomic structured errors.
 
+`max_weight_matching` has an explicit serial performance disposition (#558):
+exact weighted blossom labels, dual updates, contractions, and augmenting paths
+mutate one alternating forest and canonical tuple tie objective. No parallel
+crossover, GPU, or foreign-engine fallback is claimed.
+
 For `by="max_cardinality_matching"`, pass `directed=False` to compute an exact
 maximum-cardinality matching of a general graph. The result contains as many
 stored edges as possible without using any selected node more than once.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #558: serial disposition for max_weight_matching.

Closes #558

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788957490&installation_model_id=20486&pr_number=668&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F668&signature=4c5782a05beb769fc15cc590fa8fa7d713abacf0c19f6db9fd85c053779c5f02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add serial execution disposition for `max_weight_matching` in weighted undirected graph algorithm
> - Introduces `WeightedMatchingExecutionPath` enum and `select_weighted_matching_path` helper in [`algorithm_weighted_undirected.rs`](https://github.com/CurateLabs/graphforge/pull/668/files#diff-1cef91bf9f10afbbdda2e636466d321012cbd8ef613c750d42301bc10ad9bb84); currently always returns `SerialWeightedBlossom` regardless of thread budget.
> - Adds a test asserting that `select_weighted_matching_path` selects serial disposition under multi-thread controls and that `solve_exact_matching` output matches a 1-thread oracle for 2, 4, and 8 threads.
> - Documents the serial disposition in architecture, API reference, and execution resource policy docs, noting that weighted blossom primal-dual state mutates within a single shared alternating forest.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 40f7d5e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->