### PR TITLE
docs(io): define portable v2 multi-ontology compatibility

### DIFF
--- a/crates/graphforge-storage/src/project_portable_v2.rs
+++ b/crates/graphforge-storage/src/project_portable_v2.rs
@@ -2197,6 +2197,22 @@ mod tests {
     }
 
     #[test]
+    fn pre_m9_reader_rejects_required_ontology_composition_before_payload_access() {
+        let mut value: Value = serde_json::from_str(include_str!(
+            "../../../tests/fixtures/portable-v2/ontology-only.manifest.json"
+        ))
+        .unwrap();
+        let capabilities = value["requirements"]["capabilities"]
+            .as_array_mut()
+            .unwrap();
+        capabilities.push(Value::String("ontology-composition@1".into()));
+        capabilities.sort_by(|left, right| left.as_str().cmp(&right.as_str()));
+        let manifest: Manifest = serde_json::from_value(value).unwrap();
+        let error = validate_semantics(&manifest, PortableV2Limits::default()).unwrap_err();
+        assert_eq!(error.code, PortableV2ErrorCode::UnsupportedFuture);
+    }
+
+    #[test]
     fn expanded_full_and_structure_only_have_honest_distinct_integrity() {
         let root = package();
         let full = verify_portable_v2(

--- a/docs/adr/0022-portable-v2-multi-ontology-compatibility.md
+++ b/docs/adr/0022-portable-v2-multi-ontology-compatibility.md
@@ -1,0 +1,143 @@
+# ADR 0022: Multi-ontology semantics in portable project v2
+
+- Status: Accepted
+- Date: 2026-08-19
+- Issue: #835
+- Supersedes: none
+
+## Decision
+
+M9 uses decision-gate option 1: it is representable through portable-v2's
+existing authenticated, versioned compatibility semantics. It does not add a
+component kind, change `graphforge-project/2`, or require portable v3.
+
+Every M9 package contains one `compatibility` component whose participant ID is
+`graphforge-ontology-composition`. Its one canonical JSON file is
+`data/components/compatibility/graphforge-ontology-composition/composition.json`,
+with media type `application/vnd.graphforge.ontology-composition+json`. The
+manifest declares the required capability `ontology-composition@1`. This token
+is intentionally unknown to pre-M9 readers, which already return
+`unsupported_future` while validating manifest requirements and before reading
+component payloads, materializing staging, or mutating a project.
+
+The control document contract is `graphforge-ontology-composition/1`. It owns:
+
+- the canonically ordered ontology inventory and each module's stable ID,
+  exact version, canonical content digest, and dialect/profile;
+- canonically ordered bridge-set identities, versions, canonical digests, and
+  exact module endpoints;
+- the activation profile and its exact active module and bridge-set identities;
+- the composition digest over the preceding semantic fields; and
+- required and optional feature tokens.
+
+Its closed machine-readable shape is
+`docs/contracts/graphforge-ontology-composition-v1.schema.json`. Arrays MUST be
+in ascending UTF-8 identity order despite JSON Schema being unable to express
+order; the Rust decoder enforces order and uniqueness before semantic use.
+
+The manifest authenticates the control document's path, length, and digest and
+therefore includes it in `package_digest`. The composition digest is
+`sha256("graphforge-ontology-composition/1\0" || JCS(document without
+composition_digest))`. Exact module and bridge payloads remain ordinary
+`ontology` and `schema` components and are dependencies of the compatibility
+component. TCK reports, validation transcripts, and benchmarks may be
+`evidence` or `provenance` components, but the compatibility component MUST NOT
+depend on them and their identities MUST NOT enter the composition digest.
+
+Runtime catalog IDs, host paths, parser/library versions, machine configuration,
+session state, credentials, and TCK outcomes are forbidden in the control
+document. Interpretation and validation are Rust-owned; bindings and CLI only
+project typed requests and reports.
+
+## Why this is compatible v2
+
+The current schema already closes component kinds while permitting versioned
+required capability tokens. `compatibility` and `ontology` are existing kinds;
+`requirements.capabilities` permits `ontology-composition@1`; and the existing
+verifier rejects an unsupported token before payload verification. Both
+expanded and bundle representations authenticate the same semantic manifest
+and component bytes, so they retain one package digest.
+
+The current verifier recognizes only `compatibility@1` and the closed runtime
+generation map. It therefore correctly rejects an M9 package today rather than
+silently importing semantics it cannot interpret. #841 must add the new closed
+control schema and capability to the Rust verifier before it can accept M9.
+
+## Current-v2 inventory reviewed
+
+This decision was checked against
+`docs/contracts/graphforge-project-v2.schema.json` and
+`crates/graphforge-storage/src/project_portable_v2.rs` at `68a1655`.
+
+| Surface | Existing v2 contract | M9 use or constraint |
+|---|---|---|
+| semantic component kinds | `ontology`, `schema`, `migration`, `settings`, `graph-data`, `derived-artifact`, `evidence`, `provenance`, `compatibility` | reuse `ontology`, `schema`, and `compatibility`; add no kind |
+| compatibility fields | manifest `requirements.capabilities`, `dependency_rule`; state `compatibility`; authenticated compatibility component files | require `ontology-composition@1`; retain `required-transitive-closure/1` |
+| schema extension points | versioned capability tokens, media types, participant IDs, files and dependency edges inside closed manifest fields | closed composition control is a versioned compatibility payload, not an unknown manifest member |
+| semantic identity inputs | format/class, source generation, selection, components and file digests, requirements, states | composition control and exact ontology payload descriptors are included through existing component identity |
+| excluded transport identity | representation headers/tags and `transport_digest` | expanded/bundle transport differences remain excluded |
+| existing runtime control | `graphforge-runtime-generation-map/1`: capabilities, participants, graph placement, encoding, schema fingerprint, row count | remains separate; M9 semantics never enter runtime catalog IDs or host placement |
+| verifier compatibility rule | closed supported capability list; unknown capability/dependency rule/major returns `unsupported_future` | pre-M9 rejection point for every M9 package |
+| verifier schema rule | duplicate-free canonical JSON, closed manifest/runtime-map fields, closed kinds/classes, ordered unique IDs and paths | #841 adds an equally closed canonical composition decoder after capability recognition |
+| verifier integrity rule | manifest/package digest and every path/length/content digest authenticated | composition and module/bridge corruption fail before authority change |
+| expanded form | closed BagIt-compatible tree and manifests | composition path is an ordinary authenticated data component file |
+| bundled form | canonical uncompressed PAX/ustar stream over the same files | byte transport differs; semantic manifest and query composition do not |
+
+The schema's capability pattern is the intentional compatibility extension
+point. Adding `ontology-composition@1` to a package is valid schema but not
+supported semantics for the current reader, exactly the distinction represented
+by `PortableV2ErrorCode::UnsupportedFuture` and
+`PortableV2Compatibility::UnsupportedFuture`.
+
+## Closure rules
+
+- `complete`: all committed modules, bridge sets, activation profile, exact
+  composition control, and graph/data components are included.
+- `ontology-only`: all active modules, bridge sets, their schema authorities,
+  and composition control are included; graph data is excluded.
+- `component-selective`: selected modules or data require the transitive module,
+  bridge, schema, activation, and composition closure needed to interpret them.
+  Strict selection refuses implicit widening.
+- `graph-data-subset`: the generic #786 graph selector applies, followed by the
+  same exact ontology/bridge/schema composition closure as graph data.
+
+No profile may contain a dangling module endpoint, bridge endpoint, activation
+member, or composition input. Omissions are explicit stable portable participant
+IDs. Inventory order never selects authority or resolves ambiguity.
+
+## Reader and failure matrix
+
+| Input | Pre-M9 v2 reader | M9-aware v2 reader | Mutation |
+|---|---|---|---|
+| valid M9 package | `unsupported_future` on `ontology-composition@1` | verify and report exact composition | none during verify/inspect |
+| malformed control JSON/schema/order | normally `unsupported_future`; payload is not read | typed incompatible/invalid structure | none |
+| component or composition digest mismatch | normally `unsupported_future`; payload is not read | typed digest mismatch | none |
+| unknown optional feature | normally `unsupported_future`; M9 itself is unknown | ignore only when declared optional and semantics-neutral | none |
+| unknown required feature/version | `unsupported_future` | `unsupported_future` | none |
+
+Import never adopts, replaces, removes, activates, deactivates, or clears an
+ontology module or bridge as a side effect of verify, inspect, or preview. A
+separate explicit authority-change operation must validate and atomically
+publish the already verified closure.
+
+## Operational conformance
+
+The generic portable-v2 limits, streaming copy buffer, cancellation checks,
+source identity checks, private staging, cleanup, and no-replace publication
+rules apply unchanged. The composition document is bounded by
+`max_manifest_bytes`; inventory collections are bounded by `max_components`;
+all arithmetic is checked. Cancellation or any structural, compatibility,
+integrity, authority, or I/O failure removes private residue and leaves the
+previous project generation authoritative.
+
+Normative semantic vectors are in
+`tests/fixtures/portable-v2/multi-ontology-vectors.json`. They cover every
+package class, representation equivalence, exact identity inputs, malformed and
+unknown features, closure, cancellation, cleanup, and authority non-mutation.
+
+## Consequences
+
+M9 implementation can proceed in #836 and #841 without inventing a v2 dialect
+or flattening ontologies. Adding a field with required interpretation requires a
+new required feature token or `ontology-composition@2`; changing the generic
+manifest/component contract would require a deliberate portable format decision.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,6 +27,7 @@ are not retained in this tree.
 | 0019 | [Authoritative durable graph delta journal](0019-authoritative-graph-delta-journal.md) | `0019-authoritative-graph-delta-journal.md` |
 | 0020 | [NTFS write-through namespace durability](0020-ntfs-write-through-namespace-durability.md) | `0020-ntfs-write-through-namespace-durability.md` |
 | 0021 | [Portable project v2 package layout and identity](0021-portable-project-v2.md) | `0021-portable-project-v2.md` |
+| 0022 | [Multi-ontology semantics in portable project v2](0022-portable-v2-multi-ontology-compatibility.md) | `0022-portable-v2-multi-ontology-compatibility.md` |
 
 ## Numbering
 

--- a/docs/contracts/graphforge-ontology-composition-v1.schema.json
+++ b/docs/contracts/graphforge-ontology-composition-v1.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://graphforge.sh/contracts/graphforge-ontology-composition-v1.schema.json",
+  "title": "GraphForge portable-v2 ontology composition compatibility control",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["contract", "activation_profile", "modules", "bridge_sets", "required_features", "optional_features", "composition_digest"],
+  "properties": {
+    "contract": {"const": "graphforge-ontology-composition/1"},
+    "activation_profile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["profile_id", "active_modules", "active_bridge_sets"],
+      "properties": {
+        "profile_id": {"$ref": "#/$defs/id"},
+        "active_modules": {"$ref": "#/$defs/exactIdentityList"},
+        "active_bridge_sets": {"$ref": "#/$defs/exactIdentityList"}
+      }
+    },
+    "modules": {
+      "type": "array",
+      "maxItems": 10000,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["module_id", "version", "content_digest", "dialect", "profile"],
+        "properties": {
+          "module_id": {"$ref": "#/$defs/id"},
+          "version": {"$ref": "#/$defs/version"},
+          "content_digest": {"$ref": "#/$defs/digest"},
+          "dialect": {"$ref": "#/$defs/id"},
+          "profile": {"$ref": "#/$defs/id"}
+        }
+      }
+    },
+    "bridge_sets": {
+      "type": "array",
+      "maxItems": 10000,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["bridge_set_id", "version", "content_digest", "source_module", "target_module"],
+        "properties": {
+          "bridge_set_id": {"$ref": "#/$defs/id"},
+          "version": {"$ref": "#/$defs/version"},
+          "content_digest": {"$ref": "#/$defs/digest"},
+          "source_module": {"$ref": "#/$defs/exactIdentity"},
+          "target_module": {"$ref": "#/$defs/exactIdentity"}
+        }
+      }
+    },
+    "required_features": {"$ref": "#/$defs/featureList"},
+    "optional_features": {"$ref": "#/$defs/featureList"},
+    "composition_digest": {"$ref": "#/$defs/digest"}
+  },
+  "$defs": {
+    "id": {"type": "string", "minLength": 1, "maxLength": 256, "pattern": "^[a-z][a-z0-9._-]*$"},
+    "version": {"type": "string", "minLength": 1, "maxLength": 128, "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:-[0-9A-Za-z.-]+)?$"},
+    "digest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "exactIdentity": {"type": "string", "minLength": 3, "maxLength": 385, "pattern": "^[a-z][a-z0-9._-]*@[0-9]+\\.[0-9]+\\.[0-9]+(?:-[0-9A-Za-z.-]+)?$"},
+    "exactIdentityList": {"type": "array", "maxItems": 10000, "uniqueItems": true, "items": {"$ref": "#/$defs/exactIdentity"}},
+    "featureList": {"type": "array", "maxItems": 256, "uniqueItems": true, "items": {"type": "string", "pattern": "^[a-z][a-z0-9-]*@[1-9][0-9]*$"}}
+  }
+}

