### PR TITLE
perf(exec): serial disposition for min_cut (#549)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_paths_min_cut.rs
+++ b/crates/graphforge-exec/src/algorithm_paths_min_cut.rs
@@ -1,3 +1,8 @@
+//! `min_cut` intentionally remains serial (#549). The canonical source-side
+//! partition is built by a sequence of constrained max-flow oracle calls; each
+//! membership decision depends on the previously forced partition, so there are
+//! no independent cut decisions to send to the private compute pool.
+
 use crate::algorithm_dispatch::{AlgorithmControl, AlgorithmError};
 use crate::algorithm_paths_max_flow::{CapacityEdge, maximum_flow};
 

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -740,6 +740,26 @@ The path still uses bounded Arrow output (#341), structured cancellation and
 resource checks, and no process-global Rayon pool. The M4 harness records
 `paths-astar` evidence and verifies one-thread parity; timing is report-only.
 
+## Serial paths(by="min_cut") (#549)
+
+`paths(by="min_cut")` has no parallel crossover. Its disposition is
+**serial constrained min-cut oracle** for every `compute_threads` setting,
+including `1`/`2`/`4`/`8`/automatic resource policies.
+
+The Rust kernel consumes CSR-native capacity adjacency (#340), computes the
+minimum value through the shared serial max-flow oracle, then constructs the
+canonical source-side partition one UUID at a time. Every include/exclude
+decision runs a constrained cut-value oracle against the partition forced by
+previous decisions. That dependency chain fixes tie behavior and row ordering;
+parallelizing it would require speculative shared residual state and could
+change the accepted cut fingerprint.
+
+The path still uses bounded Arrow output (#341), structured cancellation and
+resource checks, and never uses Rayon's process-global pool. The M4 entry
+harness records `paths-min-cut` structural evidence and verifies one-thread
+fingerprint parity for supported resource-policy cells. Timing is evidence
+only, never a CI threshold.
+
 ## Observability
 
 `GraphForge::resource_policy()` and `GraphForge::resource_diagnostics()` expose


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #549: serial disposition for min_cut.

Closes #549

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788957490&installation_model_id=20486&pr_number=672&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F672&signature=3cab69158fc9604b396ecad5e46cf5bd68c109dc0fa9bc59f9dd3c6821baa647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document serial execution disposition for `paths(by="min_cut")`
> - Adds a module-level doc comment to [algorithm_paths_min_cut.rs](https://github.com/CurateLabs/graphforge/pull/672/files#diff-f6f964e7e69da7a01f9462aae6791ec791f95e545f85e354d673453304383fe0) explaining that `min_cut` is inherently serial: each membership decision in the canonical source-side partition depends on prior forced partition decisions, preventing parallelization.
> - Adds a new section to [execution-resource-policy.md](https://github.com/CurateLabs/graphforge/pull/672/files#diff-978cd3c64399512fe02ce13768a045b47b2b98e5e672d553ee1bb69be7843971) specifying that `paths(by="min_cut")` always runs serially regardless of `compute_threads`, uses a shared serial max-flow oracle over CSR-native capacity adjacency, and avoids Rayon's global pool.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b977d97.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->