### PR TITLE
feat(io): import expanded and bundled portable projects atomically

### DIFF
--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -117,7 +117,8 @@ pub use graphforge_storage::{
 };
 pub use portable::{
     PortableExportRequest, PortableExportResult, PortableImportRequest, PortableImportResult,
-    PortableSelection, PortableVerifyRequest, PortableVerifyResult, verify_portable_v2,
+    PortableSelection, PortableV2ImportRequest, PortableV2ImportResult, PortableVerifyRequest,
+    PortableVerifyResult, verify_portable_v2,
 };
 pub use repository::{
     GitProvenance, InfraCapabilityCompatibility, InfraNotChecked, InfraPlan, InfraStaticValidity,

--- a/crates/graphforge-api/src/portable.rs
+++ b/crates/graphforge-api/src/portable.rs
@@ -38,6 +38,30 @@ pub struct PortableImportRequest {
     pub operation_id: OperationId,
 }
 
+/// Verification-first portable-v2 complete-project import request.
+#[derive(Clone, Debug)]
+pub struct PortableV2ImportRequest {
+    /// Expanded package directory or canonical `.gfpb` bundle.
+    pub input: PathBuf,
+    /// Caller-owned idempotency identity.
+    pub operation_id: OperationId,
+    /// Caller-selected finite verifier and streaming limits.
+    pub limits: graphforge_storage::PortableV2Limits,
+}
+
+/// Stable Rust-owned portable-v2 import result.
+#[derive(Clone, Debug)]
+pub struct PortableV2ImportResult {
+    /// Canonical semantic package identity.
+    pub package_digest: String,
+    /// Representation-specific transport identity.
+    pub transport_digest: Option<String>,
+    /// Newly published local generation UUID.
+    pub generation_uuid: Uuid,
+    /// Whether the operation replayed an identical publication.
+    pub idempotent_replay: bool,
+}
+
 /// Read-only portable-v2 verification request.
 #[derive(Clone, Debug)]
 pub struct PortableVerifyRequest {
@@ -167,6 +191,51 @@ impl GraphForge {
             source_generation_uuid: receipt.source_generation_uuid,
             generation_uuid: receipt.publication.generation_uuid,
             envelope_sha256: hex(receipt.envelope_sha256),
+            idempotent_replay: receipt.publication.idempotent_replay,
+        })
+    }
+
+    /// Verify and atomically import a complete portable-v2 package.
+    pub fn import_portable_v2(
+        project_root: &Path,
+        request: &PortableV2ImportRequest,
+        cancelled: Option<&AtomicBool>,
+    ) -> Result<PortableV2ImportResult, graphforge_storage::PortableV2Error> {
+        let generation_uuid = Uuid::new_v5(
+            &request.operation_id.0,
+            b"graphforge-portable-v2-import-generation/1",
+        );
+        let receipt = graphforge_storage::import_complete_portable_v2(
+            &request.input,
+            project_root,
+            request.operation_id.0,
+            generation_uuid,
+            &supported_capabilities(),
+            request.limits,
+            cancelled,
+        )?;
+        let root = project_root.to_str().ok_or_else(|| {
+            graphforge_storage::PortableV2Error::new(
+                graphforge_storage::PortableV2ErrorCode::InvalidPath,
+                "invalid project path",
+            )
+        })?;
+        let reopened = Self::new(Some(root)).map_err(|_| {
+            graphforge_storage::PortableV2Error::new(
+                graphforge_storage::PortableV2ErrorCode::Io,
+                "imported project did not reopen",
+            )
+        })?;
+        if reopened.resolved_generation.generation_uuid() != receipt.publication.generation_uuid {
+            return Err(graphforge_storage::PortableV2Error::new(
+                graphforge_storage::PortableV2ErrorCode::Io,
+                "imported generation did not reopen",
+            ));
+        }
+        Ok(PortableV2ImportResult {
+            package_digest: receipt.package_digest,
+            transport_digest: receipt.transport_digest,
+            generation_uuid: receipt.publication.generation_uuid,
             idempotent_replay: receipt.publication.idempotent_replay,
         })
     }

--- a/crates/graphforge-api/src/portable.rs
+++ b/crates/graphforge-api/src/portable.rs
@@ -337,6 +337,48 @@ mod tests {
     }
 
     #[test]
