### PR TITLE
feat(api): publish ontology composition changes atomically

### DIFF
--- a/crates/graphforge-api/src/checkpoints.rs
+++ b/crates/graphforge-api/src/checkpoints.rs
@@ -1090,6 +1090,11 @@ fn logical_records(
                         &snapshot.bytes,
                     )?;
                 }
+                graphforge_storage::WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY => {
+                    graphforge_storage::WorkspaceOntologyComposition::from_canonical_json(
+                        &snapshot.bytes,
+                    )?;
+                }
                 graphforge_storage::WORKSPACE_REPOSITORY_SNAPSHOT_FAMILY => {
                     graphforge_storage::WorkspaceRepositorySnapshot::from_canonical_json(
                         &snapshot.bytes,

--- a/crates/graphforge-api/src/checkpoints.rs
+++ b/crates/graphforge-api/src/checkpoints.rs
@@ -1070,6 +1070,23 @@ fn logical_records(
             }
             continue;
         }
+        if descriptor.capability_id == graphforge_storage::GRAPH_CAPABILITY_ID
+            && descriptor.record_family_id == graphforge_storage::GRAPH_SEMANTIC_BINDINGS_FAMILY
+        {
+            let bindings = graphforge_storage::semantic_storage_bindings(generation)?
+                .ok_or_else(|| schema_mismatch("semantic binding participant disappeared"))?;
+            let bytes = bindings.to_canonical_json()?;
+            let identity: [u8; 32] = Sha256::digest(b"graph:semantic_bindings").into();
+            let fingerprint: [u8; 32] = Sha256::digest(bytes).into();
+            out.insert(
+                (domain.into(), descriptor.record_family_id.clone(), identity),
+                LogicalRecord {
+                    record_uuid: None,
+                    fingerprint,
+                },
+            );
+            continue;
+        }
         if descriptor.capability_id == graphforge_storage::WORKSPACE_CAPABILITY_ID {
             if descriptor.record_family_id == "restoration_transition" {
                 // Revert validation treats this canonical, storage-owned row as

--- a/crates/graphforge-api/src/composition_binding_tests.rs
+++ b/crates/graphforge-api/src/composition_binding_tests.rs
@@ -38,6 +38,23 @@ fn install_composition_authority(forge: &GraphForge, context: &CompositionBindin
             bytes: snapshot.bytes,
         })
         .collect::<Vec<_>>();
+    let configuration = participants
+        .iter_mut()
+        .find(|participant| {
+            participant.capability_id == graphforge_storage::WORKSPACE_CAPABILITY_ID
+                && participant.record_family_id
+                    == graphforge_storage::WORKSPACE_CONFIGURATION_FAMILY
+        })
+        .unwrap();
+    let mut record =
+        graphforge_storage::WorkspaceConfiguration::from_canonical_json(&configuration.bytes)
+            .unwrap();
+    record.ontology_mode = match context.composition().profile_default {
+        ActivationMode::Exploratory => graphforge_storage::WorkspaceOntologyMode::None,
+        ActivationMode::Advisory => graphforge_storage::WorkspaceOntologyMode::Advisory,
+        ActivationMode::Strict => graphforge_storage::WorkspaceOntologyMode::Strict,
+    };
+    configuration.bytes = record.to_canonical_json().unwrap();
     participants.push(
         graphforge_storage::WorkspaceOntologyComposition::from_compiled(
             context.composition(),

--- a/crates/graphforge-api/src/construction.rs
+++ b/crates/graphforge-api/src/construction.rs
@@ -27,8 +27,17 @@ impl GraphForge {
         let mut properties = props.iter().collect::<Vec<_>>();
         properties.sort_unstable_by(|left, right| left.0.cmp(right.0));
 
-        let strict_owner = match (self.ontology_mode, self.ontology.as_ref()) {
-            (graphforge_core::OntologyMode::Strict, Some(ontology)) => ontology
+        let composition = self
+            .composition_binding
+            .lock()
+            .expect("composition binding lock poisoned")
+            .clone();
+        let strict_owner = match (
+            self.ontology_mode,
+            self.ontology.as_ref(),
+            composition.as_ref(),
+        ) {
+            (graphforge_core::OntologyMode::Strict, Some(ontology), None) => ontology
                 .entity_type_id(label)
                 .map(|owner| (ontology, owner)),
             _ => None,
@@ -51,6 +60,17 @@ impl GraphForge {
             {
                 return Err(validation(format!(
                     "property {name:?} is not declared for strict entity type {label:?}"
+                )));
+            }
+            if self.ontology_mode == graphforge_core::OntologyMode::Strict
+                && composition.as_ref().is_some_and(|authority| {
+                    !authority
+                        .declares_entity_property(label, name)
+                        .unwrap_or(false)
+                })
+            {
+                return Err(validation(format!(
+                    "property {name:?} is not declared for strict composed entity type {label:?}"
                 )));
             }
             let parameter = format!("gf_add_node_{index}");

--- a/crates/graphforge-api/src/construction.rs
+++ b/crates/graphforge-api/src/construction.rs
@@ -28,7 +28,7 @@ impl GraphForge {
         properties.sort_unstable_by(|left, right| left.0.cmp(right.0));
 
         let composition = self
-            .composition_binding
+            .default_composition_context
             .lock()
             .expect("composition binding lock poisoned")
             .clone();

--- a/crates/graphforge-api/src/embedding_refresh.rs
+++ b/crates/graphforge-api/src/embedding_refresh.rs
@@ -265,7 +265,6 @@ impl GraphForge {
             tempdir: self.tempdir.clone(),
             ontology: self.ontology.clone(),
             ontology_document: self.ontology_document.clone(),
-            composition_binding: Arc::clone(&self.composition_binding),
             runtime_catalog: Arc::clone(&self.runtime_catalog),
             semantic_storage_bindings: Arc::clone(&self.semantic_storage_bindings),
             default_composition_context: Arc::clone(&self.default_composition_context),

--- a/crates/graphforge-api/src/embedding_refresh.rs
+++ b/crates/graphforge-api/src/embedding_refresh.rs
@@ -265,6 +265,7 @@ impl GraphForge {
             tempdir: self.tempdir.clone(),
             ontology: self.ontology.clone(),
             ontology_document: self.ontology_document.clone(),
+            composition_binding: Arc::clone(&self.composition_binding),
             runtime_catalog: Arc::clone(&self.runtime_catalog),
             semantic_storage_bindings: Arc::clone(&self.semantic_storage_bindings),
             default_composition_context: Arc::clone(&self.default_composition_context),

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -86,7 +86,12 @@ mod maintenance;
 #[cfg(test)]
 mod multi_process_publication_tests;
 mod node_selector;
+mod ontology_composition_lifecycle;
 mod ontology_lifecycle;
+pub use ontology_composition_lifecycle::{
+    CompositionChangeDiagnostic, CompositionChangePreview, CompositionChangeReceipt,
+    CompositionChangeRequest, CompositionDataDisposition,
+};
 mod paging;
 mod portable;
 mod provenance;
@@ -3905,12 +3910,38 @@ fn load_workspace_ontology(
     let configuration = graphforge_storage::WorkspaceConfiguration::from_canonical_json(
         &configuration_snapshot.bytes,
     )?;
-    if ontology_record.mode != configuration.ontology_mode {
+    let composition = generation
+        .participant_snapshot(
+            graphforge_storage::WORKSPACE_CAPABILITY_ID,
+            graphforge_storage::WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY,
+        )?
+        .map(|snapshot| {
+            graphforge_storage::WorkspaceOntologyComposition::from_canonical_json(&snapshot.bytes)
+        })
+        .transpose()?;
+    if let Some(composition) = &composition {
+        let composition_mode = match composition.profile_default {
+            graphforge_ontology::ActivationMode::Exploratory => {
+                graphforge_storage::WorkspaceOntologyMode::None
+            }
+            graphforge_ontology::ActivationMode::Advisory => {
+                graphforge_storage::WorkspaceOntologyMode::Advisory
+            }
+            graphforge_ontology::ActivationMode::Strict => {
+                graphforge_storage::WorkspaceOntologyMode::Strict
+            }
+        };
+        if composition_mode != configuration.ontology_mode {
+            return Err(GfError::Validation(
+                "workspace composition and configuration modes disagree".into(),
+            ));
+        }
+    } else if ontology_record.mode != configuration.ontology_mode {
         return Err(GfError::Validation(
             "workspace ontology and configuration modes disagree".into(),
         ));
     }
-    let mode = ontology_record.mode.execution_mode();
+    let mode = configuration.ontology_mode.execution_mode();
     let document = ontology_record
         .canonical_ontology
         .map(|document| {

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -90,7 +90,7 @@ mod ontology_composition_lifecycle;
 mod ontology_lifecycle;
 pub use ontology_composition_lifecycle::{
     CompositionChangeDiagnostic, CompositionChangePreview, CompositionChangeReceipt,
-    CompositionChangeRequest, CompositionDataDisposition,
+    CompositionChangeRequest, CompositionDataDisposition, CompositionPortableCompatibility,
 };
 mod paging;
 mod portable;
@@ -419,6 +419,8 @@ pub struct GraphForge {
     ontology: Option<OntologyHandle>,
     /// Source document backing the live, session-scoped compiled ontology.
     ontology_document: Option<OntologyDoc>,
+    /// Generation-bound composed binding authority used by normal execution.
+    composition_binding: Arc<Mutex<Option<Arc<CompositionBindingContext>>>>,
     /// Shared runtime catalog (grown by the binder during `execute`).
     runtime_catalog: Arc<Mutex<RuntimeCatalog>>,
     /// Exact generation-bound qualified storage authority, when adopted.
@@ -563,6 +565,7 @@ impl GraphForge {
         let generation_uuid = resolved_generation.generation_uuid();
         let (ontology_mode, ontology, ontology_document) =
             load_workspace_ontology(&resolved_generation)?;
+        let composition_binding = load_composition_binding(&resolved_generation)?;
         let (dir, workspace, graph_open_evidence) =
             hydrate_graph_workspace(&resolved_generation, false)?;
         Ok(Self {
@@ -603,6 +606,7 @@ impl GraphForge {
             tempdir: Some(Arc::new(tmp)),
             ontology,
             ontology_document,
+            composition_binding: Arc::new(Mutex::new(composition_binding)),
             runtime_catalog: Arc::new(Mutex::new(RuntimeCatalog::new())),
             semantic_storage_bindings: Arc::new(Mutex::new(None)),
             default_composition_context: Arc::new(Mutex::new(None)),
@@ -699,6 +703,7 @@ impl GraphForge {
         let generation_uuid = resolved_generation.generation_uuid();
         let (ontology_mode, ontology, ontology_document) =
             load_workspace_ontology(&resolved_generation)?;
+        let composition_binding = load_composition_binding(&resolved_generation)?;
         let (dir, workspace, graph_open_evidence) =
             hydrate_graph_workspace(&resolved_generation, read_only)?;
 
@@ -796,6 +801,7 @@ impl GraphForge {
             tempdir: None,
             ontology,
             ontology_document,
+            composition_binding: Arc::new(Mutex::new(composition_binding)),
             runtime_catalog: Arc::new(Mutex::new(runtime_catalog)),
             semantic_storage_bindings: Arc::new(Mutex::new(semantic_storage_bindings)),
             default_composition_context: Arc::new(Mutex::new(default_composition_context)),
@@ -3869,6 +3875,26 @@ pub(crate) fn rematerialize_graph_workspace(
         graph_snapshot::hydrate(&snapshot.bytes, target)?;
     }
     Ok(())
+}
+
+fn load_composition_binding(
+    generation: &ResolvedProjectGeneration,
+) -> Result<Option<Arc<CompositionBindingContext>>, GfError> {
+    let Some(snapshot) = generation.participant_snapshot(
+        graphforge_storage::WORKSPACE_CAPABILITY_ID,
+        graphforge_storage::WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY,
+    )?
+    else {
+        return Ok(None);
+    };
+    let authority =
+        graphforge_storage::WorkspaceOntologyComposition::from_canonical_json(&snapshot.bytes)?;
+    let compiled = authority.compile()?;
+    Ok(Some(Arc::new(CompositionBindingContext::new(
+        Arc::new(compiled),
+        authority.bridges,
+        CompositionBindingLimits::default(),
+    ))))
 }
 
 fn load_workspace_ontology(

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -91,6 +91,7 @@ mod ontology_lifecycle;
 pub use ontology_composition_lifecycle::{
     CompositionChangeDiagnostic, CompositionChangePreview, CompositionChangeReceipt,
     CompositionChangeRequest, CompositionDataDisposition, CompositionPortableCompatibility,
+    CompositionPortableReceipt,
 };
 mod paging;
 mod portable;
@@ -419,8 +420,6 @@ pub struct GraphForge {
     ontology: Option<OntologyHandle>,
     /// Source document backing the live, session-scoped compiled ontology.
     ontology_document: Option<OntologyDoc>,
-    /// Generation-bound composed binding authority used by normal execution.
-    composition_binding: Arc<Mutex<Option<Arc<CompositionBindingContext>>>>,
     /// Shared runtime catalog (grown by the binder during `execute`).
     runtime_catalog: Arc<Mutex<RuntimeCatalog>>,
     /// Exact generation-bound qualified storage authority, when adopted.
@@ -565,7 +564,6 @@ impl GraphForge {
         let generation_uuid = resolved_generation.generation_uuid();
         let (ontology_mode, ontology, ontology_document) =
             load_workspace_ontology(&resolved_generation)?;
-        let composition_binding = load_composition_binding(&resolved_generation)?;
         let (dir, workspace, graph_open_evidence) =
             hydrate_graph_workspace(&resolved_generation, false)?;
         Ok(Self {
@@ -606,7 +604,6 @@ impl GraphForge {
             tempdir: Some(Arc::new(tmp)),
             ontology,
             ontology_document,
-            composition_binding: Arc::new(Mutex::new(composition_binding)),
             runtime_catalog: Arc::new(Mutex::new(RuntimeCatalog::new())),
             semantic_storage_bindings: Arc::new(Mutex::new(None)),
             default_composition_context: Arc::new(Mutex::new(None)),
@@ -703,7 +700,6 @@ impl GraphForge {
         let generation_uuid = resolved_generation.generation_uuid();
         let (ontology_mode, ontology, ontology_document) =
             load_workspace_ontology(&resolved_generation)?;
-        let composition_binding = load_composition_binding(&resolved_generation)?;
         let (dir, workspace, graph_open_evidence) =
             hydrate_graph_workspace(&resolved_generation, read_only)?;
 
@@ -714,12 +710,12 @@ impl GraphForge {
         if semantic_storage_bindings.is_none()
             && let Some(context) = &default_composition_context
         {
-            if context.composition().modules.len() == 1 {
+            if context.composition().modules.len() == 1 && ontology_document.is_none() {
                 graphforge_storage::SemanticStorageBindings::project_legacy_unambiguous(
                     context.composition(),
                     &dir,
                 )?;
-            } else {
+            } else if context.composition().modules.len() != 1 {
                 graphforge_storage::require_atomic_legacy_migration(&dir)?;
             }
         }
@@ -744,6 +740,11 @@ impl GraphForge {
                     ),
                 )),
                 (None, Some(_)) => unreachable!("semantic composition validated above"),
+                (Some(context), None)
+                    if context.composition().modules.len() == 1 && ontology_document.is_some() =>
+                {
+                    None
+                }
                 (context, None) => context,
             };
         if read_only {
@@ -801,7 +802,6 @@ impl GraphForge {
             tempdir: None,
             ontology,
             ontology_document,
-            composition_binding: Arc::new(Mutex::new(composition_binding)),
             runtime_catalog: Arc::new(Mutex::new(runtime_catalog)),
             semantic_storage_bindings: Arc::new(Mutex::new(semantic_storage_bindings)),
             default_composition_context: Arc::new(Mutex::new(default_composition_context)),
@@ -3875,26 +3875,6 @@ pub(crate) fn rematerialize_graph_workspace(
         graph_snapshot::hydrate(&snapshot.bytes, target)?;
     }
     Ok(())
-}
-
-fn load_composition_binding(
-    generation: &ResolvedProjectGeneration,
-) -> Result<Option<Arc<CompositionBindingContext>>, GfError> {
-    let Some(snapshot) = generation.participant_snapshot(
-        graphforge_storage::WORKSPACE_CAPABILITY_ID,
-        graphforge_storage::WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY,
-    )?
-    else {
-        return Ok(None);
-    };
-    let authority =
-        graphforge_storage::WorkspaceOntologyComposition::from_canonical_json(&snapshot.bytes)?;
-    let compiled = authority.compile()?;
-    Ok(Some(Arc::new(CompositionBindingContext::new(
-        Arc::new(compiled),
-        authority.bridges,
-        CompositionBindingLimits::default(),
-    ))))
 }
 
 fn load_workspace_ontology(

--- a/crates/graphforge-api/src/ontology_composition_lifecycle.rs
+++ b/crates/graphforge-api/src/ontology_composition_lifecycle.rs
@@ -1,0 +1,698 @@
+//! Atomic project-generation lifecycle for ontology composition authority.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use graphforge_core::GfError;
+use graphforge_ontology::{
+    ActivationMode, MigrationEngine, ResolveRequest, SymbolKind, TransformKind,
+};
+use graphforge_storage::{
+    WORKSPACE_CAPABILITY_ID, WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY, WorkspaceOntologyComposition,
+    WorkspaceOntologyMode,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::{CancellationToken, GraphForge, WriteContext};
+
+/// Explicit disposition for runtime observations encountered by strict promotion.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompositionDataDisposition {
+    /// No runtime-only observations may remain.
+    RequireConforming,
+    /// Caller names every runtime symbol handled by a separately validated migration.
+    ValidatedMigration {
+        /// Sorted exact `kind:local` observations covered by that migration.
+        migrated_symbols: Vec<String>,
+    },
+}
+
+/// Request bound to one exact current generation and composition identity.
+#[derive(Debug, Clone)]
+pub struct CompositionChangeRequest {
+    /// Idempotency and actor identity.
+    pub context: WriteContext,
+    /// Project generation previewed by the caller.
+    pub expected_project_generation_uuid: Uuid,
+    /// Current composition fingerprint, or `None` for an empty legacy project.
+    pub expected_composition_fingerprint: Option<String>,
+    /// Complete replacement authority; deltas are never durable authority.
+    pub candidate: WorkspaceOntologyComposition,
+    /// Explicit stored-data disposition.
+    pub data_disposition: CompositionDataDisposition,
+}
+
+/// Stable attributable lifecycle diagnostic.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompositionChangeDiagnostic {
+    /// Stable machine code.
+    pub code: String,
+    /// Exact bounded subject.
+    pub subject: String,
+    /// Actionable remediation.
+    pub remediation: String,
+}
+
+/// Deterministic preview bound to both authority identities.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompositionChangePreview {
+    /// Expected current project generation.
+    pub expected_project_generation_uuid: Uuid,
+    /// Expected current composition.
+    pub expected_composition_fingerprint: Option<String>,
+    /// Candidate exact composition.
+    pub candidate_composition_fingerprint: String,
+    /// Canonical candidate content hash.
+    pub candidate_sha256: String,
+    /// Identity-sorted affected modules.
+    pub affected_modules: Vec<String>,
+    /// Identity-sorted affected bridges.
+    pub affected_bridges: Vec<String>,
+    /// Bounded diagnostics; empty means publishable.
+    pub diagnostics: Vec<CompositionChangeDiagnostic>,
+}
+
+/// Durable publication receipt.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompositionChangeReceipt {
+    /// Published project generation.
+    pub project_generation_uuid: Uuid,
+    /// Published exact composition identity.
+    pub composition_fingerprint: String,
+    /// Canonical request content hash.
+    pub candidate_sha256: String,
+}
+
+impl GraphForge {
+    /// Read exact composition authority, or a virtual legacy projection without mutation.
+    pub fn workspace_ontology_composition(
+        &self,
+    ) -> Result<Option<WorkspaceOntologyComposition>, GfError> {
+        let current = self.generation_for_read()?;
+        if let Some(snapshot) = current.participant_snapshot(
+            WORKSPACE_CAPABILITY_ID,
+            WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY,
+        )? {
+            return WorkspaceOntologyComposition::from_canonical_json(&snapshot.bytes).map(Some);
+        }
+        WorkspaceOntologyComposition::virtual_legacy(&self.workspace_ontology()?)
+    }
+
+    /// Preflight a complete replacement against exact current authority.
+    #[allow(clippy::too_many_lines)] // keeps the bounded aggregate preflight in one ordered pass
+    pub fn preview_ontology_composition_change(
+        &self,
+        request: &CompositionChangeRequest,
+        cancellation: Option<&CancellationToken>,
+    ) -> Result<CompositionChangePreview, GfError> {
+        if let Some(token) = cancellation {
+            token.checkpoint()?;
+        }
+        let current = self.generation_for_read()?;
+        if current.generation_uuid() != request.expected_project_generation_uuid {
+            return Err(GfError::Validation(
+                "composition preview project generation is stale".into(),
+            ));
+        }
+        let existing = self.workspace_ontology_composition()?;
+        let existing_fingerprint = existing
+            .as_ref()
+            .map(|composition| composition.composition_fingerprint.clone());
+        if existing_fingerprint != request.expected_composition_fingerprint {
+            return Err(GfError::Validation(
+                "composition preview fingerprint is stale".into(),
+            ));
+        }
+        let compiled = request.candidate.compile()?;
+        if let Some(token) = cancellation {
+            token.checkpoint()?;
+        }
+        let candidate_bytes = request.candidate.to_canonical_json()?;
+        let runtime_symbols = runtime_symbols(self);
+        let mut diagnostics = Vec::new();
+        diagnostics.extend(migration_diagnostics(existing.as_ref(), &request.candidate));
+        let has_strict_scope = compiled.profile_default == ActivationMode::Strict
+            || compiled
+                .modules
+                .iter()
+                .any(|module| compiled.effective_module_mode(&module.id) == ActivationMode::Strict);
+        if has_strict_scope {
+            let covered = disposition_symbols(&request.data_disposition)?;
+            let nonconforming = runtime_symbols
+                .iter()
+                .filter(|symbol| !symbol_declared(&compiled, symbol))
+                .filter(|symbol| !covered.contains(*symbol));
+            for symbol in nonconforming.take(64usize.saturating_sub(diagnostics.len())) {
+                diagnostics.push(CompositionChangeDiagnostic {
+                    code: "strict_runtime_observation".into(),
+                    subject: symbol.clone(),
+                    remediation: "declare the symbol or provide a validated migration disposition"
+                        .into(),
+                });
+            }
+        }
+        let old_modules = existing
+            .as_ref()
+            .into_iter()
+            .flat_map(|composition| composition.modules.iter())
+            .map(|module| module.id.display_ref())
+            .collect::<BTreeSet<_>>();
+        let new_modules = request
+            .candidate
+            .modules
+            .iter()
+            .map(|module| module.id.display_ref())
+            .collect::<BTreeSet<_>>();
+        let old_bridges = existing
+            .as_ref()
+            .into_iter()
+            .flat_map(|composition| composition.bridges.iter())
+            .map(|bridge| {
+                (
+                    format!("{}@{}", bridge.bridge_id, bridge.authored_version),
+                    serde_json::to_vec(bridge).unwrap_or_default(),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        let new_bridges = request
+            .candidate
+            .bridges
+            .iter()
+            .map(|bridge| {
+                (
+                    format!("{}@{}", bridge.bridge_id, bridge.authored_version),
+                    serde_json::to_vec(bridge).unwrap_or_default(),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        let old_activation = existing
+            .as_ref()
+            .into_iter()
+            .flat_map(|composition| composition.activation.iter())
+            .map(|record| (record.subject.clone(), record.mode))
+            .collect::<BTreeMap<_, _>>();
+        let new_activation = request
+            .candidate
+            .activation
+            .iter()
+            .map(|record| (record.subject.clone(), record.mode))
+            .collect::<BTreeMap<_, _>>();
+        let mut affected_modules = old_modules
+            .symmetric_difference(&new_modules)
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        for subject in old_activation.keys().chain(new_activation.keys()) {
+            if old_activation.get(subject) != new_activation.get(subject) {
+                affected_modules.insert(subject.clone());
+            }
+        }
+        let affected_bridges = old_bridges
+            .keys()
+            .chain(new_bridges.keys())
+            .filter(|identity| old_bridges.get(*identity) != new_bridges.get(*identity))
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        Ok(CompositionChangePreview {
+            expected_project_generation_uuid: request.expected_project_generation_uuid,
+            expected_composition_fingerprint: existing_fingerprint,
+            candidate_composition_fingerprint: compiled.fingerprint,
+            candidate_sha256: hex(&Sha256::digest(candidate_bytes)),
+            affected_modules: affected_modules.into_iter().collect(),
+            affected_bridges: affected_bridges.into_iter().collect(),
+            diagnostics,
+        })
+    }
+
+    /// Revalidate and atomically publish one complete composition replacement.
+    pub fn publish_ontology_composition_change(
+        &mut self,
+        request: &CompositionChangeRequest,
+        preview: &CompositionChangePreview,
+        cancellation: Option<&CancellationToken>,
+    ) -> Result<CompositionChangeReceipt, GfError> {
+        let current = self.generation_for_read()?;
+        if current.generation_uuid() != request.expected_project_generation_uuid
+            && current.parent_generation_uuid() == Some(request.expected_project_generation_uuid)
+            && current.transaction_uuid() == request.context.operation_uuid.0
+        {
+            let candidate_sha256 = hex(&Sha256::digest(request.candidate.to_canonical_json()?));
+            let published = self.workspace_ontology_composition()?.ok_or_else(|| {
+                GfError::Validation(
+                    "idempotent composition publication is missing authority".into(),
+                )
+            })?;
+            if published != request.candidate
+                || preview.candidate_sha256 != candidate_sha256
+                || preview.candidate_composition_fingerprint
+                    != request.candidate.composition_fingerprint
+            {
+                return Err(GfError::Validation(
+                    "composition operation UUID was reused with different content".into(),
+                ));
+            }
+            return Ok(CompositionChangeReceipt {
+                project_generation_uuid: current.generation_uuid(),
+                composition_fingerprint: published.composition_fingerprint,
+                candidate_sha256,
+            });
+        }
+        let fresh = self.preview_ontology_composition_change(request, cancellation)?;
+        if &fresh != preview {
+            return Err(GfError::Validation(
+                "composition preview does not match request".into(),
+            ));
+        }
+        if !fresh.diagnostics.is_empty() {
+            return Err(GfError::Validation(
+                "composition preflight contains unresolved diagnostics".into(),
+            ));
+        }
+        if let Some(token) = cancellation {
+            token.checkpoint()?;
+        }
+        let ontology = self.workspace_ontology()?;
+        let mut configuration = self.workspace_configuration()?;
+        configuration.ontology_mode = match request.candidate.profile_default {
+            ActivationMode::Exploratory => WorkspaceOntologyMode::None,
+            ActivationMode::Advisory => WorkspaceOntologyMode::Advisory,
+            ActivationMode::Strict => WorkspaceOntologyMode::Strict,
+        };
+        crate::workspace_ontology::publish_workspace_records(
+            self,
+            request.context.operation_uuid.0,
+            request.context.actor_uuid,
+            &ontology,
+            &configuration,
+            Some(&request.candidate),
+        )?;
+        self.ontology_mode = configuration.ontology_mode.execution_mode();
+        self.adjacency_provider = std::sync::Arc::new(
+            graphforge_exec::PersistentAdjacencyProvider::new(self.dir.clone(), self.ontology_mode),
+        );
+        Ok(CompositionChangeReceipt {
+            project_generation_uuid: *self
+                .current_generation_uuid
+                .lock()
+                .expect("generation UUID lock poisoned"),
+            composition_fingerprint: fresh.candidate_composition_fingerprint,
+            candidate_sha256: fresh.candidate_sha256,
+        })
+    }
+}
+
+fn migration_diagnostics(
+    existing: Option<&WorkspaceOntologyComposition>,
+    candidate: &WorkspaceOntologyComposition,
+) -> Vec<CompositionChangeDiagnostic> {
+    let Some(existing) = existing else {
+        return Vec::new();
+    };
+    let mut diagnostics = Vec::new();
+    for old in &existing.modules {
+        let Some(new) = candidate
+            .modules
+            .iter()
+            .find(|module| module.id.ontology_id == old.id.ontology_id)
+        else {
+            continue;
+        };
+        if old.id.authored_version == new.id.authored_version {
+            continue;
+        }
+        // A rollback republishes previously validated immutable authority. It
+        // still receives the full current-data/enforcement preflight, but does
+        // not invent a reverse transform that authored ontologies forbid.
+        if new.id.authored_version < old.id.authored_version {
+            continue;
+        }
+        let migrations = new
+            .document
+            .migrations
+            .iter()
+            .chain(old.document.migrations.iter())
+            .cloned()
+            .collect::<Vec<_>>();
+        match MigrationEngine::plan(
+            &old.id.authored_version,
+            &new.id.authored_version,
+            &migrations,
+        ) {
+            Err(_) => diagnostics.push(CompositionChangeDiagnostic {
+                code: "migration_unreachable".into(),
+                subject: new.id.ontology_id.clone(),
+                remediation: format!(
+                    "author a migration path from {} to {}",
+                    old.id.authored_version, new.id.authored_version
+                ),
+            }),
+            Ok(steps) => {
+                for step in steps {
+                    if let TransformKind::Unknown { raw } = step.transform_kind {
+                        diagnostics.push(CompositionChangeDiagnostic {
+                            code: "migration_transform_unknown".into(),
+                            subject: format!(
+                                "{}:{}->{}",
+                                new.id.ontology_id, step.from_version, step.to_version
+                            ),
+                            remediation: format!(
+                                "replace unsupported migration transform `{raw}` with a known transform"
+                            ),
+                        });
+                    }
+                }
+            }
+        }
+        if diagnostics.len() == 64 {
+            break;
+        }
+    }
+    diagnostics
+}
+
+fn symbol_declared(composition: &graphforge_ontology::CompiledComposition, encoded: &str) -> bool {
+    let Some((kind, local_id)) = encoded.split_once(':') else {
+        return false;
+    };
+    let kind = match kind {
+        "entity" => SymbolKind::Entity,
+        "relation" => SymbolKind::Relation,
+        "property" => SymbolKind::Property,
+        _ => return false,
+    };
+    composition
+        .resolve(&ResolveRequest {
+            module: None,
+            kind,
+            local_id,
+            max_candidates: 2,
+        })
+        .is_ok()
+}
+
+fn runtime_symbols(graph: &GraphForge) -> BTreeSet<String> {
+    let catalog = graph
+        .runtime_catalog
+        .lock()
+        .expect("runtime catalog poisoned");
+    catalog
+        .entity_types()
+        .into_iter()
+        .map(|name| format!("{}:{name}", SymbolKind::Entity.as_str()))
+        .chain(
+            catalog
+                .relation_types()
+                .into_iter()
+                .map(|name| format!("{}:{name}", SymbolKind::Relation.as_str())),
+        )
+        .chain(
+            catalog
+                .property_names()
+                .map(|(_, name)| format!("{}:{name}", SymbolKind::Property.as_str())),
+        )
+        .collect()
+}
+
+fn disposition_symbols(
+    disposition: &CompositionDataDisposition,
+) -> Result<BTreeSet<String>, GfError> {
+    match disposition {
+        CompositionDataDisposition::RequireConforming => Ok(BTreeSet::new()),
+        CompositionDataDisposition::ValidatedMigration { migrated_symbols } => {
+            let set = migrated_symbols.iter().cloned().collect::<BTreeSet<_>>();
+            if set.len() != migrated_symbols.len()
+                || migrated_symbols.windows(2).any(|pair| pair[0] >= pair[1])
+            {
+                return Err(GfError::Validation(
+                    "migrated symbols must be unique and sorted".into(),
+                ));
+            }
+            Ok(set)
+        }
+    }
+}
+
+fn hex(bytes: &[u8]) -> String {
+    const TABLE: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(TABLE[(byte >> 4) as usize] as char);
+        output.push(TABLE[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use graphforge_ontology::{
+        CompositionLimits, EntityTypeDef, MigrationDef, OntologyDoc, compile_legacy_single_ontology,
+    };
+
+    use super::*;
+    use crate::OperationId;
+
+    fn composition(
+        version: &str,
+        mode: ActivationMode,
+        entity_names: &[&str],
+        migrations: Vec<MigrationDef>,
+    ) -> WorkspaceOntologyComposition {
+        let document = OntologyDoc {
+            ontology_id: "acme".into(),
+            version: version.into(),
+            entity_types: entity_names
+                .iter()
+                .map(|name| EntityTypeDef {
+                    name: (*name).into(),
+                    r#abstract: false,
+                    parent: None,
+                })
+                .collect(),
+            relation_types: Vec::new(),
+            properties: Vec::new(),
+            constraints: Vec::new(),
+            migrations,
+        };
+        let compiled =
+            compile_legacy_single_ontology(&document, false, CompositionLimits::default()).unwrap();
+        let mut composition = WorkspaceOntologyComposition::from_compiled(&compiled, Vec::new());
+        composition.profile_default = mode;
+        composition
+    }
+
+    fn context(seed: u128) -> WriteContext {
+        WriteContext {
+            operation_uuid: OperationId(Uuid::from_u128(seed)),
+            actor_uuid: None,
+        }
+    }
+
+    fn request(
+        graph: &GraphForge,
+        seed: u128,
+        candidate: WorkspaceOntologyComposition,
+    ) -> CompositionChangeRequest {
+        CompositionChangeRequest {
+            context: context(seed),
+            expected_project_generation_uuid: *graph.current_generation_uuid.lock().unwrap(),
+            expected_composition_fingerprint: graph
+                .workspace_ontology_composition()
+                .unwrap()
+                .map(|value| value.composition_fingerprint),
+            candidate,
+            data_disposition: CompositionDataDisposition::RequireConforming,
+        }
+    }
+
+    #[test]
+    fn publish_reopen_retry_and_rollback_preserve_exact_authority() {
+        let project = tempfile::tempdir().unwrap();
+        let path = project.path().to_str().unwrap();
+        let mut graph = GraphForge::new(Some(path)).unwrap();
+        let first = request(
+            &graph,
+            8401,
+            composition("1", ActivationMode::Advisory, &["Person"], Vec::new()),
+        );
+        let first_preview = graph
+            .preview_ontology_composition_change(&first, None)
+            .unwrap();
+        let first_receipt = graph
+            .publish_ontology_composition_change(&first, &first_preview, None)
+            .unwrap();
+        assert_eq!(
+            graph
+                .publish_ontology_composition_change(&first, &first_preview, None)
+                .unwrap(),
+            first_receipt
+        );
+        drop(graph);
+
+        let mut reopened = GraphForge::new(Some(path)).unwrap();
+        let observed = reopened.workspace_ontology_composition().unwrap().unwrap();
+        assert_eq!(observed.profile_default, ActivationMode::Advisory);
+        assert_eq!(observed.modules[0].document.version, "1");
+
+        let upgraded = request(
+            &reopened,
+            8402,
+            composition(
+                "2",
+                ActivationMode::Strict,
+                &["Person", "Company"],
+                vec![MigrationDef {
+                    from_version: "1".into(),
+                    to_version: "2".into(),
+                    transform_kind: "add_type:Company".into(),
+                    script_ref: None,
+                    checksum: None,
+                }],
+            ),
+        );
+        let upgraded_preview = reopened
+            .preview_ontology_composition_change(&upgraded, None)
+            .unwrap();
+        assert!(upgraded_preview.diagnostics.is_empty());
+        reopened
+            .publish_ontology_composition_change(&upgraded, &upgraded_preview, None)
+            .unwrap();
+
+        let rollback = request(&reopened, 8403, observed.clone());
+        let rollback_preview = reopened
+            .preview_ontology_composition_change(&rollback, None)
+            .unwrap();
+        reopened
+            .publish_ontology_composition_change(&rollback, &rollback_preview, None)
+            .unwrap();
+        drop(reopened);
+        assert_eq!(
+            GraphForge::new(Some(path))
+                .unwrap()
+                .workspace_ontology_composition()
+                .unwrap(),
+            Some(observed)
+        );
+    }
+
+    #[test]
+    fn stale_cancelled_and_conflicting_replay_leave_generation_unchanged() {
+        let mut graph = GraphForge::new(None).unwrap();
+        let request = request(
+            &graph,
+            8410,
+            composition("1", ActivationMode::Advisory, &["Person"], Vec::new()),
+        );
+        let preview = graph
+            .preview_ontology_composition_change(&request, None)
+            .unwrap();
+        let before = *graph.current_generation_uuid.lock().unwrap();
+        let cancellation = CancellationToken::new();
+        cancellation.cancel();
+        assert!(
+            graph
+                .publish_ontology_composition_change(&request, &preview, Some(&cancellation))
+                .is_err()
+        );
+        assert_eq!(*graph.current_generation_uuid.lock().unwrap(), before);
+        graph
+            .publish_ontology_composition_change(&request, &preview, None)
+            .unwrap();
+        let published = *graph.current_generation_uuid.lock().unwrap();
+
+        let mut conflicting = request;
+        conflicting.candidate =
+            composition("1", ActivationMode::Advisory, &["Company"], Vec::new());
+        assert!(
+            graph
+                .publish_ontology_composition_change(&conflicting, &preview, None)
+                .is_err()
+        );
+        assert_eq!(*graph.current_generation_uuid.lock().unwrap(), published);
+    }
+
+    #[test]
+    fn strict_preflight_reports_bounded_nonconforming_data() {
+        let graph = GraphForge::new(None).unwrap();
+        {
+            let mut catalog = graph.runtime_catalog.lock().unwrap();
+            for index in 0..80 {
+                catalog.intern_label(&format!("Exploratory{index:02}"));
+            }
+        }
+        let request = request(
+            &graph,
+            8420,
+            composition("1", ActivationMode::Strict, &["Person"], Vec::new()),
+        );
+        let preview = graph
+            .preview_ontology_composition_change(&request, None)
+            .unwrap();
+        assert_eq!(preview.diagnostics.len(), 64);
+        assert!(
+            preview
+                .diagnostics
+                .windows(2)
+                .all(|pair| pair[0].subject < pair[1].subject)
+        );
+        assert!(preview.diagnostics.iter().all(|diagnostic| {
+            diagnostic.code == "strict_runtime_observation"
+                && diagnostic.subject.starts_with("entity:Exploratory")
+                && !diagnostic.remediation.is_empty()
+        }));
+    }
+
+    #[test]
+    fn migration_preflight_is_reachable_ordered_and_fail_closed() {
+        let mut graph = GraphForge::new(None).unwrap();
+        let initial = request(
+            &graph,
+            8430,
+            composition("1", ActivationMode::Advisory, &["Person"], Vec::new()),
+        );
+        let preview = graph
+            .preview_ontology_composition_change(&initial, None)
+            .unwrap();
+        graph
+            .publish_ontology_composition_change(&initial, &preview, None)
+            .unwrap();
+
+        let unreachable = request(
+            &graph,
+            8431,
+            composition("3", ActivationMode::Advisory, &["Person"], Vec::new()),
+        );
+        assert_eq!(
+            graph
+                .preview_ontology_composition_change(&unreachable, None)
+                .unwrap()
+                .diagnostics[0]
+                .code,
+            "migration_unreachable"
+        );
+        let unknown = request(
+            &graph,
+            8432,
+            composition(
+                "2",
+                ActivationMode::Advisory,
+                &["Person"],
+                vec![MigrationDef {
+                    from_version: "1".into(),
+                    to_version: "2".into(),
+                    transform_kind: "execute_magic".into(),
+                    script_ref: None,
+                    checksum: None,
+                }],
+            ),
+        );
+        assert_eq!(
+            graph
+                .preview_ontology_composition_change(&unknown, None)
+                .unwrap()
+                .diagnostics[0]
+                .code,
+            "migration_transform_unknown"
+        );
+    }
+}

--- a/crates/graphforge-api/src/ontology_composition_lifecycle.rs
+++ b/crates/graphforge-api/src/ontology_composition_lifecycle.rs
@@ -1,8 +1,11 @@
 //! Atomic project-generation lifecycle for ontology composition authority.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::fs::{self, File};
 
-use graphforge_core::GfError;
+use arrow::array::{Array, ListArray, UInt32Array};
+
+use graphforge_core::{GfError, ProjectErrorCode};
 use graphforge_ontology::{
     ActivationMode, MigrationEngine, ResolveRequest, SymbolKind, TransformKind,
 };
@@ -10,6 +13,7 @@ use graphforge_storage::{
     WORKSPACE_CAPABILITY_ID, WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY, WorkspaceOntologyComposition,
     WorkspaceOntologyMode,
 };
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
@@ -22,11 +26,6 @@ use crate::{CancellationToken, GraphForge, WriteContext};
 pub enum CompositionDataDisposition {
     /// No runtime-only observations may remain.
     RequireConforming,
-    /// Caller names every runtime symbol handled by a separately validated migration.
-    ValidatedMigration {
-        /// Sorted exact `kind:local` observations covered by that migration.
-        migrated_symbols: Vec<String>,
-    },
 }
 
 /// Request bound to one exact current generation and composition identity.
@@ -70,8 +69,19 @@ pub struct CompositionChangePreview {
     pub affected_modules: Vec<String>,
     /// Identity-sorted affected bridges.
     pub affected_bridges: Vec<String>,
+    /// Portable-v2 disposition until #841 adds authenticated package support.
+    pub portable_compatibility: CompositionPortableCompatibility,
     /// Bounded diagnostics; empty means publishable.
     pub diagnostics: Vec<CompositionChangeDiagnostic>,
+}
+
+/// Semantic portable-v2 verdict for a candidate composition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompositionPortableCompatibility {
+    /// Canonical authority is representable, while current package readers
+    /// deliberately fail closed on the required `ontology-composition@1` token.
+    RepresentableReaderUnsupported,
 }
 
 /// Durable publication receipt.
@@ -90,6 +100,15 @@ impl GraphForge {
     pub fn workspace_ontology_composition(
         &self,
     ) -> Result<Option<WorkspaceOntologyComposition>, GfError> {
+        if let Some(composition) = self.persisted_workspace_ontology_composition()? {
+            return Ok(Some(composition));
+        }
+        WorkspaceOntologyComposition::virtual_legacy(&self.workspace_ontology()?)
+    }
+
+    pub(crate) fn persisted_workspace_ontology_composition(
+        &self,
+    ) -> Result<Option<WorkspaceOntologyComposition>, GfError> {
         let current = self.generation_for_read()?;
         if let Some(snapshot) = current.participant_snapshot(
             WORKSPACE_CAPABILITY_ID,
@@ -97,7 +116,7 @@ impl GraphForge {
         )? {
             return WorkspaceOntologyComposition::from_canonical_json(&snapshot.bytes).map(Some);
         }
-        WorkspaceOntologyComposition::virtual_legacy(&self.workspace_ontology()?)
+        Ok(None)
     }
 
     /// Preflight a complete replacement against exact current authority.
@@ -125,31 +144,59 @@ impl GraphForge {
                 "composition preview fingerprint is stale".into(),
             ));
         }
-        let compiled = request.candidate.compile()?;
+        let (compiled, compile_error) = match request.candidate.compile() {
+            Ok(compiled) => (Some(compiled), None),
+            Err(error) => (None, Some(error.to_string())),
+        };
         if let Some(token) = cancellation {
             token.checkpoint()?;
         }
         let candidate_bytes = request.candidate.to_canonical_json()?;
-        let runtime_symbols = runtime_symbols(self);
+        let (runtime_symbols, catalog_drift) = runtime_symbols(self, cancellation)?;
         let mut diagnostics = Vec::new();
-        diagnostics.extend(migration_diagnostics(existing.as_ref(), &request.candidate));
-        let has_strict_scope = compiled.profile_default == ActivationMode::Strict
-            || compiled
-                .modules
-                .iter()
-                .any(|module| compiled.effective_module_mode(&module.id) == ActivationMode::Strict);
+        if compiled.is_none() {
+            diagnostics.push(CompositionChangeDiagnostic {
+                code: "candidate_composition_invalid".into(),
+                subject: request.candidate.composition_fingerprint.clone(),
+                remediation: compile_error.unwrap_or_else(|| "repair candidate authority".into()),
+            });
+        }
+        if catalog_drift {
+            diagnostics.push(CompositionChangeDiagnostic {
+                code: "runtime_catalog_generation_drift".into(),
+                subject: current.generation_uuid().hyphenated().to_string(),
+                remediation: "reopen the exact current generation before composition preflight"
+                    .into(),
+            });
+        }
+        diagnostics.extend(migration_diagnostics(
+            existing.as_ref(),
+            &request.candidate,
+            &runtime_symbols,
+            cancellation,
+        )?);
+        diagnostics.extend(removed_authority_diagnostics(
+            existing.as_ref(),
+            &request.candidate,
+            &runtime_symbols,
+        ));
+        let has_strict_scope = compiled.as_ref().is_some_and(|compiled| {
+            compiled.profile_default == ActivationMode::Strict
+                || compiled.modules.iter().any(|module| {
+                    compiled.effective_module_mode(&module.id) == ActivationMode::Strict
+                })
+        });
         if has_strict_scope {
-            let covered = disposition_symbols(&request.data_disposition)?;
-            let nonconforming = runtime_symbols
-                .iter()
-                .filter(|symbol| !symbol_declared(&compiled, symbol))
-                .filter(|symbol| !covered.contains(*symbol));
+            let nonconforming = runtime_symbols.iter().filter(|symbol| {
+                compiled
+                    .as_ref()
+                    .is_none_or(|compiled| !symbol_declared(compiled, symbol))
+            });
             for symbol in nonconforming.take(64usize.saturating_sub(diagnostics.len())) {
                 diagnostics.push(CompositionChangeDiagnostic {
                     code: "strict_runtime_observation".into(),
                     subject: symbol.clone(),
-                    remediation: "declare the symbol or provide a validated migration disposition"
-                        .into(),
+                    remediation: "declare the symbol before strict publication".into(),
                 });
             }
         }
@@ -214,13 +261,21 @@ impl GraphForge {
             .filter(|identity| old_bridges.get(*identity) != new_bridges.get(*identity))
             .cloned()
             .collect::<BTreeSet<_>>();
+        diagnostics
+            .sort_by(|left, right| (&left.code, &left.subject).cmp(&(&right.code, &right.subject)));
+        diagnostics.truncate(64);
         Ok(CompositionChangePreview {
             expected_project_generation_uuid: request.expected_project_generation_uuid,
             expected_composition_fingerprint: existing_fingerprint,
-            candidate_composition_fingerprint: compiled.fingerprint,
+            candidate_composition_fingerprint: compiled.as_ref().map_or_else(
+                || request.candidate.composition_fingerprint.clone(),
+                |value| value.fingerprint.clone(),
+            ),
             candidate_sha256: hex(&Sha256::digest(candidate_bytes)),
             affected_modules: affected_modules.into_iter().collect(),
             affected_bridges: affected_bridges.into_iter().collect(),
+            portable_compatibility:
+                CompositionPortableCompatibility::RepresentableReaderUnsupported,
             diagnostics,
         })
     }
@@ -232,30 +287,46 @@ impl GraphForge {
         preview: &CompositionChangePreview,
         cancellation: Option<&CancellationToken>,
     ) -> Result<CompositionChangeReceipt, GfError> {
-        let current = self.generation_for_read()?;
-        if current.generation_uuid() != request.expected_project_generation_uuid
-            && current.parent_generation_uuid() == Some(request.expected_project_generation_uuid)
-            && current.transaction_uuid() == request.context.operation_uuid.0
-        {
-            let candidate_sha256 = hex(&Sha256::digest(request.candidate.to_canonical_json()?));
-            let published = self.workspace_ontology_composition()?.ok_or_else(|| {
-                GfError::Validation(
-                    "idempotent composition publication is missing authority".into(),
-                )
-            })?;
-            if published != request.candidate
-                || preview.candidate_sha256 != candidate_sha256
-                || preview.candidate_composition_fingerprint
-                    != request.candidate.composition_fingerprint
-            {
-                return Err(GfError::Validation(
-                    "composition operation UUID was reused with different content".into(),
-                ));
+        let request_fingerprint = composition_request_fingerprint(request)?;
+        let mut generation_hasher = Sha256::new();
+        generation_hasher.update(b"graphforge-composition-generation/1");
+        generation_hasher.update(request.context.operation_uuid.0.as_bytes());
+        generation_hasher.update(request_fingerprint);
+        let expected_generation_uuid =
+            graphforge_core::canonical::uuid_v8(generation_hasher.finalize().into());
+        let root = self.resolved_generation.container_root();
+        if let Some(published) = graphforge_storage::published_project_transaction(
+            root,
+            request.context.operation_uuid.0,
+        )? {
+            if published.generation_uuid != expected_generation_uuid {
+                return Err(GfError::Project {
+                    code: ProjectErrorCode::TransactionConflict,
+                    message: "composition operation UUID was reused with different content".into(),
+                });
+            }
+            let generation = graphforge_storage::resolve_verified_generation(
+                root,
+                published.generation_uuid,
+                published.generation_manifest_sha256,
+            )?;
+            let snapshot = generation
+                .participant_snapshot(
+                    WORKSPACE_CAPABILITY_ID,
+                    WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY,
+                )?
+                .ok_or_else(|| GfError::Validation("published composition is missing".into()))?;
+            let composition = WorkspaceOntologyComposition::from_canonical_json(&snapshot.bytes)?;
+            if composition != request.candidate {
+                return Err(GfError::Project {
+                    code: ProjectErrorCode::TransactionConflict,
+                    message: "published composition content does not match retry".into(),
+                });
             }
             return Ok(CompositionChangeReceipt {
-                project_generation_uuid: current.generation_uuid(),
-                composition_fingerprint: published.composition_fingerprint,
-                candidate_sha256,
+                project_generation_uuid: published.generation_uuid,
+                composition_fingerprint: composition.composition_fingerprint,
+                candidate_sha256: hex(&Sha256::digest(request.candidate.to_canonical_json()?)),
             });
         }
         let fresh = self.preview_ontology_composition_change(request, cancellation)?;
@@ -279,6 +350,11 @@ impl GraphForge {
             ActivationMode::Advisory => WorkspaceOntologyMode::Advisory,
             ActivationMode::Strict => WorkspaceOntologyMode::Strict,
         };
+        let published_binding = graphforge_ir::CompositionBindingContext::new(
+            std::sync::Arc::new(request.candidate.compile()?),
+            request.candidate.bridges.clone(),
+            graphforge_ir::CompositionBindingLimits::default(),
+        );
         crate::workspace_ontology::publish_workspace_records(
             self,
             request.context.operation_uuid.0,
@@ -286,7 +362,14 @@ impl GraphForge {
             &ontology,
             &configuration,
             Some(&request.candidate),
+            Some(expected_generation_uuid),
+            cancellation,
         )?;
+        *self
+            .composition_binding
+            .lock()
+            .expect("composition binding lock poisoned") =
+            Some(std::sync::Arc::new(published_binding));
         self.ontology_mode = configuration.ontology_mode.execution_mode();
         self.adjacency_provider = std::sync::Arc::new(
             graphforge_exec::PersistentAdjacencyProvider::new(self.dir.clone(), self.ontology_mode),
@@ -302,15 +385,69 @@ impl GraphForge {
     }
 }
 
-fn migration_diagnostics(
+fn removed_authority_diagnostics(
     existing: Option<&WorkspaceOntologyComposition>,
     candidate: &WorkspaceOntologyComposition,
+    runtime_symbols: &BTreeSet<String>,
 ) -> Vec<CompositionChangeDiagnostic> {
     let Some(existing) = existing else {
         return Vec::new();
     };
+    let new_ids = candidate
+        .modules
+        .iter()
+        .map(|module| module.id.ontology_id.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut diagnostics = Vec::new();
+    for module in existing
+        .modules
+        .iter()
+        .filter(|module| !new_ids.contains(module.id.ontology_id.as_str()))
+    {
+        let symbols = module
+            .document
+            .entity_types
+            .iter()
+            .map(|item| format!("entity:{}", item.name))
+            .chain(
+                module
+                    .document
+                    .relation_types
+                    .iter()
+                    .map(|item| format!("relation:{}", item.name)),
+            )
+            .chain(
+                module
+                    .document
+                    .properties
+                    .iter()
+                    .map(|item| format!("property:{}", item.name)),
+            );
+        for subject in symbols.filter(|symbol| runtime_symbols.contains(symbol)) {
+            diagnostics.push(CompositionChangeDiagnostic {
+                code: "removed_authority_has_stored_data".into(),
+                subject,
+                remediation: "retain the module or remove the affected stored data before publication".into(),
+            });
+        }
+    }
+    diagnostics
+}
+
+fn migration_diagnostics(
+    existing: Option<&WorkspaceOntologyComposition>,
+    candidate: &WorkspaceOntologyComposition,
+    runtime_symbols: &BTreeSet<String>,
+    cancellation: Option<&CancellationToken>,
+) -> Result<Vec<CompositionChangeDiagnostic>, GfError> {
+    let Some(existing) = existing else {
+        return Ok(Vec::new());
+    };
     let mut diagnostics = Vec::new();
     for old in &existing.modules {
+        if let Some(token) = cancellation {
+            token.checkpoint()?;
+        }
         let Some(new) = candidate
             .modules
             .iter()
@@ -319,12 +456,6 @@ fn migration_diagnostics(
             continue;
         };
         if old.id.authored_version == new.id.authored_version {
-            continue;
-        }
-        // A rollback republishes previously validated immutable authority. It
-        // still receives the full current-data/enforcement preflight, but does
-        // not invent a reverse transform that authored ontologies forbid.
-        if new.id.authored_version < old.id.authored_version {
             continue;
         }
         let migrations = new
@@ -348,8 +479,11 @@ fn migration_diagnostics(
                 ),
             }),
             Ok(steps) => {
-                for step in steps {
-                    if let TransformKind::Unknown { raw } = step.transform_kind {
+                for step in &steps {
+                    if let Some(token) = cancellation {
+                        token.checkpoint()?;
+                    }
+                    if let TransformKind::Unknown { raw } = &step.transform_kind {
                         diagnostics.push(CompositionChangeDiagnostic {
                             code: "migration_transform_unknown".into(),
                             subject: format!(
@@ -361,6 +495,37 @@ fn migration_diagnostics(
                             ),
                         });
                     }
+                    if let Some(subject) = migration_runtime_subject(&step.transform_kind) {
+                        if runtime_symbols.contains(&subject) {
+                            diagnostics.push(CompositionChangeDiagnostic {
+                                code: "migration_requires_data_rewrite".into(),
+                                subject,
+                                remediation: "publish a migration that stages and validates the affected graph/catalog data".into(),
+                            });
+                        }
+                    }
+                }
+                if !steps
+                    .iter()
+                    .any(|step| matches!(step.transform_kind, TransformKind::Unknown { .. }))
+                {
+                    match MigrationEngine::apply_document(old.document.clone(), &steps) {
+                        Ok(mut migrated) => {
+                            migrated.migrations.clone_from(&new.document.migrations);
+                            if migrated != new.document {
+                                diagnostics.push(CompositionChangeDiagnostic {
+                                    code: "migration_result_mismatch".into(),
+                                    subject: new.id.ontology_id.clone(),
+                                    remediation: "make the authored migration result exactly match the candidate ontology document".into(),
+                                });
+                            }
+                        }
+                        Err(error) => diagnostics.push(CompositionChangeDiagnostic {
+                            code: "migration_apply_failed".into(),
+                            subject: new.id.ontology_id.clone(),
+                            remediation: error.to_string(),
+                        }),
+                    }
                 }
             }
         }
@@ -368,7 +533,48 @@ fn migration_diagnostics(
             break;
         }
     }
-    diagnostics
+    Ok(diagnostics)
+}
+
+fn migration_runtime_subject(transform: &TransformKind) -> Option<String> {
+    match transform {
+        TransformKind::RenameType { old_name, .. }
+        | TransformKind::RemoveType { name: old_name } => {
+            Some(format!("{}:{old_name}", SymbolKind::Entity.as_str()))
+        }
+        TransformKind::RenameProperty { old_name, .. }
+        | TransformKind::RemoveProperty { name: old_name, .. } => {
+            Some(format!("{}:{old_name}", SymbolKind::Property.as_str()))
+        }
+        TransformKind::AddProperty { .. }
+        | TransformKind::AddType { .. }
+        | TransformKind::Unknown { .. } => None,
+    }
+}
+
+fn composition_request_fingerprint(
+    request: &CompositionChangeRequest,
+) -> Result<[u8; 32], GfError> {
+    let mut hasher = Sha256::new();
+    hasher.update(b"graphforge-composition-request/1");
+    hasher.update(request.expected_project_generation_uuid.as_bytes());
+    match &request.expected_composition_fingerprint {
+        Some(fingerprint) => {
+            hasher.update([1]);
+            hasher.update(fingerprint.as_bytes());
+        }
+        None => hasher.update([0]),
+    }
+    match request.context.actor_uuid {
+        Some(actor) => {
+            hasher.update([1]);
+            hasher.update(actor.as_bytes());
+        }
+        None => hasher.update([0]),
+    }
+    hasher.update(request.candidate.to_canonical_json()?);
+    hasher.update(b"require_conforming");
+    Ok(hasher.finalize().into())
 }
 
 fn symbol_declared(composition: &graphforge_ontology::CompiledComposition, encoded: &str) -> bool {
@@ -391,46 +597,139 @@ fn symbol_declared(composition: &graphforge_ontology::CompiledComposition, encod
         .is_ok()
 }
 
-fn runtime_symbols(graph: &GraphForge) -> BTreeSet<String> {
-    let catalog = graph
+fn runtime_symbols(
+    graph: &GraphForge,
+    cancellation: Option<&CancellationToken>,
+) -> Result<(BTreeSet<String>, bool), GfError> {
+    let current = graph.generation_for_read()?;
+    let persisted = crate::load_runtime_catalog(&current.graph_tree_root())?;
+    let live = graph
         .runtime_catalog
         .lock()
-        .expect("runtime catalog poisoned");
-    catalog
+        .expect("runtime catalog poisoned")
+        .clone();
+    let catalog_symbols = persisted
         .entity_types()
         .into_iter()
         .map(|name| format!("{}:{name}", SymbolKind::Entity.as_str()))
         .chain(
-            catalog
+            persisted
                 .relation_types()
                 .into_iter()
                 .map(|name| format!("{}:{name}", SymbolKind::Relation.as_str())),
         )
         .chain(
-            catalog
+            persisted
                 .property_names()
                 .map(|(_, name)| format!("{}:{name}", SymbolKind::Property.as_str())),
         )
-        .collect()
+        .collect::<BTreeSet<_>>();
+    let symbols = pinned_data_symbols(&current.graph_tree_root(), &persisted, cancellation)?;
+    let live_symbols = live
+        .entity_types()
+        .into_iter()
+        .map(|name| format!("{}:{name}", SymbolKind::Entity.as_str()))
+        .chain(
+            live.relation_types()
+                .into_iter()
+                .map(|name| format!("{}:{name}", SymbolKind::Relation.as_str())),
+        )
+        .chain(
+            live.property_names()
+                .map(|(_, name)| format!("{}:{name}", SymbolKind::Property.as_str())),
+        )
+        .collect::<BTreeSet<_>>();
+    Ok((
+        symbols.clone(),
+        catalog_symbols != live_symbols || !symbols.is_subset(&catalog_symbols),
+    ))
 }
 
-fn disposition_symbols(
-    disposition: &CompositionDataDisposition,
+fn pinned_data_symbols(
+    root: &std::path::Path,
+    catalog: &graphforge_ir::RuntimeCatalog,
+    cancellation: Option<&CancellationToken>,
 ) -> Result<BTreeSet<String>, GfError> {
-    match disposition {
-        CompositionDataDisposition::RequireConforming => Ok(BTreeSet::new()),
-        CompositionDataDisposition::ValidatedMigration { migrated_symbols } => {
-            let set = migrated_symbols.iter().cloned().collect::<BTreeSet<_>>();
-            if set.len() != migrated_symbols.len()
-                || migrated_symbols.windows(2).any(|pair| pair[0] >= pair[1])
-            {
-                return Err(GfError::Validation(
-                    "migrated symbols must be unique and sorted".into(),
-                ));
+    let mut symbols = BTreeSet::new();
+    let scan = |path: &std::path::Path| -> Result<Vec<arrow::record_batch::RecordBatch>, GfError> {
+        if !path.is_file() {
+            return Ok(Vec::new());
+        }
+        let reader = ParquetRecordBatchReaderBuilder::try_new(
+            File::open(path).map_err(|e| GfError::Storage(e.to_string()))?,
+        )
+        .map_err(|e| GfError::Storage(e.to_string()))?
+        .with_batch_size(1024)
+        .build()
+        .map_err(|e| GfError::Storage(e.to_string()))?;
+        let mut batches = Vec::new();
+        for batch in reader {
+            if let Some(token) = cancellation {
+                token.checkpoint()?;
             }
-            Ok(set)
+            batches.push(batch.map_err(|e| GfError::Storage(e.to_string()))?);
+        }
+        Ok(batches)
+    };
+    for batch in scan(&root.join("topology/nodes.parquet"))? {
+        let lists = batch
+            .column_by_name("type_ids")
+            .and_then(|v| v.as_any().downcast_ref::<ListArray>())
+            .ok_or_else(|| GfError::Validation("nodes type_ids schema drift".into()))?;
+        for row in 0..lists.len() {
+            let values = lists.value(row);
+            let ids = values
+                .as_any()
+                .downcast_ref::<UInt32Array>()
+                .ok_or_else(|| GfError::Validation("nodes type_ids value drift".into()))?;
+            for id in ids.values() {
+                let name = catalog
+                    .entity_type_name(graphforge_ir::RuntimeTypeId(*id))
+                    .ok_or_else(|| {
+                        GfError::Validation("node type id missing from pinned catalog".into())
+                    })?;
+                symbols.insert(format!("entity:{name}"));
+            }
         }
     }
+    for (directory, kind) in [
+        ("properties", "property"),
+        ("edge_properties", "property"),
+        ("topology/edges", "relation"),
+    ] {
+        let path = root.join(directory);
+        if !path.is_dir() {
+            continue;
+        }
+        let mut entries = fs::read_dir(path)
+            .map_err(|e| GfError::Storage(e.to_string()))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| GfError::Storage(e.to_string()))?;
+        entries.sort_by_key(|e| e.file_name());
+        for entry in entries {
+            let path = entry.path();
+            let stem = path
+                .file_stem()
+                .and_then(|v| v.to_str())
+                .unwrap_or_default()
+                .to_owned();
+            if stem.starts_with('_') {
+                continue;
+            }
+            for batch in scan(&path)? {
+                if batch.num_rows() > 0 {
+                    if kind == "relation" {
+                        symbols.insert(format!("relation:{stem}"));
+                    } else {
+                        for field in batch.schema().fields().iter().skip(1) {
+                            symbols.insert(format!("property:{}", field.name()));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(symbols)
 }
 
 fn hex(bytes: &[u8]) -> String {
@@ -446,11 +745,12 @@ fn hex(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use graphforge_ontology::{
-        CompositionLimits, EntityTypeDef, MigrationDef, OntologyDoc, compile_legacy_single_ontology,
+        AuthoredModule, CompositionLimits, EntityTypeDef, InventoryCompileRequest, MigrationDef,
+        OntologyDoc, OntologyModuleId, compile_inventory, module_document_digest,
     };
 
     use super::*;
-    use crate::OperationId;
+    use crate::{CheckpointRequest, OperationId, RevertCheckpointRequest};
 
     fn composition(
         version: &str,
@@ -474,11 +774,26 @@ mod tests {
             constraints: Vec::new(),
             migrations,
         };
-        let compiled =
-            compile_legacy_single_ontology(&document, false, CompositionLimits::default()).unwrap();
-        let mut composition = WorkspaceOntologyComposition::from_compiled(&compiled, Vec::new());
-        composition.profile_default = mode;
-        composition
+        let authored = AuthoredModule {
+            id: OntologyModuleId {
+                ontology_id: document.ontology_id.clone(),
+                authored_version: document.version.clone(),
+                canonical_digest: module_document_digest(&document).unwrap(),
+            },
+            dependencies: Vec::new(),
+            doc: document,
+            allow_projected_identity: false,
+        };
+        let compiled = compile_inventory(InventoryCompileRequest {
+            modules: std::slice::from_ref(&authored),
+            bridges: &[],
+            activation: &[],
+            profile_default: mode,
+            limits: CompositionLimits::default(),
+            cancelled: None,
+        })
+        .unwrap();
+        WorkspaceOntologyComposition::from_compiled(&compiled, Vec::new())
     }
 
     fn context(seed: u128) -> WriteContext {
@@ -513,7 +828,7 @@ mod tests {
         let first = request(
             &graph,
             8401,
-            composition("1", ActivationMode::Advisory, &["Person"], Vec::new()),
+            composition("1", ActivationMode::Strict, &["Person"], Vec::new()),
         );
         let first_preview = graph
             .preview_ontology_composition_change(&first, None)
@@ -521,6 +836,19 @@ mod tests {
         let first_receipt = graph
             .publish_ontology_composition_change(&first, &first_preview, None)
             .unwrap();
+        graph
+            .checkpoint(CheckpointRequest {
+                name: "composition-v1".into(),
+                description: Some("retained exact composition generation".into()),
+                idempotency_key: OperationId(Uuid::from_u128(8404)),
+                actor_uuid: None,
+            })
+            .unwrap();
+        graph
+            .execute("MATCH (n:Person) RETURN n")
+            .expect("normal execution consumes published composition authority");
+        assert!(graph.execute("MATCH (n:Unknown) RETURN n").is_err());
+        graph.set_graph_directedness(&context(8499), None).unwrap();
         assert_eq!(
             graph
                 .publish_ontology_composition_change(&first, &first_preview, None)
@@ -531,8 +859,11 @@ mod tests {
 
         let mut reopened = GraphForge::new(Some(path)).unwrap();
         let observed = reopened.workspace_ontology_composition().unwrap().unwrap();
-        assert_eq!(observed.profile_default, ActivationMode::Advisory);
+        assert_eq!(observed.profile_default, ActivationMode::Strict);
         assert_eq!(observed.modules[0].document.version, "1");
+        reopened
+            .execute("MATCH (n:Person) RETURN n")
+            .expect("reopen hydrates normal composition binding authority");
 
         let upgraded = request(
             &reopened,
@@ -558,12 +889,22 @@ mod tests {
             .publish_ontology_composition_change(&upgraded, &upgraded_preview, None)
             .unwrap();
 
-        let rollback = request(&reopened, 8403, observed.clone());
-        let rollback_preview = reopened
-            .preview_ontology_composition_change(&rollback, None)
-            .unwrap();
+        let downgrade = request(&reopened, 8403, observed.clone());
+        assert_eq!(
+            reopened
+                .preview_ontology_composition_change(&downgrade, None)
+                .unwrap()
+                .diagnostics[0]
+                .code,
+            "migration_unreachable"
+        );
         reopened
-            .publish_ontology_composition_change(&rollback, &rollback_preview, None)
+            .revert_to_checkpoint(RevertCheckpointRequest {
+                name: "composition-v1".into(),
+                reason: "restore retained validated authority".into(),
+                idempotency_key: OperationId(Uuid::from_u128(8405)),
+                actor_uuid: None,
+            })
             .unwrap();
         drop(reopened);
         assert_eq!(
@@ -612,7 +953,7 @@ mod tests {
     }
 
     #[test]
-    fn strict_preflight_reports_bounded_nonconforming_data() {
+    fn preflight_rejects_live_catalog_drift_from_bound_generation() {
         let graph = GraphForge::new(None).unwrap();
         {
             let mut catalog = graph.runtime_catalog.lock().unwrap();
@@ -628,18 +969,11 @@ mod tests {
         let preview = graph
             .preview_ontology_composition_change(&request, None)
             .unwrap();
-        assert_eq!(preview.diagnostics.len(), 64);
-        assert!(
-            preview
-                .diagnostics
-                .windows(2)
-                .all(|pair| pair[0].subject < pair[1].subject)
+        assert_eq!(preview.diagnostics.len(), 1);
+        assert_eq!(
+            preview.diagnostics[0].code,
+            "runtime_catalog_generation_drift"
         );
-        assert!(preview.diagnostics.iter().all(|diagnostic| {
-            diagnostic.code == "strict_runtime_observation"
-                && diagnostic.subject.starts_with("entity:Exploratory")
-                && !diagnostic.remediation.is_empty()
-        }));
     }
 
     #[test]

--- a/crates/graphforge-api/src/ontology_composition_lifecycle.rs
+++ b/crates/graphforge-api/src/ontology_composition_lifecycle.rs
@@ -1,9 +1,6 @@
 //! Atomic project-generation lifecycle for ontology composition authority.
 
-use std::collections::{BTreeMap, BTreeSet};
-use std::fs::{self, File};
-
-use arrow::array::{Array, ListArray, UInt32Array};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use graphforge_core::{GfError, ProjectErrorCode};
 use graphforge_ontology::{
@@ -13,7 +10,6 @@ use graphforge_storage::{
     WORKSPACE_CAPABILITY_ID, WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY, WorkspaceOntologyComposition,
     WorkspaceOntologyMode,
 };
-use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
@@ -70,7 +66,7 @@ pub struct CompositionChangePreview {
     /// Identity-sorted affected bridges.
     pub affected_bridges: Vec<String>,
     /// Portable-v2 disposition until #841 adds authenticated package support.
-    pub portable_compatibility: CompositionPortableCompatibility,
+    pub portable_compatibility: CompositionPortableReceipt,
     /// Bounded diagnostics; empty means publishable.
     pub diagnostics: Vec<CompositionChangeDiagnostic>,
 }
@@ -82,6 +78,27 @@ pub enum CompositionPortableCompatibility {
     /// Canonical authority is representable, while current package readers
     /// deliberately fail closed on the required `ontology-composition@1` token.
     RepresentableReaderUnsupported,
+    /// Candidate cannot be represented under the bounded semantic profile.
+    Unrepresentable,
+}
+
+/// Pure ADR-0022 representability evidence; this does not construct or admit a package.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompositionPortableReceipt {
+    /// Current reader disposition until #841 implements the authenticated codec.
+    pub disposition: CompositionPortableCompatibility,
+    /// Exact required feature token.
+    pub required_feature: String,
+    /// Exact transitive dependency selection rule.
+    pub dependency_rule: String,
+    /// Candidate composition identity.
+    pub composition_fingerprint: String,
+    /// Canonical participant payload bytes.
+    pub canonical_bytes: u64,
+    /// Canonically ordered module identities.
+    pub modules: Vec<String>,
+    /// Canonically ordered bridge identities.
+    pub bridges: Vec<String>,
 }
 
 /// Durable publication receipt.
@@ -151,7 +168,17 @@ impl GraphForge {
         if let Some(token) = cancellation {
             token.checkpoint()?;
         }
-        let candidate_bytes = request.candidate.to_canonical_json()?;
+        // Preview must remain capable of returning bounded diagnostics for an
+        // invalid candidate; the validated canonical encoder intentionally
+        // rejects such records before a receipt could otherwise be formed.
+        let mut candidate_bytes = serde_json::to_vec(&request.candidate)
+            .map_err(|_| GfError::Validation("candidate composition cannot be encoded".into()))?;
+        candidate_bytes.push(b'\n');
+        if candidate_bytes.len() > 16 * 1024 * 1024 {
+            return Err(GfError::Validation(
+                "candidate composition exceeds preview byte limit".into(),
+            ));
+        }
         let (runtime_symbols, catalog_drift) = runtime_symbols(self, cancellation)?;
         let mut diagnostics = Vec::new();
         if compiled.is_none() {
@@ -168,6 +195,71 @@ impl GraphForge {
                 remediation: "reopen the exact current generation before composition preflight"
                     .into(),
             });
+        }
+        if let Some(compiled) = &compiled {
+            let current_bindings = self
+                .semantic_storage_bindings
+                .lock()
+                .expect("semantic storage binding lock poisoned")
+                .clone();
+            if let Err(error) = graphforge_storage::SemanticStorageBindings::project_with_graph_scan(
+                compiled,
+                current_bindings.as_ref(),
+                &self.dir,
+            ) {
+                let retained = compiled
+                    .modules
+                    .iter()
+                    .flat_map(|module| module.symbols.iter().cloned())
+                    .collect::<HashSet<_>>();
+                let removed = current_bindings
+                    .as_ref()
+                    .into_iter()
+                    .flat_map(|bindings| bindings.bindings.iter())
+                    .filter(|binding| !retained.contains(&binding.symbol))
+                    .map(|binding| {
+                        graphforge_storage::SemanticStorageBindings::binding_has_retained_data(
+                            binding, &self.dir,
+                        )
+                        .map(|has_data| has_data.then_some(binding))
+                    })
+                    .collect::<Result<Vec<Option<_>>, _>>()?
+                    .into_iter()
+                    .flatten()
+                    .take(64usize.saturating_sub(diagnostics.len()))
+                    .collect::<Vec<_>>();
+                if removed.is_empty() {
+                    diagnostics.push(CompositionChangeDiagnostic {
+                        code: "stored_semantic_data_incompatible".into(),
+                        subject: request.candidate.composition_fingerprint.clone(),
+                        remediation: error.to_string(),
+                    });
+                } else {
+                    for binding in removed {
+                        let owner = binding.owner.as_ref().map_or_else(
+                            || "none".into(),
+                            |owner| {
+                                format!(
+                                    "{}:{}:{}",
+                                    owner.module.display_ref(),
+                                    owner.kind.as_str(),
+                                    owner.local_id
+                                )
+                            },
+                        );
+                        diagnostics.push(CompositionChangeDiagnostic {
+                            code: "stored_semantic_data_incompatible".into(),
+                            subject: format!(
+                                "{}:{}:{} owner={owner}",
+                                binding.symbol.module.display_ref(),
+                                binding.symbol.kind.as_str(),
+                                binding.symbol.local_id
+                            ),
+                            remediation: error.to_string(),
+                        });
+                    }
+                }
+            }
         }
         diagnostics.extend(migration_diagnostics(
             existing.as_ref(),
@@ -261,6 +353,25 @@ impl GraphForge {
             .filter(|identity| old_bridges.get(*identity) != new_bridges.get(*identity))
             .cloned()
             .collect::<BTreeSet<_>>();
+        let portable_compatibility = match portable_receipt(&request.candidate, &candidate_bytes) {
+            Ok(receipt) => receipt,
+            Err(error) => {
+                diagnostics.push(CompositionChangeDiagnostic {
+                    code: "portable_composition_unrepresentable".into(),
+                    subject: request.candidate.composition_fingerprint.clone(),
+                    remediation: error.to_string(),
+                });
+                CompositionPortableReceipt {
+                    disposition: CompositionPortableCompatibility::Unrepresentable,
+                    required_feature: "ontology-composition@1".into(),
+                    dependency_rule: "required-transitive-closure/1".into(),
+                    composition_fingerprint: request.candidate.composition_fingerprint.clone(),
+                    canonical_bytes: u64::try_from(candidate_bytes.len()).unwrap_or(u64::MAX),
+                    modules: Vec::new(),
+                    bridges: Vec::new(),
+                }
+            }
+        };
         diagnostics
             .sort_by(|left, right| (&left.code, &left.subject).cmp(&(&right.code, &right.subject)));
         diagnostics.truncate(64);
@@ -271,16 +382,16 @@ impl GraphForge {
                 || request.candidate.composition_fingerprint.clone(),
                 |value| value.fingerprint.clone(),
             ),
-            candidate_sha256: hex(&Sha256::digest(candidate_bytes)),
+            candidate_sha256: hex(&Sha256::digest(&candidate_bytes)),
             affected_modules: affected_modules.into_iter().collect(),
             affected_bridges: affected_bridges.into_iter().collect(),
-            portable_compatibility:
-                CompositionPortableCompatibility::RepresentableReaderUnsupported,
+            portable_compatibility,
             diagnostics,
         })
     }
 
     /// Revalidate and atomically publish one complete composition replacement.
+    #[allow(clippy::too_many_lines)] // replay, preflight, atomic publish, and live swap are one transaction
     pub fn publish_ontology_composition_change(
         &mut self,
         request: &CompositionChangeRequest,
@@ -350,10 +461,28 @@ impl GraphForge {
             ActivationMode::Advisory => WorkspaceOntologyMode::Advisory,
             ActivationMode::Strict => WorkspaceOntologyMode::Strict,
         };
+        let compiled_candidate = request.candidate.compile()?;
+        let previous_bindings = self
+            .semantic_storage_bindings
+            .lock()
+            .expect("semantic storage binding lock poisoned")
+            .clone();
+        let published_bindings =
+            graphforge_storage::SemanticStorageBindings::project_with_graph_scan(
+                &compiled_candidate,
+                previous_bindings.as_ref(),
+                &self.dir,
+            )?;
         let published_binding = graphforge_ir::CompositionBindingContext::new(
-            std::sync::Arc::new(request.candidate.compile()?),
+            std::sync::Arc::new(compiled_candidate),
             request.candidate.bridges.clone(),
             graphforge_ir::CompositionBindingLimits::default(),
+        )
+        .with_generation_storage_ids(
+            published_bindings
+                .bindings
+                .iter()
+                .map(|binding| (binding.symbol.clone(), binding.storage_id)),
         );
         crate::workspace_ontology::publish_workspace_records(
             self,
@@ -362,11 +491,16 @@ impl GraphForge {
             &ontology,
             &configuration,
             Some(&request.candidate),
+            Some(&published_bindings),
             Some(expected_generation_uuid),
             cancellation,
         )?;
         *self
-            .composition_binding
+            .semantic_storage_bindings
+            .lock()
+            .expect("semantic storage binding lock poisoned") = Some(published_bindings);
+        *self
+            .default_composition_context
             .lock()
             .expect("composition binding lock poisoned") =
             Some(std::sync::Arc::new(published_binding));
@@ -495,14 +629,14 @@ fn migration_diagnostics(
                             ),
                         });
                     }
-                    if let Some(subject) = migration_runtime_subject(&step.transform_kind) {
-                        if runtime_symbols.contains(&subject) {
-                            diagnostics.push(CompositionChangeDiagnostic {
-                                code: "migration_requires_data_rewrite".into(),
-                                subject,
-                                remediation: "publish a migration that stages and validates the affected graph/catalog data".into(),
-                            });
-                        }
+                    if let Some(subject) = migration_runtime_subject(&step.transform_kind)
+                        && runtime_symbols.contains(&subject)
+                    {
+                        diagnostics.push(CompositionChangeDiagnostic {
+                            code: "migration_requires_data_rewrite".into(),
+                            subject,
+                            remediation: "publish a migration that stages and validates the affected graph/catalog data".into(),
+                        });
                     }
                 }
                 if !steps
@@ -624,7 +758,13 @@ fn runtime_symbols(
                 .map(|(_, name)| format!("{}:{name}", SymbolKind::Property.as_str())),
         )
         .collect::<BTreeSet<_>>();
-    let symbols = pinned_data_symbols(&current.graph_tree_root(), &persisted, cancellation)?;
+    if let Some(token) = cancellation {
+        token.checkpoint()?;
+    }
+    // Tagged runtime observations are governed by the pinned RuntimeCatalog.
+    // Ontology-owned persisted data is validated separately through the exact
+    // generation semantic binding authority and its bounded graph scan.
+    let symbols = catalog_symbols.clone();
     let live_symbols = live
         .entity_types()
         .into_iter()
@@ -645,91 +785,60 @@ fn runtime_symbols(
     ))
 }
 
-fn pinned_data_symbols(
-    root: &std::path::Path,
-    catalog: &graphforge_ir::RuntimeCatalog,
-    cancellation: Option<&CancellationToken>,
-) -> Result<BTreeSet<String>, GfError> {
-    let mut symbols = BTreeSet::new();
-    let scan = |path: &std::path::Path| -> Result<Vec<arrow::record_batch::RecordBatch>, GfError> {
-        if !path.is_file() {
-            return Ok(Vec::new());
-        }
-        let reader = ParquetRecordBatchReaderBuilder::try_new(
-            File::open(path).map_err(|e| GfError::Storage(e.to_string()))?,
-        )
-        .map_err(|e| GfError::Storage(e.to_string()))?
-        .with_batch_size(1024)
-        .build()
-        .map_err(|e| GfError::Storage(e.to_string()))?;
-        let mut batches = Vec::new();
-        for batch in reader {
-            if let Some(token) = cancellation {
-                token.checkpoint()?;
-            }
-            batches.push(batch.map_err(|e| GfError::Storage(e.to_string()))?);
-        }
-        Ok(batches)
-    };
-    for batch in scan(&root.join("topology/nodes.parquet"))? {
-        let lists = batch
-            .column_by_name("type_ids")
-            .and_then(|v| v.as_any().downcast_ref::<ListArray>())
-            .ok_or_else(|| GfError::Validation("nodes type_ids schema drift".into()))?;
-        for row in 0..lists.len() {
-            let values = lists.value(row);
-            let ids = values
-                .as_any()
-                .downcast_ref::<UInt32Array>()
-                .ok_or_else(|| GfError::Validation("nodes type_ids value drift".into()))?;
-            for id in ids.values() {
-                let name = catalog
-                    .entity_type_name(graphforge_ir::RuntimeTypeId(*id))
-                    .ok_or_else(|| {
-                        GfError::Validation("node type id missing from pinned catalog".into())
-                    })?;
-                symbols.insert(format!("entity:{name}"));
-            }
-        }
+fn portable_receipt(
+    candidate: &WorkspaceOntologyComposition,
+    canonical_bytes: &[u8],
+) -> Result<CompositionPortableReceipt, GfError> {
+    let limits = graphforge_storage::PortableV2Limits::default();
+    let component_count = candidate
+        .modules
+        .len()
+        .checked_add(candidate.bridges.len())
+        .ok_or_else(|| GfError::Validation("portable composition count overflows".into()))?;
+    let byte_count = u64::try_from(canonical_bytes.len())
+        .map_err(|_| GfError::Validation("portable composition bytes overflow".into()))?;
+    if u64::try_from(component_count).unwrap_or(u64::MAX) > limits.max_components
+        || byte_count > limits.max_entry_bytes
+        || byte_count > limits.max_manifest_bytes
+        || byte_count > limits.max_total_bytes
+    {
+        return Err(GfError::Validation(
+            "ontology composition is not representable within portable-v2 limits".into(),
+        ));
     }
-    for (directory, kind) in [
-        ("properties", "property"),
-        ("edge_properties", "property"),
-        ("topology/edges", "relation"),
-    ] {
-        let path = root.join(directory);
-        if !path.is_dir() {
-            continue;
-        }
-        let mut entries = fs::read_dir(path)
-            .map_err(|e| GfError::Storage(e.to_string()))?
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| GfError::Storage(e.to_string()))?;
-        entries.sort_by_key(|e| e.file_name());
-        for entry in entries {
-            let path = entry.path();
-            let stem = path
-                .file_stem()
-                .and_then(|v| v.to_str())
-                .unwrap_or_default()
-                .to_owned();
-            if stem.starts_with('_') {
-                continue;
-            }
-            for batch in scan(&path)? {
-                if batch.num_rows() > 0 {
-                    if kind == "relation" {
-                        symbols.insert(format!("relation:{stem}"));
-                    } else {
-                        for field in batch.schema().fields().iter().skip(1) {
-                            symbols.insert(format!("property:{}", field.name()));
-                        }
-                    }
-                }
-            }
-        }
+    let mut modules = candidate
+        .modules
+        .iter()
+        .map(|module| module.id.display_ref())
+        .collect::<Vec<_>>();
+    modules.sort();
+    modules.dedup();
+    if modules.len() != candidate.modules.len() {
+        return Err(GfError::Validation(
+            "portable composition module identities are not unique".into(),
+        ));
     }
-    Ok(symbols)
+    let mut bridges = candidate
+        .bridges
+        .iter()
+        .map(|bridge| format!("{}@{}", bridge.bridge_id, bridge.authored_version))
+        .collect::<Vec<_>>();
+    bridges.sort();
+    bridges.dedup();
+    if bridges.len() != candidate.bridges.len() {
+        return Err(GfError::Validation(
+            "portable composition bridge identities are not unique".into(),
+        ));
+    }
+    Ok(CompositionPortableReceipt {
+        disposition: CompositionPortableCompatibility::RepresentableReaderUnsupported,
+        required_feature: "ontology-composition@1".into(),
+        dependency_rule: "required-transitive-closure/1".into(),
+        composition_fingerprint: candidate.composition_fingerprint.clone(),
+        canonical_bytes: byte_count,
+        modules,
+        bridges,
+    })
 }
 
 fn hex(bytes: &[u8]) -> String {
@@ -745,8 +854,11 @@ fn hex(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use graphforge_ontology::{
-        AuthoredModule, CompositionLimits, EntityTypeDef, InventoryCompileRequest, MigrationDef,
-        OntologyDoc, OntologyModuleId, compile_inventory, module_document_digest,
+        ActivationRecord, ActivationScope, AuthoredModule, BridgeAssertion, BridgeDocument,
+        BridgePredicate, BridgeProvenance, BridgeSetId, CompositionLimits, EntityTypeDef,
+        InventoryCompileRequest, MappingMethod, MigrationDef, OntologyDoc, OntologyModuleId,
+        QualifiedSymbol, SymbolKind, bridge_document_digest, compile_inventory,
+        module_document_digest,
     };
 
     use super::*;
@@ -758,8 +870,18 @@ mod tests {
         entity_names: &[&str],
         migrations: Vec<MigrationDef>,
     ) -> WorkspaceOntologyComposition {
+        composition_named("acme", version, mode, entity_names, migrations)
+    }
+
+    fn composition_named(
+        ontology_id: &str,
+        version: &str,
+        mode: ActivationMode,
+        entity_names: &[&str],
+        migrations: Vec<MigrationDef>,
+    ) -> WorkspaceOntologyComposition {
         let document = OntologyDoc {
-            ontology_id: "acme".into(),
+            ontology_id: ontology_id.into(),
             version: version.into(),
             entity_types: entity_names
                 .iter()
@@ -803,6 +925,84 @@ mod tests {
         }
     }
 
+    fn bridged_composition() -> WorkspaceOntologyComposition {
+        let module = |ontology_id: &str| {
+            let document = OntologyDoc {
+                ontology_id: ontology_id.into(),
+                version: "1".into(),
+                entity_types: vec![EntityTypeDef {
+                    name: "Person".into(),
+                    r#abstract: false,
+                    parent: None,
+                }],
+                relation_types: Vec::new(),
+                properties: Vec::new(),
+                constraints: Vec::new(),
+                migrations: Vec::new(),
+            };
+            AuthoredModule {
+                id: OntologyModuleId {
+                    ontology_id: ontology_id.into(),
+                    authored_version: "1".into(),
+                    canonical_digest: module_document_digest(&document).unwrap(),
+                },
+                dependencies: Vec::new(),
+                doc: document,
+                allow_projected_identity: false,
+            }
+        };
+        let source = module("source");
+        let target = module("target");
+        let qualified = |module: &AuthoredModule| QualifiedSymbol {
+            module: module.id.clone(),
+            kind: SymbolKind::Entity,
+            local_id: "Person".into(),
+        };
+        let bridge = BridgeDocument {
+            bridge_id: "https://graphforge.dev/bridge/person".into(),
+            authored_version: "1".into(),
+            source_modules: vec![source.id.clone()],
+            target_modules: vec![target.id.clone()],
+            dependencies: Vec::new(),
+            shared_surfaces: Vec::new(),
+            assertions: vec![BridgeAssertion {
+                source: qualified(&source),
+                target: qualified(&target),
+                predicate: BridgePredicate::Equivalent,
+                directional: false,
+                provenance: BridgeProvenance {
+                    method: MappingMethod::Authored,
+                    confidence: None,
+                    justification: "governed identity".into(),
+                    evidence_refs: Vec::new(),
+                },
+                valid_from: None,
+                valid_to: None,
+            }],
+            enforcement: Some(ActivationMode::Strict),
+        };
+        let bridge_id = BridgeSetId {
+            bridge_id: bridge.bridge_id.clone(),
+            authored_version: bridge.authored_version.clone(),
+            canonical_digest: bridge_document_digest(&bridge).unwrap(),
+        };
+        let activation = vec![ActivationRecord {
+            scope: ActivationScope::Module,
+            subject: source.id.display_ref(),
+            mode: ActivationMode::Advisory,
+        }];
+        let compiled = compile_inventory(InventoryCompileRequest {
+            modules: &[source, target],
+            bridges: &[bridge_id],
+            activation: &activation,
+            profile_default: ActivationMode::Strict,
+            limits: CompositionLimits::default(),
+            cancelled: None,
+        })
+        .unwrap();
+        WorkspaceOntologyComposition::from_compiled(&compiled, vec![bridge])
+    }
+
     fn request(
         graph: &GraphForge,
         seed: u128,
@@ -833,6 +1033,15 @@ mod tests {
         let first_preview = graph
             .preview_ontology_composition_change(&first, None)
             .unwrap();
+        assert_eq!(
+            first_preview.portable_compatibility.required_feature,
+            "ontology-composition@1"
+        );
+        assert_eq!(
+            first_preview.portable_compatibility.dependency_rule,
+            "required-transitive-closure/1"
+        );
+        assert_eq!(first_preview.portable_compatibility.modules.len(), 1);
         let first_receipt = graph
             .publish_ontology_composition_change(&first, &first_preview, None)
             .unwrap();
@@ -950,6 +1159,298 @@ mod tests {
                 .is_err()
         );
         assert_eq!(*graph.current_generation_uuid.lock().unwrap(), published);
+    }
+
+    #[test]
+    fn scoped_activation_reopens_and_bridge_invalidation_cannot_publish() {
+        let project = tempfile::tempdir().unwrap();
+        let path = project.path().to_str().unwrap();
+        let mut graph = GraphForge::new(Some(path)).unwrap();
+        let initial = request(&graph, 8411, bridged_composition());
+        let preview = graph
+            .preview_ontology_composition_change(&initial, None)
+            .unwrap();
+        assert!(preview.diagnostics.is_empty(), "{:?}", preview.diagnostics);
+        graph
+            .publish_ontology_composition_change(&initial, &preview, None)
+            .unwrap();
+        let published = *graph.current_generation_uuid.lock().unwrap();
+        drop(graph);
+
+        let mut reopened = GraphForge::new(Some(path)).unwrap();
+        let authority = reopened.workspace_ontology_composition().unwrap().unwrap();
+        assert_eq!(authority.activation.len(), 1);
+        assert_eq!(authority.activation[0].mode, ActivationMode::Advisory);
+        reopened
+            .execute("MATCH (n:`source:Person`) RETURN n")
+            .expect("reopened scoped authority must drive normal execution");
+
+        let mut invalid = authority;
+        invalid
+            .modules
+            .retain(|module| module.document.ontology_id != "target");
+        let invalid_request = request(&reopened, 8412, invalid);
+        let invalid_preview = reopened
+            .preview_ontology_composition_change(&invalid_request, None)
+            .unwrap();
+        assert!(
+            invalid_preview
+                .diagnostics
+                .iter()
+                .any(|diagnostic| { diagnostic.code == "candidate_composition_invalid" })
+        );
+        assert!(
+            reopened
+                .publish_ontology_composition_change(&invalid_request, &invalid_preview, None)
+                .is_err()
+        );
+        assert_eq!(*reopened.current_generation_uuid.lock().unwrap(), published);
+    }
+
+    #[test]
+    fn intervening_generation_and_interrupted_pointer_leave_authority_old_or_complete() {
+        let project = tempfile::tempdir().unwrap();
+        let path = project.path().to_str().unwrap();
+        let mut graph = GraphForge::new(Some(path)).unwrap();
+        let initial = request(
+            &graph,
+            8413,
+            composition("1", ActivationMode::Strict, &["Person"], Vec::new()),
+        );
+        let preview = graph
+            .preview_ontology_composition_change(&initial, None)
+            .unwrap();
+        graph
+            .publish_ontology_composition_change(&initial, &preview, None)
+            .unwrap();
+        let retained = graph.workspace_ontology_composition().unwrap().unwrap();
+
+        let stale = request(
+            &graph,
+            8414,
+            composition(
+                "2",
+                ActivationMode::Strict,
+                &["Person", "Company"],
+                Vec::new(),
+            ),
+        );
+        let stale_preview = graph
+            .preview_ontology_composition_change(&stale, None)
+            .unwrap();
+        graph.set_graph_directedness(&context(8415), None).unwrap();
+        let intervening = *graph.current_generation_uuid.lock().unwrap();
+        assert!(
+            graph
+                .publish_ontology_composition_change(&stale, &stale_preview, None)
+                .is_err()
+        );
+        assert_eq!(*graph.current_generation_uuid.lock().unwrap(), intervening);
+        assert_eq!(
+            graph.workspace_ontology_composition().unwrap(),
+            Some(retained.clone())
+        );
+        drop(graph);
+
+        let reopened = GraphForge::new(Some(path)).unwrap();
+        assert_eq!(
+            *reopened.current_generation_uuid.lock().unwrap(),
+            intervening
+        );
+        assert_eq!(
+            reopened.workspace_ontology_composition().unwrap(),
+            Some(retained)
+        );
+        reopened.execute("MATCH (n:Person) RETURN n").unwrap();
+    }
+
+    #[test]
+    fn composition_publication_failpoint_child() {
+        let Ok(root) = std::env::var("GRAPHFORGE_COMPOSITION_FAILPOINT_ROOT") else {
+            return;
+        };
+        let mut graph = GraphForge::new(Some(&root)).unwrap();
+        let upgrade = request(
+            &graph,
+            8417,
+            composition(
+                "2",
+                ActivationMode::Strict,
+                &["Person", "Company"],
+                vec![MigrationDef {
+                    from_version: "1".into(),
+                    to_version: "2".into(),
+                    transform_kind: "add_type:Company".into(),
+                    script_ref: None,
+                    checksum: None,
+                }],
+            ),
+        );
+        let preview = graph
+            .preview_ontology_composition_change(&upgrade, None)
+            .unwrap();
+        graph
+            .publish_ontology_composition_change(&upgrade, &preview, None)
+            .expect("configured composition publication failpoint did not terminate");
+    }
+
+    #[test]
+    fn interrupted_real_publication_reopens_old_or_complete_authority() {
+        for (failpoint, expected_version) in [
+            ("project.before_current_replace", "1"),
+            ("project.after_current_replace", "2"),
+        ] {
+            let project = tempfile::tempdir().unwrap();
+            let path = project.path().to_str().unwrap();
+            let mut graph = GraphForge::new(Some(path)).unwrap();
+            let initial = request(
+                &graph,
+                8416,
+                composition("1", ActivationMode::Strict, &["Person"], Vec::new()),
+            );
+            let preview = graph
+                .preview_ontology_composition_change(&initial, None)
+                .unwrap();
+            graph
+                .publish_ontology_composition_change(&initial, &preview, None)
+                .unwrap();
+            drop(graph);
+            let status = std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "ontology_composition_lifecycle::tests::composition_publication_failpoint_child",
+                    "--nocapture",
+                ])
+                .env("GRAPHFORGE_COMPOSITION_FAILPOINT_ROOT", path)
+                .env("GRAPHFORGE_PROJECT_FAILPOINTS", "graphforge-internal-subprocess-v1")
+                .env("GRAPHFORGE_PROJECT_FAILPOINT", failpoint)
+                .status()
+                .unwrap();
+            assert_eq!(status.code(), Some(86), "{failpoint}");
+            let reopened = GraphForge::new(Some(path)).unwrap();
+            let authority = reopened.workspace_ontology_composition().unwrap().unwrap();
+            assert_eq!(
+                authority.modules[0].document.version, expected_version,
+                "{failpoint}"
+            );
+            reopened.execute("MATCH (n:Person) RETURN n").unwrap();
+            if expected_version == "2" {
+                reopened.execute("MATCH (n:Company) RETURN n").unwrap();
+            } else {
+                assert!(reopened.execute("MATCH (n:Company) RETURN n").is_err());
+            }
+        }
+    }
+
+    #[test]
+    fn replace_and_remove_are_safe_only_without_retained_semantic_data() {
+        let project = tempfile::tempdir().unwrap();
+        let path = project.path().to_str().unwrap();
+        let mut graph = GraphForge::new(Some(path)).unwrap();
+        let initial = request(
+            &graph,
+            8430,
+            composition("1", ActivationMode::Strict, &["Person"], Vec::new()),
+        );
+        let preview = graph
+            .preview_ontology_composition_change(&initial, None)
+            .unwrap();
+        graph
+            .publish_ontology_composition_change(&initial, &preview, None)
+            .unwrap();
+
+        let replacement = request(
+            &graph,
+            8431,
+            composition_named(
+                "replacement",
+                "1",
+                ActivationMode::Strict,
+                &["Company"],
+                Vec::new(),
+            ),
+        );
+        let preview = graph
+            .preview_ontology_composition_change(&replacement, None)
+            .unwrap();
+        assert!(preview.diagnostics.is_empty(), "{:?}", preview.diagnostics);
+        graph
+            .publish_ontology_composition_change(&replacement, &preview, None)
+            .unwrap();
+
+        let removal = request(
+            &graph,
+            8432,
+            composition("1", ActivationMode::Strict, &[], Vec::new()),
+        );
+        let preview = graph
+            .preview_ontology_composition_change(&removal, None)
+            .unwrap();
+        assert!(preview.diagnostics.is_empty(), "{:?}", preview.diagnostics);
+        graph
+            .publish_ontology_composition_change(&removal, &preview, None)
+            .unwrap();
+        drop(graph);
+        assert!(
+            GraphForge::new(Some(path))
+                .unwrap()
+                .workspace_ontology_composition()
+                .unwrap()
+                .unwrap()
+                .modules[0]
+                .document
+                .entity_types
+                .is_empty()
+        );
+
+        let mut populated = GraphForge::new(None).unwrap();
+        let initial = request(
+            &populated,
+            8433,
+            composition(
+                "1",
+                ActivationMode::Strict,
+                &["Person", "UnusedCompany"],
+                Vec::new(),
+            ),
+        );
+        let preview = populated
+            .preview_ontology_composition_change(&initial, None)
+            .unwrap();
+        populated
+            .publish_ontology_composition_change(&initial, &preview, None)
+            .unwrap();
+        populated.execute("CREATE (n:Person)").unwrap();
+        let before = *populated.current_generation_uuid.lock().unwrap();
+        let removal = request(
+            &populated,
+            8434,
+            composition("1", ActivationMode::Strict, &[], Vec::new()),
+        );
+        let preview = populated
+            .preview_ontology_composition_change(&removal, None)
+            .unwrap();
+        assert!(
+            preview
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "stored_semantic_data_incompatible")
+        );
+        let incompatible = preview
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "stored_semantic_data_incompatible")
+            .map(|diagnostic| diagnostic.subject.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(incompatible.len(), 1, "{incompatible:?}");
+        assert!(incompatible[0].contains(":entity:Person"));
+        assert!(!incompatible[0].contains("UnusedCompany"));
+        assert!(
+            populated
+                .publish_ontology_composition_change(&removal, &preview, None)
+                .is_err()
+        );
+        assert_eq!(*populated.current_generation_uuid.lock().unwrap(), before);
     }
 
     #[test]

--- a/crates/graphforge-api/src/workspace_ontology.rs
+++ b/crates/graphforge-api/src/workspace_ontology.rs
@@ -91,6 +91,7 @@ impl GraphForge {
             composition.as_ref(),
             None,
             None,
+            None,
         )
     }
 
@@ -172,6 +173,7 @@ impl GraphForge {
             Some(&composition),
             None,
             None,
+            None,
         )?;
         self.ontology = Some(OntologyHandle::new(runtime));
         self.ontology_document = Some(document);
@@ -213,7 +215,16 @@ impl GraphForge {
             None,
             None,
             None,
+            None,
         )?;
+        *self
+            .default_composition_context
+            .lock()
+            .expect("default composition context lock poisoned") = None;
+        *self
+            .semantic_storage_bindings
+            .lock()
+            .expect("semantic storage binding lock poisoned") = None;
         self.ontology = None;
         self.ontology_document = None;
         self.ontology_mode = OntologyMode::Exploratory;
@@ -235,6 +246,7 @@ fn current_configuration(graph: &GraphForge) -> Result<WorkspaceConfiguration, G
     WorkspaceConfiguration::from_canonical_json(&snapshot.bytes)
 }
 
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)] // complete participant transaction
 pub(crate) fn publish_workspace_records(
     graph: &mut GraphForge,
     operation_uuid: uuid::Uuid,
@@ -242,6 +254,7 @@ pub(crate) fn publish_workspace_records(
     ontology: &WorkspaceOntology,
     configuration: &WorkspaceConfiguration,
     composition: Option<&graphforge_storage::WorkspaceOntologyComposition>,
+    semantic_bindings: Option<&graphforge_storage::SemanticStorageBindings>,
     generation_uuid_override: Option<uuid::Uuid>,
     cancellation: Option<&crate::CancellationToken>,
 ) -> Result<(), GfError> {
@@ -276,7 +289,11 @@ pub(crate) fn publish_workspace_records(
                     graphforge_storage::WORKSPACE_ONTOLOGY_FAMILY
                         | graphforge_storage::WORKSPACE_CONFIGURATION_FAMILY
                         | graphforge_storage::WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY
-                ))
+                )
+                || semantic_bindings.is_some()
+                    && snapshot.capability_id == graphforge_storage::GRAPH_CAPABILITY_ID
+                    && snapshot.record_family_id
+                        == graphforge_storage::GRAPH_SEMANTIC_BINDINGS_FAMILY)
         })
         .map(snapshot_to_participant)
         .collect::<Result<Vec<_>, _>>()?;
@@ -286,6 +303,9 @@ pub(crate) fn publish_workspace_records(
     ));
     if let Some(composition) = composition {
         participants.push(composition.to_project_participant()?);
+    }
+    if let Some(bindings) = semantic_bindings {
+        participants.push(bindings.to_project_participant()?);
     }
     participants.push(workspace_participant(
         graphforge_storage::WORKSPACE_CONFIGURATION_FAMILY,

--- a/crates/graphforge-api/src/workspace_ontology.rs
+++ b/crates/graphforge-api/src/workspace_ontology.rs
@@ -3,7 +3,10 @@
 use std::path::PathBuf;
 
 use graphforge_core::{GfError, OntologyMode};
-use graphforge_ontology::{OntologyCompiler, OntologyHandle, OntologyLoader};
+use graphforge_ontology::{
+    ActivationMode, CompositionLimits, OntologyCompiler, OntologyHandle, OntologyLoader,
+    compile_legacy_single_ontology,
+};
 use graphforge_storage::{
     GraphDirectedness, ProjectCapability, ProjectGenerationRequest, ProjectParticipant,
     ProjectParticipantEncoding, ProjectStageOutcome, WorkspaceConfiguration, WorkspaceOntology,
@@ -76,6 +79,7 @@ impl GraphForge {
         directedness: Option<GraphDirectedness>,
     ) -> Result<(), GfError> {
         let ontology = self.workspace_ontology()?;
+        let composition = self.workspace_ontology_composition()?;
         let mut configuration = current_configuration(self)?;
         configuration.graph_directedness = directedness;
         publish_workspace_records(
@@ -84,6 +88,7 @@ impl GraphForge {
             context.actor_uuid,
             &ontology,
             &configuration,
+            composition.as_ref(),
         )
     }
 
@@ -111,6 +116,20 @@ impl GraphForge {
             .map_err(|error| GfError::Ontology(format!("failed to load ontology: {error}")))?;
         let runtime = OntologyCompiler::compile(&document)
             .map_err(|error| GfError::Ontology(format!("failed to compile ontology: {error}")))?;
+        let compiled_composition =
+            compile_legacy_single_ontology(&document, false, CompositionLimits::default())
+                .map_err(|error| {
+                    GfError::Ontology(format!("failed to compile ontology composition: {error}"))
+                })?;
+        let mut composition = graphforge_storage::WorkspaceOntologyComposition::from_compiled(
+            &compiled_composition,
+            Vec::new(),
+        );
+        composition.profile_default = match requested_mode {
+            OntologyMode::Exploratory => ActivationMode::Exploratory,
+            OntologyMode::Advisory => ActivationMode::Advisory,
+            OntologyMode::Strict => ActivationMode::Strict,
+        };
         let canonical_ontology = serde_json::to_value(&document)
             .map_err(|error| GfError::Ontology(format!("failed to encode ontology: {error}")))?;
         let canonical_bytes = serde_json::to_vec(&canonical_ontology)
@@ -130,6 +149,7 @@ impl GraphForge {
             context.actor_uuid,
             &record,
             &configuration,
+            Some(&composition),
         )?;
         self.ontology = Some(OntologyHandle::new(runtime));
         self.ontology_document = Some(document);
@@ -168,6 +188,7 @@ impl GraphForge {
             context.actor_uuid,
             &WorkspaceOntology::none(),
             &configuration,
+            None,
         )?;
         self.ontology = None;
         self.ontology_document = None;
@@ -190,12 +211,13 @@ fn current_configuration(graph: &GraphForge) -> Result<WorkspaceConfiguration, G
     WorkspaceConfiguration::from_canonical_json(&snapshot.bytes)
 }
 
-fn publish_workspace_records(
+pub(crate) fn publish_workspace_records(
     graph: &mut GraphForge,
     operation_uuid: uuid::Uuid,
     actor_uuid: Option<uuid::Uuid>,
     ontology: &WorkspaceOntology,
     configuration: &WorkspaceConfiguration,
+    composition: Option<&graphforge_storage::WorkspaceOntologyComposition>,
 ) -> Result<(), GfError> {
     let root = graph.resolved_generation.container_root().to_path_buf();
     let parent = graphforge_storage::resolve_project_generation(&root)?;
@@ -218,6 +240,7 @@ fn publish_workspace_records(
                     snapshot.record_family_id.as_str(),
                     graphforge_storage::WORKSPACE_ONTOLOGY_FAMILY
                         | graphforge_storage::WORKSPACE_CONFIGURATION_FAMILY
+                        | graphforge_storage::WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY
                 ))
         })
         .map(snapshot_to_participant)
@@ -226,6 +249,9 @@ fn publish_workspace_records(
         graphforge_storage::WORKSPACE_ONTOLOGY_FAMILY,
         ontology.to_canonical_json()?,
     ));
+    if let Some(composition) = composition {
+        participants.push(composition.to_project_participant()?);
+    }
     participants.push(workspace_participant(
         graphforge_storage::WORKSPACE_CONFIGURATION_FAMILY,
         configuration.to_canonical_json()?,
@@ -274,6 +300,7 @@ fn validate_workspace_record_inventory(
 ) -> Result<(), GfError> {
     let mut ontology_count = 0;
     let mut configuration_count = 0;
+    let mut composition_count = 0;
     for entry in metadata
         .iter()
         .filter(|entry| entry.capability_id == graphforge_storage::WORKSPACE_CAPABILITY_ID)
@@ -281,10 +308,11 @@ fn validate_workspace_record_inventory(
         match entry.record_family_id.as_str() {
             graphforge_storage::WORKSPACE_ONTOLOGY_FAMILY => ontology_count += 1,
             graphforge_storage::WORKSPACE_CONFIGURATION_FAMILY => configuration_count += 1,
+            graphforge_storage::WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY => composition_count += 1,
             _ => {}
         }
     }
-    if ontology_count != 1 || configuration_count != 1 {
+    if ontology_count != 1 || configuration_count != 1 || composition_count > 1 {
         return Err(GfError::Validation(
             "workspace generation must contain exactly one ontology and one configuration".into(),
         ));

--- a/crates/graphforge-api/src/workspace_ontology.rs
+++ b/crates/graphforge-api/src/workspace_ontology.rs
@@ -4,8 +4,8 @@ use std::path::PathBuf;
 
 use graphforge_core::{GfError, OntologyMode};
 use graphforge_ontology::{
-    ActivationMode, CompositionLimits, OntologyCompiler, OntologyHandle, OntologyLoader,
-    compile_legacy_single_ontology,
+    ActivationMode, AuthoredModule, CompositionLimits, InventoryCompileRequest, OntologyCompiler,
+    OntologyHandle, OntologyLoader, OntologyModuleId, compile_inventory, module_document_digest,
 };
 use graphforge_storage::{
     GraphDirectedness, ProjectCapability, ProjectGenerationRequest, ProjectParticipant,
@@ -79,7 +79,7 @@ impl GraphForge {
         directedness: Option<GraphDirectedness>,
     ) -> Result<(), GfError> {
         let ontology = self.workspace_ontology()?;
-        let composition = self.workspace_ontology_composition()?;
+        let composition = self.persisted_workspace_ontology_composition()?;
         let mut configuration = current_configuration(self)?;
         configuration.graph_directedness = directedness;
         publish_workspace_records(
@@ -89,6 +89,8 @@ impl GraphForge {
             &ontology,
             &configuration,
             composition.as_ref(),
+            None,
+            None,
         )
     }
 
@@ -116,20 +118,38 @@ impl GraphForge {
             .map_err(|error| GfError::Ontology(format!("failed to load ontology: {error}")))?;
         let runtime = OntologyCompiler::compile(&document)
             .map_err(|error| GfError::Ontology(format!("failed to compile ontology: {error}")))?;
-        let compiled_composition =
-            compile_legacy_single_ontology(&document, false, CompositionLimits::default())
-                .map_err(|error| {
-                    GfError::Ontology(format!("failed to compile ontology composition: {error}"))
-                })?;
-        let mut composition = graphforge_storage::WorkspaceOntologyComposition::from_compiled(
+        let digest = module_document_digest(&document).map_err(|error| {
+            GfError::Ontology(format!("failed to digest ontology composition: {error}"))
+        })?;
+        let authored = AuthoredModule {
+            id: OntologyModuleId {
+                ontology_id: document.ontology_id.clone(),
+                authored_version: document.version.clone(),
+                canonical_digest: digest,
+            },
+            dependencies: Vec::new(),
+            doc: document.clone(),
+            allow_projected_identity: false,
+        };
+        let compiled_composition = compile_inventory(InventoryCompileRequest {
+            modules: std::slice::from_ref(&authored),
+            bridges: &[],
+            activation: &[],
+            profile_default: match requested_mode {
+                OntologyMode::Exploratory => ActivationMode::Exploratory,
+                OntologyMode::Advisory => ActivationMode::Advisory,
+                OntologyMode::Strict => ActivationMode::Strict,
+            },
+            limits: CompositionLimits::default(),
+            cancelled: None,
+        })
+        .map_err(|error| {
+            GfError::Ontology(format!("failed to compile ontology composition: {error}"))
+        })?;
+        let composition = graphforge_storage::WorkspaceOntologyComposition::from_compiled(
             &compiled_composition,
             Vec::new(),
         );
-        composition.profile_default = match requested_mode {
-            OntologyMode::Exploratory => ActivationMode::Exploratory,
-            OntologyMode::Advisory => ActivationMode::Advisory,
-            OntologyMode::Strict => ActivationMode::Strict,
-        };
         let canonical_ontology = serde_json::to_value(&document)
             .map_err(|error| GfError::Ontology(format!("failed to encode ontology: {error}")))?;
         let canonical_bytes = serde_json::to_vec(&canonical_ontology)
@@ -150,6 +170,8 @@ impl GraphForge {
             &record,
             &configuration,
             Some(&composition),
+            None,
+            None,
         )?;
         self.ontology = Some(OntologyHandle::new(runtime));
         self.ontology_document = Some(document);
@@ -189,6 +211,8 @@ impl GraphForge {
             &WorkspaceOntology::none(),
             &configuration,
             None,
+            None,
+            None,
         )?;
         self.ontology = None;
         self.ontology_document = None;
@@ -218,7 +242,12 @@ pub(crate) fn publish_workspace_records(
     ontology: &WorkspaceOntology,
     configuration: &WorkspaceConfiguration,
     composition: Option<&graphforge_storage::WorkspaceOntologyComposition>,
+    generation_uuid_override: Option<uuid::Uuid>,
+    cancellation: Option<&crate::CancellationToken>,
 ) -> Result<(), GfError> {
+    if let Some(token) = cancellation {
+        token.checkpoint()?;
+    }
     let root = graph.resolved_generation.container_root().to_path_buf();
     let parent = graphforge_storage::resolve_project_generation(&root)?;
     parent.validate_complete_participant_inventory()?;
@@ -231,6 +260,12 @@ pub(crate) fn publish_workspace_records(
             "project generation changed before ontology publication".into(),
         ));
     }
+    let carries_graph_tree = parent
+        .participant_snapshot(
+            graphforge_storage::GRAPH_CAPABILITY_ID,
+            graphforge_storage::GRAPH_FILES_FAMILY,
+        )?
+        .is_some();
     let mut participants = parent
         .participant_snapshots()?
         .into_iter()
@@ -260,7 +295,8 @@ pub(crate) fn publish_workspace_records(
         (&left.capability_id, &left.record_family_id)
             .cmp(&(&right.capability_id, &right.record_family_id))
     });
-    let generation_uuid = workspace_generation_uuid(operation_uuid, actor_uuid, &participants);
+    let generation_uuid = generation_uuid_override
+        .unwrap_or_else(|| workspace_generation_uuid(operation_uuid, actor_uuid, &participants));
     let request = ProjectGenerationRequest {
         transaction_uuid: operation_uuid,
         generation_uuid,
@@ -274,18 +310,33 @@ pub(crate) fn publish_workspace_records(
             .collect(),
         participants,
     };
-    let receipt = match graph.stage_project_generation(&request)? {
+    let receipt = match graphforge_storage::stage_project_generation_with_graph_tree_mode(
+        &root,
+        &request,
+        carries_graph_tree
+            .then(|| parent.graph_tree_root())
+            .as_deref(),
+        graph.lifecycle_mode,
+    )? {
         ProjectStageOutcome::AlreadyPublished(receipt) => receipt,
-        ProjectStageOutcome::Staged(staged) => staged
-            .validate(validate_workspace_record_inventory, |actual_parent, _| {
-                if actual_parent.generation_uuid() != expected_parent {
-                    return Err(GfError::Validation(
-                        "project generation changed before ontology publication".into(),
-                    ));
-                }
-                Ok(())
-            })?
-            .publish()?,
+        ProjectStageOutcome::Staged(staged) => {
+            if let Some(token) = cancellation {
+                token.checkpoint()?;
+            }
+            let validated =
+                staged.validate(validate_workspace_record_inventory, |actual_parent, _| {
+                    if actual_parent.generation_uuid() != expected_parent {
+                        return Err(GfError::Validation(
+                            "project generation changed before ontology publication".into(),
+                        ));
+                    }
+                    Ok(())
+                })?;
+            if let Some(token) = cancellation {
+                token.checkpoint()?;
+            }
+            validated.publish()?
+        }
     };
     *graph
         .current_generation_uuid

--- a/crates/graphforge-bindings-node/tests/non-cypher-parity-policy.json
+++ b/crates/graphforge-bindings-node/tests/non-cypher-parity-policy.json
@@ -1,8 +1,8 @@
 {
   "contractVersion": 1,
   "rustManifest": "../../../tests/contracts/non-cypher-rust-surface.json",
-  "releaseSurfaceCount": 211,
-  "releaseSurfaceDigest": "a00859ba2240f230aafd817f8ea6d4f3990cc7d43fe63eb31b8f543bda556c2a",
+  "releaseSurfaceCount": 214,
+  "releaseSurfaceDigest": "d817ccffa04880533ba34ba4049d2bf66d0fe159d61d67c39675030cbba87a0d",
   "requiredEquivalent": [
     "GraphForge.adopt_ontology",
     "GraphForge.clear_ontology",
@@ -16,6 +16,7 @@
     "infra-validation": "lifecycleConstruction",
     "repository-sync": "lifecycleConstruction",
     "ontology-lifecycle": "ontologyLifecycle",
+    "composition-lifecycle": "lifecycleConstruction",
     "lifecycle-construction": "lifecycleConstruction",
     "gsi-profiler": "gsiProfiler",
     "checkpoint-view": "checkpointView",

--- a/crates/graphforge-bindings-py/tests/non_cypher_release.py
+++ b/crates/graphforge-bindings-py/tests/non_cypher_release.py
@@ -23,8 +23,8 @@ ROOT = Path(__file__).resolve().parents[3]
 RUST_MANIFEST = ROOT / "tests/contracts/non-cypher-rust-surface.json"
 RUST_GATE = ROOT / "scripts/ci/non-cypher-surface-gate.py"
 PYO3_SOURCE = ROOT / "crates/graphforge-bindings-py/src/lib.rs"
-EXPECTED_RUST_DIGEST = "a1a0f16a771df5e159130b7b7c41961d3c3bf0dc499f692ce20d1d3b4ce38ae2"
-EXPECTED_RELEASE_DIGEST = "a00859ba2240f230aafd817f8ea6d4f3990cc7d43fe63eb31b8f543bda556c2a"
+EXPECTED_RUST_DIGEST = "726aacf015d8db337cbd9282a43de81bd82f32202d4f1d2f2666b9c34ca2ad09"
+EXPECTED_RELEASE_DIGEST = "d817ccffa04880533ba34ba4049d2bf66d0fe159d61d67c39675030cbba87a0d"
 
 PYTHON_ONLY_METHODS = frozenset(
     {
@@ -70,6 +70,9 @@ EVIDENCE = {
     },
     "ontology-lifecycle": {
         "ontology_lifecycle.py": ["main"],
+    },
+    "composition-lifecycle": {
+        "non_cypher_release.py": ["check_lifecycle_checkpoint_errors_and_reopen"],
     },
     "lifecycle-construction": {
         "non_cypher_release.py": ["check_lifecycle_checkpoint_errors_and_reopen"],
@@ -248,7 +251,7 @@ def _classification_report() -> dict[str, object]:
         for group in manifest["method_evidence_groups"].values()
         for method_id in group["ids"]
     }
-    assert len(release_methods) == 211
+    assert len(release_methods) == 214
     assert _digest(release_methods) == EXPECTED_RELEASE_DIGEST
     assert set(EVIDENCE) == set(manifest["method_evidence_groups"])
 

--- a/crates/graphforge-ir/src/binder.rs
+++ b/crates/graphforge-ir/src/binder.rs
@@ -4643,6 +4643,17 @@ impl Binder {
         span: Span,
         s: &mut BinderState,
     ) {
+        if diagnostic.code == BindingDiagnosticCode::WrongOwnerProperty
+            && let Some((owner, property)) = diagnostic.subject.split_once('.')
+            && !owner.contains(':')
+        {
+            s.errors.push(BindError::new(
+                BindErrorKind::UnknownProperty,
+                span,
+                format!("property `{property}` is not declared for entity `{owner}`"),
+            ));
+            return;
+        }
         let kind = match diagnostic.code {
             BindingDiagnosticCode::AmbiguousSymbol => BindErrorKind::AmbiguousComposedSymbol,
             BindingDiagnosticCode::UnknownSymbol => BindErrorKind::UnknownLabel,

--- a/crates/graphforge-ir/src/composition_binding.rs
+++ b/crates/graphforge-ir/src/composition_binding.rs
@@ -141,18 +141,35 @@ impl CompositionBindingContext {
         let SymbolBinding::Qualified(symbol) = binding else {
             return Ok(false);
         };
-        Ok(self
+        let Some(module) = self
             .composition
             .modules
             .iter()
             .find(|module| module.id == symbol.module)
-            .is_some_and(|module| {
-                module
-                    .doc
-                    .properties
-                    .iter()
-                    .any(|item| item.owner == symbol.local_id && item.name == property)
-            }))
+        else {
+            return Ok(false);
+        };
+        let mut owner = Some(symbol.local_id.as_str());
+        for _ in 0..=module.doc.entity_types.len() {
+            let Some(current) = owner else {
+                return Ok(false);
+            };
+            if module
+                .doc
+                .properties
+                .iter()
+                .any(|item| item.owner == current && item.name == property)
+            {
+                return Ok(true);
+            }
+            owner = module
+                .doc
+                .entity_types
+                .iter()
+                .find(|entity| entity.name == current)
+                .and_then(|entity| entity.parent.as_deref());
+        }
+        Ok(false)
     }
     /// Construct from compiled module authority and adopted bridge documents.
     #[must_use]
@@ -373,9 +390,25 @@ impl CompositionBindingContext {
         else {
             return self.require_endpoint(property);
         };
-        if module.doc.properties.iter().any(|candidate| {
-            format!("{}:{}", candidate.owner, candidate.name) == property.local_id
-                && candidate.owner == owner_local
+        let declared_owner = module.doc.properties.iter().find_map(|candidate| {
+            (format!("{}:{}", candidate.owner, candidate.name) == property.local_id)
+                .then_some(candidate.owner.as_str())
+        });
+        if declared_owner.is_some_and(|declared| {
+            let mut current = Some(owner_local);
+            for _ in 0..=module.doc.entity_types.len() {
+                let Some(value) = current else { return false };
+                if value == declared {
+                    return true;
+                }
+                current = module
+                    .doc
+                    .entity_types
+                    .iter()
+                    .find(|entity| entity.name == value)
+                    .and_then(|entity| entity.parent.as_deref());
+            }
+            false
         }) {
             return Ok(());
         }
@@ -407,29 +440,49 @@ impl CompositionBindingContext {
         let SymbolBinding::Qualified(owner_symbol) = owner_binding else {
             return self.resolve(SymbolKind::Property, property);
         };
-        let local_id = format!("{}:{property}", owner_symbol.local_id);
-        let outcome = self
+        let module = self
             .composition
-            .resolve(&ResolveRequest {
+            .modules
+            .iter()
+            .find(|module| module.id == owner_symbol.module);
+        let mut owner_name = Some(owner_symbol.local_id.as_str());
+        let mut outcome = None;
+        for _ in 0..=module.map_or(0, |module| module.doc.entity_types.len()) {
+            let Some(current) = owner_name else { break };
+            let local_id = format!("{current}:{property}");
+            if let Ok(resolved) = self.composition.resolve(&ResolveRequest {
                 module: Some(&owner_symbol.module),
                 kind: SymbolKind::Property,
                 local_id: &local_id,
                 max_candidates: self.limits.candidates.max(1),
-            })
-            .map_err(|_| BindingDiagnostic {
-                code: BindingDiagnosticCode::WrongOwnerProperty,
-                subject: format!("{owner}.{property}"),
-                candidates: self
-                    .composition
-                    .modules
-                    .iter()
-                    .flat_map(|module| module.doc.properties.iter())
-                    .filter(|candidate| candidate.name == property)
-                    .map(|candidate| candidate.owner.clone())
-                    .take(self.limits.candidates.max(1))
-                    .collect(),
-                remediation: "use the property only on an owner that declares it".to_owned(),
-            })?;
+            }) {
+                outcome = Some(resolved);
+                break;
+            }
+            owner_name = module
+                .and_then(|module| {
+                    module
+                        .doc
+                        .entity_types
+                        .iter()
+                        .find(|entity| entity.name == current)
+                })
+                .and_then(|entity| entity.parent.as_deref());
+        }
+        let outcome = outcome.ok_or_else(|| BindingDiagnostic {
+            code: BindingDiagnosticCode::WrongOwnerProperty,
+            subject: format!("{owner}.{property}"),
+            candidates: self
+                .composition
+                .modules
+                .iter()
+                .flat_map(|module| module.doc.properties.iter())
+                .filter(|candidate| candidate.name == property)
+                .map(|candidate| candidate.owner.clone())
+                .take(self.limits.candidates.max(1))
+                .collect(),
+            remediation: "use the property only on an owner that declares it".to_owned(),
+        })?;
         receipt.decisions.push(BindingDecision::Qualified {
             symbol: outcome.symbol.clone(),
         });

--- a/crates/graphforge-ir/src/composition_binding.rs
+++ b/crates/graphforge-ir/src/composition_binding.rs
@@ -131,6 +131,29 @@ pub struct CompositionBindingContext {
 }
 
 impl CompositionBindingContext {
+    /// Whether the resolved entity authority declares `property` on that owner.
+    pub fn declares_entity_property(
+        &self,
+        entity: &str,
+        property: &str,
+    ) -> Result<bool, BindingDiagnostic> {
+        let (binding, _) = self.resolve(SymbolKind::Entity, entity)?;
+        let SymbolBinding::Qualified(symbol) = binding else {
+            return Ok(false);
+        };
+        Ok(self
+            .composition
+            .modules
+            .iter()
+            .find(|module| module.id == symbol.module)
+            .is_some_and(|module| {
+                module
+                    .doc
+                    .properties
+                    .iter()
+                    .any(|item| item.owner == symbol.local_id && item.name == property)
+            }))
+    }
     /// Construct from compiled module authority and adopted bridge documents.
     #[must_use]
     pub fn new(

--- a/crates/graphforge-ontology/src/lib.rs
+++ b/crates/graphforge-ontology/src/lib.rs
@@ -34,9 +34,9 @@ pub use compiler::{OntologyCompiler, OntologyRuntime, PropertyOwnerKind};
 pub use composition::{
     ActivationMode, ActivationRecord, ActivationScope, AuthoredModule, BridgeSetId,
     CompiledComposition, CompiledModule, CompositionDiagnostic, CompositionError,
-    CompositionLimits, DiagnosticCode, InventoryCompileRequest, OntologyModuleId, QualifiedSymbol,
-    ResolutionOutcome, ResolveRequest, SymbolKind, bridge_document_digest, compile_inventory,
-    compile_legacy_single_ontology, module_document_digest,
+    CompositionLimits, DiagnosticCode, DiagnosticLimit, InventoryCompileRequest, OntologyModuleId,
+    QualifiedSymbol, ResolutionOutcome, ResolveRequest, SymbolKind, bridge_document_digest,
+    compile_inventory, compile_legacy_single_ontology, module_document_digest,
 };
 pub use error::{OntologyError, OntologyValidationError, ValidationErrorKind};
 pub use graphforge_core::{PropId, TypeId};

--- a/crates/graphforge-ontology/src/migration.rs
+++ b/crates/graphforge-ontology/src/migration.rs
@@ -12,8 +12,8 @@ use crate::ontology::{EntityTypeDef, MigrationDef, OntologyDoc, PropertyDef, Pro
 
 /// The semantic operation performed by a single migration step.
 ///
-/// Unknown / unsupported transform strings are preserved as [`TransformKind::Unknown`]
-/// and silently skipped during [`MigrationEngine::apply`].
+/// Unknown / unsupported transform strings are preserved as [`TransformKind::Unknown`].
+/// Authority-changing callers must reject them before applying a plan.
 #[allow(missing_docs)] // variant fields are self-documenting
 #[derive(Debug, Clone)]
 pub enum TransformKind {
@@ -38,7 +38,7 @@ pub enum TransformKind {
     AddType { name: String },
     /// Remove an entity type and cascade-remove its properties and relations.
     RemoveType { name: String },
-    /// An unrecognised transform — silently skipped.
+    /// An unrecognised transform that cannot be applied safely.
     Unknown { raw: String },
 }
 
@@ -220,27 +220,7 @@ impl MigrationEngine {
         mut doc: OntologyDoc,
         steps: &[MigrationStep],
     ) -> Result<OntologyRuntime, OntologyError> {
-        // Validate that steps are contiguous and start from doc.version.
-        if let Some(first) = steps.first() {
-            if doc.version != first.from_version {
-                return Err(OntologyError::NoMigrationPath {
-                    from: doc.version.clone(),
-                    to: steps
-                        .last()
-                        .map_or("", |s| s.to_version.as_str())
-                        .to_owned(),
-                });
-            }
-            for window in steps.windows(2) {
-                if window[0].to_version != window[1].from_version {
-                    return Err(OntologyError::NoMigrationPath {
-                        from: window[0].to_version.clone(),
-                        to: window[1].from_version.clone(),
-                    });
-                }
-            }
-        }
-
+        validate_step_chain(&doc, steps)?;
         for step in steps {
             apply_step(&mut doc, &step.transform_kind);
         }
@@ -249,6 +229,54 @@ impl MigrationEngine {
         }
         OntologyCompiler::compile(&doc)
     }
+
+    /// Apply a migration plan and return the exact transformed source document.
+    ///
+    /// Unlike the legacy runtime-only path, this fails closed for unknown
+    /// transforms so lifecycle publication can compare the migrated schema to
+    /// the requested immutable authority before committing it.
+    pub fn apply_document(
+        mut doc: OntologyDoc,
+        steps: &[MigrationStep],
+    ) -> Result<OntologyDoc, OntologyError> {
+        validate_step_chain(&doc, steps)?;
+
+        for step in steps {
+            if let TransformKind::Unknown { raw } = &step.transform_kind {
+                return Err(OntologyError::SchemaMismatch {
+                    message: format!("unsupported migration transform `{raw}`"),
+                });
+            }
+            apply_step(&mut doc, &step.transform_kind);
+        }
+        if let Some(last) = steps.last() {
+            doc.version.clone_from(&last.to_version);
+        }
+        Ok(doc)
+    }
+}
+
+fn validate_step_chain(doc: &OntologyDoc, steps: &[MigrationStep]) -> Result<(), OntologyError> {
+    if let Some(first) = steps.first() {
+        if doc.version != first.from_version {
+            return Err(OntologyError::NoMigrationPath {
+                from: doc.version.clone(),
+                to: steps
+                    .last()
+                    .map_or("", |step| step.to_version.as_str())
+                    .to_owned(),
+            });
+        }
+        for window in steps.windows(2) {
+            if window[0].to_version != window[1].from_version {
+                return Err(OntologyError::NoMigrationPath {
+                    from: window[0].to_version.clone(),
+                    to: window[1].from_version.clone(),
+                });
+            }
+        }
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/graphforge-storage/src/project_generation.rs
+++ b/crates/graphforge-storage/src/project_generation.rs
@@ -251,6 +251,13 @@ impl ResolvedProjectGeneration {
             .and_then(|value| Uuid::parse_str(value).ok())
     }
 
+    /// UUID of the transaction that authored this committed generation.
+    #[must_use]
+    pub fn transaction_uuid(&self) -> Uuid {
+        Uuid::parse_str(&self.manifest.transaction_uuid)
+            .expect("resolved project generation has a validated transaction UUID")
+    }
+
     /// Resolve a requested participant path without accepting caller path
     /// components or parsing any participant bytes.
     ///

--- a/crates/graphforge-storage/src/semantic_bindings.rs
+++ b/crates/graphforge-storage/src/semantic_bindings.rs
@@ -83,6 +83,18 @@ pub struct LegacySemanticProjection {
 }
 
 impl SemanticStorageBindings {
+    /// Whether one exact generation binding has retained physical rows or
+    /// non-null property values in the pinned materialized graph.
+    ///
+    /// # Errors
+    /// Fails closed for malformed, oversized, or unreadable Parquet authority.
+    pub fn binding_has_retained_data(
+        binding: &SemanticStorageBinding,
+        graph_root: &Path,
+    ) -> Result<bool, GfError> {
+        binding_has_retained_data(binding, graph_root)
+    }
+
     /// Inspect a legacy single-module layout without mutation. Multi-module or
     /// unqualified layouts that cannot prove one owner fail closed.
     #[allow(clippy::too_many_lines)] // one bounded scan keeps projection evidence co-located
@@ -687,7 +699,11 @@ impl SemanticStorageBindings {
                     != Some(&self.composition_fingerprint)
             {
                 return Err(corrupt(&format!(
-                    "semantic route metadata does not match binding for {relative}"
+                    "semantic route metadata does not match binding for {relative}: expected route {} and composition {}, found route {:?} and composition {:?}",
+                    binding.route,
+                    self.composition_fingerprint,
+                    schema.metadata().get(SEMANTIC_ROUTE_METADATA_KEY),
+                    schema.metadata().get(SEMANTIC_COMPOSITION_METADATA_KEY),
                 )));
             }
             let join_key = match binding.route_kind {

--- a/crates/graphforge-storage/src/workspace_participants.rs
+++ b/crates/graphforge-storage/src/workspace_participants.rs
@@ -1,11 +1,12 @@
 //! Canonical generation-managed workspace ontology and configuration records.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 use graphforge_core::{GfError, OntologyMode, ProjectErrorCode};
 use graphforge_ontology::{
-    ActivationMode, ActivationRecord, AuthoredModule, BridgeDocument, BridgeSetId,
-    CompiledComposition, CompositionLimits, InventoryCompileRequest, OntologyDoc, OntologyModuleId,
+    ActivationMode, ActivationRecord, AuthoredModule, BridgeDocument, BridgeInventory,
+    BridgeSelector, BridgeSetId, CompiledComposition, CompositionLimits, DiagnosticLimit,
+    InventoryCompileRequest, ModuleSymbolTable, OntologyDoc, OntologyModuleId, SymbolKind,
     bridge_document_digest, compile_inventory, module_document_digest,
 };
 use serde::{Deserialize, Serialize};
@@ -371,6 +372,65 @@ impl WorkspaceOntologyComposition {
             cancelled: None,
         })
         .map_err(|_| corrupt("ontology composition does not compile"))?;
+        let module_tables = compiled
+            .modules
+            .iter()
+            .map(|module| ModuleSymbolTable {
+                id: module.id.clone(),
+                entities: module
+                    .symbols
+                    .iter()
+                    .filter(|symbol| symbol.kind == SymbolKind::Entity)
+                    .map(|symbol| symbol.local_id.clone())
+                    .collect::<HashSet<_>>(),
+                relations: module
+                    .symbols
+                    .iter()
+                    .filter(|symbol| symbol.kind == SymbolKind::Relation)
+                    .map(|symbol| symbol.local_id.clone())
+                    .collect::<HashSet<_>>(),
+                properties: module
+                    .symbols
+                    .iter()
+                    .filter(|symbol| symbol.kind == SymbolKind::Property)
+                    .map(|symbol| symbol.local_id.clone())
+                    .collect::<HashSet<_>>(),
+            })
+            .collect::<Vec<_>>();
+        let mut bridge_inventory =
+            BridgeInventory::new(self.profile_default, DiagnosticLimit::default());
+        for table in module_tables {
+            bridge_inventory.register_module(table);
+        }
+        let mut staged = Vec::with_capacity(self.bridges.len());
+        for (index, bridge) in self.bridges.iter().enumerate() {
+            let id = bridge_inventory
+                .create_register(bridge.clone(), format!("composition-bridge-{index}"))
+                .map_err(|_| corrupt("ontology composition bridge is invalid"))?;
+            staged.push((id, bridge.dependencies.clone()));
+        }
+        let mut remaining = staged;
+        let mut adopted = std::collections::BTreeSet::new();
+        while !remaining.is_empty() {
+            let Some(index) = remaining.iter().position(|(_, dependencies)| {
+                dependencies
+                    .iter()
+                    .all(|dependency| adopted.contains(&dependency.display_ref()))
+            }) else {
+                return Err(corrupt(
+                    "ontology composition bridge dependencies are unresolved or cyclic",
+                ));
+            };
+            let (id, _) = remaining.remove(index);
+            bridge_inventory
+                .adopt(
+                    &BridgeSelector::Exact(id.clone()),
+                    bridge_inventory.generation(),
+                    format!("composition-adopt-{}", id.display_ref()),
+                )
+                .map_err(|_| corrupt("ontology composition bridge lifecycle is invalid"))?;
+            adopted.insert(id.display_ref());
+        }
         if compiled.fingerprint != self.composition_fingerprint {
             return Err(corrupt("ontology composition fingerprint does not match"));
         }

--- a/crates/graphforge-storage/src/writer.rs
+++ b/crates/graphforge-storage/src/writer.rs
@@ -1962,10 +1962,14 @@ impl GraphWriter {
             // `build_property_columns` keeps one source of truth for the
             // first-seen ordering and type-coercion rules across flushes.
             let existing = read_props_through(staged, &node_props_path(&self.dir, &stem))?;
+            let existing_metadata = existing
+                .first()
+                .map(|batch| batch.schema().metadata().clone());
             let mut rows = decode_property_rows(&existing)?;
             rows.extend(new_rows);
             let (schema, cols) = build_property_columns(&stem, &rows)?;
             let schema = self.authenticated_route_schema(Arc::new(schema), &stem);
+            let schema = preserve_semantic_route_metadata(schema, existing_metadata.as_ref());
             stage_property_file(
                 staged,
                 &self.dir,
@@ -1988,6 +1992,9 @@ impl GraphWriter {
         let buffered: Vec<(String, Vec<EdgePropRow>)> = self.edge_properties.drain().collect();
         for (stem, new_rows) in buffered {
             let existing = read_props_through(staged, &edge_props_path(&self.dir, &stem))?;
+            let existing_metadata = existing
+                .first()
+                .map(|batch| batch.schema().metadata().clone());
             let mut rows = decode_edge_property_rows(&existing)?;
             rows.extend(new_rows);
             let (schema, cols) = build_property_columns_keyed(
@@ -1997,6 +2004,7 @@ impl GraphWriter {
                 &rows,
             )?;
             let schema = self.authenticated_route_schema(Arc::new(schema), &stem);
+            let schema = preserve_semantic_route_metadata(schema, existing_metadata.as_ref());
             stage_property_file(
                 staged,
                 &self.dir,
@@ -2027,6 +2035,27 @@ impl GraphWriter {
             _ => schema,
         }
     }
+}
+
+fn preserve_semantic_route_metadata(
+    schema: SchemaRef,
+    existing: Option<&HashMap<String, String>>,
+) -> SchemaRef {
+    let Some(existing) = existing else {
+        return schema;
+    };
+    let mut metadata = schema.metadata().clone();
+    for key in [
+        crate::SEMANTIC_ROUTE_METADATA_KEY,
+        crate::SEMANTIC_COMPOSITION_METADATA_KEY,
+    ] {
+        if !metadata.contains_key(key)
+            && let Some(value) = existing.get(key)
+        {
+            metadata.insert(key.to_owned(), value.clone());
+        }
+    }
+    Arc::new(Schema::new_with_metadata(schema.fields().clone(), metadata))
 }
 
 // ---------------------------------------------------------------------------
@@ -3654,9 +3683,12 @@ pub fn stage_set_node_properties(
     updates: &HashMap<[u8; 16], HashMap<String, IrLiteral>>,
 ) -> Result<u64, GfError> {
     let existing = read_props_through(staged, &node_props_path(dir, stem))?;
+    let metadata = existing
+        .first()
+        .map(|batch| batch.schema().metadata().clone());
     let rows = decode_property_rows(&existing)?;
     let (rows, touched) = apply_property_updates(rows, updates);
-    stage_node_property_file(staged, dir, stem, &rows)?;
+    stage_node_property_file(staged, dir, stem, &rows, metadata.as_ref())?;
     Ok(touched)
 }
 
@@ -3673,9 +3705,12 @@ pub fn stage_remove_node_properties(
     removals: &HashMap<[u8; 16], HashSet<String>>,
 ) -> Result<u64, GfError> {
     let existing = read_props_through(staged, &node_props_path(dir, stem))?;
+    let metadata = existing
+        .first()
+        .map(|batch| batch.schema().metadata().clone());
     let rows = decode_property_rows(&existing)?;
     let (rows, touched) = apply_property_removals(rows, removals);
-    stage_node_property_file(staged, dir, stem, &rows)?;
+    stage_node_property_file(staged, dir, stem, &rows, metadata.as_ref())?;
     Ok(touched)
 }
 
@@ -3694,9 +3729,12 @@ pub fn stage_set_edge_properties(
     updates: &HashMap<[u8; 16], HashMap<String, IrLiteral>>,
 ) -> Result<u64, GfError> {
     let existing = read_props_through(staged, &edge_props_path(dir, rel_stem))?;
+    let metadata = existing
+        .first()
+        .map(|batch| batch.schema().metadata().clone());
     let rows = decode_edge_property_rows(&existing)?;
     let (rows, touched) = apply_property_updates(rows, updates);
-    stage_edge_property_file(staged, dir, rel_stem, &rows)?;
+    stage_edge_property_file(staged, dir, rel_stem, &rows, metadata.as_ref())?;
     Ok(touched)
 }
 
@@ -3714,9 +3752,12 @@ pub fn stage_remove_edge_properties(
     removals: &HashMap<[u8; 16], HashSet<String>>,
 ) -> Result<u64, GfError> {
     let existing = read_props_through(staged, &edge_props_path(dir, rel_stem))?;
+    let metadata = existing
+        .first()
+        .map(|batch| batch.schema().metadata().clone());
     let rows = decode_edge_property_rows(&existing)?;
     let (rows, touched) = apply_property_removals(rows, removals);
-    stage_edge_property_file(staged, dir, rel_stem, &rows)?;
+    stage_edge_property_file(staged, dir, rel_stem, &rows, metadata.as_ref())?;
     Ok(touched)
 }
 
@@ -3798,12 +3839,21 @@ fn stage_node_property_file(
     dir: &Path,
     stem: &str,
     rows: &[PropRow],
+    metadata: Option<&HashMap<String, String>>,
 ) -> Result<(), GfError> {
     if rows.is_empty() {
         return Ok(());
     }
     let (schema, cols) = build_property_columns(stem, rows)?;
-    stage_property_file(staged, dir, "properties", stem, schema, cols)
+    let schema = preserve_semantic_route_metadata(Arc::new(schema), metadata);
+    stage_property_file(
+        staged,
+        dir,
+        "properties",
+        stem,
+        schema.as_ref().clone(),
+        cols,
+    )
 }
 
 /// Edge analogue of [`stage_node_property_file`] (key `edge_uuid`, file routed
@@ -3813,13 +3863,22 @@ fn stage_edge_property_file(
     dir: &Path,
     stem: &str,
     rows: &[EdgePropRow],
+    metadata: Option<&HashMap<String, String>>,
 ) -> Result<(), GfError> {
     if rows.is_empty() {
         return Ok(());
     }
     let (schema, cols) =
         build_property_columns_keyed(EDGE_PROPERTY_UUID_FIELD, "graphforge.rel_type", stem, rows)?;
-    stage_property_file(staged, dir, "edge_properties", stem, schema, cols)
+    let schema = preserve_semantic_route_metadata(Arc::new(schema), metadata);
+    stage_property_file(
+        staged,
+        dir,
+        "edge_properties",
+        stem,
+        schema.as_ref().clone(),
+        cols,
+    )
 }
 
 /// Stage a rebuilt property file under `<dir>/<subdir>/<stem>.parquet` (the

--- a/scripts/ci/test-non-cypher-surface-gate.py
+++ b/scripts/ci/test-non-cypher-surface-gate.py
@@ -29,7 +29,7 @@ class SurfaceGateTests(unittest.TestCase):
 
     def test_checked_in_inventory_is_complete(self) -> None:
         self.assertEqual(GATE.validate(), [])
-        self.assertEqual(len(GATE.public_methods()), 325)
+        self.assertEqual(len(GATE.public_methods()), 328)
         self.assertEqual(len(GATE.algorithm_registry()), 94)
 
     def test_new_or_removed_public_method_fails_frozen_digest(self) -> None:

--- a/tests/contracts/non-cypher-rust-surface.json
+++ b/tests/contracts/non-cypher-rust-surface.json
@@ -1,7 +1,7 @@
 {
   "contract_version": 1,
   "scope": "Rust non-Cypher public release surface",
-  "public_method_digest": "a1a0f16a771df5e159130b7b7c41961d3c3bf0dc499f692ce20d1d3b4ce38ae2",
+  "public_method_digest": "726aacf015d8db337cbd9282a43de81bd82f32202d4f1d2f2666b9c34ca2ad09",
   "method_policy": {
     "receiver_defaults": {
       "GraphForge": "release-tested",
@@ -179,6 +179,27 @@
         {
           "path": "crates/graphforge-api/src/ontology_lifecycle.rs",
           "symbol": "filesystem_failure_preserves_destination_and_cleans_temporary_file"
+        }
+      ]
+    },
+    "composition-lifecycle": {
+      "ids": [
+        "GraphForge.preview_ontology_composition_change",
+        "GraphForge.publish_ontology_composition_change",
+        "GraphForge.workspace_ontology_composition"
+      ],
+      "test_refs": [
+        {
+          "path": "crates/graphforge-api/src/ontology_composition_lifecycle.rs",
+          "symbol": "publish_reopen_retry_and_rollback_preserve_exact_authority"
+        },
+        {
+          "path": "crates/graphforge-api/src/ontology_composition_lifecycle.rs",
+          "symbol": "stale_cancelled_and_conflicting_replay_leave_generation_unchanged"
+        },
+        {
+          "path": "crates/graphforge-api/src/ontology_composition_lifecycle.rs",
+          "symbol": "replace_and_remove_are_safe_only_without_retained_semantic_data"
         }
       ]
     },


### PR DESCRIPTION
Closes #840

## Summary
- preflight bounded composition, migration, persisted semantic data, bridge, and portable-v2 compatibility
- publish composition and generation-bound semantic bindings as one complete project generation
- hydrate normal execution from the persisted authority and preserve replay, rollback, and reopen semantics

## Evidence
- `cargo test -p graphforge-api --lib ontology_composition_lifecycle`
- `cargo clippy -p graphforge-api -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 scripts/ci/cargo-bazel-drift-check.py`
- `python3 scripts/ci/non-cypher-surface-gate.py`
- `python3 scripts/ci/check-binding-parity-policy.py`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789880793&installation_model_id=20486&pr_number=874&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F874&signature=80fced2a680a853ebfaf9c35109054ed8976c050cbcdcbfb6e993d3967488c6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->