### PR TITLE
feat(storage): bound delta compaction resources

### DIFF
--- a/crates/graphforge-storage/src/graph_delta_compaction.rs
+++ b/crates/graphforge-storage/src/graph_delta_compaction.rs
@@ -37,6 +37,26 @@ pub const DEFAULT_COMPACTION_MAX_MEMORY_BYTES: usize = 64 * 1024 * 1024;
 pub const DEFAULT_COMPACTION_MAX_SPILL_BYTES: u64 = 256 * 1024 * 1024;
 /// Default staged output disk budget for one compaction invocation.
 pub const DEFAULT_COMPACTION_MAX_DISK_BYTES: u64 = 512 * 1024 * 1024;
+/// Maximum supported logical memory budget.
+pub const MAX_COMPACTION_MEMORY_BYTES: usize = 1024 * 1024 * 1024;
+/// Maximum supported spill-byte budget.
+pub const MAX_COMPACTION_SPILL_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+/// Maximum supported staged output disk budget.
+pub const MAX_COMPACTION_DISK_BYTES: u64 = 8 * 1024 * 1024 * 1024;
+/// Default and supported maximum aggregate input runs.
+pub const DEFAULT_COMPACTION_MAX_INPUT_RUNS: u64 = 64;
+/// Default aggregate encoded input-byte budget.
+pub const DEFAULT_COMPACTION_MAX_INPUT_BYTES: u64 = 1024 * 1024 * 1024;
+/// Maximum supported aggregate encoded input-byte budget.
+pub const MAX_COMPACTION_INPUT_BYTES: u64 = 8 * 1024 * 1024 * 1024;
+/// Default maximum canonical output rows.
+pub const DEFAULT_COMPACTION_MAX_OUTPUT_ROWS: u64 = 100_000_000;
+/// Maximum supported canonical output rows.
+pub const MAX_COMPACTION_OUTPUT_ROWS: u64 = 1_000_000_000;
+/// Default cancellation polling cadence in rows.
+pub const DEFAULT_COMPACTION_CANCELLATION_CHECK_ROWS: u64 = 8_192;
+/// Maximum supported cancellation polling cadence in rows.
+pub const MAX_COMPACTION_CANCELLATION_CHECK_ROWS: u64 = 1_048_576;
 /// Spill directory name under the project-local spill root.
 pub const GRAPH_DELTA_COMPACTION_SPILL_DIR: &str = "graph-delta-compaction";
 
@@ -51,6 +71,14 @@ pub struct GraphDeltaCompactionLimits {
     pub max_spill_bytes: u64,
     /// Maximum staged generation bytes before CURRENT publish.
     pub max_disk_bytes: u64,
+    /// Maximum aggregate verified input runs.
+    pub max_input_runs: u64,
+    /// Maximum aggregate encoded bytes across the compacted run prefix.
+    pub max_input_bytes: u64,
+    /// Maximum canonical topology rows emitted.
+    pub max_output_rows: u64,
+    /// Maximum rows processed between cancellation checks.
+    pub cancellation_check_rows: u64,
 }
 
 impl Default for GraphDeltaCompactionLimits {
@@ -60,6 +88,10 @@ impl Default for GraphDeltaCompactionLimits {
             max_memory_bytes: DEFAULT_COMPACTION_MAX_MEMORY_BYTES,
             max_spill_bytes: DEFAULT_COMPACTION_MAX_SPILL_BYTES,
             max_disk_bytes: DEFAULT_COMPACTION_MAX_DISK_BYTES,
+            max_input_runs: DEFAULT_COMPACTION_MAX_INPUT_RUNS,
+            max_input_bytes: DEFAULT_COMPACTION_MAX_INPUT_BYTES,
+            max_output_rows: DEFAULT_COMPACTION_MAX_OUTPUT_ROWS,
+            cancellation_check_rows: DEFAULT_COMPACTION_CANCELLATION_CHECK_ROWS,
         }
     }
 }
