### PR TITLE
perf(exec): parallelize modularity on ComputePool (#583)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_analyze_modularity.rs
+++ b/crates/graphforge-exec/src/algorithm_analyze_modularity.rs
@@ -1,13 +1,18 @@
 //! Exact weighted modularity for an explicit graph-layer partition.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::panic::{AssertUnwindSafe, catch_unwind};
 
 use graphforge_core::algorithms::{Algorithm, AnalyzeAlgorithm};
+use rayon::prelude::*;
 
 use crate::algorithm_dispatch::{
     AlgorithmControl, AlgorithmError, AlgorithmLimits, AlgorithmOutput, AlgorithmValue,
 };
 use crate::algorithm_partition::ResolvedPartitionMap;
+
+/// Community counts below this stay serial to avoid private-pool scheduling tax.
+pub(crate) const MODULARITY_PARALLEL_CROSSOVER_COMMUNITIES: usize = 128;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) struct ModularityEdge {
@@ -15,6 +20,12 @@ pub(crate) struct ModularityEdge {
     pub source_uuid: [u8; 16],
     pub target_uuid: [u8; 16],
     pub weight: f64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ModularityExecutionPath {
+    Serial,
+    Parallel { threads: usize, chunks: usize },
 }
 
 /// Compute classic weighted undirected modularity at fixed resolution 1.0.
@@ -115,16 +126,50 @@ pub(crate) fn modularity(
         add_string(&mut volumes, partition, degree)?;
     }
 
+    let contributions = match select_modularity_path(control, community_order.len()) {
+        ModularityExecutionPath::Serial => modularity_contributions_serial(
+            &community_order,
+            &internal_weights,
+            &volumes,
+            total_weight,
+            two_m,
+            control,
+            &mut work,
+        )?,
+        ModularityExecutionPath::Parallel { .. } => modularity_contributions_parallel(
+            &community_order,
+            &internal_weights,
+            &volumes,
+            total_weight,
+            two_m,
+            control,
+        )?,
+    };
     let mut score = 0.0;
-    for partition in community_order {
-        checkpoint(control, &mut work)?;
-        let internal = internal_weights[&partition];
-        let volume_ratio = volumes[&partition] / two_m;
-        let contribution = finite(internal / total_weight - volume_ratio * volume_ratio)?;
+    for contribution in contributions {
         score = finite(score + contribution)?;
     }
     control.check_cancelled()?;
     finite(score)
+}
+
+pub(crate) fn select_modularity_path(
+    control: &AlgorithmControl,
+    communities: usize,
+) -> ModularityExecutionPath {
+    let threads = control.compute_threads();
+    if threads <= 1
+        || communities < MODULARITY_PARALLEL_CROSSOVER_COMMUNITIES
+        || control
+            .compute_pool()
+            .is_none_or(|pool| !pool.is_parallel())
+    {
+        return ModularityExecutionPath::Serial;
+    }
+    ModularityExecutionPath::Parallel {
+        threads,
+        chunks: community_chunks(communities, threads).len(),
+    }
 }
 
 /// Shape the stable scalar result owned by the modularity contract.
@@ -154,6 +199,118 @@ fn communities_by_minimum_uuid(partitions: &ResolvedPartitionMap) -> Vec<String>
             seen.insert(partition.clone()).then_some(partition)
         })
         .collect()
