### PR TITLE
feat(io): stream query results atomically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2164,6 +2164,7 @@ dependencies = [
  "graphforge-core",
  "graphforge-cypher",
  "graphforge-exec",
+ "graphforge-io",
  "graphforge-ir",
  "graphforge-knowledge",
  "graphforge-ontology",
@@ -2296,8 +2297,10 @@ dependencies = [
 name = "graphforge-io"
 version = "0.5.2"
 dependencies = [
- "graphforge-core",
- "graphforge-storage",
+ "arrow",
+ "futures",
+ "parquet",
+ "tempfile",
  "thiserror 2.0.20",
 ]
 

--- a/crates/graphforge-api/BUILD.bazel
+++ b/crates/graphforge-api/BUILD.bazel
@@ -23,6 +23,7 @@ _API_DEPS = [
     "//crates/graphforge-cypher:graphforge_cypher",
     "//crates/graphforge-exec:graphforge_exec",
     "//crates/graphforge-ir:graphforge_ir",
+    "//crates/graphforge-io:graphforge_io",
     "//crates/graphforge-knowledge:graphforge_knowledge",
     "//crates/graphforge-ontology:graphforge_ontology",
     "//crates/graphforge-provenance:graphforge_provenance",

--- a/crates/graphforge-api/Cargo.toml
+++ b/crates/graphforge-api/Cargo.toml
@@ -17,6 +17,7 @@ graphforge-cypher = { version = "0.5.2", path = "../graphforge-cypher" }
 graphforge-rel = { version = "0.5.2", path = "../graphforge-rel" }
 graphforge-storage = { version = "0.5.2", path = "../graphforge-storage" }
 graphforge-exec = { version = "0.5.2", path = "../graphforge-exec" }
+graphforge-io = { version = "0.5.2", path = "../graphforge-io" }
 graphforge-search = { version = "0.5.2", path = "../graphforge-search" }
 arrow = { workspace = true }
 datafusion = { workspace = true }

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -29,6 +29,9 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use arrow::datatypes::SchemaRef;
 use graphforge_core::{GraphIdentity, TypeId};
+pub use graphforge_io::{
+    ResultSinkFormat, ResultSinkOptions, ResultSinkProgress, ResultSinkReceipt,
+};
 use graphforge_ir::{
     BindError, Binder, GraphOp, GraphPlan, IrExpr, ProcedureRegistry, RuntimeCatalog,
 };
@@ -2898,12 +2901,9 @@ impl GraphForge {
 
     /// Execute `cypher` and write the result to a Parquet file at `path`.
     ///
-    /// A thin sink over [`execute`](Self::execute): the result batches are
-    /// written with a single Arrow Parquet writer (the schema — including its
-    /// `graphforge.*` metadata — is preserved; a zero-row result writes a valid
-    /// schema-only file). The write is **atomic**: batches are written to a
-    /// sibling temp file that is renamed onto `path` only after a clean close, so
-    /// a mid-write failure never leaves a torn file at the destination.
+    /// This compatibility wrapper uses the bounded streaming sink with default
+    /// limits. The write is atomic: a sibling temporary file is published only
+    /// after execution, writer finalization, and file sync all succeed.
     ///
     /// # Errors
     /// Propagates any [`execute`](Self::execute) error, or [`GfError::Storage`]
@@ -2923,50 +2923,91 @@ impl GraphForge {
         params: &HashMap<String, IrLiteral>,
         path: &str,
     ) -> Result<(), GfError> {
-        let result = self.execute_with_params(cypher, params)?;
-        let dest = std::path::Path::new(path);
-        let parent = dest
-            .parent()
-            .filter(|p| !p.as_os_str().is_empty())
-            .map_or_else(
-                || std::path::PathBuf::from("."),
-                std::path::Path::to_path_buf,
-            );
-        let tmp = tempfile::NamedTempFile::new_in(&parent)
-            .map_err(|e| GfError::Storage(format!("create temp for {path}: {e}")))?;
-        {
-            // `&File: Write`, so the writer borrows the temp file and `tmp` stays
-            // owned for the atomic persist below.
-            let mut parquet_metadata = result
-                .schema
-                .metadata()
-                .iter()
-                .map(|(key, value)| {
-                    parquet::file::metadata::KeyValue::new(key.clone(), Some(value.clone()))
-                })
-                .collect::<Vec<_>>();
-            parquet_metadata.sort_unstable_by(|left, right| left.key.cmp(&right.key));
-            let writer_properties = parquet::file::properties::WriterProperties::builder()
-                .set_key_value_metadata(Some(parquet_metadata))
-                .build();
-            let mut writer = parquet::arrow::ArrowWriter::try_new(
-                tmp.as_file(),
-                Arc::clone(&result.schema),
-                Some(writer_properties),
+        self.execute_to_result_sink_with_params(
+            cypher,
+            params,
+            path,
+            ResultSinkFormat::Parquet,
+            &ResultSinkOptions::default(),
+            None,
+        )
+        .map(|_| ())
+    }
+
+    /// Stream a query into an atomic Parquet result with explicit limits and
+    /// optional cooperative cancellation.
+    pub fn execute_to_parquet_stream_with_params(
+        &self,
+        cypher: &str,
+        params: &HashMap<String, IrLiteral>,
+        path: &str,
+        options: &ResultSinkOptions,
+        cancellation: Option<&CancellationToken>,
+    ) -> Result<ResultSinkReceipt, GfError> {
+        self.execute_to_result_sink_with_params(
+            cypher,
+            params,
+            path,
+            ResultSinkFormat::Parquet,
+            options,
+            cancellation,
+        )
+    }
+
+    /// Stream a query into an atomic Arrow IPC stream file with explicit limits
+    /// and optional cooperative cancellation.
+    pub fn execute_to_arrow_ipc_stream_with_params(
+        &self,
+        cypher: &str,
+        params: &HashMap<String, IrLiteral>,
+        path: &str,
+        options: &ResultSinkOptions,
+        cancellation: Option<&CancellationToken>,
+    ) -> Result<ResultSinkReceipt, GfError> {
+        self.execute_to_result_sink_with_params(
+            cypher,
+            params,
+            path,
+            ResultSinkFormat::ArrowIpc,
+            options,
+            cancellation,
+        )
+    }
+
+    fn execute_to_result_sink_with_params(
+        &self,
+        cypher: &str,
+        params: &HashMap<String, IrLiteral>,
+        path: &str,
+        format: ResultSinkFormat,
+        options: &ResultSinkOptions,
+        cancellation: Option<&CancellationToken>,
+    ) -> Result<ResultSinkReceipt, GfError> {
+        cancellation.map_or(Ok(()), CancellationToken::checkpoint)?;
+        let stream = self.execute_stream_with_params(cypher, params)?;
+        let schema = stream.schema();
+        let result = self.block_on(async {
+            graphforge_io::sink_record_batch_stream(
+                stream,
+                schema,
+                std::path::Path::new(path),
+                format,
+                options,
+                || cancellation.is_some_and(CancellationToken::is_cancelled),
             )
-            .map_err(|e| GfError::Storage(e.to_string()))?;
-            for batch in &result.batches {
-                writer
-                    .write(batch)
-                    .map_err(|e| GfError::Storage(e.to_string()))?;
-            }
-            writer
-                .close()
-                .map_err(|e| GfError::Storage(e.to_string()))?;
-        }
-        tmp.persist(dest)
-            .map_err(|e| GfError::Storage(format!("persist {path}: {e}")))?;
-        Ok(())
+            .await
+            .map_err(|error| {
+                if error.phase == "cancelled" {
+                    GfError::Api {
+                        code: ApiErrorCode::Cancelled,
+                        message: error.to_string(),
+                    }
+                } else {
+                    GfError::Storage(error.to_string())
+                }
+            })
+        })?;
+        Ok(result)
     }
 
     /// Return the storage path, if any (`None` for an in-memory instance).

--- a/crates/graphforge-api/tests/facade_methods.rs
+++ b/crates/graphforge-api/tests/facade_methods.rs
@@ -5,7 +5,9 @@
 use arrow::array::{Array, StringArray};
 use std::collections::HashMap;
 
-use graphforge_api::{GfError, GraphForge, OntologyMode, PropValue};
+use graphforge_api::{
+    CancellationToken, GfError, GraphForge, OntologyMode, PropValue, ResultSinkOptions,
+};
 use tempfile::TempDir;
 
 // ---------------------------------------------------------------------------
@@ -385,4 +387,72 @@ fn execute_to_parquet_zero_rows_writes_schema_only() {
     let builder =
         parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(file).unwrap();
     assert!(builder.schema().field_with_name("id").is_ok());
+}
+
+#[test]
+fn streaming_parquet_and_ipc_report_progress_and_roundtrip() {
+    let dir = TempDir::new().unwrap();
+    let parquet = dir.path().join("stream.parquet");
+    let ipc = dir.path().join("stream.arrow");
+    let gf = GraphForge::new(None).expect("in-memory instance");
+    for name in ["a", "b", "c"] {
+        gf.execute(&format!("CREATE (:Person {{name: '{name}'}})"))
+            .expect("create fixture");
+    }
+    let options = ResultSinkOptions {
+        max_row_group_rows: 2,
+        max_batch_rows: 64,
+    };
+    let query = "MATCH (p:Person) RETURN p.name AS name ORDER BY name";
+    let parquet_receipt = gf
+        .execute_to_parquet_stream_with_params(
+            query,
+            &HashMap::new(),
+            parquet.to_str().unwrap(),
+            &options,
+            None,
+        )
+        .unwrap();
+    let ipc_receipt = gf
+        .execute_to_arrow_ipc_stream_with_params(
+            query,
+            &HashMap::new(),
+            ipc.to_str().unwrap(),
+            &options,
+            None,
+        )
+        .unwrap();
+    assert_eq!(parquet_receipt.progress.rows, 3);
+    assert_eq!(ipc_receipt.progress.rows, 3);
+    assert!(parquet_receipt.progress.complete && ipc_receipt.progress.complete);
+    let parquet_rows: usize = read_parquet(&parquet)
+        .iter()
+        .map(arrow::record_batch::RecordBatch::num_rows)
+        .sum();
+    let ipc_rows: usize =
+        arrow::ipc::reader::StreamReader::try_new(std::fs::File::open(ipc).unwrap(), None)
+            .unwrap()
+            .map(|batch| batch.unwrap().num_rows())
+            .sum();
+    assert_eq!((parquet_rows, ipc_rows), (3, 3));
+}
+
+#[test]
+fn cancelled_stream_does_not_publish_destination() {
+    let dir = TempDir::new().unwrap();
+    let output = dir.path().join("cancelled.arrow");
+    let gf = GraphForge::new(None).expect("in-memory instance");
+    let cancellation = CancellationToken::new();
+    cancellation.cancel();
+    let error = gf
+        .execute_to_arrow_ipc_stream_with_params(
+            "RETURN 1 AS value",
+            &HashMap::new(),
+            output.to_str().unwrap(),
+            &ResultSinkOptions::default(),
+            Some(&cancellation),
+        )
+        .unwrap_err();
+    assert!(matches!(error, GfError::Api { .. }));
+    assert!(!output.exists());
 }

--- a/crates/graphforge-bindings-node/tests/non-cypher-parity-policy.json
+++ b/crates/graphforge-bindings-node/tests/non-cypher-parity-policy.json
@@ -1,8 +1,8 @@
 {
   "contractVersion": 1,
   "rustManifest": "../../../tests/contracts/non-cypher-rust-surface.json",
-  "releaseSurfaceCount": 192,
-  "releaseSurfaceDigest": "7b10db80d4bd05e21a94c57a7c4218e54f0d464a27dab127bdec59903afc66a0",
+  "releaseSurfaceCount": 194,
+  "releaseSurfaceDigest": "f59ec74c2dd604d3d27a096829369c54b15ba29f32fac8d4f70e4a139481751f",
   "requiredEquivalent": [
     "GraphForge.adopt_ontology",
     "GraphForge.clear_ontology",
@@ -172,6 +172,13 @@
         ],
         "reason": "Node binds parameters on PlanHandle before Promise-delivered IPC."
       },
+      "GraphForge.execute_to_arrow_ipc_stream_with_params": {
+        "nodeMembers": [
+          "GraphForge.plan",
+          "PlanHandle.collectIpc"
+        ],
+        "reason": "Node binds parameters on PlanHandle before Promise-delivered Arrow IPC."
+      },
       "GraphForge.execute_to_parquet": {
         "nodeMembers": [
           "GraphForge.plan",
@@ -185,6 +192,13 @@
           "PlanHandle.sinkParquet"
         ],
         "reason": "Node binds parameters on PlanHandle before the asynchronous Parquet sink."
+      },
+      "GraphForge.execute_to_parquet_stream_with_params": {
+        "nodeMembers": [
+          "GraphForge.plan",
+          "PlanHandle.sinkParquet"
+        ],
+        "reason": "Node binds parameters on PlanHandle before the asynchronous bounded Parquet sink."
       },
       "GraphForge.configure_provider_find_runtime": {
         "nodeMembers": [

--- a/crates/graphforge-bindings-py/tests/non_cypher_release.py
+++ b/crates/graphforge-bindings-py/tests/non_cypher_release.py
@@ -23,8 +23,8 @@ ROOT = Path(__file__).resolve().parents[3]
 RUST_MANIFEST = ROOT / "tests/contracts/non-cypher-rust-surface.json"
 RUST_GATE = ROOT / "scripts/ci/non-cypher-surface-gate.py"
 PYO3_SOURCE = ROOT / "crates/graphforge-bindings-py/src/lib.rs"
-EXPECTED_RUST_DIGEST = "51fd33865c0866530edac0f1c3e735ba72354774de93966883b5020e1a1655fb"
-EXPECTED_RELEASE_DIGEST = "7b10db80d4bd05e21a94c57a7c4218e54f0d464a27dab127bdec59903afc66a0"
+EXPECTED_RUST_DIGEST = "627ae63b3f05a0b9e27e327d93f15daab2af09c6f145c654bc6942528081be0b"
+EXPECTED_RELEASE_DIGEST = "f59ec74c2dd604d3d27a096829369c54b15ba29f32fac8d4f70e4a139481751f"
 
 PYTHON_ONLY_METHODS = frozenset(
     {
@@ -237,7 +237,7 @@ def _classification_report() -> dict[str, object]:
         for group in manifest["method_evidence_groups"].values()
         for method_id in group["ids"]
     }
-    assert len(release_methods) == 192
+    assert len(release_methods) == 194
     assert _digest(release_methods) == EXPECTED_RELEASE_DIGEST
     assert set(EVIDENCE) == set(manifest["method_evidence_groups"])
 

--- a/crates/graphforge-io/BUILD.bazel
+++ b/crates/graphforge-io/BUILD.bazel
@@ -8,17 +8,9 @@ package(default_visibility = ["//visibility:public"])
 
 gf_rust_library(
     name = "graphforge_io",
-    deps = [
-        "//crates/graphforge-core:graphforge_core",
-        "//crates/graphforge-storage:graphforge_storage",
-    ],
 )
 
 gf_rust_test(
     name = "graphforge_io_test",
     crate = ":graphforge_io",
-    deps = [
-        "//crates/graphforge-core:graphforge_core",
-        "//crates/graphforge-storage:graphforge_storage",
-    ],
 )

--- a/crates/graphforge-io/BUILD.bazel
+++ b/crates/graphforge-io/BUILD.bazel
@@ -9,8 +9,11 @@ package(default_visibility = ["//visibility:public"])
 gf_rust_library(
     name = "graphforge_io",
     deps = [
+        "@crates//:arrow",
         "@crates//:futures",
+        "@crates//:parquet",
         "@crates//:tempfile",
+        "@crates//:thiserror",
     ],
 )
 
@@ -18,7 +21,10 @@ gf_rust_test(
     name = "graphforge_io_test",
     crate = ":graphforge_io",
     deps = [
+        "@crates//:arrow",
         "@crates//:futures",
+        "@crates//:parquet",
         "@crates//:tempfile",
+        "@crates//:thiserror",
     ],
 )

--- a/crates/graphforge-io/BUILD.bazel
+++ b/crates/graphforge-io/BUILD.bazel
@@ -8,9 +8,17 @@ package(default_visibility = ["//visibility:public"])
 
 gf_rust_library(
     name = "graphforge_io",
+    deps = [
+        "@crates//:futures",
+        "@crates//:tempfile",
+    ],
 )
 
 gf_rust_test(
     name = "graphforge_io_test",
     crate = ":graphforge_io",
+    deps = [
+        "@crates//:futures",
+        "@crates//:tempfile",
+    ],
 )

--- a/crates/graphforge-io/Cargo.toml
+++ b/crates/graphforge-io/Cargo.toml
@@ -8,8 +8,10 @@ license-file.workspace = true
 repository.workspace = true
 
 [dependencies]
-graphforge-core = { version = "0.5.2", path = "../graphforge-core" }
-graphforge-storage = { version = "0.5.2", path = "../graphforge-storage" }
+arrow = { workspace = true }
+futures = { workspace = true }
+parquet = { workspace = true }
+tempfile = "3"
 thiserror = { workspace = true }
 
 [lints]

--- a/crates/graphforge-io/src/lib.rs
+++ b/crates/graphforge-io/src/lib.rs
@@ -1,18 +1,559 @@
-//! GraphForge CSV/JSON/Parquet/IPC sinks.
+//! Bounded, atomic GraphForge result sinks.
 #![forbid(unsafe_code)]
 
-/// Returns the crate name.
+use std::fmt::Display;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+#[cfg(test)]
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use arrow::datatypes::SchemaRef;
+use arrow::ipc::writer::StreamWriter;
+use arrow::record_batch::RecordBatch;
+use futures::{Stream, StreamExt};
+use parquet::arrow::ArrowWriter;
+use parquet::file::metadata::KeyValue;
+use parquet::file::properties::WriterProperties;
+use thiserror::Error;
+
+#[cfg(test)]
+static FAIL_WRITE_AFTER_BATCHES: AtomicU64 = AtomicU64::new(u64::MAX);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// On-disk representation for a streamed query result.
+pub enum ResultSinkFormat {
+    /// Apache Parquet.
+    Parquet,
+    /// Arrow IPC streaming format.
+    ArrowIpc,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+/// Resource controls for incremental writers.
+pub struct ResultSinkOptions {
+    /// Maximum rows buffered in one Parquet row group.
+    pub max_row_group_rows: usize,
+    /// Maximum rows accepted in one execution batch.
+    pub max_batch_rows: usize,
+}
+
+impl Default for ResultSinkOptions {
+    fn default() -> Self {
+        Self {
+            max_row_group_rows: 65_536,
+            max_batch_rows: 65_536,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+/// Work counters and terminal state for a sink.
+pub struct ResultSinkProgress {
+    /// Current or terminal phase.
+    pub phase: &'static str,
+    /// Rows accepted by the writer.
+    pub rows: u64,
+    /// Batches accepted by the writer.
+    pub batches: u64,
+    /// Bytes written to the output.
+    pub bytes: u64,
+    /// Wall-clock duration.
+    pub elapsed: Duration,
+    /// True only after atomic publication.
+    pub complete: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+/// Successful atomic publication receipt.
+pub struct ResultSinkReceipt {
+    /// Final destination.
+    pub destination: PathBuf,
+    /// Published representation.
+    pub format: ResultSinkFormat,
+    /// Terminal progress.
+    pub progress: ResultSinkProgress,
+}
+
+#[derive(Debug, Error)]
+/// Failed sink state with bounded progress and no completion claim.
+#[error(
+    "result sink failed during {phase}: {message} (rows={rows}, batches={batches}, bytes={bytes}, elapsed_ms={elapsed_ms})"
+)]
+pub struct ResultSinkError {
+    /// Failure phase.
+    pub phase: &'static str,
+    /// Rows accepted before failure.
+    pub rows: u64,
+    /// Batches accepted before failure.
+    pub batches: u64,
+    /// Temporary bytes observed before failure.
+    pub bytes: u64,
+    /// Milliseconds elapsed before failure.
+    pub elapsed_ms: u128,
+    /// Sanitized underlying failure.
+    pub message: String,
+}
+
+fn failure(
+    started: Instant,
+    phase: &'static str,
+    rows: u64,
+    batches: u64,
+    bytes: u64,
+    message: impl Into<String>,
+) -> ResultSinkError {
+    ResultSinkError {
+        phase,
+        rows,
+        batches,
+        bytes,
+        elapsed_ms: started.elapsed().as_millis(),
+        message: message.into(),
+    }
+}
+
+enum IncrementalWriter {
+    Parquet(Box<ArrowWriter<File>>),
+    ArrowIpc(StreamWriter<File>),
+}
+
+fn create_writer(
+    file: File,
+    schema: &SchemaRef,
+    format: ResultSinkFormat,
+    options: &ResultSinkOptions,
+) -> Result<IncrementalWriter, String> {
+    match format {
+        ResultSinkFormat::Parquet => {
+            let mut metadata = schema
+                .metadata()
+                .iter()
+                .map(|(key, value)| KeyValue::new(key.clone(), Some(value.clone())))
+                .collect::<Vec<_>>();
+            metadata.sort_unstable_by(|left, right| left.key.cmp(&right.key));
+            let properties = WriterProperties::builder()
+                .set_max_row_group_row_count(Some(options.max_row_group_rows))
+                .set_key_value_metadata(Some(metadata))
+                .build();
+            ArrowWriter::try_new(file, Arc::clone(schema), Some(properties))
+                .map(Box::new)
+                .map(IncrementalWriter::Parquet)
+                .map_err(|error| error.to_string())
+        }
+        ResultSinkFormat::ArrowIpc => StreamWriter::try_new(file, schema.as_ref())
+            .map(IncrementalWriter::ArrowIpc)
+            .map_err(|error| error.to_string()),
+    }
+}
+
+fn temp_bytes(temporary: &tempfile::NamedTempFile) -> u64 {
+    temporary
+        .as_file()
+        .metadata()
+        .map_or(0, |metadata| metadata.len())
+}
+
+async fn drain_stream<E, F>(
+    stream: &mut Pin<Box<dyn Stream<Item = Result<RecordBatch, E>> + Send>>,
+    writer: &mut IncrementalWriter,
+    schema: &SchemaRef,
+    options: &ResultSinkOptions,
+    temporary: &tempfile::NamedTempFile,
+    started: Instant,
+    cancelled: &mut F,
+) -> Result<(u64, u64), ResultSinkError>
+where
+    E: Display,
+    F: FnMut() -> bool,
+{
+    let mut rows = 0_u64;
+    let mut batches = 0_u64;
+    loop {
+        if cancelled() {
+            return Err(failure(
+                started,
+                "cancelled",
+                rows,
+                batches,
+                temp_bytes(temporary),
+                "operation was cancelled",
+            ));
+        }
+        let Some(item) = stream.next().await else {
+            break;
+        };
+        let batch = item.map_err(|error| {
+            failure(
+                started,
+                "execute",
+                rows,
+                batches,
+                temp_bytes(temporary),
+                error.to_string(),
+            )
+        })?;
+        if batch.schema() != *schema {
+            return Err(failure(
+                started,
+                "schema",
+                rows,
+                batches,
+                temp_bytes(temporary),
+                "execution batch schema changed during export",
+            ));
+        }
+        if batch.num_rows() > options.max_batch_rows {
+            return Err(failure(
+                started,
+                "limit",
+                rows,
+                batches,
+                temp_bytes(temporary),
+                format!(
+                    "execution batch has {} rows, exceeding max_batch_rows {}",
+                    batch.num_rows(),
+                    options.max_batch_rows
+                ),
+            ));
+        }
+        if cancelled() {
+            return Err(failure(
+                started,
+                "cancelled",
+                rows,
+                batches,
+                temp_bytes(temporary),
+                "operation was cancelled",
+            ));
+        }
+        #[cfg(test)]
+        if batches >= FAIL_WRITE_AFTER_BATCHES.load(Ordering::Relaxed) {
+            return Err(failure(
+                started,
+                "write",
+                rows,
+                batches,
+                temp_bytes(temporary),
+                "simulated disk exhaustion",
+            ));
+        }
+        writer.write(&batch).map_err(|error| {
+            failure(
+                started,
+                "write",
+                rows,
+                batches,
+                temp_bytes(temporary),
+                error,
+            )
+        })?;
+        rows = rows.saturating_add(batch.num_rows() as u64);
+        batches = batches.saturating_add(1);
+    }
+    Ok((rows, batches))
+}
+
+impl IncrementalWriter {
+    fn write(&mut self, batch: &RecordBatch) -> Result<(), String> {
+        match self {
+            Self::Parquet(writer) => writer.write(batch).map_err(|error| error.to_string()),
+            Self::ArrowIpc(writer) => writer.write(batch).map_err(|error| error.to_string()),
+        }
+    }
+    fn finish(self) -> Result<(), String> {
+        match self {
+            Self::Parquet(writer) => (*writer)
+                .close()
+                .map(|_| ())
+                .map_err(|error| error.to_string()),
+            Self::ArrowIpc(mut writer) => writer.finish().map_err(|error| error.to_string()),
+        }
+    }
+}
+
+/// Drain an execution stream one batch at a time and publish only after a
+/// successful writer close and file sync. Pulling only after each write gives
+/// the writer natural backpressure over query execution.
+pub async fn sink_record_batch_stream<E, F>(
+    mut stream: Pin<Box<dyn Stream<Item = Result<RecordBatch, E>> + Send>>,
+    schema: SchemaRef,
+    destination: &Path,
+    format: ResultSinkFormat,
+    options: &ResultSinkOptions,
+    mut cancelled: F,
+) -> Result<ResultSinkReceipt, ResultSinkError>
+where
+    E: Display,
+    F: FnMut() -> bool,
+{
+    let started = Instant::now();
+    if options.max_row_group_rows == 0 || options.max_batch_rows == 0 {
+        return Err(failure(
+            started,
+            "validate",
+            0,
+            0,
+            0,
+            "sink limits must be non-zero",
+        ));
+    }
+    let parent = destination
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let temporary = tempfile::Builder::new()
+        .prefix(".graphforge-result-")
+        .tempfile_in(parent)
+        .map_err(|error| failure(started, "create", 0, 0, 0, error.to_string()))?;
+    let writer_file = temporary
+        .reopen()
+        .map_err(|error| failure(started, "create", 0, 0, 0, error.to_string()))?;
+    let mut writer = create_writer(writer_file, &schema, format, options)
+        .map_err(|error| failure(started, "create", 0, 0, 0, error))?;
+    let (rows, batches) = drain_stream(
+        &mut stream,
+        &mut writer,
+        &schema,
+        options,
+        &temporary,
+        started,
+        &mut cancelled,
+    )
+    .await?;
+    writer.finish().map_err(|error| {
+        failure(
+            started,
+            "finish",
+            rows,
+            batches,
+            temp_bytes(&temporary),
+            error,
+        )
+    })?;
+    temporary.as_file().sync_all().map_err(|error| {
+        failure(
+            started,
+            "sync",
+            rows,
+            batches,
+            temp_bytes(&temporary),
+            error.to_string(),
+        )
+    })?;
+    let final_bytes = temp_bytes(&temporary);
+    temporary.persist(destination).map_err(|error| {
+        failure(
+            started,
+            "publish",
+            rows,
+            batches,
+            final_bytes,
+            error.error.to_string(),
+        )
+    })?;
+    Ok(ResultSinkReceipt {
+        destination: destination.to_path_buf(),
+        format,
+        progress: ResultSinkProgress {
+            phase: "complete",
+            rows,
+            batches,
+            bytes: final_bytes,
+            elapsed: started.elapsed(),
+            complete: true,
+        },
+    })
+}
+
 #[must_use]
+/// Return the crate name.
 pub const fn name() -> &'static str {
     "graphforge-io"
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use arrow::array::{Int64Array, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::ipc::reader::StreamReader;
+    use futures::stream;
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
     use super::*;
 
+    fn fixture() -> (SchemaRef, Vec<RecordBatch>) {
+        let schema = Arc::new(Schema::new_with_metadata(
+            vec![
+                Field::new("id", DataType::Int64, false),
+                Field::new("name", DataType::Utf8, false),
+            ],
+            [("graphforge.ordering".to_owned(), "explicit".to_owned())].into(),
+        ));
+        let batches = vec![
+            RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![
+                    Arc::new(Int64Array::from(vec![1, 2])),
+                    Arc::new(StringArray::from(vec!["a", "b"])),
+                ],
+            )
+            .unwrap(),
+            RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![
+                    Arc::new(Int64Array::from(vec![3])),
+                    Arc::new(StringArray::from(vec!["c"])),
+                ],
+            )
+            .unwrap(),
+        ];
+        (schema, batches)
+    }
+
+    fn boxed(
+        batches: Vec<RecordBatch>,
+    ) -> Pin<Box<dyn Stream<Item = Result<RecordBatch, String>> + Send>> {
+        Box::pin(stream::iter(batches.into_iter().map(Ok)))
+    }
+
     #[test]
-    fn it_works() {
-        assert_eq!(name(), "graphforge-io");
+    fn parquet_and_ipc_round_trip_schema_rows_and_batches() {
+        let root = tempfile::tempdir().unwrap();
+        for format in [ResultSinkFormat::Parquet, ResultSinkFormat::ArrowIpc] {
+            let (schema, batches) = fixture();
+            let path = root.path().join(match format {
+                ResultSinkFormat::Parquet => "result.parquet",
+                ResultSinkFormat::ArrowIpc => "result.arrow",
+            });
+            let receipt = futures::executor::block_on(sink_record_batch_stream(
+                boxed(batches),
+                Arc::clone(&schema),
+                &path,
+                format,
+                &ResultSinkOptions {
+                    max_row_group_rows: 2,
+                    max_batch_rows: 2,
+                },
+                || false,
+            ))
+            .unwrap();
+            assert_eq!(receipt.progress.rows, 3);
+            assert_eq!(receipt.progress.batches, 2);
+            assert!(receipt.progress.complete && receipt.progress.bytes > 0);
+            let (read_schema, read) = match format {
+                ResultSinkFormat::Parquet => {
+                    let builder =
+                        ParquetRecordBatchReaderBuilder::try_new(File::open(path).unwrap())
+                            .unwrap();
+                    let read_schema = Arc::clone(builder.schema());
+                    let batches = builder
+                        .build()
+                        .unwrap()
+                        .collect::<Result<Vec<_>, _>>()
+                        .unwrap();
+                    (read_schema, batches)
+                }
+                ResultSinkFormat::ArrowIpc => {
+                    let reader = StreamReader::try_new(File::open(path).unwrap(), None).unwrap();
+                    let read_schema = reader.schema();
+                    let batches = reader.collect::<Result<Vec<_>, _>>().unwrap();
+                    (read_schema, batches)
+                }
+            };
+            assert_eq!(read.iter().map(RecordBatch::num_rows).sum::<usize>(), 3);
+            assert_eq!(read_schema, schema);
+        }
+    }
+
+    #[test]
+    fn cancellation_limit_schema_and_destination_fail_without_final_output() {
+        let root = tempfile::tempdir().unwrap();
+        let (schema, batches) = fixture();
+        let cancelled = root.path().join("cancelled.parquet");
+        let error = futures::executor::block_on(sink_record_batch_stream(
+            boxed(batches.clone()),
+            Arc::clone(&schema),
+            &cancelled,
+            ResultSinkFormat::Parquet,
+            &ResultSinkOptions::default(),
+            || true,
+        ))
+        .unwrap_err();
+        assert_eq!(error.phase, "cancelled");
+        assert!(!cancelled.exists());
+
+        let limited = root.path().join("limited.arrow");
+        let error = futures::executor::block_on(sink_record_batch_stream(
+            boxed(batches.clone()),
+            Arc::clone(&schema),
+            &limited,
+            ResultSinkFormat::ArrowIpc,
+            &ResultSinkOptions {
+                max_row_group_rows: 1,
+                max_batch_rows: 1,
+            },
+            || false,
+        ))
+        .unwrap_err();
+        assert_eq!(error.phase, "limit");
+        assert!(!limited.exists());
+
+        let changed_schema = Arc::new(Schema::new(vec![Field::new(
+            "other",
+            DataType::Int64,
+            false,
+        )]));
+        let changed =
+            RecordBatch::try_new(changed_schema, vec![Arc::new(Int64Array::from(vec![1]))])
+                .unwrap();
+        let mismatch = root.path().join("mismatch.arrow");
+        let error = futures::executor::block_on(sink_record_batch_stream(
+            boxed(vec![changed]),
+            schema,
+            &mismatch,
+            ResultSinkFormat::ArrowIpc,
+            &ResultSinkOptions::default(),
+            || false,
+        ))
+        .unwrap_err();
+        assert_eq!(error.phase, "schema");
+        assert!(!mismatch.exists());
+
+        let missing = root.path().join("missing").join("result.parquet");
+        let (schema, batches) = fixture();
+        let error = futures::executor::block_on(sink_record_batch_stream(
+            boxed(batches),
+            schema,
+            &missing,
+            ResultSinkFormat::Parquet,
+            &ResultSinkOptions::default(),
+            || false,
+        ))
+        .unwrap_err();
+        assert_eq!(error.phase, "create");
+        assert!(!missing.exists());
+
+        let disk_full = root.path().join("disk-full.parquet");
+        let (schema, batches) = fixture();
+        FAIL_WRITE_AFTER_BATCHES.store(1, Ordering::Relaxed);
+        let error = futures::executor::block_on(sink_record_batch_stream(
+            boxed(batches),
+            schema,
+            &disk_full,
+            ResultSinkFormat::Parquet,
+            &ResultSinkOptions::default(),
+            || false,
+        ))
+        .unwrap_err();
+        FAIL_WRITE_AFTER_BATCHES.store(u64::MAX, Ordering::Relaxed);
+        assert_eq!(error.phase, "write");
+        assert_eq!(error.rows, 2);
+        assert!(!disk_full.exists());
     }
 }

--- a/docs/book/architecture/execution-model.md
+++ b/docs/book/architecture/execution-model.md
@@ -311,6 +311,18 @@ Arrow is used as the internal execution currency:
 - **C Stream Interface** — batch readers for streaming results
 - **Arrow IPC** — serialized stream for cross-process use (Node today; future UniFFI consumers)
 
+Query-result files use the same demand-driven `RecordBatch` stream. Parquet and
+Arrow IPC sinks request one batch only after the preceding batch has been
+accepted, enforce configured batch and Parquet row-group limits, and publish a
+sibling temporary file atomically only after writer finalization and sync.
+Receipts report rows, batches, bytes, elapsed time, and completion phase;
+cancellation or execution/writer failure reports bounded progress and never
+publishes a partial destination.
+
+File order is the query's result order. An explicit Cypher `ORDER BY` therefore
+produces deterministic row order; without an ordering clause, neither the sink
+nor the file format adds an ordering guarantee.
+
 Swift and Kotlin bindings are deferred to v0.5.1; when they ship, they will consume Arrow IPC
 bytes over UniFFI without becoming semantic owners.
 

--- a/scripts/ci/test-non-cypher-surface-gate.py
+++ b/scripts/ci/test-non-cypher-surface-gate.py
@@ -29,7 +29,7 @@ class SurfaceGateTests(unittest.TestCase):
 
     def test_checked_in_inventory_is_complete(self) -> None:
         self.assertEqual(GATE.validate(), [])
-        self.assertEqual(len(GATE.public_methods()), 300)
+        self.assertEqual(len(GATE.public_methods()), 302)
         self.assertEqual(len(GATE.algorithm_registry()), 94)
 
     def test_new_or_removed_public_method_fails_frozen_digest(self) -> None:

--- a/tests/contracts/non-cypher-rust-surface.json
+++ b/tests/contracts/non-cypher-rust-surface.json
@@ -1,7 +1,7 @@
 {
   "contract_version": 1,
   "scope": "Rust non-Cypher public release surface",
-  "public_method_digest": "51fd33865c0866530edac0f1c3e735ba72354774de93966883b5020e1a1655fb",
+  "public_method_digest": "627ae63b3f05a0b9e27e327d93f15daab2af09c6f145c654bc6942528081be0b",
   "method_policy": {
     "receiver_defaults": {
       "GraphForge": "release-tested",
@@ -700,7 +700,9 @@
         "GraphForge.execute_stream",
         "GraphForge.execute_stream_owned",
         "GraphForge.execute_stream_with_params",
+        "GraphForge.execute_to_arrow_ipc_stream_with_params",
         "GraphForge.execute_to_parquet",
+        "GraphForge.execute_to_parquet_stream_with_params",
         "GraphForge.execute_to_parquet_with_params",
         "GraphForge.execute_with_params",
         "GraphForge.explain",
@@ -740,6 +742,14 @@
         {
           "path": "crates/graphforge-api/tests/facade_methods.rs",
           "symbol": "execute_to_parquet_roundtrips"
+        },
+        {
+          "path": "crates/graphforge-api/tests/facade_methods.rs",
+          "symbol": "streaming_parquet_and_ipc_report_progress_and_roundtrip"
+        },
+        {
+          "path": "crates/graphforge-api/tests/facade_methods.rs",
+          "symbol": "cancelled_stream_does_not_publish_destination"
         },
         {
           "path": "crates/graphforge-api/tests/public_facade_remaining_conformance.rs",

--- a/tools/bazel/drift/cargo_feature_fingerprint.json
+++ b/tools/bazel/drift/cargo_feature_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "schema": "graphforge.cargo-feature-fingerprint.v1",
-  "sha256": "fe37804afbbaa557546676cb2bf6394bfa1ba376c452603d83e63557e53ba2ec",
+  "sha256": "f0f3a23ccc03ccd52bf1069449439d497a89cf23092e7964695e76e1babba756",
   "entries": [
     {
       "name": "graphforge-api",
@@ -83,6 +83,15 @@
         },
         {
           "name": "graphforge-exec",
+          "req": "^0.5.2",
+          "features": [],
+          "optional": false,
+          "uses_default_features": true,
+          "kind": null,
+          "target": null
+        },
+        {
+          "name": "graphforge-io",
           "req": "^0.5.2",
           "features": [],
           "optional": false,
@@ -938,8 +947,19 @@
       "features": [],
       "dependencies": [
         {
-          "name": "graphforge-core",
-          "req": "^0.5.2",
+          "name": "arrow",
+          "req": "^58",
+          "features": [
+            "prettyprint"
+          ],
+          "optional": false,
+          "uses_default_features": true,
+          "kind": null,
+          "target": null
+        },
+        {
+          "name": "futures",
+          "req": "^0.3",
           "features": [],
           "optional": false,
           "uses_default_features": true,
@@ -947,8 +967,17 @@
           "target": null
         },
         {
-          "name": "graphforge-storage",
-          "req": "^0.5.2",
+          "name": "parquet",
+          "req": "^58",
+          "features": [],
+          "optional": false,
+          "uses_default_features": true,
+          "kind": null,
+          "target": null
+        },
+        {
+          "name": "tempfile",
+          "req": "^3",
           "features": [],
           "optional": false,
           "uses_default_features": true,


### PR DESCRIPTION
Closes #743

## Summary
- replace the materializing Parquet helper with a demand-driven RecordBatch sink
- add shared Rust-owned Parquet and Arrow IPC writers with configurable batch/row-group limits
- finalize, sync, and atomically publish sibling temporary outputs
- expose rows, batches, bytes, elapsed time, phase, cancellation, and completion receipts
- cover schema/row round trips and cancellation, resource, schema, writer/disk, and destination failures
- document that deterministic file order requires an explicit query ordering contract

## Verification
- `cargo fmt --all -- --check`
- `python3 scripts/ci/cargo-bazel-drift-check.py`
- `CARGO_TARGET_DIR=/private/tmp/graphforge-743-target cargo test -p graphforge-io` (2 passed)
- `CARGO_TARGET_DIR=/private/tmp/graphforge-743-target cargo test -p graphforge-api --test facade_methods` (13 passed)
- `CARGO_TARGET_DIR=/private/tmp/graphforge-743-target cargo clippy -p graphforge-io --tests -- -D warnings`
- `CARGO_TARGET_DIR=/private/tmp/graphforge-743-target cargo clippy -p graphforge-api --lib -- -D warnings`

The broader API `--tests` clippy target currently reports pre-existing unrelated lint debt in existing adjacency, belief, M4, modularity, and BDD tests; this PR does not alter those findings.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789731525&installation_model_id=20486&pr_number=812&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F812&signature=672bc2a716ae03aa8fb9dd4732e87a9da16386892f3ef70fd28cf3068c52d049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->