### PR TITLE
fix(api): preserve projected node_id and edge_id aliases

### DIFF
--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -3502,12 +3502,21 @@ fn shape_result(
 struct Shaper {
     /// Source-batch column indices to keep, in output order.
     keep: Vec<usize>,
+    /// True when at least one internal surrogate column was dropped from the
+    /// source schema. Distinguishes surrogate-only projections (#703: preserve
+    /// row count) from already-empty schemas such as void `CALL` unit rows
+    /// (public result must stay empty for TCK Call1).
+    dropped_internal_surrogates: bool,
     /// The pruned, metadata-stamped public schema.
     schema: SchemaRef,
 }
 
 impl Shaper {
     fn new(schema: &SchemaRef, mode: OntologyMode, ontology: Option<&OntologyHandle>) -> Self {
+        let dropped_internal_surrogates = schema
+            .fields()
+            .iter()
+            .any(|f| graphforge_storage::is_internal_surrogate_field(f));
         let keep: Vec<usize> = schema
             .fields()
             .iter()
@@ -3522,6 +3531,7 @@ impl Shaper {
         ));
         Self {
             keep,
+            dropped_internal_surrogates,
             schema: new_schema,
         }
     }
@@ -3538,13 +3548,18 @@ impl Shaper {
             )));
         }
         let cols: Vec<_> = self.keep.iter().map(|&i| batch.column(i).clone()).collect();
-        // Preserve the logical row count even when every column was an internal
-        // surrogate (#703): an empty keep list must not collapse nonempty input
-        // into a zero-row batch.
+        // Surrogate-only projections must keep their logical row count (#703).
+        // Already-empty schemas (void CALL unit rows) must stay publicly empty
+        // so TCK Call1 "yields no results" scenarios do not regress.
+        let row_count = if self.keep.is_empty() && !self.dropped_internal_surrogates {
+            0
+        } else {
+            batch.num_rows()
+        };
         arrow::record_batch::RecordBatch::try_new_with_options(
             self.schema.clone(),
             cols,
-            &arrow::record_batch::RecordBatchOptions::new().with_row_count(Some(batch.num_rows())),
+            &arrow::record_batch::RecordBatchOptions::new().with_row_count(Some(row_count)),
         )
     }
 }
