### PR TITLE
perf(exec): serial disposition for yens (#555)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_paths_yens.rs
+++ b/crates/graphforge-exec/src/algorithm_paths_yens.rs
@@ -1,3 +1,7 @@
+//! Yen's k-shortest paths remain serial (#555). Each accepted path defines the
+//! next spur candidates, and the global candidate map is drained in canonical
+//! rank order, so iterations are not independent private-pool work.
+
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap, HashSet};
 

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -967,6 +967,25 @@ does not use Rayon's global pool, and preserves shared cancellation and limits.
 A fingerprint test attaches private compute pools for `1`/`2`/`4`/`8`
 configured compute threads and requires identical schemas, row ordering, costs,
 and paths.
+
+## Serial paths(by="yens") (#555)
+
+`paths(by="yens")` has no parallel crossover. Its disposition is **serial Yen
+spur-candidate ranking** for every `compute_threads` setting, including
+`1`/`2`/`4`/`8`/automatic policies.
+
+The Rust kernel consumes CSR-native weighted adjacency (#340), accepts the first
+shortest path, then derives spur candidates from the previously accepted path.
+A single canonical candidate map is scanned and drained by cost/path/edge ties
+for each rank. Later work depends on earlier accepted paths, so parallel spur
+search would require shared candidate coordination and could change ranks, row
+order, or fingerprints.
+
+The path still uses bounded Arrow output (#341), structured cancellation and
+resource checks, and no process-global Rayon pool. Schemas, row order, costs,
+paths, structured errors, and fingerprints match the one-thread oracle at
+supported `1`/`2`/`4`/`8`/automatic configurations.
+
 ## Observability
 
 `GraphForge::resource_policy()` and `GraphForge::resource_diagnostics()` expose


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #555: serial disposition for yens.

Closes #555

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788957490&installation_model_id=20486&pr_number=671&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F671&signature=95d90c316d32ee30953d9e9422c0bc77d973b09c77040011aa00bea2adfcab9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document serial execution disposition for `paths(by="yens")`
> - Adds a module-level doc comment to [algorithm_paths_yens.rs](https://github.com/CurateLabs/graphforge/pull/671/files#diff-dbf2d29994ffeda853c28b5c75f128229642e7a6be596a827cee4424828c4b93) explaining that Yen's k-shortest paths always runs serially, with spur candidates derived from accepted paths and drained in canonical rank order.
> - Adds a new section to [execution-resource-policy.md](https://github.com/CurateLabs/graphforge/pull/671/files#diff-978cd3c64399512fe02ce13768a045b47b2b98e5e672d553ee1bb69be7843971) clarifying that `paths(by="yens")` has no parallel crossover and ignores `compute_threads`, always using serial spur-candidate ranking.
> - Documents that outputs and fingerprints are deterministic and match a one-thread oracle across all supported configurations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 73f5810.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->