### PR TITLE
feat(storage): persist qualified semantic graph bindings

### DIFF
--- a/crates/graphforge-api/src/composition_binding_tests.rs
+++ b/crates/graphforge-api/src/composition_binding_tests.rs
@@ -15,12 +15,10 @@ use graphforge_ontology::{
 use super::GraphForge;
 use graphforge_core::OntologyMode;
 
-fn install_composition_authority(forge: &GraphForge, fingerprint: &str) {
+fn install_composition_authority(forge: &GraphForge, context: &CompositionBindingContext) {
     use graphforge_storage::{
-        ProjectCapability, ProjectGenerationRequest, ProjectParticipant,
-        ProjectParticipantEncoding, ProjectStageOutcome,
+        ProjectCapability, ProjectGenerationRequest, ProjectParticipant, ProjectStageOutcome,
     };
-    use sha2::{Digest, Sha256};
 
     let parent =
         graphforge_storage::resolve_project_generation(forge.resolved_generation.container_root())
@@ -40,21 +38,14 @@ fn install_composition_authority(forge: &GraphForge, fingerprint: &str) {
             bytes: snapshot.bytes,
         })
         .collect::<Vec<_>>();
-    let mut bytes = serde_json::to_vec(&serde_json::json!({
-        "composition_fingerprint": fingerprint
-    }))
-    .unwrap();
-    bytes.push(b'\n');
-    participants.push(ProjectParticipant {
-        capability_id: "workspace".into(),
-        capability_version: 1,
-        record_family_id: "ontology_composition".into(),
-        record_version: 1,
-        encoding: ProjectParticipantEncoding::Json,
-        schema_fingerprint: Sha256::digest(b"test-composition-authority/1").into(),
-        row_count: 1,
-        bytes,
-    });
+    participants.push(
+        graphforge_storage::WorkspaceOntologyComposition::from_compiled(
+            context.composition(),
+            context.bridges().to_vec(),
+        )
+        .to_project_participant()
+        .unwrap(),
+    );
     participants.sort_by(|left, right| {
         (&left.capability_id, &left.record_family_id)
             .cmp(&(&right.capability_id, &right.record_family_id))
@@ -142,6 +133,24 @@ fn composed_fixture(
     QualifiedSymbol,
 ) {
     composed_fixture_with_predicates(default, &[BridgePredicate::Equivalent])
+}
+
+fn single_module_fixture() -> Arc<CompositionBindingContext> {
+    let module = module("research", &["Person"]);
+    let compiled = compile_inventory(InventoryCompileRequest {
+        modules: &[module],
+        bridges: &[],
+        activation: &[],
+        profile_default: ActivationMode::Strict,
+        limits: CompositionLimits::default(),
+        cancelled: None,
+    })
+    .unwrap();
+    Arc::new(CompositionBindingContext::new(
+        Arc::new(compiled),
+        Vec::new(),
+        CompositionBindingLimits::default(),
+    ))
 }
 
 fn composed_fixture_with_predicates(
@@ -294,6 +303,74 @@ fn facade_does_not_install_unpublished_semantic_bindings() {
 }
 
 #[test]
+fn facade_migrates_legacy_routes_with_atomic_participants_and_plain_reopen() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("project");
+    let forge = GraphForge::new(Some(path.to_str().unwrap())).unwrap();
+    let mut writer =
+        graphforge_storage::GraphWriter::open_at(&forge.dir, OntologyMode::Strict, 1).unwrap();
+    let left = graphforge_core::uuid::new_v7();
+    let right = graphforge_core::uuid::new_v7();
+    writer
+        .create_node(left, graphforge_core::TypeId(0))
+        .unwrap();
+    writer
+        .create_node(right, graphforge_core::TypeId(0))
+        .unwrap();
+    writer
+        .create_edge(graphforge_core::uuid::new_v7(), "KNOWS", &left, &right)
+        .unwrap();
+    writer.flush().unwrap();
+    forge
+        .publish_graph_mutation(&graphforge_exec::MutationReceipt::default())
+        .unwrap();
+    let context = single_module_fixture();
+    install_composition_authority(&forge, &context);
+    drop(forge);
+
+    let forge = GraphForge::new(Some(path.to_str().unwrap())).unwrap();
+    let before = graphforge_storage::resolve_project_generation(&path)
+        .unwrap()
+        .generation_uuid();
+    *forge.current_generation_uuid.lock().unwrap() = uuid::Uuid::now_v7();
+    forge
+        .execute("CREATE (n:`research:Person`)")
+        .expect_err("stale legacy publication must fail");
+    assert!(forge.dir.join("topology/edges/KNOWS.parquet").exists());
+    assert_eq!(
+        std::fs::read_dir(forge.dir.join("topology/edges"))
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| entry.file_name().to_string_lossy().starts_with("s-"))
+            .count(),
+        0
+    );
+    *forge.current_generation_uuid.lock().unwrap() = before;
+    forge.execute("CREATE (n:`research:Person`)").unwrap();
+    let generation = graphforge_storage::resolve_project_generation(&path).unwrap();
+    assert_ne!(generation.generation_uuid(), before);
+    assert!(generation.graph_files_inventory().unwrap().is_some());
+    assert!(
+        generation
+            .participant_snapshot("graph", graphforge_storage::GRAPH_SEMANTIC_BINDINGS_FAMILY)
+            .unwrap()
+            .is_some()
+    );
+    drop(forge);
+    let reopened = GraphForge::new(Some(path.to_str().unwrap())).unwrap();
+    let rows = reopened
+        .execute("MATCH (n:`research:Person`) RETURN n")
+        .unwrap();
+    assert_eq!(
+        rows.batches
+            .iter()
+            .map(arrow::record_batch::RecordBatch::num_rows)
+            .sum::<usize>(),
+        3
+    );
+}
+
+#[test]
 fn stale_parent_publication_leaves_graph_and_bindings_at_old_generation() {
     let dir = tempfile::TempDir::new().unwrap();
     let path = dir.path().join("project");
@@ -365,7 +442,7 @@ fn semantic_publication_replays_one_durable_operation_idempotently() {
     let path = dir.path().join("project");
     let forge = GraphForge::new(Some(path.to_str().unwrap())).unwrap();
     let (context, _, _) = composed_fixture(ActivationMode::Strict);
-    install_composition_authority(&forge, context.fingerprint());
+    install_composition_authority(&forge, &context);
     drop(forge);
     let forge = GraphForge::new(Some(path.to_str().unwrap())).unwrap();
     forge
@@ -488,7 +565,7 @@ fn facade_publishes_reopens_and_queries_exact_colliding_semantic_routes() {
     let path_text = path.to_str().unwrap();
     let first = GraphForge::new(Some(path_text)).unwrap();
     let (context, _, _) = composed_fixture(ActivationMode::Strict);
-    install_composition_authority(&first, context.fingerprint());
+    install_composition_authority(&first, &context);
     drop(first);
 
     let forge = GraphForge::new(Some(path_text)).unwrap();
@@ -567,7 +644,7 @@ fn facade_reopens_relation_edge_property_through_default_context() {
     let path_text = path.to_str().unwrap();
     let bootstrap = GraphForge::new(Some(path_text)).unwrap();
     let (context, _, _) = composed_fixture(ActivationMode::Strict);
-    install_composition_authority(&bootstrap, context.fingerprint());
+    install_composition_authority(&bootstrap, &context);
     drop(bootstrap);
 
     let forge = GraphForge::new(Some(path_text)).unwrap();

--- a/crates/graphforge-api/src/composition_binding_tests.rs
+++ b/crates/graphforge-api/src/composition_binding_tests.rs
@@ -94,38 +94,31 @@ fn module(name: &str, entities: &[&str]) -> AuthoredModule {
                 parent: None,
             })
             .collect(),
-        relation_types: (name == "research")
-            .then_some(RelationTypeDef {
-                name: "KNOWS".to_owned(),
-                src: "Person".to_owned(),
-                dst: "Person".to_owned(),
-                inverse: None,
-                semantic: SemanticFlags::default(),
-            })
-            .into_iter()
-            .collect(),
-        properties: (name == "research")
-            .then_some(vec![
-                PropertyDef {
-                    owner: "Person".to_owned(),
-                    name: "name".to_owned(),
-                    value_type: PropertyValueType::Utf8,
-                    nullable: true,
-                    multivalued: false,
-                    default_json: None,
-                },
-                PropertyDef {
-                    owner: "KNOWS".to_owned(),
-                    name: "since".to_owned(),
-                    value_type: PropertyValueType::Int64,
-                    nullable: true,
-                    multivalued: false,
-                    default_json: None,
-                },
-            ])
-            .into_iter()
-            .flatten()
-            .collect(),
+        relation_types: vec![RelationTypeDef {
+            name: "KNOWS".to_owned(),
+            src: "Person".to_owned(),
+            dst: "Person".to_owned(),
+            inverse: None,
+            semantic: SemanticFlags::default(),
+        }],
+        properties: vec![
+            PropertyDef {
+                owner: "Person".to_owned(),
+                name: "name".to_owned(),
+                value_type: PropertyValueType::Utf8,
+                nullable: true,
+                multivalued: false,
+                default_json: None,
+            },
+            PropertyDef {
+                owner: "KNOWS".to_owned(),
+                name: "since".to_owned(),
+                value_type: PropertyValueType::Int64,
+                nullable: true,
+                multivalued: false,
+                default_json: None,
+            },
+        ],
         constraints: vec![],
         migrations: vec![],
     };
@@ -298,6 +291,115 @@ fn facade_does_not_install_unpublished_semantic_bindings() {
         .execute_with_composition("MATCH (n:Person) RETURN n", context)
         .expect_err("ambiguous bind");
     assert!(forge.semantic_storage_bindings.lock().unwrap().is_none());
+}
+
+#[test]
+fn stale_parent_publication_leaves_graph_and_bindings_at_old_generation() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("project");
+    let forge = GraphForge::new(Some(path.to_str().unwrap())).unwrap();
+    let before = graphforge_storage::resolve_project_generation(&path)
+        .unwrap()
+        .generation_uuid();
+    let (context, _, _) = composed_fixture(ActivationMode::Strict);
+    *forge.current_generation_uuid.lock().unwrap() = uuid::Uuid::now_v7();
+
+    let error = forge
+        .execute_with_composition(
+            "CREATE (n:`research:Person` {name:'must-not-publish'})",
+            context,
+        )
+        .unwrap_err();
+    assert!(
+        error.to_string().contains("generation changed"),
+        "{error:?}"
+    );
+    assert!(forge.semantic_storage_bindings.lock().unwrap().is_none());
+    assert_eq!(
+        graphforge_storage::resolve_project_generation(&path)
+            .unwrap()
+            .generation_uuid(),
+        before
+    );
+    drop(forge);
+    let reopened = GraphForge::new(Some(path.to_str().unwrap())).unwrap();
+    assert!(reopened.semantic_storage_bindings.lock().unwrap().is_none());
+    assert_eq!(
+        reopened
+            .execute("MATCH (n) RETURN n")
+            .unwrap()
+            .batches
+            .iter()
+            .map(arrow::record_batch::RecordBatch::num_rows)
+            .sum::<usize>(),
+        0
+    );
+}
+
+#[test]
+fn generation_hydration_rejects_incomplete_bindings_with_matching_fingerprint() {
+    let forge = GraphForge::new(None).unwrap();
+    let (context, _, _) = composed_fixture(ActivationMode::Strict);
+    let complete =
+        graphforge_storage::SemanticStorageBindings::project(context.composition(), None).unwrap();
+    let mut incomplete = complete.bindings.clone();
+    incomplete.pop();
+    *forge.semantic_storage_bindings.lock().unwrap() = Some(
+        graphforge_storage::SemanticStorageBindings::new(
+            context.fingerprint().to_owned(),
+            incomplete,
+        )
+        .unwrap(),
+    );
+    assert!(
+        forge
+            .install_generation_composition_context(&context)
+            .is_err()
+    );
+    assert!(forge.default_composition_context.lock().unwrap().is_none());
+}
+
+#[test]
+fn semantic_publication_replays_one_durable_operation_idempotently() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("project");
+    let forge = GraphForge::new(Some(path.to_str().unwrap())).unwrap();
+    let (context, _, _) = composed_fixture(ActivationMode::Strict);
+    install_composition_authority(&forge, context.fingerprint());
+    drop(forge);
+    let forge = GraphForge::new(Some(path.to_str().unwrap())).unwrap();
+    forge
+        .execute_with_composition(
+            "CREATE (n:`research:Person` {name:'first'})",
+            context.clone(),
+        )
+        .unwrap();
+    forge
+        .install_generation_composition_context(&context)
+        .unwrap();
+    let result = forge
+        .execute_write_without_publish(
+            "CREATE (n:`genealogy:Person` {name:'replayed'})",
+            &std::collections::HashMap::new(),
+        )
+        .unwrap();
+    let receipt = result.mutation_receipt.unwrap();
+    let operation = uuid::Uuid::now_v7();
+    forge
+        .publish_graph_mutation_with_context(&receipt, operation, None, 1)
+        .unwrap();
+    let first = graphforge_storage::resolve_project_generation(&path)
+        .unwrap()
+        .generation_uuid();
+    forge
+        .publish_graph_mutation_with_context(&receipt, operation, None, 1)
+        .unwrap();
+    assert_eq!(
+        graphforge_storage::resolve_project_generation(&path)
+            .unwrap()
+            .generation_uuid(),
+        first
+    );
 }
 
 #[test]
@@ -481,6 +583,18 @@ fn facade_reopens_relation_edge_property_through_default_context() {
             context.clone(),
         )
         .unwrap();
+    forge
+        .execute_with_composition(
+            "CREATE (a:`genealogy:Person` {name:'G1'}), (b:`genealogy:Person` {name:'G2'})",
+            context.clone(),
+        )
+        .unwrap();
+    forge
+        .execute_with_composition(
+            "MATCH (a:`genealogy:Person` {name:'G1'}), (b:`genealogy:Person` {name:'G2'}) CREATE (a)-[r:`genealogy:KNOWS` {since:1999}]->(b)",
+            context.clone(),
+        )
+        .unwrap();
     let installed = forge
         .semantic_storage_bindings
         .lock()
@@ -490,8 +604,20 @@ fn facade_reopens_relation_edge_property_through_default_context() {
     let relation = installed
         .bindings
         .iter()
-        .find(|binding| binding.route_kind == graphforge_storage::SemanticRouteKind::Relation)
+        .find(|binding| {
+            binding.route_kind == graphforge_storage::SemanticRouteKind::Relation
+                && binding.symbol.module.ontology_id.ends_with("/research")
+        })
         .unwrap();
+    let genealogy_relation = installed
+        .bindings
+        .iter()
+        .find(|binding| {
+            binding.route_kind == graphforge_storage::SemanticRouteKind::Relation
+                && binding.symbol.module.ontology_id.ends_with("/genealogy")
+        })
+        .unwrap();
+    assert_ne!(relation.route, genealogy_relation.route);
     let edge_path = forge
         .dir
         .join("topology/edges")
@@ -574,5 +700,17 @@ fn facade_reopens_relation_edge_property_through_default_context() {
     assert_eq!(
         arrow::util::display::array_value_to_string(before_batch.column(0), 0).unwrap(),
         "2020"
+    );
+    let genealogy = reopened
+        .execute("MATCH (a:`genealogy:Person`)-[r:`genealogy:KNOWS`]->(b:`genealogy:Person`) RETURN r.since")
+        .unwrap();
+    let genealogy_batch = genealogy
+        .batches
+        .iter()
+        .find(|batch| batch.num_rows() > 0)
+        .expect("colliding genealogy relation query returned no rows");
+    assert_eq!(
+        arrow::util::display::array_value_to_string(genealogy_batch.column(0), 0).unwrap(),
+        "1999"
     );
 }

--- a/crates/graphforge-api/src/composition_binding_tests.rs
+++ b/crates/graphforge-api/src/composition_binding_tests.rs
@@ -8,12 +8,79 @@ use graphforge_ontology::{
     ActivationMode, ActivationRecord, ActivationScope, AuthoredModule, BridgeAssertion,
     BridgeDocument, BridgePredicate, BridgeProvenance, BridgeSetId, CompositionLimits,
     EntityTypeDef, InventoryCompileRequest, MappingMethod, OntologyDoc, OntologyModuleId,
-    PropertyDef, PropertyValueType, QualifiedSymbol, SymbolKind, bridge_document_digest,
-    compile_inventory, module_document_digest,
+    PropertyDef, PropertyValueType, QualifiedSymbol, RelationTypeDef, SemanticFlags, SymbolKind,
+    bridge_document_digest, compile_inventory, module_document_digest,
 };
 
 use super::GraphForge;
 use graphforge_core::OntologyMode;
+
+fn install_composition_authority(forge: &GraphForge, fingerprint: &str) {
+    use graphforge_storage::{
+        ProjectCapability, ProjectGenerationRequest, ProjectParticipant,
+        ProjectParticipantEncoding, ProjectStageOutcome,
+    };
+    use sha2::{Digest, Sha256};
+
+    let parent =
+        graphforge_storage::resolve_project_generation(forge.resolved_generation.container_root())
+            .unwrap();
+    let mut participants = parent
+        .participant_snapshots()
+        .unwrap()
+        .into_iter()
+        .map(|snapshot| ProjectParticipant {
+            capability_id: snapshot.capability_id,
+            capability_version: snapshot.capability_version,
+            record_family_id: snapshot.record_family_id,
+            record_version: snapshot.record_version,
+            encoding: super::participant_encoding(&snapshot.encoding).unwrap(),
+            schema_fingerprint: snapshot.schema_fingerprint,
+            row_count: snapshot.row_count,
+            bytes: snapshot.bytes,
+        })
+        .collect::<Vec<_>>();
+    let mut bytes = serde_json::to_vec(&serde_json::json!({
+        "composition_fingerprint": fingerprint
+    }))
+    .unwrap();
+    bytes.push(b'\n');
+    participants.push(ProjectParticipant {
+        capability_id: "workspace".into(),
+        capability_version: 1,
+        record_family_id: "ontology_composition".into(),
+        record_version: 1,
+        encoding: ProjectParticipantEncoding::Json,
+        schema_fingerprint: Sha256::digest(b"test-composition-authority/1").into(),
+        row_count: 1,
+        bytes,
+    });
+    participants.sort_by(|left, right| {
+        (&left.capability_id, &left.record_family_id)
+            .cmp(&(&right.capability_id, &right.record_family_id))
+    });
+    let request = ProjectGenerationRequest {
+        transaction_uuid: uuid::Uuid::now_v7(),
+        generation_uuid: uuid::Uuid::now_v7(),
+        capabilities: parent
+            .capabilities()
+            .into_iter()
+            .map(|capability| ProjectCapability {
+                capability_id: capability.capability_id,
+                capability_version: capability.capability_version,
+            })
+            .collect(),
+        participants,
+    };
+    match forge.stage_project_generation(&request).unwrap() {
+        ProjectStageOutcome::Staged(staged) => staged
+            .validate(|_| Ok(()), |_, _| Ok(()))
+            .unwrap()
+            .publish()
+            .unwrap(),
+        ProjectStageOutcome::AlreadyPublished(receipt) => receipt,
+    };
+}
 
 fn module(name: &str, entities: &[&str]) -> AuthoredModule {
     let doc = OntologyDoc {
@@ -27,17 +94,37 @@ fn module(name: &str, entities: &[&str]) -> AuthoredModule {
                 parent: None,
             })
             .collect(),
-        relation_types: vec![],
-        properties: (name == "research")
-            .then_some(PropertyDef {
-                owner: "Person".to_owned(),
-                name: "name".to_owned(),
-                value_type: PropertyValueType::Utf8,
-                nullable: true,
-                multivalued: false,
-                default_json: None,
+        relation_types: (name == "research")
+            .then_some(RelationTypeDef {
+                name: "KNOWS".to_owned(),
+                src: "Person".to_owned(),
+                dst: "Person".to_owned(),
+                inverse: None,
+                semantic: SemanticFlags::default(),
             })
             .into_iter()
+            .collect(),
+        properties: (name == "research")
+            .then_some(vec![
+                PropertyDef {
+                    owner: "Person".to_owned(),
+                    name: "name".to_owned(),
+                    value_type: PropertyValueType::Utf8,
+                    nullable: true,
+                    multivalued: false,
+                    default_json: None,
+                },
+                PropertyDef {
+                    owner: "KNOWS".to_owned(),
+                    name: "since".to_owned(),
+                    value_type: PropertyValueType::Int64,
+                    nullable: true,
+                    multivalued: false,
+                    default_json: None,
+                },
+            ])
+            .into_iter()
+            .flatten()
             .collect(),
         constraints: vec![],
         migrations: vec![],
@@ -198,6 +285,22 @@ fn facade_rejects_ambiguity_without_publishing_runtime_observations() {
 }
 
 #[test]
+fn facade_does_not_install_unpublished_semantic_bindings() {
+    let forge = GraphForge::new(None).expect("facade");
+    let (context, _, _) = composed_fixture(ActivationMode::Strict);
+
+    forge
+        .execute_with_composition("MATCH (n:`research:Person`) RETURN n", context.clone())
+        .expect("read");
+    assert!(forge.semantic_storage_bindings.lock().unwrap().is_none());
+
+    forge
+        .execute_with_composition("MATCH (n:Person) RETURN n", context)
+        .expect_err("ambiguous bind");
+    assert!(forge.semantic_storage_bindings.lock().unwrap().is_none());
+}
+
+#[test]
 fn bridge_selection_and_explain_are_exact_bounded_and_repeatable() {
     let (context, source, target) = composed_fixture(ActivationMode::Exploratory);
     let first = context.select_bridge(&source, &target).expect("bridge");
@@ -273,5 +376,203 @@ fn facade_rejects_a_property_on_the_wrong_composed_owner() {
     assert!(
         error.to_string().contains("wrong_owner_property"),
         "{error:?}"
+    );
+}
+
+#[test]
+fn facade_publishes_reopens_and_queries_exact_colliding_semantic_routes() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("project");
+    let path_text = path.to_str().unwrap();
+    let first = GraphForge::new(Some(path_text)).unwrap();
+    let (context, _, _) = composed_fixture(ActivationMode::Strict);
+    install_composition_authority(&first, context.fingerprint());
+    drop(first);
+
+    let forge = GraphForge::new(Some(path_text)).unwrap();
+    forge
+        .execute_with_composition(
+            "CREATE (n:`research:Person` {name: 'Ada'})",
+            context.clone(),
+        )
+        .unwrap();
+    forge
+        .execute_with_composition("CREATE (n:`genealogy:Person`)", context.clone())
+        .unwrap();
+    drop(forge);
+
+    let reopened = GraphForge::new(Some(path_text)).unwrap();
+    reopened
+        .install_generation_composition_context(&context)
+        .unwrap();
+    reopened
+        .execute("MATCH (n:`research:Person`) SET n.name = 'Ada Lovelace'")
+        .unwrap();
+    let research = reopened
+        .execute("MATCH (n:`research:Person`) RETURN n.name")
+        .unwrap();
+    assert_eq!(
+        research
+            .batches
+            .iter()
+            .map(|batch| batch.num_rows())
+            .sum::<usize>(),
+        1
+    );
+    assert_eq!(
+        arrow::util::display::array_value_to_string(research.batches[0].column(0), 0).unwrap(),
+        "Ada Lovelace"
+    );
+    reopened
+        .execute("MATCH (n:`research:Person`) REMOVE n.name")
+        .unwrap();
+    let removed = reopened
+        .execute("MATCH (n:`research:Person`) RETURN n.name")
+        .unwrap();
+    assert_eq!(
+        arrow::util::display::array_value_to_string(removed.batches[0].column(0), 0).unwrap(),
+        ""
+    );
+    let genealogy = reopened
+        .execute("MATCH (n:`genealogy:Person`) RETURN n")
+        .unwrap();
+    assert_eq!(
+        genealogy
+            .batches
+            .iter()
+            .map(|batch| batch.num_rows())
+            .sum::<usize>(),
+        1
+    );
+
+    let generation = graphforge_storage::resolve_project_generation(&path).unwrap();
+    let bindings = graphforge_storage::semantic_storage_bindings(&generation)
+        .unwrap()
+        .unwrap();
+    let entity_routes = bindings
+        .bindings
+        .iter()
+        .filter(|binding| binding.route_kind == graphforge_storage::SemanticRouteKind::Entity)
+        .map(|binding| binding.route.as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(entity_routes.len(), 3);
+}
+
+#[test]
+fn facade_reopens_relation_edge_property_through_default_context() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("project");
+    let path_text = path.to_str().unwrap();
+    let bootstrap = GraphForge::new(Some(path_text)).unwrap();
+    let (context, _, _) = composed_fixture(ActivationMode::Strict);
+    install_composition_authority(&bootstrap, context.fingerprint());
+    drop(bootstrap);
+
+    let forge = GraphForge::new(Some(path_text)).unwrap();
+    forge
+        .execute_with_composition(
+            "CREATE (a:`research:Person` {name:'A'}), (b:`research:Person` {name:'B'})",
+            context.clone(),
+        )
+        .unwrap();
+    forge
+        .execute_with_composition(
+            "MATCH (a:`research:Person` {name:'A'}), (b:`research:Person` {name:'B'}) CREATE (a)-[r:`research:KNOWS` {since:2020}]->(b)",
+            context.clone(),
+        )
+        .unwrap();
+    let installed = forge
+        .semantic_storage_bindings
+        .lock()
+        .unwrap()
+        .clone()
+        .unwrap();
+    let relation = installed
+        .bindings
+        .iter()
+        .find(|binding| binding.route_kind == graphforge_storage::SemanticRouteKind::Relation)
+        .unwrap();
+    let edge_path = forge
+        .dir
+        .join("topology/edges")
+        .join(format!("{}.parquet", relation.route));
+    assert!(
+        edge_path.exists(),
+        "missing opaque edge route {}",
+        edge_path.display()
+    );
+    let edge_rows = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(
+        std::fs::File::open(&edge_path).unwrap(),
+    )
+    .unwrap()
+    .metadata()
+    .file_metadata()
+    .num_rows();
+    assert_eq!(edge_rows, 1);
+    let edge_batch = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(
+        std::fs::File::open(&edge_path).unwrap(),
+    )
+    .unwrap()
+    .build()
+    .unwrap()
+    .next()
+    .unwrap()
+    .unwrap();
+    let src_id = edge_batch
+        .column_by_name("src_id")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<arrow::array::UInt64Array>()
+        .unwrap()
+        .value(0);
+    let dst_id = edge_batch
+        .column_by_name("dst_id")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<arrow::array::UInt64Array>()
+        .unwrap()
+        .value(0);
+    let node_batch = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(
+        std::fs::File::open(forge.dir.join("topology/nodes.parquet")).unwrap(),
+    )
+    .unwrap()
+    .build()
+    .unwrap()
+    .next()
+    .unwrap()
+    .unwrap();
+    let node_ids = node_batch
+        .column_by_name("node_id")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<arrow::array::UInt64Array>()
+        .unwrap();
+    assert!(node_ids.values().contains(&src_id));
+    assert!(node_ids.values().contains(&dst_id));
+    drop(forge);
+
+    let reopened = GraphForge::new(Some(path_text)).unwrap();
+    reopened
+        .install_generation_composition_context(&context)
+        .unwrap();
+    let reopened_edge = reopened
+        .dir
+        .join("topology/edges")
+        .join(edge_path.file_name().unwrap());
+    assert!(
+        reopened_edge.exists(),
+        "opaque edge route was not materialized"
+    );
+    let before = reopened
+        .execute("MATCH (a:`research:Person`)-[r:`research:KNOWS`]->(b:`research:Person`) RETURN r.since")
+        .unwrap();
+    let before_batch = before
+        .batches
+        .iter()
+        .find(|batch| batch.num_rows() > 0)
+        .expect("qualified relation query returned no rows");
+    assert_eq!(
+        arrow::util::display::array_value_to_string(before_batch.column(0), 0).unwrap(),
+        "2020"
     );
 }

--- a/crates/graphforge-api/src/embedding_refresh.rs
+++ b/crates/graphforge-api/src/embedding_refresh.rs
@@ -266,6 +266,8 @@ impl GraphForge {
             ontology: self.ontology.clone(),
             ontology_document: self.ontology_document.clone(),
             runtime_catalog: Arc::clone(&self.runtime_catalog),
+            semantic_storage_bindings: Arc::clone(&self.semantic_storage_bindings),
+            default_composition_context: Arc::clone(&self.default_composition_context),
             procedures: Arc::clone(&self.procedures),
             ontology_mode: self.ontology_mode,
             adjacency_provider: Arc::clone(&self.adjacency_provider),

--- a/crates/graphforge-api/src/import_session.rs
+++ b/crates/graphforge-api/src/import_session.rs
@@ -304,6 +304,10 @@ impl GraphForge {
         let participants = super::graph_publication_participants(
             &parent,
             graph_files,
+            self.semantic_storage_bindings
+                .lock()
+                .expect("semantic storage binding lock poisoned")
+                .as_ref(),
             parent.capability("provenance")?.is_some(),
             &receipt,
             operation_uuid,

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -3954,6 +3954,24 @@ fn load_composition_binding(
     else {
         return Ok(None);
     };
+    let expected_schema: [u8; 32] = Sha256::digest(
+        format!(
+            "workspace/{}@1",
+            graphforge_storage::WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY
+        )
+        .as_bytes(),
+    )
+    .into();
+    if snapshot.capability_version != graphforge_storage::WORKSPACE_CAPABILITY_VERSION
+        || snapshot.record_version != graphforge_storage::WORKSPACE_ONTOLOGY_COMPOSITION_VERSION
+        || snapshot.encoding != "json"
+        || snapshot.schema_fingerprint != expected_schema
+        || snapshot.row_count != 1
+    {
+        return Err(GfError::Validation(
+            "unsupported workspace ontology composition participant contract".into(),
+        ));
+    }
     let authority =
         graphforge_storage::WorkspaceOntologyComposition::from_canonical_json(&snapshot.bytes)?;
     let compiled = authority.compile()?;

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -416,6 +416,12 @@ pub struct GraphForge {
     ontology_document: Option<OntologyDoc>,
     /// Shared runtime catalog (grown by the binder during `execute`).
     runtime_catalog: Arc<Mutex<RuntimeCatalog>>,
+    /// Exact generation-bound qualified storage authority, when adopted.
+    semantic_storage_bindings: Arc<Mutex<Option<graphforge_storage::SemanticStorageBindings>>>,
+    /// Generation-hydrated compiled composition used by ordinary query/write
+    /// entry points. The #840 composition participant loader installs this
+    /// only after compiling and authenticating the exact persisted closure.
+    default_composition_context: Arc<Mutex<Option<Arc<CompositionBindingContext>>>>,
     /// Procedures available to `CALL` clauses on this engine instance.
     procedures: Arc<Mutex<ProcedureRegistry>>,
     /// Effective ontology enforcement mode.
@@ -587,6 +593,8 @@ impl GraphForge {
             ontology,
             ontology_document,
             runtime_catalog: Arc::new(Mutex::new(RuntimeCatalog::new())),
+            semantic_storage_bindings: Arc::new(Mutex::new(None)),
+            default_composition_context: Arc::new(Mutex::new(None)),
             procedures: Arc::new(Mutex::new(ProcedureRegistry::new())),
             ontology_mode,
             runtime: build_runtime(&resource_policy)?,
@@ -683,6 +691,19 @@ impl GraphForge {
             hydrate_graph_workspace(&resolved_generation, read_only)?;
 
         let runtime_catalog = load_runtime_catalog(&dir)?;
+        let semantic_storage_bindings =
+            graphforge_storage::semantic_storage_bindings(&resolved_generation)?;
+        if semantic_storage_bindings.is_none()
+            && resolved_generation
+                .participant_snapshot("workspace", "ontology_composition")?
+                .is_some()
+        {
+            graphforge_storage::require_atomic_legacy_migration(&dir)?;
+        }
+        if let Some(bindings) = &semantic_storage_bindings {
+            let inventory = resolved_generation.graph_files_inventory()?;
+            bindings.validate_physical_routes_with_inventory(&dir, inventory.as_ref())?;
+        }
         if read_only {
             graphforge_storage::validate_runtime_entity_label_ids(
                 &dir,
@@ -739,6 +760,8 @@ impl GraphForge {
             ontology,
             ontology_document,
             runtime_catalog: Arc::new(Mutex::new(runtime_catalog)),
+            semantic_storage_bindings: Arc::new(Mutex::new(semantic_storage_bindings)),
+            default_composition_context: Arc::new(Mutex::new(None)),
             procedures: Arc::new(Mutex::new(ProcedureRegistry::new())),
             ontology_mode,
             runtime,
@@ -948,7 +971,44 @@ impl GraphForge {
         params: &HashMap<String, IrLiteral>,
         publish: bool,
     ) -> Result<ExecutionResult, GfError> {
-        self.run_query_with_optional_composition(cypher, params, None, publish)
+        let composition = self
+            .default_composition_context
+            .lock()
+            .expect("default composition context lock poisoned")
+            .clone();
+        self.run_query_with_optional_composition(cypher, params, composition, publish)
+    }
+
+    /// Install the exact compiled context reconstructed from the persisted
+    /// composition participant. This is the narrow atomic hydration seam used
+    /// by the composition lifecycle; ordinary execution consumes it by default.
+    #[allow(dead_code)] // consumed by the generation composition publisher added by issue #840
+    pub(crate) fn install_generation_composition_context(
+        &self,
+        context: &Arc<CompositionBindingContext>,
+    ) -> Result<(), GfError> {
+        let bindings = self
+            .semantic_storage_bindings
+            .lock()
+            .expect("semantic storage binding lock poisoned")
+            .clone()
+            .ok_or_else(|| {
+                GfError::Validation(
+                    "persisted composition has no generation storage binding authority".into(),
+                )
+            })?;
+        bindings.validate_against(context.composition())?;
+        let context = context.with_generation_storage_ids(
+            bindings
+                .bindings
+                .iter()
+                .map(|binding| (binding.symbol.clone(), binding.storage_id)),
+        );
+        *self
+            .default_composition_context
+            .lock()
+            .expect("default composition context lock poisoned") = Some(Arc::new(context));
+        Ok(())
     }
 
     fn run_query_with_composition(
@@ -969,6 +1029,9 @@ impl GraphForge {
         publish: bool,
     ) -> Result<ExecutionResult, GfError> {
         let _admission = self.admit_heavy_query()?;
+        let composition = composition
+            .map(|context| self.bind_generation_storage(&context))
+            .transpose()?;
         if cypher.trim().is_empty() {
             return Err(GfError::Validation("empty query".into()));
         }
@@ -1002,8 +1065,8 @@ impl GraphForge {
                 self.ontology_mode,
             )
             .with_procedures(self.procedure_snapshot());
-            if let Some(composition) = composition {
-                binder = binder.with_composition(composition);
+            if let Some((composition, _)) = &composition {
+                binder = binder.with_composition(Arc::clone(composition));
             }
             binder
                 .bind(&ast)
@@ -1012,11 +1075,54 @@ impl GraphForge {
 
         validate_call_params(&plan, params)?;
 
-        let result = self
-            .run_plan_with_publish(&plan, params, publish)
-            .map_err(publicize_query_error)?;
+        let candidate = composition.as_ref().map(|(_, candidate)| candidate);
+        let composition_mode =
+            composition
+                .as_ref()
+                .map(|(context, _)| match context.composition().profile_default {
+                    graphforge_ontology::ActivationMode::Exploratory => OntologyMode::Exploratory,
+                    graphforge_ontology::ActivationMode::Advisory => OntologyMode::Advisory,
+                    graphforge_ontology::ActivationMode::Strict => OntologyMode::Strict,
+                });
+        let result = self.run_plan_with_publish_and_bindings(
+            &plan,
+            params,
+            publish,
+            candidate,
+            composition_mode,
+        );
+        let result = result.map_err(publicize_query_error)?;
         shape_result(result, self.ontology_mode, self.ontology.as_ref())
             .map_err(publicize_query_error)
+    }
+
+    fn bind_generation_storage(
+        &self,
+        context: &Arc<CompositionBindingContext>,
+    ) -> Result<
+        (
+            Arc<CompositionBindingContext>,
+            graphforge_storage::SemanticStorageBindings,
+        ),
+        GfError,
+    > {
+        let current = self
+            .semantic_storage_bindings
+            .lock()
+            .expect("semantic storage binding lock poisoned");
+        let projected = graphforge_storage::SemanticStorageBindings::project(
+            context.composition(),
+            current.as_ref(),
+        )?;
+        projected.validate_against(context.composition())?;
+        let context = context.with_generation_storage_ids(
+            projected
+                .bindings
+                .iter()
+                .map(|binding| (binding.symbol.clone(), binding.storage_id)),
+        );
+        drop(current);
+        Ok((Arc::new(context), projected))
     }
 
     /// Build a session reflecting the current runtime catalog and run `plan`,
@@ -1035,6 +1141,18 @@ impl GraphForge {
         plan: &GraphPlan,
         params: &HashMap<String, IrLiteral>,
         publish: bool,
+    ) -> Result<ExecutionResult, GfError> {
+        self.run_plan_with_publish_and_bindings(plan, params, publish, None, None)
+    }
+
+    #[allow(clippy::too_many_lines)] // one visibility lock spans execution and publication
+    fn run_plan_with_publish_and_bindings(
+        &self,
+        plan: &GraphPlan,
+        params: &HashMap<String, IrLiteral>,
+        publish: bool,
+        candidate_bindings: Option<&graphforge_storage::SemanticStorageBindings>,
+        composition_mode: Option<OntologyMode>,
     ) -> Result<ExecutionResult, GfError> {
         use graphforge_exec::ExecutionSession;
 
@@ -1085,15 +1203,36 @@ impl GraphForge {
                 .runtime_catalog
                 .lock()
                 .expect("runtime catalog poisoned");
-            GraphCatalog::open(&self.dir, self.ontology.as_ref(), &rc)
-                .map_err(|e| GfError::Storage(e.to_string()))?
+            let installed = self
+                .semantic_storage_bindings
+                .lock()
+                .expect("semantic storage binding lock poisoned");
+            GraphCatalog::open_with_semantic_bindings(
+                &self.dir,
+                self.ontology.as_ref(),
+                &rc,
+                candidate_bindings.or(installed.as_ref()),
+            )
+            .map_err(|e| GfError::Storage(e.to_string()))?
+        };
+        // A compiled composition is explicit typed authority even when the
+        // legacy workspace ontology profile remains exploratory. Its writes
+        // must never fall back to `_untyped` host routing.
+        let execution_mode = composition_mode.unwrap_or(self.ontology_mode);
+        let adjacency_provider = if execution_mode == self.ontology_mode {
+            Arc::clone(&self.adjacency_provider)
+        } else {
+            Arc::new(graphforge_exec::PersistentAdjacencyProvider::new(
+                self.dir.clone(),
+                execution_mode,
+            ))
         };
         let session = ExecutionSession::new_with_target_provider_and_resources(
             catalog,
             self.ontology.clone(),
             self.dir.clone(),
-            self.ontology_mode,
-            Arc::clone(&self.adjacency_provider),
+            execution_mode,
+            adjacency_provider,
             &self.session_resource_config(),
         )?;
 
@@ -1127,7 +1266,9 @@ impl GraphForge {
             let rollback_generation = rollback_generation
                 .as_ref()
                 .expect("write path resolved a rollback generation");
-            if let Err(error) = self.publish_graph_mutation(receipt) {
+            if let Err(error) =
+                self.publish_graph_mutation_with_bindings(receipt, candidate_bindings)
+            {
                 let still_prior = *self
                     .current_generation_uuid
                     .lock()
@@ -1138,6 +1279,14 @@ impl GraphForge {
                     self.adjacency_provider.invalidate();
                 }
                 return Err(error);
+            }
+            if let Some(candidate) = candidate_bindings {
+                // The write visibility lock still covers this swap, so an
+                // older request can never overwrite a newer publication.
+                *self
+                    .semantic_storage_bindings
+                    .lock()
+                    .expect("semantic storage binding lock poisoned") = Some(candidate.clone());
             }
         }
         if is_write
@@ -1155,9 +1304,23 @@ impl GraphForge {
         &self,
         receipt: &graphforge_exec::MutationReceipt,
     ) -> Result<(), GfError> {
+        self.publish_graph_mutation_with_bindings(receipt, None)
+    }
+
+    fn publish_graph_mutation_with_bindings(
+        &self,
+        receipt: &graphforge_exec::MutationReceipt,
+        candidate_bindings: Option<&graphforge_storage::SemanticStorageBindings>,
+    ) -> Result<(), GfError> {
         let operation_uuid = uuid::Uuid::now_v7();
         let recorded_at_micros = (self.clock.lock().expect("clock lock poisoned"))()?;
-        self.publish_graph_mutation_with_context(receipt, operation_uuid, None, recorded_at_micros)
+        self.publish_graph_mutation_with_context_and_bindings(
+            receipt,
+            operation_uuid,
+            None,
+            recorded_at_micros,
+            candidate_bindings,
+        )
     }
 
     pub(crate) fn publish_graph_mutation_with_context(
@@ -1166,6 +1329,23 @@ impl GraphForge {
         operation_uuid: uuid::Uuid,
         actor_uuid: Option<uuid::Uuid>,
         recorded_at_micros: i64,
+    ) -> Result<(), GfError> {
+        self.publish_graph_mutation_with_context_and_bindings(
+            receipt,
+            operation_uuid,
+            actor_uuid,
+            recorded_at_micros,
+            None,
+        )
+    }
+
+    fn publish_graph_mutation_with_context_and_bindings(
+        &self,
+        receipt: &graphforge_exec::MutationReceipt,
+        operation_uuid: uuid::Uuid,
+        actor_uuid: Option<uuid::Uuid>,
+        recorded_at_micros: i64,
+        candidate_bindings: Option<&graphforge_storage::SemanticStorageBindings>,
     ) -> Result<(), GfError> {
         use graphforge_storage::{
             ProjectCapability, ProjectGenerationRequest, ProjectStageOutcome,
@@ -1192,15 +1372,21 @@ impl GraphForge {
         }
         let graph = graphforge_storage::capture_graph_files(&self.dir)?.1;
         let provenance_enabled = parent.capability("provenance")?.is_some();
+        let installed_bindings = self
+            .semantic_storage_bindings
+            .lock()
+            .expect("semantic storage binding lock poisoned");
         let participants = graph_publication_participants(
             &parent,
             graph,
+            candidate_bindings.or(installed_bindings.as_ref()),
             provenance_enabled,
             receipt,
             operation_uuid,
             actor_uuid,
             recorded_at_micros,
         )?;
+        drop(installed_bindings);
         let capabilities = parent
             .capabilities()
             .into_iter()
@@ -1289,6 +1475,10 @@ impl GraphForge {
         let participants = graph_publication_participants(
             &parent,
             graph,
+            self.semantic_storage_bindings
+                .lock()
+                .expect("semantic storage binding lock poisoned")
+                .as_ref(),
             provenance_enabled,
             receipt,
             operation_uuid,
@@ -3694,9 +3884,11 @@ fn participant_encoding(
     }
 }
 
+#[allow(clippy::too_many_arguments)] // participant assembly carries authenticated audit context
 fn graph_publication_participants(
     parent: &graphforge_storage::ResolvedProjectGeneration,
     graph: graphforge_storage::ProjectParticipant,
+    semantic_bindings: Option<&graphforge_storage::SemanticStorageBindings>,
     provenance_enabled: bool,
     receipt: &graphforge_exec::MutationReceipt,
     operation_uuid: uuid::Uuid,
@@ -3708,7 +3900,10 @@ fn graph_publication_participants(
         .into_iter()
         .filter(|snapshot| {
             !(snapshot.capability_id == "graph"
-                && matches!(snapshot.record_family_id.as_str(), "snapshot" | "files")
+                && matches!(
+                    snapshot.record_family_id.as_str(),
+                    "snapshot" | "files" | graphforge_storage::GRAPH_SEMANTIC_BINDINGS_FAMILY
+                )
                 || provenance_enabled
                     && snapshot.capability_id == "provenance"
                     && matches!(snapshot.record_family_id.as_str(), "events" | "lineage"))
@@ -3727,6 +3922,31 @@ fn graph_publication_participants(
         })
         .collect::<Result<Vec<_>, GfError>>()?;
     participants.push(graph);
+    if let Some(bindings) = semantic_bindings {
+        participants.push(bindings.to_project_participant()?);
+        let composition = participants
+            .iter()
+            .find(|participant| {
+                participant.capability_id == "workspace"
+                    && participant.record_family_id == "ontology_composition"
+            })
+            .ok_or_else(|| {
+                GfError::Validation(
+                    "semantic graph publication requires persisted composition authority".into(),
+                )
+            })?;
+        let value: serde_json::Value = serde_json::from_slice(&composition.bytes)
+            .map_err(|_| GfError::Validation("persisted composition is malformed".into()))?;
+        if value
+            .get("composition_fingerprint")
+            .and_then(serde_json::Value::as_str)
+            != Some(bindings.composition_fingerprint.as_str())
+        {
+            return Err(GfError::Validation(
+                "semantic bindings and composition must publish at one fingerprint".into(),
+            ));
+        }
+    }
     if provenance_enabled {
         participants.extend(provenance::merged_participants(
             parent,

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -33,8 +33,8 @@ pub use graphforge_io::{
     ResultSinkFormat, ResultSinkOptions, ResultSinkProgress, ResultSinkReceipt,
 };
 use graphforge_ir::{
-    BindError, Binder, CompositionBindingContext, GraphOp, GraphPlan, IrExpr, ProcedureRegistry,
-    RuntimeCatalog,
+    BindError, Binder, CompositionBindingContext, CompositionBindingLimits, GraphOp, GraphPlan,
+    IrExpr, ProcedureRegistry, RuntimeCatalog,
 };
 use graphforge_ontology::{OntologyCompiler, OntologyHandle, OntologyLoader};
 use graphforge_storage::GraphCatalog;
@@ -682,6 +682,7 @@ impl GraphForge {
         Ok(graph)
     }
 
+    #[allow(clippy::too_many_lines)] // open authenticates every coupled generation participant
     fn open_resolved_with_options(
         container_dir: PathBuf,
         resolved_generation: ResolvedProjectGeneration,
@@ -699,17 +700,42 @@ impl GraphForge {
         let runtime_catalog = load_runtime_catalog(&dir)?;
         let semantic_storage_bindings =
             graphforge_storage::semantic_storage_bindings(&resolved_generation)?;
+        let default_composition_context = load_composition_binding(&resolved_generation)?;
         if semantic_storage_bindings.is_none()
-            && resolved_generation
-                .participant_snapshot("workspace", "ontology_composition")?
-                .is_some()
+            && let Some(context) = &default_composition_context
         {
-            graphforge_storage::require_atomic_legacy_migration(&dir)?;
+            if context.composition().modules.len() == 1 {
+                graphforge_storage::SemanticStorageBindings::project_legacy_unambiguous(
+                    context.composition(),
+                    &dir,
+                )?;
+            } else {
+                graphforge_storage::require_atomic_legacy_migration(&dir)?;
+            }
         }
         if let Some(bindings) = &semantic_storage_bindings {
+            let context = default_composition_context.as_ref().ok_or_else(|| {
+                GfError::Validation(
+                    "semantic bindings have no compiled persisted composition authority".into(),
+                )
+            })?;
+            bindings.validate_against(context.composition())?;
             let inventory = resolved_generation.graph_files_inventory()?;
             bindings.validate_physical_routes_with_inventory(&dir, inventory.as_ref())?;
         }
+        let default_composition_context =
+            match (default_composition_context, &semantic_storage_bindings) {
+                (Some(context), Some(bindings)) => Some(Arc::new(
+                    context.with_generation_storage_ids(
+                        bindings
+                            .bindings
+                            .iter()
+                            .map(|binding| (binding.symbol.clone(), binding.storage_id)),
+                    ),
+                )),
+                (None, Some(_)) => unreachable!("semantic composition validated above"),
+                (context, None) => context,
+            };
         if read_only {
             graphforge_storage::validate_runtime_entity_label_ids(
                 &dir,
@@ -767,7 +793,7 @@ impl GraphForge {
             ontology_document,
             runtime_catalog: Arc::new(Mutex::new(runtime_catalog)),
             semantic_storage_bindings: Arc::new(Mutex::new(semantic_storage_bindings)),
-            default_composition_context: Arc::new(Mutex::new(None)),
+            default_composition_context: Arc::new(Mutex::new(default_composition_context)),
             procedures: Arc::new(Mutex::new(ProcedureRegistry::new())),
             ontology_mode,
             runtime,
@@ -3916,6 +3942,26 @@ fn participant_encoding(
             "committed participant has unsupported encoding".into(),
         )),
     }
+}
+
+fn load_composition_binding(
+    generation: &ResolvedProjectGeneration,
+) -> Result<Option<Arc<CompositionBindingContext>>, GfError> {
+    let Some(snapshot) = generation.participant_snapshot(
+        graphforge_storage::WORKSPACE_CAPABILITY_ID,
+        graphforge_storage::WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY,
+    )?
+    else {
+        return Ok(None);
+    };
+    let authority =
+        graphforge_storage::WorkspaceOntologyComposition::from_canonical_json(&snapshot.bytes)?;
+    let compiled = authority.compile()?;
+    Ok(Some(Arc::new(CompositionBindingContext::new(
+        Arc::new(compiled),
+        authority.bridges,
+        CompositionBindingLimits::default(),
+    ))))
 }
 
 #[allow(clippy::too_many_arguments)] // participant assembly carries authenticated audit context

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -472,6 +472,12 @@ pub struct GraphForge {
     runtime: Arc<OwnedRuntime>,
 }
 
+type BoundGenerationStorage = (
+    Arc<CompositionBindingContext>,
+    graphforge_storage::SemanticStorageBindings,
+    Vec<(std::path::PathBuf, std::path::PathBuf)>,
+);
+
 impl std::fmt::Debug for GraphForge {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // Custom impl: the ontology handle / runtime catalog are large and not
@@ -1065,7 +1071,7 @@ impl GraphForge {
                 self.ontology_mode,
             )
             .with_procedures(self.procedure_snapshot());
-            if let Some((composition, _)) = &composition {
+            if let Some((composition, _, _)) = &composition {
                 binder = binder.with_composition(Arc::clone(composition));
             }
             binder
@@ -1075,21 +1081,22 @@ impl GraphForge {
 
         validate_call_params(&plan, params)?;
 
-        let candidate = composition.as_ref().map(|(_, candidate)| candidate);
-        let composition_mode =
-            composition
-                .as_ref()
-                .map(|(context, _)| match context.composition().profile_default {
-                    graphforge_ontology::ActivationMode::Exploratory => OntologyMode::Exploratory,
-                    graphforge_ontology::ActivationMode::Advisory => OntologyMode::Advisory,
-                    graphforge_ontology::ActivationMode::Strict => OntologyMode::Strict,
-                });
+        let candidate = composition.as_ref().map(|(_, candidate, _)| candidate);
+        let legacy_route_moves = composition.as_ref().map(|(_, _, moves)| moves.as_slice());
+        let composition_mode = composition.as_ref().map(|(context, _, _)| {
+            match context.composition().profile_default {
+                graphforge_ontology::ActivationMode::Exploratory => OntologyMode::Exploratory,
+                graphforge_ontology::ActivationMode::Advisory => OntologyMode::Advisory,
+                graphforge_ontology::ActivationMode::Strict => OntologyMode::Strict,
+            }
+        });
         let result = self.run_plan_with_publish_and_bindings(
             &plan,
             params,
             publish,
             candidate,
             composition_mode,
+            legacy_route_moves,
         );
         let result = result.map_err(publicize_query_error)?;
         shape_result(result, self.ontology_mode, self.ontology.as_ref())
@@ -1099,21 +1106,31 @@ impl GraphForge {
     fn bind_generation_storage(
         &self,
         context: &Arc<CompositionBindingContext>,
-    ) -> Result<
-        (
-            Arc<CompositionBindingContext>,
-            graphforge_storage::SemanticStorageBindings,
-        ),
-        GfError,
-    > {
+    ) -> Result<BoundGenerationStorage, GfError> {
         let current = self
             .semantic_storage_bindings
             .lock()
             .expect("semantic storage binding lock poisoned");
-        let projected = graphforge_storage::SemanticStorageBindings::project(
-            context.composition(),
-            current.as_ref(),
-        )?;
+        let (projected, route_moves) =
+            if current.is_none() && context.composition().modules.len() == 1 {
+                let projection =
+                    graphforge_storage::SemanticStorageBindings::project_legacy_unambiguous(
+                        context.composition(),
+                        &self.dir,
+                    )?;
+                (projection.bindings, projection.route_moves)
+            } else {
+                if current.is_none() {
+                    graphforge_storage::require_atomic_legacy_migration(&self.dir)?;
+                }
+                (
+                    graphforge_storage::SemanticStorageBindings::project(
+                        context.composition(),
+                        current.as_ref(),
+                    )?,
+                    Vec::new(),
+                )
+            };
         projected.validate_against(context.composition())?;
         let context = context.with_generation_storage_ids(
             projected
@@ -1122,7 +1139,7 @@ impl GraphForge {
                 .map(|binding| (binding.symbol.clone(), binding.storage_id)),
         );
         drop(current);
-        Ok((Arc::new(context), projected))
+        Ok((Arc::new(context), projected, route_moves))
     }
 
     /// Build a session reflecting the current runtime catalog and run `plan`,
@@ -1142,7 +1159,7 @@ impl GraphForge {
         params: &HashMap<String, IrLiteral>,
         publish: bool,
     ) -> Result<ExecutionResult, GfError> {
-        self.run_plan_with_publish_and_bindings(plan, params, publish, None, None)
+        self.run_plan_with_publish_and_bindings(plan, params, publish, None, None, None)
     }
 
     #[allow(clippy::too_many_lines)] // one visibility lock spans execution and publication
@@ -1153,6 +1170,7 @@ impl GraphForge {
         publish: bool,
         candidate_bindings: Option<&graphforge_storage::SemanticStorageBindings>,
         composition_mode: Option<OntologyMode>,
+        legacy_route_moves: Option<&[(std::path::PathBuf, std::path::PathBuf)]>,
     ) -> Result<ExecutionResult, GfError> {
         use graphforge_exec::ExecutionSession;
 
@@ -1195,6 +1213,19 @@ impl GraphForge {
                 )
             })
             .transpose()?;
+        let mut legacy_migration = None;
+        if legacy_route_moves.is_some_and(|moves| !moves.is_empty()) {
+            if !is_write || !publish {
+                return Err(GfError::Validation(
+                    "GF_SEMANTIC_LEGACY_MIGRATION_REQUIRED: run a publishing write to migrate the unambiguous legacy generation".into(),
+                ));
+            }
+            legacy_migration = Some(graphforge_storage::apply_legacy_route_moves(
+                &self.dir,
+                legacy_route_moves.expect("checked"),
+                candidate_bindings.expect("legacy migration has candidate bindings"),
+            )?);
+        }
 
         // Open a catalog snapshot reflecting the freshly-bound runtime catalog so
         // read scans resolve property names interned during bind.
@@ -1287,6 +1318,9 @@ impl GraphForge {
                     .semantic_storage_bindings
                     .lock()
                     .expect("semantic storage binding lock poisoned") = Some(candidate.clone());
+            }
+            if let Some(migration) = &mut legacy_migration {
+                migration.commit();
             }
         }
         if is_write

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -527,6 +527,7 @@ pub struct GraphCreateExec {
     in_df_schema: DFSchemaRef,
     dir: PathBuf,
     mode: OntologyMode,
+    semantic_composition_fingerprint: Option<String>,
     schema: SchemaRef,
     /// `true` when this node emits created-entity rows (write-result RETURN);
     /// `false` for the one-row write summary (#814).
@@ -673,6 +674,7 @@ impl GraphCreateExec {
             in_df_schema: in_schema.clone(),
             dir: node.dir.clone(),
             mode: node.mode,
+            semantic_composition_fingerprint: node.semantic_composition_fingerprint.clone(),
             schema,
             emit_rows,
             effects: Arc::new(std::sync::Mutex::new(CreateTally::default())),
@@ -702,6 +704,7 @@ impl GraphCreateExec {
             in_df_schema: self.in_df_schema.clone(),
             dir: self.dir.clone(),
             mode: self.mode,
+            semantic_composition_fingerprint: self.semantic_composition_fingerprint.clone(),
             out_schema: self.schema.clone(),
         }
     }
@@ -758,6 +761,7 @@ impl ExecutionPlan for GraphCreateExec {
             in_df_schema: self.in_df_schema.clone(),
             dir: self.dir.clone(),
             mode: self.mode,
+            semantic_composition_fingerprint: self.semantic_composition_fingerprint.clone(),
             schema: self.schema.clone(),
             emit_rows: self.emit_rows,
             // Share the SAME tally so `execute_create` can read counts back after
@@ -801,8 +805,11 @@ impl ExecutionPlan for GraphCreateExec {
                 .then(|| persisted_node_ids(&cfg.dir))
                 .transpose()
                 .map_err(to_df_err)?;
-            let mut writer =
-                graphforge_storage::GraphWriter::open(&cfg.dir, cfg.mode).map_err(to_df_err)?;
+            let mut writer = graphforge_storage::GraphWriter::open(&cfg.dir, cfg.mode)
+                .map_err(to_df_err)?
+                .with_semantic_composition_fingerprint(
+                    cfg.semantic_composition_fingerprint.clone(),
+                );
             let mut tally = CreateTally::default();
             let mut emitted: Vec<RecordBatch> = Vec::new();
 
@@ -882,6 +889,7 @@ pub(crate) struct CreateConfig {
     pub(crate) in_df_schema: DFSchemaRef,
     dir: PathBuf,
     mode: OntologyMode,
+    semantic_composition_fingerprint: Option<String>,
     out_schema: SchemaRef,
 }
 
@@ -4377,6 +4385,8 @@ pub struct ExecutionSession {
     dir: PathBuf,
     /// Ontology mode driving write routing.
     mode: OntologyMode,
+    /// Exact composition fingerprint authenticating semantic write routes.
+    semantic_composition_fingerprint: Option<String>,
     /// The session's adjacency provider (also registered as a SessionConfig
     /// extension for the planner). Held concretely so successful writes can
     /// invalidate its memoized state and loaded views — a same-session
@@ -4532,6 +4542,9 @@ impl ExecutionSession {
             .with_physical_optimizer_rule(Arc::new(demand::FixedHopDemandRule))
             .build();
         let ctx = SessionContext::new_with_state(state);
+        let semantic_composition_fingerprint = catalog
+            .semantic_composition_fingerprint()
+            .map(str::to_owned);
         let catalog = Arc::new(catalog);
         ctx.register_catalog("graph", catalog.clone());
         Self {
@@ -4540,6 +4553,7 @@ impl ExecutionSession {
             ontology,
             dir,
             mode,
+            semantic_composition_fingerprint,
             adjacency_provider,
             relational_fixed_hop_reference: false,
         }
@@ -4786,7 +4800,8 @@ impl ExecutionSession {
             params,
             type_map: lowerer.entity_name_map(),
         };
-        let mut wctx = write_driver::StatementWriteContext::new(&self.dir, self.mode)?;
+        let mut wctx = write_driver::StatementWriteContext::new(&self.dir, self.mode)?
+            .with_semantic_composition_fingerprint(self.semantic_composition_fingerprint.clone());
         let create_retention =
             write_driver::create_retention_by_write(&plan.ops, &plan.exprs, &split);
         let mut cursor = split.prefix_len;

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -5474,6 +5474,7 @@ mod tests {
             computed_properties: vec![],
         };
         let cfg = CreateConfig {
+            semantic_composition_fingerprint: None,
             nodes: nodes.clone(),
             edges: vec![edge.clone()],
             ref_cols: vec![],
@@ -5510,6 +5511,7 @@ mod tests {
         assert_eq!(persisted_node_ids(dir.path()).unwrap().len(), 4);
 
         let invalid_untyped = CreateConfig {
+            semantic_composition_fingerprint: None,
             nodes: nodes.clone(),
             edges: vec![ResolvedEdgeSpec {
                 rel_type_id: None,
@@ -5529,6 +5531,7 @@ mod tests {
                 .contains("relationship type")
         );
         let invalid_undirected = CreateConfig {
+            semantic_composition_fingerprint: None,
             nodes,
             edges: vec![ResolvedEdgeSpec {
                 direction: graphforge_ir::Direction::Undirected,
@@ -5674,6 +5677,7 @@ mod tests {
             graphforge_storage::GraphWriter::open_at(dir.path(), OntologyMode::Exploratory, 1)
                 .unwrap();
         let cfg = CreateConfig {
+            semantic_composition_fingerprint: None,
             nodes: vec![reference.clone()],
             edges: vec![],
             ref_cols: vec![],
@@ -5748,6 +5752,7 @@ mod tests {
             computed_properties: vec![],
         };
         let mut edge_cfg = CreateConfig {
+            semantic_composition_fingerprint: None,
             nodes: vec![],
             edges: vec![edge.clone()],
             ref_cols: vec![],
@@ -5866,6 +5871,7 @@ mod tests {
             arrow::datatypes::Field::new("name", arrow::datatypes::DataType::Utf8, false),
         ]));
         let cfg = CreateConfig {
+            semantic_composition_fingerprint: None,
             nodes: vec![ResolvedNodeSpec {
                 var: 1,
                 label_ids: vec![7],

--- a/crates/graphforge-exec/src/write_driver.rs
+++ b/crates/graphforge-exec/src/write_driver.rs
@@ -321,6 +321,17 @@ impl StatementWriteContext {
         })
     }
 
+    #[must_use]
+    pub(crate) fn with_semantic_composition_fingerprint(
+        mut self,
+        fingerprint: Option<String>,
+    ) -> Self {
+        self.writer = self
+            .writer
+            .with_semantic_composition_fingerprint(fingerprint);
+        self
+    }
+
     fn record_mutation_input(
         &mut self,
         kind: crate::MutationKind,
@@ -1580,6 +1591,7 @@ fn run_create_phase(
         in_df_schema: Arc::new(frontier.df_schema.clone()),
         dir: env.dir.to_path_buf(),
         mode: env.mode,
+        semantic_composition_fingerprint: None,
         out_schema: graphforge_plan::GraphCreateNode::summary_schema(),
     };
     validate_edge_specs(&cfg)?;

--- a/crates/graphforge-ir/src/composition_binding.rs
+++ b/crates/graphforge-ir/src/composition_binding.rs
@@ -1,6 +1,6 @@
 //! Deterministic symbol binding over a compiled ontology composition.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use graphforge_ontology::{
@@ -127,6 +127,7 @@ pub struct CompositionBindingContext {
     composition: Arc<CompiledComposition>,
     bridges: Vec<BridgeDocument>,
     limits: CompositionBindingLimits,
+    storage_ids: HashMap<QualifiedSymbol, u32>,
 }
 
 impl CompositionBindingContext {
@@ -145,13 +146,42 @@ impl CompositionBindingContext {
             composition,
             bridges,
             limits,
+            storage_ids: HashMap::new(),
         }
+    }
+
+    /// Attach generation-pinned storage IDs. The caller must authenticate the
+    /// mapping against this context's exact composition before construction.
+    #[must_use]
+    pub fn with_storage_ids(
+        mut self,
+        storage_ids: impl IntoIterator<Item = (QualifiedSymbol, u32)>,
+    ) -> Self {
+        self.storage_ids = storage_ids.into_iter().collect();
+        self
     }
 
     /// Exact composition fingerprint.
     #[must_use]
     pub fn fingerprint(&self) -> &str {
         &self.composition.fingerprint
+    }
+
+    /// Exact compiled authority used for storage-binding authentication.
+    #[must_use]
+    pub fn composition(&self) -> &Arc<CompiledComposition> {
+        &self.composition
+    }
+
+    /// Return a copy carrying authenticated generation storage IDs.
+    #[must_use]
+    pub fn with_generation_storage_ids(
+        &self,
+        storage_ids: impl IntoIterator<Item = (QualifiedSymbol, u32)>,
+    ) -> Self {
+        let mut value = self.clone();
+        value.storage_ids = storage_ids.into_iter().collect();
+        value
     }
 
     /// Deterministic composition-local semantic ID for a qualified symbol.
@@ -161,6 +191,9 @@ impl CompositionBindingContext {
     /// catalog ID.
     #[must_use]
     pub fn semantic_id(&self, symbol: &QualifiedSymbol) -> u32 {
+        if let Some(id) = self.storage_ids.get(symbol) {
+            return *id;
+        }
         let mut symbols = self
             .composition
             .modules

--- a/crates/graphforge-ir/src/composition_binding.rs
+++ b/crates/graphforge-ir/src/composition_binding.rs
@@ -173,6 +173,12 @@ impl CompositionBindingContext {
         &self.composition
     }
 
+    /// Exact authored bridges adopted by this compiled context.
+    #[must_use]
+    pub fn bridges(&self) -> &[BridgeDocument] {
+        &self.bridges
+    }
+
     /// Return a copy carrying authenticated generation storage IDs.
     #[must_use]
     pub fn with_generation_storage_ids(

--- a/crates/graphforge-plan/src/lib.rs
+++ b/crates/graphforge-plan/src/lib.rs
@@ -955,6 +955,8 @@ pub struct GraphCreateNode {
     pub dir: PathBuf,
     /// Ontology mode (drives writer edge / property routing).
     pub mode: OntologyMode,
+    /// Exact composition fingerprint authenticating opaque storage routes.
+    pub semantic_composition_fingerprint: Option<String>,
     /// Output schema: the one-row write summary in summary mode, or the
     /// created-entity row schema in emit-rows mode (#814).
     schema: DFSchemaRef,
@@ -996,6 +998,7 @@ impl GraphCreateNode {
             edges,
             dir,
             mode,
+            semantic_composition_fingerprint: None,
             schema,
             emit_rows: false,
         }
@@ -1022,6 +1025,7 @@ impl GraphCreateNode {
             edges,
             dir,
             mode,
+            semantic_composition_fingerprint: None,
             schema: output_schema,
             emit_rows: true,
         }
@@ -1032,6 +1036,13 @@ impl GraphCreateNode {
     #[must_use]
     pub fn emits_rows(&self) -> bool {
         self.emit_rows
+    }
+
+    /// Attach exact semantic storage authentication to this write node.
+    #[must_use]
+    pub fn with_semantic_composition_fingerprint(mut self, fingerprint: Option<&str>) -> Self {
+        self.semantic_composition_fingerprint = fingerprint.map(str::to_owned);
+        self
     }
 }
 
@@ -1050,6 +1061,7 @@ impl PartialEq for GraphCreateNode {
             && self.edges == other.edges
             && self.dir == other.dir
             && self.mode == other.mode
+            && self.semantic_composition_fingerprint == other.semantic_composition_fingerprint
             && self.emit_rows == other.emit_rows
     }
 }
@@ -1256,6 +1268,7 @@ impl Hash for GraphCreateNode {
         }
         self.dir.hash(state);
         self.mode.hash(state);
+        self.semantic_composition_fingerprint.hash(state);
         self.emit_rows.hash(state);
     }
 }

--- a/crates/graphforge-rel/src/lowerer.rs
+++ b/crates/graphforge-rel/src/lowerer.rs
@@ -180,6 +180,7 @@ impl<'a> GraphPlanLowerer<'a> {
         // resolve through a colliding ontology ID.
         let mut type_id_to_rel_name = build_type_id_map(ontology);
         if let Some(c) = catalog {
+            type_id_to_rel_name.extend(c.semantic_rel_routes().clone());
             for (id, name) in c.rel_names() {
                 let plan_id =
                     graphforge_ir::runtime_relation_type_id(graphforge_ir::RuntimeTypeId(*id));
@@ -194,7 +195,13 @@ impl<'a> GraphPlanLowerer<'a> {
             // an exploratory node's properties live in `_untyped` (not a
             // per-label table). The runtime-catalog labels are merged in
             // separately for node-value rendering only — see `expr_lowerer`.
-            type_id_to_entity_name: build_entity_id_map(ontology),
+            type_id_to_entity_name: {
+                let mut names = build_entity_id_map(ontology);
+                if let Some(c) = catalog {
+                    names.extend(c.semantic_label_routes().clone());
+                }
+                names
+            },
             write_target,
             read_dir,
             node_shapes: std::sync::RwLock::new(HashMap::new()),
@@ -251,6 +258,7 @@ impl<'a> GraphPlanLowerer<'a> {
         // label name without colliding with ontology type 0 (#702).
         let mut node_label_names = self.type_id_to_entity_name.clone();
         if let Some(c) = self.catalog {
+            node_label_names.extend(c.semantic_label_names().clone());
             for (id, name) in c.label_names() {
                 let plan_id =
                     graphforge_ir::runtime_entity_type_id(graphforge_ir::RuntimeTypeId(*id));
@@ -2067,13 +2075,21 @@ impl<'a> GraphPlanLowerer<'a> {
                 dir.to_path_buf(),
                 mode,
                 out_schema,
+            )
+            .with_semantic_composition_fingerprint(
+                self.catalog
+                    .and_then(GraphCatalog::semantic_composition_fingerprint),
             );
             return Ok(LogicalPlan::Extension(Extension {
                 node: Arc::new(node),
             }));
         }
 
-        let node = GraphCreateNode::new(Arc::new(input), nodes, edges, dir.to_path_buf(), mode);
+        let node = GraphCreateNode::new(Arc::new(input), nodes, edges, dir.to_path_buf(), mode)
+            .with_semantic_composition_fingerprint(
+                self.catalog
+                    .and_then(GraphCatalog::semantic_composition_fingerprint),
+            );
         Ok(LogicalPlan::Extension(Extension {
             node: Arc::new(node),
         }))
@@ -3151,6 +3167,28 @@ fn lower_typed_edge_scan(
         ))
     })?;
 
+    // Generation-bound semantic relations must consume the exact provider
+    // authenticated and registered by GraphCatalog. Reconstructing a provider
+    // from a string route loses that authority and must never fall back to the
+    // exploratory relation-name filter.
+    if catalog.is_some_and(|catalog| catalog.semantic_rel_routes().contains_key(&rel_ty.0)) {
+        let provider = catalog
+            .and_then(|catalog| catalog.semantic_edge_table(rel_ty.0))
+            .ok_or_else(|| {
+                LoweringError::UnsupportedExpr(format!(
+                    "semantic relation TypeId({}) has no authenticated catalog provider",
+                    rel_ty.0
+                ))
+            })?;
+        return LogicalPlanBuilder::scan(
+            alias,
+            datafusion::datasource::provider_as_source(provider),
+            None,
+        )
+        .and_then(LogicalPlanBuilder::build)
+        .map_unsupported_expr();
+    }
+
     // Check if the catalog has a typed edge table for this relation.
     let use_exploratory = catalog
         .and_then(|c| c.schema("graph"))
@@ -4061,7 +4099,14 @@ fn expand_single_dir(
     // Enrich the edge scan with its persisted properties (#784) so a downstream
     // `RETURN r.<prop>` resolves to a real column. A wildcard edge scan
     // (`rel_ty == None`) has no single relation file, so no property join.
-    let edge_plan = join_edge_properties(&edge_alias, rel_ty, type_id_to_rel_name, dir, edge_plan)?;
+    let edge_plan = join_edge_properties(
+        &edge_alias,
+        rel_ty,
+        type_id_to_rel_name,
+        catalog,
+        dir,
+        edge_plan,
+    )?;
 
     // Join input (has src) with edge scan.
     let src_col = col(format!("{src_alias}.node_id"));
@@ -4196,6 +4241,7 @@ fn join_edge_properties(
     edge_alias: &str,
     rel_ty: Option<TypeId>,
     type_id_to_rel_name: &HashMap<u32, String>,
+    catalog: Option<&GraphCatalog>,
     dir: Option<&Path>,
     scan: LogicalPlan,
 ) -> Result<LogicalPlan, LoweringError> {
@@ -4218,33 +4264,39 @@ fn join_edge_properties(
     let mut prop_sources = Vec::new();
     let mut prop_order = Vec::new();
     let mut seen_props = HashSet::new();
-    let mut push_source = |stem: String| {
-        let table = graphforge_storage::EdgePropertyTable::open_discovered(dir, &stem);
-        let prop_cols: Vec<String> = table
-            .schema_ref()
-            .fields()
-            .iter()
-            .map(|f| f.name().clone())
-            .filter(|n| !base_cols.contains(n))
-            .collect();
-        if prop_cols.is_empty() {
-            return;
-        }
-        for name in &prop_cols {
-            if seen_props.insert(name.clone()) {
-                prop_order.push(name.clone());
+    let mut push_source =
+        |stem: String, registered: Option<Arc<dyn datafusion::datasource::TableProvider>>| {
+            let table = registered.unwrap_or_else(|| {
+                Arc::new(graphforge_storage::EdgePropertyTable::open_discovered(
+                    dir, &stem,
+                ))
+            });
+            let prop_cols: Vec<String> = table
+                .schema()
+                .fields()
+                .iter()
+                .map(|f| f.name().clone())
+                .filter(|n| !base_cols.contains(n))
+                .collect();
+            if prop_cols.is_empty() {
+                return;
             }
-        }
-        prop_sources.push((stem, table, prop_cols));
-    };
+            for name in &prop_cols {
+                if seen_props.insert(name.clone()) {
+                    prop_order.push(name.clone());
+                }
+            }
+            prop_sources.push((stem, table, prop_cols));
+        };
     if let Some(rel_ty) = rel_ty {
         let Some(rel_name) = type_id_to_rel_name.get(&rel_ty.0) else {
             return Ok(scan); // unknown relation name: nothing to resolve
         };
-        push_source(rel_name.clone());
+        let registered = catalog.and_then(|catalog| catalog.semantic_edge_property_table(rel_ty.0));
+        push_source(rel_name.clone(), registered);
     } else {
         for stem in graphforge_storage::list_edge_property_stems(dir) {
-            push_source(stem);
+            push_source(stem, None);
         }
     }
     if prop_sources.is_empty() {
@@ -4256,7 +4308,7 @@ fn join_edge_properties(
     let mut prop_refs: StdHashMap<String, Vec<DfExpr>> = StdHashMap::new();
     for (idx, (stem, prop_table, prop_cols)) in prop_sources.into_iter().enumerate() {
         let prop_alias = format!("{edge_alias}__eprops_{idx}");
-        let prop_src = datafusion::datasource::provider_as_source(Arc::new(prop_table));
+        let prop_src = datafusion::datasource::provider_as_source(prop_table);
         let prop_scan = LogicalPlanBuilder::scan(prop_alias.clone(), prop_src, None)
             .and_then(LogicalPlanBuilder::build)
             .map_unsupported_expr()?;

--- a/crates/graphforge-storage/src/catalog.rs
+++ b/crates/graphforge-storage/src/catalog.rs
@@ -1586,6 +1586,12 @@ pub struct GraphCatalog {
     /// [`graphforge_ir::runtime_entity_type_id`] before merging them with
     /// ontology TypeIds (#702 / #889).
     label_names: HashMap<u32, String>,
+    semantic_rel_routes: HashMap<u32, String>,
+    semantic_label_routes: HashMap<u32, String>,
+    semantic_label_names: HashMap<u32, String>,
+    semantic_composition_fingerprint: Option<String>,
+    semantic_edge_tables: HashMap<u32, Arc<dyn TableProvider>>,
+    semantic_edge_property_tables: HashMap<u32, Arc<dyn TableProvider>>,
 }
 
 impl fmt::Debug for GraphCatalog {
@@ -1611,6 +1617,17 @@ impl GraphCatalog {
         ontology: Option<&OntologyHandle>,
         runtime_catalog: &RuntimeCatalog,
     ) -> Result<Self, DataFusionError> {
+        Self::open_with_semantic_bindings(dir, ontology, runtime_catalog, None)
+    }
+
+    /// Open with exact generation-pinned qualified storage bindings.
+    #[allow(clippy::too_many_lines)] // registration must build one internally consistent catalog
+    pub fn open_with_semantic_bindings(
+        dir: &Path,
+        ontology: Option<&OntologyHandle>,
+        runtime_catalog: &RuntimeCatalog,
+        semantic: Option<&crate::SemanticStorageBindings>,
+    ) -> Result<Self, DataFusionError> {
         let mut schema = GraphSchema::new();
 
         // ---- topology nodes ----
@@ -1621,7 +1638,16 @@ impl GraphCatalog {
         );
 
         // ---- typed edge tables ----
-        if let Some(handle) = ontology {
+        if let Some(bindings) = semantic {
+            for binding in &bindings.bindings {
+                if binding.route_kind == crate::SemanticRouteKind::Relation {
+                    schema.register(
+                        format!("edges_{}", binding.route),
+                        Arc::new(TypedEdgeTable::open(dir, &binding.route)),
+                    );
+                }
+            }
+        } else if let Some(handle) = ontology {
             for rel_name in handle.relation_type_names() {
                 schema.register(
                     format!("edges_{rel_name}"),
@@ -1664,18 +1690,95 @@ impl GraphCatalog {
         }
 
         // ---- property tables ----
-        register_property_tables(dir, ontology, &mut schema);
+        if let Some(bindings) = semantic {
+            let mut node_routes = std::collections::BTreeSet::new();
+            for binding in &bindings.bindings {
+                match binding.route_kind {
+                    crate::SemanticRouteKind::NodeProperty
+                        if node_routes.insert(binding.route.clone()) =>
+                    {
+                        schema.register(
+                            format!("properties_{}", binding.route),
+                            Arc::new(PropertyTable::open_discovered(dir, &binding.route)),
+                        );
+                    }
+                    crate::SemanticRouteKind::EdgeProperty => {
+                        schema.register(
+                            format!("edge_properties_{}", binding.route),
+                            Arc::new(EdgePropertyTable::open_discovered(dir, &binding.route)),
+                        );
+                    }
+                    _ => {}
+                }
+            }
+        } else {
+            register_property_tables(dir, ontology, &mut schema);
+        }
 
         // ---- name maps (for read-path property + relation resolution) ----
-        let prop_names = build_prop_names(ontology, runtime_catalog);
+        let mut prop_names = build_prop_names(ontology, runtime_catalog);
         let rel_names = build_rel_names(runtime_catalog);
         let label_names = build_label_names(runtime_catalog);
+        let mut semantic_rel_routes = HashMap::new();
+        let mut semantic_label_routes = HashMap::new();
+        let mut semantic_label_names = HashMap::new();
+        let mut semantic_edge_tables: HashMap<u32, Arc<dyn TableProvider>> = HashMap::new();
+        let mut semantic_edge_property_tables: HashMap<u32, Arc<dyn TableProvider>> =
+            HashMap::new();
+        if let Some(bindings) = semantic {
+            for binding in &bindings.bindings {
+                match binding.route_kind {
+                    crate::SemanticRouteKind::Entity => {
+                        semantic_label_routes.insert(binding.storage_id, binding.route.clone());
+                        semantic_label_names.insert(binding.storage_id, binding.symbol.display());
+                    }
+                    crate::SemanticRouteKind::Relation => {
+                        semantic_rel_routes.insert(binding.storage_id, binding.route.clone());
+                        semantic_edge_tables.insert(
+                            binding.storage_id,
+                            Arc::new(TypedEdgeTable::open(dir, &binding.route)),
+                        );
+                    }
+                    crate::SemanticRouteKind::NodeProperty
+                    | crate::SemanticRouteKind::EdgeProperty => {
+                        let name = binding
+                            .symbol
+                            .local_id
+                            .split_once(':')
+                            .map_or(binding.symbol.local_id.as_str(), |(_, name)| name);
+                        prop_names.insert(binding.storage_id, name.to_owned());
+                    }
+                }
+            }
+            for relation in bindings
+                .bindings
+                .iter()
+                .filter(|binding| binding.route_kind == crate::SemanticRouteKind::Relation)
+            {
+                if bindings.bindings.iter().any(|binding| {
+                    binding.route_kind == crate::SemanticRouteKind::EdgeProperty
+                        && binding.owner.as_ref() == Some(&relation.symbol)
+                }) {
+                    semantic_edge_property_tables.insert(
+                        relation.storage_id,
+                        Arc::new(EdgePropertyTable::open_discovered(dir, &relation.route)),
+                    );
+                }
+            }
+        }
 
         Ok(Self {
             schema: Arc::new(schema),
             prop_names,
             rel_names,
             label_names,
+            semantic_rel_routes,
+            semantic_label_routes,
+            semantic_label_names,
+            semantic_composition_fingerprint: semantic
+                .map(|bindings| bindings.composition_fingerprint.clone()),
+            semantic_edge_tables,
+            semantic_edge_property_tables,
         })
     }
 
@@ -1701,6 +1804,42 @@ impl GraphCatalog {
     #[must_use]
     pub fn label_names(&self) -> &HashMap<u32, String> {
         &self.label_names
+    }
+
+    /// Generation-pinned semantic relation ID to opaque physical route.
+    #[must_use]
+    pub fn semantic_rel_routes(&self) -> &HashMap<u32, String> {
+        &self.semantic_rel_routes
+    }
+
+    /// Generation-pinned semantic entity ID to opaque property route.
+    #[must_use]
+    pub fn semantic_label_routes(&self) -> &HashMap<u32, String> {
+        &self.semantic_label_routes
+    }
+
+    /// Generation-pinned semantic entity ID to exact qualified display name.
+    #[must_use]
+    pub fn semantic_label_names(&self) -> &HashMap<u32, String> {
+        &self.semantic_label_names
+    }
+
+    /// Exact composition fingerprint authenticating semantic routes.
+    #[must_use]
+    pub fn semantic_composition_fingerprint(&self) -> Option<&str> {
+        self.semantic_composition_fingerprint.as_deref()
+    }
+
+    /// Registered authenticated provider for one semantic relation ID.
+    #[must_use]
+    pub fn semantic_edge_table(&self, id: u32) -> Option<Arc<dyn TableProvider>> {
+        self.semantic_edge_tables.get(&id).cloned()
+    }
+
+    /// Registered authenticated property provider for one semantic relation ID.
+    #[must_use]
+    pub fn semantic_edge_property_table(&self, id: u32) -> Option<Arc<dyn TableProvider>> {
+        self.semantic_edge_property_tables.get(&id).cloned()
     }
 }
 

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -187,9 +187,11 @@ pub use workspace_participants::{
     GraphDirectedness, MAX_WORKSPACE_REPOSITORY_SNAPSHOT_BYTES,
     MAX_WORKSPACE_REPOSITORY_SNAPSHOT_ENTRIES, MAX_WORKSPACE_REPOSITORY_SNAPSHOT_ID_BYTES,
     WORKSPACE_CAPABILITY_ID, WORKSPACE_CAPABILITY_VERSION, WORKSPACE_CONFIGURATION_FAMILY,
+    WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY, WORKSPACE_ONTOLOGY_COMPOSITION_VERSION,
     WORKSPACE_ONTOLOGY_FAMILY, WORKSPACE_REPOSITORY_SNAPSHOT_FAMILY,
-    WORKSPACE_REPOSITORY_SNAPSHOT_VERSION, WorkspaceConfiguration, WorkspaceOntology,
-    WorkspaceOntologyMode, WorkspaceOntologySourceFormat, WorkspaceRepositoryDefinitionDigest,
+    WORKSPACE_REPOSITORY_SNAPSHOT_VERSION, WorkspaceCompositionModule, WorkspaceConfiguration,
+    WorkspaceOntology, WorkspaceOntologyComposition, WorkspaceOntologyMode,
+    WorkspaceOntologySourceFormat, WorkspaceRepositoryDefinitionDigest,
     WorkspaceRepositoryGitProvenance, WorkspaceRepositorySnapshot, WorkspaceRepositorySourceDigest,
     empty_workspace_participants,
 };

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -39,10 +39,11 @@ pub use graph_files::{
 
 pub mod semantic_bindings;
 pub use semantic_bindings::{
-    GRAPH_SEMANTIC_BINDINGS_FAMILY, GRAPH_SEMANTIC_BINDINGS_VERSION, LegacySemanticProjection,
-    MAX_SEMANTIC_BINDING_BYTES, MAX_SEMANTIC_BINDINGS, SEMANTIC_COMPOSITION_METADATA_KEY,
-    SEMANTIC_ROUTE_METADATA_KEY, SemanticRouteKind, SemanticStorageBinding,
-    SemanticStorageBindings, require_atomic_legacy_migration, semantic_storage_bindings,
+    GRAPH_SEMANTIC_BINDINGS_FAMILY, GRAPH_SEMANTIC_BINDINGS_VERSION, LegacyRouteMigration,
+    LegacySemanticProjection, MAX_SEMANTIC_BINDING_BYTES, MAX_SEMANTIC_BINDINGS,
+    SEMANTIC_COMPOSITION_METADATA_KEY, SEMANTIC_ROUTE_METADATA_KEY, SemanticRouteKind,
+    SemanticStorageBinding, SemanticStorageBindings, apply_legacy_route_moves,
+    require_atomic_legacy_migration, semantic_storage_bindings,
 };
 
 pub mod graph_delta_journal;

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -37,6 +37,14 @@ pub use graph_files::{
     stage_graph_tree, verify_graph_tree,
 };
 
+pub mod semantic_bindings;
+pub use semantic_bindings::{
+    GRAPH_SEMANTIC_BINDINGS_FAMILY, GRAPH_SEMANTIC_BINDINGS_VERSION, LegacySemanticProjection,
+    MAX_SEMANTIC_BINDING_BYTES, MAX_SEMANTIC_BINDINGS, SEMANTIC_COMPOSITION_METADATA_KEY,
+    SEMANTIC_ROUTE_METADATA_KEY, SemanticRouteKind, SemanticStorageBinding,
+    SemanticStorageBindings, require_atomic_legacy_migration, semantic_storage_bindings,
+};
+
 pub mod graph_delta_journal;
 pub use graph_delta_journal::{
     GRAPH_DELTA_DIR, GRAPH_DELTA_RECORD_VERSION, GRAPH_DELTA_RUN_EXTENSION,

--- a/crates/graphforge-storage/src/project_generation.rs
+++ b/crates/graphforge-storage/src/project_generation.rs
@@ -801,7 +801,11 @@ fn reset_partial_generation(generations: &Path, generation_uuid: Uuid) -> Result
     let generation = generations.join(generation_uuid.hyphenated().to_string());
     let workspace = generation.join(PARTICIPANTS_DIR).join("workspace");
     if workspace.exists() {
-        for family in ["configuration.json", "ontology.json"] {
+        for family in [
+            "configuration.json",
+            "ontology.json",
+            "ontology_composition.json",
+        ] {
             let path = workspace.join(family);
             if path.exists() {
                 std::fs::remove_file(&path).map_err(|error| {
@@ -856,7 +860,15 @@ fn validate_partial_workspace_participants(participants: &Path) -> Result<(), Gf
         })
         .collect::<Result<Vec<_>, _>>()?;
     names.sort();
-    if names != ["configuration.json", "ontology.json"] && names != ["configuration.json"] {
+    let valid = names == ["configuration.json"]
+        || names == ["configuration.json", "ontology.json"]
+        || names
+            == [
+                "configuration.json",
+                "ontology.json",
+                "ontology_composition.json",
+            ];
+    if !valid {
         return Err(unsupported(
             "uninitialized workspace contains unknown entries",
         ));

--- a/crates/graphforge-storage/src/schemas.rs
+++ b/crates/graphforge-storage/src/schemas.rs
@@ -386,6 +386,25 @@ pub fn property_schema(entity_type: &str, property_defs: &[PropertyDef]) -> Sche
     Schema::new(fields).with_metadata(meta)
 }
 
+/// Attach authenticated generation-bound semantic routing metadata.
+#[must_use]
+pub fn with_semantic_route_metadata(
+    schema: &Schema,
+    route: &str,
+    composition_fingerprint: &str,
+) -> Schema {
+    let mut metadata = schema.metadata().clone();
+    metadata.insert(
+        crate::SEMANTIC_ROUTE_METADATA_KEY.to_owned(),
+        route.to_owned(),
+    );
+    metadata.insert(
+        crate::SEMANTIC_COMPOSITION_METADATA_KEY.to_owned(),
+        composition_fingerprint.to_owned(),
+    );
+    Schema::new_with_metadata(schema.fields().clone(), metadata)
+}
+
 /// Build a query result schema with GraphForge pipeline metadata attached.
 ///
 /// The metadata keys `graphforge.query_id`, `graphforge.ontology_version`, and

--- a/crates/graphforge-storage/src/semantic_bindings.rs
+++ b/crates/graphforge-storage/src/semantic_bindings.rs
@@ -164,6 +164,7 @@ impl SemanticStorageBindings {
         if topology_path.exists() {
             use arrow::array::{Array, ListArray, UInt32Array};
             use arrow::datatypes::DataType;
+            preflight_parquet_footer(&topology_path)?;
             let reader = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(
                 File::open(&topology_path)
                     .map_err(|_| legacy_ambiguous("legacy topology cannot be opened"))?,
@@ -561,6 +562,7 @@ impl SemanticStorageBindings {
             .filter(|binding| binding.route_kind == SemanticRouteKind::Entity)
             .map(|binding| binding.storage_id)
             .collect::<BTreeSet<_>>();
+        preflight_parquet_footer(&path)?;
         let reader = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(
             File::open(path).map_err(|_| corrupt("semantic topology cannot be opened"))?,
         )
@@ -1133,6 +1135,7 @@ fn binding_has_retained_data(
         if !path.exists() {
             return Ok(false);
         }
+        preflight_parquet_footer(&path)?;
         let reader = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(
             File::open(path).map_err(|_| corrupt("removal topology cannot be opened"))?,
         )
@@ -1168,6 +1171,7 @@ fn binding_has_retained_data(
     if !path.exists() {
         return Ok(false);
     }
+    preflight_parquet_footer(&path)?;
     let builder = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(
         File::open(path).map_err(|_| corrupt("removal route cannot be opened"))?,
     )
@@ -1603,13 +1607,31 @@ mod tests {
         use std::io::Write;
 
         let dir = tempfile::TempDir::new().unwrap();
-        let path = dir.path().join("adversarial.parquet");
+        let path = dir.path().join("topology/nodes.parquet");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         let mut file = File::create(&path).unwrap();
         file.write_all(b"PAR1").unwrap();
         file.write_all(&(u32::MAX).to_le_bytes()).unwrap();
         file.write_all(b"PAR1").unwrap();
         drop(file);
         let error = preflight_parquet_footer(&path).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("metadata exceeds admission limit"),
+            "{error:?}"
+        );
+        let composition = compiled("1");
+        let error = SemanticStorageBindings::project_legacy_unambiguous(&composition, dir.path())
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("metadata exceeds admission limit"),
+            "{error:?}"
+        );
+        let bindings = SemanticStorageBindings::project(&composition, None).unwrap();
+        let error = bindings.validate_physical_routes(dir.path()).unwrap_err();
         assert!(
             error
                 .to_string()

--- a/crates/graphforge-storage/src/semantic_bindings.rs
+++ b/crates/graphforge-storage/src/semantic_bindings.rs
@@ -2,6 +2,7 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 
 use graphforge_core::{GfError, ProjectErrorCode};
@@ -20,6 +21,7 @@ pub const MAX_SEMANTIC_BINDINGS: usize = 1_000_000;
 /// Maximum canonical participant bytes.
 pub const MAX_SEMANTIC_BINDING_BYTES: usize = 64 * 1024 * 1024;
 const MAX_SEMANTIC_PARQUET_COLUMNS: usize = 4_096;
+const MAX_SEMANTIC_PARQUET_METADATA_BYTES: u64 = 16 * 1024 * 1024;
 const MAX_SEMANTIC_STRING_BYTES: usize = 4_096;
 /// Parquet schema metadata key authenticating the opaque route.
 pub const SEMANTIC_ROUTE_METADATA_KEY: &str = "graphforge.semantic_route";
@@ -669,6 +671,7 @@ impl SemanticStorageBindings {
             if !path.exists() {
                 continue;
             }
+            preflight_parquet_footer(&path)?;
             let file = File::open(&path).map_err(|_| corrupt("semantic route file is missing"))?;
             let builder =
                 parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(file)
@@ -681,7 +684,9 @@ impl SemanticStorageBindings {
                 || schema.metadata().get(SEMANTIC_COMPOSITION_METADATA_KEY)
                     != Some(&self.composition_fingerprint)
             {
-                return Err(corrupt("semantic route metadata does not match binding"));
+                return Err(corrupt(&format!(
+                    "semantic route metadata does not match binding for {relative}"
+                )));
             }
             let join_key = match binding.route_kind {
                 SemanticRouteKind::NodeProperty => "node_uuid",
@@ -839,7 +844,24 @@ pub fn semantic_storage_bindings(
 ) -> Result<Option<SemanticStorageBindings>, GfError> {
     let bindings = generation
         .participant_snapshot(GRAPH_CAPABILITY_ID, GRAPH_SEMANTIC_BINDINGS_FAMILY)?
-        .map(|snapshot| SemanticStorageBindings::from_canonical_json(&snapshot.bytes))
+        .map(|snapshot| {
+            let expected_schema: [u8; 32] =
+                Sha256::digest(b"graphforge-semantic-storage-bindings/1").into();
+            if snapshot.capability_version != crate::GRAPH_CAPABILITY_VERSION
+                || snapshot.record_version != GRAPH_SEMANTIC_BINDINGS_VERSION
+                || snapshot.encoding != "json"
+                || snapshot.schema_fingerprint != expected_schema
+            {
+                return Err(corrupt(
+                    "semantic binding participant descriptor is unsupported",
+                ));
+            }
+            let bindings = SemanticStorageBindings::from_canonical_json(&snapshot.bytes)?;
+            if snapshot.row_count != bindings.bindings.len() as u64 {
+                return Err(corrupt("semantic binding participant row count disagrees"));
+            }
+            Ok(bindings)
+        })
         .transpose()?;
     if let Some(bindings) = &bindings {
         let composition = generation
@@ -977,6 +999,7 @@ pub fn apply_legacy_route_moves(
             return Err(corrupt(&format!("legacy migration rename failed: {error}")));
         }
         let rewrite = (|| {
+            preflight_parquet_footer(&backup)?;
             let builder = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(
                 File::open(&backup).map_err(|_| corrupt("legacy migration source cannot open"))?,
             )
@@ -1037,6 +1060,34 @@ fn corrupt(message: &str) -> GfError {
         code: ProjectErrorCode::ProjectCorrupt,
         message: message.into(),
     }
+}
+
+fn preflight_parquet_footer(path: &Path) -> Result<(), GfError> {
+    let mut file = File::open(path).map_err(|_| corrupt("semantic Parquet cannot be opened"))?;
+    let length = file
+        .metadata()
+        .map_err(|_| corrupt("semantic Parquet metadata cannot be read"))?
+        .len();
+    if length < 12 {
+        return Err(corrupt("semantic Parquet footer is truncated"));
+    }
+    file.seek(SeekFrom::End(-8))
+        .map_err(|_| corrupt("semantic Parquet footer cannot be read"))?;
+    let mut footer = [0_u8; 8];
+    file.read_exact(&mut footer)
+        .map_err(|_| corrupt("semantic Parquet footer cannot be read"))?;
+    if &footer[4..] != b"PAR1" {
+        return Err(corrupt("semantic Parquet footer magic is invalid"));
+    }
+    let metadata_len = u64::from(u32::from_le_bytes(footer[..4].try_into().unwrap()));
+    if metadata_len > MAX_SEMANTIC_PARQUET_METADATA_BYTES
+        || metadata_len
+            .checked_add(8)
+            .is_none_or(|total| total > length)
+    {
+        return Err(corrupt("semantic Parquet metadata exceeds admission limit"));
+    }
+    Ok(())
 }
 
 fn legacy_ambiguous(message: &str) -> GfError {
@@ -1545,6 +1596,26 @@ mod tests {
         )
         .unwrap_err();
         assert!(error.to_string().contains("GF_SEMANTIC_LEGACY_AMBIGUOUS"));
+    }
+
+    #[test]
+    fn parquet_footer_limit_fails_before_decoder_allocation() {
+        use std::io::Write;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("adversarial.parquet");
+        let mut file = File::create(&path).unwrap();
+        file.write_all(b"PAR1").unwrap();
+        file.write_all(&(u32::MAX).to_le_bytes()).unwrap();
+        file.write_all(b"PAR1").unwrap();
+        drop(file);
+        let error = preflight_parquet_footer(&path).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("metadata exceeds admission limit"),
+            "{error:?}"
+        );
     }
 
     #[test]

--- a/crates/graphforge-storage/src/semantic_bindings.rs
+++ b/crates/graphforge-storage/src/semantic_bindings.rs
@@ -19,6 +19,8 @@ pub const GRAPH_SEMANTIC_BINDINGS_VERSION: u32 = 1;
 pub const MAX_SEMANTIC_BINDINGS: usize = 1_000_000;
 /// Maximum canonical participant bytes.
 pub const MAX_SEMANTIC_BINDING_BYTES: usize = 64 * 1024 * 1024;
+const MAX_SEMANTIC_PARQUET_COLUMNS: usize = 4_096;
+const MAX_SEMANTIC_STRING_BYTES: usize = 4_096;
 /// Parquet schema metadata key authenticating the opaque route.
 pub const SEMANTIC_ROUTE_METADATA_KEY: &str = "graphforge.semantic_route";
 /// Parquet schema metadata key authenticating the owning composition.
@@ -526,6 +528,21 @@ impl SemanticStorageBindings {
                 ));
             }
         }
+        let expected_count = composition
+            .modules
+            .iter()
+            .try_fold(0usize, |count, module| {
+                count
+                    .checked_add(module.doc.entity_types.len())
+                    .and_then(|count| count.checked_add(module.doc.relation_types.len()))
+                    .and_then(|count| count.checked_add(module.doc.properties.len()))
+                    .ok_or_else(|| corrupt("composition semantic closure count overflows"))
+            })?;
+        if self.bindings.len() != expected_count {
+            return Err(corrupt(
+                "semantic bindings do not cover the complete composition closure",
+            ));
+        }
         Ok(())
     }
 
@@ -657,6 +674,9 @@ impl SemanticStorageBindings {
                 parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(file)
                     .map_err(|_| corrupt("semantic route Parquet metadata is invalid"))?;
             let schema = builder.schema();
+            if schema.fields().len() > MAX_SEMANTIC_PARQUET_COLUMNS {
+                return Err(corrupt("semantic route column count exceeds limit"));
+            }
             if schema.metadata().get(SEMANTIC_ROUTE_METADATA_KEY) != Some(&binding.route)
                 || schema.metadata().get(SEMANTIC_COMPOSITION_METADATA_KEY)
                     != Some(&self.composition_fingerprint)
@@ -749,6 +769,12 @@ impl SemanticStorageBindings {
         let mut ids = BTreeSet::new();
         let mut routes = BTreeMap::new();
         for binding in &self.bindings {
+            if binding.symbol.local_id.len() > MAX_SEMANTIC_STRING_BYTES
+                || binding.symbol.module.ontology_id.len() > MAX_SEMANTIC_STRING_BYTES
+                || binding.symbol.module.authored_version.len() > MAX_SEMANTIC_STRING_BYTES
+            {
+                return Err(corrupt("semantic binding string exceeds limit"));
+            }
             if binding.route
                 != Self::opaque_route(binding.route_kind, &binding.symbol, binding.owner.as_ref())
             {
@@ -885,6 +911,127 @@ pub fn require_atomic_legacy_migration(graph_root: &Path) -> Result<(), GfError>
     Ok(())
 }
 
+/// Rewrite a preflighted unambiguous legacy workspace to authenticated opaque
+/// routes. The caller must hold graph publication authority and publish the
+/// returned binding participant in the same generation. A local failure rolls
+/// every completed rename back before returning.
+pub struct LegacyRouteMigration {
+    completed: Vec<(PathBuf, PathBuf, PathBuf)>,
+    committed: bool,
+}
+
+impl LegacyRouteMigration {
+    /// Keep the opaque routes after their binding participant is published.
+    pub fn commit(&mut self) {
+        for (_, _, backup) in &self.completed {
+            let _ = std::fs::remove_file(backup);
+        }
+        self.committed = true;
+    }
+}
+
+impl Drop for LegacyRouteMigration {
+    fn drop(&mut self) {
+        if !self.committed {
+            for (old, new, backup) in self.completed.iter().rev() {
+                let _ = std::fs::remove_file(new);
+                let _ = std::fs::rename(backup, old);
+            }
+        }
+    }
+}
+
+/// Apply deterministic preflighted route moves and return a rollback guard.
+/// The caller commits the guard only after publishing the matching bindings.
+pub fn apply_legacy_route_moves(
+    graph_root: &Path,
+    route_moves: &[(PathBuf, PathBuf)],
+    bindings: &SemanticStorageBindings,
+) -> Result<LegacyRouteMigration, GfError> {
+    let mut completed = Vec::new();
+    for (old_relative, new_relative) in route_moves {
+        let old = graph_root.join(old_relative);
+        let new = graph_root.join(new_relative);
+        let binding = bindings
+            .bindings
+            .iter()
+            .find(|binding| binding.physical_path(Path::new("")).as_ref() == Some(new_relative))
+            .ok_or_else(|| corrupt("legacy migration destination has no binding"))?;
+        if new.exists() {
+            return Err(corrupt("legacy migration destination already exists"));
+        }
+        let parent = new
+            .parent()
+            .ok_or_else(|| corrupt("legacy migration destination has no parent"))?;
+        std::fs::create_dir_all(parent)
+            .map_err(|_| corrupt("legacy migration destination cannot be created"))?;
+        let backup = old.with_extension("parquet.legacy-backup");
+        if backup.exists() {
+            return Err(corrupt("legacy migration backup already exists"));
+        }
+        if let Err(error) = std::fs::rename(&old, &backup) {
+            for (prior_old, prior_new, prior_backup) in completed.iter().rev() {
+                let _ = std::fs::remove_file(prior_new);
+                let _ = std::fs::rename(prior_backup, prior_old);
+            }
+            return Err(corrupt(&format!("legacy migration rename failed: {error}")));
+        }
+        let rewrite = (|| {
+            let builder = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(
+                File::open(&backup).map_err(|_| corrupt("legacy migration source cannot open"))?,
+            )
+            .map_err(|_| corrupt("legacy migration source metadata is invalid"))?;
+            if builder.schema().fields().len() > MAX_SEMANTIC_PARQUET_COLUMNS {
+                return Err(corrupt("legacy migration column count exceeds limit"));
+            }
+            let mut metadata = builder.schema().metadata().clone();
+            metadata.insert(SEMANTIC_ROUTE_METADATA_KEY.into(), binding.route.clone());
+            metadata.insert(
+                SEMANTIC_COMPOSITION_METADATA_KEY.into(),
+                bindings.composition_fingerprint.clone(),
+            );
+            let schema = std::sync::Arc::new(arrow::datatypes::Schema::new_with_metadata(
+                builder.schema().fields().clone(),
+                metadata,
+            ));
+            let mut writer = parquet::arrow::ArrowWriter::try_new(
+                File::create(&new)
+                    .map_err(|_| corrupt("legacy migration destination cannot open"))?,
+                schema,
+                None,
+            )
+            .map_err(|_| corrupt("legacy migration writer cannot be built"))?;
+            for batch in builder
+                .with_batch_size(8192)
+                .build()
+                .map_err(|_| corrupt("legacy migration reader cannot be built"))?
+            {
+                writer
+                    .write(&batch.map_err(|_| corrupt("legacy migration batch is invalid"))?)
+                    .map_err(|_| corrupt("legacy migration batch cannot be written"))?;
+            }
+            writer
+                .close()
+                .map_err(|_| corrupt("legacy migration output cannot close"))?;
+            Ok(())
+        })();
+        if let Err(error) = rewrite {
+            let _ = std::fs::remove_file(&new);
+            let _ = std::fs::rename(&backup, &old);
+            for (prior_old, prior_new, prior_backup) in completed.iter().rev() {
+                let _ = std::fs::remove_file(prior_new);
+                let _ = std::fs::rename(prior_backup, prior_old);
+            }
+            return Err(error);
+        }
+        completed.push((old, new, backup));
+    }
+    Ok(LegacyRouteMigration {
+        completed,
+        committed: false,
+    })
+}
+
 fn corrupt(message: &str) -> GfError {
     GfError::Project {
         code: ProjectErrorCode::ProjectCorrupt,
@@ -970,14 +1117,44 @@ fn binding_has_retained_data(
     if !path.exists() {
         return Ok(false);
     }
-    let metadata = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(
+    let builder = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(
         File::open(path).map_err(|_| corrupt("removal route cannot be opened"))?,
     )
-    .map_err(|_| corrupt("removal route metadata is invalid"))?
-    .metadata()
-    .file_metadata()
-    .num_rows();
-    Ok(metadata > 0)
+    .map_err(|_| corrupt("removal route metadata is invalid"))?;
+    if matches!(
+        binding.route_kind,
+        SemanticRouteKind::NodeProperty | SemanticRouteKind::EdgeProperty
+    ) {
+        let column = binding
+            .symbol
+            .local_id
+            .split_once(':')
+            .map(|(_, property)| property)
+            .ok_or_else(|| corrupt("removal property has no qualified column"))?;
+        if !builder
+            .schema()
+            .fields()
+            .iter()
+            .any(|field| field.name() == column)
+        {
+            return Ok(false);
+        }
+        for batch in builder
+            .with_batch_size(8192)
+            .build()
+            .map_err(|_| corrupt("removal property reader cannot be built"))?
+        {
+            let batch = batch.map_err(|_| corrupt("removal property batch is invalid"))?;
+            let values = batch
+                .column_by_name(column)
+                .ok_or_else(|| corrupt("removal property column disappeared"))?;
+            if values.null_count() < values.len() {
+                return Ok(true);
+            }
+        }
+        return Ok(false);
+    }
+    Ok(builder.metadata().file_metadata().num_rows() > 0)
 }
 
 fn binding_key(
@@ -1269,6 +1446,41 @@ mod tests {
                 && binding.symbol.local_id == "KNOWS:since"
         }));
 
+        let other_column = tempfile::TempDir::new().unwrap();
+        let mut writer = crate::GraphWriter::open_at(
+            other_column.path(),
+            graphforge_core::OntologyMode::Strict,
+            1,
+        )
+        .unwrap()
+        .with_semantic_composition_fingerprint(Some(first.fingerprint.clone()));
+        let left = graphforge_core::uuid::new_v7();
+        let right = graphforge_core::uuid::new_v7();
+        writer
+            .create_node(left, graphforge_core::TypeId(1))
+            .unwrap();
+        writer
+            .create_node(right, graphforge_core::TypeId(1))
+            .unwrap();
+        let edge = graphforge_core::uuid::new_v7();
+        writer
+            .create_edge(edge, &relation.route, &left, &right)
+            .unwrap();
+        writer
+            .set_edge_properties(
+                &edge,
+                Some(&relation.route),
+                HashMap::from([("other".into(), graphforge_ir::IrLiteral::Int(1))]),
+            )
+            .unwrap();
+        writer.flush().unwrap();
+        SemanticStorageBindings::project_with_graph_scan(
+            &next,
+            Some(&initial),
+            other_column.path(),
+        )
+        .expect("an unrelated populated owner column must not retain the removed property");
+
         let retained = tempfile::TempDir::new().unwrap();
         let mut writer =
             crate::GraphWriter::open_at(retained.path(), graphforge_core::OntologyMode::Strict, 1)
@@ -1333,6 +1545,53 @@ mod tests {
         )
         .unwrap_err();
         assert!(error.to_string().contains("GF_SEMANTIC_LEGACY_AMBIGUOUS"));
+    }
+
+    #[test]
+    fn unambiguous_legacy_routes_rewrite_with_metadata_and_reopen() {
+        use std::collections::HashMap;
+
+        let composition = compiled("1");
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut writer =
+            crate::GraphWriter::open_at(dir.path(), graphforge_core::OntologyMode::Strict, 1)
+                .unwrap();
+        let left = graphforge_core::uuid::new_v7();
+        let right = graphforge_core::uuid::new_v7();
+        writer
+            .create_node(left, graphforge_core::TypeId(0))
+            .unwrap();
+        writer
+            .create_node(right, graphforge_core::TypeId(0))
+            .unwrap();
+        let edge = graphforge_core::uuid::new_v7();
+        writer.create_edge(edge, "KNOWS", &left, &right).unwrap();
+        writer
+            .set_edge_properties(
+                &edge,
+                Some("KNOWS"),
+                HashMap::from([("since".into(), graphforge_ir::IrLiteral::Int(2020))]),
+            )
+            .unwrap();
+        writer.flush().unwrap();
+
+        let projection =
+            SemanticStorageBindings::project_legacy_unambiguous(&composition, dir.path()).unwrap();
+        assert!(!projection.route_moves.is_empty());
+        let mut migration =
+            apply_legacy_route_moves(dir.path(), &projection.route_moves, &projection.bindings)
+                .unwrap();
+        projection
+            .bindings
+            .validate_physical_routes(dir.path())
+            .unwrap();
+        migration.commit();
+        drop(migration);
+        assert!(!dir.path().join("topology/edges/KNOWS.parquet").exists());
+        projection
+            .bindings
+            .validate_physical_routes(dir.path())
+            .unwrap();
     }
 
     #[test]

--- a/crates/graphforge-storage/src/semantic_bindings.rs
+++ b/crates/graphforge-storage/src/semantic_bindings.rs
@@ -1,0 +1,1413 @@
+//! Generation-bound bindings between physical graph storage and qualified ontology authority.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fs::File;
+use std::path::{Path, PathBuf};
+
+use graphforge_core::{GfError, ProjectErrorCode};
+use graphforge_ontology::{CompiledComposition, QualifiedSymbol, SymbolKind};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::{GRAPH_CAPABILITY_ID, ProjectParticipant, ProjectParticipantEncoding};
+
+/// Registered graph participant family.
+pub const GRAPH_SEMANTIC_BINDINGS_FAMILY: &str = "semantic_bindings";
+/// Frozen participant contract version.
+pub const GRAPH_SEMANTIC_BINDINGS_VERSION: u32 = 1;
+/// Maximum number of bindings accepted before allocation or serialization.
+pub const MAX_SEMANTIC_BINDINGS: usize = 1_000_000;
+/// Maximum canonical participant bytes.
+pub const MAX_SEMANTIC_BINDING_BYTES: usize = 64 * 1024 * 1024;
+/// Parquet schema metadata key authenticating the opaque route.
+pub const SEMANTIC_ROUTE_METADATA_KEY: &str = "graphforge.semantic_route";
+/// Parquet schema metadata key authenticating the owning composition.
+pub const SEMANTIC_COMPOSITION_METADATA_KEY: &str = "graphforge.composition_fingerprint";
+
+/// Physical storage route class.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SemanticRouteKind {
+    /// Node topology type binding.
+    Entity,
+    /// Typed edge physical route.
+    Relation,
+    /// Entity-owned property route.
+    NodeProperty,
+    /// Relation-owned property route.
+    EdgeProperty,
+}
+
+/// One exact physical binding. Runtime-tagged IDs are deliberately excluded.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SemanticStorageBinding {
+    /// Route class.
+    pub route_kind: SemanticRouteKind,
+    /// Untagged stable storage ID. IDs are never derived from runtime catalogs.
+    pub storage_id: u32,
+    /// Collision-free opaque route used in physical paths and Parquet metadata.
+    pub route: String,
+    /// Exact semantic symbol.
+    pub symbol: QualifiedSymbol,
+    /// Exact qualified owner for property routes.
+    pub owner: Option<QualifiedSymbol>,
+}
+
+/// Canonical complete mapping for one composition-bound graph generation.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SemanticStorageBindings {
+    /// Contract version.
+    pub contract_version: u32,
+    /// Exact composition fingerprint owning these bindings.
+    pub composition_fingerprint: String,
+    /// Canonically ordered unique bindings.
+    pub bindings: Vec<SemanticStorageBinding>,
+}
+
+/// Deterministic, mutation-free plan for converting one unambiguous legacy
+/// single-module graph into opaque semantic routes.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LegacySemanticProjection {
+    /// Exact projected authority using the IDs already persisted in topology.
+    pub bindings: SemanticStorageBindings,
+    /// Existing relative path to authenticated opaque relative path.
+    pub route_moves: Vec<(PathBuf, PathBuf)>,
+    /// Rows inspected with a fixed-size Parquet batch reader.
+    pub topology_rows_scanned: u64,
+    /// Largest resident topology batch used by the scanner.
+    pub max_topology_batch_rows: usize,
+}
+
+impl SemanticStorageBindings {
+    /// Inspect a legacy single-module layout without mutation. Multi-module or
+    /// unqualified layouts that cannot prove one owner fail closed.
+    #[allow(clippy::too_many_lines)] // one bounded scan keeps projection evidence co-located
+    pub fn project_legacy_unambiguous(
+        composition: &CompiledComposition,
+        graph_root: &Path,
+    ) -> Result<LegacySemanticProjection, GfError> {
+        let [module] = composition.modules.as_slice() else {
+            return Err(legacy_ambiguous(
+                "legacy semantic projection requires exactly one ontology module",
+            ));
+        };
+        let mut bindings = Vec::new();
+        for (id, entity) in module.doc.entity_types.iter().enumerate() {
+            let symbol = qualified(&module.id, SymbolKind::Entity, &entity.name);
+            bindings.push(binding(
+                SemanticRouteKind::Entity,
+                u32::try_from(id).map_err(|_| corrupt("legacy entity id exceeds u32"))?,
+                symbol,
+                None,
+            ));
+        }
+        for (id, relation) in module.doc.relation_types.iter().enumerate() {
+            let symbol = qualified(&module.id, SymbolKind::Relation, &relation.name);
+            bindings.push(binding(
+                SemanticRouteKind::Relation,
+                u32::try_from(id).map_err(|_| corrupt("legacy relation id exceeds u32"))?,
+                symbol,
+                None,
+            ));
+        }
+        for (id, property) in module.doc.properties.iter().enumerate() {
+            let owner_kind = if module
+                .doc
+                .entity_types
+                .iter()
+                .any(|entity| entity.name == property.owner)
+            {
+                SymbolKind::Entity
+            } else if module
+                .doc
+                .relation_types
+                .iter()
+                .any(|relation| relation.name == property.owner)
+            {
+                SymbolKind::Relation
+            } else {
+                return Err(legacy_ambiguous("legacy property owner is not declared"));
+            };
+            let owner = qualified(&module.id, owner_kind, &property.owner);
+            let symbol = qualified(
+                &module.id,
+                SymbolKind::Property,
+                &format!("{}:{}", property.owner, property.name),
+            );
+            bindings.push(binding(
+                if owner_kind == SymbolKind::Entity {
+                    SemanticRouteKind::NodeProperty
+                } else {
+                    SemanticRouteKind::EdgeProperty
+                },
+                u32::try_from(id).map_err(|_| corrupt("legacy property id exceeds u32"))?,
+                symbol,
+                Some(owner),
+            ));
+        }
+        let bindings = Self::new(composition.fingerprint.clone(), bindings)?;
+        bindings.validate_against(composition)?;
+
+        let valid_entity_ids = bindings
+            .bindings
+            .iter()
+            .filter(|binding| binding.route_kind == SemanticRouteKind::Entity)
+            .map(|binding| binding.storage_id)
+            .collect::<BTreeSet<_>>();
+        let topology_path = graph_root.join("topology/nodes.parquet");
+        let mut topology_rows_scanned = 0_u64;
+        let mut max_topology_batch_rows = 0_usize;
+        if topology_path.exists() {
+            use arrow::array::{Array, ListArray, UInt32Array};
+            use arrow::datatypes::DataType;
+            let reader = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(
+                File::open(&topology_path)
+                    .map_err(|_| legacy_ambiguous("legacy topology cannot be opened"))?,
+            )
+            .map_err(|_| legacy_ambiguous("legacy topology metadata is invalid"))?
+            .with_batch_size(8192)
+            .build()
+            .map_err(|_| legacy_ambiguous("legacy topology reader cannot be built"))?;
+            for batch in reader {
+                let batch =
+                    batch.map_err(|_| legacy_ambiguous("legacy topology batch is invalid"))?;
+                topology_rows_scanned = topology_rows_scanned
+                    .checked_add(batch.num_rows() as u64)
+                    .ok_or_else(|| corrupt("legacy topology row count overflows"))?;
+                max_topology_batch_rows = max_topology_batch_rows.max(batch.num_rows());
+                if let Some(type_ids) = batch
+                    .column_by_name("type_ids")
+                    .and_then(|array| array.as_any().downcast_ref::<ListArray>())
+                {
+                    if type_ids.value_type() != DataType::UInt32 {
+                        return Err(legacy_ambiguous("legacy topology type_ids has wrong type"));
+                    }
+                    for row in 0..type_ids.len() {
+                        let values = type_ids.value(row);
+                        let values = values.as_any().downcast_ref::<UInt32Array>().unwrap();
+                        if values
+                            .values()
+                            .iter()
+                            .any(|id| !valid_entity_ids.contains(id))
+                        {
+                            return Err(legacy_ambiguous(
+                                "legacy topology contains an undeclared entity id",
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        let mut route_moves = Vec::new();
+        for binding in &bindings.bindings {
+            let old = match binding.route_kind {
+                SemanticRouteKind::Entity => continue,
+                SemanticRouteKind::Relation => PathBuf::from("topology/edges")
+                    .join(format!("{}.parquet", binding.symbol.local_id)),
+                SemanticRouteKind::NodeProperty => PathBuf::from("properties").join(format!(
+                    "{}.parquet",
+                    binding.owner.as_ref().unwrap().local_id
+                )),
+                SemanticRouteKind::EdgeProperty => PathBuf::from("edge_properties").join(format!(
+                    "{}.parquet",
+                    binding.owner.as_ref().unwrap().local_id
+                )),
+            };
+            let new = binding
+                .physical_path(Path::new(""))
+                .expect("routed binding");
+            if graph_root.join(&old).exists() && !route_moves.iter().any(|(prior, _)| prior == &old)
+            {
+                route_moves.push((old, new));
+            }
+        }
+        route_moves.sort();
+        Ok(LegacySemanticProjection {
+            bindings,
+            route_moves,
+            topology_rows_scanned,
+            max_topology_batch_rows,
+        })
+    }
+
+    /// Project a complete composition closure, carrying stable IDs from the
+    /// prior generation and allocating new IDs monotonically without reuse.
+    pub fn project(
+        composition: &CompiledComposition,
+        previous: Option<&Self>,
+    ) -> Result<Self, GfError> {
+        Self::project_with_removal_scan(composition, previous, None)
+    }
+
+    /// Project while permitting removed bindings only when an exact pinned
+    /// graph scan proves their prior physical identity has no retained data.
+    pub fn project_with_graph_scan(
+        composition: &CompiledComposition,
+        previous: Option<&Self>,
+        graph_root: &Path,
+    ) -> Result<Self, GfError> {
+        Self::project_with_removal_scan(composition, previous, Some(graph_root))
+    }
+
+    #[allow(clippy::too_many_lines)] // projection is a single fail-closed authority calculation
+    fn project_with_removal_scan(
+        composition: &CompiledComposition,
+        previous: Option<&Self>,
+        graph_root: Option<&Path>,
+    ) -> Result<Self, GfError> {
+        if let Some(previous) = previous
+            && previous.composition_fingerprint == composition.fingerprint
+        {
+            previous.validate_against(composition)?;
+            return Ok(previous.clone());
+        }
+        if let Some(previous) = previous {
+            for prior in &previous.bindings {
+                let Some(next) = composition
+                    .modules
+                    .iter()
+                    .find(|module| module.id.ontology_id == prior.symbol.module.ontology_id)
+                else {
+                    continue;
+                };
+                if next.id != prior.symbol.module {
+                    let declared = next.doc.migrations.iter().any(|migration| {
+                        migration.from_version == prior.symbol.module.authored_version
+                            && migration.to_version == next.id.authored_version
+                    });
+                    if !declared {
+                        return Err(corrupt(
+                            "module upgrade would carry stored IDs without an explicit authored migration lineage",
+                        ));
+                    }
+                }
+            }
+        }
+        let carried = previous
+            .map(|value| {
+                value
+                    .bindings
+                    .iter()
+                    .map(|binding| {
+                        (
+                            lineage_key(
+                                binding.route_kind,
+                                &binding.symbol,
+                                binding.owner.as_ref(),
+                            ),
+                            binding.storage_id,
+                        )
+                    })
+                    .try_fold(HashMap::new(), |mut map, (key, id)| {
+                        if map.insert(key, id).is_some() {
+                            return Err(corrupt("semantic storage lineage is ambiguous"));
+                        }
+                        Ok(map)
+                    })
+            })
+            .transpose()?
+            .unwrap_or_default();
+        let mut used = previous
+            .map(|value| {
+                value.bindings.iter().fold(
+                    BTreeMap::<u8, BTreeSet<u32>>::new(),
+                    |mut used, binding| {
+                        used.entry(id_namespace(binding.route_kind))
+                            .or_default()
+                            .insert(binding.storage_id);
+                        used
+                    },
+                )
+            })
+            .unwrap_or_default();
+        let mut allocate = |key: &(SemanticRouteKind, QualifiedSymbol, Option<QualifiedSymbol>)| {
+            let key = lineage_key(key.0, &key.1, key.2.as_ref());
+            if let Some(id) = carried.get(&key) {
+                return Ok(*id);
+            }
+            let namespace = id_namespace(key.0);
+            let ids = used.entry(namespace).or_default();
+            let mut next = ids.iter().next_back().copied().unwrap_or(0);
+            loop {
+                next = next
+                    .checked_add(1)
+                    .ok_or_else(|| corrupt("semantic storage id space is exhausted"))?;
+                if next & ((1 << 30) | (1 << 31)) != 0 {
+                    return Err(corrupt(
+                        "semantic storage id space reached reserved runtime tags",
+                    ));
+                }
+                if ids.insert(next) {
+                    return Ok(next);
+                }
+            }
+        };
+        let mut keys = Vec::new();
+        for module in &composition.modules {
+            for symbol in &module.symbols {
+                match symbol.kind {
+                    SymbolKind::Entity => {
+                        keys.push((SemanticRouteKind::Entity, symbol.clone(), None));
+                    }
+                    SymbolKind::Relation => {
+                        keys.push((SemanticRouteKind::Relation, symbol.clone(), None));
+                    }
+                    SymbolKind::Property => {
+                        let owner_name = symbol
+                            .local_id
+                            .split_once(':')
+                            .map(|(owner, _)| owner)
+                            .ok_or_else(|| corrupt("property symbol has no qualified owner"))?;
+                        let owner_kind = if module
+                            .doc
+                            .entity_types
+                            .iter()
+                            .any(|entity| entity.name == owner_name)
+                        {
+                            SymbolKind::Entity
+                        } else if module
+                            .doc
+                            .relation_types
+                            .iter()
+                            .any(|relation| relation.name == owner_name)
+                        {
+                            SymbolKind::Relation
+                        } else {
+                            return Err(corrupt("property owner is absent from composition"));
+                        };
+                        let owner = QualifiedSymbol {
+                            module: symbol.module.clone(),
+                            kind: owner_kind,
+                            local_id: owner_name.to_owned(),
+                        };
+                        keys.push((
+                            if owner_kind == SymbolKind::Entity {
+                                SemanticRouteKind::NodeProperty
+                            } else {
+                                SemanticRouteKind::EdgeProperty
+                            },
+                            symbol.clone(),
+                            Some(owner),
+                        ));
+                    }
+                    SymbolKind::Constraint | SymbolKind::Migration => {}
+                }
+            }
+        }
+        keys.sort_by_key(|(kind, symbol, owner)| projection_key(*kind, symbol, owner.as_ref()));
+        let next_lineages = keys
+            .iter()
+            .map(|(kind, symbol, owner)| lineage_key(*kind, symbol, owner.as_ref()))
+            .collect::<BTreeSet<_>>();
+        if let Some(previous) = previous {
+            for removed in previous.bindings.iter().filter(|binding| {
+                !next_lineages.contains(&lineage_key(
+                    binding.route_kind,
+                    &binding.symbol,
+                    binding.owner.as_ref(),
+                ))
+            }) {
+                let root = graph_root.ok_or_else(|| {
+                    corrupt("semantic binding removal requires an exact pinned graph scan")
+                })?;
+                if binding_has_retained_data(removed, root)? {
+                    return Err(corrupt(
+                        "semantic binding removal would orphan retained data",
+                    ));
+                }
+            }
+        }
+        if keys.len() > MAX_SEMANTIC_BINDINGS {
+            return Err(corrupt("semantic binding count exceeds limit"));
+        }
+        let mut bindings = Vec::with_capacity(keys.len());
+        for (route_kind, symbol, owner) in keys {
+            let storage_id = allocate(&(route_kind, symbol.clone(), owner.clone()))?;
+            bindings.push(SemanticStorageBinding {
+                route_kind,
+                storage_id,
+                route: Self::opaque_route(route_kind, &symbol, owner.as_ref()),
+                symbol,
+                owner,
+            });
+        }
+        let value = Self::new(composition.fingerprint.clone(), bindings)?;
+        value.validate_against(composition)?;
+        Ok(value)
+    }
+
+    /// Construct and validate a canonical mapping.
+    pub fn new(
+        composition_fingerprint: String,
+        mut bindings: Vec<SemanticStorageBinding>,
+    ) -> Result<Self, GfError> {
+        bindings.sort_by_key(binding_key);
+        let value = Self {
+            contract_version: GRAPH_SEMANTIC_BINDINGS_VERSION,
+            composition_fingerprint,
+            bindings,
+        };
+        value.validate()?;
+        Ok(value)
+    }
+
+    /// Stable opaque physical route for a qualified symbol.
+    #[must_use]
+    pub fn opaque_route(
+        kind: SemanticRouteKind,
+        symbol: &QualifiedSymbol,
+        owner: Option<&QualifiedSymbol>,
+    ) -> String {
+        let mut digest = Sha256::new();
+        digest.update(b"graphforge-semantic-route/1\0");
+        let route_symbol = owner.unwrap_or(symbol);
+        // Properties are columns in their owner's physical table.  The owner
+        // binding and every property owned by it therefore authenticate one
+        // exact route; property kind must never create a second table route.
+        let table_kind = match kind {
+            SemanticRouteKind::NodeProperty => SemanticRouteKind::Entity,
+            SemanticRouteKind::EdgeProperty => SemanticRouteKind::Relation,
+            other => other,
+        };
+        digest.update(route_kind_token(table_kind).as_bytes());
+        digest.update(route_symbol.module.display_ref().as_bytes());
+        digest.update([0]);
+        digest.update(route_symbol.kind.as_str().as_bytes());
+        digest.update([0]);
+        digest.update(route_symbol.local_id.as_bytes());
+        let encoded = hex(digest.finalize().into());
+        format!("s-{encoded}")
+    }
+
+    /// Authenticate every binding against one exact compiled composition.
+    pub fn validate_against(&self, composition: &CompiledComposition) -> Result<(), GfError> {
+        if self.composition_fingerprint != composition.fingerprint {
+            return Err(corrupt("semantic bindings target a different composition"));
+        }
+        let mut semantic = BTreeSet::new();
+        for binding in &self.bindings {
+            let module = composition
+                .modules
+                .iter()
+                .find(|module| module.id == binding.symbol.module)
+                .ok_or_else(|| corrupt("semantic binding module is absent"))?;
+            if !module.symbols.contains(&binding.symbol) {
+                return Err(corrupt("semantic binding symbol is absent"));
+            }
+            if !semantic.insert((binding.route_kind, binding.symbol.display())) {
+                return Err(corrupt("semantic symbol has multiple physical bindings"));
+            }
+            if let Some(owner) = &binding.owner {
+                if owner.module != binding.symbol.module {
+                    return Err(corrupt("property binding crosses module ownership"));
+                }
+                let expected_kind = match binding.route_kind {
+                    SemanticRouteKind::NodeProperty => SymbolKind::Entity,
+                    SemanticRouteKind::EdgeProperty => SymbolKind::Relation,
+                    _ => return Err(corrupt("non-property binding has an owner")),
+                };
+                if owner.kind != expected_kind || !module.symbols.contains(owner) {
+                    return Err(corrupt(
+                        "property binding owner is absent or has wrong kind",
+                    ));
+                }
+                let declared = module.doc.properties.iter().any(|property| {
+                    format!("{}:{}", property.owner, property.name) == binding.symbol.local_id
+                        && property.owner == owner.local_id
+                });
+                if !declared {
+                    return Err(corrupt("property binding is not declared by its owner"));
+                }
+            }
+            if binding.storage_id & ((1 << 30) | (1 << 31)) != 0 {
+                return Err(corrupt(
+                    "runtime-tagged or reserved storage id is forbidden",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_topology_ids(&self, graph_root: &Path) -> Result<(), GfError> {
+        use arrow::array::{Array, ListArray, UInt32Array};
+
+        let path = graph_root.join("topology/nodes.parquet");
+        if !path.exists() {
+            return Ok(());
+        }
+        let entity_ids = self
+            .bindings
+            .iter()
+            .filter(|binding| binding.route_kind == SemanticRouteKind::Entity)
+            .map(|binding| binding.storage_id)
+            .collect::<BTreeSet<_>>();
+        let reader = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(
+            File::open(path).map_err(|_| corrupt("semantic topology cannot be opened"))?,
+        )
+        .map_err(|_| corrupt("semantic topology metadata is invalid"))?
+        .with_batch_size(8192)
+        .build()
+        .map_err(|_| corrupt("semantic topology reader cannot be built"))?;
+        for batch in reader {
+            let batch = batch.map_err(|_| corrupt("semantic topology batch is invalid"))?;
+            let primary = batch
+                .column_by_name("type_id")
+                .and_then(|array| array.as_any().downcast_ref::<UInt32Array>())
+                .ok_or_else(|| corrupt("semantic topology type_id is missing or malformed"))?;
+            let type_ids = batch
+                .column_by_name("type_ids")
+                .and_then(|array| array.as_any().downcast_ref::<ListArray>())
+                .ok_or_else(|| corrupt("semantic topology type_ids is missing or malformed"))?;
+            for row in 0..type_ids.len() {
+                if type_ids.is_null(row) {
+                    return Err(corrupt("semantic topology type_ids is null"));
+                }
+                let values = type_ids.value(row);
+                let values = values
+                    .as_any()
+                    .downcast_ref::<UInt32Array>()
+                    .ok_or_else(|| corrupt("semantic topology type_ids has wrong element type"))?;
+                let primary_id = primary.value(row);
+                if !values.values().contains(&primary_id) {
+                    return Err(corrupt(
+                        "semantic topology scalar type_id is absent from normalized type_ids",
+                    ));
+                }
+                for id in values.values() {
+                    let runtime = id & ((1 << 30) | (1 << 31)) != 0;
+                    if !runtime && !entity_ids.contains(id) {
+                        return Err(corrupt(
+                            "semantic topology contains an unbound ontology entity id",
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate every routed Parquet file against authenticated schema metadata and join keys.
+    pub fn validate_physical_routes(&self, graph_root: &Path) -> Result<(), GfError> {
+        self.validate_physical_routes_with_inventory(graph_root, None)
+    }
+
+    /// Validate routed files against the authenticated generation inventory.
+    /// Callers opening a committed generation must provide its `graph/files`
+    /// record; directory enumeration alone is not publication authority.
+    pub fn validate_physical_routes_with_inventory(
+        &self,
+        graph_root: &Path,
+        inventory: Option<&crate::GraphFilesInventory>,
+    ) -> Result<(), GfError> {
+        let expected = self
+            .bindings
+            .iter()
+            .filter_map(|binding| binding.physical_path(graph_root))
+            .collect::<BTreeSet<_>>();
+        let inventory_paths = inventory.map(|inventory| {
+            inventory
+                .files
+                .iter()
+                .map(|entry| entry.relative_path.as_str())
+                .collect::<BTreeSet<_>>()
+        });
+        for subdir in ["topology/edges", "properties", "edge_properties"] {
+            let directory = graph_root.join(subdir);
+            let Ok(entries) = std::fs::read_dir(&directory) else {
+                continue;
+            };
+            for entry in entries {
+                let path = entry
+                    .map_err(|_| corrupt("semantic route inventory cannot be read"))?
+                    .path();
+                if path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with("s-") && name.ends_with(".parquet"))
+                    && !expected.contains(&path)
+                {
+                    return Err(corrupt("unlisted opaque semantic route file is present"));
+                }
+            }
+        }
+        for binding in &self.bindings {
+            let Some(path) = binding.physical_path(graph_root) else {
+                continue;
+            };
+            let relative = path
+                .strip_prefix(graph_root)
+                .map_err(|_| corrupt("semantic route escapes graph inventory"))?
+                .to_string_lossy()
+                .replace('\\', "/");
+            if path.exists()
+                && inventory_paths
+                    .as_ref()
+                    .is_some_and(|paths| !paths.contains(relative.as_str()))
+            {
+                return Err(corrupt(
+                    "semantic route is absent from authenticated graph inventory",
+                ));
+            }
+            if !path.exists() {
+                continue;
+            }
+            let file = File::open(&path).map_err(|_| corrupt("semantic route file is missing"))?;
+            let builder =
+                parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(file)
+                    .map_err(|_| corrupt("semantic route Parquet metadata is invalid"))?;
+            let schema = builder.schema();
+            if schema.metadata().get(SEMANTIC_ROUTE_METADATA_KEY) != Some(&binding.route)
+                || schema.metadata().get(SEMANTIC_COMPOSITION_METADATA_KEY)
+                    != Some(&self.composition_fingerprint)
+            {
+                return Err(corrupt("semantic route metadata does not match binding"));
+            }
+            let join_key = match binding.route_kind {
+                SemanticRouteKind::NodeProperty => "node_uuid",
+                SemanticRouteKind::Relation | SemanticRouteKind::EdgeProperty => "edge_uuid",
+                SemanticRouteKind::Entity => unreachable!(),
+            };
+            let join_field = schema
+                .field_with_name(join_key)
+                .map_err(|_| corrupt("semantic route join key is missing"))?;
+            if join_field.is_nullable()
+                || join_field.data_type() != &arrow::datatypes::DataType::FixedSizeBinary(16)
+            {
+                return Err(corrupt("semantic route join key is missing"));
+            }
+        }
+        self.validate_topology_ids(graph_root)?;
+        Ok(())
+    }
+
+    /// Decode exact canonical JSON and fail closed on corruption or excess work.
+    pub fn from_canonical_json(bytes: &[u8]) -> Result<Self, GfError> {
+        if bytes.len() > MAX_SEMANTIC_BINDING_BYTES {
+            return Err(corrupt("semantic binding bytes exceed limit"));
+        }
+        let value: Self = serde_json::from_slice(bytes)
+            .map_err(|_| corrupt("semantic bindings are malformed"))?;
+        value.validate()?;
+        if value.to_canonical_json()? != bytes {
+            return Err(corrupt("semantic bindings are not canonical"));
+        }
+        Ok(value)
+    }
+
+    /// Encode canonical JSON plus LF.
+    pub fn to_canonical_json(&self) -> Result<Vec<u8>, GfError> {
+        self.validate()?;
+        let mut bytes =
+            serde_json::to_vec(self).map_err(|_| corrupt("semantic bindings cannot be encoded"))?;
+        bytes.push(b'\n');
+        if bytes.len() > MAX_SEMANTIC_BINDING_BYTES {
+            return Err(corrupt("semantic binding bytes exceed limit"));
+        }
+        Ok(bytes)
+    }
+
+    /// Encode as registered graph participant.
+    pub fn to_project_participant(&self) -> Result<ProjectParticipant, GfError> {
+        let bytes = self.to_canonical_json()?;
+        Ok(ProjectParticipant {
+            capability_id: GRAPH_CAPABILITY_ID.into(),
+            capability_version: crate::GRAPH_CAPABILITY_VERSION,
+            record_family_id: GRAPH_SEMANTIC_BINDINGS_FAMILY.into(),
+            record_version: GRAPH_SEMANTIC_BINDINGS_VERSION,
+            encoding: ProjectParticipantEncoding::Json,
+            schema_fingerprint: Sha256::digest(b"graphforge-semantic-storage-bindings/1").into(),
+            row_count: self.bindings.len() as u64,
+            bytes,
+        })
+    }
+
+    fn validate(&self) -> Result<(), GfError> {
+        if self.contract_version != GRAPH_SEMANTIC_BINDINGS_VERSION
+            || self.composition_fingerprint.len() != 64
+            || !self
+                .composition_fingerprint
+                .bytes()
+                .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+        {
+            return Err(corrupt(
+                "semantic binding contract or fingerprint is invalid",
+            ));
+        }
+        if self.bindings.len() > MAX_SEMANTIC_BINDINGS {
+            return Err(corrupt("semantic binding count exceeds limit"));
+        }
+        if self
+            .bindings
+            .windows(2)
+            .any(|w| binding_key(&w[0]) >= binding_key(&w[1]))
+        {
+            return Err(corrupt(
+                "semantic bindings are not strictly ordered and unique",
+            ));
+        }
+        let mut ids = BTreeSet::new();
+        let mut routes = BTreeMap::new();
+        for binding in &self.bindings {
+            if binding.route
+                != Self::opaque_route(binding.route_kind, &binding.symbol, binding.owner.as_ref())
+            {
+                return Err(corrupt("semantic binding route is not authenticated"));
+            }
+            match binding.route_kind {
+                SemanticRouteKind::Entity
+                    if binding.owner.is_none() && binding.symbol.kind == SymbolKind::Entity => {}
+                SemanticRouteKind::Relation
+                    if binding.owner.is_none() && binding.symbol.kind == SymbolKind::Relation => {}
+                SemanticRouteKind::NodeProperty | SemanticRouteKind::EdgeProperty
+                    if binding.owner.is_some() && binding.symbol.kind == SymbolKind::Property => {}
+                _ => {
+                    return Err(corrupt(
+                        "semantic binding kind, id, owner, or symbol disagrees",
+                    ));
+                }
+            }
+            if !ids.insert((id_namespace(binding.route_kind), binding.storage_id)) {
+                return Err(corrupt("semantic storage id is reused"));
+            }
+            let route_owner = binding.owner.as_ref().unwrap_or(&binding.symbol).display();
+            if routes
+                .insert(
+                    (binding.route_kind, binding.route.clone()),
+                    route_owner.clone(),
+                )
+                .is_some_and(|prior| prior != route_owner)
+            {
+                return Err(corrupt("semantic route is reused by a different owner"));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl SemanticStorageBinding {
+    /// Exact physical path for routed data, or none for numeric entity bindings.
+    #[must_use]
+    pub fn physical_path(&self, root: &Path) -> Option<PathBuf> {
+        match self.route_kind {
+            SemanticRouteKind::Entity => None,
+            SemanticRouteKind::Relation => Some(
+                root.join("topology/edges")
+                    .join(format!("{}.parquet", self.route)),
+            ),
+            SemanticRouteKind::NodeProperty => Some(
+                root.join("properties")
+                    .join(format!("{}.parquet", self.route)),
+            ),
+            SemanticRouteKind::EdgeProperty => Some(
+                root.join("edge_properties")
+                    .join(format!("{}.parquet", self.route)),
+            ),
+        }
+    }
+}
+
+/// Load and validate the optional mapping pinned to one resolved generation.
+pub fn semantic_storage_bindings(
+    generation: &crate::ResolvedProjectGeneration,
+) -> Result<Option<SemanticStorageBindings>, GfError> {
+    let bindings = generation
+        .participant_snapshot(GRAPH_CAPABILITY_ID, GRAPH_SEMANTIC_BINDINGS_FAMILY)?
+        .map(|snapshot| SemanticStorageBindings::from_canonical_json(&snapshot.bytes))
+        .transpose()?;
+    if let Some(bindings) = &bindings {
+        let composition = generation
+            .participant_snapshot("workspace", "ontology_composition")?
+            .ok_or_else(|| corrupt("semantic bindings have no persisted composition authority"))?;
+        if composition.bytes.len() > MAX_SEMANTIC_BINDING_BYTES {
+            return Err(corrupt(
+                "persisted composition authority exceeds validation limit",
+            ));
+        }
+        let value: serde_json::Value = serde_json::from_slice(&composition.bytes)
+            .map_err(|_| corrupt("persisted composition authority is malformed"))?;
+        if value
+            .get("composition_fingerprint")
+            .and_then(serde_json::Value::as_str)
+            != Some(bindings.composition_fingerprint.as_str())
+        {
+            return Err(corrupt(
+                "semantic bindings and persisted composition fingerprints disagree",
+            ));
+        }
+    }
+    Ok(bindings)
+}
+
+/// Refuse a data-bearing legacy semantic graph until the composition lifecycle
+/// stages its deterministic route rewrite and binding participant together.
+/// Empty graphs remain bootstrap-compatible.
+pub fn require_atomic_legacy_migration(graph_root: &Path) -> Result<(), GfError> {
+    let mut inspected = 0usize;
+    for subdir in [
+        "topology",
+        "topology/edges",
+        "properties",
+        "edge_properties",
+    ] {
+        let directory = graph_root.join(subdir);
+        let Ok(entries) = std::fs::read_dir(directory) else {
+            continue;
+        };
+        for entry in entries {
+            inspected = inspected
+                .checked_add(1)
+                .ok_or_else(|| corrupt("legacy migration inventory overflows"))?;
+            if inspected > MAX_SEMANTIC_BINDINGS {
+                return Err(corrupt("legacy migration inventory exceeds limit"));
+            }
+            let path = entry
+                .map_err(|_| corrupt("legacy migration inventory cannot be read"))?
+                .path();
+            if path.extension().and_then(|value| value.to_str()) != Some("parquet") {
+                continue;
+            }
+            let metadata = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(
+                File::open(&path)
+                    .map_err(|_| corrupt("legacy migration Parquet cannot be opened"))?,
+            )
+            .map_err(|_| corrupt("legacy migration Parquet metadata is invalid"))?
+            .metadata()
+            .file_metadata()
+            .num_rows();
+            if metadata > 0 {
+                return Err(GfError::Validation(
+                    "GF_SEMANTIC_LEGACY_MIGRATION_REQUIRED: data-bearing legacy routes must be rewritten and published with semantic bindings as one staged generation".into(),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn corrupt(message: &str) -> GfError {
+    GfError::Project {
+        code: ProjectErrorCode::ProjectCorrupt,
+        message: message.into(),
+    }
+}
+
+fn legacy_ambiguous(message: &str) -> GfError {
+    GfError::Validation(format!(
+        "GF_SEMANTIC_LEGACY_AMBIGUOUS: {message}; qualify module ownership or migrate explicitly"
+    ))
+}
+
+fn qualified(
+    module: &graphforge_ontology::OntologyModuleId,
+    kind: SymbolKind,
+    local_id: &str,
+) -> QualifiedSymbol {
+    QualifiedSymbol {
+        module: module.clone(),
+        kind,
+        local_id: local_id.to_owned(),
+    }
+}
+
+fn binding(
+    route_kind: SemanticRouteKind,
+    storage_id: u32,
+    symbol: QualifiedSymbol,
+    owner: Option<QualifiedSymbol>,
+) -> SemanticStorageBinding {
+    SemanticStorageBinding {
+        route_kind,
+        storage_id,
+        route: SemanticStorageBindings::opaque_route(route_kind, &symbol, owner.as_ref()),
+        symbol,
+        owner,
+    }
+}
+
+fn binding_has_retained_data(
+    binding: &SemanticStorageBinding,
+    graph_root: &Path,
+) -> Result<bool, GfError> {
+    if binding.route_kind == SemanticRouteKind::Entity {
+        use arrow::array::{Array, ListArray, UInt32Array};
+        let path = graph_root.join("topology/nodes.parquet");
+        if !path.exists() {
+            return Ok(false);
+        }
+        let reader = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(
+            File::open(path).map_err(|_| corrupt("removal topology cannot be opened"))?,
+        )
+        .map_err(|_| corrupt("removal topology metadata is invalid"))?
+        .with_batch_size(8192)
+        .build()
+        .map_err(|_| corrupt("removal topology reader cannot be built"))?;
+        for batch in reader {
+            let batch = batch.map_err(|_| corrupt("removal topology batch is invalid"))?;
+            let values = batch
+                .column_by_name("type_ids")
+                .and_then(|array| array.as_any().downcast_ref::<ListArray>())
+                .ok_or_else(|| corrupt("removal topology type_ids is malformed"))?;
+            for row in 0..values.len() {
+                if values.is_null(row) {
+                    return Err(corrupt("removal topology type_ids is null"));
+                }
+                let ids = values.value(row);
+                let ids = ids
+                    .as_any()
+                    .downcast_ref::<UInt32Array>()
+                    .ok_or_else(|| corrupt("removal topology type_ids has wrong type"))?;
+                if ids.values().contains(&binding.storage_id) {
+                    return Ok(true);
+                }
+            }
+        }
+        return Ok(false);
+    }
+    let Some(path) = binding.physical_path(graph_root) else {
+        return Ok(false);
+    };
+    if !path.exists() {
+        return Ok(false);
+    }
+    let metadata = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(
+        File::open(path).map_err(|_| corrupt("removal route cannot be opened"))?,
+    )
+    .map_err(|_| corrupt("removal route metadata is invalid"))?
+    .metadata()
+    .file_metadata()
+    .num_rows();
+    Ok(metadata > 0)
+}
+
+fn binding_key(
+    binding: &SemanticStorageBinding,
+) -> (SemanticRouteKind, u32, String, String, String) {
+    (
+        binding.route_kind,
+        binding.storage_id,
+        binding.route.clone(),
+        binding.symbol.display(),
+        binding
+            .owner
+            .as_ref()
+            .map_or_else(String::new, QualifiedSymbol::display),
+    )
+}
+
+fn projection_key(
+    kind: SemanticRouteKind,
+    symbol: &QualifiedSymbol,
+    owner: Option<&QualifiedSymbol>,
+) -> (SemanticRouteKind, String, String) {
+    (
+        kind,
+        symbol.display(),
+        owner.map_or_else(String::new, QualifiedSymbol::display),
+    )
+}
+
+fn lineage_key(
+    kind: SemanticRouteKind,
+    symbol: &QualifiedSymbol,
+    owner: Option<&QualifiedSymbol>,
+) -> (SemanticRouteKind, String, String, String) {
+    (
+        kind,
+        symbol.module.ontology_id.clone(),
+        symbol.local_id.clone(),
+        owner.map_or_else(String::new, |owner| owner.local_id.clone()),
+    )
+}
+
+const fn route_kind_token(kind: SemanticRouteKind) -> &'static str {
+    match kind {
+        SemanticRouteKind::Entity | SemanticRouteKind::NodeProperty => "entity_owner",
+        SemanticRouteKind::Relation | SemanticRouteKind::EdgeProperty => "relation_owner",
+    }
+}
+
+const fn id_namespace(kind: SemanticRouteKind) -> u8 {
+    match kind {
+        SemanticRouteKind::Entity => 0,
+        SemanticRouteKind::Relation => 1,
+        SemanticRouteKind::NodeProperty | SemanticRouteKind::EdgeProperty => 2,
+    }
+}
+fn hex(bytes: [u8; 32]) -> String {
+    use std::fmt::Write as _;
+    bytes
+        .iter()
+        .fold(String::with_capacity(64), |mut output, byte| {
+            write!(output, "{byte:02x}").expect("writing to String cannot fail");
+            output
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use graphforge_ontology::{
+        ActivationMode, AuthoredModule, CompositionLimits, EntityTypeDef, InventoryCompileRequest,
+        MigrationDef, OntologyDoc, OntologyModuleId, PropertyDef, PropertyValueType,
+        RelationTypeDef, SemanticFlags, compile_inventory, module_document_digest,
+    };
+    fn module(name: &str) -> OntologyModuleId {
+        OntologyModuleId {
+            ontology_id: name.into(),
+            authored_version: "1".into(),
+            canonical_digest: "0".repeat(64),
+        }
+    }
+    fn symbol(module_name: &str, kind: SymbolKind, local_id: &str) -> QualifiedSymbol {
+        QualifiedSymbol {
+            module: module(module_name),
+            kind,
+            local_id: local_id.into(),
+        }
+    }
+    #[test]
+    fn collisions_have_distinct_routes_and_reopen_exactly() {
+        let a = symbol("a", SymbolKind::Entity, "Person");
+        let b = symbol("b", SymbolKind::Entity, "Person");
+        let values = vec![a, b]
+            .into_iter()
+            .enumerate()
+            .map(|(id, symbol)| SemanticStorageBinding {
+                route_kind: SemanticRouteKind::Entity,
+                storage_id: id as u32,
+                route: SemanticStorageBindings::opaque_route(
+                    SemanticRouteKind::Entity,
+                    &symbol,
+                    None,
+                ),
+                symbol,
+                owner: None,
+            })
+            .collect();
+        let record = SemanticStorageBindings::new("1".repeat(64), values).unwrap();
+        assert_ne!(record.bindings[0].route, record.bindings[1].route);
+        assert_eq!(
+            SemanticStorageBindings::from_canonical_json(&record.to_canonical_json().unwrap())
+                .unwrap(),
+            record
+        );
+    }
+    #[test]
+    fn corruption_and_limits_fail_before_acceptance() {
+        let symbol = symbol("a", SymbolKind::Relation, "KNOWS");
+        let mut binding = SemanticStorageBinding {
+            route_kind: SemanticRouteKind::Relation,
+            storage_id: 1,
+            route: SemanticStorageBindings::opaque_route(
+                SemanticRouteKind::Relation,
+                &symbol,
+                None,
+            ),
+            symbol,
+            owner: None,
+        };
+        binding.route.push('x');
+        assert!(SemanticStorageBindings::new("1".repeat(64), vec![binding]).is_err());
+        assert!(
+            SemanticStorageBindings::from_canonical_json(&vec![
+                b' ';
+                MAX_SEMANTIC_BINDING_BYTES + 1
+            ])
+            .is_err()
+        );
+    }
+
+    fn compiled_with(
+        version: &str,
+        declare_migration: bool,
+        include_edge_property: bool,
+    ) -> CompiledComposition {
+        let doc = OntologyDoc {
+            ontology_id: "https://example.test/core".into(),
+            version: version.into(),
+            entity_types: vec![EntityTypeDef {
+                name: "Person".into(),
+                r#abstract: false,
+                parent: None,
+            }],
+            relation_types: vec![RelationTypeDef {
+                name: "KNOWS".into(),
+                src: "Person".into(),
+                dst: "Person".into(),
+                inverse: None,
+                semantic: SemanticFlags::default(),
+            }],
+            properties: vec![
+                PropertyDef {
+                    owner: "Person".into(),
+                    name: "name".into(),
+                    value_type: PropertyValueType::Utf8,
+                    nullable: true,
+                    multivalued: false,
+                    default_json: None,
+                },
+                PropertyDef {
+                    owner: "KNOWS".into(),
+                    name: "since".into(),
+                    value_type: PropertyValueType::Int64,
+                    nullable: true,
+                    multivalued: false,
+                    default_json: None,
+                },
+            ]
+            .into_iter()
+            .filter(|property| include_edge_property || property.name != "since")
+            .collect(),
+            constraints: vec![],
+            migrations: (declare_migration && version != "1")
+                .then_some(MigrationDef {
+                    from_version: "1".into(),
+                    to_version: version.into(),
+                    transform_kind: "identity".into(),
+                    script_ref: None,
+                    checksum: None,
+                })
+                .into_iter()
+                .collect(),
+        };
+        let module = AuthoredModule {
+            id: OntologyModuleId {
+                ontology_id: doc.ontology_id.clone(),
+                authored_version: version.into(),
+                canonical_digest: module_document_digest(&doc).unwrap(),
+            },
+            dependencies: vec![],
+            doc,
+            allow_projected_identity: false,
+        };
+        compile_inventory(InventoryCompileRequest {
+            modules: &[module],
+            bridges: &[],
+            activation: &[],
+            profile_default: ActivationMode::Strict,
+            limits: CompositionLimits::default(),
+            cancelled: None,
+        })
+        .unwrap()
+    }
+
+    fn compiled(version: &str) -> CompiledComposition {
+        compiled_with(version, true, true)
+    }
+
+    #[test]
+    fn owner_routes_match_write_routing_and_ids_carry_across_module_upgrade() {
+        let first = compiled("1");
+        let initial = SemanticStorageBindings::project(&first, None).unwrap();
+        let entity = initial
+            .bindings
+            .iter()
+            .find(|binding| binding.route_kind == SemanticRouteKind::Entity)
+            .unwrap();
+        let node_property = initial
+            .bindings
+            .iter()
+            .find(|binding| binding.route_kind == SemanticRouteKind::NodeProperty)
+            .unwrap();
+        let relation = initial
+            .bindings
+            .iter()
+            .find(|binding| binding.route_kind == SemanticRouteKind::Relation)
+            .unwrap();
+        let edge_property = initial
+            .bindings
+            .iter()
+            .find(|binding| binding.route_kind == SemanticRouteKind::EdgeProperty)
+            .unwrap();
+        assert_eq!(entity.route, node_property.route);
+        assert_eq!(relation.route, edge_property.route);
+
+        let upgraded = compiled("2");
+        let carried = SemanticStorageBindings::project(&upgraded, Some(&initial)).unwrap();
+        for binding in &carried.bindings {
+            let old = initial
+                .bindings
+                .iter()
+                .find(|old| {
+                    old.route_kind == binding.route_kind
+                        && old.symbol.local_id == binding.symbol.local_id
+                })
+                .unwrap();
+            assert_eq!(binding.storage_id, old.storage_id);
+        }
+
+        assert_eq!(
+            SemanticStorageBindings::project(&upgraded, Some(&carried)).unwrap(),
+            carried,
+            "reprojecting the same generation must be idempotent"
+        );
+        let undeclared = compiled_with("3", false, true);
+        assert!(SemanticStorageBindings::project(&undeclared, Some(&carried)).is_err());
+    }
+
+    #[test]
+    fn removal_requires_a_pinned_scan_and_refuses_retained_property_data() {
+        use std::collections::HashMap;
+
+        let first = compiled("1");
+        let initial = SemanticStorageBindings::project(&first, None).unwrap();
+        let relation = initial
+            .bindings
+            .iter()
+            .find(|binding| binding.route_kind == SemanticRouteKind::Relation)
+            .unwrap();
+        let next = compiled_with("2", true, false);
+        assert!(SemanticStorageBindings::project(&next, Some(&initial)).is_err());
+
+        let empty = tempfile::TempDir::new().unwrap();
+        let removed =
+            SemanticStorageBindings::project_with_graph_scan(&next, Some(&initial), empty.path())
+                .unwrap();
+        assert!(!removed.bindings.iter().any(|binding| {
+            binding.route_kind == SemanticRouteKind::EdgeProperty
+                && binding.symbol.local_id == "KNOWS:since"
+        }));
+
+        let retained = tempfile::TempDir::new().unwrap();
+        let mut writer =
+            crate::GraphWriter::open_at(retained.path(), graphforge_core::OntologyMode::Strict, 1)
+                .unwrap()
+                .with_semantic_composition_fingerprint(Some(first.fingerprint.clone()));
+        let left = graphforge_core::uuid::new_v7();
+        let right = graphforge_core::uuid::new_v7();
+        writer
+            .create_node(left, graphforge_core::TypeId(1))
+            .unwrap();
+        writer
+            .create_node(right, graphforge_core::TypeId(1))
+            .unwrap();
+        let edge = graphforge_core::uuid::new_v7();
+        writer
+            .create_edge(edge, &relation.route, &left, &right)
+            .unwrap();
+        writer
+            .set_edge_properties(
+                &edge,
+                Some(&relation.route),
+                HashMap::from([("since".into(), graphforge_ir::IrLiteral::Int(2026))]),
+            )
+            .unwrap();
+        writer.flush().unwrap();
+        assert!(
+            SemanticStorageBindings::project_with_graph_scan(
+                &next,
+                Some(&initial),
+                retained.path(),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn legacy_scanner_resource_ladder_is_independent_of_total_rows() {
+        let composition = compiled("1");
+        for rows in [1_usize, 8_193] {
+            let dir = tempfile::TempDir::new().unwrap();
+            let mut writer =
+                crate::GraphWriter::open_at(dir.path(), graphforge_core::OntologyMode::Strict, 1)
+                    .unwrap();
+            for _ in 0..rows {
+                writer
+                    .create_node(graphforge_core::uuid::new_v7(), graphforge_core::TypeId(0))
+                    .unwrap();
+            }
+            writer.flush().unwrap();
+            let projection =
+                SemanticStorageBindings::project_legacy_unambiguous(&composition, dir.path())
+                    .unwrap();
+            assert_eq!(projection.topology_rows_scanned, rows as u64);
+            assert!(projection.max_topology_batch_rows <= 8_192);
+        }
+
+        let mut ambiguous = composition;
+        ambiguous.modules.extend(compiled("1").modules);
+        let error = SemanticStorageBindings::project_legacy_unambiguous(
+            &ambiguous,
+            tempfile::TempDir::new().unwrap().path(),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("GF_SEMANTIC_LEGACY_AMBIGUOUS"));
+    }
+
+    #[test]
+    fn normal_writer_authenticates_owner_routes_and_reopen_validation() {
+        use std::collections::HashMap;
+
+        let composition = compiled("1");
+        let bindings = SemanticStorageBindings::project(&composition, None).unwrap();
+        let entity = bindings
+            .bindings
+            .iter()
+            .find(|binding| binding.route_kind == SemanticRouteKind::Entity)
+            .unwrap();
+        let relation = bindings
+            .bindings
+            .iter()
+            .find(|binding| binding.route_kind == SemanticRouteKind::Relation)
+            .unwrap();
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut writer =
+            crate::GraphWriter::open_at(dir.path(), graphforge_core::OntologyMode::Strict, 1)
+                .unwrap()
+                .with_semantic_composition_fingerprint(Some(composition.fingerprint.clone()));
+        let left = graphforge_core::uuid::new_v7();
+        let right = graphforge_core::uuid::new_v7();
+        writer
+            .create_node(left, graphforge_core::TypeId(entity.storage_id))
+            .unwrap();
+        writer
+            .create_node(right, graphforge_core::TypeId(entity.storage_id))
+            .unwrap();
+        writer
+            .set_properties(
+                &left,
+                Some(&entity.route),
+                HashMap::from([("name".into(), graphforge_ir::IrLiteral::Str("Ada".into()))]),
+            )
+            .unwrap();
+        let edge = graphforge_core::uuid::new_v7();
+        writer
+            .create_edge(edge, &relation.route, &left, &right)
+            .unwrap();
+        writer
+            .set_edge_properties(
+                &edge,
+                Some(&relation.route),
+                HashMap::from([("since".into(), graphforge_ir::IrLiteral::Int(2026))]),
+            )
+            .unwrap();
+        writer.flush().unwrap();
+        bindings.validate_physical_routes(dir.path()).unwrap();
+        let (inventory, _) = crate::capture_graph_files(dir.path()).unwrap();
+        bindings
+            .validate_physical_routes_with_inventory(dir.path(), Some(&inventory))
+            .unwrap();
+        let mut omitted = inventory.clone();
+        omitted.files.retain(|entry| {
+            entry.relative_path != format!("topology/edges/{}.parquet", relation.route)
+        });
+        omitted.file_count = omitted.files.len() as u64;
+        assert!(
+            bindings
+                .validate_physical_routes_with_inventory(dir.path(), Some(&omitted))
+                .is_err()
+        );
+        assert!(require_atomic_legacy_migration(dir.path()).is_err());
+
+        let injected = dir.path().join("properties/s-deadbeef.parquet");
+        std::fs::copy(
+            dir.path()
+                .join("properties")
+                .join(format!("{}.parquet", entity.route)),
+            injected,
+        )
+        .unwrap();
+        assert!(bindings.validate_physical_routes(dir.path()).is_err());
+    }
+}

--- a/crates/graphforge-storage/src/semantic_bindings.rs
+++ b/crates/graphforge-storage/src/semantic_bindings.rs
@@ -917,6 +917,7 @@ pub fn require_atomic_legacy_migration(graph_root: &Path) -> Result<(), GfError>
             if path.extension().and_then(|value| value.to_str()) != Some("parquet") {
                 continue;
             }
+            preflight_parquet_footer(&path)?;
             let metadata = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(
                 File::open(&path)
                     .map_err(|_| corrupt("legacy migration Parquet cannot be opened"))?,
@@ -1632,6 +1633,13 @@ mod tests {
         );
         let bindings = SemanticStorageBindings::project(&composition, None).unwrap();
         let error = bindings.validate_physical_routes(dir.path()).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("metadata exceeds admission limit"),
+            "{error:?}"
+        );
+        let error = require_atomic_legacy_migration(dir.path()).unwrap_err();
         assert!(
             error
                 .to_string()

--- a/crates/graphforge-storage/src/workspace_participants.rs
+++ b/crates/graphforge-storage/src/workspace_participants.rs
@@ -3,6 +3,11 @@
 use std::collections::BTreeMap;
 
 use graphforge_core::{GfError, OntologyMode, ProjectErrorCode};
+use graphforge_ontology::{
+    ActivationMode, ActivationRecord, AuthoredModule, BridgeDocument, BridgeSetId,
+    CompiledComposition, CompositionLimits, InventoryCompileRequest, OntologyDoc, OntologyModuleId,
+    bridge_document_digest, compile_inventory, module_document_digest,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
@@ -20,6 +25,12 @@ pub const WORKSPACE_ONTOLOGY_FAMILY: &str = "ontology";
 pub const WORKSPACE_CONFIGURATION_FAMILY: &str = "configuration";
 /// Canonical repository reconciliation snapshot record family.
 pub const WORKSPACE_REPOSITORY_SNAPSHOT_FAMILY: &str = "repository_snapshot";
+/// Canonical multi-ontology composition authority record family.
+pub const WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY: &str = "ontology_composition";
+/// Frozen composition participant contract version.
+pub const WORKSPACE_ONTOLOGY_COMPOSITION_VERSION: u32 = 1;
+/// Maximum canonical composition authority size.
+pub const MAX_WORKSPACE_ONTOLOGY_COMPOSITION_BYTES: usize = 16 * 1024 * 1024;
 /// Frozen repository snapshot contract version.
 pub const WORKSPACE_REPOSITORY_SNAPSHOT_VERSION: u32 = 1;
 /// Maximum canonical repository snapshot participant size.
@@ -77,6 +88,39 @@ pub struct WorkspaceOntology {
     pub canonical_ontology_sha256: Option<String>,
     /// Validated canonical ontology document, absent when mode is `none`.
     pub canonical_ontology: Option<Value>,
+}
+
+/// One exact authored module retained by composition authority.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkspaceCompositionModule {
+    /// Exact semantic module identity.
+    pub id: OntologyModuleId,
+    /// Exact dependency identities in canonical order.
+    pub dependencies: Vec<OntologyModuleId>,
+    /// Independently validated authored document.
+    pub document: OntologyDoc,
+    /// Whether this is the explicit legacy virtual identity projection.
+    #[serde(default)]
+    pub allow_projected_identity: bool,
+}
+
+/// Canonical project-generation participant for multi-ontology authority.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkspaceOntologyComposition {
+    /// Frozen record contract version.
+    pub contract_version: u32,
+    /// Exact authored modules; input order is not authority.
+    pub modules: Vec<WorkspaceCompositionModule>,
+    /// Exact adopted bridge documents.
+    pub bridges: Vec<BridgeDocument>,
+    /// Scoped activation records.
+    pub activation: Vec<ActivationRecord>,
+    /// Default progressive enforcement.
+    pub profile_default: ActivationMode,
+    /// Recomputed exact composition identity.
+    pub composition_fingerprint: String,
 }
 
 /// Project-level graph directedness metadata for GSI profiling.
@@ -218,6 +262,152 @@ impl WorkspaceOntology {
     }
 }
 
+impl WorkspaceOntologyComposition {
+    /// Build canonical persisted authority from one successfully compiled composition.
+    #[must_use]
+    pub fn from_compiled(
+        composition: &CompiledComposition,
+        mut bridges: Vec<BridgeDocument>,
+    ) -> Self {
+        bridges.sort_by(|left, right| {
+            (&left.bridge_id, &left.authored_version)
+                .cmp(&(&right.bridge_id, &right.authored_version))
+        });
+        Self {
+            contract_version: WORKSPACE_ONTOLOGY_COMPOSITION_VERSION,
+            modules: composition
+                .modules
+                .iter()
+                .map(|module| WorkspaceCompositionModule {
+                    id: module.id.clone(),
+                    dependencies: module.dependencies.clone(),
+                    document: module.doc.clone(),
+                    allow_projected_identity: module.id.ontology_id.starts_with("legacy:"),
+                })
+                .collect(),
+            bridges,
+            activation: composition.activation.clone(),
+            profile_default: composition.profile_default,
+            composition_fingerprint: composition.fingerprint.clone(),
+        }
+    }
+
+    /// Project an older single-ontology participant without publishing or rewriting it.
+    ///
+    /// # Errors
+    /// Returns corruption when the legacy authority is internally inconsistent.
+    pub fn virtual_legacy(legacy: &WorkspaceOntology) -> Result<Option<Self>, GfError> {
+        let Some(value) = &legacy.canonical_ontology else {
+            return Ok(None);
+        };
+        let document: OntologyDoc = serde_json::from_value(value.clone())
+            .map_err(|_| corrupt("legacy ontology document is malformed"))?;
+        let document_digest = module_document_digest(&document)
+            .map_err(|_| corrupt("legacy ontology document cannot be canonicalized"))?;
+        let legacy_digest = legacy
+            .canonical_ontology_sha256
+            .as_deref()
+            .ok_or_else(|| corrupt("legacy ontology digest is missing"))?;
+        let module = AuthoredModule {
+            id: OntologyModuleId {
+                ontology_id: format!("legacy:{legacy_digest}"),
+                authored_version: "legacy-v1".to_owned(),
+                canonical_digest: document_digest,
+            },
+            dependencies: Vec::new(),
+            doc: document,
+            allow_projected_identity: true,
+        };
+        let compiled = compile_inventory(InventoryCompileRequest {
+            modules: std::slice::from_ref(&module),
+            bridges: &[],
+            activation: &[],
+            profile_default: match legacy.mode {
+                WorkspaceOntologyMode::None => ActivationMode::Exploratory,
+                WorkspaceOntologyMode::Advisory => ActivationMode::Advisory,
+                WorkspaceOntologyMode::Strict => ActivationMode::Strict,
+            },
+            limits: CompositionLimits::default(),
+            cancelled: None,
+        })
+        .map_err(|_| corrupt("legacy ontology virtual composition is invalid"))?;
+        Ok(Some(Self::from_compiled(&compiled, Vec::new())))
+    }
+
+    /// Recompile and validate exact identities and the recorded fingerprint.
+    ///
+    /// # Errors
+    /// Returns corruption for malformed, incoherent, or noncanonical authority.
+    pub fn compile(&self) -> Result<CompiledComposition, GfError> {
+        validate_composition(self)?;
+        let authored = self
+            .modules
+            .iter()
+            .map(|module| AuthoredModule {
+                id: module.id.clone(),
+                dependencies: module.dependencies.clone(),
+                doc: module.document.clone(),
+                allow_projected_identity: module.allow_projected_identity,
+            })
+            .collect::<Vec<_>>();
+        let bridge_ids = self
+            .bridges
+            .iter()
+            .map(|bridge| {
+                Ok(BridgeSetId {
+                    bridge_id: bridge.bridge_id.clone(),
+                    authored_version: bridge.authored_version.clone(),
+                    canonical_digest: bridge_document_digest(bridge)
+                        .map_err(|_| corrupt("bridge document cannot be canonicalized"))?,
+                })
+            })
+            .collect::<Result<Vec<_>, GfError>>()?;
+        let compiled = compile_inventory(InventoryCompileRequest {
+            modules: &authored,
+            bridges: &bridge_ids,
+            activation: &self.activation,
+            profile_default: self.profile_default,
+            limits: CompositionLimits::default(),
+            cancelled: None,
+        })
+        .map_err(|_| corrupt("ontology composition does not compile"))?;
+        if compiled.fingerprint != self.composition_fingerprint {
+            return Err(corrupt("ontology composition fingerprint does not match"));
+        }
+        Ok(compiled)
+    }
+
+    /// Validate and return canonical JSON plus LF.
+    pub fn to_canonical_json(&self) -> Result<Vec<u8>, GfError> {
+        self.compile()?;
+        let bytes = canonical_json(self, "workspace ontology composition")?;
+        if bytes.len() > MAX_WORKSPACE_ONTOLOGY_COMPOSITION_BYTES {
+            return Err(corrupt("workspace ontology composition exceeds size limit"));
+        }
+        Ok(bytes)
+    }
+
+    /// Parse exact canonical JSON plus LF and validate its compiled identity.
+    pub fn from_canonical_json(bytes: &[u8]) -> Result<Self, GfError> {
+        if bytes.len() > MAX_WORKSPACE_ONTOLOGY_COMPOSITION_BYTES {
+            return Err(corrupt("workspace ontology composition exceeds size limit"));
+        }
+        parse_canonical_json(
+            bytes,
+            "workspace ontology composition",
+            |record: &WorkspaceOntologyComposition| record.compile().map(|_| ()),
+        )
+    }
+
+    /// Encode this authority as one registered project participant.
+    pub fn to_project_participant(&self) -> Result<ProjectParticipant, GfError> {
+        Ok(participant(
+            WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY,
+            self.to_canonical_json()?,
+        ))
+    }
+}
+
 impl WorkspaceConfiguration {
     /// Construct the empty authoritative configuration for a new project.
     #[must_use]
@@ -352,6 +542,25 @@ fn validate_ontology(record: &WorkspaceOntology) -> Result<(), GfError> {
         }
         WorkspaceOntologyMode::None => Err(corrupt("workspace ontology absence is inconsistent")),
     }
+}
+
+fn validate_composition(record: &WorkspaceOntologyComposition) -> Result<(), GfError> {
+    if record.contract_version != WORKSPACE_ONTOLOGY_COMPOSITION_VERSION {
+        return Err(corrupt(
+            "unsupported workspace ontology composition contract",
+        ));
+    }
+    if record.composition_fingerprint.len() != 64
+        || !record
+            .composition_fingerprint
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+    {
+        return Err(corrupt(
+            "workspace ontology composition fingerprint is malformed",
+        ));
+    }
+    Ok(())
 }
 
 fn validate_configuration(record: &WorkspaceConfiguration) -> Result<(), GfError> {
@@ -707,6 +916,81 @@ mod tests {
             WorkspaceRepositorySnapshot::from_canonical_json(with_unrestricted_field.as_bytes())
                 .unwrap_err()
                 .code(),
+            "GF_PROJECT_CORRUPT"
+        );
+    }
+
+    #[test]
+    fn legacy_ontology_projects_without_rewriting_and_first_composition_is_canonical() {
+        let document = OntologyDoc {
+            ontology_id: "https://graphforge.dev/ontology/legacy".into(),
+            version: "1.0.0".into(),
+            entity_types: vec![graphforge_ontology::EntityTypeDef {
+                name: "Person".into(),
+                r#abstract: false,
+                parent: None,
+            }],
+            relation_types: vec![],
+            properties: vec![],
+            constraints: vec![],
+            migrations: vec![],
+        };
+        let value = serde_json::to_value(&document).unwrap();
+        let legacy = WorkspaceOntology {
+            contract_version: 1,
+            mode: WorkspaceOntologyMode::Strict,
+            source_format: Some(WorkspaceOntologySourceFormat::Json),
+            canonical_ontology_sha256: Some(encode_hex(&Sha256::digest(
+                serde_json::to_vec(&value).unwrap(),
+            ))),
+            canonical_ontology: Some(value),
+        };
+        let projected = WorkspaceOntologyComposition::virtual_legacy(&legacy)
+            .unwrap()
+            .unwrap();
+        assert!(projected.modules[0].id.ontology_id.starts_with("legacy:"));
+        assert_eq!(projected.profile_default, ActivationMode::Strict);
+
+        let bytes = projected.to_canonical_json().unwrap();
+        assert_eq!(
+            WorkspaceOntologyComposition::from_canonical_json(&bytes).unwrap(),
+            projected
+        );
+        let participant = projected.to_project_participant().unwrap();
+        assert_eq!(
+            participant.record_family_id,
+            WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY
+        );
+        assert_eq!(
+            legacy.to_canonical_json().unwrap(),
+            legacy.to_canonical_json().unwrap()
+        );
+    }
+
+    #[test]
+    fn composition_participant_rejects_fingerprint_tampering() {
+        let legacy = WorkspaceOntology::none();
+        assert!(
+            WorkspaceOntologyComposition::virtual_legacy(&legacy)
+                .unwrap()
+                .is_none()
+        );
+
+        let mut future = WorkspaceOntologyComposition {
+            contract_version: 2,
+            modules: vec![],
+            bridges: vec![],
+            activation: vec![],
+            profile_default: ActivationMode::Exploratory,
+            composition_fingerprint: "00".repeat(32),
+        };
+        assert_eq!(
+            future.to_canonical_json().unwrap_err().code(),
+            "GF_PROJECT_CORRUPT"
+        );
+        future.contract_version = 1;
+        assert_eq!(
+            future.to_canonical_json().unwrap_err().code(),
             "GF_PROJECT_CORRUPT"
         );
     }

--- a/crates/graphforge-storage/src/writer.rs
+++ b/crates/graphforge-storage/src/writer.rs
@@ -1215,6 +1215,7 @@ pub struct GraphWriter {
     /// Edges created since the last commit, captured during `flush_edges` for
     /// the adjacency delta segment (#765). Drained by `flush`/`take_pending_delta`.
     pending_delta: Vec<crate::adjacency_delta::DeltaEdge>,
+    semantic_composition_fingerprint: Option<String>,
 }
 
 impl GraphWriter {
@@ -1257,7 +1258,16 @@ impl GraphWriter {
             properties: HashMap::new(),
             edge_properties: HashMap::new(),
             pending_delta: Vec::new(),
+            semantic_composition_fingerprint: None,
         })
+    }
+
+    /// Attach the exact composition fingerprint used to authenticate opaque
+    /// semantic routes written by this writer.
+    #[must_use]
+    pub fn with_semantic_composition_fingerprint(mut self, fingerprint: Option<String>) -> Self {
+        self.semantic_composition_fingerprint = fingerprint;
+        self
     }
 
     /// Buffer a new node and return its assigned `node_id` surrogate.
@@ -1886,6 +1896,7 @@ impl GraphWriter {
             } else {
                 TYPED_EDGE_SCHEMA.clone()
             };
+            let schema = self.authenticated_route_schema(schema, &stem);
             let batch = self.edge_batch(&rows, &schema, exploratory)?;
             // Merge with this stem's existing file so appends accumulate (#733);
             // stems not in this buffer are never opened, so they are untouched.
@@ -1954,7 +1965,15 @@ impl GraphWriter {
             let mut rows = decode_property_rows(&existing)?;
             rows.extend(new_rows);
             let (schema, cols) = build_property_columns(&stem, &rows)?;
-            stage_property_file(staged, &self.dir, "properties", &stem, schema, cols)?;
+            let schema = self.authenticated_route_schema(Arc::new(schema), &stem);
+            stage_property_file(
+                staged,
+                &self.dir,
+                "properties",
+                &stem,
+                schema.as_ref().clone(),
+                cols,
+            )?;
         }
         Ok(())
     }
@@ -1977,7 +1996,15 @@ impl GraphWriter {
                 &stem,
                 &rows,
             )?;
-            stage_property_file(staged, &self.dir, "edge_properties", &stem, schema, cols)?;
+            let schema = self.authenticated_route_schema(Arc::new(schema), &stem);
+            stage_property_file(
+                staged,
+                &self.dir,
+                "edge_properties",
+                &stem,
+                schema.as_ref().clone(),
+                cols,
+            )?;
         }
         Ok(())
     }
@@ -1985,6 +2012,20 @@ impl GraphWriter {
     fn timestamp_array(&self, n: usize) -> TimestampMicrosecondArray {
         TimestampMicrosecondArray::from(vec![self.now_micros; n])
             .with_timezone_opt(Some(Arc::from("UTC")))
+    }
+
+    fn authenticated_route_schema(&self, schema: SchemaRef, stem: &str) -> SchemaRef {
+        match (
+            &self.semantic_composition_fingerprint,
+            stem.starts_with("s-"),
+        ) {
+            (Some(fingerprint), true) => Arc::new(crate::schemas::with_semantic_route_metadata(
+                schema.as_ref(),
+                stem,
+                fingerprint,
+            )),
+            _ => schema,
+        }
     }
 }
 


### PR DESCRIPTION
Closes #872

## Summary
- persist a bounded, generation-bound qualified semantic binding participant with stable untagged IDs and authenticated opaque physical routes
- route normal facade writes, reads, replay, imports, and publication through the pinned binding authority
- fail closed on corrupt inventory/metadata, ambiguous legacy layouts, undeclared upgrades, retained removals, and unpublished/stale candidates

## Evidence
- `cargo test -p graphforge-storage semantic_bindings --lib` (6 passed)
- `cargo test -p graphforge-api composition_binding_tests::facade_ --lib` (6 passed)
- `cargo clippy -p graphforge-storage -p graphforge-rel -p graphforge-exec -p graphforge-api --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 scripts/ci/cargo-bazel-drift-check.py`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789875815&installation_model_id=20486&pr_number=873&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F873&signature=02456a1820bd5089298ff1a2d57df7af5cf8646701d38606cf5c7229d83b747f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->