### PR TITLE
ci(perf): use CodSpeed Macro Runners for walltime

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,3 +5,4 @@ self-hosted-runner:
     - blacksmith-8vcpu-windows-2025
     - blacksmith-6vcpu-macos-15
     - blacksmith-12vcpu-macos-15
+    - codspeed-macro

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -124,13 +124,14 @@ deployments remain serialized to GitHub Pages.
 Builds the divan benchmark targets with `cargo codspeed` and measures them
 under CodSpeed's CPU simulation instrument on pull requests to `main`, pushes
 to `main`, and manual dispatch. It reports performance deltas against the base
-commit as evidence; it is **not** part of the required `CI Gate` aggregate, and
-its Cargo build stays a diagnostic path next to authoritative Bazel
-compilation. A sole `lex[simple_match]` Performance Analysis failure on a
-non-cypher PR is a known short-bench noise pattern — see triage in
+commit as evidence. It is not part of the `CI Gate` aggregate, but its external
+check must still be resolved for the PR to reach the required `CLEAN` state.
+Its Cargo build stays a diagnostic path next to authoritative Bazel
+compilation. Comparable-run and measurement-floor triage is documented in
 [`docs/development/benchmarking.md`](../../docs/development/benchmarking.md).
-M6 pure kernels use simulation; durable open/recovery/commit/GC/compaction use
-the declared Blacksmith 4-vCPU Ubuntu 24.04 walltime runner. Weekly/manual runs
+M6 pure kernels use simulation on the ordinary pinned CI runner; durable
+open/recovery/commit/GC/compaction use CodSpeed's isolated bare-metal
+`codspeed-macro` ARM64 runner. Weekly/manual runs
 also retain exact-SHA replay and compaction peak-RSS artifacts while CodSpeed
 memory mode is unavailable for this project.
 

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -2,9 +2,9 @@ name: CodSpeed
 
 # Continuous performance measurement for the Rust surface. Benchmarks are
 # divan targets built through `cargo codspeed` and measured with CodSpeed's
-# CPU simulation instrument, so results are hardware-agnostic and comparable
-# across runs. Cargo builds here are diagnostics-only: Bazel remains the
-# authoritative compile/test surface (see .github/workflows/README.md).
+# CPU simulation instrument for pure kernels and CodSpeed Macro Runners for
+# durable I/O walltime. Cargo builds here are diagnostics-only: Bazel remains
+# the authoritative compile/test surface (see .github/workflows/README.md).
 on:
   push:
     branches: ["main"]
@@ -58,8 +58,10 @@ jobs:
           run: cargo codspeed run
 
   m6-walltime:
-    name: M6 Durable Walltime (Blacksmith 4 vCPU Ubuntu 24.04)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    name: M6 Durable Walltime (CodSpeed Macro ARM64)
+    # Walltime comparisons require CodSpeed's isolated bare-metal runner.
+    # Shared hosted runners are intentionally not a fallback.
+    runs-on: codspeed-macro
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/docs/development/benchmarking.md
+++ b/docs/development/benchmarking.md
@@ -1,13 +1,14 @@
 # Benchmarking with CodSpeed
 
-**Status:** Continuous on every pull request to `main` (`CodSpeed` workflow) —
-**diagnostic only**, not a merge gate
+**Status:** Continuous on every pull request to `main` (`CodSpeed` workflow)
 
-GraphForge values correctness over performance, so benchmarks are evidence, not
-a merge gate. The `CodSpeed` workflow measures a fixed set of Rust benchmarks on
-every pull request and reports the delta against the base commit; it is not part
-of the required `CI Gate` aggregate. A red **CodSpeed Performance Analysis**
-check does not block merge when `CI Gate` is green.
+GraphForge values correctness over performance, but performance claims still
+require comparable evidence. The `CodSpeed` workflow measures a fixed set of
+Rust benchmarks on every pull request and reports the delta against the base
+commit. It is not part of the `CI Gate` aggregate, but the PR must still reach
+the repository's required `CLEAN` state: a red **CodSpeed Performance Analysis**
+check must be resolved or receive an explicit, evidence-backed maintainer
+disposition.
 
 ## What is measured
 