@@ -70,14 +102,29 @@ impl GraphDeltaCompactionLimits {
     /// # Errors
     /// Returns `GF_RESOURCE_LIMIT` when any hard budget is zero.
     pub fn validate(self) -> Result<Self, GfError> {
-        if self.max_memory_bytes == 0 {
+        if self.max_memory_bytes == 0 || self.max_memory_bytes > MAX_COMPACTION_MEMORY_BYTES {
             return Err(resource_limit("compaction max_memory_bytes"));
         }
-        if self.max_spill_bytes == 0 {
+        if self.max_spill_bytes == 0 || self.max_spill_bytes > MAX_COMPACTION_SPILL_BYTES {
             return Err(resource_limit("compaction max_spill_bytes"));
         }
-        if self.max_disk_bytes == 0 {
+        if self.max_disk_bytes == 0 || self.max_disk_bytes > MAX_COMPACTION_DISK_BYTES {
             return Err(resource_limit("compaction max_disk_bytes"));
+        }
+        if self.max_input_runs == 0 || self.max_input_runs > DEFAULT_COMPACTION_MAX_INPUT_RUNS {
+            return Err(resource_limit("compaction max_input_runs"));
+        }
+        if self.max_input_bytes == 0 || self.max_input_bytes > MAX_COMPACTION_INPUT_BYTES {
+            return Err(resource_limit("compaction max_input_bytes"));
+        }
+        if self.max_output_rows == 0 || self.max_output_rows > MAX_COMPACTION_OUTPUT_ROWS {
+            return Err(resource_limit("compaction max_output_rows"));
+        }
+        if self.cancellation_check_rows == 0
+            || self.cancellation_check_rows > MAX_COMPACTION_CANCELLATION_CHECK_ROWS
+            || self.cancellation_check_rows < self.journal.max_batch_rows as u64
+        {
+            return Err(resource_limit("compaction cancellation_check_rows"));
         }
         Ok(self)
     }
@@ -437,6 +484,7 @@ struct PreparedCompaction {
     input_rows: u64,
     output_rows: u64,
     input_bytes: u64,
+    output_bytes: u64,
     spill_bytes: u64,
     peak_memory_bytes: u64,
     expected_fingerprint: [u8; 32],
@@ -466,6 +514,17 @@ fn prepare_compaction(
             "graph delta compaction requires at least one verified run",
         ));
     }
+    if input_runs > limits.max_input_runs {
+        return Err(resource_limit("compaction aggregate input runs"));
+    }
+    let input_bytes = runs.iter().try_fold(0_u64, |total, run| {
+        total
+            .checked_add(run.bytes.len() as u64)
+            .ok_or_else(|| resource_limit("compaction aggregate input bytes"))
+    })?;
+    if input_bytes > limits.max_input_bytes {
+        return Err(resource_limit("compaction aggregate input bytes"));
+    }
 
     let through = request.through_run_sequence.unwrap_or(input_runs);
     if through == 0 || through > input_runs {
@@ -491,10 +550,21 @@ fn prepare_compaction(
         limits.journal,
     )?;
     let (materialized_inventory, _) = capture_graph_files(materialized.path())?;
+    let output_bytes = materialized_inventory.total_byte_length;
+    if output_bytes > limits.max_disk_bytes {
+        return Err(resource_limit("compaction staged disk bytes"));
+    }
     let expected_fingerprint = inventory_state_fingerprint(&materialized_inventory);
     let input_rows = runs.iter().map(|run| run.records.len() as u64).sum();
-    let input_bytes = runs.iter().map(|run| run.bytes.len() as u64).sum();
-    let output_rows = canonical_topology_rows(materialized.path(), limits.journal.max_batch_rows)?;
+    let output_rows = canonical_topology_rows(
+        materialized.path(),
+        limits.journal.max_batch_rows,
+        limits.cancellation_check_rows,
+        cancel,
+    )?;
+    if output_rows > limits.max_output_rows {
+        return Err(resource_limit("compaction output rows"));
+    }
     let peak_memory_bytes = replay.estimated_replay_memory_bytes;
     enforce_memory(peak_memory_bytes, limits.max_memory_bytes)?;
     Ok(PreparedCompaction {
@@ -505,6 +575,7 @@ fn prepare_compaction(
         input_rows,
         output_rows,
         input_bytes,
+        output_bytes,
         spill_bytes: 0,
         peak_memory_bytes,
         expected_fingerprint,
@@ -543,7 +614,12 @@ fn inventory_state_fingerprint(inventory: &GraphFilesInventory) -> [u8; 32] {
     hasher.finalize().into()
 }
 
-fn canonical_topology_rows(root: &Path, batch_rows: usize) -> Result<u64, GfError> {
+fn canonical_topology_rows(
+    root: &Path,
+    batch_rows: usize,
+    cancellation_check_rows: u64,
+    cancel: Option<&AtomicBool>,
+) -> Result<u64, GfError> {
     use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
     let mut paths = vec![root.join("topology/nodes.parquet")];
     let edges = root.join("topology/edges");
@@ -563,6 +639,7 @@ fn canonical_topology_rows(root: &Path, batch_rows: usize) -> Result<u64, GfErro
         }
     }
     let mut rows = 0_u64;
+    let mut rows_since_cancel = 0_u64;
     for path in paths {
         let input =
             File::open(&path).map_err(|error| storage("open compacted topology", &path, error))?;
@@ -577,6 +654,11 @@ fn canonical_topology_rows(root: &Path, batch_rows: usize) -> Result<u64, GfErro
             rows = rows
                 .checked_add(batch.num_rows() as u64)
                 .ok_or_else(|| resource_limit("compaction topology rows"))?;
+            rows_since_cancel = rows_since_cancel.saturating_add(batch.num_rows() as u64);
+            if rows_since_cancel >= cancellation_check_rows {
+                check_cancel(cancel)?;
+                rows_since_cancel = 0;
+            }
         }
     }
     Ok(rows)
@@ -599,7 +681,7 @@ fn report_from_prepared(
         input_rows: prepared.input_rows,
         output_rows: prepared.output_rows,
         input_bytes: prepared.input_bytes,
-        output_bytes: 0,
+        output_bytes: prepared.output_bytes,
         spill_bytes: prepared.spill_bytes,
         peak_memory_bytes: prepared.peak_memory_bytes,
         elapsed_ms,
@@ -643,6 +725,8 @@ fn replay_compaction_receipt(
         output_rows: canonical_topology_rows(
             materialized.path(),
             request.limits.journal.max_batch_rows,
+            request.limits.cancellation_check_rows,
+            None,
         )?,
         input_bytes: evidence.run_bytes_validated,
         output_bytes: inventory.total_byte_length,

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -52,11 +52,15 @@ pub use graph_delta_journal::{
 
 pub mod graph_delta_compaction;
 pub use graph_delta_compaction::{
-    DEFAULT_COMPACTION_MAX_DISK_BYTES, DEFAULT_COMPACTION_MAX_MEMORY_BYTES,
+    DEFAULT_COMPACTION_CANCELLATION_CHECK_ROWS, DEFAULT_COMPACTION_MAX_DISK_BYTES,
+    DEFAULT_COMPACTION_MAX_INPUT_BYTES, DEFAULT_COMPACTION_MAX_INPUT_RUNS,
+    DEFAULT_COMPACTION_MAX_MEMORY_BYTES, DEFAULT_COMPACTION_MAX_OUTPUT_ROWS,
     DEFAULT_COMPACTION_MAX_SPILL_BYTES, GRAPH_DELTA_COMPACTION_SPILL_DIR,
     GraphDeltaCompactionLimits, GraphDeltaCompactionPolicy, GraphDeltaCompactionReport,
-    GraphDeltaCompactionRequest, GraphDeltaCompactionStatus, compact_graph_delta,
-    compact_graph_delta_with_mode, graph_delta_compaction_status,
+    GraphDeltaCompactionRequest, GraphDeltaCompactionStatus,
+    MAX_COMPACTION_CANCELLATION_CHECK_ROWS, MAX_COMPACTION_DISK_BYTES, MAX_COMPACTION_INPUT_BYTES,
+    MAX_COMPACTION_MEMORY_BYTES, MAX_COMPACTION_OUTPUT_ROWS, MAX_COMPACTION_SPILL_BYTES,
+    compact_graph_delta, compact_graph_delta_with_mode, graph_delta_compaction_status,
     graph_delta_compaction_status_with_mode, preview_graph_delta_compaction,
     preview_graph_delta_compaction_with_mode,
 };

--- a/crates/graphforge-storage/tests/graph_delta_compaction.rs
+++ b/crates/graphforge-storage/tests/graph_delta_compaction.rs
@@ -7,12 +7,15 @@ use graphforge_storage::{
     CheckpointCreateRequest, GRAPH_CAPABILITY_ID, GRAPH_CAPABILITY_VERSION,
     GraphDeltaCompactionLimits, GraphDeltaCompactionPolicy, GraphDeltaCompactionRequest,
     GraphDeltaJournalLimits, GraphDeltaOp, GraphDeltaOpKind, GraphDeltaPayload,
-    GraphDeltaPublishRequest, GraphWriter, ProjectCapability, ProjectGenerationRequest,
-    ProjectRetentionLimits, ProjectRetentionPolicy, ProjectStageOutcome, capture_graph_files,
-    compact_graph_delta, create_checkpoint, empty_workspace_participants, execute_project_cleanup,
-    graph_delta_compaction_status, list_delta_runs, open_or_initialize_project,
-    preview_graph_delta_compaction, preview_project_cleanup, publish_graph_delta,
-    reconstruct_graph_state, resolve_project_generation, stage_project_generation_with_graph_tree,
+    GraphDeltaPublishRequest, GraphWriter, MAX_COMPACTION_CANCELLATION_CHECK_ROWS,
+    MAX_COMPACTION_DISK_BYTES, MAX_COMPACTION_INPUT_BYTES, MAX_COMPACTION_MEMORY_BYTES,
+    MAX_COMPACTION_OUTPUT_ROWS, MAX_COMPACTION_SPILL_BYTES, ProjectCapability,
+    ProjectGenerationRequest, ProjectRetentionLimits, ProjectRetentionPolicy, ProjectStageOutcome,
+    capture_graph_files, compact_graph_delta, create_checkpoint, empty_workspace_participants,
+    execute_project_cleanup, graph_delta_compaction_status, list_delta_runs,
+    open_or_initialize_project, preview_graph_delta_compaction, preview_project_cleanup,
+    publish_graph_delta, reconstruct_graph_state, resolve_project_generation,
+    stage_project_generation_with_graph_tree,
 };
 use uuid::Uuid;
 
@@ -392,6 +395,94 @@ fn memory_budget_fails_closed_independently_of_graph_fixture_size() {
             .len(),
         1
     );
+}
+
+#[test]
+fn supported_budget_configuration_has_below_equal_above_ladders() {
+    let default = GraphDeltaCompactionLimits::default();
+    let ladders = [
+        ("memory", MAX_COMPACTION_MEMORY_BYTES as u64),
+        ("spill", MAX_COMPACTION_SPILL_BYTES),
+        ("disk", MAX_COMPACTION_DISK_BYTES),
+        ("input_bytes", MAX_COMPACTION_INPUT_BYTES),
+        ("output_rows", MAX_COMPACTION_OUTPUT_ROWS),
+        ("cancellation", MAX_COMPACTION_CANCELLATION_CHECK_ROWS),
+    ];
+    for (field, maximum) in ladders {
+        for (value, accepted) in [(maximum - 1, true), (maximum, true), (maximum + 1, false)] {
+            let mut limits = default;
+            match field {
+                "memory" => limits.max_memory_bytes = value as usize,
+                "spill" => limits.max_spill_bytes = value,
+                "disk" => limits.max_disk_bytes = value,
+                "input_bytes" => limits.max_input_bytes = value,
+                "output_rows" => limits.max_output_rows = value,
+                "cancellation" => limits.cancellation_check_rows = value,
+                _ => unreachable!(),
+            }
+            assert_eq!(limits.validate().is_ok(), accepted, "{field}={value}");
+        }
+    }
+
+    for (value, accepted) in [(63, true), (64, true), (65, false)] {
+        let mut limits = default;
+        limits.max_input_runs = value;
+        assert_eq!(limits.validate().is_ok(), accepted, "input_runs={value}");
+    }
+}
+
+#[test]
+fn observed_work_budgets_accept_equal_and_reject_one_below_without_publication() {
+    let root = tempfile::tempdir().unwrap();
+    publish_base(root.path());
+    publish_delta(root.path(), sample_ops());
+    let parent = resolve_project_generation(root.path())
+        .unwrap()
+        .generation_uuid();
+    let preview = preview_graph_delta_compaction(root.path(), &default_request(), None).unwrap();
+
+    let cases = [
+        ("input_runs", preview.input_runs),
+        ("input_bytes", preview.input_bytes),
+        ("output_rows", preview.output_rows),
+        ("memory", preview.peak_memory_bytes),
+        ("disk", preview.output_bytes),
+    ];
+    for (field, observed) in cases {
+        assert!(observed > 0, "fixture must exercise {field}");
+        let mut equal = default_request();
+        match field {
+            "input_runs" => equal.limits.max_input_runs = observed,
+            "input_bytes" => equal.limits.max_input_bytes = observed,
+            "output_rows" => equal.limits.max_output_rows = observed,
+            "memory" => equal.limits.max_memory_bytes = observed as usize,
+            "disk" => equal.limits.max_disk_bytes = observed,
+            _ => unreachable!(),
+        }
+        preview_graph_delta_compaction(root.path(), &equal, None).unwrap();
+
+        let mut below = equal.clone();
+        match field {
+            "input_runs" => below.limits.max_input_runs = observed - 1,
+            "input_bytes" => below.limits.max_input_bytes = observed - 1,
+            "output_rows" => below.limits.max_output_rows = observed - 1,
+            "memory" => below.limits.max_memory_bytes = (observed - 1) as usize,
+            "disk" => below.limits.max_disk_bytes = observed - 1,
+            _ => unreachable!(),
+        }
+        let error = preview_graph_delta_compaction(root.path(), &below, None).unwrap_err();
+        assert!(
+            error.to_string().contains("GF_RESOURCE_LIMIT"),
+            "{field}: {error}"
+        );
+        assert_eq!(
+            resolve_project_generation(root.path())
+                .unwrap()
+                .generation_uuid(),
+            parent,
+            "{field} failure published partial state"
+        );
+    }
 }
 
 #[test]

--- a/docs/adr/0019-authoritative-graph-delta-journal.md
+++ b/docs/adr/0019-authoritative-graph-delta-journal.md
@@ -98,8 +98,9 @@ Compaction is a normal project-generation transaction:
 2. Merge base + prefix under explicit memory, spill, disk, and cancellation
    budgets into a new canonical Parquet base. No JSON sidecar is graph-state
    authority; replay always begins from the manifest-verified Parquet files.
-3. Re-encode any later suffix runs contiguously onto the child generation so
-   post-snapshot deltas remain visible.
+3. Bounded v1 compacts the full verified chain. A partial prefix is rejected
+   before staging; a later concurrent generation wins independently through
+   the normal single-writer publication contract.
 4. Verify counts/schemas/ordering/checksums and the canonical graph fingerprint
    against the pre-compaction full chain before CURRENT publication.
 5. Reclaim subsumed input generations only through the shared retention
@@ -115,6 +116,26 @@ Crash before CURRENT leaves the prior base/deltas authoritative; after
 acknowledgement the compacted generation is authoritative. Named checkpoints
 and live reader leases retain exact prior bytes because the parent generation
 remains reachable until the shared oracle proves otherwise.
+
+The public `GraphDeltaCompactionLimits` envelope is finite and validated before
+materialization. Defaults / supported maxima are:
+
+| Field | Default | Maximum | Typed failure |
+|---|---:|---:|---|
+| `max_memory_bytes` | 64 MiB | 1 GiB | `GF_RESOURCE_LIMIT` |
+| `max_spill_bytes` | 256 MiB | 4 GiB | `GF_RESOURCE_LIMIT` |
+| `max_disk_bytes` | 512 MiB | 8 GiB | `GF_RESOURCE_LIMIT` |
+| `max_input_runs` | 64 | 64 | `GF_RESOURCE_LIMIT` |
+| `max_input_bytes` | 1 GiB | 8 GiB | `GF_RESOURCE_LIMIT` |
+| `max_output_rows` | 100 million | 1 billion | `GF_RESOURCE_LIMIT` |
+| `cancellation_check_rows` | 8,192 | 1,048,576 | `GF_RESOURCE_LIMIT` |
+
+The cancellation cadence cannot be smaller than the configured Arrow batch,
+so every poll occurs on a bounded batch boundary. Preview performs the same
+validation and merge planning without staging or changing CURRENT. Reports
+carry input/output runs, rows and bytes, peak logical memory, spill bytes,
+elapsed milliseconds, and the canonical state fingerprint. Spill and walltime
+measurements are diagnostics for #782, never correctness authority.
 
 Unsupported mutation kinds are rejected **before** acknowledgement. Supported
 kinds cover the create / update / delete surfaces required by current graph


### PR DESCRIPTION
Closes #753

## Summary
- declare finite defaults and supported maxima for compaction memory, spill, disk, aggregate input runs/bytes, output rows, and cancellation cadence
- enforce aggregate work and staged-output budgets before publication, poll cancellation on bounded Arrow batch boundaries, and report preview output bytes
- add deterministic supported-limit and observed-work boundary ladders while retaining existing fingerprint, checkpoint, cleanup, crash, concurrency, cancellation, and idempotency coverage
- document the bounded v1 full-chain policy and public resource envelope in ADR 0019

## Evidence
- `cargo test -p graphforge-storage --test graph_delta_compaction` — 10 passed
- `cargo test -p graphforge-storage --lib graph_delta_compaction::crash_oracle_tests` — 3 passed
- `cargo clippy -p graphforge-storage --lib -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed

A broader `cargo clippy -p graphforge-storage --lib --tests -- -D warnings` also found 61 pre-existing current-main test-only warnings outside this four-file diff; none are hidden or changed here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789739863&installation_model_id=20486&pr_number=820&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F820&signature=ce9f36693178395de4f18f03f365f720b56624c9299f14dd6aaa5f3ae04f090e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->