### PR TITLE
feat(io): interchange exact ontology composition closures

### DIFF
--- a/crates/graphforge-storage/BUILD.bazel
+++ b/crates/graphforge-storage/BUILD.bazel
@@ -28,7 +28,10 @@ gf_rust_test(
     name = "graphforge_storage_test",
     crate = ":graphforge_storage",
     crate_features = ["test-failpoints"],
-    compile_data = ["//tests/fixtures/portable-v2:ontology-only.manifest.json"],
+    compile_data = [
+        "//tests/fixtures/portable-v2:multi-ontology-vectors.json",
+        "//tests/fixtures/portable-v2:ontology-only.manifest.json",
+    ],
     # Unit suite exercises filesystem/async paths; default "small" is too tight.
     size = "medium",
     deps = _STORAGE_DEPS,

--- a/crates/graphforge-storage/BUILD.bazel
+++ b/crates/graphforge-storage/BUILD.bazel
@@ -30,6 +30,7 @@ gf_rust_test(
     crate_features = ["test-failpoints"],
     compile_data = [
         "//tests/fixtures/portable-v2:multi-ontology-vectors.json",
+        "//tests/fixtures/portable-v2:m9-interchange-cases.json",
         "//tests/fixtures/portable-v2:ontology-only.manifest.json",
     ],
     # Unit suite exercises filesystem/async paths; default "small" is too tight.

--- a/crates/graphforge-storage/src/graph_projection.rs
+++ b/crates/graphforge-storage/src/graph_projection.rs
@@ -12,7 +12,8 @@ use std::sync::Arc;
 use arrow::array::{
     Array, ArrayRef, BinaryArray, BooleanArray, FixedSizeBinaryArray, FixedSizeListArray,
     Float32Array, Float64Array, Int32Array, Int64Array, LargeBinaryArray, LargeListArray,
-    LargeStringArray, ListArray, StringArray, StructArray, UInt32Array, UInt64Array,
+    LargeStringArray, ListArray, ListBuilder, StringArray, StringBuilder, StructArray, UInt32Array,
+    UInt64Array,
 };
 use arrow::compute::{concat_batches, take};
 use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
@@ -443,7 +444,15 @@ fn selected_catalog_rows(target: &Path, catalog: &RecordBatch) -> Result<Vec<usi
 
     let mut active_owners = BTreeSet::new();
     for row in 0..catalog.num_rows() {
-        if kinds.value(row) == "entity_type" && type_ids.contains(&ids.value(row)) {
+        if kinds.value(row) == "entity_type"
+            && type_ids.iter().any(|stored| {
+                *stored == ids.value(row)
+                    || graphforge_ir::runtime_type_id_from_entity_plan_id(graphforge_core::TypeId(
+                        *stored,
+                    ))
+                    .is_some_and(|runtime| runtime.0 == ids.value(row))
+            })
+        {
             active_owners.insert(names.value(row).to_owned());
         }
     }
@@ -452,7 +461,13 @@ fn selected_catalog_rows(target: &Path, catalog: &RecordBatch) -> Result<Vec<usi
     let mut selected = BTreeSet::new();
     for row in 0..catalog.num_rows() {
         let keep = match kinds.value(row) {
-            "entity_type" => type_ids.contains(&ids.value(row)),
+            "entity_type" => type_ids.iter().any(|stored| {
+                *stored == ids.value(row)
+                    || graphforge_ir::runtime_type_id_from_entity_plan_id(graphforge_core::TypeId(
+                        *stored,
+                    ))
+                    .is_some_and(|runtime| runtime.0 == ids.value(row))
+            }),
             "relation_type" => relation_names.contains(names.value(row)),
             "property" => {
                 property_names.contains(names.value(row))
@@ -502,7 +517,7 @@ fn read_parquet(path: &Path) -> Result<Vec<RecordBatch>, GfError> {
         .map_err(|error| GfError::Storage(error.to_string()))
 }
 
-fn write_parquet(path: &Path, batch: &RecordBatch) -> Result<(), GfError> {
+pub(crate) fn write_parquet(path: &Path, batch: &RecordBatch) -> Result<(), GfError> {
     let parent = path
         .parent()
         .ok_or_else(|| validation("graph parquet target has no parent"))?;
@@ -514,7 +529,7 @@ fn write_parquet(path: &Path, batch: &RecordBatch) -> Result<(), GfError> {
     Ok(())
 }
 
-fn projected_graph_fingerprint(root: &Path) -> Result<[u8; 32], GfError> {
+pub(crate) fn projected_graph_fingerprint(root: &Path) -> Result<[u8; 32], GfError> {
     let mut paths = Vec::new();
     let nodes = root.join("topology/nodes.parquet");
     if nodes.exists() {
@@ -528,7 +543,34 @@ fn projected_graph_fingerprint(root: &Path) -> Result<[u8; 32], GfError> {
         paths.push(runtime_catalog);
     }
     paths.sort();
+    fingerprint_graph_paths(root, paths)
+}
 
+/// Portable semantic graph identity excludes runtime catalog IDs while
+/// retaining decoded topology, edges, node properties, and edge properties.
+pub(crate) fn portable_graph_data_fingerprint(root: &Path) -> Result<[u8; 32], GfError> {
+    let runtime_entity_names = portable_runtime_entity_names(root)?;
+    let mut paths = Vec::new();
+    let nodes = root.join("topology/nodes.parquet");
+    if nodes.exists() {
+        paths.push(nodes);
+    }
+    for directory in ["topology/edges", "properties", "edge_properties"] {
+        paths.extend(sorted_parquet_files(&root.join(directory))?);
+    }
+    paths.sort();
+    fingerprint_graph_paths_with_runtime_names(root, paths, Some(&runtime_entity_names))
+}
+
+fn fingerprint_graph_paths(root: &Path, paths: Vec<PathBuf>) -> Result<[u8; 32], GfError> {
+    fingerprint_graph_paths_with_runtime_names(root, paths, None)
+}
+
+fn fingerprint_graph_paths_with_runtime_names(
+    root: &Path,
+    paths: Vec<PathBuf>,
+    runtime_entity_names: Option<&BTreeMap<u32, String>>,
+) -> Result<[u8; 32], GfError> {
     let mut writer = CanonicalWriter::new();
     writer.raw(b"GFGP1").map_err(canonical_error)?;
     writer
@@ -547,7 +589,7 @@ fn projected_graph_fingerprint(root: &Path) -> Result<[u8; 32], GfError> {
             .map(RecordBatch::schema)
             .ok_or_else(|| validation("graph projection table has no schema"))?;
         let batch = concat_batches(&schema, &batches).map_err(storage)?;
-        let logical = logical_fingerprint_batch(relative, &batch)?;
+        let logical = logical_fingerprint_batch(relative, &batch, runtime_entity_names)?;
         encode_table(&mut writer, &logical)?;
     }
     fingerprint(
@@ -558,9 +600,13 @@ fn projected_graph_fingerprint(root: &Path) -> Result<[u8; 32], GfError> {
     .map_err(canonical_error)
 }
 
-fn logical_fingerprint_batch(relative: &str, batch: &RecordBatch) -> Result<RecordBatch, GfError> {
+fn logical_fingerprint_batch(
+    relative: &str,
+    batch: &RecordBatch,
+    runtime_entity_names: Option<&BTreeMap<u32, String>>,
+) -> Result<RecordBatch, GfError> {
     let source_schema = batch.schema();
-    let names: Vec<&str> = if relative == "topology/nodes.parquet" {
+    let mut names: Vec<&str> = if relative == "topology/nodes.parquet" {
         vec!["node_uuid", "type_id", "type_ids"]
     } else if relative.starts_with("topology/edges/") {
         let mut names = vec!["edge_uuid", "src_uuid", "dst_uuid"];
@@ -577,20 +623,146 @@ fn logical_fingerprint_batch(relative: &str, batch: &RecordBatch) -> Result<Reco
             .map(|field| field.name().as_str())
             .collect()
     };
+    if !relative.starts_with("topology/") {
+        names.sort_by(|left, right| left.as_bytes().cmp(right.as_bytes()));
+    }
     let mut fields = Vec::with_capacity(names.len());
     let mut columns = Vec::with_capacity(names.len());
     for name in names {
         let index = source_schema
             .index_of(name)
             .map_err(|_| validation(format!("graph fingerprint field {name} is absent")))?;
-        fields.push(Arc::clone(&source_schema.fields()[index]));
-        columns.push(Arc::clone(batch.column(index)));
+        if let Some(names) = runtime_entity_names.filter(|_| {
+            relative == "topology/nodes.parquet" && matches!(name, "type_id" | "type_ids")
+        }) {
+            let (field, column) = portable_node_type_column(name, batch.column(index), names)?;
+            fields.push(field);
+            columns.push(column);
+        } else {
+            fields.push(Arc::clone(&source_schema.fields()[index]));
+            columns.push(Arc::clone(batch.column(index)));
+        }
     }
     let schema = Arc::new(Schema::new_with_metadata(
         fields,
         source_schema.metadata().clone(),
     ));
     RecordBatch::try_new(schema, columns).map_err(storage)
+}
+
+fn portable_runtime_entity_names(root: &Path) -> Result<BTreeMap<u32, String>, GfError> {
+    let path = root.join("topology/runtime_catalog.parquet");
+    if !path.exists() {
+        return Ok(BTreeMap::new());
+    }
+    let batches = read_parquet(&path)?;
+    let schema = batches
+        .first()
+        .map(RecordBatch::schema)
+        .ok_or_else(|| validation("runtime catalog has no schema"))?;
+    let batch = concat_batches(&schema, &batches).map_err(storage)?;
+    // Parsing through RuntimeCatalog applies the catalog's complete structural
+    // and uniqueness validation before IDs are used as portable authority.
+    let canonical = graphforge_ir::RuntimeCatalog::from_record_batch(&batch)?.to_record_batch();
+    let kinds = string_column(&canonical, "entry_kind")?;
+    let names = string_column(&canonical, "name")?;
+    let ids = canonical
+        .column_by_name("runtime_id")
+        .and_then(|column| column.as_any().downcast_ref::<UInt32Array>())
+        .ok_or_else(|| validation("runtime catalog runtime_id is not UInt32"))?;
+    let mut result = BTreeMap::new();
+    for row in 0..canonical.num_rows() {
+        if kinds.value(row) == "entity_type"
+            && result
+                .insert(ids.value(row), names.value(row).to_owned())
+                .is_some()
+        {
+            return Err(validation("runtime catalog has a duplicate entity type ID"));
+        }
+    }
+    Ok(result)
+}
+
+fn portable_type_name(id: u32, runtime: &BTreeMap<u32, String>) -> Result<String, GfError> {
+    let id = graphforge_core::TypeId(id);
+    if graphforge_ir::is_runtime_entity_type_id(id) {
+        let local = graphforge_ir::runtime_type_id_from_entity_plan_id(id)
+            .expect("runtime entity tag checked")
+            .0;
+        return runtime
+            .get(&local)
+            .map(|name| format!("runtime-entity:{name}"))
+            .ok_or_else(|| validation("node runtime type ID has no catalog name"));
+    }
+    if id.0 & graphforge_ir::RUNTIME_RELATION_TYPE_TAG != 0 {
+        return Err(validation("node type carries a runtime relation tag"));
+    }
+    // Untagged IDs are generation-bound semantic storage IDs. Their stable
+    // namespace is deliberately distinct from runtime names; #872 validates
+    // these IDs against the authenticated semantic-binding participant when a
+    // generation is admitted.
+    Ok(format!("semantic-storage-id:{}", id.0))
+}
+
+fn portable_node_type_column(
+    name: &str,
+    column: &ArrayRef,
+    runtime: &BTreeMap<u32, String>,
+) -> Result<(Arc<Field>, ArrayRef), GfError> {
+    if name == "type_id" {
+        let values = column
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .ok_or_else(|| validation("node type_id is not UInt32"))?;
+        let mut builder = StringBuilder::with_capacity(values.len(), values.len() * 32);
+        for row in 0..values.len() {
+            if values.is_null(row) {
+                builder.append_null();
+            } else {
+                builder.append_value(portable_type_name(values.value(row), runtime)?);
+            }
+        }
+        return Ok((
+            Arc::new(Field::new(name, DataType::Utf8, true)),
+            Arc::new(builder.finish()),
+        ));
+    }
+    let lists = column
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .ok_or_else(|| validation("node type_ids is not List"))?;
+    let mut builder = ListBuilder::new(StringBuilder::new());
+    for row in 0..lists.len() {
+        if lists.is_null(row) {
+            builder.append(false);
+            continue;
+        }
+        let values = lists.value(row);
+        let values = values
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .ok_or_else(|| validation("node type_ids values are not UInt32"))?;
+        let mut resolved = Vec::with_capacity(values.len());
+        for item in 0..values.len() {
+            if values.is_null(item) {
+                return Err(validation("node type_ids contains null"));
+            }
+            resolved.push(portable_type_name(values.value(item), runtime)?);
+        }
+        resolved.sort_by(|left, right| left.as_bytes().cmp(right.as_bytes()));
+        if resolved.windows(2).any(|pair| pair[0] == pair[1]) {
+            return Err(validation("node type_ids contains a duplicate assignment"));
+        }
+        for value in resolved {
+            builder.values().append_value(value);
+        }
+        builder.append(true);
+    }
+    let values: ArrayRef = Arc::new(builder.finish());
+    Ok((
+        Arc::new(Field::new(name, values.data_type().clone(), true)),
+        values,
+    ))
 }
 
 fn encode_table(writer: &mut CanonicalWriter, batch: &RecordBatch) -> Result<(), GfError> {
@@ -2196,6 +2368,66 @@ mod tests {
             )),
             &DataType::Utf8
         );
+    }
+
+    fn portable_typed_graph(label: &str, catalog_prefix: Option<&str>) -> TempDir {
+        let root = TempDir::new().unwrap();
+        let mut catalog = RuntimeCatalog::new();
+        if let Some(prefix) = catalog_prefix {
+            catalog.intern_label(prefix);
+        }
+        let runtime_id = catalog.intern_label(label);
+        let storage_id = graphforge_ir::runtime_entity_type_id(runtime_id);
+        let mut writer = GraphWriter::open_at(root.path(), OntologyMode::Exploratory, TS).unwrap();
+        writer.create_node(uuid(91), storage_id).unwrap();
+        writer.flush().unwrap();
+        write_parquet(
+            &root.path().join("topology/runtime_catalog.parquet"),
+            &catalog.to_record_batch(),
+        )
+        .unwrap();
+        root
+    }
+
+    #[test]
+    fn portable_type_fingerprint_is_name_stable_parallel_and_semantic() {
+        let first = portable_typed_graph("Person", None);
+        let shifted = portable_typed_graph("Person", Some("EarlierInsertion"));
+        let changed = portable_typed_graph("Company", None);
+        let expected = portable_graph_data_fingerprint(first.path()).unwrap();
+        assert_eq!(
+            expected,
+            portable_graph_data_fingerprint(shifted.path()).unwrap(),
+            "runtime catalog allocation order must not leak into portable identity"
+        );
+        assert_ne!(
+            expected,
+            portable_graph_data_fingerprint(changed.path()).unwrap(),
+            "changing only the semantic type assignment must change identity"
+        );
+        std::thread::scope(|scope| {
+            let handles = (0..8)
+                .map(|_| scope.spawn(|| portable_graph_data_fingerprint(first.path()).unwrap()))
+                .collect::<Vec<_>>();
+            for handle in handles {
+                assert_eq!(handle.join().unwrap(), expected);
+            }
+        });
+    }
+
+    #[test]
+    fn portable_type_fingerprint_fails_closed_for_unresolved_runtime_id() {
+        let root = TempDir::new().unwrap();
+        let mut writer = GraphWriter::open_at(root.path(), OntologyMode::Exploratory, TS).unwrap();
+        writer
+            .create_node(
+                uuid(92),
+                graphforge_ir::runtime_entity_type_id(graphforge_ir::RuntimeTypeId(41)),
+            )
+            .unwrap();
+        writer.flush().unwrap();
+        let error = portable_graph_data_fingerprint(root.path()).unwrap_err();
+        assert!(error.to_string().contains("no catalog name"));
     }
 
     fn id_map(batch: &RecordBatch, uuid_name: &str, id_name: &str) -> BTreeMap<[u8; 16], u64> {

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -144,22 +144,25 @@ pub use project_portable_v2_export::{
 };
 pub use project_portable_v2_import::{
     PortableV2ImportPhase, PortableV2ImportProgress, PortableV2ImportReceipt,
-    import_complete_portable_v2, import_complete_portable_v2_with_progress,
+    PortableV2StagedCompositionReceipt, import_complete_portable_v2,
+    import_complete_portable_v2_with_progress, load_portable_ontology_staging,
 };
 
 pub mod project_portable_v2;
 pub use project_portable_v2::{
-    PortableV2Authenticity, PortableV2Compatibility, PortableV2Error, PortableV2ErrorCode,
-    PortableV2Integrity, PortableV2Limits, PortableV2Mode, PortableV2PackageClass,
-    PortableV2Report, PortableV2Representation, materialize_verified_portable_v2,
-    verify_portable_v2,
+    PortableV2ActivationOverride, PortableV2ActivationProfile, PortableV2Authenticity,
+    PortableV2BridgeSet, PortableV2Compatibility, PortableV2CompositionEntry, PortableV2Error,
+    PortableV2ErrorCode, PortableV2ExactIdentity, PortableV2Integrity, PortableV2Limits,
+    PortableV2Mode, PortableV2OntologyComposition, PortableV2OntologyModule,
+    PortableV2PackageClass, PortableV2Report, PortableV2Representation,
+    materialize_verified_portable_v2, verify_portable_v2,
 };
 
 mod project_portable_v2_selection;
 pub use project_portable_v2_selection::{
-    PortableV2ParticipantId, PortableV2SelectionEntry, PortableV2SelectionPlan,
-    PortableV2SelectionProfile, PortableV2SelectionReason, PortableV2SelectionRequest,
-    preview_portable_v2_selection,
+    PortableV2ParticipantId, PortableV2ProjectedSelectionEntry, PortableV2SelectionEntry,
+    PortableV2SelectionPlan, PortableV2SelectionProfile, PortableV2SelectionReason,
+    PortableV2SelectionRequest, preview_portable_v2_selection,
 };
 
 pub mod project_portable_v2_subset;
@@ -188,10 +191,11 @@ pub use workspace_participants::{
     MAX_WORKSPACE_REPOSITORY_SNAPSHOT_ENTRIES, MAX_WORKSPACE_REPOSITORY_SNAPSHOT_ID_BYTES,
     WORKSPACE_CAPABILITY_ID, WORKSPACE_CAPABILITY_VERSION, WORKSPACE_CONFIGURATION_FAMILY,
     WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY, WORKSPACE_ONTOLOGY_COMPOSITION_VERSION,
-    WORKSPACE_ONTOLOGY_FAMILY, WORKSPACE_REPOSITORY_SNAPSHOT_FAMILY,
-    WORKSPACE_REPOSITORY_SNAPSHOT_VERSION, WorkspaceCompositionModule, WorkspaceConfiguration,
-    WorkspaceOntology, WorkspaceOntologyComposition, WorkspaceOntologyMode,
-    WorkspaceOntologySourceFormat, WorkspaceRepositoryDefinitionDigest,
+    WORKSPACE_ONTOLOGY_FAMILY, WORKSPACE_PORTABLE_ONTOLOGY_STAGING_FAMILY,
+    WORKSPACE_REPOSITORY_SNAPSHOT_FAMILY, WORKSPACE_REPOSITORY_SNAPSHOT_VERSION,
+    WorkspaceCompositionModule, WorkspaceConfiguration, WorkspaceOntology,
+    WorkspaceOntologyComposition, WorkspaceOntologyMode, WorkspaceOntologySourceFormat,
+    WorkspacePortableOntologyStaging, WorkspaceRepositoryDefinitionDigest,
     WorkspaceRepositoryGitProvenance, WorkspaceRepositorySnapshot, WorkspaceRepositorySourceDigest,
     empty_workspace_participants,
 };

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -170,7 +170,8 @@ pub mod project_portable_v2_subset;
 pub use project_portable_v2_subset::{
     PortableV2GraphSelector, PortableV2GraphSubsetMeta, PortableV2PropertyProjection,
     PortableV2SubsetClosure, PortableV2SubsetPlan, PortableV2SubsetRequest,
-    plan_graph_subset_portable_v2, preview_portable_v2_graph_subset,
+    plan_graph_subset_portable_v2, portable_v2_graph_data_fingerprint,
+    preview_portable_v2_graph_subset,
 };
 
 pub mod project_portable_v2_oci;

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -144,7 +144,8 @@ pub use project_portable_v2_export::{
 };
 pub use project_portable_v2_import::{
     PortableV2ImportPhase, PortableV2ImportProgress, PortableV2ImportReceipt,
-    PortableV2StagedCompositionReceipt, import_complete_portable_v2,
+    PortableV2SelectiveCandidate, PortableV2StagedCompositionReceipt,
+    consume_selective_portable_v2, import_complete_portable_v2,
     import_complete_portable_v2_with_progress, load_portable_ontology_staging,
 };
 

--- a/crates/graphforge-storage/src/project_portable_v2.rs
+++ b/crates/graphforge-storage/src/project_portable_v2.rs
@@ -508,6 +508,10 @@ fn preflight_expanded(root: &Path, limits: PortableV2Limits) -> Result<(), Porta
     Ok(())
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "keeps bounded header census and admission ordering in one pre-mutation audit path"
+)]
 fn preflight_bundle(
     path: &Path,
     limits: PortableV2Limits,
@@ -518,6 +522,9 @@ fn preflight_bundle(
     let mut pending_pax = None;
     let mut admitted_manifest = None;
     let mut pending_composition: Option<Vec<u8>> = None;
+    let mut admitted_composition = false;
+    let mut entries = 0_u64;
+    let mut total = 0_u64;
     loop {
         check_cancel(cancelled)?;
         let mut header = [0_u8; 512];
@@ -529,6 +536,24 @@ fn preflight_bundle(
         }
         let size = parse_octal(&header[124..136])?;
         let raw_path = header_path(&header)?;
+        entries = entries.checked_add(1).ok_or_else(|| {
+            PortableV2Error::new(PortableV2ErrorCode::LimitExceeded, "bundle entry count")
+        })?;
+        if entries > limits.max_entries {
+            return Err(PortableV2Error::new(
+                PortableV2ErrorCode::LimitExceeded,
+                "bundle entry count",
+            ));
+        }
+        total = total.checked_add(size).ok_or_else(|| {
+            PortableV2Error::new(PortableV2ErrorCode::LimitExceeded, "bundle total bytes")
+        })?;
+        if total > limits.max_total_bytes {
+            return Err(PortableV2Error::new(
+                PortableV2ErrorCode::LimitExceeded,
+                "bundle total bytes",
+            ));
+        }
         if header[156] == b'x' {
             let bytes = read_unhashed_payload(&mut input, size, limits.max_path_bytes + 32)?;
             pending_pax = Some(parse_pax(std::str::from_utf8(&bytes).map_err(|_| {
@@ -552,18 +577,18 @@ fn preflight_bundle(
                     .iter()
                     .any(|capability| capability == "ontology-composition@1");
                 if !needs_composition {
-                    return Ok(());
+                    admitted_manifest = Some(admitted);
+                    continue;
                 }
                 admitted_manifest = Some(admitted);
                 if let Some(control) = pending_composition.take() {
                     admit_composition_features(&control)?;
-                    return Ok(());
+                    admitted_composition = true;
                 }
+            } else if admitted_manifest.is_some() {
+                admit_composition_features(&bytes)?;
+                admitted_composition = true;
             } else {
-                if admitted_manifest.is_some() {
-                    admit_composition_features(&bytes)?;
-                    return Ok(());
-                }
                 // Canonical bundles sort paths, so the composition control can
                 // precede the root manifest. Retain only this bounded control;
                 // no component payload is read before both admission documents
@@ -580,15 +605,27 @@ fn preflight_bundle(
             })?;
         }
     }
-    Err(PortableV2Error::at(
-        PortableV2ErrorCode::InvalidStructure,
-        if admitted_manifest.is_some() {
-            ONTOLOGY_COMPOSITION_PATH
-        } else {
-            MANIFEST_PATH
-        },
-        "required preflight control is missing",
-    ))
+    let Some(manifest) = admitted_manifest else {
+        return Err(PortableV2Error::at(
+            PortableV2ErrorCode::InvalidStructure,
+            MANIFEST_PATH,
+            "required preflight control is missing",
+        ));
+    };
+    if manifest
+        .requirements
+        .capabilities
+        .iter()
+        .any(|capability| capability == "ontology-composition@1")
+        && !admitted_composition
+    {
+        return Err(PortableV2Error::at(
+            PortableV2ErrorCode::InvalidStructure,
+            ONTOLOGY_COMPOSITION_PATH,
+            "required preflight control is missing",
+        ));
+    }
+    Ok(())
 }
 
 pub(crate) fn validate_materialized_ontology_composition(
@@ -3392,6 +3429,43 @@ mod tests {
         out.extend_from_slice(payload);
         out.resize(out.len() + ((512 - payload.len() % 512) % 512), 0);
         out
+    }
+
+    #[test]
+    fn bundle_preflight_bounds_header_scan_before_admission() {
+        let parent = tempfile::tempdir().unwrap();
+        let count_bundle = parent.path().join("count.gfpb");
+        let mut bytes = Vec::new();
+        for index in 0..3 {
+            bytes.extend(tar_entry(&format!("data/payload-{index}"), b"x"));
+        }
+        bytes.extend([0_u8; 1024]);
+        fs::write(&count_bundle, bytes).unwrap();
+        let error = preflight_bundle(
+            &count_bundle,
+            PortableV2Limits {
+                max_entries: 2,
+                ..PortableV2Limits::default()
+            },
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(error.code, PortableV2ErrorCode::LimitExceeded);
+
+        let bytes_bundle = parent.path().join("bytes.gfpb");
+        let mut bytes = tar_entry("data/payload", b"xx");
+        bytes.extend([0_u8; 1024]);
+        fs::write(&bytes_bundle, bytes).unwrap();
+        let error = preflight_bundle(
+            &bytes_bundle,
+            PortableV2Limits {
+                max_total_bytes: 1,
+                ..PortableV2Limits::default()
+            },
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(error.code, PortableV2ErrorCode::LimitExceeded);
     }
 
     #[test]

--- a/crates/graphforge-storage/src/project_portable_v2.rs
+++ b/crates/graphforge-storage/src/project_portable_v2.rs
@@ -11,7 +11,7 @@ use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::fs::{self, File};
-use std::io::{Read, Write};
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Component, Path};
 use std::sync::atomic::{AtomicBool, Ordering};
 use unicode_normalization::UnicodeNormalization;
@@ -19,6 +19,8 @@ use unicode_normalization::UnicodeNormalization;
 const MANIFEST_PATH: &str = "data/graphforge-project.json";
 pub(crate) const RUNTIME_MAP_PATH: &str =
     "data/components/compatibility/graphforge-runtime-map/runtime-generation.json";
+pub(crate) const ONTOLOGY_COMPOSITION_PATH: &str =
+    "data/components/compatibility/graphforge-ontology-composition/composition.json";
 const BAGIT: &[u8] = b"BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8\n";
 const BAG_INFO: &[u8] = b"Bag-Software-Agent: GraphForge portable-v2\nBagging-Date: 1970-01-01\n";
 
@@ -109,6 +111,76 @@ pub struct PortableV2Report {
     pub compatibility: PortableV2Compatibility,
     pub authenticity: PortableV2Authenticity,
     pub transport_digest: Option<String>,
+    /// Exact authenticated multi-ontology compatibility control, when present.
+    pub ontology_composition: Option<PortableV2OntologyComposition>,
+    /// Authenticated bounded payload entries available to explicit lifecycle consumers.
+    pub ontology_composition_entries: Vec<PortableV2CompositionEntry>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct PortableV2CompositionEntry {
+    pub kind: String,
+    pub identity: PortableV2ExactIdentity,
+    pub path: String,
+    pub media_type: String,
+    pub length: u64,
+    pub sha256: String,
+    pub required_dependencies: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PortableV2ExactIdentity {
+    pub id: String,
+    pub version: String,
+    pub content_digest: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PortableV2ActivationOverride {
+    pub scope: String,
+    pub subject: PortableV2ExactIdentity,
+    pub mode: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PortableV2ActivationProfile {
+    pub profile_default: String,
+    pub overrides: Vec<PortableV2ActivationOverride>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PortableV2OntologyModule {
+    pub ontology_id: String,
+    pub version: String,
+    pub content_digest: String,
+    pub dialect: String,
+    pub profile: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PortableV2BridgeSet {
+    pub bridge_id: String,
+    pub version: String,
+    pub content_digest: String,
+    pub source_modules: Vec<PortableV2ExactIdentity>,
+    pub target_modules: Vec<PortableV2ExactIdentity>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PortableV2OntologyComposition {
+    pub contract: String,
+    pub activation_profile: PortableV2ActivationProfile,
+    pub modules: Vec<PortableV2OntologyModule>,
+    pub bridge_sets: Vec<PortableV2BridgeSet>,
+    pub required_features: Vec<String>,
+    pub optional_features: Vec<String>,
+    pub composition_digest: String,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
@@ -291,15 +363,434 @@ pub fn verify_portable_v2(
         ));
     }
     if metadata.is_dir() {
+        preflight_expanded(source, limits)?;
+    } else if metadata.is_file() {
+        preflight_bundle(source, limits, cancelled)?;
+    }
+    let report = if metadata.is_dir() {
         verify_expanded(source, mode, limits, cancelled)
     } else if metadata.is_file() {
         verify_bundle(source, mode, limits, cancelled)
     } else {
-        Err(PortableV2Error::new(
+        return Err(PortableV2Error::new(
             PortableV2ErrorCode::InvalidStructure,
             "source is not a regular file or directory",
-        ))
+        ));
+    }?;
+    if mode == PortableV2Mode::Full && report.ontology_composition.is_some() {
+        let staging = tempfile::tempdir().map_err(|_| {
+            PortableV2Error::new(
+                PortableV2ErrorCode::Io,
+                "cannot stage semantic verification",
+            )
+        })?;
+        if metadata.is_dir() {
+            materialize_expanded(source, staging.path(), limits, cancelled)?;
+        } else {
+            materialize_bundle(source, staging.path(), limits, cancelled)?;
+        }
+        validate_materialized_ontology_composition(staging.path(), &report, limits, cancelled)?;
     }
+    Ok(report)
+}
+
+fn admit_manifest(bytes: &[u8], limits: PortableV2Limits) -> Result<Manifest, PortableV2Error> {
+    if bytes.len() as u64 > limits.max_manifest_bytes {
+        return Err(PortableV2Error::at(
+            PortableV2ErrorCode::LimitExceeded,
+            MANIFEST_PATH,
+            "manifest size",
+        ));
+    }
+    let (manifest, canonical_without_digest) = parse_manifest(bytes, limits)?;
+    let expected = format!(
+        "sha256:{}",
+        hex(&Sha256::digest(
+            [
+                b"graphforge-project/2\0".as_slice(),
+                canonical_without_digest.as_slice()
+            ]
+            .concat()
+        ))
+    );
+    if !constant_time_eq(expected.as_bytes(), manifest.package_digest.as_bytes()) {
+        return Err(PortableV2Error::at(
+            PortableV2ErrorCode::DigestMismatch,
+            MANIFEST_PATH,
+            "package digest",
+        ));
+    }
+    validate_semantics(&manifest, limits)?;
+    Ok(manifest)
+}
+
+fn admit_composition_features(bytes: &[u8]) -> Result<(), PortableV2Error> {
+    let control: PortableV2OntologyComposition = serde_json::from_slice(bytes).map_err(|_| {
+        PortableV2Error::at(
+            PortableV2ErrorCode::InvalidStructure,
+            ONTOLOGY_COMPOSITION_PATH,
+            "ontology composition schema",
+        )
+    })?;
+    if control.required_features.iter().any(|feature| {
+        !matches!(
+            feature.as_str(),
+            "provenance-bridges@1" | "qualified-symbols@1"
+        )
+    }) {
+        return Err(PortableV2Error::at(
+            PortableV2ErrorCode::UnsupportedFuture,
+            ONTOLOGY_COMPOSITION_PATH,
+            "required ontology composition feature",
+        ));
+    }
+    Ok(())
+}
+
+fn read_bounded_file(path: &Path, limit: u64, entry: &str) -> Result<Vec<u8>, PortableV2Error> {
+    let metadata = fs::symlink_metadata(path).map_err(|_| {
+        PortableV2Error::at(
+            PortableV2ErrorCode::InvalidStructure,
+            entry,
+            "control unavailable",
+        )
+    })?;
+    if !metadata.is_file() || metadata.file_type().is_symlink() || metadata.len() > limit {
+        return Err(PortableV2Error::at(
+            PortableV2ErrorCode::LimitExceeded,
+            entry,
+            "control bound",
+        ));
+    }
+    let mut file =
+        crate::project_portable_v2_export::open_source_no_follow(path).map_err(|_| {
+            PortableV2Error::at(
+                PortableV2ErrorCode::InvalidStructure,
+                entry,
+                "unsafe control",
+            )
+        })?;
+    let mut bytes = Vec::new();
+    std::io::Read::by_ref(&mut file)
+        .take(limit.saturating_add(1))
+        .read_to_end(&mut bytes)
+        .map_err(|_| PortableV2Error::at(PortableV2ErrorCode::Io, entry, "cannot read control"))?;
+    if bytes.len() as u64 > limit {
+        return Err(PortableV2Error::at(
+            PortableV2ErrorCode::LimitExceeded,
+            entry,
+            "control bound",
+        ));
+    }
+    Ok(bytes)
+}
+
+fn preflight_expanded(root: &Path, limits: PortableV2Limits) -> Result<(), PortableV2Error> {
+    let manifest = read_bounded_file(
+        &root.join(MANIFEST_PATH),
+        limits.max_manifest_bytes,
+        MANIFEST_PATH,
+    )?;
+    let admitted = admit_manifest(&manifest, limits)?;
+    if admitted
+        .requirements
+        .capabilities
+        .iter()
+        .any(|capability| capability == "ontology-composition@1")
+    {
+        let control = read_bounded_file(
+            &root.join(ONTOLOGY_COMPOSITION_PATH),
+            limits.max_manifest_bytes,
+            ONTOLOGY_COMPOSITION_PATH,
+        )?;
+        admit_composition_features(&control)?;
+    }
+    Ok(())
+}
+
+fn preflight_bundle(
+    path: &Path,
+    limits: PortableV2Limits,
+    cancelled: Option<&AtomicBool>,
+) -> Result<(), PortableV2Error> {
+    let mut input = File::open(path)
+        .map_err(|_| PortableV2Error::new(PortableV2ErrorCode::Io, "cannot open bundle"))?;
+    let mut pending_pax = None;
+    let mut admitted_manifest = None;
+    let mut pending_composition: Option<Vec<u8>> = None;
+    loop {
+        check_cancel(cancelled)?;
+        let mut header = [0_u8; 512];
+        input.read_exact(&mut header).map_err(|_| {
+            PortableV2Error::new(PortableV2ErrorCode::InvalidStructure, "truncated bundle")
+        })?;
+        if header.iter().all(|byte| *byte == 0) {
+            break;
+        }
+        let size = parse_octal(&header[124..136])?;
+        let raw_path = header_path(&header)?;
+        if header[156] == b'x' {
+            let bytes = read_unhashed_payload(&mut input, size, limits.max_path_bytes + 32)?;
+            pending_pax = Some(parse_pax(std::str::from_utf8(&bytes).map_err(|_| {
+                PortableV2Error::new(PortableV2ErrorCode::InvalidPath, "PAX path is not UTF-8")
+            })?)?);
+            continue;
+        }
+        let entry = pending_pax.take().unwrap_or(raw_path);
+        if entry == MANIFEST_PATH || entry == ONTOLOGY_COMPOSITION_PATH {
+            let cap = limits.max_manifest_bytes;
+            let bytes = read_unhashed_payload(
+                &mut input,
+                size,
+                usize::try_from(cap).unwrap_or(usize::MAX),
+            )?;
+            if entry == MANIFEST_PATH {
+                let admitted = admit_manifest(&bytes, limits)?;
+                let needs_composition = admitted
+                    .requirements
+                    .capabilities
+                    .iter()
+                    .any(|capability| capability == "ontology-composition@1");
+                if !needs_composition {
+                    return Ok(());
+                }
+                admitted_manifest = Some(admitted);
+                if let Some(control) = pending_composition.take() {
+                    admit_composition_features(&control)?;
+                    return Ok(());
+                }
+            } else {
+                if admitted_manifest.is_some() {
+                    admit_composition_features(&bytes)?;
+                    return Ok(());
+                }
+                // Canonical bundles sort paths, so the composition control can
+                // precede the root manifest. Retain only this bounded control;
+                // no component payload is read before both admission documents
+                // have been checked.
+                pending_composition = Some(bytes);
+            }
+        } else {
+            let padding = (512 - size % 512) % 512;
+            let skip = i64::try_from(size.saturating_add(padding)).map_err(|_| {
+                PortableV2Error::new(PortableV2ErrorCode::LimitExceeded, "bundle entry size")
+            })?;
+            input.seek(SeekFrom::Current(skip)).map_err(|_| {
+                PortableV2Error::new(PortableV2ErrorCode::InvalidStructure, "truncated bundle")
+            })?;
+        }
+    }
+    Err(PortableV2Error::at(
+        PortableV2ErrorCode::InvalidStructure,
+        if admitted_manifest.is_some() {
+            ONTOLOGY_COMPOSITION_PATH
+        } else {
+            MANIFEST_PATH
+        },
+        "required preflight control is missing",
+    ))
+}
+
+pub(crate) fn validate_materialized_ontology_composition(
+    root: &Path,
+    report: &PortableV2Report,
+    limits: PortableV2Limits,
+    cancelled: Option<&AtomicBool>,
+) -> Result<(), PortableV2Error> {
+    let Some(control) = &report.ontology_composition else {
+        return Ok(());
+    };
+    validate_semantic_payload_budget(report, limits)?;
+    for entry in &report.ontology_composition_entries {
+        check_cancel(cancelled)?;
+        let value = read_canonical_semantic_payload(root, entry)?;
+        if entry.kind == "ontology" {
+            validate_materialized_ontology(entry, value)?;
+        } else {
+            validate_materialized_bridge(entry, value, control)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_semantic_payload_budget(
+    report: &PortableV2Report,
+    limits: PortableV2Limits,
+) -> Result<(), PortableV2Error> {
+    let mut aggregate = 0_u64;
+    for entry in &report.ontology_composition_entries {
+        aggregate = aggregate.checked_add(entry.length).ok_or_else(|| {
+            PortableV2Error::new(
+                PortableV2ErrorCode::LimitExceeded,
+                "semantic payload overflow",
+            )
+        })?;
+        if aggregate > limits.max_manifest_bytes {
+            return Err(PortableV2Error::new(
+                PortableV2ErrorCode::LimitExceeded,
+                "semantic payload budget",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn read_canonical_semantic_payload(
+    root: &Path,
+    entry: &PortableV2CompositionEntry,
+) -> Result<Value, PortableV2Error> {
+    let path = root.join(&entry.path);
+    let metadata = fs::symlink_metadata(&path).map_err(|_| {
+        PortableV2Error::at(
+            PortableV2ErrorCode::InvalidStructure,
+            &entry.path,
+            "semantic payload unavailable",
+        )
+    })?;
+    if !metadata.is_file() || metadata.file_type().is_symlink() || metadata.len() != entry.length {
+        return Err(PortableV2Error::at(
+            PortableV2ErrorCode::InvalidStructure,
+            &entry.path,
+            "semantic payload is not the authenticated regular file",
+        ));
+    }
+    let length = usize::try_from(entry.length).map_err(|_| {
+        PortableV2Error::new(PortableV2ErrorCode::LimitExceeded, "semantic payload size")
+    })?;
+    let mut file =
+        crate::project_portable_v2_export::open_source_no_follow(&path).map_err(|_| {
+            PortableV2Error::at(
+                PortableV2ErrorCode::InvalidStructure,
+                &entry.path,
+                "cannot open semantic payload",
+            )
+        })?;
+    let mut bytes = Vec::with_capacity(length);
+    std::io::Read::by_ref(&mut file)
+        .take(entry.length.saturating_add(1))
+        .read_to_end(&mut bytes)
+        .map_err(|_| {
+            PortableV2Error::at(
+                PortableV2ErrorCode::Io,
+                &entry.path,
+                "cannot read semantic payload",
+            )
+        })?;
+    if bytes.len() != length {
+        return Err(PortableV2Error::at(
+            PortableV2ErrorCode::ConcurrentMutation,
+            &entry.path,
+            "semantic payload changed",
+        ));
+    }
+    let value = serde_json::from_slice(&bytes).map_err(|_| {
+        PortableV2Error::at(
+            PortableV2ErrorCode::InvalidStructure,
+            &entry.path,
+            "semantic payload JSON",
+        )
+    })?;
+    if canonical_json(&value)? != bytes {
+        return Err(PortableV2Error::at(
+            PortableV2ErrorCode::Incompatible,
+            &entry.path,
+            "semantic payload is noncanonical",
+        ));
+    }
+    Ok(value)
+}
+
+fn validate_materialized_ontology(
+    entry: &PortableV2CompositionEntry,
+    value: Value,
+) -> Result<(), PortableV2Error> {
+    let document: graphforge_ontology::OntologyDoc =
+        serde_json::from_value(value).map_err(|_| {
+            PortableV2Error::at(
+                PortableV2ErrorCode::InvalidStructure,
+                &entry.path,
+                "ontology module schema",
+            )
+        })?;
+    let digest = graphforge_ontology::module_document_digest(&document).map_err(|_| {
+        PortableV2Error::at(
+            PortableV2ErrorCode::Incompatible,
+            &entry.path,
+            "ontology module canonicalization",
+        )
+    })?;
+    if (!entry.identity.id.starts_with("legacy:") && document.ontology_id != entry.identity.id)
+        || (!entry.identity.id.starts_with("legacy:") && document.version != entry.identity.version)
+        || entry.identity.content_digest != format!("sha256:{digest}")
+    {
+        return Err(PortableV2Error::at(
+            PortableV2ErrorCode::DigestMismatch,
+            &entry.path,
+            "ontology module semantic identity",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_materialized_bridge(
+    entry: &PortableV2CompositionEntry,
+    value: Value,
+    control: &PortableV2OntologyComposition,
+) -> Result<(), PortableV2Error> {
+    let document: graphforge_ontology::BridgeDocument =
+        serde_json::from_value(value).map_err(|_| {
+            PortableV2Error::at(
+                PortableV2ErrorCode::InvalidStructure,
+                &entry.path,
+                "ontology bridge schema",
+            )
+        })?;
+    let digest = graphforge_ontology::bridge_document_digest(&document).map_err(|_| {
+        PortableV2Error::at(
+            PortableV2ErrorCode::Incompatible,
+            &entry.path,
+            "ontology bridge canonicalization",
+        )
+    })?;
+    let expected = control
+        .bridge_sets
+        .iter()
+        .find(|bridge| {
+            bridge.bridge_id == entry.identity.id
+                && bridge.version == entry.identity.version
+                && bridge.content_digest == entry.identity.content_digest
+        })
+        .ok_or_else(|| {
+            PortableV2Error::new(PortableV2ErrorCode::Incompatible, "bridge control closure")
+        })?;
+    let exact_identity = |module: &graphforge_ontology::OntologyModuleId| PortableV2ExactIdentity {
+        id: module.ontology_id.clone(),
+        version: module.authored_version.clone(),
+        content_digest: format!("sha256:{}", module.canonical_digest),
+    };
+    let sources = document
+        .source_modules
+        .iter()
+        .map(exact_identity)
+        .collect::<Vec<_>>();
+    let targets = document
+        .target_modules
+        .iter()
+        .map(exact_identity)
+        .collect::<Vec<_>>();
+    if document.bridge_id != entry.identity.id
+        || document.authored_version != entry.identity.version
+        || entry.identity.content_digest != format!("sha256:{digest}")
+        || sources != expected.source_modules
+        || targets != expected.target_modules
+    {
+        return Err(PortableV2Error::at(
+            PortableV2ErrorCode::DigestMismatch,
+            &entry.path,
+            "ontology bridge semantic identity",
+        ));
+    }
+    Ok(())
 }
 
 /// Fully verify a package, then stream its authenticated component entries
@@ -949,6 +1440,8 @@ fn validate_package(
     validate_semantics(&manifest, limits)?;
     validate_bag_manifests(&map, &manifest)?;
     validate_runtime_map(&map, &manifest, limits)?;
+    let (ontology_composition, ontology_composition_entries) =
+        validate_ontology_composition(&map, &manifest, limits)?;
     let full = mode == PortableV2Mode::Full;
     Ok(PortableV2Report {
         contract: "graphforge-portable-verify/2",
@@ -966,6 +1459,8 @@ fn validate_package(
         compatibility: PortableV2Compatibility::Supported,
         authenticity: PortableV2Authenticity::Unsigned,
         transport_digest: transport.map(|x| format!("sha256:{x}")),
+        ontology_composition,
+        ontology_composition_entries,
     })
 }
 
@@ -1119,6 +1614,7 @@ fn validate_semantics(m: &Manifest, limits: PortableV2Limits) -> Result<(), Port
         "evidence@1",
         "provenance@1",
         "compatibility@1",
+        "ontology-composition@1",
     ];
     if m.requirements
         .capabilities
@@ -1164,7 +1660,14 @@ fn validate_semantics(m: &Manifest, limits: PortableV2Limits) -> Result<(), Port
                 ));
             }
             previous = Some(&f.path);
-            if f.length > limits.max_entry_bytes || !sha(&f.sha256) || !valid_media(&f.media_type) {
+            if f.length > limits.max_entry_bytes {
+                return Err(PortableV2Error::at(
+                    PortableV2ErrorCode::LimitExceeded,
+                    &f.path,
+                    "file descriptor size",
+                ));
+            }
+            if !sha(&f.sha256) || !valid_media(&f.media_type) {
                 return Err(PortableV2Error::at(
                     PortableV2ErrorCode::Incompatible,
                     &f.path,
@@ -1405,6 +1908,403 @@ fn validate_runtime_map(
         ));
     }
     validate_runtime_map_contents(&runtime, manifest)
+}
+
+fn validate_ontology_composition(
+    map: &BTreeMap<&str, &Entry>,
+    manifest: &Manifest,
+    limits: PortableV2Limits,
+) -> Result<
+    (
+        Option<PortableV2OntologyComposition>,
+        Vec<PortableV2CompositionEntry>,
+    ),
+    PortableV2Error,
+> {
+    let required = manifest
+        .requirements
+        .capabilities
+        .iter()
+        .any(|capability| capability == "ontology-composition@1");
+    let component = manifest.components.iter().find(|component| {
+        component.kind == "compatibility"
+            && component.participant_id == "graphforge-ontology-composition"
+    });
+    if required != component.is_some() {
+        return Err(PortableV2Error::new(
+            PortableV2ErrorCode::Incompatible,
+            "ontology composition capability/component mismatch",
+        ));
+    }
+    let Some(component) = component else {
+        return Ok((None, Vec::new()));
+    };
+    if component.files.len() != 1
+        || component.files[0].path != ONTOLOGY_COMPOSITION_PATH
+        || component.files[0].media_type != "application/vnd.graphforge.ontology-composition+json"
+        || component.files[0].length > limits.max_manifest_bytes
+    {
+        return Err(PortableV2Error::at(
+            PortableV2ErrorCode::Incompatible,
+            ONTOLOGY_COMPOSITION_PATH,
+            "ontology composition descriptor",
+        ));
+    }
+    let bytes = read_entry_bytes_from_map(map, ONTOLOGY_COMPOSITION_PATH)?;
+    let value = UniqueValue::deserialize(&mut serde_json::Deserializer::from_slice(&bytes))
+        .map_err(|_| {
+            PortableV2Error::at(
+                PortableV2ErrorCode::InvalidStructure,
+                ONTOLOGY_COMPOSITION_PATH,
+                "ontology composition JSON",
+            )
+        })?
+        .0;
+    if canonical_json(&value).map_err(|_| {
+        PortableV2Error::at(
+            PortableV2ErrorCode::Incompatible,
+            ONTOLOGY_COMPOSITION_PATH,
+            "ontology composition canonicalization",
+        )
+    })? != bytes
+    {
+        return Err(PortableV2Error::at(
+            PortableV2ErrorCode::Incompatible,
+            ONTOLOGY_COMPOSITION_PATH,
+            "ontology composition is noncanonical",
+        ));
+    }
+    let control: PortableV2OntologyComposition =
+        serde_json::from_value(value.clone()).map_err(|_| {
+            PortableV2Error::at(
+                PortableV2ErrorCode::InvalidStructure,
+                ONTOLOGY_COMPOSITION_PATH,
+                "ontology composition schema",
+            )
+        })?;
+    validate_ontology_composition_contents(&control, component, limits)?;
+    let mut unsigned = value;
+    unsigned
+        .as_object_mut()
+        .ok_or_else(|| PortableV2Error::new(PortableV2ErrorCode::InvalidStructure, "composition"))?
+        .remove("composition_digest");
+    let mut digest = Sha256::new();
+    digest.update(b"graphforge-ontology-composition/1\0");
+    digest.update(canonical_json(&unsigned).map_err(|_| {
+        PortableV2Error::new(PortableV2ErrorCode::Incompatible, "composition identity")
+    })?);
+    let expected = format!("sha256:{}", hex(&digest.finalize()));
+    if !constant_time_eq(expected.as_bytes(), control.composition_digest.as_bytes()) {
+        return Err(PortableV2Error::at(
+            PortableV2ErrorCode::DigestMismatch,
+            ONTOLOGY_COMPOSITION_PATH,
+            "composition digest",
+        ));
+    }
+    let entries = validate_ontology_component_descriptors(&control, manifest)?;
+    Ok((Some(control), entries))
+}
+
+fn validate_ontology_component_descriptors(
+    control: &PortableV2OntologyComposition,
+    manifest: &Manifest,
+) -> Result<Vec<PortableV2CompositionEntry>, PortableV2Error> {
+    let mut entries = Vec::new();
+    for (kind, identity, component_id, file_name, media_type) in control
+        .modules
+        .iter()
+        .map(|module| {
+            let identity = PortableV2ExactIdentity {
+                id: module.ontology_id.clone(),
+                version: module.version.clone(),
+                content_digest: module.content_digest.clone(),
+            };
+            (
+                "ontology",
+                identity,
+                format!(
+                    "ontology-module-{}",
+                    module.content_digest.trim_start_matches("sha256:")
+                ),
+                "module.json",
+                "application/vnd.graphforge.ontology+json",
+            )
+        })
+        .chain(control.bridge_sets.iter().map(|bridge| {
+            let identity = PortableV2ExactIdentity {
+                id: bridge.bridge_id.clone(),
+                version: bridge.version.clone(),
+                content_digest: bridge.content_digest.clone(),
+            };
+            (
+                "schema",
+                identity,
+                format!(
+                    "ontology-bridge-{}",
+                    bridge.content_digest.trim_start_matches("sha256:")
+                ),
+                "bridge.json",
+                "application/vnd.graphforge.ontology-bridge+json",
+            )
+        }))
+    {
+        let component = manifest
+            .components
+            .iter()
+            .find(|component| component.kind == kind && component.participant_id == component_id)
+            .ok_or_else(|| {
+                PortableV2Error::new(
+                    PortableV2ErrorCode::Incompatible,
+                    "missing ontology composition payload component",
+                )
+            })?;
+        let expected_path = format!("data/components/{kind}/{component_id}/{file_name}");
+        if component.files.len() != 1
+            || component.files[0].path != expected_path
+            || component.files[0].media_type != media_type
+        {
+            return Err(PortableV2Error::at(
+                PortableV2ErrorCode::Incompatible,
+                &expected_path,
+                "ontology composition payload descriptor",
+            ));
+        }
+        let file = &component.files[0];
+        entries.push(PortableV2CompositionEntry {
+            kind: kind.into(),
+            identity,
+            path: file.path.clone(),
+            media_type: file.media_type.clone(),
+            length: file.length,
+            sha256: file.sha256.clone(),
+            required_dependencies: component.required_dependencies.clone(),
+        });
+    }
+    entries.sort_by(|left, right| left.path.as_bytes().cmp(right.path.as_bytes()));
+    Ok(entries)
+}
+
+#[expect(
+    clippy::too_many_lines,
+    reason = "keeps the closed composition contract and its closure checks auditable together"
+)]
+fn validate_ontology_composition_contents(
+    control: &PortableV2OntologyComposition,
+    component: &ManifestComponent,
+    limits: PortableV2Limits,
+) -> Result<(), PortableV2Error> {
+    if control.contract != "graphforge-ontology-composition/1"
+        || control.modules.len() as u64 > limits.max_components
+        || control.bridge_sets.len() as u64 > limits.max_components
+        || control.activation_profile.overrides.len() as u64
+            > limits.max_components.saturating_mul(2)
+        || !matches!(
+            control.activation_profile.profile_default.as_str(),
+            "exploratory" | "advisory" | "strict"
+        )
+    {
+        return Err(PortableV2Error::new(
+            PortableV2ErrorCode::LimitExceeded,
+            "ontology composition contract or bound",
+        ));
+    }
+    let modules = control
+        .modules
+        .iter()
+        .map(|module| {
+            validate_exact_fields(&module.ontology_id, &module.version, &module.content_digest)?;
+            if module.dialect != "graphforge-ontology"
+                || !matches!(
+                    module.profile.as_str(),
+                    "exploratory" | "advisory" | "strict"
+                )
+            {
+                return Err(PortableV2Error::new(
+                    PortableV2ErrorCode::Incompatible,
+                    "ontology module metadata",
+                ));
+            }
+            Ok((
+                module.ontology_id.as_str(),
+                module.version.as_str(),
+                module.content_digest.as_str(),
+            ))
+        })
+        .collect::<Result<Vec<_>, PortableV2Error>>()?;
+    if modules.windows(2).any(|pair| pair[0] >= pair[1]) {
+        return Err(PortableV2Error::new(
+            PortableV2ErrorCode::Incompatible,
+            "ontology module order",
+        ));
+    }
+    let bridges = control
+        .bridge_sets
+        .iter()
+        .map(|bridge| {
+            validate_exact_fields(&bridge.bridge_id, &bridge.version, &bridge.content_digest)?;
+            validate_identity_list(&bridge.source_modules, &modules)?;
+            validate_identity_list(&bridge.target_modules, &modules)?;
+            Ok((
+                bridge.bridge_id.as_str(),
+                bridge.version.as_str(),
+                bridge.content_digest.as_str(),
+            ))
+        })
+        .collect::<Result<Vec<_>, PortableV2Error>>()?;
+    if bridges.windows(2).any(|pair| pair[0] >= pair[1]) {
+        return Err(PortableV2Error::new(
+            PortableV2ErrorCode::Incompatible,
+            "bridge set order",
+        ));
+    }
+    let overrides = &control.activation_profile.overrides;
+    let mut prior = None;
+    for activation in overrides {
+        let identity = exact_tuple(&activation.subject)?;
+        let scope = activation.scope.as_str();
+        if !matches!(scope, "module" | "bridge")
+            || !matches!(
+                activation.mode.as_str(),
+                "exploratory" | "advisory" | "strict"
+            )
+            || (scope == "module" && !modules.contains(&identity))
+            || (scope == "bridge" && !bridges.contains(&identity))
+        {
+            return Err(PortableV2Error::new(
+                PortableV2ErrorCode::Incompatible,
+                "activation closure",
+            ));
+        }
+        let key = (scope, identity, activation.mode.as_str());
+        if prior >= Some(key) {
+            return Err(PortableV2Error::new(
+                PortableV2ErrorCode::Incompatible,
+                "activation order",
+            ));
+        }
+        prior = Some(key);
+    }
+    for features in [&control.required_features, &control.optional_features] {
+        unique_sorted(features, "ontology composition features")?;
+        if features.len() > 256 || features.iter().any(|value| !valid_feature(value)) {
+            return Err(PortableV2Error::new(
+                PortableV2ErrorCode::UnsupportedFuture,
+                "ontology composition feature",
+            ));
+        }
+    }
+    if control.required_features.iter().any(|feature| {
+        !matches!(
+            feature.as_str(),
+            "provenance-bridges@1" | "qualified-symbols@1"
+        )
+    }) {
+        return Err(PortableV2Error::new(
+            PortableV2ErrorCode::UnsupportedFuture,
+            "required ontology composition feature",
+        ));
+    }
+    let dependency_ids = component
+        .required_dependencies
+        .iter()
+        .collect::<BTreeSet<_>>();
+    let expected_dependencies = control
+        .modules
+        .iter()
+        .map(|module| {
+            format!(
+                "ontology-module-{}",
+                module.content_digest.trim_start_matches("sha256:")
+            )
+        })
+        .chain(control.bridge_sets.iter().map(|bridge| {
+            format!(
+                "ontology-bridge-{}",
+                bridge.content_digest.trim_start_matches("sha256:")
+            )
+        }))
+        .collect::<BTreeSet<_>>();
+    if dependency_ids.len() != component.required_dependencies.len()
+        || dependency_ids != expected_dependencies.iter().collect::<BTreeSet<_>>()
+    {
+        return Err(PortableV2Error::new(
+            PortableV2ErrorCode::Incompatible,
+            "ontology composition dependency closure",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_identity_list<'a>(
+    values: &'a [PortableV2ExactIdentity],
+    modules: &[(&'a str, &'a str, &'a str)],
+) -> Result<(), PortableV2Error> {
+    if values.is_empty() {
+        return Err(PortableV2Error::new(
+            PortableV2ErrorCode::Incompatible,
+            "empty bridge endpoint",
+        ));
+    }
+    let identities = values
+        .iter()
+        .map(exact_tuple)
+        .collect::<Result<Vec<_>, _>>()?;
+    if identities.windows(2).any(|pair| pair[0] >= pair[1])
+        || identities
+            .iter()
+            .any(|identity| !modules.contains(identity))
+    {
+        return Err(PortableV2Error::new(
+            PortableV2ErrorCode::Incompatible,
+            "bridge endpoint closure",
+        ));
+    }
+    Ok(())
+}
+
+fn exact_tuple(value: &PortableV2ExactIdentity) -> Result<(&str, &str, &str), PortableV2Error> {
+    validate_exact_fields(&value.id, &value.version, &value.content_digest)?;
+    Ok((&value.id, &value.version, &value.content_digest))
+}
+
+fn validate_exact_fields(id: &str, version: &str, digest: &str) -> Result<(), PortableV2Error> {
+    let scheme = id.find(':').unwrap_or_default();
+    if id.len() > 2048
+        || scheme == 0
+        || !id[..scheme].bytes().enumerate().all(|(index, byte)| {
+            if index == 0 {
+                byte.is_ascii_alphabetic()
+            } else {
+                byte.is_ascii_alphanumeric() || matches!(byte, b'+' | b'.' | b'-')
+            }
+        })
+        || id[scheme + 1..].is_empty()
+        || id.chars().any(char::is_whitespace)
+        || id.nfc().ne(id.chars())
+        || version.is_empty()
+        || version.len() > 256
+        || version.chars().any(char::is_control)
+        || version.nfc().ne(version.chars())
+        || !digest.strip_prefix("sha256:").is_some_and(sha)
+    {
+        return Err(PortableV2Error::new(
+            PortableV2ErrorCode::Incompatible,
+            "exact ontology identity",
+        ));
+    }
+    Ok(())
+}
+
+fn valid_feature(value: &str) -> bool {
+    let Some((name, version)) = value.rsplit_once('@') else {
+        return false;
+    };
+    valid_id(name)
+        && version
+            .as_bytes()
+            .first()
+            .is_some_and(|byte| byte.is_ascii_digit() && *byte != b'0')
+        && version.bytes().all(|byte| byte.is_ascii_digit())
 }
 
 fn runtime_map_descriptor(manifest: &Manifest) -> Result<Option<&ManifestFile>, PortableV2Error> {
@@ -1662,8 +2562,23 @@ fn hash_file(
     retain_limit: Option<u64>,
     cancelled: Option<&AtomicBool>,
 ) -> Result<([u8; 32], Option<Vec<u8>>), PortableV2Error> {
-    let mut f = File::open(path)
-        .map_err(|_| PortableV2Error::at(PortableV2ErrorCode::Io, entry, "cannot open entry"))?;
+    let mut f = crate::project_portable_v2_export::open_source_no_follow(path).map_err(|_| {
+        PortableV2Error::at(
+            PortableV2ErrorCode::InvalidStructure,
+            entry,
+            "cannot safely open entry",
+        )
+    })?;
+    let before = f.metadata().map_err(|_| {
+        PortableV2Error::at(PortableV2ErrorCode::Io, entry, "cannot inspect open entry")
+    })?;
+    if !before.is_file() || has_multiple_links(&before) || before.len() != length {
+        return Err(PortableV2Error::at(
+            PortableV2ErrorCode::ConcurrentMutation,
+            entry,
+            "opened entry identity differs from inventory",
+        ));
+    }
     let mut h = Sha256::new();
     if retain_limit.is_some_and(|limit| length > limit) {
         return Err(PortableV2Error::at(
@@ -1706,6 +2621,23 @@ fn hash_file(
             bytes.extend_from_slice(&b[..n]);
         }
         left -= n as u64;
+    }
+    let after = f.metadata().map_err(|_| {
+        PortableV2Error::at(
+            PortableV2ErrorCode::Io,
+            entry,
+            "cannot re-inspect open entry",
+        )
+    })?;
+    if !same_identity(&before, &after)
+        || before.len() != after.len()
+        || modified(&before) != modified(&after)
+    {
+        return Err(PortableV2Error::at(
+            PortableV2ErrorCode::ConcurrentMutation,
+            entry,
+            "open entry changed while hashing",
+        ));
     }
     Ok((h.finalize().into(), kept))
 }
@@ -2078,7 +3010,9 @@ fn hex(bytes: &[u8]) -> String {
 }
 fn retained_limit(path: &str, limits: PortableV2Limits) -> Option<u64> {
     match path {
-        MANIFEST_PATH | RUNTIME_MAP_PATH => Some(limits.max_manifest_bytes),
+        MANIFEST_PATH | RUNTIME_MAP_PATH | ONTOLOGY_COMPOSITION_PATH => {
+            Some(limits.max_manifest_bytes)
+        }
         "bagit.txt" | "bag-info.txt" | "manifest-sha256.txt" | "tagmanifest-sha256.txt" => {
             Some(limits.max_tag_manifest_bytes)
         }
@@ -2205,7 +3139,7 @@ mod tests {
     }
 
     #[test]
-    fn pre_m9_reader_rejects_required_ontology_composition_before_payload_access() {
+    fn current_reader_recognizes_the_m9_capability_before_payload_validation() {
         let mut value: Value = serde_json::from_str(include_str!(
             "../../../tests/fixtures/portable-v2/ontology-only.manifest.json"
         ))
@@ -2216,8 +3150,94 @@ mod tests {
         capabilities.push(Value::String("ontology-composition@1".into()));
         capabilities.sort_by(|left, right| left.as_str().cmp(&right.as_str()));
         let manifest: Manifest = serde_json::from_value(value).unwrap();
-        let error = validate_semantics(&manifest, PortableV2Limits::default()).unwrap_err();
-        assert_eq!(error.code, PortableV2ErrorCode::UnsupportedFuture);
+        validate_semantics(&manifest, PortableV2Limits::default()).unwrap();
+    }
+
+    fn composition_vector() -> (PortableV2OntologyComposition, ManifestComponent) {
+        let fixture: Value = serde_json::from_str(include_str!(
+            "../../../tests/fixtures/portable-v2/multi-ontology-vectors.json"
+        ))
+        .unwrap();
+        let control = serde_json::from_value(fixture["composition"].clone()).unwrap();
+        let component = serde_json::from_value(serde_json::json!({
+            "kind": "compatibility",
+            "participant_id": "graphforge-ontology-composition",
+            "required_dependencies": [
+                format!("ontology-bridge-{}", "4".repeat(64)),
+                format!("ontology-module-{}", "1".repeat(64)),
+                format!("ontology-module-{}", "2".repeat(64)),
+                format!("ontology-module-{}", "3".repeat(64))
+            ],
+            "files": [{
+                "media_type": "application/vnd.graphforge.ontology-composition+json",
+                "path": ONTOLOGY_COMPOSITION_PATH,
+                "length": 1,
+                "sha256": format!("sha256:{}", "1".repeat(64))
+            }]
+        }))
+        .unwrap();
+        (control, component)
+    }
+
+    #[test]
+    fn composition_control_rejects_duplicate_dangling_and_unbounded_closure() {
+        let (valid, component) = composition_vector();
+        validate_ontology_composition_contents(&valid, &component, PortableV2Limits::default())
+            .unwrap();
+
+        let mut duplicate = valid.clone();
+        duplicate.modules.push(duplicate.modules[0].clone());
+        assert_eq!(
+            validate_ontology_composition_contents(
+                &duplicate,
+                &component,
+                PortableV2Limits::default()
+            )
+            .unwrap_err()
+            .code,
+            PortableV2ErrorCode::Incompatible
+        );
+
+        let mut dangling = valid.clone();
+        dangling.bridge_sets[0].source_modules[0].content_digest =
+            format!("sha256:{}", "9".repeat(64));
+        assert_eq!(
+            validate_ontology_composition_contents(
+                &dangling,
+                &component,
+                PortableV2Limits::default()
+            )
+            .unwrap_err()
+            .code,
+            PortableV2ErrorCode::Incompatible
+        );
+
+        let mut unsupported = valid.clone();
+        unsupported
+            .required_features
+            .push("future-contract@2".into());
+        unsupported.required_features.sort();
+        assert_eq!(
+            validate_ontology_composition_contents(
+                &unsupported,
+                &component,
+                PortableV2Limits::default()
+            )
+            .unwrap_err()
+            .code,
+            PortableV2ErrorCode::UnsupportedFuture
+        );
+
+        let limits = PortableV2Limits {
+            max_components: 1,
+            ..PortableV2Limits::default()
+        };
+        assert_eq!(
+            validate_ontology_composition_contents(&valid, &component, limits)
+                .unwrap_err()
+                .code,
+            PortableV2ErrorCode::LimitExceeded
+        );
     }
 
     #[test]

--- a/crates/graphforge-storage/src/project_portable_v2_export.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_export.rs
@@ -2150,6 +2150,154 @@ mod tests {
         (project, generation)
     }
 
+    fn graph_generation_with_transitive_bridge_chain() -> (
+        tempfile::TempDir,
+        ResolvedProjectGeneration,
+        PortableV2ExactIdentity,
+        String,
+    ) {
+        use graphforge_ontology::{
+            ActivationMode, AuthoredModule, BridgeAssertion, BridgeDocument, BridgePredicate,
+            BridgeProvenance, BridgeSetId, CompositionLimits, EntityTypeDef,
+            InventoryCompileRequest, MappingMethod, OntologyDoc, OntologyModuleId, QualifiedSymbol,
+            SymbolKind, bridge_document_digest, compile_inventory, module_document_digest,
+        };
+        let module = |name: &str, dependencies: Vec<OntologyModuleId>| {
+            let document = OntologyDoc {
+                ontology_id: format!("https://graphforge.dev/ontology/{name}"),
+                version: "v1".into(),
+                entity_types: vec![EntityTypeDef {
+                    name: "Person".into(),
+                    r#abstract: false,
+                    parent: None,
+                }],
+                relation_types: vec![],
+                properties: vec![],
+                constraints: vec![],
+                migrations: vec![],
+            };
+            AuthoredModule {
+                id: OntologyModuleId {
+                    ontology_id: document.ontology_id.clone(),
+                    authored_version: document.version.clone(),
+                    canonical_digest: module_document_digest(&document).unwrap(),
+                },
+                dependencies,
+                doc: document,
+                allow_projected_identity: false,
+            }
+        };
+        let base = module("base", vec![]);
+        let source = module("source-chain", vec![base.id.clone()]);
+        let target = module("target-chain", vec![]);
+        let unrelated = module("unrelated", vec![]);
+        let assertion = |from: &AuthoredModule, to: &AuthoredModule| BridgeAssertion {
+            source: QualifiedSymbol {
+                module: from.id.clone(),
+                kind: SymbolKind::Entity,
+                local_id: "Person".into(),
+            },
+            target: QualifiedSymbol {
+                module: to.id.clone(),
+                kind: SymbolKind::Entity,
+                local_id: "Person".into(),
+            },
+            predicate: BridgePredicate::Equivalent,
+            directional: false,
+            provenance: BridgeProvenance {
+                method: MappingMethod::Authored,
+                confidence: None,
+                justification: "transitive portable closure fixture".into(),
+                evidence_refs: vec![],
+            },
+            valid_from: None,
+            valid_to: None,
+        };
+        let bridge_a = BridgeDocument {
+            bridge_id: "https://graphforge.dev/bridge/a".into(),
+            authored_version: "v1".into(),
+            source_modules: vec![base.id.clone()],
+            target_modules: vec![target.id.clone()],
+            dependencies: vec![],
+            shared_surfaces: vec![],
+            assertions: vec![assertion(&base, &target)],
+            enforcement: Some(ActivationMode::Advisory),
+        };
+        let bridge_a_id = BridgeSetId {
+            bridge_id: bridge_a.bridge_id.clone(),
+            authored_version: bridge_a.authored_version.clone(),
+            canonical_digest: bridge_document_digest(&bridge_a).unwrap(),
+        };
+        let bridge_b = BridgeDocument {
+            bridge_id: "https://graphforge.dev/bridge/b".into(),
+            authored_version: "v1".into(),
+            source_modules: vec![source.id.clone()],
+            target_modules: vec![target.id.clone()],
+            dependencies: vec![bridge_a_id.clone()],
+            shared_surfaces: vec![],
+            assertions: vec![assertion(&source, &target)],
+            enforcement: Some(ActivationMode::Strict),
+        };
+        let bridge_b_id = BridgeSetId {
+            bridge_id: bridge_b.bridge_id.clone(),
+            authored_version: bridge_b.authored_version.clone(),
+            canonical_digest: bridge_document_digest(&bridge_b).unwrap(),
+        };
+        let modules = [base, source, target, unrelated];
+        let compiled = compile_inventory(InventoryCompileRequest {
+            modules: &modules,
+            bridges: &[bridge_a_id, bridge_b_id.clone()],
+            activation: &[],
+            profile_default: ActivationMode::Strict,
+            limits: CompositionLimits::default(),
+            cancelled: None,
+        })
+        .unwrap();
+        let composition =
+            crate::WorkspaceOntologyComposition::from_compiled(&compiled, vec![bridge_a, bridge_b]);
+        let root_identity = exact_identity(
+            &bridge_b_id.bridge_id,
+            &bridge_b_id.authored_version,
+            &bridge_b_id.canonical_digest,
+        );
+        let unrelated_digest = modules[3].id.canonical_digest.clone();
+        let project = tempfile::tempdir().unwrap();
+        open_or_initialize_project(project.path()).unwrap();
+        let mut participants = crate::empty_workspace_participants().unwrap();
+        participants.push(composition.to_project_participant().unwrap());
+        participants.sort_by(|left, right| {
+            (&left.capability_id, &left.record_family_id)
+                .cmp(&(&right.capability_id, &right.record_family_id))
+        });
+        let request = crate::ProjectGenerationRequest {
+            transaction_uuid: Uuid::new_v4(),
+            generation_uuid: Uuid::new_v4(),
+            capabilities: vec![
+                crate::ProjectCapability {
+                    capability_id: "graph".into(),
+                    capability_version: 1,
+                },
+                crate::ProjectCapability {
+                    capability_id: "workspace".into(),
+                    capability_version: 1,
+                },
+            ],
+            participants,
+        };
+        let crate::ProjectStageOutcome::Staged(staged) =
+            crate::stage_project_generation(project.path(), &request).unwrap()
+        else {
+            panic!("fresh transitive composition replayed");
+        };
+        staged
+            .validate(|_| Ok(()), |_, _| Ok(()))
+            .unwrap()
+            .publish()
+            .unwrap();
+        let generation = crate::resolve_project_generation(project.path()).unwrap();
+        (project, generation, root_identity, unrelated_digest)
+    }
+
     fn resign_test_manifest(plan: &mut PortableV2ExportPlan) {
         let mut manifest: serde_json::Value = serde_json::from_slice(&plan.manifest).unwrap();
         manifest.as_object_mut().unwrap().remove("package_digest");
@@ -2719,6 +2867,111 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(error.code, PortableV2ErrorCode::Incompatible);
+    }
+
+    #[test]
+    fn transitive_module_and_bridge_closure_is_exact_in_both_forms() {
+        let (_project, generation, root_bridge, unrelated_digest) =
+            graph_generation_with_transitive_bridge_chain();
+        let limits = PortableV2ExportLimits::default();
+        let selection = preview_portable_v2_selection(
+            &generation,
+            &PortableV2SelectionRequest {
+                profile: PortableV2SelectionProfile::OntologyComposition(vec![root_bridge.clone()]),
+                strict: true,
+            },
+            limits,
+        )
+        .unwrap();
+        assert_eq!(selection.projected.len(), 5);
+        assert_eq!(
+            selection
+                .projected
+                .iter()
+                .filter(|entry| entry.reason == crate::PortableV2SelectionReason::Requested)
+                .count(),
+            1
+        );
+        assert!(
+            selection
+                .projected
+                .iter()
+                .any(|entry| entry.identity == root_bridge)
+        );
+        assert!(
+            !selection
+                .projected
+                .iter()
+                .any(|entry| entry.identity.content_digest.ends_with(&unrelated_digest))
+        );
+
+        let plan = plan_selected_portable_v2(&generation, &selection, limits).unwrap();
+        let manifest: serde_json::Value = serde_json::from_slice(&plan.manifest).unwrap();
+        let components = manifest["components"].as_array().unwrap();
+        assert_eq!(
+            components
+                .iter()
+                .filter(|component| matches!(
+                    component["kind"].as_str(),
+                    Some("ontology" | "schema")
+                ))
+                .count(),
+            5
+        );
+        assert!(
+            !serde_json::to_string(&manifest)
+                .unwrap()
+                .contains(&unrelated_digest)
+        );
+        let control_file = plan
+            .files
+            .iter()
+            .find(|file| file.path == crate::project_portable_v2::ONTOLOGY_COMPOSITION_PATH)
+            .unwrap();
+        let PlannedSource::Control(control_bytes) = &control_file.source else {
+            panic!("composition must be inline")
+        };
+        let control: PortableV2OntologyComposition = serde_json::from_slice(control_bytes).unwrap();
+        assert_eq!(control.modules.len(), 3);
+        assert_eq!(control.bridge_sets.len(), 2);
+        assert!(
+            !control
+                .modules
+                .iter()
+                .any(|module| module.content_digest.ends_with(&unrelated_digest))
+        );
+
+        let output = tempfile::tempdir().unwrap();
+        let mut reports = Vec::new();
+        for representation in [PortableV2Output::Expanded, PortableV2Output::Bundle] {
+            let path = output
+                .path()
+                .join(if representation == PortableV2Output::Expanded {
+                    "chain.gfproject"
+                } else {
+                    "chain.gfpb"
+                });
+            export_complete_portable_v2(
+                &plan,
+                &path,
+                representation,
+                limits,
+                &AtomicBool::new(false),
+                |_| {},
+            )
+            .unwrap();
+            reports.push(verify_portable_v2(&path, PortableV2Mode::Full, limits, None).unwrap());
+        }
+        assert_eq!(reports[0].package_digest, reports[1].package_digest);
+        assert_eq!(
+            reports[0].ontology_composition,
+            reports[1].ontology_composition
+        );
+        assert_eq!(reports[0].ontology_composition_entries.len(), 5);
+        assert_eq!(
+            reports[0].ontology_composition_entries,
+            reports[1].ontology_composition_entries
+        );
     }
 
     #[test]

--- a/crates/graphforge-storage/src/project_portable_v2_export.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_export.rs
@@ -472,6 +472,7 @@ fn bridge_component_id(digest: &str) -> String {
 )]
 fn project_ontology_composition(
     source: &Path,
+    projected: &[crate::PortableV2ProjectedSelectionEntry],
     limits: PortableV2ExportLimits,
     total: &mut u64,
     files: &mut Vec<PlannedFile>,
@@ -500,9 +501,21 @@ fn project_ontology_composition(
     let composition =
         crate::WorkspaceOntologyComposition::from_canonical_json(&bytes).map_err(storage)?;
 
-    let mut modules = Vec::with_capacity(composition.modules.len());
+    let selected = projected
+        .iter()
+        .map(|entry| entry.identity.clone())
+        .collect::<BTreeSet<_>>();
+    let mut modules = Vec::with_capacity(projected.len());
     let mut all_dependencies = Vec::new();
     for module in &composition.modules {
+        let exact = exact_identity(
+            &module.id.ontology_id,
+            &module.id.authored_version,
+            &module.id.canonical_digest,
+        );
+        if !selected.contains(&exact) {
+            continue;
+        }
         let component_id = module_component_id(&module.id.canonical_digest);
         let path = format!("data/components/ontology/{component_id}/module.json");
         let payload = canonical_json(&serde_json::to_value(&module.document).map_err(storage)?)?;
@@ -547,6 +560,10 @@ fn project_ontology_composition(
     let mut bridge_identities = std::collections::BTreeMap::new();
     for bridge in &composition.bridges {
         let digest = graphforge_ontology::bridge_document_digest(bridge).map_err(storage)?;
+        let exact = exact_identity(&bridge.bridge_id, &bridge.authored_version, &digest);
+        if !selected.contains(&exact) {
+            continue;
+        }
         bridge_identities.insert(
             format!("{}@{}#{digest}", bridge.bridge_id, bridge.authored_version),
             exact_identity(&bridge.bridge_id, &bridge.authored_version, &digest),
@@ -630,6 +647,13 @@ fn project_ontology_composition(
     let module_identities = composition
         .modules
         .iter()
+        .filter(|module| {
+            selected.contains(&exact_identity(
+                &module.id.ontology_id,
+                &module.id.authored_version,
+                &module.id.canonical_digest,
+            ))
+        })
         .map(|module| {
             (
                 module.id.display_ref(),
@@ -644,6 +668,13 @@ fn project_ontology_composition(
     let mut overrides = composition
         .activation
         .iter()
+        .filter(|activation| {
+            if activation.scope.as_str() == "module" {
+                module_identities.contains_key(&activation.subject)
+            } else {
+                bridge_identities.contains_key(&activation.subject)
+            }
+        })
         .map(|activation| {
             let subject = if activation.scope.as_str() == "module" {
                 module_identities.get(&activation.subject)
@@ -808,6 +839,7 @@ pub fn plan_selected_portable_v2(
     if let Some(source) = ontology_composition_source {
         project_ontology_composition(
             &source,
+            &selection.projected,
             limits,
             &mut total,
             &mut files,
@@ -2582,6 +2614,111 @@ mod tests {
             entry.identity == exact && entry.reason == crate::PortableV2SelectionReason::Requested
         }));
         assert!(projected.estimated_payload_bytes > 0);
+    }
+
+    #[test]
+    fn exact_composition_selection_closes_bridges_without_widening() {
+        let (_project, generation) = graph_generation_with_bridge();
+        let limits = PortableV2ExportLimits::default();
+        let all = preview_portable_v2_selection(
+            &generation,
+            &PortableV2SelectionRequest {
+                profile: PortableV2SelectionProfile::Complete,
+                strict: false,
+            },
+            limits,
+        )
+        .unwrap();
+        let source = all
+            .projected
+            .iter()
+            .find(|entry| entry.identity.id.ends_with("/source"))
+            .unwrap()
+            .identity
+            .clone();
+        let bridge = all
+            .projected
+            .iter()
+            .find(|entry| entry.identity.id.contains("/bridge/"))
+            .unwrap()
+            .identity
+            .clone();
+
+        let module_only = preview_portable_v2_selection(
+            &generation,
+            &PortableV2SelectionRequest {
+                profile: PortableV2SelectionProfile::OntologyComposition(vec![source.clone()]),
+                strict: true,
+            },
+            limits,
+        )
+        .unwrap();
+        assert_eq!(module_only.projected.len(), 1);
+        assert_eq!(module_only.projected[0].identity, source);
+        let module_plan = plan_selected_portable_v2(&generation, &module_only, limits).unwrap();
+        let module_manifest: serde_json::Value =
+            serde_json::from_slice(&module_plan.manifest).unwrap();
+        let control = module_plan
+            .files
+            .iter()
+            .find(|file| file.path == crate::project_portable_v2::ONTOLOGY_COMPOSITION_PATH)
+            .unwrap();
+        let PlannedSource::Control(bytes) = &control.source else {
+            panic!("composition must be inline")
+        };
+        let control: PortableV2OntologyComposition = serde_json::from_slice(bytes).unwrap();
+        assert_eq!(control.modules.len(), 1);
+        assert!(control.bridge_sets.is_empty());
+        assert_eq!(module_manifest["package_class"], "component-selective");
+
+        let bridge_closed = preview_portable_v2_selection(
+            &generation,
+            &PortableV2SelectionRequest {
+                profile: PortableV2SelectionProfile::OntologyComposition(vec![bridge.clone()]),
+                strict: true,
+            },
+            limits,
+        )
+        .unwrap();
+        assert_eq!(bridge_closed.projected.len(), 3);
+        assert_eq!(
+            bridge_closed
+                .projected
+                .iter()
+                .filter(|entry| entry.reason == crate::PortableV2SelectionReason::Requested)
+                .count(),
+            1
+        );
+        assert!(
+            bridge_closed
+                .projected
+                .iter()
+                .any(|entry| entry.identity == bridge)
+        );
+        assert!(
+            bridge_closed
+                .projected
+                .iter()
+                .filter(|entry| entry.kind == "ontology")
+                .all(|entry| entry.reason
+                    == crate::PortableV2SelectionReason::RequiredOntologyComposition)
+        );
+
+        let missing = PortableV2ExactIdentity {
+            id: "https://graphforge.dev/ontology/absent".into(),
+            version: "v1".into(),
+            content_digest: format!("sha256:{}", "f".repeat(64)),
+        };
+        let error = preview_portable_v2_selection(
+            &generation,
+            &PortableV2SelectionRequest {
+                profile: PortableV2SelectionProfile::OntologyComposition(vec![missing]),
+                strict: true,
+            },
+            limits,
+        )
+        .unwrap_err();
+        assert_eq!(error.code, PortableV2ErrorCode::Incompatible);
     }
 
     #[test]

--- a/crates/graphforge-storage/src/project_portable_v2_export.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_export.rs
@@ -11,6 +11,11 @@ use sha2::{Digest, Sha256};
 use unicode_normalization::UnicodeNormalization;
 use uuid::Uuid;
 
+use crate::project_portable_v2::{
+    PortableV2ActivationOverride, PortableV2ActivationProfile, PortableV2BridgeSet,
+    PortableV2ExactIdentity, PortableV2OntologyComposition, PortableV2OntologyModule,
+};
+use crate::workspace_participants::MAX_WORKSPACE_ONTOLOGY_COMPOSITION_BYTES;
 use crate::{
     PortableV2Error, PortableV2ErrorCode, PortableV2Limits, PortableV2Mode, PortableV2PackageClass,
     PortableV2SelectionPlan, PortableV2SelectionProfile, PortableV2SelectionRequest,
@@ -167,6 +172,34 @@ impl PortableV2ExportPlan {
             return Err(limit("entry count exceeds configured limit"));
         }
 
+        let existing: serde_json::Value =
+            serde_json::from_slice(&self.manifest).map_err(storage)?;
+        let dependency_map = existing["components"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .filter_map(|component| {
+                let id = component["participant_id"].as_str()?.to_owned();
+                let dependencies = component["required_dependencies"]
+                    .as_array()?
+                    .iter()
+                    .filter_map(|value| value.as_str().map(str::to_owned))
+                    .collect::<Vec<_>>();
+                Some((id, dependencies))
+            })
+            .collect::<std::collections::BTreeMap<_, _>>();
+        let media_map = existing["components"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .flat_map(|component| component["files"].as_array().into_iter().flatten())
+            .filter_map(|file| {
+                Some((
+                    file["path"].as_str()?.to_owned(),
+                    file["media_type"].as_str()?.to_owned(),
+                ))
+            })
+            .collect::<std::collections::BTreeMap<_, _>>();
         let mut components = Vec::new();
         let mut roots = Vec::new();
         let mut by_component: std::collections::BTreeMap<(String, String), Vec<&PlannedFile>> =
@@ -191,7 +224,10 @@ impl PortableV2ExportPlan {
                 files
                     .iter()
                     .map(|file| ComponentFile {
-                        media_type: media_type_for_path(&file.path).into(),
+                        media_type: media_map
+                            .get(&file.path)
+                            .cloned()
+                            .unwrap_or_else(|| media_type_for_path(&file.path).into()),
                         path: file.path.clone(),
                         length: file.length,
                         sha256: hex(file.digest),
@@ -200,8 +236,11 @@ impl PortableV2ExportPlan {
             };
             components.push(Component {
                 kind,
+                required_dependencies: dependency_map
+                    .get(&participant_id)
+                    .cloned()
+                    .unwrap_or_default(),
                 participant_id,
-                required_dependencies: vec![],
                 files: component_files,
             });
         }
@@ -209,15 +248,20 @@ impl PortableV2ExportPlan {
         roots.sort();
         roots.dedup();
 
-        let capabilities = components
+        let mut capabilities = components
             .iter()
             .map(|component| format!("{}@1", component.kind))
             .collect::<BTreeSet<_>>()
             .into_iter()
             .collect::<Vec<_>>();
+        if components
+            .iter()
+            .any(|component| component.participant_id == "graphforge-ontology-composition")
+        {
+            capabilities.push("ontology-composition@1".to_owned());
+            capabilities.sort();
+        }
         let generation_uuid = self.generation_uuid.hyphenated().to_string();
-        let existing: serde_json::Value =
-            serde_json::from_slice(&self.manifest).map_err(storage)?;
         let source_manifest = existing["source_generation"]["manifest_sha256"]
             .as_str()
             .unwrap_or_default()
@@ -406,6 +450,273 @@ struct RuntimeGraphTree {
     inventory_participant_id: String,
 }
 
+fn exact_identity(id: &str, version: &str, digest: &str) -> PortableV2ExactIdentity {
+    PortableV2ExactIdentity {
+        id: id.to_owned(),
+        version: version.to_owned(),
+        content_digest: format!("sha256:{digest}"),
+    }
+}
+
+fn module_component_id(digest: &str) -> String {
+    format!("ontology-module-{digest}")
+}
+
+fn bridge_component_id(digest: &str) -> String {
+    format!("ontology-bridge-{digest}")
+}
+
+#[expect(
+    clippy::too_many_lines,
+    reason = "projection appends one authenticated closure to the existing immutable plan"
+)]
+fn project_ontology_composition(
+    source: &Path,
+    limits: PortableV2ExportLimits,
+    total: &mut u64,
+    files: &mut Vec<PlannedFile>,
+    components: &mut Vec<Component>,
+    roots: &mut Vec<String>,
+) -> Result<(), ExportError> {
+    let mut input = open_source_no_follow(source)?;
+    let before = identity(&input.metadata().map_err(storage)?)?;
+    if before.len > MAX_WORKSPACE_ONTOLOGY_COMPOSITION_BYTES as u64 {
+        return Err(limit(
+            "ontology composition authority exceeds configured limit",
+        ));
+    }
+    let mut bytes = Vec::new();
+    std::io::Read::by_ref(&mut input)
+        .take(MAX_WORKSPACE_ONTOLOGY_COMPOSITION_BYTES as u64 + 1)
+        .read_to_end(&mut bytes)
+        .map_err(storage)?;
+    if bytes.len() as u64 != before.len || identity(&input.metadata().map_err(storage)?)? != before
+    {
+        return Err(err(
+            "GF_SOURCE_CHANGED",
+            "ontology composition changed during planning",
+        ));
+    }
+    let composition =
+        crate::WorkspaceOntologyComposition::from_canonical_json(&bytes).map_err(storage)?;
+
+    let mut modules = Vec::with_capacity(composition.modules.len());
+    let mut all_dependencies = Vec::new();
+    for module in &composition.modules {
+        let component_id = module_component_id(&module.id.canonical_digest);
+        let path = format!("data/components/ontology/{component_id}/module.json");
+        let payload = canonical_json(&serde_json::to_value(&module.document).map_err(storage)?)?;
+        let file = inline_control(&path, payload, limits, total)?;
+        let component_file = ComponentFile {
+            media_type: "application/vnd.graphforge.ontology+json".into(),
+            path,
+            length: file.length,
+            sha256: hex(file.digest),
+        };
+        files.push(file);
+        roots.push(component_id.clone());
+        all_dependencies.push(component_id.clone());
+        let subject = module.id.display_ref();
+        let profile = composition
+            .activation
+            .iter()
+            .find(|activation| {
+                activation.scope.as_str() == "module" && activation.subject == subject
+            })
+            .map_or(composition.profile_default, |activation| activation.mode);
+        modules.push(PortableV2OntologyModule {
+            ontology_id: module.id.ontology_id.clone(),
+            version: module.id.authored_version.clone(),
+            content_digest: format!("sha256:{}", module.id.canonical_digest),
+            dialect: "graphforge-ontology".into(),
+            profile: profile.as_str().into(),
+        });
+        components.push(Component {
+            kind: "ontology".into(),
+            participant_id: component_id,
+            required_dependencies: module
+                .dependencies
+                .iter()
+                .map(|dependency| module_component_id(&dependency.canonical_digest))
+                .collect(),
+            files: vec![component_file],
+        });
+    }
+
+    let mut bridges = Vec::with_capacity(composition.bridges.len());
+    let mut bridge_identities = std::collections::BTreeMap::new();
+    for bridge in &composition.bridges {
+        let digest = graphforge_ontology::bridge_document_digest(bridge).map_err(storage)?;
+        bridge_identities.insert(
+            format!("{}@{}#{digest}", bridge.bridge_id, bridge.authored_version),
+            exact_identity(&bridge.bridge_id, &bridge.authored_version, &digest),
+        );
+        let component_id = bridge_component_id(&digest);
+        let path = format!("data/components/schema/{component_id}/bridge.json");
+        let payload = canonical_json(&serde_json::to_value(bridge).map_err(storage)?)?;
+        let file = inline_control(&path, payload, limits, total)?;
+        let component_file = ComponentFile {
+            media_type: "application/vnd.graphforge.ontology-bridge+json".into(),
+            path,
+            length: file.length,
+            sha256: hex(file.digest),
+        };
+        files.push(file);
+        roots.push(component_id.clone());
+        all_dependencies.push(component_id.clone());
+        let mut dependencies = bridge
+            .source_modules
+            .iter()
+            .chain(&bridge.target_modules)
+            .map(|module| module_component_id(&module.canonical_digest))
+            .chain(
+                bridge
+                    .dependencies
+                    .iter()
+                    .map(|dependency| bridge_component_id(&dependency.canonical_digest)),
+            )
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        dependencies.sort();
+        components.push(Component {
+            kind: "schema".into(),
+            participant_id: component_id,
+            required_dependencies: dependencies,
+            files: vec![component_file],
+        });
+        bridges.push(PortableV2BridgeSet {
+            bridge_id: bridge.bridge_id.clone(),
+            version: bridge.authored_version.clone(),
+            content_digest: format!("sha256:{digest}"),
+            source_modules: bridge
+                .source_modules
+                .iter()
+                .map(|module| {
+                    exact_identity(
+                        &module.ontology_id,
+                        &module.authored_version,
+                        &module.canonical_digest,
+                    )
+                })
+                .collect(),
+            target_modules: bridge
+                .target_modules
+                .iter()
+                .map(|module| {
+                    exact_identity(
+                        &module.ontology_id,
+                        &module.authored_version,
+                        &module.canonical_digest,
+                    )
+                })
+                .collect(),
+        });
+    }
+    modules.sort_by(|left, right| {
+        (&left.ontology_id, &left.version, &left.content_digest).cmp(&(
+            &right.ontology_id,
+            &right.version,
+            &right.content_digest,
+        ))
+    });
+    bridges.sort_by(|left, right| {
+        (&left.bridge_id, &left.version, &left.content_digest).cmp(&(
+            &right.bridge_id,
+            &right.version,
+            &right.content_digest,
+        ))
+    });
+    let module_identities = composition
+        .modules
+        .iter()
+        .map(|module| {
+            (
+                module.id.display_ref(),
+                exact_identity(
+                    &module.id.ontology_id,
+                    &module.id.authored_version,
+                    &module.id.canonical_digest,
+                ),
+            )
+        })
+        .collect::<std::collections::BTreeMap<_, _>>();
+    let mut overrides = composition
+        .activation
+        .iter()
+        .map(|activation| {
+            let subject = if activation.scope.as_str() == "module" {
+                module_identities.get(&activation.subject)
+            } else {
+                bridge_identities.get(&activation.subject)
+            }
+            .ok_or_else(|| err("GF_PROJECT_CORRUPT", "composition activation is dangling"))?;
+            Ok(PortableV2ActivationOverride {
+                scope: activation.scope.as_str().into(),
+                subject: subject.clone(),
+                mode: activation.mode.as_str().into(),
+            })
+        })
+        .collect::<Result<Vec<_>, ExportError>>()?;
+    overrides.sort_by(|left, right| {
+        (
+            &left.scope,
+            &left.subject.id,
+            &left.subject.version,
+            &left.subject.content_digest,
+            &left.mode,
+        )
+            .cmp(&(
+                &right.scope,
+                &right.subject.id,
+                &right.subject.version,
+                &right.subject.content_digest,
+                &right.mode,
+            ))
+    });
+    let mut control = PortableV2OntologyComposition {
+        contract: "graphforge-ontology-composition/1".into(),
+        activation_profile: PortableV2ActivationProfile {
+            profile_default: composition.profile_default.as_str().into(),
+            overrides,
+        },
+        modules,
+        bridge_sets: bridges,
+        required_features: vec!["provenance-bridges@1".into(), "qualified-symbols@1".into()],
+        optional_features: Vec::new(),
+        composition_digest: String::new(),
+    };
+    let mut unsigned = serde_json::to_value(&control).map_err(storage)?;
+    unsigned
+        .as_object_mut()
+        .expect("composition is an object")
+        .remove("composition_digest");
+    let mut digest = Sha256::new();
+    digest.update(b"graphforge-ontology-composition/1\0");
+    digest.update(canonical_json(&unsigned)?);
+    control.composition_digest = format!("sha256:{}", hex(digest.finalize().into()));
+    let control_bytes = canonical_json(&serde_json::to_value(control).map_err(storage)?)?;
+    let path = crate::project_portable_v2::ONTOLOGY_COMPOSITION_PATH;
+    let file = inline_control(path, control_bytes, limits, total)?;
+    let component_file = ComponentFile {
+        media_type: "application/vnd.graphforge.ontology-composition+json".into(),
+        path: path.into(),
+        length: file.length,
+        sha256: hex(file.digest),
+    };
+    files.push(file);
+    roots.push("graphforge-ontology-composition".into());
+    all_dependencies.sort();
+    all_dependencies.dedup();
+    components.push(Component {
+        kind: "compatibility".into(),
+        participant_id: "graphforge-ontology-composition".into(),
+        required_dependencies: all_dependencies,
+        files: vec![component_file],
+    });
+    Ok(())
+}
+
 /// Plan every canonical participant of one already-pinned generation.
 pub fn plan_complete_portable_v2(
     g: &ResolvedProjectGeneration,
@@ -440,9 +751,17 @@ pub fn plan_selected_portable_v2(
     let mut roots = Vec::new();
     let mut runtime_participants = Vec::new();
     let mut graph_inventory_participant = None;
+    let mut ontology_composition_source = None;
     let mut total = 0;
     for d in g.participant_descriptors()? {
         if !selection.includes(&d.capability_id, &d.record_family_id) {
+            continue;
+        }
+        if d.capability_id == crate::WORKSPACE_CAPABILITY_ID
+            && d.record_family_id == crate::WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY
+        {
+            ontology_composition_source =
+                Some(g.participant_path(&d.capability_id, &d.record_family_id)?);
             continue;
         }
         let id = portable_participant_id(&d.capability_id, &d.record_family_id);
@@ -485,6 +804,16 @@ pub fn plan_selected_portable_v2(
             required_dependencies: vec![],
             files: vec![cf],
         });
+    }
+    if let Some(source) = ontology_composition_source {
+        project_ontology_composition(
+            &source,
+            limits,
+            &mut total,
+            &mut files,
+            &mut components,
+            &mut roots,
+        )?;
     }
     if selection.include_graph_tree
         && let Some(inv) = g.graph_files_inventory()?
@@ -579,12 +908,20 @@ pub fn plan_selected_portable_v2(
     roots.sort();
     collisions(&files)?;
     let capabilities = || {
-        components
+        let mut capabilities = components
             .iter()
             .map(|component| format!("{}@1", component.kind))
             .collect::<BTreeSet<_>>()
             .into_iter()
-            .collect()
+            .collect::<Vec<_>>();
+        if components.iter().any(|component| {
+            component.kind == "compatibility"
+                && component.participant_id == "graphforge-ontology-composition"
+        }) {
+            capabilities.push("ontology-composition@1".to_owned());
+            capabilities.sort();
+        }
+        capabilities
     };
     let source = || Source {
         generation_uuid: g.generation_uuid().hyphenated().to_string(),
@@ -1256,7 +1593,7 @@ fn identity(m: &fs::Metadata) -> Result<Identity, ExportError> {
     }
 }
 #[cfg(unix)]
-fn open_source_no_follow(path: &Path) -> Result<File, ExportError> {
+pub(crate) fn open_source_no_follow(path: &Path) -> Result<File, ExportError> {
     use std::path::Component;
     if fs::symlink_metadata(path)
         .map_err(storage)?
@@ -1317,7 +1654,7 @@ fn open_source_no_follow(path: &Path) -> Result<File, ExportError> {
     Ok(descriptor.into())
 }
 #[cfg(windows)]
-fn open_source_no_follow(path: &Path) -> Result<File, ExportError> {
+pub(crate) fn open_source_no_follow(path: &Path) -> Result<File, ExportError> {
     use std::os::windows::fs::OpenOptionsExt;
     const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
     reject_windows_reparse_components(path)?;
@@ -1587,6 +1924,12 @@ mod tests {
     use crate::open_or_initialize_project;
 
     fn graph_generation() -> (tempfile::TempDir, ResolvedProjectGeneration) {
+        graph_generation_with_composition(false)
+    }
+
+    fn graph_generation_with_composition(
+        include_composition: bool,
+    ) -> (tempfile::TempDir, ResolvedProjectGeneration) {
         let project = tempfile::tempdir().unwrap();
         let parent = open_or_initialize_project(project.path()).unwrap();
         let tree = tempfile::tempdir().unwrap();
@@ -1596,6 +1939,32 @@ mod tests {
         let (_, inventory) = crate::capture_graph_files(tree.path()).unwrap();
         let mut participants = crate::empty_workspace_participants().unwrap();
         participants.insert(0, inventory);
+        if include_composition {
+            let document = graphforge_ontology::OntologyDoc {
+                ontology_id: "https://graphforge.dev/ontology/portable".into(),
+                version: "release-2026.08".into(),
+                entity_types: vec![],
+                relation_types: vec![],
+                properties: vec![],
+                constraints: vec![],
+                migrations: vec![],
+            };
+            let legacy = crate::WorkspaceOntology {
+                contract_version: 1,
+                mode: crate::WorkspaceOntologyMode::Strict,
+                source_format: Some(crate::WorkspaceOntologySourceFormat::Json),
+                canonical_ontology_sha256: Some("a".repeat(64)),
+                canonical_ontology: Some(serde_json::to_value(document).unwrap()),
+            };
+            let composition = crate::WorkspaceOntologyComposition::virtual_legacy(&legacy)
+                .unwrap()
+                .unwrap();
+            participants.push(composition.to_project_participant().unwrap());
+            participants.sort_by(|left, right| {
+                (&left.capability_id, &left.record_family_id)
+                    .cmp(&(&right.capability_id, &right.record_family_id))
+            });
+        }
         let request = crate::ProjectGenerationRequest {
             transaction_uuid: Uuid::new_v4(),
             generation_uuid: Uuid::new_v4(),
@@ -1629,6 +1998,590 @@ mod tests {
         drop(parent);
         let generation = crate::resolve_project_generation(project.path()).unwrap();
         (project, generation)
+    }
+
+    fn graph_generation_with_bridge() -> (tempfile::TempDir, ResolvedProjectGeneration) {
+        use graphforge_ontology::{
+            ActivationMode, AuthoredModule, BridgeAssertion, BridgeDocument, BridgePredicate,
+            BridgeProvenance, BridgeSetId, CompositionLimits, EntityTypeDef,
+            InventoryCompileRequest, MappingMethod, OntologyDoc, OntologyModuleId, QualifiedSymbol,
+            SymbolKind, bridge_document_digest, compile_inventory, module_document_digest,
+        };
+
+        let module = |ontology_id: &str| {
+            let document = OntologyDoc {
+                ontology_id: ontology_id.into(),
+                version: "opaque-v1".into(),
+                entity_types: vec![EntityTypeDef {
+                    name: "Person".into(),
+                    r#abstract: false,
+                    parent: None,
+                }],
+                relation_types: Vec::new(),
+                properties: Vec::new(),
+                constraints: Vec::new(),
+                migrations: Vec::new(),
+            };
+            AuthoredModule {
+                id: OntologyModuleId {
+                    ontology_id: document.ontology_id.clone(),
+                    authored_version: document.version.clone(),
+                    canonical_digest: module_document_digest(&document).unwrap(),
+                },
+                dependencies: Vec::new(),
+                doc: document,
+                allow_projected_identity: false,
+            }
+        };
+        let source = module("https://graphforge.dev/ontology/source");
+        let target = module("https://graphforge.dev/ontology/target");
+        let qualified = |module: &AuthoredModule| QualifiedSymbol {
+            module: module.id.clone(),
+            kind: SymbolKind::Entity,
+            local_id: "Person".into(),
+        };
+        let bridge = BridgeDocument {
+            bridge_id: "https://graphforge.dev/bridge/person".into(),
+            authored_version: "bridge-v1".into(),
+            source_modules: vec![source.id.clone()],
+            target_modules: vec![target.id.clone()],
+            dependencies: Vec::new(),
+            shared_surfaces: Vec::new(),
+            assertions: vec![BridgeAssertion {
+                source: qualified(&source),
+                target: qualified(&target),
+                predicate: BridgePredicate::Equivalent,
+                directional: false,
+                provenance: BridgeProvenance {
+                    method: MappingMethod::Authored,
+                    confidence: None,
+                    justification: "portable fixture".into(),
+                    evidence_refs: Vec::new(),
+                },
+                valid_from: None,
+                valid_to: None,
+            }],
+            enforcement: Some(ActivationMode::Strict),
+        };
+        let bridge_id = BridgeSetId {
+            bridge_id: bridge.bridge_id.clone(),
+            authored_version: bridge.authored_version.clone(),
+            canonical_digest: bridge_document_digest(&bridge).unwrap(),
+        };
+        let compiled = compile_inventory(InventoryCompileRequest {
+            modules: &[source, target],
+            bridges: &[bridge_id],
+            activation: &[],
+            profile_default: ActivationMode::Strict,
+            limits: CompositionLimits::default(),
+            cancelled: None,
+        })
+        .unwrap();
+        let composition =
+            crate::WorkspaceOntologyComposition::from_compiled(&compiled, vec![bridge]);
+
+        let project = tempfile::tempdir().unwrap();
+        let parent = open_or_initialize_project(project.path()).unwrap();
+        let mut participants = crate::empty_workspace_participants().unwrap();
+        participants.push(composition.to_project_participant().unwrap());
+        participants.sort_by(|left, right| {
+            (&left.capability_id, &left.record_family_id)
+                .cmp(&(&right.capability_id, &right.record_family_id))
+        });
+        let request = crate::ProjectGenerationRequest {
+            transaction_uuid: Uuid::new_v4(),
+            generation_uuid: Uuid::new_v4(),
+            capabilities: vec![
+                crate::ProjectCapability {
+                    capability_id: "graph".into(),
+                    capability_version: 1,
+                },
+                crate::ProjectCapability {
+                    capability_id: "workspace".into(),
+                    capability_version: 1,
+                },
+            ],
+            participants,
+        };
+        let crate::ProjectStageOutcome::Staged(staged) =
+            crate::stage_project_generation(project.path(), &request).unwrap()
+        else {
+            panic!("fresh composition generation replayed");
+        };
+        staged
+            .validate(|_| Ok(()), |_, _| Ok(()))
+            .unwrap()
+            .publish()
+            .unwrap();
+        drop(parent);
+        let generation = crate::resolve_project_generation(project.path()).unwrap();
+        (project, generation)
+    }
+
+    fn resign_test_manifest(plan: &mut PortableV2ExportPlan) {
+        let mut manifest: serde_json::Value = serde_json::from_slice(&plan.manifest).unwrap();
+        manifest.as_object_mut().unwrap().remove("package_digest");
+        let semantic = canonical_json(&manifest).unwrap();
+        let mut digest = Sha256::new();
+        digest.update(b"graphforge-project/2\0");
+        digest.update(semantic);
+        plan.package_digest = digest.finalize().into();
+        manifest.as_object_mut().unwrap().insert(
+            "package_digest".into(),
+            serde_json::Value::String(format!("sha256:{}", hex(plan.package_digest))),
+        );
+        plan.manifest = canonical_json(&manifest).unwrap();
+    }
+
+    fn replace_test_control(plan: &mut PortableV2ExportPlan, path: &str, bytes: Vec<u8>) {
+        let file = plan
+            .files
+            .iter_mut()
+            .find(|file| file.path == path)
+            .unwrap();
+        let old_length = file.length;
+        file.length = bytes.len() as u64;
+        file.digest = Sha256::digest(&bytes).into();
+        file.source = PlannedSource::Control(bytes);
+        plan.payload_bytes = plan
+            .payload_bytes
+            .checked_sub(old_length)
+            .unwrap()
+            .checked_add(file.length)
+            .unwrap();
+
+        let mut manifest: serde_json::Value = serde_json::from_slice(&plan.manifest).unwrap();
+        let descriptor = manifest["components"]
+            .as_array_mut()
+            .unwrap()
+            .iter_mut()
+            .flat_map(|component| component["files"].as_array_mut().unwrap())
+            .find(|descriptor| descriptor["path"] == path)
+            .unwrap();
+        descriptor["length"] = file.length.into();
+        descriptor["sha256"] = hex(file.digest).into();
+        plan.manifest = canonical_json(&manifest).unwrap();
+        resign_test_manifest(plan);
+    }
+
+    fn write_test_representations(plan: &PortableV2ExportPlan, root: &Path) -> (PathBuf, PathBuf) {
+        let expanded_path = root.join("hostile.gfproject");
+        let bundle_path = root.join("hostile.gfpb");
+        let limits = PortableV2ExportLimits::default();
+        expanded(plan, &expanded_path, limits, &|| false, &mut |_| {}).unwrap();
+        bundle(plan, &bundle_path, limits, &|| false, &mut |_| {}).unwrap();
+        (expanded_path, bundle_path)
+    }
+
+    #[test]
+    fn composition_projection_has_one_identity_in_both_forms_and_is_not_runtime_authority() {
+        let (_project, generation) = graph_generation_with_composition(true);
+        let limits = PortableV2ExportLimits::default();
+        let plan = plan_complete_portable_v2(&generation, limits).unwrap();
+        let output = tempfile::tempdir().unwrap();
+        let expanded = output.path().join("composition.gfproject");
+        let bundle = output.path().join("composition.gfpb");
+        let cancelled = AtomicBool::new(false);
+        let expanded_receipt = export_complete_portable_v2(
+            &plan,
+            &expanded,
+            PortableV2Output::Expanded,
+            limits,
+            &cancelled,
+            |_| {},
+        )
+        .unwrap();
+        let bundle_receipt = export_complete_portable_v2(
+            &plan,
+            &bundle,
+            PortableV2Output::Bundle,
+            limits,
+            &cancelled,
+            |_| {},
+        )
+        .unwrap();
+        assert_eq!(
+            expanded_receipt.package_digest,
+            bundle_receipt.package_digest
+        );
+        let expanded_report =
+            verify_portable_v2(&expanded, PortableV2Mode::Full, limits, Some(&cancelled)).unwrap();
+        let bundle_report =
+            verify_portable_v2(&bundle, PortableV2Mode::Full, limits, Some(&cancelled)).unwrap();
+        assert_eq!(
+            expanded_report.ontology_composition,
+            bundle_report.ontology_composition
+        );
+        assert!(expanded_report.ontology_composition.is_some());
+
+        let runtime: serde_json::Value = serde_json::from_slice(
+            &fs::read(expanded.join(
+                "data/components/compatibility/graphforge-runtime-map/runtime-generation.json",
+            ))
+            .unwrap(),
+        )
+        .unwrap();
+        assert!(
+            runtime["participants"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|participant| {
+                    participant["record_family_id"] != crate::WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY
+                })
+        );
+
+        let supported = generation
+            .capabilities()
+            .into_iter()
+            .map(|capability| crate::ProjectCapability {
+                capability_id: capability.capability_id,
+                capability_version: capability.capability_version,
+            })
+            .collect::<Vec<_>>();
+        let imported = output.path().join("imported-project");
+        let import_receipt = crate::import_complete_portable_v2(
+            &expanded,
+            &imported,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            &supported,
+            limits,
+            Some(&cancelled),
+        )
+        .unwrap();
+        assert!(import_receipt.staged_composition.is_some());
+        let reopened = crate::resolve_project_generation(&imported).unwrap();
+        let staged = crate::load_portable_ontology_staging(&reopened, limits)
+            .unwrap()
+            .expect("verified composition remains durably staged");
+        assert_eq!(
+            staged.package_digest,
+            format!("sha256:{}", hex(expanded_receipt.package_digest))
+        );
+        assert!(
+            reopened
+                .participant_snapshots()
+                .unwrap()
+                .iter()
+                .all(|participant| participant.record_family_id
+                    != crate::WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY)
+        );
+
+        let cancelled_before_import = AtomicBool::new(true);
+        let cancelled_target = output.path().join("cancelled-project");
+        let error = crate::import_complete_portable_v2(
+            &expanded,
+            &cancelled_target,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            &supported,
+            limits,
+            Some(&cancelled_before_import),
+        )
+        .unwrap_err();
+        assert_eq!(error.code, PortableV2ErrorCode::Cancelled);
+        assert!(!cancelled_target.exists());
+    }
+
+    #[test]
+    fn semantic_tamper_and_future_feature_precede_payload() {
+        let (_project, generation) = graph_generation_with_composition(true);
+        let limits = PortableV2ExportLimits::default();
+        let original = plan_complete_portable_v2(&generation, limits).unwrap();
+        let module_path = original
+            .files
+            .iter()
+            .find(|file| file.path.ends_with("/module.json"))
+            .unwrap()
+            .path
+            .clone();
+        let module_bytes = match &original
+            .files
+            .iter()
+            .find(|file| file.path == module_path)
+            .unwrap()
+            .source
+        {
+            PlannedSource::Control(bytes) => bytes.clone(),
+            PlannedSource::File { .. } => panic!("projected module must be an inline control"),
+        };
+        let mut module: serde_json::Value = serde_json::from_slice(&module_bytes).unwrap();
+        module["ontology_id"] = "https://graphforge.dev/ontology/tampered".into();
+        let tampered_module = canonical_json(&module).unwrap();
+
+        let mut semantic_tamper = original.clone();
+        replace_test_control(&mut semantic_tamper, &module_path, tampered_module.clone());
+        let outputs = tempfile::tempdir().unwrap();
+        let (expanded, bundle) = write_test_representations(&semantic_tamper, outputs.path());
+        for package in [&expanded, &bundle] {
+            let error =
+                verify_portable_v2(package, PortableV2Mode::Full, limits, None).unwrap_err();
+            assert!(matches!(
+                error.code,
+                PortableV2ErrorCode::InvalidStructure | PortableV2ErrorCode::DigestMismatch
+            ));
+            assert_eq!(error.entry.as_deref(), Some(module_path.as_str()));
+        }
+
+        let mut future = semantic_tamper;
+        let control_path = crate::project_portable_v2::ONTOLOGY_COMPOSITION_PATH;
+        let control_bytes = match &future
+            .files
+            .iter()
+            .find(|file| file.path == control_path)
+            .unwrap()
+            .source
+        {
+            PlannedSource::Control(bytes) => bytes.clone(),
+            PlannedSource::File { .. } => panic!("composition must be an inline control"),
+        };
+        let mut control: serde_json::Value = serde_json::from_slice(&control_bytes).unwrap();
+        control["required_features"]
+            .as_array_mut()
+            .unwrap()
+            .push("future-contract@2".into());
+        control["required_features"]
+            .as_array_mut()
+            .unwrap()
+            .sort_by(|left, right| left.as_str().cmp(&right.as_str()));
+        control
+            .as_object_mut()
+            .unwrap()
+            .remove("composition_digest");
+        let mut digest = Sha256::new();
+        digest.update(b"graphforge-ontology-composition/1\0");
+        digest.update(canonical_json(&control).unwrap());
+        control["composition_digest"] = format!("sha256:{}", hex(digest.finalize().into())).into();
+        replace_test_control(&mut future, control_path, canonical_json(&control).unwrap());
+        let outputs = tempfile::tempdir().unwrap();
+        let (expanded, bundle) = write_test_representations(&future, outputs.path());
+        for package in [&expanded, &bundle] {
+            let error =
+                verify_portable_v2(package, PortableV2Mode::Full, limits, None).unwrap_err();
+            assert_eq!(error.code, PortableV2ErrorCode::UnsupportedFuture);
+            assert_eq!(error.entry.as_deref(), Some(control_path));
+        }
+    }
+
+    #[test]
+    fn bridge_semantic_tamper_fails_in_both_representations() {
+        let (_project, generation) = graph_generation_with_bridge();
+        let limits = PortableV2ExportLimits::default();
+        let mut plan = plan_complete_portable_v2(&generation, limits).unwrap();
+        let bridge_path = plan
+            .files
+            .iter()
+            .find(|file| file.path.ends_with("/bridge.json"))
+            .unwrap()
+            .path
+            .clone();
+        let bytes = match &plan
+            .files
+            .iter()
+            .find(|file| file.path == bridge_path)
+            .unwrap()
+            .source
+        {
+            PlannedSource::Control(bytes) => bytes.clone(),
+            PlannedSource::File { .. } => panic!("projected bridge must be an inline control"),
+        };
+        let mut bridge: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        bridge["authored_version"] = "tampered-v2".into();
+        replace_test_control(&mut plan, &bridge_path, canonical_json(&bridge).unwrap());
+        let outputs = tempfile::tempdir().unwrap();
+        let (expanded, bundle) = write_test_representations(&plan, outputs.path());
+        for package in [&expanded, &bundle] {
+            let error =
+                verify_portable_v2(package, PortableV2Mode::Full, limits, None).unwrap_err();
+            assert_eq!(error.code, PortableV2ErrorCode::DigestMismatch);
+            assert_eq!(error.entry.as_deref(), Some(bridge_path.as_str()));
+        }
+    }
+
+    #[test]
+    fn semantic_descriptor_kind_path_and_media_mismatches_fail_in_both_forms() {
+        let (_project, generation) = graph_generation_with_composition(true);
+        let limits = PortableV2ExportLimits::default();
+        let original = plan_complete_portable_v2(&generation, limits).unwrap();
+        let module_path = original
+            .files
+            .iter()
+            .find(|file| file.path.ends_with("/module.json"))
+            .unwrap()
+            .path
+            .clone();
+        for mutation in ["kind", "path", "media"] {
+            let mut plan = original.clone();
+            let mut manifest: serde_json::Value = serde_json::from_slice(&plan.manifest).unwrap();
+            let component = manifest["components"]
+                .as_array_mut()
+                .unwrap()
+                .iter_mut()
+                .find(|component| {
+                    component["files"]
+                        .as_array()
+                        .unwrap()
+                        .iter()
+                        .any(|file| file["path"] == module_path)
+                })
+                .unwrap();
+            match mutation {
+                "kind" => component["kind"] = "schema".into(),
+                "path" => {
+                    component["files"][0]["path"] =
+                        "data/components/ontology/wrong/module.json".into()
+                }
+                "media" => component["files"][0]["media_type"] = "application/octet-stream".into(),
+                _ => unreachable!(),
+            }
+            plan.manifest = canonical_json(&manifest).unwrap();
+            resign_test_manifest(&mut plan);
+            let outputs = tempfile::tempdir().unwrap();
+            let (expanded, bundle) = write_test_representations(&plan, outputs.path());
+            for package in [&expanded, &bundle] {
+                let error =
+                    verify_portable_v2(package, PortableV2Mode::Full, limits, None).unwrap_err();
+                assert!(
+                    matches!(
+                        error.code,
+                        PortableV2ErrorCode::Incompatible
+                            | PortableV2ErrorCode::InvalidStructure
+                            | PortableV2ErrorCode::DigestMismatch
+                    ),
+                    "{mutation}: {error:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn versioned_m9_interchange_ledger_covers_required_matrix() {
+        let ledger: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../tests/fixtures/portable-v2/m9-interchange-cases.json"
+        ))
+        .unwrap();
+        assert_eq!(
+            ledger["contract"],
+            "graphforge-portable-v2-m9-interchange-cases/1"
+        );
+        assert_eq!(
+            ledger["representations"],
+            serde_json::json!(["expanded", "bundle"])
+        );
+        assert_eq!(
+            ledger["positive_package_classes"],
+            serde_json::json!([
+                "complete",
+                "ontology-only",
+                "component-selective",
+                "graph-data-subset"
+            ])
+        );
+        let cases = ledger["negative_cases"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|case| case["name"].as_str().unwrap())
+            .collect::<BTreeSet<_>>();
+        for required in [
+            "future-manifest-capability-before-payload",
+            "future-composition-feature-before-semantic-payload",
+            "module-semantic-digest-tamper",
+            "bridge-semantic-digest-tamper",
+            "semantic-descriptor-kind-path-media-mismatch",
+            "semantic-payload-budget",
+            "cancelled-private-materialization",
+            "durable-staging-replay",
+            "durable-staging-transaction-conflict",
+            "durable-staging-publication-failure",
+        ] {
+            assert!(cases.contains(required), "missing {required}");
+        }
+    }
+
+    #[test]
+    fn complete_ontology_data_and_custom_profiles_keep_composition_closure() {
+        let (_project, generation) = graph_generation_with_composition(true);
+        let limits = PortableV2ExportLimits::default();
+        let requests = [
+            PortableV2SelectionRequest {
+                profile: PortableV2SelectionProfile::Complete,
+                strict: false,
+            },
+            PortableV2SelectionRequest {
+                profile: PortableV2SelectionProfile::OntologyOnly,
+                strict: false,
+            },
+            PortableV2SelectionRequest {
+                profile: PortableV2SelectionProfile::DataComponents,
+                strict: false,
+            },
+            PortableV2SelectionRequest {
+                profile: PortableV2SelectionProfile::Custom(vec![crate::PortableV2ParticipantId {
+                    capability_id: crate::GRAPH_CAPABILITY_ID.into(),
+                    record_family_id: crate::GRAPH_FILES_FAMILY.into(),
+                }]),
+                strict: false,
+            },
+        ];
+        for (index, request) in requests.iter().enumerate() {
+            let selection = preview_portable_v2_selection(&generation, request, limits).unwrap();
+            assert!(selection.includes(
+                crate::WORKSPACE_CAPABILITY_ID,
+                crate::WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY
+            ));
+            assert!(!selection.projected.is_empty());
+            let mut reports = Vec::new();
+            for representation in [PortableV2Output::Expanded, PortableV2Output::Bundle] {
+                let plan = plan_selected_portable_v2(&generation, &selection, limits).unwrap();
+                let output = tempfile::tempdir().unwrap();
+                let extension = if representation == PortableV2Output::Expanded {
+                    "gfproject"
+                } else {
+                    "gfpb"
+                };
+                let destination = output.path().join(format!("class-{index}.{extension}"));
+                export_complete_portable_v2(
+                    &plan,
+                    &destination,
+                    representation,
+                    limits,
+                    &AtomicBool::new(false),
+                    |_| {},
+                )
+                .unwrap();
+                let report =
+                    verify_portable_v2(&destination, PortableV2Mode::Full, limits, None).unwrap();
+                assert!(report.ontology_composition.is_some());
+                reports.push(report);
+            }
+            assert_eq!(reports[0].package_digest, reports[1].package_digest);
+            assert_eq!(
+                reports[0].ontology_composition,
+                reports[1].ontology_composition
+            );
+            assert_eq!(
+                reports[0].ontology_composition_entries,
+                reports[1].ontology_composition_entries
+            );
+        }
+
+        let complete = preview_portable_v2_selection(&generation, &requests[0], limits).unwrap();
+        let exact = complete.projected[0].identity.clone();
+        let projected = preview_portable_v2_selection(
+            &generation,
+            &PortableV2SelectionRequest {
+                profile: PortableV2SelectionProfile::OntologyComposition(vec![exact.clone()]),
+                strict: false,
+            },
+            limits,
+        )
+        .unwrap();
+        assert!(projected.projected.iter().any(|entry| {
+            entry.identity == exact && entry.reason == crate::PortableV2SelectionReason::Requested
+        }));
+        assert!(projected.estimated_payload_bytes > 0);
     }
 
     #[test]

--- a/crates/graphforge-storage/src/project_portable_v2_import.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_import.rs
@@ -49,6 +49,70 @@ pub struct PortableV2StagedCompositionReceipt {
     pub workspace_composition_fingerprint: String,
 }
 
+/// Authenticated selective-package state passed to an explicit typed consumer.
+///
+/// Payloads remain in callback-scoped private staging and are removed before
+/// [`consume_selective_portable_v2`] returns. The ontology candidate is never
+/// installed as project authority implicitly.
+#[derive(Debug)]
+pub struct PortableV2SelectiveCandidate {
+    /// Full authenticated package report.
+    pub report: PortableV2Report,
+    /// Recompiled, non-authoritative ontology candidate when present.
+    pub ontology: Option<crate::WorkspacePortableOntologyStaging>,
+    /// Payload-free staged-composition receipt when present.
+    pub staged_composition: Option<PortableV2StagedCompositionReceipt>,
+}
+
+/// Verify and privately materialize a selective package for one typed consumer.
+///
+/// Complete packages must use [`import_complete_portable_v2`]. The callback is
+/// the only scope in which authenticated data paths are available; staging is
+/// deterministically removed on success or error and no project is mutated.
+pub fn consume_selective_portable_v2<T>(
+    source: impl AsRef<Path>,
+    limits: PortableV2Limits,
+    cancelled: Option<&AtomicBool>,
+    consume: impl FnOnce(&Path, &PortableV2SelectiveCandidate) -> Result<T, PortableV2Error>,
+) -> Result<T, PortableV2Error> {
+    let owner = tempfile::tempdir().map_err(|_| {
+        PortableV2Error::new(PortableV2ErrorCode::Io, "cannot create selective staging")
+    })?;
+    let stage = owner.path().join("materialized");
+    let report = materialize_verified_portable_v2(source.as_ref(), &stage, limits, cancelled)?;
+    if report.package_class == PortableV2PackageClass::Complete {
+        return Err(PortableV2Error::new(
+            PortableV2ErrorCode::Incompatible,
+            "complete package requires complete-project import",
+        ));
+    }
+    let (ontology, staged_composition) = if report.ontology_composition.is_some() {
+        let (candidate, receipt) = build_staged_composition(&stage, &report, limits)?;
+        let bytes = read_bounded_payload(
+            &candidate.source,
+            limits.max_manifest_bytes,
+            "selective staged composition",
+        )?;
+        (
+            Some(
+                crate::WorkspacePortableOntologyStaging::from_canonical_json(&bytes)
+                    .map_err(storage)?,
+            ),
+            Some(receipt),
+        )
+    } else {
+        (None, None)
+    };
+    consume(
+        &stage,
+        &PortableV2SelectiveCandidate {
+            report,
+            ontology,
+            staged_composition,
+        },
+    )
+}
+
 /// Reopen and validate the durable non-authoritative ontology candidate.
 ///
 /// This function never changes active ontology authority. It is the storage

--- a/crates/graphforge-storage/src/project_portable_v2_import.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_import.rs
@@ -1,11 +1,15 @@
 //! Verification-first, bounded portable-v2 project import.
 
 use std::fs::{self, OpenOptions};
-use std::io::Write as _;
+use std::io::{Read as _, Write as _};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 
 use graphforge_core::GfError;
+use graphforge_ontology::{
+    ActivationMode, ActivationRecord, ActivationScope, AuthoredModule, BridgeSetId,
+    CompositionLimits, InventoryCompileRequest, OntologyModuleId, compile_inventory,
+};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
@@ -30,6 +34,50 @@ pub struct PortableV2ImportReceipt {
     pub transport_digest: Option<String>,
     /// Atomic project-generation publication receipt.
     pub publication: ProjectPublicationReceipt,
+    /// Durable non-authoritative composition candidate, when imported.
+    pub staged_composition: Option<PortableV2StagedCompositionReceipt>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Payload-free identity of the durable non-authoritative candidate.
+pub struct PortableV2StagedCompositionReceipt {
+    /// Verified portable package identity.
+    pub package_digest: String,
+    /// Verified portable composition identity.
+    pub portable_composition_digest: String,
+    /// Recompiled workspace composition identity.
+    pub workspace_composition_fingerprint: String,
+}
+
+/// Reopen and validate the durable non-authoritative ontology candidate.
+///
+/// This function never changes active ontology authority. It is the storage
+/// seam consumed by an explicit lifecycle request.
+pub fn load_portable_ontology_staging(
+    generation: &crate::ResolvedProjectGeneration,
+    limits: PortableV2Limits,
+) -> Result<Option<crate::WorkspacePortableOntologyStaging>, PortableV2Error> {
+    let present = generation
+        .participant_descriptors()
+        .map_err(storage)?
+        .iter()
+        .any(|descriptor| {
+            descriptor.capability_id == crate::WORKSPACE_CAPABILITY_ID
+                && descriptor.record_family_id == crate::WORKSPACE_PORTABLE_ONTOLOGY_STAGING_FAMILY
+        });
+    if !present {
+        return Ok(None);
+    }
+    let path = generation
+        .participant_path(
+            crate::WORKSPACE_CAPABILITY_ID,
+            crate::WORKSPACE_PORTABLE_ONTOLOGY_STAGING_FAMILY,
+        )
+        .map_err(storage)?;
+    let bytes = read_bounded_payload(&path, limits.max_manifest_bytes, "staged composition")?;
+    crate::WorkspacePortableOntologyStaging::from_canonical_json(&bytes)
+        .map(Some)
+        .map_err(storage)
 }
 
 /// Sanitized import lifecycle phase.
@@ -349,6 +397,23 @@ fn import_materialized(
             content_sha256,
         });
     }
+    let staged_composition = if report.ontology_composition.is_some() {
+        let (candidate, receipt) = build_staged_composition(stage, report, limits)?;
+        participants.push(candidate);
+        Some(receipt)
+    } else {
+        None
+    };
+    participants.sort_by(|left, right| {
+        (
+            &left.participant.capability_id,
+            &left.participant.record_family_id,
+        )
+            .cmp(&(
+                &right.participant.capability_id,
+                &right.participant.record_family_id,
+            ))
+    });
     let request = ProjectGenerationRequest {
         transaction_uuid,
         generation_uuid,
@@ -420,7 +485,310 @@ fn import_materialized(
         package_digest: report.package_digest.clone(),
         transport_digest: report.transport_digest.clone(),
         publication,
+        staged_composition,
     })
+}
+
+fn parse_mode(value: &str) -> Result<ActivationMode, PortableV2Error> {
+    match value {
+        "exploratory" => Ok(ActivationMode::Exploratory),
+        "advisory" => Ok(ActivationMode::Advisory),
+        "strict" => Ok(ActivationMode::Strict),
+        _ => Err(PortableV2Error::new(
+            PortableV2ErrorCode::Incompatible,
+            "portable activation mode",
+        )),
+    }
+}
+
+fn build_staged_composition(
+    stage: &Path,
+    report: &PortableV2Report,
+    limits: PortableV2Limits,
+) -> Result<(ProjectFileParticipant, PortableV2StagedCompositionReceipt), PortableV2Error> {
+    let control = report.ontology_composition.as_ref().ok_or_else(|| {
+        PortableV2Error::new(
+            PortableV2ErrorCode::Incompatible,
+            "composition control absent",
+        )
+    })?;
+    let module_ids = control
+        .modules
+        .iter()
+        .map(|module| {
+            (
+                format!(
+                    "ontology-module-{}",
+                    module.content_digest.trim_start_matches("sha256:")
+                ),
+                OntologyModuleId {
+                    ontology_id: module.ontology_id.clone(),
+                    authored_version: module.version.clone(),
+                    canonical_digest: module
+                        .content_digest
+                        .trim_start_matches("sha256:")
+                        .to_owned(),
+                },
+            )
+        })
+        .collect::<std::collections::BTreeMap<_, _>>();
+    let bridge_ids = control
+        .bridge_sets
+        .iter()
+        .map(|bridge| {
+            (
+                format!(
+                    "ontology-bridge-{}",
+                    bridge.content_digest.trim_start_matches("sha256:")
+                ),
+                BridgeSetId {
+                    bridge_id: bridge.bridge_id.clone(),
+                    authored_version: bridge.version.clone(),
+                    canonical_digest: bridge
+                        .content_digest
+                        .trim_start_matches("sha256:")
+                        .to_owned(),
+                },
+            )
+        })
+        .collect::<std::collections::BTreeMap<_, _>>();
+    let (authored, bridges) = load_staged_composition_entries(stage, report, limits, &module_ids)?;
+    let activations = build_staged_activations(control)?;
+    let exact_bridges = resolve_staged_bridge_ids(&bridges, &bridge_ids)?;
+    let compiled = compile_inventory(InventoryCompileRequest {
+        modules: &authored,
+        bridges: &exact_bridges,
+        activation: &activations,
+        profile_default: parse_mode(&control.activation_profile.profile_default)?,
+        limits: CompositionLimits::default(),
+        cancelled: None,
+    })
+    .map_err(|_| {
+        PortableV2Error::new(
+            PortableV2ErrorCode::Incompatible,
+            "staged composition closure",
+        )
+    })?;
+    let composition = crate::WorkspaceOntologyComposition::from_compiled(&compiled, bridges);
+    let staged = crate::WorkspacePortableOntologyStaging {
+        contract_version: 1,
+        package_digest: report.package_digest.clone(),
+        portable_composition_digest: control.composition_digest.clone(),
+        composition,
+    };
+    let (participant, source, bytes) = persist_staged_composition(stage, &staged)?;
+    let receipt = PortableV2StagedCompositionReceipt {
+        package_digest: report.package_digest.clone(),
+        portable_composition_digest: control.composition_digest.clone(),
+        workspace_composition_fingerprint: staged.composition.composition_fingerprint.clone(),
+    };
+    Ok((
+        ProjectFileParticipant {
+            participant: ProjectParticipant {
+                bytes: Vec::new(),
+                ..participant
+            },
+            source,
+            byte_length: bytes.len() as u64,
+            content_sha256: Sha256::digest(&bytes).into(),
+        },
+        receipt,
+    ))
+}
+
+fn load_staged_composition_entries(
+    stage: &Path,
+    report: &PortableV2Report,
+    limits: PortableV2Limits,
+    module_ids: &std::collections::BTreeMap<String, OntologyModuleId>,
+) -> Result<
+    (
+        Vec<AuthoredModule>,
+        Vec<graphforge_ontology::BridgeDocument>,
+    ),
+    PortableV2Error,
+> {
+    let mut authored = Vec::new();
+    let mut bridges = Vec::new();
+    for entry in &report.ontology_composition_entries {
+        let bytes = read_bounded_payload(
+            &stage.join(&entry.path),
+            limits.max_manifest_bytes,
+            &entry.path,
+        )?;
+        if entry.kind != "ontology" {
+            bridges.push(serde_json::from_slice(&bytes).map_err(|_| {
+                PortableV2Error::at(
+                    PortableV2ErrorCode::InvalidStructure,
+                    &entry.path,
+                    "staged ontology bridge",
+                )
+            })?);
+            continue;
+        }
+        let document = serde_json::from_slice(&bytes).map_err(|_| {
+            PortableV2Error::at(
+                PortableV2ErrorCode::InvalidStructure,
+                &entry.path,
+                "staged ontology module",
+            )
+        })?;
+        let id = module_ids
+            .get(entry.path.split('/').nth(3).unwrap_or_default())
+            .cloned()
+            .ok_or_else(|| {
+                PortableV2Error::new(PortableV2ErrorCode::Incompatible, "staged module identity")
+            })?;
+        let dependencies = entry
+            .required_dependencies
+            .iter()
+            .map(|dependency| {
+                module_ids.get(dependency).cloned().ok_or_else(|| {
+                    PortableV2Error::new(
+                        PortableV2ErrorCode::Incompatible,
+                        "staged module dependency closure",
+                    )
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        authored.push(AuthoredModule {
+            allow_projected_identity: id.ontology_id.starts_with("legacy:"),
+            id,
+            dependencies,
+            doc: document,
+        });
+    }
+    Ok((authored, bridges))
+}
+
+fn build_staged_activations(
+    control: &crate::project_portable_v2::PortableV2OntologyComposition,
+) -> Result<Vec<ActivationRecord>, PortableV2Error> {
+    control
+        .activation_profile
+        .overrides
+        .iter()
+        .map(|activation| {
+            let scope = match activation.scope.as_str() {
+                "module" => ActivationScope::Module,
+                "bridge" => ActivationScope::Bridge,
+                _ => {
+                    return Err(PortableV2Error::new(
+                        PortableV2ErrorCode::Incompatible,
+                        "activation scope",
+                    ));
+                }
+            };
+            Ok(ActivationRecord {
+                scope,
+                subject: format!(
+                    "{}@{}#{}",
+                    activation.subject.id,
+                    activation.subject.version,
+                    activation
+                        .subject
+                        .content_digest
+                        .trim_start_matches("sha256:")
+                ),
+                mode: parse_mode(&activation.mode)?,
+            })
+        })
+        .collect()
+}
+
+fn resolve_staged_bridge_ids(
+    bridges: &[graphforge_ontology::BridgeDocument],
+    bridge_ids: &std::collections::BTreeMap<String, BridgeSetId>,
+) -> Result<Vec<BridgeSetId>, PortableV2Error> {
+    bridges
+        .iter()
+        .map(|bridge| {
+            bridge_ids
+                .values()
+                .find(|id| {
+                    id.bridge_id == bridge.bridge_id
+                        && id.authored_version == bridge.authored_version
+                })
+                .cloned()
+                .ok_or_else(|| {
+                    PortableV2Error::new(
+                        PortableV2ErrorCode::Incompatible,
+                        "staged bridge identity",
+                    )
+                })
+        })
+        .collect()
+}
+
+fn persist_staged_composition(
+    stage: &Path,
+    staged: &crate::WorkspacePortableOntologyStaging,
+) -> Result<(ProjectParticipant, PathBuf, Vec<u8>), PortableV2Error> {
+    let participant = staged.to_project_participant().map_err(storage)?;
+    let bytes = participant.bytes.clone();
+    let source = stage.join("portable-ontology-staging.json");
+    let mut output = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&source)
+        .map_err(|_| {
+            PortableV2Error::new(
+                PortableV2ErrorCode::Io,
+                "cannot stage composition candidate",
+            )
+        })?;
+    output.write_all(&bytes).map_err(|_| {
+        PortableV2Error::new(
+            PortableV2ErrorCode::Io,
+            "cannot write composition candidate",
+        )
+    })?;
+    output.sync_all().map_err(|_| {
+        PortableV2Error::new(PortableV2ErrorCode::Io, "cannot sync composition candidate")
+    })?;
+    Ok((participant, source, bytes))
+}
+
+fn read_bounded_payload(
+    path: &Path,
+    limit: u64,
+    context: &str,
+) -> Result<Vec<u8>, PortableV2Error> {
+    let metadata = fs::symlink_metadata(path).map_err(|_| {
+        PortableV2Error::at(
+            PortableV2ErrorCode::InvalidStructure,
+            context,
+            "payload unavailable",
+        )
+    })?;
+    if !metadata.is_file() || metadata.file_type().is_symlink() || metadata.len() > limit {
+        return Err(PortableV2Error::at(
+            PortableV2ErrorCode::LimitExceeded,
+            context,
+            "payload bound",
+        ));
+    }
+    let mut file =
+        crate::project_portable_v2_export::open_source_no_follow(path).map_err(|_| {
+            PortableV2Error::at(
+                PortableV2ErrorCode::InvalidStructure,
+                context,
+                "payload open",
+            )
+        })?;
+    let mut bytes = Vec::new();
+    std::io::Read::by_ref(&mut file)
+        .take(limit.saturating_add(1))
+        .read_to_end(&mut bytes)
+        .map_err(|_| PortableV2Error::at(PortableV2ErrorCode::Io, context, "payload read"))?;
+    if bytes.len() as u64 > limit || bytes.len() as u64 != metadata.len() {
+        return Err(PortableV2Error::at(
+            PortableV2ErrorCode::LimitExceeded,
+            context,
+            "payload bound",
+        ));
+    }
+    Ok(bytes)
 }
 
 fn find_participant_file(
@@ -561,6 +929,170 @@ mod tests {
                 capability_version: 1,
             },
         ]
+    }
+
+    fn composition_package() -> (tempfile::TempDir, PathBuf) {
+        let source = tempfile::tempdir().unwrap();
+        let parent = crate::open_or_initialize_project(source.path()).unwrap();
+        let document = graphforge_ontology::OntologyDoc {
+            ontology_id: "https://graphforge.dev/ontology/portable-import".into(),
+            version: "release-2026.08".into(),
+            entity_types: Vec::new(),
+            relation_types: Vec::new(),
+            properties: Vec::new(),
+            constraints: Vec::new(),
+            migrations: Vec::new(),
+        };
+        let legacy = crate::WorkspaceOntology {
+            contract_version: 1,
+            mode: crate::WorkspaceOntologyMode::Strict,
+            source_format: Some(crate::WorkspaceOntologySourceFormat::Json),
+            canonical_ontology_sha256: Some("a".repeat(64)),
+            canonical_ontology: Some(serde_json::to_value(document).unwrap()),
+        };
+        let composition = crate::WorkspaceOntologyComposition::virtual_legacy(&legacy)
+            .unwrap()
+            .unwrap();
+        let mut participants = crate::empty_workspace_participants().unwrap();
+        participants.push(composition.to_project_participant().unwrap());
+        participants.sort_by(|left, right| {
+            (&left.capability_id, &left.record_family_id)
+                .cmp(&(&right.capability_id, &right.record_family_id))
+        });
+        let request = ProjectGenerationRequest {
+            transaction_uuid: Uuid::new_v4(),
+            generation_uuid: Uuid::new_v4(),
+            capabilities: supported(),
+            participants,
+        };
+        let ProjectStageOutcome::Staged(staged) =
+            crate::stage_project_generation(source.path(), &request).unwrap()
+        else {
+            panic!("fresh composition generation replayed");
+        };
+        staged
+            .validate(|_| Ok(()), |_, _| Ok(()))
+            .unwrap()
+            .publish()
+            .unwrap();
+        drop(parent);
+        let generation = crate::resolve_project_generation(source.path()).unwrap();
+        let package_parent = tempfile::tempdir().unwrap();
+        let package = package_parent.path().join("composition.gfproject");
+        let limits = crate::PortableV2ExportLimits::default();
+        let plan = crate::plan_complete_portable_v2(&generation, limits).unwrap();
+        crate::export_complete_portable_v2(
+            &plan,
+            &package,
+            crate::PortableV2Output::Expanded,
+            limits,
+            &AtomicBool::new(false),
+            |_| {},
+        )
+        .unwrap();
+        (package_parent, package)
+    }
+
+    #[test]
+    fn durable_composition_staging_reopens_replays_and_fails_without_partial_authority() {
+        let (_package_parent, package) = composition_package();
+        let parent = tempfile::tempdir().unwrap();
+        let target = parent.path().join("imported");
+        let transaction = Uuid::new_v4();
+        let generation = Uuid::new_v4();
+        let first = import_complete_portable_v2(
+            &package,
+            &target,
+            transaction,
+            generation,
+            &supported(),
+            PortableV2Limits::default(),
+            None,
+        )
+        .unwrap();
+        assert!(first.staged_composition.is_some());
+        let reopened = crate::resolve_project_generation(&target).unwrap();
+        let staged = load_portable_ontology_staging(&reopened, PortableV2Limits::default())
+            .unwrap()
+            .expect("verified candidate must survive reopen");
+        assert_eq!(staged.package_digest, first.package_digest);
+        assert!(
+            reopened
+                .participant_snapshots()
+                .unwrap()
+                .iter()
+                .all(|entry| {
+                    entry.record_family_id != crate::WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY
+                })
+        );
+
+        let replay = import_complete_portable_v2(
+            &package,
+            &target,
+            transaction,
+            generation,
+            &supported(),
+            PortableV2Limits::default(),
+            None,
+        )
+        .unwrap();
+        assert_eq!(replay.publication.generation_uuid, generation);
+        let conflict = import_complete_portable_v2(
+            &package,
+            &target,
+            transaction,
+            Uuid::new_v4(),
+            &supported(),
+            PortableV2Limits::default(),
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(conflict.code, PortableV2ErrorCode::Io);
+        assert_eq!(
+            crate::resolve_project_generation(&target)
+                .unwrap()
+                .generation_uuid(),
+            generation
+        );
+
+        for (name, capabilities, cancelled, expected) in [
+            (
+                "cancelled",
+                supported(),
+                AtomicBool::new(true),
+                PortableV2ErrorCode::Cancelled,
+            ),
+            (
+                "unsupported",
+                Vec::new(),
+                AtomicBool::new(false),
+                PortableV2ErrorCode::Incompatible,
+            ),
+        ] {
+            let failed = parent.path().join(name);
+            let transaction = Uuid::new_v4();
+            let error = import_complete_portable_v2(
+                &package,
+                &failed,
+                transaction,
+                Uuid::new_v4(),
+                &capabilities,
+                PortableV2Limits::default(),
+                Some(&cancelled),
+            )
+            .unwrap_err();
+            assert_eq!(error.code, expected, "{name}");
+            assert!(!failed.exists(), "{name} published a target");
+            let residue = parent
+                .path()
+                .join(format!(".{name}.portable-v2-{}", transaction.hyphenated()));
+            assert!(!residue.exists(), "{name} retained private staging");
+            let owner = residue.with_file_name(format!(
+                ".{name}.portable-v2-{}.owner",
+                transaction.hyphenated()
+            ));
+            assert!(!owner.exists(), "{name} retained its ownership marker");
+        }
     }
 
     #[test]

--- a/crates/graphforge-storage/src/project_portable_v2_selection.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_selection.rs
@@ -201,12 +201,17 @@ pub fn preview_portable_v2_selection(
         return Err(incompatible("selection matched no portable components"));
     }
 
-    let needs_schema = requested.iter().any(|identity| {
-        matches!(
-            component_kind(&identity.capability_id, &identity.record_family_id),
-            "ontology" | "graph-data" | "derived-artifact"
-        )
-    });
+    let exact_composition = matches!(
+        request.profile,
+        PortableV2SelectionProfile::OntologyComposition(_)
+    );
+    let needs_schema = !exact_composition
+        && requested.iter().any(|identity| {
+            matches!(
+                component_kind(&identity.capability_id, &identity.record_family_id),
+                "ontology" | "graph-data" | "derived-artifact"
+            )
+        });
     let schema = descriptors
         .iter()
         .filter(|descriptor| {
@@ -343,6 +348,10 @@ pub fn preview_portable_v2_selection(
     Ok(plan)
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "keeps exact identity validation and transitive module/bridge closure in one audit path"
+)]
 fn projected_composition_entries(
     generation: &ResolvedProjectGeneration,
     request: &PortableV2SelectionRequest,
@@ -381,6 +390,90 @@ fn projected_composition_entries(
         }
         _ => None,
     };
+    let module_identity = |module: &crate::WorkspaceCompositionModule| PortableV2ExactIdentity {
+        id: module.id.ontology_id.clone(),
+        version: module.id.authored_version.clone(),
+        content_digest: format!("sha256:{}", module.id.canonical_digest),
+    };
+    let bridge_identity = |bridge: &graphforge_ontology::BridgeDocument| {
+        let digest = graphforge_ontology::bridge_document_digest(bridge)
+            .map_err(|_| incompatible("composition bridge digest"))?;
+        Ok::<_, PortableV2Error>((
+            PortableV2ExactIdentity {
+                id: bridge.bridge_id.clone(),
+                version: bridge.authored_version.clone(),
+                content_digest: format!("sha256:{digest}"),
+            },
+            digest,
+        ))
+    };
+    let module_by_identity = composition
+        .modules
+        .iter()
+        .map(|module| (module_identity(module), module))
+        .collect::<std::collections::BTreeMap<_, _>>();
+    let mut bridge_by_identity = std::collections::BTreeMap::new();
+    for bridge in &composition.bridges {
+        let (identity, digest) = bridge_identity(bridge)?;
+        bridge_by_identity.insert(identity, (bridge, digest));
+    }
+    let mut closure = requested.clone().unwrap_or_else(|| {
+        module_by_identity
+            .keys()
+            .chain(bridge_by_identity.keys())
+            .cloned()
+            .collect()
+    });
+    if requested.as_ref().is_some_and(|roots| {
+        roots.iter().any(|identity| {
+            !module_by_identity.contains_key(identity) && !bridge_by_identity.contains_key(identity)
+        })
+    }) {
+        return Err(incompatible("projected ontology selector is absent"));
+    }
+    loop {
+        let before = closure.len();
+        for identity in closure.clone() {
+            if let Some(module) = module_by_identity.get(&identity) {
+                closure.extend(module.dependencies.iter().map(|dependency| {
+                    PortableV2ExactIdentity {
+                        id: dependency.ontology_id.clone(),
+                        version: dependency.authored_version.clone(),
+                        content_digest: format!("sha256:{}", dependency.canonical_digest),
+                    }
+                }));
+            } else if let Some((bridge, _)) = bridge_by_identity.get(&identity) {
+                closure.extend(
+                    bridge
+                        .source_modules
+                        .iter()
+                        .chain(&bridge.target_modules)
+                        .map(|module| PortableV2ExactIdentity {
+                            id: module.ontology_id.clone(),
+                            version: module.authored_version.clone(),
+                            content_digest: format!("sha256:{}", module.canonical_digest),
+                        }),
+                );
+                closure.extend(bridge.dependencies.iter().map(|dependency| {
+                    PortableV2ExactIdentity {
+                        id: dependency.bridge_id.clone(),
+                        version: dependency.authored_version.clone(),
+                        content_digest: format!("sha256:{}", dependency.canonical_digest),
+                    }
+                }));
+            }
+        }
+        if closure.len() == before {
+            break;
+        }
+    }
+    if closure.iter().any(|identity| {
+        !module_by_identity.contains_key(identity) && !bridge_by_identity.contains_key(identity)
+    }) {
+        return Err(incompatible(
+            "projected ontology dependency closure is missing",
+        ));
+    }
     let mut entries = Vec::new();
     for module in &composition.modules {
         let identity = PortableV2ExactIdentity {
@@ -388,6 +481,9 @@ fn projected_composition_entries(
             version: module.id.authored_version.clone(),
             content_digest: format!("sha256:{}", module.id.canonical_digest),
         };
+        if !closure.contains(&identity) {
+            continue;
+        }
         let payload = crate::project_portable_v2::canonical_json(
             &serde_json::to_value(&module.document)
                 .map_err(|_| incompatible("composition preview serialization"))?,
@@ -415,6 +511,9 @@ fn projected_composition_entries(
             version: bridge.authored_version.clone(),
             content_digest: format!("sha256:{digest}"),
         };
+        if !closure.contains(&identity) {
+            continue;
+        }
         let payload = crate::project_portable_v2::canonical_json(
             &serde_json::to_value(bridge)
                 .map_err(|_| incompatible("composition preview serialization"))?,
@@ -435,13 +534,6 @@ fn projected_composition_entries(
         });
     }
     entries.sort_by(|left, right| left.participant_id.cmp(&right.participant_id));
-    if let Some(requested) = requested
-        && requested
-            .iter()
-            .any(|identity| !entries.iter().any(|entry| &entry.identity == identity))
-    {
-        return Err(incompatible("projected ontology selector is absent"));
-    }
     Ok(entries)
 }
 

--- a/crates/graphforge-storage/src/project_portable_v2_selection.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_selection.rs
@@ -9,8 +9,8 @@ use serde_json::Value;
 use sha2::{Digest, Sha256};
 
 use crate::{
-    PortableV2Error, PortableV2ErrorCode, PortableV2Limits, ResolvedProjectGeneration,
-    WORKSPACE_CAPABILITY_ID, WORKSPACE_CONFIGURATION_FAMILY,
+    PortableV2Error, PortableV2ErrorCode, PortableV2ExactIdentity, PortableV2Limits,
+    ResolvedProjectGeneration, WORKSPACE_CAPABILITY_ID, WORKSPACE_CONFIGURATION_FAMILY,
 };
 
 /// Stable semantic participant identity. Runtime catalog IDs and host paths are never selectors.
@@ -37,6 +37,9 @@ pub enum PortableV2SelectionProfile {
     Settings,
     /// Explicit stable identities.
     Custom(Vec<PortableV2ParticipantId>),
+    /// Exact projected ontology module or bridge identities. The immutable
+    /// preview exposes the complete emitted composition closure.
+    OntologyComposition(Vec<PortableV2ExactIdentity>),
 }
 
 /// Selection planning request.
@@ -56,6 +59,8 @@ pub enum PortableV2SelectionReason {
     Requested,
     /// Required ontology/schema closure.
     RequiredSchemaAuthority,
+    /// Required exact multi-ontology composition closure.
+    RequiredOntologyComposition,
     /// Not part of the requested profile.
     ProfileExcluded,
 }
@@ -75,6 +80,21 @@ pub struct PortableV2SelectionEntry {
     pub row_count: u64,
 }
 
+/// Exact ontology module or bridge emitted by composition projection.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct PortableV2ProjectedSelectionEntry {
+    /// Projected component kind (`ontology` or `schema`).
+    pub kind: String,
+    /// Exact semantic identity addressable by callers.
+    pub identity: PortableV2ExactIdentity,
+    /// Stable component identity used by the portable manifest.
+    pub participant_id: String,
+    /// Whether this exact identity was directly requested or closure-added.
+    pub reason: PortableV2SelectionReason,
+    /// Exact canonical projected payload bytes.
+    pub estimated_bytes: u64,
+}
+
 /// Immutable deterministic preview consumed by both export representations.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct PortableV2SelectionPlan {
@@ -88,6 +108,8 @@ pub struct PortableV2SelectionPlan {
     pub included: Vec<PortableV2SelectionEntry>,
     /// Excluded participants in canonical identity order.
     pub excluded: Vec<PortableV2SelectionEntry>,
+    /// Exact projected ontology closure in canonical identity order.
+    pub projected: Vec<PortableV2ProjectedSelectionEntry>,
     /// Explicit redaction reason codes; values are never retained.
     pub redactions: Vec<String>,
     /// Required portable capability contracts.
@@ -160,12 +182,22 @@ pub fn preview_portable_v2_selection(
             PortableV2SelectionProfile::Artifacts => kind == "derived-artifact",
             PortableV2SelectionProfile::Settings => kind == "settings",
             PortableV2SelectionProfile::Custom(_) => custom.as_ref().unwrap().contains(&identity),
+            PortableV2SelectionProfile::OntologyComposition(_) => {
+                identity.capability_id == crate::WORKSPACE_CAPABILITY_ID
+                    && identity.record_family_id == crate::WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY
+            }
         };
         if selected {
             requested.insert(identity);
         }
     }
-    if requested.is_empty() && matches!(request.profile, PortableV2SelectionProfile::Custom(_)) {
+    if requested.is_empty()
+        && matches!(
+            request.profile,
+            PortableV2SelectionProfile::Custom(_)
+                | PortableV2SelectionProfile::OntologyComposition(_)
+        )
+    {
         return Err(incompatible("selection matched no portable components"));
     }
 
@@ -185,7 +217,7 @@ pub fn preview_portable_v2_selection(
             record_family_id: descriptor.record_family_id.clone(),
         })
         .collect::<BTreeSet<_>>();
-    let auto = if needs_schema {
+    let mut auto = if needs_schema {
         schema
             .difference(&requested)
             .cloned()
@@ -193,10 +225,25 @@ pub fn preview_portable_v2_selection(
     } else {
         BTreeSet::new()
     };
+    let needs_composition = requested.iter().any(|identity| {
+        matches!(
+            component_kind(&identity.capability_id, &identity.record_family_id),
+            "ontology" | "graph-data" | "derived-artifact"
+        )
+    });
+    let composition = PortableV2ParticipantId {
+        capability_id: crate::WORKSPACE_CAPABILITY_ID.to_owned(),
+        record_family_id: crate::WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY.to_owned(),
+    };
+    if needs_composition && available.contains(&composition) && !requested.contains(&composition) {
+        auto.insert(composition.clone());
+    }
     if request.strict && !auto.is_empty() {
-        return Err(incompatible(
-            "strict selection requires undeclared schema authority",
-        ));
+        return Err(incompatible(if auto.contains(&composition) {
+            "strict selection requires undeclared ontology composition closure"
+        } else {
+            "strict selection requires undeclared schema authority"
+        }));
     }
     let selected = requested.union(&auto).cloned().collect::<BTreeSet<_>>();
     validate_settings(generation, &selected, limits)?;
@@ -225,7 +272,11 @@ pub fn preview_portable_v2_selection(
         let entry = PortableV2SelectionEntry {
             kind: component_kind(&identity.capability_id, &identity.record_family_id).into(),
             reason: if auto.contains(&identity) {
-                PortableV2SelectionReason::RequiredSchemaAuthority
+                if identity == composition {
+                    PortableV2SelectionReason::RequiredOntologyComposition
+                } else {
+                    PortableV2SelectionReason::RequiredSchemaAuthority
+                }
             } else if is_selected {
                 PortableV2SelectionReason::Requested
             } else {
@@ -263,9 +314,18 @@ pub fn preview_portable_v2_selection(
         PortableV2SelectionProfile::DataComponents
         | PortableV2SelectionProfile::Artifacts
         | PortableV2SelectionProfile::Settings
-        | PortableV2SelectionProfile::Custom(_) => "component-selective",
+        | PortableV2SelectionProfile::Custom(_)
+        | PortableV2SelectionProfile::OntologyComposition(_) => "component-selective",
     }
     .to_owned();
+    let projected = projected_composition_entries(generation, request, &selected, limits)?;
+    total = projected.iter().try_fold(total, |sum, entry| {
+        sum.checked_add(entry.estimated_bytes)
+            .ok_or_else(|| limit("selection byte overflow"))
+    })?;
+    if total > limits.max_total_bytes {
+        return Err(limit("selection bytes exceed limit"));
+    }
     let mut plan = PortableV2SelectionPlan {
         source_generation_uuid: generation.generation_uuid().hyphenated().to_string(),
         source_manifest_sha256: format!("sha256:{}", hex(generation.manifest_sha256())),
@@ -273,6 +333,7 @@ pub fn preview_portable_v2_selection(
         include_graph_tree: included.iter().any(|entry| entry.kind == "graph-data"),
         included,
         excluded,
+        projected,
         redactions: Vec::new(),
         required_capabilities,
         estimated_payload_bytes: total,
@@ -280,6 +341,108 @@ pub fn preview_portable_v2_selection(
     };
     plan.selection_fingerprint = fingerprint(&plan)?;
     Ok(plan)
+}
+
+fn projected_composition_entries(
+    generation: &ResolvedProjectGeneration,
+    request: &PortableV2SelectionRequest,
+    selected: &BTreeSet<PortableV2ParticipantId>,
+    limits: PortableV2Limits,
+) -> Result<Vec<PortableV2ProjectedSelectionEntry>, PortableV2Error> {
+    let authority = PortableV2ParticipantId {
+        capability_id: crate::WORKSPACE_CAPABILITY_ID.into(),
+        record_family_id: crate::WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY.into(),
+    };
+    if !selected.contains(&authority) {
+        return Ok(Vec::new());
+    }
+    let path = generation
+        .participant_path(&authority.capability_id, &authority.record_family_id)
+        .map_err(storage)?;
+    let mut file = File::open(path).map_err(storage_io)?;
+    let cap = limits.max_manifest_bytes.min(limits.max_entry_bytes);
+    let mut bytes = Vec::new();
+    std::io::Read::by_ref(&mut file)
+        .take(cap.saturating_add(1))
+        .read_to_end(&mut bytes)
+        .map_err(storage_io)?;
+    if bytes.len() as u64 > cap {
+        return Err(limit("composition preview exceeds limit"));
+    }
+    let composition =
+        crate::WorkspaceOntologyComposition::from_canonical_json(&bytes).map_err(storage)?;
+    let requested = match &request.profile {
+        PortableV2SelectionProfile::OntologyComposition(values) => {
+            let set = values.iter().cloned().collect::<BTreeSet<_>>();
+            if set.len() != values.len() {
+                return Err(incompatible("duplicate projected ontology selector"));
+            }
+            Some(set)
+        }
+        _ => None,
+    };
+    let mut entries = Vec::new();
+    for module in &composition.modules {
+        let identity = PortableV2ExactIdentity {
+            id: module.id.ontology_id.clone(),
+            version: module.id.authored_version.clone(),
+            content_digest: format!("sha256:{}", module.id.canonical_digest),
+        };
+        let payload = crate::project_portable_v2::canonical_json(
+            &serde_json::to_value(&module.document)
+                .map_err(|_| incompatible("composition preview serialization"))?,
+        )?;
+        entries.push(PortableV2ProjectedSelectionEntry {
+            kind: "ontology".into(),
+            participant_id: format!("ontology-module-{}", module.id.canonical_digest),
+            reason: if requested
+                .as_ref()
+                .is_some_and(|set| set.contains(&identity))
+            {
+                PortableV2SelectionReason::Requested
+            } else {
+                PortableV2SelectionReason::RequiredOntologyComposition
+            },
+            identity,
+            estimated_bytes: payload.len() as u64,
+        });
+    }
+    for bridge in &composition.bridges {
+        let digest = graphforge_ontology::bridge_document_digest(bridge)
+            .map_err(|_| incompatible("composition bridge digest"))?;
+        let identity = PortableV2ExactIdentity {
+            id: bridge.bridge_id.clone(),
+            version: bridge.authored_version.clone(),
+            content_digest: format!("sha256:{digest}"),
+        };
+        let payload = crate::project_portable_v2::canonical_json(
+            &serde_json::to_value(bridge)
+                .map_err(|_| incompatible("composition preview serialization"))?,
+        )?;
+        entries.push(PortableV2ProjectedSelectionEntry {
+            kind: "schema".into(),
+            participant_id: format!("ontology-bridge-{digest}"),
+            reason: if requested
+                .as_ref()
+                .is_some_and(|set| set.contains(&identity))
+            {
+                PortableV2SelectionReason::Requested
+            } else {
+                PortableV2SelectionReason::RequiredOntologyComposition
+            },
+            identity,
+            estimated_bytes: payload.len() as u64,
+        });
+    }
+    entries.sort_by(|left, right| left.participant_id.cmp(&right.participant_id));
+    if let Some(requested) = requested
+        && requested
+            .iter()
+            .any(|identity| !entries.iter().any(|entry| &entry.identity == identity))
+    {
+        return Err(incompatible("projected ontology selector is absent"));
+    }
+    Ok(entries)
 }
 
 pub(crate) fn validate_selection_plan(

--- a/crates/graphforge-storage/src/project_portable_v2_subset.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_subset.rs
@@ -297,6 +297,7 @@ fn build_subset_component_selection(
         package_class: "graph-data-subset".into(),
         included,
         excluded,
+        projected: Vec::new(),
         redactions: redactions.iter().cloned().collect(),
         required_capabilities,
         estimated_payload_bytes: total,
@@ -481,6 +482,30 @@ mod tests {
         let (_, files) = capture_graph_files(workspace.path()).unwrap();
         let mut participants = empty_workspace_participants().unwrap();
         participants.insert(0, files);
+        let document = graphforge_ontology::OntologyDoc {
+            ontology_id: "https://graphforge.dev/ontology/subset".into(),
+            version: "v1".into(),
+            entity_types: vec![],
+            relation_types: vec![],
+            properties: vec![],
+            constraints: vec![],
+            migrations: vec![],
+        };
+        let legacy = crate::WorkspaceOntology {
+            contract_version: 1,
+            mode: crate::WorkspaceOntologyMode::Strict,
+            source_format: Some(crate::WorkspaceOntologySourceFormat::Json),
+            canonical_ontology_sha256: Some("b".repeat(64)),
+            canonical_ontology: Some(serde_json::to_value(document).unwrap()),
+        };
+        let composition = crate::WorkspaceOntologyComposition::virtual_legacy(&legacy)
+            .unwrap()
+            .unwrap();
+        participants.push(composition.to_project_participant().unwrap());
+        participants.sort_by(|left, right| {
+            (&left.capability_id, &left.record_family_id)
+                .cmp(&(&right.capability_id, &right.record_family_id))
+        });
         let generation_uuid = Uuid::now_v7();
         let request = ProjectGenerationRequest {
             transaction_uuid: Uuid::now_v7(),
@@ -564,6 +589,7 @@ mod tests {
         assert_eq!(a.selection_fingerprint, preview.subset_fingerprint);
         let report =
             verify_portable_v2(&expanded, PortableV2Mode::Full, limits, Some(&cancelled)).unwrap();
+        assert!(report.ontology_composition.is_some());
         assert_eq!(
             report.package_class,
             crate::PortableV2PackageClass::GraphDataSubset

--- a/crates/graphforge-storage/src/project_portable_v2_subset.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_subset.rs
@@ -637,4 +637,214 @@ mod tests {
         let error = preview_portable_v2_graph_subset(&generation, &unordered, limits).unwrap_err();
         assert_eq!(error.code, PortableV2ErrorCode::Incompatible);
     }
+
+    fn imported_node_query(root: &std::path::Path) -> Vec<String> {
+        let generation = resolve_project_generation(root).unwrap();
+        graph_tree_query(&generation.graph_tree_root())
+    }
+
+    fn graph_tree_query(root: &std::path::Path) -> Vec<String> {
+        use arrow::array::{Array as _, FixedSizeBinaryArray};
+        let mut rows = crate::catalog::read_nodes(root)
+            .unwrap()
+            .into_iter()
+            .flat_map(|batch| {
+                let index = batch.schema().index_of("node_uuid").unwrap();
+                let values = batch
+                    .column(index)
+                    .as_any()
+                    .downcast_ref::<FixedSizeBinaryArray>()
+                    .unwrap();
+                (0..values.len())
+                    .map(|row| {
+                        Uuid::from_slice(values.value(row))
+                            .unwrap()
+                            .hyphenated()
+                            .to_string()
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        rows.sort();
+        rows
+    }
+
+    fn query_fingerprint(rows: &[String]) -> String {
+        let mut digest = Sha256::new();
+        digest.update(b"graphforge-portable-v2-query-result/1\0");
+        digest.update(serde_json::to_vec(rows).unwrap());
+        format!("sha256:{}", hex(digest.finalize().into()))
+    }
+
+    #[test]
+    fn versioned_m9_positive_matrix_executes_both_representations() {
+        let ledger: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../tests/fixtures/portable-v2/m9-interchange-cases.json"
+        ))
+        .unwrap();
+        let (root, nodes, _edges) = publish_graph_project();
+        let generation = resolve_project_generation(root.path()).unwrap();
+        let limits = PortableV2Limits::default();
+        let complete = crate::preview_portable_v2_selection(
+            &generation,
+            &crate::PortableV2SelectionRequest {
+                profile: crate::PortableV2SelectionProfile::Complete,
+                strict: false,
+            },
+            limits,
+        )
+        .unwrap();
+        let exact = complete.projected[0].identity.clone();
+        let selected_nodes = [nodes[0], nodes[1]]
+            .map(|uuid| uuid.hyphenated().to_string())
+            .to_vec();
+        let subset = preview_portable_v2_graph_subset(
+            &generation,
+            &PortableV2SubsetRequest {
+                selector: PortableV2GraphSelector {
+                    node_uuids: selected_nodes,
+                    edge_uuids: vec![],
+                },
+                closure: PortableV2SubsetClosure::InducedEdges,
+                projection: PortableV2PropertyProjection::default(),
+            },
+            limits,
+        )
+        .unwrap();
+        let supported = generation
+            .capabilities()
+            .into_iter()
+            .map(|capability| ProjectCapability {
+                capability_id: capability.capability_id,
+                capability_version: capability.capability_version,
+            })
+            .collect::<Vec<_>>();
+
+        for case in ledger["positive_cases"].as_array().unwrap() {
+            let class = case["package_class"].as_str().unwrap();
+            let plan = match class {
+                "complete" => crate::plan_selected_portable_v2(&generation, &complete, limits),
+                "ontology-only" => {
+                    let selection = crate::preview_portable_v2_selection(
+                        &generation,
+                        &crate::PortableV2SelectionRequest {
+                            profile: crate::PortableV2SelectionProfile::OntologyOnly,
+                            strict: false,
+                        },
+                        limits,
+                    )
+                    .unwrap();
+                    crate::plan_selected_portable_v2(&generation, &selection, limits)
+                }
+                "component-selective" => {
+                    let selection = crate::preview_portable_v2_selection(
+                        &generation,
+                        &crate::PortableV2SelectionRequest {
+                            profile: crate::PortableV2SelectionProfile::OntologyComposition(vec![
+                                exact.clone(),
+                            ]),
+                            strict: true,
+                        },
+                        limits,
+                    )
+                    .unwrap();
+                    crate::plan_selected_portable_v2(&generation, &selection, limits)
+                }
+                "graph-data-subset" => plan_graph_subset_portable_v2(&generation, &subset, limits),
+                _ => panic!("unknown positive conformance class"),
+            }
+            .unwrap();
+            let outputs = tempfile::tempdir().unwrap();
+            let mut receipts = Vec::new();
+            let mut reports = Vec::new();
+            let mut query_rows = Vec::new();
+            for representation in [PortableV2Output::Expanded, PortableV2Output::Bundle] {
+                let extension = if representation == PortableV2Output::Expanded {
+                    "gfproject"
+                } else {
+                    "gfpb"
+                };
+                let package = outputs.path().join(format!("{class}.{extension}"));
+                receipts.push(
+                    export_complete_portable_v2(
+                        &plan,
+                        &package,
+                        representation,
+                        limits,
+                        &AtomicBool::new(false),
+                        |_| {},
+                    )
+                    .unwrap(),
+                );
+                reports.push(
+                    verify_portable_v2(&package, PortableV2Mode::Full, limits, None).unwrap(),
+                );
+                match (class, representation) {
+                    ("complete", _) => {
+                        let imported = outputs.path().join(format!("{class}-{extension}-import"));
+                        crate::import_complete_portable_v2(
+                            &package,
+                            &imported,
+                            Uuid::new_v4(),
+                            Uuid::new_v4(),
+                            &supported,
+                            limits,
+                            None,
+                        )
+                        .unwrap();
+                        query_rows.push(imported_node_query(&imported));
+                    }
+                    ("ontology-only" | "component-selective" | "graph-data-subset", _) => {
+                        let rows = crate::consume_selective_portable_v2(
+                            &package,
+                            limits,
+                            None,
+                            |stage, candidate| {
+                                assert_eq!(
+                                    candidate.report.package_digest,
+                                    reports.last().unwrap().package_digest
+                                );
+                                assert!(candidate.ontology.is_some());
+                                assert!(candidate.staged_composition.is_some());
+                                Ok(if class == "graph-data-subset" {
+                                    graph_tree_query(
+                                        &stage.join("data/components/graph-data/graph-tree"),
+                                    )
+                                } else {
+                                    Vec::new()
+                                })
+                            },
+                        )
+                        .unwrap();
+                        query_rows.push(rows);
+                    }
+                    _ => {}
+                }
+            }
+            assert_eq!(receipts[0].package_digest, receipts[1].package_digest);
+            assert_eq!(reports[0].package_digest, reports[1].package_digest);
+            assert_eq!(
+                reports[0]
+                    .ontology_composition
+                    .as_ref()
+                    .map(|value| &value.composition_digest),
+                reports[1]
+                    .ontology_composition
+                    .as_ref()
+                    .map(|value| &value.composition_digest)
+            );
+            let expected_rows =
+                serde_json::from_value::<Vec<String>>(case["expected_query_rows"].clone()).unwrap();
+            assert!(query_rows.iter().all(|rows| rows == &query_rows[0]));
+            assert_eq!(query_rows[0], expected_rows, "{class}");
+            assert_eq!(
+                query_fingerprint(&query_rows[0]),
+                case["expected_data_fingerprint"].as_str().unwrap()
+            );
+            if class == "graph-data-subset" {
+                assert_eq!(receipts[0].selection_fingerprint, subset.subset_fingerprint);
+                assert_eq!(receipts[1].selection_fingerprint, subset.subset_fingerprint);
+            }
+        }
+    }
 }

--- a/crates/graphforge-storage/src/project_portable_v2_subset.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_subset.rs
@@ -1,6 +1,7 @@
 //! Deterministic portable-v2 graph-data-subset planning (#786).
 
 use std::collections::BTreeSet;
+use std::path::Path;
 
 use serde::Serialize;
 use sha2::{Digest, Sha256};
@@ -89,6 +90,23 @@ pub struct PortableV2SubsetPlan {
     pub(crate) projection: GraphProjectionSelection,
 }
 
+/// Fingerprint canonical logical graph data decoded from the actual Parquet
+/// topology, edge, property, edge-property, and runtime-catalog tables.
+pub fn portable_v2_graph_data_fingerprint(
+    graph_root: &Path,
+    limits: PortableV2Limits,
+) -> Result<String, PortableV2Error> {
+    let (inventory, _) = capture_graph_files(graph_root).map_err(storage)?;
+    if inventory.file_count > limits.max_entries
+        || inventory.total_byte_length > limits.max_total_bytes
+    {
+        return Err(limit("graph data fingerprint exceeds configured limit"));
+    }
+    let digest = crate::graph_projection::portable_graph_data_fingerprint(graph_root)
+        .map_err(|_| incompatible("canonical graph data fingerprint"))?;
+    Ok(format!("sha256:{}", hex(digest)))
+}
+
 /// Resolve one bounded deterministic graph-data subset without writing a package.
 pub fn preview_portable_v2_graph_subset(
     generation: &ResolvedProjectGeneration,
@@ -174,7 +192,7 @@ pub fn preview_portable_v2_graph_subset(
         selected_node_count: summary.node_uuids.len() as u64,
         selected_edge_count: summary.edge_uuids.len() as u64,
         endpoint_node_count: summary.endpoint_node_uuids.len() as u64,
-        result_fingerprint: format!("sha256:{}", hex(summary.graph_content_fingerprint)),
+        result_fingerprint: portable_v2_graph_data_fingerprint(staging.path(), limits)?,
         subset_fingerprint: String::new(),
         projection,
     };
@@ -204,7 +222,7 @@ pub fn plan_graph_subset_portable_v2(
     .map_err(|error| map_projection(&error))?;
     if summary.node_uuids.len() as u64 != plan.selected_node_count
         || summary.edge_uuids.len() as u64 != plan.selected_edge_count
-        || format!("sha256:{}", hex(summary.graph_content_fingerprint)) != plan.result_fingerprint
+        || portable_v2_graph_data_fingerprint(staging.path(), limits)? != plan.result_fingerprint
     {
         return Err(PortableV2Error::new(
             PortableV2ErrorCode::ConcurrentMutation,
@@ -430,7 +448,7 @@ mod tests {
     use std::fs;
     use std::sync::atomic::AtomicBool;
 
-    use graphforge_core::{OntologyMode, TypeId};
+    use graphforge_core::OntologyMode;
     use graphforge_ir::IrLiteral;
     use uuid::Uuid;
 
@@ -457,10 +475,15 @@ mod tests {
         let workspace = tempfile::tempdir().unwrap();
         let nodes = [uuid(1), uuid(2), uuid(3)];
         let edges = [uuid(11), uuid(12)];
+        let mut runtime_catalog = graphforge_ir::RuntimeCatalog::new();
+        let person = graphforge_ir::runtime_entity_type_id(runtime_catalog.intern_label("Person"));
+        runtime_catalog.intern_relation_type("KNOWS");
+        runtime_catalog.intern_property("value", Some("Person"));
+        runtime_catalog.intern_property("secret", Some("Person"));
         let mut writer =
             GraphWriter::open_at(workspace.path(), OntologyMode::Exploratory, TS).unwrap();
         for (index, node) in nodes.iter().enumerate() {
-            writer.create_node(*node, TypeId(1)).unwrap();
+            writer.create_node(*node, person).unwrap();
             writer
                 .set_properties(
                     node,
@@ -479,6 +502,11 @@ mod tests {
             .create_edge(edges[1], "KNOWS", &nodes[1], &nodes[2])
             .unwrap();
         writer.flush().unwrap();
+        crate::graph_projection::write_parquet(
+            &workspace.path().join("topology/runtime_catalog.parquet"),
+            &runtime_catalog.to_record_batch(),
+        )
+        .unwrap();
         let (_, files) = capture_graph_files(workspace.path()).unwrap();
         let mut participants = empty_workspace_participants().unwrap();
         participants.insert(0, files);
@@ -758,6 +786,7 @@ mod tests {
             let mut receipts = Vec::new();
             let mut reports = Vec::new();
             let mut query_rows = Vec::new();
+            let mut data_fingerprints = Vec::new();
             for representation in [PortableV2Output::Expanded, PortableV2Output::Bundle] {
                 let extension = if representation == PortableV2Output::Expanded {
                     "gfproject"
@@ -793,6 +822,14 @@ mod tests {
                         )
                         .unwrap();
                         query_rows.push(imported_node_query(&imported));
+                        let imported_generation = resolve_project_generation(&imported).unwrap();
+                        data_fingerprints.push(Some(
+                            portable_v2_graph_data_fingerprint(
+                                &imported_generation.graph_tree_root(),
+                                limits,
+                            )
+                            .unwrap(),
+                        ));
                     }
                     ("ontology-only" | "component-selective" | "graph-data-subset", _) => {
                         let rows = crate::consume_selective_portable_v2(
@@ -807,16 +844,19 @@ mod tests {
                                 assert!(candidate.ontology.is_some());
                                 assert!(candidate.staged_composition.is_some());
                                 Ok(if class == "graph-data-subset" {
-                                    graph_tree_query(
-                                        &stage.join("data/components/graph-data/graph-tree"),
+                                    let graph = stage.join("data/components/graph-data/graph-tree");
+                                    (
+                                        graph_tree_query(&graph),
+                                        Some(portable_v2_graph_data_fingerprint(&graph, limits)?),
                                     )
                                 } else {
-                                    Vec::new()
+                                    (Vec::new(), None)
                                 })
                             },
                         )
                         .unwrap();
-                        query_rows.push(rows);
+                        query_rows.push(rows.0);
+                        data_fingerprints.push(rows.1);
                     }
                     _ => {}
                 }
@@ -839,9 +879,23 @@ mod tests {
             assert_eq!(query_rows[0], expected_rows, "{class}");
             assert_eq!(
                 query_fingerprint(&query_rows[0]),
-                case["expected_data_fingerprint"].as_str().unwrap()
+                case["expected_query_fingerprint"].as_str().unwrap()
+            );
+            assert!(
+                data_fingerprints
+                    .iter()
+                    .all(|fingerprint| fingerprint == &data_fingerprints[0])
+            );
+            assert_eq!(
+                data_fingerprints[0].as_deref(),
+                case["expected_data_fingerprint"].as_str(),
+                "{class} canonical graph data"
             );
             if class == "graph-data-subset" {
+                assert_eq!(
+                    data_fingerprints[0].as_deref(),
+                    Some(subset.result_fingerprint.as_str())
+                );
                 assert_eq!(receipts[0].selection_fingerprint, subset.subset_fingerprint);
                 assert_eq!(receipts[1].selection_fingerprint, subset.subset_fingerprint);
             }

--- a/crates/graphforge-storage/src/workspace_participants.rs
+++ b/crates/graphforge-storage/src/workspace_participants.rs
@@ -28,6 +28,8 @@ pub const WORKSPACE_CONFIGURATION_FAMILY: &str = "configuration";
 pub const WORKSPACE_REPOSITORY_SNAPSHOT_FAMILY: &str = "repository_snapshot";
 /// Canonical multi-ontology composition authority record family.
 pub const WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY: &str = "ontology_composition";
+/// Verified portable composition candidate; never runtime ontology authority.
+pub const WORKSPACE_PORTABLE_ONTOLOGY_STAGING_FAMILY: &str = "portable_ontology_staging";
 /// Frozen composition participant contract version.
 pub const WORKSPACE_ONTOLOGY_COMPOSITION_VERSION: u32 = 1;
 /// Maximum canonical composition authority size.
@@ -122,6 +124,62 @@ pub struct WorkspaceOntologyComposition {
     pub profile_default: ActivationMode,
     /// Recomputed exact composition identity.
     pub composition_fingerprint: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+/// Verified portable composition candidate staged in a generation.
+///
+/// This participant is deliberately non-authoritative. Normal project open
+/// never hydrates it into the active ontology composition; an explicit
+/// lifecycle operation must validate and adopt it.
+pub struct WorkspacePortableOntologyStaging {
+    /// Frozen staging contract version.
+    pub contract_version: u32,
+    /// Semantic identity of the verified portable package.
+    pub package_digest: String,
+    /// Semantic identity of the portable composition control.
+    pub portable_composition_digest: String,
+    /// Fully compiled candidate retained for later explicit adoption.
+    pub composition: WorkspaceOntologyComposition,
+}
+
+impl WorkspacePortableOntologyStaging {
+    /// Encode the validated candidate as canonical JSON.
+    pub fn to_canonical_json(&self) -> Result<Vec<u8>, GfError> {
+        if self.contract_version != 1 {
+            return Err(corrupt("portable ontology staging identity is invalid"));
+        }
+        validate_sha256(
+            self.package_digest
+                .strip_prefix("sha256:")
+                .unwrap_or_default(),
+            "portable package",
+        )?;
+        validate_sha256(
+            self.portable_composition_digest
+                .strip_prefix("sha256:")
+                .unwrap_or_default(),
+            "portable composition",
+        )?;
+        self.composition.compile()?;
+        canonical_json(self, "portable ontology staging")
+    }
+
+    /// Decode and fully revalidate one canonical candidate.
+    pub fn from_canonical_json(bytes: &[u8]) -> Result<Self, GfError> {
+        parse_canonical_json(bytes, "portable ontology staging", |record: &Self| {
+            record.to_canonical_json().map(|_| ())
+        })
+    }
+
+    /// Convert the candidate into its non-authoritative generation participant.
+    pub fn to_project_participant(&self) -> Result<ProjectParticipant, GfError> {
+        Ok(participant(
+            WORKSPACE_PORTABLE_ONTOLOGY_STAGING_FAMILY,
+            self.to_canonical_json()?,
+        ))
+    }
 }
 
 /// Project-level graph directedness metadata for GSI profiling.

--- a/docs/book/architecture/portable-project-v2.md
+++ b/docs/book/architecture/portable-project-v2.md
@@ -167,6 +167,16 @@ portable-relative entry. The implementation retains the bounded semantic/tag
 records, entry index, and configured copy buffer; payloads stream incrementally
 even when the declared package exceeds 16 GiB.
 
+When `ontology-composition@1` is present, the verified report also exposes the
+authenticated exact module, bridge, activation, feature, and composition
+identities. Module documents remain ordinary `ontology` components and bridge
+documents remain ordinary `schema` components. The versioned
+`graphforge-ontology-composition` compatibility component authenticates their
+closure. It deliberately does not appear in the runtime generation map:
+verify, inspect, materialize, and import therefore cannot adopt or replace
+workspace ontology authority. A consumer must pass the verified identities to
+the explicit typed ontology lifecycle API to change authority.
+
 See the [fixture guide](../../../tests/fixtures/portable-v2/README.md) for the
 positive, negative, and structural conformance vectors.
 

--- a/tests/fixtures/portable-v2/README.md
+++ b/tests/fixtures/portable-v2/README.md
@@ -30,3 +30,8 @@ inputs/exclusions, closure for all four
 package classes, older-reader behavior, typed negative results, and operational
 non-mutation invariants. It deliberately contains no runtime identity or TCK
 result in the composition identity.
+
+`m9-interchange-cases.json` is the versioned Rust conformance ledger for #841.
+It freezes the four package classes, both representations, cross-form receipts,
+semantic tamper and future-feature ordering, and the durable non-authoritative
+staging replay/conflict/cancellation/failure matrix.

--- a/tests/fixtures/portable-v2/m9-interchange-cases.json
+++ b/tests/fixtures/portable-v2/m9-interchange-cases.json
@@ -1,0 +1,29 @@
+{
+  "contract": "graphforge-portable-v2-m9-interchange-cases/1",
+  "representations": ["expanded", "bundle"],
+  "positive_package_classes": [
+    "complete",
+    "ontology-only",
+    "component-selective",
+    "graph-data-subset"
+  ],
+  "required_receipts": [
+    "package_digest",
+    "composition_digest",
+    "data_fingerprint",
+    "query_results"
+  ],
+  "negative_cases": [
+    {"name":"future-manifest-capability-before-payload","result":"unsupported_future"},
+    {"name":"future-composition-feature-before-semantic-payload","result":"unsupported_future"},
+    {"name":"module-semantic-digest-tamper","result":"digest_mismatch"},
+    {"name":"bridge-semantic-digest-tamper","result":"digest_mismatch"},
+    {"name":"semantic-descriptor-kind-path-media-mismatch","result":"incompatible"},
+    {"name":"semantic-payload-budget","result":"limit_exceeded"},
+    {"name":"cancelled-private-materialization","result":"cancelled"},
+    {"name":"durable-staging-replay","result":"idempotent_replay"},
+    {"name":"durable-staging-transaction-conflict","result":"transaction_conflict"},
+    {"name":"durable-staging-publication-failure","result":"old_or_absent"}
+  ],
+  "authority_invariant": "non-authoritative-staging-only"
+}

--- a/tests/fixtures/portable-v2/m9-interchange-cases.json
+++ b/tests/fixtures/portable-v2/m9-interchange-cases.json
@@ -11,22 +11,26 @@
     {
       "package_class": "complete",
       "expected_query_rows": ["00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002", "00000000-0000-0000-0000-000000000003"],
-      "expected_data_fingerprint": "sha256:bbb672f255891facbe5850b261c02d8b771ffc370d64c6c4387b7689aeb754a4"
+      "expected_query_fingerprint": "sha256:bbb672f255891facbe5850b261c02d8b771ffc370d64c6c4387b7689aeb754a4",
+      "expected_data_fingerprint": "sha256:f6895f68ffba0161ba9376616123fdb256abe1c59544f1292b61e8b3c042e8af"
     },
     {
       "package_class": "ontology-only",
       "expected_query_rows": [],
-      "expected_data_fingerprint": "sha256:b0e3df4931dc2a3c11b43a8b4a753e85b65f4997432004e4fd4fe76b913a222d"
+      "expected_query_fingerprint": "sha256:b0e3df4931dc2a3c11b43a8b4a753e85b65f4997432004e4fd4fe76b913a222d",
+      "expected_data_fingerprint": null
     },
     {
       "package_class": "component-selective",
       "expected_query_rows": [],
-      "expected_data_fingerprint": "sha256:b0e3df4931dc2a3c11b43a8b4a753e85b65f4997432004e4fd4fe76b913a222d"
+      "expected_query_fingerprint": "sha256:b0e3df4931dc2a3c11b43a8b4a753e85b65f4997432004e4fd4fe76b913a222d",
+      "expected_data_fingerprint": null
     },
     {
       "package_class": "graph-data-subset",
       "expected_query_rows": ["00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002"],
-      "expected_data_fingerprint": "sha256:02b3d933c8fc1f7c934e370928830e31043adae4b13fc3ae00efd06a59490148"
+      "expected_query_fingerprint": "sha256:02b3d933c8fc1f7c934e370928830e31043adae4b13fc3ae00efd06a59490148",
+      "expected_data_fingerprint": "sha256:b827191bd679e4a6b90cd41dc768cdced9293073e4974407188a961525f3c620"
     }
   ],
   "required_receipts": [

--- a/tests/fixtures/portable-v2/m9-interchange-cases.json
+++ b/tests/fixtures/portable-v2/m9-interchange-cases.json
@@ -7,6 +7,28 @@
     "component-selective",
     "graph-data-subset"
   ],
+  "positive_cases": [
+    {
+      "package_class": "complete",
+      "expected_query_rows": ["00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002", "00000000-0000-0000-0000-000000000003"],
+      "expected_data_fingerprint": "sha256:bbb672f255891facbe5850b261c02d8b771ffc370d64c6c4387b7689aeb754a4"
+    },
+    {
+      "package_class": "ontology-only",
+      "expected_query_rows": [],
+      "expected_data_fingerprint": "sha256:b0e3df4931dc2a3c11b43a8b4a753e85b65f4997432004e4fd4fe76b913a222d"
+    },
+    {
+      "package_class": "component-selective",
+      "expected_query_rows": [],
+      "expected_data_fingerprint": "sha256:b0e3df4931dc2a3c11b43a8b4a753e85b65f4997432004e4fd4fe76b913a222d"
+    },
+    {
+      "package_class": "graph-data-subset",
+      "expected_query_rows": ["00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002"],
+      "expected_data_fingerprint": "sha256:02b3d933c8fc1f7c934e370928830e31043adae4b13fc3ae00efd06a59490148"
+    }
+  ],
   "required_receipts": [
     "package_digest",
     "composition_digest",


### PR DESCRIPTION
Closes #841

## Summary
- project generation-managed ontology modules and bridge sets into ordinary portable-v2 ontology/schema components
- authenticate exact identities, activation metadata, feature requirements, and dependency closure in the ADR-0022 compatibility control
- keep inspect/verify/import non-authoritative while preserving selection and graph-subset closure

## Evidence
- `CARGO_TARGET_DIR=/private/tmp/graphforge-841-target cargo test -p graphforge-storage project_portable_v2 -- --nocapture` (37 passed)
- `CARGO_TARGET_DIR=/private/tmp/graphforge-841-target cargo clippy -p graphforge-storage --lib -- -D warnings`
- `PATH="/opt/homebrew/bin:$PATH" CARGO_TARGET_DIR=/private/tmp/graphforge-841-target make pre-push-fast`
- `cargo fmt --all -- --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/877"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789886416&installation_model_id=20486&pr_number=877&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F877&signature=9d92a04da1746595116eb2d5a3d76c44cc07b8083563053dce33b0684d1572aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->