@@ -42,19 +43,17 @@ can fail independently of a green Actions job.
 
 Treat CodSpeed as a diagnostic signal, not a release or merge authority.
 
-**Known false-positive pattern:** sole regression on
-`graphforge-cypher::compile::lex[simple_match]` (often about −19% to −31%) while
-other benches are flat or improved, especially on PRs that do not change Cypher
-lexer/front-end sources. That shape is intentionally tiny; short samples are
-sensitive to measurement floor effects even under CPU simulation. Prefer raising
-SNR in the bench (batched iterations inside the measured closure) over treating
-the failure as an M4 or lexer regression.
+First verify that the report compares the intended base and head with the same
+instrument and environment. Walltime evidence is valid only when both sides
+come from `codspeed-macro`; an unknown/different hosted environment is an
+infrastructure or baseline defect, not a regression disposition. Seed a fresh
+`main` Macro Runner baseline, then run the changed PR head once against it.
 
-**Triage rule:** if the only failing bench is `lex[simple_match]` and the PR
-diff does not touch Cypher lexer/parse/bind sources (or their direct
-dependencies), treat the report as noise and proceed with `CI Gate`. Investigate
-further only when multiple cypher benches regress together or the PR changes the
-front end.
+For CPU simulation, tiny benchmarks can still be sensitive to the measurement
+floor. Raise their signal-to-noise ratio inside the benchmark rather than
+waiving a red check. When a comparable report remains red, investigate the
+changed dependency surface and either repair the regression or document the
+measured tradeoff through explicit maintainer disposition.
 
 ## Running them locally
 
@@ -82,9 +81,15 @@ reachability, and transaction classification belong to CPU simulation; fixture
 construction and correctness assertions stay outside timed closures.
 
 Durable open, recovery, commit, garbage collection, spill, and compaction are
