### PR TITLE
perf(exec): parallelize conductance on ComputePool (#566)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_analyze_conductance.rs
+++ b/crates/graphforge-exec/src/algorithm_analyze_conductance.rs
@@ -1,7 +1,13 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+use rayon::prelude::*;
 
 use crate::algorithm_dispatch::{AlgorithmControl, AlgorithmError};
 use crate::algorithm_partition::ResolvedPartitionMap;
+
+/// Partition counts below this stay serial to avoid private-pool scheduling tax.
+pub(crate) const CONDUCTANCE_PARALLEL_CROSSOVER_PARTITIONS: usize = 128;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) struct ConductanceEdge {
@@ -15,6 +21,12 @@ pub(crate) struct ConductanceEdge {
 pub(crate) struct ConductanceRow {
     pub partition_id: String,
     pub conductance: f64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ConductanceExecutionPath {
+    Serial,
+    Parallel { threads: usize, chunks: usize },
 }
 
 pub(crate) fn conductance(
@@ -83,26 +95,143 @@ pub(crate) fn conductance(
         }
     }
 
-    let mut rows = Vec::with_capacity(volumes.len());
-    for (partition, &volume) in &volumes {
-        checkpoint(control, &mut work)?;
-        let complement = volumes
-            .iter()
-            .filter(|(other, _)| *other != partition)
-            .try_fold(0.0, |sum, (_, value)| finite(sum + value))?;
-        let denominator = volume.min(complement);
-        if denominator == 0.0 {
-            return Err(AlgorithmError::UndefinedConductance {
-                partition: partition.clone(),
-            });
+    let rows = match select_conductance_path(control, volumes.len()) {
+        ConductanceExecutionPath::Serial => {
+            conductance_rows_serial(&volumes, &cuts, control, &mut work)?
         }
-        rows.push(ConductanceRow {
-            partition_id: partition.clone(),
-            conductance: cuts[partition] / denominator,
-        });
-    }
+        ConductanceExecutionPath::Parallel { .. } => {
+            conductance_rows_parallel(&volumes, &cuts, control)?
+        }
+    };
     control.check_cancelled()?;
     Ok(rows)
+}
+
+pub(crate) fn select_conductance_path(
+    control: &AlgorithmControl,
+    partitions: usize,
+) -> ConductanceExecutionPath {
+    let threads = control.compute_threads();
+    if threads <= 1
+        || partitions < CONDUCTANCE_PARALLEL_CROSSOVER_PARTITIONS
+        || control
+            .compute_pool()
+            .is_none_or(|pool| !pool.is_parallel())
+    {
+        return ConductanceExecutionPath::Serial;
+    }
+    ConductanceExecutionPath::Parallel {
+        threads,
+        chunks: partition_chunks(partitions, threads).len(),
+    }
+}
+
+fn conductance_rows_serial(
+    volumes: &BTreeMap<String, f64>,
+    cuts: &BTreeMap<String, f64>,
+    control: &AlgorithmControl,
+    work: &mut usize,
+) -> Result<Vec<ConductanceRow>, AlgorithmError> {
+    let mut rows = Vec::with_capacity(volumes.len());
+    for (partition, &volume) in volumes {
+        checkpoint(control, work)?;
+        rows.push(conductance_row(partition, volume, volumes, cuts)?);
+    }
+    Ok(rows)
+}
+
+fn conductance_rows_parallel(
+    volumes: &BTreeMap<String, f64>,
+    cuts: &BTreeMap<String, f64>,
+    control: &AlgorithmControl,
+) -> Result<Vec<ConductanceRow>, AlgorithmError> {
+    let pool = control
+        .compute_pool()
+        .ok_or_else(|| execution("parallel conductance requires an instance-owned compute pool"))?;
+    let entries = volumes
+        .iter()
+        .map(|(partition, &volume)| (partition.as_str(), volume))
+        .collect::<Vec<_>>();
+    let ranges = partition_chunks(entries.len(), control.compute_threads());
+    let mut chunk_results = run_on_pool(pool, || {
+        Ok(ranges
+            .par_iter()
+            .map(|&(start, end)| {
+                let result = (|| {
+                    control.check_cancelled()?;
+                    let mut work = 0_usize;
+                    let mut local = Vec::with_capacity(end - start);
+                    for &(partition, volume) in &entries[start..end] {
+                        checkpoint(control, &mut work)?;
+                        local.push(conductance_row(partition, volume, volumes, cuts)?);
+                    }
+                    Ok(local)
+                })();
+                (start, result)
+            })
+            .collect::<Vec<(usize, Result<Vec<ConductanceRow>, AlgorithmError>)>>())
+    })?;
+    chunk_results.sort_unstable_by_key(|(start, _)| *start);
+    let mut rows = Vec::with_capacity(entries.len());
+    for (_, chunk) in chunk_results {
+        rows.extend(chunk?);
+    }
+    Ok(rows)
+}
+
+fn conductance_row(
+    partition: &str,
+    volume: f64,
+    volumes: &BTreeMap<String, f64>,
+    cuts: &BTreeMap<String, f64>,
+) -> Result<ConductanceRow, AlgorithmError> {
+    let complement = volumes
+        .iter()
+        .filter(|(other, _)| other.as_str() != partition)
+        .try_fold(0.0, |sum, (_, value)| finite(sum + value))?;
+    let denominator = volume.min(complement);
+    if denominator == 0.0 {
+        return Err(AlgorithmError::UndefinedConductance {
+            partition: partition.to_owned(),
+        });
+    }
+    Ok(ConductanceRow {
+        partition_id: partition.to_owned(),
+        conductance: cuts[partition] / denominator,
+    })
+}
+
+fn partition_chunks(len: usize, threads: usize) -> Vec<(usize, usize)> {
+    if len == 0 {
+        return Vec::new();
+    }
+    let workers = threads.clamp(1, len);
+    let base = len / workers;
+    let rem = len % workers;
+    let mut chunks = Vec::with_capacity(workers);
+    let mut start = 0;
+    for index in 0..workers {
+        let chunk_len = base + usize::from(index < rem);
+        let end = start + chunk_len;
+        if start < end {
+            chunks.push((start, end));
+        }
+        start = end;
+    }
+    chunks
+}
+
+fn run_on_pool<R>(
+    pool: &crate::ComputePool,
+    op: impl FnOnce() -> Result<R, AlgorithmError> + Send,
+) -> Result<R, AlgorithmError>
+where
+    R: Send,
+{
+    match catch_unwind(AssertUnwindSafe(|| pool.install(op))) {
+        Ok(result) => result,
+        Err(_) => Err(execution("conductance worker panicked")),
+    }
 }
 
 fn canonical(mut edge: ConductanceEdge) -> ConductanceEdge {
@@ -146,15 +275,28 @@ mod tests {
     use super::*;
     use crate::algorithm_dispatch::{AlgorithmCancellation, AlgorithmLimits};
     use crate::algorithm_partition::PartitionValue;
+    use crate::compute_pool::ComputePool;
+    use std::sync::Arc;
 
     fn uuid(n: u8) -> [u8; 16] {
         [n; 16]
+    }
+    fn wide_uuid(n: u128) -> [u8; 16] {
+        n.to_be_bytes()
     }
     fn edge(id: u8, source: u8, target: u8, weight: f64) -> ConductanceEdge {
         ConductanceEdge {
             edge_uuid: uuid(id),
             source_uuid: uuid(source),
             target_uuid: uuid(target),
+            weight,
+        }
+    }
+    fn wide_edge(id: u128, source: usize, target: usize, weight: f64) -> ConductanceEdge {
+        ConductanceEdge {
+            edge_uuid: wide_uuid(id),
+            source_uuid: wide_uuid(source as u128),
+            target_uuid: wide_uuid(target as u128),
             weight,
         }
     }
@@ -169,6 +311,41 @@ mod tests {
     }
     fn control() -> AlgorithmControl {
         AlgorithmControl::new(AlgorithmLimits::default(), AlgorithmCancellation::default())
+    }
+    fn control_with_threads(threads: usize) -> AlgorithmControl {
+        AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(threads),
+            AlgorithmCancellation::default(),
+        )
+        .with_compute_pool(Arc::new(ComputePool::new(threads).unwrap()))
+    }
+    fn singleton_fixture(
+        nodes: usize,
+    ) -> (Vec<[u8; 16]>, Vec<ConductanceEdge>, ResolvedPartitionMap) {
+        let node_ids = (0..nodes)
+            .map(|node| wide_uuid(node as u128))
+            .collect::<Vec<_>>();
+        let edges = (0..nodes - 1)
+            .map(|source| {
+                wide_edge(
+                    10_000 + source as u128,
+                    source,
+                    source + 1,
+                    1.0 + (source % 7) as f64,
+                )
+            })
+            .collect::<Vec<_>>();
+        let partitions = ResolvedPartitionMap::try_new(
+            node_ids.iter().copied(),
+            (0..nodes).map(|node| {
+                (
+                    wide_uuid(node as u128),
+                    PartitionValue::String(format!("p{node:04}")),
+                )
+            }),
+        )
+        .unwrap();
+        (node_ids, edges, partitions)
     }
     fn run(
         nodes: &[[u8; 16]],
@@ -212,6 +389,57 @@ mod tests {
                 partition: "left".into(),
             })
         );
+    }
+
+    #[test]
+    fn path_selection_respects_crossover_and_private_pool() {
+        let serial = control_with_threads(1);
+        assert_eq!(
+            select_conductance_path(&serial, CONDUCTANCE_PARALLEL_CROSSOVER_PARTITIONS),
+            ConductanceExecutionPath::Serial
+        );
+        let below = control_with_threads(4);
+        assert_eq!(
+            select_conductance_path(&below, CONDUCTANCE_PARALLEL_CROSSOVER_PARTITIONS - 1),
+            ConductanceExecutionPath::Serial
+        );
+        let no_pool = AlgorithmControl::new(
+            AlgorithmLimits::default().with_compute_threads(4),
+            AlgorithmCancellation::default(),
+        );
+        assert_eq!(
+            select_conductance_path(&no_pool, CONDUCTANCE_PARALLEL_CROSSOVER_PARTITIONS),
+            ConductanceExecutionPath::Serial
+        );
+        assert_eq!(
+            select_conductance_path(
+                &control_with_threads(4),
+                CONDUCTANCE_PARALLEL_CROSSOVER_PARTITIONS
+            ),
+            ConductanceExecutionPath::Parallel {
+                threads: 4,
+                chunks: 4
+            }
+        );
+    }
+
+    #[test]
+    fn thread_matrix_preserves_conductance_rows() {
+        let (nodes, edges, partitions) = singleton_fixture(192);
+        let serial =
+            conductance(&nodes, &edges, false, &partitions, &control_with_threads(1)).unwrap();
+        assert_eq!(serial.len(), 192);
+        for threads in [2_usize, 4, 8] {
+            let control = control_with_threads(threads);
+            assert!(matches!(
+                select_conductance_path(&control, 192),
+                ConductanceExecutionPath::Parallel { .. }
+            ));
+            assert_eq!(
+                conductance(&nodes, &edges, false, &partitions, &control).unwrap(),
+                serial
+            );
+        }
     }
 
     #[test]

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -83,6 +83,14 @@ Components merges worker-local forests in canonical source-range order, and
 Node2Vec skip-gram training stays serial, so fingerprints match the one-thread
 path.
 
+(#342), PageRank (#343), Node2Vec walk-corpus generation (#344), and conductance
+row evaluation (#566) may partition independent work across that pool above
+documented crossovers; work never uses Rayon's process-global pool. Cosine dot
+products retain serial coordinate order, PageRank keeps canonical contribution
+order with serial dangling/delta reductions, Node2Vec skip-gram training stays
+serial, and conductance keeps weighted cut/volume accumulation serial, so
+fingerprints match the one-thread path.
+
 ## Parallel cosine KNN (#342)
 
 Exact, all-score, and filtered cosine partition **independent source rows**
@@ -261,6 +269,26 @@ IDs are still assigned by canonical node order, so schemas, row order, labels,
 and fingerprints match the one-thread result at `1`/`2`/`4`/`8`/automatic
 configurations. Cancellation remains cooperative both before worker launch and
 inside chunk scans.
+
+## Parallel conductance row evaluation (#566)
+
+`analyze(by="conductance")` keeps weighted edge normalization, cut accumulation,
+and volume accumulation serial. Those stages contain floating-point additions
+whose order is part of the accepted bit-level contract. After the serial
+accumulators are complete, each partition row can be evaluated independently on
+the instance-owned private compute pool when:
+
+- `compute_threads > 1`, and
+- normalized partitions are at least
+  `CONDUCTANCE_PARALLEL_CROSSOVER_PARTITIONS` (`128`) in `graphforge-exec`.
+
+Below that crossover, or when the policy provides one compute thread,
+conductance stays fully serial. Parallel workers evaluate canonical partition
+ranges; each row preserves the serial `BTreeMap` complement summation order, and
+chunks merge in ascending range order so row ordering and the first undefined
+partition error remain deterministic. Schemas, row order, conductance bits,
+structured errors, and fingerprints match the one-thread result at
+`1`/`2`/`4`/`8`/automatic configurations.
 
 ## Observability
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #566: parallel conductance on ComputePool.

Closes #566

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788957506&installation_model_id=20486&pr_number=679&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F679&signature=5ccdb9baba7e8dbe05fc24ae89fdcd6edaf7d9e5931bd28fead3f39dfe1e9289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parallelize conductance row evaluation on a private `ComputePool`
> - Adds parallel execution to `conductance()` in [algorithm_analyze_conductance.rs](https://github.com/CurateLabs/graphforge/pull/679/files#diff-9db7919e513240872d4de77215b80e60ef3828e586090676528d372150f2528b): when `threads > 1`, partition count ≥ 128 (`CONDUCTANCE_PARALLEL_CROSSOVER_PARTITIONS`), and a parallel private pool is configured, rows are evaluated concurrently via Rayon inside `pool.install`.
> - Introduces `select_conductance_path` to make the serial/parallel decision explicit, and `conductance_rows_parallel` to handle chunked work distribution, deterministic merge, and cancellation checks per chunk.
> - Adds `run_on_pool` to catch worker panics and return them as `AlgorithmError` instead of aborting.
> - Determinism is preserved: accumulation remains serial, chunk ranges are canonical, and results merge in ascending order, matching the serial output.
> - Risk: parallel path introduces Rayon work-stealing inside a private pool; panics are caught, but edge cases in chunk boundary or pool teardown may surface new error paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 453f371.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->