### PR TITLE
test(storage): certify M6 durability end to end

### DIFF
--- a/.github/workflows/durability-certification-gate.yml
+++ b/.github/workflows/durability-certification-gate.yml
@@ -35,6 +35,8 @@ jobs:
       GF_CERT_SEED: "7560"
       GF_CERT_HISTORIES: ${{ github.event.inputs.histories || '64' }}
       GF_CERT_OPS: ${{ github.event.inputs.ops || '32' }}
+      GRAPHFORGE_CERT_RUNNER: blacksmith-4vcpu-ubuntu-2404
+      GRAPHFORGE_CERT_FILESYSTEM_CLASS: hosted-linux-filesystem
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master as of 2026-08-05
@@ -61,4 +63,4 @@ jobs:
           name: durability-certification-evidence-${{ github.sha }}
           path: ${{ runner.temp }}/durability-certification-evidence
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 14

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -892,7 +892,7 @@ jobs:
           name: native-oracle-windows-${{ github.sha }}
           path: ${{ runner.temp }}/durability-certification-evidence
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 14
 
       - name: Run Windows injected publication error recovery test
         shell: bash
@@ -977,7 +977,7 @@ jobs:
           name: native-oracle-macos-${{ github.sha }}
           path: ${{ runner.temp }}/durability-certification-evidence
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 14
 
       - name: Run macOS injected publication error recovery test
         run: >-
@@ -996,6 +996,43 @@ jobs:
           cargo test -p graphforge-storage --lib
           project_checkpoints::tests::checkpoint_read_guard_unlocks_before_a_cloned_descriptor_closes
           --no-fail-fast -- --exact --nocapture
+
+  native-durability-aggregate:
+    name: Native Durability Aggregate
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs:
+      - changes
+      - windows-graphforge-storage-locks
+      - macos-graphforge-storage-durability
+    if: always() && needs.changes.outputs.rust == 'true'
+    timeout-minutes: 10
+    steps:
+      - name: Checkout aggregate implementation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Download exact-SHA Windows oracle
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: native-oracle-windows-${{ github.sha }}
+          path: native/windows
+      - name: Download exact-SHA macOS oracle
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: native-oracle-macos-${{ github.sha }}
+          path: native/macos
+      - name: Validate and aggregate native durability evidence
+        run: >-
+          python3 scripts/ci/durability-certification-gate.py aggregate-native
+          --expected-sha "${{ github.sha }}"
+          --windows native/windows/native-oracle-windows.json
+          --macos native/macos/native-oracle-macos.json
+          --output native/native-durability-aggregate.json
+      - name: Upload exact-SHA native durability aggregate
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-durability-aggregate-${{ github.sha }}
+          path: native/native-durability-aggregate.json
+          if-no-files-found: error
+          retention-days: 14
 
   bazel-bootstrap:
     # Job display name kept for continuity; this is the authoritative Rust
@@ -1280,6 +1317,7 @@ jobs:
       - concurrency-matrix
       - windows-graphforge-storage-locks
       - macos-graphforge-storage-durability
+      - native-durability-aggregate
       - bazel-bootstrap
     steps:
       - name: Checkout gate implementation
@@ -1300,4 +1338,5 @@ jobs:
           "${{ needs.concurrency-matrix.result }}"
           "${{ needs.windows-graphforge-storage-locks.result }}"
           "${{ needs.macos-graphforge-storage-durability.result }}"
+          "${{ needs.native-durability-aggregate.result }}"
           "${{ needs.bazel-bootstrap.result }}"

--- a/crates/graphforge-api/src/durability_certification_tests.rs
+++ b/crates/graphforge-api/src/durability_certification_tests.rs
@@ -7,9 +7,52 @@
 
 #![cfg(test)]
 
+use std::collections::HashMap;
+
+use arrow::array::{Array, StringArray};
 use graphforge_storage::project_certification::{
     CERT_CONTRACT, CERT_SEED, WRITE_SKEW_CLASSIFICATION, evidence_summary, run_certification_suite,
 };