-filesystem walltime measurements, not CPU-simulation claims. Scheduled/manual
-hardware evidence records the exact runner image, CPU allocation, head/base SHA,
-fixture version, and artifact URL. Until CodSpeed memory mode is available on
+filesystem walltime measurements, not CPU-simulation claims. They run on
+CodSpeed's dedicated `codspeed-macro` bare-metal ARM64 runner; shared hosted
+runners are not a valid fallback because their environment variance makes
+walltime comparisons incomparable. See CodSpeed's
+[Macro Runner guidance](https://codspeed.io/docs/features/macro-runners) and
+[walltime instrument contract](https://codspeed.io/docs/instruments/walltime).
+Scheduled/manual hardware evidence records
+the exact runner image, architecture, head/base SHA, fixture version, and
+artifact URL. Until CodSpeed memory mode is available on
 the project runner, replay and compaction peak-resident counters are emitted as
 an explicit scheduled hardware artifact. CodSpeed remains diagnostic only:
 Bazel tests, deterministic fault models, and native platform lanes are the
@@ -93,11 +98,12 @@ their measured tradeoff; samples and thresholds must not be weakened.
 
 The frozen pre-M6 comparison commit is
 `aeb46d1b012d40e8a0af7873af9152b3aab752c6`, the first parent immediately
-before the #777 replay merge. The walltime host contract is the pinned
-`blacksmith-4vcpu-ubuntu-2404` runner, Rust 1.96.0, `m6_storage_io` fixture v1,
-and CodSpeed walltime mode. The scheduled memory fallback uses that same host
-contract and uploads `/usr/bin/time -v` peak-resident output for replay and
-spill/compaction, named with the exact head SHA. Certification #756 records the
+before the #777 replay merge. The walltime host contract is CodSpeed's
+`codspeed-macro` ARM64 runner, Rust 1.96.0, `m6_storage_io` fixture v1, and
+CodSpeed walltime mode. The scheduled memory fallback remains a separately
+labelled Blacksmith diagnostic and uploads `/usr/bin/time -v` peak-resident
+output for replay and spill/compaction, named with the exact head SHA.
+Certification #756 records the
 base/head SHAs, result URLs or artifact IDs, benchmark mode and any accepted
 tradeoff. `scripts/ci/check-m6-benchmarks.py` freezes the v1 names and count.
 

--- a/scripts/ci/check-m6-benchmarks.py
+++ b/scripts/ci/check-m6-benchmarks.py
@@ -6,6 +6,7 @@ import re
 import sys
 
 ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "codspeed.yml"
 EXPECTED = {
     "m6_storage.rs": {
         "gfdr_encode",
@@ -40,4 +41,24 @@ for filename, names in EXPECTED.items():
 if missing:
     print("missing M6 benchmarks: " + ", ".join(missing), file=sys.stderr)
     raise SystemExit(1)
+
+workflow = WORKFLOW.read_text(encoding="utf-8")
+walltime_job = workflow.split("  m6-walltime:\n", 1)
+if len(walltime_job) != 2:
+    raise SystemExit("CodSpeed workflow is missing the m6-walltime job")
+walltime_job = walltime_job[1].split("\n  m6-memory-fallback:", 1)[0]
+if "runs-on: codspeed-macro" not in walltime_job:
+    raise SystemExit("m6-walltime must run on the CodSpeed Macro Runner")
+if "mode: walltime" not in walltime_job:
+    raise SystemExit("m6-walltime must use the walltime instrument")
+
+simulation_job = workflow.split("  benchmarks:\n", 1)
+if len(simulation_job) != 2:
+    raise SystemExit("CodSpeed workflow is missing the simulation benchmark job")
+simulation_job = simulation_job[1].split("\n  m6-walltime:", 1)[0]
+if "runs-on: codspeed-macro" in simulation_job:
+    raise SystemExit("CPU simulation must remain separate from the Macro Runner")
+if "mode: simulation" not in simulation_job:
+    raise SystemExit("CPU benchmark job must use the simulation instrument")
+
 print(f"M6 benchmark inventory v1: {sum(map(len, EXPECTED.values()))} names verified")

--- a/scripts/ci/durability-certification-gate.py
+++ b/scripts/ci/durability-certification-gate.py
@@ -139,6 +139,8 @@ def validate_config(seed: int, histories: int, ops: int) -> None:
     benchmark = contract.get("benchmark_evidence")
     if not isinstance(benchmark, dict) or benchmark.get("walltime_bench") != "m6_storage_io":
         raise GateError("certification must bind the #782 walltime fixture")
+    if benchmark.get("walltime_host") != "codspeed-macro-arm64":
+        raise GateError("certification walltime evidence must use CodSpeed Macro ARM64")
     claims = contract.get("forbidden_positive_claims")
     if not isinstance(claims, list) or not claims:
         raise GateError("forbidden_positive_claims are required")

--- a/tests/contracts/durability-certification.json
+++ b/tests/contracts/durability-certification.json
@@ -68,7 +68,7 @@
   "native_oracle_aggregate": "native-durability-aggregate-${commit}.json",
   "benchmark_evidence": {
     "baseline_commit": "aeb46d1b012d40e8a0af7873af9152b3aab752c6",
-    "walltime_host": "blacksmith-4vcpu-ubuntu-2404",
+    "walltime_host": "codspeed-macro-arm64",
     "simulation_bench": "m6_storage",
     "walltime_bench": "m6_storage_io",
     "memory_fallback": "/usr/bin/time -v"


### PR DESCRIPTION
## Summary

- move durable I/O walltime measurements from shared Blacksmith CI to CodSpeed's isolated `codspeed-macro` ARM64 runner
- keep CPU simulation and scheduled memory diagnostics on their existing ordinary runners
- freeze the Macro Runner in the M6 durability evidence contract and reject workflow drift back to shared walltime hosts
- update workflow and benchmarking documentation to distinguish the measurement authorities

## Verification

- `make workflow-lint`
- `python3 scripts/ci/check-m6-benchmarks.py`
- `python3 scripts/ci/durability-certification-gate.py validate`
- `python3 scripts/ci/test-durability-certification-gate.py`
- `python3 scripts/ci/test-ci-storage-policy.py`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #856

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789841436&installation_model_id=20486&pr_number=857&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F857&signature=d6439996af69bb95165d37469d7e90e35ce54d1e07049cec7b7ec9a781bed3b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->