### PR TITLE
chore(deps): standardize TypeScript 5.9.3 and tsx

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -112,6 +112,8 @@ updates:
           - "patch"
 
   # Root npm / pnpm workspace
+  # Repo standard pins TypeScript exactly to 5.9.3 (see
+  # docs/development/typescript-toolchain.md and root pnpm.overrides).
   # If npm Dependabot is later added for iac/pulumi/typescript, it must carry
   # the same typescript major-update guardrail below.
   - package-ecosystem: "npm"
@@ -130,7 +132,8 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
-    # Stay on TypeScript 5.x; majors (e.g. 7.x) need an explicit coordinated bump.
+    # Pin stays 5.9.3; ignore majors so Dependabot cannot open unplanned 6+/7+ PRs.
+    # Coordinated pin/override bumps are manual (policy doc + all direct pins).
     ignore:
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -112,6 +112,8 @@ updates:
           - "patch"
 
   # Root npm / pnpm workspace
+  # If npm Dependabot is later added for iac/pulumi/typescript, it must carry
+  # the same typescript major-update guardrail below.
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -128,6 +130,10 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    # Stay on TypeScript 5.x; majors (e.g. 7.x) need an explicit coordinated bump.
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       npm-minor-patch:
         patterns:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -681,6 +681,9 @@ jobs:
           pnpm smoke:node-cli
           pnpm --filter @curatelabs/graphforge-cli test:lifecycle
 
+      - name: Typecheck Node BDD package
+        run: pnpm --filter @curatelabs/graphforge-bdd-node typecheck
+
       - name: Run Node BDD suite
         working-directory: tests/features/node
         shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,9 @@ process, and design principles — is:
 
 **[docs/development/contributing.md](docs/development/contributing.md)**
 
+TypeScript first-party policy (compiler 5.9.3, `tsx`, no `ts-node`):
+[docs/development/typescript-toolchain.md](docs/development/typescript-toolchain.md).
+
 Agent-oriented workflow and architecture rules are in [AGENTS.md](AGENTS.md).
 
 ### Validation (summary)

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -176,6 +176,8 @@ and [testing.md](testing.md) for command recipes and suite layout.
 - Thin adapters only — no semantic ownership in the binding layer
 - Type hints / typed APIs on public surfaces
 - No `# type: ignore` without explanation
+- First-party TypeScript compiler/loader policy:
+  [typescript-toolchain.md](typescript-toolchain.md)
 
 ---
 

--- a/docs/development/typescript-toolchain.md
+++ b/docs/development/typescript-toolchain.md
@@ -1,0 +1,33 @@
+# TypeScript toolchain policy
+
+Canonical GraphForge TypeScript toolchain for first-party packages that
+directly declare or invoke the compiler.
+
+## Compiler
+
+**TypeScript 5.9.3** (exact) is the canonical compiler. First-party packages
+that pin `typescript` directly:
+
+- `tests/features/node`
+- `iac/pulumi/typescript`
+
+Do not bump the compiler major without a coordinated upgrade across all direct
+pins. Verify JavaScript/JSDoc behavior, compiler-API consumers, framework
+tooling, and peer ranges (for example `@pulumi/pulumi` peers `typescript < 7`)
+before changing the pin.
+
+## Runtime loader
+
+**`tsx`** is the canonical TypeScript execution / runtime loader.
+Feature BDD (Cucumber) uses `tsx/cjs`.
+
+**`ts-node` is deprecated and prohibited** for new or first-party GraphForge
+code — manifests, scripts, CI, and docs. Do not introduce it.
+
+## Out of scope for direct pins
+
+- **`docs-site`** does not directly pin or invoke `tsc`. Astro owns its
+  embedded TypeScript integration.
+- Transitive compiler or loader copies in lockfiles (including optional
+  `ts-node` peer metadata from `@pulumi/pulumi`) are dependency implementation
+  details — not the repository standard.

--- a/docs/development/typescript-toolchain.md
+++ b/docs/development/typescript-toolchain.md
@@ -1,20 +1,39 @@
 # TypeScript toolchain policy
 
 Canonical GraphForge TypeScript toolchain for first-party packages that
-directly declare or invoke the compiler.
+directly declare or invoke the compiler, and for workspace-resolved
+`typescript` installs enforced via package-manager overrides.
 
 ## Compiler
 
-**TypeScript 5.9.3** (exact) is the canonical compiler. First-party packages
-that pin `typescript` directly:
+**TypeScript 5.9.3** (exact) is the repository standard.
+
+First-party packages that pin `typescript` directly:
 
 - `tests/features/node`
 - `iac/pulumi/typescript`
 
