### PR TITLE
feat(io): plan portable v2 component selections

### DIFF
--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -129,7 +129,7 @@ pub use project_portable::{
 pub use project_portable_v2_export::{
     PortableV2ExportLimits, PortableV2ExportPlan, PortableV2ExportProgress,
     PortableV2ExportReceipt, PortableV2Output, export_complete_portable_v2,
-    plan_complete_portable_v2,
+    plan_complete_portable_v2, plan_selected_portable_v2,
 };
 
 pub mod project_portable_v2;
@@ -138,6 +138,13 @@ pub use project_portable_v2::{
     PortableV2Integrity, PortableV2Limits, PortableV2Mode, PortableV2PackageClass,
     PortableV2Report, PortableV2Representation, materialize_verified_portable_v2,
     verify_portable_v2,
+};
+
+mod project_portable_v2_selection;
+pub use project_portable_v2_selection::{
+    PortableV2ParticipantId, PortableV2SelectionEntry, PortableV2SelectionPlan,
+    PortableV2SelectionProfile, PortableV2SelectionReason, PortableV2SelectionRequest,
+    preview_portable_v2_selection,
 };
 
 pub mod workspace_participants;

--- a/crates/graphforge-storage/src/project_portable_v2.rs
+++ b/crates/graphforge-storage/src/project_portable_v2.rs
@@ -1240,9 +1240,12 @@ fn validate_semantics(m: &Manifest, limits: PortableV2Limits) -> Result<(), Port
             ));
         }
         "ontology-only"
