### PR TITLE
test(ci): pin CodSpeed nightly workflow dependencies

### DIFF
--- a/scripts/ci/test-codspeed-nightly.py
+++ b/scripts/ci/test-codspeed-nightly.py
@@ -17,6 +17,7 @@ assert triggers["schedule"] == [{"cron": "17 7 * * *"}]
 
 jobs = workflow["jobs"]
 assert workflow["permissions"]["actions"] == "read"
+assert workflow["permissions"]["contents"] == "read"
 nightly = jobs["nightly"]
 assert nightly["outputs"]["sha"] == "${{ steps.main.outputs.sha }}"
 assert nightly["outputs"]["should-run"] == "${{ steps.decision.outputs.should-run }}"
@@ -42,6 +43,7 @@ for job_name in ("benchmarks", "m6-walltime"):
     assert checkout["with"]["ref"] == "${{ needs.nightly.outputs.sha }}"
 
 memory = jobs["m6-memory-fallback"]
+assert memory["needs"] == "nightly"
 assert memory["if"] == (
     "github.event_name == 'workflow_dispatch' && needs.nightly.outputs.should-run == 'true'"
 )


### PR DESCRIPTION
## Summary

- assert the nightly workflow retains `contents: read` for checkout
- assert the peak-memory fallback remains dependent on the nightly SHA decision
- leave production workflow behavior and benchmark configuration unchanged

## Verification

- `uv run --frozen python scripts/ci/test-codspeed-nightly.py`
- `uv run --frozen ruff check scripts/ci/test-codspeed-nightly.py`
- `uv run --frozen ruff format --check scripts/ci/test-codspeed-nightly.py`
- `python3 scripts/ci/check-m6-benchmarks.py`
- `python3 scripts/ci/test-ci-storage-policy.py`
- `make workflow-lint`
- `git diff --check`

Closes #867

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789861956&installation_model_id=20486&pr_number=868&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F868&signature=89411eb504cec8be9a56c1d309540f48072ef2467a15b3711477664cf80fa129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->