+    fn public_v2_import_facade_verifies_publishes_and_reopens() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        std::fs::create_dir(&source).unwrap();
+        GraphForge::new(source.to_str()).unwrap();
+        let generation = graphforge_storage::resolve_project_generation(&source).unwrap();
+        let limits = graphforge_storage::PortableV2Limits::default();
+        let plan = graphforge_storage::plan_complete_portable_v2(&generation, limits).unwrap();
+        let package = root.path().join("complete.gfpb");
+        graphforge_storage::export_complete_portable_v2(
+            &plan,
+            &package,
+            graphforge_storage::PortableV2Output::Bundle,
+            limits,
+            &AtomicBool::new(false),
+            |_| {},
+        )
+        .unwrap();
+
+        let target = root.path().join("target");
+        let imported = GraphForge::import_portable_v2(
+            &target,
+            &PortableV2ImportRequest {
+                input: package,
+                operation_id: OperationId(Uuid::new_v4()),
+                limits,
+            },
+            None,
+        )
+        .unwrap();
+        assert!(!imported.idempotent_replay);
+        assert!(imported.package_digest.starts_with("sha256:"));
+        assert_eq!(
+            GraphForge::new(target.to_str())
+                .unwrap()
+                .resolved_generation
+                .generation_uuid(),
+            imported.generation_uuid
+        );
+    }
+
+    #[test]
     fn in_memory_checkpoint_can_be_exported() {
         let graph = GraphForge::new(None).unwrap();
         graph

--- a/crates/graphforge-bindings-py/tests/non_cypher_release.py
+++ b/crates/graphforge-bindings-py/tests/non_cypher_release.py
@@ -23,7 +23,7 @@ ROOT = Path(__file__).resolve().parents[3]
 RUST_MANIFEST = ROOT / "tests/contracts/non-cypher-rust-surface.json"
 RUST_GATE = ROOT / "scripts/ci/non-cypher-surface-gate.py"
 PYO3_SOURCE = ROOT / "crates/graphforge-bindings-py/src/lib.rs"
-EXPECTED_RUST_DIGEST = "fdae85acac2ee4d1f4e7edf0c67cf03c01eebc56a3116366e308046cf0ea4c68"
+EXPECTED_RUST_DIGEST = "6d6b337134141d0c8e5034a8d174930106006df863a8c78197810b1c9f6670a5"
 EXPECTED_RELEASE_DIGEST = "01f642d893eeb78b9493363d6c4ac5eea6744e0a970b60a9e6a456fe9892a886"
 
 PYTHON_ONLY_METHODS = frozenset(

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -122,6 +122,7 @@ pub use project_retention::{
 
 pub mod project_portable;
 pub mod project_portable_v2_export;
+pub mod project_portable_v2_import;
 pub use project_portable::{
     PortableExportReceipt, PortableImportReceipt, PortableProjectLimits, encode_portable_project,
     export_portable_project, import_portable_project, import_portable_project_file,
@@ -130,6 +131,10 @@ pub use project_portable_v2_export::{
     PortableV2ExportLimits, PortableV2ExportPlan, PortableV2ExportProgress,
     PortableV2ExportReceipt, PortableV2Output, export_complete_portable_v2,
     plan_complete_portable_v2, plan_selected_portable_v2,
+};
+pub use project_portable_v2_import::{
+    PortableV2ImportPhase, PortableV2ImportProgress, PortableV2ImportReceipt,
+    import_complete_portable_v2, import_complete_portable_v2_with_progress,
 };
 
 pub mod project_portable_v2;

--- a/crates/graphforge-storage/src/project_portable.rs
+++ b/crates/graphforge-storage/src/project_portable.rs
@@ -534,7 +534,9 @@ fn validate_capabilities(
     Ok(())
 }
 
-fn prepare_import_target(target: &Path) -> Result<Option<ResolvedProjectGeneration>, GfError> {
+pub(crate) fn prepare_import_target(
+    target: &Path,
+) -> Result<Option<ResolvedProjectGeneration>, GfError> {
     reject_symlink_components(target, "portable import target")?;
     match std::fs::symlink_metadata(target) {
         Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
@@ -738,7 +740,7 @@ fn trusted_platform_symlink(_metadata: &std::fs::Metadata) -> bool {
 }
 
 #[cfg(unix)]
-fn open_regular_nofollow(path: &Path) -> std::io::Result<std::fs::File> {
+pub(crate) fn open_regular_nofollow(path: &Path) -> std::io::Result<std::fs::File> {
     use std::os::unix::fs::OpenOptionsExt;
 
     std::fs::OpenOptions::new()
@@ -748,7 +750,7 @@ fn open_regular_nofollow(path: &Path) -> std::io::Result<std::fs::File> {
 }
 
 #[cfg(not(unix))]
-fn open_regular_nofollow(path: &Path) -> std::io::Result<std::fs::File> {
+pub(crate) fn open_regular_nofollow(path: &Path) -> std::io::Result<std::fs::File> {
     std::fs::File::open(path)
 }
 

--- a/crates/graphforge-storage/src/project_portable.rs
+++ b/crates/graphforge-storage/src/project_portable.rs
@@ -574,8 +574,15 @@ pub(crate) fn prepare_import_target(
 }
 
 fn is_pristine_initialized_target(target: &Path) -> Result<bool, GfError> {
-    let Ok(resolved) = resolve_project_generation(target) else {
+    let Some(generation_uuid) = semantically_pristine_generation(target)? else {
         return Ok(false);
+    };
+    has_exact_pristine_layout(target, generation_uuid)
+}
+
+pub(crate) fn semantically_pristine_generation(target: &Path) -> Result<Option<Uuid>, GfError> {
+    let Ok(resolved) = resolve_project_generation(target) else {
+        return Ok(None);
     };
     let capabilities = resolved.capabilities();
     if capabilities.len() != 2
@@ -584,7 +591,7 @@ fn is_pristine_initialized_target(target: &Path) -> Result<bool, GfError> {
         || capabilities[1].capability_id != "workspace"
         || capabilities[1].capability_version != 1
     {
-        return Ok(false);
+        return Ok(None);
     }
     let actual = resolved.participant_snapshots()?;
     let expected = crate::workspace_participants::empty_workspace_participants()?;
@@ -605,9 +612,9 @@ fn is_pristine_initialized_target(target: &Path) -> Result<bool, GfError> {
                 && actual.bytes == expected.bytes
         })
     {
-        return Ok(false);
+        return Ok(None);
     }
-    has_exact_pristine_layout(target, resolved.generation_uuid())
+    Ok(Some(resolved.generation_uuid()))
 }
 
 fn has_exact_pristine_layout(target: &Path, generation_uuid: Uuid) -> Result<bool, GfError> {

--- a/crates/graphforge-storage/src/project_portable_v2.rs
+++ b/crates/graphforge-storage/src/project_portable_v2.rs
@@ -17,7 +17,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use unicode_normalization::UnicodeNormalization;
 
 const MANIFEST_PATH: &str = "data/graphforge-project.json";
-const RUNTIME_MAP_PATH: &str =
+pub(crate) const RUNTIME_MAP_PATH: &str =
     "data/components/compatibility/graphforge-runtime-map/runtime-generation.json";
 const BAGIT: &[u8] = b"BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8\n";
 const BAG_INFO: &[u8] = b"Bag-Software-Agent: GraphForge portable-v2\nBagging-Date: 1970-01-01\n";
@@ -134,7 +134,9 @@ pub struct PortableV2Error {
 }
 
 impl PortableV2Error {
-    pub(crate) fn new(code: PortableV2ErrorCode, detail: &'static str) -> Self {
+    /// Construct a sanitized package-level failure without a host path or payload value.
+    #[must_use]
+    pub fn new(code: PortableV2ErrorCode, detail: &'static str) -> Self {
         Self {
             code,
             entry: None,
@@ -214,35 +216,35 @@ struct ManifestFile {
 }
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-struct RuntimeGenerationMap {
-    contract: String,
-    capabilities: Vec<RuntimeCapability>,
-    participants: Vec<RuntimeParticipant>,
-    graph_tree: Option<RuntimeGraphTree>,
+pub(crate) struct RuntimeGenerationMap {
+    pub(crate) contract: String,
+    pub(crate) capabilities: Vec<RuntimeCapability>,
+    pub(crate) participants: Vec<RuntimeParticipant>,
+    pub(crate) graph_tree: Option<RuntimeGraphTree>,
 }
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-struct RuntimeCapability {
-    capability_id: String,
-    capability_version: u32,
+pub(crate) struct RuntimeCapability {
+    pub(crate) capability_id: String,
+    pub(crate) capability_version: u32,
 }
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-struct RuntimeParticipant {
-    participant_id: String,
-    capability_id: String,
-    capability_version: u32,
-    record_family_id: String,
-    record_version: u32,
-    encoding: String,
-    schema_fingerprint: String,
-    row_count: u64,
+pub(crate) struct RuntimeParticipant {
+    pub(crate) participant_id: String,
+    pub(crate) capability_id: String,
+    pub(crate) capability_version: u32,
+    pub(crate) record_family_id: String,
+    pub(crate) record_version: u32,
+    pub(crate) encoding: String,
+    pub(crate) schema_fingerprint: String,
+    pub(crate) row_count: u64,
 }
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-struct RuntimeGraphTree {
-    component_id: String,
-    inventory_participant_id: String,
+pub(crate) struct RuntimeGraphTree {
+    pub(crate) component_id: String,
+    pub(crate) inventory_participant_id: String,
 }
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -1493,7 +1495,9 @@ fn validate_runtime_map_contents(
     Ok(())
 }
 
-fn decode_runtime_map(bytes: &[u8]) -> Result<(Value, RuntimeGenerationMap), PortableV2Error> {
+pub(crate) fn decode_runtime_map(
+    bytes: &[u8],
+) -> Result<(Value, RuntimeGenerationMap), PortableV2Error> {
     let value = UniqueValue::deserialize(&mut serde_json::Deserializer::from_slice(bytes))
         .map_err(|_| {
             PortableV2Error::at(
@@ -2144,6 +2148,7 @@ impl<'de> Visitor<'de> for UniqueVisitor {
 mod tests {
     use super::*;
     use std::sync::atomic::AtomicBool;
+    use uuid::Uuid;
 
     fn package() -> tempfile::TempDir {
         let root = tempfile::tempdir().unwrap();
@@ -2240,6 +2245,25 @@ mod tests {
         assert_eq!(structure.integrity, PortableV2Integrity::NotChecked);
         assert_eq!(full.entry_count, 6);
         assert!(full.transport_digest.is_some());
+    }
+
+    #[test]
+    fn complete_import_refuses_selective_package_without_target_mutation() {
+        let root = package();
+        let parent = tempfile::tempdir().unwrap();
+        let target = parent.path().join("project");
+        let error = crate::import_complete_portable_v2(
+            root.path(),
+            &target,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            &[],
+            PortableV2Limits::default(),
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(error.code, PortableV2ErrorCode::Incompatible);
+        assert!(!target.exists());
     }
 
     #[test]

--- a/crates/graphforge-storage/src/project_portable_v2_export.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_export.rs
@@ -1345,6 +1345,112 @@ mod tests {
     use super::*;
     use crate::open_or_initialize_project;
 
+    fn graph_generation() -> (tempfile::TempDir, ResolvedProjectGeneration) {
+        let project = tempfile::tempdir().unwrap();
+        let parent = open_or_initialize_project(project.path()).unwrap();
+        let tree = tempfile::tempdir().unwrap();
+        fs::write(tree.path().join("a.parquet"), b"graph-a").unwrap();
+        fs::create_dir(tree.path().join("properties")).unwrap();
+        fs::write(tree.path().join("properties/Person.parquet"), b"person").unwrap();
+        let (_, inventory) = crate::capture_graph_files(tree.path()).unwrap();
+        let mut participants = crate::empty_workspace_participants().unwrap();
+        participants.insert(0, inventory);
+        let request = crate::ProjectGenerationRequest {
+            transaction_uuid: Uuid::new_v4(),
+            generation_uuid: Uuid::new_v4(),
+            capabilities: vec![
+                crate::ProjectCapability {
+                    capability_id: "graph".into(),
+                    capability_version: 1,
+                },
+                crate::ProjectCapability {
+                    capability_id: "workspace".into(),
+                    capability_version: 1,
+                },
+            ],
+            participants,
+        };
+        let crate::ProjectStageOutcome::Staged(staged) =
+            crate::stage_project_generation_with_graph_tree(
+                project.path(),
+                &request,
+                Some(tree.path()),
+            )
+            .unwrap()
+        else {
+            panic!("fresh graph generation replayed");
+        };
+        staged
+            .validate(|_| Ok(()), |_, _| Ok(()))
+            .unwrap()
+            .publish()
+            .unwrap();
+        drop(parent);
+        let generation = crate::resolve_project_generation(project.path()).unwrap();
+        (project, generation)
+    }
+
+    #[test]
+    fn graph_tree_round_trips_equivalently_from_both_representations() {
+        let (_project, generation) = graph_generation();
+        let limits = PortableV2ExportLimits::default();
+        let plan = plan_complete_portable_v2(&generation, limits).unwrap();
+        let output = tempfile::tempdir().unwrap();
+        let expanded = output.path().join("graph.gfproject");
+        let bundle = output.path().join("graph.gfpb");
+        let cancelled = AtomicBool::new(false);
+        export_complete_portable_v2(
+            &plan,
+            &expanded,
+            PortableV2Output::Expanded,
+            limits,
+            &cancelled,
+            |_| {},
+        )
+        .unwrap();
+        export_complete_portable_v2(
+            &plan,
+            &bundle,
+            PortableV2Output::Bundle,
+            limits,
+            &cancelled,
+            |_| {},
+        )
+        .unwrap();
+        let supported = generation
+            .capabilities()
+            .into_iter()
+            .map(|capability| crate::ProjectCapability {
+                capability_id: capability.capability_id,
+                capability_version: capability.capability_version,
+            })
+            .collect::<Vec<_>>();
+        let expanded_target = output.path().join("expanded");
+        let bundle_target = output.path().join("bundle");
+        for (source, target) in [(&expanded, &expanded_target), (&bundle, &bundle_target)] {
+            crate::import_complete_portable_v2(
+                source,
+                target,
+                Uuid::new_v4(),
+                Uuid::new_v4(),
+                &supported,
+                limits,
+                None,
+            )
+            .unwrap();
+        }
+        let expanded = crate::resolve_project_generation(&expanded_target).unwrap();
+        let bundle = crate::resolve_project_generation(&bundle_target).unwrap();
+        assert_eq!(
+            expanded.graph_files_inventory().unwrap(),
+            bundle.graph_files_inventory().unwrap()
+        );
+        assert_eq!(
+            tree_bytes(&expanded.graph_tree_root()),
+            tree_bytes(&bundle.graph_tree_root())
+        );
+    }
+
     #[test]
     fn selection_preview_is_stable_exact_and_consumed_by_export_plan() {
         let project = tempfile::tempdir().unwrap();

--- a/crates/graphforge-storage/src/project_portable_v2_export.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_export.rs
@@ -1597,6 +1597,130 @@ mod tests {
         assert_eq!(runtime["contract"], "graphforge-runtime-generation-map/1");
         assert!(runtime.get("host_path").is_none());
         assert!(runtime.get("secret").is_none());
+
+        let supported = generation
+            .capabilities()
+            .into_iter()
+            .map(|capability| crate::ProjectCapability {
+                capability_id: capability.capability_id,
+                capability_version: capability.capability_version,
+            })
+            .collect::<Vec<_>>();
+        let expanded_target = out.path().join("expanded-project");
+        let bundle_target = out.path().join("bundle-project");
+        let mut progress = Vec::new();
+        let expanded_transaction = Uuid::new_v4();
+        let expanded_generation = Uuid::new_v4();
+        let expanded_import = crate::import_complete_portable_v2_with_progress(
+            &expanded,
+            &expanded_target,
+            expanded_transaction,
+            expanded_generation,
+            &supported,
+            limits,
+            Some(&cancelled),
+            |event| progress.push(event),
+        )
+        .unwrap();
+        assert_eq!(
+            progress.iter().map(|event| event.phase).collect::<Vec<_>>(),
+            vec![
+                crate::PortableV2ImportPhase::Verifying,
+                crate::PortableV2ImportPhase::Materialized,
+                crate::PortableV2ImportPhase::Published,
+            ]
+        );
+        let expected_package_digest = format!("sha256:{}", hex(a.package_digest));
+        assert!(progress.iter().skip(1).all(|event| {
+            event.entries > 0
+                && event.bytes > 0
+                && event.package_digest.as_deref() == Some(expected_package_digest.as_str())
+        }));
+        let bundle_import = crate::import_complete_portable_v2(
+            &first,
+            &bundle_target,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            &supported,
+            limits,
+            Some(&cancelled),
+        )
+        .unwrap();
+        assert_eq!(expanded_import.package_digest, bundle_import.package_digest);
+        let expanded_reopened = crate::resolve_project_generation(&expanded_target).unwrap();
+        let bundle_reopened = crate::resolve_project_generation(&bundle_target).unwrap();
+        assert_eq!(
+            expanded_reopened.capabilities(),
+            bundle_reopened.capabilities()
+        );
+        assert_eq!(
+            expanded_reopened.participant_snapshots().unwrap(),
+            bundle_reopened.participant_snapshots().unwrap()
+        );
+        let protected_generation = expanded_reopened.generation_uuid();
+        let replay = crate::import_complete_portable_v2(
+            &expanded,
+            &expanded_target,
+            expanded_transaction,
+            expanded_generation,
+            &supported,
+            limits,
+            Some(&cancelled),
+        )
+        .unwrap();
+        assert!(replay.publication.idempotent_replay);
+        assert_eq!(replay.publication.generation_uuid, protected_generation);
+        let overwrite = crate::import_complete_portable_v2(
+            &expanded,
+            &expanded_target,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            &supported,
+            limits,
+            Some(&cancelled),
+        )
+        .unwrap_err();
+        assert_eq!(overwrite.code, PortableV2ErrorCode::Io);
+        assert_eq!(
+            crate::resolve_project_generation(&expanded_target)
+                .unwrap()
+                .generation_uuid(),
+            protected_generation
+        );
+        let cancelled = AtomicBool::new(true);
+        let cancelled_target = out.path().join("cancelled-project");
+        let cancelled_error = crate::import_complete_portable_v2(
+            &expanded,
+            &cancelled_target,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            &supported,
+            limits,
+            Some(&cancelled),
+        )
+        .unwrap_err();
+        assert_eq!(cancelled_error.code, PortableV2ErrorCode::Cancelled);
+        assert!(!cancelled_target.exists());
+        fs::write(
+            expanded.join(
+                "data/components/compatibility/graphforge-runtime-map/runtime-generation.json",
+            ),
+            b"{}",
+        )
+        .unwrap();
+        let corrupt_target = out.path().join("corrupt-project");
+        let corrupt = crate::import_complete_portable_v2(
+            &expanded,
+            &corrupt_target,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            &supported,
+            limits,
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(corrupt.code, PortableV2ErrorCode::DigestMismatch);
+        assert!(!corrupt_target.exists());
     }
 
     #[test]

--- a/crates/graphforge-storage/src/project_portable_v2_import.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_import.rs
@@ -1,6 +1,7 @@
 //! Verification-first, bounded portable-v2 project import.
 
-use std::fs;
+use std::fs::{self, OpenOptions};
+use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 
@@ -114,39 +115,15 @@ pub fn import_complete_portable_v2_with_progress(
             ".{target_name}.portable-v2-{}",
             transaction_uuid.hyphenated()
         ));
-    let owner = stage.join(".graphforge-portable-v2-import-owner");
-    let mut owned_retry = false;
-    if stage.exists() {
-        let expected = transaction_uuid.hyphenated().to_string();
-        if fs::read_to_string(&owner).ok().as_deref() != Some(expected.as_str()) {
-            return Err(PortableV2Error::new(
-                PortableV2ErrorCode::Io,
-                "import staging identity already exists",
-            ));
+    let (owner, owned_retry) = claim_stage(&stage, target_name, transaction_uuid, generation_uuid)?;
+    let report = match materialize_verified_portable_v2(source, &stage, limits, cancelled) {
+        Ok(report) => report,
+        Err(error) => {
+            let _ = fs::remove_file(&owner);
+            let _ = sync_parent(&owner);
+            return Err(error);
         }
-        fs::remove_dir_all(&stage).map_err(|_| {
-            PortableV2Error::new(
-                PortableV2ErrorCode::Io,
-                "owned import staging is unavailable",
-            )
-        })?;
-        owned_retry = true;
-    }
-    let report = materialize_verified_portable_v2(source, &stage, limits, cancelled)?;
-    fs::write(&owner, transaction_uuid.hyphenated().to_string()).map_err(|_| {
-        PortableV2Error::new(
-            PortableV2ErrorCode::Io,
-            "cannot mark import staging ownership",
-        )
-    })?;
-    fs::File::open(&owner)
-        .and_then(|file| file.sync_all())
-        .map_err(|_| {
-            PortableV2Error::new(
-                PortableV2ErrorCode::Io,
-                "cannot sync import staging ownership",
-            )
-        })?;
+    };
     progress(PortableV2ImportProgress {
         phase: PortableV2ImportPhase::Materialized,
         entries: report.entry_count,
@@ -165,6 +142,8 @@ pub fn import_complete_portable_v2_with_progress(
         owned_retry,
     );
     let _ = fs::remove_dir_all(&stage);
+    let _ = fs::remove_file(&owner);
+    let _ = sync_parent(&owner);
     if result.is_ok() {
         progress(PortableV2ImportProgress {
             phase: PortableV2ImportPhase::Published,
@@ -174,6 +153,100 @@ pub fn import_complete_portable_v2_with_progress(
         });
     }
     result
+}
+
+fn claim_stage(
+    stage: &Path,
+    target_name: &str,
+    transaction_uuid: Uuid,
+    generation_uuid: Uuid,
+) -> Result<(PathBuf, bool), PortableV2Error> {
+    let owner = stage.with_file_name(format!(
+        ".{target_name}.portable-v2-{}.owner",
+        transaction_uuid.hyphenated()
+    ));
+    let expected = transaction_uuid.hyphenated().to_string();
+    let mut owned_retry = false;
+    if owner.exists() && fs::read_to_string(&owner).ok().as_deref() != Some(expected.as_str()) {
+        return Err(PortableV2Error::new(
+            PortableV2ErrorCode::Io,
+            "import staging identity already exists",
+        ));
+    }
+    if stage.exists() {
+        if fs::read_to_string(&owner).ok().as_deref() != Some(expected.as_str()) {
+            return Err(PortableV2Error::new(
+                PortableV2ErrorCode::Io,
+                "import staging identity already exists",
+            ));
+        }
+        fs::remove_dir_all(stage).map_err(|_| {
+            PortableV2Error::new(
+                PortableV2ErrorCode::Io,
+                "owned import staging is unavailable",
+            )
+        })?;
+        owned_retry = true;
+    }
+    if owner.exists() {
+        owned_retry = true;
+    } else {
+        let mut marker = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&owner)
+            .map_err(|_| {
+                PortableV2Error::new(
+                    PortableV2ErrorCode::Io,
+                    "cannot claim import staging ownership",
+                )
+            })?;
+        marker.write_all(expected.as_bytes()).map_err(|_| {
+            PortableV2Error::new(
+                PortableV2ErrorCode::Io,
+                "cannot mark import staging ownership",
+            )
+        })?;
+        marker.sync_all().map_err(|_| {
+            PortableV2Error::new(
+                PortableV2ErrorCode::Io,
+                "cannot sync import staging ownership",
+            )
+        })?;
+        sync_parent(&owner)?;
+    }
+    crate::project_failpoint::hit(
+        "portable_import.after_owner",
+        Some(transaction_uuid),
+        Some(generation_uuid),
+        "IMPORT_OWNER",
+        false,
+    )
+    .map_err(storage)?;
+    Ok((owner, owned_retry))
+}
+
+fn sync_parent(path: &Path) -> Result<(), PortableV2Error> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    sync_directory_handle(parent).map_err(|_| {
+        PortableV2Error::new(PortableV2ErrorCode::Io, "cannot sync import staging parent")
+    })
+}
+
+#[cfg(not(windows))]
+fn sync_directory_handle(path: &Path) -> std::io::Result<()> {
+    fs::File::open(path)?.sync_all()
+}
+
+#[cfg(windows)]
+fn sync_directory_handle(path: &Path) -> std::io::Result<()> {
+    use std::os::windows::fs::OpenOptionsExt as _;
+    const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
+    OpenOptions::new()
+        .read(true)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
+        .open(path)?
+        .sync_all()
 }
 
 #[expect(clippy::too_many_arguments, reason = "import authority is explicit")]
@@ -572,6 +645,7 @@ mod tests {
         .unwrap();
 
         for failpoint in [
+            "portable_import.after_owner",
             "project.after_writer_lock",
             "project.after_participant_write",
             "project.after_manifest_fsync",
@@ -632,6 +706,11 @@ mod tests {
                 .unwrap()
                 .join(format!(".project.portable-v2-{}", transaction.hyphenated()));
             assert!(!residue.exists(), "owned residue survived {failpoint}");
+            let owner_residue = residue.with_file_name(format!(
+                "{}.owner",
+                residue.file_name().unwrap().to_string_lossy()
+            ));
+            assert!(!owner_residue.exists(), "owned marker survived {failpoint}");
         }
     }
 

--- a/crates/graphforge-storage/src/project_portable_v2_import.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_import.rs
@@ -1,0 +1,434 @@
+//! Verification-first, bounded portable-v2 project import.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicBool;
+
+use graphforge_core::GfError;
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::project_generation::open_or_initialize_project_admitted;
+use crate::project_portable::prepare_import_target;
+use crate::project_portable_v2::{
+    PortableV2Error, PortableV2ErrorCode, PortableV2Limits, PortableV2PackageClass,
+    PortableV2Report, RUNTIME_MAP_PATH, decode_runtime_map, materialize_verified_portable_v2,
+};
+use crate::project_publication::{
+    ProjectCapability, ProjectFileParticipant, ProjectGenerationRequest, ProjectParticipant,
+    ProjectParticipantEncoding, ProjectPublicationReceipt, ProjectStageOutcome,
+    stage_project_generation_from_files_admitted,
+};
+
+#[derive(Debug)]
+/// Durable receipt for one verified complete-package import.
+pub struct PortableV2ImportReceipt {
+    /// Canonical semantic package identity.
+    pub package_digest: String,
+    /// Representation-specific transport identity.
+    pub transport_digest: Option<String>,
+    /// Atomic project-generation publication receipt.
+    pub publication: ProjectPublicationReceipt,
+}
+
+/// Sanitized import lifecycle phase.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PortableV2ImportPhase {
+    /// Shared verification and private materialization are running.
+    Verifying,
+    /// Authenticated component entries are ready for publication.
+    Materialized,
+    /// The imported generation was published and reopened.
+    Published,
+}
+
+/// Aggregate, payload-free portable import progress.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PortableV2ImportProgress {
+    /// Current lifecycle phase.
+    pub phase: PortableV2ImportPhase,
+    /// Authenticated package entry count, when known.
+    pub entries: u64,
+    /// Authenticated aggregate payload bytes, when known.
+    pub bytes: u64,
+    /// Canonical package digest, available only after verification.
+    pub package_digest: Option<String>,
+}
+
+/// Verify, stream, publish, and reopen one complete portable-v2 project.
+///
+/// Selective classes are refused before project admission. The shared verifier
+/// authenticates the complete source before component bytes are materialized;
+/// publication then streams those files into one private generation.
+pub fn import_complete_portable_v2(
+    source: impl AsRef<Path>,
+    target: impl AsRef<Path>,
+    transaction_uuid: Uuid,
+    generation_uuid: Uuid,
+    supported_capabilities: &[ProjectCapability],
+    limits: PortableV2Limits,
+    cancelled: Option<&AtomicBool>,
+) -> Result<PortableV2ImportReceipt, PortableV2Error> {
+    import_complete_portable_v2_with_progress(
+        source,
+        target,
+        transaction_uuid,
+        generation_uuid,
+        supported_capabilities,
+        limits,
+        cancelled,
+        |_| {},
+    )
+}
+
+/// Import a complete package while reporting sanitized aggregate progress.
+#[expect(clippy::too_many_arguments, reason = "import authority is explicit")]
+pub fn import_complete_portable_v2_with_progress(
+    source: impl AsRef<Path>,
+    target: impl AsRef<Path>,
+    transaction_uuid: Uuid,
+    generation_uuid: Uuid,
+    supported_capabilities: &[ProjectCapability],
+    limits: PortableV2Limits,
+    cancelled: Option<&AtomicBool>,
+    mut progress: impl FnMut(PortableV2ImportProgress),
+) -> Result<PortableV2ImportReceipt, PortableV2Error> {
+    let source = source.as_ref();
+    let target = target.as_ref();
+    progress(PortableV2ImportProgress {
+        phase: PortableV2ImportPhase::Verifying,
+        entries: 0,
+        bytes: 0,
+        package_digest: None,
+    });
+    let target_name = target
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            PortableV2Error::new(PortableV2ErrorCode::InvalidPath, "invalid import target")
+        })?;
+    let stage = target
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(format!(
+            ".{target_name}.portable-v2-{}",
+            transaction_uuid.hyphenated()
+        ));
+    if stage.exists() {
+        return Err(PortableV2Error::new(
+            PortableV2ErrorCode::Io,
+            "import staging identity already exists",
+        ));
+    }
+    let report = materialize_verified_portable_v2(source, &stage, limits, cancelled)?;
+    progress(PortableV2ImportProgress {
+        phase: PortableV2ImportPhase::Materialized,
+        entries: report.entry_count,
+        bytes: report.payload_bytes,
+        package_digest: Some(report.package_digest.clone()),
+    });
+    let result = import_materialized(
+        &stage,
+        target,
+        transaction_uuid,
+        generation_uuid,
+        supported_capabilities,
+        limits,
+        cancelled,
+        &report,
+    );
+    let _ = fs::remove_dir_all(&stage);
+    if result.is_ok() {
+        progress(PortableV2ImportProgress {
+            phase: PortableV2ImportPhase::Published,
+            entries: report.entry_count,
+            bytes: report.payload_bytes,
+            package_digest: Some(report.package_digest.clone()),
+        });
+    }
+    result
+}
+
+#[expect(clippy::too_many_arguments, reason = "import authority is explicit")]
+#[expect(
+    clippy::too_many_lines,
+    reason = "verification, compatibility, admission, publication, and reopen gates remain explicit"
+)]
+fn import_materialized(
+    stage: &Path,
+    target: &Path,
+    transaction_uuid: Uuid,
+    generation_uuid: Uuid,
+    supported_capabilities: &[ProjectCapability],
+    limits: PortableV2Limits,
+    cancelled: Option<&AtomicBool>,
+    report: &PortableV2Report,
+) -> Result<PortableV2ImportReceipt, PortableV2Error> {
+    if report.package_class != PortableV2PackageClass::Complete {
+        return Err(PortableV2Error::new(
+            PortableV2ErrorCode::Incompatible,
+            "selective package requires an explicit class-specific consumer",
+        ));
+    }
+    if cancelled.is_some_and(|flag| flag.load(std::sync::atomic::Ordering::Relaxed)) {
+        return Err(PortableV2Error::new(
+            PortableV2ErrorCode::Cancelled,
+            "verification cancelled",
+        ));
+    }
+    let runtime_path = stage.join(RUNTIME_MAP_PATH);
+    let bytes = fs::read(&runtime_path).map_err(|_| {
+        PortableV2Error::at(
+            PortableV2ErrorCode::InvalidStructure,
+            RUNTIME_MAP_PATH,
+            "runtime map unavailable",
+        )
+    })?;
+    if bytes.len() as u64 > limits.max_manifest_bytes {
+        return Err(PortableV2Error::new(
+            PortableV2ErrorCode::LimitExceeded,
+            "runtime map exceeds limit",
+        ));
+    }
+    let (_, runtime) = decode_runtime_map(&bytes)?;
+    for capability in &runtime.capabilities {
+        if !supported_capabilities.iter().any(|supported| {
+            supported.capability_id == capability.capability_id
+                && supported.capability_version == capability.capability_version
+        }) {
+            return Err(PortableV2Error::new(
+                PortableV2ErrorCode::Incompatible,
+                "runtime capability is unsupported",
+            ));
+        }
+    }
+    let capabilities = runtime
+        .capabilities
+        .into_iter()
+        .map(|capability| ProjectCapability {
+            capability_id: capability.capability_id,
+            capability_version: capability.capability_version,
+        })
+        .collect();
+    let mut participants = Vec::with_capacity(runtime.participants.len());
+    for participant in runtime.participants {
+        let source = find_participant_file(stage, &participant.participant_id, limits)?;
+        let metadata = fs::metadata(&source).map_err(|_| {
+            PortableV2Error::new(
+                PortableV2ErrorCode::ConcurrentMutation,
+                "participant vanished",
+            )
+        })?;
+        let content_sha256: [u8; 32] = hash_file(&source, limits.copy_buffer_bytes, cancelled)?;
+        let encoding = match participant.encoding.as_str() {
+            "json" => ProjectParticipantEncoding::Json,
+            "parquet" => ProjectParticipantEncoding::Parquet,
+            "arrow" => ProjectParticipantEncoding::Arrow,
+            _ => {
+                return Err(PortableV2Error::new(
+                    PortableV2ErrorCode::Incompatible,
+                    "participant encoding is unsupported",
+                ));
+            }
+        };
+        let schema_fingerprint = parse_digest(&participant.schema_fingerprint)?;
+        participants.push(ProjectFileParticipant {
+            participant: ProjectParticipant {
+                capability_id: participant.capability_id,
+                capability_version: participant.capability_version,
+                record_family_id: participant.record_family_id,
+                record_version: participant.record_version,
+                encoding,
+                schema_fingerprint,
+                row_count: participant.row_count,
+                bytes: Vec::new(),
+            },
+            source,
+            byte_length: metadata.len(),
+            content_sha256,
+        });
+    }
+    let request = ProjectGenerationRequest {
+        transaction_uuid,
+        generation_uuid,
+        capabilities,
+        participants: participants
+            .iter()
+            .map(|participant| participant.participant.clone())
+            .collect(),
+    };
+    let admission = crate::filesystem_admission::admit_project_lifecycle(
+        target,
+        crate::filesystem_admission::ProjectLifecycleMode::Durable,
+        crate::filesystem_admission::ProjectRootRequirement::CreateIfMissing,
+    )
+    .map_err(storage)?;
+    admission.revalidate_identity().map_err(storage)?;
+    let replay = crate::published_project_transaction(admission.root(), transaction_uuid)
+        .map_err(storage)?
+        .is_some();
+    let existing = if replay {
+        Some(crate::resolve_project_generation(admission.root()).map_err(storage)?)
+    } else {
+        prepare_import_target(admission.root()).map_err(storage)?
+    };
+    let parent = match existing {
+        Some(parent) => parent,
+        None => open_or_initialize_project_admitted(admission.root()).map_err(storage)?,
+    };
+    let graph_tree = runtime
+        .graph_tree
+        .as_ref()
+        .map(|_| stage.join("data/components/graph-data/graph-tree"));
+    let publication = match stage_project_generation_from_files_admitted(
+        admission,
+        parent,
+        &request,
+        &participants,
+        graph_tree.as_deref(),
+        cancelled,
+        limits.copy_buffer_bytes,
+    )
+    .map_err(|error| storage_or_cancel(error, cancelled))?
+    {
+        ProjectStageOutcome::AlreadyPublished(receipt) => receipt,
+        ProjectStageOutcome::Staged(staged) => {
+            let validated = staged
+                .validate(|_| Ok(()), |_, _| Ok(()))
+                .map_err(storage)?;
+            validated.publish().map_err(storage)?
+        }
+    };
+    let reopened = crate::resolve_project_generation(target).map_err(storage)?;
+    if reopened.generation_uuid() != generation_uuid {
+        return Err(PortableV2Error::new(
+            PortableV2ErrorCode::Io,
+            "published generation did not reopen",
+        ));
+    }
+    Ok(PortableV2ImportReceipt {
+        package_digest: report.package_digest.clone(),
+        transport_digest: report.transport_digest.clone(),
+        publication,
+    })
+}
+
+fn find_participant_file(
+    stage: &Path,
+    participant_id: &str,
+    limits: PortableV2Limits,
+) -> Result<PathBuf, PortableV2Error> {
+    let root = stage.join("data/components");
+    let mut found = None;
+    for kind in fs::read_dir(&root).map_err(|_| {
+        PortableV2Error::new(
+            PortableV2ErrorCode::InvalidStructure,
+            "components unavailable",
+        )
+    })? {
+        let candidate = kind
+            .map_err(|_| PortableV2Error::new(PortableV2ErrorCode::Io, "component unavailable"))?
+            .path()
+            .join(participant_id);
+        if !candidate.is_dir() {
+            continue;
+        }
+        for entry in fs::read_dir(candidate)
+            .map_err(|_| PortableV2Error::new(PortableV2ErrorCode::Io, "participant unavailable"))?
+        {
+            let path = entry
+                .map_err(|_| PortableV2Error::new(PortableV2ErrorCode::Io, "entry unavailable"))?
+                .path();
+            if path.is_file() && found.replace(path).is_some() {
+                return Err(PortableV2Error::new(
+                    PortableV2ErrorCode::Incompatible,
+                    "runtime participant has multiple payloads",
+                ));
+            }
+        }
+    }
+    let path = found.ok_or_else(|| {
+        PortableV2Error::new(
+            PortableV2ErrorCode::Incompatible,
+            "runtime participant is absent",
+        )
+    })?;
+    if fs::metadata(&path)
+        .map_err(|_| PortableV2Error::new(PortableV2ErrorCode::Io, "entry unavailable"))?
+        .len()
+        > limits.max_entry_bytes
+    {
+        return Err(PortableV2Error::new(
+            PortableV2ErrorCode::LimitExceeded,
+            "participant exceeds limit",
+        ));
+    }
+    Ok(path)
+}
+
+fn hash_file(
+    path: &Path,
+    buffer_size: usize,
+    cancelled: Option<&AtomicBool>,
+) -> Result<[u8; 32], PortableV2Error> {
+    use std::io::Read;
+    let mut file = fs::File::open(path)
+        .map_err(|_| PortableV2Error::new(PortableV2ErrorCode::Io, "participant unavailable"))?;
+    let mut buffer = vec![0; buffer_size];
+    let mut hash = Sha256::new();
+    loop {
+        if cancelled.is_some_and(|flag| flag.load(std::sync::atomic::Ordering::Relaxed)) {
+            return Err(PortableV2Error::new(
+                PortableV2ErrorCode::Cancelled,
+                "verification cancelled",
+            ));
+        }
+        let count = file
+            .read(&mut buffer)
+            .map_err(|_| PortableV2Error::new(PortableV2ErrorCode::Io, "participant unreadable"))?;
+        if count == 0 {
+            return Ok(hash.finalize().into());
+        }
+        hash.update(&buffer[..count]);
+    }
+}
+
+fn parse_digest(value: &str) -> Result<[u8; 32], PortableV2Error> {
+    let mut digest = [0; 32];
+    if value.len() != 64 {
+        return Err(PortableV2Error::new(
+            PortableV2ErrorCode::Incompatible,
+            "schema fingerprint is invalid",
+        ));
+    }
+    for (index, pair) in value.as_bytes().chunks_exact(2).enumerate() {
+        let text = std::str::from_utf8(pair).map_err(|_| {
+            PortableV2Error::new(
+                PortableV2ErrorCode::Incompatible,
+                "schema fingerprint is invalid",
+            )
+        })?;
+        digest[index] = u8::from_str_radix(text, 16).map_err(|_| {
+            PortableV2Error::new(
+                PortableV2ErrorCode::Incompatible,
+                "schema fingerprint is invalid",
+            )
+        })?;
+    }
+    Ok(digest)
+}
+
+fn storage(_: GfError) -> PortableV2Error {
+    PortableV2Error::new(
+        PortableV2ErrorCode::Io,
+        "portable import publication failed",
+    )
+}
+
+fn storage_or_cancel(error: GfError, cancelled: Option<&AtomicBool>) -> PortableV2Error {
+    if cancelled.is_some_and(|flag| flag.load(std::sync::atomic::Ordering::Relaxed)) {
+        PortableV2Error::new(PortableV2ErrorCode::Cancelled, "verification cancelled")
+    } else {
+        storage(error)
+    }
+}

--- a/crates/graphforge-storage/src/project_portable_v2_import.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_import.rs
@@ -9,7 +9,7 @@ use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::project_generation::open_or_initialize_project_admitted;
-use crate::project_portable::prepare_import_target;
+use crate::project_portable::{prepare_import_target, semantically_pristine_generation};
 use crate::project_portable_v2::{
     PortableV2Error, PortableV2ErrorCode, PortableV2Limits, PortableV2PackageClass,
     PortableV2Report, RUNTIME_MAP_PATH, decode_runtime_map, materialize_verified_portable_v2,
@@ -114,13 +114,39 @@ pub fn import_complete_portable_v2_with_progress(
             ".{target_name}.portable-v2-{}",
             transaction_uuid.hyphenated()
         ));
+    let owner = stage.join(".graphforge-portable-v2-import-owner");
+    let mut owned_retry = false;
     if stage.exists() {
-        return Err(PortableV2Error::new(
-            PortableV2ErrorCode::Io,
-            "import staging identity already exists",
-        ));
+        let expected = transaction_uuid.hyphenated().to_string();
+        if fs::read_to_string(&owner).ok().as_deref() != Some(expected.as_str()) {
+            return Err(PortableV2Error::new(
+                PortableV2ErrorCode::Io,
+                "import staging identity already exists",
+            ));
+        }
+        fs::remove_dir_all(&stage).map_err(|_| {
+            PortableV2Error::new(
+                PortableV2ErrorCode::Io,
+                "owned import staging is unavailable",
+            )
+        })?;
+        owned_retry = true;
     }
     let report = materialize_verified_portable_v2(source, &stage, limits, cancelled)?;
+    fs::write(&owner, transaction_uuid.hyphenated().to_string()).map_err(|_| {
+        PortableV2Error::new(
+            PortableV2ErrorCode::Io,
+            "cannot mark import staging ownership",
+        )
+    })?;
+    fs::File::open(&owner)
+        .and_then(|file| file.sync_all())
+        .map_err(|_| {
+            PortableV2Error::new(
+                PortableV2ErrorCode::Io,
+                "cannot sync import staging ownership",
+            )
+        })?;
     progress(PortableV2ImportProgress {
         phase: PortableV2ImportPhase::Materialized,
         entries: report.entry_count,
@@ -136,6 +162,7 @@ pub fn import_complete_portable_v2_with_progress(
         limits,
         cancelled,
         &report,
+        owned_retry,
     );
     let _ = fs::remove_dir_all(&stage);
     if result.is_ok() {
@@ -163,6 +190,7 @@ fn import_materialized(
     limits: PortableV2Limits,
     cancelled: Option<&AtomicBool>,
     report: &PortableV2Report,
+    owned_retry: bool,
 ) -> Result<PortableV2ImportReceipt, PortableV2Error> {
     if report.package_class != PortableV2PackageClass::Complete {
         return Err(PortableV2Error::new(
@@ -268,6 +296,15 @@ fn import_materialized(
         .map_err(storage)?
         .is_some();
     let existing = if replay {
+        Some(crate::resolve_project_generation(admission.root()).map_err(storage)?)
+    } else if owned_retry {
+        let generation = semantically_pristine_generation(admission.root()).map_err(storage)?;
+        if generation.is_none() {
+            return Err(PortableV2Error::new(
+                PortableV2ErrorCode::Io,
+                "owned retry target is not pristine",
+            ));
+        }
         Some(crate::resolve_project_generation(admission.root()).map_err(storage)?)
     } else {
         prepare_import_target(admission.root()).map_err(storage)?
@@ -430,5 +467,195 @@ fn storage_or_cancel(error: GfError, cancelled: Option<&AtomicBool>) -> Portable
         PortableV2Error::new(PortableV2ErrorCode::Cancelled, "verification cancelled")
     } else {
         storage(error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HELPER: &str = "project_portable_v2_import::tests::subprocess_crash_import";
+    const COOKIE: &str = "graphforge-internal-subprocess-v1";
+
+    fn supported() -> Vec<ProjectCapability> {
+        vec![
+            ProjectCapability {
+                capability_id: "graph".into(),
+                capability_version: 1,
+            },
+            ProjectCapability {
+                capability_id: "workspace".into(),
+                capability_version: 1,
+            },
+        ]
+    }
+
+    #[test]
+    fn resource_ladder_fails_before_target_admission() {
+        let source_project = tempfile::tempdir().unwrap();
+        let source_generation = crate::open_or_initialize_project(source_project.path()).unwrap();
+        let package_parent = tempfile::tempdir().unwrap();
+        let package = package_parent.path().join("complete.gfproject");
+        let export_limits = crate::PortableV2ExportLimits::default();
+        let plan = crate::plan_complete_portable_v2(&source_generation, export_limits).unwrap();
+        crate::export_complete_portable_v2(
+            &plan,
+            &package,
+            crate::PortableV2Output::Expanded,
+            export_limits,
+            &AtomicBool::new(false),
+            |_| {},
+        )
+        .unwrap();
+        for (name, limits) in [
+            (
+                "entries",
+                PortableV2Limits {
+                    max_entries: 1,
+                    ..PortableV2Limits::default()
+                },
+            ),
+            (
+                "total",
+                PortableV2Limits {
+                    max_total_bytes: 1,
+                    ..PortableV2Limits::default()
+                },
+            ),
+            (
+                "entry",
+                PortableV2Limits {
+                    max_entry_bytes: 1,
+                    ..PortableV2Limits::default()
+                },
+            ),
+            (
+                "manifest",
+                PortableV2Limits {
+                    max_manifest_bytes: 1,
+                    ..PortableV2Limits::default()
+                },
+            ),
+        ] {
+            let target = package_parent.path().join(format!("target-{name}"));
+            let error = import_complete_portable_v2(
+                &package,
+                &target,
+                Uuid::new_v4(),
+                Uuid::new_v4(),
+                &supported(),
+                limits,
+                None,
+            )
+            .unwrap_err();
+            assert_eq!(error.code, PortableV2ErrorCode::LimitExceeded, "{name}");
+            assert!(!target.exists(), "{name}");
+        }
+    }
+
+    #[test]
+    fn crash_windows_recover_old_or_new_and_retry_cleans_owned_residue() {
+        let source_project = tempfile::tempdir().unwrap();
+        let source_generation = crate::open_or_initialize_project(source_project.path()).unwrap();
+        let package_parent = tempfile::tempdir().unwrap();
+        let package = package_parent.path().join("complete.gfproject");
+        let limits = crate::PortableV2ExportLimits::default();
+        let plan = crate::plan_complete_portable_v2(&source_generation, limits).unwrap();
+        crate::export_complete_portable_v2(
+            &plan,
+            &package,
+            crate::PortableV2Output::Expanded,
+            limits,
+            &AtomicBool::new(false),
+            |_| {},
+        )
+        .unwrap();
+
+        for failpoint in [
+            "project.after_writer_lock",
+            "project.after_participant_write",
+            "project.after_manifest_fsync",
+            "project.before_current_replace",
+            "project.after_current_replace",
+        ] {
+            let parent = tempfile::tempdir().unwrap();
+            let target = parent.path().join("project");
+            let old = crate::open_or_initialize_project(&target)
+                .unwrap()
+                .generation_uuid();
+            let transaction = Uuid::new_v4();
+            let generation = Uuid::new_v4();
+            let status = std::process::Command::new(std::env::current_exe().unwrap())
+                .arg("--exact")
+                .arg(HELPER)
+                .arg("--nocapture")
+                .env("GRAPHFORGE_PORTABLE_V2_CRASH_PACKAGE", &package)
+                .env("GRAPHFORGE_PORTABLE_V2_CRASH_TARGET", &target)
+                .env(
+                    "GRAPHFORGE_PORTABLE_V2_CRASH_TRANSACTION",
+                    transaction.to_string(),
+                )
+                .env(
+                    "GRAPHFORGE_PORTABLE_V2_CRASH_GENERATION",
+                    generation.to_string(),
+                )
+                .env("GRAPHFORGE_PROJECT_FAILPOINTS", COOKIE)
+                .env("GRAPHFORGE_PROJECT_FAILPOINT", failpoint)
+                .status()
+                .unwrap();
+            assert_eq!(status.code(), Some(crate::project_failpoint::exit_code()));
+
+            let _ = crate::recover_project_transactions(&target).unwrap();
+            let recovered = crate::resolve_project_generation(&target)
+                .unwrap()
+                .generation_uuid();
+            assert!(recovered == old || recovered == generation);
+            let receipt = import_complete_portable_v2(
+                &package,
+                &target,
+                transaction,
+                generation,
+                &supported(),
+                PortableV2Limits::default(),
+                None,
+            )
+            .unwrap_or_else(|error| panic!("retry after {failpoint} failed: {error:?}"));
+            assert_eq!(receipt.publication.generation_uuid, generation);
+            assert_eq!(
+                crate::resolve_project_generation(&target)
+                    .unwrap()
+                    .generation_uuid(),
+                generation
+            );
+            let residue = target
+                .parent()
+                .unwrap()
+                .join(format!(".project.portable-v2-{}", transaction.hyphenated()));
+            assert!(!residue.exists(), "owned residue survived {failpoint}");
+        }
+    }
+
+    #[test]
+    fn subprocess_crash_import() {
+        let Ok(package) = std::env::var("GRAPHFORGE_PORTABLE_V2_CRASH_PACKAGE") else {
+            return;
+        };
+        let target = std::env::var("GRAPHFORGE_PORTABLE_V2_CRASH_TARGET").unwrap();
+        let transaction =
+            Uuid::parse_str(&std::env::var("GRAPHFORGE_PORTABLE_V2_CRASH_TRANSACTION").unwrap())
+                .unwrap();
+        let generation =
+            Uuid::parse_str(&std::env::var("GRAPHFORGE_PORTABLE_V2_CRASH_GENERATION").unwrap())
+                .unwrap();
+        let _ = import_complete_portable_v2(
+            package,
+            target,
+            transaction,
+            generation,
+            &supported(),
+            PortableV2Limits::default(),
+            None,
+        );
+        panic!("configured portable import failpoint did not terminate the process");
     }
 }

--- a/crates/graphforge-storage/src/project_portable_v2_selection.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_selection.rs
@@ -243,12 +243,20 @@ pub fn preview_portable_v2_selection(
     }
     included.sort_by(|a, b| a.identity.cmp(&b.identity));
     excluded.sort_by(|a, b| a.identity.cmp(&b.identity));
-    let required_capabilities = included
-        .iter()
-        .map(|entry| entry.identity.capability_id.clone())
-        .collect::<BTreeSet<_>>()
-        .into_iter()
-        .collect::<Vec<_>>();
+    let required_capabilities = if matches!(request.profile, PortableV2SelectionProfile::Complete) {
+        generation
+            .capabilities()
+            .into_iter()
+            .map(|capability| capability.capability_id)
+            .collect()
+    } else {
+        included
+            .iter()
+            .map(|entry| entry.identity.capability_id.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>()
+    };
     let package_class = match request.profile {
         PortableV2SelectionProfile::Complete => "complete",
         PortableV2SelectionProfile::OntologyOnly => "ontology-only",

--- a/crates/graphforge-storage/src/project_publication.rs
+++ b/crates/graphforge-storage/src/project_publication.rs
@@ -461,6 +461,13 @@ pub(crate) fn stage_project_generation_from_files_admitted(
         admission.revalidate_identity()?;
         let root = canonical_supported_root(admission.root())?;
         let writer_lock = acquire_writer_lock(&root, request)?;
+        project_failpoint::hit(
+            "project.after_writer_lock",
+            Some(request.transaction_uuid),
+            Some(request.generation_uuid),
+            "WRITER_LOCK",
+            false,
+        )?;
         let current = resolve_project_generation(&root)?;
         if current.generation_uuid() != parent.generation_uuid()
             || current.manifest_sha256() != parent.manifest_sha256()

--- a/crates/graphforge-storage/src/project_publication.rs
+++ b/crates/graphforge-storage/src/project_publication.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use graphforge_core::{GfError, ProjectErrorCode};
@@ -98,6 +99,20 @@ pub struct ProjectGenerationRequest {
     pub capabilities: Vec<ProjectCapability>,
     /// Complete participant set.
     pub participants: Vec<ProjectParticipant>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ProjectFileParticipant {
+    pub participant: ProjectParticipant,
+    pub source: PathBuf,
+    pub byte_length: u64,
+    pub content_sha256: [u8; 32],
+}
+
+#[derive(Clone, Copy)]
+enum ParticipantPayloads<'a> {
+    Memory,
+    Files(&'a [ProjectFileParticipant], Option<&'a AtomicBool>, usize),
 }
 
 /// Safe participant metadata available to domain validators.
@@ -426,6 +441,46 @@ pub(crate) fn stage_project_generation_from_admitted_parent(
             None,
             None,
             graph_tree,
+            ParticipantPayloads::Memory,
+        )
+    })();
+    result.map_err(|error| map_stage_error(request, error))
+}
+
+pub(crate) fn stage_project_generation_from_files_admitted(
+    admission: crate::filesystem_admission::ProjectLifecycleAdmission,
+    parent: ResolvedProjectGeneration,
+    request: &ProjectGenerationRequest,
+    files: &[ProjectFileParticipant],
+    graph_tree: Option<&Path>,
+    cancelled: Option<&AtomicBool>,
+    copy_buffer_bytes: usize,
+) -> Result<ProjectStageOutcome, GfError> {
+    let result = (|| {
+        validate_request(request)?;
+        admission.revalidate_identity()?;
+        let root = canonical_supported_root(admission.root())?;
+        let writer_lock = acquire_writer_lock(&root, request)?;
+        let current = resolve_project_generation(&root)?;
+        if current.generation_uuid() != parent.generation_uuid()
+            || current.manifest_sha256() != parent.manifest_sha256()
+        {
+            return Err(project_error(
+                ProjectErrorCode::WriteConflict,
+                "prepared CURRENT changed before portable import publication",
+            ));
+        }
+        let identity = admission.into_identity()?;
+        stage_project_generation_inner_with_locks(
+            StagedAdmission::Exclusive(identity),
+            root,
+            PublicationLock::Exclusive(writer_lock),
+            parent,
+            request,
+            None,
+            None,
+            graph_tree,
+            ParticipantPayloads::Files(files, cancelled, copy_buffer_bytes),
         )
     })();
     result.map_err(|error| map_stage_error(request, error))
@@ -473,6 +528,7 @@ fn stage_project_generation_inner(
         None,
         None,
         graph_tree,
+        ParticipantPayloads::Memory,
     )
 }
 
@@ -503,6 +559,7 @@ fn stage_project_generation_optimistic_inner(
         None,
         Some(operation_fingerprint),
         graph_tree,
+        ParticipantPayloads::Memory,
     )
 }
 
@@ -530,6 +587,7 @@ pub(crate) fn stage_project_generation_with_lock(
         revert,
         None,
         graph_tree,
+        ParticipantPayloads::Memory,
     )
 }
 
@@ -546,9 +604,11 @@ fn stage_project_generation_inner_with_locks(
     revert: Option<RevertJournalExtension>,
     operation_fingerprint: Option<[u8; 32]>,
     graph_tree: Option<&Path>,
+    payloads: ParticipantPayloads<'_>,
 ) -> Result<ProjectStageOutcome, GfError> {
     validate_request(request)?;
-    let (capabilities, participants, request_fingerprint) = request_metadata(request)?;
+    let (capabilities, participants, request_fingerprint) =
+        request_metadata_with_payloads(request, payloads)?;
     let operation_fingerprint =
         operation_fingerprint.map_or_else(|| request_fingerprint.clone(), hex_digest);
     let transactions_dir = ensure_machine_directory(&root, Path::new(TRANSACTIONS_DIR))?;
@@ -591,9 +651,9 @@ fn stage_project_generation_inner_with_locks(
         false,
     )?;
 
-    stage_participant_files(request, &generation_root, &participants)?;
+    stage_participant_files(request, &generation_root, &participants, payloads)?;
     sync_participant_directories(&generation_root.join(PARTICIPANTS_DIR), &participants)?;
-    stage_optional_graph_tree(request, &parent, &generation_root, graph_tree)?;
+    stage_optional_graph_tree(&participants, &parent, &generation_root, graph_tree)?;
     project_failpoint::hit(
         "project.after_participant_dir_fsync",
         Some(request.transaction_uuid),
@@ -925,16 +985,16 @@ fn prepare_generation_directory(
 }
 
 fn stage_optional_graph_tree(
-    request: &ProjectGenerationRequest,
+    participants: &[StagedParticipant],
     parent: &ResolvedProjectGeneration,
     generation_root: &Path,
     graph_tree: Option<&Path>,
 ) -> Result<(), GfError> {
-    let files_participant = request.participants.iter().find(|participant| {
+    let files_participant = participants.iter().find(|participant| {
         participant.capability_id == crate::GRAPH_CAPABILITY_ID
             && participant.record_family_id == crate::GRAPH_FILES_FAMILY
     });
-    let snapshot_participant = request.participants.iter().find(|participant| {
+    let snapshot_participant = participants.iter().find(|participant| {
         participant.capability_id == crate::GRAPH_CAPABILITY_ID
             && participant.record_family_id == "snapshot"
     });
@@ -955,14 +1015,18 @@ fn stage_optional_graph_tree(
     };
     if files_participant.capability_version != crate::GRAPH_CAPABILITY_VERSION
         || files_participant.record_version != crate::GRAPH_FILES_RECORD_VERSION
-        || files_participant.encoding != ProjectParticipantEncoding::Json
+        || files_participant.encoding != ProjectParticipantEncoding::Json.extension()
     {
         return Err(project_error(
             ProjectErrorCode::PublicationFailed,
             "unsupported graph files participant contract",
         ));
     }
-    let inventory = crate::decode_inventory(&files_participant.bytes)?;
+    let inventory_path = generation_root
+        .join(PARTICIPANTS_DIR)
+        .join(&files_participant.relative_path);
+    let inventory =
+        crate::decode_inventory(&std::fs::read(inventory_path).map_err(publication_io)?)?;
     let parent_tree = parent.graph_tree_root();
     let source = match graph_tree {
         Some(path) => path,
@@ -1004,14 +1068,16 @@ fn stage_participant_files(
     request: &ProjectGenerationRequest,
     generation_root: &Path,
     participants: &[StagedParticipant],
+    payloads: ParticipantPayloads<'_>,
 ) -> Result<(), GfError> {
     for metadata in participants {
-        let input = request
+        let (index, input) = request
             .participants
             .iter()
+            .enumerate()
             .find(|candidate| {
-                candidate.capability_id == metadata.capability_id
-                    && candidate.record_family_id == metadata.record_family_id
+                candidate.1.capability_id == metadata.capability_id
+                    && candidate.1.record_family_id == metadata.record_family_id
             })
             .expect("validated canonical metadata has one source participant");
         let destination = generation_root
@@ -1029,7 +1095,39 @@ fn stage_participant_files(
             .create_new(true)
             .open(&destination)
             .map_err(publication_io)?;
-        file.write_all(&input.bytes).map_err(publication_io)?;
+        match payloads {
+            ParticipantPayloads::Memory => file.write_all(&input.bytes).map_err(publication_io)?,
+            ParticipantPayloads::Files(files, cancelled, copy_buffer_bytes) => {
+                let source = &files[index];
+                let mut input = crate::project_portable::open_regular_nofollow(&source.source)
+                    .map_err(publication_io)?;
+                let mut hash = Sha256::new();
+                let mut copied = 0;
+                let mut buffer = vec![0; copy_buffer_bytes];
+                loop {
+                    if cancelled.is_some_and(|flag| flag.load(Ordering::Relaxed)) {
+                        return Err(project_error(
+                            ProjectErrorCode::PublicationFailed,
+                            "portable import cancelled during staging",
+                        ));
+                    }
+                    let count = input.read(&mut buffer).map_err(publication_io)?;
+                    if count == 0 {
+                        break;
+                    }
+                    file.write_all(&buffer[..count]).map_err(publication_io)?;
+                    hash.update(&buffer[..count]);
+                    copied += count as u64;
+                }
+                let digest: [u8; 32] = hash.finalize().into();
+                if copied != source.byte_length || digest != source.content_sha256 {
+                    return Err(project_error(
+                        ProjectErrorCode::PublicationFailed,
+                        "portable participant changed during staging",
+                    ));
+                }
+            }
+        }
         project_failpoint::hit(
             "project.after_participant_write",
             Some(request.transaction_uuid),
@@ -1696,8 +1794,20 @@ fn validate_request(request: &ProjectGenerationRequest) -> Result<(), GfError> {
     Ok(())
 }
 
+#[cfg(test)]
 fn request_metadata(
     request: &ProjectGenerationRequest,
+) -> Result<(Vec<ProjectCapability>, Vec<StagedParticipant>, String), GfError> {
+    request_metadata_with_payloads(request, ParticipantPayloads::Memory)
+}
+
+#[expect(
+    clippy::too_many_lines,
+    reason = "canonical metadata validation keeps memory and streamed sources identical"
+)]
+fn request_metadata_with_payloads(
+    request: &ProjectGenerationRequest,
+    payloads: ParticipantPayloads<'_>,
 ) -> Result<(Vec<ProjectCapability>, Vec<StagedParticipant>, String), GfError> {
     let mut capabilities = request.capabilities.clone();
     capabilities.sort_by(|left, right| left.capability_id.cmp(&right.capability_id));
@@ -1722,8 +1832,35 @@ fn request_metadata(
         ));
     }
     let mut participants = Vec::with_capacity(request.participants.len());
-    for participant in &request.participants {
-        let content_sha256: [u8; 32] = Sha256::digest(&participant.bytes).into();
+    for (index, participant) in request.participants.iter().enumerate() {
+        let (byte_length, content_sha256) = match payloads {
+            ParticipantPayloads::Memory => (
+                u64::try_from(participant.bytes.len()).map_err(|_| {
+                    project_error(
+                        ProjectErrorCode::PublicationFailed,
+                        "participant byte length exceeds u64",
+                    )
+                })?,
+                Sha256::digest(&participant.bytes).into(),
+            ),
+            ParticipantPayloads::Files(files, _, _) => {
+                let file = files.get(index).ok_or_else(|| {
+                    project_error(
+                        ProjectErrorCode::PublicationFailed,
+                        "missing participant file",
+                    )
+                })?;
+                if file.participant.capability_id != participant.capability_id
+                    || file.participant.record_family_id != participant.record_family_id
+                {
+                    return Err(project_error(
+                        ProjectErrorCode::PublicationFailed,
+                        "participant file identity mismatch",
+                    ));
+                }
+                (file.byte_length, file.content_sha256)
+            }
+        };
         participants.push(StagedParticipant {
             capability_id: participant.capability_id.clone(),
             capability_version: participant.capability_version,
@@ -1736,12 +1873,7 @@ fn request_metadata(
                 participant.encoding.extension()
             ),
             encoding: participant.encoding.extension().into(),
-            byte_length: u64::try_from(participant.bytes.len()).map_err(|_| {
-                project_error(
-                    ProjectErrorCode::PublicationFailed,
-                    "participant byte length exceeds u64",
-                )
-            })?,
+            byte_length,
             row_count: participant.row_count,
             schema_fingerprint: hex_digest(participant.schema_fingerprint),
             content_sha256: hex_digest(content_sha256),

--- a/docs/book/architecture/portable-project-v2.md
+++ b/docs/book/architecture/portable-project-v2.md
@@ -244,3 +244,24 @@ have distinct transport digests.
 
 Portable v1 remains available through `export_portable_project`. It is a
 separate explicit contract and is never emitted with v2 markers.
+
+## Complete-package importer
+
+`import_complete_portable_v2` accepts either local representation and invokes
+the shared full verifier before admitting the destination. Authenticated
+component entries are streamed into a transaction-owned materialization tree,
+then streamed again into one private generation with their declared lengths and
+digests rechecked. The configured copy buffer and bounded verifier indexes—not
+package payload size—bound memory. Publication uses the normal generation
+journal, fsync, validation, and atomic `CURRENT` transition, followed by a clean
+public reopen.
+
+The default operation accepts only the `complete` package class and only a new,
+empty, or pristine initialized destination. Existing project state is never
+overwritten or merged. Ontology-only, settings-only/component-selective, and
+graph-subset packages require explicit class-specific consumers; complete
+import returns a typed incompatibility without admitting the destination.
+Cancellation and corruption remove the private materialization, while a crash
+inside generation publication is handled by the normal project recovery and
+transaction-idempotency protocol. Portable v1 import remains a separate,
+explicit compatibility API.

--- a/scripts/ci/non-cypher-surface-gate.py
+++ b/scripts/ci/non-cypher-surface-gate.py
@@ -226,6 +226,8 @@ def validate(manifest_path: Path = MANIFEST) -> list[str]:
                     call = rf"\bview\s*\.\s*{re.escape(name)}\s*\("
                 elif receiver == "OpenRouterProviderSession":
                     call = rf"\bsession\s*\.\s*{re.escape(name)}\s*\("
+                elif receiver == "GraphForge":
+                    call = rf"(?:\bGraphForge\s*::|\.)\s*{re.escape(name)}\s*\("
                 else:
                     call = rf"\.\s*{re.escape(name)}\s*\("
                 if bodies and re.search(call, combined_body) is None:

--- a/scripts/ci/test-non-cypher-surface-gate.py
+++ b/scripts/ci/test-non-cypher-surface-gate.py
@@ -29,7 +29,7 @@ class SurfaceGateTests(unittest.TestCase):
 
     def test_checked_in_inventory_is_complete(self) -> None:
         self.assertEqual(GATE.validate(), [])
-        self.assertEqual(len(GATE.public_methods()), 316)
+        self.assertEqual(len(GATE.public_methods()), 317)
         self.assertEqual(len(GATE.algorithm_registry()), 94)
 
     def test_new_or_removed_public_method_fails_frozen_digest(self) -> None:

--- a/tests/contracts/non-cypher-rust-surface.json
+++ b/tests/contracts/non-cypher-rust-surface.json
@@ -1,7 +1,7 @@
 {
   "contract_version": 1,
   "scope": "Rust non-Cypher public release surface",
-  "public_method_digest": "fdae85acac2ee4d1f4e7edf0c67cf03c01eebc56a3116366e308046cf0ea4c68",
+  "public_method_digest": "6d6b337134141d0c8e5034a8d174930106006df863a8c78197810b1c9f6670a5",
   "method_policy": {
     "receiver_defaults": {
       "GraphForge": "release-tested",
@@ -51,6 +51,7 @@
       "GraphForge.resource_policy": "introspection",
       "GraphForge.export_portable": "designed-only",
       "GraphForge.import_portable": "designed-only",
+      "GraphForge.import_portable_v2": "designed-only",
       "GraphForge.preview_revert_to_checkpoint": "designed-only",
       "GraphForge.show_checkpoint": "designed-only",
       "RepositoryContext.discover": "introspection",


### PR DESCRIPTION
Closes #742

## Summary
- verify and stream complete portable-v2 packages into bounded participant staging
- publish imported generations through the existing journal/fsync/CURRENT recovery protocol and reopen them through the Rust facade
- preserve compatibility metadata, graph-tree placement, ontology authority, and typed selective-package refusal
- cover expanded/bundle equivalence, cancellation, destination protection, resource ladders, and crash windows around publication

## Local evidence
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/private/tmp/graphforge-739-target cargo test -p graphforge-storage portable_v2_import -- --nocapture` (3 passed; crash subprocess covers five failpoints)
- `CARGO_TARGET_DIR=/private/tmp/graphforge-739-target cargo test -p graphforge-storage graph_tree_round_trips_equivalently_from_both_representations -- --nocapture` (1 passed)
- `CARGO_TARGET_DIR=/private/tmp/graphforge-739-target cargo test -p graphforge-api portable -- --nocapture` (6 portable tests plus required API BDD 118/118 and advisory TCK 3897/3897)
- `CARGO_TARGET_DIR=/private/tmp/graphforge-739-target cargo clippy -p graphforge-storage -p graphforge-api -- -D warnings`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/829"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789756801&installation_model_id=20486&pr_number=829&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F829&signature=c6e6d1d9a0b317376bdc03138f86c61ce3d6d595d67e381fa3549504579fb109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing complete Portable v2 packages.
  * Imports now verify package contents, validate compatibility, publish atomically, and report package and transport digests.
  * Added progress reporting for verification, materialization, and publication stages.
  * Added cancellation support, replay detection, resource limits, and cleanup for failed or interrupted imports.

* **Bug Fixes**
  * Improved validation for malformed, incomplete, oversized, or incompatible packages.
  * Prevented selective packages and concurrent mutations from creating invalid destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->