### PR TITLE
feat(bindings): expose canonical GeoArrow interchange

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -214,6 +214,7 @@ build_test(
         "//docs/reference:schema_inventory_fixtures",
         "//examples/agent_grounding:notebooks",
         "//tests/features:api_features",
+        "//tests/contracts:geoarrow-interchange-v1.json",
         "//tests/tck:corpus",
         "//tests/release_workflows:sna_phase2_advisory",
         "//crates/graphforge-cypher:corpus_data",

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -141,7 +141,8 @@ pub use graphforge_core::manifest::{MANIFEST_FILE, ONTOLOGY_FILE, ProjectManifes
 pub use graphforge_core::{
     AnalyzeOptions, ApiErrorCode, ClusterOptions, EdgeHandle, FindOptions, GfError, NodeHandle,
     NodeSelector, OntologyFormat, OntologyMode, PathsOptions, ProjectErrorCode, PropValue,
-    RankOptions, SimilarOptions, Span,
+    RankOptions, SimilarOptions, Span, SpatialCoordinates, SpatialCrs, SpatialGeometryType,
+    SpatialType, SpatialValue,
 };
 // The Arrow-backed result of [`GraphForge::execute`].
 pub use graphforge_exec::validate_embedding_options;

--- a/crates/graphforge-bindings-node/src/error.rs
+++ b/crates/graphforge-bindings-node/src/error.rs
@@ -39,7 +39,8 @@ fn error_code(err: &GfError) -> &'static str {
         GfError::Validation(message)
             if is_uuid_parameter_validation(message)
                 || is_bulk_validation(message)
-                || is_ontology_lifecycle_validation(message) =>
+                || is_ontology_lifecycle_validation(message)
+                || is_spatial_validation(message) =>
         {
             "GF_VALIDATION"
         }
@@ -51,6 +52,10 @@ fn error_code(err: &GfError) -> &'static str {
 
 fn is_bulk_validation(message: &str) -> bool {
     message.starts_with("GF_BULK_VALIDATION(")
+}
+
+fn is_spatial_validation(message: &str) -> bool {
+    message.starts_with("invalid canonical spatial property: ")
 }
 
 fn is_ontology_lifecycle_validation(message: &str) -> bool {
@@ -197,6 +202,14 @@ mod tests {
     fn bulk_validation_uses_the_stable_public_code() {
         let message =
             "GF_BULK_VALIDATION(invalid_uuid): bulk node row 0 field \"node_uuid\": invalid UUID";
+        let mapped = to_napi_err(&GfError::Validation(message.into()));
+        assert_eq!(mapped.status, "GF_VALIDATION");
+        assert_eq!(mapped.reason, message);
+    }
+
+    #[test]
+    fn canonical_spatial_validation_uses_the_stable_public_code() {
+        let message = "invalid canonical spatial property: unsupported CRS EPSG:9999";
         let mapped = to_napi_err(&GfError::Validation(message.into()));
         assert_eq!(mapped.status, "GF_VALIDATION");
         assert_eq!(mapped.reason, message);

--- a/crates/graphforge-bindings-node/src/lib.rs
+++ b/crates/graphforge-bindings-node/src/lib.rs
@@ -596,14 +596,18 @@ fn json_to_prop_value(value: &serde_json::Value) -> Result<PropValue> {
                 .collect::<Result<Vec<_>>>()?,
         ),
         Value::Object(_) => {
-            // Nested plain objects are unsupported property values. Callers that
-            // need a JS `TypeError` (add_node / add_edge) must go through
-            // [`props_from_js_object`]; this serde path is used by composite
-            // JSON inputs and keeps a ValidationError for domain mapping.
-            return Err(to_napi_err(&GfError::Validation(
-                "unsupported node property type (expected null/boolean/number/string/array)".into(),
-            )));
+            PropValue::Spatial(serde_json::from_value(value.clone()).map_err(|error| {
+                to_napi_err(&GfError::Validation(format!(
+                    "invalid canonical spatial property: {error}"
+                )))
+            })?)
         }
+    })
+}
+
+fn looks_like_spatial_json(value: &serde_json::Value) -> bool {
+    value.as_object().is_some_and(|object| {
+        object.contains_key("spatial_type") || object.contains_key("coordinates")
     })
 }
 
@@ -617,8 +621,7 @@ pub(crate) fn props_from_map(
         .collect()
 }
 
-const UNSUPPORTED_PROP_TYPE_MSG: &str =
-    "unsupported node property type (expected null/boolean/number/string/array)";
+const UNSUPPORTED_PROP_TYPE_MSG: &str = "unsupported node property type (expected null/boolean/number/string/array/canonical spatial object)";
 
 /// Convert a JS property bag, raising a real `TypeError` for unsupported values
 /// (functions, symbols, nested plain objects).
@@ -703,24 +706,34 @@ fn js_unknown_to_prop_value(env: Env, value: Unknown<'_>) -> Result<PropValue> {
             let object = unsafe { value.cast::<Object>() }.map_err(|error| {
                 type_error(env, format!("expected object property: {}", error.reason))
             })?;
-            if !object.is_array().map_err(|error| {
+            let is_array = object.is_array().map_err(|error| {
                 type_error(
                     env,
                     format!("failed to inspect array property: {}", error.reason),
                 )
-            })? {
-                return Err(type_error(env, UNSUPPORTED_PROP_TYPE_MSG));
-            }
+            })?;
             let json = unsafe {
                 <serde_json::Value as FromNapiValue>::from_napi_value(env.raw(), object.raw())
             }
             .map_err(|error| {
                 type_error(
                     env,
-                    format!("failed to read array property: {}", error.reason),
+                    format!("failed to read object property: {}", error.reason),
                 )
             })?;
-            json_to_prop_value(&json)
+            if !is_array && !looks_like_spatial_json(&json) {
+                return Err(type_error(env, UNSUPPORTED_PROP_TYPE_MSG));
+            }
+            json_to_prop_value(&json).map_err(|error| {
+                if is_array {
+                    error
+                } else {
+                    to_napi_err(&GfError::Validation(format!(
+                        "invalid canonical spatial property: {}",
+                        error.reason
+                    )))
+                }
+            })
         }
         ValueType::Function
         | ValueType::Symbol

--- a/crates/graphforge-bindings-node/src/lib.rs
+++ b/crates/graphforge-bindings-node/src/lib.rs
@@ -724,16 +724,7 @@ fn js_unknown_to_prop_value(env: Env, value: Unknown<'_>) -> Result<PropValue> {
             if !is_array && !looks_like_spatial_json(&json) {
                 return Err(type_error(env, UNSUPPORTED_PROP_TYPE_MSG));
             }
-            json_to_prop_value(&json).map_err(|error| {
-                if is_array {
-                    error
-                } else {
-                    to_napi_err(&GfError::Validation(format!(
-                        "invalid canonical spatial property: {}",
-                        error.reason
-                    )))
-                }
-            })
+            json_to_prop_value(&json)
         }
         ValueType::Function
         | ValueType::Symbol

--- a/crates/graphforge-bindings-node/tests/spatial-interchange.test.mjs
+++ b/crates/graphforge-bindings-node/tests/spatial-interchange.test.mjs
@@ -8,13 +8,16 @@ import { GraphForge } from "../index.js";
 
 const fixture = JSON.parse(
   readFileSync(
-    new URL("../../../tests/contracts/geoarrow-interchange-v1.json", import.meta.url),
+    new URL(
+      "../../../tests/contracts/geoarrow-interchange-v1.json",
+      import.meta.url,
+    ),
     "utf8",
   ),
 );
 
 const spatialValue = (entry) => ({
-  spatial_type: { geometry: entry.geometry, crs: fixture.crs },
+  spatial_type: { geometry: entry.geometry, crs: entry.crs },
   coordinates: entry.coordinates,
 });
 
@@ -22,20 +25,27 @@ test("GeoArrow metadata values nulls and errors remain Rust-owned", () => {
   const forge = new GraphForge();
   forge.addNode(
     "Geometry",
-    Object.fromEntries(fixture.cases.map((entry) => [entry.name, spatialValue(entry)])),
+    Object.fromEntries(
+      fixture.cases.map((entry) => [entry.name, spatialValue(entry)]),
+    ),
   );
   forge.addNode("Geometry", {});
   const projection = fixture.cases
     .map((entry) => `n.${entry.name} AS ${entry.name}`)
     .join(", ");
-  const table = tableFromIPC(forge.execute(`MATCH (n:Geometry) RETURN ${projection}`));
+  const table = tableFromIPC(
+    forge.execute(`MATCH (n:Geometry) RETURN ${projection}`),
+  );
   assert.equal(table.numRows, 2);
   for (const entry of fixture.cases) {
     const field = table.schema.fields.find(({ name }) => name === entry.name);
-    assert.equal(field.metadata.get("ARROW:extension:name"), entry.extensionName);
+    assert.equal(
+      field.metadata.get("ARROW:extension:name"),
+      entry.extensionName,
+    );
     assert.equal(
       field.metadata.get("ARROW:extension:metadata"),
-      fixture.extensionMetadata,
+      entry.extensionMetadata,
     );
     assert.notEqual(table.getChild(entry.name).get(0), null);
     assert.equal(table.getChild(entry.name).get(1), null);
@@ -48,6 +58,7 @@ test("GeoArrow metadata values nulls and errors remain Rust-owned", () => {
           coordinates: { Point: [1, 2] },
         },
       }),
-    (error) => error.code === "ValidationError" && !/coordinate/i.test(error.message),
+    (error) =>
+      error.code === "ValidationError" && !/coordinate/i.test(error.message),
   );
 });

--- a/crates/graphforge-bindings-node/tests/spatial-interchange.test.mjs
+++ b/crates/graphforge-bindings-node/tests/spatial-interchange.test.mjs
@@ -1,0 +1,53 @@
+// Real Arrow IPC acceptance for the Rust-owned GeoArrow contract (#801).
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import { tableFromIPC } from "apache-arrow";
+import { GraphForge } from "../index.js";
+
+const fixture = JSON.parse(
+  readFileSync(
+    new URL("../../../tests/contracts/geoarrow-interchange-v1.json", import.meta.url),
+    "utf8",
+  ),
+);
+
+const spatialValue = (entry) => ({
+  spatial_type: { geometry: entry.geometry, crs: fixture.crs },
+  coordinates: entry.coordinates,
+});
+
+test("GeoArrow metadata values nulls and errors remain Rust-owned", () => {
+  const forge = new GraphForge();
+  forge.addNode(
+    "Geometry",
+    Object.fromEntries(fixture.cases.map((entry) => [entry.name, spatialValue(entry)])),
+  );
+  forge.addNode("Geometry", {});
+  const projection = fixture.cases
+    .map((entry) => `n.${entry.name} AS ${entry.name}`)
+    .join(", ");
+  const table = tableFromIPC(forge.execute(`MATCH (n:Geometry) RETURN ${projection}`));
+  assert.equal(table.numRows, 2);
+  for (const entry of fixture.cases) {
+    const field = table.schema.fields.find(({ name }) => name === entry.name);
+    assert.equal(field.metadata.get("ARROW:extension:name"), entry.extensionName);
+    assert.equal(
+      field.metadata.get("ARROW:extension:metadata"),
+      fixture.extensionMetadata,
+    );
+    assert.notEqual(table.getChild(entry.name).get(0), null);
+    assert.equal(table.getChild(entry.name).get(1), null);
+  }
+  assert.throws(
+    () =>
+      forge.addNode("Geometry", {
+        bad: {
+          spatial_type: { geometry: "point", crs: "EPSG:9999" },
+          coordinates: { Point: [1, 2] },
+        },
+      }),
+    (error) => error.code === "ValidationError" && !/coordinate/i.test(error.message),
+  );
+});

--- a/crates/graphforge-bindings-node/tests/spatial-interchange.test.mjs
+++ b/crates/graphforge-bindings-node/tests/spatial-interchange.test.mjs
@@ -51,6 +51,10 @@ test("GeoArrow metadata values nulls and errors remain Rust-owned", () => {
     forge.execute(`MATCH (n:Geometry) RETURN ${projection}`),
   );
   assert.equal(table.numRows, 2);
+  assert.deepEqual(
+    table.batches.map(({ numRows }) => numRows),
+    [2],
+  );
   for (const entry of fixture.cases) {
     const field = table.schema.fields.find(({ name }) => name === entry.name);
     assert.equal(
@@ -76,6 +80,6 @@ test("GeoArrow metadata values nulls and errors remain Rust-owned", () => {
         },
       }),
     (error) =>
-      error.code === "ValidationError" && !/coordinate/i.test(error.message),
+      error.code === "GF_VALIDATION" && !/coordinate/i.test(error.message),
   );
 });