+}
+
+fn modularity_contributions_serial(
+    community_order: &[String],
+    internal_weights: &BTreeMap<String, f64>,
+    volumes: &BTreeMap<String, f64>,
+    total_weight: f64,
+    two_m: f64,
+    control: &AlgorithmControl,
+    work: &mut usize,
+) -> Result<Vec<f64>, AlgorithmError> {
+    let mut contributions = Vec::with_capacity(community_order.len());
+    for partition in community_order {
+        checkpoint(control, work)?;
+        contributions.push(modularity_contribution(
+            partition,
+            internal_weights,
+            volumes,
+            total_weight,
+            two_m,
+        )?);
+    }
+    Ok(contributions)
+}
+
+fn modularity_contributions_parallel(
+    community_order: &[String],
+    internal_weights: &BTreeMap<String, f64>,
+    volumes: &BTreeMap<String, f64>,
+    total_weight: f64,
+    two_m: f64,
+    control: &AlgorithmControl,
+) -> Result<Vec<f64>, AlgorithmError> {
+    let pool = control
+        .compute_pool()
+        .ok_or_else(|| execution("parallel modularity requires an instance-owned compute pool"))?;
+    let ranges = community_chunks(community_order.len(), control.compute_threads());
+    let mut chunk_results = run_on_pool(pool, || {
+        Ok(ranges
+            .par_iter()
+            .map(|&(start, end)| {
+                let result = (|| {
+                    control.check_cancelled()?;
+                    let mut work = 0_usize;
+                    let mut local = Vec::with_capacity(end - start);
+                    for partition in &community_order[start..end] {
+                        checkpoint(control, &mut work)?;
+                        local.push(modularity_contribution(
+                            partition,
+                            internal_weights,
+                            volumes,
+                            total_weight,
+                            two_m,
+                        )?);
+                    }
+                    Ok(local)
+                })();
+                (start, result)
+            })
+            .collect::<Vec<(usize, Result<Vec<f64>, AlgorithmError>)>>())
+    })?;
+    chunk_results.sort_unstable_by_key(|(start, _)| *start);
+    let mut contributions = Vec::with_capacity(community_order.len());
+    for (_, chunk) in chunk_results {
+        contributions.extend(chunk?);
+    }
+    Ok(contributions)
+}
+
+fn modularity_contribution(
+    partition: &str,
+    internal_weights: &BTreeMap<String, f64>,
+    volumes: &BTreeMap<String, f64>,
+    total_weight: f64,
+    two_m: f64,
+) -> Result<f64, AlgorithmError> {
+    let internal = internal_weights[partition];
+    let volume_ratio = volumes[partition] / two_m;
+    finite(internal / total_weight - volume_ratio * volume_ratio)
+}
+
+fn community_chunks(len: usize, threads: usize) -> Vec<(usize, usize)> {
+    if len == 0 {
+        return Vec::new();
+    }
+    let workers = threads.clamp(1, len);
+    let base = len / workers;
+    let rem = len % workers;
+    let mut chunks = Vec::with_capacity(workers);
+    let mut start = 0;
+    for index in 0..workers {
+        let chunk_len = base + usize::from(index < rem);
+        let end = start + chunk_len;
+        if start < end {
+            chunks.push((start, end));
+        }
+        start = end;
+    }
+    chunks
+}
+
+fn run_on_pool<R>(
+    pool: &crate::ComputePool,
+    op: impl FnOnce() -> Result<R, AlgorithmError> + Send,
+) -> Result<R, AlgorithmError>
+where
+    R: Send,
+{
+    match catch_unwind(AssertUnwindSafe(|| pool.install(op))) {
+        Ok(result) => result,
+        Err(_) => Err(execution("modularity worker panicked")),
+    }
 }
 
 fn add(
@@ -209,11 +366,17 @@ mod tests {
     use crate::algorithm_dispatch::{AlgorithmCancellation, AlgorithmLimits};
     use crate::algorithm_output::shape_algorithm_output;
     use crate::algorithm_partition::PartitionValue;
+    use crate::compute_pool::ComputePool;
     use arrow::array::Float64Array;
     use arrow::datatypes::DataType;
+    use std::sync::Arc;
 
     fn uuid(value: u8) -> [u8; 16] {
         [value; 16]
+    }
+
+    fn wide_uuid(value: u128) -> [u8; 16] {
+        value.to_be_bytes()
     }
 
     fn edge(id: u8, source: u8, target: u8, weight: f64) -> ModularityEdge {
@@ -221,6 +384,15 @@ mod tests {
             edge_uuid: uuid(id),
             source_uuid: uuid(source),
             target_uuid: uuid(target),
+            weight,
+        }
+    }
+
+    fn wide_edge(id: u128, source: usize, target: usize, weight: f64) -> ModularityEdge {
+        ModularityEdge {
+            edge_uuid: wide_uuid(id),
+            source_uuid: wide_uuid(source as u128),
+            target_uuid: wide_uuid(target as u128),
             weight,
         }
     }
@@ -246,6 +418,43 @@ mod tests {
 
     fn control() -> AlgorithmControl {
         AlgorithmControl::new(AlgorithmLimits::default(), AlgorithmCancellation::default())
+    }
+
+    fn control_with_threads(threads: usize) -> AlgorithmControl {
+        AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(threads),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(Arc::new(ComputePool::new(threads).unwrap()))
+    }
+
+    fn singleton_fixture(
+        nodes: usize,
+    ) -> (Vec<[u8; 16]>, Vec<ModularityEdge>, ResolvedPartitionMap) {
+        let node_ids = (0..nodes)
+            .map(|node| wide_uuid(node as u128))
+            .collect::<Vec<_>>();
+        let edges = (0..nodes - 1)
+            .map(|source| {
+                wide_edge(
+                    10_000 + source as u128,
+                    source,
+                    source + 1,
+                    1.0 + (source % 7) as f64,
+                )
+            })
+            .collect::<Vec<_>>();
+        let partitions = ResolvedPartitionMap::try_new(
+            node_ids.iter().copied(),
+            (0..nodes).map(|node| {
+                (
+                    wide_uuid(node as u128),
+                    PartitionValue::String(format!("p{node:04}")),
+                )
+            }),
+        )
+        .unwrap();
+        (node_ids, edges, partitions)
     }
 
     fn run(
@@ -378,6 +587,58 @@ mod tests {
             "1"
         );
         assert!(modularity_output(f64::NAN).is_err());
+    }
+
+    #[test]
+    fn path_selection_respects_crossover_and_private_pool() {
+        let serial = control_with_threads(1);
+        assert_eq!(
+            select_modularity_path(&serial, MODULARITY_PARALLEL_CROSSOVER_COMMUNITIES),
+            ModularityExecutionPath::Serial
+        );
+        let below = control_with_threads(4);
+        assert_eq!(
+            select_modularity_path(&below, MODULARITY_PARALLEL_CROSSOVER_COMMUNITIES - 1),
+            ModularityExecutionPath::Serial
+        );
+        let no_pool = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(4),
+            AlgorithmCancellation::default(),
+        );
+        assert_eq!(
+            select_modularity_path(&no_pool, MODULARITY_PARALLEL_CROSSOVER_COMMUNITIES),
+            ModularityExecutionPath::Serial
+        );
+        assert_eq!(
+            select_modularity_path(
+                &control_with_threads(4),
+                MODULARITY_PARALLEL_CROSSOVER_COMMUNITIES
+            ),
+            ModularityExecutionPath::Parallel {
+                threads: 4,
+                chunks: 4
+            }
+        );
+    }
+
+    #[test]
+    fn thread_matrix_preserves_modularity_score_bits() {
+        let (nodes, edges, partitions) = singleton_fixture(192);
+        let serial =
+            modularity(&nodes, &edges, false, &partitions, &control_with_threads(1)).unwrap();
+        for threads in [2_usize, 4, 8] {
+            let control = control_with_threads(threads);
+            assert!(matches!(
+                select_modularity_path(&control, 192),
+                ModularityExecutionPath::Parallel { .. }
+            ));
+            assert_eq!(
+                modularity(&nodes, &edges, false, &partitions, &control)
+                    .unwrap()
+                    .to_bits(),
+                serial.to_bits()
+            );
+        }
     }
 
     #[test]

--- a/crates/graphforge-exec/src/algorithm_analyze_modularity.rs
+++ b/crates/graphforge-exec/src/algorithm_analyze_modularity.rs
@@ -29,6 +29,10 @@ pub(crate) enum ModularityExecutionPath {
 }
 
 /// Compute classic weighted undirected modularity at fixed resolution 1.0.
+#[allow(
+    clippy::too_many_lines,
+    reason = "serial and parallel modularity paths share one validated entrypoint"
+)]
 pub(crate) fn modularity(
     nodes: &[[u8; 16]],
     edges: &[ModularityEdge],

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -1037,6 +1037,28 @@ resource errors, and bounded Arrow shaping. Schemas, row order, community IDs,
 projection fingerprints, cancellation, and limit behavior match the one-thread
 oracle at supported `1`/`2`/`4`/`8`/automatic configurations.
 
+
+## Parallel modularity community contributions (#583)
+
+`analyze(by="modularity")` keeps weighted edge normalization, degree
+accumulation, internal-weight accumulation, total edge weight, volume
+accumulation, and the final modularity score reduction serial. Those stages
+contain floating-point additions whose order is part of the accepted bit-level
+contract. After the serial accumulators are complete, each community contribution
+is independent and can be evaluated on the instance-owned private compute pool
+when:
+
+- `compute_threads > 1`, and
+- normalized communities are at least
+  `MODULARITY_PARALLEL_CROSSOVER_COMMUNITIES` (`128`) in `graphforge-exec`.
+
+Below that crossover, or when the policy provides one compute thread, modularity
+stays fully serial. Parallel workers compute contribution values for canonical
+community ranges; the values merge by ascending range and are then summed by the
+same serial community order used by the one-thread path. Schemas, scalar row
+shape, score bits, structured errors, and fingerprints match the one-thread
+result at `1`/`2`/`4`/`8`/automatic configurations.
+
 ## Observability
 
 `GraphForge::resource_policy()` and `GraphForge::resource_diagnostics()` expose


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #583: parallel modularity on ComputePool.

Closes #583

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788957507&installation_model_id=20486&pr_number=675&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F675&signature=c219d8a8919bcbef15faa7aff6d48c360e4cb84ffcf91d67d0fc498c5b760888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parallelize modularity community contribution computation on `ComputePool`
> - Adds a parallel execution path to the `modularity` function in [algorithm_analyze_modularity.rs](https://github.com/CurateLabs/graphforge/pull/675/files#diff-33f52509afc18c5049cda7a764564ac250a7a64953a1618d23b5c1e07b004e7c) that distributes per-community contribution calculations across a rayon-backed `ComputePool` using `pool.install`.
> - Parallelism activates when `compute_threads > 1`, an instance-owned pool is available, and community count is at or above the new `MODULARITY_PARALLEL_CROSSOVER_COMMUNITIES` threshold of 128; otherwise execution stays serial.
> - Results are collected as `(start_index, Vec<f64>)` pairs, sorted by start index, and flattened to preserve deterministic output order.
> - Worker panics are caught via `catch_unwind` in `run_on_pool` and returned as a structured `AlgorithmError` instead of unwinding.
> - Risk: parallel results must be bit-identical to serial; this is validated by the new `thread_matrix_preserves_modularity_score_bits` test, but any future change to floating-point accumulation order could silently break parity.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f029b6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->