### PR TITLE
docs(cypher): report the implemented MERGE subset accurately

### DIFF
--- a/docs/book/architecture/ast-and-planning.md
+++ b/docs/book/architecture/ast-and-planning.md
@@ -237,7 +237,7 @@ The following operators remain as GraphForge-owned custom DataFusion nodes becau
 | Path uniqueness / distinctness | Cypher path semantics (isomorphism vs. homomorphism) |
 | Provenance-aware semijoins | Confidence propagation during join |
 | Ontology-aware inference | Transitive/symmetric closure — not a static join |
-| MERGE | Graph upsert semantics with write-path locking |
+| MERGE | Partial graph upsert: standalone new-node and referenced-endpoint relationship forms with write-path locking; multi-node construction and row-conditional map actions are rejected (`write_driver.rs`) |
 
 ---
 

--- a/docs/book/architecture/execution-model.md
+++ b/docs/book/architecture/execution-model.md
@@ -89,7 +89,7 @@ that cannot be faithfully expressed as relational algebra:
 | `PathUnique` | Path isomorphism/homomorphism enforcement |
 | `ProvenanceSemijoin` | Semijoin with confidence propagation |
 | `OntologyInfer` | Transitive/symmetric closure materialization |
-| `GraphMerge` | MERGE upsert with write-path locking |
+| `GraphMerge` | Partial MERGE upsert (standalone new node or referenced-endpoint relationship) with write-path locking |
 
 All other operators (scan, filter, project, aggregate, sort, limit) run through standard
 DataFusion physical nodes.

--- a/docs/book/use-cases/knowledge-graph-construction.md
+++ b/docs/book/use-cases/knowledge-graph-construction.md
@@ -5,8 +5,11 @@
 Knowledge graphs give structure to information that starts life as unstructured text —
 research papers, support tickets, product catalogues, codebases, or any corpus where
 entities and their relationships matter. GraphForge is well suited to this pattern
