### PR TITLE
chore(deps): ignore Arrow/DataFusion major Dependabot bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -84,11 +84,24 @@ updates:
       prefix: "chore"
       include: "scope"
       # Reminder: Cargo bumps need Bazel crate-universe repin before merge.
-    # parquet majors pull Arrow majors; DataFusion must move in the same
-    # change set (see closed #686). Ignore isolated parquet major bumps until
-    # a coordinated DataFusion + Arrow + Parquet upgrade is ready.
+    # Arrow / Parquet / DataFusion majors must move together. Isolated majors
+    # (closed #686 parquet, #695 arrow) leave dual arrow-schema vs DataFusion.
+    # Ignore the whole stack's majors until a coordinated upgrade; do not use a
+    # Dependabot group here — partial group membership still opens broken PRs.
     ignore:
       - dependency-name: "parquet"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "arrow"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "arrow-data"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "arrow-schema"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "arrow-array"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "datafusion"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "datafusion-*"
         update-types: ["version-update:semver-major"]
     groups:
       cargo-minor-patch:
@@ -97,15 +110,6 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      # Keep Arrow / Parquet / DataFusion majors together when Dependabot
-      # sees updates for more than one; parquet majors remain ignored above.
-      arrow-datafusion-stack:
-        patterns:
-          - "arrow*"
-          - "parquet*"
-          - "datafusion*"
-        update-types:
-          - "major"
 
   # Root npm / pnpm workspace
   - package-ecosystem: "npm"


### PR DESCRIPTION
## Summary
- Close the hole left after #690: Dependabot's `arrow-datafusion-stack` major group still opened isolated **arrow / arrow-data 59** (#695) without DataFusion.
- Ignore semver-major for `parquet`, `arrow`, `arrow-data`, `arrow-schema`, `arrow-array`, `datafusion`, and `datafusion-*`.
- Remove the `arrow-datafusion-stack` major group (partial membership still opens broken PRs).

## Related
- Closed without merge: #686 (parquet), #695 (arrow stack)
- Prior ignore: #690

## Test plan
- [x] YAML-only `.github/dependabot.yml` change
- [ ] CI / CI Gate green
- [ ] Confirm #695 stays closed


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ignore semver-major Dependabot bumps for Arrow and DataFusion crates
> Updates [dependabot.yml](.github/dependabot.yml) to suppress automatic major-version PRs for `arrow`, `arrow-data`, `arrow-schema`, `arrow-array`, `datafusion`, and `datafusion-*` crates, extending the existing ignore rule for `parquet`. Also removes the `arrow-datafusion-stack` Dependabot group, since Arrow/Parquet/DataFusion majors must be coordinated manually rather than via grouped PRs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d62d5b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->