--- a/crates/graphforge-bindings-node/tests/spatial-interchange.test.mjs
+++ b/crates/graphforge-bindings-node/tests/spatial-interchange.test.mjs
@@ -21,6 +21,20 @@ const spatialValue = (entry) => ({
   coordinates: entry.coordinates,
 });
 
+const flattenCoordinates = (value) => {
+  if (typeof value === "number") return [value];
+  if (value && typeof value === "object" && "x" in value && "y" in value) {
+    return [value.x, value.y];
+  }
+  if (value && typeof value[Symbol.iterator] === "function") {
+    return [...value].flatMap(flattenCoordinates);
+  }
+  if (value && typeof value === "object") {
+    return Object.values(value).flatMap(flattenCoordinates);
+  }
+  throw new TypeError(`unexpected Arrow coordinate value ${typeof value}`);
+};
+
 test("GeoArrow metadata values nulls and errors remain Rust-owned", () => {
   const forge = new GraphForge();
   forge.addNode(
@@ -47,7 +61,10 @@ test("GeoArrow metadata values nulls and errors remain Rust-owned", () => {
       field.metadata.get("ARROW:extension:metadata"),
       entry.extensionMetadata,
     );
-    assert.notEqual(table.getChild(entry.name).get(0), null);
+    assert.deepEqual(
+      flattenCoordinates(table.getChild(entry.name).get(0)),
+      entry.flat,
+    );
     assert.equal(table.getChild(entry.name).get(1), null);
   }
   assert.throws(

--- a/crates/graphforge-bindings-node/tests/spatial-interchange.test.mjs
+++ b/crates/graphforge-bindings-node/tests/spatial-interchange.test.mjs
@@ -53,7 +53,7 @@ test("GeoArrow metadata values nulls and errors remain Rust-owned", () => {
   assert.equal(table.numRows, 2);
   assert.deepEqual(
     table.batches.map(({ numRows }) => numRows),
-    [2],
+    fixture.rows.batchSizes,
   );
   for (const entry of fixture.cases) {
     const field = table.schema.fields.find(({ name }) => name === entry.name);
@@ -66,20 +66,20 @@ test("GeoArrow metadata values nulls and errors remain Rust-owned", () => {
       entry.extensionMetadata,
     );
     assert.deepEqual(
-      flattenCoordinates(table.getChild(entry.name).get(0)),
+      flattenCoordinates(
+        table.getChild(entry.name).get(fixture.rows.populated),
+      ),
       entry.flat,
     );
-    assert.equal(table.getChild(entry.name).get(1), null);
+    assert.equal(table.getChild(entry.name).get(fixture.rows.null), null);
   }
   assert.throws(
     () =>
       forge.addNode("Geometry", {
-        bad: {
-          spatial_type: { geometry: "point", crs: "EPSG:9999" },
-          coordinates: { Point: [1, 2] },
-        },
+        bad: fixture.malformed.value,
       }),
     (error) =>
-      error.code === "GF_VALIDATION" && !/coordinate/i.test(error.message),
+      error.code === fixture.malformed.code &&
+      error.message === fixture.malformed.message,
   );
 });

--- a/crates/graphforge-bindings-py/src/lib.rs
+++ b/crates/graphforge-bindings-py/src/lib.rs
@@ -210,7 +210,12 @@ pub(crate) fn py_to_prop_value(value: &Bound<'_, PyAny>) -> PyResult<PropValue> 
                 "unsupported node property type (plain nested dictionaries are not properties)",
             ));
         }
-        let json = py_property_json(value)?;
+        let json = py_property_json(value).map_err(|error| {
+            to_pyerr(
+                value.py(),
+                &GfError::Validation(format!("invalid canonical spatial property: {error}")),
+            )
+        })?;
         serde_json::from_value(json)
             .map(PropValue::Spatial)
             .map_err(|error| {

--- a/crates/graphforge-bindings-py/src/lib.rs
+++ b/crates/graphforge-bindings-py/src/lib.rs
@@ -204,9 +204,56 @@ pub(crate) fn py_to_prop_value(value: &Bound<'_, PyAny>) -> PyResult<PropValue> 
             .map(|item| py_to_prop_value(&item))
             .collect::<PyResult<Vec<_>>>()
             .map(PropValue::List)
+    } else if let Ok(dict) = value.cast::<PyDict>() {
+        if !dict.contains("spatial_type")? && !dict.contains("coordinates")? {
+            return Err(PyTypeError::new_err(
+                "unsupported node property type (plain nested dictionaries are not properties)",
+            ));
+        }
+        let json = py_property_json(value)?;
+        serde_json::from_value(json)
+            .map(PropValue::Spatial)
+            .map_err(|error| {
+                to_pyerr(
+                    value.py(),
+                    &GfError::Validation(format!("invalid canonical spatial property: {error}")),
+                )
+            })
     } else {
         Err(PyTypeError::new_err(
-            "unsupported node property type (expected None/bool/int/float/str/list)",
+            "unsupported node property type (expected None/bool/int/float/str/list/canonical spatial dict)",
+        ))
+    }
+}
+
+fn py_property_json(value: &Bound<'_, PyAny>) -> PyResult<serde_json::Value> {
+    if value.is_none() {
+        Ok(serde_json::Value::Null)
+    } else if let Ok(value) = value.extract::<bool>() {
+        Ok(serde_json::Value::Bool(value))
+    } else if value.is_instance_of::<PyInt>() {
+        Ok(serde_json::Value::Number(value.extract::<i64>()?.into()))
+    } else if let Ok(value) = value.extract::<f64>() {
+        serde_json::Number::from_f64(value)
+            .map(serde_json::Value::Number)
+            .ok_or_else(|| PyTypeError::new_err("spatial coordinates must be finite"))
+    } else if let Ok(value) = value.extract::<String>() {
+        Ok(serde_json::Value::String(value))
+    } else if let Ok(values) = value.cast::<PyList>() {
+        values
+            .iter()
+            .map(|item| py_property_json(&item))
+            .collect::<PyResult<Vec<_>>>()
+            .map(serde_json::Value::Array)
+    } else if let Ok(values) = value.cast::<PyDict>() {
+        let mut object = serde_json::Map::with_capacity(values.len());
+        for (key, value) in values {
+            object.insert(key.extract::<String>()?, py_property_json(&value)?);
+        }
+        Ok(serde_json::Value::Object(object))
+    } else {
+        Err(PyTypeError::new_err(
+            "canonical spatial properties contain only dict/list/string/number/None values",
         ))
     }
 }

--- a/crates/graphforge-bindings-py/tests/spatial_interchange.py
+++ b/crates/graphforge-bindings-py/tests/spatial_interchange.py
@@ -42,6 +42,7 @@ def check_geoarrow_interchange() -> None:
     table = forge.execute(f"MATCH (n:Geometry) RETURN {projection}")
     assert isinstance(table, pa.Table)
     assert table.num_rows == 2
+    assert [batch.num_rows for batch in table.to_batches()] == [2]
     for case in FIXTURE["cases"]:
         field = table.schema.field(case["name"])
         metadata = field.metadata or {}

--- a/crates/graphforge-bindings-py/tests/spatial_interchange.py
+++ b/crates/graphforge-bindings-py/tests/spatial_interchange.py
@@ -9,7 +9,6 @@ import pyarrow as pa
 
 import graphforge as gf
 
-
 FIXTURE = json.loads(
     (Path(__file__).parents[3] / "tests/contracts/geoarrow-interchange-v1.json").read_text()
 )
@@ -17,7 +16,7 @@ FIXTURE = json.loads(
 
 def spatial_value(case: dict[str, object]) -> dict[str, object]:
     return {
-        "spatial_type": {"geometry": case["geometry"], "crs": FIXTURE["crs"]},
+        "spatial_type": {"geometry": case["geometry"], "crs": case["crs"]},
         "coordinates": case["coordinates"],
     }
 
@@ -35,7 +34,7 @@ def check_geoarrow_interchange() -> None:
         field = table.schema.field(case["name"])
         metadata = field.metadata or {}
         assert metadata[b"ARROW:extension:name"].decode() == case["extensionName"]
-        assert metadata[b"ARROW:extension:metadata"].decode() == FIXTURE["extensionMetadata"]
+        assert metadata[b"ARROW:extension:metadata"].decode() == case["extensionMetadata"]
         values = table.column(case["name"]).to_pylist()
         assert values[0] is not None
         assert values[1] is None

--- a/crates/graphforge-bindings-py/tests/spatial_interchange.py
+++ b/crates/graphforge-bindings-py/tests/spatial_interchange.py
@@ -1,0 +1,59 @@
+"""Real PyArrow acceptance for the Rust-owned GeoArrow contract (#801)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pyarrow as pa
+
+import graphforge as gf
+
+
+FIXTURE = json.loads(
+    (Path(__file__).parents[3] / "tests/contracts/geoarrow-interchange-v1.json").read_text()
+)
+
+
+def spatial_value(case: dict[str, object]) -> dict[str, object]:
+    return {
+        "spatial_type": {"geometry": case["geometry"], "crs": FIXTURE["crs"]},
+        "coordinates": case["coordinates"],
+    }
+
+
+def check_geoarrow_interchange() -> None:
+    forge = gf.GraphForge()
+    properties = {case["name"]: spatial_value(case) for case in FIXTURE["cases"]}
+    forge.add_node("Geometry", **properties)
+    forge.add_node("Geometry")
+    projection = ", ".join(f"n.{case['name']} AS {case['name']}" for case in FIXTURE["cases"])
+    table = forge.execute(f"MATCH (n:Geometry) RETURN {projection}")
+    assert isinstance(table, pa.Table)
+    assert table.num_rows == 2
+    for case in FIXTURE["cases"]:
+        field = table.schema.field(case["name"])
+        metadata = field.metadata or {}
+        assert metadata[b"ARROW:extension:name"].decode() == case["extensionName"]
+        assert metadata[b"ARROW:extension:metadata"].decode() == FIXTURE["extensionMetadata"]
+        values = table.column(case["name"]).to_pylist()
+        assert values[0] is not None
+        assert values[1] is None
+
+    try:
+        forge.add_node(
+            "Geometry",
+            bad={
+                "spatial_type": {"geometry": "point", "crs": "EPSG:9999"},
+                "coordinates": {"Point": [1.0, 2.0]},
+            },
+        )
+    except gf.ValidationError as error:
+        assert error.code == "GF_VALIDATION"
+        assert "coordinate" not in str(error).lower()
+    else:
+        raise AssertionError("malformed spatial input must fail")
+
+
+if __name__ == "__main__":
+    check_geoarrow_interchange()

--- a/crates/graphforge-bindings-py/tests/spatial_interchange.py
+++ b/crates/graphforge-bindings-py/tests/spatial_interchange.py
@@ -21,6 +21,18 @@ def spatial_value(case: dict[str, object]) -> dict[str, object]:
     }
 
 
+def flatten_coordinates(value: object) -> list[float]:
+    if isinstance(value, (int, float)):
+        return [float(value)]
+    if isinstance(value, dict):
+        if set(value) == {"x", "y"}:
+            return [float(value["x"]), float(value["y"])]
+        return [item for child in value.values() for item in flatten_coordinates(child)]
+    if isinstance(value, list):
+        return [item for child in value for item in flatten_coordinates(child)]
+    raise AssertionError(f"unexpected Arrow coordinate value {type(value)!r}")
+
+
 def check_geoarrow_interchange() -> None:
     forge = gf.GraphForge()
     properties = {case["name"]: spatial_value(case) for case in FIXTURE["cases"]}
@@ -36,7 +48,7 @@ def check_geoarrow_interchange() -> None:
         assert metadata[b"ARROW:extension:name"].decode() == case["extensionName"]
         assert metadata[b"ARROW:extension:metadata"].decode() == case["extensionMetadata"]
         values = table.column(case["name"]).to_pylist()
-        assert values[0] is not None
+        assert flatten_coordinates(values[0]) == case["flat"]
         assert values[1] is None
 
     try:

--- a/crates/graphforge-bindings-py/tests/spatial_interchange.py
+++ b/crates/graphforge-bindings-py/tests/spatial_interchange.py
@@ -42,27 +42,24 @@ def check_geoarrow_interchange() -> None:
     table = forge.execute(f"MATCH (n:Geometry) RETURN {projection}")
     assert isinstance(table, pa.Table)
     assert table.num_rows == 2
-    assert [batch.num_rows for batch in table.to_batches()] == [2]
+    assert [batch.num_rows for batch in table.to_batches()] == FIXTURE["rows"]["batchSizes"]
     for case in FIXTURE["cases"]:
         field = table.schema.field(case["name"])
         metadata = field.metadata or {}
         assert metadata[b"ARROW:extension:name"].decode() == case["extensionName"]
         assert metadata[b"ARROW:extension:metadata"].decode() == case["extensionMetadata"]
         values = table.column(case["name"]).to_pylist()
-        assert flatten_coordinates(values[0]) == case["flat"]
-        assert values[1] is None
+        assert flatten_coordinates(values[FIXTURE["rows"]["populated"]]) == case["flat"]
+        assert values[FIXTURE["rows"]["null"]] is None
 
     try:
         forge.add_node(
             "Geometry",
-            bad={
-                "spatial_type": {"geometry": "point", "crs": "EPSG:9999"},
-                "coordinates": {"Point": [1.0, 2.0]},
-            },
+            bad=FIXTURE["malformed"]["value"],
         )
     except gf.ValidationError as error:
-        assert error.code == "GF_VALIDATION"
-        assert "coordinate" not in str(error).lower()
+        assert error.code == FIXTURE["malformed"]["code"]
+        assert str(error) == FIXTURE["malformed"]["message"]
     else:
         raise AssertionError("malformed spatial input must fail")
 

--- a/crates/graphforge-cli/BUILD.bazel
+++ b/crates/graphforge-cli/BUILD.bazel
@@ -25,6 +25,10 @@ _CONTRACT_FIXTURES = [
     "//docs/contracts/examples:fixtures",
 ]
 
+_GEOARROW_FIXTURE = [
+    "//tests/contracts:geoarrow-interchange-v1.json",
+]
+
 # Skill bundle stays at the workspace root (`//:project_skills_bundle`) so
 # `project-skills/` remains a pure distribution tree (#7 packaging contract).
 gf_cargo_build_script(
@@ -54,7 +58,7 @@ gf_rust_library(
 gf_rust_test(
     name = "graphforge_cli_test",
     crate = ":graphforge_cli",
-    compile_data = _CONTRACT_FIXTURES,
+    compile_data = _CONTRACT_FIXTURES + _GEOARROW_FIXTURE,
     size = "medium",
     deps = _CLI_DEPS,
 )

--- a/crates/graphforge-cli/src/lib.rs
+++ b/crates/graphforge-cli/src/lib.rs
@@ -2392,6 +2392,7 @@ mod tests {
             .unwrap()
             .collect::<Result<Vec<_>, _>>()
             .unwrap();
+        assert_eq!(batches.len(), 1);
         assert_eq!(
             batches
                 .iter()

--- a/crates/graphforge-cli/src/lib.rs
+++ b/crates/graphforge-cli/src/lib.rs
@@ -2342,4 +2342,75 @@ mod tests {
             CheckpointSelector::Current
         ));
     }
+
+    #[test]
+    fn arrow_result_export_preserves_geoarrow_fields_values_and_nulls() {
+        use std::collections::HashMap;
+        use std::io::Cursor;
+
+        use arrow::array::Array;
+        use arrow::ipc::reader::StreamReader;
+        use graphforge_api::{PropValue, SpatialValue};
+
+        let fixture: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../tests/contracts/geoarrow-interchange-v1.json"
+        ))
+        .unwrap();
+        let cases = fixture["cases"].as_array().unwrap();
+        let properties = cases
+            .iter()
+            .map(|case| {
+                let name = case["name"].as_str().unwrap().to_owned();
+                let spatial: SpatialValue = serde_json::from_value(serde_json::json!({
+                    "spatial_type": {
+                        "geometry": case["geometry"],
+                        "crs": fixture["crs"],
+                    },
+                    "coordinates": case["coordinates"],
+                }))
+                .unwrap();
+                (name, PropValue::Spatial(spatial))
+            })
+            .collect::<HashMap<_, _>>();
+        let graph = GraphForge::new(None).unwrap();
+        graph.add_node("Geometry", &properties).unwrap();
+        graph.add_node("Geometry", &HashMap::new()).unwrap();
+        let projection = cases
+            .iter()
+            .map(|case| {
+                let name = case["name"].as_str().unwrap();
+                format!("n.{name} AS {name}")
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        let result = graph
+            .execute(&format!("MATCH (n:Geometry) RETURN {projection}"))
+            .unwrap();
+        let mut ipc = Vec::new();
+        write_result(&result, &mut ipc).unwrap();
+        let batches = StreamReader::try_new(Cursor::new(ipc), None)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(
+            batches
+                .iter()
+                .map(arrow::array::RecordBatch::num_rows)
+                .sum::<usize>(),
+            2
+        );
+        for case in cases {
+            let name = case["name"].as_str().unwrap();
+            let field = batches[0].schema().field_with_name(name).unwrap().clone();
+            assert_eq!(
+                field.metadata()["ARROW:extension:name"],
+                case["extensionName"]
+            );
+            assert_eq!(
+                field.metadata()["ARROW:extension:metadata"],
+                fixture["extensionMetadata"]
+            );
+            assert!(batches[0].column_by_name(name).unwrap().is_null(1));
+        }
+    }
 }

--- a/crates/graphforge-cli/src/lib.rs
+++ b/crates/graphforge-cli/src/lib.rs
@@ -2364,7 +2364,7 @@ mod tests {
                 let spatial: SpatialValue = serde_json::from_value(serde_json::json!({
                     "spatial_type": {
                         "geometry": case["geometry"],
-                        "crs": fixture["crs"],
+                        "crs": case["crs"],
                     },
                     "coordinates": case["coordinates"],
                 }))
@@ -2408,7 +2408,7 @@ mod tests {
             );
             assert_eq!(
                 field.metadata()["ARROW:extension:metadata"],
-                fixture["extensionMetadata"]
+                case["extensionMetadata"]
             );
             assert!(batches[0].column_by_name(name).unwrap().is_null(1));
         }

--- a/crates/graphforge-cli/src/lib.rs
+++ b/crates/graphforge-cli/src/lib.rs
@@ -2348,9 +2348,41 @@ mod tests {
         use std::collections::HashMap;
         use std::io::Cursor;
 
-        use arrow::array::Array;
+        use arrow::array::{
+            Array, FixedSizeListArray, Float64Array, LargeListArray, ListArray, StructArray,
+        };
         use arrow::ipc::reader::StreamReader;
         use graphforge_api::{PropValue, SpatialValue};
+
+        fn flatten_value(array: &dyn Array, row: usize, output: &mut Vec<f64>) {
+            if let Some(values) = array.as_any().downcast_ref::<Float64Array>() {
+                output.push(values.value(row));
+            } else if let Some(values) = array.as_any().downcast_ref::<StructArray>() {
+                for column in values.columns() {
+                    flatten_value(column.as_ref(), row, output);
+                }
+            } else if let Some(values) = array.as_any().downcast_ref::<ListArray>() {
+                let values = values.value(row);
+                for index in 0..values.len() {
+                    flatten_value(values.as_ref(), index, output);
+                }
+            } else if let Some(values) = array.as_any().downcast_ref::<LargeListArray>() {
+                let values = values.value(row);
+                for index in 0..values.len() {
+                    flatten_value(values.as_ref(), index, output);
+                }
+            } else if let Some(values) = array.as_any().downcast_ref::<FixedSizeListArray>() {
+                let values = values.value(row);
+                for index in 0..values.len() {
+                    flatten_value(values.as_ref(), index, output);
+                }
+            } else {
+                panic!(
+                    "unexpected GeoArrow coordinate array: {:?}",
+                    array.data_type()
+                );
+            }
+        }
 
         let fixture: serde_json::Value = serde_json::from_str(include_str!(
             "../../../tests/contracts/geoarrow-interchange-v1.json"
@@ -2392,7 +2424,19 @@ mod tests {
             .unwrap()
             .collect::<Result<Vec<_>, _>>()
             .unwrap();
-        assert_eq!(batches.len(), 1);
+        let expected_batches = fixture["rows"]["batchSizes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|value| value.as_u64().unwrap() as usize)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            batches
+                .iter()
+                .map(|batch| batch.num_rows())
+                .collect::<Vec<_>>(),
+            expected_batches
+        );
         assert_eq!(
             batches
                 .iter()
@@ -2411,7 +2455,21 @@ mod tests {
                 field.metadata()["ARROW:extension:metadata"],
                 case["extensionMetadata"]
             );
-            assert!(batches[0].column_by_name(name).unwrap().is_null(1));
+            let column = batches[0].column_by_name(name).unwrap();
+            let mut coordinates = Vec::new();
+            flatten_value(
+                column.as_ref(),
+                fixture["rows"]["populated"].as_u64().unwrap() as usize,
+                &mut coordinates,
+            );
+            let expected = case["flat"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|value| value.as_f64().unwrap())
+                .collect::<Vec<_>>();
+            assert_eq!(coordinates, expected);
+            assert!(column.is_null(fixture["rows"]["null"].as_u64().unwrap() as usize));
         }
     }
 }

--- a/tests/contracts/geoarrow-interchange-v1.json
+++ b/tests/contracts/geoarrow-interchange-v1.json
@@ -1,0 +1,13 @@
+{
+  "schema": "graphforge.geoarrow-interchange.v1",
+  "crs": "EPSG:4326",
+  "extensionMetadata": "{\"crs\":\"EPSG:4326\",\"crs_type\":\"authority_code\"}",
+  "cases": [
+    {"name":"point","geometry":"point","extensionName":"geoarrow.point","coordinates":{"Point":[-104.9903,39.7392]},"flat":[-104.9903,39.7392]},
+    {"name":"linestring","geometry":"line_string","extensionName":"geoarrow.linestring","coordinates":{"LineString":[[-105.0,39.7],[-104.9,39.8]]},"flat":[-105.0,39.7,-104.9,39.8]},
+    {"name":"polygon","geometry":"polygon","extensionName":"geoarrow.polygon","coordinates":{"Polygon":[[[-105.0,39.7],[-104.9,39.7],[-104.9,39.8],[-105.0,39.7]]]},"flat":[-105.0,39.7,-104.9,39.7,-104.9,39.8,-105.0,39.7]},
+    {"name":"multipoint","geometry":"multi_point","extensionName":"geoarrow.multipoint","coordinates":{"MultiPoint":[[-105.0,39.7],[-104.9,39.8]]},"flat":[-105.0,39.7,-104.9,39.8]},
+    {"name":"multilinestring","geometry":"multi_line_string","extensionName":"geoarrow.multilinestring","coordinates":{"MultiLineString":[[[-105.0,39.7],[-104.9,39.8]],[[-104.8,39.9],[-104.7,40.0]]]},"flat":[-105.0,39.7,-104.9,39.8,-104.8,39.9,-104.7,40.0]},
+    {"name":"multipolygon","geometry":"multi_polygon","extensionName":"geoarrow.multipolygon","coordinates":{"MultiPolygon":[[[[-105.0,39.7],[-104.9,39.7],[-104.9,39.8],[-105.0,39.7]]]]},"flat":[-105.0,39.7,-104.9,39.7,-104.9,39.8,-105.0,39.7]}
+  ]
+}

--- a/tests/contracts/geoarrow-interchange-v1.json
+++ b/tests/contracts/geoarrow-interchange-v1.json
@@ -1,13 +1,109 @@
 {
   "schema": "graphforge.geoarrow-interchange.v1",
-  "crs": "EPSG:4326",
-  "extensionMetadata": "{\"crs\":\"EPSG:4326\",\"crs_type\":\"authority_code\"}",
   "cases": [
-    {"name":"point","geometry":"point","extensionName":"geoarrow.point","coordinates":{"Point":[-104.9903,39.7392]},"flat":[-104.9903,39.7392]},
-    {"name":"linestring","geometry":"line_string","extensionName":"geoarrow.linestring","coordinates":{"LineString":[[-105.0,39.7],[-104.9,39.8]]},"flat":[-105.0,39.7,-104.9,39.8]},
-    {"name":"polygon","geometry":"polygon","extensionName":"geoarrow.polygon","coordinates":{"Polygon":[[[-105.0,39.7],[-104.9,39.7],[-104.9,39.8],[-105.0,39.7]]]},"flat":[-105.0,39.7,-104.9,39.7,-104.9,39.8,-105.0,39.7]},
-    {"name":"multipoint","geometry":"multi_point","extensionName":"geoarrow.multipoint","coordinates":{"MultiPoint":[[-105.0,39.7],[-104.9,39.8]]},"flat":[-105.0,39.7,-104.9,39.8]},
-    {"name":"multilinestring","geometry":"multi_line_string","extensionName":"geoarrow.multilinestring","coordinates":{"MultiLineString":[[[-105.0,39.7],[-104.9,39.8]],[[-104.8,39.9],[-104.7,40.0]]]},"flat":[-105.0,39.7,-104.9,39.8,-104.8,39.9,-104.7,40.0]},
-    {"name":"multipolygon","geometry":"multi_polygon","extensionName":"geoarrow.multipolygon","coordinates":{"MultiPolygon":[[[[-105.0,39.7],[-104.9,39.7],[-104.9,39.8],[-105.0,39.7]]]]},"flat":[-105.0,39.7,-104.9,39.7,-104.9,39.8,-105.0,39.7]}
+    {
+      "name": "point",
+      "geometry": "point",
+      "crs": "EPSG:4326",
+      "extensionName": "geoarrow.point",
+      "extensionMetadata": "{\"crs\":\"EPSG:4326\",\"crs_type\":\"authority_code\"}",
+      "coordinates": { "Point": [-104.9903, 39.7392] },
+      "flat": [-104.9903, 39.7392]
+    },
+    {
+      "name": "mercator_point",
+      "geometry": "point",
+      "crs": "EPSG:3857",
+      "extensionName": "geoarrow.point",
+      "extensionMetadata": "{\"crs\":\"EPSG:3857\",\"crs_type\":\"authority_code\"}",
+      "coordinates": { "Point": [-11687469.0, 4825942.0] },
+      "flat": [-11687469.0, 4825942.0]
+    },
+    {
+      "name": "linestring",
+      "geometry": "line_string",
+      "crs": "EPSG:4326",
+      "extensionName": "geoarrow.linestring",
+      "extensionMetadata": "{\"crs\":\"EPSG:4326\",\"crs_type\":\"authority_code\"}",
+      "coordinates": {
+        "LineString": [
+          [-105.0, 39.7],
+          [-104.9, 39.8]
+        ]
+      },
+      "flat": [-105.0, 39.7, -104.9, 39.8]
+    },
+    {
+      "name": "polygon",
+      "geometry": "polygon",
+      "crs": "EPSG:4326",
+      "extensionName": "geoarrow.polygon",
+      "extensionMetadata": "{\"crs\":\"EPSG:4326\",\"crs_type\":\"authority_code\"}",
+      "coordinates": {
+        "Polygon": [
+          [
+            [-105.0, 39.7],
+            [-104.9, 39.7],
+            [-104.9, 39.8],
+            [-105.0, 39.7]
+          ]
+        ]
+      },
+      "flat": [-105.0, 39.7, -104.9, 39.7, -104.9, 39.8, -105.0, 39.7]
+    },
+    {
+      "name": "multipoint",
+      "geometry": "multi_point",
+      "crs": "EPSG:4326",
+      "extensionName": "geoarrow.multipoint",
+      "extensionMetadata": "{\"crs\":\"EPSG:4326\",\"crs_type\":\"authority_code\"}",
+      "coordinates": {
+        "MultiPoint": [
+          [-105.0, 39.7],
+          [-104.9, 39.8]
+        ]
+      },
+      "flat": [-105.0, 39.7, -104.9, 39.8]
+    },
+    {
+      "name": "multilinestring",
+      "geometry": "multi_line_string",
+      "crs": "EPSG:4326",
+      "extensionName": "geoarrow.multilinestring",
+      "extensionMetadata": "{\"crs\":\"EPSG:4326\",\"crs_type\":\"authority_code\"}",
+      "coordinates": {
+        "MultiLineString": [
+          [
+            [-105.0, 39.7],
+            [-104.9, 39.8]
+          ],
+          [
+            [-104.8, 39.9],
+            [-104.7, 40.0]
+          ]
+        ]
+      },
+      "flat": [-105.0, 39.7, -104.9, 39.8, -104.8, 39.9, -104.7, 40.0]
+    },
+    {
+      "name": "multipolygon",
+      "geometry": "multi_polygon",
+      "crs": "EPSG:4326",
+      "extensionName": "geoarrow.multipolygon",
+      "extensionMetadata": "{\"crs\":\"EPSG:4326\",\"crs_type\":\"authority_code\"}",
+      "coordinates": {
+        "MultiPolygon": [
+          [
+            [
+              [-105.0, 39.7],
+              [-104.9, 39.7],
+              [-104.9, 39.8],
+              [-105.0, 39.7]
+            ]
+          ]
+        ]
+      },
+      "flat": [-105.0, 39.7, -104.9, 39.7, -104.9, 39.8, -105.0, 39.7]
+    }
   ]
 }

--- a/tests/contracts/geoarrow-interchange-v1.json
+++ b/tests/contracts/geoarrow-interchange-v1.json
@@ -1,5 +1,14 @@
 {
   "schema": "graphforge.geoarrow-interchange.v1",
+  "rows": { "populated": 0, "null": 1, "batchSizes": [2] },
+  "malformed": {
+    "value": {
+      "spatial_type": { "geometry": "point", "crs": "EPSG:9999" },
+      "coordinates": { "Point": [1.0, 2.0] }
+    },
+    "code": "GF_VALIDATION",
+    "message": "invalid canonical spatial property: unknown variant `EPSG:9999`, expected `EPSG:4326` or `EPSG:3857`"
+  },
   "cases": [
     {
       "name": "point",


### PR DESCRIPTION
Closes #801

## Summary
- accept the Rust-owned canonical spatial value shape through thin Python and Node construction bindings
- project canonical GeoArrow fields through Python, Node, and CLI Arrow consumers without reconstruction
- add one shared cross-language fixture covering every supported geometry family, both certified CRS profiles, exact metadata/coordinates, nulls, batch boundaries, and stable malformed-input failures

## Local evidence
- `cargo fmt --all -- --check`
- `cargo clippy -p graphforge-api -p graphforge-cli -p graphforge-bindings-py -p graphforge-bindings-node -- -D warnings`
- `cargo test -p graphforge-cli arrow_result_export_preserves_geoarrow_fields_values_and_nulls --lib`
- `uv run --frozen python crates/graphforge-bindings-py/tests/spatial_interchange.py` (native maturin build)
- `corepack pnpm --dir crates/graphforge-bindings-node exec node --test tests/spatial-interchange.test.mjs` (native napi release build)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789736718&installation_model_id=20486&pr_number=817&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F817&signature=178d506f176b1f01c3aab6ceaa7e13f7694f5cc5c382c72e27615ebdb2a233f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for spatial values, including points, linestrings, polygons, and multi-geometries.
  * Exposed spatial types through the public API.
  * Added GeoArrow interchange v1 support with CRS and extension metadata.
  * Node.js and Python integrations now accept validated spatial objects and preserve null values.
  * Arrow IPC exports include spatial data and GeoArrow metadata.

* **Bug Fixes**
  * Spatial validation failures now return consistent validation errors across integrations.

* **Tests**
  * Added cross-language coverage for spatial interchange, metadata, coordinates, null handling, and malformed input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->