### PR TITLE
fix(exec): remove conflict markers left on main by #605

### DIFF
--- a/crates/graphforge-exec/src/algorithm_rank.rs
+++ b/crates/graphforge-exec/src/algorithm_rank.rs
@@ -95,7 +95,6 @@ const PAGERANK_TOLERANCE: f64 = 1.0e-10;
 /// embedded hosts. Numeric results remain identical either way.
 pub const PAGERANK_PARALLEL_CROSSOVER_EDGES: u64 = 4_096;
 const PAGERANK_CHECKPOINT_DESTINATIONS: usize = 4_096;
-<<<<<<< HEAD
 /// Estimated local neighbor-pair probes below which clustering coefficient stays serial (#504).
 ///
 /// Keeps small fixtures and sparse public invocations off the worker pool; above this,
@@ -123,7 +122,6 @@ const DEGREE_CHECKPOINT_NODES: usize = 1_024;
 /// The crossover keeps small fixtures off the private pool; parallel workers
 /// still run each source's Brandes BFS serially and reduce in source order.
 pub const BETWEENNESS_PARALLEL_CROSSOVER_WORK: u64 = 65_536;
-=======
 /// Estimated pair/intersection work below which common-neighbors stays serial (#505).
 ///
 /// Chosen from manual serial-vs-parallel timings on this M4 agent host
@@ -140,7 +138,6 @@ pub const BETWEENNESS_PARALLEL_CROSSOVER_WORK: u64 = 65_536;
 /// exact counts remain identical on either path.
 pub const COMMON_NEIGHBORS_PARALLEL_CROSSOVER_WORK: u64 = 1_048_576;
 const COMMON_NEIGHBORS_CHECKPOINT_INTERVAL: usize = 1_024;
->>>>>>> ecfa5e4 (perf(exec): parallelize common neighbors rank)
 const EIGENVECTOR_MAX_ITERATIONS: usize = 20;
 const EIGENVECTOR_TOLERANCE: f64 = 1.0e-7;
 /// Selected adjacency entries below which eigenvector stays on the serial path (#507).
@@ -479,7 +476,6 @@ pub(crate) fn select_pagerank_path(
 }
 
 fn destination_chunks(nodes: usize, threads: usize) -> Vec<(usize, usize)> {
-<<<<<<< HEAD
     ordinal_chunks(nodes, threads)
 }
 
@@ -488,12 +484,6 @@ fn source_chunks(nodes: usize, threads: usize) -> Vec<(usize, usize)> {
 }
 
 fn ordinal_chunks(nodes: usize, threads: usize) -> Vec<(usize, usize)> {
-=======
-    source_chunks(nodes, threads)
-}
-
-fn source_chunks(nodes: usize, threads: usize) -> Vec<(usize, usize)> {
->>>>>>> ecfa5e4 (perf(exec): parallelize common neighbors rank)
     if nodes == 0 {
         return Vec::new();
     }


### PR DESCRIPTION
## Summary
- Removes unresolved conflict markers in `algorithm_rank.rs` introduced by the #605 squash onto main
- Keeps both sides' parallel crossover constants and the `ordinal_chunks` helper structure

Closes #699

## Test plan
- [x] Local `cargo check -p graphforge-exec`
- [ ] CI Gate CLEAN


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789089655&installation_model_id=20486&pr_number=700&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F700&signature=9fc0facb9450da23d95c6b1287f3592919002eba6623b4b10879cdd5e6239a7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove merge conflict markers left in `algorithm_rank.rs`
> Cleans up leftover conflict markers accidentally merged into `main` via #605 in [algorithm_rank.rs](https://github.com/CurateLabs/graphforge/pull/700/files#diff-d42360b7ef75ce3112d55412fae040f54af2633f4b75d8609ca211a2702172b7). Removes the duplicate `source_chunks` helper and updates `destination_chunks` to delegate to `ordinal_chunks` as the sole chunking implementation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 42ffeb4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->