### PR TITLE
feat(io): export deterministic graph data subsets with referential closure

### DIFF
--- a/crates/graphforge-api/src/belief_projection.rs
+++ b/crates/graphforge-api/src/belief_projection.rs
@@ -419,6 +419,7 @@ impl GraphForge {
                 .iter()
                 .map(|uuid| *uuid.as_bytes())
                 .collect(),
+            ..Default::default()
         };
         let materialized = graphforge_storage::materialize_graph_projection(
             &self.dir,

--- a/crates/graphforge-storage/src/graph_projection.rs
+++ b/crates/graphforge-storage/src/graph_projection.rs
@@ -26,13 +26,27 @@ use parquet::arrow::ArrowWriter;
 type GraphUuid = [u8; 16];
 type EdgeEndpoints = BTreeMap<GraphUuid, (GraphUuid, GraphUuid)>;
 
+/// Referential-closure mode for one graph projection.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum GraphProjectionClosure {
+    /// Selected edges plus both endpoint nodes. Nodes never induce edges.
+    #[default]
+    Referential,
+    /// Selected nodes plus every edge whose endpoints are both selected.
+    InducedEdges,
+}
+
 /// Explicit graph identities requested for one projection.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct GraphProjectionSelection {
-    /// Explicit node UUIDs. Selected edges add their endpoints automatically.
+    /// Explicit node UUIDs.
     pub node_uuids: BTreeSet<[u8; 16]>,
-    /// Explicit edge UUIDs. No other edge is induced from selected nodes.
+    /// Explicit edge UUIDs.
     pub edge_uuids: BTreeSet<[u8; 16]>,
+    /// Closure semantics applied before materialization.
+    pub closure: GraphProjectionClosure,
+    /// Property field names excluded from projected property tables.
+    pub exclude_properties: BTreeSet<String>,
 }
 
 /// Exact identities materialized into the graph-only target workspace.