-Do not bump the compiler major without a coordinated upgrade across all direct
-pins. Verify JavaScript/JSDoc behavior, compiler-API consumers, framework
-tooling, and peer ranges (for example `@pulumi/pulumi` peers `typescript < 7`)
-before changing the pin.
+### Workspace / lockfile enforcement
+
+The root pnpm workspace forces every resolved `typescript` dependency —
+including transitive consumers such as `@napi-rs/cli` and
+`@astrojs/starlight` / `i18next` — to **5.9.3** via `pnpm.overrides` in the
+root `package.json`. After `pnpm install`, the root lockfile should contain
+only `typescript@5.9.3` (no 6.x / 7.x copies).
+
+`iac/pulumi/typescript` is outside the pnpm workspace and already pins
+exact `5.9.3`. It also declares an npm `overrides` entry so transitive
+resolutions stay on that pin if a future dependency tries to pull another
+compiler major.
+
+Prefer an override over documenting an exception. Record an exception only
+when a dependency truly cannot run against TypeScript 5.9.3 after an
+override attempt, with evidence in the coordinating issue.
+
+Do not bump the compiler major (or the exact pin) without a coordinated
+upgrade across all direct pins and overrides. Verify JavaScript/JSDoc
+behavior, compiler-API consumers, framework tooling, and peer ranges (for
+example `@pulumi/pulumi` peers `typescript < 7`) before changing the pin.
 
 ## Runtime loader
 
@@ -27,7 +46,8 @@ code — manifests, scripts, CI, and docs. Do not introduce it.
 ## Out of scope for direct pins
 
 - **`docs-site`** does not directly pin or invoke `tsc`. Astro owns its
-  embedded TypeScript integration.
-- Transitive compiler or loader copies in lockfiles (including optional
-  `ts-node` peer metadata from `@pulumi/pulumi`) are dependency implementation
-  details — not the repository standard.
+  embedded TypeScript integration. Its transitive `typescript` peer still
+  resolves to **5.9.3** through the root `pnpm.overrides`.
+- Generated lockfile peer metadata that mentions optional loaders such as
+  `ts-node` (for example from `@pulumi/pulumi`) is not first-party usage and
+  is not the repository standard.

--- a/iac/pulumi/typescript/package.json
+++ b/iac/pulumi/typescript/package.json
@@ -26,5 +26,8 @@
     "@types/node": "24.10.1",
     "prettier": "3.9.5",
     "typescript": "5.9.3"
