### PR TITLE
test(scale): add protected billion-edge certification harness

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -137,6 +137,16 @@ open/recovery/commit/GC/compaction use CodSpeed's isolated bare-metal
 compaction peak-RSS artifacts while CodSpeed memory mode is unavailable for
 this project.
 
+### `g500-certification.yml` — Billion-edge certification
+
+This protected, manual-only workflow checks out an exact commit on a
+maintainer-approved ephemeral Linux scale host. It never provisions or spends.
+It runs the bounded target-live SCALE-26 lifecycle, writes an atomic typed phase
+journal, validates sanitized evidence, and uploads only the evidence JSON and
+journal. Provider, SKU, runner registration, cost approval, and teardown remain
+explicit maintainer decisions; see the
+[certification runbook](../../docs/development/g500-certification.md).
+
 ### CodeRabbit
 
 CodeRabbit automatic review is disabled to preserve its limited quota. After

--- a/.github/workflows/g500-certification.yml
+++ b/.github/workflows/g500-certification.yml
@@ -1,0 +1,87 @@
+name: Billion-edge certification
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Exact 40-character commit to certify
+        required: true
+        type: string
+      runner_label:
+        description: Maintainer-approved ephemeral Linux runner label
+        required: true
+        type: string
+      provider:
+        description: Provisioned provider recorded in evidence
+        required: true
+        type: string
+      sku:
+        description: Provisioned SKU recorded in evidence
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: g500-certification
+  cancel-in-progress: false
+
+jobs:
+  certify:
+    name: SCALE26 target-live certification
+    environment: scale-certification
+    runs-on: ${{ inputs.runner_label }}
+    timeout-minutes: 240
+    steps:
+      - name: Reject branch names and malformed SHAs
+        env:
+          COMMIT_SHA: ${{ inputs.commit_sha }}
+        run: |
+          case "$COMMIT_SHA" in
+            (????????????????????????????????????????) ;;
+            (*) echo "commit_sha must contain exactly 40 characters" >&2; exit 2 ;;
+          esac
+          case "$COMMIT_SHA" in (*[!0-9a-f]*) echo "commit_sha must be lowercase hex" >&2; exit 2 ;; esac
+      - name: Checkout exact commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.commit_sha }}
+          fetch-depth: 1
+      - name: Attest exact tree and provisioned envelope
+        env:
+          COMMIT_SHA: ${{ inputs.commit_sha }}
+        run: |
+          test "$(git rev-parse HEAD)" = "$COMMIT_SHA"
+          test "$(uname -s)" = Linux
+          test "$(awk '/MemTotal/ {print $2 * 1024}' /proc/meminfo)" -ge 137438953472
+          test "$(df --output=size -B1 "$RUNNER_TEMP" | tail -1 | tr -d ' ')" -ge 1099511627776
+          case "$(stat -f -c %T "$RUNNER_TEMP")" in ext2/ext3|xfs|btrfs) ;; (*) exit 2 ;; esac
+      - name: Install pinned Rust toolchain
+        run: rustup show active-toolchain
+      - name: Run bounded preflight and provisioned certification
+        env:
+          CARGO_TARGET_DIR: ${{ runner.temp }}/cargo-g500-certification
+          GF_G500_CERT_EVIDENCE_OUT: ${{ runner.temp }}/g500-certification-evidence.json
+          GF_G500_CERT_JOURNAL_OUT: ${{ runner.temp }}/g500-certification-phase-journal.json
+          GF_G500_CERT_PROVIDER: ${{ inputs.provider }}
+          GF_G500_CERT_SKU: ${{ inputs.sku }}
+          GF_G500_CERT_EXPECTED_SHA: ${{ inputs.commit_sha }}
+        run: |
+          cargo test -p graphforge-api --release --test scale_g500_ladder certification_lifecycle_journals_equivalent_round_trip_and_drills -- --exact --nocapture
+          cargo test -p graphforge-api --release --test scale_g500_ladder certification_target_live_full_lifecycle_evidence -- --ignored --exact --nocapture --test-threads=1
+      - name: Validate sanitized durable evidence
+        if: always()
+        env:
+          COMMIT_SHA: ${{ inputs.commit_sha }}
+        run: python3 scripts/ci/validate-g500-certification.py "$RUNNER_TEMP/g500-certification-evidence.json" --expected-sha "$COMMIT_SHA"
+      - name: Upload evidence without project payload
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: g500-certification-${{ inputs.commit_sha }}
+          path: |
+            ${{ runner.temp }}/g500-certification-evidence.json
+            ${{ runner.temp }}/g500-certification-phase-journal.json
+          if-no-files-found: error
+          retention-days: 14

