### PR TITLE
feat(bindings): expose transaction and maintenance parity (#755)

### DIFF
--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -72,6 +72,7 @@ mod gsi_profiler;
 mod hypotheses;
 mod invocation_descriptor;
 mod knowledge;
+mod maintenance;
 #[cfg(test)]
 mod multi_process_publication_tests;
 mod node_selector;
@@ -219,6 +220,14 @@ pub use graphforge_storage::{
     ChunkingIdentity, EmbeddingRefreshFailureClass, EmbeddingRefreshOutcomeRecord,
     EmbeddingRefreshOutcomeStatus, EmbeddingRefreshProjectPolicy, EmbeddingRefreshSpacePolicy,
     ResolvedEmbeddingRefreshPolicy, SearchArtifactError, TokenCountClass, TokenizerIdentity,
+};
+pub use graphforge_storage::{
+    GraphDeltaCompactionLimits, GraphDeltaCompactionPolicy, GraphDeltaCompactionReport,
+    GraphDeltaCompactionRequest, GraphDeltaCompactionStatus, GraphDeltaJournalLimits,
+    ProjectCleanupDisposition, ProjectCleanupEntry, ProjectCleanupLocation, ProjectCleanupReport,
+    ProjectOpenRecoveryEvidence, ProjectOpenRecoveryKind, ProjectReachabilityReport,
+    ProjectRecoveryDeferral, ProjectRecoveryGenerationClass, ProjectRetentionLimits,
+    ProjectRetentionPolicy,
 };
 pub use gsi_profiler::{GraphScaleIndexProfile, GsiDirectedness, grade_gsi};
 pub use hypotheses::{

--- a/crates/graphforge-api/src/maintenance.rs
+++ b/crates/graphforge-api/src/maintenance.rs
@@ -1,0 +1,153 @@
+//! Thin GraphForge facade over Rust-owned retention/GC and delta compaction.
+//!
+//! Bindings and CLI must call these methods rather than reimplementing
+//! reachability, cleanup, delta replay, or compaction logic.
+
+use graphforge_core::{GfError, ProjectErrorCode};
+use graphforge_storage::{
+    GraphDeltaCompactionPolicy, GraphDeltaCompactionReport, GraphDeltaCompactionRequest,
+    GraphDeltaCompactionStatus, GraphDeltaJournalLimits, ProjectCleanupReport,
+    ProjectReachabilityReport, ProjectRetentionLimits, ProjectRetentionPolicy, compact_graph_delta,
+    graph_delta_compaction_status, inspect_project_reachability, preview_graph_delta_compaction,
+    preview_project_cleanup,
+};
+
+use crate::{CancellationToken, GraphForge};
+
+impl GraphForge {
+    fn require_mutable_project_root(&self) -> Result<&std::path::Path, GfError> {
+        if self.read_only {
+            return Err(GfError::Project {
+                code: ProjectErrorCode::ReadOnlyView,
+                message: "checkpoint views cannot run project maintenance".into(),
+            });
+        }
+        Ok(self.resolved_generation.container_root())
+    }
+
+    /// Inspect verified generation reachability for retention/GC planning.
+    pub fn inspect_project_reachability(
+        &self,
+        policy: ProjectRetentionPolicy,
+        limits: ProjectRetentionLimits,
+    ) -> Result<ProjectReachabilityReport, GfError> {
+        let root = self.require_mutable_project_root()?;
+        inspect_project_reachability(root, policy, limits)
+    }
+
+    /// Preview retention/GC candidates without removing anything.
+    pub fn preview_project_cleanup(
+        &self,
+        policy: ProjectRetentionPolicy,
+        limits: ProjectRetentionLimits,
+    ) -> Result<ProjectCleanupReport, GfError> {
+        let root = self.require_mutable_project_root()?;
+        preview_project_cleanup(root, policy, limits)
+    }
+
+    /// Execute retention/GC for unreachable generations using the shared oracle.
+    pub fn execute_project_cleanup(
+        &self,
+        policy: ProjectRetentionPolicy,
+        limits: ProjectRetentionLimits,
+    ) -> Result<ProjectCleanupReport, GfError> {
+        let root = self.require_mutable_project_root()?;
+        graphforge_storage::execute_project_cleanup(root, policy, limits)
+    }
+
+    /// Report whether CURRENT's verified delta chain should compact under policy.
+    pub fn graph_delta_compaction_status(
+        &self,
+        policy: GraphDeltaCompactionPolicy,
+        limits: GraphDeltaJournalLimits,
+    ) -> Result<GraphDeltaCompactionStatus, GfError> {
+        let root = self.require_mutable_project_root()?;
+        graph_delta_compaction_status(root, policy, limits)
+    }
+
+    /// Preview delta compaction without publishing CURRENT.
+    pub fn preview_graph_delta_compaction(
+        &self,
+        request: &GraphDeltaCompactionRequest,
+        cancellation: Option<&CancellationToken>,
+    ) -> Result<GraphDeltaCompactionReport, GfError> {
+        let root = self.require_mutable_project_root()?;
+        preview_graph_delta_compaction(root, request, cancellation.map(CancellationToken::flag))
+    }
+
+    /// Compact a contiguous verified delta prefix into a new Parquet generation.
+    pub fn compact_graph_delta(
+        &self,
+        request: &GraphDeltaCompactionRequest,
+        cancellation: Option<&CancellationToken>,
+    ) -> Result<GraphDeltaCompactionReport, GfError> {
+        let root = self.require_mutable_project_root()?;
+        compact_graph_delta(root, request, cancellation.map(CancellationToken::flag))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    use tempfile::TempDir;
+    use uuid::Uuid;
+
+    use crate::{OperationId, WriteContext};
+    use graphforge_storage::{GraphDeltaCompactionLimits, GraphDeltaCompactionRequest};
+
+    #[test]
+    fn facade_exposes_transaction_and_maintenance_ops() {
+        let directory = TempDir::new().unwrap();
+        let graph = GraphForge::new(directory.path().to_str()).unwrap();
+        let _ = graph.project_open_recovery();
+        graph
+            .inspect_project_reachability(
+                ProjectRetentionPolicy::default(),
+                ProjectRetentionLimits::default(),
+            )
+            .unwrap();
+        let preview = graph
+            .preview_project_cleanup(
+                ProjectRetentionPolicy::default(),
+                ProjectRetentionLimits::default(),
+            )
+            .unwrap();
+        let executed = graph
+            .execute_project_cleanup(
+                ProjectRetentionPolicy::default(),
+                ProjectRetentionLimits::default(),
+            )
+            .unwrap();
+        assert_eq!(preview.candidates, executed.candidates);
+        let tx = graph
+            .begin_transaction(WriteContext {
+                operation_uuid: OperationId(Uuid::now_v7()),
+                actor_uuid: None,
+            })
+            .unwrap();
+        tx.stage_cypher("CREATE (:Person {name: 'A'})", HashMap::new())
+            .unwrap();
+        tx.commit(&graph).unwrap();
+
+        graph
+            .graph_delta_compaction_status(
+                GraphDeltaCompactionPolicy::default(),
+                GraphDeltaJournalLimits::default(),
+            )
+            .unwrap();
+
+        let request = GraphDeltaCompactionRequest {
+            transaction_uuid: Uuid::now_v7(),
+            generation_uuid: Uuid::now_v7(),
+            through_run_sequence: None,
+            limits: GraphDeltaCompactionLimits::default(),
+            cleanup_after_commit: false,
+            cleanup_policy: ProjectRetentionPolicy::default(),
+            cleanup_limits: ProjectRetentionLimits::default(),
+        };
+        let _ = graph.preview_graph_delta_compaction(&request, None);
+        let _ = graph.compact_graph_delta(&request, None);
+    }
+}

--- a/crates/graphforge-api/src/paging.rs
+++ b/crates/graphforge-api/src/paging.rs
@@ -181,6 +181,13 @@ impl CancellationToken {
         self.0.load(Ordering::Acquire)
     }
 
+    /// Borrow the underlying cancellation flag for Rust-owned ops that observe
+    /// cooperative cancellation via [`std::sync::atomic::AtomicBool`].
+    #[must_use]
+    pub fn flag(&self) -> &AtomicBool {
+        self.0.as_ref()
+    }
+
     pub(crate) fn checkpoint(&self) -> Result<(), GfError> {
         if self.is_cancelled() {
             Err(page_error(

--- a/crates/graphforge-api/src/transaction.rs
+++ b/crates/graphforge-api/src/transaction.rs
@@ -162,8 +162,11 @@ fn knowledge_row_count(knowledge: &CompositeKnowledgeParticipants) -> usize {
 /// owning thread must drive stage/validate/commit/rollback. Drop rolls back
 /// any still-open staged work without holding project writer locks across the
 /// handle lifetime (locks are acquired only around commit admission).
-pub struct GraphTransaction<'a> {
-    graph: &'a GraphForge,
+///
+/// The handle does not borrow [`GraphForge`]: callers pass `&GraphForge` into
+/// [`Self::validate`] / [`Self::commit`] so language bindings can keep the
+/// facade and transaction as separately owned wrappers.
+pub struct GraphTransaction {
     context: WriteContext,
     base_generation_uuid: Uuid,
     write_mode: ProjectWriteMode,
@@ -173,7 +176,7 @@ pub struct GraphTransaction<'a> {
     started_at: Instant,
 }
 
-impl GraphTransaction<'_> {
+impl GraphTransaction {
     fn ensure_owner(&self) -> Result<(), GfError> {
         if std::thread::current().id() != self.owner {
             return Err(validation(
@@ -394,7 +397,7 @@ impl GraphTransaction<'_> {
     }
 
     /// Validate staged content against the pinned base generation without publishing.
-    pub fn validate(&self) -> Result<(), GfError> {
+    pub fn validate(&self, graph: &GraphForge) -> Result<(), GfError> {
         self.ensure_open()?;
         let mut state = self
             .state
@@ -410,7 +413,7 @@ impl GraphTransaction<'_> {
             knowledge: state.knowledge.clone(),
         };
         if state.cypher.is_empty() {
-            let _ = self.graph.authorize_composite_against_current(&request)?;
+            let _ = graph.authorize_composite_against_current(&request)?;
         } else if !request.graph_mutations.is_empty() || knowledge_row_count(&request.knowledge) > 0
         {
             request.validate_request_shape()?;
@@ -421,13 +424,14 @@ impl GraphTransaction<'_> {
     }
 
     /// Publish every staged supported participant as one generation.
-    pub fn commit(&self) -> Result<TransactionCommitReceipt, GfError> {
-        self.commit_with_cancellation(None)
+    pub fn commit(&self, graph: &GraphForge) -> Result<TransactionCommitReceipt, GfError> {
+        self.commit_with_cancellation(graph, None)
     }
 
     /// Commit with cooperative queued-write cancellation observed only before admission.
     pub fn commit_with_cancellation(
         &self,
+        graph: &GraphForge,
         cancellation: Option<CancellationToken>,
     ) -> Result<TransactionCommitReceipt, GfError> {
         self.ensure_open()?;
@@ -451,7 +455,7 @@ impl GraphTransaction<'_> {
             )
         };
 
-        let result = self.commit_state(state, cancellation);
+        let result = self.commit_state(graph, state, cancellation);
         if result.is_ok() {
             if let Ok(mut state) = self.state.lock() {
                 state.phase = TransactionPhase::Committed;
@@ -465,6 +469,7 @@ impl GraphTransaction<'_> {
 
     fn commit_state(
         &self,
+        graph: &GraphForge,
         state: TransactionState,
         cancellation: Option<CancellationToken>,
     ) -> Result<TransactionCommitReceipt, GfError> {
@@ -473,9 +478,8 @@ impl GraphTransaction<'_> {
         let request = state.into_composite_request(self.context.clone());
 
         if !has_cypher {
-            let receipt = self
-                .graph
-                .publish_composite_transaction_with_cancellation(request, cancellation)?;
+            let receipt =
+                graph.publish_composite_transaction_with_cancellation(request, cancellation)?;
             let generation_uuid = generation_from_receipt(&receipt)?;
             return Ok(TransactionCommitReceipt {
                 generation_uuid,
@@ -483,9 +487,9 @@ impl GraphTransaction<'_> {
             });
         }
 
-        let _visibility = self.graph.graph_visibility.acquire(cancellation.as_ref())?;
+        let _visibility = graph.graph_visibility.acquire(cancellation.as_ref())?;
         let prior = graphforge_storage::resolve_project_generation(
-            self.graph.resolved_generation.container_root(),
+            graph.resolved_generation.container_root(),
         )?;
         if prior.generation_uuid() != self.base_generation_uuid
             && self.write_mode != ProjectWriteMode::OptimisticMultiWriter
@@ -497,24 +501,23 @@ impl GraphTransaction<'_> {
         }
 
         for (query, params) in &cypher {
-            self.graph
+            graph
                 .execute_write_without_publish(query, params)
                 .inspect_err(|_| {
-                    let _ = crate::rematerialize_graph_workspace(&prior, &self.graph.dir);
+                    let _ = crate::rematerialize_graph_workspace(&prior, &graph.dir);
                 })?;
         }
 
         if request.graph_mutations.is_empty() && knowledge_row_count(&request.knowledge) == 0 {
-            let recorded_at = (self.graph.clock.lock().expect("clock lock poisoned"))()?;
+            let recorded_at = (graph.clock.lock().expect("clock lock poisoned"))()?;
             let receipt = graphforge_exec::MutationReceipt::default();
-            self.graph.publish_graph_mutation_with_context(
+            graph.publish_graph_mutation_with_context(
                 &receipt,
                 self.context.operation_uuid.0,
                 self.context.actor_uuid,
                 recorded_at,
             )?;
-            let generation = *self
-                .graph
+            let generation = *graph
                 .current_generation_uuid
                 .lock()
                 .expect("generation UUID lock poisoned");
@@ -524,11 +527,10 @@ impl GraphTransaction<'_> {
             });
         }
 
-        let receipt = self
-            .graph
+        let receipt = graph
             .publish_composite_transaction_admitted(request)
             .inspect_err(|_| {
-                let _ = crate::rematerialize_graph_workspace(&prior, &self.graph.dir);
+                let _ = crate::rematerialize_graph_workspace(&prior, &graph.dir);
             })?;
         let generation_uuid = generation_from_receipt(&receipt)?;
         Ok(TransactionCommitReceipt {
@@ -570,7 +572,7 @@ impl GraphTransaction<'_> {
     }
 }
 
-impl Drop for GraphTransaction<'_> {
+impl Drop for GraphTransaction {
     fn drop(&mut self) {
         if !self.finished.swap(true, Ordering::AcqRel)
             && let Ok(mut state) = self.state.lock()
@@ -590,10 +592,7 @@ impl GraphForge {
     /// The handle stages supported mutations in memory and publishes them
     /// atomically on commit. Administrative families classified as rejected are
     /// refused by [`GraphTransaction::reject_admin`] before mutation.
-    pub fn begin_transaction(
-        &self,
-        context: WriteContext,
-    ) -> Result<GraphTransaction<'_>, GfError> {
+    pub fn begin_transaction(&self, context: WriteContext) -> Result<GraphTransaction, GfError> {
         if self.read_only {
             return Err(GfError::Project {
                 code: ProjectErrorCode::ReadOnlyView,
@@ -608,7 +607,6 @@ impl GraphForge {
             .lock()
             .expect("generation UUID lock poisoned");
         Ok(GraphTransaction {
-            graph: self,
             context,
             base_generation_uuid,
             write_mode: self.write_options.write_mode,
@@ -776,7 +774,7 @@ mod tests {
             row_ordinal: 0,
         }])
         .unwrap();
-        let receipt = tx.commit().unwrap();
+        let receipt = tx.commit(&graph).unwrap();
         assert_ne!(receipt.generation_uuid, before);
         assert_eq!(
             *graph
@@ -813,7 +811,7 @@ mod tests {
             HashMap::from([("name".into(), PropValue::Str("Ghost".into()))]),
         )
         .unwrap();
-        tx.validate().unwrap();
+        tx.validate(&graph).unwrap();
         tx.rollback().unwrap();
         assert_eq!(
             *graph
@@ -878,7 +876,7 @@ mod tests {
                 HashMap::from([("name".into(), PropValue::Str("Ada".into()))]),
             )
             .unwrap();
-        let first_receipt = first.commit().unwrap();
+        let first_receipt = first.commit(&graph).unwrap();
 
         let retry = graph.begin_transaction(ctx.clone()).unwrap();
         retry
@@ -888,7 +886,7 @@ mod tests {
                 HashMap::from([("name".into(), PropValue::Str("Ada".into()))]),
             )
             .unwrap();
-        let retry_receipt = retry.commit().unwrap();
+        let retry_receipt = retry.commit(&graph).unwrap();
         assert_eq!(first_receipt.generation_uuid, retry_receipt.generation_uuid);
 
         let conflict = graph.begin_transaction(ctx).unwrap();
@@ -899,7 +897,7 @@ mod tests {
                 HashMap::from([("name".into(), PropValue::Str("Other".into()))]),
             )
             .unwrap();
-        let error = conflict.commit().unwrap_err();
+        let error = conflict.commit(&graph).unwrap_err();
         assert_eq!(error.code(), "GF_IDEMPOTENCY_CONFLICT");
     }
 
@@ -930,7 +928,7 @@ mod tests {
         let tx = graph.begin_transaction(context(15)).unwrap();
         tx.stage_add_node(uuid7(25), "Person", HashMap::new())
             .unwrap();
-        tx.commit().unwrap();
+        tx.commit(&graph).unwrap();
         let error = tx
             .stage_add_node(uuid7(26), "Person", HashMap::new())
             .unwrap_err();
@@ -986,8 +984,8 @@ mod tests {
                 CompositeKnowledgeParticipants::default(),
             )
             .unwrap();
-        left.commit().unwrap();
-        right.commit().unwrap();
+        left.commit(&graph).unwrap();
+        right.commit(&right_graph).unwrap();
 
         let reopened = GraphForge::new(directory.path().to_str()).unwrap();
         let rows = reopened
@@ -1016,7 +1014,7 @@ mod tests {
         seeded
             .stage_add_node(target, "Person", HashMap::new())
             .unwrap();
-        seeded.commit().unwrap();
+        seeded.commit(&graph).unwrap();
 
         let tx = graph.begin_transaction(context(41)).unwrap();
         let status = tx.status().unwrap();
@@ -1036,7 +1034,9 @@ mod tests {
         }])
         .unwrap();
         let cancelled = CancellationToken::new();
-        let receipt = tx.commit_with_cancellation(Some(cancelled)).unwrap();
+        let receipt = tx
+            .commit_with_cancellation(&graph, Some(cancelled))
+            .unwrap();
         assert_ne!(receipt.generation_uuid, Uuid::nil());
     }
 }

--- a/crates/graphforge-bindings-node/src/lib.rs
+++ b/crates/graphforge-bindings-node/src/lib.rs
@@ -49,6 +49,7 @@ use napi_derive::napi;
 
 mod composite;
 mod error;
+mod transaction;
 use composite::CompositeTransactionInput;
 use error::{NodeError, to_napi_err, type_error};
 
@@ -5841,6 +5842,84 @@ impl GraphForge {
         self.ensure_open()?;
         let graph = self.open_guard()?;
         composite::publish_composite_transaction(&graph, request)
+    }
+
+    /// Begin an explicit multi-mutation transaction (Rust-owned lifecycle).
+    #[napi]
+    pub fn begin_transaction(
+        &self,
+        operation_uuid: String,
+        actor_uuid: Option<String>,
+    ) -> Result<transaction::GraphTransaction> {
+        self.ensure_open()?;
+        transaction::begin_transaction(Arc::clone(&self.inner), operation_uuid, actor_uuid)
+    }
+
+    /// Safe recovery-on-open evidence for this instance.
+    #[napi]
+    pub fn project_open_recovery(&self) -> Result<transaction::ProjectOpenRecoveryOutput> {
+        let graph = self.open_guard()?;
+        Ok(transaction::recovery_output(graph.project_open_recovery()))
+    }
+
+    /// Inspect verified generation reachability for retention/GC planning.
+    #[napi]
+    pub fn inspect_project_reachability(
+        &self,
+        request: Option<transaction::ProjectRetentionInput>,
+    ) -> Result<transaction::ProjectReachabilityReportOutput> {
+        let graph = self.open_guard()?;
+        transaction::inspect_reachability(&graph, request)
+    }
+
+    /// Preview retention/GC candidates without removing anything.
+    #[napi]
+    pub fn preview_project_cleanup(
+        &self,
+        request: Option<transaction::ProjectRetentionInput>,
+    ) -> Result<transaction::ProjectCleanupReportOutput> {
+        let graph = self.open_guard()?;
+        transaction::preview_cleanup(&graph, request)
+    }
+
+    /// Execute retention/GC for unreachable generations.
+    #[napi]
+    pub fn execute_project_cleanup(
+        &self,
+        request: Option<transaction::ProjectRetentionInput>,
+    ) -> Result<transaction::ProjectCleanupReportOutput> {
+        let graph = self.open_write_guard()?;
+        transaction::execute_cleanup(&graph, request)
+    }
+
+    /// Report whether CURRENT's verified delta chain should compact.
+    #[napi]
+    pub fn graph_delta_compaction_status(
+        &self,
+        request: Option<transaction::GraphDeltaCompactionStatusInput>,
+    ) -> Result<transaction::GraphDeltaCompactionStatusOutput> {
+        let graph = self.open_guard()?;
+        transaction::compaction_status(&graph, request)
+    }
+
+    /// Preview delta compaction without publishing CURRENT.
+    #[napi]
+    pub fn preview_graph_delta_compaction(
+        &self,
+        request: transaction::GraphDeltaCompactionInput,
+    ) -> Result<transaction::GraphDeltaCompactionReportOutput> {
+        let graph = self.open_guard()?;
+        transaction::preview_compaction(&graph, request, None)
+    }
+
+    /// Compact a contiguous verified delta prefix into a new Parquet generation.
+    #[napi]
+    pub fn compact_graph_delta(
+        &self,
+        request: transaction::GraphDeltaCompactionInput,
+    ) -> Result<transaction::GraphDeltaCompactionReportOutput> {
+        let graph = self.open_write_guard()?;
+        transaction::compact(&graph, request, None)
     }
 
     /// Remove all nodes and edges (in-memory instances only).

--- a/crates/graphforge-bindings-node/src/transaction.rs
+++ b/crates/graphforge-bindings-node/src/transaction.rs
@@ -1,0 +1,671 @@
+//! Thin Node wrappers for Rust-owned transactions and maintenance (#755).
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, RwLock};
+
+use graphforge_api::{
+    CancellationToken, GfError, GraphDeltaCompactionLimits, GraphDeltaCompactionPolicy,
+    GraphDeltaCompactionReport, GraphDeltaCompactionRequest, GraphDeltaCompactionStatus,
+    GraphDeltaJournalLimits, GraphTransaction as ApiTransaction, IrLiteral, OperationId,
+    ProjectCleanupReport, ProjectOpenRecoveryEvidence, ProjectReachabilityReport,
+    ProjectRetentionLimits, ProjectRetentionPolicy, ProjectWriteMode, PropValue, TransactionPhase,
+    WriteContext,
+};
+use napi::bindgen_prelude::BigInt;
+use napi_derive::napi;
+use uuid::Uuid;
+
+use crate::error::to_napi_err;
+use crate::{Result, napi_validation};
+
+fn phase_name(phase: TransactionPhase) -> &'static str {
+    match phase {
+        TransactionPhase::Open => "open",
+        TransactionPhase::Validated => "validated",
+        TransactionPhase::Committed => "committed",
+        TransactionPhase::RolledBack => "rolled_back",
+        _ => "unknown",
+    }
+}
+
+fn write_mode_name(mode: ProjectWriteMode) -> &'static str {
+    match mode {
+        ProjectWriteMode::SingleWriter => "single_writer",
+        ProjectWriteMode::QueuedWriter => "queued_writer",
+        ProjectWriteMode::OptimisticMultiWriter => "optimistic_multi_writer",
+        _ => "unknown",
+    }
+}
+
+fn fingerprint_hex(bytes: &[u8; 32]) -> String {
+    let mut out = String::with_capacity(64);
+    for byte in bytes {
+        use std::fmt::Write as _;
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+fn parse_uuid(value: &str, field: &str) -> Result<Uuid> {
+    Uuid::parse_str(value).map_err(|_| {
+        to_napi_err(&GfError::Validation(format!(
+            "{field} must be a canonical UUID string"
+        )))
+    })
+}
+
+fn canonical_operation_id(value: &str) -> Result<OperationId> {
+    crate::canonical_operation_id(value)
+}
+
+fn u64_bigint(value: u64) -> BigInt {
+    BigInt::from(value)
+}
+
+/// Safe transaction status snapshot.
+#[napi(object)]
+pub struct TransactionStatusOutput {
+    pub operation_uuid: String,
+    pub base_generation_uuid: String,
+    pub phase: String,
+    pub write_mode: String,
+    pub staged_entry_count: u32,
+    pub committed: bool,
+}
+
+/// Safe recovery-on-open evidence.
+#[napi(object)]
+pub struct ProjectOpenRecoveryOutput {
+    pub kind: String,
+    pub selected_generation_uuid: String,
+    pub selected_generation_class: String,
+    pub work_detected: bool,
+    pub repaired_journals: BigInt,
+    pub aborted_journals: BigInt,
+    pub removed_generations: BigInt,
+    pub preserved_unknown_entries: BigInt,
+    pub deferred: Option<String>,
+    pub elapsed_ms: BigInt,
+}
+
+/// One classified cleanup entry.
+#[napi(object)]
+pub struct ProjectCleanupEntryOutput {
+    pub generation_uuid: Option<String>,
+    pub location: String,
+    pub disposition: String,
+    pub bytes: BigInt,
+}
+
+/// Retention/GC report with lossless 64-bit counters.
+#[napi(object)]
+pub struct ProjectCleanupReportOutput {
+    pub dry_run: bool,
+    pub selected_generation_uuid: String,
+    pub retained_ancestors: u32,
+    pub reachable_count: BigInt,
+    pub candidates: BigInt,
+    pub removed: BigInt,
+    pub skipped_live: BigInt,
+    pub quarantined: BigInt,
+    pub unknown: BigInt,
+    pub remaining_bytes: BigInt,
+    pub bytes_scanned: BigInt,
+    pub entries_scanned: BigInt,
+    pub work_units: BigInt,
+    pub bounded: bool,
+    pub elapsed_ms: BigInt,
+    pub entries: Vec<ProjectCleanupEntryOutput>,
+}
+
+/// Reachability inspection report.
+#[napi(object)]
+pub struct ProjectReachabilityReportOutput {
+    pub selected_generation_uuid: String,
+    pub retained_ancestors_policy: u32,
+    pub reachable: Vec<String>,
+    pub checkpoint_roots: Vec<String>,
+    pub retained_ancestors: Vec<String>,
+    pub entries_scanned: BigInt,
+    pub bytes_scanned: BigInt,
+    pub elapsed_ms: BigInt,
+}
+
+/// Delta compaction progress/evidence report.
+#[napi(object)]
+pub struct GraphDeltaCompactionReportOutput {
+    pub dry_run: bool,
+    pub input_generation_uuid: String,
+    pub output_generation_uuid: Option<String>,
+    pub input_runs: BigInt,
+    pub compacted_runs: BigInt,
+    pub retained_suffix_runs: BigInt,
+    pub input_rows: BigInt,
+    pub output_rows: BigInt,
+    pub input_bytes: BigInt,
+    pub output_bytes: BigInt,
+    pub spill_bytes: BigInt,
+    pub peak_memory_bytes: BigInt,
+    pub elapsed_ms: BigInt,
+    pub state_fingerprint: String,
+    pub cleanup: Option<ProjectCleanupReportOutput>,
+}
+
+/// Compaction status under optional policy triggers.
+#[napi(object)]
+pub struct GraphDeltaCompactionStatusOutput {
+    pub generation_uuid: String,
+    pub run_count: BigInt,
+    pub run_bytes: BigInt,
+    pub estimated_replay_memory_bytes: BigInt,
+    pub state_fingerprint: String,
+    pub should_compact: bool,
+    pub trigger_reasons: Vec<String>,
+}
+
+/// Retention policy/limit overrides.
+#[napi(object)]
+pub struct ProjectRetentionInput {
+    pub retained_ancestors: Option<u32>,
+    pub max_entries: Option<u32>,
+    pub max_bytes_scanned: Option<BigInt>,
+    pub max_work_units: Option<u32>,
+    pub cleanup_batch: Option<u32>,
+}
+
+/// Compaction request overrides.
+#[napi(object)]
+pub struct GraphDeltaCompactionInput {
+    pub transaction_uuid: String,
+    pub generation_uuid: String,
+    pub through_run_sequence: Option<BigInt>,
+    pub cleanup_after_commit: Option<bool>,
+    pub retained_ancestors: Option<u32>,
+}
+
+/// Compaction status policy overrides.
+#[napi(object)]
+#[allow(clippy::struct_field_names)] // mirrors GraphDeltaCompactionPolicy field names
+pub struct GraphDeltaCompactionStatusInput {
+    pub compact_when_runs: Option<BigInt>,
+    pub compact_when_run_bytes: Option<BigInt>,
+    pub compact_when_replay_memory_bytes: Option<BigInt>,
+}
+
+fn bigint_u64(value: BigInt, field: &str) -> Result<u64> {
+    let (negative, parsed, lossless) = value.get_u64();
+    if negative || !lossless {
+        return Err(to_napi_err(&GfError::Validation(format!(
+            "{field} must be an exact unsigned 64-bit integer"
+        ))));
+    }
+    Ok(parsed)
+}
+
+fn retention_from_input(
+    input: Option<ProjectRetentionInput>,
+) -> Result<(ProjectRetentionPolicy, ProjectRetentionLimits)> {
+    let defaults = ProjectRetentionLimits::default();
+    let policy_default = ProjectRetentionPolicy::default();
+    let Some(input) = input else {
+        return Ok((policy_default, defaults));
+    };
+    Ok((
+        ProjectRetentionPolicy {
+            retained_ancestors: input
+                .retained_ancestors
+                .map(usize::try_from)
+                .transpose()
+                .map_err(|_| napi_validation("retainedAncestors exceeds usize"))?
+                .unwrap_or(policy_default.retained_ancestors),
+        },
+        ProjectRetentionLimits {
+            max_entries: input
+                .max_entries
+                .map(usize::try_from)
+                .transpose()
+                .map_err(|_| napi_validation("maxEntries exceeds usize"))?
+                .unwrap_or(defaults.max_entries),
+            max_bytes_scanned: match input.max_bytes_scanned {
+                Some(value) => bigint_u64(value, "maxBytesScanned")?,
+                None => defaults.max_bytes_scanned,
+            },
+            max_work_units: input
+                .max_work_units
+                .map(usize::try_from)
+                .transpose()
+                .map_err(|_| napi_validation("maxWorkUnits exceeds usize"))?
+                .unwrap_or(defaults.max_work_units),
+            cleanup_batch: input
+                .cleanup_batch
+                .map(usize::try_from)
+                .transpose()
+                .map_err(|_| napi_validation("cleanupBatch exceeds usize"))?
+                .unwrap_or(defaults.cleanup_batch),
+        },
+    ))
+}
+
+pub(crate) fn recovery_output(evidence: &ProjectOpenRecoveryEvidence) -> ProjectOpenRecoveryOutput {
+    ProjectOpenRecoveryOutput {
+        kind: match evidence.kind {
+            graphforge_api::ProjectOpenRecoveryKind::ProjectOpen => "project_open".into(),
+            graphforge_api::ProjectOpenRecoveryKind::Initialization => "initialization".into(),
+            graphforge_api::ProjectOpenRecoveryKind::CheckpointView => "checkpoint_view".into(),
+        },
+        selected_generation_uuid: evidence.selected_generation_uuid.to_string(),
+        selected_generation_class: evidence.selected_generation_class.as_str().into(),
+        work_detected: evidence.work_detected,
+        repaired_journals: u64_bigint(evidence.repaired_journals),
+        aborted_journals: u64_bigint(evidence.aborted_journals),
+        removed_generations: u64_bigint(evidence.removed_generations),
+        preserved_unknown_entries: u64_bigint(evidence.preserved_unknown_entries),
+        deferred: evidence.deferred.map(|value| value.as_str().into()),
+        elapsed_ms: u64_bigint(evidence.elapsed_ms),
+    }
+}
+
+fn cleanup_output(report: &ProjectCleanupReport) -> ProjectCleanupReportOutput {
+    ProjectCleanupReportOutput {
+        dry_run: report.dry_run,
+        selected_generation_uuid: report.selected_generation_uuid.to_string(),
+        retained_ancestors: u32::try_from(report.policy.retained_ancestors).unwrap_or(u32::MAX),
+        reachable_count: u64_bigint(report.reachable_count),
+        candidates: u64_bigint(report.candidates),
+        removed: u64_bigint(report.removed),
+        skipped_live: u64_bigint(report.skipped_live),
+        quarantined: u64_bigint(report.quarantined),
+        unknown: u64_bigint(report.unknown),
+        remaining_bytes: u64_bigint(report.remaining_bytes),
+        bytes_scanned: u64_bigint(report.bytes_scanned),
+        entries_scanned: u64_bigint(report.entries_scanned),
+        work_units: u64_bigint(report.work_units),
+        bounded: report.bounded,
+        elapsed_ms: u64_bigint(report.elapsed_ms),
+        entries: report
+            .entries
+            .iter()
+            .map(|entry| ProjectCleanupEntryOutput {
+                generation_uuid: entry.generation_uuid.map(|uuid| uuid.to_string()),
+                location: entry.location.as_str().into(),
+                disposition: entry.disposition.as_str().into(),
+                bytes: u64_bigint(entry.bytes),
+            })
+            .collect(),
+    }
+}
+
+fn reachability_output(report: &ProjectReachabilityReport) -> ProjectReachabilityReportOutput {
+    ProjectReachabilityReportOutput {
+        selected_generation_uuid: report.selected_generation_uuid.to_string(),
+        retained_ancestors_policy: u32::try_from(report.policy.retained_ancestors)
+            .unwrap_or(u32::MAX),
+        reachable: report.reachable.iter().map(ToString::to_string).collect(),
+        checkpoint_roots: report
+            .checkpoint_roots
+            .iter()
+            .map(ToString::to_string)
+            .collect(),
+        retained_ancestors: report
+            .retained_ancestors
+            .iter()
+            .map(ToString::to_string)
+            .collect(),
+        entries_scanned: u64_bigint(report.entries_scanned),
+        bytes_scanned: u64_bigint(report.bytes_scanned),
+        elapsed_ms: u64_bigint(report.elapsed_ms),
+    }
+}
+
+fn compaction_report_output(
+    report: &GraphDeltaCompactionReport,
+) -> GraphDeltaCompactionReportOutput {
+    GraphDeltaCompactionReportOutput {
+        dry_run: report.dry_run,
+        input_generation_uuid: report.input_generation_uuid.to_string(),
+        output_generation_uuid: report.output_generation_uuid.map(|uuid| uuid.to_string()),
+        input_runs: u64_bigint(report.input_runs),
+        compacted_runs: u64_bigint(report.compacted_runs),
+        retained_suffix_runs: u64_bigint(report.retained_suffix_runs),
+        input_rows: u64_bigint(report.input_rows),
+        output_rows: u64_bigint(report.output_rows),
+        input_bytes: u64_bigint(report.input_bytes),
+        output_bytes: u64_bigint(report.output_bytes),
+        spill_bytes: u64_bigint(report.spill_bytes),
+        peak_memory_bytes: u64_bigint(report.peak_memory_bytes),
+        elapsed_ms: u64_bigint(report.elapsed_ms),
+        state_fingerprint: fingerprint_hex(&report.state_fingerprint),
+        cleanup: report.cleanup.as_ref().map(cleanup_output),
+    }
+}
+
+fn compaction_status_output(
+    status: &GraphDeltaCompactionStatus,
+) -> GraphDeltaCompactionStatusOutput {
+    GraphDeltaCompactionStatusOutput {
+        generation_uuid: status.generation_uuid.to_string(),
+        run_count: u64_bigint(status.run_count),
+        run_bytes: u64_bigint(status.run_bytes),
+        estimated_replay_memory_bytes: u64_bigint(status.estimated_replay_memory_bytes),
+        state_fingerprint: fingerprint_hex(&status.state_fingerprint),
+        should_compact: status.should_compact,
+        trigger_reasons: status.trigger_reasons.clone(),
+    }
+}
+
+fn compaction_request(input: GraphDeltaCompactionInput) -> Result<GraphDeltaCompactionRequest> {
+    Ok(GraphDeltaCompactionRequest {
+        transaction_uuid: parse_uuid(&input.transaction_uuid, "transactionUuid")?,
+        generation_uuid: parse_uuid(&input.generation_uuid, "generationUuid")?,
+        through_run_sequence: input
+            .through_run_sequence
+            .map(|value| bigint_u64(value, "throughRunSequence"))
+            .transpose()?,
+        limits: GraphDeltaCompactionLimits::default(),
+        cleanup_after_commit: input.cleanup_after_commit.unwrap_or(false),
+        cleanup_policy: ProjectRetentionPolicy {
+            retained_ancestors: input
+                .retained_ancestors
+                .map(usize::try_from)
+                .transpose()
+                .map_err(|_| napi_validation("retainedAncestors exceeds usize"))?
+                .unwrap_or_else(|| ProjectRetentionPolicy::default().retained_ancestors),
+        },
+        cleanup_limits: ProjectRetentionLimits::default(),
+    })
+}
+
+/// Explicit multi-mutation transaction handle. Finalization rolls back without commit.
+#[napi]
+pub struct GraphTransaction {
+    engine: Arc<RwLock<graphforge_api::GraphForge>>,
+    inner: Mutex<Option<ApiTransaction>>,
+}
+
+#[napi]
+impl GraphTransaction {
+    pub(crate) fn new(
+        engine: Arc<RwLock<graphforge_api::GraphForge>>,
+        inner: ApiTransaction,
+    ) -> Self {
+        Self {
+            engine,
+            inner: Mutex::new(Some(inner)),
+        }
+    }
+
+    fn with_tx<R>(
+        &self,
+        f: impl FnOnce(&ApiTransaction) -> std::result::Result<R, GfError>,
+    ) -> Result<R> {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|_| to_napi_err(&GfError::Validation("transaction lock poisoned".into())))?;
+        let tx = guard.as_ref().ok_or_else(|| {
+            to_napi_err(&GfError::Validation(
+                "transaction handle already released".into(),
+            ))
+        })?;
+        f(tx).map_err(|error| to_napi_err(&error))
+    }
+
+    #[napi]
+    pub fn status(&self) -> Result<TransactionStatusOutput> {
+        let status = self.with_tx(ApiTransaction::status)?;
+        Ok(TransactionStatusOutput {
+            operation_uuid: status.operation_uuid.to_string(),
+            base_generation_uuid: status.base_generation_uuid.to_string(),
+            phase: phase_name(status.phase).into(),
+            write_mode: write_mode_name(status.write_mode).into(),
+            staged_entry_count: u32::try_from(status.staged_entry_count).unwrap_or(u32::MAX),
+            committed: status.committed,
+        })
+    }
+
+    #[napi]
+    pub fn stage_cypher(
+        &self,
+        query: String,
+        params: Option<HashMap<String, serde_json::Value>>,
+    ) -> Result<()> {
+        let mut converted = HashMap::new();
+        if let Some(params) = params {
+            for (key, value) in params {
+                converted.insert(key, json_to_ir_literal(value)?);
+            }
+        }
+        self.with_tx(|tx| tx.stage_cypher(query, converted))
+    }
+
+    #[napi]
+    pub fn stage_add_node(
+        &self,
+        node_uuid: String,
+        label: String,
+        properties: Option<HashMap<String, serde_json::Value>>,
+    ) -> Result<()> {
+        let node_uuid = parse_uuid(&node_uuid, "nodeUuid")?;
+        let properties = json_props(properties)?;
+        self.with_tx(|tx| tx.stage_add_node(node_uuid, label, properties))
+    }
+
+    #[napi]
+    pub fn stage_add_edge(
+        &self,
+        edge_uuid: String,
+        rel_type: String,
+        source_uuid: String,
+        target_uuid: String,
+        properties: Option<HashMap<String, serde_json::Value>>,
+    ) -> Result<()> {
+        let edge_uuid = parse_uuid(&edge_uuid, "edgeUuid")?;
+        let source_uuid = parse_uuid(&source_uuid, "sourceUuid")?;
+        let target_uuid = parse_uuid(&target_uuid, "targetUuid")?;
+        let properties = json_props(properties)?;
+        self.with_tx(|tx| {
+            tx.stage_add_edge(edge_uuid, rel_type, source_uuid, target_uuid, properties)
+        })
+    }
+
+    #[napi]
+    pub fn validate(&self) -> Result<()> {
+        let graph = self
+            .engine
+            .read()
+            .map_err(|_| to_napi_err(&GfError::Execution("GraphForge lock poisoned".into())))?;
+        self.with_tx(|tx| tx.validate(&graph))
+    }
+
+    #[napi]
+    pub fn commit(&self) -> Result<String> {
+        let graph = self
+            .engine
+            .write()
+            .map_err(|_| to_napi_err(&GfError::Execution("GraphForge lock poisoned".into())))?;
+        let receipt = self.with_tx(|tx| tx.commit(&graph))?;
+        Ok(receipt.generation_uuid.to_string())
+    }
+
+    #[napi]
+    pub fn rollback(&self) -> Result<()> {
+        self.with_tx(ApiTransaction::rollback)
+    }
+}
+
+impl Drop for GraphTransaction {
+    fn drop(&mut self) {
+        if let Ok(mut guard) = self.inner.lock() {
+            guard.take();
+        }
+    }
+}
+
+fn json_to_ir_literal(value: serde_json::Value) -> Result<IrLiteral> {
+    match value {
+        serde_json::Value::Null => Ok(IrLiteral::Null),
+        serde_json::Value::Bool(value) => Ok(IrLiteral::Bool(value)),
+        serde_json::Value::Number(value) => {
+            if let Some(int) = value.as_i64() {
+                Ok(IrLiteral::Int(int))
+            } else if let Some(float) = value.as_f64() {
+                Ok(IrLiteral::Float(float))
+            } else {
+                Err(napi_validation("unsupported numeric Cypher parameter"))
+            }
+        }
+        serde_json::Value::String(value) => Ok(IrLiteral::Str(value)),
+        serde_json::Value::Array(values) => Ok(IrLiteral::List(
+            values
+                .into_iter()
+                .map(json_to_ir_literal)
+                .collect::<Result<Vec<_>>>()?,
+        )),
+        serde_json::Value::Object(map) => Ok(IrLiteral::Map(
+            map.into_iter()
+                .map(|(key, value)| Ok((key, json_to_ir_literal(value)?)))
+                .collect::<Result<Vec<_>>>()?,
+        )),
+    }
+}
+
+fn json_to_prop_value(value: serde_json::Value) -> Result<PropValue> {
+    match value {
+        serde_json::Value::Null => Ok(PropValue::Null),
+        serde_json::Value::Bool(value) => Ok(PropValue::Bool(value)),
+        serde_json::Value::Number(value) => {
+            if let Some(int) = value.as_i64() {
+                Ok(PropValue::Int(int))
+            } else if let Some(float) = value.as_f64() {
+                Ok(PropValue::Float(float))
+            } else {
+                Err(napi_validation("unsupported numeric property value"))
+            }
+        }
+        serde_json::Value::String(value) => Ok(PropValue::Str(value)),
+        _ => Err(napi_validation(
+            "transaction property values must be null/bool/number/string",
+        )),
+    }
+}
+
+fn json_props(
+    properties: Option<HashMap<String, serde_json::Value>>,
+) -> Result<HashMap<String, PropValue>> {
+    let mut out = HashMap::new();
+    if let Some(properties) = properties {
+        for (key, value) in properties {
+            out.insert(key, json_to_prop_value(value)?);
+        }
+    }
+    Ok(out)
+}
+
+pub(crate) fn begin_transaction(
+    engine: Arc<RwLock<graphforge_api::GraphForge>>,
+    operation_uuid: String,
+    actor_uuid: Option<String>,
+) -> Result<GraphTransaction> {
+    let operation_uuid = canonical_operation_id(&operation_uuid)?;
+    let actor_uuid = actor_uuid
+        .as_deref()
+        .map(canonical_operation_id)
+        .transpose()?
+        .map(|id| id.0);
+    let context = WriteContext {
+        operation_uuid,
+        actor_uuid,
+    };
+    let graph = engine
+        .read()
+        .map_err(|_| to_napi_err(&GfError::Execution("GraphForge lock poisoned".into())))?;
+    let inner = graph
+        .begin_transaction(context)
+        .map_err(|error| to_napi_err(&error))?;
+    drop(graph);
+    Ok(GraphTransaction::new(engine, inner))
+}
+
+pub(crate) fn inspect_reachability(
+    graph: &graphforge_api::GraphForge,
+    input: Option<ProjectRetentionInput>,
+) -> Result<ProjectReachabilityReportOutput> {
+    let (policy, limits) = retention_from_input(input)?;
+    let report = graph
+        .inspect_project_reachability(policy, limits)
+        .map_err(|error| to_napi_err(&error))?;
+    Ok(reachability_output(&report))
+}
+
+pub(crate) fn preview_cleanup(
+    graph: &graphforge_api::GraphForge,
+    input: Option<ProjectRetentionInput>,
+) -> Result<ProjectCleanupReportOutput> {
+    let (policy, limits) = retention_from_input(input)?;
+    let report = graph
+        .preview_project_cleanup(policy, limits)
+        .map_err(|error| to_napi_err(&error))?;
+    Ok(cleanup_output(&report))
+}
+
+pub(crate) fn execute_cleanup(
+    graph: &graphforge_api::GraphForge,
+    input: Option<ProjectRetentionInput>,
+) -> Result<ProjectCleanupReportOutput> {
+    let (policy, limits) = retention_from_input(input)?;
+    let report = graph
+        .execute_project_cleanup(policy, limits)
+        .map_err(|error| to_napi_err(&error))?;
+    Ok(cleanup_output(&report))
+}
+
+pub(crate) fn compaction_status(
+    graph: &graphforge_api::GraphForge,
+    input: Option<GraphDeltaCompactionStatusInput>,
+) -> Result<GraphDeltaCompactionStatusOutput> {
+    let policy = match input {
+        Some(input) => GraphDeltaCompactionPolicy {
+            compact_when_runs: input
+                .compact_when_runs
+                .map(|value| bigint_u64(value, "compactWhenRuns"))
+                .transpose()?,
+            compact_when_run_bytes: input
+                .compact_when_run_bytes
+                .map(|value| bigint_u64(value, "compactWhenRunBytes"))
+                .transpose()?,
+            compact_when_replay_memory_bytes: input
+                .compact_when_replay_memory_bytes
+                .map(|value| bigint_u64(value, "compactWhenReplayMemoryBytes"))
+                .transpose()?,
+        },
+        None => GraphDeltaCompactionPolicy::default(),
+    };
+    let status = graph
+        .graph_delta_compaction_status(policy, GraphDeltaJournalLimits::default())
+        .map_err(|error| to_napi_err(&error))?;
+    Ok(compaction_status_output(&status))
+}
+
+pub(crate) fn preview_compaction(
+    graph: &graphforge_api::GraphForge,
+    input: GraphDeltaCompactionInput,
+    cancellation: Option<&CancellationToken>,
+) -> Result<GraphDeltaCompactionReportOutput> {
+    let request = compaction_request(input)?;
+    let report = graph
+        .preview_graph_delta_compaction(&request, cancellation)
+        .map_err(|error| to_napi_err(&error))?;
+    Ok(compaction_report_output(&report))
+}
+
+pub(crate) fn compact(
+    graph: &graphforge_api::GraphForge,
+    input: GraphDeltaCompactionInput,
+    cancellation: Option<&CancellationToken>,
+) -> Result<GraphDeltaCompactionReportOutput> {
+    let request = compaction_request(input)?;
+    let report = graph
+        .compact_graph_delta(&request, cancellation)
+        .map_err(|error| to_napi_err(&error))?;
+    Ok(compaction_report_output(&report))
+}

--- a/crates/graphforge-bindings-node/tests/core.test.mjs
+++ b/crates/graphforge-bindings-node/tests/core.test.mjs
@@ -174,8 +174,13 @@ function checkRemovedSurfaceIsAbsent() {
     new URL("../index.d.ts", import.meta.url),
     "utf8",
   );
+  // Forbid GraphForge-level stubs only; GraphTransaction may expose commit/rollback.
+  const forgeClass = declarations.match(
+    /export declare class GraphForge \{[\s\S]*?\n\}/,
+  )?.[0];
+  assert.ok(forgeClass, "GraphForge declaration missing");
   assert.doesNotMatch(
-    declarations,
+    forgeClass,
     /^\s+(?:begin|commit|rollback|addNodes|addEdges)\([^)]*\):/m,
   );
 }

--- a/crates/graphforge-bindings-node/tests/non-cypher-parity-policy.json
+++ b/crates/graphforge-bindings-node/tests/non-cypher-parity-policy.json
@@ -1,8 +1,8 @@
 {
   "contractVersion": 1,
   "rustManifest": "../../../tests/contracts/non-cypher-rust-surface.json",
-  "releaseSurfaceCount": 184,
-  "releaseSurfaceDigest": "98bf3c9277a0cf13146ce4ecfe98e4e213c94e21edc0e8e48536783ffd02bc7e",
+  "releaseSurfaceCount": 192,
+  "releaseSurfaceDigest": "7b10db80d4bd05e21a94c57a7c4218e54f0d464a27dab127bdec59903afc66a0",
   "requiredEquivalent": [
     "GraphForge.adopt_ontology",
     "GraphForge.clear_ontology",
@@ -24,7 +24,8 @@
     "knowledge": "knowledge",
     "epistemic": "epistemic",
     "streaming-errors-maintenance": "persistenceErrorsCancellation",
-    "compatibility": "arrowIpc"
+    "compatibility": "arrowIpc",
+    "transaction-maintenance": "transactionMaintenance"
   },
   "classification": {
     "equivalent": [
@@ -44,11 +45,13 @@
       "GraphForge.assess_confidence",
       "GraphForge.attach_evidence",
       "GraphForge.attach_resolved_run",
+      "GraphForge.begin_transaction",
       "GraphForge.bind_embedding_space_alias",
       "GraphForge.checkpoint",
       "GraphForge.clear",
       "GraphForge.clear_ontology",
       "GraphForge.cluster",
+      "GraphForge.compact_graph_delta",
       "GraphForge.confidence_assessment",
       "GraphForge.confidence_inputs",
       "GraphForge.create_assertion",
@@ -65,19 +68,22 @@
       "GraphForge.epistemic_snapshot",
       "GraphForge.evidence_link",
       "GraphForge.execute",
+      "GraphForge.execute_project_cleanup",
       "GraphForge.explain",
       "GraphForge.export_ontology",
       "GraphForge.find",
+      "GraphForge.graph_delta_compaction_status",
       "GraphForge.graph_directedness",
       "GraphForge.hypothesis_members",
       "GraphForge.hypothesis_selection",
       "GraphForge.index",
       "GraphForge.index_adjacency",
       "GraphForge.inspect_adjacency",
-      "GraphForge.inspect_runtime_catalog",
       "GraphForge.inspect_embedding_refresh",
       "GraphForge.inspect_embedding_space_freshness",
+      "GraphForge.inspect_project_reachability",
       "GraphForge.inspect_provider_embedding_plan",
+      "GraphForge.inspect_runtime_catalog",
       "GraphForge.inspect_text_index",
       "GraphForge.invoke_descriptor",
       "GraphForge.invoke_descriptor_bytes",
@@ -102,19 +108,22 @@
       "GraphForge.ontology_mode",
       "GraphForge.open_checkpoint",
       "GraphForge.paths",
-      "GraphForge.prepare_rank_invocation",
+      "GraphForge.prepare_analyze_invocation",
       "GraphForge.prepare_cluster_invocation",
       "GraphForge.prepare_paths_invocation",
-      "GraphForge.prepare_analyze_invocation",
+      "GraphForge.prepare_rank_invocation",
       "GraphForge.prepare_similar_invocation",
+      "GraphForge.preview_graph_delta_compaction",
+      "GraphForge.preview_project_cleanup",
       "GraphForge.profile_gsi",
       "GraphForge.project_capabilities",
+      "GraphForge.project_open_recovery",
       "GraphForge.provenance_event",
+      "GraphForge.publish_algorithm_embeddings",
       "GraphForge.publish_bulk_edges",
       "GraphForge.publish_bulk_nodes",
       "GraphForge.publish_caller_embeddings",
       "GraphForge.publish_composite_transaction",
-      "GraphForge.publish_algorithm_embeddings",
       "GraphForge.publish_provider_embeddings",
       "GraphForge.rank",
       "GraphForge.reasoning",
@@ -136,38 +145,57 @@
       "GraphForge.set_embedding_refresh_space_policy",
       "GraphForge.set_graph_directedness",
       "GraphForge.similar",
-      "GraphForge.supersede_assertion",
       "GraphForge.suggest_ontology",
+      "GraphForge.supersede_assertion",
       "GraphForge.validate_ontology",
       "GraphForge.workspace_ontology"
     ],
     "languageSpecific": {
       "GraphForge.execute_stream": {
-        "nodeMembers": ["GraphForge.plan", "PlanHandle.collectIpc"],
+        "nodeMembers": [
+          "GraphForge.plan",
+          "PlanHandle.collectIpc"
+        ],
         "reason": "Node uses Promise-delivered IPC instead of exposing Rust streams."
       },
       "GraphForge.execute_stream_owned": {
-        "nodeMembers": ["GraphForge.plan", "PlanHandle.collectIpc"],
+        "nodeMembers": [
+          "GraphForge.plan",
+          "PlanHandle.collectIpc"
+        ],
         "reason": "Node uses Promise-delivered IPC instead of exposing Rust streams."
       },
       "GraphForge.execute_stream_with_params": {
-        "nodeMembers": ["GraphForge.plan", "PlanHandle.collectIpc"],
+        "nodeMembers": [
+          "GraphForge.plan",
+          "PlanHandle.collectIpc"
+        ],
         "reason": "Node binds parameters on PlanHandle before Promise-delivered IPC."
       },
       "GraphForge.execute_to_parquet": {
-        "nodeMembers": ["GraphForge.plan", "PlanHandle.sinkParquet"],
+        "nodeMembers": [
+          "GraphForge.plan",
+          "PlanHandle.sinkParquet"
+        ],
         "reason": "Node uses the asynchronous PlanHandle Parquet sink."
       },
       "GraphForge.execute_to_parquet_with_params": {
-        "nodeMembers": ["GraphForge.plan", "PlanHandle.sinkParquet"],
+        "nodeMembers": [
+          "GraphForge.plan",
+          "PlanHandle.sinkParquet"
+        ],
         "reason": "Node binds parameters on PlanHandle before the asynchronous Parquet sink."
       },
       "GraphForge.configure_provider_find_runtime": {
-        "nodeMembers": ["GraphForge.configureOpenrouter"],
+        "nodeMembers": [
+          "GraphForge.configureOpenrouter"
+        ],
         "reason": "Node exposes a bounded OpenRouter adapter instead of Rust runtime injection."
       },
       "crate.algorithm_descriptor_contracts": {
-        "nodeMembers": ["GraphForge.algorithmDescriptorContracts"],
+        "nodeMembers": [
+          "GraphForge.algorithmDescriptorContracts"
+        ],
         "reason": "Node projects the live Rust registry as a thin GraphForge method without opening knowledge or epistemic storage."
       }
     },
@@ -197,8 +225,13 @@
       ]
     },
     "lifecycleConstruction": {
-      "core.test.mjs": ["add node", "graph inspection surface"],
-      "smoke.test.mjs": ["lifecycle"]
+      "core.test.mjs": [
+        "add node",
+        "graph inspection surface"
+      ],
+      "smoke.test.mjs": [
+        "lifecycle"
+      ]
     },
     "gsiProfiler": {
       "gsi-profiler.test.mjs": [
@@ -221,11 +254,21 @@
         "live registry contracts are catalog-exhaustive and descriptor reachable",
         "registry discovery and descriptor preparation stay knowledge isolated"
       ],
-      "rank-centrality.test.mjs": ["degree rank"],
-      "cluster-connectivity.test.mjs": ["components cluster"],
-      "paths-shortest.test.mjs": ["dijkstra paths"],
-      "analyze.test.mjs": ["is dag"],
-      "similar-knn.test.mjs": ["knn"]
+      "rank-centrality.test.mjs": [
+        "degree rank"
+      ],
+      "cluster-connectivity.test.mjs": [
+        "components cluster"
+      ],
+      "paths-shortest.test.mjs": [
+        "dijkstra paths"
+      ],
+      "analyze.test.mjs": [
+        "is dag"
+      ],
+      "similar-knn.test.mjs": [
+        "knn"
+      ]
     },
     "m19ProviderRerank": {
       "search-index.test.mjs": [
@@ -280,11 +323,24 @@
       ]
     },
     "persistenceErrorsCancellation": {
-      "core.test.mjs": ["pre-v1 project error", "parse error", "graph inspection surface"],
+      "core.test.mjs": [
+        "pre-v1 project error",
+        "parse error",
+        "graph inspection surface"
+      ],
       "checkpoints.test.mjs": [
         "checkpoint pagination and diff cancellation use the shared adapter"
       ],
-      "cluster-vector.test.mjs": ["k means cluster"]
+      "cluster-vector.test.mjs": [
+        "k means cluster"
+      ]
+    },
+    "transactionMaintenance": {
+      "transaction-parity.test.mjs": [
+        "mixed transaction commit and explicit rollback have parity",
+        "dropped wrapper handles roll back and never commit",
+        "maintenance preview and execution reconcile candidate identities"
+      ]
     }
   }
 }

--- a/crates/graphforge-bindings-node/tests/transaction-parity.test.mjs
+++ b/crates/graphforge-bindings-node/tests/transaction-parity.test.mjs
@@ -1,0 +1,84 @@
+// Native acceptance for transaction and maintenance parity (#755).
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { GraphForge } from "../index.js";
+
+const OP_COMMIT = "018f0f4e-7b8c-7000-8000-000000007501";
+const OP_ROLLBACK = "018f0f4e-7b8c-7000-8000-000000007502";
+const OP_DROP = "018f0f4e-7b8c-7000-8000-000000007503";
+const OP_SEED = "018f0f4e-7b8c-7000-8000-000000007504";
+const NODE_BULK = "018f0f4e-7b8c-7000-8000-000000007511";
+const NODE_GHOST = "018f0f4e-7b8c-7000-8000-000000007512";
+
+async function withProject(run) {
+  const root = await mkdtemp(join(tmpdir(), "gf-755-"));
+  try {
+    await run(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+test("mixed transaction commit and explicit rollback have parity", async () => {
+  await withProject(async (root) => {
+    const forge = new GraphForge(root);
+    const tx = forge.beginTransaction(OP_COMMIT);
+    const status = tx.status();
+    assert.equal(status.phase, "open");
+    assert.equal(status.committed, false);
+    tx.stageCypher("CREATE (:Person {name: 'Cypher'})");
+    tx.stageAddNode(NODE_BULK, "Person", { name: "Bulk" });
+    tx.validate();
+    const generation = tx.commit();
+    assert.match(generation, /^[0-9a-f-]{36}$/i);
+
+    const rolled = forge.beginTransaction(OP_ROLLBACK);
+    rolled.stageAddNode(NODE_GHOST, "Person", { name: "Ghost" });
+    rolled.rollback();
+
+    const recovery = forge.projectOpenRecovery();
+    assert.ok(recovery.selectedGenerationUuid);
+    assert.equal(typeof recovery.repairedJournals, "bigint");
+  });
+});
+
+test("dropped wrapper handles roll back and never commit", async () => {
+  await withProject(async (root) => {
+    const forge = new GraphForge(root);
+    {
+      const tx = forge.beginTransaction(OP_DROP);
+      tx.stageCypher("CREATE (:Person {name: 'Dropped'})");
+    }
+    const reopened = new GraphForge(root);
+    const cleanup = reopened.previewProjectCleanup({ retainedAncestors: 2 });
+    assert.equal(typeof cleanup.candidates, "bigint");
+    assert.equal(typeof cleanup.remainingBytes, "bigint");
+    // Values above Number.MAX_SAFE_INTEGER stay exact as bigint (not Number).
+    const aboveSafe = cleanup.candidates + 9007199254740993n;
+    assert.equal(aboveSafe > cleanup.candidates, true);
+    assert.equal(Number.isSafeInteger(Number(aboveSafe)), false);
+  });
+});
+
+test("maintenance preview and execution reconcile candidate identities", async () => {
+  await withProject(async (root) => {
+    const forge = new GraphForge(root);
+    const seed = forge.beginTransaction(OP_SEED);
+    seed.stageCypher("CREATE (:Person {name: 'Keep'})");
+    seed.commit();
+    const preview = forge.previewProjectCleanup({ retainedAncestors: 2 });
+    const executed = forge.executeProjectCleanup({ retainedAncestors: 2 });
+    assert.equal(preview.candidates, executed.candidates);
+    assert.equal(preview.reachableCount, executed.reachableCount);
+    assert.deepEqual(
+      preview.entries.map((entry) => entry.generationUuid),
+      executed.entries.map((entry) => entry.generationUuid),
+    );
+    const status = forge.graphDeltaCompactionStatus({});
+    assert.equal(typeof status.runCount, "bigint");
+    assert.equal(typeof status.runBytes, "bigint");
+  });
+});

--- a/crates/graphforge-bindings-py/python/graphforge/_graphforge_rs.pyi
+++ b/crates/graphforge-bindings-py/python/graphforge/_graphforge_rs.pyi
@@ -46,9 +46,7 @@ class CancellationToken:
 
 class GraphTransaction:
     def status(self) -> dict[str, Any]: ...
-    def stage_cypher(
-        self, query: str, params: dict[str, Any] | None = None
-    ) -> None: ...
+    def stage_cypher(self, query: str, params: dict[str, Any] | None = None) -> None: ...
     def stage_add_node(
         self,
         node_uuid: str,

--- a/crates/graphforge-bindings-py/python/graphforge/_graphforge_rs.pyi
+++ b/crates/graphforge-bindings-py/python/graphforge/_graphforge_rs.pyi
@@ -44,6 +44,36 @@ class CancellationToken:
     @property
     def is_cancelled(self) -> bool: ...
 
+class GraphTransaction:
+    def status(self) -> dict[str, Any]: ...
+    def stage_cypher(
+        self, query: str, params: dict[str, Any] | None = None
+    ) -> None: ...
+    def stage_add_node(
+        self,
+        node_uuid: str,
+        label: str,
+        properties: dict[str, Any] | None = None,
+    ) -> None: ...
+    def stage_add_edge(
+        self,
+        edge_uuid: str,
+        rel_type: str,
+        source_uuid: str,
+        target_uuid: str,
+        properties: dict[str, Any] | None = None,
+    ) -> None: ...
+    def validate(self) -> None: ...
+    def commit(self, *, cancellation: CancellationToken | None = None) -> str: ...
+    def rollback(self) -> None: ...
+    def __enter__(self) -> GraphTransaction: ...
+    def __exit__(
+        self,
+        exc_type: Any = None,
+        _exc: Any = None,
+        _tb: Any = None,
+    ) -> bool: ...
+
 class CheckpointView:
     @property
     def checkpoint_uuid(self) -> str: ...
@@ -841,6 +871,64 @@ class GraphForge:
     ) -> dict[str, Any]: ...
     def add_node(self, label: str, **props: Any) -> NodeHandle: ...
     def add_edge(self, src: Any, rel_type: str, dst: Any, **props: Any) -> EdgeHandle: ...
+    def begin_transaction(
+        self, *, operation_uuid: str, actor_uuid: str | None = None
+    ) -> GraphTransaction: ...
+    def project_open_recovery(self) -> dict[str, Any]: ...
+    def inspect_project_reachability(
+        self,
+        *,
+        retained_ancestors: int | None = None,
+        max_entries: int | None = None,
+        max_bytes_scanned: int | None = None,
+        max_work_units: int | None = None,
+        cleanup_batch: int | None = None,
+    ) -> dict[str, Any]: ...
+    def preview_project_cleanup(
+        self,
+        *,
+        retained_ancestors: int | None = None,
+        max_entries: int | None = None,
+        max_bytes_scanned: int | None = None,
+        max_work_units: int | None = None,
+        cleanup_batch: int | None = None,
+    ) -> dict[str, Any]: ...
+    def execute_project_cleanup(
+        self,
+        *,
+        retained_ancestors: int | None = None,
+        max_entries: int | None = None,
+        max_bytes_scanned: int | None = None,
+        max_work_units: int | None = None,
+        cleanup_batch: int | None = None,
+    ) -> dict[str, Any]: ...
+    def graph_delta_compaction_status(
+        self,
+        *,
+        compact_when_runs: int | None = None,
+        compact_when_run_bytes: int | None = None,
+        compact_when_replay_memory_bytes: int | None = None,
+    ) -> dict[str, Any]: ...
+    def preview_graph_delta_compaction(
+        self,
+        *,
+        transaction_uuid: str,
+        generation_uuid: str,
+        through_run_sequence: int | None = None,
+        cleanup_after_commit: bool = False,
+        retained_ancestors: int | None = None,
+        cancellation: CancellationToken | None = None,
+    ) -> dict[str, Any]: ...
+    def compact_graph_delta(
+        self,
+        *,
+        transaction_uuid: str,
+        generation_uuid: str,
+        through_run_sequence: int | None = None,
+        cleanup_after_commit: bool = False,
+        retained_ancestors: int | None = None,
+        cancellation: CancellationToken | None = None,
+    ) -> dict[str, Any]: ...
     def publish_composite_transaction(
         self,
         *,

--- a/crates/graphforge-bindings-py/src/lib.rs
+++ b/crates/graphforge-bindings-py/src/lib.rs
@@ -3,6 +3,7 @@
 #![warn(unsafe_code)]
 
 mod composite;
+mod transaction;
 
 use std::collections::{BTreeMap, HashMap};
 use std::ffi::CString;
@@ -2297,9 +2298,9 @@ fn py_rerank_options(
 /// analyst verbs (`rank`/`cluster`/…) are exposed in a follow-up binding-surface PR.
 #[pyclass(module = "graphforge")]
 pub struct GraphForge {
-    inner: graphforge_api::GraphForge,
+    pub(crate) inner: graphforge_api::GraphForge,
     provider: Option<ConfiguredProviderBinding>,
-    closed: bool,
+    pub(crate) closed: bool,
 }
 
 /// Read-only native facade pinned to one checkpoint generation.
@@ -2351,7 +2352,7 @@ impl PyCheckpointView {
 /// Native cloneable cooperative cancellation token.
 #[pyclass(name = "CancellationToken", module = "graphforge")]
 pub struct PyCancellationToken {
-    inner: graphforge_api::CancellationToken,
+    pub(crate) inner: graphforge_api::CancellationToken,
 }
 
 #[pymethods]
@@ -5340,6 +5341,163 @@ impl GraphForge {
             .map_err(|error| to_pyerr(py, &error))
     }
 
+    /// Begin an explicit multi-mutation transaction (Rust-owned lifecycle).
+    #[pyo3(signature = (*, operation_uuid, actor_uuid=None))]
+    fn begin_transaction(
+        slf: &Bound<'_, Self>,
+        py: Python<'_>,
+        operation_uuid: &str,
+        actor_uuid: Option<&str>,
+    ) -> PyResult<Py<transaction::PyGraphTransaction>> {
+        transaction::begin_transaction(slf, py, operation_uuid, actor_uuid)
+    }
+
+    /// Safe recovery-on-open evidence for this instance.
+    fn project_open_recovery<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        self.ensure_open()?;
+        transaction::ops::project_open_recovery(self, py)
+    }
+
+    /// Inspect verified generation reachability for retention/GC planning.
+    #[pyo3(signature = (*, retained_ancestors=None, max_entries=None, max_bytes_scanned=None, max_work_units=None, cleanup_batch=None))]
+    fn inspect_project_reachability<'py>(
+        &self,
+        py: Python<'py>,
+        retained_ancestors: Option<usize>,
+        max_entries: Option<usize>,
+        max_bytes_scanned: Option<u64>,
+        max_work_units: Option<usize>,
+        cleanup_batch: Option<usize>,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        self.ensure_open()?;
+        transaction::ops::inspect_project_reachability(
+            self,
+            py,
+            retained_ancestors,
+            max_entries,
+            max_bytes_scanned,
+            max_work_units,
+            cleanup_batch,
+        )
+    }
+
+    /// Preview retention/GC candidates without removing anything.
+    #[pyo3(signature = (*, retained_ancestors=None, max_entries=None, max_bytes_scanned=None, max_work_units=None, cleanup_batch=None))]
+    fn preview_project_cleanup<'py>(
+        &self,
+        py: Python<'py>,
+        retained_ancestors: Option<usize>,
+        max_entries: Option<usize>,
+        max_bytes_scanned: Option<u64>,
+        max_work_units: Option<usize>,
+        cleanup_batch: Option<usize>,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        self.ensure_open()?;
+        transaction::ops::preview_project_cleanup(
+            self,
+            py,
+            retained_ancestors,
+            max_entries,
+            max_bytes_scanned,
+            max_work_units,
+            cleanup_batch,
+        )
+    }
+
+    /// Execute retention/GC for unreachable generations.
+    #[pyo3(signature = (*, retained_ancestors=None, max_entries=None, max_bytes_scanned=None, max_work_units=None, cleanup_batch=None))]
+    fn execute_project_cleanup<'py>(
+        &self,
+        py: Python<'py>,
+        retained_ancestors: Option<usize>,
+        max_entries: Option<usize>,
+        max_bytes_scanned: Option<u64>,
+        max_work_units: Option<usize>,
+        cleanup_batch: Option<usize>,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        self.ensure_open()?;
+        transaction::ops::execute_project_cleanup(
+            self,
+            py,
+            retained_ancestors,
+            max_entries,
+            max_bytes_scanned,
+            max_work_units,
+            cleanup_batch,
+        )
+    }
+
+    /// Report whether CURRENT's verified delta chain should compact.
+    #[pyo3(signature = (*, compact_when_runs=None, compact_when_run_bytes=None, compact_when_replay_memory_bytes=None))]
+    fn graph_delta_compaction_status<'py>(
+        &self,
+        py: Python<'py>,
+        compact_when_runs: Option<u64>,
+        compact_when_run_bytes: Option<u64>,
+        compact_when_replay_memory_bytes: Option<u64>,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        self.ensure_open()?;
+        transaction::ops::graph_delta_compaction_status(
+            self,
+            py,
+            compact_when_runs,
+            compact_when_run_bytes,
+            compact_when_replay_memory_bytes,
+        )
+    }
+
+    /// Preview delta compaction without publishing CURRENT.
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (*, transaction_uuid, generation_uuid, through_run_sequence=None, cleanup_after_commit=false, retained_ancestors=None, cancellation=None))]
+    fn preview_graph_delta_compaction<'py>(
+        &self,
+        py: Python<'py>,
+        transaction_uuid: &str,
+        generation_uuid: &str,
+        through_run_sequence: Option<u64>,
+        cleanup_after_commit: bool,
+        retained_ancestors: Option<usize>,
+        cancellation: Option<&PyCancellationToken>,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        self.ensure_open()?;
+        transaction::ops::preview_graph_delta_compaction(
+            self,
+            py,
+            transaction_uuid,
+            generation_uuid,
+            through_run_sequence,
+            cleanup_after_commit,
+            retained_ancestors,
+            cancellation,
+        )
+    }
+
+    /// Compact a contiguous verified delta prefix into a new Parquet generation.
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (*, transaction_uuid, generation_uuid, through_run_sequence=None, cleanup_after_commit=false, retained_ancestors=None, cancellation=None))]
+    fn compact_graph_delta<'py>(
+        &self,
+        py: Python<'py>,
+        transaction_uuid: &str,
+        generation_uuid: &str,
+        through_run_sequence: Option<u64>,
+        cleanup_after_commit: bool,
+        retained_ancestors: Option<usize>,
+        cancellation: Option<&PyCancellationToken>,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        self.ensure_open()?;
+        transaction::ops::compact_graph_delta(
+            self,
+            py,
+            transaction_uuid,
+            generation_uuid,
+            through_run_sequence,
+            cleanup_after_commit,
+            retained_ancestors,
+            cancellation,
+        )
+    }
+
     /// Publish one composite graph + knowledge/epistemic transaction through Rust.
     ///
     /// Python only converts the request; validation, staging, publication,
@@ -5801,6 +5959,7 @@ fn _graphforge_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(_test_release_writer_hold, m)?)?;
     m.add_function(wrap_pyfunction!(_cli_execute, m)?)?;
     m.add_class::<GraphForge>()?;
+    m.add_class::<transaction::PyGraphTransaction>()?;
     m.add_class::<PyCheckpointView>()?;
     m.add_class::<PyCancellationToken>()?;
     m.add_class::<PyNodeHandle>()?;

--- a/crates/graphforge-bindings-py/src/transaction.rs
+++ b/crates/graphforge-bindings-py/src/transaction.rs
@@ -1,0 +1,633 @@
+//! Thin Python wrappers for the Rust-owned [`GraphTransaction`] lifecycle (#755).
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use graphforge_api::{GfError, GraphTransaction, IrLiteral, TransactionPhase, WriteContext};
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList};
+use uuid::Uuid;
+
+fn fingerprint_hex(bytes: &[u8; 32]) -> String {
+    let mut out = String::with_capacity(64);
+    for byte in bytes {
+        use std::fmt::Write as _;
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+use crate::{
+    GraphForge, PyCancellationToken, canonical_operation_id, props_from_dict, py_to_ir_literal,
+    to_pyerr,
+};
+
+fn phase_name(phase: TransactionPhase) -> &'static str {
+    match phase {
+        TransactionPhase::Open => "open",
+        TransactionPhase::Validated => "validated",
+        TransactionPhase::Committed => "committed",
+        TransactionPhase::RolledBack => "rolled_back",
+        _ => "unknown",
+    }
+}
+
+fn write_mode_name(mode: graphforge_api::ProjectWriteMode) -> &'static str {
+    match mode {
+        graphforge_api::ProjectWriteMode::SingleWriter => "single_writer",
+        graphforge_api::ProjectWriteMode::QueuedWriter => "queued_writer",
+        graphforge_api::ProjectWriteMode::OptimisticMultiWriter => "optimistic_multi_writer",
+        _ => "unknown",
+    }
+}
+
+fn parse_uuid(py: Python<'_>, value: &str, field: &str) -> PyResult<Uuid> {
+    Uuid::parse_str(value).map_err(|_| {
+        to_pyerr(
+            py,
+            &GfError::Validation(format!("{field} must be a canonical UUID string")),
+        )
+    })
+}
+
+fn params_from_dict(
+    py: Python<'_>,
+    value: Option<&Bound<'_, PyDict>>,
+) -> PyResult<HashMap<String, IrLiteral>> {
+    let Some(dict) = value else {
+        return Ok(HashMap::new());
+    };
+    let mut params = HashMap::with_capacity(dict.len());
+    for (key, item) in dict {
+        params.insert(key.extract::<String>()?, py_to_ir_literal(&item)?);
+    }
+    let _ = py;
+    Ok(params)
+}
+
+/// Explicit multi-mutation transaction handle. Drop / context exit rolls back
+/// without publishing when the handle was not committed.
+#[pyclass(name = "GraphTransaction", module = "graphforge")]
+pub struct PyGraphTransaction {
+    parent: Py<GraphForge>,
+    inner: Mutex<Option<GraphTransaction>>,
+}
+
+impl PyGraphTransaction {
+    pub(crate) fn new(parent: Py<GraphForge>, inner: GraphTransaction) -> Self {
+        Self {
+            parent,
+            inner: Mutex::new(Some(inner)),
+        }
+    }
+
+    fn with_tx<R>(
+        &self,
+        py: Python<'_>,
+        f: impl FnOnce(&GraphTransaction) -> Result<R, GfError>,
+    ) -> PyResult<R> {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|_| to_pyerr(py, &GfError::Validation("transaction lock poisoned".into())))?;
+        let tx = guard.as_ref().ok_or_else(|| {
+            to_pyerr(
+                py,
+                &GfError::Validation("transaction handle already released".into()),
+            )
+        })?;
+        f(tx).map_err(|error| to_pyerr(py, &error))
+    }
+}
+
+#[pymethods]
+impl PyGraphTransaction {
+    /// Safe lifecycle status snapshot (no graph content).
+    fn status<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let status = self.with_tx(py, GraphTransaction::status)?;
+        let dict = PyDict::new(py);
+        dict.set_item("operation_uuid", status.operation_uuid.to_string())?;
+        dict.set_item(
+            "base_generation_uuid",
+            status.base_generation_uuid.to_string(),
+        )?;
+        dict.set_item("phase", phase_name(status.phase))?;
+        dict.set_item("write_mode", write_mode_name(status.write_mode))?;
+        dict.set_item("staged_entry_count", status.staged_entry_count)?;
+        dict.set_item("committed", status.committed)?;
+        Ok(dict)
+    }
+
+    /// Stage one write Cypher statement for deferred execution at commit.
+    #[pyo3(signature = (query, params=None))]
+    fn stage_cypher(
+        &self,
+        py: Python<'_>,
+        query: &str,
+        params: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<()> {
+        let params = params_from_dict(py, params)?;
+        self.with_tx(py, |tx| tx.stage_cypher(query, params))
+    }
+
+    /// Stage scalar node construction.
+    #[pyo3(signature = (node_uuid, label, properties=None))]
+    fn stage_add_node(
+        &self,
+        py: Python<'_>,
+        node_uuid: &str,
+        label: &str,
+        properties: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<()> {
+        let node_uuid = parse_uuid(py, node_uuid, "node_uuid")?;
+        let properties = props_from_dict(properties)?;
+        self.with_tx(py, |tx| tx.stage_add_node(node_uuid, label, properties))
+    }
+
+    /// Stage scalar edge construction.
+    #[pyo3(signature = (edge_uuid, rel_type, source_uuid, target_uuid, properties=None))]
+    fn stage_add_edge(
+        &self,
+        py: Python<'_>,
+        edge_uuid: &str,
+        rel_type: &str,
+        source_uuid: &str,
+        target_uuid: &str,
+        properties: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<()> {
+        let edge_uuid = parse_uuid(py, edge_uuid, "edge_uuid")?;
+        let source_uuid = parse_uuid(py, source_uuid, "source_uuid")?;
+        let target_uuid = parse_uuid(py, target_uuid, "target_uuid")?;
+        let properties = props_from_dict(properties)?;
+        self.with_tx(py, |tx| {
+            tx.stage_add_edge(edge_uuid, rel_type, source_uuid, target_uuid, properties)
+        })
+    }
+
+    /// Validate staged content without publishing.
+    fn validate(&self, py: Python<'_>) -> PyResult<()> {
+        let parent = self.parent.clone_ref(py);
+        self.with_tx(py, |tx| {
+            let graph = parent.bind(py).borrow();
+            tx.validate(&graph.inner)
+        })
+    }
+
+    /// Publish every staged participant as one generation.
+    #[pyo3(signature = (*, cancellation=None))]
+    fn commit(
+        &self,
+        py: Python<'_>,
+        cancellation: Option<&PyCancellationToken>,
+    ) -> PyResult<String> {
+        let parent = self.parent.clone_ref(py);
+        let cancellation = cancellation.map(|token| token.inner.clone());
+        let receipt = self.with_tx(py, |tx| {
+            let graph = parent.bind(py).borrow();
+            tx.commit_with_cancellation(&graph.inner, cancellation.clone())
+        })?;
+        Ok(receipt.generation_uuid.to_string())
+    }
+
+    /// Abandon staged work without publishing.
+    fn rollback(&self, py: Python<'_>) -> PyResult<()> {
+        self.with_tx(py, GraphTransaction::rollback)
+    }
+
+    fn __enter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    #[pyo3(signature = (exc_type=None, _exc=None, _tb=None))]
+    fn __exit__(
+        &self,
+        py: Python<'_>,
+        exc_type: Option<&Bound<'_, PyAny>>,
+        _exc: Option<&Bound<'_, PyAny>>,
+        _tb: Option<&Bound<'_, PyAny>>,
+    ) -> bool {
+        let _ = exc_type;
+        let _ = self.with_tx(py, |tx| {
+            // Already finished (commit/rollback) is fine — Drop is the safety net.
+            let _ = tx.rollback();
+            Ok(())
+        });
+        false
+    }
+}
+
+/// Begin an explicit transaction on `forge`.
+pub(crate) fn begin_transaction(
+    forge: &Bound<'_, GraphForge>,
+    py: Python<'_>,
+    operation_uuid: &str,
+    actor_uuid: Option<&str>,
+) -> PyResult<Py<PyGraphTransaction>> {
+    if forge.borrow().closed {
+        return Err(to_pyerr(
+            py,
+            &GfError::Lifecycle("operation on a closed GraphForge instance".into()),
+        ));
+    }
+    let operation_uuid =
+        canonical_operation_id(operation_uuid).map_err(|error| to_pyerr(py, &error))?;
+    let actor_uuid = actor_uuid
+        .map(canonical_operation_id)
+        .transpose()
+        .map_err(|error| to_pyerr(py, &error))?
+        .map(|id| id.0);
+    let context = WriteContext {
+        operation_uuid,
+        actor_uuid,
+    };
+    let inner = forge
+        .borrow()
+        .inner
+        .begin_transaction(context)
+        .map_err(|error| to_pyerr(py, &error))?;
+    let parent = forge.clone().unbind();
+    Bound::new(py, PyGraphTransaction::new(parent, inner)).map(Bound::unbind)
+}
+
+/// Convert recovery evidence into a safe Python dict.
+pub(crate) fn recovery_evidence_dict<'py>(
+    py: Python<'py>,
+    evidence: &graphforge_api::ProjectOpenRecoveryEvidence,
+) -> PyResult<Bound<'py, PyDict>> {
+    let dict = PyDict::new(py);
+    dict.set_item(
+        "kind",
+        match evidence.kind {
+            graphforge_api::ProjectOpenRecoveryKind::ProjectOpen => "project_open",
+            graphforge_api::ProjectOpenRecoveryKind::Initialization => "initialization",
+            graphforge_api::ProjectOpenRecoveryKind::CheckpointView => "checkpoint_view",
+        },
+    )?;
+    dict.set_item(
+        "selected_generation_uuid",
+        evidence.selected_generation_uuid.to_string(),
+    )?;
+    dict.set_item(
+        "selected_generation_class",
+        match evidence.selected_generation_class {
+            graphforge_api::ProjectRecoveryGenerationClass::CommittedCurrent => "committed_current",
+            graphforge_api::ProjectRecoveryGenerationClass::CheckpointPinned => "checkpoint_pinned",
+        },
+    )?;
+    dict.set_item("work_detected", evidence.work_detected)?;
+    dict.set_item("repaired_journals", evidence.repaired_journals)?;
+    dict.set_item("aborted_journals", evidence.aborted_journals)?;
+    dict.set_item("removed_generations", evidence.removed_generations)?;
+    dict.set_item(
+        "preserved_unknown_entries",
+        evidence.preserved_unknown_entries,
+    )?;
+    dict.set_item(
+        "deferred",
+        evidence.deferred.map(|deferral| match deferral {
+            graphforge_api::ProjectRecoveryDeferral::LiveWriterOwnsKernelLock => {
+                "live_writer_owns_kernel_lock"
+            }
+        }),
+    )?;
+    dict.set_item("elapsed_ms", evidence.elapsed_ms)?;
+    Ok(dict)
+}
+
+fn retention_policy(retained_ancestors: Option<usize>) -> graphforge_api::ProjectRetentionPolicy {
+    graphforge_api::ProjectRetentionPolicy {
+        retained_ancestors: retained_ancestors
+            .unwrap_or(graphforge_api::ProjectRetentionPolicy::default().retained_ancestors),
+    }
+}
+
+fn retention_limits(
+    max_entries: Option<usize>,
+    max_bytes_scanned: Option<u64>,
+    max_work_units: Option<usize>,
+    cleanup_batch: Option<usize>,
+) -> graphforge_api::ProjectRetentionLimits {
+    let defaults = graphforge_api::ProjectRetentionLimits::default();
+    graphforge_api::ProjectRetentionLimits {
+        max_entries: max_entries.unwrap_or(defaults.max_entries),
+        max_bytes_scanned: max_bytes_scanned.unwrap_or(defaults.max_bytes_scanned),
+        max_work_units: max_work_units.unwrap_or(defaults.max_work_units),
+        cleanup_batch: cleanup_batch.unwrap_or(defaults.cleanup_batch),
+    }
+}
+
+fn cleanup_report_dict<'py>(
+    py: Python<'py>,
+    report: &graphforge_api::ProjectCleanupReport,
+) -> PyResult<Bound<'py, PyDict>> {
+    let dict = PyDict::new(py);
+    dict.set_item("dry_run", report.dry_run)?;
+    dict.set_item(
+        "selected_generation_uuid",
+        report.selected_generation_uuid.to_string(),
+    )?;
+    dict.set_item("retained_ancestors", report.policy.retained_ancestors)?;
+    dict.set_item("reachable_count", report.reachable_count)?;
+    dict.set_item("candidates", report.candidates)?;
+    dict.set_item("removed", report.removed)?;
+    dict.set_item("skipped_live", report.skipped_live)?;
+    dict.set_item("quarantined", report.quarantined)?;
+    dict.set_item("unknown", report.unknown)?;
+    dict.set_item("remaining_bytes", report.remaining_bytes)?;
+    dict.set_item("bytes_scanned", report.bytes_scanned)?;
+    dict.set_item("entries_scanned", report.entries_scanned)?;
+    dict.set_item("work_units", report.work_units)?;
+    dict.set_item("bounded", report.bounded)?;
+    dict.set_item("elapsed_ms", report.elapsed_ms)?;
+    let entries = PyList::empty(py);
+    for entry in &report.entries {
+        let item = PyDict::new(py);
+        item.set_item(
+            "generation_uuid",
+            entry.generation_uuid.map(|uuid| uuid.to_string()),
+        )?;
+        item.set_item("location", entry.location.as_str())?;
+        item.set_item("disposition", entry.disposition.as_str())?;
+        item.set_item("bytes", entry.bytes)?;
+        entries.append(item)?;
+    }
+    dict.set_item("entries", entries)?;
+    Ok(dict)
+}
+
+fn reachability_report_dict<'py>(
+    py: Python<'py>,
+    report: &graphforge_api::ProjectReachabilityReport,
+) -> PyResult<Bound<'py, PyDict>> {
+    let dict = PyDict::new(py);
+    dict.set_item(
+        "selected_generation_uuid",
+        report.selected_generation_uuid.to_string(),
+    )?;
+    dict.set_item(
+        "retained_ancestors_policy",
+        report.policy.retained_ancestors,
+    )?;
+    dict.set_item(
+        "reachable",
+        report
+            .reachable
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>(),
+    )?;
+    dict.set_item(
+        "checkpoint_roots",
+        report
+            .checkpoint_roots
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>(),
+    )?;
+    dict.set_item(
+        "retained_ancestors",
+        report
+            .retained_ancestors
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>(),
+    )?;
+    dict.set_item("entries_scanned", report.entries_scanned)?;
+    dict.set_item("bytes_scanned", report.bytes_scanned)?;
+    dict.set_item("elapsed_ms", report.elapsed_ms)?;
+    Ok(dict)
+}
+
+fn compaction_report_dict<'py>(
+    py: Python<'py>,
+    report: &graphforge_api::GraphDeltaCompactionReport,
+) -> PyResult<Bound<'py, PyDict>> {
+    let dict = PyDict::new(py);
+    dict.set_item("dry_run", report.dry_run)?;
+    dict.set_item(
+        "input_generation_uuid",
+        report.input_generation_uuid.to_string(),
+    )?;
+    dict.set_item(
+        "output_generation_uuid",
+        report.output_generation_uuid.map(|uuid| uuid.to_string()),
+    )?;
+    dict.set_item("input_runs", report.input_runs)?;
+    dict.set_item("compacted_runs", report.compacted_runs)?;
+    dict.set_item("retained_suffix_runs", report.retained_suffix_runs)?;
+    dict.set_item("input_rows", report.input_rows)?;
+    dict.set_item("output_rows", report.output_rows)?;
+    dict.set_item("input_bytes", report.input_bytes)?;
+    dict.set_item("output_bytes", report.output_bytes)?;
+    dict.set_item("spill_bytes", report.spill_bytes)?;
+    dict.set_item("peak_memory_bytes", report.peak_memory_bytes)?;
+    dict.set_item("elapsed_ms", report.elapsed_ms)?;
+    dict.set_item(
+        "state_fingerprint",
+        fingerprint_hex(&report.state_fingerprint),
+    )?;
+    if let Some(cleanup) = &report.cleanup {
+        dict.set_item("cleanup", cleanup_report_dict(py, cleanup)?)?;
+    } else {
+        dict.set_item("cleanup", py.None())?;
+    }
+    Ok(dict)
+}
+
+fn compaction_status_dict<'py>(
+    py: Python<'py>,
+    status: &graphforge_api::GraphDeltaCompactionStatus,
+) -> PyResult<Bound<'py, PyDict>> {
+    let dict = PyDict::new(py);
+    dict.set_item("generation_uuid", status.generation_uuid.to_string())?;
+    dict.set_item("run_count", status.run_count)?;
+    dict.set_item("run_bytes", status.run_bytes)?;
+    dict.set_item(
+        "estimated_replay_memory_bytes",
+        status.estimated_replay_memory_bytes,
+    )?;
+    dict.set_item(
+        "state_fingerprint",
+        fingerprint_hex(&status.state_fingerprint),
+    )?;
+    dict.set_item("should_compact", status.should_compact)?;
+    dict.set_item("trigger_reasons", status.trigger_reasons.clone())?;
+    Ok(dict)
+}
+
+fn parse_compaction_request(
+    py: Python<'_>,
+    transaction_uuid: &str,
+    generation_uuid: &str,
+    through_run_sequence: Option<u64>,
+    cleanup_after_commit: bool,
+    retained_ancestors: Option<usize>,
+) -> PyResult<graphforge_api::GraphDeltaCompactionRequest> {
+    Ok(graphforge_api::GraphDeltaCompactionRequest {
+        transaction_uuid: parse_uuid(py, transaction_uuid, "transaction_uuid")?,
+        generation_uuid: parse_uuid(py, generation_uuid, "generation_uuid")?,
+        through_run_sequence,
+        limits: graphforge_api::GraphDeltaCompactionLimits::default(),
+        cleanup_after_commit,
+        cleanup_policy: retention_policy(retained_ancestors),
+        cleanup_limits: graphforge_api::ProjectRetentionLimits::default(),
+    })
+}
+
+/// Shared maintenance helpers invoked from [`GraphForge`] pymethods.
+pub(crate) mod ops {
+    #![allow(clippy::wildcard_imports)] // thin re-exports of parent helpers
+    #![allow(clippy::too_many_arguments)] // keyword-shaped maintenance surface
+
+    use super::*;
+
+    pub(crate) fn project_open_recovery<'py>(
+        forge: &GraphForge,
+        py: Python<'py>,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        recovery_evidence_dict(py, forge.inner.project_open_recovery())
+    }
+
+    pub(crate) fn inspect_project_reachability<'py>(
+        forge: &GraphForge,
+        py: Python<'py>,
+        retained_ancestors: Option<usize>,
+        max_entries: Option<usize>,
+        max_bytes_scanned: Option<u64>,
+        max_work_units: Option<usize>,
+        cleanup_batch: Option<usize>,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        let report = forge
+            .inner
+            .inspect_project_reachability(
+                retention_policy(retained_ancestors),
+                retention_limits(
+                    max_entries,
+                    max_bytes_scanned,
+                    max_work_units,
+                    cleanup_batch,
+                ),
+            )
+            .map_err(|error| to_pyerr(py, &error))?;
+        reachability_report_dict(py, &report)
+    }
+
+    pub(crate) fn preview_project_cleanup<'py>(
+        forge: &GraphForge,
+        py: Python<'py>,
+        retained_ancestors: Option<usize>,
+        max_entries: Option<usize>,
+        max_bytes_scanned: Option<u64>,
+        max_work_units: Option<usize>,
+        cleanup_batch: Option<usize>,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        let report = forge
+            .inner
+            .preview_project_cleanup(
+                retention_policy(retained_ancestors),
+                retention_limits(
+                    max_entries,
+                    max_bytes_scanned,
+                    max_work_units,
+                    cleanup_batch,
+                ),
+            )
+            .map_err(|error| to_pyerr(py, &error))?;
+        cleanup_report_dict(py, &report)
+    }
+
+    pub(crate) fn execute_project_cleanup<'py>(
+        forge: &GraphForge,
+        py: Python<'py>,
+        retained_ancestors: Option<usize>,
+        max_entries: Option<usize>,
+        max_bytes_scanned: Option<u64>,
+        max_work_units: Option<usize>,
+        cleanup_batch: Option<usize>,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        let report = forge
+            .inner
+            .execute_project_cleanup(
+                retention_policy(retained_ancestors),
+                retention_limits(
+                    max_entries,
+                    max_bytes_scanned,
+                    max_work_units,
+                    cleanup_batch,
+                ),
+            )
+            .map_err(|error| to_pyerr(py, &error))?;
+        cleanup_report_dict(py, &report)
+    }
+
+    pub(crate) fn graph_delta_compaction_status<'py>(
+        forge: &GraphForge,
+        py: Python<'py>,
+        compact_when_runs: Option<u64>,
+        compact_when_run_bytes: Option<u64>,
+        compact_when_replay_memory_bytes: Option<u64>,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        let status = forge
+            .inner
+            .graph_delta_compaction_status(
+                graphforge_api::GraphDeltaCompactionPolicy {
+                    compact_when_runs,
+                    compact_when_run_bytes,
+                    compact_when_replay_memory_bytes,
+                },
+                graphforge_api::GraphDeltaJournalLimits::default(),
+            )
+            .map_err(|error| to_pyerr(py, &error))?;
+        compaction_status_dict(py, &status)
+    }
+
+    pub(crate) fn preview_graph_delta_compaction<'py>(
+        forge: &GraphForge,
+        py: Python<'py>,
+        transaction_uuid: &str,
+        generation_uuid: &str,
+        through_run_sequence: Option<u64>,
+        cleanup_after_commit: bool,
+        retained_ancestors: Option<usize>,
+        cancellation: Option<&PyCancellationToken>,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        let request = parse_compaction_request(
+            py,
+            transaction_uuid,
+            generation_uuid,
+            through_run_sequence,
+            cleanup_after_commit,
+            retained_ancestors,
+        )?;
+        let report = forge
+            .inner
+            .preview_graph_delta_compaction(&request, cancellation.map(|token| &token.inner))
+            .map_err(|error| to_pyerr(py, &error))?;
+        compaction_report_dict(py, &report)
+    }
+
+    pub(crate) fn compact_graph_delta<'py>(
+        forge: &GraphForge,
+        py: Python<'py>,
+        transaction_uuid: &str,
+        generation_uuid: &str,
+        through_run_sequence: Option<u64>,
+        cleanup_after_commit: bool,
+        retained_ancestors: Option<usize>,
+        cancellation: Option<&PyCancellationToken>,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        let request = parse_compaction_request(
+            py,
+            transaction_uuid,
+            generation_uuid,
+            through_run_sequence,
+            cleanup_after_commit,
+            retained_ancestors,
+        )?;
+        let report = forge
+            .inner
+            .compact_graph_delta(&request, cancellation.map(|token| &token.inner))
+            .map_err(|error| to_pyerr(py, &error))?;
+        compaction_report_dict(py, &report)
+    }
+}

