### PR TITLE
chore(deps): ignore isolated parquet major Dependabot bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -84,6 +84,12 @@ updates:
       prefix: "chore"
       include: "scope"
       # Reminder: Cargo bumps need Bazel crate-universe repin before merge.
+    # parquet majors pull Arrow majors; DataFusion must move in the same
+    # change set (see closed #686). Ignore isolated parquet major bumps until
+    # a coordinated DataFusion + Arrow + Parquet upgrade is ready.
+    ignore:
+      - dependency-name: "parquet"
+        update-types: ["version-update:semver-major"]
     groups:
       cargo-minor-patch:
         patterns:
@@ -91,6 +97,15 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      # Keep Arrow / Parquet / DataFusion majors together when Dependabot
+      # sees updates for more than one; parquet majors remain ignored above.
+      arrow-datafusion-stack:
+        patterns:
+          - "arrow*"
+          - "parquet*"
+          - "datafusion*"
+        update-types:
+          - "major"
 
   # Root npm / pnpm workspace
   - package-ecosystem: "npm"


### PR DESCRIPTION
## Summary
- Ignore Dependabot `parquet` **semver-major** updates so isolated bumps like closed #686 do not reopen while DataFusion still requires Arrow 58.
- Add an `arrow-datafusion-stack` major group (`arrow*` / `parquet*` / `datafusion*`) so coordinated majors land together when more than one is available (parquet majors remain ignored until the ignore is removed).

## Why
Bumping parquet alone to 59 pulls Arrow 59 into the lockfile with dual `arrow-schema` vs DataFusion 54 / Arrow 58. No crates.io DataFusion for Arrow 59 yet. Coordinated DF + Arrow + Parquet upgrade is the path forward.

## Test plan
- [x] YAML-only change to `.github/dependabot.yml`
- [ ] CI / CI Gate green on this PR
- [ ] Confirm #686 remains closed (no force-merge)


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789081192&installation_model_id=20486&pr_number=690&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F690&signature=58b67b9d835f300c18837c65b64f9b17fb7495c7c5122689d0d7f0cb302680a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ignore isolated parquet major version bumps and group arrow/datafusion updates in Dependabot
> Updates [dependabot.yml](.github/dependabot.yml) to prevent noisy standalone major-version PRs for the `parquet` crate. Adds an ignore rule for semver-major `parquet` updates and a new `arrow-datafusion-stack` group that batches major updates for `arrow*`, `parquet*`, and `datafusion*` into a single PR when multiple are detected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 57c9790.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->