--- a/docs/engineering/adrs/README.md
+++ b/docs/engineering/adrs/README.md
@@ -58,3 +58,4 @@ Keeper set after #2730 (mirrors [`../../adr/README.md`](../../adr/README.md)):
 | 0019 | Authoritative durable graph delta journal | Accepted | [`../../adr/0019-authoritative-graph-delta-journal.md`](../../adr/0019-authoritative-graph-delta-journal.md) |
 | 0020 | NTFS write-through namespace durability | Accepted | [`../../adr/0020-ntfs-write-through-namespace-durability.md`](../../adr/0020-ntfs-write-through-namespace-durability.md) |
 | 0021 | Portable project v2 package layout and identity | Proposed | [`../../adr/0021-portable-project-v2.md`](../../adr/0021-portable-project-v2.md) |
+| 0022 | Multi-ontology semantics in portable project v2 | Accepted | [`../../adr/0022-portable-v2-multi-ontology-compatibility.md`](../../adr/0022-portable-v2-multi-ontology-compatibility.md) |

--- a/scripts/ci/portable-v2-contract.py
+++ b/scripts/ci/portable-v2-contract.py
@@ -11,7 +11,9 @@ from typing import NoReturn
 ROOT = Path(__file__).resolve().parents[2]
 FIXTURES = ROOT / "tests/fixtures/portable-v2"
 SCHEMA = ROOT / "docs/contracts/graphforge-project-v2.schema.json"
