### PR TITLE
feat(ir): resolve composed ontology authority

### DIFF
--- a/crates/graphforge-api/src/composition_binding_tests.rs
+++ b/crates/graphforge-api/src/composition_binding_tests.rs
@@ -1,7 +1,8 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use graphforge_ir::{
-    BindingDecision, BindingDiagnosticCode, CompositionBindingContext, CompositionBindingLimits,
+    Binder, BindingDecision, BindingDiagnosticCode, CompositionBindingContext,
+    CompositionBindingLimits, RuntimeCatalog,
 };
 use graphforge_ontology::{
     ActivationMode, ActivationRecord, ActivationScope, AuthoredModule, BridgeAssertion,
@@ -12,6 +13,7 @@ use graphforge_ontology::{
 };
 
 use super::GraphForge;
+use graphforge_core::OntologyMode;
 
 fn module(name: &str, entities: &[&str]) -> AuthoredModule {
     let doc = OntologyDoc {
@@ -59,6 +61,17 @@ fn composed_fixture(
     QualifiedSymbol,
     QualifiedSymbol,
 ) {
+    composed_fixture_with_predicates(default, &[BridgePredicate::Equivalent])
+}
+
+fn composed_fixture_with_predicates(
+    default: ActivationMode,
+    predicates: &[BridgePredicate],
+) -> (
+    Arc<CompositionBindingContext>,
+    QualifiedSymbol,
+    QualifiedSymbol,
+) {
     let research = module("research", &["Person", "Study"]);
     let genealogy = module("genealogy", &["Person"]);
     let source = QualifiedSymbol {
@@ -71,34 +84,41 @@ fn composed_fixture(
         kind: SymbolKind::Entity,
         local_id: "Person".to_owned(),
     };
-    let bridge = BridgeDocument {
-        bridge_id: "https://graphforge.dev/bridge/person".to_owned(),
-        authored_version: "1.0.0".to_owned(),
-        source_modules: vec![research.id.clone()],
-        target_modules: vec![genealogy.id.clone()],
-        dependencies: vec![],
-        shared_surfaces: vec![],
-        assertions: vec![BridgeAssertion {
-            source: source.clone(),
-            target: target.clone(),
-            predicate: BridgePredicate::Equivalent,
-            directional: false,
-            provenance: BridgeProvenance {
-                method: MappingMethod::Authored,
-                confidence: None,
-                justification: "the same governed person concept".to_owned(),
-                evidence_refs: vec![],
-            },
-            valid_from: None,
-            valid_to: None,
-        }],
-        enforcement: Some(ActivationMode::Strict),
-    };
-    let bridge_id = BridgeSetId {
-        bridge_id: bridge.bridge_id.clone(),
-        authored_version: bridge.authored_version.clone(),
-        canonical_digest: bridge_document_digest(&bridge).expect("bridge digest"),
-    };
+    let bridges = predicates
+        .iter()
+        .enumerate()
+        .map(|(index, predicate)| BridgeDocument {
+            bridge_id: format!("https://graphforge.dev/bridge/person-{index}"),
+            authored_version: "1.0.0".to_owned(),
+            source_modules: vec![research.id.clone()],
+            target_modules: vec![genealogy.id.clone()],
+            dependencies: vec![],
+            shared_surfaces: vec![],
+            assertions: vec![BridgeAssertion {
+                source: source.clone(),
+                target: target.clone(),
+                predicate: *predicate,
+                directional: !predicate.is_symmetric(),
+                provenance: BridgeProvenance {
+                    method: MappingMethod::Authored,
+                    confidence: None,
+                    justification: "governed person mapping".to_owned(),
+                    evidence_refs: vec![],
+                },
+                valid_from: None,
+                valid_to: None,
+            }],
+            enforcement: Some(ActivationMode::Strict),
+        })
+        .collect::<Vec<_>>();
+    let bridge_ids = bridges
+        .iter()
+        .map(|bridge| BridgeSetId {
+            bridge_id: bridge.bridge_id.clone(),
+            authored_version: bridge.authored_version.clone(),
+            canonical_digest: bridge_document_digest(bridge).expect("bridge digest"),
+        })
+        .collect::<Vec<_>>();
     let activation = vec![ActivationRecord {
         scope: ActivationScope::Module,
         subject: research.id.display_ref(),
@@ -106,7 +126,7 @@ fn composed_fixture(
     }];
     let composition = compile_inventory(InventoryCompileRequest {
         modules: &[research, genealogy],
-        bridges: &[bridge_id],
+        bridges: &bridge_ids,
         activation: &activation,
         profile_default: default,
         limits: CompositionLimits::default(),
@@ -116,7 +136,7 @@ fn composed_fixture(
     (
         Arc::new(CompositionBindingContext::new(
             Arc::new(composition),
-            vec![bridge],
+            bridges,
             CompositionBindingLimits::default(),
         )),
         source,
@@ -135,6 +155,29 @@ fn facade_executes_qualified_and_unique_composed_queries() {
     forge
         .execute_with_composition("MATCH (n:Study) RETURN n", context)
         .expect("unique shorthand execution");
+}
+
+#[test]
+fn graph_plan_carries_exact_composition_identity_and_receipts() {
+    let (context, _, _) = composed_fixture(ActivationMode::Strict);
+    let ast = graphforge_cypher::parse("MATCH (n:`research:Person`) RETURN n").expect("parse");
+    let plan = Binder::new(
+        None,
+        Arc::new(Mutex::new(RuntimeCatalog::new())),
+        OntologyMode::Exploratory,
+    )
+    .with_composition(context.clone())
+    .bind(&ast)
+    .expect("bind");
+    assert_eq!(
+        plan.composition_fingerprint.as_deref(),
+        Some(context.fingerprint())
+    );
+    assert_eq!(plan.binding_receipts.len(), 1);
+    assert_eq!(
+        plan.binding_receipts[0].composition_fingerprint,
+        context.fingerprint()
+    );
 }
 
 #[test]
@@ -170,7 +213,7 @@ fn bridge_selection_and_explain_are_exact_bounded_and_repeatable() {
     assert!(matches!(
         first.decisions.as_slice(),
         [BindingDecision::Bridge { bridge_id, predicate, .. }]
-            if bridge_id == "https://graphforge.dev/bridge/person"
+            if bridge_id == "https://graphforge.dev/bridge/person-0"
                 && predicate == "equivalent"
     ));
     assert_eq!(
@@ -187,6 +230,19 @@ fn bridge_selection_and_explain_are_exact_bounded_and_repeatable() {
         context.select_bridge(&invalid, &target).unwrap_err().code,
         BindingDiagnosticCode::UnknownSymbol
     );
+}
+
+#[test]
+fn conflicting_bridge_paths_are_rejected_with_bounded_candidates() {
+    let (context, source, target) = composed_fixture_with_predicates(
+        ActivationMode::Exploratory,
+        &[BridgePredicate::Equivalent, BridgePredicate::Related],
+    );
+    let error = context
+        .select_bridge(&source, &target)
+        .expect_err("conflicting predicates");
+    assert_eq!(error.code, BindingDiagnosticCode::ConflictingBridgePaths);
+    assert_eq!(error.candidates, ["equivalent", "related"]);
 }
 
 #[test]

--- a/crates/graphforge-api/src/composition_binding_tests.rs
+++ b/crates/graphforge-api/src/composition_binding_tests.rs
@@ -1,0 +1,221 @@
+use std::sync::Arc;
+
+use graphforge_ir::{
+    BindingDecision, BindingDiagnosticCode, CompositionBindingContext, CompositionBindingLimits,
+};
+use graphforge_ontology::{
+    ActivationMode, ActivationRecord, ActivationScope, AuthoredModule, BridgeAssertion,
+    BridgeDocument, BridgePredicate, BridgeProvenance, BridgeSetId, CompositionLimits,
+    EntityTypeDef, InventoryCompileRequest, MappingMethod, OntologyDoc, OntologyModuleId,
+    PropertyDef, PropertyValueType, QualifiedSymbol, SymbolKind, bridge_document_digest,
+    compile_inventory, module_document_digest,
+};
+
+use super::GraphForge;
+
+fn module(name: &str, entities: &[&str]) -> AuthoredModule {
+    let doc = OntologyDoc {
+        ontology_id: format!("https://graphforge.dev/ontology/{name}"),
+        version: "1.0.0".to_owned(),
+        entity_types: entities
+            .iter()
+            .map(|entity| EntityTypeDef {
+                name: (*entity).to_owned(),
+                r#abstract: false,
+                parent: None,
+            })
+            .collect(),
+        relation_types: vec![],
+        properties: (name == "research")
+            .then_some(PropertyDef {
+                owner: "Person".to_owned(),
+                name: "name".to_owned(),
+                value_type: PropertyValueType::Utf8,
+                nullable: true,
+                multivalued: false,
+                default_json: None,
+            })
+            .into_iter()
+            .collect(),
+        constraints: vec![],
+        migrations: vec![],
+    };
+    AuthoredModule {
+        id: OntologyModuleId {
+            ontology_id: doc.ontology_id.clone(),
+            authored_version: doc.version.clone(),
+            canonical_digest: module_document_digest(&doc).expect("module digest"),
+        },
+        dependencies: vec![],
+        doc,
+        allow_projected_identity: false,
+    }
+}
+
+fn composed_fixture(
+    default: ActivationMode,
+) -> (
+    Arc<CompositionBindingContext>,
+    QualifiedSymbol,
+    QualifiedSymbol,
+) {
+    let research = module("research", &["Person", "Study"]);
+    let genealogy = module("genealogy", &["Person"]);
+    let source = QualifiedSymbol {
+        module: research.id.clone(),
+        kind: SymbolKind::Entity,
+        local_id: "Person".to_owned(),
+    };
+    let target = QualifiedSymbol {
+        module: genealogy.id.clone(),
+        kind: SymbolKind::Entity,
+        local_id: "Person".to_owned(),
+    };
+    let bridge = BridgeDocument {
+        bridge_id: "https://graphforge.dev/bridge/person".to_owned(),
+        authored_version: "1.0.0".to_owned(),
+        source_modules: vec![research.id.clone()],
+        target_modules: vec![genealogy.id.clone()],
+        dependencies: vec![],
+        shared_surfaces: vec![],
+        assertions: vec![BridgeAssertion {
+            source: source.clone(),
+            target: target.clone(),
+            predicate: BridgePredicate::Equivalent,
+            directional: false,
+            provenance: BridgeProvenance {
+                method: MappingMethod::Authored,
+                confidence: None,
+                justification: "the same governed person concept".to_owned(),
+                evidence_refs: vec![],
+            },
+            valid_from: None,
+            valid_to: None,
+        }],
+        enforcement: Some(ActivationMode::Strict),
+    };
+    let bridge_id = BridgeSetId {
+        bridge_id: bridge.bridge_id.clone(),
+        authored_version: bridge.authored_version.clone(),
+        canonical_digest: bridge_document_digest(&bridge).expect("bridge digest"),
+    };
+    let activation = vec![ActivationRecord {
+        scope: ActivationScope::Module,
+        subject: research.id.display_ref(),
+        mode: ActivationMode::Advisory,
+    }];
+    let composition = compile_inventory(InventoryCompileRequest {
+        modules: &[research, genealogy],
+        bridges: &[bridge_id],
+        activation: &activation,
+        profile_default: default,
+        limits: CompositionLimits::default(),
+        cancelled: None,
+    })
+    .expect("composition");
+    (
+        Arc::new(CompositionBindingContext::new(
+            Arc::new(composition),
+            vec![bridge],
+            CompositionBindingLimits::default(),
+        )),
+        source,
+        target,
+    )
+}
+
+#[test]
+fn facade_executes_qualified_and_unique_composed_queries() {
+    let forge = GraphForge::new(None).expect("facade");
+    let (context, _, _) = composed_fixture(ActivationMode::Strict);
+
+    forge
+        .execute_with_composition("MATCH (n:`research:Person`) RETURN n", context.clone())
+        .expect("qualified execution");
+    forge
+        .execute_with_composition("MATCH (n:Study) RETURN n", context)
+        .expect("unique shorthand execution");
+}
+
+#[test]
+fn facade_rejects_ambiguity_without_publishing_runtime_observations() {
+    let forge = GraphForge::new(None).expect("facade");
+    let (context, _, _) = composed_fixture(ActivationMode::Strict);
+    let error = forge
+        .execute_with_composition("MATCH (n:Person) RETURN n", context)
+        .expect_err("ambiguous shorthand must fail");
+    assert!(error.to_string().contains("ambiguous_symbol"), "{error:?}");
+
+    let first = forge
+        .runtime_catalog()
+        .lock()
+        .expect("catalog")
+        .intern_label("after_failed_bind");
+    assert_eq!(first.0, 0, "failed bind published a catalog observation");
+}
+
+#[test]
+fn bridge_selection_and_explain_are_exact_bounded_and_repeatable() {
+    let (context, source, target) = composed_fixture(ActivationMode::Exploratory);
+    let first = context.select_bridge(&source, &target).expect("bridge");
+    let second = context
+        .select_bridge(&target, &source)
+        .expect("symmetric bridge");
+    assert_eq!(
+        first.composition_fingerprint,
+        second.composition_fingerprint
+    );
+    assert_eq!(first.effective_mode, second.effective_mode);
+    assert_eq!(first.effective_mode, ActivationMode::Strict);
+    assert!(matches!(
+        first.decisions.as_slice(),
+        [BindingDecision::Bridge { bridge_id, predicate, .. }]
+            if bridge_id == "https://graphforge.dev/bridge/person"
+                && predicate == "equivalent"
+    ));
+    assert_eq!(
+        serde_json::to_string(&first).expect("receipt json"),
+        serde_json::to_string(&context.select_bridge(&source, &target).expect("repeat"))
+            .expect("repeat json")
+    );
+
+    let invalid = QualifiedSymbol {
+        local_id: "Missing".to_owned(),
+        ..source
+    };
+    assert_eq!(
+        context.select_bridge(&invalid, &target).unwrap_err().code,
+        BindingDiagnosticCode::UnknownSymbol
+    );
+}
+
+#[test]
+fn scoped_advisory_and_exploratory_fallbacks_emit_distinct_receipts() {
+    let (context, _, _) = composed_fixture(ActivationMode::Exploratory);
+    let (_, advisory) = context
+        .resolve(SymbolKind::Entity, "research:Unknown")
+        .expect("advisory fallback");
+    let (_, exploratory) = context
+        .resolve(SymbolKind::Entity, "Unknown")
+        .expect("exploratory fallback");
+    assert_eq!(advisory.effective_mode, ActivationMode::Advisory);
+    assert_eq!(
+        advisory.diagnostics[0].code,
+        BindingDiagnosticCode::RuntimeFallback
+    );
+    assert_eq!(exploratory.effective_mode, ActivationMode::Exploratory);
+    assert!(exploratory.diagnostics.is_empty());
+}
+
+#[test]
+fn facade_rejects_a_property_on_the_wrong_composed_owner() {
+    let forge = GraphForge::new(None).expect("facade");
+    let (context, _, _) = composed_fixture(ActivationMode::Strict);
+    let error = forge
+        .execute_with_composition("MATCH (n:`research:Study`) RETURN n.name", context)
+        .expect_err("wrong-owner property must fail");
+    assert!(
+        error.to_string().contains("wrong_owner_property"),
+        "{error:?}"
+    );
+}

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -33,7 +33,8 @@ pub use graphforge_io::{
     ResultSinkFormat, ResultSinkOptions, ResultSinkProgress, ResultSinkReceipt,
 };
 use graphforge_ir::{
-    BindError, Binder, GraphOp, GraphPlan, IrExpr, ProcedureRegistry, RuntimeCatalog,
+    BindError, Binder, CompositionBindingContext, GraphOp, GraphPlan, IrExpr, ProcedureRegistry,
+    RuntimeCatalog,
 };
 use graphforge_ontology::{OntologyCompiler, OntologyHandle, OntologyLoader};
 use graphforge_storage::GraphCatalog;
@@ -57,6 +58,8 @@ mod composite_receipt;
 mod composite_recovery_tests;
 mod composite_transaction;
 mod composite_validation;
+#[cfg(test)]
+mod composition_binding_tests;
 /// Hidden writer-hold helpers for native binding concurrency probes.
 #[doc(hidden)]
 pub mod concurrency_test_support;
@@ -903,6 +906,23 @@ impl GraphForge {
         self.run_query(cypher, params)
     }
 
+    /// Execute a query using exact compiled multi-ontology binding authority.
+    ///
+    /// The composition is consumed by the same parse, bind, lower, and execute
+    /// path as [`execute`](Self::execute). Its fingerprint and deterministic
+    /// binding receipts are retained in the plan; runtime-catalog observations
+    /// are published only after the complete bind succeeds.
+    ///
+    /// # Errors
+    /// As [`execute`](Self::execute), including scoped composition diagnostics.
+    pub fn execute_with_composition(
+        &self,
+        cypher: &str,
+        composition: Arc<CompositionBindingContext>,
+    ) -> Result<ExecutionResult, GfError> {
+        self.run_query_with_composition(cypher, &HashMap::new(), composition, true)
+    }
+
     fn run_query(
         &self,
         cypher: &str,
@@ -926,6 +946,26 @@ impl GraphForge {
         &self,
         cypher: &str,
         params: &HashMap<String, IrLiteral>,
+        publish: bool,
+    ) -> Result<ExecutionResult, GfError> {
+        self.run_query_with_optional_composition(cypher, params, None, publish)
+    }
+
+    fn run_query_with_composition(
+        &self,
+        cypher: &str,
+        params: &HashMap<String, IrLiteral>,
+        composition: Arc<CompositionBindingContext>,
+        publish: bool,
+    ) -> Result<ExecutionResult, GfError> {
+        self.run_query_with_optional_composition(cypher, params, Some(composition), publish)
+    }
+
+    fn run_query_with_optional_composition(
+        &self,
+        cypher: &str,
+        params: &HashMap<String, IrLiteral>,
+        composition: Option<Arc<CompositionBindingContext>>,
         publish: bool,
     ) -> Result<ExecutionResult, GfError> {
         let _admission = self.admit_heavy_query()?;
@@ -956,12 +996,15 @@ impl GraphForge {
         // Bind against the shared runtime catalog so newly observed types/props
         // persist across queries in this instance.
         let plan = {
-            let binder = Binder::new(
+            let mut binder = Binder::new(
                 self.ontology.clone(),
                 self.runtime_catalog.clone(),
                 self.ontology_mode,
             )
             .with_procedures(self.procedure_snapshot());
+            if let Some(composition) = composition {
+                binder = binder.with_composition(composition);
+            }
             binder
                 .bind(&ast)
                 .map_err(|errs| bind_errors_to_gferror(&errs))?

--- a/crates/graphforge-bindings-node/tests/non-cypher-parity-policy.json
+++ b/crates/graphforge-bindings-node/tests/non-cypher-parity-policy.json
@@ -1,8 +1,8 @@
 {
   "contractVersion": 1,
   "rustManifest": "../../../tests/contracts/non-cypher-rust-surface.json",
-  "releaseSurfaceCount": 210,
-  "releaseSurfaceDigest": "9ca796af78a3ea51e4c0d404e9f74e3eb1cdd49a0b862dc15838cd9ada037877",
+  "releaseSurfaceCount": 211,
+  "releaseSurfaceDigest": "a00859ba2240f230aafd817f8ea6d4f3990cc7d43fe63eb31b8f543bda556c2a",
   "requiredEquivalent": [
     "GraphForge.adopt_ontology",
     "GraphForge.clear_ontology",

--- a/crates/graphforge-bindings-py/tests/non_cypher_release.py
+++ b/crates/graphforge-bindings-py/tests/non_cypher_release.py
@@ -23,7 +23,7 @@ ROOT = Path(__file__).resolve().parents[3]
 RUST_MANIFEST = ROOT / "tests/contracts/non-cypher-rust-surface.json"
 RUST_GATE = ROOT / "scripts/ci/non-cypher-surface-gate.py"
 PYO3_SOURCE = ROOT / "crates/graphforge-bindings-py/src/lib.rs"
-EXPECTED_RUST_DIGEST = "268d0832e1fa2bc823e1aa6a0f7a5129c29f4b0b23886a6fc2927616671a3b73"
+EXPECTED_RUST_DIGEST = "a1a0f16a771df5e159130b7b7c41961d3c3bf0dc499f692ce20d1d3b4ce38ae2"
 EXPECTED_RELEASE_DIGEST = "9ca796af78a3ea51e4c0d404e9f74e3eb1cdd49a0b862dc15838cd9ada037877"
 
 PYTHON_ONLY_METHODS = frozenset(

--- a/crates/graphforge-bindings-py/tests/non_cypher_release.py
+++ b/crates/graphforge-bindings-py/tests/non_cypher_release.py
@@ -24,7 +24,7 @@ RUST_MANIFEST = ROOT / "tests/contracts/non-cypher-rust-surface.json"
 RUST_GATE = ROOT / "scripts/ci/non-cypher-surface-gate.py"
 PYO3_SOURCE = ROOT / "crates/graphforge-bindings-py/src/lib.rs"
 EXPECTED_RUST_DIGEST = "a1a0f16a771df5e159130b7b7c41961d3c3bf0dc499f692ce20d1d3b4ce38ae2"
-EXPECTED_RELEASE_DIGEST = "9ca796af78a3ea51e4c0d404e9f74e3eb1cdd49a0b862dc15838cd9ada037877"
+EXPECTED_RELEASE_DIGEST = "a00859ba2240f230aafd817f8ea6d4f3990cc7d43fe63eb31b8f543bda556c2a"
 
 PYTHON_ONLY_METHODS = frozenset(
     {
@@ -248,7 +248,7 @@ def _classification_report() -> dict[str, object]:
         for group in manifest["method_evidence_groups"].values()
         for method_id in group["ids"]
     }
-    assert len(release_methods) == 210
+    assert len(release_methods) == 211
     assert _digest(release_methods) == EXPECTED_RELEASE_DIGEST
     assert set(EVIDENCE) == set(manifest["method_evidence_groups"])
 

--- a/crates/graphforge-ir/src/binder.rs
+++ b/crates/graphforge-ir/src/binder.rs
@@ -22,6 +22,7 @@ use graphforge_core::{PropId, Span, TypeId};
 use graphforge_ontology::OntologyHandle;
 
 use crate::catalog::RuntimeCatalog;
+use crate::composition_binding::{BindingDiagnosticCode, CompositionBindingContext, SymbolBinding};
 use crate::expr::{BinaryOpKind, CaseArm, IrExpr, IrLiteral, UnaryOpKind};
 use crate::plan::{
     GraphOp, GraphPlan, GraphPlanBuilder, OntologyMode, PATTERN_COMPREHENSION_VALUE_ALIAS, SortKey,
@@ -73,6 +74,10 @@ pub enum BindErrorKind {
     /// / `NoSingleRelationshipType` / … — the harness checks the phase, not the
     /// sub-code, so one kind with a descriptive message suffices (#956).
     InvalidArgument,
+    /// A composed ontology symbol has multiple valid candidates.
+    AmbiguousComposedSymbol,
+    /// A composed ontology qualifier or bridge path is invalid/conflicting.
+    CompositionConflict,
 }
 
 /// The semantic kind a pattern variable is bound to, tracked so a later use
@@ -143,6 +148,7 @@ pub struct Binder {
     mode: OntologyMode,
     procedures: Arc<ProcedureRegistry>,
     typed_uuid_params: HashMap<String, UuidParamClass>,
+    composition: Option<Arc<CompositionBindingContext>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -169,7 +175,15 @@ impl Binder {
             mode,
             procedures: Arc::new(ProcedureRegistry::new()),
             typed_uuid_params: HashMap::new(),
+            composition: None,
         }
+    }
+
+    /// Supplies compiled multi-ontology binding authority.
+    #[must_use]
+    pub fn with_composition(mut self, composition: Arc<CompositionBindingContext>) -> Self {
+        self.composition = Some(composition);
+        self
     }
 
     /// Supplies the procedures available while binding `CALL` clauses.
@@ -212,6 +226,7 @@ impl Binder {
             mode: self.mode,
             procedures: Arc::clone(&self.procedures),
             typed_uuid_params: self.typed_uuid_params.clone(),
+            composition: self.composition.clone(),
         };
         let result = staged_binder.bind_staged(ast);
         if result.is_ok() {
@@ -242,6 +257,9 @@ impl Binder {
         }
 
         let mut builder = GraphPlan::builder(dialect).ontology_mode(self.mode);
+        if let Some(composition) = &self.composition {
+            builder = builder.composition_fingerprint(composition.fingerprint());
+        }
         if let Some(v) = ontology_version {
             builder = builder.ontology_version(v);
         }
@@ -341,6 +359,9 @@ impl Binder {
         }
 
         let mut builder = GraphPlan::builder(dialect).ontology_mode(self.mode);
+        if let Some(composition) = &self.composition {
+            builder = builder.composition_fingerprint(composition.fingerprint());
+        }
         if let Some(version) = ontology_version {
             builder = builder.ontology_version(version);
         }
@@ -4452,6 +4473,25 @@ impl Binder {
     // -----------------------------------------------------------------------
 
     fn resolve_label(&self, name: &str, span: Span, s: &mut BinderState) -> TypeId {
+        if let Some(composition) = &self.composition {
+            return match composition.resolve(graphforge_ontology::SymbolKind::Entity, name) {
+                Ok((binding, receipt)) => {
+                    s.builder.push_binding_receipt(receipt);
+                    match binding {
+                        SymbolBinding::Qualified(symbol) => {
+                            TypeId(composition.semantic_id(&symbol))
+                        }
+                        SymbolBinding::Runtime { local_id, .. } => crate::runtime_entity_type_id(
+                            self.catalog.lock().unwrap().intern_label(&local_id),
+                        ),
+                    }
+                }
+                Err(diagnostic) => {
+                    Self::push_composition_error(diagnostic, span, s);
+                    TypeId(u32::MAX)
+                }
+            };
+        }
         if let Some(handle) = &self.ontology
             && let Some(id) = handle.entity_type_id(name)
         {
@@ -4481,6 +4521,25 @@ impl Binder {
     }
 
     fn resolve_relation_type(&self, name: &str, span: Span, s: &mut BinderState) -> TypeId {
+        if let Some(composition) = &self.composition {
+            return match composition.resolve(graphforge_ontology::SymbolKind::Relation, name) {
+                Ok((binding, receipt)) => {
+                    s.builder.push_binding_receipt(receipt);
+                    match binding {
+                        SymbolBinding::Qualified(symbol) => {
+                            TypeId(composition.semantic_id(&symbol))
+                        }
+                        SymbolBinding::Runtime { local_id, .. } => crate::runtime_relation_type_id(
+                            self.catalog.lock().unwrap().intern_relation_type(&local_id),
+                        ),
+                    }
+                }
+                Err(diagnostic) => {
+                    Self::push_composition_error(diagnostic, span, s);
+                    TypeId(u32::MAX)
+                }
+            };
+        }
         if let Some(handle) = &self.ontology
             && let Some(id) = handle.relation_type_id(name)
         {
@@ -4525,6 +4584,44 @@ impl Binder {
         if matches!(name, "node_uuid" | "edge_uuid") {
             return PropId(self.catalog.lock().unwrap().intern_property(name, None).0);
         }
+        if let Some(composition) = &self.composition {
+            let owned = match &owner {
+                BoundPropertyOwner::Entity(Some(owner)) => {
+                    Some((graphforge_ontology::SymbolKind::Entity, owner.as_str()))
+                }
+                BoundPropertyOwner::Relationship(Some(owner)) => {
+                    Some((graphforge_ontology::SymbolKind::Relation, owner.as_str()))
+                }
+                BoundPropertyOwner::Entity(None)
+                | BoundPropertyOwner::Relationship(None)
+                | BoundPropertyOwner::Value => None,
+            };
+            let resolution = owned.map_or_else(
+                || composition.resolve(graphforge_ontology::SymbolKind::Property, name),
+                |(kind, owner)| composition.resolve_owned_property(kind, owner, name),
+            );
+            return match resolution {
+                Ok((binding, receipt)) => {
+                    s.builder.push_binding_receipt(receipt);
+                    match binding {
+                        SymbolBinding::Qualified(symbol) => {
+                            PropId(composition.semantic_id(&symbol))
+                        }
+                        SymbolBinding::Runtime { local_id, .. } => PropId(
+                            self.catalog
+                                .lock()
+                                .unwrap()
+                                .intern_property(&local_id, None)
+                                .0,
+                        ),
+                    }
+                }
+                Err(diagnostic) => {
+                    Self::push_composition_error(diagnostic, span, s);
+                    PropId(u32::MAX)
+                }
+            };
+        }
         match self.mode {
             OntologyMode::Strict => self.resolve_strict_property(name, span, owner, s),
             OntologyMode::Advisory => {
@@ -4539,6 +4636,37 @@ impl Binder {
                 PropId(self.catalog.lock().unwrap().intern_property(name, None).0)
             }
         }
+    }
+
+    fn push_composition_error(
+        diagnostic: crate::BindingDiagnostic,
+        span: Span,
+        s: &mut BinderState,
+    ) {
+        let kind = match diagnostic.code {
+            BindingDiagnosticCode::AmbiguousSymbol => BindErrorKind::AmbiguousComposedSymbol,
+            BindingDiagnosticCode::UnknownSymbol => BindErrorKind::UnknownLabel,
+            _ => BindErrorKind::CompositionConflict,
+        };
+        let candidates = if diagnostic.candidates.is_empty() {
+            String::new()
+        } else {
+            format!("; candidates: {}", diagnostic.candidates.join(", "))
+        };
+        s.errors.push(BindError::new(
+            kind,
+            span,
+            format!(
+                "{}: {}{}; remediation: {}",
+                serde_json::to_value(diagnostic.code)
+                    .ok()
+                    .and_then(|value| value.as_str().map(ToOwned::to_owned))
+                    .unwrap_or_else(|| "composition_error".to_owned()),
+                diagnostic.subject,
+                candidates,
+                diagnostic.remediation
+            ),
+        ));
     }
 
     fn resolve_strict_property(

--- a/crates/graphforge-ir/src/binder.rs
+++ b/crates/graphforge-ir/src/binder.rs
@@ -4487,7 +4487,7 @@ impl Binder {
                     }
                 }
                 Err(diagnostic) => {
-                    Self::push_composition_error(diagnostic, span, s);
+                    Self::push_composition_error(&diagnostic, span, s);
                     TypeId(u32::MAX)
                 }
             };
@@ -4535,7 +4535,7 @@ impl Binder {
                     }
                 }
                 Err(diagnostic) => {
-                    Self::push_composition_error(diagnostic, span, s);
+                    Self::push_composition_error(&diagnostic, span, s);
                     TypeId(u32::MAX)
                 }
             };
@@ -4585,7 +4585,7 @@ impl Binder {
             return PropId(self.catalog.lock().unwrap().intern_property(name, None).0);
         }
         if let Some(composition) = &self.composition {
-            let owned = match &owner {
+            let scoped_owner = match &owner {
                 BoundPropertyOwner::Entity(Some(owner)) => {
                     Some((graphforge_ontology::SymbolKind::Entity, owner.as_str()))
                 }
@@ -4596,7 +4596,7 @@ impl Binder {
                 | BoundPropertyOwner::Relationship(None)
                 | BoundPropertyOwner::Value => None,
             };
-            let resolution = owned.map_or_else(
+            let resolution = scoped_owner.map_or_else(
                 || composition.resolve(graphforge_ontology::SymbolKind::Property, name),
                 |(kind, owner)| composition.resolve_owned_property(kind, owner, name),
             );
@@ -4617,7 +4617,7 @@ impl Binder {
                     }
                 }
                 Err(diagnostic) => {
-                    Self::push_composition_error(diagnostic, span, s);
+                    Self::push_composition_error(&diagnostic, span, s);
                     PropId(u32::MAX)
                 }
             };
@@ -4639,7 +4639,7 @@ impl Binder {
     }
 
     fn push_composition_error(
-        diagnostic: crate::BindingDiagnostic,
+        diagnostic: &crate::BindingDiagnostic,
         span: Span,
         s: &mut BinderState,
     ) {

--- a/crates/graphforge-ir/src/composition_binding.rs
+++ b/crates/graphforge-ir/src/composition_binding.rs
@@ -217,7 +217,9 @@ impl CompositionBindingContext {
                     },
                 ))
             }
-            Err(error) => self.resolve_via_bridge_or_policy(kind, local_id, module.as_ref(), error),
+            Err(error) => {
+                self.resolve_via_bridge_or_policy(kind, local_id, module.as_ref(), &error)
+            }
         }
     }
 
@@ -420,12 +422,13 @@ impl CompositionBindingContext {
         })
     }
 
+    #[allow(clippy::too_many_lines)]
     fn resolve_via_bridge_or_policy(
         &self,
         kind: SymbolKind,
         local_id: &str,
         qualified_module: Option<&OntologyModuleId>,
-        error: graphforge_ontology::CompositionError,
+        error: &graphforge_ontology::CompositionError,
     ) -> Result<(SymbolBinding, BindingExplainReceipt), BindingDiagnostic> {
         if error
             .diagnostics

--- a/crates/graphforge-ir/src/composition_binding.rs
+++ b/crates/graphforge-ir/src/composition_binding.rs
@@ -1,0 +1,559 @@
+//! Deterministic symbol binding over a compiled ontology composition.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use graphforge_ontology::{
+    ActivationMode, BridgeDocument, CompiledComposition, OntologyModuleId, QualifiedSymbol,
+    ResolveRequest, SymbolKind,
+};
+use serde::{Deserialize, Serialize};
+
+/// Finite output limits for one binding explanation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CompositionBindingLimits {
+    /// Maximum ambiguity candidates retained.
+    pub candidates: usize,
+    /// Maximum bridge decisions retained.
+    pub bridge_steps: usize,
+}
+
+impl Default for CompositionBindingLimits {
+    fn default() -> Self {
+        Self {
+            candidates: 64,
+            bridge_steps: 64,
+        }
+    }
+}
+
+/// Stable diagnostic code for composed binding failures and warnings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BindingDiagnosticCode {
+    /// A qualified or strict symbol was not found.
+    UnknownSymbol,
+    /// An unqualified symbol has multiple valid owners.
+    AmbiguousSymbol,
+    /// A qualifier names no module or more than one module.
+    InvalidQualifier,
+    /// Multiple bridge paths produce conflicting outcomes.
+    ConflictingBridgePaths,
+    /// A declared property is used with an owner that does not declare it.
+    WrongOwnerProperty,
+    /// A bridge requires semantics this binder does not support.
+    UnsupportedRequiredSemantics,
+    /// Resolution continued through the runtime catalog.
+    RuntimeFallback,
+}
+
+/// Stable, attributable composed-binding diagnostic.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BindingDiagnostic {
+    /// Machine-readable code.
+    pub code: BindingDiagnosticCode,
+    /// Exact module, bridge, or input subject.
+    pub subject: String,
+    /// Deterministically ordered bounded candidates.
+    pub candidates: Vec<String>,
+    /// Human remediation.
+    pub remediation: String,
+}
+
+/// One deterministic decision in a binding explanation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "decision")]
+pub enum BindingDecision {
+    /// Exact qualified lookup.
+    Qualified {
+        /// Resolved exact symbol.
+        symbol: QualifiedSymbol,
+    },
+    /// Unique unqualified lookup.
+    Unique {
+        /// Sole valid candidate.
+        symbol: QualifiedSymbol,
+    },
+    /// Explicit bridge traversal.
+    Bridge {
+        /// Adopted bridge authority.
+        bridge_id: String,
+        /// Applied bounded predicate.
+        predicate: String,
+        /// Traversal source.
+        source: QualifiedSymbol,
+        /// Traversal target.
+        target: QualifiedSymbol,
+    },
+    /// Progressive runtime-catalog fallback.
+    RuntimeFallback {
+        /// Runtime symbol kind.
+        kind: SymbolKind,
+        /// Observed local identifier.
+        local_id: String,
+    },
+}
+
+/// Bounded deterministic explanation returned with a successful binding.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BindingExplainReceipt {
+    /// Exact composition identity carried into the plan.
+    pub composition_fingerprint: String,
+    /// Effective progressive policy.
+    pub effective_mode: ActivationMode,
+    /// Ordered decisions.
+    pub decisions: Vec<BindingDecision>,
+    /// Advisory diagnostics; empty for clean/strict success.
+    pub diagnostics: Vec<BindingDiagnostic>,
+}
+
+/// Resolved semantic symbol, or a permitted runtime-catalog observation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SymbolBinding {
+    /// Exact composition-owned identity.
+    Qualified(QualifiedSymbol),
+    /// Runtime-local fallback; never confused with ontology identity.
+    Runtime {
+        /// Runtime symbol kind.
+        kind: SymbolKind,
+        /// Runtime-local identifier.
+        local_id: String,
+    },
+}
+
+/// Immutable consumer-neutral binding context.
+#[derive(Clone)]
+pub struct CompositionBindingContext {
+    composition: Arc<CompiledComposition>,
+    bridges: Vec<BridgeDocument>,
+    limits: CompositionBindingLimits,
+}
+
+impl CompositionBindingContext {
+    /// Construct from compiled module authority and adopted bridge documents.
+    #[must_use]
+    pub fn new(
+        composition: Arc<CompiledComposition>,
+        mut bridges: Vec<BridgeDocument>,
+        limits: CompositionBindingLimits,
+    ) -> Self {
+        bridges.sort_by(|left, right| {
+            (&left.bridge_id, &left.authored_version)
+                .cmp(&(&right.bridge_id, &right.authored_version))
+        });
+        Self {
+            composition,
+            bridges,
+            limits,
+        }
+    }
+
+    /// Exact composition fingerprint.
+    #[must_use]
+    pub fn fingerprint(&self) -> &str {
+        &self.composition.fingerprint
+    }
+
+    /// Deterministic composition-local semantic ID for a qualified symbol.
+    ///
+    /// IDs are plan-local projections only; exact semantic identity remains in
+    /// the fingerprint and binding receipt and is never confused with a runtime
+    /// catalog ID.
+    #[must_use]
+    pub fn semantic_id(&self, symbol: &QualifiedSymbol) -> u32 {
+        let mut symbols = self
+            .composition
+            .modules
+            .iter()
+            .flat_map(|module| module.symbols.iter())
+            .collect::<Vec<_>>();
+        symbols.sort_by_key(|candidate| {
+            (
+                candidate.module.sort_key(),
+                candidate.kind.as_str().as_bytes().to_vec(),
+                candidate.local_id.as_bytes().to_vec(),
+            )
+        });
+        symbols
+            .iter()
+            .position(|candidate| *candidate == symbol)
+            .and_then(|index| u32::try_from(index).ok())
+            .expect("compiled composition symbol count is bounded to u32")
+    }
+
+    /// Resolve `local_id`, accepting `module-short:local` as an explicit qualifier.
+    pub fn resolve(
+        &self,
+        kind: SymbolKind,
+        input: &str,
+    ) -> Result<(SymbolBinding, BindingExplainReceipt), BindingDiagnostic> {
+        let (module, local_id) = self.parse_qualifier(input)?;
+        match self.composition.resolve(&ResolveRequest {
+            module: module.as_ref(),
+            kind,
+            local_id,
+            max_candidates: self.limits.candidates.max(1),
+        }) {
+            Ok(outcome) => {
+                let mode = self
+                    .composition
+                    .effective_module_mode(&outcome.symbol.module);
+                let decision = if outcome.via_unqualified {
+                    BindingDecision::Unique {
+                        symbol: outcome.symbol.clone(),
+                    }
+                } else {
+                    BindingDecision::Qualified {
+                        symbol: outcome.symbol.clone(),
+                    }
+                };
+                Ok((
+                    SymbolBinding::Qualified(outcome.symbol),
+                    BindingExplainReceipt {
+                        composition_fingerprint: self.fingerprint().to_owned(),
+                        effective_mode: mode,
+                        decisions: vec![decision],
+                        diagnostics: Vec::new(),
+                    },
+                ))
+            }
+            Err(error) => self.resolve_via_bridge_or_policy(kind, local_id, module.as_ref(), error),
+        }
+    }
+
+    /// Select an adopted bridge assertion between two exact endpoints.
+    ///
+    /// Directional assertions are considered only source-to-target. Symmetric
+    /// predicates may be traversed in either direction. Required disjoint
+    /// semantics are rejected because they cannot produce a positive binding.
+    pub fn select_bridge(
+        &self,
+        source: &QualifiedSymbol,
+        target: &QualifiedSymbol,
+    ) -> Result<BindingExplainReceipt, BindingDiagnostic> {
+        self.require_endpoint(source)?;
+        self.require_endpoint(target)?;
+        let mut matches = self
+            .bridges
+            .iter()
+            .flat_map(|bridge| {
+                bridge.assertions.iter().filter_map(move |assertion| {
+                    let forward = assertion.source == *source && assertion.target == *target;
+                    let reverse = assertion.predicate.is_symmetric()
+                        && assertion.source == *target
+                        && assertion.target == *source;
+                    (forward || reverse).then_some((bridge, assertion))
+                })
+            })
+            .collect::<Vec<_>>();
+        matches.sort_by_key(|(bridge, assertion)| {
+            (bridge.bridge_id.as_str(), assertion.predicate.as_str())
+        });
+        if matches.is_empty() {
+            return Err(BindingDiagnostic {
+                code: BindingDiagnosticCode::UnknownSymbol,
+                subject: format!("{} -> {}", source.display(), target.display()),
+                candidates: Vec::new(),
+                remediation: "adopt an explicit bridge for these exact endpoints".to_owned(),
+            });
+        }
+        let predicates = matches
+            .iter()
+            .map(|(_, assertion)| assertion.predicate.as_str())
+            .collect::<std::collections::BTreeSet<_>>();
+        if predicates.len() > 1 {
+            return Err(BindingDiagnostic {
+                code: BindingDiagnosticCode::ConflictingBridgePaths,
+                subject: format!("{} -> {}", source.display(), target.display()),
+                candidates: predicates.into_iter().map(str::to_owned).collect(),
+                remediation: "remove conflicting adopted bridge assertions".to_owned(),
+            });
+        }
+        let (bridge, assertion) = matches[0];
+        if assertion.predicate.as_str() == "disjoint" {
+            return Err(BindingDiagnostic {
+                code: BindingDiagnosticCode::UnsupportedRequiredSemantics,
+                subject: bridge.bridge_id.clone(),
+                candidates: vec![assertion.predicate.as_str().to_owned()],
+                remediation: "use disjointness for validation, not positive symbol binding"
+                    .to_owned(),
+            });
+        }
+        Ok(BindingExplainReceipt {
+            composition_fingerprint: self.fingerprint().to_owned(),
+            effective_mode: bridge
+                .enforcement
+                .unwrap_or_else(|| self.composition.effective_module_mode(&source.module)),
+            decisions: vec![BindingDecision::Bridge {
+                bridge_id: bridge.bridge_id.clone(),
+                predicate: assertion.predicate.as_str().to_owned(),
+                source: source.clone(),
+                target: target.clone(),
+            }],
+            diagnostics: Vec::new(),
+        })
+    }
+
+    /// Verify that a resolved property belongs to the bound entity or relation.
+    pub fn validate_property_owner(
+        &self,
+        property: &QualifiedSymbol,
+        owner: &str,
+    ) -> Result<(), BindingDiagnostic> {
+        let owner_local = owner.rsplit_once(':').map_or(owner, |(_, local)| local);
+        let Some(module) = self
+            .composition
+            .modules
+            .iter()
+            .find(|module| module.id == property.module)
+        else {
+            return self.require_endpoint(property);
+        };
+        if module.doc.properties.iter().any(|candidate| {
+            format!("{}:{}", candidate.owner, candidate.name) == property.local_id
+                && candidate.owner == owner_local
+        }) {
+            return Ok(());
+        }
+        Err(BindingDiagnostic {
+            code: BindingDiagnosticCode::WrongOwnerProperty,
+            subject: format!("{}.{}", owner, property.local_id),
+            candidates: module
+                .doc
+                .properties
+                .iter()
+                .filter(|candidate| {
+                    format!("{}:{}", candidate.owner, candidate.name) == property.local_id
+                })
+                .map(|candidate| candidate.owner.clone())
+                .take(self.limits.candidates.max(1))
+                .collect(),
+            remediation: "use the property only on an owner that declares it".to_owned(),
+        })
+    }
+
+    /// Resolve a property against the exact owner bound by the query pattern.
+    pub fn resolve_owned_property(
+        &self,
+        owner_kind: SymbolKind,
+        owner: &str,
+        property: &str,
+    ) -> Result<(SymbolBinding, BindingExplainReceipt), BindingDiagnostic> {
+        let (owner_binding, mut receipt) = self.resolve(owner_kind, owner)?;
+        let SymbolBinding::Qualified(owner_symbol) = owner_binding else {
+            return self.resolve(SymbolKind::Property, property);
+        };
+        let local_id = format!("{}:{property}", owner_symbol.local_id);
+        let outcome = self
+            .composition
+            .resolve(&ResolveRequest {
+                module: Some(&owner_symbol.module),
+                kind: SymbolKind::Property,
+                local_id: &local_id,
+                max_candidates: self.limits.candidates.max(1),
+            })
+            .map_err(|_| BindingDiagnostic {
+                code: BindingDiagnosticCode::WrongOwnerProperty,
+                subject: format!("{owner}.{property}"),
+                candidates: self
+                    .composition
+                    .modules
+                    .iter()
+                    .flat_map(|module| module.doc.properties.iter())
+                    .filter(|candidate| candidate.name == property)
+                    .map(|candidate| candidate.owner.clone())
+                    .take(self.limits.candidates.max(1))
+                    .collect(),
+                remediation: "use the property only on an owner that declares it".to_owned(),
+            })?;
+        receipt.decisions.push(BindingDecision::Qualified {
+            symbol: outcome.symbol.clone(),
+        });
+        Ok((SymbolBinding::Qualified(outcome.symbol), receipt))
+    }
+
+    fn require_endpoint(&self, endpoint: &QualifiedSymbol) -> Result<(), BindingDiagnostic> {
+        let found = self.composition.modules.iter().any(|module| {
+            module.id == endpoint.module && module.symbols.iter().any(|symbol| symbol == endpoint)
+        });
+        if found {
+            Ok(())
+        } else {
+            Err(BindingDiagnostic {
+                code: BindingDiagnosticCode::UnknownSymbol,
+                subject: endpoint.display(),
+                candidates: Vec::new(),
+                remediation: "use an endpoint declared by an activated module".to_owned(),
+            })
+        }
+    }
+
+    fn parse_qualifier<'a>(
+        &'a self,
+        input: &'a str,
+    ) -> Result<(Option<OntologyModuleId>, &'a str), BindingDiagnostic> {
+        let Some((qualifier, local_id)) = input.split_once(':') else {
+            return Ok((None, input));
+        };
+        let mut matches = self
+            .composition
+            .modules
+            .iter()
+            .filter(|module| {
+                module.id.short_name() == qualifier || module.id.display_ref() == qualifier
+            })
+            .map(|module| module.id.clone())
+            .collect::<Vec<_>>();
+        matches.sort_by_key(OntologyModuleId::sort_key);
+        if matches.len() == 1 && !local_id.is_empty() {
+            return Ok((matches.pop(), local_id));
+        }
+        Err(BindingDiagnostic {
+            code: BindingDiagnosticCode::InvalidQualifier,
+            subject: input.to_owned(),
+            candidates: matches
+                .into_iter()
+                .take(self.limits.candidates.max(1))
+                .map(|module| module.display_ref())
+                .collect(),
+            remediation: "use one exact module short name or display_ref".to_owned(),
+        })
+    }
+
+    fn resolve_via_bridge_or_policy(
+        &self,
+        kind: SymbolKind,
+        local_id: &str,
+        qualified_module: Option<&OntologyModuleId>,
+        error: graphforge_ontology::CompositionError,
+    ) -> Result<(SymbolBinding, BindingExplainReceipt), BindingDiagnostic> {
+        if error
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code.as_str() == "resolution.ambiguous")
+        {
+            return Err(BindingDiagnostic {
+                code: BindingDiagnosticCode::AmbiguousSymbol,
+                subject: local_id.to_owned(),
+                candidates: error
+                    .diagnostics
+                    .iter()
+                    .flat_map(|diagnostic| diagnostic.candidates.iter().cloned())
+                    .take(self.limits.candidates.max(1))
+                    .collect(),
+                remediation: "qualify the symbol with its exact module".to_owned(),
+            });
+        }
+        let mut bridge_matches = Vec::new();
+        for bridge in &self.bridges {
+            for assertion in &bridge.assertions {
+                let source_matches = assertion.source.kind == kind
+                    && assertion.source.local_id == local_id
+                    && qualified_module.is_none_or(|module| module == &assertion.source.module);
+                let reverse_matches = assertion.predicate.is_symmetric()
+                    && assertion.target.kind == kind
+                    && assertion.target.local_id == local_id
+                    && qualified_module.is_none_or(|module| module == &assertion.target.module);
+                if source_matches {
+                    bridge_matches.push((bridge, assertion, false));
+                } else if reverse_matches {
+                    bridge_matches.push((bridge, assertion, true));
+                }
+            }
+        }
+        bridge_matches.sort_by(|(left, assertion_left, _), (right, assertion_right, _)| {
+            (&left.bridge_id, assertion_left.target.display())
+                .cmp(&(&right.bridge_id, assertion_right.target.display()))
+        });
+        let targets = bridge_matches
+            .iter()
+            .map(|(_, assertion, reverse)| {
+                let target = if *reverse {
+                    assertion.source.clone()
+                } else {
+                    assertion.target.clone()
+                };
+                (target.display(), target)
+            })
+            .collect::<BTreeMap<_, _>>();
+        if targets.len() == 1 {
+            let target = targets.into_values().next().expect("one target");
+            let (bridge, assertion, reverse) = bridge_matches[0];
+            let source = if reverse {
+                assertion.target.clone()
+            } else {
+                assertion.source.clone()
+            };
+            let mode = bridge
+                .enforcement
+                .unwrap_or_else(|| self.composition.effective_module_mode(&target.module));
+            return Ok((
+                SymbolBinding::Qualified(target.clone()),
+                BindingExplainReceipt {
+                    composition_fingerprint: self.fingerprint().to_owned(),
+                    effective_mode: mode,
+                    decisions: vec![BindingDecision::Bridge {
+                        bridge_id: bridge.bridge_id.clone(),
+                        predicate: assertion.predicate.as_str().to_owned(),
+                        source,
+                        target,
+                    }],
+                    diagnostics: Vec::new(),
+                },
+            ));
+        }
+        if targets.len() > 1 {
+            return Err(BindingDiagnostic {
+                code: BindingDiagnosticCode::ConflictingBridgePaths,
+                subject: local_id.to_owned(),
+                candidates: targets
+                    .into_iter()
+                    .take(self.limits.candidates.max(1))
+                    .map(|(_, target)| target.display())
+                    .collect(),
+                remediation: "qualify the symbol or remove conflicting bridge paths".to_owned(),
+            });
+        }
+
+        let mode = qualified_module.map_or(self.composition.profile_default, |module| {
+            self.composition.effective_module_mode(module)
+        });
+        if mode == ActivationMode::Strict {
+            return Err(BindingDiagnostic {
+                code: BindingDiagnosticCode::UnknownSymbol,
+                subject: local_id.to_owned(),
+                candidates: error
+                    .diagnostics
+                    .iter()
+                    .flat_map(|diagnostic| diagnostic.candidates.iter().cloned())
+                    .take(self.limits.candidates.max(1))
+                    .collect(),
+                remediation: "qualify or activate a declaring module/bridge".to_owned(),
+            });
+        }
+        let diagnostic = BindingDiagnostic {
+            code: BindingDiagnosticCode::RuntimeFallback,
+            subject: local_id.to_owned(),
+            candidates: Vec::new(),
+            remediation: "adopt an ontology declaration before enabling strict mode".to_owned(),
+        };
+        Ok((
+            SymbolBinding::Runtime {
+                kind,
+                local_id: local_id.to_owned(),
+            },
+            BindingExplainReceipt {
+                composition_fingerprint: self.fingerprint().to_owned(),
+                effective_mode: mode,
+                decisions: vec![BindingDecision::RuntimeFallback {
+                    kind,
+                    local_id: local_id.to_owned(),
+                }],
+                diagnostics: (mode == ActivationMode::Advisory)
+                    .then_some(diagnostic)
+                    .into_iter()
+                    .collect(),
+            },
+        ))
+    }
+}

--- a/crates/graphforge-ir/src/lib.rs
+++ b/crates/graphforge-ir/src/lib.rs
@@ -22,6 +22,12 @@ pub use catalog::{
     runtime_type_id_from_entity_plan_id,
 };
 
+pub mod composition_binding;
+pub use composition_binding::{
+    BindingDecision, BindingDiagnostic, BindingDiagnosticCode, BindingExplainReceipt,
+    CompositionBindingContext, CompositionBindingLimits, SymbolBinding,
+};
+
 pub mod expr;
 pub use expr::{BinaryOpKind, CaseArm, ExprArena, IrExpr, IrLiteral, UnaryOpKind};
 pub use graphforge_ast::QuantifierKind;

--- a/crates/graphforge-ir/src/plan.rs
+++ b/crates/graphforge-ir/src/plan.rs
@@ -555,6 +555,8 @@ mod tests {
             dialect: "openCypher".into(),
             ontology_version: Some(OntologyVersion::from("v1")),
             ontology_mode: OntologyMode::Advisory,
+            composition_fingerprint: None,
+            binding_receipts: vec![],
             feature_flags: vec![],
             ops: vec![
                 GraphOp::NodeScan {
@@ -607,6 +609,8 @@ mod tests {
             dialect: "openCypher".into(),
             ontology_version: None,
             ontology_mode: OntologyMode::Exploratory,
+            composition_fingerprint: None,
+            binding_receipts: vec![],
             feature_flags: vec![],
             ops: vec![
                 GraphOp::NodeScan {

--- a/crates/graphforge-ir/src/plan.rs
+++ b/crates/graphforge-ir/src/plan.rs
@@ -8,9 +8,9 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    AggExpr, CreatePattern, Direction, ExprArena, ExprId, IrVersion, OntologyVersion,
-    ProcedureDefinition, ProcedureYield, ProjectItem, RemovePropItem, SetMapItem, SetPropItem,
-    SortOrder, TypeId, VarId,
+    AggExpr, BindingExplainReceipt, CreatePattern, Direction, ExprArena, ExprId, IrVersion,
+    OntologyVersion, ProcedureDefinition, ProcedureYield, ProjectItem, RemovePropItem, SetMapItem,
+    SetPropItem, SortOrder, TypeId, VarId,
 };
 
 /// Child projection column consumed by pattern-comprehension lowering.
@@ -387,6 +387,12 @@ pub struct GraphPlan {
     ///
     /// `None` in `Exploratory` mode (no formal ontology present).
     pub ontology_version: Option<OntologyVersion>,
+    /// Exact multi-ontology composition identity used during binding.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub composition_fingerprint: Option<String>,
+    /// Deterministic bounded semantic-resolution explanations.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub binding_receipts: Vec<BindingExplainReceipt>,
     /// Active ontology enforcement mode.
     pub ontology_mode: OntologyMode,
     /// Optional feature flags that affect plan behaviour.
@@ -409,6 +415,8 @@ impl GraphPlan {
             ir_version: IrVersion::CURRENT,
             dialect: dialect.into(),
             ontology_version: None,
+            composition_fingerprint: None,
+            binding_receipts: Vec::new(),
             ontology_mode: OntologyMode::default(),
             feature_flags: Vec::new(),
             ops: Vec::new(),
@@ -429,6 +437,8 @@ pub struct GraphPlanBuilder {
     ir_version: IrVersion,
     dialect: String,
     ontology_version: Option<OntologyVersion>,
+    composition_fingerprint: Option<String>,
+    binding_receipts: Vec<BindingExplainReceipt>,
     ontology_mode: OntologyMode,
     feature_flags: Vec<String>,
     ops: Vec<GraphOp>,
@@ -448,6 +458,18 @@ impl GraphPlanBuilder {
     pub fn ontology_version(mut self, v: impl Into<OntologyVersion>) -> Self {
         self.ontology_version = Some(v.into());
         self
+    }
+
+    /// Carry exact composition identity through the plan.
+    #[must_use]
+    pub fn composition_fingerprint(mut self, fingerprint: impl Into<String>) -> Self {
+        self.composition_fingerprint = Some(fingerprint.into());
+        self
+    }
+
+    /// Append one deterministic symbol-binding explanation.
+    pub fn push_binding_receipt(&mut self, receipt: BindingExplainReceipt) {
+        self.binding_receipts.push(receipt);
     }
 
     /// Set the ontology mode (default: [`OntologyMode::Exploratory`]).
@@ -491,6 +513,8 @@ impl GraphPlanBuilder {
             ir_version: self.ir_version,
             dialect: self.dialect,
             ontology_version: self.ontology_version,
+            composition_fingerprint: self.composition_fingerprint,
+            binding_receipts: self.binding_receipts,
             ontology_mode: self.ontology_mode,
             feature_flags: self.feature_flags,
             ops: self.ops,

--- a/crates/graphforge-ontology/src/bridge/store.rs
+++ b/crates/graphforge-ontology/src/bridge/store.rs
@@ -606,6 +606,24 @@ impl BridgeInventory {
         ids
     }
 
+    /// Adopted bridge documents in deterministic identity order.
+    ///
+    /// Consumers use these immutable documents to compile binding behavior;
+    /// candidate and validated staging records are deliberately excluded.
+    #[must_use]
+    pub fn adopted_documents(&self) -> Vec<BridgeDocument> {
+        let mut records: Vec<_> = self
+            .adopted
+            .values()
+            .filter(|record| record.status == BridgeLifecycleStatus::Adopted)
+            .collect();
+        records.sort_by_key(|record| record.id.sort_key());
+        records
+            .into_iter()
+            .map(|record| record.doc.clone())
+            .collect()
+    }
+
     /// Serialize durable authority (staging excluded).
     #[must_use]
     pub fn snapshot(&self) -> BridgeSnapshot {

--- a/docs/book/architecture/composable-multi-ontology.md
+++ b/docs/book/architecture/composable-multi-ontology.md
@@ -93,6 +93,29 @@ inventory. The legacy canonical ontology digest is retained; a deterministic
 when an explicit migration publishes the first M9 authority generation. Until
 then export remains legacy and no implicit format upgrade occurs.
 
+## Query binding and explain receipts
+
+`CompositionBindingContext` is the immutable Rust authority supplied to the
+Binder and `GraphForge::execute_with_composition`. Resolution tries an exact
+module qualifier first and permits shorthand only for one candidate. Adopted
+bridge assertions retain their authored direction and bounded predicate;
+symmetric predicates may be traversed in reverse, while conflicting or
+non-computable required semantics fail deterministically.
+
+Activation remains scoped. A module or bridge override determines the effective
+exploratory, advisory, or strict policy for that decision; the composition
+default is used only when no exact override exists. Advisory and exploratory
+fallbacks intern a separately tagged RuntimeCatalog identity, while strict,
+ambiguous, wrong-owner, invalid-endpoint, and conflicting binds fail without
+publishing the staged catalog snapshot.
+
+Every successful composed resolution adds a bounded `BindingExplainReceipt` to
+the `GraphPlan`. It contains the exact composition fingerprint, effective mode,
+ordered qualified/unique/bridge/runtime decisions, and attributable advisory
+diagnostics with remediation. The plan-local numeric semantic projection is
+derived only from identity-sorted qualified symbols; it is never persisted or
+presented as an ontology or runtime-catalog identity.
+
 ## Diagnostics and resource contract
 
 Every failure is `{ code, phase, message, subjects, candidates, limit }`.

--- a/scripts/ci/test-non-cypher-surface-gate.py
+++ b/scripts/ci/test-non-cypher-surface-gate.py
@@ -29,7 +29,7 @@ class SurfaceGateTests(unittest.TestCase):
 
     def test_checked_in_inventory_is_complete(self) -> None:
         self.assertEqual(GATE.validate(), [])
-        self.assertEqual(len(GATE.public_methods()), 324)
+        self.assertEqual(len(GATE.public_methods()), 325)
         self.assertEqual(len(GATE.algorithm_registry()), 94)
 
     def test_new_or_removed_public_method_fails_frozen_digest(self) -> None:

--- a/tests/contracts/non-cypher-rust-surface.json
+++ b/tests/contracts/non-cypher-rust-surface.json
@@ -1,7 +1,7 @@
 {
   "contract_version": 1,
   "scope": "Rust non-Cypher public release surface",
-  "public_method_digest": "268d0832e1fa2bc823e1aa6a0f7a5129c29f4b0b23886a6fc2927616671a3b73",
+  "public_method_digest": "a1a0f16a771df5e159130b7b7c41961d3c3bf0dc499f692ce20d1d3b4ce38ae2",
   "method_policy": {
     "receiver_defaults": {
       "GraphForge": "release-tested",
@@ -704,6 +704,7 @@
       "ids": [
         "GraphForge.clear",
         "GraphForge.execute",
+        "GraphForge.execute_with_composition",
         "GraphForge.execute_stream",
         "GraphForge.execute_stream_owned",
         "GraphForge.execute_stream_with_params",
@@ -718,6 +719,10 @@
         "GraphForge.schema"
       ],
       "test_refs": [
+        {
+          "path": "crates/graphforge-api/src/composition_binding_tests.rs",
+          "symbol": "facade_executes_qualified_and_unique_composed_queries"
+        },
         {
           "path": "crates/graphforge-api/src/lib.rs",
           "symbol": "registered_procedure_missing_parameter_matches_streaming_path"


### PR DESCRIPTION
Closes #839

## Summary
- compile exact ontology composition and adopted bridge authority into deterministic Binder resolution
- enforce scoped module and bridge policy with stable bounded diagnostics and transactional RuntimeCatalog publication
- carry composition fingerprints and explain receipts through GraphPlan and expose real GraphForge facade execution
- cover qualified/unique resolution, ambiguity, bridges/conflicts, strict/advisory/exploratory behavior, wrong owners, rollback, and repeatability

## Verification
- `CARGO_TARGET_DIR=/private/tmp/graphforge-839-target cargo test -p graphforge-api --lib composition_binding_tests` (7 passed)
- `CARGO_TARGET_DIR=/private/tmp/graphforge-839-target cargo test -p graphforge-ir --lib` (168 passed)
- `CARGO_TARGET_DIR=/private/tmp/graphforge-839-target cargo clippy -p graphforge-ir -p graphforge-api --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 scripts/ci/cargo-bazel-drift-check.py`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789866374&installation_model_id=20486&pr_number=871&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F871&signature=1a43f9d96848e28e21aacf6b52a9e9f7c43d3f7e5b295e5926015e0f9251a1e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->