### PR TITLE
test(api): certify generation diff contract

### DIFF
--- a/crates/graphforge-api/src/generation_diff.rs
+++ b/crates/graphforge-api/src/generation_diff.rs
@@ -680,6 +680,64 @@ mod tests {
         canonical_rows(&batches)
     }
 
+    fn assert_public_stream_schema(
+        stream: &GraphChangeStream,
+        change_kind: &str,
+        source: CommittedGenerationIdentity,
+        target: CommittedGenerationIdentity,
+        edge: bool,
+    ) {
+        let reader = StreamReader::try_new(Cursor::new(&stream.ipc), None).unwrap();
+        let schema = reader.schema();
+        let metadata = schema.metadata();
+        assert_eq!(
+            metadata.get("graphforge.contract").map(String::as_str),
+            Some("semantic-generation-diff/1")
+        );
+        assert_eq!(
+            metadata.get("graphforge.change_kind").map(String::as_str),
+            Some(change_kind)
+        );
+        assert_eq!(
+            metadata.get("graphforge.source_generation_uuid"),
+            Some(&source.generation_uuid.to_string())
+        );
+        assert_eq!(
+            metadata.get("graphforge.source_manifest_sha256"),
+            Some(&hex(&source.manifest_sha256))
+        );
+        assert_eq!(
+            metadata.get("graphforge.target_generation_uuid"),
+            Some(&target.generation_uuid.to_string())
+        );
+        assert_eq!(
+            metadata.get("graphforge.target_manifest_sha256"),
+            Some(&hex(&target.manifest_sha256))
+        );
+        let record_uuid = schema.field_with_name("record_uuid").unwrap();
+        assert_eq!(record_uuid.data_type(), &DataType::FixedSizeBinary(16));
+        assert!(!record_uuid.is_nullable());
+        let changed = schema.field_with_name("changed_properties").unwrap();
+        assert!(!changed.is_nullable());
+        assert_eq!(
+            changed.data_type(),
+            &DataType::List(Arc::new(Field::new("item", DataType::Utf8, true)))
+        );
+        if edge {
+            for name in ["source_uuid", "target_uuid"] {
+                let field = schema.field_with_name(name).unwrap();
+                assert_eq!(field.data_type(), &DataType::FixedSizeBinary(16));
+                assert!(!field.is_nullable());
+            }
+            let relation = schema.field_with_name("relationship_type").unwrap();
+            assert_eq!(relation.data_type(), &DataType::Utf8);
+            assert!(relation.is_nullable());
+        } else {
+            assert!(schema.field_with_name("labels").is_ok());
+        }
+        assert!(schema.field_with_name("properties").is_ok());
+    }
+
     fn pinned_graph(graph: &GraphForge, identity: CommittedGenerationIdentity) -> GraphForge {
         let generation = graphforge_storage::resolve_verified_generation(
             graph.resolved_generation.container_root(),
@@ -850,6 +908,115 @@ mod tests {
         );
         assert!(diff.modified_node_properties.get(&added.uuid).is_none());
         assert_ne!(diff.checkpoint_binding, [0; 32]);
+        for (stream, kind, edge) in [
+            (&diff.added_nodes, "added", false),
+            (&diff.removed_nodes, "removed", false),
+            (&diff.modified_nodes, "modified", false),
+            (&diff.added_edges, "added", true),
+            (&diff.removed_edges, "removed", true),
+            (&diff.modified_edges, "modified", true),
+        ] {
+            assert_public_stream_schema(stream, kind, source, target, edge);
+        }
+    }
+
+    #[test]
+    fn generation_ladder_and_direct_range_reconstruct_the_exact_target() {
+        let graph = GraphForge::new(None).unwrap();
+        let first = graph
+            .add_node(
+                "Person",
+                &HashMap::from([("name".into(), PropValue::Str("Ada".into()))]),
+            )
+            .unwrap();
+        let source = identity(&graph);
+        let second = graph
+            .add_node(
+                "Person",
+                &HashMap::from([("name".into(), PropValue::Str("Grace".into()))]),
+            )
+            .unwrap();
+        graph
+            .add_edge(&first, "KNOWS", &second, &HashMap::new())
+            .unwrap();
+        let middle = identity(&graph);
+        graph.execute("MATCH (n) SET n.active = true").unwrap();
+        let target = identity(&graph);
+
+        let ready = |from, to| {
+            let GenerationDiffDisposition::Ready(diff) = graph
+                .diff_committed_generations(&request(from, to))
+                .unwrap()
+            else {
+                panic!("retained generation ladder must be diffable")
+            };
+            diff
+        };
+        let source_graph = pinned_graph(&graph, source);
+        let target_graph = pinned_graph(&graph, target);
+        let expected_nodes = canonical_rows(
+            &target_graph
+                .execute_read_only(node_query())
+                .unwrap()
+                .batches,
+        );
+        let expected_edges = canonical_rows(
+            &target_graph
+                .execute_read_only(edge_query())
+                .unwrap()
+                .batches,
+        );
+        let initial_nodes = canonical_rows(
+            &source_graph
+                .execute_read_only(node_query())
+                .unwrap()
+                .batches,
+        );
+        let initial_edges = canonical_rows(
+            &source_graph
+                .execute_read_only(edge_query())
+                .unwrap()
+                .batches,
+        );
+
+        let mut ladder_nodes = initial_nodes.clone();
+        let mut ladder_edges = initial_edges.clone();
+        for diff in [ready(source, middle), ready(middle, target)] {
+            apply_streams(
+                &mut ladder_nodes,
+                &diff.removed_nodes,
+                &diff.added_nodes,
+                &diff.modified_nodes,
+            );
+            apply_streams(
+                &mut ladder_edges,
+                &diff.removed_edges,
+                &diff.added_edges,
+                &diff.modified_edges,
+            );
+        }
+        assert_eq!(ladder_nodes, expected_nodes);
+        assert_eq!(ladder_edges, expected_edges);
+
+        let direct = ready(source, target);
+        let mut direct_nodes = initial_nodes;
+        let mut direct_edges = initial_edges;
+        apply_streams(
+            &mut direct_nodes,
+            &direct.removed_nodes,
+            &direct.added_nodes,
+            &direct.modified_nodes,
+        );
+        apply_streams(
+            &mut direct_edges,
+            &direct.removed_edges,
+            &direct.added_edges,
+            &direct.modified_edges,
+        );
+        assert_eq!(direct_nodes, expected_nodes);
+        assert_eq!(direct_edges, expected_edges);
+        assert_eq!(direct.source, source);
+        assert_eq!(direct.target, target);
     }
 
     #[test]

--- a/crates/graphforge-bindings-node/tests/generation-diff.test.mjs
+++ b/crates/graphforge-bindings-node/tests/generation-diff.test.mjs
@@ -37,6 +37,26 @@ test("generation diff forwards exact Rust IPC, identities, limits, and cancellat
   assert.equal(result.addedNodes.rowCount, 1n);
   assert.equal(result.addedEdges.rowCount, 1n);
 
+  forge.execute("MATCH (n) SET n.active = true");
+  const finalTarget = forge.committedGenerationIdentity();
+  const ladder = await forge.diffCommittedGenerations({
+    source: target,
+    target: finalTarget,
+  });
+  const direct = await forge.diffCommittedGenerations({
+    source,
+    target: finalTarget,
+  });
+  assert.equal(ladder.kind, "ready");
+  assert.equal(direct.kind, "ready");
+  assert.deepEqual(ladder.source, target);
+  assert.deepEqual(ladder.target, finalTarget);
+  assert.deepEqual(direct.source, source);
+  assert.deepEqual(direct.target, finalTarget);
+  assert.equal(ladder.modifiedNodes.rowCount, 2n);
+  assert.equal(direct.addedNodes.rowCount, 1n);
+  assert.equal(direct.modifiedNodes.rowCount, 1n);
+
   const wrongManifest = Buffer.from(source.manifestSha256);
   wrongManifest[0] ^= 0xff;
   assert.deepEqual(
@@ -50,6 +70,13 @@ test("generation diff forwards exact Rust IPC, identities, limits, and cancellat
     await forge.diffCommittedGenerations({
       ...request,
       maxRecordsPerGeneration: 0n,
+    }),
+    { kind: "reload_required", reason: "resource_limit" },
+  );
+  assert.deepEqual(
+    await forge.diffCommittedGenerations({
+      ...request,
+      maxOutputBytes: 1n,
     }),
     { kind: "reload_required", reason: "resource_limit" },
   );

--- a/crates/graphforge-bindings-py/tests/generation_diff.py
+++ b/crates/graphforge-bindings-py/tests/generation_diff.py
@@ -43,6 +43,30 @@ def check_generation_diff() -> None:
     assert result["added_nodes"]["row_count"] == 1
     assert result["added_edges"]["row_count"] == 1
 
+    forge.execute("MATCH (n) SET n.active = true")
+    final_target = forge.committed_generation_identity()
+    ladder = forge.diff_committed_generations(
+        source_generation_uuid=target["generation_uuid"],
+        source_manifest_sha256=target["manifest_sha256"],
+        target_generation_uuid=final_target["generation_uuid"],
+        target_manifest_sha256=final_target["manifest_sha256"],
+    )
+    direct = forge.diff_committed_generations(
+        source_generation_uuid=source["generation_uuid"],
+        source_manifest_sha256=source["manifest_sha256"],
+        target_generation_uuid=final_target["generation_uuid"],
+        target_manifest_sha256=final_target["manifest_sha256"],
+    )
+    assert ladder["kind"] == "ready"
+    assert direct["kind"] == "ready"
+    assert ladder["source"] == target
+    assert ladder["target"] == final_target
+    assert direct["source"] == source
+    assert direct["target"] == final_target
+    assert ladder["modified_nodes"]["row_count"] == 2
+    assert direct["added_nodes"]["row_count"] == 1
+    assert direct["modified_nodes"]["row_count"] == 1
+
     wrong_manifest = bytearray(source["manifest_sha256"])
     wrong_manifest[0] ^= 0xFF
     reload = forge.diff_committed_generations(
@@ -51,6 +75,8 @@ def check_generation_diff() -> None:
     assert reload == {"kind": "reload_required", "reason": "identity_mismatch"}
     bounded = forge.diff_committed_generations(**request, max_records_per_generation=0)
     assert bounded == {"kind": "reload_required", "reason": "resource_limit"}
+    byte_bounded = forge.diff_committed_generations(**request, max_output_bytes=1)
+    assert byte_bounded == {"kind": "reload_required", "reason": "resource_limit"}
 
     cancellation = gf.CancellationToken()
     cancellation.cancel()

--- a/docs/book/architecture/semantic-generation-diff.md
+++ b/docs/book/architecture/semantic-generation-diff.md
@@ -14,6 +14,53 @@ Modified-record maps carry the canonical sorted names of properties whose value
 changed. Every stream schema identifies the contract, change kind, endpoint
 UUIDs, and endpoint manifest fingerprints.
 
+## Frozen Arrow contract
+
+All six streams use schema metadata `graphforge.contract =
+semantic-generation-diff/1`. They also carry `graphforge.change_kind` plus the
+source and target generation UUID and manifest SHA-256 under the corresponding
+`graphforge.source_*` and `graphforge.target_*` keys. Consumers must reject an
+unknown contract value or metadata that does not match the requested endpoints.
+
+Node rows contain non-null `record_uuid: FixedSizeBinary(16)`, `labels`, and
+`properties`. Edge rows contain non-null `record_uuid`, `source_uuid`, and
+`target_uuid` fields of `FixedSizeBinary(16)`, `relationship_type: Utf8`, and
+`properties`. The relationship field is nullable
+in the Arrow schema for forward-compatible query projection, although committed
+edge rows always carry a value. The property struct is the complete
+typed row projected by the target for added and modified records and by the
+source for removed records. Every stream appends non-null
+`changed_properties: List<Utf8>`; it is empty for added and removed records and
+contains sorted property names for modified records. Field additions require a
+new contract version; consumers must address fields by name and may not infer
+record identity from row position.
+
+## Consumer state machine
+
+1. Pin the locally applied generation UUID and manifest SHA-256 as the source,
+   and request one exact committed target identity.
+2. Accept `ready` only when both returned identities and all six stream metadata
+   match the request. Validate every stream before mutating consumer state.
+3. Remove rows first, then upsert complete added and modified target rows. Apply
+   nodes and edges as one checkpoint; do not expose a partially applied set.
+4. Commit the returned target identity and checkpoint binding only after the
+   reconstructed canonical graph equals that target. A retry with the same
+   endpoints and limits returns identical bytes.
+5. On `reload_required`, discard the incremental attempt and full-load the exact
+   target. `generation_unavailable` includes retention/compaction;
+   `identity_mismatch`, `corrupt_generation`, and `incompatible_graph` are
+   integrity or compatibility failures; `resource_limit` means no partial bytes
+   were admitted. Cancellation is the typed `GF_CANCELLED` error and likewise
+   exposes no partial result.
+
+Version 1 is a single bounded response, not a pagination protocol. Callers set
+record and output-byte limits before execution and provide cooperative
+cancellation. They may walk a retained generation ladder or request a direct
+source-to-target range; both must reconstruct the same exact target. If any
+intermediate generation was compacted, the caller full-loads instead of guessing
+across the missing range. Polling cadence, backpressure queues, rendering, and
+cache eviction remain consumer-owned.
+
 Requests have record and encoded-byte limits plus cooperative cancellation.
 Generation loss, corruption, incompatible state, identity mismatch, and
 resource exhaustion produce distinct typed reload-required dispositions.


### PR DESCRIPTION
Closes #805

## Summary
- freeze the field-level Arrow IPC schema and endpoint metadata contract
- prove retained generation ladders and direct ranges reconstruct the exact target
- extend real Python and Node binding conformance for ladder identities and byte limits
- document the consumer apply/reload state machine, limits, cancellation, and compaction behavior

## Verification
- `CARGO_TARGET_DIR=/private/tmp/graphforge-805-target cargo test -p graphforge-api generation_diff --lib` (8 passed)
- `cargo fmt --all -- --check`
- `ruff format --check crates/graphforge-bindings-py/tests/generation_diff.py`
- `ruff check crates/graphforge-bindings-py/tests/generation_diff.py`
- `node --check crates/graphforge-bindings-node/tests/generation-diff.test.mjs`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789769993&installation_model_id=20486&pr_number=848&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F848&signature=47f06941aac1f5d1f17d52221eff615c030b5736ba39c8e8dd2a1c3ecb051ad1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->