+COMPOSITION_SCHEMA = ROOT / "docs/contracts/graphforge-ontology-composition-v1.schema.json"
 DOMAIN = b"graphforge-project/2\0"
+COMPOSITION_DOMAIN = b"graphforge-ontology-composition/1\0"
 
 
 def fail(message: str) -> NoReturn:
@@ -235,6 +237,63 @@ def main() -> None:
         digest = "sha256:" + hashlib.sha256(DOMAIN + canonical(candidate)).hexdigest()
         require(digest == vector["package_digest"], f"{vector['package_class']} digest")
         require(vector["representations"] == ["expanded", "bundle"], "representations")
+
+    multi = load_json(FIXTURES / "multi-ontology-vectors.json")
+    require(isinstance(multi, dict), "multi-ontology vectors must be an object")
+    require(multi["decision"] == "existing-versioned-compatibility", "M9 decision")
+    require(multi["component"]["kind"] == "compatibility", "M9 component kind")
+    require(multi["required_capability"] == "ontology-composition@1", "M9 capability")
+    composition_schema = load_json(COMPOSITION_SCHEMA)
+    require(isinstance(composition_schema, dict), "composition schema must be an object")
+    require(
+        composition_schema.get("$id", "").endswith(
+            "graphforge-ontology-composition-v1.schema.json"
+        ),
+        "composition schema id",
+    )
+    composition = dict(multi["composition"])
+    expected_composition = composition.pop("composition_digest")
+    actual_composition = (
+        "sha256:" + hashlib.sha256(COMPOSITION_DOMAIN + canonical(composition)).hexdigest()
+    )
+    require(actual_composition == expected_composition, "M9 composition digest")
+    module_ids = [f"{item['module_id']}@{item['version']}" for item in composition["modules"]]
+    bridge_ids = [
+        f"{item['bridge_set_id']}@{item['version']}" for item in composition["bridge_sets"]
+    ]
+    require(module_ids == sorted(set(module_ids)), "M9 module identity order")
+    require(bridge_ids == sorted(set(bridge_ids)), "M9 bridge identity order")
+    active = composition["activation_profile"]
+    require(active["active_modules"] == sorted(set(active["active_modules"])), "active modules")
+    require(
+        active["active_bridge_sets"] == sorted(set(active["active_bridge_sets"])),
+        "active bridge sets",
+    )
+    require(set(active["active_modules"]) <= set(module_ids), "active module closure")
+    require(set(active["active_bridge_sets"]) <= set(bridge_ids), "active bridge closure")
+    for bridge in composition["bridge_sets"]:
+        require(bridge["source_module"] in module_ids, "bridge source closure")
+        require(bridge["target_module"] in module_ids, "bridge target closure")
+    for feature_set in ("required_features", "optional_features"):
+        values = composition[feature_set]
+        require(values == sorted(set(values)), f"M9 {feature_set} order")
+    forbidden = {
+        "runtime_catalog_ids",
+        "host_paths",
+        "parser_versions",
+        "machine_configuration",
+        "session_state",
+        "credentials",
+        "tck_results",
+    }
+    require(set(multi["identity_exclusions"]) == forbidden, "M9 identity exclusions")
+    require(set(multi["package_classes"]) == classes, "M9 closure classes")
+    require(multi["representations"] == ["expanded", "bundle"], "M9 representations")
+    require(all(not vector["mutation"] for vector in multi["negative_vectors"]), "M9 mutation")
+    require(
+        set(multi["older_v2_reader"].values()) == {"unsupported_future-before-payload"},
+        "M9 older-reader behavior",
+    )
     print("portable-v2 contract fixtures: PASS")
 
 

