### PR TITLE
feat(storage): add persistent UUID membership indexes

### DIFF
--- a/crates/graphforge-api/src/bulk_construction.rs
+++ b/crates/graphforge-api/src/bulk_construction.rs
@@ -362,8 +362,19 @@ impl GraphForge {
         let mut existing = BTreeSet::new();
         if reject_existing {
             let candidates = candidate_uuids(batches, BulkInputKind::Node, "node_uuid")?;
-            existing = existing_node_uuids(self, &candidates)?;
-            existing.extend(existing_edge_uuids(self, &candidates)?);
+            let mut index = open_membership_index(self, BulkInputKind::Node)?;
+            existing = indexed_existing(
+                index.as_mut(),
+                &candidates,
+                graphforge_storage::UuidIndexKind::Node,
+                BulkInputKind::Node,
+            )?;
+            existing.extend(indexed_existing(
+                index.as_mut(),
+                &candidates,
+                graphforge_storage::UuidIndexKind::Edge,
+                BulkInputKind::Node,
+            )?);
         }
         let mut observed = BTreeSet::new();
         let mut rows = Vec::new();
@@ -473,8 +484,19 @@ impl GraphForge {
         }
 
         let candidates = normalized.identities().collect::<BTreeSet<_>>();
-        let mut existing = existing_node_uuids(self, &candidates)?;
-        existing.extend(existing_edge_uuids(self, &candidates)?);
+        let mut index = open_membership_index(self, BulkInputKind::Node)?;
+        let mut existing = indexed_existing(
+            index.as_mut(),
+            &candidates,
+            graphforge_storage::UuidIndexKind::Node,
+            BulkInputKind::Node,
+        )?;
+        existing.extend(indexed_existing(
+            index.as_mut(),
+            &candidates,
+            graphforge_storage::UuidIndexKind::Edge,
+            BulkInputKind::Node,
+        )?);
         if normalized
             .rows
             .iter()
@@ -624,14 +646,12 @@ impl GraphForge {
         }
         validate_partition_schemas(BulkInputKind::Edge, &EDGE_REQUIRED, batches)?;
         let endpoint_candidates = candidate_endpoint_uuids(batches)?;
-        let mut known_nodes = existing_node_uuids(self, &endpoint_candidates)?;
+        let edge_candidates = reject_existing
+            .then(|| candidate_uuids(batches, BulkInputKind::Edge, "edge_uuid"))
+            .transpose()?;
+        let (mut known_nodes, existing_edges) =
+            existing_edge_context(self, &endpoint_candidates, edge_candidates.as_ref())?;
         known_nodes.extend(same_request_nodes.identities());
-        let existing_edges = if reject_existing {
-            let edge_candidates = candidate_uuids(batches, BulkInputKind::Edge, "edge_uuid")?;
-            existing_edge_uuids(self, &edge_candidates)?
-        } else {
-            BTreeSet::new()
-        };
         let mut observed = BTreeSet::new();
         let mut rows = Vec::new();
         let mut ordinal = 0_u64;
@@ -760,7 +780,19 @@ impl GraphForge {
             .iter()
             .map(|row| row.edge_uuid)
             .collect::<BTreeSet<_>>();
-        let existing = existing_edge_uuids(self, &candidates)?;
+        let mut index = open_membership_index(self, BulkInputKind::Edge)?;
+        let mut existing = indexed_existing(
+            index.as_mut(),
+            &candidates,
+            graphforge_storage::UuidIndexKind::Edge,
+            BulkInputKind::Edge,
+        )?;
+        existing.extend(indexed_existing(
+            index.as_mut(),
+            &candidates,
+            graphforge_storage::UuidIndexKind::Node,
+            BulkInputKind::Edge,
+        )?);
         if let Some(row) = normalized
             .rows
             .iter()
@@ -1671,51 +1703,105 @@ fn generated_uuid(operation_uuid: OperationId, kind: BulkInputKind, ordinal: u64
     Uuid::from_bytes(bytes)
 }
 
-fn existing_node_uuids(
+fn open_membership_index(
     graph: &GraphForge,
-    candidates: &BTreeSet<Uuid>,
-) -> Result<BTreeSet<Uuid>, BulkValidationError> {
-    indexed_existing(graph, candidates, graphforge_storage::UuidIndexKind::Node)
-}
-
-fn existing_edge_uuids(
-    graph: &GraphForge,
-    candidates: &BTreeSet<Uuid>,
-) -> Result<BTreeSet<Uuid>, BulkValidationError> {
-    indexed_existing(graph, candidates, graphforge_storage::UuidIndexKind::Edge)
-}
-
-fn indexed_existing(
-    graph: &GraphForge,
-    candidates: &BTreeSet<Uuid>,
-    index_kind: graphforge_storage::UuidIndexKind,
-) -> Result<BTreeSet<Uuid>, BulkValidationError> {
-    let manifest = graph.dir.join("indexes/uuid-membership/manifest.json");
-    if !manifest.exists() {
+    input_kind: BulkInputKind,
+) -> Result<
+    std::sync::MutexGuard<'_, Option<graphforge_storage::UuidMembershipIndex>>,
+    BulkValidationError,
+> {
+    let current_generation =
+        graphforge_storage::read_topology_generation(&graph.dir).map_err(|error| {
+            contract_error(
+                input_kind,
+                BulkValidationReason::ProjectState,
+                &error.to_string(),
+            )
+        })?;
+    let mut cached = graph.uuid_membership_index.lock().map_err(|error| {
+        contract_error(
+            input_kind,
+            BulkValidationReason::ProjectState,
+            &error.to_string(),
+        )
+    })?;
+    if cached
+        .as_ref()
+        .is_some_and(|index| index.topology_generation() != current_generation)
+    {
+        *cached = None;
+    }
+    if !graphforge_storage::uuid_membership_index_present(&graph.dir) {
         let has_nodes = graph.dir.join("topology/nodes.parquet").exists();
         let has_edges = std::fs::read_dir(graph.dir.join("topology/edges"))
             .ok()
             .is_some_and(|mut entries| entries.any(|entry| entry.is_ok()));
         if has_nodes || has_edges {
             return Err(contract_error(
-                BulkInputKind::Node,
+                input_kind,
                 BulkValidationReason::ProjectState,
                 "UUID membership index is missing; run the bounded storage rebuild before ingest",
             ));
         }
-        return Ok(BTreeSet::new());
+        return Ok(cached);
     }
-    let mut index = graphforge_storage::UuidMembershipIndex::open(&graph.dir).map_err(|error| {
-        contract_error(
-            BulkInputKind::Node,
-            BulkValidationReason::ProjectState,
-            &error.to_string(),
-        )
-    })?;
+    if cached.is_none() {
+        *cached = Some(
+            graphforge_storage::UuidMembershipIndex::open(&graph.dir).map_err(|error| {
+                contract_error(
+                    input_kind,
+                    BulkValidationReason::ProjectState,
+                    &error.to_string(),
+                )
+            })?,
+        );
+    }
+    Ok(cached)
+}
+
+fn existing_edge_context(
+    graph: &GraphForge,
+    endpoint_candidates: &BTreeSet<Uuid>,
+    edge_candidates: Option<&BTreeSet<Uuid>>,
+) -> Result<(BTreeSet<Uuid>, BTreeSet<Uuid>), BulkValidationError> {
+    let mut index = open_membership_index(graph, BulkInputKind::Edge)?;
+    let known_nodes = indexed_existing(
+        index.as_mut(),
+        endpoint_candidates,
+        graphforge_storage::UuidIndexKind::Node,
+        BulkInputKind::Edge,
+    )?;
+    let Some(edge_candidates) = edge_candidates else {
+        return Ok((known_nodes, BTreeSet::new()));
+    };
+    let mut existing = indexed_existing(
+        index.as_mut(),
+        edge_candidates,
+        graphforge_storage::UuidIndexKind::Edge,
+        BulkInputKind::Edge,
+    )?;
+    existing.extend(indexed_existing(
+        index.as_mut(),
+        edge_candidates,
+        graphforge_storage::UuidIndexKind::Node,
+        BulkInputKind::Edge,
+    )?);
+    Ok((known_nodes, existing))
+}
+
+fn indexed_existing(
+    index: Option<&mut graphforge_storage::UuidMembershipIndex>,
+    candidates: &BTreeSet<Uuid>,
+    index_kind: graphforge_storage::UuidIndexKind,
+    input_kind: BulkInputKind,
+) -> Result<BTreeSet<Uuid>, BulkValidationError> {
+    let Some(index) = index else {
+        return Ok(BTreeSet::new());
+    };
     let requested = candidates.iter().copied().collect::<Vec<_>>();
     let (found, _) = index.probe(index_kind, &requested).map_err(|error| {
         contract_error(
-            BulkInputKind::Node,
+            input_kind,
             BulkValidationReason::ProjectState,
             &error.to_string(),
         )
@@ -3708,6 +3794,19 @@ mod tests {
                 .sum::<usize>(),
             256
         );
+        let node_collision =
+            edge_batch(&[node_ids[31]], &["KNOWS"], &[node_ids[0]], &[node_ids[1]]);
+        let collision = reopened
+            .publish_bulk_edges(operation(934), &[node_collision])
+            .unwrap_err();
+        assert!(matches!(
+            collision,
+            BulkEdgePublicationError::Validation(BulkValidationError {
+                kind: BulkInputKind::Edge,
+                reason: BulkValidationReason::IdentityConflict,
+                ..
+            })
+        ));
         let replay = reopened
             .publish_bulk_edges(operation(932), std::slice::from_ref(&batch))
             .unwrap();

--- a/crates/graphforge-api/src/bulk_construction.rs
+++ b/crates/graphforge-api/src/bulk_construction.rs
@@ -361,8 +361,9 @@ impl GraphForge {
         validate_partition_schemas(BulkInputKind::Node, &NODE_REQUIRED, batches)?;
         let mut existing = BTreeSet::new();
         if reject_existing {
-            existing = existing_node_uuids(self)?;
-            existing.extend(existing_edge_uuids(self)?);
+            let candidates = candidate_uuids(batches, BulkInputKind::Node, "node_uuid")?;
+            existing = existing_node_uuids(self, &candidates)?;
+            existing.extend(existing_edge_uuids(self, &candidates)?);
         }
         let mut observed = BTreeSet::new();
         let mut rows = Vec::new();
@@ -471,8 +472,9 @@ impl GraphForge {
             )?);
         }
 
-        let mut existing = existing_node_uuids(self)?;
-        existing.extend(existing_edge_uuids(self)?);
+        let candidates = normalized.identities().collect::<BTreeSet<_>>();
+        let mut existing = existing_node_uuids(self, &candidates)?;
+        existing.extend(existing_edge_uuids(self, &candidates)?);
         if normalized
             .rows
             .iter()
@@ -621,10 +623,12 @@ impl GraphForge {
             ));
         }
         validate_partition_schemas(BulkInputKind::Edge, &EDGE_REQUIRED, batches)?;
-        let mut known_nodes = existing_node_uuids(self)?;
+        let endpoint_candidates = candidate_endpoint_uuids(batches)?;
+        let mut known_nodes = existing_node_uuids(self, &endpoint_candidates)?;
         known_nodes.extend(same_request_nodes.identities());
         let existing_edges = if reject_existing {
-            existing_edge_uuids(self)?
+            let edge_candidates = candidate_uuids(batches, BulkInputKind::Edge, "edge_uuid")?;
+            existing_edge_uuids(self, &edge_candidates)?
         } else {
             BTreeSet::new()
         };
@@ -751,7 +755,12 @@ impl GraphForge {
             )?);
         }
 
-        let existing = existing_edge_uuids(self)?;
+        let candidates = normalized
+            .rows
+            .iter()
+            .map(|row| row.edge_uuid)
+            .collect::<BTreeSet<_>>();
+        let existing = existing_edge_uuids(self, &candidates)?;
         if let Some(row) = normalized
             .rows
             .iter()
@@ -1662,57 +1671,102 @@ fn generated_uuid(operation_uuid: OperationId, kind: BulkInputKind, ordinal: u64
     Uuid::from_bytes(bytes)
 }
 
-fn existing_node_uuids(graph: &GraphForge) -> Result<BTreeSet<Uuid>, BulkValidationError> {
-    let batches = graphforge_storage::read_nodes(&graph.dir).map_err(|error| {
+fn existing_node_uuids(
+    graph: &GraphForge,
+    candidates: &BTreeSet<Uuid>,
+) -> Result<BTreeSet<Uuid>, BulkValidationError> {
+    indexed_existing(graph, candidates, graphforge_storage::UuidIndexKind::Node)
+}
+
+fn existing_edge_uuids(
+    graph: &GraphForge,
+    candidates: &BTreeSet<Uuid>,
+) -> Result<BTreeSet<Uuid>, BulkValidationError> {
+    indexed_existing(graph, candidates, graphforge_storage::UuidIndexKind::Edge)
+}
+
+fn indexed_existing(
+    graph: &GraphForge,
+    candidates: &BTreeSet<Uuid>,
+    index_kind: graphforge_storage::UuidIndexKind,
+) -> Result<BTreeSet<Uuid>, BulkValidationError> {
+    let manifest = graph.dir.join("indexes/uuid-membership/manifest.json");
+    if !manifest.exists() {
+        let has_nodes = graph.dir.join("topology/nodes.parquet").exists();
+        let has_edges = std::fs::read_dir(graph.dir.join("topology/edges"))
+            .ok()
+            .is_some_and(|mut entries| entries.any(|entry| entry.is_ok()));
+        if has_nodes || has_edges {
+            return Err(contract_error(
+                BulkInputKind::Node,
+                BulkValidationReason::ProjectState,
+                "UUID membership index is missing; run the bounded storage rebuild before ingest",
+            ));
+        }
+        return Ok(BTreeSet::new());
+    }
+    let mut index = graphforge_storage::UuidMembershipIndex::open(&graph.dir).map_err(|error| {
         contract_error(
             BulkInputKind::Node,
             BulkValidationReason::ProjectState,
             &error.to_string(),
         )
     })?;
-    collect_existing_uuids(
-        batches,
-        BulkInputKind::Node,
-        "node_uuid",
-        "persisted node UUID is malformed",
-    )
+    let requested = candidates.iter().copied().collect::<Vec<_>>();
+    let (found, _) = index.probe(index_kind, &requested).map_err(|error| {
+        contract_error(
+            BulkInputKind::Node,
+            BulkValidationReason::ProjectState,
+            &error.to_string(),
+        )
+    })?;
+    Ok(requested
+        .into_iter()
+        .zip(found)
+        .filter_map(|(uuid, present)| present.then_some(uuid))
+        .collect())
 }
 
-fn existing_edge_uuids(graph: &GraphForge) -> Result<BTreeSet<Uuid>, BulkValidationError> {
-    let batches =
-        graphforge_storage::read_edges(&graph.dir, "*", graph.ontology_mode).map_err(|error| {
-            contract_error(
-                BulkInputKind::Edge,
-                BulkValidationReason::ProjectState,
-                &error.to_string(),
-            )
-        })?;
-    collect_existing_uuids(
-        batches,
-        BulkInputKind::Edge,
-        "edge_uuid",
-        "persisted edge UUID is malformed",
-    )
-}
-
-fn collect_existing_uuids(
-    batches: Vec<RecordBatch>,
+fn candidate_uuids(
+    batches: &[RecordBatch],
     kind: BulkInputKind,
     field: &str,
-    malformed_message: &str,
 ) -> Result<BTreeSet<Uuid>, BulkValidationError> {
     let mut values = BTreeSet::new();
     for batch in batches {
-        let uuids = uuid_column(&batch, kind, field)?;
+        let uuids = uuid_column(batch, kind, field)?;
         for row in 0..uuids.len() {
             if !uuids.is_null(row) {
-                values.insert(Uuid::from_slice(uuids.value(row)).map_err(|_| {
-                    contract_error(kind, BulkValidationReason::ProjectState, malformed_message)
+                values.insert(Uuid::from_slice(uuids.value(row)).map_err(|error| {
+                    contract_error(
+                        kind,
+                        BulkValidationReason::SchemaMismatch,
+                        &error.to_string(),
+                    )
                 })?);
             }
         }
     }
     Ok(values)
+}
+
+fn candidate_endpoint_uuids(
+    batches: &[RecordBatch],
+) -> Result<BTreeSet<Uuid>, BulkValidationError> {
+    let mut values = candidate_uuids(batches, BulkInputKind::Edge, "source_uuid")?;
+    values.extend(candidate_uuids(
+        batches,
+        BulkInputKind::Edge,
+        "target_uuid",
+    )?);
+    Ok(values)
+}
+
+#[cfg(test)]
+fn indexed_uuid_count(graph: &GraphForge, kind: graphforge_storage::UuidIndexKind) -> u64 {
+    graphforge_storage::UuidMembershipIndex::open(&graph.dir)
+        .expect("published graph has an authenticated UUID membership index")
+        .count(kind)
 }
 
 fn register_existing_endpoints(
@@ -1721,29 +1775,34 @@ fn register_existing_endpoints(
     endpoints: &BTreeSet<Uuid>,
 ) -> Result<(), super::GfError> {
     let mut unresolved = endpoints.clone();
-    for batch in graphforge_storage::read_nodes(dir).map_err(|error| {
-        super::GfError::Storage(format!("failed to read node topology: {error}"))
-    })? {
+    graphforge_storage::visit_nodes_batched(dir, 8_192, |batch| {
         let uuids = batch
             .column_by_name("node_uuid")
             .and_then(|column| column.as_any().downcast_ref::<FixedSizeBinaryArray>())
             .ok_or_else(|| {
-                super::GfError::Storage("node topology has malformed UUID column".into())
+                datafusion::error::DataFusionError::Execution(
+                    "node topology has malformed UUID column".into(),
+                )
             })?;
         let ids = batch
             .column_by_name("node_id")
             .and_then(|column| column.as_any().downcast_ref::<UInt64Array>())
             .ok_or_else(|| {
-                super::GfError::Storage("node topology has malformed ID column".into())
+                datafusion::error::DataFusionError::Execution(
+                    "node topology has malformed ID column".into(),
+                )
             })?;
         for row in 0..batch.num_rows() {
-            let uuid = Uuid::from_slice(uuids.value(row))
-                .map_err(|error| super::GfError::Storage(error.to_string()))?;
+            let uuid = Uuid::from_slice(uuids.value(row)).map_err(|error| {
+                datafusion::error::DataFusionError::Execution(error.to_string())
+            })?;
             if unresolved.remove(&uuid) {
                 writer.register_existing_node(uuid, ids.value(row));
             }
         }
-    }
+        Ok(!unresolved.is_empty())
+    })
+    .map_err(|error| super::GfError::Storage(format!("failed to read node topology: {error}")))?;
     if unresolved.is_empty() {
         Ok(())
     } else {
@@ -3501,7 +3560,10 @@ mod tests {
             })
         ));
         assert_eq!(*graph.current_generation_uuid.lock().unwrap(), generation);
-        assert_eq!(existing_edge_uuids(&graph).unwrap().len(), 0);
+        assert_eq!(
+            indexed_uuid_count(&graph, graphforge_storage::UuidIndexKind::Edge),
+            0
+        );
     }
 
     #[test]
@@ -3540,7 +3602,10 @@ mod tests {
             *reopened.current_generation_uuid.lock().unwrap(),
             generation
         );
-        assert_eq!(existing_node_uuids(&reopened).unwrap().len(), 2);
+        assert_eq!(
+            indexed_uuid_count(&reopened, graphforge_storage::UuidIndexKind::Node),
+            2
+        );
 
         let changed = node_batch(&[uuid(924)], &["Person"], &[Some("Changed")]);
         let error = reopened
@@ -3553,7 +3618,10 @@ mod tests {
                 ..
             })
         ));
-        assert_eq!(existing_node_uuids(&reopened).unwrap().len(), 2);
+        assert_eq!(
+            indexed_uuid_count(&reopened, graphforge_storage::UuidIndexKind::Node),
+            2
+        );
     }
 
     #[test]
@@ -3626,7 +3694,10 @@ mod tests {
         drop(graph);
 
         let reopened = GraphForge::new(path.to_str()).unwrap();
-        assert_eq!(existing_edge_uuids(&reopened).unwrap().len(), 256);
+        assert_eq!(
+            indexed_uuid_count(&reopened, graphforge_storage::UuidIndexKind::Edge),
+            256
+        );
         assert_eq!(
             reopened
                 .execute("MATCH ()-[r:KNOWS]->() RETURN r.weight")
@@ -3661,7 +3732,10 @@ mod tests {
                 ..
             })
         ));
-        assert_eq!(existing_edge_uuids(&reopened).unwrap().len(), 256);
+        assert_eq!(
+            indexed_uuid_count(&reopened, graphforge_storage::UuidIndexKind::Edge),
+            256
+        );
     }
 
     #[test]
@@ -3697,7 +3771,10 @@ mod tests {
             })
         ));
         assert_eq!(*graph.current_generation_uuid.lock().unwrap(), generation);
