### PR TITLE
feat(storage): recover interrupted project transactions during open

### DIFF
--- a/crates/graphforge-api/src/checkpoints.rs
+++ b/crates/graphforge-api/src/checkpoints.rs
@@ -166,6 +166,11 @@ impl CheckpointView {
     pub fn graph_open_evidence(&self) -> &graphforge_storage::GraphFilesOpenEvidence {
         self.graph.graph_open_evidence()
     }
+    /// Recovery evidence for this read-only checkpoint open (cleanup skipped).
+    #[must_use]
+    pub fn project_open_recovery(&self) -> &graphforge_storage::ProjectOpenRecoveryEvidence {
+        self.graph.project_open_recovery()
+    }
     /// Execute a read-only Cypher statement against the pinned generation.
     pub fn execute(&self, cypher: &str) -> Result<ExecutionResult, GfError> {
         self.graph.execute_read_only(cypher)
@@ -767,6 +772,9 @@ impl GraphForge {
                     true,
                     write_options.clone(),
                     resource_policy.clone(),
+                    graphforge_storage::ProjectOpenRecoveryEvidence::checkpoint_view(
+                        generation.generation_uuid(),
+                    ),
                 )?));
                 Ok(())
             },
@@ -783,6 +791,10 @@ impl GraphForge {
             .expect("generation UUID lock poisoned") =
             reopened.resolved_generation.generation_uuid();
         reopened.read_only = false;
+        reopened.project_open_recovery =
+            graphforge_storage::ProjectOpenRecoveryEvidence::clean_open(
+                reopened.resolved_generation.generation_uuid(),
+            );
         let procedures = Arc::clone(&self.procedures);
         let provider_refresh_runtimes = Arc::clone(&self.provider_refresh_runtimes);
         let provider_find_runtimes = Arc::clone(&self.provider_find_runtimes);

--- a/crates/graphforge-api/src/embedding_refresh.rs
+++ b/crates/graphforge-api/src/embedding_refresh.rs
@@ -259,6 +259,7 @@ impl GraphForge {
             dir: self.dir.clone(),
             workspace_guard: Arc::clone(&self.workspace_guard),
             graph_open_evidence: self.graph_open_evidence.clone(),
+            project_open_recovery: self.project_open_recovery.clone(),
             tempdir: self.tempdir.clone(),
             ontology: self.ontology.clone(),
             ontology_document: self.ontology_document.clone(),

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -353,6 +353,8 @@ pub struct GraphForge {
     workspace_guard: Arc<tempfile::TempDir>,
     /// Structural evidence for how the graph workspace was opened.
     graph_open_evidence: graphforge_storage::GraphFilesOpenEvidence,
+    /// Safe recovery-on-open summary (cleanup, deferral, or checkpoint skip).
+    project_open_recovery: graphforge_storage::ProjectOpenRecoveryEvidence,
     /// Keeps an in-memory instance's temp directory alive for the engine's life.
     tempdir: Option<Arc<tempfile::TempDir>>,
     /// Compiled ontology, present in advisory/strict mode.
@@ -470,7 +472,8 @@ impl GraphForge {
         // engine's lifetime.
         let tmp = tempfile::TempDir::new()
             .map_err(|e| GfError::Storage(format!("failed to create temp dir: {e}")))?;
-        let resolved_generation = graphforge_storage::open_or_initialize_project(tmp.path())?;
+        let (resolved_generation, project_open_recovery) =
+            graphforge_storage::open_or_initialize_project_with_recovery(tmp.path())?;
         let generation_uuid = resolved_generation.generation_uuid();
         let (ontology_mode, ontology, ontology_document) =
             load_workspace_ontology(&resolved_generation)?;
@@ -507,6 +510,7 @@ impl GraphForge {
             dir,
             workspace_guard: workspace,
             graph_open_evidence,
+            project_open_recovery,
             tempdir: Some(Arc::new(tmp)),
             ontology,
             ontology_document,
@@ -529,6 +533,12 @@ impl GraphForge {
         &self.graph_open_evidence
     }
 
+    /// Safe recovery-on-open summary for this facade instance.
+    #[must_use]
+    pub fn project_open_recovery(&self) -> &graphforge_storage::ProjectOpenRecoveryEvidence {
+        &self.project_open_recovery
+    }
+
     fn open_dir_with_options(
         dir: PathBuf,
         options: GraphForgeOptions,
@@ -541,8 +551,16 @@ impl GraphForge {
             )));
         }
 
-        let resolved_generation = graphforge_storage::open_or_initialize_project(&dir)?;
-        Self::open_resolved_with_options(dir, resolved_generation, false, options, resource_policy)
+        let (resolved_generation, project_open_recovery) =
+            graphforge_storage::open_or_initialize_project_with_recovery(&dir)?;
+        Self::open_resolved_with_options(
+            dir,
+            resolved_generation,
+            false,
+            options,
+            resource_policy,
+            project_open_recovery,
+        )
     }
 
     fn open_resolved_with_mode(
@@ -552,12 +570,22 @@ impl GraphForge {
     ) -> Result<Self, GfError> {
         let options = GraphForgeOptions::default();
         let (_, resource_policy) = options.clone().validate()?;
+        let project_open_recovery = if read_only {
+            graphforge_storage::ProjectOpenRecoveryEvidence::checkpoint_view(
+                resolved_generation.generation_uuid(),
+            )
+        } else {
+            graphforge_storage::ProjectOpenRecoveryEvidence::initialization(
+                resolved_generation.generation_uuid(),
+            )
+        };
         Self::open_resolved_with_options(
             container_dir,
             resolved_generation,
             read_only,
             options,
             resource_policy,
+            project_open_recovery,
         )
     }
 
@@ -567,6 +595,7 @@ impl GraphForge {
         read_only: bool,
         write_options: GraphForgeOptions,
         resource_policy: resource_policy::NormalizedResourcePolicy,
+        project_open_recovery: graphforge_storage::ProjectOpenRecoveryEvidence,
     ) -> Result<Self, GfError> {
         let generation_uuid = resolved_generation.generation_uuid();
         let (ontology_mode, ontology, ontology_document) =
@@ -624,6 +653,7 @@ impl GraphForge {
             dir,
             workspace_guard: workspace,
             graph_open_evidence,
+            project_open_recovery,
             tempdir: None,
             ontology,
             ontology_document,

--- a/crates/graphforge-api/tests/file_backed_graph_generation.rs
+++ b/crates/graphforge-api/tests/file_backed_graph_generation.rs
@@ -112,11 +112,42 @@ fn checkpoint_read_only_open_pins_graph_tree_in_place() {
     assert_eq!(evidence.files_copied, 0);
     assert_eq!(evidence.bytes_copied, 0);
     assert_eq!(evidence.files_opened_in_place, evidence.files_validated);
+    assert_eq!(
+        view.project_open_recovery().kind,
+        graphforge_storage::ProjectOpenRecoveryKind::CheckpointView
+    );
 
     let result = view
         .execute("MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN count(*) AS n")
         .unwrap();
     assert_eq!(result.stats.rows_produced, 1);
+}
+
+#[test]
+fn project_open_exposes_recovery_evidence_and_repeat_open_stays_stable() {
+    let root = tempfile::tempdir().unwrap();
+    let path = root.path().to_str().unwrap();
+    let first = GraphForge::new(Some(path)).unwrap();
+    assert_eq!(
+        first.project_open_recovery().kind,
+        graphforge_storage::ProjectOpenRecoveryKind::Initialization
+    );
+    let generation = first.project_open_recovery().selected_generation_uuid;
+    drop(first);
+
+    let second = GraphForge::new(Some(path)).unwrap();
+    let evidence = second.project_open_recovery();
+    assert_eq!(
+        evidence.kind,
+        graphforge_storage::ProjectOpenRecoveryKind::ProjectOpen
+    );
+    assert_eq!(evidence.selected_generation_uuid, generation);
+    assert_eq!(
+        evidence.selected_generation_class,
+        graphforge_storage::ProjectRecoveryGenerationClass::CommittedCurrent
+    );
+    assert!(!evidence.work_detected);
+    assert!(evidence.deferred.is_none());
 }
 
 #[test]

--- a/crates/graphforge-bindings-py/tests/non_cypher_release.py
+++ b/crates/graphforge-bindings-py/tests/non_cypher_release.py
@@ -23,7 +23,7 @@ ROOT = Path(__file__).resolve().parents[3]
 RUST_MANIFEST = ROOT / "tests/contracts/non-cypher-rust-surface.json"
 RUST_GATE = ROOT / "scripts/ci/non-cypher-surface-gate.py"
 PYO3_SOURCE = ROOT / "crates/graphforge-bindings-py/src/lib.rs"
-EXPECTED_RUST_DIGEST = "489b4ddff8728689a29476d5b4927eb6b0b1fb83e7b7be8988f923ea8d09b83d"
+EXPECTED_RUST_DIGEST = "61136f545830f1ac67d7f8c643e40d83e8b2a5b0b0bea77bde3e0724d03064fa"
 EXPECTED_RELEASE_DIGEST = "98bf3c9277a0cf13146ce4ecfe98e4e213c94e21edc0e8e48536783ffd02bc7e"
 
 PYTHON_ONLY_METHODS = frozenset(

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -76,7 +76,12 @@ pub use project_publication::{
 };
 
 pub mod project_recovery;
-pub use project_recovery::{ProjectRecoveryReport, recover_project_transactions};
+pub use project_recovery::{
+    ProjectOpenRecoveryEvidence, ProjectOpenRecoveryKind, ProjectRecoveryDeferral,
+    ProjectRecoveryGenerationClass, ProjectRecoveryReport,
+    open_or_initialize_project_with_recovery, recover_project_on_open,
+    recover_project_transactions,
+};
 
 pub mod project_portable;
 pub use project_portable::{

--- a/crates/graphforge-storage/src/project_checkpoints.rs
+++ b/crates/graphforge-storage/src/project_checkpoints.rs
@@ -794,8 +794,14 @@ fn revert_receipt(
 }
 
 pub(crate) struct CheckpointRetentionRoots {
-    _checkpoint_lock: File,
+    checkpoint_lock: File,
     pub(crate) roots: Vec<(Uuid, [u8; 32])>,
+}
+
+impl Drop for CheckpointRetentionRoots {
+    fn drop(&mut self) {
+        let _ = crate::file_lock::unlock(&self.checkpoint_lock);
+    }
 }
 
 pub(crate) fn checkpoint_retention_roots_after_writer_lock(
@@ -821,7 +827,7 @@ pub(crate) fn checkpoint_retention_roots_after_writer_lock(
         })
         .collect::<Result<Vec<_>, GfError>>()?;
     Ok(CheckpointRetentionRoots {
-        _checkpoint_lock: checkpoint_lock,
+        checkpoint_lock,
         roots,
     })
 }

--- a/crates/graphforge-storage/src/project_recovery.rs
+++ b/crates/graphforge-storage/src/project_recovery.rs
@@ -7,6 +7,7 @@
 use std::collections::BTreeSet;
 use std::fs::File;
 use std::path::{Path, PathBuf};
+use std::time::Instant;
 
 use graphforge_core::{GfError, ProjectErrorCode};
 use uuid::Uuid;
@@ -14,6 +15,7 @@ use uuid::Uuid;
 use crate::project_checkpoints::checkpoint_retention_roots_after_writer_lock;
 use crate::project_failpoint;
 use crate::project_generation::{
+    CURRENT_FILE, ResolvedProjectGeneration, open_or_initialize_project,
     resolve_project_generation, validated_generation_manifest_sha256, validated_generation_parent,
 };
 use crate::project_publication::{
@@ -39,6 +41,327 @@ pub struct ProjectRecoveryReport {
     pub removed_generations: u64,
     /// Unknown machine-owned entries preserved for explicit inspection.
     pub preserved_unknown_entries: u64,
+}
+
+/// Why an open-lifecycle recovery pass did not complete cleanup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProjectRecoveryDeferral {
+    /// A live writer holds `locks/writer.lock`; snapshot open remains safe.
+    LiveWriterOwnsKernelLock,
+}
+
+impl ProjectRecoveryDeferral {
+    /// Stable machine-readable deferral token (no paths or payload data).
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::LiveWriterOwnsKernelLock => "live_writer_owns_kernel_lock",
+        }
+    }
+}
+
+/// Authority class of the generation pinned by open/recovery.
+///
+/// Recovery never elects by UUID, time, or directory order; only a validated
+/// `CURRENT` pointer grants authority.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProjectRecoveryGenerationClass {
+    /// Exact generation named by a validated `CURRENT` record.
+    CommittedCurrent,
+}
+
+impl ProjectRecoveryGenerationClass {
+    /// Stable machine-readable class token.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::CommittedCurrent => "committed_current",
+        }
+    }
+}
+
+/// Open-path context for recovery evidence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProjectOpenRecoveryKind {
+    /// Ordinary project open inspected (and possibly cleaned) abandoned state.
+    ProjectOpen,
+    /// First committed generation / resumed initialization; cleanup not applicable.
+    Initialization,
+    /// Read-only checkpoint pin; recovery cleanup intentionally skipped.
+    CheckpointView,
+}
+
+/// Safe recovery summary exposed through open evidence / the Rust facade.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectOpenRecoveryEvidence {
+    /// Which open path produced this evidence.
+    pub kind: ProjectOpenRecoveryKind,
+    /// Generation selected by validated `CURRENT` (or the checkpoint pin).
+    pub selected_generation_uuid: Uuid,
+    /// Authority class of [`Self::selected_generation_uuid`].
+    pub selected_generation_class: ProjectRecoveryGenerationClass,
+    /// Whether bounded inspection found candidate recovery work.
+    pub work_detected: bool,
+    /// Journals repaired to `PUBLISHED`.
+    pub repaired_journals: u64,
+    /// Journals classified as `ABORTED`.
+    pub aborted_journals: u64,
+    /// Abandoned private generation or trash directories removed/quarantined.
+    pub removed_generations: u64,
+    /// Unknown or unclassified entries preserved for inspection.
+    pub preserved_unknown_entries: u64,
+    /// Present when cleanup was deferred because recovery locks were busy.
+    pub deferred: Option<ProjectRecoveryDeferral>,
+    /// Wall-clock duration of the recovery/inspection phase in milliseconds.
+    pub elapsed_ms: u64,
+}
+
+impl ProjectOpenRecoveryEvidence {
+    /// Evidence for first initialization (no recovery pass).
+    #[must_use]
+    pub fn initialization(selected_generation_uuid: Uuid) -> Self {
+        Self {
+            kind: ProjectOpenRecoveryKind::Initialization,
+            selected_generation_uuid,
+            selected_generation_class: ProjectRecoveryGenerationClass::CommittedCurrent,
+            work_detected: false,
+            repaired_journals: 0,
+            aborted_journals: 0,
+            removed_generations: 0,
+            preserved_unknown_entries: 0,
+            deferred: None,
+            elapsed_ms: 0,
+        }
+    }
+
+    /// Evidence for a read-only checkpoint open (recovery cleanup skipped).
+    #[must_use]
+    pub fn checkpoint_view(selected_generation_uuid: Uuid) -> Self {
+        Self {
+            kind: ProjectOpenRecoveryKind::CheckpointView,
+            selected_generation_uuid,
+            selected_generation_class: ProjectRecoveryGenerationClass::CommittedCurrent,
+            work_detected: false,
+            repaired_journals: 0,
+            aborted_journals: 0,
+            removed_generations: 0,
+            preserved_unknown_entries: 0,
+            deferred: None,
+            elapsed_ms: 0,
+        }
+    }
+
+    /// Evidence for an already-clean committed open with no recovery work.
+    #[must_use]
+    pub fn clean_open(selected_generation_uuid: Uuid) -> Self {
+        Self {
+            kind: ProjectOpenRecoveryKind::ProjectOpen,
+            selected_generation_uuid,
+            selected_generation_class: ProjectRecoveryGenerationClass::CommittedCurrent,
+            work_detected: false,
+            repaired_journals: 0,
+            aborted_journals: 0,
+            removed_generations: 0,
+            preserved_unknown_entries: 0,
+            deferred: None,
+            elapsed_ms: 0,
+        }
+    }
+}
+
+/// Open or initialize a project, then run recovery-on-open when applicable.
+///
+/// First initialization and resumed uninitialized layouts skip cleanup and
+/// report [`ProjectOpenRecoveryKind::Initialization`]. Ordinary reopens resolve
+/// and validate `CURRENT`, then recover abandoned state when locks are free.
+///
+/// # Errors
+/// Propagates initialization, resolution, and recovery integrity errors.
+/// A live writer never fails an otherwise valid snapshot open: cleanup is
+/// reported as deferred instead of `GF_WRITER_BUSY`.
+pub fn open_or_initialize_project_with_recovery(
+    container_root: impl AsRef<Path>,
+) -> Result<(ResolvedProjectGeneration, ProjectOpenRecoveryEvidence), GfError> {
+    let root = container_root.as_ref();
+    if root.join(CURRENT_FILE).exists() {
+        return recover_project_on_open(root);
+    }
+    let resolved = open_or_initialize_project(root)?;
+    Ok((
+        resolved.clone(),
+        ProjectOpenRecoveryEvidence::initialization(resolved.generation_uuid()),
+    ))
+}
+
+/// Resolve `CURRENT`, then recover interrupted transactions as part of open.
+///
+/// Cleanup runs only when bounded inspection finds candidate work and the
+/// existing writer/transaction/checkpoint lock order can be acquired. When a
+/// live writer owns those locks, this returns the validated committed
+/// generation with [`ProjectRecoveryDeferral::LiveWriterOwnsKernelLock`].
+///
+/// # Errors
+/// Returns typed integrity errors when `CURRENT`/manifest authority is
+/// ambiguous. Never elects a generation by UUID, time, or directory order.
+pub fn recover_project_on_open(
+    container_root: impl AsRef<Path>,
+) -> Result<(ResolvedProjectGeneration, ProjectOpenRecoveryEvidence), GfError> {
+    let started = Instant::now();
+    let root = container_root.as_ref();
+    let selected = resolve_project_generation(root).map_err(map_recovery_resolution)?;
+    let work_detected = project_needs_recovery_pass(root)?;
+    if !work_detected {
+        return Ok((
+            selected.clone(),
+            ProjectOpenRecoveryEvidence {
+                kind: ProjectOpenRecoveryKind::ProjectOpen,
+                selected_generation_uuid: selected.generation_uuid(),
+                selected_generation_class: ProjectRecoveryGenerationClass::CommittedCurrent,
+                work_detected: false,
+                repaired_journals: 0,
+                aborted_journals: 0,
+                removed_generations: 0,
+                preserved_unknown_entries: 0,
+                deferred: None,
+                elapsed_ms: elapsed_ms(started),
+            },
+        ));
+    }
+
+    match recover_project_transactions(root) {
+        Ok(report) => {
+            let selected = resolve_project_generation(root).map_err(map_recovery_resolution)?;
+            Ok((
+                selected.clone(),
+                evidence_from_report(&report, selected.generation_uuid(), started, None),
+            ))
+        }
+        Err(error) if error.code() == "GF_WRITER_BUSY" => {
+            let selected = resolve_project_generation(root).map_err(map_recovery_resolution)?;
+            Ok((
+                selected.clone(),
+                ProjectOpenRecoveryEvidence {
+                    kind: ProjectOpenRecoveryKind::ProjectOpen,
+                    selected_generation_uuid: selected.generation_uuid(),
+                    selected_generation_class: ProjectRecoveryGenerationClass::CommittedCurrent,
+                    work_detected: true,
+                    repaired_journals: 0,
+                    aborted_journals: 0,
+                    removed_generations: 0,
+                    preserved_unknown_entries: 0,
+                    deferred: Some(ProjectRecoveryDeferral::LiveWriterOwnsKernelLock),
+                    elapsed_ms: elapsed_ms(started),
+                },
+            ))
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn evidence_from_report(
+    report: &ProjectRecoveryReport,
+    selected_generation_uuid: Uuid,
+    started: Instant,
+    deferred: Option<ProjectRecoveryDeferral>,
+) -> ProjectOpenRecoveryEvidence {
+    ProjectOpenRecoveryEvidence {
+        kind: ProjectOpenRecoveryKind::ProjectOpen,
+        selected_generation_uuid,
+        selected_generation_class: ProjectRecoveryGenerationClass::CommittedCurrent,
+        work_detected: true,
+        repaired_journals: report.repaired_journals,
+        aborted_journals: report.aborted_journals,
+        removed_generations: report.removed_generations,
+        preserved_unknown_entries: report.preserved_unknown_entries,
+        deferred,
+        elapsed_ms: elapsed_ms(started),
+    }
+}
+
+fn elapsed_ms(started: Instant) -> u64 {
+    u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX)
+}
+
+/// Bounded, link-safe inspection for journals/attempts/trash that may need work.
+fn project_needs_recovery_pass(root: &Path) -> Result<bool, GfError> {
+    let trash_root = root.join(TRASH_DIR);
+    if trash_root.exists() {
+        reject_real_directory(&trash_root)?;
+        if !bounded_directory_entries(&trash_root)?.is_empty() {
+            return Ok(true);
+        }
+    }
+
+    let transactions_root = root.join(TRANSACTIONS_DIR);
+    if !transactions_root.exists() {
+        return Ok(false);
+    }
+    reject_real_directory(&transactions_root)?;
+    for path in bounded_directory_entries(&transactions_root)? {
+        if looks_like_atomicwrite_temp(&path) {
+            return Ok(true);
+        }
+        let Some(transaction_uuid) = journal_file_uuid(&path) else {
+            // Noncanonical entry: recovery must fail closed without deleting it.
+            return Ok(true);
+        };
+        let Ok(journal) = read_journal(&path) else {
+            return Ok(true);
+        };
+        if parse_canonical_uuid(&journal.transaction_uuid) != Some(transaction_uuid) {
+            return Ok(true);
+        }
+        match journal.phase {
+            JournalPhase::Published => {}
+            JournalPhase::Aborted => {
+                let Some(generation_uuid) = parse_canonical_uuid(&journal.generation_uuid) else {
+                    return Ok(true);
+                };
+                if aborted_journal_still_needs_cleanup(
+                    root,
+                    transaction_uuid,
+                    generation_uuid,
+                    &journal,
+                ) {
+                    return Ok(true);
+                }
+            }
+            JournalPhase::Preparing
+            | JournalPhase::Staged
+            | JournalPhase::Validated
+            | JournalPhase::Durable => return Ok(true),
+        }
+    }
+    Ok(false)
+}
+
+fn aborted_journal_still_needs_cleanup(
+    root: &Path,
+    transaction_uuid: Uuid,
+    generation_uuid: Uuid,
+    journal: &crate::project_publication::JournalRecord,
+) -> bool {
+    let generation_name = generation_uuid.hyphenated().to_string();
+    if root.join(GENERATIONS_DIR).join(&generation_name).exists() {
+        return true;
+    }
+    if root.join(TRASH_DIR).join(&generation_name).exists() {
+        return true;
+    }
+    root.join(ATTEMPTS_DIR)
+        .join(transaction_uuid.hyphenated().to_string())
+        .join(&journal.request_fingerprint)
+        .exists()
+}
+
+fn looks_like_atomicwrite_temp(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    let Some(suffix) = name.strip_prefix(".atomicwrite") else {
+        return false;
+    };
+    suffix.len() == 6 && suffix.bytes().all(|byte| byte.is_ascii_alphanumeric())
 }
 
 /// Recover interrupted project transactions without changing commit authority.
@@ -1089,6 +1412,142 @@ mod tests {
                     .exists()
             );
         }
+    }
+
+    #[test]
+    fn open_recovers_pre_publication_kill_to_parent_idempotently() {
+        let root = tempfile::tempdir().unwrap();
+        let parent = open_or_initialize_project(root.path())
+            .unwrap()
+            .generation_uuid();
+        let abandoned = Uuid::now_v7();
+        let status = spawn_writer(
+            root.path(),
+            Uuid::now_v7(),
+            abandoned,
+            "graph",
+            "project.after_journal_durable",
+        );
+        assert_eq!(status.code(), Some(crate::project_failpoint::exit_code()));
+
+        let (first, evidence) = open_or_initialize_project_with_recovery(root.path()).unwrap();
+        assert_eq!(first.generation_uuid(), parent);
+        assert_eq!(
+            evidence.selected_generation_class,
+            ProjectRecoveryGenerationClass::CommittedCurrent
+        );
+        assert_eq!(evidence.kind, ProjectOpenRecoveryKind::ProjectOpen);
+        assert!(evidence.work_detected);
+        assert!(evidence.aborted_journals >= 1 || evidence.removed_generations >= 1);
+        assert!(evidence.deferred.is_none());
+        assert!(
+            !root
+                .path()
+                .join(GENERATIONS_DIR)
+                .join(abandoned.hyphenated().to_string())
+                .exists()
+        );
+
+        let (second, again) = open_or_initialize_project_with_recovery(root.path()).unwrap();
+        assert_eq!(second.generation_uuid(), parent);
+        assert_eq!(again.selected_generation_uuid, parent);
+        assert!(!again.work_detected);
+        assert_eq!(again.aborted_journals, 0);
+        assert_eq!(again.removed_generations, 0);
+    }
+
+    #[test]
+    fn open_recovers_post_publication_kill_to_child_and_repairs_journal() {
+        let root = tempfile::tempdir().unwrap();
+        open_or_initialize_project(root.path()).unwrap();
+        let child = Uuid::now_v7();
+        let status = spawn_writer(
+            root.path(),
+            Uuid::now_v7(),
+            child,
+            "graph",
+            "project.after_current_replace",
+        );
+        assert_eq!(status.code(), Some(crate::project_failpoint::exit_code()));
+
+        let (opened, evidence) = open_or_initialize_project_with_recovery(root.path()).unwrap();
+        assert_eq!(opened.generation_uuid(), child);
+        assert_eq!(
+            evidence.selected_generation_class.as_str(),
+            "committed_current"
+        );
+        assert!(evidence.work_detected);
+        assert!(evidence.repaired_journals >= 1);
+        assert!(evidence.deferred.is_none());
+
+        let (again, second) = open_or_initialize_project_with_recovery(root.path()).unwrap();
+        assert_eq!(again.generation_uuid(), child);
+        assert!(!second.work_detected);
+        assert_eq!(second.repaired_journals, 0);
+    }
+
+    #[test]
+    fn open_with_live_writer_defers_cleanup_and_pins_valid_current() {
+        let root = tempfile::tempdir().unwrap();
+        let selected = open_or_initialize_project(root.path())
+            .unwrap()
+            .generation_uuid();
+        // Leave an abandoned journal so open detects work and attempts recovery.
+        let status = spawn_writer(
+            root.path(),
+            Uuid::now_v7(),
+            Uuid::now_v7(),
+            "graph",
+            "project.after_journal_staged",
+        );
+        assert_eq!(status.code(), Some(crate::project_failpoint::exit_code()));
+        let lock_dir = ensure_machine_directory(root.path(), Path::new(LOCKS_DIR)).unwrap();
+        let lock = open_regular_lock(&lock_dir.join(WRITER_LOCK_FILE)).unwrap();
+        crate::file_lock::lock_exclusive(&lock).unwrap();
+
+        let (opened, evidence) = open_or_initialize_project_with_recovery(root.path()).unwrap();
+        assert_eq!(opened.generation_uuid(), selected);
+        assert!(evidence.work_detected);
+        assert_eq!(
+            evidence.deferred,
+            Some(ProjectRecoveryDeferral::LiveWriterOwnsKernelLock)
+        );
+        assert_eq!(
+            evidence.deferred.unwrap().as_str(),
+            "live_writer_owns_kernel_lock"
+        );
+        assert_eq!(evidence.repaired_journals, 0);
+        assert_eq!(evidence.removed_generations, 0);
+    }
+
+    #[test]
+    fn open_corrupt_current_fails_closed_without_fallback_election() {
+        let root = tempfile::tempdir().unwrap();
+        let selected = open_or_initialize_project(root.path())
+            .unwrap()
+            .generation_uuid();
+        std::fs::write(root.path().join(CURRENT_FILE), b"{invalid\n").unwrap();
+
+        let error = open_or_initialize_project_with_recovery(root.path()).unwrap_err();
+
+        assert_eq!(error.code(), "GF_PROJECT_CORRUPT");
+        assert!(error.to_string().contains("verified backup"));
+        assert!(
+            root.path()
+                .join(GENERATIONS_DIR)
+                .join(selected.hyphenated().to_string())
+                .exists()
+        );
+    }
+
+    #[test]
+    fn initialization_open_reports_distinct_recovery_kind() {
+        let root = tempfile::tempdir().unwrap();
+        let (opened, evidence) = open_or_initialize_project_with_recovery(root.path()).unwrap();
+        assert_eq!(evidence.kind, ProjectOpenRecoveryKind::Initialization);
+        assert_eq!(evidence.selected_generation_uuid, opened.generation_uuid());
+        assert!(!evidence.work_detected);
+        assert!(evidence.deferred.is_none());
     }
 
     #[test]