+use graphforge_storage::{ProjectRetentionLimits, ProjectRetentionPolicy};
+use uuid::Uuid;
+
+use crate::{
+    CancellationToken, CheckpointRequest, GraphForge, GraphForgeOptions, OperationId,
+    ProjectWriteMode, PropValue, WriteContext,
+};
+
+const READ_NAMES: &str = "MATCH (n:CertPerson) RETURN n.name AS name ORDER BY name";
+
+fn uuid7(seed: u8) -> Uuid {
+    let mut bytes = [0_u8; 16];
+    bytes[0] = seed;
+    bytes[6] = 0x70;
+    bytes[8] = 0x80;
+    Uuid::from_bytes(bytes)
+}
+
+fn context(seed: u8) -> WriteContext {
+    WriteContext {
+        operation_uuid: OperationId(uuid7(seed)),
+        actor_uuid: None,
+    }
+}
+
+fn names(graph: &GraphForge) -> Vec<String> {
+    let result = graph.execute(READ_NAMES).expect("certification query");
+    let mut names = Vec::new();
+    for batch in result.batches {
+        if batch.num_rows() == 0 {
+            continue;
+        }
+        let values = batch
+            .column_by_name("name")
+            .and_then(|array| array.as_any().downcast_ref::<StringArray>())
+            .expect("certification name column");
+        names.extend((0..values.len()).map(|row| values.value(row).to_owned()));
+    }
+    names
+}
 
 #[test]
 fn seeded_certification_suite_is_clean_at_required_budget() {
@@ -38,4 +81,138 @@ fn seeded_certification_suite_is_clean_at_required_budget() {
 fn write_skew_classification_remains_honest() {
     assert_eq!(WRITE_SKEW_CLASSIFICATION, "allowed_documented_not_ssi");
     assert!(!WRITE_SKEW_CLASSIFICATION.contains("serializable"));
+}
+
+#[test]
+fn production_histories_observe_pinned_and_reopened_state_in_every_write_mode() {
+    for (mode_index, mode) in [
+        ProjectWriteMode::SingleWriter,
+        ProjectWriteMode::QueuedWriter,
+        ProjectWriteMode::OptimisticMultiWriter,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let project = tempfile::tempdir().expect("certification project");
+        let path = project.path().to_str().expect("utf-8 project path");
+        let options = GraphForgeOptions {
+            write_mode: mode,
+            ..GraphForgeOptions::default()
+        };
+        let writer =
+            GraphForge::new_with_options(Some(path), options.clone()).expect("writer open");
+        let pinned = GraphForge::new_with_options(Some(path), options).expect("pinned open");
+        assert!(names(&pinned).is_empty());
+
+        let seed = u8::try_from(mode_index + 1).expect("bounded mode index");
+        let tx = writer.begin_transaction(context(seed)).expect("begin");
+        tx.stage_add_node(
+            uuid7(seed + 16),
+            "CertPerson",
+            HashMap::from([("name".into(), PropValue::Str(format!("mode-{mode_index}")))]),
+        )
+        .expect("stage production node");
+        tx.validate(&writer)
+            .expect("validate production transaction");
+        let receipt = tx.commit(&writer).expect("commit production transaction");
+
+        // A facade is a pinned reader. It must not drift after a later commit.
+        assert!(names(&pinned).is_empty());
+        let reopened = GraphForge::new(Some(path)).expect("fresh reopen");
+        assert_eq!(
+            reopened.project_open_recovery().selected_generation_uuid,
+            receipt.generation_uuid
+        );
+        assert_eq!(names(&reopened), [format!("mode-{mode_index}")]);
+
+        reopened
+            .checkpoint(CheckpointRequest {
+                name: format!("mode-{mode_index}"),
+                description: Some("production certification root".into()),
+                idempotency_key: OperationId(uuid7(seed + 32)),
+                actor_uuid: None,
+            })
+            .expect("checkpoint production generation");
+        let reachability = reopened
+            .inspect_project_reachability(
+                ProjectRetentionPolicy::default(),
+                ProjectRetentionLimits::default(),
+            )
+            .expect("inspect production reachability");
+        assert!(
+            reachability
+                .checkpoint_roots
+                .contains(&receipt.generation_uuid)
+        );
+        let preview = reopened
+            .preview_project_cleanup(
+                ProjectRetentionPolicy::default(),
+                ProjectRetentionLimits::default(),
+            )
+            .expect("preview production cleanup");
+        assert_eq!(preview.selected_generation_uuid, receipt.generation_uuid);
+    }
+}
+
+#[test]
+fn production_history_certifies_cancel_drop_and_idempotent_retry() {
+    let project = tempfile::tempdir().expect("certification project");
+    let path = project.path().to_str().expect("utf-8 project path");
+    let graph = GraphForge::new_with_options(
+        Some(path),
+        GraphForgeOptions {
+            write_mode: ProjectWriteMode::QueuedWriter,
+            ..GraphForgeOptions::default()
+        },
+    )
+    .expect("queued writer open");
+
+    {
+        let dropped = graph.begin_transaction(context(80)).expect("begin dropped");
+        dropped
+            .stage_add_node(
+                uuid7(81),
+                "CertPerson",
+                HashMap::from([("name".into(), PropValue::Str("dropped".into()))]),
+            )
+            .expect("stage dropped");
+    }
+    assert!(names(&GraphForge::new(Some(path)).expect("reopen after drop")).is_empty());
+
+    let cancelled = graph
+        .begin_transaction(context(82))
+        .expect("begin cancelled");
+    cancelled
+        .stage_add_node(
+            uuid7(83),
+            "CertPerson",
+            HashMap::from([("name".into(), PropValue::Str("cancelled".into()))]),
+        )
+        .expect("stage cancelled");
+    let token = CancellationToken::new();
+    token.cancel();
+    let error = cancelled
+        .commit_with_cancellation(&graph, Some(token))
+        .expect_err("pre-admission cancellation must fail");
+    assert_eq!(error.code(), "GF_CANCELLED");
+    assert!(names(&GraphForge::new(Some(path)).expect("reopen after cancel")).is_empty());
+
+    let retry_context = context(84);
+    let node = uuid7(85);
+    let properties = HashMap::from([("name".into(), PropValue::Str("durable".into()))]);
+    let first = graph
+        .begin_transaction(retry_context.clone())
+        .expect("begin first");
+    first
+        .stage_add_node(node, "CertPerson", properties.clone())
+        .expect("stage first");
+    let first_receipt = first.commit(&graph).expect("commit first");
+    let retry = graph.begin_transaction(retry_context).expect("begin retry");
+    retry
+        .stage_add_node(node, "CertPerson", properties)
+        .expect("stage retry");
+    let retry_receipt = retry.commit(&graph).expect("commit retry");
+    assert_eq!(first_receipt.generation_uuid, retry_receipt.generation_uuid);
+    let reopened = GraphForge::new(Some(path)).expect("reopen durable retry");
+    assert_eq!(names(&reopened), ["durable"]);
 }

--- a/crates/graphforge-bindings-node/tests/transaction-parity.test.mjs
+++ b/crates/graphforge-bindings-node/tests/transaction-parity.test.mjs
@@ -4,6 +4,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { tableFromIPC } from "apache-arrow";
 import { GraphForge } from "../index.js";
 
 const OP_COMMIT = "018f0f4e-7b8c-7000-8000-000000007501";
@@ -11,6 +12,7 @@ const OP_ROLLBACK = "018f0f4e-7b8c-7000-8000-000000007502";
 const OP_DROP = "018f0f4e-7b8c-7000-8000-000000007503";
 const OP_SEED = "018f0f4e-7b8c-7000-8000-000000007504";
 const OP_CERT = "018f0f4e-7b8c-7000-8000-000000007560";
+const OP_CERT_CHECKPOINT = "018f0f4e-7b8c-7000-8000-000000007562";
 const NODE_BULK = "018f0f4e-7b8c-7000-8000-000000007511";
 const NODE_GHOST = "018f0f4e-7b8c-7000-8000-000000007512";
 const NODE_CERT = "018f0f4e-7b8c-7000-8000-000000007561";
@@ -95,5 +97,17 @@ test("certification observations agree across reopen", async () => {
     const reopened = new GraphForge(root);
     const again = reopened.projectOpenRecovery();
     assert.equal(again.selectedGenerationUuid, generation);
+    const names = tableFromIPC(
+      reopened.execute("MATCH (n:Person) RETURN n.name AS name ORDER BY name"),
+    );
+    assert.deepEqual([...names.getChild("name").toArray()], ["Cert"]);
+    await reopened.checkpoint({
+      name: "certification",
+      idempotencyKey: OP_CERT_CHECKPOINT,
+    });
+    const reachability = reopened.inspectProjectReachability();
+    assert.ok(reachability.checkpointRoots.includes(generation));
+    const cleanup = reopened.previewProjectCleanup();
+    assert.equal(cleanup.selectedGenerationUuid, generation);
   });
 });