--- a/crates/graphforge-api/BUILD.bazel
+++ b/crates/graphforge-api/BUILD.bazel
@@ -190,7 +190,10 @@ gf_rust_integration_test(
 gf_rust_integration_test(
     name = "scale_g500_ladder",
     srcs = ["tests/scale_g500_ladder.rs"],
-    compile_data = ["tests/fixtures/scale_g500_ladder.v1.json"],
+    compile_data = [
+        "tests/fixtures/scale_g500_certification.v1.json",
+        "tests/fixtures/scale_g500_ladder.v1.json",
+    ],
     crate = ":graphforge_api",
     data = _API_TEST_DATA,
     size = "large",

--- a/crates/graphforge-api/tests/fixtures/scale_g500_certification.v1.json
+++ b/crates/graphforge-api/tests/fixtures/scale_g500_certification.v1.json
@@ -1,0 +1,23 @@
+{
+  "schema": "graphforge-billion-edge-certification-profile/1",
+  "scale": 26,
+  "edgefactor": 16,
+  "target_live_edges": 1000000000,
+  "seed": 1,
+  "initiator": { "A": 0.57, "B": 0.19, "C": 0.19, "D": 0.05 },
+  "policy": {
+    "directionality": "undirected",
+    "self_loops": "drop",
+    "duplicates": "drop",
+    "canonicalization": "sorted_lo_hi_pair",
+    "termination": "append deterministic attempt windows and merge all windows until a complete window verifies at least 1000000000 unique canonical pairs"
+  },
+  "envelope": {
+    "rss_bytes": 137438953472,
+    "disk_bytes": 1099511627776,
+    "timeout_s": 14400
+  },
+  "preflight_scale": 10,
+  "provider_decision": "required-at-dispatch",
+  "runner_label": "required-at-dispatch"
+}

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -23,11 +23,18 @@ use std::io::{BufReader, BufWriter, ErrorKind, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
-use std::time::Instant;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
 
 use arrow::array::{Array, FixedSizeBinaryArray, Int64Array, StringArray, UInt64Array};
 use arrow::record_batch::RecordBatch;
-use graphforge_api::{GraphForge, OperationId, bulk_edge_input_schema, bulk_node_input_schema};
+use graphforge_api::{
+    CancellationToken, GraphForge, OperationId, PortableSelection, PortableV2ExportRequest,
+    PortableV2ImportRequest, PortableV2Limits, PortableV2Mode, PortableV2Output,
+    PortableV2SelectionProfile, PortableVerifyRequest, bulk_edge_input_schema,
+    bulk_node_input_schema, verify_portable_v2,
+};
 use graphforge_core::uuid::Uuid;
 use serde::Deserialize;
 use serde_json::{Value, json};
@@ -99,9 +106,28 @@ struct Rung {
 /// The profile is embedded at compile time so the runner is hermetic under both
 /// Cargo and Bazel (no runtime `CARGO_MANIFEST_DIR` path dependency).
 const PROFILE_JSON: &str = include_str!("fixtures/scale_g500_ladder.v1.json");
+const CERTIFICATION_PROFILE_JSON: &str = include_str!("fixtures/scale_g500_certification.v1.json");
+
+#[derive(Debug, Deserialize)]
+struct CertificationProfile {
+    schema: String,
+    scale: u32,
+    edgefactor: u32,
+    target_live_edges: u64,
+    seed: u64,
+    initiator: Initiator,
+    envelope: Envelope,
+    preflight_scale: u32,
+    provider_decision: String,
+    runner_label: String,
+}
 
 fn load_profile() -> ScaleProfile {
     serde_json::from_str(PROFILE_JSON).expect("parse ladder profile fixture")
+}
+
+fn load_certification_profile() -> CertificationProfile {
+    serde_json::from_str(CERTIFICATION_PROFILE_JSON).expect("parse certification profile fixture")
 }
 
 // ---------------------------------------------------------------------------
@@ -303,6 +329,51 @@ fn bounded_generation(
         input_fingerprint: format!("sha256:{}", hex_encode(hasher.finalize())),
     };
     (summary, edges)
+}
+
+/// Append deterministic, independently seeded attempt windows until a complete
+/// external merge proves the requested live-edge floor. Every window remains
+/// on disk and the final merge deduplicates across window boundaries, so the
+/// stopping decision never relies on a probabilistic estimate.
+fn generate_target_live_runs(
+    scale: u32,
+    edge_factor: u32,
+    initiator: Initiator,
+    seed: u64,
+    buffer_edges: usize,
+    target_live_edges: u64,
+    work: &Path,
+) -> (SpillRuns, MergeCounts) {
+    let mut combined = SpillRuns {
+        runs: Vec::new(),
+        raw_attempts: 0,
+        self_loops_rejected: 0,
+        peak_buffer_len: 0,
+    };
+    for window in 0u64.. {
+        let window_dir = work.join(format!("window-{window:04}"));
+        fs::create_dir_all(&window_dir).expect("target-live window directory");
+        let window_seed = seed.wrapping_add(window.wrapping_mul(0x9E37_79B9_7F4A_7C15));
+        let generated = generate_spill_runs(
+            scale,
+            edge_factor,
+            initiator,
+            window_seed,
+            buffer_edges,
+            &window_dir,
+        );
+        combined.raw_attempts = combined.raw_attempts.saturating_add(generated.raw_attempts);
+        combined.self_loops_rejected = combined
+            .self_loops_rejected
+            .saturating_add(generated.self_loops_rejected);
+        combined.peak_buffer_len = combined.peak_buffer_len.max(generated.peak_buffer_len);
+        combined.runs.extend(generated.runs);
+        let counts = merge_runs(&combined.runs, |_, _| {});
+        if counts.live_unique_edges >= target_live_edges {
+            return (combined, counts);
+        }
+    }
+    unreachable!("unbounded deterministic window iterator")
 }
 
 // ---------------------------------------------------------------------------
@@ -1195,4 +1266,721 @@ fn ladder_public_facade_first_fail_evidence() {
             "an evaluated rung must reconcile; got {rec}"
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// #745 integrated certification lifecycle. The small test proves that the
+// journaled public-facade path is executable in ordinary CI. The provisioned
+// entry point below uses the same phases after target-live generation.
+// ---------------------------------------------------------------------------
+
+const CERTIFICATION_PHASES: [&str; 17] = [
+    "preflight",
+    "generate",
+    "ingest",
+    "csr",
+    "source_reopen",
+    "source_query_1hop",
+    "source_query_2hop",
+    "export",
+    "verify",
+    "import",
+    "imported_reopen",
+    "imported_query_1hop",
+    "imported_query_2hop",
+    "drill_corruption",
+    "drill_cancellation",
+    "drill_resource_limit",
+    "drill_interrupted_finalization",
+];
+
+struct PhaseJournal {
+    path: PathBuf,
+    phases: Vec<Value>,
+    monitor: ResourceMonitor,
+}
+
+impl PhaseJournal {
+    fn new(path: PathBuf, workspace: &Path, envelope: Envelope) -> Self {
+        Self {
+            path,
+            phases: Vec::new(),
+            monitor: ResourceMonitor::start(workspace.to_path_buf(), envelope),
+        }
+    }
+
+    fn pass(&mut self, id: &str, started: Instant, fingerprint: Option<String>) {
+        let fingerprint = fingerprint.map_or(Value::Null, Value::String);
+        self.monitor.sample_disk();
+        if let Some(code) = self.monitor.failure_code() {
+            self.phases.push(json!({
+                "id": id, "status": "fail",
+                "elapsed_ms": u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+                "rss_peak_bytes": self.monitor.peak_rss.load(Ordering::Relaxed),
+                "disk_peak_bytes": self.monitor.peak_disk.load(Ordering::Relaxed),
+                "fingerprint": fingerprint, "failure_code": code,
+            }));
+            self.flush();
+            panic!("certification resource watchdog stopped phase {id}: {code}");
+        }
+        let rss_peak_bytes = self.monitor.peak_rss.swap(0, Ordering::SeqCst);
+        let disk_peak_bytes = self.monitor.peak_disk.swap(0, Ordering::SeqCst);
+        self.phases.push(json!({
+            "id": id, "status": "pass",
+            "elapsed_ms": u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+            "rss_peak_bytes": rss_peak_bytes,
+            "disk_peak_bytes": disk_peak_bytes,
+            "fingerprint": fingerprint,
+            "failure_code": null,
+        }));
+        self.flush();
+    }
+
+    fn cancellation(&self) -> &AtomicBool {
+        self.monitor.cancellation.flag()
+    }
+
+    fn cancellation_token(&self) -> CancellationToken {
+        self.monitor.cancellation.clone()
+    }
+
+    fn flush(&self) {
+        let staged = self.path.with_extension("json.tmp");
+        fs::write(
+            &staged,
+            serde_json::to_vec_pretty(&self.phases).expect("phase journal JSON"),
+        )
+        .expect("write staged phase journal");
+        fs::rename(staged, &self.path).expect("publish phase journal atomically");
+    }
+}
+
+impl Drop for PhaseJournal {
+    fn drop(&mut self) {
+        let already_failed = self
+            .phases
+            .last()
+            .is_some_and(|phase| phase["status"] != "pass");
+        if already_failed || self.phases.len() >= CERTIFICATION_PHASES.len() {
+            return;
+        }
+        let failure_code = self
+            .monitor
+            .failure_code()
+            .or_else(|| std::thread::panicking().then_some("operation_failed"));
+        if let Some(code) = failure_code {
+            self.monitor.sample_disk();
+            self.phases.push(json!({
+                "id": CERTIFICATION_PHASES[self.phases.len()], "status": "fail",
+                "elapsed_ms": 0,
+                "rss_peak_bytes": self.monitor.peak_rss.load(Ordering::Relaxed),
+                "disk_peak_bytes": self.monitor.peak_disk.load(Ordering::Relaxed),
+                "fingerprint": null, "failure_code": code,
+            }));
+            self.flush();
+        }
+    }
+}
+
+struct ResourceMonitor {
+    workspace: PathBuf,
+    cancellation: CancellationToken,
+    stop: Arc<AtomicBool>,
+    peak_rss: Arc<AtomicU64>,
+    peak_disk: Arc<AtomicU64>,
+    failure: Arc<AtomicU64>,
+    envelope: Envelope,
+    worker: Option<JoinHandle<()>>,
+}
+
+impl ResourceMonitor {
+    fn start(workspace: PathBuf, envelope: Envelope) -> Self {
+        let cancellation = CancellationToken::new();
+        let stop = Arc::new(AtomicBool::new(false));
+        let peak_rss = Arc::new(AtomicU64::new(0));
+        let peak_disk = Arc::new(AtomicU64::new(0));
+        let failure = Arc::new(AtomicU64::new(0));
+        let worker_cancellation = cancellation.clone();
+        let worker_stop = Arc::clone(&stop);
+        let worker_peak_rss = Arc::clone(&peak_rss);
+        let worker_peak_disk = Arc::clone(&peak_disk);
+        let worker_failure = Arc::clone(&failure);
+        let worker_workspace = workspace.clone();
+        let started = Instant::now();
+        let worker = thread::spawn(move || {
+            let mut samples = 0_u8;
+            while !worker_stop.load(Ordering::Relaxed) {
+                let rss = current_rss_bytes();
+                worker_peak_rss.fetch_max(rss, Ordering::Relaxed);
+                let mut code = if rss > envelope.rss_bytes {
+                    1
+                } else if started.elapsed().as_secs() > envelope.timeout_s {
+                    3
+                } else {
+                    0
+                };
+                if samples == 0 {
+                    let disk = allocated_bytes(&worker_workspace);
+                    worker_peak_disk.fetch_max(disk, Ordering::Relaxed);
+                    if disk > envelope.disk_bytes {
+                        code = 2;
+                    }
+                }
+                if code != 0 {
+                    worker_failure
+                        .compare_exchange(0, code, Ordering::SeqCst, Ordering::Relaxed)
+                        .ok();
+                    worker_cancellation.cancel();
+                    break;
+                }
+                samples = (samples + 1) % 20;
+                thread::sleep(Duration::from_millis(250));
+            }
+        });
+        Self {
+            workspace,
+            cancellation,
+            stop,
+            peak_rss,
+            peak_disk,
+            failure,
+            envelope,
+            worker: Some(worker),
+        }
+    }
+
+    fn sample_disk(&self) {
+        let disk = allocated_bytes(&self.workspace);
+        self.peak_disk.fetch_max(disk, Ordering::Relaxed);
+        if disk > self.envelope.disk_bytes {
+            self.failure
+                .compare_exchange(0, 2, Ordering::SeqCst, Ordering::Relaxed)
+                .ok();
+            self.cancellation.cancel();
+        }
+    }
+
+    fn failure_code(&self) -> Option<&'static str> {
+        match self.failure.load(Ordering::SeqCst) {
+            1 => Some("rss_limit_exceeded"),
+            2 => Some("disk_limit_exceeded"),
+            3 => Some("wall_time_limit_exceeded"),
+            _ => None,
+        }
+    }
+}
+
+fn current_rss_bytes() -> u64 {
+    fs::read_to_string("/proc/self/status")
+        .ok()
+        .and_then(|text| {
+            text.lines()
+                .find(|line| line.starts_with("VmRSS:"))?
+                .split_whitespace()
+                .nth(1)?
+                .parse::<u64>()
+                .ok()
+        })
+        .map_or_else(
+            || peak_rss().map_or(0, |value| value.0),
+            |kibibytes| kibibytes.saturating_mul(1024),
+        )
+}
+
+impl Drop for ResourceMonitor {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        if let Some(worker) = self.worker.take() {
+            worker.join().expect("resource watchdog thread");
+        }
+    }
+}
+
+fn allocated_bytes(path: &Path) -> u64 {
+    let output = Command::new("du").arg("-sk").arg(path).output();
+    output
+        .ok()
+        .filter(|out| out.status.success())
+        .and_then(|out| {
+            String::from_utf8(out.stdout)
+                .ok()?
+                .split_whitespace()
+                .next()?
+                .parse::<u64>()
+                .ok()
+        })
+        .unwrap_or(0)
+        .saturating_mul(1024)
+}
+
+fn result_fingerprint(result: &graphforge_api::ExecutionResult) -> String {
+    let mut hasher = Sha256::new();
+    for batch in &result.batches {
+        hasher.update(batch.num_rows().to_le_bytes());
+        hasher.update(batch.num_columns().to_le_bytes());
+        for column in batch.columns() {
+            hasher.update(format!("{:?}", column.data_type()).as_bytes());
+            hasher.update(format!("{column:?}").as_bytes());
+        }
+    }
+    format!("sha256:{}", hex_encode(hasher.finalize()))
+}
+
+#[allow(clippy::too_many_lines)]
+fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value {
+    let source = root.join("source");
+    let imported = root.join("imported");
+    let package = root.join("project.gfpb");
+    fs::create_dir_all(&source).expect("source project directory");
+    let journal_path = std::env::var("GF_G500_CERT_JOURNAL_OUT")
+        .map_or_else(|_| root.join("phase-journal.json"), PathBuf::from);
+    let certification_profile = load_certification_profile();
+    assert_eq!(
+        certification_profile.schema,
+        "graphforge-billion-edge-certification-profile/1"
+    );
+    assert_eq!(
+        certification_profile.provider_decision,
+        "required-at-dispatch"
+    );
+    assert_eq!(certification_profile.runner_label, "required-at-dispatch");
+    let certification_envelope = certification_profile.envelope;
+    let mut journal = PhaseJournal::new(journal_path, root, certification_envelope);
+    let limits = PortableV2Limits::default();
+    let phase = Instant::now();
+    journal.pass("preflight", phase, None);
+
+    let phase = Instant::now();
+    let scale = if target_live.is_some() {
+        certification_profile.scale
+    } else {
+        certification_profile.preflight_scale
+    };
+    let edge_factor = if target_live.is_some() {
+        certification_profile.edgefactor
+    } else {
+        4
+    };
+    let initiator = if target_live.is_some() {
+        certification_profile.initiator
+    } else {
+        load_profile().initiator
+    };
+    let seed = if target_live.is_some() {
+        certification_profile.seed
+    } else {
+        load_profile().seed
+    };
+    let spill_root = root.join("spill");
+    fs::create_dir_all(&spill_root).expect("certification spill root");
+    let (spills, generated_counts) = target_live
+        .map(|target| {
+            generate_target_live_runs(
+                scale,
+                edge_factor,
+                initiator,
+                seed,
+                if scale == 26 { 16_777_216 } else { 512 },
+                target,
+                &spill_root,
+            )
+        })
+        .unzip();
+    let (summary, edges) = if target_live.is_none() {
+        let (summary, edges) = bounded_generation(scale, edge_factor, initiator, seed, 512);
+        assert!(summary.reconciles());
+        (Some(summary), Some(edges))
+    } else {
+        (None, None)
+    };
+    let generation_fingerprint = summary.as_ref().map_or_else(
+        || {
+            format!(
+                "sha256:{}",
+                hex_encode(Sha256::digest(b"target-live-window-set"))
+            )
+        },
+        |value| value.input_fingerprint.clone(),
+    );
+    journal.pass("generate", phase, Some(generation_fingerprint));
+
+    let phase = Instant::now();
+    let graph = GraphForge::new(source.to_str()).expect("open certification source");
+    publish_nodes(&graph, 1u64 << scale);
+    let mut sink = EdgeSink::new(&graph);
+    if let Some(edges) = edges {
+        for (src, dst) in edges {
+            sink.push(src, dst);
+        }
+    } else {
+        merge_runs(&spills.as_ref().expect("target spills").runs, |src, dst| {
+            sink.push(src, dst);
+        });
+    }
+    sink.flush();
+    let input_fingerprint = format!("sha256:{}", sink.finish());
+    journal.pass("ingest", phase, Some(input_fingerprint));
+
+    let phase = Instant::now();
+    let csr = graph
+        .rebuild_adjacency(Some(journal.cancellation_token()))
+        .expect("build certification CSR");
+    journal.pass(
+        "csr",
+        phase,
+        csr.artifact_fingerprint
+            .map(|value| format!("sha256:{value}")),
+    );
+    drop(graph);
+
+    let phase = Instant::now();
+    let graph = GraphForge::new(source.to_str()).expect("reopen source");
+    let source_nodes = graph.node_count(NODE_LABEL).expect("source nodes");
+    let source_edges = scalar_count(&graph.execute(COUNT_EDGES).expect("source edges"));
+    journal.pass("source_reopen", phase, None);
+    let phase = Instant::now();
+    let source_1hop = result_fingerprint(&graph.execute(ONE_HOP).expect("source 1hop"));
+    journal.pass("source_query_1hop", phase, Some(source_1hop.clone()));
+    let phase = Instant::now();
+    let source_2hop = result_fingerprint(&graph.execute(TWO_HOP).expect("source 2hop"));
+    journal.pass("source_query_2hop", phase, Some(source_2hop.clone()));
+
+    let phase = Instant::now();
+    let exported = graph
+        .export_portable_v2(
+            &PortableV2ExportRequest {
+                selection: PortableSelection::Current,
+                output_path: package.clone(),
+                representation: PortableV2Output::Bundle,
+                profile: PortableV2SelectionProfile::Complete,
+                subset: None,
+                limits,
+            },
+            Some(journal.cancellation()),
+            |_| {},
+        )
+        .expect("portable-v2 export");
+    journal.pass("export", phase, Some(exported.package_digest.clone()));
+    let phase = Instant::now();
+    let verified = verify_portable_v2(
+        &PortableVerifyRequest {
+            input: package.clone(),
+            mode: PortableV2Mode::Full,
+            limits,
+        },
+        Some(journal.cancellation()),
+    )
+    .expect("full portable-v2 verification");
+    assert_eq!(verified.package_digest, exported.package_digest);
+    assert_eq!(verified.contract, "graphforge-portable-verify/2");
+    journal.pass("verify", phase, Some(verified.package_digest.clone()));
+
+    let phase = Instant::now();
+    let imported_receipt = GraphForge::import_portable_v2(
+        &imported,
+        &PortableV2ImportRequest {
+            input: package.clone(),
+            operation_id: OperationId(uuidv7(0x745)),
+            limits,
+        },
+        Some(journal.cancellation()),
+    )
+    .expect("atomic portable-v2 import");
+    assert_ne!(exported.generation_uuid, imported_receipt.generation_uuid);
+    journal.pass(
+        "import",
+        phase,
+        Some(imported_receipt.package_digest.clone()),
+    );
+    let phase = Instant::now();
+    let imported_graph = GraphForge::new(imported.to_str()).expect("reopen import");
+    let imported_nodes = imported_graph
+        .node_count(NODE_LABEL)
+        .expect("imported nodes");
+    let imported_edges =
+        scalar_count(&imported_graph.execute(COUNT_EDGES).expect("imported edges"));
+    assert_eq!(
+        (source_nodes, source_edges),
+        (imported_nodes, imported_edges)
+    );
+    journal.pass("imported_reopen", phase, None);
+    let phase = Instant::now();
+    let imported_1hop = result_fingerprint(&imported_graph.execute(ONE_HOP).expect("import 1hop"));
+    assert_eq!(source_1hop, imported_1hop);
+    journal.pass("imported_query_1hop", phase, Some(imported_1hop.clone()));
+    let phase = Instant::now();
+    let imported_2hop = result_fingerprint(&imported_graph.execute(TWO_HOP).expect("import 2hop"));
+    assert_eq!(source_2hop, imported_2hop);
+    journal.pass("imported_query_2hop", phase, Some(imported_2hop.clone()));
+
+    // Representative drills use the same verifier/import boundaries but never
+    // repeat the billion-edge payload.
+    let phase = Instant::now();
+    let corrupt = root.join("corrupt.gfpb");
+    fs::copy(&package, &corrupt).expect("copy corrupt drill");
+    let mut file = fs::OpenOptions::new().append(true).open(&corrupt).unwrap();
+    file.write_all(b"corruption").unwrap();
+    assert!(
+        verify_portable_v2(
+            &PortableVerifyRequest {
+                input: corrupt,
+                mode: PortableV2Mode::Full,
+                limits
+            },
+            None
+        )
+        .is_err()
+    );
+    journal.pass("drill_corruption", phase, None);
+    let phase = Instant::now();
+    let cancelled = AtomicBool::new(true);
+    assert!(
+        verify_portable_v2(
+            &PortableVerifyRequest {
+                input: package.clone(),
+                mode: PortableV2Mode::Full,
+                limits
+            },
+            Some(&cancelled)
+        )
+        .is_err()
+    );
+    journal.pass("drill_cancellation", phase, None);
+    let phase = Instant::now();
+    let tiny = PortableV2Limits {
+        max_entries: 1,
+        ..limits
+    };
+    assert!(
+        verify_portable_v2(
+            &PortableVerifyRequest {
+                input: package.clone(),
+                mode: PortableV2Mode::Full,
+                limits: tiny
+            },
+            None
+        )
+        .is_err()
+    );
+    journal.pass("drill_resource_limit", phase, None);
+    let phase = Instant::now();
+    let interrupted = root.join("interrupted-target");
+    assert!(
+        GraphForge::import_portable_v2(
+            &interrupted,
+            &PortableV2ImportRequest {
+                input: package,
+                operation_id: OperationId(uuidv7(0x746)),
+                limits,
+            },
+            Some(&AtomicBool::new(true))
+        )
+        .is_err()
+    );
+    assert!(!interrupted.join("CURRENT").exists());
+    journal.pass("drill_interrupted_finalization", phase, None);
+
+    assert_eq!(journal.phases.len(), CERTIFICATION_PHASES.len());
+    let project_fingerprint = |nodes: u64, edges: u64, one_hop: &str, two_hop: &str| {
+        let mut digest = Sha256::new();
+        digest.update(nodes.to_le_bytes());
+        digest.update(edges.to_le_bytes());
+        digest.update(one_hop.as_bytes());
+        digest.update(two_hop.as_bytes());
+        format!("sha256:{}", hex_encode(digest.finalize()))
+    };
+    json!({
+        "source_generation": exported.generation_uuid.to_string(),
+        "package": exported.package_digest, "transport": exported.transport_digest,
+        "imported_generation": imported_receipt.generation_uuid.to_string(),
+        "raw_attempts": spills.as_ref().map_or_else(|| summary.as_ref().unwrap().raw_attempts, |value| value.raw_attempts),
+        "self_loops_rejected": spills.as_ref().map_or_else(|| summary.as_ref().unwrap().self_loops_rejected, |value| value.self_loops_rejected),
+        "duplicates_rejected": generated_counts.as_ref().map_or_else(|| summary.as_ref().unwrap().duplicates_rejected, |value| value.duplicates_rejected),
+        "source_nodes": source_nodes, "source_edges": source_edges,
+        "imported_nodes": imported_nodes, "imported_edges": imported_edges,
+        "source_project_fingerprint": project_fingerprint(source_nodes, source_edges, &source_1hop, &source_2hop),
+        "imported_project_fingerprint": project_fingerprint(imported_nodes, imported_edges, &imported_1hop, &imported_2hop),
+        "portable_contract": verified.contract,
+        "package_class": serde_json::to_value(verified.package_class).expect("package class JSON"),
+        "integrity": serde_json::to_value(verified.integrity).expect("integrity JSON"),
+        "compatibility": serde_json::to_value(verified.compatibility).expect("compatibility JSON"),
+        "phases": journal.phases,
+    })
+}
+
+#[test]
+fn certification_lifecycle_journals_equivalent_round_trip_and_drills() {
+    let root = TempDir::new().expect("certification smoke root");
+    let evidence = run_integrated_certification(root.path(), None);
+    assert_eq!(evidence["source_edges"], evidence["imported_edges"]);
+    assert_ne!(
+        evidence["source_generation"],
+        evidence["imported_generation"]
+    );
+}
+
+#[test]
+fn certification_watchdog_persists_typed_first_failure() {
+    let root = TempDir::new().expect("watchdog root");
+    fs::write(root.path().join("allocated.bin"), [0_u8; 4096]).expect("allocated fixture");
+    let journal_path = root.path().join("journal.json");
+    let mut journal = PhaseJournal::new(
+        journal_path.clone(),
+        root.path(),
+        Envelope {
+            rss_bytes: u64::MAX,
+            disk_bytes: 0,
+            timeout_s: u64::MAX,
+        },
+    );
+    let failure = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        journal.pass("resource_probe", Instant::now(), None);
+    }));
+    assert!(failure.is_err());
+    assert!(journal.cancellation().load(Ordering::SeqCst));
+    let persisted: Vec<Value> =
+        serde_json::from_slice(&fs::read(journal_path).expect("persisted failure journal"))
+            .expect("failure journal JSON");
+    assert_eq!(persisted[0]["status"], "fail");
+    assert_eq!(persisted[0]["failure_code"], "disk_limit_exceeded");
+}
+
+#[test]
+fn target_live_windows_are_deterministic_bounded_and_reconciled() {
+    let profile = load_profile();
+    let first = TempDir::new().unwrap();
+    let second = TempDir::new().unwrap();
+    let run = |root: &Path| {
+        let (spills, counts) =
+            generate_target_live_runs(10, 1, profile.initiator, profile.seed, 128, 1_000, root);
+        let mut digest = Sha256::new();
+        let replay = merge_runs(&spills.runs, |src, dst| {
+            digest.update(src.to_le_bytes());
+            digest.update(dst.to_le_bytes());
+        });
+        assert_eq!(counts.live_unique_edges, replay.live_unique_edges);
+        assert_eq!(
+            spills.raw_attempts,
+            counts.live_unique_edges + spills.self_loops_rejected + counts.duplicates_rejected
+        );
+        assert!(counts.live_unique_edges >= 1_000);
+        assert!(spills.peak_buffer_len <= 128);
+        (counts.live_unique_edges, hex_encode(digest.finalize()))
+    };
+    assert_eq!(run(first.path()), run(second.path()));
+}
+
+#[test]
+#[ignore = "requires approved 128 GiB / 1 TiB Linux certification host"]
+fn certification_target_live_full_lifecycle_evidence() {
+    let started = Instant::now();
+    let profile = load_certification_profile();
+    let root = TempDir::new().expect("certification workspace");
+    let lifecycle = run_integrated_certification(root.path(), Some(profile.target_live_edges));
+    let phases = lifecycle["phases"].as_array().expect("phase array");
+    let peak_rss = phases
+        .iter()
+        .filter_map(|p| p["rss_peak_bytes"].as_u64())
+        .max()
+        .unwrap_or(0);
+    let peak_disk = phases
+        .iter()
+        .filter_map(|p| p["disk_peak_bytes"].as_u64())
+        .max()
+        .unwrap_or(0);
+    let source_edges = lifecycle["source_edges"].as_u64().unwrap();
+    assert!(source_edges >= 1_000_000_000);
+    let profile_digest = format!(
+        "sha256:{}",
+        hex_encode(Sha256::digest(include_bytes!(
+            "fixtures/scale_g500_certification.v1.json"
+        )))
+    );
+    let empty_authority = format!(
+        "sha256:{}",
+        hex_encode(Sha256::digest(
+            b"graphforge-empty-ontology-capability-authority/1"
+        ))
+    );
+    let evidence = json!({
+        "schema": "graphforge-billion-edge-certification-evidence/1",
+        "git_sha": std::env::var("GF_G500_CERT_EXPECTED_SHA").unwrap_or_else(|_| git_sha().as_str().unwrap_or("unknown").to_owned()),
+        "profile_sha256": profile_digest,
+        "run": {
+            "command": "cargo test -p graphforge-api --release --test scale_g500_ladder certification_target_live_full_lifecycle_evidence -- --ignored --exact --nocapture --test-threads=1",
+            "scale": profile.scale, "edgefactor": profile.edgefactor, "seed": profile.seed,
+            "directionality": "undirected", "self_loops": "drop", "duplicates": "drop"
+        },
+        "host": {
+            "provider": std::env::var("GF_G500_CERT_PROVIDER").expect("approved provider input"),
+            "sku": std::env::var("GF_G500_CERT_SKU").expect("approved SKU input"),
+            "os": format!("Linux {}", command_text("uname", &["-r"])),
+            "kernel": command_text("uname", &["-r"]),
+            "filesystem": normalized_filesystem(root.path()),
+            "memory_bytes": linux_memory_bytes(),
+            "nvme_bytes": filesystem_capacity_bytes(root.path()),
+        },
+        "tools": { "rustc": command_text("rustc", &["--version"]), "cargo": command_text("cargo", &["--version"]) },
+        "counts": {
+            "raw_attempts": lifecycle["raw_attempts"], "self_loops_rejected": lifecycle["self_loops_rejected"],
+            "duplicates_rejected": lifecycle["duplicates_rejected"], "live_unique_edges": source_edges,
+            "source_nodes": lifecycle["source_nodes"], "source_edges": source_edges,
+            "imported_nodes": lifecycle["imported_nodes"], "imported_edges": lifecycle["imported_edges"],
+        },
+        "identities": { "source_generation": lifecycle["source_generation"], "package": lifecycle["package"], "transport": lifecycle["transport"], "imported_generation": lifecycle["imported_generation"] },
+        "package": {
+            "contract": lifecycle["portable_contract"], "format": "portable-project-v2-bundle",
+            "class": lifecycle["package_class"], "integrity": lifecycle["integrity"],
+            "compatibility": lifecycle["compatibility"],
+            "policy": "complete-current-generation"
+        },
+        "equivalence": { "source_project_fingerprint": lifecycle["source_project_fingerprint"], "imported_project_fingerprint": lifecycle["imported_project_fingerprint"] },
+        "authority": { "source_fingerprint": empty_authority.clone(), "imported_fingerprint": empty_authority },
+        "phases": phases,
+        "envelope": { "peak_rss_bytes": peak_rss, "peak_disk_bytes": peak_disk, "wall_time_s": started.elapsed().as_secs_f64() },
+        "result": "pass", "first_failure": null,
+    });
+    let out = PathBuf::from(std::env::var("GF_G500_CERT_EVIDENCE_OUT").expect("evidence output"));
+    fs::write(out, serde_json::to_vec_pretty(&evidence).unwrap())
+        .expect("write certification evidence");
+}
+
+fn normalized_filesystem(path: &Path) -> String {
+    match command_text("stat", &["-f", "-c", "%T", path.to_str().unwrap()]).as_str() {
+        "ext2/ext3" => "ext4".to_owned(),
+        value => value.to_owned(),
+    }
+}
+
+fn command_text(program: &str, args: &[&str]) -> String {
+    let output = Command::new(program)
+        .args(args)
+        .output()
+        .expect("host attestation command");
+    assert!(output.status.success(), "host attestation command failed");
+    String::from_utf8(output.stdout).unwrap().trim().to_owned()
+}
+
+fn linux_memory_bytes() -> u64 {
+    fs::read_to_string("/proc/meminfo")
+        .ok()
+        .and_then(|text| {
+            text.lines()
+                .find(|line| line.starts_with("MemTotal:"))?
+                .split_whitespace()
+                .nth(1)?
+                .parse::<u64>()
+                .ok()
+        })
+        .unwrap_or(0)
+        .saturating_mul(1024)
+}
+
+fn filesystem_capacity_bytes(path: &Path) -> u64 {
+    command_text("df", &["-k", "--output=size", path.to_str().unwrap()])
+        .lines()
+        .last()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .unwrap_or(0)
+        .saturating_mul(1024)
 }

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -52,8 +52,9 @@ const REL_TYPE: &str = "LINK";
 const BATCH_ROWS: usize = 8_192;
 const EDGE_PUBLISH_ROWS: usize = 1_048_576;
 
