### PR TITLE
perf(exec): serial disposition for min_steiner_tree (#551)

### DIFF
--- a/crates/graphforge-api/tests/m4_entry_baseline.rs
+++ b/crates/graphforge-api/tests/m4_entry_baseline.rs
@@ -13,6 +13,7 @@ use std::path::PathBuf;
 use std::sync::Mutex;
 use std::time::Instant;
 
+use arrow::array::FixedSizeBinaryArray;
 use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
 use graphforge_api::{
@@ -413,6 +414,14 @@ fn collect_workloads_for(gf: &GraphForge) -> Vec<WorkloadEvidence> {
             ev
         },
         {
+            let ev = run_paths_min_steiner_tree(gf);
+            assert!(
+                ev.output_rows > 0,
+                "paths-min-steiner-tree must produce rows"
+            );
+            ev
+        },
+        {
             let ev = run_knn(gf);
             assert!(ev.output_rows > 0, "knn must produce rows");
             ev
@@ -513,6 +522,19 @@ fn person_selector(name: &str) -> NodeSelector {
     }
 }
 
+fn person_uuid(gf: &GraphForge, name: &str) -> [u8; 16] {
+    let query = format!("MATCH (n:Person {{name:'{name}'}}) RETURN n.node_uuid AS id");
+    let result = gf.execute(&query).expect("person uuid lookup");
+    assert_eq!(result.stats.rows_produced, 1, "{name} must be unique");
+    let ids = result.batches[0]
+        .column_by_name("id")
+        .expect("id column")
+        .as_any()
+        .downcast_ref::<FixedSizeBinaryArray>()
+        .expect("uuid column");
+    ids.value(0).try_into().expect("fixed-size UUID bytes")
+}
+
 fn run_paths_gomory_hu_tree(gf: &GraphForge) -> WorkloadEvidence {
     let options = PathsOptions {
         by: PathAlgorithm::GomoryHuTree,
@@ -556,6 +578,61 @@ fn run_paths_gomory_hu_tree(gf: &GraphForge) -> WorkloadEvidence {
             (
                 "work_units",
                 serde_json::json!("component_bfs_and_ordered_min_cut_parent_updates"),
+            ),
+            ("threads_path", serde_json::json!("serial_for_all_policies")),
+            ("csr_native_projection", serde_json::json!(true)),
+            ("bounded_arrow_sink", serde_json::json!(true)),
+        ]),
+    }
+}
+
+fn run_paths_min_steiner_tree(gf: &GraphForge) -> WorkloadEvidence {
+    let options = PathsOptions {
+        by: PathAlgorithm::MinSteinerTree,
+        via: Some("KNOWS".into()),
+        directed: false,
+        k: 1,
+        weight: Some("cost".into()),
+        capacity_property: None,
+        cost_property: None,
+        heuristic: None,
+        walk_length: None,
+        seed: None,
+        terminal_uuids: vec![
+            person_uuid(gf, "Alice"),
+            person_uuid(gf, "Carol"),
+            person_uuid(gf, "Dave"),
+        ],
+        prize_property: None,
+    };
+    let before_rss = peak_rss_bytes();
+    let started = Instant::now();
+    let first = gf
+        .paths(Option::<&NodeSelector>::None, None, options.clone())
+        .expect("min_steiner_tree");
+    let second = gf
+        .paths(Option::<&NodeSelector>::None, None, options)
+        .expect("min_steiner_tree repeat");
+    let wall_time_ms = started.elapsed().as_secs_f64() * 1_000.0;
+    assert_logical_batch_equal(&first, &second, "min_steiner_tree must be deterministic");
+    let fingerprint = batch_structural_fingerprint(std::slice::from_ref(&first));
+    WorkloadEvidence {
+        id: "paths-min-steiner-tree",
+        schema_fields: schema_field_names(first.schema().as_ref()),
+        output_rows: first.num_rows() as u64,
+        fingerprint,
+        wall_time_ms,
+        peak_rss_bytes: peak_rss_bytes().or(before_rss),
+        structural: BTreeMap::from([
+            ("surface", serde_json::json!("GraphForge::paths")),
+            ("algorithm", serde_json::json!("min_steiner_tree")),
+            (
+                "disposition",
+                serde_json::json!("serial_exact_subset_steiner_search"),
+            ),
+            (
+                "work_units",
+                serde_json::json!("reachable_preflight_and_ordered_subset_search"),
             ),
             ("threads_path", serde_json::json!("serial_for_all_policies")),
             ("csr_native_projection", serde_json::json!(true)),
@@ -695,6 +772,14 @@ fn collect_short_matrix() -> (serde_json::Value, Vec<WorkloadEvidence>) {
             ev
         },
         {
+            let ev = run_paths_min_steiner_tree(&gf);
+            assert!(
+                ev.output_rows > 0,
+                "paths-min-steiner-tree must produce rows"
+            );
+            ev
+        },
+        {
             let ev = run_knn(&gf);
             assert!(ev.output_rows > 0, "knn must produce rows");
             ev
@@ -743,7 +828,7 @@ fn build_evidence(
 #[test]
 fn short_ci_matrix_runs_through_public_facade_under_fixed_two_workers() {
     let (contract, workloads) = collect_short_matrix();
-    assert_eq!(workloads.len(), 7);
+    assert_eq!(workloads.len(), 8);
     let ids: Vec<_> = workloads.iter().map(|w| w.id).collect();
     assert_eq!(
         ids,
@@ -753,6 +838,7 @@ fn short_ci_matrix_runs_through_public_facade_under_fixed_two_workers() {
             "aggregate-top-n",
             "pagerank",
             "paths-gomory-hu-tree",
+            "paths-min-steiner-tree",
             "exact-cosine-knn",
             "node2vec"
         ]

--- a/crates/graphforge-exec/src/algorithm_paths_min_steiner.rs
+++ b/crates/graphforge-exec/src/algorithm_paths_min_steiner.rs
@@ -4,6 +4,10 @@
 //! It returns stored edge identities in the canonical order required by the
 //! dedicated Steiner edge schema.
 
+//! Minimum Steiner tree remains serial (#551). The exact subset search keeps one
+//! global best candidate with cost/fewer-edge/edge-UUID ties, so branch order and
+//! pruning are part of the deterministic public contract.
+
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -778,6 +778,17 @@ resource checks, and no process-global Rayon pool. The M4 harness records
 `analyze-minimum-spanning-tree` evidence and verifies one-thread parity; timing
 is report-only.
 
+## Serial paths(by="min_steiner_tree") (#551)
+
+`paths(by="min_steiner_tree")` has no parallel crossover. Its disposition is
+`serial_exact_subset_steiner_search`: exact subset search keeps one global best
+candidate, and cost / fewer-edge / edge-UUID ties make branch order and pruning
+part of the deterministic public contract.
+
+Acceptance for #551 is documented here and covered by the short CI matrix
+`paths-min-steiner-tree` evidence with one-thread parity across supported worker
+counts.
+
 ## Observability
 
 `GraphForge::resource_policy()` and `GraphForge::resource_diagnostics()` expose

--- a/scripts/ci/m4-entry-matrix.py
+++ b/scripts/ci/m4-entry-matrix.py
@@ -19,6 +19,7 @@ REQUIRED_WORKLOAD_IDS = {
     "aggregate-top-n",
     "pagerank",
     "paths-gomory-hu-tree",
+    "paths-min-steiner-tree",
     "exact-cosine-knn",
     "node2vec",
 }

--- a/tests/contracts/m4-entry-matrix.json
+++ b/tests/contracts/m4-entry-matrix.json
@@ -160,6 +160,23 @@
       ]
     },
     {
+      "id": "paths-min-steiner-tree",
+      "class": "serial-steiner-graph-algorithm",
+      "surface": "GraphForge::paths",
+      "short_ci": true,
+      "large_manual": true,
+      "disposition": "serial_exact_subset_steiner_search",
+      "structural_gates": [
+        "schema",
+        "row_count",
+        "ordering",
+        "result_fingerprint",
+        "csr_native_projection",
+        "bounded_arrow_sink",
+        "serial_disposition"
+      ]
+    },
+    {
       "id": "exact-cosine-knn",
       "class": "exact-vector-search",
       "surface": "GraphForge::similar",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #551: serial disposition for min_steiner_tree.

Closes #551

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788957489&installation_model_id=20486&pr_number=669&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F669&signature=896b218673dc86a0808a1b867899171c8bf57dc51751d1cb26ac809ea5842fd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add serial disposition for `min_steiner_tree` path algorithm
> - Formally documents `paths(by="min_steiner_tree")` as serial-only with disposition `serial_exact_subset_steiner_search` and deterministic tie-breaking in [`algorithm_paths_min_steiner.rs`](https://github.com/CurateLabs/graphforge/pull/669/files#diff-0e1aaa528befb9c07f0415853920bfab4cbd61d6ce767cbc0ff3854cd1570790) and [`execution-resource-policy.md`](https://github.com/CurateLabs/graphforge/pull/669/files#diff-978cd3c64399512fe02ce13768a045b47b2b98e5e672d553ee1bb69be7843971).
> - Adds a `paths-min-steiner-tree` contract entry to [`m4-entry-matrix.json`](https://github.com/CurateLabs/graphforge/pull/669/files#diff-c7c779d06f868896c69a9da9fb4e4d4845e561b0809e8ece2e5a446efa038ab6) with structural gates covering schema, row count, ordering, fingerprint, and serial disposition.
> - Extends the M4 entry baseline test suite to run the min Steiner tree workload, assert determinism across two executions, and verify its position in the ordered workload list (total count increases from 7 to 8).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 89a8fb6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for minimum Steiner tree workloads, including deterministic repeated results and structural, ordering, fingerprint, and timing checks.
  * Included the workload in short CI and extended entry matrices.
  * Added validation for serial execution behavior and bounded output handling.

* **Documentation**
  * Clarified that minimum Steiner tree results are deterministic, including candidate selection, tie-breaking, branch order, and pruning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->