### PR TITLE
docs(io): preserve exact portable composition identities

### DIFF
--- a/docs/adr/0022-portable-v2-multi-ontology-compatibility.md
+++ b/docs/adr/0022-portable-v2-multi-ontology-compatibility.md
@@ -22,18 +22,25 @@ component payloads, materializing staging, or mutating a project.
 
 The control document contract is `graphforge-ontology-composition/1`. It owns:
 
-- the canonically ordered ontology inventory and each module's stable ID,
-  exact version, canonical content digest, and dialect/profile;
-- canonically ordered bridge-set identities, versions, canonical digests, and
-  exact module endpoints;
-- the activation profile and its exact active module and bridge-set identities;
+- the canonically ordered ontology inventory and each module's globally unique
+  NFC URI, exact opaque NFC version, canonical content digest, and
+  dialect/profile;
+- canonically ordered bridge-set URI identities, opaque versions, canonical
+  digests, and the complete non-empty ordered source and target module sets;
+- the default activation profile and canonically ordered overrides whose
+  structured subjects retain URI, version, and digest without delimiter-based
+  aliases;
 - the composition digest over the preceding semantic fields; and
 - required and optional feature tokens.
 
 Its closed machine-readable shape is
-`docs/contracts/graphforge-ontology-composition-v1.schema.json`. Arrays MUST be
-in ascending UTF-8 identity order despite JSON Schema being unable to express
-order; the Rust decoder enforces order and uniqueness before semantic use.
+`docs/contracts/graphforge-ontology-composition-v1.schema.json`. URI and version
+strings MUST already be NFC. Versions are opaque authority values, not SemVer.
+Exact identities are closed objects (`id`, `version`, `content_digest`) so URI
+characters and version text cannot make a joined identity ambiguous. Arrays
+MUST be in ascending UTF-8 tuple order despite JSON Schema being unable to
+express order; the Rust decoder enforces normalization, order, uniqueness, and
+closure before semantic use.
 
 The manifest authenticates the control document's path, length, and digest and
 therefore includes it in `package_digest`. The composition digest is
@@ -102,8 +109,10 @@ by `PortableV2ErrorCode::UnsupportedFuture` and
   same exact ontology/bridge/schema composition closure as graph data.
 
 No profile may contain a dangling module endpoint, bridge endpoint, activation
-member, or composition input. Omissions are explicit stable portable participant
-IDs. Inventory order never selects authority or resolves ambiguity.
+member, or composition input. Every bridge retains all source and target module
+identities; neither endpoint set may be empty. Omissions are explicit stable
+portable participant IDs. Inventory order never selects authority or resolves
+ambiguity.
 
 ## Reader and failure matrix
 

--- a/docs/contracts/graphforge-ontology-composition-v1.schema.json
+++ b/docs/contracts/graphforge-ontology-composition-v1.schema.json
@@ -10,11 +10,23 @@
     "activation_profile": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["profile_id", "active_modules", "active_bridge_sets"],
+      "required": ["profile_default", "overrides"],
       "properties": {
-        "profile_id": {"$ref": "#/$defs/id"},
-        "active_modules": {"$ref": "#/$defs/exactIdentityList"},
-        "active_bridge_sets": {"$ref": "#/$defs/exactIdentityList"}
+        "profile_default": {"$ref": "#/$defs/profile"},
+        "overrides": {
+          "type": "array",
+          "maxItems": 20000,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["scope", "subject", "mode"],
+            "properties": {
+              "scope": {"enum": ["module", "bridge"]},
+              "subject": {"$ref": "#/$defs/exactIdentity"},
+              "mode": {"$ref": "#/$defs/profile"}
+            }
+          }
+        }
       }
     },
     "modules": {
@@ -23,13 +35,13 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["module_id", "version", "content_digest", "dialect", "profile"],
+        "required": ["ontology_id", "version", "content_digest", "dialect", "profile"],
         "properties": {
-          "module_id": {"$ref": "#/$defs/id"},
+          "ontology_id": {"$ref": "#/$defs/uri"},
           "version": {"$ref": "#/$defs/version"},
           "content_digest": {"$ref": "#/$defs/digest"},
-          "dialect": {"$ref": "#/$defs/id"},
-          "profile": {"$ref": "#/$defs/id"}
+          "dialect": {"$ref": "#/$defs/machineId"},
+          "profile": {"$ref": "#/$defs/profile"}
         }
       }
     },
