### PR TITLE
perf(exec): serial disposition for maximum_spanning_tree (#580)

### DIFF
--- a/crates/graphforge-api/tests/m4_entry_baseline.rs
+++ b/crates/graphforge-api/tests/m4_entry_baseline.rs
@@ -21,6 +21,7 @@ use graphforge_api::{
     GraphForge, GraphForgeOptions, Node2VecOptions, NodeSelector, PathsOptions, PropValue,
     RankOptions, ResourcePolicyMode, SimilarOptions, SpillPolicy,
 };
+use graphforge_core::AnalyzeOptions;
 use graphforge_core::algorithms::{
     AnalyzeAlgorithm, PathAlgorithm, RankAlgorithm, SimilarAlgorithm,
 };

--- a/crates/graphforge-api/tests/m4_entry_baseline.rs
+++ b/crates/graphforge-api/tests/m4_entry_baseline.rs
@@ -1022,7 +1022,7 @@ fn build_evidence(
 #[test]
 fn short_ci_matrix_runs_through_public_facade_under_fixed_two_workers() {
     let (contract, workloads) = collect_short_matrix();
-    assert_eq!(workloads.len(), 10);
+    assert_eq!(workloads.len(), 11);
     let ids: Vec<_> = workloads.iter().map(|w| w.id).collect();
     assert_eq!(
         ids,

--- a/crates/graphforge-api/tests/m4_entry_baseline.rs
+++ b/crates/graphforge-api/tests/m4_entry_baseline.rs
@@ -973,6 +973,7 @@ fn build_evidence(
 fn short_ci_matrix_runs_through_public_facade_under_fixed_two_workers() {
     let (contract, workloads) = collect_short_matrix();
     assert_eq!(workloads.len(), 10);
+    assert_eq!(workloads.len(), 9);
     let ids: Vec<_> = workloads.iter().map(|w| w.id).collect();
     assert_eq!(
         ids,

--- a/crates/graphforge-api/tests/m4_entry_baseline.rs
+++ b/crates/graphforge-api/tests/m4_entry_baseline.rs
@@ -17,9 +17,9 @@ use arrow::array::FixedSizeBinaryArray;
 use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
 use graphforge_api::{
-    AnalyzeOptions, CancellationToken, EmbeddingAnalyzeOptions, EmbeddingOptions,
-    ExecutionResourcePolicy, GraphForge, GraphForgeOptions, Node2VecOptions, NodeSelector,
-    PathsOptions, PropValue, RankOptions, ResourcePolicyMode, SimilarOptions, SpillPolicy,
+    CancellationToken, EmbeddingAnalyzeOptions, EmbeddingOptions, ExecutionResourcePolicy,
+    GraphForge, GraphForgeOptions, Node2VecOptions, NodeSelector, PathsOptions, PropValue,
+    RankOptions, ResourcePolicyMode, SimilarOptions, SpillPolicy,
 };
 use graphforge_core::algorithms::{
     AnalyzeAlgorithm, PathAlgorithm, RankAlgorithm, SimilarAlgorithm,
@@ -662,6 +662,58 @@ fn run_paths_min_steiner_tree(gf: &GraphForge) -> WorkloadEvidence {
     }
 }
 
+fn run_paths_bellman_ford(gf: &GraphForge) -> WorkloadEvidence {
+    let source = person_selector("Alice");
+    let options = PathsOptions {
+        by: PathAlgorithm::BellmanFord,
+        via: None,
+        directed: true,
+        k: 1,
+        weight: Some("cost".into()),
+        capacity_property: None,
+        cost_property: None,
+        heuristic: None,
+        walk_length: None,
+        seed: None,
+        terminal_uuids: Vec::new(),
+        prize_property: None,
+    };
+    let before_rss = peak_rss_bytes();
+    let started = Instant::now();
+    let first = gf
+        .paths(&source, None, options.clone())
+        .expect("bellman_ford");
+    let second = gf
+        .paths(&source, None, options)
+        .expect("bellman_ford repeat");
+    let wall_time_ms = started.elapsed().as_secs_f64() * 1_000.0;
+    assert_logical_batch_equal(&first, &second, "bellman_ford must be deterministic");
+    let fingerprint = batch_structural_fingerprint(std::slice::from_ref(&first));
+    WorkloadEvidence {
+        id: "paths-bellman-ford",
+        schema_fields: schema_field_names(first.schema().as_ref()),
+        output_rows: first.num_rows() as u64,
+        fingerprint,
+        wall_time_ms,
+        peak_rss_bytes: peak_rss_bytes().or(before_rss),
+        structural: BTreeMap::from([
+            ("surface", serde_json::json!("GraphForge::paths")),
+            ("algorithm", serde_json::json!("bellman_ford")),
+            (
+                "disposition",
+                serde_json::json!("serial_ordered_bellman_ford_relaxation"),
+            ),
+            (
+                "work_units",
+                serde_json::json!("ordered_relaxation_rounds_and_negative_cycle_scan"),
+            ),
+            ("threads_path", serde_json::json!("serial_for_all_policies")),
+            ("csr_native_projection", serde_json::json!(true)),
+            ("bounded_arrow_sink", serde_json::json!(true)),
+        ]),
+    }
+}
+
 fn run_analyze_maximum_spanning_tree(gf: &GraphForge) -> WorkloadEvidence {
     let options = AnalyzeOptions {
         by: AnalyzeAlgorithm::MaximumSpanningTree,
@@ -694,17 +746,14 @@ fn run_analyze_maximum_spanning_tree(gf: &GraphForge) -> WorkloadEvidence {
         wall_time_ms,
         peak_rss_bytes: peak_rss_bytes().or(before_rss),
         structural: BTreeMap::from([
-            ("surface", serde_json::json!("GraphForge::paths")),
-            ("algorithm", serde_json::json!("bellman_ford")),
-            (
-                "disposition",
-                serde_json::json!("serial_ordered_bellman_ford_relaxation"),
-            ),
-                "work_units",
-                serde_json::json!("ordered_relaxation_rounds_and_negative_cycle_scan"),
             ("surface", serde_json::json!("GraphForge::analyze")),
             ("algorithm", serde_json::json!("maximum_spanning_tree")),
+            (
+                "disposition",
                 serde_json::json!("serial_kruskal_descending_union_find"),
+            ),
+            (
+                "work_units",
                 serde_json::json!("stable_edge_sort_and_union_find_acceptance"),
             ),
             ("threads_path", serde_json::json!("serial_for_all_policies")),
@@ -973,7 +1022,6 @@ fn build_evidence(
 fn short_ci_matrix_runs_through_public_facade_under_fixed_two_workers() {
     let (contract, workloads) = collect_short_matrix();
     assert_eq!(workloads.len(), 10);
-    assert_eq!(workloads.len(), 9);
     let ids: Vec<_> = workloads.iter().map(|w| w.id).collect();
     assert_eq!(
         ids,

--- a/crates/graphforge-api/tests/m4_entry_baseline.rs
+++ b/crates/graphforge-api/tests/m4_entry_baseline.rs
@@ -417,6 +417,14 @@ fn collect_workloads_for(gf: &GraphForge) -> Vec<WorkloadEvidence> {
             ev
         },
         {
+            let ev = run_analyze_maximum_spanning_tree(gf);
+            assert!(
+                ev.output_rows > 0,
+                "analyze-maximum-spanning-tree must produce rows"
+            );
+            ev
+        },
+        {
             let ev = run_paths_min_steiner_tree(gf);
             assert!(
                 ev.output_rows > 0,
@@ -654,35 +662,32 @@ fn run_paths_min_steiner_tree(gf: &GraphForge) -> WorkloadEvidence {
     }
 }
 
-fn run_paths_bellman_ford(gf: &GraphForge) -> WorkloadEvidence {
-    let source = person_selector("Alice");
-    let options = PathsOptions {
-        by: PathAlgorithm::BellmanFord,
+fn run_analyze_maximum_spanning_tree(gf: &GraphForge) -> WorkloadEvidence {
+    let options = AnalyzeOptions {
+        by: AnalyzeAlgorithm::MaximumSpanningTree,
         via: None,
-        directed: true,
-        k: 1,
+        directed: false,
         weight: Some("cost".into()),
-        capacity_property: None,
-        cost_property: None,
-        heuristic: None,
-        walk_length: None,
-        seed: None,
-        terminal_uuids: Vec::new(),
-        prize_property: None,
+        k: None,
+        partition_property: None,
     };
     let before_rss = peak_rss_bytes();
     let started = Instant::now();
     let first = gf
-        .paths(&source, None, options.clone())
-        .expect("bellman_ford");
+        .analyze(Some("Person"), options.clone())
+        .expect("maximum_spanning_tree");
     let second = gf
-        .paths(&source, None, options)
-        .expect("bellman_ford repeat");
+        .analyze(Some("Person"), options)
+        .expect("maximum_spanning_tree repeat");
     let wall_time_ms = started.elapsed().as_secs_f64() * 1_000.0;
-    assert_logical_batch_equal(&first, &second, "bellman_ford must be deterministic");
+    assert_logical_batch_equal(
+        &first,
+        &second,
+        "maximum_spanning_tree must be deterministic",
+    );
     let fingerprint = batch_structural_fingerprint(std::slice::from_ref(&first));
     WorkloadEvidence {
-        id: "paths-bellman-ford",
+        id: "analyze-maximum-spanning-tree",
         schema_fields: schema_field_names(first.schema().as_ref()),
         output_rows: first.num_rows() as u64,
         fingerprint,
@@ -695,9 +700,12 @@ fn run_paths_bellman_ford(gf: &GraphForge) -> WorkloadEvidence {
                 "disposition",
                 serde_json::json!("serial_ordered_bellman_ford_relaxation"),
             ),
-            (
                 "work_units",
                 serde_json::json!("ordered_relaxation_rounds_and_negative_cycle_scan"),
+            ("surface", serde_json::json!("GraphForge::analyze")),
+            ("algorithm", serde_json::json!("maximum_spanning_tree")),
+                serde_json::json!("serial_kruskal_descending_union_find"),
+                serde_json::json!("stable_edge_sort_and_union_find_acceptance"),
             ),
             ("threads_path", serde_json::json!("serial_for_all_policies")),
             ("csr_native_projection", serde_json::json!(true)),
@@ -890,6 +898,14 @@ fn collect_short_matrix() -> (serde_json::Value, Vec<WorkloadEvidence>) {
             ev
         },
         {
+            let ev = run_analyze_maximum_spanning_tree(&gf);
+            assert!(
+                ev.output_rows > 0,
+                "analyze-maximum-spanning-tree must produce rows"
+            );
+            ev
+        },
+        {
             let ev = run_paths_min_steiner_tree(&gf);
             assert!(
                 ev.output_rows > 0,
@@ -966,6 +982,7 @@ fn short_ci_matrix_runs_through_public_facade_under_fixed_two_workers() {
             "aggregate-top-n",
             "pagerank",
             "paths-gomory-hu-tree",
+            "analyze-maximum-spanning-tree",
             "paths-min-steiner-tree",
             "paths-bellman-ford",
             "paths-min-cost-max-flow",

--- a/crates/graphforge-api/tests/m4_entry_baseline.rs
+++ b/crates/graphforge-api/tests/m4_entry_baseline.rs
@@ -17,9 +17,9 @@ use arrow::array::FixedSizeBinaryArray;
 use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
 use graphforge_api::{
-    CancellationToken, EmbeddingAnalyzeOptions, EmbeddingOptions, ExecutionResourcePolicy,
-    GraphForge, GraphForgeOptions, Node2VecOptions, NodeSelector, PathsOptions, PropValue,
-    RankOptions, ResourcePolicyMode, SimilarOptions, SpillPolicy,
+    AnalyzeOptions, CancellationToken, EmbeddingAnalyzeOptions, EmbeddingOptions,
+    ExecutionResourcePolicy, GraphForge, GraphForgeOptions, Node2VecOptions, NodeSelector,
+    PathsOptions, PropValue, RankOptions, ResourcePolicyMode, SimilarOptions, SpillPolicy,
 };
 use graphforge_core::algorithms::{
     AnalyzeAlgorithm, PathAlgorithm, RankAlgorithm, SimilarAlgorithm,

--- a/crates/graphforge-exec/src/algorithm_analyze_minimum_spanning_forest.rs
+++ b/crates/graphforge-exec/src/algorithm_analyze_minimum_spanning_forest.rs
@@ -1,6 +1,9 @@
-//! Spanning-forest analysis remains serial for minimum spanning trees (#582).
-//! Stable edge order and union-find acceptance define public ties, and each
-//! accepted edge mutates component state consumed by later candidates.
+//! Spanning-forest analysis remains serial for minimum spanning trees (#582) and
+//! maximum spanning trees (#580). Stable edge order and union-find acceptance
+//! define public ties; each accepted edge mutates component state consumed by
+//! later candidates, so there is no independent edge frontier for private-pool
+//! execution without changing ties.
+
 
 use std::cmp::Ordering;
 

--- a/crates/graphforge-exec/src/algorithm_analyze_minimum_spanning_forest.rs
+++ b/crates/graphforge-exec/src/algorithm_analyze_minimum_spanning_forest.rs
@@ -4,7 +4,6 @@
 //! later candidates, so there is no independent edge frontier for private-pool
 //! execution without changing ties.
 
-
 use std::cmp::Ordering;
 
 use crate::algorithm_dispatch::{AlgorithmControl, AlgorithmError};

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -795,6 +795,11 @@ only, never a CI threshold.
 
 `analyze(by="minimum_spanning_tree")` has no parallel crossover. Its
 disposition is **serial Kruskal ascending union-find** for every
+
+## Serial analyze(by="maximum_spanning_tree") (#580)
+
+`analyze(by="maximum_spanning_tree")` has no parallel crossover. Its
+disposition is **serial Kruskal descending union-find** for every
 `compute_threads` setting, including `1`/`2`/`4`/`8`/automatic policies.
 
 The Rust kernel consumes CSR-native weighted undirected adjacency (#340),

--- a/scripts/ci/m4-entry-matrix.py
+++ b/scripts/ci/m4-entry-matrix.py
@@ -19,6 +19,7 @@ REQUIRED_WORKLOAD_IDS = {
     "aggregate-top-n",
     "pagerank",
     "paths-gomory-hu-tree",
+    "analyze-maximum-spanning-tree",
     "paths-min-steiner-tree",
     "paths-bellman-ford",
     "paths-min-cost-max-flow",

--- a/tests/contracts/m4-entry-matrix.json
+++ b/tests/contracts/m4-entry-matrix.json
@@ -160,6 +160,23 @@
       ]
     },
     {
+      "id": "analyze-maximum-spanning-tree",
+      "class": "serial-spanning-tree-graph-algorithm",
+      "surface": "GraphForge::analyze",
+      "short_ci": true,
+      "large_manual": true,
+      "disposition": "serial_kruskal_descending_union_find",
+      "structural_gates": [
+        "schema",
+        "row_count",
+        "ordering",
+        "result_fingerprint",
+        "csr_native_projection",
+        "bounded_arrow_sink",
+        "serial_disposition"
+      ]
+    },
+    {
       "id": "paths-min-steiner-tree",
       "class": "serial-steiner-graph-algorithm",
       "surface": "GraphForge::paths",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #580: serial disposition for maximum_spanning_tree.

Closes #580

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788957506&installation_model_id=20486&pr_number=678&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F678&signature=1f8bac1f7f853eddf147a473096674ce413131f1cdff352db94c69c0df7e70d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add serial disposition for `analyze(by=MaximumSpanningTree)` with test coverage
> - Adds `serial_kruskal_descending_union_find` as the fixed disposition for `GraphForge::analyze` with `MaximumSpanningTree`, with no parallel crossover regardless of `compute_threads`.
> - Adds a `run_analyze_maximum_spanning_tree` test helper that exercises the analyze call, checks determinism across two invocations, and records `WorkloadEvidence` with the new disposition.
> - Extends the M4 entry matrix contract and CI validation script to require the `analyze-maximum-spanning-tree` workload and validate it against structural gates.
> - Documents the serial-only policy in [execution-resource-policy.md](https://github.com/CurateLabs/graphforge/pull/678/files#diff-978cd3c64399512fe02ce13768a045b47b2b98e5e672d553ee1bb69be7843971).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ceb8dc4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for maximum-spanning-tree analysis using deterministic, cost-weighted graph data.
  * Added repeatability checks for results, output fingerprints, ordering, row counts, and bounded output.
  * Included the workload in short and large execution matrices with validation of serial processing behavior.

* **Documentation**
  * Documented why spanning-forest analysis uses serial processing to preserve consistent edge-selection results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->