### PR TITLE
perf(exec): serial disposition for min_cost_max_flow (#547)

### DIFF
--- a/crates/graphforge-api/tests/m4_entry_baseline.rs
+++ b/crates/graphforge-api/tests/m4_entry_baseline.rs
@@ -60,7 +60,10 @@ const CREATE_FIXTURE: &str = "CREATE \
          (bob)-[:KNOWS {capacity:2.0, cost:1.0}]->(carol), \
          (carol)-[:KNOWS {capacity:3.0, cost:2.0}]->(dave), \
          (alice)-[:KNOWS {capacity:2.0, cost:2.0}]->(carol), \
-         (dave)-[:LIKES {capacity:1.0, cost:1.0}]->(eve)";
+         (dave)-[:LIKES {capacity:1.0, cost:1.0}]->(eve), \
+         (alice)-[:PIPE {capacity:2.0, cost:1.0}]->(bob), \
+         (bob)-[:PIPE {capacity:2.0, cost:2.0}]->(dave), \
+         (alice)-[:PIPE {capacity:1.0, cost:5.0}]->(dave)";
 
 fn load_contract_json() -> serde_json::Value {
     serde_json::from_str(CONTRACT_JSON).expect("parse m4-entry-matrix.json")
@@ -427,6 +430,11 @@ fn collect_workloads_for(gf: &GraphForge) -> Vec<WorkloadEvidence> {
             ev
         },
         {
+            let ev = run_paths_min_cost_max_flow(gf);
+            assert_eq!(ev.output_rows, 1);
+            ev
+        },
+        {
             let ev = run_knn(gf);
             assert!(ev.output_rows > 0, "knn must produce rows");
             ev
@@ -698,6 +706,59 @@ fn run_paths_bellman_ford(gf: &GraphForge) -> WorkloadEvidence {
     }
 }
 
+fn run_paths_min_cost_max_flow(gf: &GraphForge) -> WorkloadEvidence {
+    let source = person_selector("Alice");
+    let target = person_selector("Dave");
+    let options = PathsOptions {
+        by: PathAlgorithm::MinCostMaxFlow,
+        via: Some("PIPE".into()),
+        directed: true,
+        k: 1,
+        weight: None,
+        capacity_property: Some("capacity".into()),
+        cost_property: Some("cost".into()),
+        heuristic: None,
+        walk_length: None,
+        seed: None,
+        terminal_uuids: Vec::new(),
+        prize_property: None,
+    };
+    let before_rss = peak_rss_bytes();
+    let started = Instant::now();
+    let first = gf
+        .paths(&source, Some(&target), options.clone())
+        .expect("min_cost_max_flow");
+    let second = gf
+        .paths(&source, Some(&target), options)
+        .expect("min_cost_max_flow repeat");
+    let wall_time_ms = started.elapsed().as_secs_f64() * 1_000.0;
+    assert_logical_batch_equal(&first, &second, "min_cost_max_flow must be deterministic");
+    let fingerprint = batch_structural_fingerprint(std::slice::from_ref(&first));
+    WorkloadEvidence {
+        id: "paths-min-cost-max-flow",
+        schema_fields: schema_field_names(first.schema().as_ref()),
+        output_rows: first.num_rows() as u64,
+        fingerprint,
+        wall_time_ms,
+        peak_rss_bytes: peak_rss_bytes().or(before_rss),
+        structural: BTreeMap::from([
+            ("surface", serde_json::json!("GraphForge::paths")),
+            ("algorithm", serde_json::json!("min_cost_max_flow")),
+            (
+                "disposition",
+                serde_json::json!("serial_bellman_ford_residual_augmentations"),
+            ),
+            (
+                "work_units",
+                serde_json::json!("shortest_residual_augmentations_with_cost_updates"),
+            ),
+            ("threads_path", serde_json::json!("serial_for_all_policies")),
+            ("csr_native_projection", serde_json::json!(true)),
+            ("bounded_arrow_sink", serde_json::json!(true)),
+        ]),
+    }
+}
+
 fn run_knn(gf: &GraphForge) -> WorkloadEvidence {
     let options = SimilarOptions {
         by: SimilarAlgorithm::Knn,
@@ -842,6 +903,11 @@ fn collect_short_matrix() -> (serde_json::Value, Vec<WorkloadEvidence>) {
             ev
         },
         {
+            let ev = run_paths_min_cost_max_flow(&gf);
+            assert_eq!(ev.output_rows, 1);
+            ev
+        },
+        {
             let ev = run_knn(&gf);
             assert!(ev.output_rows > 0, "knn must produce rows");
             ev
@@ -870,7 +936,7 @@ fn build_evidence(
         "dataset": {
             "fixture_id": "synthetic-small",
             "nodes": 5,
-            "edges": 5,
+            "edges": 8,
             "opt_in": false,
         },
         "workloads": workloads.iter().map(evidence_workload).collect::<Vec<_>>(),
@@ -890,7 +956,7 @@ fn build_evidence(
 #[test]
 fn short_ci_matrix_runs_through_public_facade_under_fixed_two_workers() {
     let (contract, workloads) = collect_short_matrix();
-    assert_eq!(workloads.len(), 9);
+    assert_eq!(workloads.len(), 10);
     let ids: Vec<_> = workloads.iter().map(|w| w.id).collect();
     assert_eq!(
         ids,
@@ -902,6 +968,7 @@ fn short_ci_matrix_runs_through_public_facade_under_fixed_two_workers() {
             "paths-gomory-hu-tree",
             "paths-min-steiner-tree",
             "paths-bellman-ford",
+            "paths-min-cost-max-flow",
             "exact-cosine-knn",
             "node2vec"
         ]

--- a/crates/graphforge-exec/src/algorithm_paths_min_cost_flow.rs
+++ b/crates/graphforge-exec/src/algorithm_paths_min_cost_flow.rs
@@ -1,3 +1,8 @@
+//! Min-cost maximum-flow views intentionally remain serial (#547/#548). Each
+//! Bellman-Ford residual shortest path mutates capacities, costs, and flow
+//! assignments consumed by the next augmentation, so private-pool work would
+//! change residual visibility and public tie behavior.
+
 use std::collections::HashMap;
 use std::hash::Hash;
 

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -806,6 +806,25 @@ resource checks, and no process-global Rayon pool. The M4 harness records
 `paths-bellman-ford` evidence and verifies one-thread parity; timing is
 report-only.
 
+## Serial paths(by="min_cost_max_flow") (#547)
+
+`paths(by="min_cost_max_flow")` has no parallel crossover. Its disposition is
+**serial Bellman-Ford residual augmentation** for every `compute_threads`
+setting, including `1`/`2`/`4`/`8`/automatic resource policies.
+
+The Rust kernel consumes CSR-native capacity and cost projections (#340), sorts
+public identities canonically, rejects undefined negative residual cycles, and
+then augments along one Bellman-Ford shortest residual path at a time. Each
+augmentation mutates residual capacities and accumulated cost before the next
+path is chosen, so the scalar optimum is a sequential state machine rather than
+independent work for the private compute pool.
+
+The path still uses bounded Arrow output (#341), structured cancellation and
+resource checks, and never uses Rayon's process-global pool. The M4 harness
+records `paths-min-cost-max-flow` structural evidence and verifies parity
+against the one-thread oracle for supported resource-policy cells. Timing is
+hardware-specific evidence only.
+
 ## Observability
 
 `GraphForge::resource_policy()` and `GraphForge::resource_diagnostics()` expose

--- a/scripts/ci/m4-entry-matrix.py
+++ b/scripts/ci/m4-entry-matrix.py
@@ -21,6 +21,7 @@ REQUIRED_WORKLOAD_IDS = {
     "paths-gomory-hu-tree",
     "paths-min-steiner-tree",
     "paths-bellman-ford",
+    "paths-min-cost-max-flow",
     "exact-cosine-knn",
     "node2vec",
 }

--- a/tests/contracts/m4-entry-matrix.json
+++ b/tests/contracts/m4-entry-matrix.json
@@ -63,8 +63,8 @@
       "kind": "deterministic-synthetic",
       "matrix": "short_ci",
       "nodes": 5,
-      "edges": 5,
-      "density_note": "Person/KNOWS(+LIKES) e2e-shaped fixture with vector, capacity, cost, heuristic, and prize properties",
+      "edges": 8,
+      "density_note": "Person/KNOWS(+LIKES+PIPE) e2e-shaped fixture with vector, capacity, cost, heuristic, and prize properties",
       "opt_in": false
     },
     {
@@ -183,6 +183,23 @@
       "short_ci": true,
       "large_manual": true,
       "disposition": "serial_ordered_bellman_ford_relaxation",
+      "structural_gates": [
+        "schema",
+        "row_count",
+        "ordering",
+        "result_fingerprint",
+        "csr_native_projection",
+        "bounded_arrow_sink",
+        "serial_disposition"
+      ]
+    },
+    {
+      "id": "paths-min-cost-max-flow",
+      "class": "serial-costed-flow-graph-algorithm",
+      "surface": "GraphForge::paths",
+      "short_ci": true,
+      "large_manual": true,
+      "disposition": "serial_bellman_ford_residual_augmentations",
       "structural_gates": [
         "schema",
         "row_count",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #547: serial disposition for min_cost_max_flow.

Closes #547

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788957490&installation_model_id=20486&pr_number=673&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F673&signature=8d4b547fb238a499485d06db0c3688e738ca869db9a2753e9079b5136d8ebc37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add serial disposition for `min_cost_max_flow` paths to execution policy
> - Adds `paths-min-cost-max-flow` as a tracked workload in the M4 entry baseline, using a `serial_bellman_ford_residual_augmentations` disposition to reflect that residual path dependencies require serial execution.
> - Extends the synthetic test graph in [m4_entry_baseline.rs](https://github.com/CurateLabs/graphforge/pull/673/files#diff-0552cbf7f10b2eb5e9d8a2fc9fd33329209500d28a521bbb4b07f497e48cbfb8) from 5 to 8 edges by adding three `PIPE` edges with capacity and cost properties.
> - Documents the serial behavior and Arrow output contract for `paths(by="min_cost_max_flow")` in [execution-resource-policy.md](https://github.com/CurateLabs/graphforge/pull/673/files#diff-978cd3c64399512fe02ce13768a045b47b2b98e5e672d553ee1bb69be7843971).
> - Updates the CI matrix script and contract JSON to require the new workload and its structural gates.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 804017b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->