@@ -51,10 +65,10 @@ pub struct GraphProjectionSummary {
 /// Materialize one deterministic graph-only workspace projection.
 ///
 /// The target must be absent or empty. Node/edge UUIDs and surrogate IDs are
-/// preserved. Every selected edge adds both endpoint nodes; node selection
-/// never induces an edge. Topology and property rows are rewritten in UUID
-/// order. Only core graph files and required ontology/runtime-catalog metadata
-/// are copied; derived indexes and every non-graph domain are excluded.
+/// preserved. Closure semantics follow [`GraphProjectionClosure`]. Topology and
+/// property rows are rewritten in UUID order. Only core graph files and
+/// required ontology/runtime-catalog metadata are copied; derived indexes and
+/// every non-graph domain are excluded.
 ///
 /// # Errors
 /// Returns validation for missing identities, unsafe/non-empty targets, or
@@ -63,6 +77,27 @@ pub fn materialize_graph_projection(
     source: &Path,
     target: &Path,
     selection: &GraphProjectionSelection,
+) -> Result<GraphProjectionSummary, GfError> {
+    materialize_graph_projection_with_options(source, target, selection, true)
+}
+
+/// Materialize a portable graph-tree projection without copying ontology files.
+///
+/// # Errors
+/// Same as [`materialize_graph_projection`].
+pub fn materialize_portable_graph_tree_projection(
+    source: &Path,
+    target: &Path,
+    selection: &GraphProjectionSelection,
+) -> Result<GraphProjectionSummary, GfError> {
+    materialize_graph_projection_with_options(source, target, selection, false)
+}
+
+fn materialize_graph_projection_with_options(
+    source: &Path,
+    target: &Path,
+    selection: &GraphProjectionSelection,
+    copy_ontology_files: bool,
 ) -> Result<GraphProjectionSummary, GfError> {
     validate_distinct_paths(source, target)?;
     validate_graph_empty_target(target)?;
@@ -76,19 +111,8 @@ pub fn materialize_graph_projection(
     let edge_ids = edges.keys().copied().collect::<BTreeSet<_>>();
     require_present(&selection.edge_uuids, &edge_ids, "edge")?;
 
-    let mut selected_nodes = selection.node_uuids.clone();
-    for edge_uuid in &selection.edge_uuids {
-        let (src, dst) = edges
-            .get(edge_uuid)
-            .expect("selected edge presence was validated");
-        if !node_ids.contains(src) || !node_ids.contains(dst) {
-            return Err(validation(
-                "selected edge references a missing endpoint node",
-            ));
-        }
-        selected_nodes.insert(*src);
-        selected_nodes.insert(*dst);
-    }
+    let (selected_nodes, selected_edges) =
+        resolve_projection_closure(selection, &node_ids, &edges)?;
     let endpoint_node_uuids = selected_nodes
         .difference(&selection.node_uuids)
         .copied()
@@ -101,40 +125,86 @@ pub fn materialize_graph_projection(
         &target.join("topology/nodes.parquet"),
         "node_uuid",
         &selected_nodes,
+        &selection.exclude_properties,
     )?;
     project_parquet_directory(
         &source.join("topology/edges"),
         &target.join("topology/edges"),
         "edge_uuid",
-        &selection.edge_uuids,
+        &selected_edges,
+        &BTreeSet::new(),
     )?;
     project_parquet_directory(
         &source.join("properties"),
         &target.join("properties"),
         "node_uuid",
         &selected_nodes,
+        &selection.exclude_properties,
     )?;
     project_parquet_directory(
         &source.join("edge_properties"),
         &target.join("edge_properties"),
         "edge_uuid",
-        &selection.edge_uuids,
+        &selected_edges,
+        &selection.exclude_properties,
     )?;
     copy_runtime_catalog(source, target)?;
-    for file in [
-        graphforge_core::manifest::MANIFEST_FILE,
-        graphforge_core::manifest::ONTOLOGY_FILE,
-    ] {
-        copy_regular_file_if_present(&source.join(file), &target.join(file))?;
+    if copy_ontology_files {
+        for file in [
+            graphforge_core::manifest::MANIFEST_FILE,
+            graphforge_core::manifest::ONTOLOGY_FILE,
+        ] {
+            copy_regular_file_if_present(&source.join(file), &target.join(file))?;
+        }
     }
     let graph_content_fingerprint = projected_graph_fingerprint(target)?;
 
     Ok(GraphProjectionSummary {
         node_uuids: selected_nodes.into_iter().collect(),
-        edge_uuids: selection.edge_uuids.iter().copied().collect(),
+        edge_uuids: selected_edges.into_iter().collect(),
         endpoint_node_uuids,
         graph_content_fingerprint,
     })
+}
+
+fn resolve_projection_closure(
+    selection: &GraphProjectionSelection,
+    node_ids: &BTreeSet<GraphUuid>,
+    edges: &EdgeEndpoints,
+) -> Result<(BTreeSet<GraphUuid>, BTreeSet<GraphUuid>), GfError> {
+    match selection.closure {
+        GraphProjectionClosure::Referential => {
+            let mut selected_nodes = selection.node_uuids.clone();
+            for edge_uuid in &selection.edge_uuids {
+                let (src, dst) = edges
+                    .get(edge_uuid)
+                    .expect("selected edge presence was validated");
+                if !node_ids.contains(src) || !node_ids.contains(dst) {
+                    return Err(validation(
+                        "selected edge references a missing endpoint node",
+                    ));
+                }
+                selected_nodes.insert(*src);
+                selected_nodes.insert(*dst);
+            }
+            Ok((selected_nodes, selection.edge_uuids.clone()))
+        }
+        GraphProjectionClosure::InducedEdges => {
+            if !selection.edge_uuids.is_empty() {
+                return Err(validation(
+                    "induced-edges closure rejects explicit edge selectors",
+                ));
+            }
+            let selected_nodes = selection.node_uuids.clone();
+            let mut selected_edges = BTreeSet::new();
+            for (edge_uuid, (src, dst)) in edges {
+                if selected_nodes.contains(src) && selected_nodes.contains(dst) {
+                    selected_edges.insert(*edge_uuid);
+                }
+            }
+            Ok((selected_nodes, selected_edges))
+        }
+    }
 }
 
 fn edge_endpoints(files: &[PathBuf]) -> Result<EdgeEndpoints, GfError> {
@@ -177,12 +247,13 @@ fn project_parquet_directory(
     target: &Path,
     key: &str,
     selected: &BTreeSet<[u8; 16]>,
+    exclude_properties: &BTreeSet<String>,
 ) -> Result<(), GfError> {
     for path in sorted_parquet_files(source)? {
         let name = path
             .file_name()
             .ok_or_else(|| validation("graph parquet path has no file name"))?;
-        project_parquet_file(&path, &target.join(name), key, selected)?;
+        project_parquet_file(&path, &target.join(name), key, selected, exclude_properties)?;
     }
     Ok(())
 }
@@ -192,6 +263,7 @@ fn project_parquet_file(
     target: &Path,
     key: &str,
     selected: &BTreeSet<[u8; 16]>,
+    exclude_properties: &BTreeSet<String>,
 ) -> Result<(), GfError> {
     if !source.exists() {
         return Ok(());
@@ -223,12 +295,26 @@ fn project_parquet_file(
         })
         .collect::<Result<Vec<_>, _>>()?;
     let indices = UInt32Array::from(indices);
-    let columns = combined
-        .columns()
+    let keep_columns = combined
+        .schema()
+        .fields()
         .iter()
-        .map(|column| take(column.as_ref(), &indices, None).map_err(storage))
+        .enumerate()
+        .filter(|(_, field)| {
+            field.name() == key || !exclude_properties.contains(field.name().as_str())
+        })
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    let fields = keep_columns
+        .iter()
+        .map(|index| combined.schema().field(*index).clone())
+        .collect::<Vec<_>>();
+    let projected_schema = Arc::new(Schema::new(fields));
+    let columns = keep_columns
+        .into_iter()
+        .map(|index| take(combined.column(index).as_ref(), &indices, None).map_err(storage))
         .collect::<Result<Vec<_>, _>>()?;
-    let projected = RecordBatch::try_new(Arc::clone(&schema), columns).map_err(storage)?;
+    let projected = RecordBatch::try_new(projected_schema, columns).map_err(storage)?;
     write_parquet(target, &projected)
 }
 
@@ -1151,6 +1237,7 @@ mod tests {
             &GraphProjectionSelection {
                 node_uuids: BTreeSet::from([*nodes[2].as_bytes()]),
                 edge_uuids: BTreeSet::from([*edges[0].as_bytes()]),
+                ..Default::default()
             },
         )
         .unwrap();
@@ -1269,6 +1356,7 @@ mod tests {
         let selection = GraphProjectionSelection {
             node_uuids: BTreeSet::from([*nodes[2].as_bytes()]),
             edge_uuids: BTreeSet::from([*edges[0].as_bytes()]),
+            ..Default::default()
         };
         let left = materialize_graph_projection(source.path(), first.path(), &selection).unwrap();
         let right = materialize_graph_projection(source.path(), second.path(), &selection).unwrap();
@@ -1297,6 +1385,7 @@ mod tests {
         let selection = GraphProjectionSelection {
             node_uuids: BTreeSet::from([*nodes[2].as_bytes()]),
             edge_uuids: BTreeSet::from([*edges[0].as_bytes()]),
+            ..Default::default()
         };
         let baseline =
             materialize_graph_projection(source.path(), baseline_target.path(), &selection)
@@ -1345,6 +1434,7 @@ mod tests {
         let selection = GraphProjectionSelection {
             node_uuids: BTreeSet::from([*nodes[0].as_bytes()]),
             edge_uuids: BTreeSet::from([*edges[0].as_bytes()]),
+            ..Default::default()
         };
         let baseline =
             materialize_graph_projection(source.path(), first.path(), &selection).unwrap();
@@ -1437,6 +1527,7 @@ mod tests {
             &GraphProjectionSelection {
                 node_uuids: BTreeSet::from([*alice.as_bytes()]),
                 edge_uuids: BTreeSet::from([*knows.as_bytes()]),
+                ..Default::default()
             },
         )
         .unwrap();
@@ -1516,6 +1607,7 @@ mod tests {
             &GraphProjectionSelection {
                 node_uuids: BTreeSet::from([*nodes[0].as_bytes()]),
                 edge_uuids: BTreeSet::new(),
+                ..Default::default()
             },
         )
         .unwrap();
@@ -1573,6 +1665,7 @@ mod tests {
             &GraphProjectionSelection {
                 node_uuids: BTreeSet::from([*missing.as_bytes()]),
                 edge_uuids: BTreeSet::new(),
+                ..Default::default()
             },
         )
         .unwrap_err();
@@ -1708,6 +1801,7 @@ mod tests {
             &source_path,
             &target.path().join("properties/Person.parquet"),
             "node_uuid",
+            &BTreeSet::new(),
             &BTreeSet::new(),
         )
         .unwrap_err();
@@ -2044,6 +2138,7 @@ mod tests {
                 &missing,
                 &root.path().join("unused.parquet"),
                 "node_uuid",
+                &BTreeSet::new(),
                 &BTreeSet::new(),
             )
             .is_ok()

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -24,7 +24,8 @@ pub use generation::{
 
 pub mod graph_projection;
 pub use graph_projection::{
-    GraphProjectionSelection, GraphProjectionSummary, materialize_graph_projection,
+    GraphProjectionClosure, GraphProjectionSelection, GraphProjectionSummary,
+    materialize_graph_projection, materialize_portable_graph_tree_projection,
 };
 
 pub mod graph_files;
@@ -145,6 +146,13 @@ pub use project_portable_v2_selection::{
     PortableV2ParticipantId, PortableV2SelectionEntry, PortableV2SelectionPlan,
     PortableV2SelectionProfile, PortableV2SelectionReason, PortableV2SelectionRequest,
     preview_portable_v2_selection,
+};
+
+pub mod project_portable_v2_subset;
+pub use project_portable_v2_subset::{
+    PortableV2GraphSelector, PortableV2GraphSubsetMeta, PortableV2PropertyProjection,
+    PortableV2SubsetClosure, PortableV2SubsetPlan, PortableV2SubsetRequest,
+    plan_graph_subset_portable_v2, preview_portable_v2_graph_subset,
 };
 
 pub mod workspace_participants;

--- a/crates/graphforge-storage/src/project_portable_v2_export.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_export.rs
@@ -78,6 +78,8 @@ pub struct PortableV2ExportPlan {
     payload_bytes: u64,
     selection_fingerprint: String,
     package_class: PortableV2PackageClass,
+    /// Keeps subset materialization alive for the plan lifetime.
+    retained_subset: Option<std::sync::Arc<tempfile::TempDir>>,
 }
 impl std::fmt::Debug for PortableV2ExportPlan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -88,6 +90,218 @@ impl std::fmt::Debug for PortableV2ExportPlan {
             .field("payload_bytes", &self.payload_bytes)
             .field("selection_fingerprint", &self.selection_fingerprint)
             .finish_non_exhaustive()
+    }
+}
+
+impl PortableV2ExportPlan {
+    /// Replace whole-graph tree payload with a projected subset staging tree.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "subset replacement keeps staging inventory selector and limits explicit"
+    )]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "subset tree replacement must rebuild inventory components and semantic identity together"
+    )]
+    pub(crate) fn replace_graph_tree_with_subset(
+        &mut self,
+        staging: tempfile::TempDir,
+        inventory: &crate::GraphFilesInventory,
+        inventory_bytes: Vec<u8>,
+        selector: &str,
+        closure: &str,
+        selection_fingerprint: &str,
+        limits: PortableV2ExportLimits,
+    ) -> Result<(), ExportError> {
+        let inventory_id =
+            portable_participant_id(crate::GRAPH_CAPABILITY_ID, crate::GRAPH_FILES_FAMILY);
+        let inventory_path = format!("data/components/graph-data/{inventory_id}/participant.json");
+        self.files.retain(|file| {
+            !file
+                .path
+                .starts_with("data/components/graph-data/graph-tree/")
+                && file.path != inventory_path
+        });
+        let mut total = self
+            .files
+            .iter()
+            .map(|file| file.length)
+            .try_fold(0_u64, u64::checked_add)
+            .ok_or_else(|| limit("subset byte overflow"))?;
+        let inventory_file = inline_control(&inventory_path, inventory_bytes, limits, &mut total)?;
+        self.files.push(inventory_file);
+
+        let mut graph_files = Vec::new();
+        for entry in &inventory.files {
+            if matches!(
+                entry.role,
+                crate::GraphFileRole::Index | crate::GraphFileRole::Delta
+            ) {
+                continue;
+            }
+            let source = staging.path().join(&entry.relative_path);
+            let path = format!(
+                "data/components/graph-data/graph-tree/{}",
+                entry.relative_path
+            );
+            let planned = inspect(&source, &path, limits, &mut total)?;
+            if planned.length != entry.byte_length || hex(planned.digest) != entry.content_sha256 {
+                return Err(err(
+                    "GF_SOURCE_CHANGED",
+                    "subset graph file differs from captured inventory",
+                ));
+            }
+            graph_files.push(ComponentFile {
+                media_type: graph_media(&entry.relative_path).into(),
+                path: path.clone(),
+                length: planned.length,
+                sha256: hex(planned.digest),
+            });
+            self.files.push(planned);
+        }
+        graph_files.sort_by(|a, b| a.path.as_bytes().cmp(b.path.as_bytes()));
+        self.files
+            .sort_by(|a, b| a.path.as_bytes().cmp(b.path.as_bytes()));
+        collisions(&self.files)?;
+        if self.files.len() as u64 > limits.max_entries {
+            return Err(limit("entry count exceeds configured limit"));
+        }
+
+        let mut components = Vec::new();
+        let mut roots = Vec::new();
+        let mut by_component: std::collections::BTreeMap<(String, String), Vec<&PlannedFile>> =
+            std::collections::BTreeMap::new();
+        for file in &self.files {
+            let Some(rest) = file.path.strip_prefix("data/components/") else {
+                continue;
+            };
+            let mut parts = rest.splitn(3, '/');
+            let kind = parts.next().unwrap_or_default().to_owned();
+            let participant = parts.next().unwrap_or_default().to_owned();
+            by_component
+                .entry((kind, participant))
+                .or_default()
+                .push(file);
+        }
+        for ((kind, participant_id), files) in by_component {
+            roots.push(participant_id.clone());
+            let component_files = if participant_id == "graph-tree" {
+                graph_files.clone()
+            } else {
+                files
+                    .iter()
+                    .map(|file| ComponentFile {
+                        media_type: media_type_for_path(&file.path).into(),
+                        path: file.path.clone(),
+                        length: file.length,
+                        sha256: hex(file.digest),
+                    })
+                    .collect()
+            };
+            components.push(Component {
+                kind,
+                participant_id,
+                required_dependencies: vec![],
+                files: component_files,
+            });
+        }
+        components.sort_by(|a, b| (&a.kind, &a.participant_id).cmp(&(&b.kind, &b.participant_id)));
+        roots.sort();
+        roots.dedup();
+
+        let capabilities = components
+            .iter()
+            .map(|component| format!("{}@1", component.kind))
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        let generation_uuid = self.generation_uuid.hyphenated().to_string();
+        let existing: serde_json::Value =
+            serde_json::from_slice(&self.manifest).map_err(storage)?;
+        let source_manifest = existing["source_generation"]["manifest_sha256"]
+            .as_str()
+            .unwrap_or_default()
+            .to_owned();
+        let omissions = existing["selection"]["omissions"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|value| value.as_str().map(str::to_owned))
+            .collect::<Vec<_>>();
+        let redactions = existing["selection"]["redactions"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|value| value.as_str().map(str::to_owned))
+            .collect::<Vec<_>>();
+        let draft = Manifest {
+            format: "graphforge-project/2",
+            package_digest: String::new(),
+            package_class: "graph-data-subset",
+            source_generation: Source {
+                generation_uuid: generation_uuid.clone(),
+                manifest_sha256: source_manifest.clone(),
+            },
+            selection: Selection {
+                roots: &roots,
+                omissions: omissions.clone(),
+                redactions: redactions.clone(),
+                graph_subset: Some(GraphSubsetRef { selector, closure }),
+            },
+            components: &components,
+            requirements: Requirements {
+                capabilities: capabilities.clone(),
+                dependency_rule: "required-transitive-closure/1",
+            },
+            states: States {
+                integrity: "verified",
+                compatibility: "supported",
+                authenticity: "unsigned",
+            },
+        };
+        let mut value = serde_json::to_value(&draft).map_err(storage)?;
+        value.as_object_mut().unwrap().remove("package_digest");
+        let semantic = canonical_json(&value)?;
+        let mut hasher = Sha256::new();
+        hasher.update(b"graphforge-project/2\0");
+        hasher.update(semantic);
+        self.package_digest = hasher.finalize().into();
+        let final_manifest = Manifest {
+            format: "graphforge-project/2",
+            package_digest: format!("sha256:{}", hex(self.package_digest)),
+            package_class: "graph-data-subset",
+            source_generation: Source {
+                generation_uuid,
+                manifest_sha256: source_manifest,
+            },
+            selection: Selection {
+                roots: &roots,
+                omissions,
+                redactions,
+                graph_subset: Some(GraphSubsetRef { selector, closure }),
+            },
+            components: &components,
+            requirements: Requirements {
+                capabilities,
+                dependency_rule: "required-transitive-closure/1",
+            },
+            states: States {
+                integrity: "verified",
+                compatibility: "supported",
+                authenticity: "unsigned",
+            },
+        };
+        self.manifest = canonical_json(&serde_json::to_value(final_manifest).map_err(storage)?)?;
+        if self.manifest.len() as u64 > limits.max_manifest_bytes {
+            return Err(limit("semantic manifest exceeds configured limit"));
+        }
+        self.payload_bytes = total;
+        selection_fingerprint.clone_into(&mut self.selection_fingerprint);
+        self.package_class = PortableV2PackageClass::GraphDataSubset;
+        self.retained_subset = Some(std::sync::Arc::new(staging));
+        Ok(())
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -130,6 +344,13 @@ struct Selection<'a> {
     roots: &'a [String],
     omissions: Vec<String>,
     redactions: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    graph_subset: Option<GraphSubsetRef<'a>>,
+}
+#[derive(Serialize)]
+struct GraphSubsetRef<'a> {
+    selector: &'a str,
+    closure: &'a str,
 }
 #[derive(Serialize)]
 struct Component {
@@ -138,7 +359,7 @@ struct Component {
     required_dependencies: Vec<String>,
     files: Vec<ComponentFile>,
 }
-#[derive(Serialize)]
+#[derive(Clone, Serialize)]
 struct ComponentFile {
     media_type: String,
     path: String,
@@ -387,6 +608,7 @@ pub fn plan_selected_portable_v2(
                 })
                 .collect(),
             redactions: selection.redactions.clone(),
+            graph_subset: None,
         },
         components: &components,
         requirements: Requirements {
@@ -424,6 +646,7 @@ pub fn plan_selected_portable_v2(
                 })
                 .collect(),
             redactions: selection.redactions.clone(),
+            graph_subset: None,
         },
         components: &components,
         requirements: Requirements {
@@ -448,6 +671,7 @@ pub fn plan_selected_portable_v2(
         payload_bytes: total,
         selection_fingerprint: selection.selection_fingerprint.clone(),
         package_class: package_class(&selection.package_class)?,
+        retained_subset: None,
     })
 }
 
@@ -538,6 +762,7 @@ fn package_class(value: &str) -> Result<PortableV2PackageClass, ExportError> {
         "complete" => Ok(PortableV2PackageClass::Complete),
         "ontology-only" => Ok(PortableV2PackageClass::OntologyOnly),
         "component-selective" => Ok(PortableV2PackageClass::ComponentSelective),
+        "graph-data-subset" => Ok(PortableV2PackageClass::GraphDataSubset),
         _ => Err(err(
             "GF_INCOMPATIBLE",
             "unsupported selection package class",
@@ -1185,6 +1410,22 @@ fn media_type(e: &str) -> &str {
         "json" => "application/json",
         "parquet" => "application/vnd.apache.parquet",
         "arrow" => "application/vnd.apache.arrow.file",
+        _ => "application/octet-stream",
+    }
+}
+fn media_type_for_path(path: &str) -> &'static str {
+    if path.ends_with("runtime-generation.json") {
+        return "application/vnd.graphforge.runtime-generation+json";
+    }
+    match std::path::Path::new(path)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("json") => "application/json",
+        Some("parquet") => "application/vnd.apache.parquet",
+        Some("yaml" | "yml") => "application/yaml",
         _ => "application/octet-stream",
     }
 }

--- a/crates/graphforge-storage/src/project_portable_v2_selection.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_selection.rs
@@ -287,7 +287,7 @@ pub(crate) fn validate_selection_plan(
     Ok(())
 }
 
-fn fingerprint(plan: &PortableV2SelectionPlan) -> Result<String, PortableV2Error> {
+pub(crate) fn fingerprint(plan: &PortableV2SelectionPlan) -> Result<String, PortableV2Error> {
     let mut unsigned = plan.clone();
     unsigned.selection_fingerprint.clear();
     let bytes = crate::project_portable_v2::canonical_json(

--- a/crates/graphforge-storage/src/project_portable_v2_subset.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_subset.rs
@@ -1,0 +1,614 @@
+//! Deterministic portable-v2 graph-data-subset planning (#786).
+
+use std::collections::BTreeSet;
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::graph_projection::{
+    GraphProjectionClosure, GraphProjectionSelection, materialize_portable_graph_tree_projection,
+};
+use crate::project_portable_v2_export::{
+    PortableV2ExportLimits, PortableV2ExportPlan, plan_selected_portable_v2,
+};
+use crate::project_portable_v2_selection::{
+    PortableV2ParticipantId, PortableV2SelectionEntry, PortableV2SelectionPlan,
+    PortableV2SelectionReason, component_kind, fingerprint, validate_selection_plan,
+};
+use crate::{
+    GRAPH_CAPABILITY_ID, GRAPH_FILES_FAMILY, PortableV2Error, PortableV2ErrorCode,
+    PortableV2Limits, ResolvedProjectGeneration, capture_graph_files,
+};
+
+/// Stable UUID selector for one pinned generation.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct PortableV2GraphSelector {
+    /// Ordered node UUIDs (hyphenated).
+    pub node_uuids: Vec<String>,
+    /// Ordered edge UUIDs (hyphenated).
+    pub edge_uuids: Vec<String>,
+}
+
+/// Portable-v2 on-wire closure tokens.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PortableV2SubsetClosure {
+    /// Selected nodes plus edges whose endpoints are both selected.
+    InducedEdges,
+    /// Selected edges plus both endpoint nodes.
+    Referential,
+}
+
+/// Property projection/redaction for subset packages.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct PortableV2PropertyProjection {
+    /// Property field names excluded from payloads.
+    pub exclude: Vec<String>,
+}
+
+/// Subset planning request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PortableV2SubsetRequest {
+    /// Stable UUID selector.
+    pub selector: PortableV2GraphSelector,
+    /// Closure mode.
+    pub closure: PortableV2SubsetClosure,
+    /// Property projection.
+    pub projection: PortableV2PropertyProjection,
+}
+
+/// Content-free graph-subset receipt retained in the semantic manifest.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct PortableV2GraphSubsetMeta {
+    /// Canonical content-free selector digest token.
+    pub selector: String,
+    /// On-wire closure token.
+    pub closure: String,
+}
+
+/// Immutable subset preview consumed by planning and export.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct PortableV2SubsetPlan {
+    /// Component selection consumed by the exporter.
+    pub selection: PortableV2SelectionPlan,
+    /// Graph-subset metadata emitted into the semantic manifest.
+    pub graph_subset: PortableV2GraphSubsetMeta,
+    /// Resolved node count after closure.
+    pub selected_node_count: u64,
+    /// Resolved edge count after closure.
+    pub selected_edge_count: u64,
+    /// Endpoint nodes added beyond the caller's explicit node set.
+    pub endpoint_node_count: u64,
+    /// Domain-separated projected graph fingerprint.
+    pub result_fingerprint: String,
+    /// Stable digest over the full subset preview.
+    pub subset_fingerprint: String,
+    /// Resolved projection used by the planner.
+    #[serde(skip)]
+    pub(crate) projection: GraphProjectionSelection,
+}
+
+/// Resolve one bounded deterministic graph-data subset without writing a package.
+pub fn preview_portable_v2_graph_subset(
+    generation: &ResolvedProjectGeneration,
+    request: &PortableV2SubsetRequest,
+    limits: PortableV2Limits,
+) -> Result<PortableV2SubsetPlan, PortableV2Error> {
+    let graph_root = generation.graph_tree_root();
+    if !graph_root.exists() {
+        return Err(incompatible("pinned generation has no graph tree"));
+    }
+    generation
+        .graph_files_inventory()
+        .map_err(storage)?
+        .ok_or_else(|| incompatible("pinned generation has no graph inventory"))?;
+
+    let selector = canonicalize_selector(&request.selector)?;
+    if selector.node_uuids.is_empty() && selector.edge_uuids.is_empty() {
+        return Err(incompatible("subset selector matched no graph identities"));
+    }
+    match request.closure {
+        PortableV2SubsetClosure::InducedEdges if !selector.edge_uuids.is_empty() => {
+            return Err(incompatible(
+                "induced-edges closure rejects explicit edge selectors",
+            ));
+        }
+        PortableV2SubsetClosure::Referential if selector.edge_uuids.is_empty() => {
+            return Err(incompatible(
+                "referential closure requires explicit edge selectors",
+            ));
+        }
+        _ => {}
+    }
+
+    let exclude = request
+        .projection
+        .exclude
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    if exclude.iter().any(|name| {
+        matches!(
+            name.as_str(),
+            "node_uuid" | "edge_uuid" | "src_uuid" | "dst_uuid" | "node_id" | "edge_id"
+        )
+    }) {
+        return Err(incompatible("topology identity columns cannot be redacted"));
+    }
+
+    let projection = GraphProjectionSelection {
+        node_uuids: parse_uuids(&selector.node_uuids)?,
+        edge_uuids: parse_uuids(&selector.edge_uuids)?,
+        closure: match request.closure {
+            PortableV2SubsetClosure::InducedEdges => GraphProjectionClosure::InducedEdges,
+            PortableV2SubsetClosure::Referential => GraphProjectionClosure::Referential,
+        },
+        exclude_properties: exclude.clone(),
+    };
+
+    let staging = tempfile::tempdir().map_err(storage_io)?;
+    let summary =
+        materialize_portable_graph_tree_projection(&graph_root, staging.path(), &projection)
+            .map_err(|error| map_projection(&error))?;
+    let (captured, _) = capture_graph_files(staging.path()).map_err(storage)?;
+    if captured.total_byte_length > limits.max_total_bytes {
+        return Err(limit("subset bytes exceed configured limit"));
+    }
+    if captured.file_count > limits.max_entries {
+        return Err(limit("subset entry count exceeds configured limit"));
+    }
+
+    let mut selection = build_subset_component_selection(generation, &exclude, limits)?;
+    selection.selection_fingerprint = fingerprint(&selection)?;
+    let graph_subset = PortableV2GraphSubsetMeta {
+        selector: selector_digest(&selector, request.closure, &exclude)?,
+        closure: match request.closure {
+            PortableV2SubsetClosure::InducedEdges => "induced-edges".into(),
+            PortableV2SubsetClosure::Referential => "referential".into(),
+        },
+    };
+    let mut plan = PortableV2SubsetPlan {
+        selection,
+        graph_subset,
+        selected_node_count: summary.node_uuids.len() as u64,
+        selected_edge_count: summary.edge_uuids.len() as u64,
+        endpoint_node_count: summary.endpoint_node_uuids.len() as u64,
+        result_fingerprint: format!("sha256:{}", hex(summary.graph_content_fingerprint)),
+        subset_fingerprint: String::new(),
+        projection,
+    };
+    plan.subset_fingerprint = subset_fingerprint(&plan)?;
+    Ok(plan)
+}
+
+/// Materialize one immutable subset preview into a representation-independent export plan.
+pub fn plan_graph_subset_portable_v2(
+    generation: &ResolvedProjectGeneration,
+    plan: &PortableV2SubsetPlan,
+    limits: PortableV2ExportLimits,
+) -> Result<PortableV2ExportPlan, PortableV2Error> {
+    if plan.selection.package_class != "graph-data-subset"
+        || plan.subset_fingerprint != subset_fingerprint(plan)?
+    {
+        return Err(incompatible("subset plan identity mismatch"));
+    }
+    validate_selection_plan(generation, &plan.selection)?;
+
+    let staging = tempfile::tempdir().map_err(storage_io)?;
+    let summary = materialize_portable_graph_tree_projection(
+        &generation.graph_tree_root(),
+        staging.path(),
+        &plan.projection,
+    )
+    .map_err(|error| map_projection(&error))?;
+    if summary.node_uuids.len() as u64 != plan.selected_node_count
+        || summary.edge_uuids.len() as u64 != plan.selected_edge_count
+        || format!("sha256:{}", hex(summary.graph_content_fingerprint)) != plan.result_fingerprint
+    {
+        return Err(PortableV2Error::new(
+            PortableV2ErrorCode::ConcurrentMutation,
+            "subset source changed after preview",
+        ));
+    }
+    let (inventory, inventory_participant) =
+        capture_graph_files(staging.path()).map_err(storage)?;
+    let mut selection = plan.selection.clone();
+    selection.include_graph_tree = false;
+    selection.selection_fingerprint = fingerprint(&selection)?;
+    let mut export = plan_selected_portable_v2(generation, &selection, limits)?;
+    export.replace_graph_tree_with_subset(
+        staging,
+        &inventory,
+        inventory_participant.bytes,
+        &plan.graph_subset.selector,
+        &plan.graph_subset.closure,
+        &plan.subset_fingerprint,
+        limits,
+    )?;
+    Ok(export)
+}
+
+fn build_subset_component_selection(
+    generation: &ResolvedProjectGeneration,
+    redactions: &BTreeSet<String>,
+    limits: PortableV2Limits,
+) -> Result<PortableV2SelectionPlan, PortableV2Error> {
+    let descriptors = generation.participant_descriptors().map_err(storage)?;
+    if descriptors.len() as u64 > limits.max_components {
+        return Err(limit("selection component count exceeds limit"));
+    }
+    let mut included = Vec::new();
+    let mut excluded = Vec::new();
+    let mut total = 0_u64;
+    for descriptor in descriptors {
+        let identity = PortableV2ParticipantId {
+            capability_id: descriptor.capability_id.clone(),
+            record_family_id: descriptor.record_family_id.clone(),
+        };
+        let kind = component_kind(&identity.capability_id, &identity.record_family_id);
+        let selected = matches!(kind, "graph-data" | "schema" | "ontology");
+        let path = generation
+            .participant_path(&identity.capability_id, &identity.record_family_id)
+            .map_err(storage)?;
+        let bytes = std::fs::metadata(path).map_err(storage_io)?.len();
+        if selected {
+            total = total
+                .checked_add(bytes)
+                .ok_or_else(|| limit("selection byte overflow"))?;
+            if total > limits.max_total_bytes {
+                return Err(limit("selection bytes exceed limit"));
+            }
+        }
+        let entry = PortableV2SelectionEntry {
+            kind: kind.into(),
+            reason: if selected {
+                PortableV2SelectionReason::Requested
+            } else {
+                PortableV2SelectionReason::ProfileExcluded
+            },
+            identity,
+            estimated_bytes: bytes,
+            row_count: descriptor.row_count,
+        };
+        if selected {
+            included.push(entry);
+        } else {
+            excluded.push(entry);
+        }
+    }
+    if !included.iter().any(|entry| {
+        entry.identity.capability_id == GRAPH_CAPABILITY_ID
+            && entry.identity.record_family_id == GRAPH_FILES_FAMILY
+    }) {
+        return Err(incompatible("subset requires graph files inventory"));
+    }
+    included.sort_by(|a, b| a.identity.cmp(&b.identity));
+    excluded.sort_by(|a, b| a.identity.cmp(&b.identity));
+    let required_capabilities = included
+        .iter()
+        .map(|entry| entry.identity.capability_id.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    Ok(PortableV2SelectionPlan {
+        source_generation_uuid: generation.generation_uuid().hyphenated().to_string(),
+        source_manifest_sha256: format!("sha256:{}", hex(generation.manifest_sha256())),
+        package_class: "graph-data-subset".into(),
+        included,
+        excluded,
+        redactions: redactions.iter().cloned().collect(),
+        required_capabilities,
+        estimated_payload_bytes: total,
+        selection_fingerprint: String::new(),
+        include_graph_tree: true,
+    })
+}
+
+fn subset_fingerprint(plan: &PortableV2SubsetPlan) -> Result<String, PortableV2Error> {
+    #[derive(Serialize)]
+    struct Signed<'a> {
+        selection_fingerprint: &'a str,
+        graph_subset: &'a PortableV2GraphSubsetMeta,
+        selected_node_count: u64,
+        selected_edge_count: u64,
+        endpoint_node_count: u64,
+        result_fingerprint: &'a str,
+    }
+    let signed = Signed {
+        selection_fingerprint: &plan.selection.selection_fingerprint,
+        graph_subset: &plan.graph_subset,
+        selected_node_count: plan.selected_node_count,
+        selected_edge_count: plan.selected_edge_count,
+        endpoint_node_count: plan.endpoint_node_count,
+        result_fingerprint: &plan.result_fingerprint,
+    };
+    let bytes = crate::project_portable_v2::canonical_json(
+        &serde_json::to_value(signed).map_err(|_| incompatible("subset serialization"))?,
+    )?;
+    let mut digest = Sha256::new();
+    digest.update(b"graphforge-portable-subset/1\0");
+    digest.update(bytes);
+    Ok(format!("sha256:{}", hex(digest.finalize().into())))
+}
+
+fn canonicalize_selector(
+    selector: &PortableV2GraphSelector,
+) -> Result<PortableV2GraphSelector, PortableV2Error> {
+    let mut nodes = selector.node_uuids.clone();
+    let mut edges = selector.edge_uuids.clone();
+    nodes.sort();
+    edges.sort();
+    nodes.dedup();
+    edges.dedup();
+    if nodes.len() != selector.node_uuids.len() || edges.len() != selector.edge_uuids.len() {
+        return Err(incompatible("duplicate subset selector identity"));
+    }
+    if nodes != selector.node_uuids || edges != selector.edge_uuids {
+        return Err(incompatible("subset selector order is not deterministic"));
+    }
+    Ok(PortableV2GraphSelector {
+        node_uuids: nodes,
+        edge_uuids: edges,
+    })
+}
+
+fn selector_digest(
+    selector: &PortableV2GraphSelector,
+    closure: PortableV2SubsetClosure,
+    exclude: &BTreeSet<String>,
+) -> Result<String, PortableV2Error> {
+    #[derive(Serialize)]
+    struct Body<'a> {
+        closure: PortableV2SubsetClosure,
+        node_uuids: &'a [String],
+        edge_uuids: &'a [String],
+        exclude_properties: Vec<&'a String>,
+    }
+    let body = Body {
+        closure,
+        node_uuids: &selector.node_uuids,
+        edge_uuids: &selector.edge_uuids,
+        exclude_properties: exclude.iter().collect(),
+    };
+    let bytes = crate::project_portable_v2::canonical_json(
+        &serde_json::to_value(body).map_err(|_| incompatible("selector serialization"))?,
+    )?;
+    let mut digest = Sha256::new();
+    digest.update(b"graphforge-portable-subset-selector/1\0");
+    digest.update(bytes);
+    Ok(format!("sha256:{}", hex(digest.finalize().into())))
+}
+
+fn parse_uuids(values: &[String]) -> Result<BTreeSet<[u8; 16]>, PortableV2Error> {
+    let mut out = BTreeSet::new();
+    for value in values {
+        let uuid = Uuid::parse_str(value).map_err(|_| incompatible("invalid subset UUID"))?;
+        if uuid.is_nil() {
+            return Err(incompatible("nil UUID is not a portable identity"));
+        }
+        if !out.insert(*uuid.as_bytes()) {
+            return Err(incompatible("duplicate subset selector identity"));
+        }
+    }
+    Ok(out)
+}
+
+fn hex(digest: [u8; 32]) -> String {
+    use std::fmt::Write as _;
+    digest
+        .iter()
+        .fold(String::with_capacity(64), |mut output, byte| {
+            write!(output, "{byte:02x}").expect("writing to String cannot fail");
+            output
+        })
+}
+
+fn map_projection(error: &crate::GfError) -> PortableV2Error {
+    match error {
+        crate::GfError::Validation(_) => incompatible("subset projection rejected"),
+        _ => PortableV2Error::new(PortableV2ErrorCode::Io, "subset projection failed"),
+    }
+}
+fn storage(_: crate::GfError) -> PortableV2Error {
+    PortableV2Error::new(PortableV2ErrorCode::Io, "subset inventory unavailable")
+}
+fn storage_io(_: std::io::Error) -> PortableV2Error {
+    PortableV2Error::new(PortableV2ErrorCode::Io, "subset staging unavailable")
+}
+fn incompatible(detail: &'static str) -> PortableV2Error {
+    PortableV2Error::new(PortableV2ErrorCode::Incompatible, detail)
+}
+fn limit(_: &str) -> PortableV2Error {
+    PortableV2Error::new(PortableV2ErrorCode::LimitExceeded, "subset limit exceeded")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::fs;
+    use std::sync::atomic::AtomicBool;
+
+    use graphforge_core::{OntologyMode, TypeId};
+    use graphforge_ir::IrLiteral;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::project_portable_v2_export::{PortableV2Output, export_complete_portable_v2};
+    use crate::{
+        GRAPH_CAPABILITY_VERSION, GraphWriter, PortableV2Mode, ProjectCapability,
+        ProjectGenerationRequest, ProjectStageOutcome, capture_graph_files,
+        empty_workspace_participants, open_or_initialize_project, resolve_project_generation,
+        stage_project_generation_with_graph_tree, verify_portable_v2,
+    };
+
+    const TS: i64 = 1_700_000_000_000_000;
+
+    fn uuid(marker: u8) -> Uuid {
+        let mut bytes = [0_u8; 16];
+        bytes[15] = marker;
+        Uuid::from_bytes(bytes)
+    }
+
+    fn publish_graph_project() -> (tempfile::TempDir, [Uuid; 3], [Uuid; 2]) {
+        let root = tempfile::tempdir().unwrap();
+        open_or_initialize_project(root.path()).unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let nodes = [uuid(1), uuid(2), uuid(3)];
+        let edges = [uuid(11), uuid(12)];
+        let mut writer =
+            GraphWriter::open_at(workspace.path(), OntologyMode::Exploratory, TS).unwrap();
+        for (index, node) in nodes.iter().enumerate() {
+            writer.create_node(*node, TypeId(1)).unwrap();
+            writer
+                .set_properties(
+                    node,
+                    None,
+                    HashMap::from([
+                        ("value".into(), IrLiteral::Int(index as i64)),
+                        ("secret".into(), IrLiteral::Str(format!("leak-{index}"))),
+                    ]),
+                )
+                .unwrap();
+        }
+        writer
+            .create_edge(edges[0], "KNOWS", &nodes[0], &nodes[1])
+            .unwrap();
+        writer
+            .create_edge(edges[1], "KNOWS", &nodes[1], &nodes[2])
+            .unwrap();
+        writer.flush().unwrap();
+        let (_, files) = capture_graph_files(workspace.path()).unwrap();
+        let mut participants = empty_workspace_participants().unwrap();
+        participants.insert(0, files);
+        let generation_uuid = Uuid::now_v7();
+        let request = ProjectGenerationRequest {
+            transaction_uuid: Uuid::now_v7(),
+            generation_uuid,
+            capabilities: vec![
+                ProjectCapability {
+                    capability_id: GRAPH_CAPABILITY_ID.into(),
+                    capability_version: GRAPH_CAPABILITY_VERSION,
+                },
+                ProjectCapability {
+                    capability_id: "workspace".into(),
+                    capability_version: 1,
+                },
+            ],
+            participants,
+        };
+        let ProjectStageOutcome::Staged(staged) =
+            stage_project_generation_with_graph_tree(root.path(), &request, Some(workspace.path()))
+                .unwrap()
+        else {
+            panic!("expected staged publication");
+        };
+        staged
+            .validate(|_| Ok(()), |_, _| Ok(()))
+            .unwrap()
+            .publish()
+            .unwrap();
+        (root, nodes, edges)
+    }
+
+    #[test]
+    fn induced_subset_export_is_deterministic_and_verifies() {
+        let (root, nodes, _edges) = publish_graph_project();
+        let generation = resolve_project_generation(root.path()).unwrap();
+        let limits = PortableV2Limits::default();
+        let mut selected = [nodes[0], nodes[1]].map(|uuid| uuid.hyphenated().to_string());
+        selected.sort();
+        let request = PortableV2SubsetRequest {
+            selector: PortableV2GraphSelector {
+                node_uuids: selected.to_vec(),
+                edge_uuids: vec![],
+            },
+            closure: PortableV2SubsetClosure::InducedEdges,
+            projection: PortableV2PropertyProjection {
+                exclude: vec!["secret".into()],
+            },
+        };
+        let preview = preview_portable_v2_graph_subset(&generation, &request, limits).unwrap();
+        assert_eq!(preview.selected_node_count, 2);
+        assert_eq!(preview.selected_edge_count, 1);
+        assert_eq!(preview.graph_subset.closure, "induced-edges");
+        assert!(preview.selection.redactions.contains(&"secret".into()));
+        let again = preview_portable_v2_graph_subset(&generation, &request, limits).unwrap();
+        assert_eq!(preview.subset_fingerprint, again.subset_fingerprint);
+        assert_eq!(preview.result_fingerprint, again.result_fingerprint);
+
+        let plan = plan_graph_subset_portable_v2(&generation, &preview, limits).unwrap();
+        let out = tempfile::tempdir().unwrap();
+        let expanded = out.path().join("subset.gfproject");
+        let bundle = out.path().join("subset.gfpb");
+        let cancelled = AtomicBool::new(false);
+        let a = export_complete_portable_v2(
+            &plan,
+            &expanded,
+            PortableV2Output::Expanded,
+            limits,
+            &cancelled,
+            |_| {},
+        )
+        .unwrap();
+        let b = export_complete_portable_v2(
+            &plan,
+            &bundle,
+            PortableV2Output::Bundle,
+            limits,
+            &cancelled,
+            |_| {},
+        )
+        .unwrap();
+        assert_eq!(a.package_digest, b.package_digest);
+        assert_eq!(a.selection_fingerprint, preview.subset_fingerprint);
+        let report =
+            verify_portable_v2(&expanded, PortableV2Mode::Full, limits, Some(&cancelled)).unwrap();
+        assert_eq!(
+            report.package_class,
+            crate::PortableV2PackageClass::GraphDataSubset
+        );
+        let manifest = fs::read_to_string(expanded.join("data/graphforge-project.json")).unwrap();
+        assert!(manifest.contains("\"graph-data-subset\""));
+        assert!(manifest.contains("\"induced-edges\""));
+        assert!(!manifest.contains("leak-"));
+    }
+
+    #[test]
+    fn referential_subset_closes_endpoints_and_rejects_unordered_selectors() {
+        let (root, nodes, edges) = publish_graph_project();
+        let generation = resolve_project_generation(root.path()).unwrap();
+        let limits = PortableV2Limits::default();
+        let edge = edges[0].hyphenated().to_string();
+        let preview = preview_portable_v2_graph_subset(
+            &generation,
+            &PortableV2SubsetRequest {
+                selector: PortableV2GraphSelector {
+                    node_uuids: vec![],
+                    edge_uuids: vec![edge.clone()],
+                },
+                closure: PortableV2SubsetClosure::Referential,
+                projection: PortableV2PropertyProjection::default(),
+            },
+            limits,
+        )
+        .unwrap();
+        assert_eq!(preview.selected_edge_count, 1);
+        assert_eq!(preview.selected_node_count, 2);
+        assert_eq!(preview.endpoint_node_count, 2);
+
+        let unordered = PortableV2SubsetRequest {
+            selector: PortableV2GraphSelector {
+                node_uuids: vec![
+                    nodes[1].hyphenated().to_string(),
+                    nodes[0].hyphenated().to_string(),
+                ],
+                edge_uuids: vec![],
+            },
+            closure: PortableV2SubsetClosure::InducedEdges,
+            projection: PortableV2PropertyProjection::default(),
+        };
+        let error = preview_portable_v2_graph_subset(&generation, &unordered, limits).unwrap_err();
+        assert_eq!(error.code, PortableV2ErrorCode::Incompatible);
+    }
+}