--- a/tests/fixtures/portable-v2/README.md
+++ b/tests/fixtures/portable-v2/README.md
@@ -18,3 +18,10 @@ format state is bounded by the configured manifest/entry/copy buffers.
 
 Fixture updates are format changes: review them with ADR 0021 and regenerate
 canonical bytes/digests in every supported language before acceptance.
+
+`multi-ontology-vectors.json` and ADR 0022 define the M9 extension through the
+existing authenticated `compatibility` kind and a new required capability. The
+fixture freezes composition identity inputs/exclusions, closure for all four
+package classes, older-reader behavior, typed negative results, and operational
+non-mutation invariants. It deliberately contains no runtime identity or TCK
+result in the composition identity.

--- a/tests/fixtures/portable-v2/multi-ontology-vectors.json
+++ b/tests/fixtures/portable-v2/multi-ontology-vectors.json
@@ -1,0 +1,61 @@
+{
+  "contract": "graphforge-portable-v2-multi-ontology-conformance/1",
+  "decision": "existing-versioned-compatibility",
+  "required_capability": "ontology-composition@1",
+  "component": {
+    "kind": "compatibility",
+    "participant_id": "graphforge-ontology-composition",
+    "path": "data/components/compatibility/graphforge-ontology-composition/composition.json",
+    "media_type": "application/vnd.graphforge.ontology-composition+json"
+  },
+  "composition": {
+    "contract": "graphforge-ontology-composition/1",
+    "activation_profile": {
+      "profile_id": "research-default",
+      "active_modules": ["genealogy@2.1.0", "provenance@1.4.0"],
+      "active_bridge_sets": ["genealogy-provenance@1.0.0"]
+    },
+    "modules": [
+      {"module_id":"genealogy","version":"2.1.0","content_digest":"sha256:1111111111111111111111111111111111111111111111111111111111111111","dialect":"graphforge-ontology","profile":"strict"},
+      {"module_id":"provenance","version":"1.4.0","content_digest":"sha256:2222222222222222222222222222222222222222222222222222222222222222","dialect":"graphforge-ontology","profile":"advisory"}
+    ],
+    "bridge_sets": [
+      {"bridge_set_id":"genealogy-provenance","version":"1.0.0","content_digest":"sha256:3333333333333333333333333333333333333333333333333333333333333333","source_module":"genealogy@2.1.0","target_module":"provenance@1.4.0"}
+    ],
+    "required_features": ["provenance-bridges@1", "qualified-symbols@1"],
+    "optional_features": ["display-hints@1"],
+    "composition_digest": "sha256:ac9c0f89453317734f7869225d6fe095d1c6c497e7e543fc104b053cade728ac"
+  },
+  "identity_inputs": ["contract", "activation_profile", "modules", "bridge_sets", "required_features", "optional_features"],
+  "identity_exclusions": ["runtime_catalog_ids", "host_paths", "parser_versions", "machine_configuration", "session_state", "credentials", "tck_results"],
+  "package_classes": {
+    "complete": {"requires":["all-committed-modules","all-committed-bridge-sets","activation-profile","composition-control","graph-data"],"round_trip":true},
+    "ontology-only": {"requires":["active-modules","active-bridge-sets","schema-authorities","activation-profile","composition-control"],"round_trip":true},
+    "component-selective": {"requires":["selected-components","transitive-module-bridge-schema-closure","activation-profile","composition-control"],"round_trip":true},
+    "graph-data-subset": {"requires":["graph-subset","transitive-module-bridge-schema-closure","activation-profile","composition-control"],"round_trip":true}
+  },
+  "representations": ["expanded", "bundle"],
+  "negative_vectors": [
+    {"name":"missing-required-capability","outcome":"unsupported_future","mutation":false},
+    {"name":"unknown-required-feature","outcome":"unsupported_future","mutation":false},
+    {"name":"unknown-optional-feature","outcome":"supported","mutation":false},
+    {"name":"malformed-control-json","outcome":"invalid_structure","mutation":false},
+    {"name":"duplicate-control-member","outcome":"invalid_structure","mutation":false},
+    {"name":"noncanonical-control","outcome":"incompatible","mutation":false},
+    {"name":"composition-digest-mismatch","outcome":"digest_mismatch","mutation":false},
+    {"name":"component-digest-mismatch","outcome":"digest_mismatch","mutation":false},
+    {"name":"dangling-module-or-bridge","outcome":"incompatible","mutation":false},
+    {"name":"unbounded-inventory","outcome":"limit_exceeded","mutation":false},
+    {"name":"cancelled-before-staging","outcome":"cancelled","mutation":false},
+    {"name":"cancelled-during-copy","outcome":"cancelled","mutation":false},
+    {"name":"authority-change-via-verify-import-inspect","outcome":"incompatible","mutation":false}
+  ],
+  "older_v2_reader": {
+    "valid_m9": "unsupported_future-before-payload",
+    "malformed": "unsupported_future-before-payload",
+    "digest_mismatched": "unsupported_future-before-payload",
+    "unknown_optional": "unsupported_future-before-payload",
+    "unknown_required": "unsupported_future-before-payload"
+  },
+  "operational_invariants": ["bounded-streaming","deterministic-output","cancellation","private-staging","cleanup-on-failure","no-partial-import","no-implicit-authority-change","same-package-digest-and-query-semantics"]
+}


### PR DESCRIPTION
Closes #835

## Decision

Select decision-gate option 1: M9 uses portable-v2's existing authenticated, versioned compatibility mechanism. Packages reuse the `compatibility` kind and require `ontology-composition@1`; pre-M9 readers therefore fail `unsupported_future` during manifest compatibility validation before payload access or mutation. No ad hoc kind or portable v3 is introduced.

## Scope
- inventory current manifest/schema/verifier/transport extension points
- define a closed ontology composition control schema and exact identity exclusions
- freeze complete, ontology-only, selective, and graph-subset closure vectors
- define older-reader, malformed, digest, optional/required feature, resource, cancellation, cleanup, and authority behavior
- add deterministic corpus validation and a current-reader regression

## Evidence
- `python3 scripts/ci/portable-v2-contract.py`
- `ruff check scripts/ci/portable-v2-contract.py`
- `cargo test -p graphforge-storage pre_m9_reader_rejects_required_ontology_composition_before_payload_access`
- `make pre-push-fast`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789759786&installation_model_id=20486&pr_number=845&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F845&signature=06e0eaf4f086c4b3037ee7355b2879e49d3eebf7dc24589b4317f9bc0ca7b4d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->