@@ -6644,6 +6659,27 @@ mod tests {
         let shaped = shaper.apply(&batch).expect("zero-column shape");
         assert_eq!(shaped.num_columns(), 0);
         assert_eq!(shaped.num_rows(), 3);
+    }
+
+    #[test]
+    fn shaper_collapses_void_unit_row_without_surrogate_drops() {
+        use arrow::datatypes::Schema;
+
+        // Empty-plan / void CALL execution yields a zero-column unit row. Public
+        // shaping must report an empty result (TCK Call1), not preserve the
+        // internal unit row when no surrogate columns were dropped.
+        let source_schema = Arc::new(Schema::empty());
+        let batch = arrow::record_batch::RecordBatch::try_new_with_options(
+            source_schema.clone(),
+            vec![],
+            &arrow::record_batch::RecordBatchOptions::new().with_row_count(Some(1)),
+        )
+        .unwrap();
+        assert_eq!(batch.num_rows(), 1);
+        let shaper = Shaper::new(&source_schema, OntologyMode::Exploratory, None);
+        let shaped = shaper.apply(&batch).expect("void shape");
+        assert_eq!(shaped.num_columns(), 0);
+        assert_eq!(shaped.num_rows(), 0);
     }
 
     #[test]

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -720,8 +720,9 @@ impl GraphForge {
     /// Runs the full pipeline: `parse → bind → lower → execute`. A query
     /// containing `CREATE` writes through [`graphforge_exec::ExecutionSession::execute_create`];
     /// a read query runs through `execute_plan`. The result exposes UUID
-    /// identity columns (`node_uuid`/`edge_uuid`) — never the internal
-    /// surrogate `node_id`/`edge_id` — and carries query metadata on its schema.
+    /// identity columns (`node_uuid`/`edge_uuid`) — never internal surrogate
+    /// scan keys — while preserving legal user aliases such as
+    /// `RETURN id(n) AS node_id` (#703). The schema carries query metadata.
     ///
     /// # Errors
     /// Returns [`GfError::Parse`] on a parse failure, [`GfError::Plan`] on a bind
@@ -1141,9 +1142,10 @@ impl GraphForge {
     /// Execute a read-only openCypher query and return a lazy stream of its
     /// result batches (the streaming counterpart of [`execute`](Self::execute)).
     ///
-    /// Like `execute`, each batch exposes UUID identity columns (never the
-    /// surrogate `node_id`/`edge_id`) and the stream's schema carries query
-    /// metadata. `CREATE`/`MERGE` are not supported on the streaming path — use
+    /// Like `execute`, each batch exposes UUID identity (never internal surrogate
+    /// scan keys) while preserving legal user aliases named `node_id`/`edge_id`
+    /// (#703), and the stream's schema carries query metadata. `CREATE`/`MERGE`
+    /// are not supported on the streaming path — use
     /// [`execute`](Self::execute) for writes.
     ///
     /// # Errors
@@ -3456,12 +3458,9 @@ fn system_time_micros() -> Result<i64, GfError> {
         .map_err(|_| GfError::Execution("system clock exceeds microsecond range".into()))
 }
 
-/// Internal surrogate identity columns that must never appear in public results
-/// (UUIDs are the public identity — see #719).
-const SURROGATE_COLUMNS: [&str; 2] = ["node_id", "edge_id"];
-
 /// Shape an [`ExecutionResult`] for the public API:
-/// - drop the surrogate `node_id`/`edge_id` columns (UUIDs are public identity),
+/// - drop internal surrogate identity columns (provenance-marked / UInt64 scan
+///   keys — never by final field name alone; see #703 / #719),
 /// - attach query metadata (`graphforge.query_id`, `ontology_version`,
 ///   `ir_version`, `ontology_mode`) to the schema.
 fn shape_result(
@@ -3494,9 +3493,9 @@ fn shape_result(
     })
 }
 
-/// Per-batch output shaper: prunes the surrogate identity columns and re-stamps
-/// the public schema (kept fields + query metadata). Built once from the raw
-/// result schema, then applied to each batch — shared by the collected
+/// Per-batch output shaper: prunes internal surrogate identity columns and
+/// re-stamps the public schema (kept fields + query metadata). Built once from
+/// the raw result schema, then applied to each batch — shared by the collected
 /// ([`shape_result`]) and streaming ([`shape_stream`]) paths.
 struct Shaper {
     /// Source-batch column indices to keep, in output order.
@@ -3511,7 +3510,7 @@ impl Shaper {
             .fields()
             .iter()
             .enumerate()
-            .filter(|(_, f)| !SURROGATE_COLUMNS.contains(&f.name().as_str()))
+            .filter(|(_, f)| !graphforge_storage::is_internal_surrogate_field(f))
             .map(|(i, _)| i)
             .collect();
         let kept_fields: Vec<_> = keep.iter().map(|&i| schema.field(i).clone()).collect();
@@ -3537,17 +3536,13 @@ impl Shaper {
             )));
         }
         let cols: Vec<_> = self.keep.iter().map(|&i| batch.column(i).clone()).collect();
-        // The projected columns line up with `self.schema` by construction.
+        // Preserve the logical row count even when every column was an internal
+        // surrogate (#703): an empty keep list must not collapse nonempty input
+        // into a zero-row batch.
         arrow::record_batch::RecordBatch::try_new_with_options(
             self.schema.clone(),
             cols,
-            &arrow::record_batch::RecordBatchOptions::new().with_row_count(Some(
-                if self.keep.is_empty() {
-                    0
-                } else {
-                    batch.num_rows()
-                },
-            )),
+            &arrow::record_batch::RecordBatchOptions::new().with_row_count(Some(batch.num_rows())),
         )
     }
 }
