### PR TITLE
perf(exec): serial disposition for min_cost_max_flow_edges (#548)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_paths_min_cost_flow.rs
+++ b/crates/graphforge-exec/src/algorithm_paths_min_cost_flow.rs
@@ -2,6 +2,8 @@
 //! Bellman-Ford residual shortest path mutates capacities, costs, and flow
 //! assignments consumed by the next augmentation, so private-pool work would
 //! change residual visibility and public tie behavior.
+//! The `min_cost_max_flow_edges` view (#548) projects per-edge flow/cost rows
+//! from that final canonical residual state, not from independent edge tasks.
 
 use std::collections::HashMap;
 use std::hash::Hash;

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -985,6 +985,22 @@ The path still uses bounded Arrow output (#341), structured cancellation and
 resource checks, and no process-global Rayon pool. Schemas, row order, costs,
 paths, structured errors, and fingerprints match the one-thread oracle at
 supported `1`/`2`/`4`/`8`/automatic configurations.
+## Serial paths(by="min_cost_max_flow_edges") (#548)
+
+`paths(by="min_cost_max_flow_edges")` has no parallel crossover. Its
+disposition is **serial Bellman-Ford residual edge projection** for every
+`compute_threads` setting, including `1`/`2`/`4`/`8`/automatic policies.
+
+The edge view shares the min-cost maximum-flow optimizer. Capacity, unit cost,
+flow, and flow-cost state change after every selected residual shortest path;
+edge rows are valid only after the final residual graph is known and sorted by
+public edge UUID. Parallel augmentations would risk changing residual path
+choice, signed edge assignments, and fingerprints.
+
+The path still uses CSR-native projections (#340), bounded Arrow output (#341),
+structured cancellation/resource checks, and no process-global Rayon pool.
+Schemas, row order, signed edge assignments, structured errors, and fingerprints
+match the one-thread oracle at supported `1`/`2`/`4`/`8`/automatic configurations.
 
 ## Serial paths(by="floyd_warshall") (#543)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #548: serial disposition for min_cost_max_flow_edges.

Closes #548

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/670"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788957490&installation_model_id=20486&pr_number=670&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F670&signature=357248272fbacc70ea9a561158f636320519fcd09e0cb893f115cade3cd4b053"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run `min_cost_max_flow_edges` path projection serially regardless of `compute_threads`
> - The `paths(by="min_cost_max_flow_edges")` view now runs as a serial Bellman-Ford residual edge projection, overriding any `compute_threads` setting.
> - This is required because the projection depends on the final canonical residual graph state rather than independent per-edge tasks, so parallel execution would produce inconsistent results.
> - Documents the resulting guarantees (row order, signed edge assignments, structured errors, fingerprints) matching the single-thread oracle in [execution-resource-policy.md](https://github.com/CurateLabs/graphforge/pull/670/files#diff-978cd3c64399512fe02ce13768a045b47b2b98e5e672d553ee1bb69be7843971).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5e4eba5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that minimum-cost flow edge results are derived from the final canonical residual state, ensuring the documented output behavior is accurately described.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->