### PR TITLE
Persist and query canonical GeoArrow spatial properties

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2381,6 +2381,7 @@ dependencies = [
  "graphforge-plan",
  "graphforge-storage",
  "insta",
+ "serde_json",
  "tempfile",
  "thiserror 2.0.20",
 ]

--- a/crates/graphforge-api/src/bulk_construction.rs
+++ b/crates/graphforge-api/src/bulk_construction.rs
@@ -372,6 +372,7 @@ impl GraphForge {
             let uuids = uuid_column(batch, BulkInputKind::Node, "node_uuid")?;
             let labels = string_column(batch, BulkInputKind::Node, "label")?;
             let properties = property_columns(batch, &NODE_REQUIRED);
+            preflight_spatial_columns(BulkInputKind::Node, ordinal, &properties)?;
             for row in 0..batch.num_rows() {
                 let node_uuid = uuid_at(
                     uuids,
@@ -637,6 +638,7 @@ impl GraphForge {
             let sources = uuid_column(batch, BulkInputKind::Edge, "source_uuid")?;
             let targets = uuid_column(batch, BulkInputKind::Edge, "target_uuid")?;
             let properties = property_columns(batch, &EDGE_REQUIRED);
+            preflight_spatial_columns(BulkInputKind::Edge, ordinal, &properties)?;
             for row in 0..batch.num_rows() {
                 let edge_uuid = uuid_at(
                     uuids,
@@ -886,7 +888,18 @@ fn input_schema(
             ));
         }
         validate_property_name(kind, field.name())?;
-        validate_property_type(kind, field.name(), field.data_type())?;
+        if field.metadata().contains_key("ARROW:extension:name") {
+            spatial_type_from_field(field).ok_or_else(|| {
+                field_error(
+                    kind,
+                    BulkValidationReason::UnsupportedPropertyType,
+                    field.name(),
+                    "unsupported or non-canonical Arrow extension property",
+                )
+            })?;
+        } else {
+            validate_property_type(kind, field.name(), field.data_type())?;
+        }
         if prior == Some(field.name()) {
             return Err(field_error(
                 kind,
@@ -1002,7 +1015,18 @@ fn validate_batch_schema(
     }
     for field in properties {
         validate_property_name(kind, field.name())?;
-        validate_property_type(kind, field.name(), field.data_type())?;
+        if field.metadata().contains_key("ARROW:extension:name") {
+            spatial_type_from_field(field).ok_or_else(|| {
+                field_error(
+                    kind,
+                    BulkValidationReason::UnsupportedPropertyType,
+                    field.name(),
+                    "unsupported or non-canonical Arrow extension property",
+                )
+            })?;
+        } else {
+            validate_property_type(kind, field.name(), field.data_type())?;
+        }
     }
     Ok(())
 }
@@ -1074,18 +1098,96 @@ where
     let mut values = BTreeMap::new();
     for (field, array) in columns {
         owner_validation(field.name(), field)?;
-        let value = property_value_at(array.as_ref(), row).map_err(|message| {
-            row_error(
-                kind,
-                BulkValidationReason::UnsupportedPropertyType,
-                ordinal,
-                field.name(),
-                &message,
-            )
-        })?;
+        let value = if field.metadata().contains_key("ARROW:extension:name") {
+            spatial_type_from_field(field).ok_or_else(|| {
+                row_error(
+                    kind,
+                    BulkValidationReason::PropertyTypeMismatch,
+                    ordinal,
+                    field.name(),
+                    "spatial field metadata is not canonical",
+                )
+            })?;
+            if array.is_null(row) {
+                PropValue::Null
+            } else {
+                PropValue::Spatial(
+                    graphforge_storage::decode_spatial_property_value(array.as_ref(), field, row)
+                        .map_err(|error| {
+                        row_error(
+                            kind,
+                            BulkValidationReason::UnsupportedPropertyType,
+                            ordinal,
+                            field.name(),
+                            &error.to_string(),
+                        )
+                    })?,
+                )
+            }
+        } else {
+            property_value_at(array.as_ref(), row).map_err(|message| {
+                row_error(
+                    kind,
+                    BulkValidationReason::UnsupportedPropertyType,
+                    ordinal,
+                    field.name(),
+                    &message,
+                )
+            })?
+        };
         values.insert(field.name().to_owned(), value);
     }
     Ok(values)
+}
+
+fn preflight_spatial_columns(
+    kind: BulkInputKind,
+    first_ordinal: u64,
+    columns: &[(&Field, &ArrayRef)],
+) -> Result<(), BulkValidationError> {
+    for (field, array) in columns {
+        let Some(spatial) = spatial_type_from_field(field) else {
+            continue;
+        };
+        spatial
+            .validate_array(
+                field,
+                array.as_ref(),
+                graphforge_ontology::SpatialValidationLimits::default(),
+            )
+            .map_err(|error| {
+                row_error(
+                    kind,
+                    BulkValidationReason::PropertyTypeMismatch,
+                    first_ordinal,
+                    field.name(),
+                    error.code(),
+                )
+            })?;
+    }
+    Ok(())
+}
+
+fn spatial_type_from_field(field: &Field) -> Option<graphforge_ontology::SpatialType> {
+    use graphforge_ontology::{SpatialCrs, SpatialGeometryType, SpatialType};
+    let geometry = match field.metadata().get("ARROW:extension:name")?.as_str() {
+        "geoarrow.point" => SpatialGeometryType::Point,
+        "geoarrow.linestring" => SpatialGeometryType::LineString,
+        "geoarrow.polygon" => SpatialGeometryType::Polygon,
+        "geoarrow.multipoint" => SpatialGeometryType::MultiPoint,
+        "geoarrow.multilinestring" => SpatialGeometryType::MultiLineString,
+        "geoarrow.multipolygon" => SpatialGeometryType::MultiPolygon,
+        _ => return None,
+    };
+    let metadata = field.metadata().get("ARROW:extension:metadata")?;
+    let crs = if metadata == &SpatialCrs::Epsg4326.extension_metadata() {
+        SpatialCrs::Epsg4326
+    } else if metadata == &SpatialCrs::Epsg3857.extension_metadata() {
+        SpatialCrs::Epsg3857
+    } else {
+        return None;
+    };
+    Some(SpatialType { geometry, crs })
 }
 
 fn property_value_at(array: &dyn Array, row: usize) -> Result<PropValue, String> {
@@ -1313,10 +1415,11 @@ fn validate_ontology_field(
                 DataType::List(_) | DataType::LargeList(_)
             )
         }
-        PropertyValueType::Duration
-        | PropertyValueType::DateTime
-        | PropertyValueType::Map
-        | PropertyValueType::Spatial(_) => false,
+        PropertyValueType::Spatial(spatial) => {
+            field.data_type() == &spatial.data_type()
+                && field.metadata() == &spatial.field_metadata()
+        }
+        PropertyValueType::Duration | PropertyValueType::DateTime | PropertyValueType::Map => false,
     };
     if !compatible {
         return Err(row_error(
@@ -1850,7 +1953,7 @@ fn row_error(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{FixedSizeBinaryArray, Int64Array, StringArray};
+    use arrow::array::{FixedSizeBinaryArray, Float64Array, Int64Array, StringArray, StructArray};
     use std::process::Command;
 
     const FAILPOINT_COOKIE: &str = "graphforge-internal-subprocess-v1";
@@ -1864,6 +1967,32 @@ mod tests {
 
     fn operation(seed: u128) -> OperationId {
         OperationId(uuid(seed))
+    }
+
+    #[test]
+    fn spatial_bulk_preflight_validates_the_complete_array_before_row_normalization() {
+        use graphforge_ontology::{SpatialCrs, SpatialGeometryType, SpatialType};
+        let spatial = SpatialType {
+            geometry: SpatialGeometryType::Point,
+            crs: SpatialCrs::Epsg4326,
+        };
+        let field = spatial.field("location", false);
+        let array: ArrayRef = Arc::new(StructArray::from(vec![
+            (
+                Arc::new(Field::new("x", DataType::Float64, false)),
+                Arc::new(Float64Array::from(vec![-105.0, 181.0])) as ArrayRef,
+            ),
+            (
+                Arc::new(Field::new("y", DataType::Float64, false)),
+                Arc::new(Float64Array::from(vec![39.7, 0.0])) as ArrayRef,
+            ),
+        ]));
+        let error =
+            preflight_spatial_columns(BulkInputKind::Node, 40, &[(&field, &array)]).unwrap_err();
+        assert_eq!(error.reason, BulkValidationReason::PropertyTypeMismatch);
+        assert_eq!(error.row_ordinal, Some(40));
+        assert_eq!(error.field.as_deref(), Some("location"));
+        assert_eq!(error.message, "GF_SPATIAL_COORDINATE_OUT_OF_RANGE");
     }
 
     #[test]

--- a/crates/graphforge-api/src/construction.rs
+++ b/crates/graphforge-api/src/construction.rs
@@ -204,6 +204,7 @@ pub(crate) fn prop_literal(value: &PropValue) -> Result<IrLiteral, GfError> {
         PropValue::Int(value) => Ok(IrLiteral::Int(*value)),
         PropValue::Float(value) => Ok(IrLiteral::Float(*value)),
         PropValue::Str(value) => Ok(IrLiteral::Str(value.clone())),
+        PropValue::Spatial(value) => Ok(IrLiteral::Spatial(value.clone())),
         PropValue::List(values) => values
             .iter()
             .map(prop_literal)
@@ -253,12 +254,63 @@ fn validation(message: impl Into<String>) -> GfError {
 mod tests {
     use super::*;
     use arrow::array::{FixedSizeBinaryArray, Int64Array, StringArray};
+    use graphforge_core::{
+        SpatialCoordinates, SpatialCrs, SpatialGeometryType, SpatialType, SpatialValue,
+    };
 
     fn properties() -> HashMap<String, PropValue> {
         HashMap::from([
             ("name".into(), PropValue::Str("Alice".into())),
             ("score".into(), PropValue::Int(7)),
         ])
+    }
+
+    #[test]
+    fn scalar_spatial_node_and_edge_project_after_reopen_with_geoarrow_metadata() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().to_str().unwrap();
+        let graph = GraphForge::new(Some(path)).unwrap();
+        let location = PropValue::Spatial(SpatialValue {
+            spatial_type: SpatialType {
+                geometry: SpatialGeometryType::Point,
+                crs: SpatialCrs::Epsg4326,
+            },
+            coordinates: SpatialCoordinates::Point([-104.9903, 39.7392]),
+        });
+        let source = graph
+            .add_node(
+                "Place",
+                &HashMap::from([("location".into(), location.clone())]),
+            )
+            .unwrap();
+        let target = graph.add_node("Place", &HashMap::new()).unwrap();
+        graph
+            .add_edge(
+                &source,
+                "ROUTE",
+                &target,
+                &HashMap::from([("location".into(), location)]),
+            )
+            .unwrap();
+        drop(graph);
+
+        let reopened = GraphForge::new(Some(path)).unwrap();
+        for query in [
+            "MATCH (n:Place) WHERE n.location IS NOT NULL RETURN n.location AS location",
+            "MATCH ()-[r:ROUTE]->() RETURN r.location AS location",
+        ] {
+            let result = reopened.execute(query).unwrap();
+            let field = result.schema.field_with_name("location").unwrap();
+            assert_eq!(field.metadata()["ARROW:extension:name"], "geoarrow.point");
+            assert_eq!(
+                field.metadata()["ARROW:extension:metadata"],
+                "{\"crs\":\"EPSG:4326\",\"crs_type\":\"authority_code\"}"
+            );
+            assert_eq!(
+                result.batches[0].column_by_name("location").unwrap().len(),
+                1
+            );
+        }
     }
 
     #[test]

--- a/crates/graphforge-api/tests/e2e_baseline.rs
+++ b/crates/graphforge-api/tests/e2e_baseline.rs
@@ -5080,3 +5080,59 @@ fn dynamic_subscript_parameter_type_errors_remain_runtime_errors() {
         .expect_err("scalar subscript must fail");
     assert!(matches!(error, graphforge_api::GfError::Execution(_)));
 }
+
+#[test]
+fn certified_spatial_point_and_distance_execute_in_rust() {
+    let gf = GraphForge::new(None).expect("in-memory instance");
+    let result = rows(
+        &gf,
+        "RETURN point({x: 3, y: 4, crs: 'EPSG:3857'}) AS point, \
+         distance(point({x: 0, y: 0}), point({x: 3, y: 4})) AS distance",
+    );
+    let point = result.batches[0]
+        .column_by_name("point")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .expect("point is a native Arrow struct");
+    assert_eq!(
+        point
+            .column_by_name("x")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap()
+            .value(0),
+        3.0
+    );
+    assert_eq!(
+        point
+            .column_by_name("y")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap()
+            .value(0),
+        4.0
+    );
+    assert_eq!(
+        result.batches[0]
+            .column_by_name("distance")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap()
+            .value(0),
+        5.0
+    );
+
+    let error = gf
+        .execute("RETURN distance(point({x: 0, y: 0}), point({longitude: 0, latitude: 0}))")
+        .expect_err("mixed CRS must not be silently reprojected");
+    assert!(
+        error
+            .to_string()
+            .contains("does not implicitly reproject mixed CRS"),
+        "{error}"
+    );
+}

--- a/crates/graphforge-core/src/lib.rs
+++ b/crates/graphforge-core/src/lib.rs
@@ -329,6 +329,70 @@ impl fmt::Display for ProjectErrorCode {
 // PropValue — minimal property value type
 // ---------------------------------------------------------------------------
 
+/// Coordinate reference systems certified by GraphForge's spatial v1 profile.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub enum SpatialCrs {
+    /// WGS 84 longitude/latitude in canonical x/y order.
+    #[serde(rename = "EPSG:4326")]
+    Epsg4326,
+    /// Web Mercator easting/northing in canonical x/y order.
+    #[serde(rename = "EPSG:3857")]
+    Epsg3857,
+}
+
+/// Homogeneous geometry kinds in GraphForge's spatial v1 profile.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SpatialGeometryType {
+    /// One x/y coordinate.
+    Point,
+    /// One ordered sequence of vertices.
+    LineString,
+    /// One polygon represented as ordered rings.
+    Polygon,
+    /// A collection of points.
+    MultiPoint,
+    /// A collection of line strings.
+    MultiLineString,
+    /// A collection of polygons.
+    MultiPolygon,
+}
+
+/// Complete homogeneous spatial property type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct SpatialType {
+    /// Homogeneous geometry kind.
+    pub geometry: SpatialGeometryType,
+    /// Coordinate reference system for every coordinate.
+    pub crs: SpatialCrs,
+}
+
+/// Canonical f64 coordinate payload for one spatial property value.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum SpatialCoordinates {
+    /// Point coordinate.
+    Point([f64; 2]),
+    /// Line-string vertices.
+    LineString(Vec<[f64; 2]>),
+    /// Polygon rings and their vertices.
+    Polygon(Vec<Vec<[f64; 2]>>),
+    /// Multi-point coordinates.
+    MultiPoint(Vec<[f64; 2]>),
+    /// Multi-line-string vertices.
+    MultiLineString(Vec<Vec<[f64; 2]>>),
+    /// Multi-polygon rings and vertices.
+    MultiPolygon(Vec<Vec<Vec<[f64; 2]>>>),
+}
+
+/// One canonical typed spatial property value.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct SpatialValue {
+    /// Geometry kind and CRS.
+    pub spatial_type: SpatialType,
+    /// Coordinates matching `spatial_type.geometry`.
+    pub coordinates: SpatialCoordinates,
+}
+
 /// A graph property value.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[non_exhaustive]
@@ -345,6 +409,8 @@ pub enum PropValue {
     Str(String),
     /// Ordered list.
     List(Vec<PropValue>),
+    /// Canonical typed spatial value.
+    Spatial(SpatialValue),
 }
 
 impl fmt::Display for PropValue {
@@ -365,6 +431,11 @@ impl fmt::Display for PropValue {
                 }
                 write!(f, "]")
             }
+            Self::Spatial(value) => write!(
+                f,
+                "spatial({:?}, {:?})",
+                value.spatial_type, value.coordinates
+            ),
         }
     }
 }

--- a/crates/graphforge-ir/src/binder.rs
+++ b/crates/graphforge-ir/src/binder.rs
@@ -4694,6 +4694,7 @@ fn is_known_cypher_function(call: &FunctionCall) -> bool {
             | "duration.indays"
             | "duration.inmonths"
             | "duration.inseconds"
+            | "distance"
             | "elementid"
             | "endnode"
             | "exp"

--- a/crates/graphforge-ir/src/expr.rs
+++ b/crates/graphforge-ir/src/expr.rs
@@ -10,6 +10,7 @@
 //! - collapse AST-level sugar (`IsNull`, `InList`, `StringOp`, `RegexMatch`)
 //!   into `UnaryOp` / `BinaryOp` variants handled uniformly by the executor
 
+use graphforge_core::SpatialValue;
 use serde::de::{self, MapAccess, Visitor};
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -106,6 +107,8 @@ pub enum IrLiteral {
         /// Named IANA zone, or `None` for an offset-only datetime.
         zone: Option<String>,
     },
+    /// A canonical typed spatial property value.
+    Spatial(SpatialValue),
     /// A homogeneous list of values, persisted as an Arrow `List<inner>` column
     /// (the inner type is inferred from the elements). Stores e.g. a property
     /// whose value is `[date(…), date(…)]`. Heterogeneous lists are out of scope
@@ -152,6 +155,7 @@ impl Serialize for IrLiteral {
                 offset,
                 zone,
             } => IrLiteralSer::ZonedDateTime(*days, *nanos, *offset, zone.clone()).serialize(s),
+            Self::Spatial(value) => IrLiteralSer::Spatial(value).serialize(s),
             // Each element serialises via `IrLiteral`'s own impl (so nested
             // non-finite floats keep their tagged encoding).
             Self::List(items) => IrLiteralSer::List(items).serialize(s),
@@ -195,6 +199,7 @@ enum IrLiteralSer<'a> {
     Time(i64),
     ZonedTime(i64, i32),
     ZonedDateTime(i64, i64, i32, Option<String>),
+    Spatial(&'a SpatialValue),
     List(&'a [IrLiteral]),
     Map(&'a [(String, IrLiteral)]),
 }
@@ -290,6 +295,7 @@ impl<'de> Visitor<'de> for IrLiteralVisitor {
                     zone,
                 })
             }
+            "Spatial" => Ok(IrLiteral::Spatial(read_value_field(&mut map)?)),
             "List" => Ok(IrLiteral::List(read_value_field(&mut map)?)),
             "Map" => Ok(IrLiteral::Map(read_value_field(&mut map)?)),
             other => Err(de::Error::unknown_variant(
@@ -308,6 +314,7 @@ impl<'de> Visitor<'de> for IrLiteralVisitor {
                     "Time",
                     "ZonedTime",
                     "ZonedDateTime",
+                    "Spatial",
                     "List",
                     "Map",
                 ],

--- a/crates/graphforge-plan/src/lib.rs
+++ b/crates/graphforge-plan/src/lib.rs
@@ -1125,6 +1125,11 @@ fn hash_literal<H: Hasher>(lit: &IrLiteral, state: &mut H) {
             offset.hash(state);
             zone.hash(state);
         }
+        IrLiteral::Spatial(value) => {
+            15u8.hash(state);
+            value.spatial_type.hash(state);
+            hash_spatial_coordinates(&value.coordinates, state);
+        }
         IrLiteral::List(items) => {
             12u8.hash(state);
             items.len().hash(state);
@@ -1138,6 +1143,70 @@ fn hash_literal<H: Hasher>(lit: &IrLiteral, state: &mut H) {
             for (key, value) in entries {
                 key.hash(state);
                 hash_literal(value, state);
+            }
+        }
+    }
+}
+
+fn hash_spatial_coordinates<H: Hasher>(
+    coordinates: &graphforge_core::SpatialCoordinates,
+    state: &mut H,
+) {
+    use graphforge_core::SpatialCoordinates;
+    fn point<H: Hasher>(value: &[f64; 2], state: &mut H) {
+        value[0].to_bits().hash(state);
+        value[1].to_bits().hash(state);
+    }
+    match coordinates {
+        SpatialCoordinates::Point(value) => {
+            0u8.hash(state);
+            point(value, state);
+        }
+        SpatialCoordinates::LineString(values) => {
+            1u8.hash(state);
+            values.len().hash(state);
+            for value in values {
+                point(value, state);
+            }
+        }
+        SpatialCoordinates::Polygon(rings) => {
+            2u8.hash(state);
+            rings.len().hash(state);
+            for ring in rings {
+                ring.len().hash(state);
+                for value in ring {
+                    point(value, state);
+                }
+            }
+        }
+        SpatialCoordinates::MultiPoint(values) => {
+            3u8.hash(state);
+            values.len().hash(state);
+            for value in values {
+                point(value, state);
+            }
+        }
+        SpatialCoordinates::MultiLineString(lines) => {
+            4u8.hash(state);
+            lines.len().hash(state);
+            for line in lines {
+                line.len().hash(state);
+                for value in line {
+                    point(value, state);
+                }
+            }
+        }
+        SpatialCoordinates::MultiPolygon(polygons) => {
+            5u8.hash(state);
+            polygons.len().hash(state);
+            for polygon in polygons {
+                polygon.len().hash(state);
+                for ring in polygon {
+                    ring.len().hash(state);
+                    for value in ring {
+                        point(value, state);
+                    }
+                }
             }
         }
     }

--- a/crates/graphforge-rel/Cargo.toml
+++ b/crates/graphforge-rel/Cargo.toml
@@ -19,6 +19,7 @@ datafusion-functions-aggregate = "54"
 chrono = "0.4"
 chrono-tz = "0.10"
 thiserror = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/graphforge-rel/src/expr.rs
+++ b/crates/graphforge-rel/src/expr.rs
@@ -507,6 +507,14 @@ impl<'a> ExprLowerer<'a> {
 
             IrExpr::FunctionCall { name, args } if name == "labels" => self.lower_labels(args),
 
+            IrExpr::FunctionCall { name, args } if name.eq_ignore_ascii_case("point") => {
+                self.lower_spatial_point(args)
+            }
+
+            IrExpr::FunctionCall { name, args } if name.eq_ignore_ascii_case("distance") => {
+                self.lower_spatial_distance(args)
+            }
+
             IrExpr::FunctionCall { name, args }
                 if matches!(name.as_str(), "nodes" | "relationships") =>
             {
@@ -2017,6 +2025,143 @@ impl<'a> ExprLowerer<'a> {
         let a = self.lower(*a_id)?;
         let b = self.lower(*b_id)?;
         Ok(CYPHER_DURATION_BETWEEN.call(vec![a, b, lit(name)]))
+    }
+
+    fn lower_spatial_point(&self, args: &[ExprId]) -> Result<DfExpr, LoweringError> {
+        let [arg] = args else {
+            return Err(LoweringError::InvalidType(
+                "point() expects one map argument".into(),
+            ));
+        };
+        let value = self.const_spatial_point(*arg)?;
+        Ok(DfExpr::Literal(spatial_scalar(&value), None))
+    }
+
+    fn const_spatial_point(
+        &self,
+        id: ExprId,
+    ) -> Result<graphforge_core::SpatialValue, LoweringError> {
+        use graphforge_core::{
+            SpatialCoordinates, SpatialCrs, SpatialGeometryType, SpatialType, SpatialValue,
+        };
+        let IrExpr::MapLiteral(entries) = self.arena.get(id) else {
+            return Err(LoweringError::InvalidType(
+                "point() requires a literal coordinate map in the certified profile".into(),
+            ));
+        };
+        let number = |key: &str| -> Option<f64> {
+            let (_, id) = entries
+                .iter()
+                .find(|(name, _)| name.eq_ignore_ascii_case(key))?;
+            match self.arena.get(*id) {
+                IrExpr::Literal(IrLiteral::Int(value)) => {
+                    #[allow(
+                        clippy::cast_precision_loss,
+                        reason = "Cypher point coordinates are represented as f64"
+                    )]
+                    let value = *value as f64;
+                    Some(value)
+                }
+                IrExpr::Literal(IrLiteral::Float(value)) => Some(*value),
+                _ => None,
+            }
+        };
+        let string = |key: &str| -> Option<&str> {
+            let (_, id) = entries
+                .iter()
+                .find(|(name, _)| name.eq_ignore_ascii_case(key))?;
+            match self.arena.get(*id) {
+                IrExpr::Literal(IrLiteral::Str(value)) => Some(value.as_str()),
+                _ => None,
+            }
+        };
+        let geographic = number("longitude").zip(number("latitude"));
+        let cartesian = number("x").zip(number("y"));
+        let ((x, y), default_crs) = match (cartesian, geographic) {
+            (Some(value), None) => (value, SpatialCrs::Epsg3857),
+            (None, Some(value)) => (value, SpatialCrs::Epsg4326),
+            _ => {
+                return Err(LoweringError::InvalidType(
+                    "point() requires exactly x/y or longitude/latitude numeric coordinates".into(),
+                ));
+            }
+        };
+        if !x.is_finite() || !y.is_finite() {
+            return Err(LoweringError::InvalidType(
+                "point() coordinates must be finite".into(),
+            ));
+        }
+        let crs = match string("crs") {
+            None => default_crs,
+            Some(value) if value.eq_ignore_ascii_case("EPSG:4326") => SpatialCrs::Epsg4326,
+            Some(value) if value.eq_ignore_ascii_case("EPSG:3857") => SpatialCrs::Epsg3857,
+            Some(value) => {
+                return Err(LoweringError::InvalidType(format!(
+                    "unsupported spatial CRS `{value}` for point() computation"
+                )));
+            }
+        };
+        if (geographic.is_some() && crs != SpatialCrs::Epsg4326)
+            || (cartesian.is_some() && crs != SpatialCrs::Epsg3857)
+        {
+            return Err(LoweringError::InvalidType(
+                "point() coordinate keys do not match the declared CRS".into(),
+            ));
+        }
+        Ok(SpatialValue {
+            spatial_type: SpatialType {
+                geometry: SpatialGeometryType::Point,
+                crs,
+            },
+            coordinates: SpatialCoordinates::Point([x, y]),
+        })
+    }
+
+    fn lower_spatial_distance(&self, args: &[ExprId]) -> Result<DfExpr, LoweringError> {
+        use graphforge_core::{SpatialCoordinates, SpatialCrs};
+        let [left, right] = args else {
+            return Err(LoweringError::InvalidType(
+                "distance() expects two Point values".into(),
+            ));
+        };
+        let point = |id| match self.arena.get(id) {
+            IrExpr::FunctionCall { name, args }
+                if name.eq_ignore_ascii_case("point") && args.len() == 1 =>
+            {
+                self.const_spatial_point(args[0])
+            }
+            IrExpr::Literal(IrLiteral::Spatial(value)) => Ok(value.clone()),
+            _ => Err(LoweringError::InvalidType(
+                "distance() certified profile requires Point values".into(),
+            )),
+        };
+        let a = point(*left)?;
+        let b = point(*right)?;
+        if a.spatial_type.crs != b.spatial_type.crs {
+            return Err(LoweringError::InvalidType(
+                "distance() does not implicitly reproject mixed CRS values".into(),
+            ));
+        }
+        let (SpatialCoordinates::Point([ax, ay]), SpatialCoordinates::Point([bx, by])) =
+            (&a.coordinates, &b.coordinates)
+        else {
+            return Err(LoweringError::InvalidType(
+                "distance() accepts Point geometry only".into(),
+            ));
+        };
+        let distance = match a.spatial_type.crs {
+            SpatialCrs::Epsg3857 => (bx - ax).hypot(by - ay),
+            SpatialCrs::Epsg4326 => {
+                const EARTH_RADIUS_METRES: f64 = 6_371_008.8;
+                let (lat1, lat2) = (ay.to_radians(), by.to_radians());
+                let dlat = lat2 - lat1;
+                let dlon = (bx - ax).to_radians();
+                let h = (dlat / 2.0).sin().powi(2)
+                    + lat1.cos() * lat2.cos() * (dlon / 2.0).sin().powi(2);
+                2.0 * EARTH_RADIUS_METRES * h.sqrt().asin()
+            }
+        };
+        Ok(lit(distance))
     }
 
     fn extract_temporal_fields(
@@ -4689,6 +4834,7 @@ pub fn ir_literal_to_scalar(lit_val: &IrLiteral) -> ScalarValue {
             offset,
             zone,
         } => datetime_scalar(Some((*days, *nanos, *offset, zone.clone()))),
+        IrLiteral::Spatial(value) => spatial_property_scalar(value),
         // A homogeneous list → a `ScalarValue::List` of the element scalars; the
         // inner type is the first element's (re-typing untyped nulls to it so the
         // array stays homogeneous, as the list-literal lowering does). (#1006)
@@ -4720,6 +4866,83 @@ pub fn ir_literal_to_scalar(lit_val: &IrLiteral) -> ScalarValue {
     }
 }
 
+fn spatial_scalar(value: &graphforge_core::SpatialValue) -> ScalarValue {
+    use datafusion::arrow::array::{Float64Array, StructArray};
+    use datafusion::arrow::buffer::NullBuffer;
+    use datafusion::arrow::datatypes::{Field, Fields};
+    use graphforge_core::SpatialCoordinates;
+
+    fn coordinate(value: [f64; 2]) -> ScalarValue {
+        let fields = Fields::from(vec![
+            Field::new("x", DataType::Float64, false),
+            Field::new("y", DataType::Float64, false),
+        ]);
+        ScalarValue::Struct(Arc::new(StructArray::new(
+            fields,
+            vec![
+                Arc::new(Float64Array::from(vec![value[0]])),
+                Arc::new(Float64Array::from(vec![value[1]])),
+            ],
+            Some(NullBuffer::from(vec![true])),
+        )))
+    }
+
+    fn list(values: &[ScalarValue]) -> ScalarValue {
+        let data_type = values
+            .first()
+            .map_or(DataType::Null, ScalarValue::data_type);
+        ScalarValue::List(ScalarValue::new_list(values, &data_type, false))
+    }
+
+    fn coordinates(values: &[[f64; 2]]) -> ScalarValue {
+        list(&values.iter().copied().map(coordinate).collect::<Vec<_>>())
+    }
+
+    match &value.coordinates {
+        SpatialCoordinates::Point(value) => coordinate(*value),
+        SpatialCoordinates::LineString(values) | SpatialCoordinates::MultiPoint(values) => {
+            coordinates(values)
+        }
+        SpatialCoordinates::Polygon(parts) | SpatialCoordinates::MultiLineString(parts) => list(
+            &parts
+                .iter()
+                .map(|part| coordinates(part))
+                .collect::<Vec<_>>(),
+        ),
+        SpatialCoordinates::MultiPolygon(polygons) => list(
+            &polygons
+                .iter()
+                .map(|polygon| {
+                    list(
+                        &polygon
+                            .iter()
+                            .map(|ring| coordinates(ring))
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .collect::<Vec<_>>(),
+        ),
+    }
+}
+
+fn spatial_property_scalar(value: &graphforge_core::SpatialValue) -> ScalarValue {
+    use datafusion::arrow::array::{StringArray, StructArray};
+    use datafusion::arrow::buffer::NullBuffer;
+    use datafusion::arrow::datatypes::{Field, Fields};
+    let fields = Fields::from(vec![Field::new(
+        "__graphforge_spatial_v1",
+        DataType::Utf8,
+        false,
+    )]);
+    ScalarValue::Struct(Arc::new(StructArray::new(
+        fields,
+        vec![Arc::new(StringArray::from(vec![
+            serde_json::to_string(value).expect("spatial value serialization is infallible"),
+        ]))],
+        Some(NullBuffer::from(vec![true])),
+    )))
+}
+
 /// Convert a DataFusion [`ScalarValue`] back to an [`IrLiteral`] for storage as
 /// a property value (#791 SET).
 ///
@@ -4736,6 +4959,10 @@ pub fn ir_literal_to_scalar(lit_val: &IrLiteral) -> ScalarValue {
 /// # Errors
 /// Returns [`LoweringError::InvalidType`] for a value that openCypher does not
 /// permit as a stored property.
+#[allow(
+    clippy::too_many_lines,
+    reason = "closed exhaustive property scalar conversion table"
+)]
 pub fn scalar_to_ir_literal(value: &ScalarValue) -> Result<IrLiteral, LoweringError> {
     // Any null (typed `Int64(None)` or untyped `Null`) stores as Cypher null.
     if value.is_null() {
@@ -4786,6 +5013,21 @@ pub fn scalar_to_ir_literal(value: &ScalarValue) -> Result<IrLiteral, LoweringEr
         // A date keeps its date identity (ADR 0009/0012): a `Struct{epoch_day}` of
         // i64 days, not coerced to a `DateTime` — so it reads back and renders as a
         // date.
+        ScalarValue::Struct(arr)
+            if arr.fields().len() == 1 && arr.fields()[0].name() == "__graphforge_spatial_v1" =>
+        {
+            let json = arr
+                .column(0)
+                .as_any()
+                .downcast_ref::<datafusion::arrow::array::StringArray>()
+                .ok_or_else(|| {
+                    LoweringError::InvalidType("malformed internal spatial value".into())
+                })?
+                .value(0);
+            IrLiteral::Spatial(serde_json::from_str(json).map_err(|_| {
+                LoweringError::InvalidType("malformed internal spatial value".into())
+            })?)
+        }
         ScalarValue::Struct(arr) if is_date_struct(&DataType::Struct(arr.fields().clone())) => {
             match date_struct_value(arr, 0) {
                 Some(days) => IrLiteral::Date(days),

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -252,10 +252,11 @@ pub use schemas::{
 
 pub mod writer;
 pub use writer::{
-    GraphWriter, count_entity_properties, read_entity_properties, read_entity_property_keys,
-    read_node_property_rows, remove_edge_properties, remove_node_properties,
-    set_edge_properties_rewrite, set_node_properties, stage_remove_edge_properties,
-    stage_remove_node_properties, stage_set_edge_properties, stage_set_node_properties,
+    GraphWriter, count_entity_properties, decode_spatial_property_value, read_entity_properties,
+    read_entity_property_keys, read_node_property_rows, remove_edge_properties,
+    remove_node_properties, set_edge_properties_rewrite, set_node_properties,
+    stage_remove_edge_properties, stage_remove_node_properties, stage_set_edge_properties,
+    stage_set_node_properties,
 };
 
 pub mod mutator;

--- a/crates/graphforge-storage/src/writer.rs
+++ b/crates/graphforge-storage/src/writer.rs
@@ -63,7 +63,10 @@ use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 
 use graphforge_core::uuid::{Uuid, to_bytes};
-use graphforge_core::{GfError, OntologyMode, TypeId};
+use graphforge_core::{
+    GfError, OntologyMode, SpatialCoordinates, SpatialCrs, SpatialGeometryType, SpatialType,
+    SpatialValue, TypeId,
+};
 use graphforge_ir::IrLiteral;
 
 /// Identity, labels, and properties of a buffered node matched by MERGE.
@@ -1020,6 +1023,7 @@ enum ColType {
     Time,
     ZonedTime,
     ZonedDateTime,
+    Spatial(SpatialType),
     /// A homogeneous `List<inner>` column (#1006).
     List(Box<ColType>),
 }
@@ -1043,6 +1047,7 @@ impl ColType {
             IrLiteral::Time(_) => Some(Self::Time),
             IrLiteral::ZonedTime { .. } => Some(Self::ZonedTime),
             IrLiteral::ZonedDateTime { .. } => Some(Self::ZonedDateTime),
+            IrLiteral::Spatial(value) => Some(Self::Spatial(value.spatial_type)),
             // A homogeneous list: infer the inner type from the first non-null
             // element. A list whose elements are all null (or an empty list)
             // yields no type and the column falls back to `Str`. (#1006)
@@ -1068,6 +1073,7 @@ impl ColType {
             Self::Time => DataType::Time64(TimeUnit::Nanosecond),
             Self::ZonedTime => DataType::Struct(crate::schemas::time_struct_fields()),
             Self::ZonedDateTime => DataType::Struct(crate::schemas::datetime_struct_fields()),
+            Self::Spatial(spatial_type) => spatial_data_type(*spatial_type),
             Self::List(inner) => {
                 DataType::List(Arc::new(Field::new("item", inner.data_type(), true)))
             }
@@ -1080,6 +1086,46 @@ impl ColType {
             Self::Int | Self::Float | Self::Bool | Self::Str | Self::HetScalar
         )
     }
+}
+
+fn spatial_data_type(spatial_type: SpatialType) -> DataType {
+    let coordinate = DataType::Struct(arrow::datatypes::Fields::from(vec![
+        Field::new("x", DataType::Float64, false),
+        Field::new("y", DataType::Float64, false),
+    ]));
+    let list = |name: &str, child| DataType::List(Arc::new(Field::new(name, child, false)));
+    match spatial_type.geometry {
+        SpatialGeometryType::Point => coordinate,
+        SpatialGeometryType::LineString => list("vertices", coordinate),
+        SpatialGeometryType::Polygon => list("rings", list("vertices", coordinate)),
+        SpatialGeometryType::MultiPoint => list("points", coordinate),
+        SpatialGeometryType::MultiLineString => list("linestrings", list("vertices", coordinate)),
+        SpatialGeometryType::MultiPolygon => {
+            list("polygons", list("rings", list("vertices", coordinate)))
+        }
+    }
+}
+
+fn spatial_field(name: &str, spatial_type: SpatialType, nullable: bool) -> Field {
+    let extension_name = match spatial_type.geometry {
+        SpatialGeometryType::Point => "geoarrow.point",
+        SpatialGeometryType::LineString => "geoarrow.linestring",
+        SpatialGeometryType::Polygon => "geoarrow.polygon",
+        SpatialGeometryType::MultiPoint => "geoarrow.multipoint",
+        SpatialGeometryType::MultiLineString => "geoarrow.multilinestring",
+        SpatialGeometryType::MultiPolygon => "geoarrow.multipolygon",
+    };
+    let crs = match spatial_type.crs {
+        SpatialCrs::Epsg4326 => "EPSG:4326",
+        SpatialCrs::Epsg3857 => "EPSG:3857",
+    };
+    Field::new(name, spatial_data_type(spatial_type), nullable).with_metadata(HashMap::from([
+        ("ARROW:extension:name".to_owned(), extension_name.to_owned()),
+        (
+            "ARROW:extension:metadata".to_owned(),
+            format!("{{\"crs\":\"{crs}\",\"crs_type\":\"authority_code\"}}"),
+        ),
+    ]))
 }
 
 fn heterogeneous_scalar_fields() -> arrow::datatypes::Fields {
@@ -1159,7 +1205,10 @@ fn build_property_columns_keyed<R: PropRowLike>(
     let mut fields: Vec<Field> = vec![uuid_field(uuid_field_name)];
     for name in &order {
         let ct = col_types.get(name).cloned().unwrap_or(ColType::Str);
-        fields.push(Field::new(name, ct.data_type(), true));
+        fields.push(match ct {
+            ColType::Spatial(spatial_type) => spatial_field(name, spatial_type, true),
+            _ => Field::new(name, ct.data_type(), true),
+        });
     }
     let meta: HashMap<String, String> = [(meta_key.to_owned(), meta_value.to_owned())]
         .into_iter()
@@ -1432,6 +1481,7 @@ fn build_property_array<R: PropRowLike>(name: &str, ct: ColType, rows: &[R]) -> 
                 Some(NullBuffer::from(valid)),
             ))
         }
+        ColType::Spatial(spatial_type) => build_spatial_array(name, spatial_type, rows),
         ColType::Str => {
             let mut b = StringBuilder::new();
             for row in rows {
@@ -1477,6 +1527,197 @@ fn build_property_array<R: PropRowLike>(name: &str, ct: ColType, rows: &[R]) -> 
                 child,
                 Some(NullBuffer::from(valid)),
             ))
+        }
+    }
+}
+
+fn coordinate_builder(capacity: usize) -> arrow::array::StructBuilder {
+    use arrow::array::{ArrayBuilder, Float64Builder, StructBuilder};
+    let DataType::Struct(fields) = spatial_data_type(SpatialType {
+        geometry: SpatialGeometryType::Point,
+        crs: SpatialCrs::Epsg4326,
+    }) else {
+        unreachable!()
+    };
+    StructBuilder::new(
+        fields,
+        vec![
+            Box::new(Float64Builder::with_capacity(capacity)) as Box<dyn ArrayBuilder>,
+            Box::new(Float64Builder::with_capacity(capacity)),
+        ],
+    )
+}
+
+fn append_coordinate(builder: &mut arrow::array::StructBuilder, coordinate: [f64; 2]) {
+    builder
+        .field_builder::<Float64Builder>(0)
+        .expect("canonical x builder")
+        .append_value(coordinate[0]);
+    builder
+        .field_builder::<Float64Builder>(1)
+        .expect("canonical y builder")
+        .append_value(coordinate[1]);
+    builder.append(true);
+}
+
+#[allow(
+    clippy::too_many_lines,
+    reason = "six canonical GeoArrow nesting shapes share one exhaustive writer"
+)]
+fn build_spatial_array<R: PropRowLike>(
+    name: &str,
+    spatial_type: SpatialType,
+    rows: &[R],
+) -> ArrayRef {
+    use arrow::array::ListBuilder;
+
+    match spatial_type.geometry {
+        SpatialGeometryType::Point => {
+            let mut builder = coordinate_builder(rows.len());
+            for row in rows {
+                match row.props().get(name) {
+                    Some(IrLiteral::Spatial(SpatialValue {
+                        spatial_type: observed,
+                        coordinates: SpatialCoordinates::Point(coordinate),
+                    })) if *observed == spatial_type => {
+                        append_coordinate(&mut builder, *coordinate);
+                    }
+                    _ => builder.append(false),
+                }
+            }
+            Arc::new(builder.finish())
+        }
+        SpatialGeometryType::LineString | SpatialGeometryType::MultiPoint => {
+            let child_name = if spatial_type.geometry == SpatialGeometryType::LineString {
+                "vertices"
+            } else {
+                "points"
+            };
+            let mut builder =
+                ListBuilder::new(coordinate_builder(0)).with_field(Arc::new(Field::new(
+                    child_name,
+                    spatial_data_type(SpatialType {
+                        geometry: SpatialGeometryType::Point,
+                        crs: spatial_type.crs,
+                    }),
+                    false,
+                )));
+            for row in rows {
+                let coordinates = match row.props().get(name) {
+                    Some(IrLiteral::Spatial(SpatialValue {
+                        spatial_type: observed,
+                        coordinates: SpatialCoordinates::LineString(values),
+                    })) if *observed == spatial_type => Some(values.as_slice()),
+                    Some(IrLiteral::Spatial(SpatialValue {
+                        spatial_type: observed,
+                        coordinates: SpatialCoordinates::MultiPoint(values),
+                    })) if *observed == spatial_type => Some(values.as_slice()),
+                    _ => None,
+                };
+                if let Some(coordinates) = coordinates {
+                    for coordinate in coordinates {
+                        append_coordinate(builder.values(), *coordinate);
+                    }
+                    builder.append(true);
+                } else {
+                    builder.append(false);
+                }
+            }
+            Arc::new(builder.finish())
+        }
+        SpatialGeometryType::Polygon | SpatialGeometryType::MultiLineString => {
+            let coordinate_type = spatial_data_type(SpatialType {
+                geometry: SpatialGeometryType::Point,
+                crs: spatial_type.crs,
+            });
+            let inner = ListBuilder::new(coordinate_builder(0)).with_field(Arc::new(Field::new(
+                "vertices",
+                coordinate_type.clone(),
+                false,
+            )));
+            let outer_name = if spatial_type.geometry == SpatialGeometryType::Polygon {
+                "rings"
+            } else {
+                "linestrings"
+            };
+            let mut builder = ListBuilder::new(inner).with_field(Arc::new(Field::new(
+                outer_name,
+                DataType::List(Arc::new(Field::new("vertices", coordinate_type, false))),
+                false,
+            )));
+            for row in rows {
+                let parts = match row.props().get(name) {
+                    Some(IrLiteral::Spatial(SpatialValue {
+                        spatial_type: observed,
+                        coordinates: SpatialCoordinates::Polygon(values),
+                    })) if *observed == spatial_type => Some(values.as_slice()),
+                    Some(IrLiteral::Spatial(SpatialValue {
+                        spatial_type: observed,
+                        coordinates: SpatialCoordinates::MultiLineString(values),
+                    })) if *observed == spatial_type => Some(values.as_slice()),
+                    _ => None,
+                };
+                if let Some(parts) = parts {
+                    for coordinates in parts {
+                        for coordinate in coordinates {
+                            append_coordinate(builder.values().values(), *coordinate);
+                        }
+                        builder.values().append(true);
+                    }
+                    builder.append(true);
+                } else {
+                    builder.append(false);
+                }
+            }
+            Arc::new(builder.finish())
+        }
+        SpatialGeometryType::MultiPolygon => {
+            let coordinate_type = spatial_data_type(SpatialType {
+                geometry: SpatialGeometryType::Point,
+                crs: spatial_type.crs,
+            });
+            let vertices = ListBuilder::new(coordinate_builder(0)).with_field(Arc::new(
+                Field::new("vertices", coordinate_type.clone(), false),
+            ));
+            let rings_type = DataType::List(Arc::new(Field::new(
+                "vertices",
+                coordinate_type.clone(),
+                false,
+            )));
+            let rings = ListBuilder::new(vertices).with_field(Arc::new(Field::new(
+                "rings",
+                rings_type.clone(),
+                false,
+            )));
+            let mut builder = ListBuilder::new(rings).with_field(Arc::new(Field::new(
+                "polygons",
+                DataType::List(Arc::new(Field::new("rings", rings_type, false))),
+                false,
+            )));
+            for row in rows {
+                let polygons = match row.props().get(name) {
+                    Some(IrLiteral::Spatial(SpatialValue {
+                        spatial_type: observed,
+                        coordinates: SpatialCoordinates::MultiPolygon(values),
+                    })) if *observed == spatial_type => Some(values.as_slice()),
+                    _ => None,
+                };
+                if let Some(polygons) = polygons {
+                    for rings in polygons {
+                        for coordinates in rings {
+                            for coordinate in coordinates {
+                                append_coordinate(builder.values().values().values(), *coordinate);
+                            }
+                            builder.values().values().append(true);
+                        }
+                        builder.values().append(true);
+                    }
+                    builder.append(true);
+                } else {
+                    builder.append(false);
+                }
+            }
+            Arc::new(builder.finish())
         }
     }
 }
@@ -1586,6 +1827,9 @@ fn literal_to_string(lit: &IrLiteral) -> String {
             "{days}d{nanos}ns{offset:+}s{}",
             zone.as_deref().unwrap_or("")
         ),
+        IrLiteral::Spatial(value) => {
+            serde_json::to_string(value).expect("canonical spatial values are serializable")
+        }
         // A list in a mixed (stringified) column: a deterministic bracketed form.
         IrLiteral::List(items) => {
             let parts: Vec<String> = items.iter().map(literal_to_string).collect();
@@ -1837,6 +2081,9 @@ fn decode_value(
     use arrow::array::{
         Array, BooleanArray, Int32Array, Int64Array, ListArray, StructArray, Time64NanosecondArray,
     };
+    if field.metadata().contains_key("ARROW:extension:name") {
+        return decode_spatial_value(col, field, r);
+    }
     Ok(match field.data_type() {
         DataType::Int64 => IrLiteral::Int(downcast::<Int64Array>(col, field)?.value(r)),
         DataType::Float64 => IrLiteral::Float(downcast::<Float64Array>(col, field)?.value(r)),
@@ -2034,6 +2281,160 @@ fn decode_value(
             )));
         }
     })
+}
+
+fn decode_spatial_value(col: &ArrayRef, field: &Field, row: usize) -> Result<IrLiteral, GfError> {
+    decode_spatial_property_value(col.as_ref(), field, row).map(IrLiteral::Spatial)
+}
+
+/// Decode one canonical GeoArrow property row without reconstructing geometry
+/// in a language binding.
+#[allow(
+    clippy::too_many_lines,
+    reason = "six canonical GeoArrow nesting shapes share one exhaustive decoder"
+)]
+pub fn decode_spatial_property_value(
+    col: &dyn arrow::array::Array,
+    field: &Field,
+    row: usize,
+) -> Result<SpatialValue, GfError> {
+    use arrow::array::{Array, ListArray, StructArray};
+    let extension_name = field
+        .metadata()
+        .get("ARROW:extension:name")
+        .ok_or_else(|| GfError::Storage("spatial field missing extension name".into()))?;
+    let geometry = match extension_name.as_str() {
+        "geoarrow.point" => SpatialGeometryType::Point,
+        "geoarrow.linestring" => SpatialGeometryType::LineString,
+        "geoarrow.polygon" => SpatialGeometryType::Polygon,
+        "geoarrow.multipoint" => SpatialGeometryType::MultiPoint,
+        "geoarrow.multilinestring" => SpatialGeometryType::MultiLineString,
+        "geoarrow.multipolygon" => SpatialGeometryType::MultiPolygon,
+        _ => {
+            return Err(GfError::Storage(
+                "unsupported spatial extension name".into(),
+            ));
+        }
+    };
+    let metadata = field
+        .metadata()
+        .get("ARROW:extension:metadata")
+        .ok_or_else(|| GfError::Storage("spatial field missing extension metadata".into()))?;
+    let crs = if metadata.contains("EPSG:4326") {
+        SpatialCrs::Epsg4326
+    } else if metadata.contains("EPSG:3857") {
+        SpatialCrs::Epsg3857
+    } else {
+        return Err(GfError::Storage("unsupported spatial CRS metadata".into()));
+    };
+    let coordinates = match geometry {
+        SpatialGeometryType::Point => SpatialCoordinates::Point(read_coordinate(
+            col.as_any()
+                .downcast_ref::<StructArray>()
+                .ok_or_else(|| GfError::Storage("spatial point is not a struct".into()))?,
+            row,
+        )?),
+        SpatialGeometryType::LineString | SpatialGeometryType::MultiPoint => {
+            let value = col
+                .as_any()
+                .downcast_ref::<ListArray>()
+                .ok_or_else(|| GfError::Storage("spatial geometry is not a list".into()))?
+                .value(row);
+            let values =
+                read_coordinates(value.as_any().downcast_ref::<StructArray>().ok_or_else(
+                    || GfError::Storage("spatial coordinate payload is not a struct".into()),
+                )?)?;
+            if geometry == SpatialGeometryType::LineString {
+                SpatialCoordinates::LineString(values)
+            } else {
+                SpatialCoordinates::MultiPoint(values)
+            }
+        }
+        SpatialGeometryType::Polygon | SpatialGeometryType::MultiLineString => {
+            let value = col
+                .as_any()
+                .downcast_ref::<ListArray>()
+                .ok_or_else(|| GfError::Storage("spatial geometry is not a nested list".into()))?
+                .value(row);
+            let lists = value
+                .as_any()
+                .downcast_ref::<ListArray>()
+                .ok_or_else(|| GfError::Storage("spatial parts are not lists".into()))?;
+            let mut parts = Vec::with_capacity(lists.len());
+            for index in 0..lists.len() {
+                let coordinates = lists.value(index);
+                parts.push(read_coordinates(
+                    coordinates
+                        .as_any()
+                        .downcast_ref::<StructArray>()
+                        .ok_or_else(|| {
+                            GfError::Storage("spatial coordinates are not structs".into())
+                        })?,
+                )?);
+            }
+            if geometry == SpatialGeometryType::Polygon {
+                SpatialCoordinates::Polygon(parts)
+            } else {
+                SpatialCoordinates::MultiLineString(parts)
+            }
+        }
+        SpatialGeometryType::MultiPolygon => {
+            let value = col
+                .as_any()
+                .downcast_ref::<ListArray>()
+                .ok_or_else(|| GfError::Storage("multipolygon is not a nested list".into()))?
+                .value(row);
+            let polygons = value
+                .as_any()
+                .downcast_ref::<ListArray>()
+                .ok_or_else(|| GfError::Storage("multipolygon polygons are not lists".into()))?;
+            let mut decoded = Vec::with_capacity(polygons.len());
+            for polygon_index in 0..polygons.len() {
+                let polygon = polygons.value(polygon_index);
+                let rings = polygon
+                    .as_any()
+                    .downcast_ref::<ListArray>()
+                    .ok_or_else(|| GfError::Storage("multipolygon rings are not lists".into()))?;
+                let mut decoded_rings = Vec::with_capacity(rings.len());
+                for ring_index in 0..rings.len() {
+                    let coordinates = rings.value(ring_index);
+                    decoded_rings.push(read_coordinates(
+                        coordinates
+                            .as_any()
+                            .downcast_ref::<StructArray>()
+                            .ok_or_else(|| {
+                                GfError::Storage("multipolygon coordinates are not structs".into())
+                            })?,
+                    )?);
+                }
+                decoded.push(decoded_rings);
+            }
+            SpatialCoordinates::MultiPolygon(decoded)
+        }
+    };
+    Ok(SpatialValue {
+        spatial_type: SpatialType { geometry, crs },
+        coordinates,
+    })
+}
+
+fn read_coordinates(array: &arrow::array::StructArray) -> Result<Vec<[f64; 2]>, GfError> {
+    use arrow::array::Array;
+    (0..array.len())
+        .map(|index| read_coordinate(array, index))
+        .collect()
+}
+
+fn read_coordinate(array: &arrow::array::StructArray, row: usize) -> Result<[f64; 2], GfError> {
+    let x = array
+        .column_by_name("x")
+        .and_then(|column| column.as_any().downcast_ref::<Float64Array>())
+        .ok_or_else(|| GfError::Storage("spatial x coordinate is not Float64".into()))?;
+    let y = array
+        .column_by_name("y")
+        .and_then(|column| column.as_any().downcast_ref::<Float64Array>())
+        .ok_or_else(|| GfError::Storage("spatial y coordinate is not Float64".into()))?;
+    Ok([x.value(row), y.value(row)])
 }
 
 /// Downcast a column to a concrete Arrow array type, erroring with the column
@@ -3343,6 +3744,121 @@ mod tests {
             reopened
                 .get(&to_bytes(&propertyless))
                 .is_none_or(HashMap::is_empty)
+        );
+    }
+
+    #[test]
+    fn canonical_spatial_properties_round_trip_with_exact_geoarrow_metadata() {
+        let dir = TempDir::new().unwrap();
+        let node = new_v7();
+        let other = new_v7();
+        let edge = new_v7();
+        let spatial = |geometry, coordinates| {
+            IrLiteral::Spatial(SpatialValue {
+                spatial_type: SpatialType {
+                    geometry,
+                    crs: SpatialCrs::Epsg4326,
+                },
+                coordinates,
+            })
+        };
+        let values = HashMap::from([
+            (
+                "point".into(),
+                spatial(
+                    SpatialGeometryType::Point,
+                    SpatialCoordinates::Point([-104.9903, 39.7392]),
+                ),
+            ),
+            (
+                "line".into(),
+                spatial(
+                    SpatialGeometryType::LineString,
+                    SpatialCoordinates::LineString(vec![[0.0, 1.0], [2.0, 3.0]]),
+                ),
+            ),
+            (
+                "polygon".into(),
+                spatial(
+                    SpatialGeometryType::Polygon,
+                    SpatialCoordinates::Polygon(vec![vec![[0.0, 0.0], [1.0, 0.0], [0.0, 0.0]]]),
+                ),
+            ),
+            (
+                "multipoint".into(),
+                spatial(
+                    SpatialGeometryType::MultiPoint,
+                    SpatialCoordinates::MultiPoint(vec![[4.0, 5.0], [6.0, 7.0]]),
+                ),
+            ),
+            (
+                "multiline".into(),
+                spatial(
+                    SpatialGeometryType::MultiLineString,
+                    SpatialCoordinates::MultiLineString(vec![vec![[8.0, 9.0], [10.0, 11.0]]]),
+                ),
+            ),
+            (
+                "multipolygon".into(),
+                spatial(
+                    SpatialGeometryType::MultiPolygon,
+                    SpatialCoordinates::MultiPolygon(vec![vec![vec![
+                        [0.0, 0.0],
+                        [2.0, 0.0],
+                        [0.0, 0.0],
+                    ]]]),
+                ),
+            ),
+        ]);
+
+        let mut writer = GraphWriter::open_at(dir.path(), OntologyMode::Exploratory, TS).unwrap();
+        writer.create_node(node, TypeId(0)).unwrap();
+        writer.create_node(other, TypeId(0)).unwrap();
+        writer.create_edge(edge, "ROUTE", &node, &other).unwrap();
+        writer.set_properties(&node, None, values.clone()).unwrap();
+        writer
+            .set_edge_properties(
+                &edge,
+                Some("ROUTE"),
+                HashMap::from([("location".into(), values["point"].clone())]),
+            )
+            .unwrap();
+        writer.flush().unwrap();
+
+        let node_schema =
+            crate::catalog::discover_parquet_schema(&node_props_path(dir.path(), "_untyped"))
+                .unwrap();
+        for (name, extension_name) in [
+            ("point", "geoarrow.point"),
+            ("line", "geoarrow.linestring"),
+            ("polygon", "geoarrow.polygon"),
+            ("multipoint", "geoarrow.multipoint"),
+            ("multiline", "geoarrow.multilinestring"),
+            ("multipolygon", "geoarrow.multipolygon"),
+        ] {
+            let field = node_schema.field_with_name(name).unwrap();
+            assert_eq!(field.metadata()["ARROW:extension:name"], extension_name);
+            assert_eq!(
+                field.metadata()["ARROW:extension:metadata"],
+                "{\"crs\":\"EPSG:4326\",\"crs_type\":\"authority_code\"}"
+            );
+        }
+        assert_eq!(
+            read_node_props(dir.path(), "_untyped")[&to_bytes(&node)],
+            values
+        );
+        assert_eq!(
+            read_edge_props(dir.path(), "ROUTE")[&to_bytes(&edge)]["location"],
+            values["point"]
+        );
+
+        // Opening and flushing again exercises the persisted decode/re-encode path.
+        let mut reopened =
+            GraphWriter::open_at(dir.path(), OntologyMode::Exploratory, TS + 1).unwrap();
+        reopened.flush().unwrap();
+        assert_eq!(
+            read_node_props(dir.path(), "_untyped")[&to_bytes(&node)],
+            values
         );
     }
 

--- a/docs/reference/implementation-status/functions.md
+++ b/docs/reference/implementation-status/functions.md
@@ -294,11 +294,15 @@ All temporal functions are ✅ COMPLETE with comprehensive support.
 
 ### point() ✅
 **Signature:** `point({x, y [, crs]})` or `point({latitude, longitude [, crs]})`
-**Notes:** Supports 2D/3D, Cartesian and Geographic coordinate systems.
+**Notes:** The certified profile is 2D only: `x`/`y` uses EPSG:3857 and
+`longitude`/`latitude` uses EPSG:4326. The optional CRS must agree with those
+keys. Unsupported CRS values fail explicitly; GraphForge never swaps axes or
+implicitly reprojects.
 
 ### distance() ✅
 **Signature:** `distance(point1, point2)`
-**Notes:** Haversine for geographic coordinates; Euclidean for Cartesian.
+**Notes:** Deterministic haversine metres for EPSG:4326 and Euclidean metres for
+EPSG:3857. Both arguments must be Points in the same CRS.
 
 ---
 

--- a/docs/reference/opencypher-compatibility-matrix.md
+++ b/docs/reference/opencypher-compatibility-matrix.md
@@ -31,7 +31,7 @@ Comprehensive status matrix for GraphForge's OpenCypher implementation, showing 
 - Writing: CREATE, SET, REMOVE, DELETE, DETACH DELETE
 - Advanced: OPTIONAL MATCH, UNION, UNWIND, variable-length paths
 - Temporal: All date/time types and functions (100% complete)
-- Spatial: legacy documentation only; executable `point()`/`distance()` Cypher support is not yet certified
+- Spatial: canonical GeoArrow properties plus the bounded `point()`/`distance()` profile below
 - Pattern matching: All node/relationship pattern variations, pattern predicates
 - Predicate functions: all(), any(), none(), single(), exists(), isEmpty()
 - List operations: extract(), filter(), reduce(), slicing, negative indexing
@@ -186,8 +186,8 @@ Comprehensive status matrix for GraphForge's OpenCypher implementation, showing 
 
 | Function | Status | TCK Scenarios | File | Notes |
 |----------|--------|---------------|------|-------|
-| point() | ⚠️ Documentation only | 0 | — | Not part of the canonical GeoArrow property contract |
-| distance() | ⚠️ Documentation only | 0 | — | No executable Rust query implementation is currently certified |
+| point() | ✅ Bounded profile | Rust E2E | #800 | Literal 2D `x`/`y` EPSG:3857 or `longitude`/`latitude` EPSG:4326 maps; no implicit axis swap or reprojection |
+| distance() | ✅ Bounded profile | Rust E2E | #800 | Euclidean metres for EPSG:3857 and deterministic haversine metres for EPSG:4326 Point values; mixed CRS and non-Point values are typed errors |
 
 #### Path Functions (3 total: 3 complete) ✅ COMPLETE CATEGORY
 

--- a/tools/bazel/drift/cargo_feature_fingerprint.json
+++ b/tools/bazel/drift/cargo_feature_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "schema": "graphforge.cargo-feature-fingerprint.v1",
-  "sha256": "fe37804afbbaa557546676cb2bf6394bfa1ba376c452603d83e63557e53ba2ec",
+  "sha256": "64f2bcf3b532b032b3a7f5c5db9a24515fde3c4d5225dee895f5263efb66916f",
   "entries": [
     {
       "name": "graphforge-api",
@@ -1462,6 +1462,15 @@
           "optional": false,
           "uses_default_features": true,
           "kind": "dev",
+          "target": null
+        },
+        {
+          "name": "serde_json",
+          "req": "^1",
+          "features": [],
+          "optional": false,
+          "uses_default_features": true,
+          "kind": null,
           "target": null
         },
         {


### PR DESCRIPTION
## Summary

- carry canonical GeoArrow spatial values through scalar and bulk Rust construction
- persist all six v1 geometry shapes with exact CRS extension metadata and decode them on reopen
- retain spatial schemas through node/edge query projection and deterministic plan hashing
- certify bounded Rust `point()` and `distance()` semantics with explicit mixed/unsupported CRS failures
- preflight complete bulk spatial arrays against the #799 resource and validity limits before normalization

## Verification

- `cargo fmt --all`
- `cargo clippy -p graphforge-core -p graphforge-ir -p graphforge-plan -p graphforge-storage -p graphforge-rel -p graphforge-api --lib -- -D warnings`
- `cargo test -p graphforge-storage canonical_spatial_properties_round_trip_with_exact_geoarrow_metadata -- --nocapture`
- `cargo test -p graphforge-api construction::tests::scalar_spatial_node_and_edge_project_after_reopen_with_geoarrow_metadata --lib -- --nocapture`
- `cargo test -p graphforge-api spatial_bulk_preflight_validates_the_complete_array_before_row_normalization --lib -- --nocapture`
- `cargo test -p graphforge-api --test e2e_baseline certified_spatial_point_and_distance_execute_in_rust -- --nocapture`

Closes #800

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/814"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789732742&installation_model_id=20486&pr_number=814&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F814&signature=5a441c70f9f1ec70a5b1490a63027770d87446ce04f5d101d66e72c3d36424db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->