--- a/crates/graphforge-bindings-py/tests/transaction_parity.py
+++ b/crates/graphforge-bindings-py/tests/transaction_parity.py
@@ -14,6 +14,7 @@ OP_ROLLBACK = "018f0f4e-7b8c-7000-8000-000000007502"
 OP_DROP = "018f0f4e-7b8c-7000-8000-000000007503"
 OP_CLI = "018f0f4e-7b8c-7000-8000-000000007504"
 OP_CERT = "018f0f4e-7b8c-7000-8000-000000007560"
+OP_CERT_CHECKPOINT = "018f0f4e-7b8c-7000-8000-000000007562"
 NODE_BULK = "018f0f4e-7b8c-7000-8000-000000007511"
 NODE_GHOST = "018f0f4e-7b8c-7000-8000-000000007512"
 NODE_CERT = "018f0f4e-7b8c-7000-8000-000000007561"
@@ -125,6 +126,17 @@ def check_certification_observation_parity(project: Path) -> None:
     reopened = g.GraphForge(str(project))
     again = reopened.project_open_recovery()
     assert again["selected_generation_uuid"] == generation
+    names = (
+        reopened.execute("MATCH (n:Person) RETURN n.name AS name ORDER BY name")
+        .column("name")
+        .to_pylist()
+    )
+    assert "Cert" in names
+    reopened.checkpoint(name="certification", idempotency_key=OP_CERT_CHECKPOINT)
+    reachability = reopened.inspect_project_reachability()
+    assert generation in reachability["checkpoint_roots"]
+    cleanup = reopened.preview_project_cleanup()
+    assert cleanup["selected_generation_uuid"] == generation
     code, stdout, _stderr = _cli_execute(
         [
             "gf",

--- a/crates/graphforge-storage/src/project_certification.rs
+++ b/crates/graphforge-storage/src/project_certification.rs
@@ -1018,6 +1018,100 @@ pub fn minimize_oracle_failure(seed: u64, phase: PublicationPhase) -> Vec<u64> {
 mod tests {
     use super::*;
 
+    fn finite_transition_basis() -> Vec<HistoryOp> {
+        let mut operations = vec![
+            HistoryOp::AckCommit {
+                writer: ModelId(1),
+                generation: ModelId(1),
+            },
+            HistoryOp::TearBytes { tear_current: true },
+            HistoryOp::TearBytes {
+                tear_current: false,
+            },
+            HistoryOp::PinReader { reader: ModelId(1) },
+            HistoryOp::ReadPinned { reader: ModelId(1) },
+            HistoryOp::FreshOpen {
+                observer: ModelId(1),
+            },
+            HistoryOp::CreateCheckpoint {
+                checkpoint: ModelId(0),
+            },
+            HistoryOp::AcquireLease { lease: ModelId(0) },
+            HistoryOp::ReleaseLease { lease: ModelId(0) },
+            HistoryOp::PublishDeltaRun { run: ModelId(1) },
+            HistoryOp::CompactDeltas {
+                generation: ModelId(1),
+                subsumed: vec![ModelId(1)],
+            },
+            HistoryOp::RunGc,
+            HistoryOp::OptimisticWriteSkew {
+                left: ModelId(1),
+                right: ModelId(2),
+                account: ModelId(99),
+            },
+            HistoryOp::CancelUnstarted { writer: ModelId(1) },
+            HistoryOp::IdempotentRetry {
+                transaction: ModelId(1),
+            },
+        ];
+        operations.extend(
+            PublicationPhase::all()
+                .iter()
+                .copied()
+                .map(|phase| HistoryOp::CrashAtPhase { phase }),
+        );
+        operations
+    }
+
+    #[test]
+    fn finite_transition_basis_covers_every_mode_operation_and_publication_phase() {
+        let operations = finite_transition_basis();
+        let names: BTreeSet<_> = operations.iter().map(op_name).collect();
+        assert_eq!(
+            names,
+            BTreeSet::from([
+                "ack_commit",
+                "cancel_unstarted",
+                "compact_deltas",
+                "crash_at_phase",
+                "create_checkpoint",
+                "fresh_open",
+                "idempotent_retry",
+                "acquire_lease",
+                "pin_reader",
+                "publish_delta_run",
+                "read_pinned",
+                "release_lease",
+                "run_gc",
+                "optimistic_write_skew",
+                "tear_bytes",
+            ])
+        );
+        assert_eq!(
+            operations
+                .iter()
+                .filter(|op| matches!(op, HistoryOp::CrashAtPhase { .. }))
+                .count(),
+            PublicationPhase::all().len()
+        );
+        for mode in [
+            ModelWriteMode::SingleWriter,
+            ModelWriteMode::QueuedWriter,
+            ModelWriteMode::OptimisticMultiWriter,
+        ] {
+            for (index, operation) in operations.iter().enumerate() {
+                run_history(
+                    CERT_SEED + index as u64,
+                    mode,
+                    std::slice::from_ref(operation),
+                )
+                .unwrap_or_else(|report| {
+                    panic!("finite basis failed mode={mode:?} op={operation:?}: {report:?}")
+                });
+            }
+        }
+    }
+
     #[test]
     fn bounded_ci_state_space_passes_without_untriaged_failures() {
         let evidence = run_certification_suite();

--- a/docs/book/architecture/concurrency-recovery.md
+++ b/docs/book/architecture/concurrency-recovery.md
@@ -168,15 +168,29 @@ There are four CI surfaces for concurrency and durability contracts:
    publishes a new Parquet generation through the same CURRENT path and reclaims
    subsumed inputs only after acknowledgement via that shared oracle.
 4. **Seeded durability/isolation certification** (`Durability Certification Gate`)
-   — integrated reference state machine in
-   `crates/graphforge-storage/src/project_certification.rs`
+   — independent reference model in
+   `crates/graphforge-storage/src/project_certification.rs`, compared at each
+   certified boundary with production `graphforge_api::GraphForge` opens,
+   transactions, queries, checkpoints, reachability, cleanup, delta replay, and
+   compaction. Rust, Python, Node, and CLI probes normalize the same generation,
+   query-state, checkpoint-root, and recovery observations; bindings never own
+   a second model or storage implementation.
    (`graphforge-durability-certification/1`, published seed `7560`). Required CI
    runs the bounded history budget; the scheduled/manual lane raises
    `GRAPHFORGE_CERT_HISTORIES` / `GRAPHFORGE_CERT_OPS`, records declared counts,
-   minimized traces, commands, platform/tool versions, and artifact digests, and
+   minimized traces, commands, exact commit, runner/filesystem class,
+   platform/tool versions, and artifact digests, and
    fails closed on the first untriaged invariant (no seed retries). Evidence and
    docs make no SSI, universal-filesystem, or distributed-durability claim;
    optimistic write-skew remains `allowed_documented_not_ssi`.
+
+The deterministic fault oracle and native POSIX/Windows subprocess kill lanes
+remain the process-death and persistent-media authority. Required CI aggregates
+the Windows and macOS reports under the exact tested SHA and rejects a missing,
+empty, wrong-platform, or mixed-seed report; the production history runner does
+not model a successful API call as proof of a process crash. M6 CPU-simulation, durable walltime, and peak
+RSS fallback evidence use the frozen `m6-storage-v1` / `m6_storage_io` fixture
+contract documented in [Benchmarking](../../development/benchmarking.md).
 
 The finite Rust recovery ledger remains
 `tests/contracts/concurrency-recovery-matrix.json` and is validated by

--- a/scripts/ci/durability-certification-gate.py
+++ b/scripts/ci/durability-certification-gate.py
@@ -14,6 +14,7 @@ import json
 import os
 from pathlib import Path
 import platform
+import re
 import subprocess
 import sys
 import time
@@ -26,6 +27,23 @@ DEFAULT_CI_HISTORIES = 8
 DEFAULT_CI_OPS = 12
 SCHEDULED_HISTORIES = 64
 SCHEDULED_OPS = 32
+REQUIRED_OPERATIONS = [
+    "ack_commit",
+    "crash_at_phase",
+    "tear_bytes",
+    "pin_reader",
+    "read_pinned",
+    "fresh_open",
+    "create_checkpoint",
+    "acquire_lease",
+    "release_lease",
+    "publish_delta_run",
+    "compact_deltas",
+    "run_gc",
+    "optimistic_write_skew",
+    "cancel_unstarted",
+    "idempotent_retry",
+]
 MATRIX_PATH = ROOT / "tests/contracts/durability-isolation-matrix.json"
 CERT_CONTRACT_PATH = ROOT / "tests/contracts/durability-certification.json"
 
@@ -59,6 +77,13 @@ def git_head() -> str:
     return (completed.stdout or "").strip() or "unknown"
 
 
+def command_version(argv: list[str]) -> str:
+    completed = subprocess.run(argv, cwd=ROOT, text=True, capture_output=True, check=False)
+    if completed.returncode != 0:
+        return "unavailable"
+    return ((completed.stdout or completed.stderr) or "").splitlines()[0].strip()
+
+
 def load_cert_contract() -> dict[str, Any]:
     try:
         value = json.loads(CERT_CONTRACT_PATH.read_text(encoding="utf-8"))
@@ -83,6 +108,37 @@ def validate_config(seed: int, histories: int, ops: int) -> None:
         raise GateError(f"certification contract seed must be {CERT_SEED}")
     if contract.get("issue") != 756 or contract.get("parent_issue") != 747:
         raise GateError("certification contract must bind issues 756 / 747")
+    observation = contract.get("production_observation")
+    if (
+        not isinstance(observation, dict)
+        or observation.get("driver") != "graphforge_api::GraphForge"
+    ):
+        raise GateError("certification must use the production GraphForge driver")
+    if observation.get("write_modes") != [
+        "single_writer",
+        "queued_writer",
+        "optimistic_multi_writer",
+    ]:
+        raise GateError("production certification must cover all write modes")
+    finite = contract.get("finite_coverage")
+    if not isinstance(finite, dict) or finite.get("operations") != REQUIRED_OPERATIONS:
+        raise GateError("certification must enumerate the complete finite transition basis")
+    if finite.get("publication_phases") != "all":
+        raise GateError("certification must cover every publication phase")
+    native = contract.get("native_oracle_artifacts")
+    if native != [
+        "native-oracle-windows-${commit}.json",
+        "native-oracle-macos-${commit}.json",
+    ]:
+        raise GateError("certification must bind both exact-SHA native oracle artifacts")
+    if contract.get("native_oracle_aggregate") != "native-durability-aggregate-${commit}.json":
+        raise GateError("certification must bind the exact-SHA native oracle aggregate")
+    versions = contract.get("versions")
+    if not isinstance(versions, dict) or versions.get("m6_benchmark_inventory") != "m6-storage-v1":
+        raise GateError("certification must freeze the merged #782 benchmark inventory")
+    benchmark = contract.get("benchmark_evidence")
+    if not isinstance(benchmark, dict) or benchmark.get("walltime_bench") != "m6_storage_io":
+        raise GateError("certification must bind the #782 walltime fixture")
     claims = contract.get("forbidden_positive_claims")
     if not isinstance(claims, list) or not claims:
         raise GateError("forbidden_positive_claims are required")
@@ -166,6 +222,70 @@ def write_evidence(output: Path, payload: dict[str, Any]) -> None:
     (output / "reproduction.txt").write_text("\n".join(commands) + "\n", encoding="utf-8")
 
 
+def load_native_oracle(path: Path, expected_platform: str) -> dict[str, Any]:
+    try:
+        report = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise GateError(f"cannot read native oracle {path}: {error}") from error
+    if report.get("contract") != "graphforge-native-durability-oracle/v1":
+        raise GateError(f"native oracle contract drift: {path}")
+    if report.get("platform") != expected_platform:
+        raise GateError(
+            f"native oracle platform mismatch: expected {expected_platform}, "
+            f"got {report.get('platform')!r}"
+        )
+    if not isinstance(report.get("filesystem_class"), str) or not report["filesystem_class"]:
+        raise GateError(f"native oracle filesystem class is missing: {path}")
+    if not isinstance(report.get("observations"), list) or not report["observations"]:
+        raise GateError(f"native oracle observations are missing: {path}")
+    if not isinstance(report.get("modeled_faults"), list) or not report["modeled_faults"]:
+        raise GateError(f"native oracle modeled faults are missing: {path}")
+    if not isinstance(report.get("minimized_failure"), dict):
+        raise GateError(f"native oracle minimized trace is missing: {path}")
+    return report
+
+
+def cmd_aggregate_native(args: argparse.Namespace) -> int:
+    if not re.fullmatch(r"[0-9a-f]{40}", args.expected_sha):
+        raise GateError("native aggregate expected SHA must be 40 lowercase hex characters")
+    inputs = {
+        "windows": Path(args.windows),
+        "macos": Path(args.macos),
+    }
+    reports = {
+        platform_name: load_native_oracle(path, platform_name)
+        for platform_name, path in inputs.items()
+    }
+    seeds = {report.get("seed") for report in reports.values()}
+    if len(seeds) != 1 or not all(isinstance(seed, int) for seed in seeds):
+        raise GateError("native oracle seeds do not match")
+    payload = {
+        "contract": "graphforge-native-durability-aggregate/v1",
+        "issue": 756,
+        "commit": args.expected_sha,
+        "status": "passed",
+        "platforms": [
+            {
+                "platform": platform_name,
+                "filesystem_class": reports[platform_name]["filesystem_class"],
+                "seed": reports[platform_name]["seed"],
+                "observation_count": len(reports[platform_name]["observations"]),
+                "modeled_fault_count": len(reports[platform_name]["modeled_faults"]),
+                "sha256": sha256_file(inputs[platform_name]),
+            }
+            for platform_name in ("windows", "macos")
+        ],
+    }
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(
+        "native durability aggregate ok: "
+        f"commit={args.expected_sha} platforms=windows,macos seed={next(iter(seeds))}"
+    )
+    return 0
+
+
 def cmd_validate(_: argparse.Namespace) -> int:
     validate_config(CERT_SEED, DEFAULT_CI_HISTORIES, DEFAULT_CI_OPS)
     print(
@@ -181,6 +301,8 @@ def cmd_run(args: argparse.Namespace) -> int:
     ops = args.ops
     validate_config(args.seed, histories, ops)
     commit = git_head()
+    output = Path(args.output)
+    output.mkdir(parents=True, exist_ok=True)
     result = run_cargo_certification(histories, ops, commit, args.timeout)
     # Also run the API surface wrapper + write-skew honesty cell.
     api_argv = [
@@ -236,6 +358,99 @@ def cmd_run(args: argparse.Namespace) -> int:
             f"{(skew.stdout or '')[-1500:]}\n{(skew.stderr or '')[-1500:]}"
         )
 
+    production_cases = [
+        [
+            "cargo",
+            "test",
+            "-p",
+            "graphforge-storage",
+            "--features",
+            "test-failpoints",
+            "--lib",
+            "project_certification::tests::finite_transition_basis_covers_every_mode_operation_and_publication_phase",
+            "--",
+            "--exact",
+            "--nocapture",
+        ],
+        [
+            "cargo",
+            "test",
+            "-p",
+            "graphforge-storage",
+            "--test",
+            "graph_delta_journal",
+            "--",
+            "--nocapture",
+        ],
+        [
+            "cargo",
+            "test",
+            "-p",
+            "graphforge-storage",
+            "--lib",
+            "project_retention::tests::checkpoint_root_and_live_lease_are_never_selected",
+            "--",
+            "--exact",
+            "--nocapture",
+        ],
+        [
+            "cargo",
+            "test",
+            "-p",
+            "graphforge-storage",
+            "--lib",
+            "graph_delta_compaction::tests::crash_oracle_before_and_after_ack_matches_frozen_contract",
+            "--",
+            "--exact",
+            "--nocapture",
+        ],
+    ]
+    for production_argv in production_cases:
+        production = subprocess.run(
+            production_argv,
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            timeout=args.timeout,
+            check=False,
+        )
+        if production.returncode != 0:
+            raise GateError(
+                "production durability case failed\n"
+                f"argv={' '.join(production_argv)}\n"
+                f"{(production.stdout or '')[-1500:]}\n{(production.stderr or '')[-1500:]}"
+            )
+
+    native_path = output / f"native-oracle-{platform.system().lower()}.json"
+    native_argv = [
+        "cargo",
+        "test",
+        "-p",
+        "graphforge-storage",
+        "--features",
+        "test-failpoints",
+        "--lib",
+        "project_recovery::tests::subprocess_kill_matrix_never_exposes_a_partial_generation",
+        "--",
+        "--exact",
+        "--nocapture",
+    ]
+    native = subprocess.run(
+        native_argv,
+        cwd=ROOT,
+        env={**os.environ, "GRAPHFORGE_NATIVE_ORACLE_EVIDENCE": str(native_path)},
+        text=True,
+        capture_output=True,
+        timeout=args.timeout,
+        check=False,
+    )
+    if native.returncode != 0 or not native_path.is_file():
+        raise GateError(
+            "native subprocess oracle failed or emitted no evidence\n"
+            f"argv={' '.join(native_argv)}\n"
+            f"{(native.stdout or '')[-1500:]}\n{(native.stderr or '')[-1500:]}"
+        )
+
     payload = {
         "contract": CONTRACT,
         "issue": 756,
@@ -246,18 +461,40 @@ def cmd_run(args: argparse.Namespace) -> int:
         "untriaged_failures": 0,
         "commit": commit,
         "platform": f"{platform.system()}-{platform.machine()}-{platform.python_version()}",
-        "toolchain": "rustc-workspace",
+        "toolchain": command_version(["rustc", "--version"]),
+        "tool_versions": {
+            "cargo": command_version(["cargo", "--version"]),
+            "python": platform.python_version(),
+        },
+        "runner": os.environ.get("GRAPHFORGE_CERT_RUNNER", "local"),
+        "filesystem_class": os.environ.get("GRAPHFORGE_CERT_FILESYSTEM_CLASS", "undeclared-local"),
         "versions": {
             "durability_isolation": "graphforge-durability-isolation/1",
             "durability_certification": CONTRACT,
             "delta_journal": "adr-0019",
             "fault_oracle": "project_fault_oracle",
+            "m6_benchmark_inventory": "m6-storage-v1",
+            "m6_storage_io_fixture": "v1",
         },
+        "production_observation": load_cert_contract()["production_observation"],
+        "finite_coverage": load_cert_contract()["finite_coverage"],
+        "native_oracle_artifacts": [
+            name.replace("${commit}", commit)
+            for name in load_cert_contract()["native_oracle_artifacts"]
+        ],
+        "native_oracle_observed": {
+            "platform": platform.system().lower(),
+            "path": native_path.name,
+            "sha256": sha256_file(native_path),
+        },
+        "benchmark_evidence": load_cert_contract()["benchmark_evidence"],
         "cases": [result],
         "commands": [
             result["reproduction"],
             " ".join(api_argv),
             " ".join(skew_argv),
+            *(" ".join(argv) for argv in production_cases),
+            " ".join(native_argv),
         ],
         "claims": {
             "ssi": False,
@@ -280,7 +517,7 @@ def cmd_run(args: argparse.Namespace) -> int:
                 "distributed durability",
             }:
                 raise GateError(f"evidence contains forbidden claim {forbidden!r}")
-    write_evidence(Path(args.output), payload)
+    write_evidence(output, payload)
     print(
         f"durability certification ok: seed={CERT_SEED} histories={histories} "
         f"ops={ops} untriaged=0 commit={commit}"
@@ -302,6 +539,15 @@ def main(argv: list[str] | None = None) -> int:
     run.add_argument("--timeout", type=int, default=900)
     run.add_argument("--output", required=True)
     run.set_defaults(func=cmd_run)
+
+    aggregate_native = sub.add_parser(
+        "aggregate-native", help="Validate and aggregate exact-SHA native oracle evidence"
+    )
+    aggregate_native.add_argument("--expected-sha", required=True)
+    aggregate_native.add_argument("--windows", required=True)
+    aggregate_native.add_argument("--macos", required=True)
+    aggregate_native.add_argument("--output", required=True)
+    aggregate_native.set_defaults(func=cmd_aggregate_native)
 
     args = parser.parse_args(argv)
     try:

--- a/scripts/ci/test-binding-release-candidate.py
+++ b/scripts/ci/test-binding-release-candidate.py
@@ -221,7 +221,7 @@ def validate_native_oracle_artifact(
         f"name: native-oracle-{artifact_slug}-${{{{ github.sha }}}}",
         f"path: {NATIVE_ORACLE_ARTIFACT_PATH}",
         "if-no-files-found: error",
-        "retention-days: 1",
+        "retention-days: 14",
     )
     assert "continue-on-error" not in upload_step
 
@@ -294,7 +294,7 @@ def validate_native_workflow_negative_fixtures() -> None:
           name: native-oracle-windows-${{{{ github.sha }}}}
           path: {NATIVE_ORACLE_ARTIFACT_PATH}
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 14
       - run: >-
           {INJECTED_OPERATION_ERROR_COMMAND}
       - run: >-
@@ -324,7 +324,7 @@ def validate_native_workflow_negative_fixtures() -> None:
           name: native-oracle-macos-${{{{ github.sha }}}}
           path: {NATIVE_ORACLE_ARTIFACT_PATH}
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 14
       - run: >-
           {INJECTED_OPERATION_ERROR_COMMAND}
       - run: >-

--- a/scripts/ci/test-ci-storage-policy.py
+++ b/scripts/ci/test-ci-storage-policy.py
@@ -95,6 +95,7 @@ EXPECTED_ARTIFACT_UPLOADS = Counter(
         "durability-certification-evidence-${{ github.sha }}": 1,
         "native-oracle-windows-${{ github.sha }}": 1,
         "native-oracle-macos-${{ github.sha }}": 1,
+        "native-durability-aggregate-${{ github.sha }}": 1,
         "m6-memory-${{ github.sha }}-blacksmith-4vcpu-ubuntu-2404": 1,
     }
 )
@@ -118,6 +119,8 @@ EXPECTED_ARTIFACT_DOWNLOADS = Counter(
         "Release-Candidate-evidence-${{ needs.resolve_source.outputs.release_sha }}": 1,
         "pr-python-wheel-${{ github.sha }}": 1,
         "pr-node-addon-${{ github.sha }}": 1,
+        "native-oracle-windows-${{ github.sha }}": 1,
+        "native-oracle-macos-${{ github.sha }}": 1,
     }
 )
 EXPECTED_DEPENDENCY_KEYS = Counter(
@@ -254,7 +257,15 @@ def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
             f"artifact upload is not fail-closed: {name}"
         )
         publication = name.startswith(("Release-", "Binding-", "Rust-"))
-        expected_retention = "30" if publication else "1"
+        certification = name.startswith(
+            (
+                "durability-certification-evidence-",
+                "native-oracle-windows-",
+                "native-oracle-macos-",
+                "native-durability-aggregate-",
+            )
+        )
+        expected_retention = "30" if publication else "14" if certification else "1"
         assert field(step, "retention-days") == expected_retention, (
             f"artifact retention drift: {name}"
         )
@@ -289,6 +300,7 @@ def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
                 "docs/development/bazel-migration-evidence/perf-sample.json"
             ),
             "${{ runner.temp }}/durability-certification-evidence",
+            "native/native-durability-aggregate.json",
             "replay-memory.txt\ncompaction-memory.txt",
         }, f"artifact upload contains unapproved bytes: {path}"
         uploaded.append(name)
@@ -315,6 +327,8 @@ def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
             "candidate/release-artifacts",
             "dist",
             "crates/graphforge-bindings-node",
+            "native/windows",
+            "native/macos",
         }, f"artifact download path drift: {selector}"
         if pattern is not None:
             assert field(step, "merge-multiple") == "true", (
@@ -327,7 +341,10 @@ def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
             assert field(step, "merge-multiple") is None, (
                 f"single artifact unexpectedly merged: {name}"
             )
-            cross_run = name != "Release-Load-${{ github.run_id }}" and not name.startswith("pr-")
+            same_run = name == "Release-Load-${{ github.run_id }}" or name.startswith(
+                ("pr-", "native-oracle-")
+            )
+            cross_run = not same_run
             if cross_run:
                 assert field(step, "github-token") == "${{ github.token }}", (
                     f"cross-run artifact has no token: {name}"
@@ -661,7 +678,7 @@ def main() -> None:
         f"{len(artifact_downloads)} consumer, {len(saved)} cache transfer producers, "
         f"{len(restored)} consumers, "
         f"{len(dependency_keys)} dependency caches, {len(sticky_keys)} bounded sticky disks, "
-        "one-day transfer and 30-day publication artifact retention"
+        "one-day transfer, 14-day certification, and 30-day publication artifact retention"
     )
 
 

--- a/scripts/ci/test-durability-certification-gate.py
+++ b/scripts/ci/test-durability-certification-gate.py
@@ -22,6 +22,11 @@ class DurabilityCertificationGateTests(unittest.TestCase):
         contract = GATE.load_cert_contract()
         self.assertEqual(contract["contract"], GATE.CONTRACT)
         self.assertEqual(contract["seed"], GATE.CERT_SEED)
+        self.assertEqual(
+            contract["production_observation"]["driver"],
+            "graphforge_api::GraphForge",
+        )
+        self.assertEqual(contract["versions"]["m6_benchmark_inventory"], "m6-storage-v1")
 
     def test_seed_and_budget_mutations_fail_closed(self) -> None:
         with self.assertRaises(GATE.GateError):
@@ -49,6 +54,47 @@ class DurabilityCertificationGateTests(unittest.TestCase):
             self.assertEqual(report["contract"], GATE.CONTRACT)
             self.assertTrue((output / "durability-certification-report.sha256").is_file())
             self.assertTrue((output / "reproduction.txt").is_file())
+
+    def test_native_aggregate_is_exact_sha_and_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            template = {
+                "contract": "graphforge-native-durability-oracle/v1",
+                "filesystem_class": "native-test",
+                "profile": "ordered",
+                "seed": 7490,
+                "observations": [{"phase": "before_ack"}],
+                "modeled_faults": [{"safe": True}],
+                "minimized_failure": {"minimized_op_ids": [1]},
+            }
+            paths = {}
+            for platform in ("windows", "macos"):
+                path = root / f"native-oracle-{platform}.json"
+                path.write_text(json.dumps({**template, "platform": platform}))
+                paths[platform] = path
+            output = root / "aggregate.json"
+            args = type(
+                "Args",
+                (),
+                {
+                    "expected_sha": "a" * 40,
+                    "windows": str(paths["windows"]),
+                    "macos": str(paths["macos"]),
+                    "output": str(output),
+                },
+            )()
+            self.assertEqual(GATE.cmd_aggregate_native(args), 0)
+            aggregate = json.loads(output.read_text())
+            self.assertEqual(aggregate["commit"], "a" * 40)
+            self.assertEqual(
+                [row["platform"] for row in aggregate["platforms"]],
+                ["windows", "macos"],
+            )
+            bad = json.loads(paths["windows"].read_text())
+            bad["observations"] = []
+            paths["windows"].write_text(json.dumps(bad))
+            with self.assertRaises(GATE.GateError):
+                GATE.cmd_aggregate_native(args)
 
 
 if __name__ == "__main__":

--- a/tests/contracts/durability-certification.json
+++ b/tests/contracts/durability-certification.json
@@ -16,7 +16,62 @@
     "durability_isolation": "graphforge-durability-isolation/1",
     "durability_certification": "graphforge-durability-certification/1",
     "delta_journal": "adr-0019",
-    "fault_oracle": "project_fault_oracle"
+    "fault_oracle": "project_fault_oracle",
+    "m6_benchmark_inventory": "m6-storage-v1",
+    "m6_storage_io_fixture": "v1"
+  },
+  "production_observation": {
+    "driver": "graphforge_api::GraphForge",
+    "write_modes": [
+      "single_writer",
+      "queued_writer",
+      "optimistic_multi_writer"
+    ],
+    "required_fields": [
+      "selected_generation_uuid",
+      "query_state",
+      "pinned_query_state",
+      "checkpoint_roots",
+      "cleanup_selected_generation_uuid"
+    ]
+  },
+  "finite_coverage": {
+    "method": "enumerated_transition_basis_plus_seeded_histories",
+    "operations": [
+      "ack_commit",
+      "crash_at_phase",
+      "tear_bytes",
+      "pin_reader",
+      "read_pinned",
+      "fresh_open",
+      "create_checkpoint",
+      "acquire_lease",
+      "release_lease",
+      "publish_delta_run",
+      "compact_deltas",
+      "run_gc",
+      "optimistic_write_skew",
+      "cancel_unstarted",
+      "idempotent_retry"
+    ],
+    "write_modes": [
+      "single_writer",
+      "queued_writer",
+      "optimistic_multi_writer"
+    ],
+    "publication_phases": "all"
+  },
+  "native_oracle_artifacts": [
+    "native-oracle-windows-${commit}.json",
+    "native-oracle-macos-${commit}.json"
+  ],
+  "native_oracle_aggregate": "native-durability-aggregate-${commit}.json",
+  "benchmark_evidence": {
+    "baseline_commit": "aeb46d1b012d40e8a0af7873af9152b3aab752c6",
+    "walltime_host": "blacksmith-4vcpu-ubuntu-2404",
+    "simulation_bench": "m6_storage",
+    "walltime_bench": "m6_storage_io",
+    "memory_fallback": "/usr/bin/time -v"
   },
   "forbidden_positive_claims": [
     "ACID",


### PR DESCRIPTION
Closes #756

## Summary

- compare the independent seeded model with production `GraphForge` reopen, pinned-reader, checkpoint, cleanup, cancellation, idempotency, and write-mode observations
- enumerate the finite operation/write-mode/publication-phase basis and run delta, compaction, retention, and native subprocess authorities in the certification gate
- exercise installed Python and native Node bindings plus CLI recovery observations
- aggregate exact-SHA Windows/macOS native oracle artifacts fail closed and freeze the merged #782 benchmark fixture/baseline contract

## Evidence

- `CARGO_TARGET_DIR=$PWD/target python3 scripts/ci/durability-certification-gate.py run --output /tmp/graphforge-756-cert-evidence-v3` (8 histories x 12 operations, zero untriaged failures; report SHA-256 `c311017cf407597f06a2ab10eacd0a57dedc21ac9d2665a575b5930a0982edf6`)
- `CARGO_TARGET_DIR=$PWD/target cargo clippy -p graphforge-api -p graphforge-storage -- -D warnings`
- built `dist/graphforge-0.5.2-cp310-abi3-macosx_11_0_arm64.whl`; installed into isolated venv; `/tmp/gf756-python.X7rgvf/bin/python crates/graphforge-bindings-py/tests/transaction_parity.py`
- `CARGO_TARGET_DIR=$PWD/target pnpm --filter @curatelabs/graphforge exec napi build --platform`; `node --test crates/graphforge-bindings-node/tests/transaction-parity.test.mjs`
- `python3 scripts/ci/test-durability-certification-gate.py`
- `python3 scripts/ci/test-ci-storage-policy.py`
- `scripts/ci/test-require-gates.sh`
- `make workflow-lint`
- `ruff check scripts/ci/durability-certification-gate.py scripts/ci/test-durability-certification-gate.py scripts/ci/test-ci-storage-policy.py crates/graphforge-bindings-py/tests/transaction_parity.py`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/847"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789765374&installation_model_id=20486&pr_number=847&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F847&signature=b85ca0fa43877dccbb38ccf3026dc440a2063ee18de0b53133c165a21c5236d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->