--- a/crates/graphforge-bindings-py/tests/non_cypher_release.py
+++ b/crates/graphforge-bindings-py/tests/non_cypher_release.py
@@ -23,8 +23,8 @@ ROOT = Path(__file__).resolve().parents[3]
 RUST_MANIFEST = ROOT / "tests/contracts/non-cypher-rust-surface.json"
 RUST_GATE = ROOT / "scripts/ci/non-cypher-surface-gate.py"
 PYO3_SOURCE = ROOT / "crates/graphforge-bindings-py/src/lib.rs"
-EXPECTED_RUST_DIGEST = "fa206ee0082ce40a4729ddb79b4b65fe26f458d6e1ca7356f0526dd47d525a03"
-EXPECTED_RELEASE_DIGEST = "98bf3c9277a0cf13146ce4ecfe98e4e213c94e21edc0e8e48536783ffd02bc7e"
+EXPECTED_RUST_DIGEST = "51fd33865c0866530edac0f1c3e735ba72354774de93966883b5020e1a1655fb"
+EXPECTED_RELEASE_DIGEST = "7b10db80d4bd05e21a94c57a7c4218e54f0d464a27dab127bdec59903afc66a0"
 
 PYTHON_ONLY_METHODS = frozenset(
     {
@@ -118,6 +118,14 @@ EVIDENCE = {
     },
     "streaming-errors-maintenance": {
         "smoke.py": ["check_execute_stream", "check_lifecycle", "check_parse_error_span"],
+    },
+    "transaction-maintenance": {
+        "transaction_parity.py": [
+            "check_mixed_commit_and_rollback",
+            "check_dropped_handle_never_commits",
+            "check_maintenance_preview_execute_reconcile",
+            "check_cli_parity",
+        ],
     },
     "compatibility": {
         "non_cypher_release.py": ["check_native_artifact_and_no_fallback"],
@@ -229,7 +237,7 @@ def _classification_report() -> dict[str, object]:
         for group in manifest["method_evidence_groups"].values()
         for method_id in group["ids"]
     }
-    assert len(release_methods) == 184
+    assert len(release_methods) == 192
     assert _digest(release_methods) == EXPECTED_RELEASE_DIGEST
     assert set(EVIDENCE) == set(manifest["method_evidence_groups"])
 

--- a/crates/graphforge-bindings-py/tests/stub_surface.py
+++ b/crates/graphforge-bindings-py/tests/stub_surface.py
@@ -102,7 +102,11 @@ def _native_members(source: str) -> dict[str, set[str]]:
         assert matches, f"missing PyO3 receiver {rust}"
         for match in matches:
             body = source[match.end() : _matching_brace(source, match.end() - 1)]
-            for name in re.findall(r"^\s*fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(", body, re.M):
+            for name in re.findall(
+                r"^\s*fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*(?:<[^>]*>)?\s*\(",
+                body,
+                re.M,
+            ):
                 members[public].add("__init__" if name == "new" else name)
     return members
 

--- a/crates/graphforge-bindings-py/tests/transaction_parity.py
+++ b/crates/graphforge-bindings-py/tests/transaction_parity.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import json
-import tempfile
 from pathlib import Path
+import tempfile
 
 import graphforge as g
 from graphforge._graphforge_rs import _cli_execute
@@ -30,17 +30,21 @@ def check_mixed_commit_and_rollback(project: Path) -> None:
     tx.validate()
     generation = tx.commit()
     assert generation != before
-    names = forge.execute(
-        "MATCH (n:Person) RETURN n.name AS name ORDER BY name"
-    ).column("name").to_pylist()
+    names = (
+        forge.execute("MATCH (n:Person) RETURN n.name AS name ORDER BY name")
+        .column("name")
+        .to_pylist()
+    )
     assert names == ["Bulk", "Cypher"]
 
     rolled = forge.begin_transaction(operation_uuid=OP_ROLLBACK)
     rolled.stage_add_node(NODE_GHOST, "Person", {"name": "Ghost"})
     rolled.rollback()
-    names = forge.execute(
-        "MATCH (n:Person) RETURN n.name AS name ORDER BY name"
-    ).column("name").to_pylist()
+    names = (
+        forge.execute("MATCH (n:Person) RETURN n.name AS name ORDER BY name")
+        .column("name")
+        .to_pylist()
+    )
     assert names == ["Bulk", "Cypher"]
 
 
@@ -53,9 +57,11 @@ def check_dropped_handle_never_commits(project: Path) -> None:
     after = forge.execute("MATCH (n:Person) RETURN count(n) AS c").column("c").to_pylist()[0]
     assert after == before
     reopened = g.GraphForge(str(project))
-    names = reopened.execute(
-        "MATCH (n:Person) RETURN n.name AS name ORDER BY name"
-    ).column("name").to_pylist()
+    names = (
+        reopened.execute("MATCH (n:Person) RETURN n.name AS name ORDER BY name")
+        .column("name")
+        .to_pylist()
+    )
     assert "Dropped" not in names
 
 

--- a/crates/graphforge-bindings-py/tests/transaction_parity.py
+++ b/crates/graphforge-bindings-py/tests/transaction_parity.py
@@ -1,0 +1,121 @@
+"""Native acceptance for transaction and maintenance parity (#755)."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import graphforge as g
+from graphforge._graphforge_rs import _cli_execute
+
+OP_COMMIT = "018f0f4e-7b8c-7000-8000-000000007501"
+OP_ROLLBACK = "018f0f4e-7b8c-7000-8000-000000007502"
+OP_DROP = "018f0f4e-7b8c-7000-8000-000000007503"
+OP_CLI = "018f0f4e-7b8c-7000-8000-000000007504"
+NODE_BULK = "018f0f4e-7b8c-7000-8000-000000007511"
+NODE_GHOST = "018f0f4e-7b8c-7000-8000-000000007512"
+
+
+def check_mixed_commit_and_rollback(project: Path) -> None:
+    forge = g.GraphForge(str(project))
+    before = forge.project_open_recovery()["selected_generation_uuid"]
+
+    tx = forge.begin_transaction(operation_uuid=OP_COMMIT)
+    status = tx.status()
+    assert status["phase"] == "open"
+    assert status["committed"] is False
+    tx.stage_cypher("CREATE (:Person {name: 'Cypher'})")
+    tx.stage_add_node(NODE_BULK, "Person", {"name": "Bulk"})
+    tx.validate()
+    generation = tx.commit()
+    assert generation != before
+    names = forge.execute(
+        "MATCH (n:Person) RETURN n.name AS name ORDER BY name"
+    ).column("name").to_pylist()
+    assert names == ["Bulk", "Cypher"]
+
+    rolled = forge.begin_transaction(operation_uuid=OP_ROLLBACK)
+    rolled.stage_add_node(NODE_GHOST, "Person", {"name": "Ghost"})
+    rolled.rollback()
+    names = forge.execute(
+        "MATCH (n:Person) RETURN n.name AS name ORDER BY name"
+    ).column("name").to_pylist()
+    assert names == ["Bulk", "Cypher"]
+
+
+def check_dropped_handle_never_commits(project: Path) -> None:
+    forge = g.GraphForge(str(project))
+    before = forge.execute("MATCH (n:Person) RETURN count(n) AS c").column("c").to_pylist()[0]
+    tx = forge.begin_transaction(operation_uuid=OP_DROP)
+    tx.stage_cypher("CREATE (:Person {name: 'Dropped'})")
+    del tx
+    after = forge.execute("MATCH (n:Person) RETURN count(n) AS c").column("c").to_pylist()[0]
+    assert after == before
+    reopened = g.GraphForge(str(project))
+    names = reopened.execute(
+        "MATCH (n:Person) RETURN n.name AS name ORDER BY name"
+    ).column("name").to_pylist()
+    assert "Dropped" not in names
+
+
+def check_maintenance_preview_execute_reconcile(project: Path) -> None:
+    forge = g.GraphForge(str(project))
+    recovery = forge.project_open_recovery()
+    assert "selected_generation_uuid" in recovery
+    preview = forge.preview_project_cleanup(retained_ancestors=2)
+    execute = forge.execute_project_cleanup(retained_ancestors=2)
+    assert preview["candidates"] == execute["candidates"]
+    assert preview["reachable_count"] == execute["reachable_count"]
+    assert [entry["generation_uuid"] for entry in preview["entries"]] == [
+        entry["generation_uuid"] for entry in execute["entries"]
+    ]
+    status = forge.graph_delta_compaction_status()
+    assert isinstance(status["run_count"], int)
+    assert status["run_count"] >= 0
+
+
+def check_cli_parity(project: Path) -> None:
+    code, stdout, _stderr = _cli_execute(
+        [
+            "gf",
+            "--project",
+            str(project),
+            "--json",
+            "transaction",
+            "commit",
+            "--operation-uuid",
+            OP_CLI,
+            "--cypher",
+            "CREATE (:Person {name: 'Cli'})",
+        ]
+    )
+    assert code == 0, stdout
+    payload = json.loads(stdout.decode())
+    assert payload["phase"] == "committed"
+    code, stdout, _stderr = _cli_execute(
+        [
+            "gf",
+            "--project",
+            str(project),
+            "--json",
+            "recovery",
+        ]
+    )
+    assert code == 0, stdout
+    recovery = json.loads(stdout.decode())
+    assert "selected_generation_uuid" in recovery
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        project = Path(directory)
+        check_mixed_commit_and_rollback(project)
+        check_dropped_handle_never_commits(project)
+        check_maintenance_preview_execute_reconcile(project)
+        check_cli_parity(project)
+    print("transaction_parity: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/graphforge-cli/src/lib.rs
+++ b/crates/graphforge-cli/src/lib.rs
@@ -19,6 +19,8 @@ use uuid::Uuid;
 
 include!(concat!(env!("OUT_DIR"), "/project_skills.rs"));
 
+mod maintenance_cli;
+
 const MAX_SKILL_MANIFEST_BYTES: u64 = 256 * 1024;
 const MAX_SKILL_FILE_BYTES: u64 = 4 * 1024 * 1024;
 const MAX_SKILL_BUNDLE_BYTES: u64 = 8 * 1024 * 1024;
@@ -269,6 +271,18 @@ enum Command {
         #[command(subcommand)]
         command: CheckpointCommand,
     },
+    /// Explicit multi-mutation transactions (Rust-owned lifecycle).
+    Transaction {
+        #[command(subcommand)]
+        command: maintenance_cli::TransactionCommand,
+    },
+    /// Retention/GC and graph-delta compaction maintenance.
+    Maintenance {
+        #[command(subcommand)]
+        command: maintenance_cli::MaintenanceCommand,
+    },
+    /// Emit safe recovery-on-open evidence for the project.
+    Recovery,
 }
 
 #[derive(Args)]
@@ -484,7 +498,7 @@ struct ImportArgs {
     idempotency_key: String,
 }
 
-fn canonical_uuid(value: &str) -> Result<Uuid, graphforge_api::GfError> {
+pub(crate) fn canonical_uuid(value: &str) -> Result<Uuid, graphforge_api::GfError> {
     let parsed = Uuid::parse_str(value)
         .map_err(|_| graphforge_api::GfError::Validation("expected canonical UUID".into()))?;
     if parsed.hyphenated().to_string() != value {
@@ -1019,6 +1033,7 @@ fn is_repository_command(command: &Command) -> bool {
     )
 }
 
+#[allow(clippy::too_many_lines)] // CLI command dispatch table
 fn run(cli: Cli, output: &mut dyn Write) -> Result<i32, graphforge_api::GfError> {
     if cli.info {
         writeln!(output, "graphforge {}", env!("CARGO_PKG_VERSION"))
@@ -1053,6 +1068,15 @@ fn run(cli: Cli, output: &mut dyn Write) -> Result<i32, graphforge_api::GfError>
     let mut graph = GraphForge::new(Some(path_text))?;
     let command = match command {
         Command::Export(args) => return run_export(&graph, args, cli.json, output).map(|()| 0),
+        Command::Recovery => {
+            return maintenance_cli::run_recovery(&graph, cli.json, output).map(|()| 0);
+        }
+        Command::Transaction { command } => {
+            return maintenance_cli::run_transaction(&graph, command, cli.json, output).map(|()| 0);
+        }
+        Command::Maintenance { command } => {
+            return maintenance_cli::run_maintenance(&graph, command, cli.json, output).map(|()| 0);
+        }
         command => command,
     };
     let command = match command {

--- a/crates/graphforge-cli/src/maintenance_cli.rs
+++ b/crates/graphforge-cli/src/maintenance_cli.rs
@@ -1,0 +1,424 @@
+//! CLI surfaces for transactions, recovery evidence, and maintenance (#755).
+
+use std::collections::HashMap;
+use std::io::Write;
+
+use clap::{Args, Subcommand};
+use graphforge_api::{
+    GraphDeltaCompactionLimits, GraphDeltaCompactionPolicy, GraphDeltaCompactionRequest,
+    GraphDeltaJournalLimits, GraphForge, OperationId, ProjectRetentionLimits,
+    ProjectRetentionPolicy, PropValue, WriteContext,
+};
+use uuid::Uuid;
+
+use crate::canonical_uuid;
+
+fn write_json_value(
+    value: &serde_json::Value,
+    output: &mut dyn Write,
+) -> Result<(), graphforge_api::GfError> {
+    serde_json::to_writer(&mut *output, value)
+        .map_err(|error| graphforge_api::GfError::Execution(error.to_string()))?;
+    writeln!(output).map_err(|error| graphforge_api::GfError::Execution(error.to_string()))
+}
+
+#[derive(Subcommand)]
+pub(crate) enum TransactionCommand {
+    /// Stage supported mutations and commit one generation.
+    Commit(TransactionArgs),
+    /// Stage supported mutations then explicitly roll back.
+    Rollback(TransactionArgs),
+}
+
+#[derive(Args)]
+pub(crate) struct TransactionArgs {
+    /// Caller-owned UUIDv7 operation identity.
+    #[arg(long)]
+    operation_uuid: String,
+    /// Optional actor UUID.
+    #[arg(long)]
+    actor_uuid: Option<String>,
+    /// Write Cypher statement to stage (repeatable).
+    #[arg(long = "cypher")]
+    cypher: Vec<String>,
+    /// Stage a node as `uuid:Label` (optional trailing `:{"k":"v"}` JSON props).
+    #[arg(long = "add-node")]
+    add_node: Vec<String>,
+}
+
+#[derive(Subcommand)]
+pub(crate) enum MaintenanceCommand {
+    /// Inspect verified generation reachability.
+    Reachability(RetentionArgs),
+    /// Preview retention/GC candidates without deletion.
+    CleanupPreview(RetentionArgs),
+    /// Execute retention/GC (requires --yes).
+    CleanupExecute(CleanupExecuteArgs),
+    /// Report whether CURRENT should compact under policy triggers.
+    CompactionStatus(CompactionStatusArgs),
+    /// Preview delta compaction without publishing CURRENT.
+    CompactionPreview(CompactionArgs),
+    /// Compact a contiguous verified delta prefix (requires --yes).
+    CompactionRun(CompactionRunArgs),
+}
+
+#[derive(Args)]
+pub(crate) struct RetentionArgs {
+    #[arg(long)]
+    retained_ancestors: Option<usize>,
+    #[arg(long)]
+    max_entries: Option<usize>,
+    #[arg(long)]
+    max_bytes_scanned: Option<u64>,
+    #[arg(long)]
+    max_work_units: Option<usize>,
+    #[arg(long)]
+    cleanup_batch: Option<usize>,
+}
+
+#[derive(Args)]
+pub(crate) struct CleanupExecuteArgs {
+    #[command(flatten)]
+    retention: RetentionArgs,
+    /// Required explicit confirmation for destructive cleanup.
+    #[arg(long)]
+    yes: bool,
+}
+
+#[derive(Args)]
+#[allow(clippy::struct_field_names)] // clap long names mirror GraphDeltaCompactionPolicy fields
+pub(crate) struct CompactionStatusArgs {
+    #[arg(long)]
+    compact_when_runs: Option<u64>,
+    #[arg(long)]
+    compact_when_run_bytes: Option<u64>,
+    #[arg(long)]
+    compact_when_replay_memory_bytes: Option<u64>,
+}
+
+#[derive(Args)]
+pub(crate) struct CompactionArgs {
+    #[arg(long)]
+    transaction_uuid: String,
+    #[arg(long)]
+    generation_uuid: String,
+    #[arg(long)]
+    through_run_sequence: Option<u64>,
+    #[arg(long, default_value_t = false)]
+    cleanup_after_commit: bool,
+    #[arg(long)]
+    retained_ancestors: Option<usize>,
+}
+
+#[derive(Args)]
+pub(crate) struct CompactionRunArgs {
+    #[command(flatten)]
+    compaction: CompactionArgs,
+    /// Required explicit confirmation for CURRENT publication.
+    #[arg(long)]
+    yes: bool,
+}
+
+fn retention_policy(args: &RetentionArgs) -> ProjectRetentionPolicy {
+    ProjectRetentionPolicy {
+        retained_ancestors: args
+            .retained_ancestors
+            .unwrap_or_else(|| ProjectRetentionPolicy::default().retained_ancestors),
+    }
+}
+
+fn retention_limits(args: &RetentionArgs) -> ProjectRetentionLimits {
+    let defaults = ProjectRetentionLimits::default();
+    ProjectRetentionLimits {
+        max_entries: args.max_entries.unwrap_or(defaults.max_entries),
+        max_bytes_scanned: args.max_bytes_scanned.unwrap_or(defaults.max_bytes_scanned),
+        max_work_units: args.max_work_units.unwrap_or(defaults.max_work_units),
+        cleanup_batch: args.cleanup_batch.unwrap_or(defaults.cleanup_batch),
+    }
+}
+
+fn fingerprint_hex(bytes: &[u8; 32]) -> String {
+    let mut out = String::with_capacity(64);
+    for byte in bytes {
+        use std::fmt::Write as _;
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+fn parse_add_node(
+    spec: &str,
+) -> Result<(Uuid, String, HashMap<String, PropValue>), graphforge_api::GfError> {
+    let mut parts = spec.splitn(3, ':');
+    let uuid = parts.next().ok_or_else(|| {
+        graphforge_api::GfError::Validation("--add-node requires uuid:Label".into())
+    })?;
+    let label = parts.next().ok_or_else(|| {
+        graphforge_api::GfError::Validation("--add-node requires uuid:Label".into())
+    })?;
+    let props = match parts.next() {
+        Some(raw) if !raw.is_empty() => {
+            let value: serde_json::Value = serde_json::from_str(raw).map_err(|error| {
+                graphforge_api::GfError::Validation(format!("invalid --add-node JSON: {error}"))
+            })?;
+            let serde_json::Value::Object(map) = value else {
+                return Err(graphforge_api::GfError::Validation(
+                    "--add-node properties must be a JSON object".into(),
+                ));
+            };
+            let mut out = HashMap::new();
+            for (key, item) in map {
+                out.insert(
+                    key,
+                    match item {
+                        serde_json::Value::Null => PropValue::Null,
+                        serde_json::Value::Bool(v) => PropValue::Bool(v),
+                        serde_json::Value::Number(v) if v.as_i64().is_some() => {
+                            PropValue::Int(v.as_i64().unwrap())
+                        }
+                        serde_json::Value::Number(v) if v.as_f64().is_some() => {
+                            PropValue::Float(v.as_f64().unwrap())
+                        }
+                        serde_json::Value::String(v) => PropValue::Str(v),
+                        _ => {
+                            return Err(graphforge_api::GfError::Validation(
+                                "--add-node property values must be null/bool/number/string".into(),
+                            ));
+                        }
+                    },
+                );
+            }
+            out
+        }
+        _ => HashMap::new(),
+    };
+    Ok((canonical_uuid(uuid)?, label.to_owned(), props))
+}
+
+fn cleanup_json(report: &graphforge_api::ProjectCleanupReport) -> serde_json::Value {
+    serde_json::json!({
+        "dry_run": report.dry_run,
+        "selected_generation_uuid": report.selected_generation_uuid.to_string(),
+        "retained_ancestors": report.policy.retained_ancestors,
+        "reachable_count": report.reachable_count,
+        "candidates": report.candidates,
+        "removed": report.removed,
+        "skipped_live": report.skipped_live,
+        "quarantined": report.quarantined,
+        "unknown": report.unknown,
+        "remaining_bytes": report.remaining_bytes,
+        "bytes_scanned": report.bytes_scanned,
+        "entries_scanned": report.entries_scanned,
+        "work_units": report.work_units,
+        "bounded": report.bounded,
+        "elapsed_ms": report.elapsed_ms,
+        "entries": report.entries.iter().map(|entry| serde_json::json!({
+            "generation_uuid": entry.generation_uuid.map(|uuid| uuid.to_string()),
+            "location": entry.location.as_str(),
+            "disposition": entry.disposition.as_str(),
+            "bytes": entry.bytes,
+        })).collect::<Vec<_>>(),
+    })
+}
+
+fn reachability_json(report: &graphforge_api::ProjectReachabilityReport) -> serde_json::Value {
+    serde_json::json!({
+        "selected_generation_uuid": report.selected_generation_uuid.to_string(),
+        "retained_ancestors_policy": report.policy.retained_ancestors,
+        "reachable": report.reachable.iter().map(ToString::to_string).collect::<Vec<_>>(),
+        "checkpoint_roots": report.checkpoint_roots.iter().map(ToString::to_string).collect::<Vec<_>>(),
+        "retained_ancestors": report.retained_ancestors.iter().map(ToString::to_string).collect::<Vec<_>>(),
+        "entries_scanned": report.entries_scanned,
+        "bytes_scanned": report.bytes_scanned,
+        "elapsed_ms": report.elapsed_ms,
+    })
+}
+
+fn compaction_report_json(
+    report: &graphforge_api::GraphDeltaCompactionReport,
+) -> serde_json::Value {
+    serde_json::json!({
+        "dry_run": report.dry_run,
+        "input_generation_uuid": report.input_generation_uuid.to_string(),
+        "output_generation_uuid": report.output_generation_uuid.map(|uuid| uuid.to_string()),
+        "input_runs": report.input_runs,
+        "compacted_runs": report.compacted_runs,
+        "retained_suffix_runs": report.retained_suffix_runs,
+        "input_rows": report.input_rows,
+        "output_rows": report.output_rows,
+        "input_bytes": report.input_bytes,
+        "output_bytes": report.output_bytes,
+        "spill_bytes": report.spill_bytes,
+        "peak_memory_bytes": report.peak_memory_bytes,
+        "elapsed_ms": report.elapsed_ms,
+        "state_fingerprint": fingerprint_hex(&report.state_fingerprint),
+        "cleanup": report.cleanup.as_ref().map(cleanup_json),
+    })
+}
+
+fn compaction_request(
+    args: &CompactionArgs,
+) -> Result<GraphDeltaCompactionRequest, graphforge_api::GfError> {
+    Ok(GraphDeltaCompactionRequest {
+        transaction_uuid: canonical_uuid(&args.transaction_uuid)?,
+        generation_uuid: canonical_uuid(&args.generation_uuid)?,
+        through_run_sequence: args.through_run_sequence,
+        limits: GraphDeltaCompactionLimits::default(),
+        cleanup_after_commit: args.cleanup_after_commit,
+        cleanup_policy: ProjectRetentionPolicy {
+            retained_ancestors: args
+                .retained_ancestors
+                .unwrap_or_else(|| ProjectRetentionPolicy::default().retained_ancestors),
+        },
+        cleanup_limits: ProjectRetentionLimits::default(),
+    })
+}
+
+pub(crate) fn run_recovery(
+    graph: &GraphForge,
+    json: bool,
+    output: &mut dyn Write,
+) -> Result<(), graphforge_api::GfError> {
+    let evidence = graph.project_open_recovery();
+    let value = serde_json::json!({
+        "kind": match evidence.kind {
+            graphforge_api::ProjectOpenRecoveryKind::ProjectOpen => "project_open",
+            graphforge_api::ProjectOpenRecoveryKind::Initialization => "initialization",
+            graphforge_api::ProjectOpenRecoveryKind::CheckpointView => "checkpoint_view",
+        },
+        "selected_generation_uuid": evidence.selected_generation_uuid.to_string(),
+        "selected_generation_class": evidence.selected_generation_class.as_str(),
+        "work_detected": evidence.work_detected,
+        "repaired_journals": evidence.repaired_journals,
+        "aborted_journals": evidence.aborted_journals,
+        "removed_generations": evidence.removed_generations,
+        "preserved_unknown_entries": evidence.preserved_unknown_entries,
+        "deferred": evidence.deferred.map(graphforge_api::ProjectRecoveryDeferral::as_str),
+        "elapsed_ms": evidence.elapsed_ms,
+    });
+    write_machine(&value, json, output)
+}
+
+pub(crate) fn run_transaction(
+    graph: &GraphForge,
+    command: TransactionCommand,
+    json: bool,
+    output: &mut dyn Write,
+) -> Result<(), graphforge_api::GfError> {
+    let (args, commit) = match command {
+        TransactionCommand::Commit(args) => (args, true),
+        TransactionCommand::Rollback(args) => (args, false),
+    };
+    if args.cypher.is_empty() && args.add_node.is_empty() {
+        return Err(graphforge_api::GfError::Validation(
+            "transaction requires at least one --cypher or --add-node".into(),
+        ));
+    }
+    let context = WriteContext {
+        operation_uuid: OperationId(canonical_uuid(&args.operation_uuid)?),
+        actor_uuid: args.actor_uuid.as_deref().map(canonical_uuid).transpose()?,
+    };
+    let tx = graph.begin_transaction(context)?;
+    for query in &args.cypher {
+        tx.stage_cypher(query.clone(), HashMap::new())?;
+    }
+    for spec in &args.add_node {
+        let (node_uuid, label, properties) = parse_add_node(spec)?;
+        tx.stage_add_node(node_uuid, label, properties)?;
+    }
+    let value = if commit {
+        let receipt = tx.commit(graph)?;
+        serde_json::json!({
+            "phase": "committed",
+            "generation_uuid": receipt.generation_uuid.to_string(),
+            "operation_uuid": args.operation_uuid,
+        })
+    } else {
+        tx.rollback()?;
+        serde_json::json!({
+            "phase": "rolled_back",
+            "operation_uuid": args.operation_uuid,
+        })
+    };
+    write_machine(&value, json, output)
+}
+
+pub(crate) fn run_maintenance(
+    graph: &GraphForge,
+    command: MaintenanceCommand,
+    json: bool,
+    output: &mut dyn Write,
+) -> Result<(), graphforge_api::GfError> {
+    let value = match command {
+        MaintenanceCommand::Reachability(args) => {
+            let report = graph
+                .inspect_project_reachability(retention_policy(&args), retention_limits(&args))?;
+            reachability_json(&report)
+        }
+        MaintenanceCommand::CleanupPreview(args) => {
+            let report =
+                graph.preview_project_cleanup(retention_policy(&args), retention_limits(&args))?;
+            cleanup_json(&report)
+        }
+        MaintenanceCommand::CleanupExecute(args) => {
+            if !args.yes {
+                return Err(graphforge_api::GfError::Validation(
+                    "cleanup execute requires --yes".into(),
+                ));
+            }
+            let report = graph.execute_project_cleanup(
+                retention_policy(&args.retention),
+                retention_limits(&args.retention),
+            )?;
+            cleanup_json(&report)
+        }
+        MaintenanceCommand::CompactionStatus(args) => {
+            let status = graph.graph_delta_compaction_status(
+                GraphDeltaCompactionPolicy {
+                    compact_when_runs: args.compact_when_runs,
+                    compact_when_run_bytes: args.compact_when_run_bytes,
+                    compact_when_replay_memory_bytes: args.compact_when_replay_memory_bytes,
+                },
+                GraphDeltaJournalLimits::default(),
+            )?;
+            serde_json::json!({
+                "generation_uuid": status.generation_uuid.to_string(),
+                "run_count": status.run_count,
+                "run_bytes": status.run_bytes,
+                "estimated_replay_memory_bytes": status.estimated_replay_memory_bytes,
+                "state_fingerprint": fingerprint_hex(&status.state_fingerprint),
+                "should_compact": status.should_compact,
+                "trigger_reasons": status.trigger_reasons,
+            })
+        }
+        MaintenanceCommand::CompactionPreview(args) => {
+            let report = graph.preview_graph_delta_compaction(&compaction_request(&args)?, None)?;
+            compaction_report_json(&report)
+        }
+        MaintenanceCommand::CompactionRun(args) => {
+            if !args.yes {
+                return Err(graphforge_api::GfError::Validation(
+                    "compaction run requires --yes".into(),
+                ));
+            }
+            let report = graph.compact_graph_delta(&compaction_request(&args.compaction)?, None)?;
+            compaction_report_json(&report)
+        }
+    };
+    write_machine(&value, json, output)
+}
+
+fn write_machine(
+    value: &serde_json::Value,
+    json: bool,
+    output: &mut dyn Write,
+) -> Result<(), graphforge_api::GfError> {
+    if json {
+        write_json_value(value, output)
+    } else {
+        writeln!(output, "{value}").map_err(|error| {
+            graphforge_api::GfError::Storage(format!("write maintenance output: {error}"))
+        })?;
+        Ok(())
+    }
+}

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -3746,6 +3746,34 @@ GraphForge exposes a Rust-owned `begin_transaction()` / stage / `validate()` /
 and knowledge mutations must share one committed generation. Administrative
 operations classified as rejected cannot join a transaction.
 
+### transaction and maintenance parity
+
+Python, Node, and CLI thin-wrap the same Rust facade for transactions,
+recovery-on-open evidence, retention/GC preview/execute, and graph-delta
+compaction preview/run/status. Bindings never implement recovery, reachability,
+delta replay, or compaction logic, never accept arbitrary cleanup paths, and
+never silently commit when a wrapper handle is dropped—finalization rolls back
+or releases staged work.
+
+Acknowledgement follows the frozen durability contract: commit returns only
+after CURRENT publication succeeds; exact idempotent retries replay the same
+generation; cancellation is observed before writer admission; optimistic
+multi-writer remains non-serializable (write-skew is possible and documented).
+Busy writers, resource limits, and conflicts map to the same typed project
+error codes across surfaces. Node reports 64-bit counts and sizes as `bigint`
+so values above `Number.MAX_SAFE_INTEGER` stay exact.
+
+```text
+gf --project PATH --json recovery
+gf --project PATH --json transaction commit --operation-uuid UUID --cypher 'CREATE (:Person {name: "A"})'
+gf --project PATH --json transaction rollback --operation-uuid UUID --add-node UUID:Person:{"name":"Ghost"}
+gf --project PATH --json maintenance cleanup-preview [--retained-ancestors N]
+gf --project PATH --json maintenance cleanup-execute --yes [--retained-ancestors N]
+gf --project PATH --json maintenance compaction-status
+gf --project PATH --json maintenance compaction-preview --transaction-uuid UUID --generation-uuid UUID
+gf --project PATH --json maintenance compaction-run --yes --transaction-uuid UUID --generation-uuid UUID
+```
+
 ### `explain(query, stage=None)` → `str`
 
 Compiler plan for a Cypher query. `stage`: `"ast"`, `"ir"`, `"logical"`, `"physical"`,

--- a/scripts/ci/test-non-cypher-surface-gate.py
+++ b/scripts/ci/test-non-cypher-surface-gate.py
@@ -29,7 +29,7 @@ class SurfaceGateTests(unittest.TestCase):
 
     def test_checked_in_inventory_is_complete(self) -> None:
         self.assertEqual(GATE.validate(), [])
-        self.assertEqual(len(GATE.public_methods()), 293)
+        self.assertEqual(len(GATE.public_methods()), 300)
         self.assertEqual(len(GATE.algorithm_registry()), 94)
 
     def test_new_or_removed_public_method_fails_frozen_digest(self) -> None:

--- a/tests/contracts/durability-isolation-matrix.json
+++ b/tests/contracts/durability-isolation-matrix.json
@@ -11,8 +11,21 @@
     "docs/adr/0014-workspace-checkpoints.md",
     "docs/adr/0015-embedded-write-modes.md"
   ],
-  "m5_consumer_issues": [738, 742, 745],
-  "deferred_owner_issues": [749, 750, 751, 752, 753, 754, 755, 756],
+  "m5_consumer_issues": [
+    738,
+    742,
+    745
+  ],
+  "deferred_owner_issues": [
+    749,
+    750,
+    751,
+    752,
+    753,
+    754,
+    755,
+    756
+  ],
   "acknowledgement": {
     "name": "acknowledged-durable",
     "requires": [
@@ -24,7 +37,12 @@
       "project_root_directory_flush"
     ],
     "linearization_point": "current_atomic_replace_or_create",
-    "not_authority": ["journals", "directory_scans", "timestamps", "uuid_order"]
+    "not_authority": [
+      "journals",
+      "directory_scans",
+      "timestamps",
+      "uuid_order"
+    ]
   },
   "filesystem_scope": {
     "supported": [
@@ -44,7 +62,10 @@
   },
   "recovery_authority": {
     "sole": "exact_valid_CURRENT",
-    "advisory": ["journals", "directory_scans"],
+    "advisory": [
+      "journals",
+      "directory_scans"
+    ],
     "corrupt_error": "GF_PROJECT_CORRUPT"
   },
   "write_modes": {
@@ -52,37 +73,77 @@
       "reader_isolation": "pinned_immutable_snapshot",
       "writer_isolation": "serial_exclusive",
       "conflicts": [
-        {"concurrent_work": "competing_writer", "outcome": "GF_WRITER_BUSY"}
+        {
+          "concurrent_work": "competing_writer",
+          "outcome": "GF_WRITER_BUSY"
+        }
       ]
     },
     "queued_writer": {
       "reader_isolation": "pinned_immutable_snapshot_reads_bypass_queue",
       "writer_isolation": "serial_after_bounded_fifo",
       "conflicts": [
-        {"concurrent_work": "queue_full", "outcome": "structured_queue_limit_error"},
-        {"concurrent_work": "cancel_unstarted", "outcome": "GF_CANCELLED"},
-        {"concurrent_work": "cancel_started", "outcome": "not_removable_from_queue"}
+        {
+          "concurrent_work": "queue_full",
+          "outcome": "structured_queue_limit_error"
+        },
+        {
+          "concurrent_work": "cancel_unstarted",
+          "outcome": "GF_CANCELLED"
+        },
+        {
+          "concurrent_work": "cancel_started",
+          "outcome": "not_removable_from_queue"
+        }
       ]
     },
     "optimistic_multi_writer": {
       "reader_isolation": "pinned_immutable_snapshot_per_attempt",
       "writer_isolation": "optimistic_snapshot_with_serialized_CURRENT",
       "conflicts": [
-        {"concurrent_work": "distinct_graph_creates", "outcome": "rebase_and_merge"},
-        {"concurrent_work": "distinct_immutable_ledger_identities", "outcome": "rebase_and_merge"},
-        {"concurrent_work": "different_properties_same_object", "outcome": "rebase_and_merge"},
-        {"concurrent_work": "same_property_or_removed_target", "outcome": "GF_WRITE_CONFLICT"},
-        {"concurrent_work": "delete_or_administrative", "outcome": "GF_WRITE_CONFLICT"},
-        {"concurrent_work": "retry_budget_exhausted", "outcome": "GF_REBASE_EXHAUSTED"},
-        {"concurrent_work": "same_operation_same_content", "outcome": "exact_idempotent_replay"},
-        {"concurrent_work": "same_operation_changed_content", "outcome": "GF_IDEMPOTENCY_CONFLICT"}
+        {
+          "concurrent_work": "distinct_graph_creates",
+          "outcome": "rebase_and_merge"
+        },
+        {
+          "concurrent_work": "distinct_immutable_ledger_identities",
+          "outcome": "rebase_and_merge"
+        },
+        {
+          "concurrent_work": "different_properties_same_object",
+          "outcome": "rebase_and_merge"
+        },
+        {
+          "concurrent_work": "same_property_or_removed_target",
+          "outcome": "GF_WRITE_CONFLICT"
+        },
+        {
+          "concurrent_work": "delete_or_administrative",
+          "outcome": "GF_WRITE_CONFLICT"
+        },
+        {
+          "concurrent_work": "retry_budget_exhausted",
+          "outcome": "GF_REBASE_EXHAUSTED"
+        },
+        {
+          "concurrent_work": "same_operation_same_content",
+          "outcome": "exact_idempotent_replay"
+        },
+        {
+          "concurrent_work": "same_operation_changed_content",
+          "outcome": "GF_IDEMPOTENCY_CONFLICT"
+        }
       ],
       "ssi_claimed": false,
       "serializable_claimed": false
     }
   },
   "claims": {
-    "forbidden_positive": ["ACID", "serializable isolation", "SSI"],
+    "forbidden_positive": [
+      "ACID",
+      "serializable isolation",
+      "SSI"
+    ],
     "required_honest": [
       "acknowledged-durable",
       "write-skew",
@@ -105,19 +166,26 @@
       "id": "acknowledged-success",
       "given": "caller_receives_success",
       "then": "durable_state_and_crash_assumptions_unambiguous",
-      "matrix_refs": ["acknowledgement", "crash_phases"]
+      "matrix_refs": [
+        "acknowledgement",
+        "crash_phases"
+      ]
     },
     {
       "id": "write-skew-honesty",
       "given": "two_optimistic_transactions_form_write_skew",
       "then": "docs_classify_not_serializable",
-      "matrix_refs": ["anomalies.write_skew"]
+      "matrix_refs": [
+        "anomalies.write_skew"
+      ]
     },
     {
       "id": "unsupported-filesystem-fail-closed",
       "given": "unsupported_filesystem",
       "then": "fail_closed_preflight",
-      "matrix_refs": ["filesystem_scope"]
+      "matrix_refs": [
+        "filesystem_scope"
+      ]
     }
   ],
   "crash_phases": [
@@ -182,7 +250,9 @@
     },
     {
       "id": "post_linearization_api_error",
-      "failpoints": ["project.after_current_replace.error"],
+      "failpoints": [
+        "project.after_current_replace.error"
+      ],
       "required_authority": "new_generation_committed_true",
       "coverage": "covered",
       "evidence": [
@@ -195,7 +265,9 @@
     },
     {
       "id": "lost_root_directory_flush_power_loss",
-      "failpoints": ["project.after_current_replace"],
+      "failpoints": [
+        "project.after_current_replace"
+      ],
       "required_authority": "exact_valid_CURRENT_presented_by_filesystem",
       "coverage": "covered",
       "evidence": [
@@ -457,9 +529,40 @@
     },
     {
       "id": "binding_cli_transaction_parity",
-      "coverage": "deferred",
-      "owner_issue": 755,
-      "rationale": "Python/Node/CLI parity for transaction and maintenance surfaces is #755."
+      "coverage": "covered",
+      "rationale": "Python/Node/CLI thin-wrap the Rust transaction and maintenance facade with parity tests and public docs for acknowledgement/retry/cancellation.",
+      "evidence": [
+        {
+          "kind": "rust",
+          "path": "crates/graphforge-api/src/transaction.rs",
+          "symbol": "mixed_cypher_and_bulk_commit_as_one_generation"
+        },
+        {
+          "kind": "rust",
+          "path": "crates/graphforge-api/src/transaction.rs",
+          "symbol": "drop_rolls_back_without_publication"
+        },
+        {
+          "kind": "rust",
+          "path": "crates/graphforge-api/src/transaction.rs",
+          "symbol": "rollback_leaves_prior_generation_unchanged_across_reopen"
+        },
+        {
+          "kind": "rust",
+          "path": "crates/graphforge-storage/src/project_retention.rs",
+          "symbol": "dry_run_and_execute_share_reachability_oracle"
+        },
+        {
+          "kind": "rust",
+          "path": "crates/graphforge-storage/tests/graph_delta_compaction.rs",
+          "symbol": "cleanup_reclaims_unreachable_inputs_after_compaction"
+        },
+        {
+          "kind": "doc",
+          "path": "docs/reference/api.md",
+          "symbol": "transaction and maintenance parity"
+        }
+      ]
     },
     {
       "id": "durable_delta_journal",

--- a/tests/contracts/non-cypher-rust-surface.json
+++ b/tests/contracts/non-cypher-rust-surface.json
@@ -1,7 +1,7 @@
 {
   "contract_version": 1,
   "scope": "Rust non-Cypher public release surface",
-  "public_method_digest": "fa206ee0082ce40a4729ddb79b4b65fe26f458d6e1ca7356f0526dd47d525a03",
+  "public_method_digest": "51fd33865c0866530edac0f1c3e735ba72354774de93966883b5020e1a1655fb",
   "method_policy": {
     "receiver_defaults": {
       "GraphForge": "release-tested",
@@ -43,10 +43,8 @@
       "crate.hold_writer": "internal-helper",
       "GraphForge.new": "introspection",
       "GraphForge.new_with_options": "introspection",
-      "GraphForge.begin_transaction": "introspection",
       "GraphForge.path": "introspection",
       "GraphForge.graph_open_evidence": "introspection",
-      "GraphForge.project_open_recovery": "introspection",
       "GraphForge.resource_diagnostics": "introspection",
       "GraphForge.resource_policy": "introspection",
       "GraphForge.export_portable": "designed-only",
@@ -86,7 +84,8 @@
       "CheckpointView.remove_embedding_space_alias": "designed-only",
       "CheckpointView.remove_hypothesis_member": "designed-only",
       "CheckpointView.set_default_embedding_space": "designed-only",
-      "CheckpointView.supersede_assertion": "designed-only"
+      "CheckpointView.supersede_assertion": "designed-only",
+      "CancellationToken.flag": "introspection"
     },
     "reasons": {
       "internal-helper": "exported execution plumbing, not a persisted product facade",
@@ -101,8 +100,14 @@
         "RepositoryContext.validate_infra_target"
       ],
       "test_refs": [
-        {"path": "crates/graphforge-api/src/repository.rs", "symbol": "checked_in_fixture_resolves_to_the_contract_golden"},
-        {"path": "crates/graphforge-api/src/repository.rs", "symbol": "target_semantics_fail_closed_before_state_or_secret_materialization"}
+        {
+          "path": "crates/graphforge-api/src/repository.rs",
+          "symbol": "checked_in_fixture_resolves_to_the_contract_golden"
+        },
+        {
+          "path": "crates/graphforge-api/src/repository.rs",
+          "symbol": "target_semantics_fail_closed_before_state_or_secret_materialization"
+        }
       ]
     },
     "repository-sync": {
@@ -110,41 +115,102 @@
         "RepositoryContext.sync"
       ],
       "test_refs": [
-        {"path": "crates/graphforge-api/src/repository.rs", "symbol": "repository_sync_checks_applies_replays_conflicts_and_preserves_authority"},
-        {"path": "crates/graphforge-api/src/repository.rs", "symbol": "repository_sync_rechecks_definitions_at_publication_boundary"},
-        {"path": "crates/graphforge-api/src/repository.rs", "symbol": "repository_sync_failure_boundaries_recover_to_one_authoritative_state"}
+        {
+          "path": "crates/graphforge-api/src/repository.rs",
+          "symbol": "repository_sync_checks_applies_replays_conflicts_and_preserves_authority"
+        },
+        {
+          "path": "crates/graphforge-api/src/repository.rs",
+          "symbol": "repository_sync_rechecks_definitions_at_publication_boundary"
+        },
+        {
+          "path": "crates/graphforge-api/src/repository.rs",
+          "symbol": "repository_sync_failure_boundaries_recover_to_one_authoritative_state"
+        }
       ]
     },
     "ontology-lifecycle": {
       "ids": [
-        "GraphForge.export_ontology", "GraphForge.inspect_runtime_catalog",
-        "GraphForge.suggest_ontology", "GraphForge.validate_ontology"
+        "GraphForge.export_ontology",
+        "GraphForge.inspect_runtime_catalog",
+        "GraphForge.suggest_ontology",
+        "GraphForge.validate_ontology"
       ],
       "test_refs": [
-        {"path": "crates/graphforge-api/src/ontology_lifecycle.rs", "symbol": "snapshot_hides_runtime_identity_and_orders_entries"},
-        {"path": "crates/graphforge-api/src/ontology_lifecycle.rs", "symbol": "catalog_inspection_reports_poisoned_lock_and_schema_mismatch"},
-        {"path": "crates/graphforge-api/src/ontology_lifecycle.rs", "symbol": "equivalent_observation_order_produces_identical_suggestion"},
-        {"path": "crates/graphforge-api/src/ontology_lifecycle.rs", "symbol": "yaml_and_json_exports_are_atomic_valid_documents"},
-        {"path": "crates/graphforge-api/src/ontology_lifecycle.rs", "symbol": "suggested_source_is_canonicalized_before_serialization"},
-        {"path": "crates/graphforge-api/src/ontology_lifecycle.rs", "symbol": "export_round_trip_preserves_migration_route_tie_breaking"},
-        {"path": "crates/graphforge-api/src/ontology_lifecycle.rs", "symbol": "validation_and_failed_export_do_not_replace_destination"},
-        {"path": "crates/graphforge-api/src/ontology_lifecycle.rs", "symbol": "loaded_and_adopted_sources_are_explicit_and_leave_authority_unchanged"},
-        {"path": "crates/graphforge-api/src/ontology_lifecycle.rs", "symbol": "filesystem_failure_preserves_destination_and_cleans_temporary_file"}
+        {
+          "path": "crates/graphforge-api/src/ontology_lifecycle.rs",
+          "symbol": "snapshot_hides_runtime_identity_and_orders_entries"
+        },
+        {
+          "path": "crates/graphforge-api/src/ontology_lifecycle.rs",
+          "symbol": "catalog_inspection_reports_poisoned_lock_and_schema_mismatch"
+        },
+        {
+          "path": "crates/graphforge-api/src/ontology_lifecycle.rs",
+          "symbol": "equivalent_observation_order_produces_identical_suggestion"
+        },
+        {
+          "path": "crates/graphforge-api/src/ontology_lifecycle.rs",
+          "symbol": "yaml_and_json_exports_are_atomic_valid_documents"
+        },
+        {
+          "path": "crates/graphforge-api/src/ontology_lifecycle.rs",
+          "symbol": "suggested_source_is_canonicalized_before_serialization"
+        },
+        {
+          "path": "crates/graphforge-api/src/ontology_lifecycle.rs",
+          "symbol": "export_round_trip_preserves_migration_route_tie_breaking"
+        },
+        {
+          "path": "crates/graphforge-api/src/ontology_lifecycle.rs",
+          "symbol": "validation_and_failed_export_do_not_replace_destination"
+        },
+        {
+          "path": "crates/graphforge-api/src/ontology_lifecycle.rs",
+          "symbol": "loaded_and_adopted_sources_are_explicit_and_leave_authority_unchanged"
+        },
+        {
+          "path": "crates/graphforge-api/src/ontology_lifecycle.rs",
+          "symbol": "filesystem_failure_preserves_destination_and_cleans_temporary_file"
+        }
       ]
     },
     "lifecycle-construction": {
       "ids": [
-        "GraphForge.add_edge", "GraphForge.add_node",
-        "GraphForge.adopt_ontology", "GraphForge.clear_ontology", "GraphForge.labels", "GraphForge.node_count",
-        "GraphForge.ontology_mode", "GraphForge.publish_bulk_edges", "GraphForge.publish_bulk_nodes",
-        "GraphForge.relationship_types", "GraphForge.workspace_configuration", "GraphForge.workspace_ontology"
+        "GraphForge.add_edge",
+        "GraphForge.add_node",
+        "GraphForge.adopt_ontology",
+        "GraphForge.clear_ontology",
+        "GraphForge.labels",
+        "GraphForge.node_count",
+        "GraphForge.ontology_mode",
+        "GraphForge.publish_bulk_edges",
+        "GraphForge.publish_bulk_nodes",
+        "GraphForge.relationship_types",
+        "GraphForge.workspace_configuration",
+        "GraphForge.workspace_ontology"
       ],
       "test_refs": [
-        {"path": "crates/graphforge-api/tests/public_lifecycle_conformance.rs", "symbol": "persisted_construction_reopens_with_exact_uuid_properties_and_order"},
-        {"path": "crates/graphforge-api/tests/public_facade_remaining_conformance.rs", "symbol": "public_lifecycle_inventory_covers_remaining_facade_methods"},
-        {"path": "crates/graphforge-api/tests/release_load_construction.rs", "symbol": "bulk_load_construction_stays_within_recovery_bound"},
-        {"path": "crates/graphforge-api/src/workspace_ontology.rs", "symbol": "clear_ontology_publishes_explicit_absence"},
-        {"path": "crates/graphforge-api/src/checkpoint_graph_diff.rs", "symbol": "extracts_uuid_ordered_logical_nodes_and_edges_from_pinned_generation"}
+        {
+          "path": "crates/graphforge-api/tests/public_lifecycle_conformance.rs",
+          "symbol": "persisted_construction_reopens_with_exact_uuid_properties_and_order"
+        },
+        {
+          "path": "crates/graphforge-api/tests/public_facade_remaining_conformance.rs",
+          "symbol": "public_lifecycle_inventory_covers_remaining_facade_methods"
+        },
+        {
+          "path": "crates/graphforge-api/tests/release_load_construction.rs",
+          "symbol": "bulk_load_construction_stays_within_recovery_bound"
+        },
+        {
+          "path": "crates/graphforge-api/src/workspace_ontology.rs",
+          "symbol": "clear_ontology_publishes_explicit_absence"
+        },
+        {
+          "path": "crates/graphforge-api/src/checkpoint_graph_diff.rs",
+          "symbol": "extracts_uuid_ordered_logical_nodes_and_edges_from_pinned_generation"
+        }
       ]
     },
     "gsi-profiler": {
@@ -154,268 +220,845 @@
         "GraphForge.set_graph_directedness"
       ],
       "test_refs": [
-        {"path": "crates/graphforge-api/src/gsi_profiler.rs", "symbol": "empty_workspace_profiles_without_error"},
-        {"path": "crates/graphforge-api/src/gsi_profiler.rs", "symbol": "singleton_and_configured_directedness_grade"},
-        {"path": "crates/graphforge-api/src/gsi_profiler.rs", "symbol": "triangle_grades_gd_gu_and_gx"}
+        {
+          "path": "crates/graphforge-api/src/gsi_profiler.rs",
+          "symbol": "empty_workspace_profiles_without_error"
+        },
+        {
+          "path": "crates/graphforge-api/src/gsi_profiler.rs",
+          "symbol": "singleton_and_configured_directedness_grade"
+        },
+        {
+          "path": "crates/graphforge-api/src/gsi_profiler.rs",
+          "symbol": "triangle_grades_gd_gu_and_gx"
+        }
       ]
     },
     "checkpoint-view": {
       "ids": [
-        "CheckpointView.algorithm_run", "CheckpointView.algorithm_run_events", "CheckpointView.analyze", "CheckpointView.analyze_embedding",
-        "CheckpointView.apply_valid_time", "CheckpointView.assertion", "CheckpointView.assertion_graph_refs", "CheckpointView.assertion_status",
-        "CheckpointView.cluster", "CheckpointView.confidence_assessment", "CheckpointView.confidence_inputs", "CheckpointView.embedding_space",
-        "CheckpointView.embedding_spaces", "CheckpointView.epistemic_snapshot", "CheckpointView.evidence_link", "CheckpointView.execute",
-        "CheckpointView.find", "CheckpointView.hypothesis_members", "CheckpointView.hypothesis_selection", "CheckpointView.inspect_embedding_refresh",
-        "CheckpointView.inspect_adjacency", "CheckpointView.inspect_embedding_space_freshness", "CheckpointView.list_algorithm_runs", "CheckpointView.list_assertion_status",
-        "CheckpointView.list_assertion_supersessions", "CheckpointView.list_assertion_validity", "CheckpointView.list_assertions",
-        "CheckpointView.list_confidence_assessments", "CheckpointView.list_evidence_links", "CheckpointView.list_hypothesis_groups",
-        "CheckpointView.list_hypothesis_membership", "CheckpointView.list_hypothesis_selection", "CheckpointView.list_provenance_history",
-        "CheckpointView.list_reasoning", "CheckpointView.paths", "CheckpointView.project_capabilities", "CheckpointView.provenance_event",
-        "CheckpointView.rank", "CheckpointView.reasoning", "CheckpointView.resolve_belief_projection", "CheckpointView.similar",
-        "CheckpointView.workspace_configuration", "CheckpointView.workspace_ontology", "GraphForge.checkpoint", "GraphForge.delete_checkpoint",
-        "GraphForge.diff_checkpoints", "GraphForge.list_checkpoints", "GraphForge.open_checkpoint", "GraphForge.revert_to_checkpoint"
+        "CheckpointView.algorithm_run",
+        "CheckpointView.algorithm_run_events",
+        "CheckpointView.analyze",
+        "CheckpointView.analyze_embedding",
+        "CheckpointView.apply_valid_time",
+        "CheckpointView.assertion",
+        "CheckpointView.assertion_graph_refs",
+        "CheckpointView.assertion_status",
+        "CheckpointView.cluster",
+        "CheckpointView.confidence_assessment",
+        "CheckpointView.confidence_inputs",
+        "CheckpointView.embedding_space",
+        "CheckpointView.embedding_spaces",
+        "CheckpointView.epistemic_snapshot",
+        "CheckpointView.evidence_link",
+        "CheckpointView.execute",
+        "CheckpointView.find",
+        "CheckpointView.hypothesis_members",
+        "CheckpointView.hypothesis_selection",
+        "CheckpointView.inspect_embedding_refresh",
+        "CheckpointView.inspect_adjacency",
+        "CheckpointView.inspect_embedding_space_freshness",
+        "CheckpointView.list_algorithm_runs",
+        "CheckpointView.list_assertion_status",
+        "CheckpointView.list_assertion_supersessions",
+        "CheckpointView.list_assertion_validity",
+        "CheckpointView.list_assertions",
+        "CheckpointView.list_confidence_assessments",
+        "CheckpointView.list_evidence_links",
+        "CheckpointView.list_hypothesis_groups",
+        "CheckpointView.list_hypothesis_membership",
+        "CheckpointView.list_hypothesis_selection",
+        "CheckpointView.list_provenance_history",
+        "CheckpointView.list_reasoning",
+        "CheckpointView.paths",
+        "CheckpointView.project_capabilities",
+        "CheckpointView.provenance_event",
+        "CheckpointView.rank",
+        "CheckpointView.reasoning",
+        "CheckpointView.resolve_belief_projection",
+        "CheckpointView.similar",
+        "CheckpointView.workspace_configuration",
+        "CheckpointView.workspace_ontology",
+        "GraphForge.checkpoint",
+        "GraphForge.delete_checkpoint",
+        "GraphForge.diff_checkpoints",
+        "GraphForge.list_checkpoints",
+        "GraphForge.open_checkpoint",
+        "GraphForge.revert_to_checkpoint"
       ],
       "test_refs": [
-        {"path": "crates/graphforge-api/tests/public_lifecycle_conformance.rs", "symbol": "checkpoint_lifecycle_is_persisted_pinned_read_only_and_revertible"},
-        {"path": "crates/graphforge-api/tests/public_facade_remaining_conformance.rs", "symbol": "checkpoint_view_inventory_covers_all_read_wrappers"},
-        {"path": "crates/graphforge-api/src/checkpoints.rs", "symbol": "checkpoint_view_stays_pinned_and_rejects_writes"},
-        {"path": "crates/graphforge-api/src/belief_projection.rs", "symbol": "statusless_include_materializes_the_same_neutral_rank_projection"},
-        {"path": "crates/graphforge-api/src/knowledge.rs", "symbol": "confidence_publication_is_atomic_idempotent_deterministic_and_reopenable"},
-        {"path": "crates/graphforge-api/src/embedding_spaces.rs", "symbol": "aliases_defaults_replacement_removal_and_reopen_are_deterministic"},
-        {"path": "crates/graphforge-api/src/hypotheses.rs", "symbol": "explicit_selection_and_atomic_selected_member_removal_survive_reopen"},
-        {"path": "crates/graphforge-api/src/knowledge.rs", "symbol": "supersession_is_atomic_branch_preserving_idempotent_and_reopenable"},
-        {"path": "crates/graphforge-api/src/knowledge.rs", "symbol": "reasoning_is_append_only_exact_idempotent_and_reopenable"},
-        {"path": "crates/graphforge-api/src/knowledge.rs", "symbol": "assertion_lists_filter_and_page_with_generation_bound_tokens"},
-        {"path": "crates/graphforge-api/src/knowledge.rs", "symbol": "evidence_publication_is_atomic_idempotent_filterable_and_reopenable"},
-        {"path": "crates/graphforge-api/src/algorithm_runs.rs", "symbol": "recorded_dispatch_commits_start_and_completed_before_return"},
-        {"path": "crates/graphforge-api/src/capabilities.rs", "symbol": "initial_project_reports_mandatory_graph_and_workspace_capabilities"},
-        {"path": "crates/graphforge-api/src/checkpoints.rs", "symbol": "populated_checkpoint_shapes_restore_real_domain_records"},
-        {"path": "crates/graphforge-api/src/embedding_freshness.rs", "symbol": "fresh_alias_and_default_survive_reopen"},
-        {"path": "crates/graphforge-api/src/embedding_refresh.rs", "symbol": "defaults_and_space_overrides_are_durable_and_content_free"},
-        {"path": "crates/graphforge-api/src/invocation_descriptor.rs", "symbol": "every_verb_prepares_and_dispatches_through_the_direct_executor"},
-        {"path": "crates/graphforge-api/src/provenance.rs", "symbol": "enabled_project_commits_graph_and_provenance_in_one_generation"},
-        {"path": "crates/graphforge-api/src/valid_time.rs", "symbol": "correction_preserves_prior_cutoff_base_snapshot_and_reopen_fingerprint"}
+        {
+          "path": "crates/graphforge-api/tests/public_lifecycle_conformance.rs",
+          "symbol": "checkpoint_lifecycle_is_persisted_pinned_read_only_and_revertible"
+        },
+        {
+          "path": "crates/graphforge-api/tests/public_facade_remaining_conformance.rs",
+          "symbol": "checkpoint_view_inventory_covers_all_read_wrappers"
+        },
+        {
+          "path": "crates/graphforge-api/src/checkpoints.rs",
+          "symbol": "checkpoint_view_stays_pinned_and_rejects_writes"
+        },
+        {
+          "path": "crates/graphforge-api/src/belief_projection.rs",
+          "symbol": "statusless_include_materializes_the_same_neutral_rank_projection"
+        },
+        {
+          "path": "crates/graphforge-api/src/knowledge.rs",
+          "symbol": "confidence_publication_is_atomic_idempotent_deterministic_and_reopenable"
+        },
+        {
+          "path": "crates/graphforge-api/src/embedding_spaces.rs",
+          "symbol": "aliases_defaults_replacement_removal_and_reopen_are_deterministic"
+        },
+        {
+          "path": "crates/graphforge-api/src/hypotheses.rs",
+          "symbol": "explicit_selection_and_atomic_selected_member_removal_survive_reopen"
+        },
+        {
+          "path": "crates/graphforge-api/src/knowledge.rs",
+          "symbol": "supersession_is_atomic_branch_preserving_idempotent_and_reopenable"
+        },
+        {
+          "path": "crates/graphforge-api/src/knowledge.rs",
+          "symbol": "reasoning_is_append_only_exact_idempotent_and_reopenable"
+        },
+        {
+          "path": "crates/graphforge-api/src/knowledge.rs",
+          "symbol": "assertion_lists_filter_and_page_with_generation_bound_tokens"
+        },
+        {
+          "path": "crates/graphforge-api/src/knowledge.rs",
+          "symbol": "evidence_publication_is_atomic_idempotent_filterable_and_reopenable"
+        },
+        {
+          "path": "crates/graphforge-api/src/algorithm_runs.rs",
+          "symbol": "recorded_dispatch_commits_start_and_completed_before_return"
+        },
+        {
+          "path": "crates/graphforge-api/src/capabilities.rs",
+          "symbol": "initial_project_reports_mandatory_graph_and_workspace_capabilities"
+        },
+        {
+          "path": "crates/graphforge-api/src/checkpoints.rs",
+          "symbol": "populated_checkpoint_shapes_restore_real_domain_records"
+        },
+        {
+          "path": "crates/graphforge-api/src/embedding_freshness.rs",
+          "symbol": "fresh_alias_and_default_survive_reopen"
+        },
+        {
+          "path": "crates/graphforge-api/src/embedding_refresh.rs",
+          "symbol": "defaults_and_space_overrides_are_durable_and_content_free"
+        },
+        {
+          "path": "crates/graphforge-api/src/invocation_descriptor.rs",
+          "symbol": "every_verb_prepares_and_dispatches_through_the_direct_executor"
+        },
+        {
+          "path": "crates/graphforge-api/src/provenance.rs",
+          "symbol": "enabled_project_commits_graph_and_provenance_in_one_generation"
+        },
+        {
+          "path": "crates/graphforge-api/src/valid_time.rs",
+          "symbol": "correction_preserves_prior_cutoff_base_snapshot_and_reopen_fingerprint"
+        }
       ]
     },
     "algorithm": {
       "ids": [
-        "GraphForge.analyze", "GraphForge.analyze_embedding", "GraphForge.cluster", "GraphForge.invoke_analyze_descriptor",
-        "GraphForge.invoke_cluster_descriptor", "GraphForge.invoke_descriptor", "GraphForge.invoke_descriptor_bytes",
-        "GraphForge.invoke_embedding_descriptor", "GraphForge.invoke_paths_descriptor", "GraphForge.invoke_rank_descriptor",
-        "GraphForge.invoke_similar_descriptor", "GraphForge.paths", "GraphForge.prepare_analyze_invocation",
-        "GraphForge.prepare_cluster_invocation", "GraphForge.prepare_embedding_invocation", "GraphForge.prepare_paths_invocation",
-        "GraphForge.prepare_rank_invocation", "GraphForge.prepare_similar_invocation", "GraphForge.rank", "GraphForge.similar",
+        "GraphForge.analyze",
+        "GraphForge.analyze_embedding",
+        "GraphForge.cluster",
+        "GraphForge.invoke_analyze_descriptor",
+        "GraphForge.invoke_cluster_descriptor",
+        "GraphForge.invoke_descriptor",
+        "GraphForge.invoke_descriptor_bytes",
+        "GraphForge.invoke_embedding_descriptor",
+        "GraphForge.invoke_paths_descriptor",
+        "GraphForge.invoke_rank_descriptor",
+        "GraphForge.invoke_similar_descriptor",
+        "GraphForge.paths",
+        "GraphForge.prepare_analyze_invocation",
+        "GraphForge.prepare_cluster_invocation",
+        "GraphForge.prepare_embedding_invocation",
+        "GraphForge.prepare_paths_invocation",
+        "GraphForge.prepare_rank_invocation",
+        "GraphForge.prepare_similar_invocation",
+        "GraphForge.rank",
+        "GraphForge.similar",
         "crate.algorithm_descriptor_contracts"
       ],
       "test_refs": [
-        {"path": "crates/graphforge-api/tests/algorithm_public_surface.rs", "symbol": "all_94_public_algorithm_contracts_are_unique_typed_and_repeatable"},
-        {"path": "crates/graphforge-api/tests/algorithm_public_surface.rs", "symbol": "descriptor_byte_and_embedding_dispatch_are_publicly_covered"},
-        {"path": "crates/graphforge-api/src/invocation_descriptor.rs", "symbol": "every_verb_prepares_and_dispatches_through_the_direct_executor"},
-        {"path": "crates/graphforge-api/src/belief_projection.rs", "symbol": "statusless_include_materializes_the_same_neutral_rank_projection"},
-        {"path": "crates/graphforge-api/src/invocation_descriptor.rs", "symbol": "registry_is_exhaustive_for_all_94_catalog_entries"},
-        {"path": "crates/graphforge-api/src/invocation_descriptor.rs", "symbol": "prepared_rank_dispatch_is_arrow_equivalent_and_detects_projection_change"}
+        {
+          "path": "crates/graphforge-api/tests/algorithm_public_surface.rs",
+          "symbol": "all_94_public_algorithm_contracts_are_unique_typed_and_repeatable"
+        },
+        {
+          "path": "crates/graphforge-api/tests/algorithm_public_surface.rs",
+          "symbol": "descriptor_byte_and_embedding_dispatch_are_publicly_covered"
+        },
+        {
+          "path": "crates/graphforge-api/src/invocation_descriptor.rs",
+          "symbol": "every_verb_prepares_and_dispatches_through_the_direct_executor"
+        },
+        {
+          "path": "crates/graphforge-api/src/belief_projection.rs",
+          "symbol": "statusless_include_materializes_the_same_neutral_rank_projection"
+        },
+        {
+          "path": "crates/graphforge-api/src/invocation_descriptor.rs",
+          "symbol": "registry_is_exhaustive_for_all_94_catalog_entries"
+        },
+        {
+          "path": "crates/graphforge-api/src/invocation_descriptor.rs",
+          "symbol": "prepared_rank_dispatch_is_arrow_equivalent_and_detects_projection_change"
+        }
       ]
     },
     "search-provider-rerank": {
       "ids": [
-        "GraphForge.bind_embedding_space_alias", "GraphForge.configure_provider_find_runtime", "GraphForge.delete_embedding_space",
-        "GraphForge.embedding_refresh_project_policy", "GraphForge.embedding_space", "GraphForge.embedding_spaces", "GraphForge.find",
-        "GraphForge.find_with_diagnostics", "GraphForge.find_with_provider", "GraphForge.index_adjacency", "GraphForge.index_search", "GraphForge.inspect_adjacency",
-        "GraphForge.inspect_embedding_refresh", "GraphForge.inspect_embedding_space_freshness", "GraphForge.inspect_provider_embedding_plan", "GraphForge.inspect_text_index",
-        "GraphForge.inspect_provider_rerank_plan", "GraphForge.publish_caller_embeddings", "GraphForge.publish_algorithm_embeddings",
-        "GraphForge.publish_provider_embeddings", "GraphForge.refresh_provider_embeddings", "GraphForge.remove_embedding_space_alias",
-        "GraphForge.rebuild_adjacency", "GraphForge.rerank_find_results", "GraphForge.set_default_embedding_space", "GraphForge.set_embedding_refresh_project_policy",
-        "GraphForge.set_embedding_refresh_space_policy", "OpenRouterProviderSession.find", "OpenRouterProviderSession.inspect_embedding_plan",
-        "OpenRouterProviderSession.publish_embeddings", "OpenRouterProviderSession.refresh_embeddings"
+        "GraphForge.bind_embedding_space_alias",
+        "GraphForge.configure_provider_find_runtime",
+        "GraphForge.delete_embedding_space",
+        "GraphForge.embedding_refresh_project_policy",
+        "GraphForge.embedding_space",
+        "GraphForge.embedding_spaces",
+        "GraphForge.find",
+        "GraphForge.find_with_diagnostics",
+        "GraphForge.find_with_provider",
+        "GraphForge.index_adjacency",
+        "GraphForge.index_search",
+        "GraphForge.inspect_adjacency",
+        "GraphForge.inspect_embedding_refresh",
+        "GraphForge.inspect_embedding_space_freshness",
+        "GraphForge.inspect_provider_embedding_plan",
+        "GraphForge.inspect_text_index",
+        "GraphForge.inspect_provider_rerank_plan",
+        "GraphForge.publish_caller_embeddings",
+        "GraphForge.publish_algorithm_embeddings",
+        "GraphForge.publish_provider_embeddings",
+        "GraphForge.refresh_provider_embeddings",
+        "GraphForge.remove_embedding_space_alias",
+        "GraphForge.rebuild_adjacency",
+        "GraphForge.rerank_find_results",
+        "GraphForge.set_default_embedding_space",
+        "GraphForge.set_embedding_refresh_project_policy",
+        "GraphForge.set_embedding_refresh_space_policy",
+        "OpenRouterProviderSession.find",
+        "OpenRouterProviderSession.inspect_embedding_plan",
+        "OpenRouterProviderSession.publish_embeddings",
+        "OpenRouterProviderSession.refresh_embeddings"
       ],
       "test_refs": [
-        {"path": "crates/graphforge-api/tests/search_public_surface.rs", "symbol": "public_text_vector_hybrid_find_is_exact_repeatable_and_persistent"},
-        {"path": "crates/graphforge-api/tests/provider_public_surface.rs", "symbol": "provider_refresh_and_rerank_public_facades_are_covered"},
-        {"path": "crates/graphforge-api/tests/provider_public_surface.rs", "symbol": "openrouter_session_refresh_embeddings_rejects_drift_without_transport"},
-        {"path": "crates/graphforge-api/src/provider_rerank.rs", "symbol": "default_error_and_explicit_canonical_fallback_are_distinct"},
-        {"path": "crates/graphforge-api/src/embedding_spaces.rs", "symbol": "aliases_defaults_replacement_removal_and_reopen_are_deterministic"},
-        {"path": "crates/graphforge-api/src/embedding_refresh.rs", "symbol": "defaults_and_space_overrides_are_durable_and_content_free"},
-        {"path": "crates/graphforge-api/src/search_index.rs", "symbol": "adjacency_is_explicit_and_never_treats_a_search_label_as_magic"},
-        {"path": "crates/graphforge-api/src/search_index.rs", "symbol": "adjacency_rebuild_cancellation_preserves_prior_authoritative_artifact"},
-        {"path": "crates/graphforge-api/tests/provider_session.rs", "symbol": "configured_session_composes_embedding_query_rerank_and_advisory"},
-        {"path": "crates/graphforge-api/src/embedding_freshness.rs", "symbol": "fresh_alias_and_default_survive_reopen"},
-        {"path": "crates/graphforge-api/src/embedding_publication.rs", "symbol": "complete_batch_is_canonical_idempotent_replaceable_and_reopenable"},
-        {"path": "crates/graphforge-api/src/embedding_spaces.rs", "symbol": "explicit_deletion_removes_one_lineage_all_aliases_and_default"},
-        {"path": "crates/graphforge-api/src/algorithm_embedding_publication.rs", "symbol": "canonical_result_is_idempotent_uuid_keyed_and_reopenable"},
-        {"path": "crates/graphforge-api/src/provider_embedding.rs", "symbol": "inspection_is_order_independent_content_free_and_openrouter_explicit"},
-        {"path": "crates/graphforge-api/src/provider_embedding_execution.rs", "symbol": "cancellation_is_structured_before_provider_or_alias_mutation"},
-        {"path": "crates/graphforge-api/src/provider_find.rs", "symbol": "ordinary_find_resolves_and_replaces_exact_configured_runtime"},
-        {"path": "crates/graphforge-api/src/provider_find.rs", "symbol": "alias_lineage_change_retries_once_and_second_change_fails_structurally"},
-        {"path": "crates/graphforge-api/src/provider_rerank.rs", "symbol": "detailed_find_keeps_omission_neutral_and_reranks_explicitly"},
-        {"path": "crates/graphforge-api/src/provider_rerank.rs", "symbol": "inspection_is_payload_free_and_execution_reorders_canonical_arrow"},
-        {"path": "crates/graphforge-api/src/search_index.rs", "symbol": "text_receipt_tracks_stale_rebuild_incompatible_and_reopen_transitions"}
+        {
+          "path": "crates/graphforge-api/tests/search_public_surface.rs",
+          "symbol": "public_text_vector_hybrid_find_is_exact_repeatable_and_persistent"
+        },
+        {
+          "path": "crates/graphforge-api/tests/provider_public_surface.rs",
+          "symbol": "provider_refresh_and_rerank_public_facades_are_covered"
+        },
+        {
+          "path": "crates/graphforge-api/tests/provider_public_surface.rs",
+          "symbol": "openrouter_session_refresh_embeddings_rejects_drift_without_transport"
+        },
+        {
+          "path": "crates/graphforge-api/src/provider_rerank.rs",
+          "symbol": "default_error_and_explicit_canonical_fallback_are_distinct"
+        },
+        {
+          "path": "crates/graphforge-api/src/embedding_spaces.rs",
+          "symbol": "aliases_defaults_replacement_removal_and_reopen_are_deterministic"
+        },
+        {
+          "path": "crates/graphforge-api/src/embedding_refresh.rs",
+          "symbol": "defaults_and_space_overrides_are_durable_and_content_free"
+        },
+        {
+          "path": "crates/graphforge-api/src/search_index.rs",
+          "symbol": "adjacency_is_explicit_and_never_treats_a_search_label_as_magic"
+        },
+        {
+          "path": "crates/graphforge-api/src/search_index.rs",
+          "symbol": "adjacency_rebuild_cancellation_preserves_prior_authoritative_artifact"
+        },
+        {
+          "path": "crates/graphforge-api/tests/provider_session.rs",
+          "symbol": "configured_session_composes_embedding_query_rerank_and_advisory"
+        },
+        {
+          "path": "crates/graphforge-api/src/embedding_freshness.rs",
+          "symbol": "fresh_alias_and_default_survive_reopen"
+        },
+        {
+          "path": "crates/graphforge-api/src/embedding_publication.rs",
+          "symbol": "complete_batch_is_canonical_idempotent_replaceable_and_reopenable"
+        },
+        {
+          "path": "crates/graphforge-api/src/embedding_spaces.rs",
+          "symbol": "explicit_deletion_removes_one_lineage_all_aliases_and_default"
+        },
+        {
+          "path": "crates/graphforge-api/src/algorithm_embedding_publication.rs",
+          "symbol": "canonical_result_is_idempotent_uuid_keyed_and_reopenable"
+        },
+        {
+          "path": "crates/graphforge-api/src/provider_embedding.rs",
+          "symbol": "inspection_is_order_independent_content_free_and_openrouter_explicit"
+        },
+        {
+          "path": "crates/graphforge-api/src/provider_embedding_execution.rs",
+          "symbol": "cancellation_is_structured_before_provider_or_alias_mutation"
+        },
+        {
+          "path": "crates/graphforge-api/src/provider_find.rs",
+          "symbol": "ordinary_find_resolves_and_replaces_exact_configured_runtime"
+        },
+        {
+          "path": "crates/graphforge-api/src/provider_find.rs",
+          "symbol": "alias_lineage_change_retries_once_and_second_change_fails_structurally"
+        },
+        {
+          "path": "crates/graphforge-api/src/provider_rerank.rs",
+          "symbol": "detailed_find_keeps_omission_neutral_and_reranks_explicitly"
+        },
+        {
+          "path": "crates/graphforge-api/src/provider_rerank.rs",
+          "symbol": "inspection_is_payload_free_and_execution_reorders_canonical_arrow"
+        },
+        {
+          "path": "crates/graphforge-api/src/search_index.rs",
+          "symbol": "text_receipt_tracks_stale_rebuild_incompatible_and_reopen_transitions"
+        }
       ]
     },
     "knowledge": {
       "ids": [
-        "GraphForge.assertion", "GraphForge.assertion_graph_refs", "GraphForge.assertion_status", "GraphForge.assess_confidence",
-        "GraphForge.attach_evidence", "GraphForge.confidence_assessment", "GraphForge.confidence_inputs", "GraphForge.create_assertion",
-        "GraphForge.create_assertion_with_evidence", "GraphForge.create_assertion_with_status", "GraphForge.enable_capability", "GraphForge.publish_composite_transaction", "GraphForge.publish_composite_transaction_with_cancellation",
-        "GraphForge.evidence_link", "GraphForge.list_assertion_status", "GraphForge.list_assertion_supersessions",
-        "GraphForge.list_assertion_validity", "GraphForge.list_assertions", "GraphForge.list_confidence_assessments",
-        "GraphForge.list_evidence_links", "GraphForge.list_provenance_history", "GraphForge.list_reasoning",
-        "GraphForge.project_capabilities", "GraphForge.provenance_event", "GraphForge.reasoning", "GraphForge.record_assertion_status",
-        "GraphForge.record_assertion_validity", "GraphForge.record_reasoning"
+        "GraphForge.assertion",
+        "GraphForge.assertion_graph_refs",
+        "GraphForge.assertion_status",
+        "GraphForge.assess_confidence",
+        "GraphForge.attach_evidence",
+        "GraphForge.confidence_assessment",
+        "GraphForge.confidence_inputs",
+        "GraphForge.create_assertion",
+        "GraphForge.create_assertion_with_evidence",
+        "GraphForge.create_assertion_with_status",
+        "GraphForge.enable_capability",
+        "GraphForge.publish_composite_transaction",
+        "GraphForge.publish_composite_transaction_with_cancellation",
+        "GraphForge.evidence_link",
+        "GraphForge.list_assertion_status",
+        "GraphForge.list_assertion_supersessions",
+        "GraphForge.list_assertion_validity",
+        "GraphForge.list_assertions",
+        "GraphForge.list_confidence_assessments",
+        "GraphForge.list_evidence_links",
+        "GraphForge.list_provenance_history",
+        "GraphForge.list_reasoning",
+        "GraphForge.project_capabilities",
+        "GraphForge.provenance_event",
+        "GraphForge.reasoning",
+        "GraphForge.record_assertion_status",
+        "GraphForge.record_assertion_validity",
+        "GraphForge.record_reasoning"
       ],
       "test_refs": [
-        {"path": "crates/graphforge-api/src/knowledge.rs", "symbol": "assertion_publication_is_atomic_idempotent_and_reopenable"},
-        {"path": "crates/graphforge-api/tests/public_facade_remaining_conformance.rs", "symbol": "public_history_list_surfaces_are_exact"},
-        {"path": "crates/graphforge-api/src/provenance.rs", "symbol": "enabled_project_commits_graph_and_provenance_in_one_generation"},
-        {"path": "crates/graphforge-api/src/knowledge.rs", "symbol": "confidence_publication_is_atomic_idempotent_deterministic_and_reopenable"},
-        {"path": "crates/graphforge-api/src/knowledge.rs", "symbol": "assertion_status_is_explicit_append_only_idempotent_and_reopenable"},
-        {"path": "crates/graphforge-api/src/knowledge.rs", "symbol": "evidence_publication_is_atomic_idempotent_filterable_and_reopenable"},
-        {"path": "crates/graphforge-api/src/capabilities.rs", "symbol": "enabled_capability_is_selected_after_persistent_reopen"},
-        {"path": "crates/graphforge-api/src/checkpoints.rs", "symbol": "populated_checkpoint_shapes_restore_real_domain_records"},
-        {"path": "crates/graphforge-api/src/knowledge.rs", "symbol": "reasoning_is_append_only_exact_idempotent_and_reopenable"},
-        {"path": "crates/graphforge-api/src/knowledge.rs", "symbol": "assertion_lists_filter_and_page_with_generation_bound_tokens"},
-        {"path": "crates/graphforge-api/src/belief_projection.rs", "symbol": "statusless_include_materializes_the_same_neutral_rank_projection"},
-        {"path": "crates/graphforge-api/src/knowledge.rs", "symbol": "assertion_with_evidence_is_one_atomic_idempotent_generation"},
-        {"path": "crates/graphforge-api/src/composite_publish.rs", "symbol": "publish_composite_is_one_generation_with_canonical_receipt"},
-        {"path": "crates/graphforge-api/src/composite_publish.rs", "symbol": "cancelled_public_composite_publish_never_mutates"},
-        {"path": "crates/graphforge-api/src/composite_publish.rs", "symbol": "invalid_composite_request_does_not_mutate"},
-        {"path": "crates/graphforge-api/src/knowledge.rs", "symbol": "supersession_is_atomic_branch_preserving_idempotent_and_reopenable"}
+        {
+          "path": "crates/graphforge-api/src/knowledge.rs",
+          "symbol": "assertion_publication_is_atomic_idempotent_and_reopenable"
+        },
+        {
+          "path": "crates/graphforge-api/tests/public_facade_remaining_conformance.rs",
+          "symbol": "public_history_list_surfaces_are_exact"
+        },
+        {
+          "path": "crates/graphforge-api/src/provenance.rs",
+          "symbol": "enabled_project_commits_graph_and_provenance_in_one_generation"
+        },
+        {
+          "path": "crates/graphforge-api/src/knowledge.rs",
+          "symbol": "confidence_publication_is_atomic_idempotent_deterministic_and_reopenable"
+        },
+        {
+          "path": "crates/graphforge-api/src/knowledge.rs",
+          "symbol": "assertion_status_is_explicit_append_only_idempotent_and_reopenable"
+        },
+        {
+          "path": "crates/graphforge-api/src/knowledge.rs",
+          "symbol": "evidence_publication_is_atomic_idempotent_filterable_and_reopenable"
+        },
+        {
+          "path": "crates/graphforge-api/src/capabilities.rs",
+          "symbol": "enabled_capability_is_selected_after_persistent_reopen"
+        },
+        {
+          "path": "crates/graphforge-api/src/checkpoints.rs",
+          "symbol": "populated_checkpoint_shapes_restore_real_domain_records"
+        },
+        {
+          "path": "crates/graphforge-api/src/knowledge.rs",
+          "symbol": "reasoning_is_append_only_exact_idempotent_and_reopenable"
+        },
+        {
+          "path": "crates/graphforge-api/src/knowledge.rs",
+          "symbol": "assertion_lists_filter_and_page_with_generation_bound_tokens"
+        },
+        {
+          "path": "crates/graphforge-api/src/belief_projection.rs",
+          "symbol": "statusless_include_materializes_the_same_neutral_rank_projection"
+        },
+        {
+          "path": "crates/graphforge-api/src/knowledge.rs",
+          "symbol": "assertion_with_evidence_is_one_atomic_idempotent_generation"
+        },
+        {
+          "path": "crates/graphforge-api/src/composite_publish.rs",
+          "symbol": "publish_composite_is_one_generation_with_canonical_receipt"
+        },
+        {
+          "path": "crates/graphforge-api/src/composite_publish.rs",
+          "symbol": "cancelled_public_composite_publish_never_mutates"
+        },
+        {
+          "path": "crates/graphforge-api/src/composite_publish.rs",
+          "symbol": "invalid_composite_request_does_not_mutate"
+        },
+        {
+          "path": "crates/graphforge-api/src/knowledge.rs",
+          "symbol": "supersession_is_atomic_branch_preserving_idempotent_and_reopenable"
+        }
       ]
     },
     "epistemic": {
       "ids": [
-        "GraphForge.algorithm_run", "GraphForge.algorithm_run_events", "GraphForge.apply_valid_time", "GraphForge.attach_resolved_run",
-        "GraphForge.create_hypothesis_group", "GraphForge.epistemic_snapshot", "GraphForge.hypothesis_members",
-        "GraphForge.hypothesis_selection", "GraphForge.invoke_recorded", "GraphForge.invoke_resolved_recorded",
-        "GraphForge.list_algorithm_runs", "GraphForge.list_hypothesis_groups", "GraphForge.list_hypothesis_membership",
-        "GraphForge.list_hypothesis_selection", "GraphForge.record_hypothesis_membership", "GraphForge.record_hypothesis_selection",
-        "GraphForge.remove_hypothesis_member", "GraphForge.resolve_belief_projection", "GraphForge.resolve_belief_subject",
+        "GraphForge.algorithm_run",
+        "GraphForge.algorithm_run_events",
+        "GraphForge.apply_valid_time",
+        "GraphForge.attach_resolved_run",
+        "GraphForge.create_hypothesis_group",
+        "GraphForge.epistemic_snapshot",
+        "GraphForge.hypothesis_members",
+        "GraphForge.hypothesis_selection",
+        "GraphForge.invoke_recorded",
+        "GraphForge.invoke_resolved_recorded",
+        "GraphForge.list_algorithm_runs",
+        "GraphForge.list_hypothesis_groups",
+        "GraphForge.list_hypothesis_membership",
+        "GraphForge.list_hypothesis_selection",
+        "GraphForge.record_hypothesis_membership",
+        "GraphForge.record_hypothesis_selection",
+        "GraphForge.remove_hypothesis_member",
+        "GraphForge.resolve_belief_projection",
+        "GraphForge.resolve_belief_subject",
         "GraphForge.supersede_assertion"
       ],
       "test_refs": [
-        {"path": "crates/graphforge-api/src/hypotheses.rs", "symbol": "explicit_selection_and_atomic_selected_member_removal_survive_reopen"},
-        {"path": "crates/graphforge-api/tests/public_facade_remaining_conformance.rs", "symbol": "public_history_list_surfaces_are_exact"},
-        {"path": "crates/graphforge-api/src/valid_time.rs", "symbol": "correction_preserves_prior_cutoff_base_snapshot_and_reopen_fingerprint"},
-        {"path": "crates/graphforge-api/src/belief_projection.rs", "symbol": "statusless_include_materializes_the_same_neutral_rank_projection"},
-        {"path": "crates/graphforge-api/tests/belief_subject_contract.rs", "symbol": "public_belief_subject_contract_is_exact_temporal_and_reopenable"},
-        {"path": "crates/graphforge-api/tests/belief_subject_contract.rs", "symbol": "public_belief_subject_is_stable_across_independent_event_order"},
-        {"path": "crates/graphforge-api/src/belief_projection.rs", "symbol": "subject_snapshot_and_projection_hold_one_generation_guard"},
-        {"path": "crates/graphforge-api/src/algorithm_runs.rs", "symbol": "recorded_dispatch_commits_start_and_completed_before_return"},
-        {"path": "crates/graphforge-api/src/knowledge.rs", "symbol": "supersession_is_atomic_branch_preserving_idempotent_and_reopenable"}
+        {
+          "path": "crates/graphforge-api/src/hypotheses.rs",
+          "symbol": "explicit_selection_and_atomic_selected_member_removal_survive_reopen"
+        },
+        {
+          "path": "crates/graphforge-api/tests/public_facade_remaining_conformance.rs",
+          "symbol": "public_history_list_surfaces_are_exact"
+        },
+        {
+          "path": "crates/graphforge-api/src/valid_time.rs",
+          "symbol": "correction_preserves_prior_cutoff_base_snapshot_and_reopen_fingerprint"
+        },
+        {
+          "path": "crates/graphforge-api/src/belief_projection.rs",
+          "symbol": "statusless_include_materializes_the_same_neutral_rank_projection"
+        },
+        {
+          "path": "crates/graphforge-api/tests/belief_subject_contract.rs",
+          "symbol": "public_belief_subject_contract_is_exact_temporal_and_reopenable"
+        },
+        {
+          "path": "crates/graphforge-api/tests/belief_subject_contract.rs",
+          "symbol": "public_belief_subject_is_stable_across_independent_event_order"
+        },
+        {
+          "path": "crates/graphforge-api/src/belief_projection.rs",
+          "symbol": "subject_snapshot_and_projection_hold_one_generation_guard"
+        },
+        {
+          "path": "crates/graphforge-api/src/algorithm_runs.rs",
+          "symbol": "recorded_dispatch_commits_start_and_completed_before_return"
+        },
+        {
+          "path": "crates/graphforge-api/src/knowledge.rs",
+          "symbol": "supersession_is_atomic_branch_preserving_idempotent_and_reopenable"
+        }
       ]
     },
     "streaming-errors-maintenance": {
       "ids": [
-        "GraphForge.clear", "GraphForge.execute", "GraphForge.execute_stream", "GraphForge.execute_stream_owned",
-        "GraphForge.execute_stream_with_params", "GraphForge.execute_to_parquet", "GraphForge.execute_to_parquet_with_params",
-        "GraphForge.execute_with_params", "GraphForge.explain", "GraphForge.register_procedure", "GraphForge.runtime_catalog", "GraphForge.schema"
+        "GraphForge.clear",
+        "GraphForge.execute",
+        "GraphForge.execute_stream",
+        "GraphForge.execute_stream_owned",
+        "GraphForge.execute_stream_with_params",
+        "GraphForge.execute_to_parquet",
+        "GraphForge.execute_to_parquet_with_params",
+        "GraphForge.execute_with_params",
+        "GraphForge.explain",
+        "GraphForge.register_procedure",
+        "GraphForge.runtime_catalog",
+        "GraphForge.schema"
       ],
       "test_refs": [
-        {"path": "crates/graphforge-api/src/lib.rs", "symbol": "registered_procedure_missing_parameter_matches_streaming_path"},
-        {"path": "crates/graphforge-api/tests/public_facade_remaining_conformance.rs", "symbol": "parameterized_stream_and_parquet_surfaces_are_exact"},
-        {"path": "crates/graphforge-api/src/lib.rs", "symbol": "clear_resets_in_memory_state_after_partial_filesystem_failure"},
-        {"path": "crates/graphforge-api/tests/e2e_baseline.rs", "symbol": "execute_stream_yields_shaped_batches"},
-        {"path": "crates/graphforge-api/tests/facade_methods.rs", "symbol": "explain_is_side_effect_free_on_the_shared_catalog"},
-        {"path": "crates/graphforge-api/src/lib.rs", "symbol": "parameter_binding_filters_by_value"},
-        {"path": "crates/graphforge-api/tests/e2e_baseline.rs", "symbol": "execute_stream_owned_guard_outlives_dropped_forge"},
-        {"path": "crates/graphforge-api/tests/facade_methods.rs", "symbol": "execute_to_parquet_roundtrips"},
-        {"path": "crates/graphforge-api/tests/public_facade_remaining_conformance.rs", "symbol": "public_lifecycle_inventory_covers_remaining_facade_methods"}
+        {
+          "path": "crates/graphforge-api/src/lib.rs",
+          "symbol": "registered_procedure_missing_parameter_matches_streaming_path"
+        },
+        {
+          "path": "crates/graphforge-api/tests/public_facade_remaining_conformance.rs",
+          "symbol": "parameterized_stream_and_parquet_surfaces_are_exact"
+        },
+        {
+          "path": "crates/graphforge-api/src/lib.rs",
+          "symbol": "clear_resets_in_memory_state_after_partial_filesystem_failure"
+        },
+        {
+          "path": "crates/graphforge-api/tests/e2e_baseline.rs",
+          "symbol": "execute_stream_yields_shaped_batches"
+        },
+        {
+          "path": "crates/graphforge-api/tests/facade_methods.rs",
+          "symbol": "explain_is_side_effect_free_on_the_shared_catalog"
+        },
+        {
+          "path": "crates/graphforge-api/src/lib.rs",
+          "symbol": "parameter_binding_filters_by_value"
+        },
+        {
+          "path": "crates/graphforge-api/tests/e2e_baseline.rs",
+          "symbol": "execute_stream_owned_guard_outlives_dropped_forge"
+        },
+        {
+          "path": "crates/graphforge-api/tests/facade_methods.rs",
+          "symbol": "execute_to_parquet_roundtrips"
+        },
+        {
+          "path": "crates/graphforge-api/tests/public_facade_remaining_conformance.rs",
+          "symbol": "public_lifecycle_inventory_covers_remaining_facade_methods"
+        }
       ]
     },
     "compatibility": {
-      "ids": ["GraphForge.index", "GraphForge.load_ontology"],
+      "ids": [
+        "GraphForge.index",
+        "GraphForge.load_ontology"
+      ],
       "test_refs": [
-        {"path": "crates/graphforge-api/tests/facade_methods.rs", "symbol": "load_ontology_applies_and_promotes_mode"},
-        {"path": "crates/graphforge-api/tests/search_public_surface.rs", "symbol": "public_find_option_and_legacy_index_errors_are_exact_and_repeatable"}
+        {
+          "path": "crates/graphforge-api/tests/facade_methods.rs",
+          "symbol": "load_ontology_applies_and_promotes_mode"
+        },
+        {
+          "path": "crates/graphforge-api/tests/search_public_surface.rs",
+          "symbol": "public_find_option_and_legacy_index_errors_are_exact_and_repeatable"
+        }
+      ]
+    },
+    "transaction-maintenance": {
+      "ids": [
+        "GraphForge.begin_transaction",
+        "GraphForge.project_open_recovery",
+        "GraphForge.inspect_project_reachability",
+        "GraphForge.preview_project_cleanup",
+        "GraphForge.execute_project_cleanup",
+        "GraphForge.graph_delta_compaction_status",
+        "GraphForge.preview_graph_delta_compaction",
+        "GraphForge.compact_graph_delta"
+      ],
+      "test_refs": [
+        {
+          "path": "crates/graphforge-api/src/maintenance.rs",
+          "symbol": "facade_exposes_transaction_and_maintenance_ops"
+        },
+        {
+          "path": "crates/graphforge-api/src/transaction.rs",
+          "symbol": "drop_rolls_back_without_publication"
+        }
       ]
     }
   },
   "algorithm_registry": {
     "release-tested": {
       "ids": [
-        "rank.adamic_adar", "rank.article_rank", "rank.betweenness", "rank.celf", "rank.closeness", "rank.clustering_coefficient", "rank.common_neighbors", "rank.degree", "rank.eigenvector", "rank.harmonic_closeness", "rank.hits_authority", "rank.hits_hub", "rank.k_core", "rank.pagerank", "rank.preferential_attachment", "rank.resource_allocation", "rank.total_neighbors", "rank.triangles",
-        "cluster.approximate_max_k_cut", "cluster.biconnected", "cluster.components", "cluster.fastgreedy", "cluster.girvan_newman", "cluster.hdbscan", "cluster.infomap", "cluster.k_core_decomposition", "cluster.k_means", "cluster.label_propagation", "cluster.leading_eigenvector", "cluster.leiden", "cluster.louvain", "cluster.modularity_optimization", "cluster.speaker_listener", "cluster.spinglass", "cluster.strongly_connected", "cluster.walktrap",
-        "paths.astar", "paths.bellman_ford", "paths.bfs", "paths.delta_stepping", "paths.dfs", "paths.dijkstra", "paths.dijkstra_all_pairs", "paths.floyd_warshall", "paths.gomory_hu_tree", "paths.max_flow", "paths.max_flow_edges", "paths.min_cost_max_flow", "paths.min_cost_max_flow_edges", "paths.min_cut", "paths.min_cut_edges", "paths.min_steiner_tree", "paths.prize_collecting_steiner_tree", "paths.random_walk", "paths.transitive_closure", "paths.yens",
-        "analyze.articulation_points", "analyze.bridges", "analyze.chromatic_number", "analyze.conductance", "analyze.count_automorphisms", "analyze.dag_longest_path", "analyze.dag_longest_path_weighted", "analyze.dyad_census", "analyze.edge_coloring", "analyze.euler_circuit", "analyze.euler_path", "analyze.fast_random_projection", "analyze.find_cycles", "analyze.graphsage", "analyze.has_euler_circuit", "analyze.has_euler_path", "analyze.hashgnn", "analyze.is_dag", "analyze.is_planar", "analyze.k1_coloring", "analyze.max_bipartite_matching", "analyze.max_cardinality_matching", "analyze.max_weight_matching", "analyze.maximum_spanning_tree", "analyze.minimum_k_spanning_tree", "analyze.minimum_spanning_tree", "analyze.modularity", "analyze.node2vec", "analyze.node_coloring", "analyze.topological_sort", "analyze.transitivity", "analyze.triad_census", "analyze.triangle_count",
-        "similar.cosine", "similar.filtered_knn", "similar.filtered_node_similarity", "similar.knn", "similar.node_similarity"
+        "rank.adamic_adar",
+        "rank.article_rank",
+        "rank.betweenness",
+        "rank.celf",
+        "rank.closeness",
+        "rank.clustering_coefficient",
+        "rank.common_neighbors",
+        "rank.degree",
+        "rank.eigenvector",
+        "rank.harmonic_closeness",
+        "rank.hits_authority",
+        "rank.hits_hub",
+        "rank.k_core",
+        "rank.pagerank",
+        "rank.preferential_attachment",
+        "rank.resource_allocation",
+        "rank.total_neighbors",
+        "rank.triangles",
+        "cluster.approximate_max_k_cut",
+        "cluster.biconnected",
+        "cluster.components",
+        "cluster.fastgreedy",
+        "cluster.girvan_newman",
+        "cluster.hdbscan",
+        "cluster.infomap",
+        "cluster.k_core_decomposition",
+        "cluster.k_means",
+        "cluster.label_propagation",
+        "cluster.leading_eigenvector",
+        "cluster.leiden",
+        "cluster.louvain",
+        "cluster.modularity_optimization",
+        "cluster.speaker_listener",
+        "cluster.spinglass",
+        "cluster.strongly_connected",
+        "cluster.walktrap",
+        "paths.astar",
+        "paths.bellman_ford",
+        "paths.bfs",
+        "paths.delta_stepping",
+        "paths.dfs",
+        "paths.dijkstra",
+        "paths.dijkstra_all_pairs",
+        "paths.floyd_warshall",
+        "paths.gomory_hu_tree",
+        "paths.max_flow",
+        "paths.max_flow_edges",
+        "paths.min_cost_max_flow",
+        "paths.min_cost_max_flow_edges",
+        "paths.min_cut",
+        "paths.min_cut_edges",
+        "paths.min_steiner_tree",
+        "paths.prize_collecting_steiner_tree",
+        "paths.random_walk",
+        "paths.transitive_closure",
+        "paths.yens",
+        "analyze.articulation_points",
+        "analyze.bridges",
+        "analyze.chromatic_number",
+        "analyze.conductance",
+        "analyze.count_automorphisms",
+        "analyze.dag_longest_path",
+        "analyze.dag_longest_path_weighted",
+        "analyze.dyad_census",
+        "analyze.edge_coloring",
+        "analyze.euler_circuit",
+        "analyze.euler_path",
+        "analyze.fast_random_projection",
+        "analyze.find_cycles",
+        "analyze.graphsage",
+        "analyze.has_euler_circuit",
+        "analyze.has_euler_path",
+        "analyze.hashgnn",
+        "analyze.is_dag",
+        "analyze.is_planar",
+        "analyze.k1_coloring",
+        "analyze.max_bipartite_matching",
+        "analyze.max_cardinality_matching",
+        "analyze.max_weight_matching",
+        "analyze.maximum_spanning_tree",
+        "analyze.minimum_k_spanning_tree",
+        "analyze.minimum_spanning_tree",
+        "analyze.modularity",
+        "analyze.node2vec",
+        "analyze.node_coloring",
+        "analyze.topological_sort",
+        "analyze.transitivity",
+        "analyze.triad_census",
+        "analyze.triangle_count",
+        "similar.cosine",
+        "similar.filtered_knn",
+        "similar.filtered_node_similarity",
+        "similar.knn",
+        "similar.node_similarity"
       ],
       "test_refs": [
-        {"path": "crates/graphforge-api/src/invocation_descriptor.rs", "symbol": "registry_is_exhaustive_for_all_94_catalog_entries"},
-        {"path": "crates/graphforge-api/tests/knowledge_isolation.rs", "symbol": "typed_catalog_partition_is_unique_exhaustive_and_probes_unavailable_handlers"}
+        {
+          "path": "crates/graphforge-api/src/invocation_descriptor.rs",
+          "symbol": "registry_is_exhaustive_for_all_94_catalog_entries"
+        },
+        {
+          "path": "crates/graphforge-api/tests/knowledge_isolation.rs",
+          "symbol": "typed_catalog_partition_is_unique_exhaustive_and_probes_unavailable_handlers"
+        }
       ]
     }
   },
   "required_search_contracts": [
-    "find.mode.text", "find.mode.vector", "find.mode.hybrid",
-    "find.freshness.default", "find.freshness.force_stale",
-    "index.text.create", "index.vector.publish", "index.adjacency.create",
-    "embedding.producer.caller", "embedding.producer.provider", "embedding.producer.algorithm",
-    "embedding.normalization.none", "embedding.normalization.l2",
+    "find.mode.text",
+    "find.mode.vector",
+    "find.mode.hybrid",
+    "find.freshness.default",
+    "find.freshness.force_stale",
+    "index.text.create",
+    "index.vector.publish",
+    "index.adjacency.create",
+    "embedding.producer.caller",
+    "embedding.producer.provider",
+    "embedding.producer.algorithm",
+    "embedding.normalization.none",
+    "embedding.normalization.l2",
     "embedding.distance.cosine",
-    "provider.workflow.plan", "provider.workflow.publish", "provider.workflow.refresh", "provider.workflow.find",
-    "rerank.failure.error", "rerank.failure.canonical_unreranked",
-    "rerank.advisory.emit", "rerank.advisory.suppress"
+    "provider.workflow.plan",
+    "provider.workflow.publish",
+    "provider.workflow.refresh",
+    "provider.workflow.find",
+    "rerank.failure.error",
+    "rerank.failure.canonical_unreranked",
+    "rerank.advisory.emit",
+    "rerank.advisory.suppress"
   ],
   "search_contracts": {
     "release-tested": {
       "ids": [
-        "find.mode.text", "find.mode.vector", "find.mode.hybrid",
-        "find.freshness.default", "find.freshness.force_stale",
-        "index.text.create", "index.vector.publish", "index.adjacency.create",
-        "embedding.producer.caller", "embedding.producer.provider", "embedding.producer.algorithm",
-        "embedding.normalization.none", "embedding.normalization.l2",
+        "find.mode.text",
+        "find.mode.vector",
+        "find.mode.hybrid",
+        "find.freshness.default",
+        "find.freshness.force_stale",
+        "index.text.create",
+        "index.vector.publish",
+        "index.adjacency.create",
+        "embedding.producer.caller",
+        "embedding.producer.provider",
+        "embedding.producer.algorithm",
+        "embedding.normalization.none",
+        "embedding.normalization.l2",
         "embedding.distance.cosine",
-        "provider.workflow.plan", "provider.workflow.publish", "provider.workflow.refresh", "provider.workflow.find",
-        "rerank.failure.error", "rerank.failure.canonical_unreranked",
-        "rerank.advisory.emit", "rerank.advisory.suppress"
+        "provider.workflow.plan",
+        "provider.workflow.publish",
+        "provider.workflow.refresh",
+        "provider.workflow.find",
+        "rerank.failure.error",
+        "rerank.failure.canonical_unreranked",
+        "rerank.advisory.emit",
+        "rerank.advisory.suppress"
       ],
-      "test_refs": [{"path": "crates/graphforge-api/tests/search_public_surface.rs", "symbol": "public_text_vector_hybrid_find_is_exact_repeatable_and_persistent"}]
+      "test_refs": [
+        {
+          "path": "crates/graphforge-api/tests/search_public_surface.rs",
+          "symbol": "public_text_vector_hybrid_find_is_exact_repeatable_and_persistent"
+        }
+      ]
     }
   },
   "search_evidence_groups": {
     "find-modes": {
-      "ids": ["find.mode.text", "find.mode.vector", "find.mode.hybrid"],
-      "test_refs": [{"path": "crates/graphforge-api/tests/search_public_surface.rs", "symbol": "public_text_vector_hybrid_find_is_exact_repeatable_and_persistent"}]
+      "ids": [
+        "find.mode.text",
+        "find.mode.vector",
+        "find.mode.hybrid"
+      ],
+      "test_refs": [
+        {
+          "path": "crates/graphforge-api/tests/search_public_surface.rs",
+          "symbol": "public_text_vector_hybrid_find_is_exact_repeatable_and_persistent"
+        }
+      ]
     },
     "freshness": {
-      "ids": ["find.freshness.default", "find.freshness.force_stale"],
+      "ids": [
+        "find.freshness.default",
+        "find.freshness.force_stale"
+      ],
       "test_refs": [
-        {"path": "crates/graphforge-api/src/embedding_freshness.rs", "symbol": "fresh_alias_and_default_survive_reopen"},
-        {"path": "crates/graphforge-api/src/embedding_freshness.rs", "symbol": "proven_small_mutation_is_mildly_stale_and_serveable"}
+        {
+          "path": "crates/graphforge-api/src/embedding_freshness.rs",
+          "symbol": "fresh_alias_and_default_survive_reopen"
+        },
+        {
+          "path": "crates/graphforge-api/src/embedding_freshness.rs",
+          "symbol": "proven_small_mutation_is_mildly_stale_and_serveable"
+        }
       ]
     },
     "indexes": {
-      "ids": ["index.text.create", "index.vector.publish", "index.adjacency.create"],
+      "ids": [
+        "index.text.create",
+        "index.vector.publish",
+        "index.adjacency.create"
+      ],
       "test_refs": [
-        {"path": "crates/graphforge-api/tests/search_public_surface.rs", "symbol": "public_text_vector_hybrid_find_is_exact_repeatable_and_persistent"},
-        {"path": "crates/graphforge-api/src/search_index.rs", "symbol": "adjacency_is_explicit_and_never_treats_a_search_label_as_magic"}
+        {
+          "path": "crates/graphforge-api/tests/search_public_surface.rs",
+          "symbol": "public_text_vector_hybrid_find_is_exact_repeatable_and_persistent"
+        },
+        {
+          "path": "crates/graphforge-api/src/search_index.rs",
+          "symbol": "adjacency_is_explicit_and_never_treats_a_search_label_as_magic"
+        }
       ]
     },
     "embedding-contract": {
       "ids": [
-        "embedding.producer.caller", "embedding.producer.provider", "embedding.producer.algorithm",
-        "embedding.normalization.none", "embedding.normalization.l2", "embedding.distance.cosine"
+        "embedding.producer.caller",
+        "embedding.producer.provider",
+        "embedding.producer.algorithm",
+        "embedding.normalization.none",
+        "embedding.normalization.l2",
+        "embedding.distance.cosine"
       ],
       "test_refs": [
-        {"path": "crates/graphforge-api/src/embedding_publication.rs", "symbol": "complete_batch_is_canonical_idempotent_replaceable_and_reopenable"},
-        {"path": "crates/graphforge-api/tests/provider_public_surface.rs", "symbol": "provider_refresh_and_rerank_public_facades_are_covered"},
-        {"path": "crates/graphforge-api/src/algorithm_embedding_publication.rs", "symbol": "canonical_result_is_idempotent_uuid_keyed_and_reopenable"}
+        {
+          "path": "crates/graphforge-api/src/embedding_publication.rs",
+          "symbol": "complete_batch_is_canonical_idempotent_replaceable_and_reopenable"
+        },
+        {
+          "path": "crates/graphforge-api/tests/provider_public_surface.rs",
+          "symbol": "provider_refresh_and_rerank_public_facades_are_covered"
+        },
+        {
+          "path": "crates/graphforge-api/src/algorithm_embedding_publication.rs",
+          "symbol": "canonical_result_is_idempotent_uuid_keyed_and_reopenable"
+        }
       ]
     },
     "provider-workflows": {
-      "ids": ["provider.workflow.plan", "provider.workflow.publish", "provider.workflow.refresh", "provider.workflow.find"],
+      "ids": [
+        "provider.workflow.plan",
+        "provider.workflow.publish",
+        "provider.workflow.refresh",
+        "provider.workflow.find"
+      ],
       "test_refs": [
-        {"path": "crates/graphforge-api/tests/provider_public_surface.rs", "symbol": "provider_refresh_and_rerank_public_facades_are_covered"},
-        {"path": "crates/graphforge-api/tests/provider_session.rs", "symbol": "configured_session_composes_embedding_query_rerank_and_advisory"}
+        {
+          "path": "crates/graphforge-api/tests/provider_public_surface.rs",
+          "symbol": "provider_refresh_and_rerank_public_facades_are_covered"
+        },
+        {
+          "path": "crates/graphforge-api/tests/provider_session.rs",
+          "symbol": "configured_session_composes_embedding_query_rerank_and_advisory"
+        }
       ]
     },
     "rerank-policies": {
       "ids": [
-        "rerank.failure.error", "rerank.failure.canonical_unreranked",
-        "rerank.advisory.emit", "rerank.advisory.suppress"
+        "rerank.failure.error",
+        "rerank.failure.canonical_unreranked",
+        "rerank.advisory.emit",
+        "rerank.advisory.suppress"
       ],
       "test_refs": [
-        {"path": "crates/graphforge-api/src/provider_rerank.rs", "symbol": "default_error_and_explicit_canonical_fallback_are_distinct"},
-        {"path": "crates/graphforge-api/tests/provider_session.rs", "symbol": "configured_session_composes_embedding_query_rerank_and_advisory"}
+        {
+          "path": "crates/graphforge-api/src/provider_rerank.rs",
+          "symbol": "default_error_and_explicit_canonical_fallback_are_distinct"
+        },
+        {
+          "path": "crates/graphforge-api/tests/provider_session.rs",
+          "symbol": "configured_session_composes_embedding_query_rerank_and_advisory"
+        }
       ]
     }
   }


### PR DESCRIPTION
## Summary
- Thin-wrap Rust `GraphTransaction` (begin/stage/validate/commit/rollback/status) plus retention/GC and delta-compaction facade ops through Python, Node, and CLI.
- Add parity tests for mixed commit/rollback, dropped-handle safety, lossless Node `bigint` counts, and preview/execute candidate reconciliation; flip `binding_cli_transaction_parity`.
- Document acknowledgement, retry, cancellation, and non-serializable optimistic behavior in the public API reference.

Closes #755

## Test plan
- [x] `cargo test -p graphforge-api --lib facade_exposes_transaction`
- [x] `cargo clippy` on touched crates with `-D warnings`
- [x] `python3 scripts/ci/non-cypher-surface-gate.py`
- [x] `python3 scripts/ci/durability-isolation-gate.py`
- [x] `python3 scripts/ci/check-binding-parity-policy.py`
- [x] Python `transaction_parity.py` (maturin develop)
- [x] Node `transaction-parity.test.mjs` (napi build)
- [ ] CI Gate CLEAN at exact head SHA


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789435256&installation_model_id=20486&pr_number=772&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F772&signature=96a7407c5d9b1508f13b73d5c0527e8174959f5d834e74ab7c5cb4579047391e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added transaction support with staging, validation, commit, rollback, and cancellation across Python, Node.js, and CLI interfaces.
  - Added recovery inspection and project reachability tools.
  - Added cleanup preview and execution with safeguards for destructive actions.
  - Added graph-delta compaction status, preview, and execution workflows.
  - Added structured reports and transaction context-manager support in Python.

- **Bug Fixes**
  - Transactions now safely roll back when discarded instead of committing unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->