+  },
+  "overrides": {
+    "typescript": "5.9.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "onlyBuiltDependencies": [
       "esbuild",
       "sharp"
-    ]
+    ],
+    "overrides": {
+      "typescript": "5.9.3"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  typescript: 5.9.3
+
 importers:
 
   .:
@@ -28,7 +31,7 @@ importers:
     dependencies:
       '@astrojs/starlight':
         specifier: ^0.41.6
-        version: 0.41.7(@astrojs/markdown-remark@7.2.2)(astro@7.2.0(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(tsx@4.23.12)(yaml@2.9.0))(typescript@7.0.2)
+        version: 0.41.7(@astrojs/markdown-remark@7.2.2)(astro@7.2.0(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(tsx@4.23.12)(yaml@2.9.0))(typescript@5.9.3)
       astro:
         specifier: ^7.1.6
         version: 7.2.0(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(tsx@4.23.12)(yaml@2.9.0)
@@ -1424,126 +1427,6 @@ packages:
   '@types/uuid@10.0.0':
     resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
-  '@typescript/typescript-aix-ppc64@7.0.2':
-    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [ppc64]
-    os: [aix]
-
-  '@typescript/typescript-darwin-arm64@7.0.2':
-    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@typescript/typescript-darwin-x64@7.0.2':
-    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@typescript/typescript-freebsd-arm64@7.0.2':
-    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@typescript/typescript-freebsd-x64@7.0.2':
-    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@typescript/typescript-linux-arm64@7.0.2':
-    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@typescript/typescript-linux-arm@7.0.2':
-    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm]
-    os: [linux]
-
-  '@typescript/typescript-linux-loong64@7.0.2':
-    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@typescript/typescript-linux-mips64el@7.0.2':
-    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
-    engines: {node: '>=16.20.0'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@typescript/typescript-linux-ppc64@7.0.2':
-    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
-    engines: {node: '>=16.20.0'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@typescript/typescript-linux-riscv64@7.0.2':
-    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@typescript/typescript-linux-s390x@7.0.2':
-    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
-    engines: {node: '>=16.20.0'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@typescript/typescript-linux-x64@7.0.2':
-    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [linux]
-
-  '@typescript/typescript-netbsd-arm64@7.0.2':
-    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@typescript/typescript-netbsd-x64@7.0.2':
-    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [netbsd]
-
-  '@typescript/typescript-openbsd-arm64@7.0.2':
-    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@typescript/typescript-openbsd-x64@7.0.2':
-    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@typescript/typescript-sunos-x64@7.0.2':
-    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@typescript/typescript-win32-arm64@7.0.2':
-    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@typescript/typescript-win32-x64@7.0.2':
-    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [win32]
-
   '@ungap/structured-clone@1.3.3':
     resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
 
@@ -2139,7 +2022,7 @@ packages:
   i18next@26.3.6:
     resolution: {integrity: sha512-Bu5Z2nAXgfVyM8xvW3jk9EKRIuX37PudsrBViThNFx7CR7aaYTpP01cxNB/E4c4UUzTDiAZRstEhsRfPOL/8xA==}
     peerDependencies:
-      typescript: ^5 || ^6 || ^7
+      typescript: 5.9.3
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -3066,16 +2949,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@6.0.3:
-    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
-  typescript@7.0.2:
-    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
-    engines: {node: '>=16.20.0'}
-    hasBin: true
-
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
@@ -3482,7 +3355,7 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.4.3
 
-  '@astrojs/starlight@0.41.7(@astrojs/markdown-remark@7.2.2)(astro@7.2.0(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(tsx@4.23.12)(yaml@2.9.0))(typescript@7.0.2)':
+  '@astrojs/starlight@0.41.7(@astrojs/markdown-remark@7.2.2)(astro@7.2.0(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(tsx@4.23.12)(yaml@2.9.0))(typescript@5.9.3)':
     dependencies:
       '@astrojs/markdown-satteri': 0.3.5
       '@astrojs/mdx': 7.0.5(@astrojs/markdown-satteri@0.3.5)(astro@7.2.0(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -3498,7 +3371,7 @@ snapshots:
       hast-util-select: 6.0.4
       hast-util-to-string: 3.0.1
       hastscript: 9.0.1
-      i18next: 26.3.6(typescript@7.0.2)
+      i18next: 26.3.6(typescript@5.9.3)
       js-yaml: 4.1.1
       klona: 2.0.6
       magic-string: 0.30.21
@@ -4123,7 +3996,7 @@ snapshots:
       obug: 2.1.4
       semver: 7.8.5
       typanion: 3.14.0
-      typescript: 6.0.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@napi-rs/cross-toolchain-arm64-target-aarch64'
@@ -4625,66 +4498,6 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/uuid@10.0.0': {}
-
-  '@typescript/typescript-aix-ppc64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-darwin-arm64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-darwin-x64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-freebsd-arm64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-freebsd-x64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-linux-arm64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-linux-arm@7.0.2':
-    optional: true
-
-  '@typescript/typescript-linux-loong64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-linux-mips64el@7.0.2':
-    optional: true
-
-  '@typescript/typescript-linux-ppc64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-linux-riscv64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-linux-s390x@7.0.2':
-    optional: true
-
-  '@typescript/typescript-linux-x64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-netbsd-arm64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-netbsd-x64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-openbsd-arm64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-openbsd-x64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-sunos-x64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-win32-arm64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-win32-x64@7.0.2':
-    optional: true
 
   '@ungap/structured-clone@1.3.3': {}
 
@@ -5460,9 +5273,9 @@ snapshots:
 
   http-cache-semantics@4.2.0: {}
 
-  i18next@26.3.6(typescript@7.0.2):
+  i18next@26.3.6(typescript@5.9.3):
     optionalDependencies:
-      typescript: 7.0.2
+      typescript: 5.9.3
 
   iconv-lite@0.7.2:
     dependencies:
@@ -6741,32 +6554,6 @@ snapshots:
   type-fest@4.41.0: {}
 
   typescript@5.9.3: {}
-
-  typescript@6.0.3: {}
-
-  typescript@7.0.2:
-    optionalDependencies:
-      '@typescript/typescript-aix-ppc64': 7.0.2
-      '@typescript/typescript-darwin-arm64': 7.0.2
-      '@typescript/typescript-darwin-x64': 7.0.2
-      '@typescript/typescript-freebsd-arm64': 7.0.2
-      '@typescript/typescript-freebsd-x64': 7.0.2
-      '@typescript/typescript-linux-arm': 7.0.2
-      '@typescript/typescript-linux-arm64': 7.0.2
-      '@typescript/typescript-linux-loong64': 7.0.2
-      '@typescript/typescript-linux-mips64el': 7.0.2
-      '@typescript/typescript-linux-ppc64': 7.0.2
-      '@typescript/typescript-linux-riscv64': 7.0.2
-      '@typescript/typescript-linux-s390x': 7.0.2
-      '@typescript/typescript-linux-x64': 7.0.2
-      '@typescript/typescript-netbsd-arm64': 7.0.2
-      '@typescript/typescript-netbsd-x64': 7.0.2
-      '@typescript/typescript-openbsd-arm64': 7.0.2
-      '@typescript/typescript-openbsd-x64': 7.0.2
-      '@typescript/typescript-sunos-x64': 7.0.2
-      '@typescript/typescript-win32-arm64': 7.0.2
-      '@typescript/typescript-win32-x64': 7.0.2
-    optional: true
 
   ufo@1.6.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: ^4.20.0
         version: 4.23.12
       typescript:
-        specifier: ^7.0.2
-        version: 7.0.2
+        specifier: 5.9.3
+        version: 5.9.3
 
 packages:
 
@@ -3060,6 +3060,11 @@ packages:
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
@@ -6735,6 +6740,8 @@ snapshots:
 
   type-fest@4.41.0: {}
 
+  typescript@5.9.3: {}
+
   typescript@6.0.3: {}
 
   typescript@7.0.2:
@@ -6759,6 +6766,7 @@ snapshots:
       '@typescript/typescript-sunos-x64': 7.0.2
       '@typescript/typescript-win32-arm64': 7.0.2
       '@typescript/typescript-win32-x64': 7.0.2
+    optional: true
 
   ufo@1.6.4: {}
 

--- a/scripts/ci/test-coverage-rust.sh
+++ b/scripts/ci/test-coverage-rust.sh
@@ -16,6 +16,12 @@ grep -Fq 'wait "$python_pid"' "$RUNNER"
 grep -Fq 'wait "$node_pid"' "$RUNNER"
 grep -Fq 'stamp_matches()' "$RUNNER"
 grep -Fq 'write_stamp()' "$RUNNER"
+# Node acceptance must load TypeScript via tsx, not ts-node (#719).
+grep -Fq -- 'tsx/cjs' "$RUNNER"
+if grep -Fq -- 'ts-node' "$RUNNER"; then
+  echo "coverage-rust.sh must not reference ts-node" >&2
+  exit 1
+fi
 
 if rg -n --glob '*.{yml,yaml}' 'coverage-rust|make coverage|make pre-push' "$ROOT/.github"; then
   echo "Rust coverage must remain outside PR CI" >&2

--- a/scripts/coverage-rust.sh
+++ b/scripts/coverage-rust.sh
@@ -201,7 +201,7 @@ run_node_acceptance() {
     cd tests/features/node
     node node_modules/@cucumber/cucumber/bin/cucumber.js \
       "../api/**/*.feature" \
-      --require-module ts-node/register \
+      --require-module tsx/cjs \
       --require "step_definitions/**/*.ts" \
       --tags "not @excluded-api-bdd and not @excluded-node-api-bdd" \
       --format summary

--- a/tests/features/node/package.json
+++ b/tests/features/node/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "license": "Apache-2.0",
   "scripts": {
-    "test:bdd": "cucumber-js"
+    "test:bdd": "cucumber-js",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@curatelabs/graphforge": "workspace:*"
@@ -14,6 +15,6 @@
     "@types/node": "^26.2.0",
     "apache-arrow": "^21.2.0",
     "tsx": "^4.20.0",
-    "typescript": "^7.0.2"
+    "typescript": "5.9.3"
   }
 }


### PR DESCRIPTION
## Summary
- Pin first-party TypeScript to exact **5.9.3** (`tests/features/node`, `iac/pulumi/typescript`) and keep `tsx` as the only first-party loader (including coverage-rust).
- Enforce a **clean sweep** with root `pnpm.overrides` (`typescript: 5.9.3`) so transitive consumers (`@napi-rs/cli`, Starlight/`i18next`) resolve only **5.9.3**; Pulumi adds matching npm `overrides`.
- Document the repo standard and override enforcement; Dependabot keeps ignoring `typescript` majors while the pin stays **5.9.3**.

## Test plan
- [x] `pnpm --filter @curatelabs/graphforge-bdd-node typecheck` (pass under 5.9.3)
- [x] After `pnpm install`, lockfile / `node_modules/.pnpm` contain only `typescript@5.9.3` (no 6.x/7.x)
- [x] `npx tsc -p tsconfig.json --noEmit` in `iac/pulumi/typescript`
- [x] Confirm Dependabot root npm ignore targets `typescript` semver-major
- [ ] CI: Node binding / BDD path green at PR head

Closes #719

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rust coverage test reliability by standardizing TypeScript loading.
  * Added validation to prevent outdated TypeScript runtime loading from being used.

* **Chores**
  * Pinned TypeScript to version 5.9.3 across supported projects.
  * Added a TypeScript type-checking command for Node acceptance tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->