### PR TITLE
test(storage): cross-check native durability oracle

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -98,10 +98,14 @@ Python, Gherkin, native binding, Pulumi, Terraform, or Bazel jobs. Pull-request
 native binding acceptance is Linux-only and uses Cargo's `dev` profile for
 maturin/napi assembly. Authoritative Rust compile/test is Bazel
 (`//:ci_rust_tests`) under `Bazel Bootstrap`.
-When Rust surfaces change, `Windows graphforge-storage Locks` runs
-`cargo test -p graphforge-storage project_generation::tests:: --lib` on
-`blacksmith-4vcpu-windows-2025` so the `#[cfg(windows)]` project-root lock unit
-tests stay covered outside Binding RC.
+When Rust surfaces change, `Windows graphforge-storage Locks` runs the native
+project-root lock, exact filesystem primitive, NTFS admission, and real
+publication-kill/fault-oracle cross-checks on `blacksmith-4vcpu-windows-2025`.
+`macOS graphforge-storage Durability` runs the corresponding native APFS
+primitive, admission, and publication-kill cross-checks. Linux executes the same
+storage unit suite through authoritative `//:ci_rust_tests`. These platform jobs
+record actual subprocess/handle observations; the simulator does not stand in
+for native evidence.
 
 ### Behavioral acceptance
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -876,6 +876,52 @@ jobs:
           cargo test -p graphforge-storage
           filesystem_admission::tests:: --lib --no-fail-fast
 
+      - name: Cross-check Windows publication-kill results against the fault oracle
+        shell: bash
+        env:
+          GRAPHFORGE_NATIVE_ORACLE_EVIDENCE: ${{ runner.temp }}/durability-certification-evidence/native-oracle-windows.json
+        run: >-
+          cargo test -p graphforge-storage --features test-failpoints --lib
+          project_recovery::tests::subprocess_kill_matrix_never_exposes_a_partial_generation
+          --no-fail-fast -- --exact --nocapture
+
+      - name: Upload Windows native oracle evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-oracle-windows-${{ github.sha }}
+          path: ${{ runner.temp }}/durability-certification-evidence
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Run Windows injected publication error recovery test
+        shell: bash
+        run: >-
+          cargo test -p graphforge-storage --features test-failpoints --lib
+          project_recovery::tests::injected_operation_errors_report_exact_commit_state
+          --no-fail-fast -- --exact --nocapture
+
+      - name: Run Windows commit-lock cloned-descriptor test
+        shell: bash
+        run: >-
+          cargo test -p graphforge-storage --lib
+          project_publication::tests::commit_lock_guard_unlocks_before_a_cloned_descriptor_closes
+          --no-fail-fast -- --exact --nocapture
+
+      - name: Run Windows checkpoint-lock cloned-descriptor test
+        shell: bash
+        run: >-
+          cargo test -p graphforge-storage --lib
+          project_checkpoints::tests::checkpoint_read_guard_unlocks_before_a_cloned_descriptor_closes
+          --no-fail-fast -- --exact --nocapture
+
+      - name: Run Windows optimistic-promotion handle test
+        shell: bash
+        run: >-
+          cargo test -p graphforge-storage --lib
+          project_publication::tests::optimistic_promotion_closes_staged_handles_before_directory_rename
+          --no-fail-fast -- --exact --nocapture
+
       - name: Run Windows durability certification unit tests
         shell: bash
         run: >-
@@ -915,6 +961,41 @@ jobs:
       - name: Run macOS exact filesystem primitive tests
         run: >-
           cargo test -p graphforge-filesystem --lib --no-fail-fast
+
+      - name: Cross-check macOS publication-kill results against the fault oracle
+        env:
+          GRAPHFORGE_NATIVE_ORACLE_EVIDENCE: ${{ runner.temp }}/durability-certification-evidence/native-oracle-macos.json
+        run: >-
+          cargo test -p graphforge-storage --features test-failpoints --lib
+          project_recovery::tests::subprocess_kill_matrix_never_exposes_a_partial_generation
+          --no-fail-fast -- --exact --nocapture
+
+      - name: Upload macOS native oracle evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-oracle-macos-${{ github.sha }}
+          path: ${{ runner.temp }}/durability-certification-evidence
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Run macOS injected publication error recovery test
+        run: >-
+          cargo test -p graphforge-storage --features test-failpoints --lib
+          project_recovery::tests::injected_operation_errors_report_exact_commit_state
+          --no-fail-fast -- --exact --nocapture
+
+      - name: Run macOS commit-lock cloned-descriptor test
+        run: >-
+          cargo test -p graphforge-storage --lib
+          project_publication::tests::commit_lock_guard_unlocks_before_a_cloned_descriptor_closes
+          --no-fail-fast -- --exact --nocapture
+
+      - name: Run macOS checkpoint-lock cloned-descriptor test
+        run: >-
+          cargo test -p graphforge-storage --lib
+          project_checkpoints::tests::checkpoint_read_guard_unlocks_before_a_cloned_descriptor_closes
+          --no-fail-fast -- --exact --nocapture
 
   bazel-bootstrap:
     # Job display name kept for continuity; this is the authoritative Rust

--- a/crates/graphforge-api/src/durability_certification_tests.rs
+++ b/crates/graphforge-api/src/durability_certification_tests.rs
@@ -10,9 +10,6 @@
 use graphforge_storage::project_certification::{
     CERT_CONTRACT, CERT_SEED, WRITE_SKEW_CLASSIFICATION, evidence_summary, run_certification_suite,
 };
-use graphforge_storage::project_fault_oracle::{
-    AuthorityClass, PublicationPhase, native_shared_boundary_authority,
-};
 
 #[test]
 fn seeded_certification_suite_is_clean_at_required_budget() {
@@ -35,25 +32,6 @@ fn seeded_certification_suite_is_clean_at_required_budget() {
     assert!(!rendered.contains("serializable isolation"));
     assert!(!rendered.contains("distributed durability"));
     assert!(!rendered.contains("universal filesystem"));
-}
-
-#[test]
-fn native_shared_boundaries_agree_with_oracle_authority() {
-    for phase in [
-        PublicationPhase::BeforeCurrentReplace,
-        PublicationPhase::AfterCurrentReplace,
-        PublicationPhase::AfterRootFsync,
-    ] {
-        let native = native_shared_boundary_authority(phase);
-        let expected = match phase {
-            PublicationPhase::BeforeCurrentReplace => AuthorityClass::PriorGeneration,
-            PublicationPhase::AfterCurrentReplace | PublicationPhase::AfterRootFsync => {
-                AuthorityClass::NewGeneration
-            }
-            _ => unreachable!(),
-        };
-        assert_eq!(native, expected, "phase={phase:?}");
-    }
 }
 
 #[test]

--- a/crates/graphforge-storage/src/filesystem_admission.rs
+++ b/crates/graphforge-storage/src/filesystem_admission.rs
@@ -2411,4 +2411,29 @@ mod tests {
         assert_eq!(std::fs::read_dir(parent.path()).unwrap().count(), 0);
         filesystem_durability_preflight(&target).unwrap();
     }
+
+    #[test]
+    fn admitted_filesystem_class_selects_the_matching_fault_oracle_profile() {
+        let parent = canonical_tempdir();
+        let target = parent.path().join("project");
+        let evidence = filesystem_durability_preflight(&target).unwrap();
+        let profile =
+            crate::project_fault_oracle::DurabilityProfile::for_admitted_filesystem_class(
+                &evidence.filesystem_class,
+            )
+            .expect("every admitted durable filesystem has oracle semantics");
+        let outcomes =
+            crate::project_fault_oracle::simulate_all_phases_for_profile(0x749a, profile)
+                .expect("admission profile phase sweep");
+        assert_eq!(
+            outcomes.len(),
+            crate::project_fault_oracle::PublicationPhase::all().len()
+        );
+        assert!(outcomes.iter().all(|outcome| {
+            outcome.actual == outcome.expected
+                && outcome.actual != crate::project_fault_oracle::AuthorityClass::Unexpected
+                && (!outcome.acknowledged
+                    || outcome.actual == crate::project_fault_oracle::AuthorityClass::NewGeneration)
+        }));
+    }
 }

--- a/crates/graphforge-storage/src/project_certification.rs
+++ b/crates/graphforge-storage/src/project_certification.rs
@@ -20,8 +20,7 @@ use sha2::{Digest, Sha256};
 
 use crate::project_fault_oracle::{
     AuthorityClass, PublicationPhase, default_durable_ids, expected_authority, history_budget,
-    minimize_durable_ids, native_shared_boundary_authority, publication_ops, simulate_crash,
-    simulate_torn_bytes,
+    minimize_durable_ids, publication_ops, simulate_crash, simulate_torn_bytes,
 };
 
 /// Contract id frozen with the certification evidence schema.
@@ -566,21 +565,6 @@ fn apply_op(model: &mut ReferenceModel, seed: u64, op: &HistoryOp) -> Result<(),
                     expected: authority_label(report.expected).into(),
                     actual: authority_label(report.actual).into(),
                 });
