### PR TITLE
feat(storage): add authoritative durable small-write delta journal

### DIFF
--- a/crates/graphforge-storage/BUILD.bazel
+++ b/crates/graphforge-storage/BUILD.bazel
@@ -52,6 +52,15 @@ gf_rust_integration_test(
 )
 
 gf_rust_integration_test(
+    name = "graph_delta_journal",
+    srcs = ["tests/graph_delta_journal.rs"],
+    crate = ":graphforge_storage",
+    crate_features = ["test-failpoints"],
+    size = "medium",
+    deps = _STORAGE_DEPS,
+)
+
+gf_rust_integration_test(
     name = "graph_writer",
     srcs = ["tests/graph_writer.rs"],
     crate = ":graphforge_storage",
@@ -74,6 +83,7 @@ test_suite(
     tests = [
         ":adjacency_delta_write",
         ":filtered_read",
+        ":graph_delta_journal",
         ":graph_writer",
         ":io_stats",
     ],

--- a/crates/graphforge-storage/src/graph_delta_journal.rs
+++ b/crates/graphforge-storage/src/graph_delta_journal.rs
@@ -1,0 +1,1156 @@
+//! Authoritative durable graph mutation delta journal (ADR 0019 / #752).
+//!
+//! Base Parquet plus immutable ordered `.gfdr` runs form one
+//! inventory-verified graph generation. Derived adjacency deltas remain a
+//! separate rebuildable accelerator (`adjacency_delta`).
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::Path;
+
+use graphforge_core::{GfError, ProjectErrorCode};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::graph_files::{
+    GraphFileEntry, GraphFileRole, GraphFilesInventory, capture_graph_files, verify_graph_tree,
+};
+use crate::project_generation::resolve_project_generation;
+use crate::project_publication::{
+    ProjectCapability, ProjectGenerationRequest, ProjectPublicationReceipt, ProjectStageOutcome,
+    published_project_transaction, stage_project_generation_with_graph_tree,
+};
+use crate::{GRAPH_CAPABILITY_ID, GRAPH_CAPABILITY_VERSION, empty_workspace_participants};
+
+/// Run file format identity implemented by this release.
+pub const GRAPH_DELTA_RUN_FORMAT_VERSION: u32 = 1;
+/// Record frame version implemented by this release.
+pub const GRAPH_DELTA_RECORD_VERSION: u16 = 1;
+/// File extension for authoritative delta runs.
+pub const GRAPH_DELTA_RUN_EXTENSION: &str = "gfdr";
+/// Directory holding authoritative runs beneath a generation graph tree.
+pub const GRAPH_DELTA_DIR: &str = "deltas";
+
+/// Maximum contiguous runs retained in one generation before compaction (#753).
+pub const MAX_GRAPH_DELTA_RUNS: u64 = 64;
+/// Maximum encoded bytes for one run file (including framing).
+pub const MAX_GRAPH_DELTA_RUN_BYTES: usize = 16 * 1024 * 1024;
+/// Maximum framed records in one run.
+pub const MAX_GRAPH_DELTA_RECORDS_PER_RUN: usize = 100_000;
+/// Maximum payload bytes for one framed record.
+pub const MAX_GRAPH_DELTA_PAYLOAD_BYTES: usize = 1024 * 1024;
+/// Estimated replay memory budget (logical row + property maps).
+pub const MAX_GRAPH_DELTA_REPLAY_MEMORY_BYTES: usize = 256 * 1024 * 1024;
+
+const MAGIC: &[u8; 4] = b"GFDR";
+const SCHEMA_JSON_V1: u16 = 1;
+
+/// Bounds enforced for encode, open validation, and replay.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GraphDeltaJournalLimits {
+    /// Maximum runs in one generation chain.
+    pub max_runs: u64,
+    /// Maximum bytes per run file.
+    pub max_run_bytes: usize,
+    /// Maximum records per run.
+    pub max_records_per_run: usize,
+    /// Maximum payload bytes per record.
+    pub max_payload_bytes: usize,
+    /// Estimated replay memory ceiling.
+    pub max_replay_memory_bytes: usize,
+}
+
+impl Default for GraphDeltaJournalLimits {
+    fn default() -> Self {
+        Self {
+            max_runs: MAX_GRAPH_DELTA_RUNS,
+            max_run_bytes: MAX_GRAPH_DELTA_RUN_BYTES,
+            max_records_per_run: MAX_GRAPH_DELTA_RECORDS_PER_RUN,
+            max_payload_bytes: MAX_GRAPH_DELTA_PAYLOAD_BYTES,
+            max_replay_memory_bytes: MAX_GRAPH_DELTA_REPLAY_MEMORY_BYTES,
+        }
+    }
+}
+
+/// Supported authoritative mutation kinds for current graph surfaces.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[repr(u8)]
+pub enum GraphDeltaOpKind {
+    /// Insert or replace a node identity row.
+    UpsertNode = 1,
+    /// Delete a node by UUID.
+    DeleteNode = 2,
+    /// Insert or replace an edge identity row.
+    UpsertEdge = 3,
+    /// Delete an edge by UUID.
+    DeleteEdge = 4,
+    /// Set one node property.
+    SetNodeProperty = 5,
+    /// Remove one node property.
+    RemoveNodeProperty = 6,
+    /// Set one edge property.
+    SetEdgeProperty = 7,
+    /// Remove one edge property.
+    RemoveEdgeProperty = 8,
+}
+
+impl GraphDeltaOpKind {
+    fn from_u8(value: u8) -> Result<Self, GfError> {
+        match value {
+            1 => Ok(Self::UpsertNode),
+            2 => Ok(Self::DeleteNode),
+            3 => Ok(Self::UpsertEdge),
+            4 => Ok(Self::DeleteEdge),
+            5 => Ok(Self::SetNodeProperty),
+            6 => Ok(Self::RemoveNodeProperty),
+            7 => Ok(Self::SetEdgeProperty),
+            8 => Ok(Self::RemoveEdgeProperty),
+            other => Err(validation(format!(
+                "unsupported graph delta mutation kind {other}"
+            ))),
+        }
+    }
+}
+
+/// One framed mutation before encoding.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GraphDeltaOp {
+    /// Stable operation identity for idempotent replay.
+    pub operation_uuid: Uuid,
+    /// Mutation kind.
+    pub kind: GraphDeltaOpKind,
+    /// Canonical JSON payload matching schema id 1.
+    pub payload: GraphDeltaPayload,
+}
+
+/// Typed payloads for supported mutation kinds.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum GraphDeltaPayload {
+    /// Node upsert.
+    UpsertNode {
+        /// Node UUID (hyphenated lowercase).
+        node_uuid: String,
+        /// Complete label type id set.
+        type_ids: Vec<u32>,
+    },
+    /// Node delete.
+    DeleteNode {
+        /// Node UUID.
+        node_uuid: String,
+    },
+    /// Edge upsert.
+    UpsertEdge {
+        /// Edge UUID.
+        edge_uuid: String,
+        /// Source node UUID.
+        src_uuid: String,
+        /// Destination node UUID.
+        dst_uuid: String,
+        /// Relation type name (exploratory or typed stem).
+        rel_type: String,
+    },
+    /// Edge delete.
+    DeleteEdge {
+        /// Edge UUID.
+        edge_uuid: String,
+    },
+    /// Node property set.
+    SetNodeProperty {
+        /// Node UUID.
+        node_uuid: String,
+        /// Property key.
+        key: String,
+        /// Canonical scalar text encoding.
+        value: String,
+    },
+    /// Node property remove.
+    RemoveNodeProperty {
+        /// Node UUID.
+        node_uuid: String,
+        /// Property key.
+        key: String,
+    },
+    /// Edge property set.
+    SetEdgeProperty {
+        /// Edge UUID.
+        edge_uuid: String,
+        /// Property key.
+        key: String,
+        /// Canonical scalar text encoding.
+        value: String,
+    },
+    /// Edge property remove.
+    RemoveEdgeProperty {
+        /// Edge UUID.
+        edge_uuid: String,
+        /// Property key.
+        key: String,
+    },
+}
+
+impl GraphDeltaPayload {
+    fn expected_kind(&self) -> GraphDeltaOpKind {
+        match self {
+            Self::UpsertNode { .. } => GraphDeltaOpKind::UpsertNode,
+            Self::DeleteNode { .. } => GraphDeltaOpKind::DeleteNode,
+            Self::UpsertEdge { .. } => GraphDeltaOpKind::UpsertEdge,
+            Self::DeleteEdge { .. } => GraphDeltaOpKind::DeleteEdge,
+            Self::SetNodeProperty { .. } => GraphDeltaOpKind::SetNodeProperty,
+            Self::RemoveNodeProperty { .. } => GraphDeltaOpKind::RemoveNodeProperty,
+            Self::SetEdgeProperty { .. } => GraphDeltaOpKind::SetEdgeProperty,
+            Self::RemoveEdgeProperty { .. } => GraphDeltaOpKind::RemoveEdgeProperty,
+        }
+    }
+
+    fn encode(&self) -> Result<Vec<u8>, GfError> {
+        serde_json::to_vec(self)
+            .map_err(|error| validation(format!("graph delta payload encode failed: {error}")))
+    }
+
+    fn decode(bytes: &[u8]) -> Result<Self, GfError> {
+        serde_json::from_slice(bytes)
+            .map_err(|error| corrupt(format!("graph delta payload decode failed: {error}")))
+    }
+}
+
+/// Decoded framed record.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GraphDeltaRecord {
+    /// Record contract version.
+    pub record_version: u16,
+    /// Operation UUID.
+    pub operation_uuid: Uuid,
+    /// Contiguous sequence inside the run (0-based).
+    pub op_sequence: u32,
+    /// Mutation kind.
+    pub kind: GraphDeltaOpKind,
+    /// Payload schema id.
+    pub schema_id: u16,
+    /// Decoded payload.
+    pub payload: GraphDeltaPayload,
+}
+
+/// One verified delta run.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GraphDeltaRun {
+    /// Contiguous 1-based sequence in the generation.
+    pub run_sequence: u64,
+    /// Run identity.
+    pub run_uuid: Uuid,
+    /// Publishing transaction identity.
+    pub transaction_uuid: Uuid,
+    /// Ordered records.
+    pub records: Vec<GraphDeltaRecord>,
+    /// Exact on-disk bytes.
+    pub bytes: Vec<u8>,
+}
+
+/// Logical reconstructed graph after base load + ordered replay.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReconstructedGraphState {
+    /// Surviving nodes: uuid -> sorted type ids.
+    pub nodes: BTreeMap<String, Vec<u32>>,
+    /// Surviving edges: uuid -> (src, dst, rel_type).
+    pub edges: BTreeMap<String, (String, String, String)>,
+    /// Node properties: (node_uuid, key) -> value.
+    pub node_properties: BTreeMap<(String, String), String>,
+    /// Edge properties: (edge_uuid, key) -> value.
+    pub edge_properties: BTreeMap<(String, String), String>,
+    /// Operation UUIDs already applied (idempotency).
+    pub applied_operations: BTreeMap<String, GraphDeltaPayload>,
+}
+
+impl ReconstructedGraphState {
+    /// Canonical fingerprint over reconstructed logical state.
+    #[must_use]
+    pub fn fingerprint(&self) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        hasher.update(b"graphforge-graph-delta-state/1\n");
+        for (uuid, types) in &self.nodes {
+            hasher.update(uuid.as_bytes());
+            hasher.update(b"|");
+            for type_id in types {
+                hasher.update(type_id.to_le_bytes());
+            }
+            hasher.update(b"\n");
+        }
+        hasher.update(b"--edges--\n");
+        for (uuid, (src, dst, rel)) in &self.edges {
+            hasher.update(uuid.as_bytes());
+            hasher.update(b"|");
+            hasher.update(src.as_bytes());
+            hasher.update(b"|");
+            hasher.update(dst.as_bytes());
+            hasher.update(b"|");
+            hasher.update(rel.as_bytes());
+            hasher.update(b"\n");
+        }
+        hasher.update(b"--node-props--\n");
+        for ((uuid, key), value) in &self.node_properties {
+            hasher.update(uuid.as_bytes());
+            hasher.update(b"|");
+            hasher.update(key.as_bytes());
+            hasher.update(b"|");
+            hasher.update(value.as_bytes());
+            hasher.update(b"\n");
+        }
+        hasher.update(b"--edge-props--\n");
+        for ((uuid, key), value) in &self.edge_properties {
+            hasher.update(uuid.as_bytes());
+            hasher.update(b"|");
+            hasher.update(key.as_bytes());
+            hasher.update(b"|");
+            hasher.update(value.as_bytes());
+            hasher.update(b"\n");
+        }
+        hasher.finalize().into()
+    }
+
+    fn estimated_memory(&self) -> usize {
+        let nodes = self.nodes.len().saturating_mul(64);
+        let edges = self.edges.len().saturating_mul(128);
+        let nprops = self.node_properties.len().saturating_mul(96);
+        let eprops = self.edge_properties.len().saturating_mul(96);
+        let ops = self.applied_operations.len().saturating_mul(128);
+        nodes
+            .saturating_add(edges)
+            .saturating_add(nprops)
+            .saturating_add(eprops)
+            .saturating_add(ops)
+    }
+}
+
+/// Evidence from validating and replaying a generation's delta chain.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct GraphDeltaReplayEvidence {
+    /// Base generation UUID selected by CURRENT (caller-supplied context).
+    pub base_generation_uuid: Option<Uuid>,
+    /// Number of verified runs replayed.
+    pub runs_replayed: u64,
+    /// Total framed records applied (including idempotent no-ops).
+    pub records_seen: u64,
+    /// Exact run file bytes validated.
+    pub run_bytes_validated: u64,
+    /// Estimated peak logical replay memory.
+    pub estimated_replay_memory_bytes: u64,
+    /// Canonical reconstructed fingerprint.
+    pub state_fingerprint: [u8; 32],
+}
+
+/// Input for publishing one small-write delta generation.
+#[derive(Clone, Debug)]
+pub struct GraphDeltaPublishRequest {
+    /// Caller-stable transaction UUID (publication idempotency).
+    pub transaction_uuid: Uuid,
+    /// Generation UUID to publish.
+    pub generation_uuid: Uuid,
+    /// Run UUID for the new append-only run.
+    pub run_uuid: Uuid,
+    /// Ordered operations in the new run.
+    pub operations: Vec<GraphDeltaOp>,
+    /// Resource limits.
+    pub limits: GraphDeltaJournalLimits,
+}
+
+/// Receipt for a small-write delta publication.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GraphDeltaPublicationReceipt {
+    /// Underlying project publication receipt.
+    pub publication: ProjectPublicationReceipt,
+    /// Sequence assigned to the new run.
+    pub run_sequence: u64,
+    /// Whether Parquet base digests were byte-preserved from the parent.
+    pub preserved_base_parquet_digests: bool,
+    /// Count of base (non-delta) files whose digests matched the parent.
+    pub unchanged_base_files: u64,
+    /// Reconstructed fingerprint after the new run.
+    pub state_fingerprint: [u8; 32],
+}
+
+/// Relative path for run sequence `n` (`1..=MAX`).
+#[must_use]
+pub fn delta_run_relative_path(run_sequence: u64) -> String {
+    format!("{GRAPH_DELTA_DIR}/run_{run_sequence:016}.{GRAPH_DELTA_RUN_EXTENSION}")
+}
+
+/// Encode one immutable run file.
+///
+/// # Errors
+/// Returns validation or resource-limit errors for empty ops, oversized
+/// payloads, kind/payload mismatch, or limit exhaustion.
+pub fn encode_delta_run(
+    run_sequence: u64,
+    run_uuid: Uuid,
+    transaction_uuid: Uuid,
+    operations: &[GraphDeltaOp],
+    limits: GraphDeltaJournalLimits,
+) -> Result<Vec<u8>, GfError> {
+    if run_sequence == 0 || run_sequence > limits.max_runs {
+        return Err(validation("graph delta run_sequence out of bounds"));
+    }
+    if operations.is_empty() {
+        return Err(validation(
+            "graph delta run must contain at least one operation",
+        ));
+    }
+    if operations.len() > limits.max_records_per_run {
+        return Err(resource_limit("graph delta records per run"));
+    }
+
+    let mut seen_ops = BTreeSet::new();
+    let mut body = Vec::new();
+    body.extend_from_slice(MAGIC);
+    body.extend_from_slice(&GRAPH_DELTA_RUN_FORMAT_VERSION.to_le_bytes());
+    body.extend_from_slice(&run_sequence.to_le_bytes());
+    body.extend_from_slice(run_uuid.as_bytes());
+    body.extend_from_slice(transaction_uuid.as_bytes());
+    let record_count = u32::try_from(operations.len())
+        .map_err(|_| validation("graph delta record count overflow"))?;
+    body.extend_from_slice(&record_count.to_le_bytes());
+    let header_checksum = Sha256::digest(&body);
+    body.extend_from_slice(&header_checksum);
+
+    for (index, op) in operations.iter().enumerate() {
+        if !seen_ops.insert(op.operation_uuid) {
+            return Err(validation(
+                "graph delta run contains duplicate operation_uuid",
+            ));
+        }
+        if op.payload.expected_kind() != op.kind {
+            return Err(validation(
+                "graph delta operation kind does not match payload",
+            ));
+        }
+        let payload = op.payload.encode()?;
+        if payload.len() > limits.max_payload_bytes {
+            return Err(resource_limit("graph delta payload bytes"));
+        }
+        let op_sequence = u32::try_from(index).map_err(|_| validation("op sequence overflow"))?;
+        let mut record = Vec::new();
+        record.extend_from_slice(&GRAPH_DELTA_RECORD_VERSION.to_le_bytes());
+        record.extend_from_slice(op.operation_uuid.as_bytes());
+        record.extend_from_slice(&op_sequence.to_le_bytes());
+        record.push(op.kind as u8);
+        record.extend_from_slice(&SCHEMA_JSON_V1.to_le_bytes());
+        let payload_len = u32::try_from(payload.len())
+            .map_err(|_| validation("graph delta payload length overflow"))?;
+        record.extend_from_slice(&payload_len.to_le_bytes());
+        record.extend_from_slice(&payload);
+        let record_checksum = Sha256::digest(&record);
+        body.extend_from_slice(&record);
+        body.extend_from_slice(&record_checksum);
+        if body.len() > limits.max_run_bytes.saturating_sub(32) {
+            return Err(resource_limit("graph delta run bytes"));
+        }
+    }
+
+    let file_checksum = Sha256::digest(&body);
+    body.extend_from_slice(&file_checksum);
+    if body.len() > limits.max_run_bytes {
+        return Err(resource_limit("graph delta run bytes"));
+    }
+    Ok(body)
+}
+
+/// Decode and mechanically validate one run file.
+///
+/// # Errors
+/// Returns corruption errors for torn, truncated, reordered, duplicated, or
+/// checksum-invalid bytes. Unknown format versions are unsupported.
+#[allow(clippy::too_many_lines)] // Framed decode must check every field fail-closed.
+pub fn decode_delta_run(
+    bytes: &[u8],
+    expected_sequence: Option<u64>,
+    limits: GraphDeltaJournalLimits,
+) -> Result<GraphDeltaRun, GfError> {
+    if bytes.len() > limits.max_run_bytes {
+        return Err(resource_limit("graph delta run bytes"));
+    }
+    if bytes.len() < 4 + 4 + 8 + 16 + 16 + 4 + 32 + 32 {
+        return Err(corrupt("graph delta run truncated before header"));
+    }
+    if &bytes[..4] != MAGIC {
+        return Err(corrupt("graph delta run magic mismatch"));
+    }
+    let format_version = read_u32(bytes, 4)?;
+    if format_version != GRAPH_DELTA_RUN_FORMAT_VERSION {
+        return Err(unsupported_run_version(format_version));
+    }
+    let run_sequence = read_u64(bytes, 8)?;
+    if expected_sequence.is_some_and(|expected| run_sequence != expected) {
+        return Err(corrupt("graph delta run sequence mismatch"));
+    }
+    if run_sequence == 0 || run_sequence > limits.max_runs {
+        return Err(corrupt("graph delta run sequence out of bounds"));
+    }
+    let run_uuid = read_uuid(bytes, 16)?;
+    let transaction_uuid = read_uuid(bytes, 32)?;
+    let record_count = read_u32(bytes, 48)? as usize;
+    if record_count == 0 || record_count > limits.max_records_per_run {
+        return Err(corrupt("graph delta record count invalid"));
+    }
+    let header_end = 52;
+    let stored_header_checksum = &bytes[header_end..header_end + 32];
+    let actual_header_checksum = Sha256::digest(&bytes[..header_end]);
+    if stored_header_checksum != actual_header_checksum.as_slice() {
+        return Err(corrupt("graph delta run header checksum mismatch"));
+    }
+
+    let file_checksum_offset = bytes.len().saturating_sub(32);
+    if file_checksum_offset <= header_end + 32 {
+        return Err(corrupt("graph delta run truncated"));
+    }
+    let stored_file_checksum = &bytes[file_checksum_offset..];
+    let actual_file_checksum = Sha256::digest(&bytes[..file_checksum_offset]);
+    if stored_file_checksum != actual_file_checksum.as_slice() {
+        return Err(corrupt("graph delta run file checksum mismatch"));
+    }
+
+    let mut cursor = header_end + 32;
+    let mut records = Vec::with_capacity(record_count);
+    let mut seen_ops = BTreeSet::new();
+    for expected_op_sequence in 0..record_count {
+        if cursor + 2 + 16 + 4 + 1 + 2 + 4 + 32 > file_checksum_offset {
+            return Err(corrupt("graph delta run truncated mid-record"));
+        }
+        let record_start = cursor;
+        let record_version = read_u16(bytes, cursor)?;
+        cursor += 2;
+        if record_version != GRAPH_DELTA_RECORD_VERSION {
+            return Err(unsupported_run_version(u32::from(record_version)));
+        }
+        let operation_uuid = read_uuid(bytes, cursor)?;
+        cursor += 16;
+        if !seen_ops.insert(operation_uuid) {
+            return Err(corrupt("graph delta run has duplicated operation_uuid"));
+        }
+        let op_sequence = read_u32(bytes, cursor)?;
+        cursor += 4;
+        if op_sequence as usize != expected_op_sequence {
+            return Err(corrupt("graph delta op_sequence reordered or gapped"));
+        }
+        let kind = GraphDeltaOpKind::from_u8(bytes[cursor])?;
+        cursor += 1;
+        let schema_id = read_u16(bytes, cursor)?;
+        cursor += 2;
+        if schema_id != SCHEMA_JSON_V1 {
+            return Err(unsupported_run_version(u32::from(schema_id)));
+        }
+        let payload_len = read_u32(bytes, cursor)? as usize;
+        cursor += 4;
+        if payload_len > limits.max_payload_bytes {
+            return Err(resource_limit("graph delta payload bytes"));
+        }
+        if cursor + payload_len + 32 > file_checksum_offset {
+            return Err(corrupt("graph delta record payload truncated"));
+        }
+        let payload_bytes = &bytes[cursor..cursor + payload_len];
+        cursor += payload_len;
+        let stored_record_checksum = &bytes[cursor..cursor + 32];
+        let actual_record_checksum = Sha256::digest(&bytes[record_start..cursor]);
+        if stored_record_checksum != actual_record_checksum.as_slice() {
+            return Err(corrupt("graph delta record checksum mismatch"));
+        }
+        cursor += 32;
+        let payload = GraphDeltaPayload::decode(payload_bytes)?;
+        if payload.expected_kind() != kind {
+            return Err(corrupt("graph delta record kind/payload mismatch"));
+        }
+        records.push(GraphDeltaRecord {
+            record_version,
+            operation_uuid,
+            op_sequence,
+            kind,
+            schema_id,
+            payload,
+        });
+    }
+    if cursor != file_checksum_offset {
+        return Err(corrupt(
+            "graph delta run has trailing garbage before checksum",
+        ));
+    }
+    if records.len() != record_count {
+        return Err(corrupt("graph delta record count mismatch"));
+    }
+
+    Ok(GraphDeltaRun {
+        run_sequence,
+        run_uuid,
+        transaction_uuid,
+        records,
+        bytes: bytes.to_vec(),
+    })
+}
+
+/// Split inventory entries into ordered delta runs.
+///
+/// # Errors
+/// Fails closed on gaps, duplicates, unknown extensions under `deltas/`, or
+/// non-contiguous sequences.
+pub fn list_delta_runs(
+    inventory: &GraphFilesInventory,
+    limits: GraphDeltaJournalLimits,
+) -> Result<Vec<&GraphFileEntry>, GfError> {
+    let mut runs = Vec::new();
+    for entry in &inventory.files {
+        if entry.relative_path == format!("{GRAPH_DELTA_DIR}/.base_state.json") {
+            continue;
+        }
+        if !entry.relative_path.starts_with("deltas/") {
+            continue;
+        }
+        if entry.role != GraphFileRole::Delta {
+            return Err(corrupt("delta path has non-delta inventory role"));
+        }
+        let sequence = parse_run_sequence(&entry.relative_path)?;
+        runs.push((sequence, entry));
+    }
+    runs.sort_by_key(|(sequence, _)| *sequence);
+    if runs.len() as u64 > limits.max_runs {
+        return Err(resource_limit("graph delta runs per generation"));
+    }
+    for (index, (sequence, _)) in runs.iter().enumerate() {
+        let expected = (index as u64).saturating_add(1);
+        if *sequence != expected {
+            return Err(corrupt(
+                "graph delta run sequence missing, duplicated, or reordered",
+            ));
+        }
+    }
+    Ok(runs.into_iter().map(|(_, entry)| entry).collect())
+}
+
+/// Load, verify, and order every delta run under `graph_root` for `inventory`.
+///
+/// # Errors
+/// Missing, extra, torn, or checksum-invalid runs fail closed.
+pub fn load_verified_delta_runs(
+    graph_root: &Path,
+    inventory: &GraphFilesInventory,
+    limits: GraphDeltaJournalLimits,
+) -> Result<Vec<GraphDeltaRun>, GfError> {
+    verify_graph_tree(graph_root, inventory)?;
+    let entries = list_delta_runs(inventory, limits)?;
+    let mut runs = Vec::with_capacity(entries.len());
+    for (index, entry) in entries.iter().enumerate() {
+        let expected = (index as u64).saturating_add(1);
+        if usize::try_from(entry.byte_length).unwrap_or(usize::MAX) > limits.max_run_bytes {
+            return Err(resource_limit("graph delta run bytes"));
+        }
+        let path = graph_root.join(&entry.relative_path);
+        let bytes = fs::read(&path).map_err(|error| storage("read delta run", &path, error))?;
+        if bytes.len() as u64 != entry.byte_length {
+            return Err(corrupt("graph delta run length mismatch"));
+        }
+        let digest = hex_digest(Sha256::digest(&bytes).into());
+        if digest != entry.content_sha256 {
+            return Err(corrupt("graph delta run digest mismatch"));
+        }
+        let run = decode_delta_run(&bytes, Some(expected), limits)?;
+        runs.push(run);
+    }
+    Ok(runs)
+}
+
+/// Apply verified runs onto `state` with idempotent operation semantics.
+///
+/// # Errors
+/// Conflicting operation UUID reuse returns `GF_IDEMPOTENCY_CONFLICT`.
+pub fn apply_delta_runs(
+    state: &mut ReconstructedGraphState,
+    runs: &[GraphDeltaRun],
+    limits: GraphDeltaJournalLimits,
+) -> Result<GraphDeltaReplayEvidence, GfError> {
+    let mut evidence = GraphDeltaReplayEvidence::default();
+    for run in runs {
+        evidence.runs_replayed = evidence.runs_replayed.saturating_add(1);
+        evidence.run_bytes_validated = evidence
+            .run_bytes_validated
+            .saturating_add(run.bytes.len() as u64);
+        for record in &run.records {
+            evidence.records_seen = evidence.records_seen.saturating_add(1);
+            apply_one(state, record)?;
+            let memory = state.estimated_memory();
+            if memory > limits.max_replay_memory_bytes {
+                return Err(resource_limit("graph delta replay memory"));
+            }
+            evidence.estimated_replay_memory_bytes =
+                evidence.estimated_replay_memory_bytes.max(memory as u64);
+        }
+    }
+    evidence.state_fingerprint = state.fingerprint();
+    Ok(evidence)
+}
+
+/// Reconstruct logical graph state from a verified graph tree + inventory.
+///
+/// # Errors
+/// Fail-closed validation/corruption/resource errors.
+pub fn reconstruct_graph_state(
+    graph_root: &Path,
+    inventory: &GraphFilesInventory,
+    limits: GraphDeltaJournalLimits,
+) -> Result<(ReconstructedGraphState, GraphDeltaReplayEvidence), GfError> {
+    let runs = load_verified_delta_runs(graph_root, inventory, limits)?;
+    let mut state = load_base_state(graph_root)?;
+    let evidence = apply_delta_runs(&mut state, &runs, limits)?;
+    Ok((state, evidence))
+}
+
+/// Publish one small-write generation that preserves unchanged base Parquet.
+///
+/// # Errors
+/// Unsupported kinds are rejected before staging. Publication and idempotency
+/// errors follow the project generation protocol.
+#[allow(clippy::too_many_lines)] // Publication stages copy, encode, and CURRENT commit together.
+pub fn publish_graph_delta(
+    container_root: &Path,
+    request: &GraphDeltaPublishRequest,
+) -> Result<GraphDeltaPublicationReceipt, GfError> {
+    for op in &request.operations {
+        if op.payload.expected_kind() != op.kind {
+            return Err(validation(
+                "graph delta operation kind does not match payload",
+            ));
+        }
+    }
+
+    if let Some(publication) =
+        published_project_transaction(container_root, request.transaction_uuid)?
+    {
+        if publication.generation_uuid != request.generation_uuid {
+            return Err(idempotency_conflict(
+                "graph delta transaction_uuid reused with different generation_uuid",
+            ));
+        }
+        let resolved = resolve_project_generation(container_root)?;
+        let inventory = resolved
+            .graph_files_inventory()?
+            .ok_or_else(|| corrupt("published generation missing graph inventory"))?;
+        let (_state, evidence) =
+            reconstruct_graph_state(&resolved.graph_tree_root(), &inventory, request.limits)?;
+        let run_sequence = list_delta_runs(&inventory, request.limits)?.len() as u64;
+        return Ok(GraphDeltaPublicationReceipt {
+            publication,
+            run_sequence,
+            preserved_base_parquet_digests: true,
+            unchanged_base_files: inventory
+                .files
+                .iter()
+                .filter(|entry| !is_gfdr_path(&entry.relative_path))
+                .count() as u64,
+            state_fingerprint: evidence.state_fingerprint,
+        });
+    }
+
+    let parent = resolve_project_generation(container_root)?;
+    let parent_inventory = parent
+        .graph_files_inventory()?
+        .ok_or_else(|| validation("parent generation lacks graph/files inventory"))?;
+    let parent_tree = parent.graph_tree_root();
+    verify_graph_tree(&parent_tree, &parent_inventory)?;
+
+    let parent_runs = load_verified_delta_runs(&parent_tree, &parent_inventory, request.limits)?;
+    let mut committed_ops: BTreeMap<Uuid, GraphDeltaPayload> = BTreeMap::new();
+    for run in &parent_runs {
+        for record in &run.records {
+            committed_ops.insert(record.operation_uuid, record.payload.clone());
+        }
+    }
+    for op in &request.operations {
+        if let Some(prior) = committed_ops.get(&op.operation_uuid) {
+            if prior == &op.payload {
+                return Err(idempotency_conflict(
+                    "graph delta operation_uuid already committed",
+                ));
+            }
+            return Err(idempotency_conflict(
+                "graph delta operation_uuid reused with different payload",
+            ));
+        }
+    }
+
+    let next_sequence = (parent_runs.len() as u64).saturating_add(1);
+    if next_sequence > request.limits.max_runs {
+        return Err(resource_limit("graph delta runs per generation"));
+    }
+    let run_bytes = encode_delta_run(
+        next_sequence,
+        request.run_uuid,
+        request.transaction_uuid,
+        &request.operations,
+        request.limits,
+    )?;
+
+    let staging = tempfile::tempdir().map_err(|error| {
+        GfError::Storage(format!("create graph delta staging directory: {error}"))
+    })?;
+    for entry in &parent_inventory.files {
+        let source = parent_tree.join(&entry.relative_path);
+        let destination = staging.path().join(&entry.relative_path);
+        if let Some(parent_dir) = destination.parent() {
+            fs::create_dir_all(parent_dir)
+                .map_err(|error| storage("create delta staging parent", parent_dir, error))?;
+        }
+        fs::copy(&source, &destination)
+            .map_err(|error| storage("copy parent graph file", &source, error))?;
+    }
+    let new_relative = delta_run_relative_path(next_sequence);
+    let new_path = staging.path().join(&new_relative);
+    if let Some(parent_dir) = new_path.parent() {
+        fs::create_dir_all(parent_dir)
+            .map_err(|error| storage("create deltas directory", parent_dir, error))?;
+    }
+    {
+        let mut file = File::create(&new_path)
+            .map_err(|error| storage("create delta run", &new_path, error))?;
+        file.write_all(&run_bytes)
+            .map_err(|error| storage("write delta run", &new_path, error))?;
+        file.sync_all()
+            .map_err(|error| storage("flush delta run", &new_path, error))?;
+    }
+
+    let (inventory, files_participant) = capture_graph_files(staging.path())?;
+    let unchanged_base_files = count_preserved_base_files(&parent_inventory, &inventory);
+    let parent_base_count = parent_inventory
+        .files
+        .iter()
+        .filter(|entry| {
+            !entry.relative_path.starts_with("deltas/")
+                || entry.relative_path.ends_with(".base_state.json")
+        })
+        .filter(|entry| !is_gfdr_path(&entry.relative_path))
+        .count() as u64;
+    let preserved_base_parquet_digests = unchanged_base_files == parent_base_count
+        && parent_inventory
+            .files
+            .iter()
+            .filter(|entry| {
+                Path::new(&entry.relative_path)
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("parquet"))
+            })
+            .all(|parent_entry| {
+                inventory.files.iter().any(|child| {
+                    child.relative_path == parent_entry.relative_path
+                        && child.content_sha256 == parent_entry.content_sha256
+                })
+            });
+
+    let mut participants = empty_workspace_participants()?;
+    participants.insert(0, files_participant);
+    let generation_request = ProjectGenerationRequest {
+        transaction_uuid: request.transaction_uuid,
+        generation_uuid: request.generation_uuid,
+        capabilities: vec![
+            ProjectCapability {
+                capability_id: GRAPH_CAPABILITY_ID.into(),
+                capability_version: GRAPH_CAPABILITY_VERSION,
+            },
+            ProjectCapability {
+                capability_id: "workspace".into(),
+                capability_version: 1,
+            },
+        ],
+        participants,
+    };
+
+    let publication = match stage_project_generation_with_graph_tree(
+        container_root,
+        &generation_request,
+        Some(staging.path()),
+    )? {
+        ProjectStageOutcome::Staged(staged) => {
+            staged.validate(|_| Ok(()), |_, _| Ok(()))?.publish()?
+        }
+        ProjectStageOutcome::AlreadyPublished(receipt) => receipt,
+    };
+
+    let resolved = resolve_project_generation(container_root)?;
+    let child_inventory = resolved
+        .graph_files_inventory()?
+        .ok_or_else(|| corrupt("published generation missing graph inventory"))?;
+    let (_state, mut evidence) = reconstruct_graph_state(
+        &resolved.graph_tree_root(),
+        &child_inventory,
+        request.limits,
+    )?;
+    evidence.base_generation_uuid = Some(parent.generation_uuid());
+
+    Ok(GraphDeltaPublicationReceipt {
+        publication,
+        run_sequence: next_sequence,
+        preserved_base_parquet_digests,
+        unchanged_base_files,
+        state_fingerprint: evidence.state_fingerprint,
+    })
+}
+
+/// Seed a workspace with opaque base files and optional base-state marker.
+///
+/// # Errors
+/// Returns storage errors when directories or files cannot be written.
+pub fn stage_base_graph_workspace(
+    workspace: &Path,
+    files: &[(&str, &[u8])],
+    base_state: Option<&ReconstructedGraphState>,
+) -> Result<(), GfError> {
+    for (relative, bytes) in files {
+        let path = workspace.join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|error| storage("create base workspace dir", parent, error))?;
+        }
+        fs::write(&path, bytes)
+            .map_err(|error| storage("write base workspace file", &path, error))?;
+    }
+    if let Some(state) = base_state {
+        let marker = workspace.join(GRAPH_DELTA_DIR).join(".base_state.json");
+        if let Some(parent) = marker.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|error| storage("create base state dir", parent, error))?;
+        }
+        let bytes = serde_json::to_vec(state)
+            .map_err(|error| validation(format!("base state encode failed: {error}")))?;
+        fs::write(&marker, bytes)
+            .map_err(|error| storage("write base state marker", &marker, error))?;
+    }
+    Ok(())
+}
+
+fn load_base_state(graph_root: &Path) -> Result<ReconstructedGraphState, GfError> {
+    let marker = graph_root.join(GRAPH_DELTA_DIR).join(".base_state.json");
+    if !marker.exists() {
+        return Ok(ReconstructedGraphState::default());
+    }
+    let bytes =
+        fs::read(&marker).map_err(|error| storage("read base state marker", &marker, error))?;
+    serde_json::from_slice(&bytes)
+        .map_err(|error| corrupt(format!("invalid base state marker: {error}")))
+}
+
+fn apply_one(
+    state: &mut ReconstructedGraphState,
+    record: &GraphDeltaRecord,
+) -> Result<(), GfError> {
+    let key = record.operation_uuid.hyphenated().to_string();
+    if let Some(prior) = state.applied_operations.get(&key) {
+        if prior == &record.payload {
+            return Ok(());
+        }
+        return Err(idempotency_conflict(
+            "graph delta operation_uuid reused with different payload",
+        ));
+    }
+    match &record.payload {
+        GraphDeltaPayload::UpsertNode {
+            node_uuid,
+            type_ids,
+        } => {
+            let mut sorted = type_ids.clone();
+            sorted.sort_unstable();
+            state.nodes.insert(node_uuid.clone(), sorted);
+        }
+        GraphDeltaPayload::DeleteNode { node_uuid } => {
+            state.nodes.remove(node_uuid);
+            state
+                .node_properties
+                .retain(|(uuid, _), _| uuid != node_uuid);
+        }
+        GraphDeltaPayload::UpsertEdge {
+            edge_uuid,
+            src_uuid,
+            dst_uuid,
+            rel_type,
+        } => {
+            state.edges.insert(
+                edge_uuid.clone(),
+                (src_uuid.clone(), dst_uuid.clone(), rel_type.clone()),
+            );
+        }
+        GraphDeltaPayload::DeleteEdge { edge_uuid } => {
+            state.edges.remove(edge_uuid);
+            state
+                .edge_properties
+                .retain(|(uuid, _), _| uuid != edge_uuid);
+        }
+        GraphDeltaPayload::SetNodeProperty {
+            node_uuid,
+            key,
+            value,
+        } => {
+            state
+                .node_properties
+                .insert((node_uuid.clone(), key.clone()), value.clone());
+        }
+        GraphDeltaPayload::RemoveNodeProperty { node_uuid, key } => {
+            state
+                .node_properties
+                .remove(&(node_uuid.clone(), key.clone()));
+        }
+        GraphDeltaPayload::SetEdgeProperty {
+            edge_uuid,
+            key,
+            value,
+        } => {
+            state
+                .edge_properties
+                .insert((edge_uuid.clone(), key.clone()), value.clone());
+        }
+        GraphDeltaPayload::RemoveEdgeProperty { edge_uuid, key } => {
+            state
+                .edge_properties
+                .remove(&(edge_uuid.clone(), key.clone()));
+        }
+    }
+    state.applied_operations.insert(key, record.payload.clone());
+    Ok(())
+}
+
+fn is_gfdr_path(relative: &str) -> bool {
+    Path::new(relative)
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case(GRAPH_DELTA_RUN_EXTENSION))
+}
+
+fn count_preserved_base_files(parent: &GraphFilesInventory, child: &GraphFilesInventory) -> u64 {
+    parent
+        .files
+        .iter()
+        .filter(|entry| !is_gfdr_path(&entry.relative_path))
+        .filter(|parent_entry| {
+            child.files.iter().any(|child_entry| {
+                child_entry.relative_path == parent_entry.relative_path
+                    && child_entry.content_sha256 == parent_entry.content_sha256
+                    && child_entry.byte_length == parent_entry.byte_length
+            })
+        })
+        .count() as u64
+}
+
+fn parse_run_sequence(relative: &str) -> Result<u64, GfError> {
+    let prefix = "deltas/run_";
+    let suffix = format!(".{GRAPH_DELTA_RUN_EXTENSION}");
+    let Some(rest) = relative.strip_prefix(prefix) else {
+        return Err(corrupt("unexpected graph delta run path"));
+    };
+    let Some(digits) = rest.strip_suffix(&suffix) else {
+        return Err(corrupt("unexpected graph delta run extension"));
+    };
+    if digits.len() != 16 || !digits.chars().all(|ch| ch.is_ascii_digit()) {
+        return Err(corrupt("graph delta run filename not canonical"));
+    }
+    digits
+        .parse::<u64>()
+        .map_err(|_| corrupt("graph delta run sequence parse failed"))
+}
+
+fn read_u16(bytes: &[u8], offset: usize) -> Result<u16, GfError> {
+    let slice = bytes
+        .get(offset..offset + 2)
+        .ok_or_else(|| corrupt("graph delta truncated u16"))?;
+    Ok(u16::from_le_bytes([slice[0], slice[1]]))
+}
+
+fn read_u32(bytes: &[u8], offset: usize) -> Result<u32, GfError> {
+    let slice = bytes
+        .get(offset..offset + 4)
+        .ok_or_else(|| corrupt("graph delta truncated u32"))?;
+    Ok(u32::from_le_bytes(slice.try_into().unwrap()))
+}
+
+fn read_u64(bytes: &[u8], offset: usize) -> Result<u64, GfError> {
+    let slice = bytes
+        .get(offset..offset + 8)
+        .ok_or_else(|| corrupt("graph delta truncated u64"))?;
+    Ok(u64::from_le_bytes(slice.try_into().unwrap()))
+}
+
+fn read_uuid(bytes: &[u8], offset: usize) -> Result<Uuid, GfError> {
+    let slice = bytes
+        .get(offset..offset + 16)
+        .ok_or_else(|| corrupt("graph delta truncated uuid"))?;
+    Uuid::from_slice(slice).map_err(|_| corrupt("graph delta invalid uuid"))
+}
+
+fn hex_digest(digest: [u8; 32]) -> String {
+    use std::fmt::Write as _;
+    digest
+        .iter()
+        .fold(String::with_capacity(64), |mut out, byte| {
+            let _ = write!(out, "{byte:02x}");
+            out
+        })
+}
+
+fn validation(message: impl Into<String>) -> GfError {
+    GfError::Validation(message.into())
+}
+
+fn corrupt(message: impl Into<String>) -> GfError {
+    GfError::Project {
+        code: ProjectErrorCode::ProjectCorrupt,
+        message: message.into(),
+    }
+}
+
+fn unsupported_run_version(version: u32) -> GfError {
+    GfError::Project {
+        code: ProjectErrorCode::UnsupportedProjectFormat,
+        message: format!("unsupported graph delta run format version {version}"),
+    }
+}
+
+fn resource_limit(message: impl Into<String>) -> GfError {
+    GfError::Execution(format!("GF_RESOURCE_LIMIT: {}", message.into()))
+}
+
+fn idempotency_conflict(message: impl Into<String>) -> GfError {
+    GfError::Project {
+        code: ProjectErrorCode::TransactionConflict,
+        message: message.into(),
+    }
+}
+
+fn storage(action: &str, path: &Path, error: impl std::fmt::Display) -> GfError {
+    GfError::Storage(format!("{action} at {}: {error}", path.display()))
+}
+
+#[cfg(test)]
+mod crash_oracle_tests {
+    use crate::project_fault_oracle::{
+        AuthorityClass, PublicationIds, PublicationPhase, default_durable_ids, expected_authority,
+        publication_ops, simulate_crash,
+    };
+
+    #[test]
+    fn crash_oracle_before_and_after_ack_matches_frozen_contract() {
+        let seed = 752u64;
+        let ids = PublicationIds::from_seed(seed);
+        for phase in [
+            PublicationPhase::BeforeCurrentReplace,
+            PublicationPhase::AfterCurrentReplace,
+            PublicationPhase::AfterRootFsync,
+        ] {
+            let ops = publication_ops(ids, phase);
+            let durable = default_durable_ids(&ops, phase);
+            let report = simulate_crash(seed, phase, &durable).unwrap();
+            assert_eq!(report.expected, expected_authority(phase));
+            assert_eq!(report.actual, report.expected);
+            match phase {
+                PublicationPhase::BeforeCurrentReplace => {
+                    assert_eq!(report.expected, AuthorityClass::PriorGeneration);
+                }
+                PublicationPhase::AfterCurrentReplace | PublicationPhase::AfterRootFsync => {
+                    assert_eq!(report.expected, AuthorityClass::NewGeneration);
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
+}

--- a/crates/graphforge-storage/src/graph_files.rs
+++ b/crates/graphforge-storage/src/graph_files.rs
@@ -46,6 +46,8 @@ pub enum GraphFileRole {
     Properties,
     /// Derived adjacency CSR and related index files.
     Index,
+    /// Authoritative graph delta journal run (ADR 0019).
+    Delta,
     /// Runtime catalog and similar control files.
     Catalog,
     /// Any other regular workspace file.
@@ -374,8 +376,9 @@ pub fn infer_role(relative: &Path) -> GraphFileRole {
             let first = first.to_string_lossy();
             match first.as_ref() {
                 "topology" => GraphFileRole::Topology,
-                "properties" => GraphFileRole::Properties,
+                "properties" | "edge_properties" => GraphFileRole::Properties,
                 "indexes" | "index" => GraphFileRole::Index,
+                "deltas" => GraphFileRole::Delta,
                 "runtime_catalog.parquet" => GraphFileRole::Catalog,
                 _ if first.starts_with("runtime_catalog") => GraphFileRole::Catalog,
                 _ => GraphFileRole::Other,

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -34,6 +34,19 @@ pub use graph_files::{
     stage_graph_tree, verify_graph_tree,
 };
 
+pub mod graph_delta_journal;
+pub use graph_delta_journal::{
+    GRAPH_DELTA_DIR, GRAPH_DELTA_RECORD_VERSION, GRAPH_DELTA_RUN_EXTENSION,
+    GRAPH_DELTA_RUN_FORMAT_VERSION, GraphDeltaJournalLimits, GraphDeltaOp, GraphDeltaOpKind,
+    GraphDeltaPayload, GraphDeltaPublicationReceipt, GraphDeltaPublishRequest,
+    GraphDeltaReplayEvidence, GraphDeltaRun, MAX_GRAPH_DELTA_PAYLOAD_BYTES,
+    MAX_GRAPH_DELTA_RECORDS_PER_RUN, MAX_GRAPH_DELTA_REPLAY_MEMORY_BYTES,
+    MAX_GRAPH_DELTA_RUN_BYTES, MAX_GRAPH_DELTA_RUNS, ReconstructedGraphState, apply_delta_runs,
+    decode_delta_run, delta_run_relative_path, encode_delta_run, list_delta_runs,
+    load_verified_delta_runs, publish_graph_delta, reconstruct_graph_state,
+    stage_base_graph_workspace,
+};
+
 pub mod project_generation;
 pub use project_generation::{
     CURRENT_FILE, FORMAT_FILE, PROJECT_FORMAT_BYTES, ProjectCapabilityDescriptor,

--- a/crates/graphforge-storage/tests/graph_delta_journal.rs
+++ b/crates/graphforge-storage/tests/graph_delta_journal.rs
@@ -1,0 +1,353 @@
+//! Integration tests for the authoritative graph delta journal (#752).
+
+use std::fs;
+
+use graphforge_storage::{
+    GRAPH_CAPABILITY_ID, GRAPH_CAPABILITY_VERSION, GraphDeltaJournalLimits, GraphDeltaOp,
+    GraphDeltaOpKind, GraphDeltaPayload, GraphDeltaPublishRequest, GraphFileEntry, GraphFileRole,
+    GraphFilesInventory, ProjectCapability, ProjectGenerationRequest, ProjectStageOutcome,
+    ReconstructedGraphState, capture_graph_files, decode_delta_run, delta_run_relative_path,
+    empty_workspace_participants, encode_delta_run, list_delta_runs, open_or_initialize_project,
+    publish_graph_delta, reconstruct_graph_state, resolve_project_generation,
+    stage_base_graph_workspace, stage_project_generation_with_graph_tree,
+};
+use uuid::Uuid;
+
+fn sample_ops() -> Vec<GraphDeltaOp> {
+    let edge = Uuid::now_v7();
+    let src = Uuid::now_v7();
+    let dst = Uuid::now_v7();
+    vec![
+        GraphDeltaOp {
+            operation_uuid: Uuid::now_v7(),
+            kind: GraphDeltaOpKind::UpsertNode,
+            payload: GraphDeltaPayload::UpsertNode {
+                node_uuid: src.hyphenated().to_string(),
+                type_ids: vec![1],
+            },
+        },
+        GraphDeltaOp {
+            operation_uuid: Uuid::now_v7(),
+            kind: GraphDeltaOpKind::UpsertNode,
+            payload: GraphDeltaPayload::UpsertNode {
+                node_uuid: dst.hyphenated().to_string(),
+                type_ids: vec![1],
+            },
+        },
+        GraphDeltaOp {
+            operation_uuid: Uuid::now_v7(),
+            kind: GraphDeltaOpKind::UpsertEdge,
+            payload: GraphDeltaPayload::UpsertEdge {
+                edge_uuid: edge.hyphenated().to_string(),
+                src_uuid: src.hyphenated().to_string(),
+                dst_uuid: dst.hyphenated().to_string(),
+                rel_type: "KNOWS".into(),
+            },
+        },
+    ]
+}
+
+fn publish_base(container: &std::path::Path, parquet_a: &[u8], parquet_b: &[u8]) -> Uuid {
+    open_or_initialize_project(container).unwrap();
+    let workspace = tempfile::tempdir().unwrap();
+    let mut base = ReconstructedGraphState::default();
+    base.nodes
+        .insert("00000000-0000-7000-8000-000000000001".into(), vec![1]);
+    stage_base_graph_workspace(
+        workspace.path(),
+        &[
+            ("topology/nodes.parquet", parquet_a),
+            ("topology/edges/KNOWS.parquet", parquet_b),
+        ],
+        Some(&base),
+    )
+    .unwrap();
+    let (_, files) = capture_graph_files(workspace.path()).unwrap();
+    let mut participants = empty_workspace_participants().unwrap();
+    participants.insert(0, files);
+    let generation_uuid = Uuid::now_v7();
+    let request = ProjectGenerationRequest {
+        transaction_uuid: Uuid::now_v7(),
+        generation_uuid,
+        capabilities: vec![
+            ProjectCapability {
+                capability_id: GRAPH_CAPABILITY_ID.into(),
+                capability_version: GRAPH_CAPABILITY_VERSION,
+            },
+            ProjectCapability {
+                capability_id: "workspace".into(),
+                capability_version: 1,
+            },
+        ],
+        participants,
+    };
+    let ProjectStageOutcome::Staged(staged) =
+        stage_project_generation_with_graph_tree(container, &request, Some(workspace.path()))
+            .unwrap()
+    else {
+        panic!("base publication replayed");
+    };
+    staged
+        .validate(|_| Ok(()), |_, _| Ok(()))
+        .unwrap()
+        .publish()
+        .unwrap();
+    generation_uuid
+}
+
+#[test]
+fn encode_decode_round_trip_and_golden_magic() {
+    let ops = sample_ops();
+    let bytes = encode_delta_run(
+        1,
+        Uuid::now_v7(),
+        Uuid::now_v7(),
+        &ops,
+        GraphDeltaJournalLimits::default(),
+    )
+    .unwrap();
+    assert_eq!(&bytes[..4], b"GFDR");
+    let decoded = decode_delta_run(&bytes, Some(1), GraphDeltaJournalLimits::default()).unwrap();
+    assert_eq!(decoded.records.len(), ops.len());
+    assert_eq!(decoded.records[0].operation_uuid, ops[0].operation_uuid);
+}
+
+#[test]
+fn torn_truncated_reordered_and_checksum_invalid_fail_closed() {
+    let ops = sample_ops();
+    let mut bytes = encode_delta_run(
+        1,
+        Uuid::now_v7(),
+        Uuid::now_v7(),
+        &ops,
+        GraphDeltaJournalLimits::default(),
+    )
+    .unwrap();
+    let truncated = &bytes[..bytes.len() / 2];
+    assert_eq!(
+        decode_delta_run(truncated, Some(1), GraphDeltaJournalLimits::default())
+            .unwrap_err()
+            .code(),
+        "GF_PROJECT_CORRUPT"
+    );
+    let mut corrupted = bytes.clone();
+    let flip = corrupted.len() / 3;
+    corrupted[flip] ^= 0xff;
+    assert_eq!(
+        decode_delta_run(&corrupted, Some(1), GraphDeltaJournalLimits::default())
+            .unwrap_err()
+            .code(),
+        "GF_PROJECT_CORRUPT"
+    );
+    bytes[8..16].copy_from_slice(&2u64.to_le_bytes());
+    assert!(decode_delta_run(&bytes, Some(1), GraphDeltaJournalLimits::default()).is_err());
+}
+
+#[test]
+fn small_write_preserves_unchanged_parquet_and_reopen_replays() {
+    let root = tempfile::tempdir().unwrap();
+    let _base = publish_base(root.path(), b"NODES-PARQUET-V1", b"EDGES-PARQUET-V1");
+    let parent = resolve_project_generation(root.path()).unwrap();
+    let parent_inventory = parent.graph_files_inventory().unwrap().unwrap();
+    let parent_nodes_digest = parent_inventory
+        .files
+        .iter()
+        .find(|entry| entry.relative_path == "topology/nodes.parquet")
+        .unwrap()
+        .content_sha256
+        .clone();
+
+    let ops = sample_ops();
+    let edge_uuid = match &ops[2].payload {
+        GraphDeltaPayload::UpsertEdge { edge_uuid, .. } => edge_uuid.clone(),
+        _ => unreachable!(),
+    };
+    let receipt = publish_graph_delta(
+        root.path(),
+        &GraphDeltaPublishRequest {
+            transaction_uuid: Uuid::now_v7(),
+            generation_uuid: Uuid::now_v7(),
+            run_uuid: Uuid::now_v7(),
+            operations: ops,
+            limits: GraphDeltaJournalLimits::default(),
+        },
+    )
+    .unwrap();
+    assert!(receipt.preserved_base_parquet_digests);
+    assert!(receipt.unchanged_base_files >= 2);
+
+    let reopened = resolve_project_generation(root.path()).unwrap();
+    let inventory = reopened.graph_files_inventory().unwrap().unwrap();
+    let child_nodes_digest = inventory
+        .files
+        .iter()
+        .find(|entry| entry.relative_path == "topology/nodes.parquet")
+        .unwrap()
+        .content_sha256
+        .clone();
+    assert_eq!(parent_nodes_digest, child_nodes_digest);
+
+    let (state, evidence) = reconstruct_graph_state(
+        &reopened.graph_tree_root(),
+        &inventory,
+        GraphDeltaJournalLimits::default(),
+    )
+    .unwrap();
+    assert_eq!(evidence.runs_replayed, 1);
+    assert!(state.edges.contains_key(&edge_uuid));
+    assert_eq!(state.fingerprint(), receipt.state_fingerprint);
+}
+
+#[test]
+fn exact_retry_transaction_is_idempotent_and_conflict_is_typed() {
+    let root = tempfile::tempdir().unwrap();
+    publish_base(root.path(), b"N", b"E");
+    let ops = sample_ops();
+    let transaction_uuid = Uuid::now_v7();
+    let generation_uuid = Uuid::now_v7();
+    let run_uuid = Uuid::now_v7();
+    let request = GraphDeltaPublishRequest {
+        transaction_uuid,
+        generation_uuid,
+        run_uuid,
+        operations: ops.clone(),
+        limits: GraphDeltaJournalLimits::default(),
+    };
+    let first = publish_graph_delta(root.path(), &request).unwrap();
+    assert!(!first.publication.idempotent_replay);
+    let second = publish_graph_delta(root.path(), &request).unwrap();
+    assert!(second.publication.idempotent_replay);
+    assert_eq!(
+        first.publication.generation_uuid,
+        second.publication.generation_uuid
+    );
+
+    let mut conflicting = ops;
+    if let GraphDeltaPayload::UpsertEdge { rel_type, .. } = &mut conflicting[2].payload {
+        *rel_type = "OTHER".into();
+    }
+    let err = publish_graph_delta(
+        root.path(),
+        &GraphDeltaPublishRequest {
+            transaction_uuid: Uuid::now_v7(),
+            generation_uuid: Uuid::now_v7(),
+            run_uuid: Uuid::now_v7(),
+            operations: conflicting,
+            limits: GraphDeltaJournalLimits::default(),
+        },
+    )
+    .unwrap_err();
+    assert_eq!(err.code(), "GF_IDEMPOTENCY_CONFLICT");
+}
+
+#[test]
+fn missing_run_referenced_by_inventory_fails_closed() {
+    let root = tempfile::tempdir().unwrap();
+    publish_base(root.path(), b"N", b"E");
+    publish_graph_delta(
+        root.path(),
+        &GraphDeltaPublishRequest {
+            transaction_uuid: Uuid::now_v7(),
+            generation_uuid: Uuid::now_v7(),
+            run_uuid: Uuid::now_v7(),
+            operations: sample_ops(),
+            limits: GraphDeltaJournalLimits::default(),
+        },
+    )
+    .unwrap();
+    let resolved = resolve_project_generation(root.path()).unwrap();
+    let inventory = resolved.graph_files_inventory().unwrap().unwrap();
+    let run_path = resolved.graph_tree_root().join(delta_run_relative_path(1));
+    fs::remove_file(&run_path).unwrap();
+    let err = reconstruct_graph_state(
+        &resolved.graph_tree_root(),
+        &inventory,
+        GraphDeltaJournalLimits::default(),
+    )
+    .unwrap_err();
+    assert_eq!(err.code(), "GF_PROJECT_CORRUPT");
+}
+
+#[test]
+fn resource_limits_reject_tiny_run_accumulation() {
+    let limits = GraphDeltaJournalLimits {
+        max_runs: 1,
+        ..GraphDeltaJournalLimits::default()
+    };
+    let root = tempfile::tempdir().unwrap();
+    publish_base(root.path(), b"N", b"E");
+    publish_graph_delta(
+        root.path(),
+        &GraphDeltaPublishRequest {
+            transaction_uuid: Uuid::now_v7(),
+            generation_uuid: Uuid::now_v7(),
+            run_uuid: Uuid::now_v7(),
+            operations: sample_ops(),
+            limits,
+        },
+    )
+    .unwrap();
+    let err = publish_graph_delta(
+        root.path(),
+        &GraphDeltaPublishRequest {
+            transaction_uuid: Uuid::now_v7(),
+            generation_uuid: Uuid::now_v7(),
+            run_uuid: Uuid::now_v7(),
+            operations: sample_ops(),
+            limits,
+        },
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("GF_RESOURCE_LIMIT"));
+}
+
+#[test]
+fn legacy_v1_project_without_deltas_remains_readable() {
+    let root = tempfile::tempdir().unwrap();
+    publish_base(root.path(), b"LEGACY", b"BASE");
+    let resolved = resolve_project_generation(root.path()).unwrap();
+    let inventory = resolved.graph_files_inventory().unwrap().unwrap();
+    assert!(
+        list_delta_runs(&inventory, GraphDeltaJournalLimits::default())
+            .unwrap()
+            .is_empty()
+    );
+    let (state, evidence) = reconstruct_graph_state(
+        &resolved.graph_tree_root(),
+        &inventory,
+        GraphDeltaJournalLimits::default(),
+    )
+    .unwrap();
+    assert_eq!(evidence.runs_replayed, 0);
+    assert!(
+        state
+            .nodes
+            .contains_key("00000000-0000-7000-8000-000000000001")
+    );
+}
+
+#[test]
+fn gapped_run_sequence_in_inventory_fails_closed() {
+    let inventory = GraphFilesInventory {
+        format: "graphforge-graph-files".into(),
+        format_version: 1,
+        files: vec![
+            GraphFileEntry {
+                relative_path: delta_run_relative_path(1),
+                byte_length: 1,
+                content_sha256: "a".repeat(64),
+                role: GraphFileRole::Delta,
+            },
+            GraphFileEntry {
+                relative_path: delta_run_relative_path(3),
+                byte_length: 2,
+                content_sha256: "b".repeat(64),
+                role: GraphFileRole::Delta,
+            },
+        ],
+        file_count: 2,
+        total_byte_length: 3,
+    };
+    let err = list_delta_runs(&inventory, GraphDeltaJournalLimits::default()).unwrap_err();
+    assert_eq!(err.code(), "GF_PROJECT_CORRUPT");
+}

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -265,6 +265,10 @@ export default defineConfig({
                   label: '0018 — Durability and Isolation',
                   slug: 'adr/0018-acknowledged-durability-isolation',
                 },
+                {
+                  label: '0019 Authoritative graph delta journal',
+                  slug: 'adr/0019-authoritative-graph-delta-journal',
+                },
               ],
             },
           ],

--- a/docs-site/scripts/sync-content.mjs
+++ b/docs-site/scripts/sync-content.mjs
@@ -133,6 +133,7 @@ const PAGES = [
   'adr/0016-repository-integration-and-deployment-configuration.md',
   'adr/0017-unified-release-version.md',
   'adr/0018-acknowledged-durability-isolation.md',
+  'adr/0019-authoritative-graph-delta-journal.md',
   'releases/roadmap.md',
   'legal/licensing.md',
   'community/security.md',

--- a/docs/adr/0013-project-generation-protocol.md
+++ b/docs/adr/0013-project-generation-protocol.md
@@ -5,13 +5,17 @@
 **Build target:** v0.5.0
 
 **Related:** ADR 0012 (domain ownership), ADR 0018 (acknowledged durability and
-isolation)
+isolation), ADR 0019 (authoritative graph delta journal)
 
 The public acknowledgement boundary, isolation honesty rules, and anomaly
 coverage matrix are frozen by
-[ADR 0018](0018-acknowledged-durability-isolation.md). This ADR remains the
-normative publication protocol; semantic changes to acknowledgement or recovery
-authority require an amending ADR rather than silent edits here.
+[ADR 0018](0018-acknowledged-durability-isolation.md). Authoritative small-write
+graph delta runs inside a generation-owned `graph/` tree are frozen by
+[ADR 0019](0019-authoritative-graph-delta-journal.md); they remain ordinary
+inventory-listed generation bytes and never replace `CURRENT` as commit
+authority. This ADR remains the normative publication protocol; semantic
+changes to acknowledgement or recovery authority require an amending ADR rather
+than silent edits here.
 
 ## Context
 
@@ -80,12 +84,19 @@ project/
 │   └── <generation-uuid>/
 │       ├── lease.lock
 │       ├── manifest.json
+│       ├── graph/              # optional generation-owned graph workspace
+│       │   └── deltas/         # optional authoritative delta runs (ADR 0019)
 │       └── participants/
 │           └── <capability-id>/<record-family-id>.<parquet|arrow|json>
 ├── cache/                  # derived, fingerprint-keyed, never authoritative
 └── trash/
     └── <generation-uuid>/
 ```
+
+When a generation includes authoritative graph delta runs, those runs live only
+under that generation's `graph/deltas/` tree and are listed in the `graph`/`files`
+inventory with exact digests. Replay reconstructs graph state from the verified
+base plus ordered runs; recovery never elects a run by directory scan (ADR 0019).
 
 `FORMAT` is immutable and contains exactly:
 

--- a/docs/adr/0019-authoritative-graph-delta-journal.md
+++ b/docs/adr/0019-authoritative-graph-delta-journal.md
@@ -1,0 +1,157 @@
+# ADR 0019: Authoritative durable graph delta journal
+
+**Status:** Accepted
+**Date:** 2026-08-15
+**Build target:** v0.5.x (M6)
+**Related:** ADR 0013 (publication protocol), ADR 0018 (acknowledgement),
+ADR 0004 (derived adjacency), issues #747 / #752 / #753
+
+## Context
+
+Immutable complete generations already publish graph bytes through `CURRENT` and
+a generation manifest (ADR 0013). Small mutations still pay full Parquet rewrite
+amplification when every unchanged topology or property file is re-encoded into
+the child generation.
+
+Derived adjacency delta segments (`adjacency_delta`) remain rebuildable index
+accelerators. They must not recover acknowledged graph mutations and are not
+commit authority.
+
+M6 requires an authoritative, checksummed, bounded, append-oriented mutation
+journal that stays inside the immutable-generation model: one generation still
+owns its bytes, `CURRENT` plus the generation manifest remain the sole commit
+authority, and torn or corrupt runs fail closed.
+
+## Decision
+
+### Authority and layout
+
+A committed graph generation may represent state as:
+
+1. a verified **base** set of graph Parquet (and related) files under the
+   generation-owned `graph/` tree; plus
+2. zero or more immutable ordered **delta runs** under `graph/deltas/`.
+
+Both base files and delta runs are listed in the existing `graph`/`files`
+inventory participant with exact lengths and SHA-256 digests. Open and
+publication validate inventory against on-disk bytes. Directory scans, newest
+run filenames, or unmanifested logs never elect authority.
+
+```text
+generations/<generation-uuid>/
+├── manifest.json
+├── graph/
+│   ├── topology/...
+│   ├── properties/...
+│   └── deltas/
+│       ├── run_0000000000000001.gfdr
+│       └── run_0000000000000002.gfdr
+└── participants/graph/files.json
+```
+
+`FORMAT` remains `graphforge-project/v1`. Generations without `graph/deltas/`
+entries remain the baseline readable layout. Adding delta runs does not bump
+the project container format; unsupported run format versions fail closed with
+`GF_UNSUPPORTED_PROJECT_FORMAT` or `GF_PROJECT_CORRUPT` as appropriate.
+
+### Run framing
+
+Each `.gfdr` file is one immutable run. Records are length-prefixed frames with:
+
+| Field | Role |
+| --- | --- |
+| format / record version | reject unknown versions |
+| run sequence | contiguous `1..=N` within the generation |
+| transaction UUID | publication idempotency identity |
+| operation UUID | per-mutation identity |
+| op sequence | contiguous order inside the run |
+| kind | create / update / delete surface enum |
+| schema id | payload contract |
+| payload length + bytes | bounded mutation body |
+| per-record checksum | SHA-256 over the framed record |
+| trailing file checksum | SHA-256 over preceding file bytes |
+
+Acknowledged runs are durable only through the ADR 0013 / ADR 0018 publication
+contract (participant and generation flushes, atomic `CURRENT` replacement, and
+project-root directory flush). The journal never becomes a second commit
+pointer.
+
+### Publication and small-write rule
+
+A small-write publication may:
+
+- byte-copy unchanged base Parquet and prior verified delta runs from the pinned
+  parent into the private child generation; and
+- append exactly the new immutable run(s) required by the mutation.
+
+It must not re-encode unchanged Parquet files solely to incorporate the
+mutation. Compaction of base+deltas back into canonical Parquet is a separate
+generation transaction (#753).
+
+Unsupported mutation kinds are rejected **before** acknowledgement. Supported
+kinds cover the create / update / delete surfaces required by current graph
+mutation paths for topology rows and property set/remove operations.
+
+### Replay, idempotency, and conflicts
+
+Reopen reconstructs graph state only from the CURRENT-selected generation's
+verified base plus its ordered, contiguous, checksum-valid runs. Replay is
+idempotent on operation UUID: an exact retry returns the prior result without
+duplicating the mutation. Reusing an operation UUID with a different payload is
+a typed `GF_IDEMPOTENCY_CONFLICT`.
+
+Torn, truncated, reordered, duplicated, missing, or checksum-invalid runs
+referenced by the committed inventory cannot become visible: open fails closed
+and never partially applies a prefix of a corrupt chain.
+
+### Bounds
+
+Implementations enforce finite limits on:
+
+- runs per generation;
+- bytes and records per run;
+- payload size;
+- open-time validation work; and
+- estimated replay memory.
+
+Exhaustion returns a structured resource-limit error without guessing.
+
+### Separation from derived adjacency deltas
+
+| Mechanism | Authoritative? | Purpose |
+| --- | --- | --- |
+| `graph/deltas/*.gfdr` | yes | recover acknowledged graph mutations |
+| `indexes/adjacency/deltas/` | no | optional CSR acceleration; rebuildable |
+
+Absence or corruption of adjacency delta segments never changes graph results.
+Absence or corruption of an inventory-listed authoritative run fails open.
+
+## Consequences
+
+- Small acknowledged mutations avoid Parquet rewrite amplification while
+  remaining one immutable generation under `CURRENT`.
+- Crash cases before/after acknowledgement continue to follow ADR 0018 and the
+  frozen fault oracle (#749).
+- Compaction (#753) can later fold a verified prefix into a new Parquet base
+  without inventing a side WAL.
+- Pre-delta v1 projects remain readable; delta-bearing generations remain v1
+  containers with an explicit run-format version gate.
+
+## Rejected alternatives
+
+| Alternative | Reason |
+|---|---|
+| Side WAL outside the generation manifest | Second authority; recovery by log scan |
+| Treating adjacency deltas as durable mutations | Rebuildable accelerator only |
+| In-place Parquet append as commit | Breaks immutable snapshot readers |
+| Recover by newest `.gfdr` mtime | Directory election protocol |
+
+## Required verification
+
+- Small mutation publishes without rewriting unchanged Parquet digests.
+- Reopen reconstructs exact state from base + ordered runs.
+- Exact retry is idempotent; conflicting identity reuse is typed.
+- Torn/truncated/reordered/duplicated/missing/checksum-invalid runs fail closed.
+- Crash before/after acknowledgement matches the frozen durability oracle.
+- Resource limits bound replay and tiny-run accumulation.
+- Legacy v1 projects without deltas remain readable.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,6 +24,7 @@ are not retained in this tree.
 | 0016 | [Repository integration and deployment configuration boundary](0016-repository-integration-and-deployment-configuration.md) | `0016-repository-integration-and-deployment-configuration.md` |
 | 0017 | [One version across core and adapters](0017-unified-release-version.md) | `0017-unified-release-version.md` |
 | 0018 | [Acknowledged durability and isolation contract](0018-acknowledged-durability-isolation.md) | `0018-acknowledged-durability-isolation.md` |
+| 0019 | [Authoritative durable graph delta journal](0019-authoritative-graph-delta-journal.md) | `0019-authoritative-graph-delta-journal.md` |
 
 ## Numbering
 

--- a/docs/book/architecture/concurrency-recovery.md
+++ b/docs/book/architecture/concurrency-recovery.md
@@ -129,7 +129,9 @@ There are three CI surfaces for concurrency and durability contracts:
    `crates/graphforge-storage/src/project_fault_oracle.rs`. Native POSIX and
    Windows subprocess failpoint matrices remain required for real API and handle
    behavior; the oracle is reusable by recovery, delta, compaction, and final
-   certification.
+   certification. Authoritative graph delta runs (#752 / ADR 0019) publish only
+   through the same `CURRENT` contract; they never recover by scanning newest
+   logs.
 
 The finite Rust recovery ledger remains
 `tests/contracts/concurrency-recovery-matrix.json` and is validated by

--- a/docs/book/architecture/storage.md
+++ b/docs/book/architecture/storage.md
@@ -117,6 +117,7 @@ project/
 │       ├── lease.lock
 │       ├── manifest.json
 │       ├── graph/              # file-backed graph workspace (optional; with graph/files)
+│       │   └── deltas/         # authoritative mutation runs (ADR 0019; not adjacency)
 │       └── participants/
 │           ├── graph/...       # snapshot.arrow (legacy) or files.json (inventory)
 │           ├── workspace/
@@ -136,7 +137,10 @@ data. New publications store graph workspace files under the generation-owned
 `graph/` tree with a `graph`/`files` inventory participant; legacy
 `graph`/`snapshot` Arrow envelopes remain readable. Root YAML/JSON and
 environment settings are inputs only and cannot override the selected
-generation.
+generation. Authoritative small-write delta runs, when present, live under
+`graph/deltas/` inside the same generation and are inventory-verified
+([ADR 0019](../../adr/0019-authoritative-graph-delta-journal.md)). They are
+distinct from rebuildable `indexes/adjacency/deltas/` accelerators.
 
 Optional capability absence is recorded in the generation manifest; it is not
 inferred by scanning folders. Graph-only readers validate the mandatory

--- a/docs/development/bazel-migration-ledger.md
+++ b/docs/development/bazel-migration-ledger.md
@@ -13,14 +13,14 @@ Performance baseline: [bazel-migration-baseline.md](bazel-migration-baseline.md)
 | Inventory SHA | `6e8b8e3fdc1ecd960eacf14a73e5be7b54fcef3c` |
 | Authoritative source | `cargo metadata --format-version=1 --no-deps` |
 | Workspace packages | 17 |
-| Cargo metadata targets | **98** |
-| Bazel modeling claimed complete? | **Yes** — all 97 Cargo targets mapped (#10–#6 + #338 + #336); retained tools justified in exceptions |
+| Cargo metadata targets | **99** |
+| Bazel modeling claimed complete? | **Yes** — all 99 Cargo targets mapped (#10–#6 + #338 + #336 + #752); retained tools justified in exceptions |
 | Machine-readable map | `tools/bazel/parity/migration_target_map.json` (fail-closed via `scripts/ci/bazel-migration-ledger-check.py`) |
 | Bootstrap note | See [bazel-bootstrap.md](bazel-bootstrap.md); parity evidence [bazel-migration-parity.md](bazel-migration-parity.md) |
 
 Issue #1 historically cited ~71 Cargo targets / ~53 integration-test binaries.
-This freeze uses the **current authoritative** metadata count (**98** targets;
-**63** integration-test binaries). Later slices must update rows,
+This freeze uses the **current authoritative** metadata count (**99** targets;
+**65** integration-test binaries). Later slices must update rows,
 not silently ignore new targets.
 
 ## Target class summary
@@ -28,12 +28,12 @@ not silently ignore new targets.
 | Class | Count | Notes |
 | --- | ---: | --- |
 | `lib` | 15 | First-party libraries (unit/doctest surface rides these targets under `cargo test --lib` / doctests) |
-| `integration-test` | 64 | `tests/*.rs` integration binaries |
+| `integration-test` | 65 | `tests/*.rs` integration binaries |
 | `cdylib` | 2 | PyO3 + napi-rs native libs |
 | `bin` | 1 | CLI (`gf`) |
 | `custom-build` | 2 | `build.rs` scripts |
 | `example` | 11 | API examples mapped as `//crates/graphforge-api:<name>` (#6) |
-| **Total** | **98** | |
+| **Total** | **99** | |
 
 ### Unit tests and doctests
 

--- a/docs/development/bazel-migration-ledger.md
+++ b/docs/development/bazel-migration-ledger.md
@@ -151,6 +151,7 @@ Authoritative machine-readable map: `tools/bazel/parity/migration_target_map.jso
 | `graphforge-storage` | `graphforge_storage` | `lib` | `crates/graphforge-storage/src/lib.rs` | `//crates/graphforge-storage:graphforge_storage` | `mapped` | #10 early / #9; Bazel enables `test-failpoints` for api subprocess unification; unit tests `//crates/graphforge-storage:graphforge_storage_test` |
 | `graphforge-storage` | `adjacency_delta_write` | `integration-test` | `crates/graphforge-storage/tests/adjacency_delta_write.rs` | `//crates/graphforge-storage:adjacency_delta_write` | `mapped` | #8 |
 | `graphforge-storage` | `filtered_read` | `integration-test` | `crates/graphforge-storage/tests/filtered_read.rs` | `//crates/graphforge-storage:filtered_read` | `mapped` | #8 |
+| `graphforge-storage` | `graph_delta_journal` | `integration-test` | `crates/graphforge-storage/tests/graph_delta_journal.rs` | `//crates/graphforge-storage:graph_delta_journal` | `mapped` | #8 / #752 |
 | `graphforge-storage` | `graph_writer` | `integration-test` | `crates/graphforge-storage/tests/graph_writer.rs` | `//crates/graphforge-storage:graph_writer` | `mapped` | #8 |
 | `graphforge-storage` | `io_stats` | `integration-test` | `crates/graphforge-storage/tests/io_stats.rs` | `//crates/graphforge-storage:io_stats` | `mapped` | #8 |
 

--- a/docs/engineering/adrs/README.md
+++ b/docs/engineering/adrs/README.md
@@ -55,3 +55,4 @@ Keeper set after #2730 (mirrors [`../../adr/README.md`](../../adr/README.md)):
 | 0016 | Repository integration and deployment configuration boundary | Accepted | [`../../adr/0016-repository-integration-and-deployment-configuration.md`](../../adr/0016-repository-integration-and-deployment-configuration.md) |
 | 0017 | One version across core and adapters | Accepted | [`../../adr/0017-unified-release-version.md`](../../adr/0017-unified-release-version.md) |
 | 0018 | Acknowledged durability and isolation contract | Accepted | [`../../adr/0018-acknowledged-durability-isolation.md`](../../adr/0018-acknowledged-durability-isolation.md) |
+| 0019 | Authoritative durable graph delta journal | Accepted | [`../../adr/0019-authoritative-graph-delta-journal.md`](../../adr/0019-authoritative-graph-delta-journal.md) |

--- a/tests/contracts/durability-isolation-matrix.json
+++ b/tests/contracts/durability-isolation-matrix.json
@@ -414,9 +414,35 @@
     },
     {
       "id": "durable_delta_journal",
-      "coverage": "deferred",
-      "owner_issue": 752,
-      "rationale": "Authoritative small-write deltas are #752."
+      "coverage": "covered",
+      "evidence": [
+        {
+          "kind": "rust",
+          "path": "crates/graphforge-storage/tests/graph_delta_journal.rs",
+          "symbol": "small_write_preserves_unchanged_parquet_and_reopen_replays"
+        },
+        {
+          "kind": "rust",
+          "path": "crates/graphforge-storage/tests/graph_delta_journal.rs",
+          "symbol": "torn_truncated_reordered_and_checksum_invalid_fail_closed"
+        },
+        {
+          "kind": "rust",
+          "path": "crates/graphforge-storage/tests/graph_delta_journal.rs",
+          "symbol": "exact_retry_transaction_is_idempotent_and_conflict_is_typed"
+        },
+        {
+          "kind": "rust",
+          "path": "crates/graphforge-storage/src/graph_delta_journal.rs",
+          "symbol": "crash_oracle_before_and_after_ack_matches_frozen_contract"
+        },
+        {
+          "kind": "doc",
+          "path": "docs/adr/0019-authoritative-graph-delta-journal.md",
+          "symbol": "sole commit"
+        }
+      ],
+      "rationale": "Authoritative small-write deltas with CURRENT-bound publication, fail-closed runs, and oracle-aligned crash phases."
     },
     {
       "id": "bounded_retention_orphan_gc",

--- a/tools/bazel/parity/migration_target_map.json
+++ b/tools/bazel/parity/migration_target_map.json
@@ -1,7 +1,7 @@
 {
   "schema": "graphforge.bazel-migration-target-map.v1",
   "issue": 6,
-  "cargo_target_count": 98,
+  "cargo_target_count": 99,
   "targets": [
     {
       "package": "graphforge-api",
@@ -952,6 +952,16 @@
       "bazel_label": "//crates/graphforge-storage:filtered_read",
       "exception_id": null,
       "notes": "#8"
+    },
+    {
+      "package": "graphforge-storage",
+      "target": "graph_delta_journal",
+      "class": "integration-test",
+      "source": "crates/graphforge-storage/tests/graph_delta_journal.rs",
+      "status": "mapped",
+      "bazel_label": "//crates/graphforge-storage:graph_delta_journal",
+      "exception_id": null,
+      "notes": "#8 / #752"
     },
     {
       "package": "graphforge-storage",


### PR DESCRIPTION
## Summary
- Freeze ADR 0019 (and amend ADR 0013/layout docs) for authoritative `graph/deltas/*.gfdr` runs that remain inventory-verified generation bytes under `CURRENT`.
- Add `graph_delta_journal` encode/decode/replay/publish: small-write publications byte-copy unchanged Parquet, append bounded checksummed runs, reconstruct state on reopen, and fail closed on torn/gapped/corrupt runs.
- Cover AC with integration + fault-oracle tests; mark `durable_delta_journal` covered in `graphforge-durability-isolation/1`.

## Test plan
- [x] `cargo test -p graphforge-storage --test graph_delta_journal`
- [x] `cargo test -p graphforge-storage --lib crash_oracle_before_and_after_ack`
- [x] `cargo clippy -p graphforge-storage --lib -- -D warnings`
- [x] `python3 scripts/ci/durability-isolation-gate.py validate`
- [x] `python3 scripts/ci/test-durability-isolation-gate.py`
- [ ] CI Gate green at exact head SHA

Closes #752


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789426818&installation_model_id=20486&pr_number=768&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F768&signature=a365de395292ef8bc3359237cd13744b5f113df0df1c177e6658bbb824f2e97f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->