### PR TITLE
perf(exec): parallelize transitivity on ComputePool (#586)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_analyze_transitivity.rs
+++ b/crates/graphforge-exec/src/algorithm_analyze_transitivity.rs
@@ -1,8 +1,13 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+use rayon::prelude::*;
 
 use crate::algorithm_dispatch::{AlgorithmControl, AlgorithmError};
 
 const CHECKPOINT_INTERVAL: usize = 4_096;
+/// Wedges below this count stay serial to avoid private-pool scheduling tax.
+pub(crate) const TRANSITIVITY_PARALLEL_CROSSOVER_WEDGES: u64 = 32_768;
 
 /// One stored edge entry in the selected UUID projection.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -10,6 +15,12 @@ pub(crate) struct TransitivityEdge {
     pub edge: [u8; 16],
     pub source: [u8; 16],
     pub target: [u8; 16],
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TransitivityExecutionPath {
+    Serial,
+    Parallel { threads: usize, chunks: usize },
 }
 
 impl TransitivityEdge {
@@ -36,8 +47,34 @@ pub(crate) fn transitivity(
     if wedges == 0 {
         return Ok(0.0);
     }
-    let triangles = count_triangles(&neighbors, control, &mut work)?;
+    let triangles = match select_transitivity_path(control, neighbors.len(), wedges) {
+        TransitivityExecutionPath::Serial => count_triangles(&neighbors, control, &mut work)?,
+        TransitivityExecutionPath::Parallel { .. } => {
+            count_triangles_parallel(&neighbors, control)?
+        }
+    };
     ratio(triangles, wedges)
+}
+
+pub(crate) fn select_transitivity_path(
+    control: &AlgorithmControl,
+    nodes: usize,
+    wedges: u64,
+) -> TransitivityExecutionPath {
+    let threads = control.compute_threads();
+    if threads <= 1
+        || nodes < 3
+        || wedges < TRANSITIVITY_PARALLEL_CROSSOVER_WEDGES
+        || control
+            .compute_pool()
+            .is_none_or(|pool| !pool.is_parallel())
+    {
+        return TransitivityExecutionPath::Serial;
+    }
+    TransitivityExecutionPath::Parallel {
+        threads,
+        chunks: source_chunks(nodes, threads).len(),
+    }
 }
 
 fn ratio(triangles: u64, wedges: u64) -> Result<f64, AlgorithmError> {
@@ -132,8 +169,48 @@ fn count_triangles(
     control: &AlgorithmControl,
     work: &mut usize,
 ) -> Result<u64, AlgorithmError> {
+    count_triangles_range(0, neighbors.len(), neighbors, control, work)
+}
+
+fn count_triangles_parallel(
+    neighbors: &[BTreeSet<usize>],
+    control: &AlgorithmControl,
+) -> Result<u64, AlgorithmError> {
+    let pool = control.compute_pool().ok_or_else(|| {
+        execution("parallel transitivity requires an instance-owned compute pool")
+    })?;
+    let ranges = source_chunks(neighbors.len(), control.compute_threads());
+    let mut chunk_results = run_on_pool(pool, || {
+        Ok(ranges
+            .par_iter()
+            .map(|&(start, end)| {
+                let mut work = 0_usize;
+                (
+                    start,
+                    count_triangles_range(start, end, neighbors, control, &mut work),
+                )
+            })
+            .collect::<Vec<_>>())
+    })?;
+    chunk_results.sort_unstable_by_key(|(start, _)| *start);
     let mut triangles = 0_u64;
-    for source in 0..neighbors.len() {
+    for (_, chunk) in chunk_results {
+        triangles = triangles
+            .checked_add(chunk?)
+            .ok_or_else(|| execution("transitivity triangle count exceeds supported range"))?;
+    }
+    Ok(triangles)
+}
+
+fn count_triangles_range(
+    start: usize,
+    end: usize,
+    neighbors: &[BTreeSet<usize>],
+    control: &AlgorithmControl,
+    work: &mut usize,
+) -> Result<u64, AlgorithmError> {
+    let mut triangles = 0_u64;
+    for source in start..end {
         checkpoint(control, work)?;
         for &middle in neighbors[source].range(source.saturating_add(1)..) {
             for &target in neighbors[middle].range(middle.saturating_add(1)..) {
@@ -147,6 +224,39 @@ fn count_triangles(
         }
     }
     Ok(triangles)
+}
+
+fn source_chunks(len: usize, threads: usize) -> Vec<(usize, usize)> {
+    if len == 0 {
+        return Vec::new();
+    }
+    let workers = threads.clamp(1, len);
+    let base = len / workers;
+    let rem = len % workers;
+    let mut chunks = Vec::with_capacity(workers);
+    let mut start = 0;
+    for index in 0..workers {
+        let chunk_len = base + usize::from(index < rem);
+        let end = start + chunk_len;
+        if start < end {
+            chunks.push((start, end));
+        }
+        start = end;
+    }
+    chunks
+}
+
+fn run_on_pool<R>(
+    pool: &crate::ComputePool,
+    op: impl FnOnce() -> Result<R, AlgorithmError> + Send,
+) -> Result<R, AlgorithmError>
+where
+    R: Send,
+{
+    match catch_unwind(AssertUnwindSafe(|| pool.install(op))) {
+        Ok(result) => result,
+        Err(_) => Err(execution("transitivity worker panicked")),
+    }
 }
 
 fn checkpoint(control: &AlgorithmControl, work: &mut usize) -> Result<(), AlgorithmError> {
@@ -169,9 +279,15 @@ fn execution(message: impl Into<String>) -> AlgorithmError {
 mod tests {
     use super::*;
     use crate::algorithm_dispatch::{AlgorithmCancellation, AlgorithmLimits};
+    use crate::compute_pool::ComputePool;
+    use std::sync::Arc;
 
     fn uuid(value: u8) -> [u8; 16] {
         [value; 16]
+    }
+
+    fn wide_uuid(value: u128) -> [u8; 16] {
+        value.to_be_bytes()
     }
 
     fn edge(id: u8, source: u8, target: u8) -> TransitivityEdge {
@@ -184,6 +300,33 @@ mod tests {
 
     fn control() -> AlgorithmControl {
         AlgorithmControl::new(AlgorithmLimits::default(), AlgorithmCancellation::default())
+    }
+
+    fn control_with_threads(threads: usize) -> AlgorithmControl {
+        AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(threads),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(Arc::new(ComputePool::new(threads).unwrap()))
+    }
+
+    fn complete_graph_fixture(nodes: usize) -> (Vec<[u8; 16]>, Vec<TransitivityEdge>) {
+        let nodes = (0..nodes)
+            .map(|node| wide_uuid(node as u128))
+            .collect::<Vec<_>>();
+        let mut edges = Vec::new();
+        let mut edge_id = 1_u128;
+        for source in 0..nodes.len() {
+            for target in source + 1..nodes.len() {
+                edges.push(TransitivityEdge {
+                    edge: wide_uuid(edge_id),
+                    source: nodes[source],
+                    target: nodes[target],
+                });
+                edge_id += 1;
+            }
+        }
+        (nodes, edges)
     }
 
     #[test]
@@ -235,6 +378,57 @@ mod tests {
             let value = transitivity(&nodes, &edges, &control()).unwrap();
             assert_eq!(value, 0.0);
             assert!(value.is_finite());
+        }
+    }
+
+    #[test]
+    fn path_selection_respects_crossover_and_private_pool() {
+        let serial = control_with_threads(1);
+        assert_eq!(
+            select_transitivity_path(&serial, 128, TRANSITIVITY_PARALLEL_CROSSOVER_WEDGES),
+            TransitivityExecutionPath::Serial
+        );
+        let below = control_with_threads(4);
+        assert_eq!(
+            select_transitivity_path(&below, 128, TRANSITIVITY_PARALLEL_CROSSOVER_WEDGES - 1),
+            TransitivityExecutionPath::Serial
+        );
+        let no_pool = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(4),
+            AlgorithmCancellation::default(),
+        );
+        assert_eq!(
+            select_transitivity_path(&no_pool, 128, TRANSITIVITY_PARALLEL_CROSSOVER_WEDGES),
+            TransitivityExecutionPath::Serial
+        );
+        assert_eq!(
+            select_transitivity_path(
+                &control_with_threads(4),
+                128,
+                TRANSITIVITY_PARALLEL_CROSSOVER_WEDGES
+            ),
+            TransitivityExecutionPath::Parallel {
+                threads: 4,
+                chunks: 4
+            }
+        );
+    }
+
+    #[test]
+    fn thread_matrix_preserves_complete_graph_ratio_bits() {
+        let (nodes, edges) = complete_graph_fixture(128);
+        let serial = transitivity(&nodes, &edges, &control_with_threads(1)).unwrap();
+        assert_eq!(serial, 1.0);
+        for threads in [2_usize, 4, 8] {
+            let control = control_with_threads(threads);
+            assert!(matches!(
+                select_transitivity_path(&control, nodes.len(), 1_024_128),
+                TransitivityExecutionPath::Parallel { .. }
+            ));
+            assert_eq!(
+                transitivity(&nodes, &edges, &control).unwrap().to_bits(),
+                serial.to_bits()
+            );
         }
     }
 

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -83,6 +83,14 @@ Components merges worker-local forests in canonical source-range order, and
 Node2Vec skip-gram training stays serial, so fingerprints match the one-thread
 path.
 
+(#342), PageRank (#343), Node2Vec walk-corpus generation (#344), and transitivity
+triangle counting (#586) may partition independent work across that pool above
+documented crossovers; work never uses Rayon's process-global pool. Cosine dot
+products retain serial coordinate order, PageRank keeps canonical contribution
+order with serial dangling/delta reductions, Node2Vec skip-gram training stays
+serial, and transitivity merges integer triangle counts in canonical source-range
+order, so fingerprints match the one-thread path.
+
 ## Parallel cosine KNN (#342)
 
 Exact, all-score, and filtered cosine partition **independent source rows**
@@ -261,6 +269,25 @@ IDs are still assigned by canonical node order, so schemas, row order, labels,
 and fingerprints match the one-thread result at `1`/`2`/`4`/`8`/automatic
 configurations. Cancellation remains cooperative both before worker launch and
 inside chunk scans.
+
+## Parallel transitivity triangle counting (#586)
+
+`analyze(by="transitivity")` keeps UUID indexing, undirected simple-neighbor
+normalization, and the wedge denominator serial. Those steps validate duplicate
+edge UUIDs, self-loops, endpoint membership, and the zero-wedge early return
+before any pool scheduling. The triangle-closure scan then partitions independent
+source-ordinal ranges across the instance-owned private compute pool when:
+
+- `compute_threads > 1`, and
+- closed-wedge candidates are at least
+  `TRANSITIVITY_PARALLEL_CROSSOVER_WEDGES` (`32_768`) in `graphforge-exec`.
+
+Below that crossover, or when the policy provides one compute thread,
+transitivity stays serial. Parallel workers return local `u64` triangle counts;
+chunks merge in ascending source-range order before the single final `3T / wedge`
+floating-point division. Schemas, scalar row shape, ratio bits, structured
+errors, and fingerprints match the one-thread result at `1`/`2`/`4`/`8`/automatic
+configurations.
 
 ## Observability
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #586: parallel transitivity on ComputePool.

Closes #586

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788957507&installation_model_id=20486&pr_number=676&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F676&signature=fef2243cbd3883de8d1d748235500f791afe190ed79ec6afebcedd50d0524689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parallelize transitivity triangle counting on ComputePool
> - Adds parallel triangle counting in [algorithm_analyze_transitivity.rs](https://github.com/CurateLabs/graphforge/pull/676/files#diff-6cb734f72c5ab3696e7d2918df1344a25b16cfe2f905df95799d23a001881527) via a new `count_triangles_parallel` function that splits source vertices into chunks and runs them on the instance-owned `ComputePool` using rayon.
> - Parallel execution is selected when `compute_threads > 1`, node count ≥ 3, wedge count ≥ 32,768 (`TRANSITIVITY_PARALLEL_CROSSOVER_WEDGES`), and a parallel compute pool is present; otherwise falls back to serial.
> - Worker panics are caught via `catch_unwind` and converted to a structured `AlgorithmError` rather than unwinding across the thread boundary.
> - Updates [execution-resource-policy.md](https://github.com/CurateLabs/graphforge/pull/676/files#diff-978cd3c64399512fe02ce13768a045b47b2b98e5e672d553ee1bb69be7843971) to document transitivity as a parallelized algorithm with the crossover threshold and chunking behavior.
> - Behavioral Change: graphs with ≥ 32,768 wedges will now execute triangle counting in parallel by default when a parallel compute pool is configured.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a4b8685.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->