@@ -6558,6 +6553,223 @@ mod tests {
 
         let error = shaper.apply(&batch).expect_err("schema mismatch must fail");
         assert!(matches!(error, arrow::error::ArrowError::SchemaError(_)));
+    }
+
+    #[test]
+    fn shaper_preserves_user_aliases_named_like_surrogates() {
+        use arrow::array::{Int64Array, StringArray, UInt64Array};
+        use arrow::datatypes::{DataType, Field, Schema};
+        use graphforge_storage::{INTERNAL_SURROGATE_META_KEY, is_internal_surrogate_field};
+
+        let marked_node = Field::new("node_id", DataType::UInt64, false).with_metadata(
+            [(INTERNAL_SURROGATE_META_KEY.to_owned(), "true".to_owned())]
+                .into_iter()
+                .collect(),
+        );
+        let marked_edge = Field::new("edge_id", DataType::UInt64, false).with_metadata(
+            [(INTERNAL_SURROGATE_META_KEY.to_owned(), "true".to_owned())]
+                .into_iter()
+                .collect(),
+        );
+        assert!(is_internal_surrogate_field(&marked_node));
+        assert!(is_internal_surrogate_field(&marked_edge));
+
+        let source_schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, true),
+            Field::new("node_id", DataType::Int64, false),
+            marked_node,
+            Field::new("edge_id", DataType::FixedSizeBinary(16), false),
+            marked_edge,
+        ]));
+        let batch = arrow::record_batch::RecordBatch::try_new(
+            source_schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec![Some("Alice")])) as arrow::array::ArrayRef,
+                Arc::new(Int64Array::from(vec![42])),
+                Arc::new(UInt64Array::from(vec![7])),
+                Arc::new(
+                    arrow::array::FixedSizeBinaryArray::try_from_iter(std::iter::once(
+                        [0u8; 16].as_slice(),
+                    ))
+                    .unwrap(),
+                ),
+                Arc::new(UInt64Array::from(vec![9])),
+            ],
+        )
+        .unwrap();
+        let shaper = Shaper::new(&source_schema, OntologyMode::Exploratory, None);
+        let shaped = shaper.apply(&batch).expect("shape user aliases");
+        assert_eq!(
+            shaped
+                .schema()
+                .fields()
+                .iter()
+                .map(|f| f.name().as_str())
+                .collect::<Vec<_>>(),
+            ["name", "node_id", "edge_id"]
+        );
+        assert_eq!(shaped.num_rows(), 1);
+        assert_eq!(
+            shaped
+                .column_by_name("node_id")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .value(0),
+            42
+        );
+    }
+
+    #[test]
+    fn shaper_preserves_row_count_when_only_surrogates_remain() {
+        use arrow::array::UInt64Array;
+        use arrow::datatypes::{DataType, Field, Schema};
+        use graphforge_storage::INTERNAL_SURROGATE_META_KEY;
+
+        let marked = Field::new("node_id", DataType::UInt64, false).with_metadata(
+            [(INTERNAL_SURROGATE_META_KEY.to_owned(), "true".to_owned())]
+                .into_iter()
+                .collect(),
+        );
+        let source_schema = Arc::new(Schema::new(vec![marked]));
+        let batch = arrow::record_batch::RecordBatch::try_new(
+            source_schema.clone(),
+            vec![Arc::new(UInt64Array::from(vec![1, 2, 3])) as arrow::array::ArrayRef],
+        )
+        .unwrap();
+        let shaper = Shaper::new(&source_schema, OntologyMode::Exploratory, None);
+        let shaped = shaper.apply(&batch).expect("zero-column shape");
+        assert_eq!(shaped.num_columns(), 0);
+        assert_eq!(shaped.num_rows(), 3);
+    }
+
+    #[test]
+    fn projected_node_id_and_edge_id_aliases_survive_execute() {
+        let gf = GraphForge::new(None).unwrap();
+
+        let node = gf
+            .execute("RETURN 42 AS node_id")
+            .expect("literal node_id alias");
+        assert_eq!(node.stats.rows_produced, 1);
+        assert_eq!(
+            node.schema
+                .fields()
+                .iter()
+                .map(|f| f.name().as_str())
+                .collect::<Vec<_>>(),
+            ["node_id"]
+        );
+        assert_eq!(
+            node.batches[0]
+                .column_by_name("node_id")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .value(0),
+            42
+        );
+
+        let edge = gf
+            .execute("RETURN 42 AS edge_id")
+            .expect("literal edge_id alias");
+        assert_eq!(edge.stats.rows_produced, 1);
+        assert_eq!(
+            edge.schema
+                .fields()
+                .iter()
+                .map(|f| f.name().as_str())
+                .collect::<Vec<_>>(),
+            ["edge_id"]
+        );
+        assert_eq!(
+            edge.batches[0]
+                .column_by_name("edge_id")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .value(0),
+            42
+        );
+
+        gf.execute("CREATE (p:Person {name: 'Alice', hub: 107})")
+            .expect("seed person");
+        let mixed = gf
+            .execute(
+                "MATCH (p:Person {name: 'Alice'}) \
+                 RETURN p.name AS name, p.node_uuid AS node_id, p.hub AS edge_id, 1 AS keep",
+            )
+            .expect("mixed reserved-looking aliases");
+        assert_eq!(mixed.stats.rows_produced, 1);
+        assert_eq!(
+            mixed
+                .schema
+                .fields()
+                .iter()
+                .map(|f| f.name().as_str())
+                .collect::<Vec<_>>(),
+            ["name", "node_id", "edge_id", "keep"]
+        );
+        assert_eq!(
+            mixed.schema.field_with_name("node_id").unwrap().data_type(),
+            &DataType::FixedSizeBinary(16)
+        );
+        assert_eq!(
+            mixed.batches[0]
+                .column_by_name("name")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap()
+                .value(0),
+            "Alice"
+        );
+        assert_eq!(
+            mixed.batches[0]
+                .column_by_name("edge_id")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .value(0),
+            107
+        );
+        assert_eq!(
+            mixed.batches[0]
+                .column_by_name("keep")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .value(0),
+            1
+        );
+
+        // Documented network-analysis style: property projected AS node_id.
+        let hubs = gf
+            .execute(
+                "MATCH (p:Person {name: 'Alice'}) \
+                 RETURN p.hub AS node_id, 1 AS degree",
+            )
+            .expect("property AS node_id");
+        assert_eq!(hubs.stats.rows_produced, 1);
+        assert_eq!(
+            hubs.schema
+                .fields()
+                .iter()
+                .map(|f| f.name().as_str())
+                .collect::<Vec<_>>(),
+            ["node_id", "degree"]
+        );
+
+        // Internal scan surrogates still stay private on ordinary projections.
+        let uuid_only = gf
+            .execute("MATCH (p:Person) RETURN p.node_uuid AS node_uuid")
+            .expect("uuid projection");
+        assert!(uuid_only.schema.column_with_name("node_id").is_none());
+        assert!(uuid_only.schema.column_with_name("edge_id").is_none());
     }
 
     #[test]

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -184,8 +184,9 @@ pub use parquet_scan::{GraphForgeParquetExec, IoConcurrencyExt, ParquetFragment}
 pub mod schemas;
 pub use schemas::{
     ADJACENCY_CSR_SCHEMA, ADJACENCY_MANIFEST_SCHEMA, EDGE_PROPERTY_BASE_SCHEMA,
-    EXPLORATORY_EDGE_SCHEMA, PROPERTY_BASE_SCHEMA, TOPOLOGY_NODES_SCHEMA, TYPED_EDGE_SCHEMA,
-    property_schema, property_type_to_arrow, result_schema,
+    EXPLORATORY_EDGE_SCHEMA, INTERNAL_SURROGATE_META_KEY, PROPERTY_BASE_SCHEMA,
+    TOPOLOGY_NODES_SCHEMA, TYPED_EDGE_SCHEMA, is_internal_surrogate_field, property_schema,
+    property_type_to_arrow, result_schema,
 };
 
 pub mod writer;