-because it is embedded (no server, no network hop), fully openCypher-compatible, and
-provides MERGE semantics that make incremental, idempotent graph construction natural.
+because it is embedded (no server, no network hop), openCypher-compatible for the
+shipped surface, and provides MERGE semantics (standalone nodes and
+referenced-endpoint relationships; see
+[MERGE status](../../reference/implementation-status/clauses.md#merge)) that make
+incremental, idempotent graph construction natural.
 
 ### When to use this pattern
 

--- a/docs/guide/cypher-guide.md
+++ b/docs/guide/cypher-guide.md
@@ -219,7 +219,17 @@ RETURN p.name AS name, id(p) AS node_id
 
 ### MERGE
 
-Find or create — safe for idempotent upserts.
+Find or create — safe for idempotent upserts within the shipped Rust subset
+([implementation status](../reference/implementation-status/clauses.md#merge)).
+
+**Supported:**
+- Standalone new-node MERGE: `MERGE (p:Person {email: '…'})`
+- Relationship MERGE when both endpoints are already bound: `MATCH (a), (b) MERGE (a)-[:KNOWS]->(b)`
+- `ON CREATE SET` / `ON MATCH SET` property (and label) actions when every row takes the same create-or-match branch
+
+**Not supported (structured plan errors):**
+- Multi-node / relationship-construction MERGE such as `MERGE (a:A)-[:R]->(b:B)` → `relationship and multi-node MERGE execution is not implemented yet`
+- Row-conditional map actions (`+=` / `=`) when some rows create and others match → `row-conditional MERGE map actions are not implemented yet`
 
 ```cypher
 -- Merge node (create if not exists, match if exists)

--- a/docs/guide/datasets/cypher-script-loading.md
+++ b/docs/guide/datasets/cypher-script-loading.md
@@ -58,7 +58,7 @@ CREATE (keanu)-[:ACTED_IN]->(matrix);
 All standard Cypher query statements are executed:
 
 - **CREATE** - Node and relationship creation
-- **MERGE** - Create or match patterns with ON CREATE/MATCH SET
+- **MERGE** - Partial: standalone new-node and referenced-endpoint relationship MERGE with ON CREATE/MATCH SET (see [MERGE status](../implementation-status/clauses.md#merge))
 - **MATCH** - Pattern matching
 - **SET** - Property updates
 - **DELETE** / **DETACH DELETE** - Node and relationship deletion

--- a/docs/guide/graph-construction.md
+++ b/docs/guide/graph-construction.md
@@ -76,6 +76,11 @@ forge.execute("""
 
 ### MERGE (idempotent upsert)
 
+Standalone new-node MERGE and `ON CREATE` / `ON MATCH` property sets are
+supported. Prefer binding endpoints first, then merging the relationship —
+inline multi-node MERGE patterns are rejected. See
+[MERGE status](../reference/implementation-status/clauses.md#merge).
+
 ```python
 forge.execute("""
     MERGE (p:Person {email: $email})

--- a/docs/reference/INCOMPLETE_FEATURES_ISSUES.md
+++ b/docs/reference/INCOMPLETE_FEATURES_ISSUES.md
@@ -8,24 +8,28 @@ Inventory of partially implemented and unimplemented OpenCypher features in Grap
 
 | Category | Partial | Not Implemented | Total |
 |----------|---------|-----------------|-------|
-| **Clauses** | 1 | 3 | 4 |
+| **Clauses** | 2 | 3 | 5 |
 | **Functions** | 0 | 19 | 19 |
 | **Operators** | 0 | 4 | 4 |
 | **Patterns** | 1 | 1 | 2 |
-| **TOTAL** | **2** | **27** | **29** |
+| **TOTAL** | **3** | **27** | **30** |
 
 ---
 
-## Clauses (4 features)
+## Clauses (5 features)
 
-### Partial Implementation (1)
+### Partial Implementation (2)
 
 | Feature | Status | TCK Scenarios | Priority |
 |---------|--------|---------------|----------|
 | CALL { } subqueries | ⚠️ PARTIAL | ~10 | Medium |
+| MERGE | ⚠️ PARTIAL | 75 | High |
 
-**Current:** EXISTS/COUNT subqueries only
-**Needs:** General CALL { } syntax, UNION in subqueries, variable importing
+**CALL { } — Current:** EXISTS/COUNT subqueries only
+**CALL { } — Needs:** General CALL { } syntax, UNION in subqueries, variable importing
+
+**MERGE — Current:** Standalone new-node MERGE and relationship MERGE with already-bound endpoints; `ON CREATE` / `ON MATCH` property/label actions when all frontier rows share one branch. Authority: `crates/graphforge-exec/src/write_driver.rs`. Direct evidence: `crates/graphforge-api/tests/e2e_baseline.rs` (`merge_node_*`, `merge_relationship_*`).
+**MERGE — Rejected (not support):** multi-node / relationship-construction MERGE (`relationship and multi-node MERGE execution is not implemented yet`); row-conditional map actions (`row-conditional MERGE map actions are not implemented yet`). Details: [clauses.md](implementation-status/clauses.md#merge).
 
 ### Not Implemented (3)
 

--- a/docs/reference/feature-mapping/clause-to-tck.md
+++ b/docs/reference/feature-mapping/clause-to-tck.md
@@ -12,7 +12,7 @@ Mapping of OpenCypher clauses to their corresponding TCK test scenarios.
 |--------|---------------|-----------------|---------------------|----------|
 | MATCH | match, match-where | 195 | ✅ Complete | Excellent |
 | CREATE | create | 78 | ✅ Complete | Excellent |
-| MERGE | merge | 75 | ✅ Complete | Excellent |
+| MERGE | merge | 75 | ⚠️ Partial | Subset — see MERGE section |
 | RETURN | return, return-orderby, return-skip-limit | 129 | ✅ Complete | Excellent |
 | WHERE | match-where, with-where | 53 | ✅ Complete | Good |
 | WITH | with, with-where, with-orderBy, with-skip-limit | 156 | ✅ Complete | Excellent |
@@ -307,15 +307,21 @@ tests/tck/features/official/clauses/match-where/MatchWhere1-6.feature (34 scenar
 
 **Total TCK Coverage:** 75 scenarios
 
-**Implementation Status:** ✅ COMPLETE
+**Implementation Status:** ⚠️ PARTIAL
 
 **TCK Coverage Details:**
-- Merge1-9.feature: Match or create semantics
-- ON CREATE SET
-- ON MATCH SET
-- Node and relationship merging
+- Inventory covers Merge1–9 (node/relationship MERGE, ON CREATE / ON MATCH)
+- GraphForge executes only the Rust subset below; remaining TCK shapes are not shipped support
 
-**Coverage Assessment:** Excellent - comprehensive MERGE scenarios
+**Shipped subset (direct execution tests in `crates/graphforge-api/tests/e2e_baseline.rs`):**
+- Standalone new-node MERGE (`merge_node_is_idempotent_by_label_and_properties`, `merge_node_runs_only_the_selected_on_action`)
+- Referenced-endpoint relationship MERGE (`merge_relationship_*`)
+
+**Explicitly unsupported (plan errors, not support):**
+- Multi-node / relationship-construction MERGE → `relationship and multi-node MERGE execution is not implemented yet`
+- Row-conditional MERGE map actions → `row-conditional MERGE map actions are not implemented yet`
+
+**Coverage Assessment:** TCK inventory is broad; execution completeness is partial — see [clauses.md](../implementation-status/clauses.md#merge)
 
 ---
 

--- a/docs/reference/implementation-status/clauses.md
+++ b/docs/reference/implementation-status/clauses.md
@@ -13,12 +13,12 @@ Implementation status of OpenCypher query clauses in GraphForge.
 
 | Status | Count | Percentage |
 |--------|-------|------------|
-| ✅ Complete | 17 | 85% |
-| ⚠️ Partial | 0 | 0% |
+| ✅ Complete | 16 | 80% |
+| ⚠️ Partial | 1 | 5% |
 | ❌ Not Implemented | 3 | 15% |
 | **TOTAL** | **20** | **100%** |
 
-*Updated for v0.3.8 — all TCK-covered clauses are fully compliant (3,885/3,885 scenarios passing).*
+*Updated for v0.5.0 — MERGE is a documented partial Rust subset; authoritative TCK status is in [tck-compliance.md](../tck-compliance.md).*
 
 ---
 
@@ -290,20 +290,31 @@ Implementation status of OpenCypher query clauses in GraphForge.
 ## Reading/Writing Clauses
 
 ### MERGE
-**Status:** ✅ COMPLETE
+**Status:** ⚠️ PARTIAL
 
-**Implementation:**
-- File: `src/graphforge/executor/executor.py:2269` (`_execute_merge`)
-- Grammar: `src/graphforge/parser/cypher.lark:96`
+**Implementation (Rust authority):**
+- Parser: `crates/graphforge-cypher/src/parser/clauses.rs` (`parse_merge_clause`)
+- Binder / IR: `crates/graphforge-ir/src/binder.rs` (MERGE op with `on_create` / `on_match`)
+- Planner node: `crates/graphforge-plan/src/lib.rs` (`GraphMergeNode`)
+- Executor: `crates/graphforge-exec/src/write_driver.rs` (`run_merge_phase`, `run_relationship_merge_phase`)
 
-**Features:**
-- ✅ Match or create pattern (idempotent)
-- ✅ ON CREATE SET
-- ✅ ON MATCH SET
-- ✅ Works with nodes and relationships
-- ✅ Multiple patterns
+**Supported forms (direct execution evidence):**
+- ✅ Standalone new-node MERGE by label + properties — `MERGE (:Person {name:'Alice'})`
+  - Evidence: `crates/graphforge-api/tests/e2e_baseline.rs` (`merge_node_is_idempotent_by_label_and_properties`)
+- ✅ `ON CREATE SET` / `ON MATCH SET` property (and label) actions when every frontier row takes the same create-or-match branch
+  - Evidence: `merge_node_runs_only_the_selected_on_action`, `merge_relationship_is_idempotent_and_runs_selected_action`
+- ✅ Relationship MERGE whose endpoints are already-bound references — `MATCH (a), (b) MERGE (a)-[r:TYPE {…}]->(b)`
+  - Evidence: `merge_relationship_is_idempotent_and_runs_selected_action`, `merge_relationship_preserves_all_existing_matches`, `merge_relationship_combines_pending_and_committed_matches`, `merge_relationship_resolves_row_properties_after_entity_aliasing`
 
-**Test Coverage:** Good (Merge1-9.feature, ~75 TCK scenarios)
+**Unsupported forms (structured plan errors — not support):**
+- ❌ Multi-node / relationship-construction MERGE that creates endpoints in the same pattern (for example `MERGE (a:A)-[:R]->(b:B)`), merging an already-bound node alone, or any MERGE pattern that is not exactly one standalone new node or one edge with reference-only endpoints
+  - Error: `relationship and multi-node MERGE execution is not implemented yet` (`write_driver.rs` `run_merge_phase`)
+- ❌ Row-conditional `ON CREATE` / `ON MATCH` map actions (`n += {…}` / `n = {…}`) when some frontier rows create and others match in the same MERGE
+  - Error: `row-conditional MERGE map actions are not implemented yet` (`write_driver.rs` `run_merge_actions_masked`)
+- ❌ Comma-separated / multi-pattern MERGE in one clause (parser accepts a single `PathPattern` only)
+- ❌ Treating parse/bind/plan success or TCK inventory counts as end-to-end proof — logical-plan / wrapper tests are not execution support
+
+**Test Coverage:** Direct facade tests in `e2e_baseline.rs` above. Official TCK `clauses/merge` (Merge1–9, ~75 scenarios) is inventory coverage, not a completeness claim for the unsupported shapes.
 
 ---
 
@@ -417,16 +428,17 @@ Implementation status of OpenCypher query clauses in GraphForge.
 
 ### Strengths
 
-1. **Core clauses complete**: All essential reading, writing, and projecting clauses fully implemented
+1. **Core clauses mostly complete**: Essential reading, writing, and projecting clauses are implemented; MERGE is an explicit partial subset
 2. **Advanced features**: Variable-length paths, OPTIONAL MATCH, UNION, subquery expressions
 3. **Query chaining**: WITH clause with full spec compliance (v0.3.0)
 4. **Pattern matching**: Comprehensive pattern support including variable-length and path binding
 
 ### Limitations
 
-1. **CALL procedures**: No procedure system implemented
-2. **CALL { } subqueries**: Only EXISTS/COUNT supported, not general syntax
-3. **Import/Export**: No LOAD CSV or equivalent (use dataset system instead)
+1. **MERGE**: Partial — standalone new-node and referenced-endpoint relationship forms only; multi-node construction and row-conditional map actions reject with structured plan errors
+2. **CALL procedures**: No procedure system implemented
+3. **CALL { } subqueries**: Only EXISTS/COUNT supported, not general syntax
+4. **Import/Export**: No LOAD CSV or equivalent (use dataset system instead)
 
 ### Recommended Priority for v0.4.0+
 
@@ -449,6 +461,8 @@ Implementation status of OpenCypher query clauses in GraphForge.
 ## References
 
 - OpenCypher Specification: https://opencypher.org/resources/
-- GraphForge Grammar: `src/graphforge/parser/cypher.lark`
-- GraphForge Executor: `src/graphforge/executor/executor.py`
-- GraphForge Planner: `src/graphforge/planner/planner.py`
+- MERGE executor authority: `crates/graphforge-exec/src/write_driver.rs`
+- MERGE parser: `crates/graphforge-cypher/src/parser/clauses.rs`
+- MERGE binder: `crates/graphforge-ir/src/binder.rs`
+- MERGE planner node: `crates/graphforge-plan/src/lib.rs` (`GraphMergeNode`)
+- Direct MERGE execution tests: `crates/graphforge-api/tests/e2e_baseline.rs`

--- a/docs/reference/opencypher-compatibility-matrix.md
+++ b/docs/reference/opencypher-compatibility-matrix.md
@@ -13,11 +13,11 @@ Comprehensive status matrix for GraphForge's OpenCypher implementation, showing 
 
 | Category | Total Features | Complete | Partial | Not Implemented | Coverage |
 |----------|---------------|----------|---------|-----------------|----------|
-| **Clauses** | 20 | 17 (85%) | 1 (5%) | 2 (10%) | Excellent |
+| **Clauses** | 20 | 16 (80%) | 2 (10%) | 2 (10%) | Excellent |
 | **Functions** | 83 | 82 (99%) | 0 (0%) | 1 (1%) | Excellent |
 | **Operators** | 34 | 34 (100%) | 0 (0%) | 0 (0%) | Complete |
 | **Patterns** | 8 | 7 (87%) | 0 (0%) | 1 (13%) | Excellent |
-| **TOTAL** | **145** | **140 (97%)** | **1 (1%)** | **4 (3%)** | **Excellent** |
+| **TOTAL** | **145** | **139 (96%)** | **2 (1%)** | **4 (3%)** | **Excellent** |
 
 ### Overall Compliance: **~99% TCK Compliant (3,801/3,885 scenarios)**
 
@@ -25,10 +25,10 @@ Comprehensive status matrix for GraphForge's OpenCypher implementation, showing 
 
 ## Quick Reference
 
-### ✅ Fully Supported (140 features)
+### ✅ Fully Supported (139 features)
 - Core querying: MATCH, RETURN, WHERE, ORDER BY, LIMIT, SKIP
 - Query chaining: WITH (full spec compliance)
-- Writing: CREATE, MERGE, SET, REMOVE, DELETE, DETACH DELETE
+- Writing: CREATE, SET, REMOVE, DELETE, DETACH DELETE
 - Advanced: OPTIONAL MATCH, UNION, UNWIND, variable-length paths
 - Temporal: All date/time types and functions (100% complete)
 - Spatial: Point and distance functions (100% complete)
@@ -41,7 +41,8 @@ Comprehensive status matrix for GraphForge's OpenCypher implementation, showing 
 - Aggregation: count, sum, avg, min, max, collect, percentileDisc, percentileCont, stDev, stDevP (10/10)
 - Numeric math: Full suite including trig, log, exp, e(), pi(), degrees(), radians() (19 functions)
 
-### ⚠️ Partially Supported (1 feature)
+### ⚠️ Partially Supported (2 features)
+- MERGE (standalone new-node and referenced-endpoint relationship forms; multi-node construction and row-conditional map actions rejected)
 - CALL { } / EXISTS subquery (simple EXISTS implemented; full correlated subquery syntax pending)
 
 ### ❌ Not Supported (4 features)
@@ -54,7 +55,7 @@ Comprehensive status matrix for GraphForge's OpenCypher implementation, showing 
 
 ## Detailed Feature Matrix
 
-### Clauses (20 total: 17 complete, 1 partial, 2 not implemented)
+### Clauses (20 total: 16 complete, 2 partial, 2 not implemented)
 
 | Clause | Status | TCK Scenarios | Implementation Files | Notes |
 |--------|--------|---------------|---------------------|-------|
@@ -66,7 +67,7 @@ Comprehensive status matrix for GraphForge's OpenCypher implementation, showing 
 | **ORDER BY** | ✅ Complete | 134 | executor.py | ASC/DESC, multiple keys, NULL ordering |
 | **LIMIT** | ✅ Complete | 40 | executor.py | Result limiting |
 | **SKIP** | ✅ Complete | 40 | executor.py | Pagination support |
-| **MERGE** | ✅ Complete | 75 | executor.py | With ON CREATE/MATCH |
+| **MERGE** | ⚠️ Partial | 75 | `write_driver.rs` (`run_merge_phase`) | Standalone new-node + referenced-endpoint relationship forms; multi-node construction and row-conditional map actions rejected |
 | **SET** | ✅ Complete | 53 | executor.py | Property/label updates |
 | **REMOVE** | ✅ Complete | 33 | executor.py | Property/label removal |
 | **DELETE** | ✅ Complete | 41 | executor.py | Node/relationship deletion |

--- a/docs/reference/opencypher-compatibility.md
+++ b/docs/reference/opencypher-compatibility.md
@@ -42,7 +42,7 @@ GraphForge prioritizes:
 ### Writing clauses
 
 - **CREATE**, **SET**, **REMOVE**, **DELETE**, **DETACH DELETE**
-- **MERGE** with **ON CREATE** / **ON MATCH**
+- **MERGE** (partial) — standalone new-node upsert and relationship MERGE with already-bound endpoints; multi-node construction and row-conditional map actions are rejected. See [implementation-status/clauses.md](implementation-status/clauses.md#merge).
 
 ### Aggregations
 

--- a/docs/reference/opencypher-features/01-clauses.md
+++ b/docs/reference/opencypher-features/01-clauses.md
@@ -740,6 +740,8 @@ RETURN product
 
 **Purpose**: Ensure that a pattern exists in the graph. Either the pattern already exists (and is matched), or it needs to be created. Combines MATCH and CREATE functionality.
 
+**GraphForge support:** Partial — see [implementation-status/clauses.md](../implementation-status/clauses.md#merge). Spec text below describes openCypher MERGE; GraphForge executes standalone new-node MERGE and referenced-endpoint relationship MERGE only. Multi-node construction and row-conditional map actions raise structured plan errors and are not shipped support.
+
 **Syntax**:
 ```cypher
 MERGE (variable:Label {properties})
@@ -767,7 +769,7 @@ ON MATCH SET person.last_seen = datetime()
 RETURN person
 ```
 
-*Complex - Merge pattern with relationships*:
+*Supported GraphForge relationship form (endpoints already bound)*:
 ```cypher
 MERGE (user:User {id: $user_id})
 ON CREATE SET user.created_at = datetime(),

--- a/docs/reference/tck-failure-histogram.md
+++ b/docs/reference/tck-failure-histogram.md
@@ -51,7 +51,7 @@ TCK_DUMP_FAILURES=/tmp/tck_failures.jsonl cargo test -p graphforge-api --test bd
 | 8 | Binder: composite-var reference after projection | 71 | (bug) | — | `graphforge-rel/lowerer.rs` |
 | 9 | SET/REMOVE `<label>` | 25 | 25\* | high | \*needs full multi-label storage+exec+ledger (4 layers) |
 | 10 | Aggregation in `WITH` | 60 | ~15 | med | binder; blocked by read-after-write for write-area scenarios |
-| 11 | MERGE (node only) | 32 | ~5 | high | binder stub + IR; ON-clauses & rel-MERGE are separate |
+| 11 | MERGE (partial subset) | 32 | ~5+ | high | Standalone node + referenced-endpoint rel MERGE ship; multi-node construction and row-conditional map actions still reject |
 | 12 | CALL procedures | 52 | **0** | high | greenfield: harness registry + CALL/YIELD exec + error codes; every scenario double-blocked |
 | — | "ORDER BY wrong result" | 58 | **0** | high | **mislabeled** — ORDER BY works; folds into finding #3 (renderer) |
 
@@ -74,7 +74,7 @@ Pure test-harness work, no engine risk — the highest ROI on the board, and the
 - **CALL (52 → 0):** double-blocked (no harness fixture step *and* CALL is a binder stub).
 - **ORDER BY (58 → 0):** ORDER BY is implemented; failures are renderer formatting.
 - **Agg-in-WITH (60 → 15):** write-area scenarios blocked by read-after-write.
-- **MERGE (32 → 5):** binder stub; ON-clauses dropped; rel-MERGE separate.
+- **MERGE (32 → 5):** standalone node + referenced-endpoint relationship MERGE ship; multi-node construction and row-conditional map actions remain rejected.
 - **duration (122 → 51), params (62 → 31), typed-prop (65 → 49):** each hides a value-model gap.
 
 ## E. Recommended sequencing


### PR DESCRIPTION
## Summary
- Mark MERGE as **partial** across implementation status, compatibility matrix, feature mapping, and incomplete-features inventory.
- Replace removed Python executor / Lark MERGE authority with Rust parser, binder, planner, and `write_driver` paths.
- Enumerate supported standalone-node and referenced-endpoint relationship forms with direct `e2e_baseline` evidence, plus unsupported multi-node construction and row-conditional map-action errors.

Closes #707

## Test plan
- [x] Repo search: no `_execute_merge` / `cypher.lark:96` / `executor.py:2269` MERGE authority cites
- [x] Repo search: no page labels MERGE `COMPLETE` while unsupported shapes remain
- [x] `pnpm docs:build` succeeds in worktree
- [ ] CI docs checks on PR head
- Cited MERGE facade tests unchanged (docs-only); optional local: `CARGO_TARGET_DIR=/tmp/gf-target-707 cargo test -p graphforge-api --test e2e_baseline merge_`


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789311897&installation_model_id=20486&pr_number=714&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F714&signature=d6ef6238956ab60af0e545e547c275d36506cf68b57ab57bb7628fa17462b5dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->