@@ -39,13 +51,13 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["bridge_set_id", "version", "content_digest", "source_module", "target_module"],
+        "required": ["bridge_id", "version", "content_digest", "source_modules", "target_modules"],
         "properties": {
-          "bridge_set_id": {"$ref": "#/$defs/id"},
+          "bridge_id": {"$ref": "#/$defs/uri"},
           "version": {"$ref": "#/$defs/version"},
           "content_digest": {"$ref": "#/$defs/digest"},
-          "source_module": {"$ref": "#/$defs/exactIdentity"},
-          "target_module": {"$ref": "#/$defs/exactIdentity"}
+          "source_modules": {"$ref": "#/$defs/exactIdentityList"},
+          "target_modules": {"$ref": "#/$defs/exactIdentityList"}
         }
       }
     },
@@ -54,11 +66,22 @@
     "composition_digest": {"$ref": "#/$defs/digest"}
   },
   "$defs": {
-    "id": {"type": "string", "minLength": 1, "maxLength": 256, "pattern": "^[a-z][a-z0-9._-]*$"},
-    "version": {"type": "string", "minLength": 1, "maxLength": 128, "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:-[0-9A-Za-z.-]+)?$"},
+    "machineId": {"type": "string", "minLength": 1, "maxLength": 256, "pattern": "^[a-z][a-z0-9._-]*$"},
+    "uri": {"type": "string", "minLength": 3, "maxLength": 2048, "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:[^\\u0000-\\u0020]+$"},
+    "version": {"type": "string", "minLength": 1, "maxLength": 256, "pattern": "^[^\\u0000-\\u001f\\u007f]+$"},
     "digest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
-    "exactIdentity": {"type": "string", "minLength": 3, "maxLength": 385, "pattern": "^[a-z][a-z0-9._-]*@[0-9]+\\.[0-9]+\\.[0-9]+(?:-[0-9A-Za-z.-]+)?$"},
-    "exactIdentityList": {"type": "array", "maxItems": 10000, "uniqueItems": true, "items": {"$ref": "#/$defs/exactIdentity"}},
+    "profile": {"enum": ["exploratory", "advisory", "strict"]},
+    "exactIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "version", "content_digest"],
+      "properties": {
+        "id": {"$ref": "#/$defs/uri"},
+        "version": {"$ref": "#/$defs/version"},
+        "content_digest": {"$ref": "#/$defs/digest"}
+      }
+    },
+    "exactIdentityList": {"type": "array", "minItems": 1, "maxItems": 10000, "uniqueItems": true, "items": {"$ref": "#/$defs/exactIdentity"}},
     "featureList": {"type": "array", "maxItems": 256, "uniqueItems": true, "items": {"type": "string", "pattern": "^[a-z][a-z0-9-]*@[1-9][0-9]*$"}}
   }
 }

--- a/scripts/ci/portable-v2-contract.py
+++ b/scripts/ci/portable-v2-contract.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 import hashlib
 import json
 from pathlib import Path
+import re
 from typing import NoReturn
+import unicodedata
 
 ROOT = Path(__file__).resolve().parents[2]
 FIXTURES = ROOT / "tests/fixtures/portable-v2"
@@ -14,6 +16,8 @@ SCHEMA = ROOT / "docs/contracts/graphforge-project-v2.schema.json"
 COMPOSITION_SCHEMA = ROOT / "docs/contracts/graphforge-ontology-composition-v1.schema.json"
 DOMAIN = b"graphforge-project/2\0"
 COMPOSITION_DOMAIN = b"graphforge-ontology-composition/1\0"