--- a/crates/graphforge-storage/src/schemas.rs
+++ b/crates/graphforge-storage/src/schemas.rs
@@ -34,14 +34,44 @@ use graphforge_ontology::ontology::{PropertyDef, PropertyValueType};
 // Helpers
 // ---------------------------------------------------------------------------
 
+/// Arrow field metadata key marking an execution-internal surrogate identity
+/// column (`node_id`, `edge_id`, `src_id`, `dst_id`, …). Public result shaping
+/// drops fields that carry this marker; user projections that happen to reuse
+/// the same spelling (e.g. `RETURN 42 AS node_id`) must not (#703).
+pub const INTERNAL_SURROGATE_META_KEY: &str = "graphforge.internal_surrogate";
+
 /// UUID column: `FixedSizeBinary(16)`, not nullable.
 pub(crate) fn uuid_field(name: &str) -> Field {
     Field::new(name, DataType::FixedSizeBinary(16), false)
 }
 
-/// Surrogate ID column: `UInt64`, not nullable.
+/// Surrogate ID column: `UInt64`, not nullable, stamped with
+/// [`INTERNAL_SURROGATE_META_KEY`] so public shaping can distinguish it from a
+/// legal user alias of the same name (#703).
 pub(crate) fn id_field(name: &str) -> Field {
-    Field::new(name, DataType::UInt64, false)
+    Field::new(name, DataType::UInt64, false).with_metadata(
+        [(INTERNAL_SURROGATE_META_KEY.to_owned(), "true".to_owned())]
+            .into_iter()
+            .collect(),
+    )
+}
+
+/// True when `field` is an execution-internal surrogate identity column.
+///
+/// Provenance is the stamped metadata from [`id_field`]. As a storage-contract
+/// fallback, an unmarked top-level `node_id`/`edge_id` that is still `UInt64`
+/// is treated as a surrogate (user Cypher projections of those names are never
+/// bare `UInt64` scan keys). Name alone is never sufficient (#703).
+#[must_use]
+pub fn is_internal_surrogate_field(field: &Field) -> bool {
+    if field
+        .metadata()
+        .get(INTERNAL_SURROGATE_META_KEY)
+        .is_some_and(|value| value == "true")
+    {
+        return true;
+    }
+    matches!(field.name().as_str(), "node_id" | "edge_id") && *field.data_type() == DataType::UInt64
 }
 
 /// The Arrow fields of a typed Cypher `duration` value (ADR 0009): signed