-const ONE_HOP: &str = "MATCH (a)-[r]->(b) RETURN b.node_uuid AS id LIMIT 1000";
-const TWO_HOP: &str = "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN c.node_uuid AS id LIMIT 1000";
+const ONE_HOP: &str = "MATCH (a)-[r]->(b) RETURN b.node_uuid AS id ORDER BY id LIMIT 1000";
+const TWO_HOP: &str =
+    "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN c.node_uuid AS id ORDER BY id LIMIT 1000";
 const COUNT_EDGES: &str = "MATCH ()-[r:LINK]->() RETURN count(r) AS total";
 
 // ---------------------------------------------------------------------------
@@ -156,6 +157,7 @@ fn generate_spill_runs(
     seed: u64,
     buffer_edges: usize,
     work: &Path,
+    cancelled: Option<&AtomicBool>,
 ) -> SpillRuns {
     assert!((1..=31).contains(&scale), "SCALE must fit u32 vertex ids");
     assert!(buffer_edges >= 1, "buffer_edges must be positive");
@@ -169,7 +171,13 @@ fn generate_spill_runs(
     let mut self_loops_rejected = 0u64;
     let mut peak_buffer_len = 0usize;
 
-    for _ in 0..raw_attempts {
+    for attempt in 0..raw_attempts {
+        if attempt % 65_536 == 0 {
+            assert!(
+                !cancelled.is_some_and(|flag| flag.load(Ordering::SeqCst)),
+                "certification watchdog cancelled bounded generation"
+            );
+        }
         let (src, dst) = kronecker_edge(scale, initiator, &mut rng);
         if src == dst {
             self_loops_rejected += 1;
@@ -311,6 +319,7 @@ fn bounded_generation(
         seed,
         buffer_edges,
         work.path(),
+        None,
     );
     let mut edges = Vec::new();
     let mut hasher = Sha256::new();
@@ -335,15 +344,29 @@ fn bounded_generation(
 /// external merge proves the requested live-edge floor. Every window remains
 /// on disk and the final merge deduplicates across window boundaries, so the
 /// stopping decision never relies on a probabilistic estimate.
-fn generate_target_live_runs(
+#[derive(Clone, Copy)]
+struct TargetLiveGeneration {
     scale: u32,
     edge_factor: u32,
     initiator: Initiator,
     seed: u64,
     buffer_edges: usize,
     target_live_edges: u64,
+}
+
+fn generate_target_live_runs(
+    request: &TargetLiveGeneration,
     work: &Path,
-) -> (SpillRuns, MergeCounts) {
+    cancelled: &AtomicBool,
+) -> (SpillRuns, MergeCounts, String) {
+    let TargetLiveGeneration {
+        scale,
+        edge_factor,
+        initiator,
+        seed,
+        buffer_edges,
+        target_live_edges,
+    } = *request;
     let mut combined = SpillRuns {
         runs: Vec::new(),
         raw_attempts: 0,
@@ -351,6 +374,10 @@ fn generate_target_live_runs(
         peak_buffer_len: 0,
     };
     for window in 0u64.. {
+        assert!(
+            !cancelled.load(Ordering::SeqCst),
+            "certification watchdog cancelled target-live generation"
+        );
         let window_dir = work.join(format!("window-{window:04}"));
         fs::create_dir_all(&window_dir).expect("target-live window directory");
         let window_seed = seed.wrapping_add(window.wrapping_mul(0x9E37_79B9_7F4A_7C15));
@@ -361,6 +388,7 @@ fn generate_target_live_runs(
             window_seed,
             buffer_edges,
             &window_dir,
+            Some(cancelled),
         );
         combined.raw_attempts = combined.raw_attempts.saturating_add(generated.raw_attempts);
         combined.self_loops_rejected = combined
@@ -368,9 +396,37 @@ fn generate_target_live_runs(
             .saturating_add(generated.self_loops_rejected);
         combined.peak_buffer_len = combined.peak_buffer_len.max(generated.peak_buffer_len);
         combined.runs.extend(generated.runs);
-        let counts = merge_runs(&combined.runs, |_, _| {});
+        let compact_path = work.join(format!("accumulated-{window:04}.bin"));
+        let mut writer = BufWriter::new(File::create(&compact_path).expect("create compact run"));
+        let mut digest = Sha256::new();
+        let counts = merge_runs(&combined.runs, |src, dst| {
+            let src = src.to_le_bytes();
+            let dst = dst.to_le_bytes();
+            writer.write_all(&src).expect("write compact src");
+            writer.write_all(&dst).expect("write compact dst");
+            digest.update(src);
+            digest.update(dst);
+        });
+        writer.flush().expect("flush compact run");
+        drop(writer);
+        for obsolete in &combined.runs {
+            fs::remove_file(obsolete).expect("remove superseded spill run");
+        }
+        combined.runs = vec![compact_path];
         if counts.live_unique_edges >= target_live_edges {
-            return (combined, counts);
+            let duplicates_rejected = combined
+                .raw_attempts
+                .checked_sub(combined.self_loops_rejected)
+                .and_then(|value| value.checked_sub(counts.live_unique_edges))
+                .expect("target-live generator counts reconcile");
+            return (
+                combined,
+                MergeCounts {
+                    live_unique_edges: counts.live_unique_edges,
+                    duplicates_rejected,
+                },
+                format!("sha256:{}", hex_encode(digest.finalize())),
+            );
         }
     }
     unreachable!("unbounded deterministic window iterator")
@@ -484,6 +540,7 @@ fn run_rung(
         profile.seed,
         rung.buffer_edges,
         &spill_dir,
+        None,
     );
     let generate_s = gen_started.elapsed().as_secs_f64();
     let gen_violation = envelope_violation(&env, ladder_started, &project, &spill_dir);
@@ -1395,10 +1452,13 @@ struct ResourceMonitor {
 
 impl ResourceMonitor {
     fn start(workspace: PathBuf, envelope: Envelope) -> Self {
+        let initial_rss = current_rss_bytes().expect("certification host must expose process RSS");
+        let initial_disk = allocated_bytes(&workspace)
+            .expect("certification host must expose allocated disk bytes");
         let cancellation = CancellationToken::new();
         let stop = Arc::new(AtomicBool::new(false));
-        let peak_rss = Arc::new(AtomicU64::new(0));
-        let peak_disk = Arc::new(AtomicU64::new(0));
+        let peak_rss = Arc::new(AtomicU64::new(initial_rss));
+        let peak_disk = Arc::new(AtomicU64::new(initial_disk));
         let failure = Arc::new(AtomicU64::new(0));
         let worker_cancellation = cancellation.clone();
         let worker_stop = Arc::clone(&stop);
@@ -1410,7 +1470,7 @@ impl ResourceMonitor {
         let worker = thread::spawn(move || {
             let mut samples = 0_u8;
             while !worker_stop.load(Ordering::Relaxed) {
-                let rss = current_rss_bytes();
+                let rss = current_rss_bytes().expect("certification RSS probe failed");
                 worker_peak_rss.fetch_max(rss, Ordering::Relaxed);
                 let mut code = if rss > envelope.rss_bytes {
                     1
@@ -1420,7 +1480,8 @@ impl ResourceMonitor {
                     0
                 };
                 if samples == 0 {
-                    let disk = allocated_bytes(&worker_workspace);
+                    let disk = allocated_bytes(&worker_workspace)
+                        .expect("certification disk probe failed");
                     worker_peak_disk.fetch_max(disk, Ordering::Relaxed);
                     if disk > envelope.disk_bytes {
                         code = 2;
@@ -1450,7 +1511,7 @@ impl ResourceMonitor {
     }
 
     fn sample_disk(&self) {
-        let disk = allocated_bytes(&self.workspace);
+        let disk = allocated_bytes(&self.workspace).expect("certification disk probe failed");
         self.peak_disk.fetch_max(disk, Ordering::Relaxed);
         if disk > self.envelope.disk_bytes {
             self.failure
@@ -1470,7 +1531,7 @@ impl ResourceMonitor {
     }
 }
 
-fn current_rss_bytes() -> u64 {
+fn current_rss_bytes() -> Result<u64, &'static str> {
     fs::read_to_string("/proc/self/status")
         .ok()
         .and_then(|text| {
@@ -1481,10 +1542,9 @@ fn current_rss_bytes() -> u64 {
                 .parse::<u64>()
                 .ok()
         })
-        .map_or_else(
-            || peak_rss().map_or(0, |value| value.0),
-            |kibibytes| kibibytes.saturating_mul(1024),
-        )
+        .map(|kibibytes| kibibytes.saturating_mul(1024))
+        .or_else(|| peak_rss().map(|value| value.0))
+        .ok_or("process RSS is unavailable")
 }
 
 impl Drop for ResourceMonitor {
@@ -1496,7 +1556,7 @@ impl Drop for ResourceMonitor {
     }
 }
 
-fn allocated_bytes(path: &Path) -> u64 {
+fn allocated_bytes(path: &Path) -> Result<u64, &'static str> {
     let output = Command::new("du").arg("-sk").arg(path).output();
     output
         .ok()
@@ -1509,18 +1569,65 @@ fn allocated_bytes(path: &Path) -> u64 {
                 .parse::<u64>()
                 .ok()
         })
-        .unwrap_or(0)
-        .saturating_mul(1024)
+        .map(|kibibytes| kibibytes.saturating_mul(1024))
+        .ok_or("allocated disk usage is unavailable")
 }
 
 fn result_fingerprint(result: &graphforge_api::ExecutionResult) -> String {
     let mut hasher = Sha256::new();
+    if let Some(batch) = result.batches.first() {
+        for field in batch.schema().fields() {
+            hasher.update(field.name().as_bytes());
+            hasher.update([0]);
+            hasher.update(field.data_type().to_string().as_bytes());
+            hasher.update([u8::from(field.is_nullable())]);
+        }
+    }
     for batch in &result.batches {
-        hasher.update(batch.num_rows().to_le_bytes());
-        hasher.update(batch.num_columns().to_le_bytes());
-        for column in batch.columns() {
-            hasher.update(format!("{:?}", column.data_type()).as_bytes());
-            hasher.update(format!("{column:?}").as_bytes());
+        for row in 0..batch.num_rows() {
+            for column in batch.columns() {
+                let value = arrow::util::display::array_value_to_string(column, row)
+                    .expect("canonical Arrow display value");
+                hasher.update(value.len().to_le_bytes());
+                hasher.update(value.as_bytes());
+            }
+        }
+    }
+    format!("sha256:{}", hex_encode(hasher.finalize()))
+}
+
+fn authority_fingerprint(graph: &GraphForge) -> String {
+    let mut hasher = Sha256::new();
+    let ontology = graph.workspace_ontology().expect("workspace ontology");
+    hasher.update(
+        ontology
+            .to_canonical_json()
+            .expect("canonical workspace ontology"),
+    );
+    hasher.update(
+        graph
+            .workspace_configuration()
+            .expect("workspace configuration authority")
+            .to_canonical_json()
+            .expect("canonical workspace configuration"),
+    );
+    let capabilities = graph
+        .project_capabilities()
+        .expect("project capability authority");
+    // The final public column is the generation identity, which is expected to
+    // change during import and therefore is not capability authority.
+    for field in capabilities.schema.fields().iter().take(4) {
+        hasher.update(field.name().as_bytes());
+        hasher.update(field.data_type().to_string().as_bytes());
+    }
+    for batch in &capabilities.batches {
+        for row in 0..batch.num_rows() {
+            for column in batch.columns().iter().take(4) {
+                let value = arrow::util::display::array_value_to_string(column, row)
+                    .expect("canonical capability value");
+                hasher.update(value.len().to_le_bytes());
+                hasher.update(value.as_bytes());
+            }
         }
     }
     format!("sha256:{}", hex_encode(hasher.finalize()))
@@ -1573,19 +1680,24 @@ fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value 
     };
     let spill_root = root.join("spill");
     fs::create_dir_all(&spill_root).expect("certification spill root");
-    let (spills, generated_counts) = target_live
-        .map(|target| {
-            generate_target_live_runs(
+    let generated = target_live.map(|target| {
+        generate_target_live_runs(
+            &TargetLiveGeneration {
                 scale,
                 edge_factor,
                 initiator,
                 seed,
-                if scale == 26 { 16_777_216 } else { 512 },
-                target,
-                &spill_root,
-            )
-        })
-        .unzip();
+                buffer_edges: if scale == 26 { 16_777_216 } else { 512 },
+                target_live_edges: target,
+            },
+            &spill_root,
+            journal.cancellation(),
+        )
+    });
+    let (spills, generated_counts, target_live_fingerprint) = generated
+        .map_or((None, None, None), |(spills, counts, fingerprint)| {
+            (Some(spills), Some(counts), Some(fingerprint))
+        });
     let (summary, edges) = if target_live.is_none() {
         let (summary, edges) = bounded_generation(scale, edge_factor, initiator, seed, 512);
         assert!(summary.reconciles());
@@ -1594,12 +1706,7 @@ fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value 
         (None, None)
     };
     let generation_fingerprint = summary.as_ref().map_or_else(
-        || {
-            format!(
-                "sha256:{}",
-                hex_encode(Sha256::digest(b"target-live-window-set"))
-            )
-        },
+        || target_live_fingerprint.expect("target-live payload fingerprint"),
         |value| value.input_fingerprint.clone(),
     );
     journal.pass("generate", phase, Some(generation_fingerprint));
@@ -1643,6 +1750,7 @@ fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value 
     journal.pass("source_query_1hop", phase, Some(source_1hop.clone()));
     let phase = Instant::now();
     let source_2hop = result_fingerprint(&graph.execute(TWO_HOP).expect("source 2hop"));
+    let source_authority_fingerprint = authority_fingerprint(&graph);
     journal.pass("source_query_2hop", phase, Some(source_2hop.clone()));
 
     let phase = Instant::now();
@@ -1710,7 +1818,9 @@ fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value 
     journal.pass("imported_query_1hop", phase, Some(imported_1hop.clone()));
     let phase = Instant::now();
     let imported_2hop = result_fingerprint(&imported_graph.execute(TWO_HOP).expect("import 2hop"));
+    let imported_authority_fingerprint = authority_fingerprint(&imported_graph);
     assert_eq!(source_2hop, imported_2hop);
+    assert_eq!(source_authority_fingerprint, imported_authority_fingerprint);
     journal.pass("imported_query_2hop", phase, Some(imported_2hop.clone()));
 
     // Representative drills use the same verifier/import boundaries but never
@@ -1718,8 +1828,14 @@ fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value 
     let phase = Instant::now();
     let corrupt = root.join("corrupt.gfpb");
     fs::copy(&package, &corrupt).expect("copy corrupt drill");
-    let mut file = fs::OpenOptions::new().append(true).open(&corrupt).unwrap();
-    file.write_all(b"corruption").unwrap();
+    {
+        let mut file = fs::OpenOptions::new()
+            .append(true)
+            .open(&corrupt)
+            .expect("open corrupt drill package");
+        file.write_all(b"corruption").expect("append corruption");
+        file.flush().expect("flush corruption");
+    }
     assert!(
         verify_portable_v2(
             &PortableVerifyRequest {
@@ -1796,6 +1912,7 @@ fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value 
         "raw_attempts": spills.as_ref().map_or_else(|| summary.as_ref().unwrap().raw_attempts, |value| value.raw_attempts),
         "self_loops_rejected": spills.as_ref().map_or_else(|| summary.as_ref().unwrap().self_loops_rejected, |value| value.self_loops_rejected),
         "duplicates_rejected": generated_counts.as_ref().map_or_else(|| summary.as_ref().unwrap().duplicates_rejected, |value| value.duplicates_rejected),
+        "generated_live_unique_edges": generated_counts.as_ref().map_or_else(|| summary.as_ref().unwrap().live_unique_edges, |value| value.live_unique_edges),
         "source_nodes": source_nodes, "source_edges": source_edges,
         "imported_nodes": imported_nodes, "imported_edges": imported_edges,
         "source_project_fingerprint": project_fingerprint(source_nodes, source_edges, &source_1hop, &source_2hop),
@@ -1804,6 +1921,8 @@ fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value 
         "package_class": serde_json::to_value(verified.package_class).expect("package class JSON"),
         "integrity": serde_json::to_value(verified.integrity).expect("integrity JSON"),
         "compatibility": serde_json::to_value(verified.compatibility).expect("compatibility JSON"),
+        "source_authority_fingerprint": source_authority_fingerprint,
+        "imported_authority_fingerprint": imported_authority_fingerprint,
         "phases": journal.phases,
     })
 }
@@ -1851,8 +1970,19 @@ fn target_live_windows_are_deterministic_bounded_and_reconciled() {
     let first = TempDir::new().unwrap();
     let second = TempDir::new().unwrap();
     let run = |root: &Path| {
-        let (spills, counts) =
-            generate_target_live_runs(10, 1, profile.initiator, profile.seed, 128, 1_000, root);
+        let cancelled = AtomicBool::new(false);
+        let (spills, counts, generated_fingerprint) = generate_target_live_runs(
+            &TargetLiveGeneration {
+                scale: 10,
+                edge_factor: 1,
+                initiator: profile.initiator,
+                seed: profile.seed,
+                buffer_edges: 128,
+                target_live_edges: 1_000,
+            },
+            root,
+            &cancelled,
+        );
         let mut digest = Sha256::new();
         let replay = merge_runs(&spills.runs, |src, dst| {
             digest.update(src.to_le_bytes());
@@ -1865,7 +1995,11 @@ fn target_live_windows_are_deterministic_bounded_and_reconciled() {
         );
         assert!(counts.live_unique_edges >= 1_000);
         assert!(spills.peak_buffer_len <= 128);
-        (counts.live_unique_edges, hex_encode(digest.finalize()))
+        assert_eq!(
+            generated_fingerprint,
+            format!("sha256:{}", hex_encode(digest.finalize()))
+        );
+        (counts.live_unique_edges, generated_fingerprint)
     };
     assert_eq!(run(first.path()), run(second.path()));
 }
@@ -1889,18 +2023,14 @@ fn certification_target_live_full_lifecycle_evidence() {
         .max()
         .unwrap_or(0);
     let source_edges = lifecycle["source_edges"].as_u64().unwrap();
+    let generated_live_edges = lifecycle["generated_live_unique_edges"].as_u64().unwrap();
     assert!(source_edges >= 1_000_000_000);
+    assert_eq!(source_edges, generated_live_edges);
     let profile_digest = format!(
         "sha256:{}",
         hex_encode(Sha256::digest(include_bytes!(
             "fixtures/scale_g500_certification.v1.json"
         )))
-    );
-    let empty_authority = format!(
-        "sha256:{}",
-        hex_encode(Sha256::digest(
-            b"graphforge-empty-ontology-capability-authority/1"
-        ))
     );
     let evidence = json!({
         "schema": "graphforge-billion-edge-certification-evidence/1",
@@ -1914,7 +2044,7 @@ fn certification_target_live_full_lifecycle_evidence() {
         "host": {
             "provider": std::env::var("GF_G500_CERT_PROVIDER").expect("approved provider input"),
             "sku": std::env::var("GF_G500_CERT_SKU").expect("approved SKU input"),
-            "os": format!("Linux {}", command_text("uname", &["-r"])),
+            "os": command_text("uname", &["-s"]),
             "kernel": command_text("uname", &["-r"]),
             "filesystem": normalized_filesystem(root.path()),
             "memory_bytes": linux_memory_bytes(),
@@ -1923,7 +2053,7 @@ fn certification_target_live_full_lifecycle_evidence() {
         "tools": { "rustc": command_text("rustc", &["--version"]), "cargo": command_text("cargo", &["--version"]) },
         "counts": {
             "raw_attempts": lifecycle["raw_attempts"], "self_loops_rejected": lifecycle["self_loops_rejected"],
-            "duplicates_rejected": lifecycle["duplicates_rejected"], "live_unique_edges": source_edges,
+            "duplicates_rejected": lifecycle["duplicates_rejected"], "live_unique_edges": generated_live_edges,
             "source_nodes": lifecycle["source_nodes"], "source_edges": source_edges,
             "imported_nodes": lifecycle["imported_nodes"], "imported_edges": lifecycle["imported_edges"],
         },
@@ -1935,7 +2065,7 @@ fn certification_target_live_full_lifecycle_evidence() {
             "policy": "complete-current-generation"
         },
         "equivalence": { "source_project_fingerprint": lifecycle["source_project_fingerprint"], "imported_project_fingerprint": lifecycle["imported_project_fingerprint"] },
-        "authority": { "source_fingerprint": empty_authority.clone(), "imported_fingerprint": empty_authority },
+        "authority": { "source_fingerprint": lifecycle["source_authority_fingerprint"], "imported_fingerprint": lifecycle["imported_authority_fingerprint"] },
         "phases": phases,
         "envelope": { "peak_rss_bytes": peak_rss, "peak_disk_bytes": peak_disk, "wall_time_s": started.elapsed().as_secs_f64() },
         "result": "pass", "first_failure": null,

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -199,6 +199,7 @@ export default defineConfig({
             { label: 'Contributing', slug: 'development/contributing' },
             { label: 'Workflow', slug: 'development/workflow' },
             { label: 'Testing Strategy', slug: 'development/testing' },
+            { label: 'Billion-edge certification', slug: 'development/g500-certification' },
             { label: 'Product roadmap', slug: 'releases/roadmap' },
             { label: 'Publishing', slug: 'engineering/publishing' },
             { label: 'Release Process', slug: 'development/release-process' },

--- a/docs-site/scripts/sync-content.mjs
+++ b/docs-site/scripts/sync-content.mjs
@@ -111,6 +111,7 @@ const PAGES = [
   'development/contributing.md',
   'development/workflow.md',
   'development/testing.md',
+  'development/g500-certification.md',
   'development/release-load-matrix.md',
   'development/release-process.md',
   'development/publication-order.md',

--- a/docs/development/evidence/g500-certification.schema.json
+++ b/docs/development/evidence/g500-certification.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://graphforge.dev/schemas/g500-certification-evidence-1.json",
+  "title": "GraphForge billion-live-edge certification evidence",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "git_sha", "profile_sha256", "run", "host", "tools", "counts", "identities", "package", "authority", "equivalence", "phases", "envelope", "result", "first_failure"],
+  "properties": {
+    "schema": { "const": "graphforge-billion-edge-certification-evidence/1" },
+    "git_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "profile_sha256": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "run": { "type": "object", "additionalProperties": false, "required": ["command", "scale", "edgefactor", "seed", "directionality", "self_loops", "duplicates"], "properties": { "command": { "const": "cargo test -p graphforge-api --release --test scale_g500_ladder certification_target_live_full_lifecycle_evidence -- --ignored --exact --nocapture --test-threads=1" }, "scale": { "const": 26 }, "edgefactor": { "const": 16 }, "seed": { "const": 1 }, "directionality": { "const": "undirected" }, "self_loops": { "const": "drop" }, "duplicates": { "const": "drop" } } },
+    "host": {
+      "type": "object", "additionalProperties": false,
+      "required": ["provider", "sku", "os", "kernel", "filesystem", "memory_bytes", "nvme_bytes"],
+      "properties": {
+        "provider": { "type": "string", "minLength": 1, "maxLength": 64 },
+        "sku": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "os": { "type": "string", "pattern": "^Linux" },
+        "kernel": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "filesystem": { "enum": ["ext4", "xfs", "btrfs"] },
+        "memory_bytes": { "type": "integer", "minimum": 137438953472 },
+        "nvme_bytes": { "type": "integer", "minimum": 1099511627776 }
+      }
+    },
+    "tools": { "type": "object", "additionalProperties": { "type": "string", "maxLength": 128 } },
+    "counts": {
+      "type": "object", "additionalProperties": false,
+      "required": ["raw_attempts", "self_loops_rejected", "duplicates_rejected", "live_unique_edges", "source_nodes", "source_edges", "imported_nodes", "imported_edges"],
+      "properties": {
+        "raw_attempts": { "type": "integer", "minimum": 1000000000 },
+        "self_loops_rejected": { "type": "integer", "minimum": 0 },
+        "duplicates_rejected": { "type": "integer", "minimum": 0 },
+        "live_unique_edges": { "type": "integer", "minimum": 1000000000 },
+        "source_nodes": { "const": 67108864 }, "source_edges": { "type": "integer", "minimum": 1000000000 },
+        "imported_nodes": { "const": 67108864 }, "imported_edges": { "type": "integer", "minimum": 1000000000 }
+      }
+    },
+    "identities": {
+      "type": "object", "additionalProperties": false,
+      "required": ["source_generation", "package", "transport", "imported_generation"],
+      "properties": {
+        "source_generation": { "$ref": "#/$defs/nonSecretIdentity" },
+        "package": { "$ref": "#/$defs/sha256" }, "transport": { "$ref": "#/$defs/sha256" },
+        "imported_generation": { "$ref": "#/$defs/nonSecretIdentity" }
+      }
+    },
+    "package": { "type": "object", "additionalProperties": false, "required": ["contract", "format", "class", "integrity", "compatibility", "policy"], "properties": { "contract": { "const": "graphforge-portable-verify/2" }, "format": { "const": "portable-project-v2-bundle" }, "class": { "const": "complete" }, "integrity": { "const": "verified" }, "compatibility": { "const": "supported" }, "policy": { "const": "complete-current-generation" } } },
+    "authority": { "type": "object", "required": ["source_fingerprint", "imported_fingerprint"], "properties": { "source_fingerprint": { "$ref": "#/$defs/sha256" }, "imported_fingerprint": { "$ref": "#/$defs/sha256" } }, "additionalProperties": false },
+    "equivalence": { "type": "object", "additionalProperties": false, "required": ["source_project_fingerprint", "imported_project_fingerprint"], "properties": { "source_project_fingerprint": { "$ref": "#/$defs/sha256" }, "imported_project_fingerprint": { "$ref": "#/$defs/sha256" } } },
+    "phases": { "type": "array", "minItems": 17, "maxItems": 32, "items": { "$ref": "#/$defs/phase" } },
+    "envelope": { "type": "object", "required": ["peak_rss_bytes", "peak_disk_bytes", "wall_time_s"], "properties": { "peak_rss_bytes": { "type": "integer", "maximum": 137438953472 }, "peak_disk_bytes": { "type": "integer", "maximum": 1099511627776 }, "wall_time_s": { "type": "number", "maximum": 14400 } }, "additionalProperties": false },
+    "result": { "enum": ["pass", "fail"] },
+    "first_failure": { "type": ["object", "null"] }
+  },
+  "$defs": {
+    "sha256": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "nonSecretIdentity": { "type": "string", "pattern": "^[0-9a-f-]{32,64}$" },
+    "phase": { "type": "object", "additionalProperties": false, "required": ["id", "status", "elapsed_ms", "rss_peak_bytes", "disk_peak_bytes"], "properties": { "id": { "type": "string", "pattern": "^[a-z0-9_-]+$" }, "status": { "enum": ["pass", "fail", "cancelled"] }, "elapsed_ms": { "type": "integer", "minimum": 0 }, "rss_peak_bytes": { "type": "integer", "minimum": 0 }, "disk_peak_bytes": { "type": "integer", "minimum": 0 }, "fingerprint": { "anyOf": [{ "$ref": "#/$defs/sha256" }, { "type": "null" }] }, "failure_code": { "type": ["string", "null"], "maxLength": 96 } } }
+  }
+}

--- a/docs/development/g500-certification.md
+++ b/docs/development/g500-certification.md
@@ -1,0 +1,54 @@
+# Billion-live-edge certification
+
+Issue #745 certifies the complete persisted GraphForge lifecycle on an explicitly
+provisioned Linux evidence host. The workflow is manual, protected by the
+`scale-certification` GitHub environment, and never provisions infrastructure.
+A maintainer must approve the provider, exact SKU, ephemeral runner label, cost,
+and teardown before dispatch.
+
+The committed profile fixes SCALE 26, seed 1, the Graph500/R-MAT initiator,
+undirected canonicalization, and a **target-live** stopping rule. Deterministic
+attempt windows are externally sorted and merged until a complete merge proves
+at least one billion unique canonical live edges. Raw attempts are never called
+live edges, and evidence must reconcile attempts, self-loops, duplicates, and
+unique edges.
+
+## Dispatch and abort policy
+
+1. Freeze the exact commit after normal PR CI is green.
+2. Provision a fresh Linux host with at least 128 GiB RAM and 1 TiB local NVMe
+   formatted as ext4, XFS, or Btrfs. Register it with one unique runner label.
+3. Configure required reviewers on the `scale-certification` environment.
+4. Dispatch `Billion-edge certification` with the exact 40-character SHA,
+   runner label, provider, and SKU. Branch names and moving refs are rejected.
+5. Do not retry an unchanged failing tree. Preserve the partial phase journal,
+   identify the first failed phase, repair the root cause, and certify a new SHA.
+6. Deregister and destroy the host after artifacts are uploaded. Never retain
+   the project, portable bundle, credentials, registry tokens, or spill files.
+
+The workflow has a four-hour outer timeout. An in-process watchdog samples Linux
+resident memory every 250 ms and allocated workspace bytes every five seconds,
+sets the shared cooperative-cancellation token on the first RSS, disk, or time
+breach, and records a typed failure at the affected phase. The Rust journal is
+atomically replaced after each phase so cancellation or host loss retains the
+last complete bounded observation. The validator rejects capacity or runtime
+breaches.
+
+## Required phases and evidence
+
+The same public Rust-facade run performs preflight, target-live generation,
+bounded ingest, CSR construction, source reopen and one/two-hop observations,
+portable-v2 bundle export, full verification, atomic import, imported reopen and
+matching observations, plus representative corruption, cancellation, resource
+limit, and interrupted-finalization drills. Source generation, semantic package,
+transport, and imported generation identities remain distinct and reconciled.
+
+Only the sanitized JSON evidence and phase journal may be downloaded and checked
+in. The schema and semantic validator reject missing phases, count or authority
+mismatches, query-fingerprint drift, identity collapse, unsafe paths, sensitive
+fields, insufficient hosts, and envelope overruns. Project payloads, bundles,
+spills, secrets, credentials, absolute host paths, and mutable runner state are
+not evidence and must never be committed.
+
+Local developer runs validate the small lifecycle and hostile fixtures only;
+they are not certification evidence and cannot close #745.

--- a/docs/development/perf-g500-ladder.md
+++ b/docs/development/perf-g500-ladder.md
@@ -140,3 +140,8 @@ Graph500 runs **must not** be wired into normal GitHub Actions. Only the S10 CI
 rung runs in `test.yml`. SCALE-20+ / #745 certification must run on an
 **approved dedicated Linux cloud evidence job** (or equivalent provisioned host)
 tracked with #745 — not on developer laptops.
+
+The target-live SCALE-26 lifecycle, protected dispatch policy, typed phase
+journal, and sanitized evidence contract are defined in the
+[billion-live-edge certification runbook](g500-certification.md). The ladder is
+preflight evidence only; it cannot substitute for that exact-SHA lifecycle.

--- a/scripts/ci/test-ci-storage-policy.py
+++ b/scripts/ci/test-ci-storage-policy.py
@@ -97,6 +97,7 @@ EXPECTED_ARTIFACT_UPLOADS = Counter(
         "native-oracle-macos-${{ github.sha }}": 1,
         "native-durability-aggregate-${{ github.sha }}": 1,
         "m6-memory-${{ github.sha }}-blacksmith-4vcpu-ubuntu-2404": 1,
+        "g500-certification-${{ inputs.commit_sha }}": 1,
     }
 )
 EXPECTED_ARTIFACT_DOWNLOADS = Counter(
@@ -263,6 +264,7 @@ def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
                 "native-oracle-windows-",
                 "native-oracle-macos-",
                 "native-durability-aggregate-",
+                "g500-certification-",
             )
         )
         expected_retention = "30" if publication else "14" if certification else "1"
@@ -302,6 +304,10 @@ def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
             "${{ runner.temp }}/durability-certification-evidence",
             "native/native-durability-aggregate.json",
             "replay-memory.txt\ncompaction-memory.txt",
+            (
+                "${{ runner.temp }}/g500-certification-evidence.json\n"
+                "${{ runner.temp }}/g500-certification-phase-journal.json"
+            ),
         }, f"artifact upload contains unapproved bytes: {path}"
         uploaded.append(name)
     for step in action_steps(text, "actions/download-artifact@"):
@@ -385,6 +391,30 @@ def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
                 )
         downloaded.append(selector)
     return uploaded, downloaded
+
+
+def validate_g500_artifact_negative_fixtures() -> None:
+    text = (WORKFLOWS / "g500-certification.yml").read_text()
+    artifact_contracts(text)
+    mutations = (
+        text.replace(
+            "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1",
+            "actions/upload-artifact@65f0bc87b66c8c4f1891f20b5c7a8028c9d7c796 # v4.6.2",
+            1,
+        ),
+        text.replace("retention-days: 14", "retention-days: 30", 1),
+        text.replace(
+            "            ${{ runner.temp }}/g500-certification-phase-journal.json",
+            "            ${{ runner.temp }}/project.gfpb",
+            1,
+        ),
+    )
+    for mutation in mutations:
+        try:
+            artifact_contracts(mutation)
+        except AssertionError:
+            continue
+        raise AssertionError("G500 artifact policy accepted an unsafe mutation")
 
 
 def cache_contracts(text: str) -> tuple[list[str], list[str]]:
@@ -614,6 +644,7 @@ def main() -> None:
     test_suite = texts[WORKFLOWS / "test.yml"]
     validate_test_suite_trigger(test_suite)
     validate_required_run_negative_fixtures()
+    validate_g500_artifact_negative_fixtures()
     validate_ci_gate_cutover(test_suite)
     jobs = workflow_jobs(test_suite)
     for job_id, runner in (

--- a/scripts/ci/test-ci-storage-policy.py
+++ b/scripts/ci/test-ci-storage-policy.py
@@ -396,13 +396,21 @@ def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
 def validate_g500_artifact_negative_fixtures() -> None:
     text = (WORKFLOWS / "g500-certification.yml").read_text()
     artifact_contracts(text)
+    g500_marker = "          name: g500-certification-${{ inputs.commit_sha }}"
+    g500_start = text.index(g500_marker)
+    retention = "          retention-days: 14"
+    retention_at = text.index(retention, g500_start)
+    retention_mutation = (
+        text[:retention_at] + "          retention-days: 30" + text[retention_at + len(retention) :]
+    )
+    assert retention_mutation[g500_start:].count("retention-days: 30") == 1
     mutations = (
         text.replace(
             "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1",
             "actions/upload-artifact@65f0bc87b66c8c4f1891f20b5c7a8028c9d7c796 # v4.6.2",
             1,
         ),
-        text.replace("retention-days: 14", "retention-days: 30", 1),
+        retention_mutation,
         text.replace(
             "            ${{ runner.temp }}/g500-certification-phase-journal.json",
             "            ${{ runner.temp }}/project.gfpb",

--- a/scripts/ci/test-validate-g500-certification.py
+++ b/scripts/ci/test-validate-g500-certification.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+import pytest
+
+SCRIPT = Path(__file__).with_name("validate-g500-certification.py")
+SPEC = importlib.util.spec_from_file_location("g500_validator", SCRIPT)
+assert SPEC and SPEC.loader
+VALIDATOR = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(VALIDATOR)
+
+SHA = "a" * 40
+DIGEST_A = "sha256:" + "a" * 64
+DIGEST_B = "sha256:" + "b" * 64
+
+
+def evidence():
+    phases = []
+    for phase in VALIDATOR.REQUIRED_PHASES:
+        fingerprint = DIGEST_A if "query_1hop" in phase else DIGEST_B
+        phases.append(
+            {
+                "id": phase,
+                "status": "pass",
+                "elapsed_ms": 1,
+                "rss_peak_bytes": 1,
+                "disk_peak_bytes": 1,
+                "fingerprint": fingerprint,
+            }
+        )
+    return {
+        "schema": "graphforge-billion-edge-certification-evidence/1",
+        "git_sha": SHA,
+        "profile_sha256": "sha256:" + hashlib.sha256(VALIDATOR.PROFILE.read_bytes()).hexdigest(),
+        "run": {
+            "command": VALIDATOR.RUN_COMMAND,
+            "scale": 26,
+            "edgefactor": 16,
+            "seed": 1,
+            "directionality": "undirected",
+            "self_loops": "drop",
+            "duplicates": "drop",
+        },
+        "host": {
+            "provider": "example",
+            "sku": "cert",
+            "os": "Linux",
+            "kernel": "6",
+            "filesystem": "xfs",
+            "memory_bytes": 137_438_953_472,
+            "nvme_bytes": 1_099_511_627_776,
+        },
+        "tools": {"rustc": "1.90"},
+        "counts": {
+            "raw_attempts": 1_000_000_002,
+            "self_loops_rejected": 1,
+            "duplicates_rejected": 1,
+            "live_unique_edges": 1_000_000_000,
+            "source_nodes": 67_108_864,
+            "source_edges": 1_000_000_000,
+            "imported_nodes": 67_108_864,
+            "imported_edges": 1_000_000_000,
+        },
+        "identities": {
+            "source_generation": "11111111-1111-1111-1111-111111111111",
+            "package": DIGEST_A,
+            "transport": DIGEST_B,
+            "imported_generation": "22222222-2222-2222-2222-222222222222",
+        },
+        "package": {
+            "contract": "graphforge-portable-verify/2",
+            "format": "portable-project-v2-bundle",
+            "class": "complete",
+            "integrity": "verified",
+            "compatibility": "supported",
+            "policy": "complete-current-generation",
+        },
+        "authority": {"source_fingerprint": DIGEST_A, "imported_fingerprint": DIGEST_A},
+        "equivalence": {
+            "source_project_fingerprint": DIGEST_A,
+            "imported_project_fingerprint": DIGEST_A,
+        },
+        "phases": phases,
+        "envelope": {"peak_rss_bytes": 1, "peak_disk_bytes": 1, "wall_time_s": 1},
+        "result": "pass",
+        "first_failure": None,
+    }
+
+
+def test_accepts_complete_sanitized_evidence():
+    schema = Path("docs/development/evidence/g500-certification.schema.json")
+    contract = json.loads(schema.read_text())
+    Draft202012Validator.check_schema(contract)
+    Draft202012Validator(contract).validate(evidence())
+    VALIDATOR.validate(evidence(), SHA)
+
+
+@pytest.mark.parametrize("mutation", ["short", "identity", "authority", "path", "rss", "phase"])
+def test_rejects_incomplete_or_unsafe_evidence(mutation):
+    value = evidence()
+    if mutation == "short":
+        value["counts"]["live_unique_edges"] -= 1
+    if mutation == "identity":
+        value["identities"]["imported_generation"] = value["identities"]["source_generation"]
+    if mutation == "authority":
+        value["authority"]["imported_fingerprint"] = DIGEST_B
+    if mutation == "path":
+        value["tools"]["rustc"] = "/usr/bin/rustc"
+    if mutation == "rss":
+        value["envelope"]["peak_rss_bytes"] = 137_438_953_473
+    if mutation == "phase":
+        value["phases"].pop()
+    with pytest.raises(VALIDATOR.EvidenceError):
+        VALIDATOR.validate(value, SHA)

--- a/scripts/ci/test-validate-g500-certification.py
+++ b/scripts/ci/test-validate-g500-certification.py
@@ -93,27 +93,82 @@ def evidence():
 
 
 def test_accepts_complete_sanitized_evidence():
-    schema = Path("docs/development/evidence/g500-certification.schema.json")
+    schema = VALIDATOR.ROOT / "docs/development/evidence/g500-certification.schema.json"
     contract = json.loads(schema.read_text())
     Draft202012Validator.check_schema(contract)
     Draft202012Validator(contract).validate(evidence())
     VALIDATOR.validate(evidence(), SHA)
 
 
-@pytest.mark.parametrize("mutation", ["short", "identity", "authority", "path", "rss", "phase"])
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "short",
+        "unreconciled",
+        "run",
+        "identity",
+        "authority",
+        "missing_authority",
+        "path",
+        "rss",
+        "disk",
+        "wall_time",
+        "phase",
+        "package",
+        "equivalence",
+        "missing_equivalence",
+        "provider",
+        "capacity",
+        "failed_result",
+        "missing_node_count",
+    ],
+)
 def test_rejects_incomplete_or_unsafe_evidence(mutation):
     value = evidence()
     if mutation == "short":
-        value["counts"]["live_unique_edges"] -= 1
+        for key in ("raw_attempts", "live_unique_edges", "source_edges", "imported_edges"):
+            value["counts"][key] -= 1
+    if mutation == "unreconciled":
+        value["counts"]["raw_attempts"] += 1
+    if mutation == "run":
+        value["run"]["seed"] = 2
     if mutation == "identity":
         value["identities"]["imported_generation"] = value["identities"]["source_generation"]
     if mutation == "authority":
         value["authority"]["imported_fingerprint"] = DIGEST_B
+    if mutation == "missing_authority":
+        value.pop("authority")
     if mutation == "path":
         value["tools"]["rustc"] = "/usr/bin/rustc"
     if mutation == "rss":
         value["envelope"]["peak_rss_bytes"] = 137_438_953_473
+    if mutation == "disk":
+        value["envelope"]["peak_disk_bytes"] = 1_099_511_627_777
+    if mutation == "wall_time":
+        value["envelope"]["wall_time_s"] = 14_401
     if mutation == "phase":
         value["phases"].pop()
+    if mutation == "package":
+        value["package"]["class"] = "partial"
+    if mutation == "equivalence":
+        value["equivalence"]["imported_project_fingerprint"] = DIGEST_B
+    if mutation == "missing_equivalence":
+        value.pop("equivalence")
+    if mutation == "provider":
+        value["host"]["provider"] = "local"
+    if mutation == "capacity":
+        value["host"]["memory_bytes"] -= 1
+    if mutation == "failed_result":
+        value["result"] = "fail"
+        value["first_failure"] = "generate"
+    if mutation == "missing_node_count":
+        value["counts"].pop("source_nodes")
     with pytest.raises(VALIDATOR.EvidenceError):
         VALIDATOR.validate(value, SHA)
+
+
+def test_requires_expected_sha():
+    with pytest.raises(VALIDATOR.EvidenceError, match="expected-sha"):
+        VALIDATOR.validate(evidence(), None)
+    with pytest.raises(VALIDATOR.EvidenceError, match="40-hex"):
+        VALIDATOR.validate(evidence(), "A" * 40)

--- a/scripts/ci/validate-g500-certification.py
+++ b/scripts/ci/validate-g500-certification.py
@@ -44,6 +44,16 @@ class EvidenceError(ValueError):
     pass
 
 
+def require_mapping(evidence: dict[str, Any], key: str, fields: tuple[str, ...]) -> dict[str, Any]:
+    section = evidence.get(key)
+    if not isinstance(section, dict):
+        raise EvidenceError(f"missing or malformed section: {key}")
+    absent = [field for field in fields if field not in section or section[field] is None]
+    if absent:
+        raise EvidenceError(f"missing {key} fields: " + ", ".join(absent))
+    return section
+
+
 def reject_sensitive(value: Any, trail: str = "$") -> None:
     if isinstance(value, dict):
         for key, child in value.items():
@@ -61,7 +71,11 @@ def validate(evidence: dict[str, Any], expected_sha: str | None) -> None:
     reject_sensitive(evidence)
     if evidence.get("schema") != "graphforge-billion-edge-certification-evidence/1":
         raise EvidenceError("unsupported evidence schema")
-    if expected_sha and evidence.get("git_sha") != expected_sha:
+    if not expected_sha:
+        raise EvidenceError("--expected-sha is required to pin the dispatched commit")
+    if re.fullmatch(r"[0-9a-f]{40}", expected_sha) is None:
+        raise EvidenceError("--expected-sha must be an exact lowercase 40-hex commit")
+    if evidence.get("git_sha") != expected_sha:
         raise EvidenceError("evidence git_sha does not match dispatched commit")
     expected_profile = "sha256:" + hashlib.sha256(PROFILE.read_bytes()).hexdigest()
     if evidence.get("profile_sha256") != expected_profile:
@@ -77,7 +91,20 @@ def validate(evidence: dict[str, Any], expected_sha: str | None) -> None:
     }
     if evidence.get("run") != expected_run:
         raise EvidenceError("run command/profile is not the approved target-live contract")
-    counts = evidence.get("counts", {})
+    counts = require_mapping(
+        evidence,
+        "counts",
+        (
+            "raw_attempts",
+            "self_loops_rejected",
+            "duplicates_rejected",
+            "live_unique_edges",
+            "source_nodes",
+            "source_edges",
+            "imported_nodes",
+            "imported_edges",
+        ),
+    )
     raw = counts.get("raw_attempts")
     loops = counts.get("self_loops_rejected")
     dupes = counts.get("duplicates_rejected")
@@ -109,10 +136,16 @@ def validate(evidence: dict[str, Any], expected_sha: str | None) -> None:
     }
     if package != expected_package:
         raise EvidenceError("portable-v2 package contract is incomplete or incompatible")
-    authority = evidence.get("authority", {})
+    authority = require_mapping(
+        evidence, "authority", ("source_fingerprint", "imported_fingerprint")
+    )
     if authority.get("source_fingerprint") != authority.get("imported_fingerprint"):
         raise EvidenceError("ontology/capability authority changed across import")
-    equivalence = evidence.get("equivalence", {})
+    equivalence = require_mapping(
+        evidence,
+        "equivalence",
+        ("source_project_fingerprint", "imported_project_fingerprint"),
+    )
     if equivalence.get("source_project_fingerprint") != equivalence.get(
         "imported_project_fingerprint"
     ):
@@ -156,7 +189,7 @@ def validate(evidence: dict[str, Any], expected_sha: str | None) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("evidence", type=Path)
-    parser.add_argument("--expected-sha")
+    parser.add_argument("--expected-sha", required=True)
     args = parser.parse_args()
     value = json.loads(args.evidence.read_text(encoding="utf-8"))
     if not isinstance(value, dict):

--- a/scripts/ci/validate-g500-certification.py
+++ b/scripts/ci/validate-g500-certification.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Fail-closed semantic validator for sanitized #745 evidence."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+from typing import Any
+
+REQUIRED_PHASES = (
+    "preflight",
+    "generate",
+    "ingest",
+    "csr",
+    "source_reopen",
+    "source_query_1hop",
+    "source_query_2hop",
+    "export",
+    "verify",
+    "import",
+    "imported_reopen",
+    "imported_query_1hop",
+    "imported_query_2hop",
+    "drill_corruption",
+    "drill_cancellation",
+    "drill_resource_limit",
+    "drill_interrupted_finalization",
+)
+FORBIDDEN_KEY = re.compile(r"(secret|credential|token|password|host_path|absolute_path)", re.I)
+ABSOLUTE_PATH = re.compile(r"(?:^|[\s=:])(?:/|[A-Za-z]:[\\/])")
+ROOT = Path(__file__).resolve().parents[2]
+PROFILE = ROOT / "crates/graphforge-api/tests/fixtures/scale_g500_certification.v1.json"
+RUN_COMMAND = (
+    "cargo test -p graphforge-api --release --test scale_g500_ladder "
+    "certification_target_live_full_lifecycle_evidence -- --ignored --exact "
+    "--nocapture --test-threads=1"
+)
+
+
+class EvidenceError(ValueError):
+    pass
+
+
+def reject_sensitive(value: Any, trail: str = "$") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if FORBIDDEN_KEY.search(key):
+                raise EvidenceError(f"forbidden sensitive field at {trail}.{key}")
+            reject_sensitive(child, f"{trail}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            reject_sensitive(child, f"{trail}[{index}]")
+    elif isinstance(value, str) and ABSOLUTE_PATH.search(value):
+        raise EvidenceError(f"absolute host path at {trail}")
+
+
+def validate(evidence: dict[str, Any], expected_sha: str | None) -> None:
+    reject_sensitive(evidence)
+    if evidence.get("schema") != "graphforge-billion-edge-certification-evidence/1":
+        raise EvidenceError("unsupported evidence schema")
+    if expected_sha and evidence.get("git_sha") != expected_sha:
+        raise EvidenceError("evidence git_sha does not match dispatched commit")
+    expected_profile = "sha256:" + hashlib.sha256(PROFILE.read_bytes()).hexdigest()
+    if evidence.get("profile_sha256") != expected_profile:
+        raise EvidenceError("evidence profile does not match the committed certification profile")
+    expected_run = {
+        "command": RUN_COMMAND,
+        "scale": 26,
+        "edgefactor": 16,
+        "seed": 1,
+        "directionality": "undirected",
+        "self_loops": "drop",
+        "duplicates": "drop",
+    }
+    if evidence.get("run") != expected_run:
+        raise EvidenceError("run command/profile is not the approved target-live contract")
+    counts = evidence.get("counts", {})
+    raw = counts.get("raw_attempts")
+    loops = counts.get("self_loops_rejected")
+    dupes = counts.get("duplicates_rejected")
+    live = counts.get("live_unique_edges")
+    if not all(isinstance(item, int) and item >= 0 for item in (raw, loops, dupes, live)):
+        raise EvidenceError("counts must be non-negative integers")
+    if raw != live + loops + dupes:
+        raise EvidenceError("generator counts do not reconcile")
+    if live < 1_000_000_000:
+        raise EvidenceError("certification requires at least one billion live edges")
+    if any(counts.get(key) != live for key in ("source_edges", "imported_edges")):
+        raise EvidenceError("source/imported edge counts differ")
+    if counts.get("source_nodes") != counts.get("imported_nodes"):
+        raise EvidenceError("source/imported node counts differ")
+
+    identities = evidence.get("identities", {})
+    if identities.get("source_generation") == identities.get("imported_generation"):
+        raise EvidenceError("source and imported generations must be distinct")
+    if len({identities.get("package"), identities.get("transport")}) != 2:
+        raise EvidenceError("semantic package and transport identities must be distinct")
+    package = evidence.get("package", {})
+    expected_package = {
+        "contract": "graphforge-portable-verify/2",
+        "format": "portable-project-v2-bundle",
+        "class": "complete",
+        "integrity": "verified",
+        "compatibility": "supported",
+        "policy": "complete-current-generation",
+    }
+    if package != expected_package:
+        raise EvidenceError("portable-v2 package contract is incomplete or incompatible")
+    authority = evidence.get("authority", {})
+    if authority.get("source_fingerprint") != authority.get("imported_fingerprint"):
+        raise EvidenceError("ontology/capability authority changed across import")
+    equivalence = evidence.get("equivalence", {})
+    if equivalence.get("source_project_fingerprint") != equivalence.get(
+        "imported_project_fingerprint"
+    ):
+        raise EvidenceError("source/imported project fingerprints differ")
+
+    phases = evidence.get("phases")
+    if not isinstance(phases, list):
+        raise EvidenceError("phases must be an array")
+    by_id = {phase.get("id"): phase for phase in phases if isinstance(phase, dict)}
+    missing = [phase for phase in REQUIRED_PHASES if phase not in by_id]
+    if missing:
+        raise EvidenceError("missing phases: " + ", ".join(missing))
+    failed = [phase for phase in phases if phase.get("status") != "pass"]
+    if evidence.get("result") == "pass" and failed:
+        raise EvidenceError("passing evidence contains non-passing phases")
+    for query in ("source_query_1hop", "source_query_2hop"):
+        imported = query.replace("source_", "imported_")
+        if by_id[query].get("fingerprint") != by_id[imported].get("fingerprint"):
+            raise EvidenceError(f"query fingerprint mismatch: {query}")
+    envelope = evidence.get("envelope", {})
+    if envelope.get("peak_rss_bytes", 2**64) > 137_438_953_472:
+        raise EvidenceError("RSS envelope exceeded")
+    if envelope.get("peak_disk_bytes", 2**64) > 1_099_511_627_776:
+        raise EvidenceError("disk envelope exceeded")
+    if envelope.get("wall_time_s", 2**64) > 14_400:
+        raise EvidenceError("wall-time envelope exceeded")
+    host = evidence.get("host", {})
+    if not str(host.get("os", "")).startswith("Linux"):
+        raise EvidenceError("certification host must be Linux")
+    if str(host.get("provider", "")).lower() in {"local", "localhost", "developer"}:
+        raise EvidenceError("certification provider must identify provisioned infrastructure")
+    if (
+        host.get("memory_bytes", 0) < 137_438_953_472
+        or host.get("nvme_bytes", 0) < 1_099_511_627_776
+    ):
+        raise EvidenceError("host does not meet declared capacity")
+    if evidence.get("result") != "pass" or evidence.get("first_failure") is not None:
+        raise EvidenceError("certification evidence is not a pass")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("evidence", type=Path)
+    parser.add_argument("--expected-sha")
+    args = parser.parse_args()
+    value = json.loads(args.evidence.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise EvidenceError("evidence root must be an object")
+    validate(value, args.expected_sha)
+    print(f"valid #745 evidence: {args.evidence}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a deterministic target-live SCALE26 profile and bounded Rust lifecycle runner over public construction, CSR, query, portable-v2 verify/import, reopen, and equivalence surfaces
- add an atomic typed phase journal plus RSS/disk/time watchdog and representative corruption, cancellation, resource-limit, and interrupted-finalization drills
- add a strict sanitized evidence schema/validator, protected manual exact-SHA workflow, workflow inventory, and operator runbook

The workflow never provisions infrastructure or spends. Provider, SKU, ephemeral runner, cost approval, and teardown remain explicit maintainer inputs. The dedicated billion-edge run stays ignored in ordinary CI; #745 remains open for the approved run and checked-in evidence.

## Validation

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/private/tmp/graphforge-739-target cargo test -p graphforge-api --test scale_g500_ladder` (11 passed, 2 provisioned-only ignored)
- `CARGO_TARGET_DIR=/private/tmp/graphforge-739-target cargo clippy -p graphforge-api --test scale_g500_ladder -- -D warnings`
- `uv run --extra dev pytest -q scripts/ci/test-validate-g500-certification.py` (7 passed)
- `uv run --extra dev ruff check scripts/ci/validate-g500-certification.py scripts/ci/test-validate-g500-certification.py`
- `make workflow-lint`

Closes #869
Refs #745

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789865804&installation_model_id=20486&pr_number=870&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F870&signature=24686c76aeb6f7fc2f6a93a353df1652bd1293559c386eb1da0141b5d4332cdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added billion-edge certification coverage spanning generation, ingestion, queries, export, recovery, cancellation, and resource limits.
  * Added deterministic certification evidence validation with checks for schema, metadata, scale, identities, tool paths, and resource requirements.
  * Added a certification profile fixture and safeguards for approved artifact storage and retention.

* **Documentation**
  * Added the billion-edge certification guide to the documentation site navigation and publishing workflow.

* **Tests**
  * Added comprehensive validation tests, negative storage-policy checks, watchdog coverage, and deterministic scale-certification tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->