-            if m.components
-                .iter()
-                .any(|component| component.kind != "ontology") =>
+            if m.components.iter().any(|component| {
+                !matches!(
+                    component.kind.as_str(),
+                    "ontology" | "schema" | "compatibility"
+                )
+            }) =>
         {
             return Err(PortableV2Error::new(
                 PortableV2ErrorCode::Incompatible,

--- a/crates/graphforge-storage/src/project_portable_v2_export.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_export.rs
@@ -13,7 +13,9 @@ use uuid::Uuid;
 
 use crate::{
     PortableV2Error, PortableV2ErrorCode, PortableV2Limits, PortableV2Mode, PortableV2PackageClass,
-    ResolvedProjectGeneration, project_portable_v2::canonical_json, verify_portable_v2,
+    PortableV2SelectionPlan, PortableV2SelectionProfile, PortableV2SelectionRequest,
+    ResolvedProjectGeneration, preview_portable_v2_selection, project_portable_v2::canonical_json,
+    verify_portable_v2,
 };
 
 type ExportError = PortableV2Error;
@@ -74,6 +76,8 @@ pub struct PortableV2ExportPlan {
     manifest: Vec<u8>,
     package_digest: [u8; 32],
     payload_bytes: u64,
+    selection_fingerprint: String,
+    package_class: PortableV2PackageClass,
 }
 impl std::fmt::Debug for PortableV2ExportPlan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -82,6 +86,7 @@ impl std::fmt::Debug for PortableV2ExportPlan {
             .field("entry_count", &self.files.len())
             .field("package_digest", &hex(self.package_digest))
             .field("payload_bytes", &self.payload_bytes)
+            .field("selection_fingerprint", &self.selection_fingerprint)
             .finish_non_exhaustive()
     }
 }
@@ -100,13 +105,15 @@ pub struct PortableV2ExportReceipt {
     pub payload_bytes: u64,
     /// Published representation.
     pub output: PortableV2Output,
+    /// Fingerprint of the immutable content-free selection preview used by the writer.
+    pub selection_fingerprint: String,
 }
 
 #[derive(Serialize)]
 struct Manifest<'a> {
     format: &'static str,
     package_digest: String,
-    package_class: &'static str,
+    package_class: &'a str,
     source_generation: Source,
     selection: Selection<'a>,
     components: &'a [Component],
@@ -179,15 +186,33 @@ struct RuntimeGraphTree {
 }
 
 /// Plan every canonical participant of one already-pinned generation.
-#[expect(
-    clippy::too_many_lines,
-    reason = "keeps one auditable sequence from pinned inventory through semantic identity"
-)]
 pub fn plan_complete_portable_v2(
     g: &ResolvedProjectGeneration,
     limits: PortableV2ExportLimits,
 ) -> Result<PortableV2ExportPlan, ExportError> {
+    let selection = preview_portable_v2_selection(
+        g,
+        &PortableV2SelectionRequest {
+            profile: PortableV2SelectionProfile::Complete,
+            strict: false,
+        },
+        limits,
+    )?;
+    plan_selected_portable_v2(g, &selection, limits)
+}
+
+/// Materialize one immutable selection preview into a representation-independent export plan.
+#[expect(
+    clippy::too_many_lines,
+    reason = "keeps one auditable sequence from immutable selection through semantic identity"
+)]
+pub fn plan_selected_portable_v2(
+    g: &ResolvedProjectGeneration,
+    selection: &PortableV2SelectionPlan,
+    limits: PortableV2ExportLimits,
+) -> Result<PortableV2ExportPlan, ExportError> {
     validate_limits(limits)?;
+    crate::project_portable_v2_selection::validate_selection_plan(g, selection)?;
     g.validate_complete_participant_inventory()?;
     let mut files = Vec::new();
     let mut components = Vec::new();
@@ -196,8 +221,14 @@ pub fn plan_complete_portable_v2(
     let mut graph_inventory_participant = None;
     let mut total = 0;
     for d in g.participant_descriptors()? {
+        if !selection.includes(&d.capability_id, &d.record_family_id) {
+            continue;
+        }
         let id = portable_participant_id(&d.capability_id, &d.record_family_id);
-        let kind = kind(&d.capability_id, &d.record_family_id);
+        let kind = crate::project_portable_v2_selection::component_kind(
+            &d.capability_id,
+            &d.record_family_id,
+        );
         let source = g.participant_path(&d.capability_id, &d.record_family_id)?;
         let path = format!(
             "data/components/{kind}/{id}/participant.{}",
@@ -234,7 +265,9 @@ pub fn plan_complete_portable_v2(
             files: vec![cf],
         });
     }
-    if let Some(inv) = g.graph_files_inventory()? {
+    if selection.include_graph_tree
+        && let Some(inv) = g.graph_files_inventory()?
+    {
         let id = "graph-tree".to_owned();
         let mut owned = Vec::new();
         for e in inv.files {
@@ -274,6 +307,11 @@ pub fn plan_complete_portable_v2(
         capabilities: g
             .capabilities()
             .into_iter()
+            .filter(|capability| {
+                selection
+                    .required_capabilities
+                    .contains(&capability.capability_id)
+            })
             .map(|capability| RuntimeCapability {
                 capability_id: capability.capability_id,
                 capability_version: capability.capability_version,
@@ -334,12 +372,21 @@ pub fn plan_complete_portable_v2(
     let draft = Manifest {
         format: "graphforge-project/2",
         package_digest: String::new(),
-        package_class: "complete",
+        package_class: &selection.package_class,
         source_generation: source(),
         selection: Selection {
             roots: &roots,
-            omissions: vec![],
-            redactions: vec![],
+            omissions: selection
+                .excluded
+                .iter()
+                .map(|entry| {
+                    portable_participant_id(
+                        &entry.identity.capability_id,
+                        &entry.identity.record_family_id,
+                    )
+                })
+                .collect(),
+            redactions: selection.redactions.clone(),
         },
         components: &components,
         requirements: Requirements {
@@ -362,12 +409,21 @@ pub fn plan_complete_portable_v2(
     let final_manifest = Manifest {
         format: "graphforge-project/2",
         package_digest: format!("sha256:{}", hex(package_digest)),
-        package_class: "complete",
+        package_class: &selection.package_class,
         source_generation: source(),
         selection: Selection {
             roots: &roots,
-            omissions: vec![],
-            redactions: vec![],
+            omissions: selection
+                .excluded
+                .iter()
+                .map(|entry| {
+                    portable_participant_id(
+                        &entry.identity.capability_id,
+                        &entry.identity.record_family_id,
+                    )
+                })
+                .collect(),
+            redactions: selection.redactions.clone(),
         },
         components: &components,
         requirements: Requirements {
@@ -390,6 +446,8 @@ pub fn plan_complete_portable_v2(
         manifest,
         package_digest,
         payload_bytes: total,
+        selection_fingerprint: selection.selection_fingerprint.clone(),
+        package_class: package_class(&selection.package_class)?,
     })
 }
 
@@ -439,7 +497,7 @@ pub fn export_complete_portable_v2(
     let verified = verify_portable_v2(&stage, PortableV2Mode::Full, limits, Some(cancelled))
         .inspect_err(|_| remove(&stage))?;
     let expected_transport = format!("sha256:{}", hex(digest));
-    if verified.package_class != PortableV2PackageClass::Complete
+    if verified.package_class != plan.package_class
         || verified.package_digest != format!("sha256:{}", hex(plan.package_digest))
     {
         remove(&stage);
@@ -471,7 +529,20 @@ pub fn export_complete_portable_v2(
             .map_err(|_| limit("verified entry count exceeds platform capacity"))?,
         payload_bytes: plan.payload_bytes,
         output,
+        selection_fingerprint: plan.selection_fingerprint.clone(),
     })
+}
+
+fn package_class(value: &str) -> Result<PortableV2PackageClass, ExportError> {
+    match value {
+        "complete" => Ok(PortableV2PackageClass::Complete),
+        "ontology-only" => Ok(PortableV2PackageClass::OntologyOnly),
+        "component-selective" => Ok(PortableV2PackageClass::ComponentSelective),
+        _ => Err(err(
+            "GF_INCOMPATIBLE",
+            "unsupported selection package class",
+        )),
+    }
 }
 
 fn expanded(
@@ -1101,17 +1172,6 @@ fn portable_participant_id(capability: &str, family: &str) -> String {
     digest.update(family.as_bytes());
     format!("{prefix}-{}", &hex(digest.finalize().into())[..12])
 }
-fn kind(c: &str, f: &str) -> &'static str {
-    if c == "graph" {
-        "graph-data"
-    } else if f.contains("ontology") {
-        "ontology"
-    } else if f.contains("schema") {
-        "schema"
-    } else {
-        "settings"
-    }
-}
 fn extension(e: &str) -> &str {
     match e {
         "json" => "json",
@@ -1284,6 +1344,177 @@ fn storage(e: impl std::fmt::Display) -> ExportError {
 mod tests {
     use super::*;
     use crate::open_or_initialize_project;
+
+    #[test]
+    fn selection_preview_is_stable_exact_and_consumed_by_export_plan() {
+        let project = tempfile::tempdir().unwrap();
+        let generation = open_or_initialize_project(project.path()).unwrap();
+        let limits = PortableV2ExportLimits::default();
+        let request = PortableV2SelectionRequest {
+            profile: PortableV2SelectionProfile::Settings,
+            strict: true,
+        };
+        let first = preview_portable_v2_selection(&generation, &request, limits).unwrap();
+        let second = preview_portable_v2_selection(&generation, &request, limits).unwrap();
+        assert_eq!(first, second);
+        assert_eq!(first.package_class, "component-selective");
+        assert!(first.selection_fingerprint.starts_with("sha256:"));
+        assert!(first.included.iter().all(|entry| entry.kind == "settings"));
+
+        let plan = plan_selected_portable_v2(&generation, &first, limits).unwrap();
+        assert_eq!(plan.selection_fingerprint, first.selection_fingerprint);
+        assert_eq!(
+            plan.package_class,
+            PortableV2PackageClass::ComponentSelective
+        );
+        let out = tempfile::tempdir().unwrap();
+        let receipt = export_complete_portable_v2(
+            &plan,
+            out.path().join("settings.gfpb"),
+            PortableV2Output::Bundle,
+            limits,
+            &AtomicBool::new(false),
+            |_| {},
+        )
+        .unwrap();
+        assert_eq!(receipt.selection_fingerprint, first.selection_fingerprint);
+        let mut tampered = first.clone();
+        tampered.redactions.push("invented-after-preview".into());
+        let error = plan_selected_portable_v2(&generation, &tampered, limits).unwrap_err();
+        assert_eq!(error.code, PortableV2ErrorCode::Incompatible);
+
+        let exact = PortableV2SelectionRequest {
+            profile: PortableV2SelectionProfile::Custom(
+                first
+                    .included
+                    .iter()
+                    .map(|entry| entry.identity.clone())
+                    .collect(),
+            ),
+            strict: true,
+        };
+        let exact = preview_portable_v2_selection(&generation, &exact, limits).unwrap();
+        assert_eq!(
+            first
+                .included
+                .iter()
+                .map(|entry| &entry.identity)
+                .collect::<Vec<_>>(),
+            exact
+                .included
+                .iter()
+                .map(|entry| &entry.identity)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn selection_rejects_ambiguous_identity_and_resource_overflow() {
+        let project = tempfile::tempdir().unwrap();
+        let generation = open_or_initialize_project(project.path()).unwrap();
+        let limits = PortableV2ExportLimits::default();
+        let complete = preview_portable_v2_selection(
+            &generation,
+            &PortableV2SelectionRequest {
+                profile: PortableV2SelectionProfile::Complete,
+                strict: false,
+            },
+            limits,
+        )
+        .unwrap();
+        let identity = complete.included[0].identity.clone();
+        let error = preview_portable_v2_selection(
+            &generation,
+            &PortableV2SelectionRequest {
+                profile: PortableV2SelectionProfile::Custom(vec![identity.clone(), identity]),
+                strict: false,
+            },
+            limits,
+        )
+        .unwrap_err();
+        assert_eq!(error.code, PortableV2ErrorCode::Incompatible);
+        let error = preview_portable_v2_selection(
+            &generation,
+            &PortableV2SelectionRequest {
+                profile: PortableV2SelectionProfile::Complete,
+                strict: false,
+            },
+            PortableV2ExportLimits {
+                max_components: 1,
+                ..limits
+            },
+        )
+        .unwrap_err();
+        assert_eq!(error.code, PortableV2ErrorCode::LimitExceeded);
+    }
+
+    #[test]
+    fn selection_rejects_secret_and_host_path_settings_without_leaking_values() {
+        for unsafe_settings in [
+            serde_json::json!({"api_token": "do-not-export"}),
+            serde_json::json!({"cache": {"directory": "/Users/example/private"}}),
+        ] {
+            let project = tempfile::tempdir().unwrap();
+            let generation = open_or_initialize_project(project.path()).unwrap();
+            let path = generation
+                .participant_path(
+                    crate::WORKSPACE_CAPABILITY_ID,
+                    crate::WORKSPACE_CONFIGURATION_FAMILY,
+                )
+                .unwrap();
+            fs::write(path, serde_json::to_vec(&unsafe_settings).unwrap()).unwrap();
+            let error = preview_portable_v2_selection(
+                &generation,
+                &PortableV2SelectionRequest {
+                    profile: PortableV2SelectionProfile::Settings,
+                    strict: true,
+                },
+                PortableV2ExportLimits::default(),
+            )
+            .unwrap_err();
+            assert_eq!(error.code, PortableV2ErrorCode::Incompatible);
+            assert!(!error.to_string().contains("do-not-export"));
+            assert!(!error.to_string().contains("/Users/example"));
+        }
+    }
+
+    #[test]
+    fn built_in_profiles_select_only_their_canonical_component_classes() {
+        let project = tempfile::tempdir().unwrap();
+        let generation = open_or_initialize_project(project.path()).unwrap();
+        let limits = PortableV2ExportLimits::default();
+        for (profile, allowed) in [
+            (
+                PortableV2SelectionProfile::OntologyOnly,
+                &["ontology", "schema"][..],
+            ),
+            (
+                PortableV2SelectionProfile::DataComponents,
+                &["graph-data", "schema"][..],
+            ),
+            (
+                PortableV2SelectionProfile::Artifacts,
+                &["derived-artifact", "schema"][..],
+            ),
+            (PortableV2SelectionProfile::Settings, &["settings"][..]),
+        ] {
+            let plan = preview_portable_v2_selection(
+                &generation,
+                &PortableV2SelectionRequest {
+                    profile,
+                    strict: false,
+                },
+                limits,
+            )
+            .unwrap();
+            assert!(
+                plan.included
+                    .iter()
+                    .all(|entry| allowed.contains(&entry.kind.as_str()))
+            );
+            plan_selected_portable_v2(&generation, &plan, limits).unwrap();
+        }
+    }
 
     #[test]
     fn expanded_and_bundle_share_semantic_identity_and_are_deterministic() {

--- a/crates/graphforge-storage/src/project_portable_v2_selection.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_selection.rs
@@ -1,0 +1,392 @@
+//! Deterministic, content-safe portable-v2 component selection.
+
+use std::collections::BTreeSet;
+use std::fs::File;
+use std::io::Read as _;
+
+use serde::Serialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::{
+    PortableV2Error, PortableV2ErrorCode, PortableV2Limits, ResolvedProjectGeneration,
+    WORKSPACE_CAPABILITY_ID, WORKSPACE_CONFIGURATION_FAMILY,
+};
+
+/// Stable semantic participant identity. Runtime catalog IDs and host paths are never selectors.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct PortableV2ParticipantId {
+    /// Owning portable capability contract.
+    pub capability_id: String,
+    /// Stable record-family contract.
+    pub record_family_id: String,
+}
+
+/// Built-in deterministic selection profiles.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PortableV2SelectionProfile {
+    /// Every committed participant and graph-tree payload.
+    Complete,
+    /// Authored/adopted ontology plus required schema participants.
+    OntologyOnly,
+    /// Whole graph/data components. Row or subgraph selection belongs to #786.
+    DataComponents,
+    /// Derived and repository artifact participants.
+    Artifacts,
+    /// Closed-schema portable settings only.
+    Settings,
+    /// Explicit stable identities.
+    Custom(Vec<PortableV2ParticipantId>),
+}
+
+/// Selection planning request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PortableV2SelectionRequest {
+    /// Requested built-in or custom profile.
+    pub profile: PortableV2SelectionProfile,
+    /// Refuse any automatically required dependency instead of widening visibly.
+    pub strict: bool,
+}
+
+/// Stable reason for inclusion/exclusion.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PortableV2SelectionReason {
+    /// Directly requested by profile or exact identity.
+    Requested,
+    /// Required ontology/schema closure.
+    RequiredSchemaAuthority,
+    /// Not part of the requested profile.
+    ProfileExcluded,
+}
+
+/// Content-free preview row.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct PortableV2SelectionEntry {
+    /// Stable semantic identity.
+    pub identity: PortableV2ParticipantId,
+    /// Canonical component kind.
+    pub kind: String,
+    /// Stable selection reason.
+    pub reason: PortableV2SelectionReason,
+    /// Exact committed payload bytes.
+    pub estimated_bytes: u64,
+    /// Manifest row count.
+    pub row_count: u64,
+}
+
+/// Immutable deterministic preview consumed by both export representations.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct PortableV2SelectionPlan {
+    /// Pinned source generation identity.
+    pub source_generation_uuid: String,
+    /// Pinned source generation manifest identity.
+    pub source_manifest_sha256: String,
+    /// Portable package class token.
+    pub package_class: String,
+    /// Included participants in canonical identity order.
+    pub included: Vec<PortableV2SelectionEntry>,
+    /// Excluded participants in canonical identity order.
+    pub excluded: Vec<PortableV2SelectionEntry>,
+    /// Explicit redaction reason codes; values are never retained.
+    pub redactions: Vec<String>,
+    /// Required portable capability contracts.
+    pub required_capabilities: Vec<String>,
+    /// Exact known participant bytes, excluding bounded control metadata.
+    pub estimated_payload_bytes: u64,
+    /// Stable digest over canonical content-free plan metadata.
+    pub selection_fingerprint: String,
+    pub(crate) include_graph_tree: bool,
+}
+
+impl PortableV2SelectionPlan {
+    pub(crate) fn includes(&self, capability: &str, family: &str) -> bool {
+        self.included.iter().any(|entry| {
+            entry.identity.capability_id == capability && entry.identity.record_family_id == family
+        })
+    }
+}
+
+/// Resolve one bounded deterministic selection without retaining payload values.
+#[expect(
+    clippy::too_many_lines,
+    reason = "keeps identity matching, dependency closure, and fingerprinting in one audit path"
+)]
+pub fn preview_portable_v2_selection(
+    generation: &ResolvedProjectGeneration,
+    request: &PortableV2SelectionRequest,
+    limits: PortableV2Limits,
+) -> Result<PortableV2SelectionPlan, PortableV2Error> {
+    let descriptors = generation.participant_descriptors().map_err(storage)?;
+    if descriptors.len() as u64 > limits.max_components {
+        return Err(limit("selection component count exceeds limit"));
+    }
+    let custom = match &request.profile {
+        PortableV2SelectionProfile::Custom(values) => {
+            let set = values.iter().cloned().collect::<BTreeSet<_>>();
+            if set.len() != values.len() {
+                return Err(incompatible("duplicate custom selector"));
+            }
+            Some(set)
+        }
+        _ => None,
+    };
+    let available = descriptors
+        .iter()
+        .map(|descriptor| PortableV2ParticipantId {
+            capability_id: descriptor.capability_id.clone(),
+            record_family_id: descriptor.record_family_id.clone(),
+        })
+        .collect::<BTreeSet<_>>();
+    if custom.as_ref().is_some_and(|selectors| {
+        selectors
+            .iter()
+            .any(|selector| !available.contains(selector))
+    }) {
+        return Err(incompatible("custom selector is missing or ambiguous"));
+    }
+
+    let mut requested = BTreeSet::new();
+    for descriptor in &descriptors {
+        let identity = PortableV2ParticipantId {
+            capability_id: descriptor.capability_id.clone(),
+            record_family_id: descriptor.record_family_id.clone(),
+        };
+        let kind = component_kind(&identity.capability_id, &identity.record_family_id);
+        let selected = match &request.profile {
+            PortableV2SelectionProfile::Complete => true,
+            PortableV2SelectionProfile::OntologyOnly => kind == "ontology",
+            PortableV2SelectionProfile::DataComponents => kind == "graph-data",
+            PortableV2SelectionProfile::Artifacts => kind == "derived-artifact",
+            PortableV2SelectionProfile::Settings => kind == "settings",
+            PortableV2SelectionProfile::Custom(_) => custom.as_ref().unwrap().contains(&identity),
+        };
+        if selected {
+            requested.insert(identity);
+        }
+    }
+    if requested.is_empty() && matches!(request.profile, PortableV2SelectionProfile::Custom(_)) {
+        return Err(incompatible("selection matched no portable components"));
+    }
+
+    let needs_schema = requested.iter().any(|identity| {
+        matches!(
+            component_kind(&identity.capability_id, &identity.record_family_id),
+            "ontology" | "graph-data" | "derived-artifact"
+        )
+    });
+    let schema = descriptors
+        .iter()
+        .filter(|descriptor| {
+            component_kind(&descriptor.capability_id, &descriptor.record_family_id) == "schema"
+        })
+        .map(|descriptor| PortableV2ParticipantId {
+            capability_id: descriptor.capability_id.clone(),
+            record_family_id: descriptor.record_family_id.clone(),
+        })
+        .collect::<BTreeSet<_>>();
+    let auto = if needs_schema {
+        schema
+            .difference(&requested)
+            .cloned()
+            .collect::<BTreeSet<_>>()
+    } else {
+        BTreeSet::new()
+    };
+    if request.strict && !auto.is_empty() {
+        return Err(incompatible(
+            "strict selection requires undeclared schema authority",
+        ));
+    }
+    let selected = requested.union(&auto).cloned().collect::<BTreeSet<_>>();
+    validate_settings(generation, &selected, limits)?;
+
+    let mut included = Vec::new();
+    let mut excluded = Vec::new();
+    let mut total = 0_u64;
+    for descriptor in descriptors {
+        let identity = PortableV2ParticipantId {
+            capability_id: descriptor.capability_id.clone(),
+            record_family_id: descriptor.record_family_id.clone(),
+        };
+        let path = generation
+            .participant_path(&identity.capability_id, &identity.record_family_id)
+            .map_err(storage)?;
+        let bytes = std::fs::metadata(path).map_err(storage_io)?.len();
+        let is_selected = selected.contains(&identity);
+        if is_selected {
+            total = total
+                .checked_add(bytes)
+                .ok_or_else(|| limit("selection byte overflow"))?;
+            if total > limits.max_total_bytes {
+                return Err(limit("selection bytes exceed limit"));
+            }
+        }
+        let entry = PortableV2SelectionEntry {
+            kind: component_kind(&identity.capability_id, &identity.record_family_id).into(),
+            reason: if auto.contains(&identity) {
+                PortableV2SelectionReason::RequiredSchemaAuthority
+            } else if is_selected {
+                PortableV2SelectionReason::Requested
+            } else {
+                PortableV2SelectionReason::ProfileExcluded
+            },
+            identity,
+            estimated_bytes: bytes,
+            row_count: descriptor.row_count,
+        };
+        if is_selected {
+            included.push(entry);
+        } else {
+            excluded.push(entry);
+        }
+    }
+    included.sort_by(|a, b| a.identity.cmp(&b.identity));
+    excluded.sort_by(|a, b| a.identity.cmp(&b.identity));
+    let required_capabilities = included
+        .iter()
+        .map(|entry| entry.identity.capability_id.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let package_class = match request.profile {
+        PortableV2SelectionProfile::Complete => "complete",
+        PortableV2SelectionProfile::OntologyOnly => "ontology-only",
+        PortableV2SelectionProfile::DataComponents
+        | PortableV2SelectionProfile::Artifacts
+        | PortableV2SelectionProfile::Settings
+        | PortableV2SelectionProfile::Custom(_) => "component-selective",
+    }
+    .to_owned();
+    let mut plan = PortableV2SelectionPlan {
+        source_generation_uuid: generation.generation_uuid().hyphenated().to_string(),
+        source_manifest_sha256: format!("sha256:{}", hex(generation.manifest_sha256())),
+        package_class,
+        include_graph_tree: included.iter().any(|entry| entry.kind == "graph-data"),
+        included,
+        excluded,
+        redactions: Vec::new(),
+        required_capabilities,
+        estimated_payload_bytes: total,
+        selection_fingerprint: String::new(),
+    };
+    plan.selection_fingerprint = fingerprint(&plan)?;
+    Ok(plan)
+}
+
+pub(crate) fn validate_selection_plan(
+    generation: &ResolvedProjectGeneration,
+    plan: &PortableV2SelectionPlan,
+) -> Result<(), PortableV2Error> {
+    if plan.source_generation_uuid != generation.generation_uuid().hyphenated().to_string()
+        || plan.source_manifest_sha256 != format!("sha256:{}", hex(generation.manifest_sha256()))
+        || plan.selection_fingerprint != fingerprint(plan)?
+    {
+        return Err(incompatible("selection plan identity mismatch"));
+    }
+    Ok(())
+}
+
+fn fingerprint(plan: &PortableV2SelectionPlan) -> Result<String, PortableV2Error> {
+    let mut unsigned = plan.clone();
+    unsigned.selection_fingerprint.clear();
+    let bytes = crate::project_portable_v2::canonical_json(
+        &serde_json::to_value(unsigned).map_err(|_| incompatible("selection serialization"))?,
+    )?;
+    let mut digest = Sha256::new();
+    digest.update(b"graphforge-portable-selection/1\0");
+    digest.update(bytes);
+    Ok(format!("sha256:{}", hex(digest.finalize().into())))
+}
+
+pub(crate) fn component_kind(capability: &str, family: &str) -> &'static str {
+    if capability == crate::GRAPH_CAPABILITY_ID {
+        "graph-data"
+    } else if family.contains("ontology") {
+        "ontology"
+    } else if family.contains("schema") {
+        "schema"
+    } else if family.contains("artifact") || family.contains("repository_snapshot") {
+        "derived-artifact"
+    } else {
+        "settings"
+    }
+}
+
+fn validate_settings(
+    generation: &ResolvedProjectGeneration,
+    selected: &BTreeSet<PortableV2ParticipantId>,
+    limits: PortableV2Limits,
+) -> Result<(), PortableV2Error> {
+    let identity = PortableV2ParticipantId {
+        capability_id: WORKSPACE_CAPABILITY_ID.into(),
+        record_family_id: WORKSPACE_CONFIGURATION_FAMILY.into(),
+    };
+    if !selected.contains(&identity) {
+        return Ok(());
+    }
+    let path = generation
+        .participant_path(&identity.capability_id, &identity.record_family_id)
+        .map_err(storage)?;
+    let mut file = File::open(path).map_err(storage_io)?;
+    let cap = limits.max_manifest_bytes.min(limits.max_entry_bytes);
+    let mut bytes = Vec::new();
+    file.by_ref()
+        .take(cap + 1)
+        .read_to_end(&mut bytes)
+        .map_err(storage_io)?;
+    if bytes.len() as u64 > cap {
+        return Err(limit("settings validation state exceeds limit"));
+    }
+    let value: Value = serde_json::from_slice(&bytes).map_err(|_| incompatible("settings JSON"))?;
+    validate_setting_value(None, &value)
+}
+
+fn validate_setting_value(key: Option<&str>, value: &Value) -> Result<(), PortableV2Error> {
+    if key.is_some_and(|key| {
+        let key = key.to_ascii_lowercase();
+        ["secret", "password", "token", "credential", "private_key"]
+            .iter()
+            .any(|needle| key.contains(needle))
+    }) {
+        return Err(incompatible("secret-bearing setting is not portable"));
+    }
+    match value {
+        Value::String(value)
+            if value.starts_with('/')
+                || value.starts_with("\\\\")
+                || value.as_bytes().get(1) == Some(&b':') =>
+        {
+            Err(incompatible("absolute host path setting is not portable"))
+        }
+        Value::Array(values) => values
+            .iter()
+            .try_for_each(|value| validate_setting_value(key, value)),
+        Value::Object(values) => values
+            .iter()
+            .try_for_each(|(key, value)| validate_setting_value(Some(key), value)),
+        _ => Ok(()),
+    }
+}
+
+fn storage(_: crate::GfError) -> PortableV2Error {
+    PortableV2Error::new(PortableV2ErrorCode::Io, "selection inventory unavailable")
+}
+fn storage_io(_: std::io::Error) -> PortableV2Error {
+    PortableV2Error::new(PortableV2ErrorCode::Io, "selection entry unavailable")
+}
+fn incompatible(detail: &'static str) -> PortableV2Error {
+    PortableV2Error::new(PortableV2ErrorCode::Incompatible, detail)
+}
+fn limit(detail: &'static str) -> PortableV2Error {
+    PortableV2Error::new(PortableV2ErrorCode::LimitExceeded, detail)
+}
+fn hex(digest: [u8; 32]) -> String {
+    use std::fmt::Write as _;
+    digest
+        .iter()
+        .fold(String::with_capacity(64), |mut output, byte| {
+            write!(output, "{byte:02x}").expect("writing to String cannot fail");
+            output
+        })
+}

--- a/docs/book/architecture/portable-project-v2.md
+++ b/docs/book/architecture/portable-project-v2.md
@@ -172,6 +172,35 @@ positive, negative, and structural conformance vectors.
 
 ## Complete-package exporter
 
+### Selection planning
+
+`graphforge_storage::preview_portable_v2_selection` resolves a selection before
+any destination is created. Profiles are `Complete`, `OntologyOnly`,
+`DataComponents`, `Artifacts`, `Settings`, and `Custom`. Custom selectors use
+the pair `(capability_id, record_family_id)`; runtime catalog IDs, display names,
+and host paths are not accepted as identity. Graph data selection always means
+the whole committed graph component. Fine-grained row or subgraph selection is
+a separate contract.
+
+The preview lists included and excluded stable identities, inclusion reasons,
+row counts, exact committed participant byte estimates, required capabilities,
+redaction reason codes, package class, and a canonical SHA-256 selection
+fingerprint. It never includes setting values or source paths. Results are
+canonically ordered and bounded by the portable component and byte limits.
+Duplicate, missing, or ambiguous custom identities fail rather than guessing.
+
+Schema authority is added as visible required closure for ontology, graph, and
+artifact selections. Strict mode refuses that widening unless the caller
+selected the authority explicitly. Portable settings use a closed recursive
+JSON scan and fail closed on secret-bearing keys or absolute host paths; neither
+the preview nor its typed failure echoes the rejected value.
+
+`graphforge_storage::plan_selected_portable_v2` consumes that immutable preview
+for both expanded and bundle output. It filters the authenticated runtime map,
+participants, capabilities, and graph-tree placement to the same selected
+closure. The durable receipt repeats the selection fingerprint, so callers can
+prove that the reviewed preview is the plan the writer used.
+
 `graphforge_storage::plan_complete_portable_v2` resolves a current generation
 or checkpoint before planning and retains that generation's lease. The plan is
 a bounded index of portable paths, lengths, digests, and source identities; it


### PR DESCRIPTION
Closes #785

## Summary
- add typed deterministic complete/profile/custom portable-v2 selection previews over stable participant identities
- enforce visible schema closure, strict refusal, safe settings validation, finite resources, and source-bound fingerprints
- consume the immutable preview in one canonical exporter plan for expanded and bundle output
- document profile, identity, redaction, dependency, and preview/receipt policy

## Evidence
- `cargo test -p graphforge-storage project_portable_v2_export::tests` (11 passed)
- `cargo clippy -p graphforge-storage -- -D warnings`
- `make pre-push-fast`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789758813&installation_model_id=20486&pr_number=831&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F831&signature=4987928fcd99ebb32dcf0938dd156be832c1afa9f0828a67740a7b20386efecd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->