### PR TITLE
perf(exec): serial disposition for minimum_spanning_tree (#582)

### DIFF
--- a/crates/graphforge-exec/src/algorithm_analyze_minimum_spanning_forest.rs
+++ b/crates/graphforge-exec/src/algorithm_analyze_minimum_spanning_forest.rs
@@ -1,3 +1,7 @@
+//! Spanning-forest analysis remains serial for minimum spanning trees (#582).
+//! Stable edge order and union-find acceptance define public ties, and each
+//! accepted edge mutates component state consumed by later candidates.
+
 use std::cmp::Ordering;
 
 use crate::algorithm_dispatch::{AlgorithmControl, AlgorithmError};

--- a/docs/development/execution-resource-policy.md
+++ b/docs/development/execution-resource-policy.md
@@ -760,6 +760,24 @@ harness records `paths-min-cut` structural evidence and verifies one-thread
 fingerprint parity for supported resource-policy cells. Timing is evidence
 only, never a CI threshold.
 
+## Serial analyze(by="minimum_spanning_tree") (#582)
+
+`analyze(by="minimum_spanning_tree")` has no parallel crossover. Its
+disposition is **serial Kruskal ascending union-find** for every
+`compute_threads` setting, including `1`/`2`/`4`/`8`/automatic policies.
+
+The Rust kernel consumes CSR-native weighted undirected adjacency (#340),
+collapses mirrored entries by edge UUID, performs a stable canonical edge sort,
+and accepts candidates through one union-find state. Each accepted edge changes
+component state for all later edges, while equal-weight edge UUID ties are part
+of the public fingerprint. Parallel acceptance would need shared union-find
+coordination and could change rows or cancellation boundaries.
+
+The path still uses bounded Arrow output (#341), structured cancellation and
+resource checks, and no process-global Rayon pool. The M4 harness records
+`analyze-minimum-spanning-tree` evidence and verifies one-thread parity; timing
+is report-only.
+
 ## Observability
 
 `GraphForge::resource_policy()` and `GraphForge::resource_diagnostics()` expose


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #582: serial disposition for minimum_spanning_tree.

Closes #582

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe819-3776-70b7-a0b7-45bc4c96c6a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788957506&installation_model_id=20486&pr_number=680&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F680&signature=37ca504299ce59817cfc057e6e835b50cde23738a252ea01ef39dbf89c7f332d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document serial disposition for `analyze(by="minimum_spanning_tree")` execution
> - Adds module-level documentation to [`algorithm_analyze_minimum_spanning_forest.rs`](https://github.com/CurateLabs/graphforge/pull/680/files#diff-00acc697b3e0d4a407415f0f2880cb402b5e099dbe38b72a3ea12b72cbb6622a) clarifying that spanning-forest analysis runs serially with stable edge ordering and union-find acceptance defining tie-breaking.
> - Adds a new section to [`execution-resource-policy.md`](https://github.com/CurateLabs/graphforge/pull/680/files#diff-978cd3c64399512fe02ce13768a045b47b2b98e5e672d553ee1bb69be7843971) documenting that the minimum spanning tree analysis uses a serial Kruskal ascending union-find approach regardless of `compute_threads` settings, with no global Rayon pool involvement.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 90c6815.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->