+URI = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*:\S+$")
+DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
 
 
 def fail(message: str) -> NoReturn:
@@ -51,6 +55,109 @@ def load_json(path: Path) -> object:
 def canonical(value: object) -> bytes:
     reject_surrogates(value)
     return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode()
+
+
+def exact_identity(value: object, label: str) -> tuple[str, str, str]:
+    require(isinstance(value, dict), f"{label} identity object")
+    require(set(value) == {"id", "version", "content_digest"}, f"{label} identity fields")
+    identifier, version, digest = value["id"], value["version"], value["content_digest"]
+    require(isinstance(identifier, str) and URI.fullmatch(identifier), f"{label} URI")
+    require(identifier == unicodedata.normalize("NFC", identifier), f"{label} URI NFC")
+    require(
+        isinstance(version, str)
+        and 0 < len(version.encode()) <= 256
+        and version == unicodedata.normalize("NFC", version)
+        and not any(ord(char) < 32 or ord(char) == 127 for char in version),
+        f"{label} opaque version",
+    )
+    require(isinstance(digest, str) and DIGEST.fullmatch(digest), f"{label} digest")
+    return identifier, version, digest
+
+
+def composition_with_digest(value: dict[str, object]) -> dict[str, object]:
+    result = json.loads(json.dumps(value))
+    result.pop("composition_digest", None)
+    digest = hashlib.sha256(COMPOSITION_DOMAIN + canonical(result)).hexdigest()
+    result["composition_digest"] = f"sha256:{digest}"
+    return result
+
+
+def validate_composition_control(composition: object) -> None:
+    require(isinstance(composition, dict), "M9 composition object")
+    require(
+        set(composition)
+        == {
+            "contract",
+            "activation_profile",
+            "modules",
+            "bridge_sets",
+            "required_features",
+            "optional_features",
+            "composition_digest",
+        },
+        "M9 composition fields",
+    )
+    require(composition["contract"] == "graphforge-ontology-composition/1", "M9 contract")
+    semantic = dict(composition)
+    expected_digest = semantic.pop("composition_digest")
+    actual_digest = "sha256:" + hashlib.sha256(COMPOSITION_DOMAIN + canonical(semantic)).hexdigest()
+    require(actual_digest == expected_digest, "M9 composition digest")
+    modules = composition["modules"]
+    bridges = composition["bridge_sets"]
+    require(isinstance(modules, list) and len(modules) <= 10000, "M9 module bound")
+    require(isinstance(bridges, list) and len(bridges) <= 10000, "M9 bridge bound")
+    module_ids = [
+        exact_identity(
+            {
+                "id": item["ontology_id"],
+                "version": item["version"],
+                "content_digest": item["content_digest"],
+            },
+            "module",
+        )
+        for item in modules
+    ]
+    bridge_ids = [
+        exact_identity(
+            {
+                "id": item["bridge_id"],
+                "version": item["version"],
+                "content_digest": item["content_digest"],
+            },
+            "bridge",
+        )
+        for item in bridges
+    ]
+    require(module_ids == sorted(set(module_ids)), "M9 module identity order")
+    require(bridge_ids == sorted(set(bridge_ids)), "M9 bridge identity order")
+    active = composition["activation_profile"]
+    require(set(active) == {"profile_default", "overrides"}, "activation fields")
+    require(active["profile_default"] in {"exploratory", "advisory", "strict"}, "profile")
+    overrides = [
+        (item["scope"], exact_identity(item["subject"], "activation"), item["mode"])
+        for item in active["overrides"]
+    ]
+    require(overrides == sorted(set(overrides)), "activation order")
+    for scope, subject, mode in overrides:
+        require(scope in {"module", "bridge"}, "activation scope")
+        require(mode in {"exploratory", "advisory", "strict"}, "activation mode")
+        require(subject in (module_ids if scope == "module" else bridge_ids), "activation closure")
+    for bridge in bridges:
+        for endpoint in ("source_modules", "target_modules"):
+            identities = [exact_identity(item, f"bridge {endpoint}") for item in bridge[endpoint]]
+            require(identities == sorted(set(identities)), f"bridge {endpoint} order")
+            require(identities and set(identities) <= set(module_ids), f"bridge {endpoint} closure")
+    for feature_set in ("required_features", "optional_features"):
+        values = composition[feature_set]
+        require(values == sorted(set(values)), f"M9 {feature_set} order")
+
+
+def require_invalid_control(value: dict[str, object], label: str) -> None:
+    try:
+        validate_composition_control(composition_with_digest(value))
+    except (KeyError, SystemExit, TypeError):
+        return
+    fail(f"{label} control mutation was accepted")
 
 
 def octal(value: int, width: int) -> bytes:
