### PR TITLE
perf(exec): serial disposition for prize_collecting_steiner_tree (#552)

### DIFF
--- a/crates/graphforge-api/tests/m4_entry_baseline.rs
+++ b/crates/graphforge-api/tests/m4_entry_baseline.rs
@@ -452,6 +452,14 @@ fn collect_workloads_for(gf: &GraphForge) -> Vec<WorkloadEvidence> {
             ev
         },
         {
+            let ev = run_paths_prize_collecting_steiner_tree(gf);
+            assert!(
+                ev.output_rows > 0,
+                "paths-prize-collecting-steiner-tree must produce rows"
+            );
+            ev
+        },
+        {
             let ev = run_paths_bellman_ford(gf);
             assert!(ev.output_rows > 0, "paths-bellman-ford must produce rows");
             ev
@@ -831,6 +839,64 @@ fn run_paths_min_steiner_tree(gf: &GraphForge) -> WorkloadEvidence {
             (
                 "work_units",
                 serde_json::json!("reachable_preflight_and_ordered_subset_search"),
+            ),
+            ("threads_path", serde_json::json!("serial_for_all_policies")),
+            ("csr_native_projection", serde_json::json!(true)),
+            ("bounded_arrow_sink", serde_json::json!(true)),
+        ]),
+    }
+}
+
+fn run_paths_prize_collecting_steiner_tree(gf: &GraphForge) -> WorkloadEvidence {
+    let options = PathsOptions {
+        by: PathAlgorithm::PrizeCollectingSteinerTree,
+        via: Some("KNOWS".into()),
+        directed: false,
+        k: 1,
+        weight: Some("cost".into()),
+        capacity_property: None,
+        cost_property: None,
+        heuristic: None,
+        walk_length: None,
+        seed: None,
+        terminal_uuids: vec![person_uuid(gf, "Alice"), person_uuid(gf, "Dave")],
+        prize_property: Some("prize".into()),
+    };
+    let before_rss = peak_rss_bytes();
+    let started = Instant::now();
+    let first = gf
+        .paths(Option::<&NodeSelector>::None, None, options.clone())
+        .expect("prize_collecting_steiner_tree");
+    let second = gf
+        .paths(Option::<&NodeSelector>::None, None, options)
+        .expect("prize_collecting_steiner_tree repeat");
+    let wall_time_ms = started.elapsed().as_secs_f64() * 1_000.0;
+    assert_logical_batch_equal(
+        &first,
+        &second,
+        "prize_collecting_steiner_tree must be deterministic",
+    );
+    let fingerprint = batch_structural_fingerprint(std::slice::from_ref(&first));
+    WorkloadEvidence {
+        id: "paths-prize-collecting-steiner-tree",
+        schema_fields: schema_field_names(first.schema().as_ref()),
+        output_rows: first.num_rows() as u64,
+        fingerprint,
+        wall_time_ms,
+        peak_rss_bytes: peak_rss_bytes().or(before_rss),
+        structural: BTreeMap::from([
+            ("surface", serde_json::json!("GraphForge::paths")),
+            (
+                "algorithm",
+                serde_json::json!("prize_collecting_steiner_tree"),
+            ),
+            (
+                "disposition",
+                serde_json::json!("serial_exact_prize_subset_search"),
+            ),
+            (
+                "work_units",
+                serde_json::json!("state_space_preflight_and_ordered_prize_subset_search"),
             ),
             ("threads_path", serde_json::json!("serial_for_all_policies")),
             ("csr_native_projection", serde_json::json!(true)),
@@ -1256,6 +1322,14 @@ fn collect_short_matrix() -> (serde_json::Value, Vec<WorkloadEvidence>) {
             ev
         },
         {
+            let ev = run_paths_prize_collecting_steiner_tree(&gf);
+            assert!(
+                ev.output_rows > 0,
+                "paths-prize-collecting-steiner-tree must produce rows"
+            );
+            ev
+        },
+        {
             let ev = run_paths_bellman_ford(&gf);
             assert!(ev.output_rows > 0, "paths-bellman-ford must produce rows");
             ev
@@ -1327,7 +1401,7 @@ fn build_evidence(
 #[test]
 fn short_ci_matrix_runs_through_public_facade_under_fixed_two_workers() {
     let (contract, workloads) = collect_short_matrix();
-    assert_eq!(workloads.len(), 16);
+    assert_eq!(workloads.len(), 17);
     let ids: Vec<_> = workloads.iter().map(|w| w.id).collect();
     assert_eq!(
         ids,
@@ -1342,6 +1416,7 @@ fn short_ci_matrix_runs_through_public_facade_under_fixed_two_workers() {
             "rank-k-core",
             "analyze-maximum-spanning-tree",
             "paths-min-steiner-tree",
+            "paths-prize-collecting-steiner-tree",
             "paths-bellman-ford",
             "paths-min-cost-max-flow",
             "analyze-minimum-k-spanning-tree",

--- a/crates/graphforge-exec/src/algorithm_paths_prize_steiner.rs
+++ b/crates/graphforge-exec/src/algorithm_paths_prize_steiner.rs
@@ -1,5 +1,9 @@
 //! Exact deterministic prize-collecting Steiner trees for undirected graphs.
 
+//! Prize-collecting Steiner tree remains serial (#552). Exact subset evaluation
+//! compares one global objective with canonical edge ties; parallel workers
+//! would need shared best-candidate coordination and could alter fingerprints.
+
 use crate::algorithm_dispatch::{AlgorithmControl, AlgorithmError};
 
 /// A graph-native numeric property resolved before kernel dispatch.

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -1059,6 +1059,25 @@ same serial community order used by the one-thread path. Schemas, scalar row
 shape, score bits, structured errors, and fingerprints match the one-thread
 result at `1`/`2`/`4`/`8`/automatic configurations.
 
+## Serial paths(by="prize_collecting_steiner_tree") (#552)
+
+`paths(by="prize_collecting_steiner_tree")` has no parallel crossover. Its
+disposition is **serial exact prize subset search** for every `compute_threads`
+setting, including `1`/`2`/`4`/`8`/automatic policies.
+
+The Rust kernel consumes CSR-native undirected adjacency plus graph-native prize
+properties (#340), checks the exact state-space bound, and enumerates candidate
+edge subsets against one canonical objective. The best feasible tree is selected
+by objective, fewer edges, and edge UUID order, and every candidate observes the
+same global incumbent. Parallel subset workers would require shared incumbent
+coordination and could alter row order, fingerprints, or structured resource
+failures.
+
+The path still uses bounded Arrow output (#341), structured cancellation and
+resource checks, and no process-global Rayon pool. The M4 harness records
+`paths-prize-collecting-steiner-tree` evidence and verifies one-thread parity;
+timing is report-only.
+
 ## Observability
 
 `GraphForge::resource_policy()` and `GraphForge::resource_diagnostics()` expose

--- a/scripts/ci/m4-entry-matrix.py
+++ b/scripts/ci/m4-entry-matrix.py
@@ -24,6 +24,7 @@ REQUIRED_WORKLOAD_IDS = {
     "rank-k-core",
     "analyze-maximum-spanning-tree",
     "paths-min-steiner-tree",
+    "paths-prize-collecting-steiner-tree",
     "paths-bellman-ford",
     "paths-min-cost-max-flow",
     "analyze-minimum-k-spanning-tree",

--- a/tests/contracts/m4-entry-matrix.json
+++ b/tests/contracts/m4-entry-matrix.json
@@ -244,6 +244,23 @@
       ]
     },
     {
+      "id": "paths-prize-collecting-steiner-tree",
+      "class": "serial-steiner-graph-algorithm",
+      "surface": "GraphForge::paths",
+      "short_ci": true,
+      "large_manual": true,
+      "disposition": "serial_exact_prize_subset_search",
+      "structural_gates": [
+        "schema",
+        "row_count",
+        "ordering",
+        "result_fingerprint",
+        "csr_native_projection",
+        "bounded_arrow_sink",
+        "serial_disposition"
+      ]
+    },
+    {
       "id": "paths-bellman-ford",
       "class": "serial-shortest-path-graph-algorithm",
       "surface": "GraphForge::paths",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #552: serial disposition for prize_collecting_steiner_tree.

Closes #552

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788957490&installation_model_id=20486&pr_number=674&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F674&signature=c9619607630ade547675fdff459fedefb013ce2d6cbd2c655b06f2f46edf811d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add serial disposition for `prize_collecting_steiner_tree` paths algorithm
> - Registers `PrizeCollectingSteinerTree` as a serial-only algorithm across all `compute_threads` settings, documented in [execution-resource-policy.md](https://github.com/CurateLabs/graphforge/pull/674/files#diff-978cd3c64399512fe02ce13768a045b47b2b98e5e672d553ee1bb69be7843971) with rationale around incumbent coordination and determinism.
> - Adds `run_paths_prize_collecting_steiner_tree` to the M4 test harness, asserting deterministic output across repeated runs and recording structural evidence (disposition `serial_exact_prize_subset_search`, CSR native projection, bounded Arrow sink).
> - Adds `"paths-prize-collecting-steiner-tree"` to the CI required workload set and the [m4-entry-matrix.json](https://github.com/CurateLabs/graphforge/pull/674/files#diff-c7c779d06f868896c69a9da9fb4e4d4845e561b0809e8ece2e5a446efa038ab6) contract, raising the expected workload count from 16 to 17.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a5be998.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->