### PR TITLE
feat(api): route eligible mutations through prepared deltas

### DIFF
--- a/crates/graphforge-api/src/composite_publish.rs
+++ b/crates/graphforge-api/src/composite_publish.rs
@@ -26,6 +26,78 @@ use crate::composite_transaction::{CompositeGraphMutation, CompositeTransactionR
 use crate::composite_validation::{CompositeOntologySnapshot, CompositeValidationSnapshot};
 use crate::construction::prop_literal;
 
+fn eligible_delta_operations(
+    request: &CompositeTransactionRequest,
+) -> Result<Option<Vec<graphforge_storage::GraphDeltaOp>>, GfError> {
+    if request.graph_mutations.is_empty() {
+        return Ok(None);
+    }
+    let mut operations = Vec::with_capacity(request.graph_mutations.len());
+    for (index, mutation) in request.graph_mutations.iter().enumerate() {
+        let (kind, payload) = match mutation {
+            CompositeGraphMutation::SetNodeProperty {
+                node_uuid,
+                property,
+                value,
+            } => (
+                graphforge_storage::GraphDeltaOpKind::SetNodeProperty,
+                graphforge_storage::GraphDeltaPayload::SetNodeProperty {
+                    node_uuid: node_uuid.hyphenated().to_string(),
+                    property_stem: "_untyped".into(),
+                    key: property.clone(),
+                    value: graphforge_storage::encode_graph_delta_value(&prop_literal(value)?)?,
+                },
+            ),
+            CompositeGraphMutation::RemoveNodeProperty {
+                node_uuid,
+                property,
+            } => (
+                graphforge_storage::GraphDeltaOpKind::RemoveNodeProperty,
+                graphforge_storage::GraphDeltaPayload::RemoveNodeProperty {
+                    node_uuid: node_uuid.hyphenated().to_string(),
+                    property_stem: "_untyped".into(),
+                    key: property.clone(),
+                },
+            ),
+            CompositeGraphMutation::SetEdgeProperty {
+                edge_uuid,
+                property,
+                value,
+            } => (
+                graphforge_storage::GraphDeltaOpKind::SetEdgeProperty,
+                graphforge_storage::GraphDeltaPayload::SetEdgeProperty {
+                    edge_uuid: edge_uuid.hyphenated().to_string(),
+                    property_stem: "_untyped".into(),
+                    key: property.clone(),
+                    value: graphforge_storage::encode_graph_delta_value(&prop_literal(value)?)?,
+                },
+            ),
+            CompositeGraphMutation::RemoveEdgeProperty {
+                edge_uuid,
+                property,
+            } => (
+                graphforge_storage::GraphDeltaOpKind::RemoveEdgeProperty,
+                graphforge_storage::GraphDeltaPayload::RemoveEdgeProperty {
+                    edge_uuid: edge_uuid.hyphenated().to_string(),
+                    property_stem: "_untyped".into(),
+                    key: property.clone(),
+                },
+            ),
+            _ => return Ok(None),
+        };
+        let operation_uuid = Uuid::new_v5(
+            &request.context.operation_uuid.0,
+            format!("graphforge-composite-delta-operation/1/{index}").as_bytes(),
+        );
+        operations.push(graphforge_storage::GraphDeltaOp {
+            operation_uuid,
+            kind,
+            payload,
+        });
+    }
+    Ok(Some(operations))
+}
+
 impl GraphForge {
     /// Validate, stage, and publish one composite graph + knowledge generation.
     ///
@@ -210,11 +282,35 @@ impl GraphForge {
         let recorded_at = (self.clock.lock().expect("clock lock poisoned"))()?;
 
         let publication = (|| -> Result<RecordBatch, GfError> {
+            // Select the storage route from explicit typed input before the
+            // private workspace is mutated. Capacity exhaustion deliberately
+            // falls back to canonical full-Parquet publication.
+            let prepared_delta = if !optimistic
+                && let Some(operations) = eligible_delta_operations(request)?
+            {
+                let delta_request = graphforge_storage::GraphDeltaPublishRequest {
+                    transaction_uuid,
+                    generation_uuid,
+                    run_uuid: Uuid::new_v5(&transaction_uuid, b"graphforge-composite-delta-run/1"),
+                    operations,
+                    limits: graphforge_storage::GraphDeltaJournalLimits::default(),
+                };
+                match graphforge_storage::prepare_graph_delta(parent, &delta_request) {
+                    Ok(prepared) => Some(prepared),
+                    Err(error) if error.code() == "GF_RESOURCE_LIMIT" => None,
+                    Err(error) => return Err(error),
+                }
+            } else {
+                None
+            };
             apply_graph_mutations(self, request, &mut next_catalog, recorded_at)?;
             if self.path.is_some() {
                 crate::persist_runtime_catalog(&self.dir, &next_catalog)?;
             }
-            let graph = graphforge_storage::capture_graph_files(&self.dir)?.1;
+            let graph = match prepared_delta.as_ref() {
+                Some(prepared) => prepared.files_participant.clone(),
+                None => graphforge_storage::capture_graph_files(&self.dir)?.1,
+            };
             let participants = assemble_composite_participants(self, parent, request, graph)?;
             let capabilities = parent
                 .capabilities()
@@ -235,14 +331,22 @@ impl GraphForge {
                     root,
                     &publication,
                     content_fingerprint,
-                    Some(self.dir.as_path()),
+                    Some(
+                        prepared_delta
+                            .as_ref()
+                            .map_or(self.dir.as_path(), |prepared| prepared.graph_tree_root()),
+                    ),
                     self.lifecycle_mode,
                 )?
             } else {
                 graphforge_storage::stage_project_generation_with_graph_tree_mode(
                     root,
                     &publication,
-                    Some(self.dir.as_path()),
+                    Some(
+                        prepared_delta
+                            .as_ref()
+                            .map_or(self.dir.as_path(), |prepared| prepared.graph_tree_root()),
+                    ),
                     self.lifecycle_mode,
                 )?
             };
@@ -1809,6 +1913,71 @@ mod tests {
             .execute("MATCH (n:Person) RETURN n.node_uuid AS id")
             .unwrap();
         assert_eq!(rows.batches[0].num_rows(), 2);
+    }
+
+    #[test]
+    fn eligible_property_commit_preserves_complete_generation_and_reopens_from_delta() {
+        let directory = TempDir::new().unwrap();
+        let graph = GraphForge::new(directory.path().to_str()).unwrap();
+        graph
+            .publish_composite_transaction(graph_request(121, 122, "Initial"))
+            .unwrap();
+        enable(&graph, CapabilityId::Provenance, 123);
+        let root = graph.resolved_generation.container_root();
+        let parent = graphforge_storage::resolve_project_generation(root).unwrap();
+        let parent_graph = parent.graph_files_inventory().unwrap().unwrap();
+        let unrelated = parent
+            .participant_snapshots()
+            .unwrap()
+            .into_iter()
+            .filter(|snapshot| snapshot.capability_id != "graph")
+            .collect::<Vec<_>>();
+        let request = property_request(124, 122, "nickname", "delta-visible");
+        let first = graph
+            .publish_composite_transaction(request.clone())
+            .unwrap();
+        let retry = graph.publish_composite_transaction(request).unwrap();
+        assert_eq!(first, retry);
+
+        let published = graphforge_storage::resolve_project_generation(root).unwrap();
+        assert_eq!(
+            unrelated,
+            published
+                .participant_snapshots()
+                .unwrap()
+                .into_iter()
+                .filter(|snapshot| snapshot.capability_id != "graph")
+                .collect::<Vec<_>>()
+        );
+        let published_graph = published.graph_files_inventory().unwrap().unwrap();
+        assert_eq!(
+            graphforge_storage::list_delta_runs(&published_graph, Default::default())
+                .unwrap()
+                .len(),
+            1
+        );
+        for entry in parent_graph.files.iter().filter(|entry| {
+            std::path::Path::new(&entry.relative_path)
+                .extension()
+                .is_some_and(|extension| extension == "parquet")
+        }) {
+            assert!(published_graph.files.iter().any(|candidate| {
+                candidate.relative_path == entry.relative_path
+                    && candidate.content_sha256 == entry.content_sha256
+            }));
+        }
+        drop(graph);
+        let reopened = GraphForge::new(directory.path().to_str()).unwrap();
+        let rows = reopened
+            .execute("MATCH (n:Person) RETURN n.nickname AS nickname")
+            .unwrap();
+        let values = rows.batches[0]
+            .column_by_name("nickname")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(values.value(0), "delta-visible");
     }
 
     #[test]

--- a/crates/graphforge-storage/src/graph_delta_journal.rs
+++ b/crates/graphforge-storage/src/graph_delta_journal.rs
@@ -591,6 +591,30 @@ pub struct GraphDeltaPublicationReceipt {
     pub state_fingerprint: [u8; 32],
 }
 
+/// An owning, validated graph-tree candidate prepared for assembly into one
+/// complete project generation. Preparation never stages or publishes CURRENT.
+pub struct PreparedGraphDelta {
+    workspace: tempfile::TempDir,
+    /// Authenticated `graph/files` participant for the prepared tree.
+    pub files_participant: crate::ProjectParticipant,
+    /// Sequence assigned to the appended run.
+    pub run_sequence: u64,
+    /// Whether all canonical base Parquet digests were preserved.
+    pub preserved_base_parquet_digests: bool,
+    /// Number of unchanged non-delta base files.
+    pub unchanged_base_files: u64,
+    /// Canonical logical fingerprint after replay.
+    pub state_fingerprint: [u8; 32],
+}
+
+impl PreparedGraphDelta {
+    /// Private owning graph-tree path, valid for this value's lifetime.
+    #[must_use]
+    pub fn graph_tree_root(&self) -> &Path {
+        self.workspace.path()
+    }
+}
+
 /// Relative path for run sequence `n` (`1..=MAX`).
 #[must_use]
 pub fn delta_run_relative_path(run_sequence: u64) -> String {
@@ -1197,6 +1221,115 @@ fn bounded_materialized_fingerprint(
     Ok(hasher.finalize().into())
 }
 
+/// Prepare one owning base-plus-run graph tree without staging or publishing it.
+///
+/// # Errors
+/// Fails closed on invalid payloads, corrupt parent inventory, idempotency
+/// conflicts, or journal resource limits.
+pub fn prepare_graph_delta(
+    parent: &crate::ResolvedProjectGeneration,
+    request: &GraphDeltaPublishRequest,
+) -> Result<PreparedGraphDelta, GfError> {
+    for op in &request.operations {
+        if op.payload.expected_kind() != op.kind {
+            return Err(validation(
+                "graph delta operation kind does not match payload",
+            ));
+        }
+    }
+    let parent_inventory = parent
+        .graph_files_inventory()?
+        .ok_or_else(|| validation("parent generation lacks graph/files inventory"))?;
+    let parent_tree = parent.graph_tree_root();
+    verify_graph_tree(&parent_tree, &parent_inventory)?;
+    let parent_runs = load_verified_delta_runs(&parent_tree, &parent_inventory, request.limits)?;
+    let committed_ops = parent_runs
+        .iter()
+        .flat_map(|run| run.records.iter())
+        .map(|record| (record.operation_uuid, &record.payload))
+        .collect::<BTreeMap<_, _>>();
+    for op in &request.operations {
+        if let Some(prior) = committed_ops.get(&op.operation_uuid) {
+            let message = if *prior == &op.payload {
+                "graph delta operation_uuid already committed"
+            } else {
+                "graph delta operation_uuid reused with different payload"
+            };
+            return Err(idempotency_conflict(message));
+        }
+    }
+    let next_sequence = (parent_runs.len() as u64).saturating_add(1);
+    if next_sequence > request.limits.max_runs {
+        return Err(resource_limit("graph delta runs per generation"));
+    }
+    let run_bytes = encode_delta_run(
+        next_sequence,
+        request.run_uuid,
+        request.transaction_uuid,
+        &request.operations,
+        request.limits,
+    )?;
+    let workspace = tempfile::tempdir().map_err(|error| {
+        GfError::Storage(format!("create graph delta staging directory: {error}"))
+    })?;
+    for entry in &parent_inventory.files {
+        let source = parent_tree.join(&entry.relative_path);
+        let destination = workspace.path().join(&entry.relative_path);
+        if let Some(parent_dir) = destination.parent() {
+            fs::create_dir_all(parent_dir)
+                .map_err(|error| storage("create delta staging parent", parent_dir, error))?;
+        }
+        fs::copy(&source, &destination)
+            .map_err(|error| storage("copy parent graph file", &source, error))?;
+    }
+    let new_path = workspace
+        .path()
+        .join(delta_run_relative_path(next_sequence));
+    if let Some(parent_dir) = new_path.parent() {
+        fs::create_dir_all(parent_dir)
+            .map_err(|error| storage("create deltas directory", parent_dir, error))?;
+    }
+    let mut file =
+        File::create(&new_path).map_err(|error| storage("create delta run", &new_path, error))?;
+    file.write_all(&run_bytes)
+        .map_err(|error| storage("write delta run", &new_path, error))?;
+    file.sync_all()
+        .map_err(|error| storage("flush delta run", &new_path, error))?;
+    let (inventory, files_participant) = capture_graph_files(workspace.path())?;
+    let unchanged_base_files = count_preserved_base_files(&parent_inventory, &inventory);
+    let parent_base_count = parent_inventory
+        .files
+        .iter()
+        .filter(|entry| !entry.relative_path.starts_with("deltas/"))
+        .filter(|entry| !is_gfdr_path(&entry.relative_path))
+        .count() as u64;
+    let preserved_base_parquet_digests = unchanged_base_files == parent_base_count
+        && parent_inventory
+            .files
+            .iter()
+            .filter(|entry| {
+                Path::new(&entry.relative_path)
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("parquet"))
+            })
+            .all(|parent_entry| {
+                inventory.files.iter().any(|child| {
+                    child.relative_path == parent_entry.relative_path
+                        && child.content_sha256 == parent_entry.content_sha256
+                })
+            });
+    let state_fingerprint =
+        bounded_materialized_fingerprint(workspace.path(), &inventory, request.limits)?;
+    Ok(PreparedGraphDelta {
+        workspace,
+        files_participant,
+        run_sequence: next_sequence,
+        preserved_base_parquet_digests,
+        unchanged_base_files,
+        state_fingerprint,
+    })
+}
+
 /// Publish one small-write generation that preserves unchanged base Parquet.
 ///
 /// # Errors
@@ -1281,98 +1414,10 @@ fn publish_graph_delta_after_prepare(
     }
 
     let parent = resolve_project_generation(container_root)?;
-    let parent_inventory = parent
-        .graph_files_inventory()?
-        .ok_or_else(|| validation("parent generation lacks graph/files inventory"))?;
-    let parent_tree = parent.graph_tree_root();
-    verify_graph_tree(&parent_tree, &parent_inventory)?;
-
-    let parent_runs = load_verified_delta_runs(&parent_tree, &parent_inventory, request.limits)?;
-    let mut committed_ops: BTreeMap<Uuid, GraphDeltaPayload> = BTreeMap::new();
-    for run in &parent_runs {
-        for record in &run.records {
-            committed_ops.insert(record.operation_uuid, record.payload.clone());
-        }
-    }
-    for op in &request.operations {
-        if let Some(prior) = committed_ops.get(&op.operation_uuid) {
-            if prior == &op.payload {
-                return Err(idempotency_conflict(
-                    "graph delta operation_uuid already committed",
-                ));
-            }
-            return Err(idempotency_conflict(
-                "graph delta operation_uuid reused with different payload",
-            ));
-        }
-    }
-
-    let next_sequence = (parent_runs.len() as u64).saturating_add(1);
-    if next_sequence > request.limits.max_runs {
-        return Err(resource_limit("graph delta runs per generation"));
-    }
-    let run_bytes = encode_delta_run(
-        next_sequence,
-        request.run_uuid,
-        request.transaction_uuid,
-        &request.operations,
-        request.limits,
-    )?;
-
-    let staging = tempfile::tempdir().map_err(|error| {
-        GfError::Storage(format!("create graph delta staging directory: {error}"))
-    })?;
-    for entry in &parent_inventory.files {
-        let source = parent_tree.join(&entry.relative_path);
-        let destination = staging.path().join(&entry.relative_path);
-        if let Some(parent_dir) = destination.parent() {
-            fs::create_dir_all(parent_dir)
-                .map_err(|error| storage("create delta staging parent", parent_dir, error))?;
-        }
-        fs::copy(&source, &destination)
-            .map_err(|error| storage("copy parent graph file", &source, error))?;
-    }
-    let new_relative = delta_run_relative_path(next_sequence);
-    let new_path = staging.path().join(&new_relative);
-    if let Some(parent_dir) = new_path.parent() {
-        fs::create_dir_all(parent_dir)
-            .map_err(|error| storage("create deltas directory", parent_dir, error))?;
-    }
-    {
-        let mut file = File::create(&new_path)
-            .map_err(|error| storage("create delta run", &new_path, error))?;
-        file.write_all(&run_bytes)
-            .map_err(|error| storage("write delta run", &new_path, error))?;
-        file.sync_all()
-            .map_err(|error| storage("flush delta run", &new_path, error))?;
-    }
-
-    let (inventory, files_participant) = capture_graph_files(staging.path())?;
-    let unchanged_base_files = count_preserved_base_files(&parent_inventory, &inventory);
-    let parent_base_count = parent_inventory
-        .files
-        .iter()
-        .filter(|entry| !entry.relative_path.starts_with("deltas/"))
-        .filter(|entry| !is_gfdr_path(&entry.relative_path))
-        .count() as u64;
-    let preserved_base_parquet_digests = unchanged_base_files == parent_base_count
-        && parent_inventory
-            .files
-            .iter()
-            .filter(|entry| {
-                Path::new(&entry.relative_path)
-                    .extension()
-                    .is_some_and(|ext| ext.eq_ignore_ascii_case("parquet"))
-            })
-            .all(|parent_entry| {
-                inventory.files.iter().any(|child| {
-                    child.relative_path == parent_entry.relative_path
-                        && child.content_sha256 == parent_entry.content_sha256
-                })
-            });
+    let prepared = prepare_graph_delta(&parent, request)?;
 
     let mut participants = empty_workspace_participants()?;
-    participants.insert(0, files_participant);
+    participants.insert(0, prepared.files_participant.clone());
     let generation_request = ProjectGenerationRequest {
         transaction_uuid: request.transaction_uuid,
         generation_uuid: request.generation_uuid,
@@ -1388,15 +1433,12 @@ fn publish_graph_delta_after_prepare(
         ],
         participants,
     };
-    let state_fingerprint =
-        bounded_materialized_fingerprint(staging.path(), &inventory, request.limits)?;
-
     before_stage(container_root)?;
     let publication = match stage_project_generation_from_admitted_parent(
         admission,
         parent,
         &generation_request,
-        Some(staging.path()),
+        Some(prepared.graph_tree_root()),
     )? {
         ProjectStageOutcome::Staged(staged) => {
             staged.validate(|_| Ok(()), |_, _| Ok(()))?.publish()?
@@ -1406,10 +1448,10 @@ fn publish_graph_delta_after_prepare(
 
     Ok(GraphDeltaPublicationReceipt {
         publication,
-        run_sequence: next_sequence,
-        preserved_base_parquet_digests,
-        unchanged_base_files,
-        state_fingerprint,
+        run_sequence: prepared.run_sequence,
+        preserved_base_parquet_digests: prepared.preserved_base_parquet_digests,
+        unchanged_base_files: prepared.unchanged_base_files,
+        state_fingerprint: prepared.state_fingerprint,
     })
 }
 

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -43,11 +43,11 @@ pub use graph_delta_journal::{
     GraphDeltaPayload, GraphDeltaPublicationReceipt, GraphDeltaPublishRequest,
     GraphDeltaReplayEvidence, GraphDeltaRun, MAX_GRAPH_DELTA_PAYLOAD_BYTES,
     MAX_GRAPH_DELTA_RECORDS_PER_RUN, MAX_GRAPH_DELTA_REPLAY_MEMORY_BYTES,
-    MAX_GRAPH_DELTA_RUN_BYTES, MAX_GRAPH_DELTA_RUNS, ReconstructedGraphState, apply_delta_runs,
-    decode_delta_run, decode_graph_delta_value, delta_run_relative_path, encode_delta_run,
-    encode_graph_delta_value, list_delta_runs, load_verified_delta_runs,
-    materialize_replayed_graph_tree, publish_graph_delta, publish_graph_delta_with_mode,
-    reconstruct_graph_state, stage_base_graph_workspace,
+    MAX_GRAPH_DELTA_RUN_BYTES, MAX_GRAPH_DELTA_RUNS, PreparedGraphDelta, ReconstructedGraphState,
+    apply_delta_runs, decode_delta_run, decode_graph_delta_value, delta_run_relative_path,
+    encode_delta_run, encode_graph_delta_value, list_delta_runs, load_verified_delta_runs,
+    materialize_replayed_graph_tree, prepare_graph_delta, publish_graph_delta,
+    publish_graph_delta_with_mode, reconstruct_graph_state, stage_base_graph_workspace,
 };
 
 pub mod graph_delta_compaction;

--- a/docs/book/architecture/storage.md
+++ b/docs/book/architecture/storage.md
@@ -153,6 +153,15 @@ immutable generation (`compact_graph_delta`) and reclaims unreachable inputs
 only through the shared retention/GC oracle. They are
 distinct from rebuildable `indexes/adjacency/deltas/` accelerators.
 
+For explicit bounded composite property set/remove requests, the Rust facade
+selects GFDR before mutating its private workspace. Storage prepares an owning
+child graph tree but cannot publish it independently; the facade combines its
+authenticated `graph/files` participant with every unchanged or updated parent
+participant and stages one complete generation. Creates, deletes, Cypher,
+bulk/algorithm writes, optimistic multi-writer requests, unsupported values,
+and journal capacity exhaustion select canonical full-Parquet publication
+before staging. Bindings and the CLI do not implement a second routing engine.
+
 Optional capability absence is recorded in the generation manifest; it is not
 inferred by scanning folders. Graph-only readers validate the mandatory
 workspace control records and graph participants but never open provenance,


### PR DESCRIPTION
Closes #778

## Summary
- add a non-publishing, owning prepared graph-delta primitive shared by standalone and facade publication
- classify explicit bounded property mutations before workspace mutation and assemble the prepared graph with every complete project participant
- preserve full-Parquet fallback for unsupported, capacity-bound, and optimistic operations
- prove exact retry, unrelated participant byte preservation, unchanged base Parquet, immediate visibility, and reopen replay

## Verification
- cargo test -p graphforge-api --lib composite_publish::tests
- cargo test -p graphforge-api --lib composite_recovery_tests
- cargo test -p graphforge-storage --test graph_delta_journal
- cargo clippy -p graphforge-storage -p graphforge-api --lib -- -D warnings
- cargo fmt --all -- --check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789738040&installation_model_id=20486&pr_number=818&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F818&signature=58fe9225adb3faaa359d2c2d9b2119cc149d68b2e3074173c8f92a45449b066b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->