@@ -251,32 +358,8 @@ def main() -> None:
         ),
         "composition schema id",
     )
-    composition = dict(multi["composition"])
-    expected_composition = composition.pop("composition_digest")
-    actual_composition = (
-        "sha256:" + hashlib.sha256(COMPOSITION_DOMAIN + canonical(composition)).hexdigest()
-    )
-    require(actual_composition == expected_composition, "M9 composition digest")
-    module_ids = [f"{item['module_id']}@{item['version']}" for item in composition["modules"]]
-    bridge_ids = [
-        f"{item['bridge_set_id']}@{item['version']}" for item in composition["bridge_sets"]
-    ]
-    require(module_ids == sorted(set(module_ids)), "M9 module identity order")
-    require(bridge_ids == sorted(set(bridge_ids)), "M9 bridge identity order")
-    active = composition["activation_profile"]
-    require(active["active_modules"] == sorted(set(active["active_modules"])), "active modules")
-    require(
-        active["active_bridge_sets"] == sorted(set(active["active_bridge_sets"])),
-        "active bridge sets",
-    )
-    require(set(active["active_modules"]) <= set(module_ids), "active module closure")
-    require(set(active["active_bridge_sets"]) <= set(bridge_ids), "active bridge closure")
-    for bridge in composition["bridge_sets"]:
-        require(bridge["source_module"] in module_ids, "bridge source closure")
-        require(bridge["target_module"] in module_ids, "bridge target closure")
-    for feature_set in ("required_features", "optional_features"):
-        values = composition[feature_set]
-        require(values == sorted(set(values)), f"M9 {feature_set} order")
+    composition = multi["composition"]
+    validate_composition_control(composition)
     forbidden = {
         "runtime_catalog_ids",
         "host_paths",
@@ -290,6 +373,47 @@ def main() -> None:
     require(set(multi["package_classes"]) == classes, "M9 closure classes")
     require(multi["representations"] == ["expanded", "bundle"], "M9 representations")
     require(all(not vector["mutation"] for vector in multi["negative_vectors"]), "M9 mutation")
+    negative_names = {vector["name"] for vector in multi["negative_vectors"]}
+    require(
+        {
+            "non-nfc-uri-or-version",
+            "malformed-uri",
+            "malformed-digest-qualified-identity",
+            "duplicate-or-unsorted-endpoint",
+            "dangling-module-or-bridge",
+        }
+        <= negative_names,
+        "M9 exact identity negative vectors",
+    )
+    malformed_uri = json.loads(json.dumps(composition))
+    malformed_uri["modules"][0]["ontology_id"] = "not a URI"
+    require_invalid_control(malformed_uri, "malformed URI")
+    non_nfc = json.loads(json.dumps(composition))
+    non_nfc["modules"][0]["version"] = "cafe\u0301"
+    require_invalid_control(non_nfc, "non-NFC version")
+    malformed_digest = json.loads(json.dumps(composition))
+    malformed_digest["activation_profile"]["overrides"][0]["subject"]["content_digest"] = (
+        "sha256:ABC"
+    )
+    require_invalid_control(malformed_digest, "malformed activation digest")
+    empty_endpoint = json.loads(json.dumps(composition))
+    empty_endpoint["bridge_sets"][0]["source_modules"] = []
+    require_invalid_control(empty_endpoint, "empty bridge endpoint")
+    duplicate_endpoint = json.loads(json.dumps(composition))
+    duplicate_endpoint["bridge_sets"][0]["source_modules"].append(
+        duplicate_endpoint["bridge_sets"][0]["source_modules"][0]
+    )
+    require_invalid_control(duplicate_endpoint, "duplicate bridge endpoint")
+    unsorted_endpoint = json.loads(json.dumps(composition))
+    unsorted_endpoint["bridge_sets"][0]["source_modules"].reverse()
+    require_invalid_control(unsorted_endpoint, "unsorted bridge endpoint")
+    dangling_endpoint = json.loads(json.dumps(composition))
+    dangling_endpoint["bridge_sets"][0]["target_modules"][0] = {
+        "id": "urn:graphforge:ontology:missing",
+        "version": "1",
+        "content_digest": "sha256:" + "f" * 64,
+    }
+    require_invalid_control(dangling_endpoint, "dangling bridge endpoint")
     require(
         set(multi["older_v2_reader"].values()) == {"unsupported_future-before-payload"},
         "M9 older-reader behavior",

--- a/tests/fixtures/portable-v2/README.md
+++ b/tests/fixtures/portable-v2/README.md
@@ -21,7 +21,12 @@ canonical bytes/digests in every supported language before acceptance.
 
 `multi-ontology-vectors.json` and ADR 0022 define the M9 extension through the
 existing authenticated `compatibility` kind and a new required capability. The
-fixture freezes composition identity inputs/exclusions, closure for all four
+control vector deliberately uses URI identities, opaque non-SemVer versions,
+digest-qualified activation subjects, and a multi-source bridge so lossy
+identity projections cannot satisfy the contract. The dependency-free contract
+gate checks NFC-safe exact identity tuples, canonical order, uniqueness, and
+complete endpoint/activation closure. The fixture freezes composition identity
+inputs/exclusions, closure for all four
 package classes, older-reader behavior, typed negative results, and operational
 non-mutation invariants. It deliberately contains no runtime identity or TCK
 result in the composition identity.

--- a/tests/fixtures/portable-v2/multi-ontology-vectors.json
+++ b/tests/fixtures/portable-v2/multi-ontology-vectors.json
@@ -11,20 +11,23 @@
   "composition": {
     "contract": "graphforge-ontology-composition/1",
     "activation_profile": {
-      "profile_id": "research-default",
-      "active_modules": ["genealogy@2.1.0", "provenance@1.4.0"],
-      "active_bridge_sets": ["genealogy-provenance@1.0.0"]
+      "profile_default": "exploratory",
+      "overrides": [
+        {"scope":"bridge","subject":{"id":"https://graphforge.dev/bridge/research-provenance","version":"1","content_digest":"sha256:4444444444444444444444444444444444444444444444444444444444444444"},"mode":"advisory"},
+        {"scope":"module","subject":{"id":"https://graphforge.dev/ontology/genealogy","version":"release-2026.08","content_digest":"sha256:1111111111111111111111111111111111111111111111111111111111111111"},"mode":"strict"}
+      ]
     },
     "modules": [
-      {"module_id":"genealogy","version":"2.1.0","content_digest":"sha256:1111111111111111111111111111111111111111111111111111111111111111","dialect":"graphforge-ontology","profile":"strict"},
-      {"module_id":"provenance","version":"1.4.0","content_digest":"sha256:2222222222222222222222222222222222222222222222222222222222222222","dialect":"graphforge-ontology","profile":"advisory"}
+      {"ontology_id":"https://graphforge.dev/ontology/genealogy","version":"release-2026.08","content_digest":"sha256:1111111111111111111111111111111111111111111111111111111111111111","dialect":"graphforge-ontology","profile":"strict"},
+      {"ontology_id":"https://graphforge.dev/ontology/provenance","version":"1","content_digest":"sha256:2222222222222222222222222222222222222222222222222222222222222222","dialect":"graphforge-ontology","profile":"advisory"},
+      {"ontology_id":"urn:graphforge:ontology:research","version":"v1 beta","content_digest":"sha256:3333333333333333333333333333333333333333333333333333333333333333","dialect":"graphforge-ontology","profile":"exploratory"}
     ],
     "bridge_sets": [
-      {"bridge_set_id":"genealogy-provenance","version":"1.0.0","content_digest":"sha256:3333333333333333333333333333333333333333333333333333333333333333","source_module":"genealogy@2.1.0","target_module":"provenance@1.4.0"}
+      {"bridge_id":"https://graphforge.dev/bridge/research-provenance","version":"1","content_digest":"sha256:4444444444444444444444444444444444444444444444444444444444444444","source_modules":[{"id":"https://graphforge.dev/ontology/genealogy","version":"release-2026.08","content_digest":"sha256:1111111111111111111111111111111111111111111111111111111111111111"},{"id":"urn:graphforge:ontology:research","version":"v1 beta","content_digest":"sha256:3333333333333333333333333333333333333333333333333333333333333333"}],"target_modules":[{"id":"https://graphforge.dev/ontology/provenance","version":"1","content_digest":"sha256:2222222222222222222222222222222222222222222222222222222222222222"}]}
     ],
     "required_features": ["provenance-bridges@1", "qualified-symbols@1"],
     "optional_features": ["display-hints@1"],
-    "composition_digest": "sha256:ac9c0f89453317734f7869225d6fe095d1c6c497e7e543fc104b053cade728ac"
+    "composition_digest": "sha256:5c60015c9a58722e7779666b227c931cfbc47e420025896e9be530799613e832"
   },
   "identity_inputs": ["contract", "activation_profile", "modules", "bridge_sets", "required_features", "optional_features"],
   "identity_exclusions": ["runtime_catalog_ids", "host_paths", "parser_versions", "machine_configuration", "session_state", "credentials", "tck_results"],
@@ -42,6 +45,10 @@
     {"name":"malformed-control-json","outcome":"invalid_structure","mutation":false},
     {"name":"duplicate-control-member","outcome":"invalid_structure","mutation":false},
     {"name":"noncanonical-control","outcome":"incompatible","mutation":false},
+    {"name":"non-nfc-uri-or-version","outcome":"incompatible","mutation":false},
+    {"name":"malformed-uri","outcome":"incompatible","mutation":false},
+    {"name":"malformed-digest-qualified-identity","outcome":"incompatible","mutation":false},
+    {"name":"duplicate-or-unsorted-endpoint","outcome":"incompatible","mutation":false},
     {"name":"composition-digest-mismatch","outcome":"digest_mismatch","mutation":false},
     {"name":"component-digest-mismatch","outcome":"digest_mismatch","mutation":false},
     {"name":"dangling-module-or-bridge","outcome":"incompatible","mutation":false},


### PR DESCRIPTION
## Summary

- align ADR-0022 and its closed schema with #840's URI identities and opaque NFC versions
- retain digest-qualified activation identity as closed structured objects
- preserve complete ordered multi-source and multi-target bridge closure
- harden normative fixtures and the dependency-free contract gate against lossy and malformed projections

## Validation

- `python3 scripts/ci/portable-v2-contract.py`
- `python3 -m json.tool docs/contracts/graphforge-ontology-composition-v1.schema.json`
- `python3 -m json.tool tests/fixtures/portable-v2/multi-ontology-vectors.json`
- `uv run ruff check scripts/ci/portable-v2-contract.py`
- `uv run ruff format --check scripts/ci/portable-v2-contract.py`
- `make pre-push-fast`
- `git diff --check`

Closes #875

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789883956&installation_model_id=20486&pr_number=876&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F876&signature=5fa23f276e7e0f0d0976ec970690fb27850be7360d2a64cef986f139a66180b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->