### PR TITLE
fix(ci): stabilize CodSpeed lex[simple_match] false regressions

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -121,7 +121,8 @@ under CodSpeed's CPU simulation instrument on pull requests to `main`, pushes
 to `main`, and manual dispatch. It reports performance deltas against the base
 commit as evidence; it is **not** part of the required `CI Gate` aggregate, and
 its Cargo build stays a diagnostic path next to authoritative Bazel
-compilation. See
+compilation. A sole `lex[simple_match]` Performance Analysis failure on a
+non-cypher PR is a known short-bench noise pattern — see triage in
 [`docs/development/benchmarking.md`](../../docs/development/benchmarking.md).
 
 ### `binding-release-candidate.yml`

--- a/crates/graphforge-cypher/benches/compile.rs
+++ b/crates/graphforge-cypher/benches/compile.rs
@@ -90,15 +90,36 @@ fn bind(ast: &AstQuery) -> usize {
     binder.bind(ast).map_or(0, |plan| plan.ops.len())
 }
 
+/// How many lexer passes run inside one measured sample.
+///
+/// `SimpleMatch` is a few dozen tokens; a single pass is short enough that
+/// CodSpeed CPU-simulation overhead can dominate and produce intermittent
+/// sole `lex[simple_match]` false regressions (~−19% to −31%) on PRs that
+/// never touch the Cypher front end. Batching raises SNR without changing
+/// lexer semantics. Longer shapes already have enough work per sample.
+const fn lex_iters(shape: Shape) -> usize {
+    match shape {
+        Shape::SimpleMatch => 256,
+        _ => 1,
+    }
+}
+
 /// Tokenization only — the first pass over the query text.
 #[divan::bench(args = SHAPES)]
 fn lex(bencher: Bencher, shape: Shape) {
     let query = shape.query();
+    let iters = lex_iters(shape);
     bencher.bench(|| {
-        let tokens = Lexer::new(divan::black_box(query))
-            .collect::<Result<Vec<_>, _>>()
-            .expect("benchmark query lexes");
-        divan::black_box(tokens.len())
+        let mut tokens = 0_usize;
+        for _ in 0..iters {
+            tokens = tokens.wrapping_add(
+                Lexer::new(divan::black_box(query))
+                    .collect::<Result<Vec<_>, _>>()
+                    .expect("benchmark query lexes")
+                    .len(),
+            );
+        }
+        divan::black_box(tokens)
     });
 }
 

--- a/docs/development/benchmarking.md
+++ b/docs/development/benchmarking.md
@@ -1,11 +1,13 @@
 # Benchmarking with CodSpeed
 
-**Status:** Continuous on every pull request to `main` (`CodSpeed` workflow)
+**Status:** Continuous on every pull request to `main` (`CodSpeed` workflow) —
+**diagnostic only**, not a merge gate
 
 GraphForge values correctness over performance, so benchmarks are evidence, not
 a merge gate. The `CodSpeed` workflow measures a fixed set of Rust benchmarks on
 every pull request and reports the delta against the base commit; it is not part
-of the required `CI Gate` aggregate.
+of the required `CI Gate` aggregate. A red **CodSpeed Performance Analysis**
+check does not block merge when `CI Gate` is green.
 
 ## What is measured
 
@@ -31,6 +33,28 @@ sources stay plain divan code.
 Both targets run under the **CPU simulation** instrument: measurements are
 instruction-level and hardware-agnostic, so a 4 vCPU shared runner still yields
 comparable numbers between runs.
+
+The Actions job **Rust Benchmarks** only builds and runs the suite; CodSpeed's
+separate **Performance Analysis** check compares results to the base commit and
+can fail independently of a green Actions job.
+
+## Triaging Performance Analysis failures
+
+Treat CodSpeed as a diagnostic signal, not a release or merge authority.
+
+**Known false-positive pattern:** sole regression on
+`graphforge-cypher::compile::lex[simple_match]` (often about −19% to −31%) while
+other benches are flat or improved, especially on PRs that do not change Cypher
+lexer/front-end sources. That shape is intentionally tiny; short samples are
+sensitive to measurement floor effects even under CPU simulation. Prefer raising
+SNR in the bench (batched iterations inside the measured closure) over treating
+the failure as an M4 or lexer regression.
+
+**Triage rule:** if the only failing bench is `lex[simple_match]` and the PR
+diff does not touch Cypher lexer/parse/bind sources (or their direct
+dependencies), treat the report as noise and proceed with `CI Gate`. Investigate
+further only when multiple cypher benches regress together or the PR changes the
+front end.
 
 ## Running them locally
 


### PR DESCRIPTION
## Summary
- Batch 256 `lex` passes for `Shape::SimpleMatch` inside the measured closure to raise SNR without changing lexer semantics.
- Document CodSpeed as diagnostic-only, the known sole `lex[simple_match]` false-positive pattern, and triage (no cypher diff ⇒ noise).
- Short pointer in `.github/workflows/README.md`.

Closes #774

## Test plan
- [x] `cargo clippy -p graphforge-cypher --benches -- -D warnings`
- [ ] `cargo bench -p graphforge-cypher --bench compile` (isolated target dir)
- [ ] CI Gate green on this PR
- [ ] CodSpeed Performance Analysis observed (informational; not a merge gate)


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/775"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789481726&installation_model_id=20486&pr_number=775&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F775&signature=5d5a48efd168303fe832459b5be75c7bdc8f73c70a0d301a64c4600f0bfa6d3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Updated lexer benchmarking to measure repeated `SimpleMatch` processing.
  * Improved benchmark accuracy by aggregating token counts across iterations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->