--- a/docs/book/architecture/portable-project-v2.md
+++ b/docs/book/architecture/portable-project-v2.md
@@ -180,7 +180,10 @@ any destination is created. Profiles are `Complete`, `OntologyOnly`,
 the pair `(capability_id, record_family_id)`; runtime catalog IDs, display names,
 and host paths are not accepted as identity. Graph data selection always means
 the whole committed graph component. Fine-grained row or subgraph selection is
-a separate contract.
+handled by `preview_portable_v2_graph_subset` / `plan_graph_subset_portable_v2`
+(#786): typed UUID selectors, `induced-edges` and `referential` closure, property
+redaction, and `package_class: graph-data-subset` with a content-free
+`selection.graph_subset` receipt.
 
 The preview lists included and excluded stable identities, inclusion reasons,
 row counts, exact committed participant byte estimates, required capabilities,


### PR DESCRIPTION
Closes #786

## Summary
- add portable-v2 graph-data-subset preview/plan APIs over pinned generations
- support `induced-edges` and `referential` closure with property redaction
- emit verified expanded/bundle packages with content-free `selection.graph_subset` receipts

## Test plan
- [x] `cargo test -p graphforge-storage --lib project_portable_v2_subset`
- [x] `cargo clippy -p graphforge-storage --lib -- -D warnings`
- [ ] CI Gate green on exact head


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789784576&installation_model_id=20486&pr_number=849&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F849&signature=a267856bed47bb1c26c47dfe82f5f22772ebeca68b0af5d6b4be61ddc9fd9d2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->