### PR TITLE
perf(exec): serial disposition for minimum_k_spanning_tree (#581)

### DIFF
--- a/crates/graphforge-api/tests/m4_entry_baseline.rs
+++ b/crates/graphforge-api/tests/m4_entry_baseline.rs
@@ -17,9 +17,9 @@ use arrow::array::FixedSizeBinaryArray;
 use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
 use graphforge_api::{
-    CancellationToken, EmbeddingAnalyzeOptions, EmbeddingOptions, ExecutionResourcePolicy,
-    GraphForge, GraphForgeOptions, Node2VecOptions, NodeSelector, PathsOptions, PropValue,
-    RankOptions, ResourcePolicyMode, SimilarOptions, SpillPolicy,
+    AnalyzeOptions, CancellationToken, EmbeddingAnalyzeOptions, EmbeddingOptions,
+    ExecutionResourcePolicy, GraphForge, GraphForgeOptions, Node2VecOptions, NodeSelector,
+    PathsOptions, PropValue, RankOptions, ResourcePolicyMode, SimilarOptions, SpillPolicy,
 };
 use graphforge_core::algorithms::{
     AnalyzeAlgorithm, PathAlgorithm, RankAlgorithm, SimilarAlgorithm,
@@ -435,6 +435,14 @@ fn collect_workloads_for(gf: &GraphForge) -> Vec<WorkloadEvidence> {
             ev
         },
         {
+            let ev = run_analyze_minimum_k_spanning_tree(gf);
+            assert!(
+                ev.output_rows > 0,
+                "analyze-minimum-k-spanning-tree must produce rows"
+            );
+            ev
+        },
+        {
             let ev = run_knn(gf);
             assert!(ev.output_rows > 0, "knn must produce rows");
             ev
@@ -759,6 +767,55 @@ fn run_paths_min_cost_max_flow(gf: &GraphForge) -> WorkloadEvidence {
     }
 }
 
+fn run_analyze_minimum_k_spanning_tree(gf: &GraphForge) -> WorkloadEvidence {
+    let options = AnalyzeOptions {
+        by: AnalyzeAlgorithm::MinimumKSpanningTree,
+        via: None,
+        directed: false,
+        weight: Some("cost".into()),
+        k: Some(2),
+        partition_property: None,
+    };
+    let before_rss = peak_rss_bytes();
+    let started = Instant::now();
+    let first = gf
+        .analyze(Some("Person"), options.clone())
+        .expect("minimum_k_spanning_tree");
+    let second = gf
+        .analyze(Some("Person"), options)
+        .expect("minimum_k_spanning_tree repeat");
+    let wall_time_ms = started.elapsed().as_secs_f64() * 1_000.0;
+    assert_logical_batch_equal(
+        &first,
+        &second,
+        "minimum_k_spanning_tree must be deterministic",
+    );
+    let fingerprint = batch_structural_fingerprint(std::slice::from_ref(&first));
+    WorkloadEvidence {
+        id: "analyze-minimum-k-spanning-tree",
+        schema_fields: schema_field_names(first.schema().as_ref()),
+        output_rows: first.num_rows() as u64,
+        fingerprint,
+        wall_time_ms,
+        peak_rss_bytes: peak_rss_bytes().or(before_rss),
+        structural: BTreeMap::from([
+            ("surface", serde_json::json!("GraphForge::analyze")),
+            ("algorithm", serde_json::json!("minimum_k_spanning_tree")),
+            (
+                "disposition",
+                serde_json::json!("serial_exact_k_spanning_tree_enumeration"),
+            ),
+            (
+                "work_units",
+                serde_json::json!("ordered_combination_search_and_top_k_tree_set"),
+            ),
+            ("threads_path", serde_json::json!("serial_for_all_policies")),
+            ("csr_native_projection", serde_json::json!(true)),
+            ("bounded_arrow_sink", serde_json::json!(true)),
+        ]),
+    }
+}
+
 fn run_knn(gf: &GraphForge) -> WorkloadEvidence {
     let options = SimilarOptions {
         by: SimilarAlgorithm::Knn,
@@ -908,6 +965,14 @@ fn collect_short_matrix() -> (serde_json::Value, Vec<WorkloadEvidence>) {
             ev
         },
         {
+            let ev = run_analyze_minimum_k_spanning_tree(&gf);
+            assert!(
+                ev.output_rows > 0,
+                "analyze-minimum-k-spanning-tree must produce rows"
+            );
+            ev
+        },
+        {
             let ev = run_knn(&gf);
             assert!(ev.output_rows > 0, "knn must produce rows");
             ev
@@ -956,7 +1021,7 @@ fn build_evidence(
 #[test]
 fn short_ci_matrix_runs_through_public_facade_under_fixed_two_workers() {
     let (contract, workloads) = collect_short_matrix();
-    assert_eq!(workloads.len(), 10);
+    assert_eq!(workloads.len(), 11);
     let ids: Vec<_> = workloads.iter().map(|w| w.id).collect();
     assert_eq!(
         ids,
@@ -969,6 +1034,7 @@ fn short_ci_matrix_runs_through_public_facade_under_fixed_two_workers() {
             "paths-min-steiner-tree",
             "paths-bellman-ford",
             "paths-min-cost-max-flow",
+            "analyze-minimum-k-spanning-tree",
             "exact-cosine-knn",
             "node2vec"
         ]

--- a/crates/graphforge-exec/src/algorithm_analyze_minimum_k_spanning_tree.rs
+++ b/crates/graphforge-exec/src/algorithm_analyze_minimum_k_spanning_tree.rs
@@ -1,3 +1,7 @@
+//! Minimum-k spanning tree enumeration remains serial (#581). The exact
+//! combination search updates one canonical top-k set ordered by total weight
+//! and edge UUIDs, so workers would contend on public tie state.
+
 use crate::algorithm_dispatch::{AlgorithmControl, AlgorithmError};
 use crate::algorithm_weighted_undirected::{WeightedEdge, normalize_weighted_undirected};
 use std::cmp::Ordering;

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -887,6 +887,24 @@ Evidence is carried by:
 
 
 There is no crossover for SCC in M4: the documented disposition is `serial_tarjan`. Timing remains hardware-specific evidence, never a CI pass/fail gate.
+## Serial analyze(by="minimum_k_spanning_tree") (#581)
+
+`analyze(by="minimum_k_spanning_tree")` has no parallel crossover. Its
+disposition is **serial exact k-spanning-tree enumeration** for every
+`compute_threads` setting, including `1`/`2`/`4`/`8`/automatic policies.
+
+The Rust kernel consumes CSR-native weighted undirected adjacency (#340),
+normalizes candidates, then explores edge combinations while maintaining one
+canonical top-k tree set ordered by total weight and edge UUID sequence. Every
+accepted candidate can replace the current worst tree, so parallel enumeration
+would require shared top-k coordination and could alter tie order, resource
+errors, or fingerprints.
+
+The path still uses bounded Arrow output (#341), structured cancellation and
+resource checks, and no process-global Rayon pool. The M4 harness records
+`analyze-minimum-k-spanning-tree` evidence and verifies one-thread parity;
+timing is report-only.
+
 ## Observability
 
 `GraphForge::resource_policy()` and `GraphForge::resource_diagnostics()` expose

--- a/scripts/ci/m4-entry-matrix.py
+++ b/scripts/ci/m4-entry-matrix.py
@@ -22,6 +22,7 @@ REQUIRED_WORKLOAD_IDS = {
     "paths-min-steiner-tree",
     "paths-bellman-ford",
     "paths-min-cost-max-flow",
+    "analyze-minimum-k-spanning-tree",
     "exact-cosine-knn",
     "node2vec",
 }

--- a/tests/contracts/m4-entry-matrix.json
+++ b/tests/contracts/m4-entry-matrix.json
@@ -211,6 +211,23 @@
       ]
     },
     {
+      "id": "analyze-minimum-k-spanning-tree",
+      "class": "serial-k-spanning-tree-graph-algorithm",
+      "surface": "GraphForge::analyze",
+      "short_ci": true,
+      "large_manual": true,
+      "disposition": "serial_exact_k_spanning_tree_enumeration",
+      "structural_gates": [
+        "schema",
+        "row_count",
+        "ordering",
+        "result_fingerprint",
+        "csr_native_projection",
+        "bounded_arrow_sink",
+        "serial_disposition"
+      ]
+    },
+    {
       "id": "exact-cosine-knn",
       "class": "exact-vector-search",
       "surface": "GraphForge::similar",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #581: serial disposition for minimum_k_spanning_tree.

Closes #581

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788957507&installation_model_id=20486&pr_number=677&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F677&signature=1d4523eaecec16cde42cd223cf09c14dffe103a9b786951655129726b1124a81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add serial disposition for `minimum_k_spanning_tree` to the M4 baseline harness
> - Adds a new `run_analyze_minimum_k_spanning_tree` workload to the M4 entry baseline that calls `GraphForge::analyze` with `MinimumKSpanningTree`, verifies determinism, and records timing, memory, and a result fingerprint.
> - Documents that `minimum_k_spanning_tree` runs serially across all `compute_threads` policies due to contention on shared top-k state in [execution-resource-policy.md](https://github.com/CurateLabs/graphforge/pull/677/files#diff-978cd3c64399512fe02ce13768a045b47b2b98e5e672d553ee1bb69be7843971).
> - Registers `analyze-minimum-k-spanning-tree` in the CI matrix validation set and the [m4-entry-matrix.json](https://github.com/CurateLabs/graphforge/pull/677/files#diff-c7c779d06f868896c69a9da9fb4e4d4845e561b0809e8ece2e5a446efa038ab6) contract with gates for schema, row count, ordering, fingerprint, CSR projection, bounded Arrow sink, and serial disposition.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f5580ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->