--- a/crates/graphforge-storage/src/project_recovery.rs
+++ b/crates/graphforge-storage/src/project_recovery.rs
@@ -404,6 +404,7 @@ pub fn recover_project_transactions(
     // observe the issue #275 signature (writer free, checkpoints still held).
     // Matches MutationLocks::Drop order in project_checkpoints.
     drop(checkpoint_roots);
+    crate::file_lock::unlock(&writer_lock).map_err(storage_io)?;
     drop(writer_lock);
     Ok(report)
 }
@@ -1184,6 +1185,7 @@ mod tests {
         );
         assert_eq!(status.code(), Some(crate::project_failpoint::exit_code()));
         recover_project_transactions(root.path()).unwrap();
+        wait_for_writer_lock_release(root.path());
         let request = ProjectGenerationRequest {
             transaction_uuid,
             generation_uuid,

--- a/docs/book/architecture/concurrency-recovery.md
+++ b/docs/book/architecture/concurrency-recovery.md
@@ -131,7 +131,10 @@ There are three CI surfaces for concurrency and durability contracts:
    behavior; the oracle is reusable by recovery, delta, compaction, and final
    certification. Authoritative graph delta runs (#752 / ADR 0019) publish only
    through the same `CURRENT` contract; they never recover by scanning newest
-   logs.
+   logs. Recovery-on-open
+   (`open_or_initialize_project_with_recovery` / facade open) runs bounded
+   inspection and idempotent cleanup when locks are free, and defers cleanup
+   without blocking a valid `CURRENT` snapshot when a live writer holds them.
 
 The finite Rust recovery ledger remains
 `tests/contracts/concurrency-recovery-matrix.json` and is validated by

--- a/docs/book/architecture/project-format-compatibility.md
+++ b/docs/book/architecture/project-format-compatibility.md
@@ -97,27 +97,44 @@ caller-managed public transactions are outside the v0.5 contract.
 
 ## Interrupted transaction recovery
 
-`recover_project_transactions()` first resolves the exact committed
-generation, then acquires `locks/writer.lock` non-blockingly and resolves it
-again. Successful kernel lock acquisition is the only evidence that an earlier
-writer is gone. PID, owner text, timestamps, heartbeats, and file age never
-permit lock stealing.
+Ordinary project open runs recovery as a first-class lifecycle step.
+`open_or_initialize_project_with_recovery()` (and therefore
+`GraphForge::new` / directory open) first resolves the exact committed
+generation, then uses bounded, link-safe inspection of journals, atomic
+temps, and trash. When candidate work exists it acquires `locks/writer.lock`
+non-blockingly in the established writer/transaction/checkpoint order,
+recovers idempotently, re-resolves `CURRENT`, and opens that pinned
+generation. Successful kernel lock acquisition is the only evidence that an
+earlier writer is gone. PID, owner text, timestamps, heartbeats, and file age
+never permit lock stealing.
 
-While holding that lock, recovery classifies canonical transaction journals in
-bounded lexical order. A journal whose generation and manifest digest match
-`CURRENT` is repaired to `PUBLISHED`. A non-published journal for any other
-generation is marked `ABORTED`; its UUID-named private generation is removed
-only after the current generation and its two verified ancestors are retained,
-an exclusive generation lease is acquired when present, and `CURRENT` is
-rechecked. Published historical journals remain published. Missing journals
-never affect authority, while a torn or ambiguous journal returns
-`GF_PROJECT_CORRUPT` with restore guidance and preserves the evidence.
+When a live writer already owns the recovery locks, open still pins the
+validated `CURRENT` generation and reports recovery as deferred
+(`live_writer_owns_kernel_lock`) instead of failing the snapshot open or
+stealing locks. Explicit `recover_project_transactions()` retains the
+`GF_WRITER_BUSY` contract for callers that require exclusive cleanup.
+
+While holding the recovery lock, cleanup classifies canonical transaction
+journals in bounded lexical order. A journal whose generation and manifest
+digest match `CURRENT` is repaired to `PUBLISHED`. A non-published journal for
+any other generation is marked `ABORTED`; its UUID-named private generation is
+removed only after the current generation and its two verified ancestors are
+retained, an exclusive generation lease is acquired when present, and
+`CURRENT` is rechecked. Published historical journals remain published.
+Missing journals never affect authority, while a torn or ambiguous journal
+returns `GF_PROJECT_CORRUPT` with restore guidance and preserves the evidence.
 
 Cleanup atomically moves an authorized abandoned generation into root
 `trash/`, flushes both directories, then deletes and flushes the trash entry.
 A crash at either cleanup boundary is idempotently completed by the next
 recovery pass. Unknown, linked, noncanonical, or journal-less generation
 entries are counted and preserved rather than traversed or guessed about.
+
+Initialization of an empty or resumable uninitialized container and
+read-only checkpoint opens remain semantically distinct: they do not run the
+recovery cleanup pass. Safe open evidence exposes selected generation class,
+repaired/aborted journal counts, removed/quarantined entries, deferral
+reason, and elapsed phase without payload data or sensitive paths.
 
 New-container interruption after `FORMAT` is durable leaves a supported
 uninitialized container. A later `open_or_initialize_project()` resumes that

--- a/scripts/ci/test-non-cypher-surface-gate.py
+++ b/scripts/ci/test-non-cypher-surface-gate.py
@@ -29,7 +29,7 @@ class SurfaceGateTests(unittest.TestCase):
 
     def test_checked_in_inventory_is_complete(self) -> None:
         self.assertEqual(GATE.validate(), [])
-        self.assertEqual(len(GATE.public_methods()), 277)
+        self.assertEqual(len(GATE.public_methods()), 279)
         self.assertEqual(len(GATE.algorithm_registry()), 94)
 
     def test_new_or_removed_public_method_fails_frozen_digest(self) -> None:

--- a/tests/contracts/durability-isolation-matrix.json
+++ b/tests/contracts/durability-isolation-matrix.json
@@ -228,16 +228,34 @@
       "id": "recovery_on_open_interrupted_transaction",
       "failpoints": [],
       "required_authority": "exact_valid_CURRENT_with_advisory_journal_cleanup",
-      "coverage": "partial",
-      "owner_issue": 750,
+      "coverage": "covered",
       "evidence": [
+        {
+          "kind": "rust",
+          "path": "crates/graphforge-storage/src/project_recovery.rs",
+          "symbol": "open_recovers_pre_publication_kill_to_parent_idempotently"
+        },
+        {
+          "kind": "rust",
+          "path": "crates/graphforge-storage/src/project_recovery.rs",
+          "symbol": "open_recovers_post_publication_kill_to_child_and_repairs_journal"
+        },
+        {
+          "kind": "rust",
+          "path": "crates/graphforge-storage/src/project_recovery.rs",
+          "symbol": "open_with_live_writer_defers_cleanup_and_pins_valid_current"
+        },
+        {
+          "kind": "rust",
+          "path": "crates/graphforge-storage/src/project_recovery.rs",
+          "symbol": "open_corrupt_current_fails_closed_without_fallback_election"
+        },
         {
           "kind": "rust",
           "path": "crates/graphforge-storage/src/project_recovery.rs",
           "symbol": "subprocess_kill_matrix_never_exposes_a_partial_generation"
         }
-      ],
-      "rationale": "Automatic recovery-on-open productization remains #750; existing kill matrices already prove authority selection."
+      ]
     }
   ],
   "anomalies": [

--- a/tests/contracts/non-cypher-rust-surface.json
+++ b/tests/contracts/non-cypher-rust-surface.json
@@ -1,7 +1,7 @@
 {
   "contract_version": 1,
   "scope": "Rust non-Cypher public release surface",
-  "public_method_digest": "489b4ddff8728689a29476d5b4927eb6b0b1fb83e7b7be8988f923ea8d09b83d",
+  "public_method_digest": "61136f545830f1ac67d7f8c643e40d83e8b2a5b0b0bea77bde3e0724d03064fa",
   "method_policy": {
     "receiver_defaults": {
       "GraphForge": "release-tested",
@@ -44,6 +44,7 @@
       "GraphForge.new_with_options": "introspection",
       "GraphForge.path": "introspection",
       "GraphForge.graph_open_evidence": "introspection",
+      "GraphForge.project_open_recovery": "introspection",
       "GraphForge.resource_diagnostics": "introspection",
       "GraphForge.resource_policy": "introspection",
       "GraphForge.export_portable": "designed-only",
@@ -55,6 +56,7 @@
       "RepositoryContext.validate_infra_target": "release-tested",
       "CheckpointView.checkpoint_uuid": "introspection",
       "CheckpointView.graph_open_evidence": "introspection",
+      "CheckpointView.project_open_recovery": "introspection",
       "CheckpointView.generation_uuid": "introspection",
       "OpenRouterProviderSession.new": "introspection",
       "CheckpointView.add_edge": "designed-only",


### PR DESCRIPTION
## Summary
- Wire recovery-on-open through `open_or_initialize_project_with_recovery` / facade open: resolve validated `CURRENT`, inspect journals/trash boundedly, recover when locks are free, re-pin the committed generation.
- Live writers defer cleanup (`live_writer_owns_kernel_lock`) without failing a valid snapshot open; initialization and checkpoint opens stay distinct; corrupt CURRENT/manifest still fails closed.
- Expose `ProjectOpenRecoveryEvidence` on `GraphForge` / checkpoint views and mark `recovery_on_open_interrupted_transaction` covered in the durability matrix.

## Test plan
- [x] `cargo test -p graphforge-storage --lib project_recovery`
- [x] `cargo test -p graphforge-api --test file_backed_graph_generation project_open_exposes_recovery_evidence`
- [x] `cargo test -p graphforge-api --test file_backed_graph_generation checkpoint_read_only_open_pins`
- [x] `cargo clippy -p graphforge-storage -p graphforge-api --features test-failpoints -- -D warnings`
- [x] `python3 scripts/ci/durability-isolation-gate.py validate`
- [ ] CI Gate green at exact head SHA

Closes #750


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789426784&installation_model_id=20486&pr_number=767&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F767&signature=bd51d3cea996e1b8875dd54cc6fa8e86fe6ab9f3b71b24f1d23acd7d17f49839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured project-open recovery status, including selected generation, recovery classification, detected work, timing, and deferred cleanup details.
  * Recovery now runs when opening projects, repairs eligible interrupted work, and safely defers cleanup when a live writer is active.
  * Exposed recovery evidence for regular project opens, initialization, checkpoint views, and embedding refresh operations.

* **Bug Fixes**
  * Improved handling of invalid project state, incomplete transactions, journal repairs, and temporary files with fail-closed validation.
  * Checkpoint retention locks are now released automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->