-        assert_eq!(existing_edge_uuids(&graph).unwrap().len(), 0);
+        assert_eq!(
+            indexed_uuid_count(&graph, graphforge_storage::UuidIndexKind::Edge),
+            0
+        );
         assert_eq!(
             std::fs::read_dir(path.join("generations")).unwrap().count(),
             generation_count
@@ -3720,7 +3797,10 @@ mod tests {
                 ..
             })
         ));
-        assert_eq!(existing_edge_uuids(&graph).unwrap().len(), 0);
+        assert_eq!(
+            indexed_uuid_count(&graph, graphforge_storage::UuidIndexKind::Edge),
+            0
+        );
         assert_eq!(
             std::fs::read_dir(path.join("generations")).unwrap().count(),
             generation_count
@@ -3829,9 +3909,15 @@ mod tests {
         if expect_committed {
             assert_ne!(durable, parent);
             assert_eq!(visible, durable);
-            assert_eq!(existing_edge_uuids(&graph).unwrap().len(), 1);
+            assert_eq!(
+                indexed_uuid_count(&graph, graphforge_storage::UuidIndexKind::Edge),
+                1
+            );
             let reopened = GraphForge::new(Some(&root)).unwrap();
-            assert_eq!(existing_edge_uuids(&reopened).unwrap().len(), 1);
+            assert_eq!(
+                indexed_uuid_count(&reopened, graphforge_storage::UuidIndexKind::Edge),
+                1
+            );
             assert_eq!(
                 graph.runtime_catalog.lock().unwrap().to_record_batch(),
                 reopened.runtime_catalog.lock().unwrap().to_record_batch()
@@ -3839,7 +3925,10 @@ mod tests {
         } else {
             assert_eq!(durable, parent);
             assert_eq!(visible, parent);
-            assert_eq!(existing_edge_uuids(&graph).unwrap().len(), 0);
+            assert_eq!(
+                indexed_uuid_count(&graph, graphforge_storage::UuidIndexKind::Edge),
+                0
+            );
             assert_eq!(
                 graph.runtime_catalog.lock().unwrap().to_record_batch(),
                 prior_catalog

--- a/crates/graphforge-api/src/embedding_refresh.rs
+++ b/crates/graphforge-api/src/embedding_refresh.rs
@@ -254,6 +254,7 @@ impl GraphForge {
             resolved_generation: self.resolved_generation.clone(),
             read_only: self.read_only,
             current_generation_uuid: Arc::clone(&self.current_generation_uuid),
+            uuid_membership_index: std::sync::Mutex::new(None),
             clock: std::sync::Mutex::new(Arc::clone(
                 &self.clock.lock().expect("clock lock poisoned"),
             )),

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -364,6 +364,8 @@ pub struct GraphForge {
     read_only: bool,
     /// Generation UUID whose graph snapshot was hydrated into `dir`.
     current_generation_uuid: Arc<Mutex<uuid::Uuid>>,
+    /// Authenticated UUID index handle cached for one topology generation.
+    uuid_membership_index: Mutex<Option<graphforge_storage::UuidMembershipIndex>>,
     /// Injected durable-write UTC microsecond clock.
     clock: Mutex<Arc<dyn Fn() -> Result<i64, GfError> + Send + Sync>>,
     /// Project directory backing topology/properties Parquet files. For an
@@ -524,6 +526,7 @@ impl GraphForge {
             resolved_generation,
             read_only: false,
             current_generation_uuid: Arc::new(Mutex::new(generation_uuid)),
+            uuid_membership_index: Mutex::new(None),
             clock: Mutex::new(Arc::new(system_time_micros)),
             adjacency_provider: Arc::new(graphforge_exec::PersistentAdjacencyProvider::new(
                 dir.clone(),
@@ -678,6 +681,7 @@ impl GraphForge {
             resolved_generation,
             read_only,
             current_generation_uuid: Arc::new(Mutex::new(generation_uuid)),
+            uuid_membership_index: Mutex::new(None),
             clock: Mutex::new(Arc::new(system_time_micros)),
             adjacency_provider: Arc::new(graphforge_exec::PersistentAdjacencyProvider::new(
                 dir.clone(),
@@ -1110,10 +1114,12 @@ impl GraphForge {
             ));
         }
 
-        graphforge_storage::rebuild_uuid_membership_indexes(
-            &self.dir,
-            graphforge_storage::UuidIndexBuildLimits::default(),
-        )?;
+        if !graphforge_storage::uuid_membership_index_is_fresh(&self.dir)? {
+            graphforge_storage::rebuild_uuid_membership_indexes(
+                &self.dir,
+                graphforge_storage::UuidIndexBuildLimits::default(),
+            )?;
+        }
         let graph = graphforge_storage::capture_graph_files(&self.dir)?.1;
         let provenance_enabled = parent.capability("provenance")?.is_some();
         let participants = graph_publication_participants(
@@ -1202,10 +1208,12 @@ impl GraphForge {
                 "project generation changed before graph publication".into(),
             ));
         }
-        graphforge_storage::rebuild_uuid_membership_indexes(
-            &self.dir,
-            graphforge_storage::UuidIndexBuildLimits::default(),
-        )?;
+        if !graphforge_storage::uuid_membership_index_is_fresh(&self.dir)? {
+            graphforge_storage::rebuild_uuid_membership_indexes(
+                &self.dir,
+                graphforge_storage::UuidIndexBuildLimits::default(),
+            )?;
+        }
         let graph = graphforge_storage::capture_graph_files(&self.dir)?.1;
         let provenance_enabled = parent.capability("provenance")?.is_some();
         let participants = graph_publication_participants(

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -1110,6 +1110,10 @@ impl GraphForge {
             ));
         }
 
+        graphforge_storage::rebuild_uuid_membership_indexes(
+            &self.dir,
+            graphforge_storage::UuidIndexBuildLimits::default(),
+        )?;
         let graph = graphforge_storage::capture_graph_files(&self.dir)?.1;
         let provenance_enabled = parent.capability("provenance")?.is_some();
         let participants = graph_publication_participants(
@@ -1198,6 +1202,10 @@ impl GraphForge {
                 "project generation changed before graph publication".into(),
             ));
         }
+        graphforge_storage::rebuild_uuid_membership_indexes(
+            &self.dir,
+            graphforge_storage::UuidIndexBuildLimits::default(),
+        )?;
         let graph = graphforge_storage::capture_graph_files(&self.dir)?.1;
         let provenance_enabled = parent.capability("provenance")?.is_some();
         let participants = graph_publication_participants(

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -222,6 +222,12 @@ pub use vector_store::{
 pub mod io_stats;
 pub use io_stats::{IoSnapshot, snapshot as io_snapshot};
 
+pub mod uuid_membership;
+pub use uuid_membership::{
+    UuidIndexBuildLimits, UuidIndexBuildMetrics, UuidIndexKind, UuidMembershipIndex,
+    UuidProbeMetrics, rebuild_uuid_membership_indexes,
+};
+
 pub mod catalog;
 pub use catalog::{
     EdgePropertyTable, GraphCatalog, PropertyTable, TopologyNodeTable, TypedEdgeTable,

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -225,7 +225,8 @@ pub use io_stats::{IoSnapshot, snapshot as io_snapshot};
 pub mod uuid_membership;
 pub use uuid_membership::{
     UuidIndexBuildLimits, UuidIndexBuildMetrics, UuidIndexKind, UuidMembershipIndex,
-    UuidProbeMetrics, rebuild_uuid_membership_indexes,
+    UuidProbeMetrics, rebuild_uuid_membership_indexes, uuid_membership_index_is_fresh,
+    uuid_membership_index_present,
 };
 
 pub mod catalog;

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -1,0 +1,643 @@
+//! Persistent, bounded-memory UUID membership indexes used by bulk ingest.
+//!
+//! The canonical graph remains Parquet.  This derived format is deliberately
+//! small: a manifest (published last with an atomic rename) names two immutable
+//! sorted files containing 16-byte UUID records. Readers verify version,
+//! topology generation, length, count, and SHA-256 before serving probes.
+
+use std::cmp::Reverse;
+use std::collections::{BTreeSet, BinaryHeap};
+use std::fmt::Write as _;
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader, BufWriter, Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+use arrow::array::{Array, FixedSizeBinaryArray};
+use graphforge_core::GfError;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+const FORMAT_VERSION: u32 = 1;
+const RECORD_BYTES: u64 = 16;
+const INDEX_DIR: &str = "indexes/uuid-membership";
+const MANIFEST: &str = "manifest.json";
+
+fn storage_err(error: impl std::fmt::Display) -> GfError {
+    GfError::Storage(format!("UUID membership index: {error}"))
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// Selects the canonical identity domain to probe.
+pub enum UuidIndexKind {
+    /// Canonical node UUIDs.
+    Node,
+    /// Canonical edge UUIDs.
+    Edge,
+}
+
+#[derive(Clone, Copy, Debug)]
+/// Hard work limits for a bounded index build.
+pub struct UuidIndexBuildLimits {
+    /// Maximum Parquet rows decoded per scan batch.
+    pub scan_batch_rows: usize,
+    /// Maximum UUID records held by one sort run.
+    pub run_records: usize,
+    /// Maximum run files opened by one merge group.
+    pub merge_fan_in: usize,
+}
+
+impl Default for UuidIndexBuildLimits {
+    fn default() -> Self {
+        Self {
+            scan_batch_rows: 8_192,
+            run_records: 65_536,
+            merge_fan_in: 32,
+        }
+    }
+}
+
+impl UuidIndexBuildLimits {
+    fn validate(self) -> Result<Self, GfError> {
+        if self.scan_batch_rows == 0 || self.run_records == 0 || self.merge_fan_in < 2 {
+            return Err(storage_err(
+                "build limits must be non-zero and merge_fan_in >= 2",
+            ));
+        }
+        Ok(self)
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// Aggregate-only build evidence; it never contains graph identities.
+pub struct UuidIndexBuildMetrics {
+    /// Unique node identities written.
+    pub node_count: u64,
+    /// Unique edge identities written.
+    pub edge_count: u64,
+    /// Maximum UUID records simultaneously held by the sorter.
+    pub peak_buffered_records: usize,
+    /// Number of temporary sort and merge runs produced.
+    pub temporary_runs: u64,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// Aggregate-only probe evidence; it never contains graph identities.
+pub struct UuidProbeMetrics {
+    /// Total requested identities, including duplicates.
+    pub requested: u64,
+    /// Distinct requested identities.
+    pub unique_requested: u64,
+    /// Distinct identities found.
+    pub found: u64,
+    /// Binary-search file seeks performed.
+    pub file_seeks: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct FileRecord {
+    name: String,
+    count: u64,
+    sha256: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct Manifest {
+    format_version: u32,
+    topology_generation: u64,
+    nodes: FileRecord,
+    edges: FileRecord,
+}
+
+#[derive(Debug)]
+/// An authenticated node-and-edge index snapshot pinned by one manifest.
+pub struct UuidMembershipIndex {
+    node: File,
+    edge: File,
+    manifest: Manifest,
+}
+
+impl UuidMembershipIndex {
+    /// Open and fully authenticate the current immutable index snapshot.
+    pub fn open(project_dir: &Path) -> Result<Self, GfError> {
+        let root = project_dir.join(INDEX_DIR);
+        let body = fs::read(root.join(MANIFEST)).map_err(storage_err)?;
+        let manifest: Manifest = serde_json::from_slice(&body).map_err(storage_err)?;
+        if manifest.format_version != FORMAT_VERSION {
+            return Err(storage_err(format!(
+                "unsupported format version {}",
+                manifest.format_version
+            )));
+        }
+        let generation = crate::read_topology_generation(project_dir)?;
+        if manifest.topology_generation != generation {
+            return Err(storage_err(format!(
+                "stale index generation {} (graph generation {generation})",
+                manifest.topology_generation
+            )));
+        }
+        let node = open_verified(&root, &manifest.nodes)?;
+        let edge = open_verified(&root, &manifest.edges)?;
+        Ok(Self {
+            node,
+            edge,
+            manifest,
+        })
+    }
+
+    #[must_use]
+    /// Return the authenticated unique-record count for one identity domain.
+    pub fn count(&self, kind: UuidIndexKind) -> u64 {
+        match kind {
+            UuidIndexKind::Node => self.manifest.nodes.count,
+            UuidIndexKind::Edge => self.manifest.edges.count,
+        }
+    }
+
+    /// Probe a batch in caller order. Memory is O(unique requested UUIDs).
+    pub fn probe(
+        &mut self,
+        kind: UuidIndexKind,
+        requested: &[Uuid],
+    ) -> Result<(Vec<bool>, UuidProbeMetrics), GfError> {
+        let mut metrics = UuidProbeMetrics {
+            requested: requested.len() as u64,
+            ..Default::default()
+        };
+        let unique = requested.iter().copied().collect::<BTreeSet<_>>();
+        metrics.unique_requested = unique.len() as u64;
+        let (file, count) = match kind {
+            UuidIndexKind::Node => (&mut self.node, self.manifest.nodes.count),
+            UuidIndexKind::Edge => (&mut self.edge, self.manifest.edges.count),
+        };
+        let mut membership = std::collections::BTreeMap::new();
+        for uuid in unique {
+            let found = binary_search(file, count, uuid, &mut metrics.file_seeks)?;
+            metrics.found += u64::from(found);
+            membership.insert(uuid, found);
+        }
+        Ok((requested.iter().map(|u| membership[u]).collect(), metrics))
+    }
+}
+
+fn open_verified(root: &Path, record: &FileRecord) -> Result<File, GfError> {
+    if Path::new(&record.name).components().count() != 1 {
+        return Err(storage_err("manifest contains a non-local index filename"));
+    }
+    let path = root.join(&record.name);
+    let mut file = File::open(&path).map_err(storage_err)?;
+    let expected_len = record
+        .count
+        .checked_mul(RECORD_BYTES)
+        .ok_or_else(|| storage_err("record length overflow"))?;
+    if file.metadata().map_err(storage_err)?.len() != expected_len {
+        return Err(storage_err(format!(
+            "length mismatch for {}",
+            path.display()
+        )));
+    }
+    let actual = sha256_reader(&mut file)?;
+    if actual != record.sha256 {
+        return Err(storage_err(format!(
+            "checksum mismatch for {}",
+            path.display()
+        )));
+    }
+    file.seek(SeekFrom::Start(0)).map_err(storage_err)?;
+    Ok(file)
+}
+
+fn binary_search(
+    file: &mut File,
+    count: u64,
+    target: Uuid,
+    seeks: &mut u64,
+) -> Result<bool, GfError> {
+    let mut lo = 0_u64;
+    let mut hi = count;
+    let target = *target.as_bytes();
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        file.seek(SeekFrom::Start(mid * RECORD_BYTES))
+            .map_err(storage_err)?;
+        *seeks += 1;
+        let mut current = [0_u8; 16];
+        file.read_exact(&mut current).map_err(storage_err)?;
+        match current.cmp(&target) {
+            std::cmp::Ordering::Less => lo = mid + 1,
+            std::cmp::Ordering::Greater => hi = mid,
+            std::cmp::Ordering::Equal => return Ok(true),
+        }
+    }
+    Ok(false)
+}
+
+/// Explicit bounded rebuild/migration path. Immutable data files are completed
+/// and synced first; `manifest.json` is atomically replaced last.
+pub fn rebuild_uuid_membership_indexes(
+    project_dir: &Path,
+    limits: UuidIndexBuildLimits,
+) -> Result<UuidIndexBuildMetrics, GfError> {
+    let limits = limits.validate()?;
+    let root = project_dir.join(INDEX_DIR);
+    fs::create_dir_all(&root).map_err(storage_err)?;
+    let scratch = tempfile::Builder::new()
+        .prefix("build-")
+        .tempdir_in(&root)
+        .map_err(storage_err)?;
+    let mut metrics = UuidIndexBuildMetrics::default();
+    let node_runs = scan_to_runs(
+        &[project_dir.join("topology/nodes.parquet")],
+        "node_uuid",
+        scratch.path(),
+        "node",
+        limits,
+        &mut metrics,
+    )?;
+    let mut edge_paths =
+        crate::mutator::parquet_files_in(project_dir, "topology/edges").map_err(storage_err)?;
+    edge_paths.sort();
+    let edge_runs = scan_to_runs(
+        &edge_paths,
+        "edge_uuid",
+        scratch.path(),
+        "edge",
+        limits,
+        &mut metrics,
+    )?;
+    let node_tmp = merge_all(
+        node_runs,
+        scratch.path(),
+        "nodes",
+        limits.merge_fan_in,
+        &mut metrics,
+    )?;
+    let edge_tmp = merge_all(
+        edge_runs,
+        scratch.path(),
+        "edges",
+        limits.merge_fan_in,
+        &mut metrics,
+    )?;
+    let generation = crate::read_topology_generation(project_dir)?;
+    let nodes = publish_data(&node_tmp, &root, "nodes", generation)?;
+    let edges = publish_data(&edge_tmp, &root, "edges", generation)?;
+    metrics.node_count = nodes.count;
+    metrics.edge_count = edges.count;
+    let manifest = Manifest {
+        format_version: FORMAT_VERSION,
+        topology_generation: generation,
+        nodes,
+        edges,
+    };
+    let mut tmp = tempfile::Builder::new()
+        .prefix("manifest-")
+        .suffix(".tmp")
+        .tempfile_in(&root)
+        .map_err(storage_err)?;
+    serde_json::to_writer(&mut tmp, &manifest).map_err(storage_err)?;
+    tmp.flush().map_err(storage_err)?;
+    tmp.as_file().sync_all().map_err(storage_err)?;
+    tmp.persist(root.join(MANIFEST))
+        .map_err(|e| storage_err(e.error))?;
+    sync_dir(&root)?;
+    Ok(metrics)
+}
+
+fn scan_to_runs(
+    paths: &[PathBuf],
+    column: &str,
+    scratch: &Path,
+    prefix: &str,
+    limits: UuidIndexBuildLimits,
+    metrics: &mut UuidIndexBuildMetrics,
+) -> Result<Vec<PathBuf>, GfError> {
+    let mut buffer = Vec::<[u8; 16]>::with_capacity(limits.run_records);
+    let mut runs = Vec::new();
+    for path in paths {
+        if !path.exists() {
+            continue;
+        }
+        let file = File::open(path).map_err(storage_err)?;
+        let reader = ParquetRecordBatchReaderBuilder::try_new(file)
+            .map_err(storage_err)?
+            .with_batch_size(limits.scan_batch_rows)
+            .build()
+            .map_err(storage_err)?;
+        for batch in reader {
+            let batch = batch.map_err(storage_err)?;
+            let array = batch
+                .column_by_name(column)
+                .ok_or_else(|| storage_err(format!("{} lacks {column}", path.display())))?
+                .as_any()
+                .downcast_ref::<FixedSizeBinaryArray>()
+                .ok_or_else(|| storage_err(format!("{column} is not FixedSizeBinary")))?;
+            for row in 0..array.len() {
+                if array.is_null(row) || array.value(row).len() != 16 {
+                    return Err(storage_err(format!("invalid {column} at row {row}")));
+                }
+                buffer.push(array.value(row).try_into().expect("length checked"));
+                metrics.peak_buffered_records = metrics.peak_buffered_records.max(buffer.len());
+                if buffer.len() == limits.run_records {
+                    flush_run(&mut buffer, scratch, prefix, &mut runs, metrics)?;
+                }
+            }
+        }
+    }
+    if !buffer.is_empty() {
+        flush_run(&mut buffer, scratch, prefix, &mut runs, metrics)?;
+    }
+    if runs.is_empty() {
+        let path = scratch.join(format!("{prefix}-empty.run"));
+        File::create(&path)
+            .map_err(storage_err)?
+            .sync_all()
+            .map_err(storage_err)?;
+        runs.push(path);
+    }
+    Ok(runs)
+}
+
+fn flush_run(
+    buffer: &mut Vec<[u8; 16]>,
+    scratch: &Path,
+    prefix: &str,
+    runs: &mut Vec<PathBuf>,
+    metrics: &mut UuidIndexBuildMetrics,
+) -> Result<(), GfError> {
+    buffer.sort_unstable();
+    buffer.dedup();
+    let path = scratch.join(format!("{prefix}-{:08}.run", runs.len()));
+    let mut out = BufWriter::new(File::create(&path).map_err(storage_err)?);
+    for value in buffer.iter() {
+        out.write_all(value).map_err(storage_err)?;
+    }
+    out.flush().map_err(storage_err)?;
+    out.get_ref().sync_all().map_err(storage_err)?;
+    buffer.clear();
+    runs.push(path);
+    metrics.temporary_runs += 1;
+    Ok(())
+}
+
+fn merge_all(
+    mut runs: Vec<PathBuf>,
+    scratch: &Path,
+    prefix: &str,
+    fan_in: usize,
+    metrics: &mut UuidIndexBuildMetrics,
+) -> Result<PathBuf, GfError> {
+    let mut round = 0;
+    while runs.len() > 1 {
+        let mut next = Vec::new();
+        for (group, chunk) in runs.chunks(fan_in).enumerate() {
+            let path = scratch.join(format!("{prefix}-merge-{round}-{group}.run"));
+            merge_runs(chunk, &path)?;
+            next.push(path);
+            metrics.temporary_runs += 1;
+        }
+        for path in runs {
+            let _ = fs::remove_file(path);
+        }
+        runs = next;
+        round += 1;
+    }
+    Ok(runs.pop().expect("at least one run"))
+}
+
+fn merge_runs(inputs: &[PathBuf], output: &Path) -> Result<(), GfError> {
+    let mut readers = inputs
+        .iter()
+        .map(|p| File::open(p).map(BufReader::new).map_err(storage_err))
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut heap = BinaryHeap::<Reverse<([u8; 16], usize)>>::new();
+    for (idx, reader) in readers.iter_mut().enumerate() {
+        if let Some(value) = read_record(reader)? {
+            heap.push(Reverse((value, idx)));
+        }
+    }
+    let mut out = BufWriter::new(File::create(output).map_err(storage_err)?);
+    let mut previous = None;
+    while let Some(Reverse((value, idx))) = heap.pop() {
+        if previous != Some(value) {
+            out.write_all(&value).map_err(storage_err)?;
+            previous = Some(value);
+        }
+        if let Some(next) = read_record(&mut readers[idx])? {
+            heap.push(Reverse((next, idx)));
+        }
+    }
+    out.flush().map_err(storage_err)?;
+    out.get_ref().sync_all().map_err(storage_err)?;
+    Ok(())
+}
+
+fn read_record(reader: &mut BufReader<File>) -> Result<Option<[u8; 16]>, GfError> {
+    let mut value = [0_u8; 16];
+    match reader.read_exact(&mut value) {
+        Ok(()) => Ok(Some(value)),
+        Err(error)
+            if error.kind() == std::io::ErrorKind::UnexpectedEof
+                && reader.fill_buf().map_err(storage_err)?.is_empty() =>
+        {
+            Ok(None)
+        }
+        Err(error) => Err(storage_err(error)),
+    }
+}
+
+fn publish_data(
+    source: &Path,
+    root: &Path,
+    kind: &str,
+    generation: u64,
+) -> Result<FileRecord, GfError> {
+    let length = source.metadata().map_err(storage_err)?.len();
+    if length % RECORD_BYTES != 0 {
+        return Err(storage_err("internal run has a partial UUID record"));
+    }
+    let mut input = File::open(source).map_err(storage_err)?;
+    let sha256 = sha256_reader(&mut input)?;
+    let name = format!("{kind}-{generation}-{}.uuidx", &sha256[..16]);
+    let destination = root.join(&name);
+    if !destination.exists() {
+        let mut tmp = tempfile::Builder::new()
+            .prefix(kind)
+            .suffix(".tmp")
+            .tempfile_in(root)
+            .map_err(storage_err)?;
+        let mut input = File::open(source).map_err(storage_err)?;
+        std::io::copy(&mut input, &mut tmp).map_err(storage_err)?;
+        tmp.flush().map_err(storage_err)?;
+        tmp.as_file().sync_all().map_err(storage_err)?;
+        tmp.persist(&destination)
+            .map_err(|e| storage_err(e.error))?;
+    }
+    Ok(FileRecord {
+        name,
+        count: length / RECORD_BYTES,
+        sha256,
+    })
+}
+
+fn sync_dir(path: &Path) -> Result<(), GfError> {
+    #[cfg(unix)]
+    {
+        File::open(path)
+            .and_then(|f| f.sync_all())
+            .map_err(storage_err)?;
+    }
+    Ok(())
+}
+
+fn sha256_reader(reader: &mut impl Read) -> Result<String, GfError> {
+    let mut digest = Sha256::new();
+    let mut buffer = vec![0_u8; 64 * 1024];
+    loop {
+        let read = reader.read(&mut buffer).map_err(storage_err)?;
+        if read == 0 {
+            break;
+        }
+        digest.update(&buffer[..read]);
+    }
+    let mut encoded = String::with_capacity(64);
+    for byte in digest.finalize() {
+        write!(&mut encoded, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    Ok(encoded)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Barrier};
+
+    use arrow::array::FixedSizeBinaryArray;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use parquet::arrow::ArrowWriter;
+
+    use super::*;
+
+    fn write_uuid_parquet(path: &Path, column: &str, values: &[Uuid]) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            column,
+            DataType::FixedSizeBinary(16),
+            false,
+        )]));
+        let array = FixedSizeBinaryArray::try_from_iter(
+            values.iter().map(|value| value.as_bytes().as_slice()),
+        )
+        .unwrap();
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(array)]).unwrap();
+        let mut writer = ArrowWriter::try_new(File::create(path).unwrap(), schema, None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+    }
+
+    fn fixture() -> (tempfile::TempDir, Vec<Uuid>, Vec<Uuid>) {
+        let dir = tempfile::tempdir().unwrap();
+        let nodes = vec![Uuid::from_u128(3), Uuid::from_u128(1), Uuid::from_u128(2)];
+        let edges = vec![
+            Uuid::from_u128(12),
+            Uuid::from_u128(11),
+            Uuid::from_u128(11),
+        ];
+        write_uuid_parquet(
+            &dir.path().join("topology/nodes.parquet"),
+            "node_uuid",
+            &nodes,
+        );
+        write_uuid_parquet(
+            &dir.path().join("topology/edges/R.parquet"),
+            "edge_uuid",
+            &edges,
+        );
+        (dir, nodes, edges)
+    }
+
+    #[test]
+    fn bounded_build_reopens_and_probes_in_caller_order() {
+        let (dir, nodes, _) = fixture();
+        let metrics = rebuild_uuid_membership_indexes(
+            dir.path(),
+            UuidIndexBuildLimits {
+                scan_batch_rows: 1,
+                run_records: 1,
+                merge_fan_in: 2,
+            },
+        )
+        .unwrap();
+        assert_eq!((metrics.node_count, metrics.edge_count), (3, 2));
+        assert_eq!(metrics.peak_buffered_records, 1);
+        let mut index = UuidMembershipIndex::open(dir.path()).unwrap();
+        let missing = Uuid::from_u128(99);
+        let (found, probe) = index
+            .probe(UuidIndexKind::Node, &[nodes[1], missing, nodes[1]])
+            .unwrap();
+        assert_eq!(found, vec![true, false, true]);
+        assert_eq!(
+            (probe.requested, probe.unique_requested, probe.found),
+            (3, 2, 1)
+        );
+    }
+
+    #[test]
+    fn corrupt_data_fails_closed_without_replacing_manifest() {
+        let (dir, _, _) = fixture();
+        rebuild_uuid_membership_indexes(dir.path(), UuidIndexBuildLimits::default()).unwrap();
+        let root = dir.path().join(INDEX_DIR);
+        let manifest: Manifest =
+            serde_json::from_slice(&fs::read(root.join(MANIFEST)).unwrap()).unwrap();
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .open(root.join(manifest.nodes.name))
+            .unwrap();
+        file.seek(SeekFrom::Start(0)).unwrap();
+        file.write_all(&[0xff]).unwrap();
+        assert!(
+            UuidMembershipIndex::open(dir.path())
+                .unwrap_err()
+                .to_string()
+                .contains("checksum mismatch")
+        );
+    }
+
+    #[test]
+    fn missing_and_stale_manifests_fail_closed() {
+        let (dir, _, _) = fixture();
+        assert!(UuidMembershipIndex::open(dir.path()).is_err());
+        rebuild_uuid_membership_indexes(dir.path(), UuidIndexBuildLimits::default()).unwrap();
+        crate::generation::bump_topology_generation(dir.path()).unwrap();
+        assert!(
+            UuidMembershipIndex::open(dir.path())
+                .unwrap_err()
+                .to_string()
+                .contains("stale index generation")
+        );
+    }
+
+    #[test]
+    fn unpublished_build_artifacts_do_not_change_concurrent_readers() {
+        let (dir, nodes, _) = fixture();
+        rebuild_uuid_membership_indexes(dir.path(), UuidIndexBuildLimits::default()).unwrap();
+        let barrier = Arc::new(Barrier::new(2));
+        let reader_root = dir.path().to_path_buf();
+        let reader_barrier = barrier.clone();
+        let expected = nodes[0];
+        let reader = std::thread::spawn(move || {
+            let mut index = UuidMembershipIndex::open(&reader_root).unwrap();
+            reader_barrier.wait();
+            index.probe(UuidIndexKind::Node, &[expected]).unwrap().0
+        });
+        let scratch = tempfile::Builder::new()
+            .prefix("build-crash-")
+            .tempdir_in(dir.path().join(INDEX_DIR))
+            .unwrap();
+        fs::write(scratch.path().join("nodes-unpublished.uuidx"), [7_u8; 16]).unwrap();
+        barrier.wait();
+        assert_eq!(reader.join().unwrap(), vec![true]);
+        assert!(UuidMembershipIndex::open(dir.path()).is_ok());
+    }
+}

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -242,9 +242,12 @@ pub fn rebuild_uuid_membership_indexes(
     let limits = limits.validate()?;
     let root = project_dir.join(INDEX_DIR);
     fs::create_dir_all(&root).map_err(storage_err)?;
+    let staging = project_dir
+        .parent()
+        .ok_or_else(|| storage_err("project directory has no staging parent"))?;
     let scratch = tempfile::Builder::new()
-        .prefix("build-")
-        .tempdir_in(&root)
+        .prefix("uuid-membership-build-")
+        .tempdir_in(staging)
         .map_err(storage_err)?;
     let mut metrics = UuidIndexBuildMetrics::default();
     let node_runs = scan_to_runs(
@@ -281,8 +284,8 @@ pub fn rebuild_uuid_membership_indexes(
         &mut metrics,
     )?;
     let generation = crate::read_topology_generation(project_dir)?;
-    let nodes = publish_data(&node_tmp, &root, "nodes", generation)?;
-    let edges = publish_data(&edge_tmp, &root, "edges", generation)?;
+    let nodes = publish_data(&node_tmp, &root, staging, "nodes", generation)?;
+    let edges = publish_data(&edge_tmp, &root, staging, "edges", generation)?;
     metrics.node_count = nodes.count;
     metrics.edge_count = edges.count;
     let manifest = Manifest {
@@ -294,7 +297,7 @@ pub fn rebuild_uuid_membership_indexes(
     let mut tmp = tempfile::Builder::new()
         .prefix("manifest-")
         .suffix(".tmp")
-        .tempfile_in(&root)
+        .tempfile_in(staging)
         .map_err(storage_err)?;
     serde_json::to_writer(&mut tmp, &manifest).map_err(storage_err)?;
     tmp.flush().map_err(storage_err)?;
@@ -450,6 +453,7 @@ fn read_record(reader: &mut BufReader<File>) -> Result<Option<[u8; 16]>, GfError
 fn publish_data(
     source: &Path,
     root: &Path,
+    staging: &Path,
     kind: &str,
     generation: u64,
 ) -> Result<FileRecord, GfError> {
@@ -465,14 +469,17 @@ fn publish_data(
         let mut tmp = tempfile::Builder::new()
             .prefix(kind)
             .suffix(".tmp")
-            .tempfile_in(root)
+            .tempfile_in(staging)
             .map_err(storage_err)?;
         let mut input = File::open(source).map_err(storage_err)?;
         std::io::copy(&mut input, &mut tmp).map_err(storage_err)?;
         tmp.flush().map_err(storage_err)?;
         tmp.as_file().sync_all().map_err(storage_err)?;
-        tmp.persist(&destination)
-            .map_err(|e| storage_err(e.error))?;
+        if let Err(error) = tmp.persist(&destination)
+            && !destination.exists()
+        {
+            return Err(storage_err(error.error));
+        }
     }
     Ok(FileRecord {
         name,
@@ -633,11 +640,47 @@ mod tests {
         });
         let scratch = tempfile::Builder::new()
             .prefix("build-crash-")
-            .tempdir_in(dir.path().join(INDEX_DIR))
+            .tempdir_in(dir.path().parent().unwrap())
             .unwrap();
         fs::write(scratch.path().join("nodes-unpublished.uuidx"), [7_u8; 16]).unwrap();
         barrier.wait();
         assert_eq!(reader.join().unwrap(), vec![true]);
         assert!(UuidMembershipIndex::open(dir.path()).is_ok());
+    }
+
+    #[test]
+    fn concurrent_rebuilds_publish_one_authenticated_snapshot() {
+        let (dir, _, _) = fixture();
+        let root = Arc::new(dir.path().to_path_buf());
+        let barrier = Arc::new(Barrier::new(3));
+        let workers = (0..2)
+            .map(|_| {
+                let root = root.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    rebuild_uuid_membership_indexes(
+                        &root,
+                        UuidIndexBuildLimits {
+                            scan_batch_rows: 1,
+                            run_records: 1,
+                            merge_fan_in: 2,
+                        },
+                    )
+                })
+            })
+            .collect::<Vec<_>>();
+        barrier.wait();
+        for worker in workers {
+            worker.join().unwrap().unwrap();
+        }
+        let index = UuidMembershipIndex::open(&root).unwrap();
+        assert_eq!(index.count(UuidIndexKind::Node), 3);
+        assert_eq!(index.count(UuidIndexKind::Edge), 2);
+        let names = fs::read_dir(root.join(INDEX_DIR))
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        assert!(names.iter().all(|name| !name.ends_with(".tmp")));
     }
 }

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -146,6 +146,12 @@ impl UuidMembershipIndex {
         })
     }
 
+    /// Topology generation authenticated by this open handle.
+    #[must_use]
+    pub const fn topology_generation(&self) -> u64 {
+        self.manifest.topology_generation
+    }
+
     #[must_use]
     /// Return the authenticated unique-record count for one identity domain.
     pub fn count(&self, kind: UuidIndexKind) -> u64 {
@@ -179,6 +185,26 @@ impl UuidMembershipIndex {
         }
         Ok((requested.iter().map(|u| membership[u]).collect(), metrics))
     }
+}
+
+/// Whether a membership manifest exists, without duplicating its private layout.
+#[must_use]
+pub fn uuid_membership_index_present(project_dir: &Path) -> bool {
+    project_dir.join(INDEX_DIR).join(MANIFEST).is_file()
+}
+
+/// Whether the manifest version and topology generation match the workspace.
+/// This cheap publication-path check deliberately does not authenticate data;
+/// readers still use [`UuidMembershipIndex::open`] before trusting membership.
+pub fn uuid_membership_index_is_fresh(project_dir: &Path) -> Result<bool, GfError> {
+    let body = match fs::read(project_dir.join(INDEX_DIR).join(MANIFEST)) {
+        Ok(body) => body,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(storage_err(error)),
+    };
+    let manifest: Manifest = serde_json::from_slice(&body).map_err(storage_err)?;
+    Ok(manifest.format_version == FORMAT_VERSION
+        && manifest.topology_generation == crate::read_topology_generation(project_dir)?)
 }
 
 fn open_verified(root: &Path, record: &FileRecord) -> Result<File, GfError> {
@@ -250,6 +276,7 @@ pub fn rebuild_uuid_membership_indexes(
         .tempdir_in(staging)
         .map_err(storage_err)?;
     let mut metrics = UuidIndexBuildMetrics::default();
+    let generation = crate::read_topology_generation(project_dir)?;
     let node_runs = scan_to_runs(
         &[project_dir.join("topology/nodes.parquet")],
         "node_uuid",
@@ -283,9 +310,18 @@ pub fn rebuild_uuid_membership_indexes(
         limits.merge_fan_in,
         &mut metrics,
     )?;
-    let generation = crate::read_topology_generation(project_dir)?;
+    if crate::read_topology_generation(project_dir)? != generation {
+        return Err(storage_err(
+            "topology generation changed during the index build",
+        ));
+    }
     let nodes = publish_data(&node_tmp, &root, staging, "nodes", generation)?;
     let edges = publish_data(&edge_tmp, &root, staging, "edges", generation)?;
+    if crate::read_topology_generation(project_dir)? != generation {
+        return Err(storage_err(
+            "topology generation changed before index manifest publication",
+        ));
+    }
     metrics.node_count = nodes.count;
     metrics.edge_count = edges.count;
     let manifest = Manifest {
@@ -495,6 +531,8 @@ fn sync_dir(path: &Path) -> Result<(), GfError> {
             .and_then(|f| f.sync_all())
             .map_err(storage_err)?;
     }
+    #[cfg(not(unix))]
+    let _ = path;
     Ok(())
 }
 
@@ -591,6 +629,29 @@ mod tests {
     }
 
     #[test]
+    fn probe_work_is_candidate_logarithmic_not_index_linear() {
+        let dir = tempfile::tempdir().unwrap();
+        let nodes = (1..=8_192).map(Uuid::from_u128).collect::<Vec<_>>();
+        write_uuid_parquet(
+            &dir.path().join("topology/nodes.parquet"),
+            "node_uuid",
+            &nodes,
+        );
+        rebuild_uuid_membership_indexes(dir.path(), UuidIndexBuildLimits::default()).unwrap();
+
+        let mut index = UuidMembershipIndex::open(dir.path()).unwrap();
+        let (found, metrics) = index
+            .probe(UuidIndexKind::Node, &[nodes[4_095], Uuid::from_u128(9_000)])
+            .unwrap();
+        assert_eq!(found, [true, false]);
+        assert_eq!(metrics.unique_requested, 2);
+        assert!(
+            metrics.file_seeks <= 28,
+            "two probes in 8192 records require at most 2 * (log2(8192) + 1) seeks"
+        );
+    }
+
+    #[test]
     fn corrupt_data_fails_closed_without_replacing_manifest() {
         let (dir, _, _) = fixture();
         rebuild_uuid_membership_indexes(dir.path(), UuidIndexBuildLimits::default()).unwrap();
@@ -614,9 +675,12 @@ mod tests {
     #[test]
     fn missing_and_stale_manifests_fail_closed() {
         let (dir, _, _) = fixture();
+        assert!(!uuid_membership_index_is_fresh(dir.path()).unwrap());
         assert!(UuidMembershipIndex::open(dir.path()).is_err());
         rebuild_uuid_membership_indexes(dir.path(), UuidIndexBuildLimits::default()).unwrap();
+        assert!(uuid_membership_index_is_fresh(dir.path()).unwrap());
         crate::generation::bump_topology_generation(dir.path()).unwrap();
+        assert!(!uuid_membership_index_is_fresh(dir.path()).unwrap());
         assert!(
             UuidMembershipIndex::open(dir.path())
                 .unwrap_err()
@@ -638,14 +702,18 @@ mod tests {
             reader_barrier.wait();
             index.probe(UuidIndexKind::Node, &[expected]).unwrap().0
         });
-        let scratch = tempfile::Builder::new()
-            .prefix("build-crash-")
-            .tempdir_in(dir.path().parent().unwrap())
-            .unwrap();
-        fs::write(scratch.path().join("nodes-unpublished.uuidx"), [7_u8; 16]).unwrap();
+        fs::write(
+            dir.path().join(INDEX_DIR).join("nodes-unpublished.uuidx"),
+            [7_u8; 16],
+        )
+        .unwrap();
         barrier.wait();
         assert_eq!(reader.join().unwrap(), vec![true]);
-        assert!(UuidMembershipIndex::open(dir.path()).is_ok());
+        let mut reopened = UuidMembershipIndex::open(dir.path()).unwrap();
+        assert_eq!(
+            reopened.probe(UuidIndexKind::Node, &[expected]).unwrap().0,
+            vec![true]
+        );
     }
 
     #[test]

--- a/docs/book/architecture/uuid-membership-index.md
+++ b/docs/book/architecture/uuid-membership-index.md
@@ -1,0 +1,34 @@
+# UUID membership index
+
+GraphForge persists authoritative node and edge identities in Parquet. Bulk
+ingest uses a derived UUID membership index so validation does not materialize
+the complete graph in memory.
+
+## Format version 1
+
+`indexes/uuid-membership/manifest.json` records the format version, canonical
+`topology_generation`, and the filename, record count, and SHA-256 digest for
+the node and edge indexes. Each immutable `.uuidx` file is an ascending,
+duplicate-free sequence of raw 16-byte UUID values. The file length must equal
+`count * 16`.
+
+Readers fail closed if the manifest is missing, has an unsupported version,
+names a non-local file, disagrees with the topology generation, or if an index
+length or checksum differs. They never fall back to a graph-wide in-memory set.
+Lookups use binary search and preserve the caller's request order; metrics
+contain only counts and file-seek totals, never UUIDs.
+
+## Publication and recovery
+
+Rebuild scans canonical Parquet in configured record batches, sorts bounded
+runs, and merges them with a configured fan-in. Immutable data files are
+synced before a sibling temporary manifest is atomically renamed and the index
+directory is synced. A crash before that final rename leaves the prior manifest
+and its immutable files authoritative. Readers that opened the prior snapshot
+continue to use it while a rebuild is in progress.
+
+Graph mutation publication rebuilds the workspace index before the graph tree
+is captured, so the Parquet topology and its membership manifest enter the same
+immutable project generation. Existing projects migrate through the explicit
+bounded rebuild API. Corrupt or stale indexes are integrity errors and are not
+silently rebuilt during reads.


### PR DESCRIPTION
Closes #737

## Summary
- add versioned, checksummed persistent node and edge UUID membership indexes
- build through bounded Parquet batches, external sorted runs, and bounded fan-in merges
- publish immutable index files and an atomic manifest with each graph generation
- replace bulk validation full UUID materialization with candidate-only batched probes
- stream endpoint registration in bounded node batches
- fail closed on missing, stale, or corrupt persisted indexes and document migration/rebuild behavior

## Verification
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/private/tmp/graphforge-737-target cargo test -p graphforge-storage uuid_membership --lib` (4 passed)
- `CARGO_TARGET_DIR=/private/tmp/graphforge-737-target cargo test -p graphforge-api bulk_construction::tests --lib` (26 passed)
- `CARGO_TARGET_DIR=/private/tmp/graphforge-737-target cargo check -p graphforge-api --tests`
- `CARGO_TARGET_DIR=/private/tmp/graphforge-737-target cargo clippy -p graphforge-storage --lib -- -D warnings`
- `CARGO_TARGET_DIR=/private/tmp/graphforge-737-target cargo clippy -p graphforge-api --lib -- -D warnings`
- `python3 scripts/ci/cargo-bazel-drift-check.py`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789732779&installation_model_id=20486&pr_number=815&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F815&signature=4c2ca0cf71c7333c267a616e590062035289690db45b54f2fa411d43ebcf92ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Faster validation of bulk node and edge changes by checking only UUIDs referenced in the request.
  * Improved handling of large projects through bounded-memory index processing and batched endpoint resolution.

* **Reliability**
  * Publication now refreshes UUID indexes automatically.
  * Added safeguards that detect missing, stale, or corrupted indexes and report clear project-state validation errors.

* **Validation**
  * Edge checks now include nodes created within the same request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->