### PR TITLE
ci: slim pull request automation

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -15,7 +15,10 @@ reviews:
   collapse_walkthrough: false
 
   auto_review:
-    enabled: true
+    # Reviews consume a limited CodeRabbit quota. Request one manually only
+    # after the required CI Gate is green and the PR is otherwise ready to
+    # merge (for example, with `@coderabbitai review`).
+    enabled: false
     drafts: false
     base_branches:
       - main

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -98,6 +98,8 @@ Python, Gherkin, native binding, Pulumi, Terraform, or Bazel jobs. Pull-request
 native binding acceptance is Linux-only and uses Cargo's `dev` profile for
 maturin/napi assembly. Authoritative Rust compile/test is Bazel
 (`//:ci_rust_tests`) under `Bazel Bootstrap`.
+The non-required Cargo/Bazel parity and cache-observation diagnostics do not
+run on pull requests; they remain available for future maintenance CI.
 When Rust surfaces change, `Windows graphforge-storage Locks` runs the native
 project-root lock, exact filesystem primitive, NTFS admission, and real
 publication-kill/fault-oracle cross-checks on `blacksmith-4vcpu-windows-2025`.
@@ -134,6 +136,12 @@ open/recovery/commit/GC/compaction use CodSpeed's isolated bare-metal
 `codspeed-macro` ARM64 runner. Manual runs also retain exact-SHA replay and
 compaction peak-RSS artifacts while CodSpeed memory mode is unavailable for
 this project.
+
+### CodeRabbit
+
+CodeRabbit automatic review is disabled to preserve its limited quota. After
+the required `CI Gate` is green and a pull request is otherwise ready to merge,
+request the final review explicitly with `@coderabbitai review`.
 
 ### `binding-release-candidate.yml`
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1123,12 +1123,12 @@ jobs:
           python3 scripts/ci/test-assemble-bazel-binding-packages.py
 
   bazel-diagnostics:
-    # Non-required: dual-build parity + cache observe/collect. Must not be in
-    # ci-gate needs. Fail closed on harness crashes (no fabricated JSON).
+    # Non-required parity/cache diagnostics are intentionally disabled for
+    # pull requests. Preserve the recipe until it moves to maintenance CI.
     name: Bazel Diagnostics
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: changes
-    if: needs.changes.outputs.bazel == 'true'
+    if: github.event_name == 'workflow_dispatch' && needs.changes.outputs.bazel == 'true'
     timeout-minutes: 120
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- enable repository auto-merge
- skip non-required Bazel diagnostics on pull requests
- disable automatic CodeRabbit reviews; request the final review only after CI Gate is green

## Verification
- `scripts/ci/test-require-gates.sh`
- `uv run --frozen python scripts/ci/test-codspeed-nightly.py`
- `make workflow-lint`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/866"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789861648&installation_model_id=20486&pr_number=866&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F866&signature=9775b94981169ee44125fe3ee6b8230c70a5223be41f460a78f6f4a7b63ccd91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->