-            }
-            // Native process-kill boundary must agree with the oracle at shared phases.
-            if matches!(
-                *phase,
-                PublicationPhase::BeforeCurrentReplace
-                    | PublicationPhase::AfterCurrentReplace
-                    | PublicationPhase::AfterRootFsync
-            ) {
-                let native = native_shared_boundary_authority(*phase);
-                if native != report.expected {
-                    return Err(CertInvariant::AuthorityMismatch {
-                        expected: authority_label(report.expected).into(),
-                        actual: format!("native:{}", authority_label(native)),
-                    });
-                }
             }
             if !phase.is_linearized() && report.actual == AuthorityClass::NewGeneration {
                 return Err(CertInvariant::PreAckAtomicityBroken);

--- a/crates/graphforge-storage/src/project_fault_oracle.rs
+++ b/crates/graphforge-storage/src/project_fault_oracle.rs
@@ -63,6 +63,18 @@ pub enum PublicationPhase {
 }
 
 impl PublicationPhase {
+    /// Resolve a native publication failpoint to its modeled ADR phase.
+    ///
+    /// Lock acquisition, journal preparation, and validation failpoints have no
+    /// persistence operation of their own and intentionally return `None`.
+    #[must_use]
+    pub fn from_failpoint(failpoint: &str) -> Option<Self> {
+        Self::all()
+            .iter()
+            .copied()
+            .find(|phase| phase.failpoint() == failpoint)
+    }
+
     /// Named failpoint cookie shared with native subprocess matrices.
     #[must_use]
     pub const fn failpoint(self) -> &'static str {
@@ -133,6 +145,58 @@ pub enum AuthorityClass {
     Unexpected,
 }
 
+/// Native durability primitive whose successful completion defines acknowledgement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DurabilityProfile {
+    /// Local POSIX filesystems admitted for file plus directory `fsync`.
+    PosixDirectoryFsync,
+    /// Fixed, writable local NTFS using the ADR 0020 write-through handle rename.
+    WindowsNtfsWriteThrough,
+}
+
+impl DurabilityProfile {
+    /// Profile for the current native test target.
+    #[must_use]
+    pub const fn native() -> Self {
+        if cfg!(windows) {
+            Self::WindowsNtfsWriteThrough
+        } else {
+            Self::PosixDirectoryFsync
+        }
+    }
+
+    /// Map #776's stable admitted filesystem class into oracle semantics.
+    #[must_use]
+    pub fn for_admitted_filesystem_class(filesystem_class: &str) -> Option<Self> {
+        match filesystem_class {
+            "ntfs" => Some(Self::WindowsNtfsWriteThrough),
+            "apfs" | "ext" | "ext2" | "ext3" | "ext4" | "xfs" | "btrfs" => {
+                Some(Self::PosixDirectoryFsync)
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Explicit injected result for an operation that did not acknowledge success.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InjectedOperationResult {
+    /// A required file-content flush returned an error.
+    FileFlushError,
+    /// The platform-native namespace barrier returned an error.
+    NamespaceBarrierError,
+    /// Replacement reported a definite error before changing authority.
+    ReplacementNotPerformed,
+    /// Replacement reported an error with prior authority after reconciliation.
+    ReplacementStateUnknownPrior,
+    /// Replacement reported an error with new authority after reconciliation.
+    ReplacementStateUnknownNew,
+    /// Durable bytes were torn or truncated before acknowledgement.
+    TornBytes,
+}
+
 /// One recorded persistence-relevant operation.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct PersistenceOp {
@@ -148,6 +212,20 @@ pub struct PersistenceOp {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PersistenceOpKind {
+    /// Open the staging handle retained through replacement reconciliation.
+    OpenHandle {
+        /// Stable trace-local handle name.
+        handle: String,
+        /// Project-relative staging path.
+        path: String,
+        /// Whether the native handle has write-through semantics.
+        write_through: bool,
+    },
+    /// Close a previously opened staging handle.
+    CloseHandle {
+        /// Stable trace-local handle name.
+        handle: String,
+    },
     /// Create or overwrite file bytes in the volatile view.
     WriteFile {
         /// Project-relative file path.
@@ -171,6 +249,8 @@ pub enum PersistenceOpKind {
         path: String,
         /// Exact bytes installed by the replacement.
         bytes: Vec<u8>,
+        /// Staging handle retained through the replacement call.
+        handle: String,
     },
     /// Flush directory entries for `path`.
     FsyncDir {
@@ -212,6 +292,12 @@ pub struct FaultOracleReport {
     pub phase: PublicationPhase,
     /// Failpoint name.
     pub failpoint: &'static str,
+    /// Platform durability primitive used by this history.
+    pub profile: DurabilityProfile,
+    /// Whether every required operation completed successfully before death.
+    pub acknowledged: bool,
+    /// Injected non-success outcome, when applicable.
+    pub injected_result: Option<InjectedOperationResult>,
     /// Persistence op ids that were made durable before crash.
     pub durable_op_ids: Vec<u64>,
     /// Expected authority class.
@@ -308,6 +394,8 @@ struct Media {
     volatile_files: BTreeMap<String, Vec<u8>>,
     durable_dirs: BTreeMap<String, BTreeSet<String>>,
     volatile_dirs: BTreeMap<String, BTreeSet<String>>,
+    pending_replacements: BTreeMap<String, Vec<u8>>,
+    open_handles: BTreeMap<String, (String, bool)>,
 }
 
 impl Media {
@@ -349,33 +437,76 @@ impl Media {
         self.ensure_dir_volatile(path);
     }
 
-    fn atomic_replace(&mut self, path: &str, bytes: Vec<u8>) {
+    fn open_handle(&mut self, handle: &str, path: &str, write_through: bool) {
+        assert!(
+            self.open_handles
+                .insert(handle.to_owned(), (path.to_owned(), write_through))
+                .is_none(),
+            "oracle handle names are unique"
+        );
+    }
+
+    fn close_handle(&mut self, handle: &str) {
+        assert!(
+            self.open_handles.remove(handle).is_some(),
+            "oracle closes only an open handle"
+        );
+    }
+
+    fn atomic_replace(
+        &mut self,
+        path: &str,
+        bytes: Vec<u8>,
+        handle: &str,
+        profile: DurabilityProfile,
+    ) {
+        let (_, write_through) = self
+            .open_handles
+            .get(handle)
+            .expect("atomic replacement retains its staging handle");
+        if profile == DurabilityProfile::WindowsNtfsWriteThrough {
+            assert!(
+                *write_through,
+                "NTFS replacement requires a write-through staging handle"
+            );
+        }
         let parent = parent_path(path);
         let temp = format!("{parent}/.oracle-tmp-{}", file_name(path));
         self.write_file(&temp, bytes.clone());
         self.fsync_file(&temp);
+        let durable_bytes = self
+            .durable_files
+            .remove(&temp)
+            .expect("atomic replacement temp was flushed");
         self.volatile_files.remove(&temp);
         self.unlink_volatile(&parent, file_name(&temp));
-        self.durable_files.remove(&temp);
-        // Flushed sibling proves data durability; the destination name remains
-        // volatile until the parent directory flush promotes it.
+        // The renamed file's bytes are durable, but the new name remains only
+        // visible until either the rename itself persists or the platform's
+        // later namespace barrier completes.
+        self.pending_replacements
+            .insert(path.to_owned(), durable_bytes);
         self.write_file(path, bytes);
+    }
+
+    fn persist_replacement(&mut self, path: &str) {
+        if let Some(bytes) = self.pending_replacements.remove(path) {
+            self.durable_files.insert(path.to_owned(), bytes);
+            self.link_durable_only(&parent_path(path), file_name(path));
+        }
     }
 
     fn fsync_dir(&mut self, path: &str) {
         let children = self.volatile_dirs.get(path).cloned().unwrap_or_default();
         self.durable_dirs.insert(path.to_owned(), children.clone());
-        // Directory flush makes currently linked children's volatile bytes
-        // durable when their content was already written.
-        for name in children {
+        // A namespace barrier persists directory edges and completed renames;
+        // it never substitutes for a file-content flush.
+        for name in &children {
             let child = if path == "." {
-                name
+                name.clone()
             } else {
                 format!("{path}/{name}")
             };
-            if let Some(bytes) = self.volatile_files.get(&child).cloned() {
-                self.durable_files.insert(child, bytes);
-            }
+            self.persist_replacement(&child);
         }
     }
 
@@ -413,18 +544,33 @@ impl Media {
         self.durable_files = kept_files;
         self.volatile_files = self.durable_files.clone();
         self.volatile_dirs = self.durable_dirs.clone();
+        self.pending_replacements.clear();
+        self.open_handles.clear();
     }
 
-    fn apply_subset(&mut self, ops: &[PersistenceOp], durable_ids: &BTreeSet<u64>) {
+    fn apply_subset(
+        &mut self,
+        ops: &[PersistenceOp],
+        durable_ids: &BTreeSet<u64>,
+        profile: DurabilityProfile,
+    ) {
         let mut scratch = Self {
             durable_files: self.durable_files.clone(),
             durable_dirs: self.durable_dirs.clone(),
             volatile_files: self.durable_files.clone(),
             volatile_dirs: self.durable_dirs.clone(),
+            pending_replacements: BTreeMap::new(),
+            open_handles: BTreeMap::new(),
         };
 
         for op in ops {
             match &op.kind {
+                PersistenceOpKind::OpenHandle {
+                    handle,
+                    path,
+                    write_through,
+                } => scratch.open_handle(handle, path, *write_through),
+                PersistenceOpKind::CloseHandle { handle } => scratch.close_handle(handle),
                 PersistenceOpKind::WriteFile { path, bytes } => {
                     scratch.write_file(path, bytes.clone());
                     if durable_ids.contains(&op.id) {
@@ -445,12 +591,14 @@ impl Media {
                         scratch.link_durable_only(&parent_path(path), file_name(path));
                     }
                 }
-                PersistenceOpKind::AtomicReplace { path, bytes } => {
+                PersistenceOpKind::AtomicReplace {
+                    path,
+                    bytes,
+                    handle,
+                } => {
+                    scratch.atomic_replace(path, bytes.clone(), handle, profile);
                     if durable_ids.contains(&op.id) {
-                        scratch.atomic_replace(path, bytes.clone());
-                        scratch.fsync_dir(&parent_path(path));
-                    } else {
-                        scratch.write_file(path, bytes.clone());
+                        scratch.persist_replacement(path);
                     }
                 }
                 PersistenceOpKind::FsyncDir { path } => {
@@ -472,13 +620,28 @@ impl Media {
 
 fn trace_op(op: &PersistenceOp) -> String {
     let kind = match &op.kind {
+        PersistenceOpKind::OpenHandle {
+            handle,
+            path,
+            write_through,
+        } => format!("open_handle handle={handle} path={path} write_through={write_through}"),
+        PersistenceOpKind::CloseHandle { handle } => {
+            format!("close_handle handle={handle}")
+        }
         PersistenceOpKind::WriteFile { path, bytes } => {
             format!("write_file path={path} len={}", bytes.len())
         }
         PersistenceOpKind::FsyncFile { path } => format!("fsync_file path={path}"),
         PersistenceOpKind::MkDir { path } => format!("mkdir path={path}"),
-        PersistenceOpKind::AtomicReplace { path, bytes } => {
-            format!("atomic_replace path={path} len={}", bytes.len())
+        PersistenceOpKind::AtomicReplace {
+            path,
+            bytes,
+            handle,
+        } => {
+            format!(
+                "atomic_replace path={path} handle={handle} len={}",
+                bytes.len()
+            )
         }
         PersistenceOpKind::FsyncDir { path } => format!("fsync_dir path={path}"),
         PersistenceOpKind::TearFile { path, bytes } => {
@@ -563,6 +726,17 @@ fn current_bytes_for(generation: Uuid, manifest_bytes: &[u8]) -> Vec<u8> {
 #[must_use]
 #[allow(clippy::too_many_lines)] // Phase-ordered durability script mirrors ADR vocabulary.
 pub fn publication_ops(ids: PublicationIds, until: PublicationPhase) -> Vec<PersistenceOp> {
+    publication_ops_for_profile(ids, until, DurabilityProfile::PosixDirectoryFsync)
+}
+
+/// Build a publication history using one admitted platform durability profile.
+#[must_use]
+#[allow(clippy::too_many_lines)] // Phase-ordered durability script mirrors ADR vocabulary.
+pub fn publication_ops_for_profile(
+    ids: PublicationIds,
+    until: PublicationPhase,
+    profile: DurabilityProfile,
+) -> Vec<PersistenceOp> {
     let mut ops = Vec::new();
     let mut next_id = 1u64;
     let mut push = |phase: PublicationPhase, kind: PersistenceOpKind| {
@@ -585,6 +759,7 @@ pub fn publication_ops(ids: PublicationIds, until: PublicationPhase) -> Vec<Pers
     let lease_path = format!("{GENERATIONS_DIR}/{neu}/{LEASE_FILE}");
     let journal_path = format!("transactions/{}.json", ids.transaction.hyphenated());
     let participant_bytes = b"graph:nodes".to_vec();
+    let write_through = profile == DurabilityProfile::WindowsNtfsWriteThrough;
 
     push(
         PublicationPhase::AfterParticipantWrite,
@@ -675,9 +850,24 @@ pub fn publication_ops(ids: PublicationIds, until: PublicationPhase) -> Vec<Pers
     );
     push(
         PublicationPhase::AfterJournalDurable,
+        PersistenceOpKind::OpenHandle {
+            handle: "journal_durable_stage".into(),
+            path: "transactions/.journal-durable.tmp".into(),
+            write_through,
+        },
+    );
+    push(
+        PublicationPhase::AfterJournalDurable,
         PersistenceOpKind::AtomicReplace {
             path: journal_path.clone(),
             bytes: b"{\"phase\":\"DURABLE\"}\n".to_vec(),
+            handle: "journal_durable_stage".into(),
+        },
+    );
+    push(
+        PublicationPhase::AfterJournalDurable,
+        PersistenceOpKind::CloseHandle {
+            handle: "journal_durable_stage".into(),
         },
     );
     push(
@@ -688,6 +878,14 @@ pub fn publication_ops(ids: PublicationIds, until: PublicationPhase) -> Vec<Pers
     );
 
     let current_bytes = current_bytes_for(ids.new_generation, &manifest_bytes);
+    push(
+        PublicationPhase::AfterCurrentTempWrite,
+        PersistenceOpKind::OpenHandle {
+            handle: "current_stage".into(),
+            path: ".CURRENT.tmp".into(),
+            write_through,
+        },
+    );
     push(
         PublicationPhase::AfterCurrentTempWrite,
         PersistenceOpKind::WriteFile {
@@ -707,17 +905,41 @@ pub fn publication_ops(ids: PublicationIds, until: PublicationPhase) -> Vec<Pers
         PersistenceOpKind::AtomicReplace {
             path: CURRENT_FILE.into(),
             bytes: current_bytes,
+            handle: "current_stage".into(),
         },
     );
     push(
-        PublicationPhase::AfterRootFsync,
-        PersistenceOpKind::FsyncDir { path: ".".into() },
+        PublicationPhase::AfterCurrentReplace,
+        PersistenceOpKind::CloseHandle {
+            handle: "current_stage".into(),
+        },
+    );
+    if profile == DurabilityProfile::PosixDirectoryFsync {
+        push(
+            PublicationPhase::AfterRootFsync,
+            PersistenceOpKind::FsyncDir { path: ".".into() },
+        );
+    }
+    push(
+        PublicationPhase::AfterJournalPublished,
+        PersistenceOpKind::OpenHandle {
+            handle: "journal_published_stage".into(),
+            path: "transactions/.journal-published.tmp".into(),
+            write_through,
+        },
     );
     push(
         PublicationPhase::AfterJournalPublished,
         PersistenceOpKind::AtomicReplace {
             path: journal_path,
             bytes: b"{\"phase\":\"PUBLISHED\"}\n".to_vec(),
+            handle: "journal_published_stage".into(),
+        },
+    );
+    push(
+        PublicationPhase::AfterJournalPublished,
+        PersistenceOpKind::CloseHandle {
+            handle: "journal_published_stage".into(),
         },
     );
     push(
@@ -778,7 +1000,6 @@ pub fn default_durable_ids(ops: &[PersistenceOp], phase: PublicationPhase) -> BT
                     | PersistenceOpKind::AtomicReplace { .. }
                     | PersistenceOpKind::MkDir { .. }
                     | PersistenceOpKind::TearFile { .. }
-                    | PersistenceOpKind::WriteFile { .. }
             ),
         })
         .map(|op| op.id)
@@ -819,7 +1040,25 @@ fn materialize_durable(media: &Media, root: &Path) -> Result<(), GfError> {
     }
 
     std::fs::create_dir_all(root).map_err(|error| io_err(&error))?;
-    let mut dirs: Vec<_> = media.durable_dirs.keys().cloned().collect();
+    let mut reachable_dirs = BTreeSet::from([".".to_owned()]);
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for dir in media.durable_dirs.keys() {
+            if dir == "." || reachable_dirs.contains(dir) {
+                continue;
+            }
+            let parent = parent_path(dir);
+            let linked = media
+                .durable_dirs
+                .get(&parent)
+                .is_some_and(|children| children.contains(file_name(dir)));
+            if reachable_dirs.contains(&parent) && linked {
+                changed |= reachable_dirs.insert(dir.clone());
+            }
+        }
+    }
+    let mut dirs = reachable_dirs.iter().cloned().collect::<Vec<_>>();
     dirs.sort_by_key(|path| path.matches('/').count());
     for dir in dirs {
         if dir == "." {
@@ -828,11 +1067,14 @@ fn materialize_durable(media: &Media, root: &Path) -> Result<(), GfError> {
         std::fs::create_dir_all(root.join(&dir)).map_err(|error| io_err(&error))?;
     }
     for (path, bytes) in &media.durable_files {
-        let full = root.join(path);
-        if let Some(parent) = full.parent() {
-            std::fs::create_dir_all(parent).map_err(|error| io_err(&error))?;
+        let parent = parent_path(path);
+        let linked = media
+            .durable_dirs
+            .get(&parent)
+            .is_some_and(|children| children.contains(file_name(path)));
+        if reachable_dirs.contains(&parent) && linked {
+            std::fs::write(root.join(path), bytes).map_err(|error| io_err(&error))?;
         }
-        std::fs::write(&full, bytes).map_err(|error| io_err(&error))?;
     }
     Ok(())
 }
@@ -864,7 +1106,6 @@ fn io_err(error: &std::io::Error) -> GfError {
 }
 
 fn expected_authority_for_subset(
-    phase: PublicationPhase,
     ops: &[PersistenceOp],
     durable_ids: &BTreeSet<u64>,
 ) -> AuthorityClass {
@@ -896,23 +1137,68 @@ fn expected_authority_for_subset(
     let replace_durable = current_replace.is_some_and(|op| durable_ids.contains(&op.id));
     let root_durable = root_fsync.is_some_and(|op| durable_ids.contains(&op.id));
 
-    if phase.is_acknowledged() {
-        if root_durable && replace_durable {
-            AuthorityClass::NewGeneration
-        } else if replace_durable {
-            // Linearized but not acknowledged: filesystem may still present new.
+    if replace_durable || root_durable {
+        let new_generation_complete = ops.iter().all(|op| {
+            if op.phase > PublicationPhase::AfterGenerationDirFsync {
+                return true;
+            }
+            match op.kind {
+                PersistenceOpKind::FsyncFile { .. } | PersistenceOpKind::FsyncDir { .. } => {
+                    durable_ids.contains(&op.id)
+                }
+                _ => true,
+            }
+        });
+        if new_generation_complete {
             AuthorityClass::NewGeneration
         } else {
-            AuthorityClass::PriorGeneration
-        }
-    } else if phase.is_linearized() {
-        if replace_durable {
-            AuthorityClass::NewGeneration
-        } else {
-            AuthorityClass::PriorGeneration
+            AuthorityClass::Corrupt
         }
     } else {
         AuthorityClass::PriorGeneration
+    }
+}
+
+fn acknowledged_for_subset(
+    profile: DurabilityProfile,
+    phase: PublicationPhase,
+    ops: &[PersistenceOp],
+    durable_ids: &BTreeSet<u64>,
+) -> bool {
+    let required_pre_ack_effects_complete = ops.iter().all(|op| match &op.kind {
+        PersistenceOpKind::FsyncFile { .. }
+        | PersistenceOpKind::FsyncDir { .. }
+        | PersistenceOpKind::MkDir { .. } => durable_ids.contains(&op.id),
+        PersistenceOpKind::OpenHandle { .. }
+        | PersistenceOpKind::CloseHandle { .. }
+        | PersistenceOpKind::WriteFile { .. }
+        | PersistenceOpKind::AtomicReplace { .. }
+        | PersistenceOpKind::TearFile { .. } => true,
+    });
+    if !required_pre_ack_effects_complete {
+        return false;
+    }
+    match profile {
+        DurabilityProfile::PosixDirectoryFsync => {
+            phase.is_acknowledged()
+                && ops.iter().any(|op| {
+                    durable_ids.contains(&op.id)
+                        && op.phase == PublicationPhase::AfterRootFsync
+                        && matches!(&op.kind, PersistenceOpKind::FsyncDir { path } if path == ".")
+                })
+        }
+        DurabilityProfile::WindowsNtfsWriteThrough => {
+            phase >= PublicationPhase::AfterCurrentReplace
+                && ops.iter().any(|op| {
+                    durable_ids.contains(&op.id)
+                        && op.phase == PublicationPhase::AfterCurrentReplace
+                        && matches!(
+                            &op.kind,
+                            PersistenceOpKind::AtomicReplace { path, .. }
+                                if path == CURRENT_FILE
+                        )
+                })
+        }
     }
 }
 
@@ -922,22 +1208,40 @@ pub fn simulate_crash(
     phase: PublicationPhase,
     durable_ids: &BTreeSet<u64>,
 ) -> Result<FaultOracleReport, GfError> {
+    simulate_crash_for_profile(
+        seed,
+        phase,
+        durable_ids,
+        DurabilityProfile::PosixDirectoryFsync,
+    )
+}
+
+/// Run one simulated crash under a specific admitted platform profile.
+pub fn simulate_crash_for_profile(
+    seed: u64,
+    phase: PublicationPhase,
+    durable_ids: &BTreeSet<u64>,
+    profile: DurabilityProfile,
+) -> Result<FaultOracleReport, GfError> {
     let ids = PublicationIds::from_seed(seed);
-    let ops = publication_ops(ids, phase);
+    let ops = publication_ops_for_profile(ids, phase, profile);
     let mut media = Media::default();
     install_parent_baseline(&mut media, ids);
-    media.apply_subset(&ops, durable_ids);
+    media.apply_subset(&ops, durable_ids, profile);
 
     let root = tempfile::tempdir().map_err(|error| io_err(&error))?;
     materialize_durable(&media, root.path())?;
     let resolved = resolve_project_generation(root.path());
     let actual = classify_resolution(&resolved, ids);
-    let expected = expected_authority_for_subset(phase, &ops, durable_ids);
+    let expected = expected_authority_for_subset(&ops, durable_ids);
 
     Ok(FaultOracleReport {
         seed,
         phase,
         failpoint: phase.failpoint(),
+        profile,
+        acknowledged: acknowledged_for_subset(profile, phase, &ops, durable_ids),
+        injected_result: None,
         durable_op_ids: durable_ids.iter().copied().collect(),
         expected,
         actual,
@@ -947,9 +1251,14 @@ pub fn simulate_crash(
 }
 
 /// Demonstrate that omitting the root directory flush violates acknowledgement.
+///
+/// Rename persistence is deliberately omitted from both cases. The only
+/// difference is whether the later root namespace barrier persists the already
+/// visible replacement, so this witness cannot accidentally treat rename as a
+/// directory flush.
 #[must_use]
 pub fn lost_root_flush_witness(seed: u64) -> (FaultOracleReport, FaultOracleReport) {
-    let phase = PublicationPhase::AfterCurrentReplace;
+    let phase = PublicationPhase::AfterRootFsync;
     let ids = PublicationIds::from_seed(seed);
     let ops = publication_ops(ids, phase);
     let replace_id = ops
@@ -963,19 +1272,20 @@ pub fn lost_root_flush_witness(seed: u64) -> (FaultOracleReport, FaultOracleRepo
         .map(|op| op.id)
         .expect("CURRENT replace op");
 
-    let mut with_replace = default_durable_ids(&ops, phase);
-    with_replace.insert(replace_id);
-    for op in &ops {
-        if matches!(&op.kind, PersistenceOpKind::FsyncDir { path } if path == ".") {
-            with_replace.remove(&op.id);
-        }
-    }
+    let root_fsync_id = ops
+        .iter()
+        .find(|op| matches!(&op.kind, PersistenceOpKind::FsyncDir { path } if path == "."))
+        .map(|op| op.id)
+        .expect("root fsync op");
 
-    let mut without_replace = with_replace.clone();
-    without_replace.remove(&replace_id);
+    let mut with_barrier = default_durable_ids(&ops, phase);
+    with_barrier.remove(&replace_id);
+    with_barrier.insert(root_fsync_id);
+    let mut without_barrier = with_barrier.clone();
+    without_barrier.remove(&root_fsync_id);
 
-    let kept = simulate_crash(seed, phase, &with_replace).expect("simulate");
-    let lost = simulate_crash(seed, phase, &without_replace).expect("simulate");
+    let kept = simulate_crash(seed, phase, &with_barrier).expect("simulate");
+    let lost = simulate_crash(seed, phase, &without_barrier).expect("simulate");
     (kept, lost)
 }
 
@@ -990,9 +1300,18 @@ pub enum TornTarget {
 
 /// Inject torn CURRENT or manifest bytes and classify reopen.
 pub fn simulate_torn_bytes(seed: u64, target: TornTarget) -> Result<FaultOracleReport, GfError> {
+    simulate_torn_bytes_for_profile(seed, target, DurabilityProfile::PosixDirectoryFsync)
+}
+
+/// Inject torn bytes under one admitted platform profile before API success.
+pub fn simulate_torn_bytes_for_profile(
+    seed: u64,
+    target: TornTarget,
+    profile: DurabilityProfile,
+) -> Result<FaultOracleReport, GfError> {
     let ids = PublicationIds::from_seed(seed);
-    let phase = PublicationPhase::AfterRootFsync;
-    let mut ops = publication_ops(ids, phase);
+    let phase = PublicationPhase::AfterCurrentReplace;
+    let mut ops = publication_ops_for_profile(ids, phase, profile);
     let next_id = ops.last().map_or(1, |op| op.id + 1);
     let path = match target {
         TornTarget::Current => CURRENT_FILE.to_owned(),
@@ -1015,7 +1334,7 @@ pub fn simulate_torn_bytes(seed: u64, target: TornTarget) -> Result<FaultOracleR
 
     let mut media = Media::default();
     install_parent_baseline(&mut media, ids);
-    media.apply_subset(&ops, &durable_ids);
+    media.apply_subset(&ops, &durable_ids, profile);
     let root = tempfile::tempdir().map_err(|error| io_err(&error))?;
     materialize_durable(&media, root.path())?;
     let resolved = resolve_project_generation(root.path());
@@ -1025,12 +1344,80 @@ pub fn simulate_torn_bytes(seed: u64, target: TornTarget) -> Result<FaultOracleR
         seed,
         phase,
         failpoint: phase.failpoint(),
+        profile,
+        acknowledged: false,
+        injected_result: Some(InjectedOperationResult::TornBytes),
         durable_op_ids: durable_ids.iter().copied().collect(),
         expected: AuthorityClass::Corrupt,
         actual,
         minimized_op_ids: None,
         operation_trace: ops.iter().map(trace_op).collect(),
     })
+}
+
+/// Inject a typed operation non-success and reconcile authority without ack.
+pub fn simulate_injected_operation(
+    seed: u64,
+    profile: DurabilityProfile,
+    injected: InjectedOperationResult,
+) -> Result<FaultOracleReport, GfError> {
+    assert_ne!(
+        injected,
+        InjectedOperationResult::TornBytes,
+        "use simulate_torn_bytes for byte corruption"
+    );
+    let phase = match injected {
+        InjectedOperationResult::FileFlushError => PublicationPhase::AfterManifestFsync,
+        InjectedOperationResult::NamespaceBarrierError => PublicationPhase::AfterRootFsync,
+        InjectedOperationResult::ReplacementNotPerformed
+        | InjectedOperationResult::ReplacementStateUnknownPrior
+        | InjectedOperationResult::ReplacementStateUnknownNew => {
+            PublicationPhase::AfterCurrentReplace
+        }
+        InjectedOperationResult::TornBytes => unreachable!(),
+    };
+    let ids = PublicationIds::from_seed(seed);
+    let ops = publication_ops_for_profile(ids, phase, profile);
+    let mut durable = default_durable_ids(&ops, phase);
+
+    match injected {
+        InjectedOperationResult::FileFlushError => {
+            let failed = ops
+                .iter()
+                .find(|op| {
+                    op.phase == PublicationPhase::AfterManifestFsync
+                        && matches!(op.kind, PersistenceOpKind::FsyncFile { .. })
+                })
+                .expect("manifest flush");
+            durable.remove(&failed.id);
+        }
+        InjectedOperationResult::NamespaceBarrierError => {
+            for op in &ops {
+                if op.phase == PublicationPhase::AfterRootFsync
+                    && matches!(op.kind, PersistenceOpKind::FsyncDir { .. })
+                {
+                    durable.remove(&op.id);
+                }
+            }
+        }
+        InjectedOperationResult::ReplacementNotPerformed
+        | InjectedOperationResult::ReplacementStateUnknownPrior => {
+            for op in &ops {
+                if op.phase == PublicationPhase::AfterCurrentReplace
+                    && matches!(op.kind, PersistenceOpKind::AtomicReplace { .. })
+                {
+                    durable.remove(&op.id);
+                }
+            }
+        }
+        InjectedOperationResult::ReplacementStateUnknownNew => {}
+        InjectedOperationResult::TornBytes => unreachable!(),
+    }
+
+    let mut report = simulate_crash_for_profile(seed, phase, &durable, profile)?;
+    report.acknowledged = false;
+    report.injected_result = Some(injected);
+    Ok(report)
 }
 
 /// Shrink a durable-id set to a minimal subset that preserves `predicate`.
@@ -1063,13 +1450,122 @@ pub fn minimize_durable_ids(
     current
 }
 
+/// Shrink an omitted-operation fault set while preserving `predicate`.
+///
+/// The default successful history remains fixed; only the specified persistence
+/// effects are removed. This avoids the vacuous empty-durable-set result that
+/// does not explain which omissions are required to reproduce a failure.
+#[must_use]
+pub fn minimize_omitted_ids(
+    seed: u64,
+    phase: PublicationPhase,
+    initial_omitted: &BTreeSet<u64>,
+    predicate: impl Fn(&FaultOracleReport) -> bool,
+) -> BTreeSet<u64> {
+    minimize_omitted_ids_for_profile(
+        seed,
+        phase,
+        initial_omitted,
+        DurabilityProfile::PosixDirectoryFsync,
+        predicate,
+    )
+}
+
+/// Shrink omissions under one admitted platform profile.
+#[must_use]
+pub fn minimize_omitted_ids_for_profile(
+    seed: u64,
+    phase: PublicationPhase,
+    initial_omitted: &BTreeSet<u64>,
+    profile: DurabilityProfile,
+    predicate: impl Fn(&FaultOracleReport) -> bool,
+) -> BTreeSet<u64> {
+    let ids = PublicationIds::from_seed(seed);
+    let ops = publication_ops_for_profile(ids, phase, profile);
+    let successful = default_durable_ids(&ops, phase);
+    let mut current = initial_omitted.clone();
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for id in current.iter().copied().collect::<Vec<_>>() {
+            let mut candidate = current.clone();
+            candidate.remove(&id);
+            let durable = successful
+                .difference(&candidate)
+                .copied()
+                .collect::<BTreeSet<_>>();
+            let Ok(report) = simulate_crash_for_profile(seed, phase, &durable, profile) else {
+                continue;
+            };
+            if predicate(&report) {
+                current = candidate;
+                changed = true;
+            }
+        }
+    }
+    current
+}
+
+/// Return a reproducing report carrying its stable, 1-minimal omitted trace.
+#[must_use]
+pub fn minimized_omission_report(
+    seed: u64,
+    phase: PublicationPhase,
+    initial_omitted: &BTreeSet<u64>,
+    predicate: impl Fn(&FaultOracleReport) -> bool + Copy,
+) -> FaultOracleReport {
+    minimized_omission_report_for_profile(
+        seed,
+        phase,
+        initial_omitted,
+        DurabilityProfile::PosixDirectoryFsync,
+        predicate,
+    )
+}
+
+/// Return a reproducing minimal omission report for one platform profile.
+#[must_use]
+pub fn minimized_omission_report_for_profile(
+    seed: u64,
+    phase: PublicationPhase,
+    initial_omitted: &BTreeSet<u64>,
+    profile: DurabilityProfile,
+    predicate: impl Fn(&FaultOracleReport) -> bool + Copy,
+) -> FaultOracleReport {
+    let omitted =
+        minimize_omitted_ids_for_profile(seed, phase, initial_omitted, profile, predicate);
+    let ids = PublicationIds::from_seed(seed);
+    let ops = publication_ops_for_profile(ids, phase, profile);
+    let successful = default_durable_ids(&ops, phase);
+    let durable = successful
+        .difference(&omitted)
+        .copied()
+        .collect::<BTreeSet<_>>();
+    let mut report = simulate_crash_for_profile(seed, phase, &durable, profile)
+        .expect("minimized oracle report");
+    assert!(predicate(&report), "minimized trace stopped reproducing");
+    report.minimized_op_ids = Some(omitted.iter().copied().collect());
+    report
+}
+
 /// Bounded CI history count; override with `GRAPHFORGE_FAULT_ORACLE_HISTORIES`.
 #[must_use]
 pub fn history_budget() -> usize {
-    std::env::var("GRAPHFORGE_FAULT_ORACLE_HISTORIES")
-        .ok()
-        .and_then(|value| value.parse().ok())
-        .unwrap_or(8)
+    parse_history_budget(
+        std::env::var("GRAPHFORGE_FAULT_ORACLE_HISTORIES")
+            .ok()
+            .as_deref(),
+    )
+}
+
+const DEFAULT_HISTORY_BUDGET: usize = 8;
+const MAX_HISTORY_BUDGET: usize = 4096;
+
+fn parse_history_budget(value: Option<&str>) -> usize {
+    value
+        .and_then(|candidate| candidate.parse::<usize>().ok())
+        .filter(|count| (1..=MAX_HISTORY_BUDGET).contains(count))
+        .unwrap_or(DEFAULT_HISTORY_BUDGET)
 }
 
 /// Seeded enumeration of pending CURRENT-entry persistence before acknowledgement.
@@ -1111,29 +1607,64 @@ pub fn enumerate_lost_root_flush_subsets(seed: u64) -> Vec<FaultOracleReport> {
     reports
 }
 
-/// Shared-boundary authority classes matching native subprocess-kill matrices.
-///
-/// Process kill after a returned rename observes the new `CURRENT`. The oracle
-/// default durable set mirrors that host-visibility model via
-/// [`expected_authority`]. Power-loss lost-flush subsets are certified
-/// separately and are not claimed to match process kill.
+/// Seed causally ordered pre-ack persistence subsets for bounded CI histories.
 #[must_use]
-pub fn native_shared_boundary_authority(phase: PublicationPhase) -> AuthorityClass {
-    expected_authority(phase)
+pub fn seed_pre_ack_persistence_subsets(seed: u64, count: usize) -> Vec<FaultOracleReport> {
+    let count = count.clamp(1, MAX_HISTORY_BUDGET);
+    let phase = PublicationPhase::AfterCurrentReplace;
+    let ids = PublicationIds::from_seed(seed);
+    let ops = publication_ops(ids, phase);
+    let candidates = ops
+        .iter()
+        .filter(|op| {
+            matches!(
+                op.kind,
+                PersistenceOpKind::FsyncFile { .. }
+                    | PersistenceOpKind::FsyncDir { .. }
+                    | PersistenceOpKind::AtomicReplace { .. }
+                    | PersistenceOpKind::MkDir { .. }
+            )
+        })
+        .map(|op| op.id)
+        .collect::<Vec<_>>();
+    let default = default_durable_ids(&ops, phase);
+    (0..count)
+        .map(|history| {
+            let mut state = seed ^ (history as u64).wrapping_mul(0x9e37_79b9_7f4a_7c15);
+            let mut durable = default.clone();
+            for id in &candidates {
+                state ^= state >> 12;
+                state ^= state << 25;
+                state ^= state >> 27;
+                if state.wrapping_mul(0x2545_f491_4f6c_dd1d) & 1 == 0 {
+                    durable.remove(id);
+                }
+            }
+            simulate_crash(seed ^ history as u64, phase, &durable).expect("seeded subset")
+        })
+        .collect()
 }
 
 /// Run default-durable simulations for every ADR publication phase.
 pub fn simulate_all_phases(seed: u64) -> Result<Vec<PhaseOutcome>, GfError> {
+    simulate_all_phases_for_profile(seed, DurabilityProfile::PosixDirectoryFsync)
+}
+
+/// Run every shared phase under one platform durability profile.
+pub fn simulate_all_phases_for_profile(
+    seed: u64,
+    profile: DurabilityProfile,
+) -> Result<Vec<PhaseOutcome>, GfError> {
     let ids = PublicationIds::from_seed(seed);
     let mut outcomes = Vec::new();
     for phase in PublicationPhase::all() {
-        let ops = publication_ops(ids, *phase);
+        let ops = publication_ops_for_profile(ids, *phase, profile);
         let durable = default_durable_ids(&ops, *phase);
-        let report = simulate_crash(seed, *phase, &durable)?;
+        let report = simulate_crash_for_profile(seed, *phase, &durable, profile)?;
         outcomes.push(PhaseOutcome {
             phase: *phase,
             failpoint: phase.failpoint(),
-            acknowledged: phase.is_acknowledged(),
+            acknowledged: report.acknowledged,
             expected: report.expected,
             actual: report.actual,
             selected_generation: match report.actual {
@@ -1183,8 +1714,8 @@ mod tests {
         let (kept, lost) = lost_root_flush_witness(0x7490);
         assert_eq!(kept.actual, AuthorityClass::NewGeneration);
         assert_eq!(lost.actual, AuthorityClass::PriorGeneration);
-        assert!(!PublicationPhase::AfterCurrentReplace.is_acknowledged());
-        assert!(PublicationPhase::AfterRootFsync.is_acknowledged());
+        assert!(kept.acknowledged);
+        assert!(!lost.acknowledged);
         assert_ne!(
             kept.actual, lost.actual,
             "root flush omission admits loss of the linearized CURRENT entry"
@@ -1206,21 +1737,33 @@ mod tests {
 
     #[test]
     fn torn_current_and_manifest_fail_closed() {
-        for target in [TornTarget::Current, TornTarget::Manifest] {
-            let report = simulate_torn_bytes(0x7491, target).expect("torn");
-            assert_eq!(report.expected, AuthorityClass::Corrupt);
-            assert_eq!(
-                report.actual,
-                AuthorityClass::Corrupt,
-                "torn bytes must surface GF_PROJECT_CORRUPT, not Unexpected"
-            );
+        for profile in [
+            DurabilityProfile::PosixDirectoryFsync,
+            DurabilityProfile::WindowsNtfsWriteThrough,
+        ] {
+            for target in [TornTarget::Current, TornTarget::Manifest] {
+                let report =
+                    simulate_torn_bytes_for_profile(0x7491, target, profile).expect("torn");
+                assert_eq!(report.profile, profile);
+                assert_eq!(report.expected, AuthorityClass::Corrupt);
+                assert!(!report.acknowledged);
+                assert_eq!(
+                    report.injected_result,
+                    Some(InjectedOperationResult::TornBytes)
+                );
+                assert_eq!(
+                    report.actual,
+                    AuthorityClass::Corrupt,
+                    "torn bytes must surface GF_PROJECT_CORRUPT, not Unexpected"
+                );
+            }
         }
     }
 
     #[test]
     fn generated_failures_shrink_to_stable_minimal_trace() {
         let seed = 0x7492;
-        let phase = PublicationPhase::AfterCurrentReplace;
+        let phase = PublicationPhase::AfterRootFsync;
         let ids = PublicationIds::from_seed(seed);
         let ops = publication_ops(ids, phase);
         let replace_id = ops
@@ -1233,39 +1776,50 @@ mod tests {
             })
             .map(|op| op.id)
             .unwrap();
-        let mut initial = default_durable_ids(&ops, phase);
-        for op in &ops {
-            if matches!(&op.kind, PersistenceOpKind::FsyncDir { path } if path == ".") {
-                initial.remove(&op.id);
-            }
-        }
-        initial.remove(&replace_id);
+        let root_fsync_id = ops
+            .iter()
+            .find(|op| matches!(&op.kind, PersistenceOpKind::FsyncDir { path } if path == "."))
+            .map(|op| op.id)
+            .unwrap();
+        let initial = BTreeSet::from([replace_id, root_fsync_id]);
 
-        let minimized = minimize_durable_ids(seed, phase, &initial, |report| {
+        let minimized_report = minimized_omission_report(seed, phase, &initial, |report| {
             report.actual == AuthorityClass::PriorGeneration
         });
-        let again = minimize_durable_ids(seed, phase, &minimized, |report| {
+        let minimized = minimized_report
+            .minimized_op_ids
+            .clone()
+            .expect("artifact records minimized omissions")
+            .into_iter()
+            .collect::<BTreeSet<_>>();
+        let again = minimize_omitted_ids(seed, phase, &minimized, |report| {
             report.actual == AuthorityClass::PriorGeneration
         });
         assert_eq!(minimized, again, "minimizer must be idempotent");
-        let report = simulate_crash(seed, phase, &minimized).unwrap();
+        assert_eq!(minimized, initial, "both namespace effects are required");
+        let successful = default_durable_ids(&ops, phase);
+        let durable = successful
+            .difference(&minimized)
+            .copied()
+            .collect::<BTreeSet<_>>();
+        let report = simulate_crash(seed, phase, &durable).unwrap();
         assert_eq!(report.actual, AuthorityClass::PriorGeneration);
-        assert!(
-            !minimized.contains(&replace_id),
-            "minimal prior-generation trace must omit durable CURRENT replace"
-        );
-    }
-
-    #[test]
-    fn native_and_simulated_results_agree_at_shared_phase_boundaries() {
-        for outcome in simulate_all_phases(0x7493).unwrap() {
-            let native = native_shared_boundary_authority(outcome.phase);
+        for omitted in &minimized {
+            let candidate = minimized
+                .iter()
+                .copied()
+                .filter(|id| id != omitted)
+                .collect::<BTreeSet<_>>();
+            let durable = successful
+                .difference(&candidate)
+                .copied()
+                .collect::<BTreeSet<_>>();
+            let report = simulate_crash(seed, phase, &durable).unwrap();
             assert_eq!(
-                outcome.actual, native,
-                "shared boundary mismatch at {}",
-                outcome.failpoint
+                report.actual,
+                AuthorityClass::NewGeneration,
+                "omission {omitted} was not necessary"
             );
-            assert_ne!(outcome.actual, AuthorityClass::Unexpected);
         }
     }
 
@@ -1278,7 +1832,7 @@ mod tests {
         let durable = default_durable_ids(&ops, phase);
         let report = simulate_crash(seed, phase, &durable).unwrap();
         assert_eq!(report.actual, AuthorityClass::NewGeneration);
-        assert!(phase.is_acknowledged());
+        assert!(report.acknowledged);
     }
 
     #[test]
@@ -1323,9 +1877,112 @@ mod tests {
         let report = simulate_crash(seed, phase, &durable).unwrap();
         assert_eq!(report.actual, AuthorityClass::NewGeneration);
         assert_eq!(report.expected, AuthorityClass::NewGeneration);
+        assert!(report.acknowledged);
         assert!(matches!(
             (report.expected, report.actual),
             (AuthorityClass::NewGeneration, AuthorityClass::NewGeneration)
         ));
+    }
+
+    #[test]
+    fn typed_operation_errors_reconcile_without_acknowledgement() {
+        for profile in [
+            DurabilityProfile::PosixDirectoryFsync,
+            DurabilityProfile::WindowsNtfsWriteThrough,
+        ] {
+            for injected in [
+                (InjectedOperationResult::FileFlushError),
+                (InjectedOperationResult::NamespaceBarrierError),
+                (InjectedOperationResult::ReplacementNotPerformed),
+                (InjectedOperationResult::ReplacementStateUnknownPrior),
+                (InjectedOperationResult::ReplacementStateUnknownNew),
+            ] {
+                let report = simulate_injected_operation(0x7496, profile, injected).unwrap();
+                let expected = match injected {
+                    InjectedOperationResult::NamespaceBarrierError
+                    | InjectedOperationResult::ReplacementStateUnknownNew => {
+                        AuthorityClass::NewGeneration
+                    }
+                    _ => AuthorityClass::PriorGeneration,
+                };
+                assert_eq!(report.injected_result, Some(injected));
+                assert!(!report.acknowledged);
+                assert_eq!(report.expected, expected);
+                assert_eq!(report.actual, expected);
+            }
+        }
+    }
+
+    #[test]
+    fn ntfs_profile_uses_write_through_handle_rename_as_acknowledgement() {
+        let profile = DurabilityProfile::WindowsNtfsWriteThrough;
+        let phase = PublicationPhase::AfterCurrentReplace;
+        let ids = PublicationIds::from_seed(0x7497);
+        let ops = publication_ops_for_profile(ids, phase, profile);
+        let durable = default_durable_ids(&ops, phase);
+        let report = simulate_crash_for_profile(0x7497, phase, &durable, profile).unwrap();
+        assert!(report.acknowledged);
+        assert_eq!(report.actual, AuthorityClass::NewGeneration);
+        assert!(report.operation_trace.iter().any(|line| {
+            line.contains("open_handle handle=current_stage") && line.contains("write_through=true")
+        }));
+        assert!(!ops.iter().any(|op| {
+            op.phase == PublicationPhase::AfterRootFsync
+                && matches!(op.kind, PersistenceOpKind::FsyncDir { .. })
+        }));
+    }
+
+    #[test]
+    fn bounded_seeded_subsets_never_select_an_unexpected_authority() {
+        let reports = seed_pre_ack_persistence_subsets(0x7498, history_budget());
+        assert_eq!(reports.len(), history_budget());
+        assert!(reports.iter().all(|report| {
+            matches!(
+                report.actual,
+                AuthorityClass::PriorGeneration
+                    | AuthorityClass::NewGeneration
+                    | AuthorityClass::Corrupt
+            ) && report.actual == report.expected
+                && !report.acknowledged
+        }));
+    }
+
+    #[test]
+    fn history_budget_is_positive_and_bounded() {
+        assert_eq!(parse_history_budget(None), DEFAULT_HISTORY_BUDGET);
+        assert_eq!(parse_history_budget(Some("0")), DEFAULT_HISTORY_BUDGET);
+        assert_eq!(parse_history_budget(Some("4096")), MAX_HISTORY_BUDGET);
+        assert_eq!(parse_history_budget(Some("4097")), DEFAULT_HISTORY_BUDGET);
+        assert_eq!(
+            parse_history_budget(Some("not-a-number")),
+            DEFAULT_HISTORY_BUDGET
+        );
+    }
+
+    #[test]
+    fn directory_fsync_never_promotes_unflushed_file_bytes() {
+        let mut media = Media::default();
+        media.mkdir(".");
+        media.fsync_dir(".");
+        media.write_file("unflushed", b"volatile".to_vec());
+        media.fsync_dir(".");
+        media.crash();
+        assert!(!media.durable_files.contains_key("unflushed"));
+    }
+
+    #[test]
+    fn materialization_does_not_recreate_unreachable_namespace_ancestors() {
+        let root = tempfile::tempdir().unwrap();
+        let media = Media {
+            durable_files: BTreeMap::from([("orphan/child/file".into(), b"bytes".to_vec())]),
+            durable_dirs: BTreeMap::from([
+                (".".into(), BTreeSet::new()),
+                ("orphan".into(), BTreeSet::from(["child".into()])),
+                ("orphan/child".into(), BTreeSet::from(["file".into()])),
+            ]),
+            ..Media::default()
+        };
+        materialize_durable(&media, root.path()).unwrap();
+        assert!(!root.path().join("orphan").exists());
     }
 }

--- a/crates/graphforge-storage/src/project_recovery.rs
+++ b/crates/graphforge-storage/src/project_recovery.rs
@@ -654,6 +654,25 @@ pub(crate) enum GenerationCleanupOutcome {
     Retained,
 }
 
+/// Probe `lease.lock` and release any acquired handle before returning.
+///
+/// Windows rejects renaming or deleting a directory while a descendant file
+/// handle is still live. Recovery already holds `writer.lock`; exclusive lease
+/// acquisition proves no live readers. The handle must not remain open across
+/// the trash rename.
+fn generation_lease_is_idle(generation_path: &Path) -> Result<bool, GfError> {
+    let lease_path = generation_path.join("lease.lock");
+    if !lease_path.exists() {
+        return Ok(true);
+    }
+    let lease = open_regular_lock(&lease_path)?;
+    if !crate::file_lock::try_lock_exclusive(&lease).map_err(storage_io)? {
+        return Ok(false);
+    }
+    crate::file_lock::unlock(&lease).map_err(storage_io)?;
+    Ok(true)
+}
+
 /// Move an unreachable generation to trash and delete it (ADR 0013 GC path).
 ///
 /// Rechecks reachability and `CURRENT` under the caller's writer lock before
@@ -684,16 +703,9 @@ pub(crate) fn cleanup_unreachable_generation(
         return Ok(GenerationCleanupOutcome::Absent);
     }
     reject_real_directory(&generation_path)?;
-    let lease_path = generation_path.join("lease.lock");
-    let _lease = if lease_path.exists() {
-        let lease = open_regular_lock(&lease_path)?;
-        if !crate::file_lock::try_lock_exclusive(&lease).map_err(storage_io)? {
-            return Ok(GenerationCleanupOutcome::SkippedLiveLease);
-        }
-        Some(lease)
-    } else {
-        None
-    };
+    if !generation_lease_is_idle(&generation_path)? {
+        return Ok(GenerationCleanupOutcome::SkippedLiveLease);
+    }
 
     let current = resolve_project_generation(root).map_err(map_recovery_resolution)?;
     if current.generation_uuid() == generation_uuid {
@@ -778,16 +790,9 @@ fn cleanup_abandoned_generation(
         return Ok(removed);
     }
     reject_real_directory(&generation_path)?;
-    let lease_path = generation_path.join("lease.lock");
-    let _lease = if lease_path.exists() {
-        let lease = open_regular_lock(&lease_path)?;
-        if !crate::file_lock::try_lock_exclusive(&lease).map_err(storage_io)? {
-            return Ok(0);
-        }
-        Some(lease)
-    } else {
-        None
-    };
+    if !generation_lease_is_idle(&generation_path)? {
+        return Ok(0);
+    }
 
     let current = resolve_project_generation(root).map_err(map_recovery_resolution)?;
     if current.generation_uuid() == generation_uuid {
@@ -1400,6 +1405,45 @@ mod tests {
             report.seed,
             report.observations.len(),
             digest
+        );
+    }
+
+    #[test]
+    fn recovery_gc_releases_generation_lease_before_directory_rename() {
+        let root = tempfile::tempdir().unwrap();
+        let parent = open_or_initialize_project(root.path())
+            .unwrap()
+            .generation_uuid();
+        let abandoned = Uuid::now_v7();
+        let status = spawn_writer(
+            root.path(),
+            Uuid::now_v7(),
+            abandoned,
+            "graph",
+            "project.after_manifest_write",
+        );
+        assert_eq!(status.code(), Some(crate::project_failpoint::exit_code()));
+        let generation_path = root
+            .path()
+            .join(GENERATIONS_DIR)
+            .join(abandoned.hyphenated().to_string());
+        assert!(
+            generation_path.join("lease.lock").exists(),
+            "after_manifest_write is the first publication boundary that creates lease.lock"
+        );
+
+        let report = recover_project_transactions(root.path()).unwrap();
+        assert_eq!(report.selected_generation_uuid, parent);
+        assert!(report.removed_generations >= 1);
+        assert!(
+            !generation_path.exists(),
+            "abandoned generation with lease.lock must be removable after the lease handle is released"
+        );
+        assert_eq!(
+            resolve_project_generation(root.path())
+                .unwrap()
+                .generation_uuid(),
+            parent
         );
     }
 

--- a/crates/graphforge-storage/src/project_recovery.rs
+++ b/crates/graphforge-storage/src/project_recovery.rs
@@ -967,12 +967,19 @@ pub(crate) fn recovery_corrupt(cause: &str) -> GfError {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
     use std::process::Command;
     use std::time::{Duration, Instant};
 
     use sha2::{Digest, Sha256};
 
     use super::*;
+    use crate::project_fault_oracle::{
+        AuthorityClass, DurabilityProfile, FaultOracleReport, InjectedOperationResult,
+        PersistenceOpKind, PublicationIds, PublicationPhase, TornTarget, default_durable_ids,
+        minimized_omission_report_for_profile, publication_ops_for_profile,
+        simulate_crash_for_profile, simulate_injected_operation, simulate_torn_bytes_for_profile,
+    };
     use crate::{
         ProjectCapability, ProjectGenerationRequest, ProjectParticipant,
         ProjectParticipantEncoding, ProjectStageOutcome, open_or_initialize_project,
@@ -983,6 +990,7 @@ mod tests {
     const WRITER_HELPER: &str = "project_recovery::tests::subprocess_publication_writer";
     const RECOVERY_HELPER: &str = "project_recovery::tests::subprocess_recovery_runner";
     const INITIALIZER_HELPER: &str = "project_recovery::tests::subprocess_initializer";
+    const NATIVE_ORACLE_SEED: u64 = 0x7493;
     const PRE_COMMIT_FAILPOINTS: &[&str] = &[
         "project.after_writer_lock",
         "project.after_journal_preparing",
@@ -1006,6 +1014,30 @@ mod tests {
         "project.after_root_fsync",
         "project.after_journal_published",
     ];
+
+    #[derive(serde::Serialize)]
+    struct NativeOracleObservation {
+        phase: PublicationPhase,
+        failpoint: &'static str,
+        child_exit_code: Option<i32>,
+        native: AuthorityClass,
+        simulated: AuthorityClass,
+        expected: AuthorityClass,
+        durable_op_ids: Vec<u64>,
+        operation_trace: Vec<String>,
+    }
+
+    #[derive(serde::Serialize)]
+    struct NativeOracleEvidence {
+        contract: &'static str,
+        platform: &'static str,
+        filesystem_class: String,
+        profile: DurabilityProfile,
+        seed: u64,
+        observations: Vec<NativeOracleObservation>,
+        modeled_faults: Vec<FaultOracleReport>,
+        minimized_failure: FaultOracleReport,
+    }
 
     fn wait_for_writer_lock_release(root: &Path) {
         let lock = open_regular_lock(&root.join(LOCKS_DIR).join(WRITER_LOCK_FILE)).unwrap();
@@ -1176,8 +1208,29 @@ mod tests {
         assert_eq!(second.aborted_journals, 0);
     }
 
+    fn classify_native_authority(root: &Path, parent: Uuid, generation: Uuid) -> AuthorityClass {
+        match resolve_project_generation(root) {
+            Ok(resolved) if resolved.generation_uuid() == parent => AuthorityClass::PriorGeneration,
+            Ok(resolved) if resolved.generation_uuid() == generation => {
+                AuthorityClass::NewGeneration
+            }
+            Err(error) if error.code() == "GF_PROJECT_CORRUPT" => AuthorityClass::Corrupt,
+            Ok(_) | Err(_) => AuthorityClass::Unexpected,
+        }
+    }
+
     #[test]
     fn subprocess_kill_matrix_never_exposes_a_partial_generation() {
+        let admission_parent = tempfile::tempdir().unwrap();
+        let evidence = crate::filesystem_admission::filesystem_durability_preflight(
+            admission_parent.path().join("native-oracle-project"),
+        )
+        .unwrap();
+        let profile = DurabilityProfile::for_admitted_filesystem_class(&evidence.filesystem_class)
+            .expect("admitted filesystem has an oracle profile");
+        assert_eq!(profile, DurabilityProfile::native());
+        let mut observed_phases = BTreeSet::new();
+        let mut observations = Vec::new();
         for (failpoint, committed) in PRE_COMMIT_FAILPOINTS
             .iter()
             .map(|name| (*name, false))
@@ -1201,6 +1254,45 @@ mod tests {
                 Some(crate::project_failpoint::exit_code()),
                 "{failpoint} did not terminate at the named boundary"
             );
+            if let Some(phase) = PublicationPhase::from_failpoint(failpoint) {
+                assert!(
+                    observed_phases.insert(phase),
+                    "native matrix repeated modeled phase {failpoint}"
+                );
+                let native = classify_native_authority(root.path(), parent, generation_uuid);
+                let ids = PublicationIds::from_seed(NATIVE_ORACLE_SEED);
+                let ops = publication_ops_for_profile(ids, phase, profile);
+                let durable = default_durable_ids(&ops, phase);
+                let simulated =
+                    simulate_crash_for_profile(NATIVE_ORACLE_SEED, phase, &durable, profile)
+                        .unwrap();
+
+                eprintln!(
+                    "native_oracle_crosscheck platform={} seed={} phase={} native={native:?} simulated={:?}",
+                    std::env::consts::OS,
+                    NATIVE_ORACLE_SEED,
+                    phase.failpoint(),
+                    simulated.actual,
+                );
+                assert_eq!(
+                    native, simulated.actual,
+                    "native process-kill result disagreed with simulator at {failpoint}"
+                );
+                assert_eq!(
+                    simulated.actual, simulated.expected,
+                    "simulator disagreed with its contract at {failpoint}"
+                );
+                observations.push(NativeOracleObservation {
+                    phase,
+                    failpoint: phase.failpoint(),
+                    child_exit_code: status.code(),
+                    native,
+                    simulated: simulated.actual,
+                    expected: simulated.expected,
+                    durable_op_ids: simulated.durable_op_ids,
+                    operation_trace: simulated.operation_trace,
+                });
+            }
             assert_reopen(
                 root.path(),
                 if committed { generation_uuid } else { parent },
@@ -1208,6 +1300,107 @@ mod tests {
                 committed,
             );
         }
+        let expected_phases = PublicationPhase::all()
+            .iter()
+            .copied()
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            observed_phases, expected_phases,
+            "native matrix must cover every shared oracle phase exactly once"
+        );
+        let modeled_faults = [
+            InjectedOperationResult::FileFlushError,
+            InjectedOperationResult::NamespaceBarrierError,
+            InjectedOperationResult::ReplacementNotPerformed,
+            InjectedOperationResult::ReplacementStateUnknownPrior,
+            InjectedOperationResult::ReplacementStateUnknownNew,
+        ]
+        .into_iter()
+        .map(|injected| simulate_injected_operation(NATIVE_ORACLE_SEED, profile, injected).unwrap())
+        .chain([
+            simulate_torn_bytes_for_profile(NATIVE_ORACLE_SEED, TornTarget::Current, profile)
+                .unwrap(),
+            simulate_torn_bytes_for_profile(NATIVE_ORACLE_SEED, TornTarget::Manifest, profile)
+                .unwrap(),
+        ])
+        .collect::<Vec<_>>();
+        assert!(modeled_faults.iter().all(|fault| {
+            !fault.acknowledged
+                && fault.actual == fault.expected
+                && fault.actual != AuthorityClass::Unexpected
+        }));
+
+        let minimize_phase = PublicationPhase::AfterRootFsync;
+        let minimize_ids = PublicationIds::from_seed(NATIVE_ORACLE_SEED);
+        let minimize_ops = publication_ops_for_profile(minimize_ids, minimize_phase, profile);
+        let current_replace_id = minimize_ops
+            .iter()
+            .find(|op| {
+                matches!(
+                    &op.kind,
+                    PersistenceOpKind::AtomicReplace { path, .. } if path == CURRENT_FILE
+                )
+            })
+            .map(|op| op.id)
+            .unwrap();
+        let mut initial_omissions = BTreeSet::from([current_replace_id]);
+        if let Some(root_fsync_id) = minimize_ops
+            .iter()
+            .find(|op| matches!(&op.kind, PersistenceOpKind::FsyncDir { path } if path == "."))
+            .map(|op| op.id)
+        {
+            initial_omissions.insert(root_fsync_id);
+        }
+        let minimized_failure = minimized_omission_report_for_profile(
+            NATIVE_ORACLE_SEED,
+            minimize_phase,
+            &initial_omissions,
+            profile,
+            |fault| fault.actual == AuthorityClass::PriorGeneration,
+        );
+        assert_eq!(
+            minimized_failure.minimized_op_ids.as_ref().map(Vec::len),
+            Some(initial_omissions.len())
+        );
+
+        let report = NativeOracleEvidence {
+            contract: "graphforge-native-durability-oracle/v1",
+            platform: std::env::consts::OS,
+            filesystem_class: evidence.filesystem_class,
+            profile,
+            seed: NATIVE_ORACLE_SEED,
+            observations,
+            modeled_faults,
+            minimized_failure,
+        };
+        let encoded = serde_json::to_vec_pretty(&report).unwrap();
+        let output_path = std::env::var_os("GRAPHFORGE_NATIVE_ORACLE_EVIDENCE")
+            .map(PathBuf::from)
+            .or_else(|| {
+                std::env::var_os("TEST_UNDECLARED_OUTPUTS_DIR").map(|directory| {
+                    PathBuf::from(directory)
+                        .join(format!("native-oracle-{}.json", std::env::consts::OS))
+                })
+            });
+        if let Some(path) = output_path {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            std::fs::write(path, &encoded).unwrap();
+        }
+        let digest = Sha256::digest(&encoded)
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+        eprintln!(
+            "native_oracle_evidence contract={} platform={} filesystem_class={} seed={} phases={} sha256={}",
+            report.contract,
+            report.platform,
+            report.filesystem_class,
+            report.seed,
+            report.observations.len(),
+            digest
+        );
     }
 
     #[test]
@@ -1322,10 +1515,17 @@ mod tests {
 
     #[test]
     fn injected_operation_errors_report_exact_commit_state() {
+        let admission_parent = tempfile::tempdir().unwrap();
+        let evidence = crate::filesystem_admission::filesystem_durability_preflight(
+            admission_parent.path().join("native-error-oracle-project"),
+        )
+        .unwrap();
+        let profile = DurabilityProfile::for_admitted_filesystem_class(&evidence.filesystem_class)
+            .expect("admitted filesystem has an oracle profile");
         for failpoint in PRE_COMMIT_FAILPOINTS
             .iter()
             .copied()
-            .chain(std::iter::once("project.after_current_replace"))
+            .chain(POST_COMMIT_FAILPOINTS.iter().copied())
         {
             let root = tempfile::tempdir().unwrap();
             let parent = open_or_initialize_project(root.path())
@@ -1341,7 +1541,25 @@ mod tests {
                 &format!("{failpoint}.error"),
             );
             assert!(status.success(), "{failpoint}.error helper failed");
-            let committed = failpoint == "project.after_current_replace";
+            let committed = POST_COMMIT_FAILPOINTS.contains(&failpoint);
+            let native = classify_native_authority(root.path(), parent, generation_uuid);
+            let injected = match failpoint {
+                "project.after_current_replace" => {
+                    InjectedOperationResult::ReplacementStateUnknownNew
+                }
+                "project.after_root_fsync" | "project.after_journal_published" => {
+                    InjectedOperationResult::NamespaceBarrierError
+                }
+                _ => InjectedOperationResult::FileFlushError,
+            };
+            let simulated =
+                simulate_injected_operation(NATIVE_ORACLE_SEED, profile, injected).unwrap();
+            assert!(!simulated.acknowledged);
+            assert_eq!(simulated.actual, simulated.expected);
+            assert_eq!(
+                native, simulated.actual,
+                "native reconciliation disagreed with {injected:?} at {failpoint}"
+            );
             assert_reopen(
                 root.path(),
                 if committed { generation_uuid } else { parent },
@@ -1833,15 +2051,14 @@ mod tests {
         })();
         let error = result.expect_err("configured failpoint did not fire");
         assert_eq!(error.code(), "GF_PUBLICATION_FAILED");
-        assert!(
-            error
-                .to_string()
-                .contains(if active == "project.after_current_replace.error" {
-                    "committed=true"
-                } else {
-                    "committed=false"
-                })
-        );
+        let committed = active
+            .strip_suffix(".error")
+            .is_some_and(|failpoint| POST_COMMIT_FAILPOINTS.contains(&failpoint));
+        assert!(error.to_string().contains(if committed {
+            "committed=true"
+        } else {
+            "committed=false"
+        }));
     }
 
     #[test]

--- a/docs/engineering/TESTING.md
+++ b/docs/engineering/TESTING.md
@@ -132,8 +132,9 @@ parity mismatches reject the candidate. It does not tag or publish.
 
 **Windows posture:** the Windows Python lane proves user-facing use of the
 installed abi3 wheel (build → clean-install → native contracts). It is **not** a
-second MSVC `cargo test` of the full Rust workspace. Windows project-root lock
-unit tests are hosted by Test Suite `Windows graphforge-storage Locks`, not Binding RC.
+second MSVC `cargo test` of the full Rust workspace. Windows project-root lock,
+filesystem admission/primitive, and publication-kill fault-oracle cross-checks
+are hosted by Test Suite `Windows graphforge-storage Locks`, not Binding RC.
 Do not treat “wheel contracts green” as “every Rust unit test ran under MSVC.”
 
 ### Non-Cypher surface and other publication gates

--- a/scripts/ci/test-binding-release-candidate.py
+++ b/scripts/ci/test-binding-release-candidate.py
@@ -155,6 +155,75 @@ STORAGE_ADMISSION_COMMAND = (
     "cargo test -p graphforge-storage filesystem_admission::tests:: --lib --no-fail-fast"
 )
 FILESYSTEM_COMMAND = "cargo test -p graphforge-filesystem --lib --no-fail-fast"
+NATIVE_ORACLE_CROSSCHECK_COMMAND = (
+    "cargo test -p graphforge-storage --features test-failpoints --lib "
+    "project_recovery::tests::subprocess_kill_matrix_never_exposes_a_partial_generation "
+    "--no-fail-fast -- --exact --nocapture"
+)
+INJECTED_OPERATION_ERROR_COMMAND = (
+    "cargo test -p graphforge-storage --features test-failpoints --lib "
+    "project_recovery::tests::injected_operation_errors_report_exact_commit_state "
+    "--no-fail-fast -- --exact --nocapture"
+)
+COMMIT_LOCK_CLONED_DESCRIPTOR_COMMAND = (
+    "cargo test -p graphforge-storage --lib "
+    "project_publication::tests::commit_lock_guard_unlocks_before_a_cloned_descriptor_closes "
+    "--no-fail-fast -- --exact --nocapture"
+)
+CHECKPOINT_LOCK_CLONED_DESCRIPTOR_COMMAND = (
+    "cargo test -p graphforge-storage --lib "
+    "project_checkpoints::tests::checkpoint_read_guard_unlocks_before_a_cloned_descriptor_closes "
+    "--no-fail-fast -- --exact --nocapture"
+)
+WINDOWS_OPTIMISTIC_PROMOTION_COMMAND = (
+    "cargo test -p graphforge-storage --lib "
+    "project_publication::tests::"
+    "optimistic_promotion_closes_staged_handles_before_directory_rename "
+    "--no-fail-fast -- --exact --nocapture"
+)
+UPLOAD_ARTIFACT_ACTION = "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1"
+NATIVE_ORACLE_EVIDENCE_ENV = "GRAPHFORGE_NATIVE_ORACLE_EVIDENCE"
+WINDOWS_NATIVE_ORACLE_EVIDENCE = (
+    "${{ runner.temp }}/durability-certification-evidence/native-oracle-windows.json"
+)
+MACOS_NATIVE_ORACLE_EVIDENCE = (
+    "${{ runner.temp }}/durability-certification-evidence/native-oracle-macos.json"
+)
+NATIVE_ORACLE_ARTIFACT_PATH = "${{ runner.temp }}/durability-certification-evidence"
+
+
+def validate_native_oracle_artifact(
+    job_body: str,
+    *,
+    platform_name: str,
+    evidence_path: str,
+) -> None:
+    """Require active evidence output and a pinned, fail-closed artifact upload."""
+    oracle_step = workflow_step(
+        job_body,
+        "project_recovery::tests::subprocess_kill_matrix_never_exposes_a_partial_generation",
+    )
+    assert_active_lines(
+        oracle_step,
+        f"{NATIVE_ORACLE_EVIDENCE_ENV}: {evidence_path}",
+    )
+    assert oracle_step.count(NATIVE_ORACLE_EVIDENCE_ENV) == 1
+
+    upload_name = f"Upload {platform_name} native oracle evidence"
+    assert job_body.count(upload_name) == 1
+    upload_step = workflow_step(job_body, upload_name)
+    artifact_slug = platform_name.lower()
+    assert_active_lines(
+        upload_step,
+        f"- name: {upload_name}",
+        "if: always()",
+        f"uses: {UPLOAD_ARTIFACT_ACTION}",
+        f"name: native-oracle-{artifact_slug}-${{{{ github.sha }}}}",
+        f"path: {NATIVE_ORACLE_ARTIFACT_PATH}",
+        "if-no-files-found: error",
+        "retention-days: 1",
+    )
+    assert "continue-on-error" not in upload_step
 
 
 def validate_native_test_workflow(workflow_text: str) -> None:
@@ -169,7 +238,22 @@ def validate_native_test_workflow(workflow_text: str) -> None:
         assert job_scalar(body, "if") == "needs.changes.outputs.rust == 'true'"
         assert job_runs_exact(body, STORAGE_ADMISSION_COMMAND)
         assert job_runs_exact(body, FILESYSTEM_COMMAND)
+        assert job_runs_exact(body, NATIVE_ORACLE_CROSSCHECK_COMMAND)
+        assert job_runs_exact(body, INJECTED_OPERATION_ERROR_COMMAND)
+        assert job_runs_exact(body, COMMIT_LOCK_CLONED_DESCRIPTOR_COMMAND)
+        assert job_runs_exact(body, CHECKPOINT_LOCK_CLONED_DESCRIPTOR_COMMAND)
     assert job_runs_exact(windows, WINDOWS_PROJECT_LOCK_COMMAND)
+    assert job_runs_exact(windows, WINDOWS_OPTIMISTIC_PROMOTION_COMMAND)
+    validate_native_oracle_artifact(
+        windows,
+        platform_name="Windows",
+        evidence_path=WINDOWS_NATIVE_ORACLE_EVIDENCE,
+    )
+    validate_native_oracle_artifact(
+        macos,
+        platform_name="macOS",
+        evidence_path=MACOS_NATIVE_ORACLE_EVIDENCE,
+    )
 
     gate = jobs["ci-gate"]
     assert {WINDOWS_DURABILITY_JOB, MACOS_DURABILITY_JOB} <= job_needs(gate)
@@ -198,6 +282,27 @@ def validate_native_workflow_negative_fixtures() -> None:
           {STORAGE_ADMISSION_COMMAND}
       - run: >-
           {FILESYSTEM_COMMAND}
+      - name: Cross-check Windows publication-kill results against the fault oracle
+        env:
+          {NATIVE_ORACLE_EVIDENCE_ENV}: {WINDOWS_NATIVE_ORACLE_EVIDENCE}
+        run: >-
+          {NATIVE_ORACLE_CROSSCHECK_COMMAND}
+      - name: Upload Windows native oracle evidence
+        if: always()
+        uses: {UPLOAD_ARTIFACT_ACTION}
+        with:
+          name: native-oracle-windows-${{{{ github.sha }}}}
+          path: {NATIVE_ORACLE_ARTIFACT_PATH}
+          if-no-files-found: error
+          retention-days: 1
+      - run: >-
+          {INJECTED_OPERATION_ERROR_COMMAND}
+      - run: >-
+          {COMMIT_LOCK_CLONED_DESCRIPTOR_COMMAND}
+      - run: >-
+          {CHECKPOINT_LOCK_CLONED_DESCRIPTOR_COMMAND}
+      - run: >-
+          {WINDOWS_OPTIMISTIC_PROMOTION_COMMAND}
   {MACOS_DURABILITY_JOB}:
     runs-on: {MACOS_RUNNER}
     needs: changes
@@ -207,6 +312,25 @@ def validate_native_workflow_negative_fixtures() -> None:
           {STORAGE_ADMISSION_COMMAND}
       - run: >-
           {FILESYSTEM_COMMAND}
+      - name: Cross-check macOS publication-kill results against the fault oracle
+        env:
+          {NATIVE_ORACLE_EVIDENCE_ENV}: {MACOS_NATIVE_ORACLE_EVIDENCE}
+        run: >-
+          {NATIVE_ORACLE_CROSSCHECK_COMMAND}
+      - name: Upload macOS native oracle evidence
+        if: always()
+        uses: {UPLOAD_ARTIFACT_ACTION}
+        with:
+          name: native-oracle-macos-${{{{ github.sha }}}}
+          path: {NATIVE_ORACLE_ARTIFACT_PATH}
+          if-no-files-found: error
+          retention-days: 1
+      - run: >-
+          {INJECTED_OPERATION_ERROR_COMMAND}
+      - run: >-
+          {COMMIT_LOCK_CLONED_DESCRIPTOR_COMMAND}
+      - run: >-
+          {CHECKPOINT_LOCK_CLONED_DESCRIPTOR_COMMAND}
   ci-gate:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs:
@@ -240,6 +364,55 @@ def validate_native_workflow_negative_fixtures() -> None:
         fixture.replace(
             f"          {STORAGE_ADMISSION_COMMAND}",
             f'          echo "{STORAGE_ADMISSION_COMMAND}"',
+            1,
+        ),
+        fixture.replace(
+            f"          {NATIVE_ORACLE_CROSSCHECK_COMMAND}",
+            f'          echo "{NATIVE_ORACLE_CROSSCHECK_COMMAND}"',
+            1,
+        ),
+        fixture.replace(
+            f"          {INJECTED_OPERATION_ERROR_COMMAND}",
+            f'          echo "{INJECTED_OPERATION_ERROR_COMMAND}"',
+            1,
+        ),
+        fixture.replace(
+            f"          {COMMIT_LOCK_CLONED_DESCRIPTOR_COMMAND}",
+            f'          echo "{COMMIT_LOCK_CLONED_DESCRIPTOR_COMMAND}"',
+            1,
+        ),
+        fixture.replace(
+            f"          {CHECKPOINT_LOCK_CLONED_DESCRIPTOR_COMMAND}",
+            f'          echo "{CHECKPOINT_LOCK_CLONED_DESCRIPTOR_COMMAND}"',
+            1,
+        ),
+        fixture.replace(
+            f"          {WINDOWS_OPTIMISTIC_PROMOTION_COMMAND}",
+            f'          echo "{WINDOWS_OPTIMISTIC_PROMOTION_COMMAND}"',
+            1,
+        ),
+        fixture.replace(
+            f"          {NATIVE_ORACLE_EVIDENCE_ENV}: {WINDOWS_NATIVE_ORACLE_EVIDENCE}",
+            f"          # {NATIVE_ORACLE_EVIDENCE_ENV}: {WINDOWS_NATIVE_ORACLE_EVIDENCE}",
+            1,
+        ),
+        fixture.replace(
+            f"          path: {NATIVE_ORACLE_ARTIFACT_PATH}",
+            "          path: wrong-native-oracle-evidence.json",
+            1,
+        ),
+        fixture.replace(
+            f"        uses: {UPLOAD_ARTIFACT_ACTION}",
+            "        uses: actions/upload-artifact@unapproved # wrong",
+            1,
+        ),
+        fixture.replace("        if: always()", "        if: false", 1),
+        fixture.replace(
+            "          if-no-files-found: error", "          if-no-files-found: warn", 1
+        ),
+        fixture.replace(
+            "      - name: Upload macOS native oracle evidence",
+            "      # - name: Upload macOS native oracle evidence",
             1,
         ),
         fixture.replace(

--- a/scripts/ci/test-ci-storage-policy.py
+++ b/scripts/ci/test-ci-storage-policy.py
@@ -93,6 +93,8 @@ EXPECTED_ARTIFACT_UPLOADS = Counter(
         "cargo-bazel-parity-evidence-${{ github.run_id }}": 1,
         "bazel-cache-perf-evidence-${{ github.run_id }}": 1,
         "durability-certification-evidence-${{ github.sha }}": 1,
+        "native-oracle-windows-${{ github.sha }}": 1,
+        "native-oracle-macos-${{ github.sha }}": 1,
     }
 )
 EXPECTED_ARTIFACT_DOWNLOADS = Counter(

--- a/tests/contracts/durability-isolation-matrix.json
+++ b/tests/contracts/durability-isolation-matrix.json
@@ -748,11 +748,6 @@
         },
         {
           "kind": "rust",
-          "path": "crates/graphforge-api/src/durability_certification_tests.rs",
-          "symbol": "native_shared_boundaries_agree_with_oracle_authority"
-        },
-        {
-          "kind": "rust",
           "path": "crates/graphforge-storage/src/project_recovery.rs",
           "symbol": "subprocess_kill_matrix_never_exposes_a_partial_generation"
         },


### PR DESCRIPTION
## Summary

- separate durable file content, namespace visibility, and namespace persistence in the deterministic fault oracle
- model POSIX directory-fsync and Windows NTFS write-through handle-rename acknowledgement independently
- cover bounded persistence subsets, torn metadata, typed flush/barrier/replacement errors, handle lifetime, restart, and stable minimized omission traces
- compare real native publication-kill and injected-error outcomes with the profile-matched oracle at every shared phase
- upload safe, structured Windows/macOS native evidence and enforce the workflow shape structurally
- remove the prior expected-vs-expected pseudo-native checks and reuse the oracle from admission, recovery, delta, compaction, and final certification

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p graphforge-storage --lib --features test-failpoints -- -D warnings`
- `cargo clippy -p graphforge-api --lib -- -D warnings`
- `cargo test -p graphforge-storage project_fault_oracle::tests:: --lib --features test-failpoints --no-fail-fast` (14 passed)
- exact native macOS publication-kill/oracle matrix (13/13 phases, APFS artifact emitted and validated)
- exact native injected-error reconciliation/oracle matrix (all PRE_COMMIT and POST_COMMIT boundaries)
- exact admission/profile, cloned-descriptor, and optimistic-promotion handle tests
- `cargo test -p graphforge-api durability_certification_tests --lib` (2 passed)
- durability-isolation, workflow-structure, CI artifact-policy, and policy-classifier tests
- `make pre-push-fast`

Hosted Windows NTFS and authoritative Linux Bazel evidence remain required at the exact PR head.

Closes #749

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789525554&installation_model_id=20486&pr_number=790&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F790&signature=8723923d6ad13a1b50233a73dff270b3461ad1c38b89147cb7abcbf451c537d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery cleanup by releasing generation locks before removing or renaming directories.
  * Strengthened durability handling across POSIX and Windows environments, including crash, write, and publication failure scenarios.
  * Ensured incomplete or corrupted persistence states fail safely or reconcile correctly without false acknowledgement.

* **Tests**
  * Expanded durability, recovery, lease-handling, and fault-injection coverage.
  * Added validation of native durability evidence and required platform-specific CI artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->