@@ -339,9 +369,9 @@ pub fn property_schema(entity_type: &str, property_defs: &[PropertyDef]) -> Sche
 ///
 /// # Panics (debug builds only)
 ///
-/// Panics if any field name ends with `_id`.  Surrogate ID columns (`node_id`,
-/// `src_id`, `dst_id`, `edge_id`) are execution-internal and must never appear
-/// in public API result schemas — see the storage architecture contract.
+/// Panics if any field is an internal surrogate ([`is_internal_surrogate_field`]).
+/// Legal user aliases that reuse surrogate spellings (e.g. `RETURN id(n) AS
+/// node_id`) are allowed (#703).
 #[must_use]
 pub fn result_schema(
     fields: Vec<Field>,
@@ -350,12 +380,12 @@ pub fn result_schema(
     ir_ver: &str,
 ) -> Schema {
     debug_assert!(
-        fields.iter().all(|f| !f.name().ends_with("_id")),
-        "result_schema: surrogate '*_id' columns must not appear in public API results \
+        fields.iter().all(|f| !is_internal_surrogate_field(f)),
+        "result_schema: internal surrogate columns must not appear in public API results \
          (offending fields: {:?})",
         fields
             .iter()
-            .filter(|f| f.name().ends_with("_id"))
+            .filter(|f| is_internal_surrogate_field(f))
             .map(arrow::datatypes::Field::name)
             .collect::<Vec<_>>()
     );
@@ -625,14 +655,34 @@ mod tests {
 
     #[cfg(debug_assertions)]
     #[test]
-    #[should_panic(expected = "surrogate '*_id' columns must not appear")]
+    #[should_panic(expected = "internal surrogate columns must not appear")]
     fn result_schema_rejects_surrogate_id_field() {
-        // In debug builds, passing a *_id field must panic.
-        let _ = result_schema(
-            vec![Field::new("node_id", DataType::UInt64, false)],
+        // In debug builds, a stamped / UInt64 surrogate field must panic.
+        let _ = result_schema(vec![id_field("node_id")], "q1", "v1", "0.1.0");
+    }
+
+    #[test]
+    fn result_schema_allows_user_alias_named_node_id() {
+        // #703: a non-surrogate projection aliased `node_id` is public data.
+        let schema = result_schema(
+            vec![Field::new("node_id", DataType::Int64, false)],
             "q1",
             "v1",
             "0.1.0",
         );
+        assert_eq!(schema.fields().len(), 1);
+        assert_eq!(schema.field(0).name(), "node_id");
+    }
+
+    #[test]
+    fn id_field_stamps_internal_surrogate_marker() {
+        let field = id_field("node_id");
+        assert!(is_internal_surrogate_field(&field));
+        assert_eq!(
+            field.metadata().get(INTERNAL_SURROGATE_META_KEY),
+            Some(&"true".to_owned())
+        );
+        let user_alias = Field::new("node_id", DataType::Int64, false);
+        assert!(!is_internal_surrogate_field(&user_alias));
     }
 }

--- a/crates/graphforge-storage/src/schemas.rs
+++ b/crates/graphforge-storage/src/schemas.rs
@@ -58,12 +58,26 @@ pub(crate) fn id_field(name: &str) -> Field {
 
 /// True when `field` is an execution-internal surrogate identity column.
 ///
+/// Dropping requires the **current public field name** to still be a scan-key
+/// spelling (`node_id` / `edge_id` / `src_id` / `dst_id` / `neighbor_id`).
+/// DataFusion preserves [`INTERNAL_SURROGATE_META_KEY`] across `AS` renames, so
+/// a projection like `RETURN b.node_id AS id` must remain public under `id`
+/// (#703 / fixed-hop LIMIT regressions).
+///
 /// Provenance is the stamped metadata from [`id_field`]. As a storage-contract
 /// fallback, an unmarked top-level `node_id`/`edge_id` that is still `UInt64`
 /// is treated as a surrogate (user Cypher projections of those names are never
 /// bare `UInt64` scan keys). Name alone is never sufficient (#703).
 #[must_use]
 pub fn is_internal_surrogate_field(field: &Field) -> bool {
+    let name = field.name().as_str();
+    let is_scan_key_name = matches!(
+        name,
+        "node_id" | "edge_id" | "src_id" | "dst_id" | "neighbor_id"
+    );
+    if !is_scan_key_name {
+        return false;
+    }
     if field
         .metadata()
         .get(INTERNAL_SURROGATE_META_KEY)
@@ -71,7 +85,7 @@ pub fn is_internal_surrogate_field(field: &Field) -> bool {
     {
         return true;
     }
-    matches!(field.name().as_str(), "node_id" | "edge_id") && *field.data_type() == DataType::UInt64
+    matches!(name, "node_id" | "edge_id") && *field.data_type() == DataType::UInt64
 }
 
 /// The Arrow fields of a typed Cypher `duration` value (ADR 0009): signed
@@ -684,5 +698,10 @@ mod tests {
         );
         let user_alias = Field::new("node_id", DataType::Int64, false);
         assert!(!is_internal_surrogate_field(&user_alias));
+        // Metadata may survive DataFusion rename; aliased-away scan keys stay public.
+        let stamped = id_field("node_id");
+        let renamed = Field::new("id", stamped.data_type().clone(), stamped.is_nullable())
+            .with_metadata(stamped.metadata().clone());
+        assert!(!is_internal_surrogate_field(&renamed));
     }
 }


### PR DESCRIPTION
## Summary
- Stamp `graphforge.internal_surrogate` on storage surrogate `id_field`s and drop only provenance-marked (or unmarked UInt64 `node_id`/`edge_id` scan-key) columns in the public result shaper.
- Preserve legal user projections aliased as `node_id`/`edge_id`, keep schema order/values, and retain logical row count when every column was an internal surrogate.
- Add Rust facade/unit regressions covering literals, mixed aliases, surrogate suppression, and zero-column row-count preservation.

Closes #703

## Test plan
- [x] `cargo test -p graphforge-storage --lib schemas::tests` (CARGO_TARGET_DIR=/tmp/gf-target-703)
- [x] `cargo test -p graphforge-api --lib projected_node_id`
- [x] `cargo test -p graphforge-api --lib shaper_preserves`
- [x] `cargo test -p graphforge-api --lib shaper_schema_mismatch`
- [ ] CI green on exact head SHA


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789312964&installation_model_id=20486&pr_number=716&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F716&signature=526091194701c6ca1fd429c2b5cb988a63dcb396aa68d5bfa1772e95000b8d3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * User-selected fields aliased as `node_id` or `edge_id` now remain visible in results.
  * Results with no selected columns preserve the correct number of rows.
  * Internal identifier fields are now distinguished from user-provided aliases more reliably.

* **Documentation**
  * Updated collected and streaming result documentation to clarify alias preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->