### PR TITLE
feat(bindings): expose multi-ontology lifecycle parity

### DIFF
--- a/.github/workflows/binding-release-candidate.yml
+++ b/.github/workflows/binding-release-candidate.yml
@@ -194,7 +194,8 @@ jobs:
           # package smoke, GIL, and non-Cypher contracts required before publish.
           for test_file in \
             crates/graphforge-bindings-py/tests/smoke.py \
-            crates/graphforge-bindings-py/tests/gil_release.py; do
+            crates/graphforge-bindings-py/tests/gil_release.py \
+            crates/graphforge-bindings-py/tests/multi_ontology.py; do
             uv run --isolated --no-project --with "${wheels[0]}" python "$test_file"
           done
           GRAPHFORGE_PYTHON_PARITY_REPORT="$PYTHON_RC_EVIDENCE_DIR/python-classification.json" \
@@ -675,6 +676,23 @@ jobs:
           popd
           wait "$cli_pack_pid"
           wait "$agent_skills_pack_pid"
+
+      - name: Clean-install packed Node package and CLI binary
+        shell: bash
+        run: |
+          package_root="$RUNNER_TEMP/graphforge-multi-ontology-package-smoke"
+          mkdir -p "$package_root"
+          cd "$package_root"
+          npm init --yes
+          npm_artifacts="$GITHUB_WORKSPACE/candidate/release-artifacts/npm"
+          main_packages=("$npm_artifacts"/curatelabs-graphforge-[0-9]*.tgz)
+          cli_packages=("$npm_artifacts"/curatelabs-graphforge-cli-*.tgz)
+          native_packages=("$npm_artifacts"/curatelabs-graphforge-linux-x64-gnu-*.tgz)
+          test "${#main_packages[@]}" -eq 1
+          test "${#cli_packages[@]}" -eq 1
+          test "${#native_packages[@]}" -eq 1
+          npm install "${main_packages[0]}" "${cli_packages[0]}" "${native_packages[0]}"
+          node "$GITHUB_WORKSPACE/scripts/ci/multi-ontology-packaged-smoke.mjs"
 
       - name: Package the complete Rust surface
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,14 @@ jobs:
       - name: Validate multi-ontology contract fixtures
         run: python3 scripts/ci/multi-ontology-contract-check.py
 
+      - name: Test multi-ontology four-surface gate
+        run: |
+          python3 scripts/ci/test-multi-ontology-surface-gate.py
+          python3 scripts/ci/test-compare-multi-ontology-parity.py
+
+      - name: Validate multi-ontology four-surface parity
+        run: python3 scripts/ci/multi-ontology-surface-gate.py
+
       - name: Test aggregate merge gate
         run: scripts/ci/test-require-gates.sh
 
@@ -570,6 +578,7 @@ jobs:
           for test_file in crates/graphforge-bindings-py/tests/*.py; do
             /tmp/gf-native/bin/python "$test_file"
           done
+          /tmp/gf-native/bin/python crates/graphforge-bindings-py/tests/multi_ontology.py
           GRAPHFORGE_PYTHON_PARITY_REPORT=dist/python-non-cypher-classification.json \
             /tmp/gf-native/bin/python \
             crates/graphforge-bindings-py/tests/non_cypher_release.py \
@@ -830,6 +839,28 @@ jobs:
           uv venv /tmp/gf-concurrency --python 3.13
           uv pip install --python /tmp/gf-concurrency/bin/python "${wheels[0]}"
           pnpm install --frozen-lockfile
+
+      - name: Compare real multi-ontology semantics across all public surfaces
+        shell: bash
+        run: |
+          report_root="${{ runner.temp }}/multi-ontology-parity"
+          mkdir -p "$report_root"
+          GRAPHFORGE_MULTI_ONTOLOGY_PARITY_REPORT="$report_root/rust.json" \
+            cargo test -q -p graphforge-api --lib \
+              writes_canonical_rust_semantic_parity_report_when_requested
+          GRAPHFORGE_MULTI_ONTOLOGY_PARITY_REPORT="$report_root/cli.json" \
+            cargo test -q -p graphforge-cli --test multi_ontology \
+              emit_authenticated_parity_report
+          GRAPHFORGE_MULTI_ONTOLOGY_PARITY_REPORT="$report_root/python.json" \
+            /tmp/gf-concurrency/bin/python \
+              crates/graphforge-bindings-py/tests/multi_ontology.py
+          GRAPHFORGE_MULTI_ONTOLOGY_PARITY_REPORT="$report_root/node.json" \
+            node --test crates/graphforge-bindings-node/tests/multi-ontology.test.mjs
+          python3 scripts/ci/compare-multi-ontology-parity.py \
+            --rust "$report_root/rust.json" \
+            --python "$report_root/python.json" \
+            --node "$report_root/node.json" \
+            --cli "$report_root/cli.json"
 
       - name: Run required short concurrency matrix
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2203,6 +2203,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+ "serde",
  "serde_json",
  "uuid",
 ]
@@ -2216,6 +2217,7 @@ dependencies = [
  "graphforge-api",
  "graphforge-cli",
  "pyo3",
+ "serde",
  "serde_json",
  "uuid",
 ]
@@ -2227,9 +2229,12 @@ dependencies = [
  "arrow",
  "clap",
  "graphforge-api",
+ "graphforge-storage",
  "parquet",
  "serde",
  "serde_json",
+ "serde_yaml_ng",
+ "sha2",
  "tempfile",
  "uuid",
 ]

--- a/Makefile
+++ b/Makefile
@@ -209,6 +209,9 @@ pre-push-fast:  ## Run fast checks only — format, lint, type, security, docstr
 	@python3 scripts/ci/test-api-bdd-policy.py
 	@echo "━━━ Multi-ontology contract fixtures ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 	@python3 scripts/ci/multi-ontology-contract-check.py
+	@python3 scripts/ci/test-multi-ontology-surface-gate.py
+	@python3 scripts/ci/multi-ontology-surface-gate.py
+	@python3 scripts/ci/test-compare-multi-ontology-parity.py
 	@echo "━━━ Format check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 	@$(MAKE) format-check
 	@echo "━━━ Lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "115b96cc2f71a9518e66a493357c5a36fabfa8911d60c734b577612bd5a8ceb8",
+  "checksum": "fb283564fd3498c1dd8968a3a7ec2bbebf603eb6f6e3d401bac7af43302d9def",
   "crates": {
     "adler2 2.0.1": {
       "name": "adler2",
@@ -12743,6 +12743,10 @@
               "target": "napi"
             },
             {
+              "id": "serde 1.0.228",
+              "target": "serde"
+            },
+            {
               "id": "serde_json 1.0.151",
               "target": "serde_json"
             },
@@ -12823,6 +12827,10 @@
               "target": "pyo3"
             },
             {
+              "id": "serde 1.0.228",
+              "target": "serde"
+            },
+            {
               "id": "serde_json 1.0.151",
               "target": "serde_json"
             },
@@ -12897,6 +12905,11 @@
               "target": "serde_json"
             },
             {
+              "id": "serde_yaml_ng 0.9.36",
+              "target": "serde_yaml_ng",
+              "alias": "serde_yaml"
+            },
+            {
               "id": "uuid 1.24.1",
               "target": "uuid"
             }
@@ -12914,6 +12927,10 @@
             {
               "id": "parquet 58.3.0",
               "target": "parquet"
+            },
+            {
+              "id": "sha2 0.11.0",
+              "target": "sha2"
             },
             {
               "id": "tempfile 3.27.0",

--- a/crates/graphforge-api/BUILD.bazel
+++ b/crates/graphforge-api/BUILD.bazel
@@ -16,6 +16,9 @@ package(default_visibility = ["//visibility:public"])
 # Unit tests include_str! contract fixtures from docs/contracts/examples.
 _API_COMPILE_DATA = [
     "//docs/contracts/examples:fixtures",
+    "//tests/contracts:multi-ontology-surface-v1.json",
+    "//tests/fixtures/multi-ontology-v1:binding-parity-v1.json",
+    "//tests/fixtures/portable-v2:ontology-only.manifest.json",
 ]
 
 _API_DEPS = [

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -36,6 +36,11 @@ use graphforge_ir::{
     BindError, Binder, CompositionBindingContext, CompositionBindingLimits, GraphOp, GraphPlan,
     IrExpr, ProcedureRegistry, RuntimeCatalog,
 };
+pub use graphforge_ontology::{
+    ActivationMode, ActivationRecord, ActivationScope, BridgeDocument, BridgeExportFormat,
+    BridgeImportFormatHint, BridgeSelector, BridgeSetId, ExportFormat, ImportFormatHint,
+    ModuleSelector, OntologyModuleId, SymbolKind,
+};
 use graphforge_ontology::{OntologyCompiler, OntologyHandle, OntologyLoader};
 use graphforge_storage::GraphCatalog;
 use graphforge_storage::ResolvedProjectGeneration;
@@ -83,6 +88,15 @@ mod import_session;
 mod invocation_descriptor;
 mod knowledge;
 mod maintenance;
+mod multi_ontology;
+pub use multi_ontology::{
+    ActivationProfileChangeRequest, BridgeAdoptionRequest, BridgeCandidate, BridgeDeleteRequest,
+    BridgeUpdateRequest, CompositionValidationReceipt, ModuleAdoptionRequest, ModuleCandidate,
+    ModuleDeleteRequest, ModuleUpdateRequest, MultiOntologyCaseResult, MultiOntologyDiagnostic,
+    MultiOntologyError, MultiOntologyMutationReceipt, MultiOntologyParityReport,
+    MultiOntologyValidationReceipt, OntologyAuthorityExpectation, OntologyAuthorityState,
+    ResolutionExplainRequest, ResolutionExplanation,
+};
 #[cfg(test)]
 mod multi_process_publication_tests;
 mod node_selector;
@@ -130,6 +144,7 @@ pub use graphforge_storage::{
     PortableV2Representation, PortableV2SelectionEntry, PortableV2SelectionPlan,
     PortableV2SelectionProfile, PortableV2SelectionReason, PortableV2SelectionRequest,
     PortableV2SubsetClosure, PortableV2SubsetPlan, PortableV2SubsetRequest,
+    WorkspaceOntologyComposition, WorkspacePortableOntologyStaging,
 };
 pub use portable::{
     PortableExportRequest, PortableExportResult, PortableImportRequest, PortableImportResult,

--- a/crates/graphforge-api/src/multi_ontology.rs
+++ b/crates/graphforge-api/src/multi_ontology.rs
@@ -596,7 +596,7 @@ impl GraphForge {
             BridgeImportFormatHint::Json => serde_json::from_str(text),
             BridgeImportFormatHint::Yaml => serde_yaml::from_str(text)
                 .map_err(|e| serde_json::Error::io(std::io::Error::other(e))),
-            BridgeImportFormatHint::Auto if text.trim_start().starts_with('{') => {
+            BridgeImportFormatHint::Auto if text.trim_start().starts_with(char::from(0x7b)) => {
                 serde_json::from_str(text)
             }
             BridgeImportFormatHint::Auto => serde_yaml::from_str(text)
@@ -2413,6 +2413,217 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
+    }
+
+    #[test]
+    fn multi_ontology_public_facade_inventory_is_runtime_covered() {
+        let mut graph = GraphForge::new(None).unwrap();
+        let _authority = graph.ontology_authority_state().unwrap();
+        assert!(graph.ontology_modules().unwrap().is_empty());
+        assert!(
+            graph
+                .inspect_ontology_module(&ModuleSelector::OntologyId("urn:missing".into()))
+                .is_err()
+        );
+        assert!(
+            graph
+                .validate_ontology_module(&parity_document("base"))
+                .unwrap()
+                .valid
+        );
+        let base = graph
+            .create_ontology_module(parity_document("base"), Vec::new(), None)
+            .unwrap();
+        let dependent = graph
+            .import_ontology_module(
+                &serde_json::to_string(&parity_document("dependent")).unwrap(),
+                ImportFormatHint::Json,
+                vec![base.id.clone()],
+            )
+            .unwrap();
+        for (seed, candidate) in [(9_200, base.clone()), (9_201, dependent.clone())] {
+            graph
+                .adopt_ontology_module(
+                    &ModuleAdoptionRequest {
+                        authority: expectation(&graph, seed),
+                        candidate,
+                    },
+                    None,
+                )
+                .unwrap();
+        }
+        graph
+            .inspect_ontology_module(&ModuleSelector::Exact(base.id.clone()))
+            .unwrap();
+        graph
+            .export_ontology_module(&ModuleSelector::Exact(base.id.clone()), ExportFormat::Json)
+            .unwrap();
+
+        let bridge_document = parity_bridge(&base.id, &dependent.id);
+        assert!(
+            graph
+                .validate_ontology_bridge(&bridge_document)
+                .unwrap()
+                .valid
+        );
+        let created_bridge = graph
+            .create_ontology_bridge(bridge_document.clone())
+            .unwrap();
+        let imported_bridge = graph
+            .import_ontology_bridge(
+                &serde_json::to_string(&bridge_document).unwrap(),
+                BridgeImportFormatHint::Json,
+            )
+            .unwrap();
+        assert_eq!(created_bridge.id, imported_bridge.id);
+        graph
+            .adopt_ontology_bridge(
+                &BridgeAdoptionRequest {
+                    authority: expectation(&graph, 9_202),
+                    candidate: imported_bridge,
+                },
+                None,
+            )
+            .unwrap();
+        let bridge_id = graph.ontology_bridges().unwrap()[0].id.clone();
+        graph
+            .inspect_ontology_bridge(&BridgeSelector::Exact(bridge_id.clone()))
+            .unwrap();
+        graph
+            .export_ontology_bridge(
+                &BridgeSelector::Exact(bridge_id.clone()),
+                BridgeExportFormat::Json,
+            )
+            .unwrap();
+        let mut bridge_update = bridge_document;
+        bridge_update.authored_version = "2.0.0".into();
+        graph
+            .preview_update_ontology_bridge(
+                &BridgeSelector::Exact(bridge_id.clone()),
+                &bridge_update,
+            )
+            .unwrap();
+        graph
+            .update_ontology_bridge(
+                &BridgeUpdateRequest {
+                    authority: expectation(&graph, 9_203),
+                    selector: BridgeSelector::Exact(bridge_id),
+                    document: bridge_update,
+                },
+                None,
+            )
+            .unwrap();
+        let updated_bridge = graph.ontology_bridges().unwrap()[0].id.clone();
+        assert!(
+            graph
+                .preview_delete_ontology_bridge(&BridgeSelector::Exact(updated_bridge.clone()))
+                .unwrap()
+                .safe
+        );
+        graph
+            .delete_ontology_bridge(
+                &BridgeDeleteRequest {
+                    authority: expectation(&graph, 9_204),
+                    selector: BridgeSelector::Exact(updated_bridge),
+                },
+                None,
+            )
+            .unwrap();
+
+        let (profile_default, activation) = graph.ontology_activation_profile().unwrap();
+        graph
+            .change_ontology_activation_profile(
+                &ActivationProfileChangeRequest {
+                    authority: expectation(&graph, 9_205),
+                    profile_default,
+                    activation,
+                },
+                None,
+            )
+            .unwrap();
+        let composition = graph.required_composition().unwrap();
+        graph.validate_ontology_composition(&composition).unwrap();
+        graph
+            .preflight_ontology_composition(
+                &CompositionChangeRequest {
+                    context: WriteContext {
+                        operation_uuid: OperationId(Uuid::from_u128(9_206)),
+                        actor_uuid: None,
+                    },
+                    expected_project_generation_uuid: graph
+                        .ontology_authority_state()
+                        .unwrap()
+                        .project_generation_uuid,
+                    expected_composition_fingerprint: graph
+                        .ontology_authority_state()
+                        .unwrap()
+                        .composition_fingerprint,
+                    candidate: composition,
+                    data_disposition: CompositionDataDisposition::RequireConforming,
+                },
+                None,
+            )
+            .unwrap();
+        graph
+            .explain_ontology_resolution(&ResolutionExplainRequest {
+                module: Some(base.id.clone()),
+                kind: SymbolKind::Entity,
+                local_id: "Person".into(),
+                max_candidates: 4,
+            })
+            .unwrap();
+        assert!(
+            graph
+                .portable_ontology_staging(graphforge_storage::PortableV2Limits::default())
+                .unwrap()
+                .is_none()
+        );
+        let authority = expectation(&graph, 9_207);
+        assert!(
+            graph
+                .adopt_portable_ontology_staging(
+                    &authority,
+                    graphforge_storage::PortableV2Limits::default(),
+                    None,
+                )
+                .is_err()
+        );
+
+        graph
+            .preview_update_ontology_module(
+                &ModuleSelector::Exact(dependent.id.clone()),
+                &parity_document("dependent_update"),
+                &[base.id.clone()],
+            )
+            .unwrap();
+        graph
+            .update_ontology_module(
+                &ModuleUpdateRequest {
+                    authority: expectation(&graph, 9_208),
+                    selector: ModuleSelector::Exact(dependent.id),
+                    document: parity_document("dependent_update"),
+                    dependencies: vec![base.id],
+                    enforcement: None,
+                },
+                None,
+            )
+            .unwrap();
+        let updated_module = graph.ontology_modules().unwrap()[1].id.clone();
+        assert!(
+            graph
+                .preview_delete_ontology_module(&ModuleSelector::Exact(updated_module.clone()))
+                .unwrap()
+                .safe
+        );
+        graph
+            .delete_ontology_module(
+                &ModuleDeleteRequest {
+                    authority: expectation(&graph, 9_209),
+                    selector: ModuleSelector::Exact(updated_module),
+                },
+                None,
+            )
+            .unwrap();
     }
 
     #[test]

--- a/crates/graphforge-api/src/multi_ontology.rs
+++ b/crates/graphforge-api/src/multi_ontology.rs
@@ -1,0 +1,2493 @@
+//! Rust-owned public lifecycle facade for multi-ontology authority.
+//!
+//! Bindings project these request and receipt types. They never rebuild
+//! inventory closure, identity, bridge, activation, or resolution semantics.
+
+use std::collections::HashSet;
+
+use graphforge_core::{GfError as EngineError, ProjectErrorCode};
+use graphforge_ontology::{
+    ActivationMode, ActivationRecord, ActivationScope, BridgeDocument, BridgeExportFormat,
+    BridgeImportFormatHint, BridgeInspect, BridgeInventory, BridgeListEntry, BridgeSelector,
+    BridgeSetId, BridgeUpdatePreview, CompositionDiagnostic, CompositionLimits, ExportFormat,
+    ImportFormatHint, InventorySnapshot, ModuleInspect, ModuleListEntry, ModuleSelector,
+    OntologyDoc, OntologyInventory, OntologyModuleId, ResolutionOutcome, ResolveRequest,
+    SymbolKind, UpdatePreview,
+};
+use graphforge_storage::{WorkspaceCompositionModule, WorkspaceOntologyComposition};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    CancellationToken, CompositionChangePreview, CompositionChangeRequest,
+    CompositionDataDisposition, GraphForge, WriteContext,
+};
+
+const MAX_ERROR_TEXT_BYTES: usize = 4096;
+const MAX_ERROR_DIAGNOSTICS: usize = 64;
+
+/// One stable bounded Rust-owned multi-ontology diagnostic.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MultiOntologyDiagnostic {
+    /// Stable dotted semantic code.
+    pub code: String,
+    /// Stable lifecycle phase.
+    pub phase: String,
+    /// Bounded path-free explanation.
+    pub message: String,
+    /// Sorted bounded semantic subjects.
+    pub subjects: Vec<String>,
+    /// Sorted bounded ambiguity candidates.
+    pub candidates: Vec<String>,
+    /// Bounded remediation owned by Rust.
+    pub remediation: String,
+    /// Applied per-diagnostic item cap.
+    pub limit: usize,
+}
+
+/// Stable error envelope returned by every multi-ontology facade method.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MultiOntologyError {
+    /// Existing GraphForge outer code, or `GF_ONTOLOGY_DIAGNOSTIC`.
+    pub code: String,
+    /// Bounded safe summary; clients branch on codes, never this string.
+    pub message: String,
+    /// Deterministically ordered bounded semantic diagnostics.
+    pub diagnostics: Vec<MultiOntologyDiagnostic>,
+}
+
+/// Canonical Rust-owned validation result returned unchanged by every host.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MultiOntologyValidationReceipt {
+    /// True only when no validation diagnostics were produced.
+    pub valid: bool,
+    /// Stable bounded diagnostics; empty exactly when `valid` is true.
+    pub diagnostics: Vec<MultiOntologyDiagnostic>,
+}
+
+/// Host-neutral semantic case result for four-surface conformance comparison.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MultiOntologyCaseResult {
+    /// Frozen comparison schema.
+    pub contract: String,
+    /// Canonical case identifier from the shared contract.
+    pub case_id: String,
+    /// `success` or `error`.
+    pub outcome: String,
+    /// Stable outer code (`GF_OK` on success).
+    pub code: String,
+    /// Sorted stable dotted diagnostic codes.
+    pub diagnostic_codes: Vec<String>,
+    /// Whether durable ontology authority changed during the case.
+    pub authority_changed: bool,
+    /// Semantic result cardinality, when the case returns a collection.
+    pub item_count: Option<usize>,
+    /// Canonically ordered semantic identities, never runtime UUIDs or paths.
+    pub ordered_ids: Vec<String>,
+}
+
+/// Complete Rust semantic report compared byte-for-semantics with host reports.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MultiOntologyParityReport {
+    /// `graphforge-multi-ontology-parity-result/1`.
+    pub contract: String,
+    /// Exactly the ten canonical ledger cases.
+    pub cases: std::collections::BTreeMap<String, serde_json::Value>,
+}
+
+impl MultiOntologyError {
+    #[allow(non_snake_case)]
+    fn Validation(message: impl AsRef<str>) -> Self {
+        Self {
+            code: "GF_VALIDATION".into(),
+            message: bounded_text(message.as_ref()),
+            diagnostics: Vec::new(),
+        }
+    }
+
+    /// Stable outer code.
+    #[must_use]
+    pub fn code(&self) -> &str {
+        &self.code
+    }
+}
+
+impl std::fmt::Display for MultiOntologyError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for MultiOntologyError {}
+
+impl From<EngineError> for MultiOntologyError {
+    fn from(error: EngineError) -> Self {
+        Self {
+            code: error.code().into(),
+            message: bounded_text(&error.to_string()),
+            diagnostics: Vec::new(),
+        }
+    }
+}
+
+impl From<graphforge_storage::PortableV2Error> for MultiOntologyError {
+    fn from(error: graphforge_storage::PortableV2Error) -> Self {
+        portable_error(error)
+    }
+}
+
+type GfError = MultiOntologyError;
+
+/// Exact authority identities every mutation is bound to.
+#[derive(Debug, Clone)]
+pub struct OntologyAuthorityExpectation {
+    /// Caller operation and actor identity.
+    pub context: WriteContext,
+    /// Exact project generation observed by the caller.
+    pub expected_project_generation_uuid: Uuid,
+    /// Exact current composition fingerprint.
+    pub expected_composition_fingerprint: Option<String>,
+}
+
+/// Immutable identities callers use for optimistic lifecycle requests.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OntologyAuthorityState {
+    /// Current selected project generation.
+    pub project_generation_uuid: Uuid,
+    /// Current composition identity, absent before first adoption.
+    pub composition_fingerprint: Option<String>,
+}
+
+/// Validated but non-authoritative ontology module candidate.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ModuleCandidate {
+    /// Exact content-derived module identity.
+    pub id: OntologyModuleId,
+    /// Authored document; retained without flattening.
+    pub document: OntologyDoc,
+    /// Exact dependency identities.
+    pub dependencies: Vec<OntologyModuleId>,
+    /// Optional module activation override.
+    pub enforcement: Option<ActivationMode>,
+    /// Candidate state distinguishes create from text import.
+    pub status: String,
+}
+
+/// Validated but non-authoritative bridge candidate.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BridgeCandidate {
+    /// Exact content-derived bridge identity.
+    pub id: BridgeSetId,
+    /// Authored bridge document.
+    pub document: BridgeDocument,
+    /// Candidate state distinguishes create from text import.
+    pub status: String,
+}
+
+/// Explicit module adoption request.
+#[derive(Debug, Clone)]
+pub struct ModuleAdoptionRequest {
+    /// Exact authority expectation.
+    pub authority: OntologyAuthorityExpectation,
+    /// Candidate returned by create/import.
+    pub candidate: ModuleCandidate,
+}
+
+/// Atomic module replacement request.
+#[derive(Debug, Clone)]
+pub struct ModuleUpdateRequest {
+    /// Exact authority expectation.
+    pub authority: OntologyAuthorityExpectation,
+    /// Exact current module selector.
+    pub selector: ModuleSelector,
+    /// Replacement document.
+    pub document: OntologyDoc,
+    /// Replacement exact dependencies.
+    pub dependencies: Vec<OntologyModuleId>,
+    /// Optional replacement activation override.
+    pub enforcement: Option<ActivationMode>,
+}
+
+/// Safe module deletion request.
+#[derive(Debug, Clone)]
+pub struct ModuleDeleteRequest {
+    /// Exact authority expectation.
+    pub authority: OntologyAuthorityExpectation,
+    /// Exact or uniquely-resolved selector.
+    pub selector: ModuleSelector,
+}
+
+/// Explicit bridge adoption request.
+#[derive(Debug, Clone)]
+pub struct BridgeAdoptionRequest {
+    /// Exact authority expectation.
+    pub authority: OntologyAuthorityExpectation,
+    /// Candidate returned by create/import.
+    pub candidate: BridgeCandidate,
+}
+
+/// Atomic bridge replacement request.
+#[derive(Debug, Clone)]
+pub struct BridgeUpdateRequest {
+    /// Exact authority expectation.
+    pub authority: OntologyAuthorityExpectation,
+    /// Exact current bridge selector.
+    pub selector: BridgeSelector,
+    /// Replacement bridge document.
+    pub document: BridgeDocument,
+}
+
+/// Safe bridge deletion request.
+#[derive(Debug, Clone)]
+pub struct BridgeDeleteRequest {
+    /// Exact authority expectation.
+    pub authority: OntologyAuthorityExpectation,
+    /// Exact or uniquely-resolved selector.
+    pub selector: BridgeSelector,
+}
+
+/// Atomic activation-profile replacement request.
+#[derive(Debug, Clone)]
+pub struct ActivationProfileChangeRequest {
+    /// Exact authority expectation.
+    pub authority: OntologyAuthorityExpectation,
+    /// New default mode.
+    pub profile_default: ActivationMode,
+    /// Complete replacement activation records.
+    pub activation: Vec<ActivationRecord>,
+}
+
+/// Stable receipt shared by module, bridge, and activation mutations.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MultiOntologyMutationReceipt {
+    /// Published project generation.
+    pub project_generation_uuid: Uuid,
+    /// Published composition identity.
+    pub composition_fingerprint: String,
+    /// Canonical candidate digest.
+    pub candidate_sha256: String,
+    /// Caller operation identity.
+    pub operation_uuid: Uuid,
+}
+
+/// Pure composition validation receipt.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompositionValidationReceipt {
+    /// Recomputed exact composition identity.
+    pub composition_fingerprint: String,
+    /// Identity-sorted module closure.
+    pub modules: Vec<String>,
+    /// Identity-sorted bridge closure.
+    pub bridges: Vec<String>,
+}
+
+/// Request for Rust-owned qualified/unqualified resolution explanation.
+#[derive(Debug, Clone)]
+pub struct ResolutionExplainRequest {
+    /// Optional exact module identity.
+    pub module: Option<OntologyModuleId>,
+    /// Symbol kind.
+    pub kind: SymbolKind,
+    /// Local symbol identifier.
+    pub local_id: String,
+    /// Bounded ambiguity candidate count.
+    pub max_candidates: usize,
+}
+
+/// Stable resolution success or bounded diagnostic explanation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolutionExplanation {
+    /// Successful outcome, absent on failure.
+    pub outcome: Option<ResolutionOutcome>,
+    /// Stable Rust-owned diagnostics, absent on success.
+    pub diagnostics: Vec<CompositionDiagnostic>,
+}
+
+impl GraphForge {
+    /// Inspect exact authority identities for a subsequent mutation request.
+    pub fn ontology_authority_state(&self) -> Result<OntologyAuthorityState, GfError> {
+        Ok(OntologyAuthorityState {
+            project_generation_uuid: self.generation_for_read()?.generation_uuid(),
+            composition_fingerprint: self
+                .workspace_ontology_composition()?
+                .map(|composition| composition.composition_fingerprint),
+        })
+    }
+
+    /// List durable ontology modules in exact identity order.
+    pub fn ontology_modules(&self) -> Result<Vec<ModuleListEntry>, GfError> {
+        Ok(module_inventory(&self.required_composition()?)?.list())
+    }
+
+    /// Inspect one durable ontology module.
+    pub fn inspect_ontology_module(
+        &self,
+        selector: &ModuleSelector,
+    ) -> Result<ModuleInspect, GfError> {
+        module_inventory(&self.required_composition()?)?
+            .inspect(selector)
+            .map_err(composition_error)
+    }
+
+    /// Validate a module without changing staging or durable authority.
+    pub fn validate_ontology_module(
+        &self,
+        document: &OntologyDoc,
+    ) -> Result<MultiOntologyValidationReceipt, GfError> {
+        let inventory = module_inventory(&self.required_composition()?)?;
+        Ok(validation_receipt(inventory.validate_document(document)))
+    }
+
+    /// Create/register a validated non-authoritative module candidate.
+    pub fn create_ontology_module(
+        &self,
+        document: OntologyDoc,
+        dependencies: Vec<OntologyModuleId>,
+        enforcement: Option<ActivationMode>,
+    ) -> Result<ModuleCandidate, GfError> {
+        let composition = self.required_composition()?;
+        let mut inventory = module_inventory(&composition)?;
+        inventory
+            .validate_document(&document)
+            .map_err(composition_error)?;
+        let exact_id = OntologyModuleId {
+            ontology_id: document.ontology_id.clone(),
+            authored_version: document.version.clone(),
+            canonical_digest: graphforge_ontology::module_document_digest(&document)
+                .map_err(GfError::Validation)?,
+        };
+        if composition.modules.iter().any(|module| {
+            module.id == exact_id
+                && module.document == document
+                && module.dependencies == dependencies
+        }) {
+            return Ok(ModuleCandidate {
+                id: exact_id,
+                document,
+                dependencies,
+                enforcement,
+                status: "validated".into(),
+            });
+        }
+        let id = inventory
+            .create_register(
+                document.clone(),
+                dependencies.clone(),
+                enforcement,
+                "candidate",
+            )
+            .map_err(composition_error)?;
+        Ok(ModuleCandidate {
+            id,
+            document,
+            dependencies,
+            enforcement,
+            status: "validated".into(),
+        })
+    }
+
+    /// Parse and validate a non-authoritative module import candidate.
+    pub fn import_ontology_module(
+        &self,
+        text: &str,
+        format: ImportFormatHint,
+        dependencies: Vec<OntologyModuleId>,
+    ) -> Result<ModuleCandidate, GfError> {
+        let mut inventory = module_inventory(&self.required_composition()?)?;
+        let id = inventory
+            .import_text(text, format, dependencies.clone(), "candidate")
+            .map_err(composition_error)?;
+        let document = staged_module_document(text, format)?;
+        Ok(ModuleCandidate {
+            id,
+            document,
+            dependencies,
+            enforcement: None,
+            status: "candidate".into(),
+        })
+    }
+
+    /// Explicitly adopt a validated/imported module and publish atomically.
+    pub fn adopt_ontology_module(
+        &mut self,
+        request: &ModuleAdoptionRequest,
+        cancellation: Option<&CancellationToken>,
+    ) -> Result<MultiOntologyMutationReceipt, GfError> {
+        let mut candidate = self.checked_candidate(&request.authority)?;
+        reject_duplicate_module(&candidate, &request.candidate.id)?;
+        candidate.modules.push(WorkspaceCompositionModule {
+            id: request.candidate.id.clone(),
+            dependencies: request.candidate.dependencies.clone(),
+            document: request.candidate.document.clone(),
+            allow_projected_identity: false,
+        });
+        if let Some(mode) = request.candidate.enforcement {
+            candidate.activation.push(ActivationRecord {
+                scope: ActivationScope::Module,
+                subject: request.candidate.id.display_ref(),
+                mode,
+            });
+        }
+        let operation = format!("module.adopt:{}", request.candidate.id.display_ref());
+        self.publish_multi_ontology_candidate(
+            &request.authority,
+            candidate,
+            operation,
+            cancellation,
+        )
+    }
+
+    /// Preview one exact module replacement using inventory authority.
+    pub fn preview_update_ontology_module(
+        &self,
+        selector: &ModuleSelector,
+        document: &OntologyDoc,
+        dependencies: &[OntologyModuleId],
+    ) -> Result<UpdatePreview, GfError> {
+        module_inventory(&self.required_composition()?)?
+            .preview_update(selector, document, dependencies)
+            .map_err(composition_error)
+    }
+
+    /// Replace one exact module and publish atomically.
+    pub fn update_ontology_module(
+        &mut self,
+        request: &ModuleUpdateRequest,
+        cancellation: Option<&CancellationToken>,
+    ) -> Result<MultiOntologyMutationReceipt, GfError> {
+        let mut candidate = self.checked_candidate(&request.authority)?;
+        let index = resolve_module_index(&candidate, &request.selector)?;
+        let prior = candidate.modules[index].id.clone();
+        if request.document.ontology_id != candidate.modules[index].document.ontology_id {
+            return Err(GfError::Validation("module update must retain ontology_id"));
+        }
+        let mut inventory = module_inventory(&candidate)?;
+        let next_id = inventory
+            .create_register(
+                request.document.clone(),
+                request.dependencies.clone(),
+                request.enforcement,
+                "update-validation",
+            )
+            .map_err(composition_error)?;
+        let next = ModuleCandidate {
+            id: next_id,
+            document: request.document.clone(),
+            dependencies: request.dependencies.clone(),
+            enforcement: request.enforcement,
+            status: "validated".into(),
+        };
+        candidate.modules[index] = WorkspaceCompositionModule {
+            id: next.id.clone(),
+            dependencies: next.dependencies,
+            document: next.document,
+            allow_projected_identity: false,
+        };
+        rewrite_module_identity(&mut candidate, &prior, &next.id)?;
+        set_module_activation(&mut candidate, &next.id, request.enforcement);
+        let operation = format!("module.update:{}", prior.display_ref());
+        self.publish_multi_ontology_candidate(
+            &request.authority,
+            candidate,
+            operation,
+            cancellation,
+        )
+    }
+
+    /// Preview safe module deletion, including dependency/activation blockers.
+    pub fn preview_delete_ontology_module(
+        &self,
+        selector: &ModuleSelector,
+    ) -> Result<graphforge_ontology::DeletePreview, GfError> {
+        let composition = self.required_composition()?;
+        let preview = module_inventory(&composition)?
+            .preview_delete(selector)
+            .map_err(composition_error)?;
+        enrich_module_delete_preview(preview, &composition)
+    }
+
+    /// Delete one unreferenced module and publish atomically.
+    pub fn delete_ontology_module(
+        &mut self,
+        request: &ModuleDeleteRequest,
+        cancellation: Option<&CancellationToken>,
+    ) -> Result<MultiOntologyMutationReceipt, GfError> {
+        let mut candidate = self.checked_candidate(&request.authority)?;
+        let preview = module_inventory(&candidate)?
+            .preview_delete(&request.selector)
+            .map_err(composition_error)?;
+        let preview = enrich_module_delete_preview(preview, &candidate)?;
+        if !preview.safe {
+            return Err(dependency_blocked_error(&preview));
+        }
+        candidate
+            .modules
+            .retain(|module| module.id != preview.target);
+        candidate
+            .activation
+            .retain(|record| record.subject != preview.target.display_ref());
+        let operation = format!("module.delete:{}", preview.target.display_ref());
+        self.publish_multi_ontology_candidate(
+            &request.authority,
+            candidate,
+            operation,
+            cancellation,
+        )
+    }
+
+    /// Deterministically export one module.
+    pub fn export_ontology_module(
+        &self,
+        selector: &ModuleSelector,
+        format: ExportFormat,
+    ) -> Result<String, GfError> {
+        module_inventory(&self.required_composition()?)?
+            .export_module(selector, format)
+            .map_err(composition_error)
+    }
+
+    /// List durable bridges in exact identity order.
+    pub fn ontology_bridges(&self) -> Result<Vec<BridgeListEntry>, GfError> {
+        Ok(bridge_inventory(&self.required_composition()?)?.list())
+    }
+
+    /// Inspect one durable bridge.
+    pub fn inspect_ontology_bridge(
+        &self,
+        selector: &BridgeSelector,
+    ) -> Result<BridgeInspect, GfError> {
+        bridge_inventory(&self.required_composition()?)?
+            .inspect(selector)
+            .map_err(composition_error)
+    }
+
+    /// Validate a bridge without mutation.
+    pub fn validate_ontology_bridge(
+        &self,
+        document: &BridgeDocument,
+    ) -> Result<MultiOntologyValidationReceipt, GfError> {
+        let inventory = bridge_inventory(&self.required_composition()?)?;
+        Ok(validation_receipt(inventory.validate_document(document)))
+    }
+
+    /// Create/register a validated non-authoritative bridge candidate.
+    pub fn create_ontology_bridge(
+        &self,
+        document: BridgeDocument,
+    ) -> Result<BridgeCandidate, GfError> {
+        let mut inventory = bridge_inventory(&self.required_composition()?)?;
+        let id = inventory
+            .create_register(document.clone(), "candidate")
+            .map_err(composition_error)?;
+        Ok(BridgeCandidate {
+            id,
+            document,
+            status: "validated".into(),
+        })
+    }
+
+    /// Parse and validate a non-authoritative bridge import candidate.
+    pub fn import_ontology_bridge(
+        &self,
+        text: &str,
+        format: BridgeImportFormatHint,
+    ) -> Result<BridgeCandidate, GfError> {
+        let document: BridgeDocument = match format {
+            BridgeImportFormatHint::Json => serde_json::from_str(text),
+            BridgeImportFormatHint::Yaml => serde_yaml::from_str(text)
+                .map_err(|e| serde_json::Error::io(std::io::Error::other(e))),
+            BridgeImportFormatHint::Auto if text.trim_start().starts_with('{') => {
+                serde_json::from_str(text)
+            }
+            BridgeImportFormatHint::Auto => serde_yaml::from_str(text)
+                .map_err(|e| serde_json::Error::io(std::io::Error::other(e))),
+        }
+        .map_err(|_| GfError::Validation("bridge import is malformed"))?;
+        let mut inventory = bridge_inventory(&self.required_composition()?)?;
+        let id = inventory
+            .import_text(text, format, "candidate")
+            .map_err(composition_error)?;
+        Ok(BridgeCandidate {
+            id,
+            document,
+            status: "candidate".into(),
+        })
+    }
+
+    /// Explicitly adopt a bridge and publish atomically.
+    pub fn adopt_ontology_bridge(
+        &mut self,
+        request: &BridgeAdoptionRequest,
+        cancellation: Option<&CancellationToken>,
+    ) -> Result<MultiOntologyMutationReceipt, GfError> {
+        let mut candidate = self.checked_candidate(&request.authority)?;
+        reject_duplicate_bridge(&candidate, &request.candidate.id)?;
+        let mut inventory = bridge_inventory(&candidate)?;
+        let computed = inventory
+            .create_register(request.candidate.document.clone(), "adopt-validation")
+            .map_err(composition_error)?;
+        if computed != request.candidate.id {
+            return Err(GfError::Validation(
+                "bridge candidate identity does not match document",
+            ));
+        }
+        candidate.bridges.push(request.candidate.document.clone());
+        let operation = format!("bridge.adopt:{}", request.candidate.id.display_ref());
+        self.publish_multi_ontology_candidate(
+            &request.authority,
+            candidate,
+            operation,
+            cancellation,
+        )
+    }
+
+    /// Preview one bridge replacement.
+    pub fn preview_update_ontology_bridge(
+        &self,
+        selector: &BridgeSelector,
+        document: &BridgeDocument,
+    ) -> Result<BridgeUpdatePreview, GfError> {
+        bridge_inventory(&self.required_composition()?)?
+            .preview_update(selector, document)
+            .map_err(composition_error)
+    }
+
+    /// Replace one exact bridge and publish atomically.
+    pub fn update_ontology_bridge(
+        &mut self,
+        request: &BridgeUpdateRequest,
+        cancellation: Option<&CancellationToken>,
+    ) -> Result<MultiOntologyMutationReceipt, GfError> {
+        let mut candidate = self.checked_candidate(&request.authority)?;
+        let index = resolve_bridge_index(&candidate, &request.selector)?;
+        let prior_ids = candidate
+            .bridges
+            .iter()
+            .map(bridge_id)
+            .collect::<Result<Vec<_>, _>>()?;
+        let operation = format!("bridge.update:{}", prior_ids[index].display_ref());
+        if request.document.bridge_id != candidate.bridges[index].bridge_id {
+            return Err(GfError::Validation("bridge update must retain bridge_id"));
+        }
+        let mut inventory = bridge_inventory(&candidate)?;
+        let computed = inventory
+            .create_register(request.document.clone(), "update-validation")
+            .map_err(composition_error)?;
+        if computed != bridge_id(&request.document)? {
+            return Err(GfError::Validation(
+                "bridge replacement identity does not match document",
+            ));
+        }
+        candidate.bridges[index] = request.document.clone();
+        cascade_bridge_identities(&mut candidate, prior_ids)?;
+        self.publish_multi_ontology_candidate(
+            &request.authority,
+            candidate,
+            operation,
+            cancellation,
+        )
+    }
+
+    /// Preview safe bridge deletion.
+    pub fn preview_delete_ontology_bridge(
+        &self,
+        selector: &BridgeSelector,
+    ) -> Result<graphforge_ontology::BridgeDeletePreview, GfError> {
+        bridge_inventory(&self.required_composition()?)?
+            .preview_delete(selector)
+            .map_err(composition_error)
+    }
+
+    /// Delete one unreferenced bridge and publish atomically.
+    pub fn delete_ontology_bridge(
+        &mut self,
+        request: &BridgeDeleteRequest,
+        cancellation: Option<&CancellationToken>,
+    ) -> Result<MultiOntologyMutationReceipt, GfError> {
+        let mut candidate = self.checked_candidate(&request.authority)?;
+        let preview = bridge_inventory(&candidate)?
+            .preview_delete(&request.selector)
+            .map_err(composition_error)?;
+        if !preview.safe {
+            return Err(GfError::Validation("bridge deletion is dependency-blocked"));
+        }
+        candidate
+            .bridges
+            .retain(|doc| bridge_id(doc).ok().as_ref() != Some(&preview.target));
+        candidate
+            .activation
+            .retain(|record| record.subject != preview.target.display_ref());
+        let operation = format!("bridge.delete:{}", preview.target.display_ref());
+        self.publish_multi_ontology_candidate(
+            &request.authority,
+            candidate,
+            operation,
+            cancellation,
+        )
+    }
+
+    /// Deterministically export one bridge.
+    pub fn export_ontology_bridge(
+        &self,
+        selector: &BridgeSelector,
+        format: BridgeExportFormat,
+    ) -> Result<String, GfError> {
+        bridge_inventory(&self.required_composition()?)?
+            .export_bridge(selector, format)
+            .map_err(composition_error)
+    }
+
+    /// Inspect the complete current activation profile.
+    pub fn ontology_activation_profile(
+        &self,
+    ) -> Result<(ActivationMode, Vec<ActivationRecord>), GfError> {
+        let composition = self.required_composition()?;
+        Ok((composition.profile_default, composition.activation))
+    }
+
+    /// Replace the activation profile and publish atomically.
+    pub fn change_ontology_activation_profile(
+        &mut self,
+        request: &ActivationProfileChangeRequest,
+        cancellation: Option<&CancellationToken>,
+    ) -> Result<MultiOntologyMutationReceipt, GfError> {
+        let mut candidate = self.checked_candidate(&request.authority)?;
+        candidate.profile_default = request.profile_default;
+        candidate.activation.clone_from(&request.activation);
+        self.publish_multi_ontology_candidate(
+            &request.authority,
+            candidate,
+            "activation.change".into(),
+            cancellation,
+        )
+    }
+
+    /// Validate and deterministically inventory one complete composition.
+    pub fn validate_ontology_composition(
+        &self,
+        candidate: &WorkspaceOntologyComposition,
+    ) -> Result<CompositionValidationReceipt, GfError> {
+        let compiled = candidate.compile()?;
+        let mut bridges = candidate
+            .bridges
+            .iter()
+            .map(bridge_id)
+            .collect::<Result<Vec<_>, _>>()?;
+        bridges.sort_by_key(BridgeSetId::sort_key);
+        Ok(CompositionValidationReceipt {
+            composition_fingerprint: compiled.fingerprint,
+            modules: compiled
+                .modules
+                .iter()
+                .map(|m| m.id.display_ref())
+                .collect(),
+            bridges: bridges.into_iter().map(|id| id.display_ref()).collect(),
+        })
+    }
+
+    /// Run the #840 full stored-data and portability preflight authority.
+    pub fn preflight_ontology_composition(
+        &self,
+        request: &CompositionChangeRequest,
+        cancellation: Option<&CancellationToken>,
+    ) -> Result<CompositionChangePreview, GfError> {
+        Ok(self.preview_ontology_composition_change(request, cancellation)?)
+    }
+
+    /// Inspect a verified durable portable candidate without adopting it.
+    pub fn portable_ontology_staging(
+        &self,
+        limits: graphforge_storage::PortableV2Limits,
+    ) -> Result<Option<graphforge_storage::WorkspacePortableOntologyStaging>, GfError> {
+        graphforge_storage::load_portable_ontology_staging(&self.generation_for_read()?, limits)
+            .map_err(MultiOntologyError::from)
+    }
+
+    /// Explicitly adopt the verified post-import portable ontology candidate.
+    pub fn adopt_portable_ontology_staging(
+        &mut self,
+        authority: &OntologyAuthorityExpectation,
+        limits: graphforge_storage::PortableV2Limits,
+        cancellation: Option<&CancellationToken>,
+    ) -> Result<MultiOntologyMutationReceipt, GfError> {
+        let parent = graphforge_storage::resolve_generation_by_uuid(
+            self.resolved_generation.container_root(),
+            authority.expected_project_generation_uuid,
+        )?;
+        let staged = graphforge_storage::load_portable_ontology_staging(&parent, limits)
+            .map_err(MultiOntologyError::from)?
+            .ok_or_else(|| GfError::Validation("portable ontology staging is absent"))?;
+        // Bind adoption to the current authority even though the candidate is
+        // stored as a separate, deliberately non-authoritative participant.
+        let _ = self.checked_candidate(authority)?;
+        let operation = format!("portable.staging.adopt:{}", staged.package_digest);
+        self.publish_multi_ontology_candidate(
+            authority,
+            staged.composition,
+            operation,
+            cancellation,
+        )
+    }
+
+    /// Explain qualified/unqualified resolution with stable bounded diagnostics.
+    pub fn explain_ontology_resolution(
+        &self,
+        request: &ResolutionExplainRequest,
+    ) -> Result<ResolutionExplanation, GfError> {
+        let compiled = self.required_composition()?.compile()?;
+        match compiled.resolve(&ResolveRequest {
+            module: request.module.as_ref(),
+            kind: request.kind,
+            local_id: &request.local_id,
+            max_candidates: request.max_candidates.clamp(1, 64),
+        }) {
+            Ok(outcome) => Ok(ResolutionExplanation {
+                outcome: Some(outcome),
+                diagnostics: Vec::new(),
+            }),
+            Err(error) => Ok(ResolutionExplanation {
+                outcome: None,
+                diagnostics: error.diagnostics,
+            }),
+        }
+    }
+
+    fn required_composition(&self) -> Result<WorkspaceOntologyComposition, GfError> {
+        self.workspace_ontology_composition()?
+            .map_or_else(empty_composition, Ok)
+    }
+
+    fn checked_candidate(
+        &self,
+        expected: &OntologyAuthorityExpectation,
+    ) -> Result<WorkspaceOntologyComposition, GfError> {
+        let replay_exists = graphforge_storage::published_project_transaction(
+            self.resolved_generation.container_root(),
+            expected.context.operation_uuid.0,
+        )?
+        .is_some();
+        let generation = graphforge_storage::resolve_generation_by_uuid(
+            self.resolved_generation.container_root(),
+            expected.expected_project_generation_uuid,
+        )
+        .map_err(|error| replay_authority_error(replay_exists, error))?;
+        let persisted = composition_from_generation(&generation)?;
+        let actual_fingerprint = persisted
+            .as_ref()
+            .map(|composition| composition.composition_fingerprint.clone());
+        if actual_fingerprint != expected.expected_composition_fingerprint {
+            return if replay_exists {
+                Err(transaction_conflict(
+                    "operation UUID was already published with different ontology authority",
+                ))
+            } else {
+                Err(GfError::Validation(
+                    "ontology authority composition fingerprint is stale",
+                ))
+            };
+        }
+        persisted.map_or_else(empty_composition, Ok)
+    }
+
+    fn publish_multi_ontology_candidate(
+        &mut self,
+        expected: &OntologyAuthorityExpectation,
+        candidate: WorkspaceOntologyComposition,
+        operation: String,
+        cancellation: Option<&CancellationToken>,
+    ) -> Result<MultiOntologyMutationReceipt, GfError> {
+        let compiled = compile_candidate(&candidate)?;
+        let candidate = WorkspaceOntologyComposition::from_compiled(&compiled, candidate.bridges);
+        let change = CompositionChangeRequest {
+            context: expected.context.clone(),
+            expected_project_generation_uuid: expected.expected_project_generation_uuid,
+            expected_composition_fingerprint: expected.expected_composition_fingerprint.clone(),
+            candidate,
+            data_disposition: CompositionDataDisposition::RequireConformingOperation { operation },
+        };
+        if let Some(receipt) = self.replay_ontology_composition_change(&change)? {
+            return Ok(MultiOntologyMutationReceipt {
+                project_generation_uuid: receipt.project_generation_uuid,
+                composition_fingerprint: receipt.composition_fingerprint,
+                candidate_sha256: receipt.candidate_sha256,
+                operation_uuid: expected.context.operation_uuid.0,
+            });
+        }
+        let preview = self.preview_ontology_composition_change(&change, cancellation)?;
+        if !preview.diagnostics.is_empty() {
+            return Err(composition_change_error(preview.diagnostics));
+        }
+        let receipt = self.publish_ontology_composition_change(&change, &preview, cancellation)?;
+        Ok(MultiOntologyMutationReceipt {
+            project_generation_uuid: receipt.project_generation_uuid,
+            composition_fingerprint: receipt.composition_fingerprint,
+            candidate_sha256: receipt.candidate_sha256,
+            operation_uuid: expected.context.operation_uuid.0,
+        })
+    }
+}
+
+fn replay_authority_error(replay_exists: bool, error: EngineError) -> GfError {
+    if replay_exists {
+        transaction_conflict(
+            "operation UUID was already published with different ontology authority",
+        )
+    } else {
+        error.into()
+    }
+}
+
+fn transaction_conflict(message: &str) -> GfError {
+    EngineError::Project {
+        code: ProjectErrorCode::TransactionConflict,
+        message: message.into(),
+    }
+    .into()
+}
+
+fn module_inventory(
+    composition: &WorkspaceOntologyComposition,
+) -> Result<OntologyInventory, GfError> {
+    if let [module] = composition.modules.as_slice()
+        && module.allow_projected_identity
+        && module.dependencies.is_empty()
+        && composition.bridges.is_empty()
+        && composition.activation.is_empty()
+    {
+        return OntologyInventory::from_legacy_single(
+            module.document.clone(),
+            true,
+            composition.profile_default,
+        )
+        .map_err(composition_error);
+    }
+    OntologyInventory::reopen(InventorySnapshot {
+        schema_version: 1,
+        generation: 0,
+        profile_default: composition.profile_default,
+        activation: composition.activation.clone(),
+        bridges: composition
+            .bridges
+            .iter()
+            .map(bridge_id)
+            .collect::<Result<Vec<_>, _>>()?,
+        adopted: composition
+            .modules
+            .iter()
+            .map(|m| graphforge_ontology::SnapshotModule {
+                id: m.id.clone(),
+                dependencies: m.dependencies.clone(),
+                doc: m.document.clone(),
+                enforcement: None,
+            })
+            .collect(),
+        composition_fingerprint: composition.composition_fingerprint.clone(),
+        receipts: Vec::new(),
+    })
+    .map_err(composition_error)
+}
+
+fn bridge_inventory(
+    composition: &WorkspaceOntologyComposition,
+) -> Result<BridgeInventory, GfError> {
+    let compiled = composition.compile()?;
+    let modules = compiled
+        .modules
+        .iter()
+        .map(|module| graphforge_ontology::SnapshotModuleSymbols {
+            id: module.id.clone(),
+            entities: module
+                .symbols
+                .iter()
+                .filter(|s| s.kind == SymbolKind::Entity)
+                .map(|s| s.local_id.clone())
+                .collect(),
+            relations: module
+                .symbols
+                .iter()
+                .filter(|s| s.kind == SymbolKind::Relation)
+                .map(|s| s.local_id.clone())
+                .collect(),
+            properties: module
+                .symbols
+                .iter()
+                .filter(|s| s.kind == SymbolKind::Property)
+                .map(|s| s.local_id.clone())
+                .collect(),
+        })
+        .collect();
+    let adopted = composition
+        .bridges
+        .iter()
+        .map(|document| {
+            Ok(graphforge_ontology::SnapshotBridge {
+                id: bridge_id(document)?,
+                dependencies: document.dependencies.clone(),
+                doc: document.clone(),
+            })
+        })
+        .collect::<Result<Vec<_>, GfError>>()?;
+    let known = adopted
+        .iter()
+        .map(|bridge| bridge.id.display_ref())
+        .collect::<HashSet<_>>();
+    let activation_subjects = composition
+        .activation
+        .iter()
+        .filter(|record| record.scope == ActivationScope::Bridge && known.contains(&record.subject))
+        .map(|record| record.subject.clone())
+        .collect();
+    BridgeInventory::reopen(graphforge_ontology::BridgeSnapshot {
+        schema_version: 1,
+        generation: 0,
+        profile_default: composition.profile_default,
+        activation_subjects,
+        modules,
+        adopted,
+        receipts: Vec::new(),
+    })
+    .map_err(composition_error)
+}
+
+fn enrich_module_delete_preview(
+    mut preview: graphforge_ontology::DeletePreview,
+    composition: &WorkspaceOntologyComposition,
+) -> Result<graphforge_ontology::DeletePreview, GfError> {
+    preview.bridge_refs = composition
+        .bridges
+        .iter()
+        .filter(|bridge| bridge_references_module(bridge, &preview.target))
+        .map(bridge_id)
+        .collect::<Result<Vec<_>, _>>()?;
+    preview.bridge_refs.sort_by_key(BridgeSetId::sort_key);
+    preview.bridge_refs.dedup();
+    preview.safe = preview.safe && preview.bridge_refs.is_empty();
+    Ok(preview)
+}
+
+fn bridge_references_module(bridge: &BridgeDocument, module: &OntologyModuleId) -> bool {
+    bridge.source_modules.iter().any(|id| id == module)
+        || bridge.target_modules.iter().any(|id| id == module)
+        || bridge.assertions.iter().any(|assertion| {
+            assertion.source.module == *module || assertion.target.module == *module
+        })
+}
+
+fn compile_candidate(
+    candidate: &WorkspaceOntologyComposition,
+) -> Result<graphforge_ontology::CompiledComposition, GfError> {
+    let modules = candidate
+        .modules
+        .iter()
+        .map(|m| graphforge_ontology::AuthoredModule {
+            id: m.id.clone(),
+            dependencies: m.dependencies.clone(),
+            doc: m.document.clone(),
+            allow_projected_identity: m.allow_projected_identity,
+        })
+        .collect::<Vec<_>>();
+    let bridges = candidate
+        .bridges
+        .iter()
+        .map(bridge_id)
+        .collect::<Result<Vec<_>, _>>()?;
+    graphforge_ontology::compile_inventory(graphforge_ontology::InventoryCompileRequest {
+        modules: &modules,
+        bridges: &bridges,
+        activation: &candidate.activation,
+        profile_default: candidate.profile_default,
+        limits: CompositionLimits::default(),
+        cancelled: None,
+    })
+    .map_err(composition_error)
+}
+
+fn empty_composition() -> Result<WorkspaceOntologyComposition, GfError> {
+    let compiled =
+        graphforge_ontology::compile_inventory(graphforge_ontology::InventoryCompileRequest {
+            modules: &[],
+            bridges: &[],
+            activation: &[],
+            profile_default: ActivationMode::Exploratory,
+            limits: CompositionLimits::default(),
+            cancelled: None,
+        })
+        .map_err(composition_error)?;
+    Ok(WorkspaceOntologyComposition::from_compiled(
+        &compiled,
+        Vec::new(),
+    ))
+}
+
+fn composition_from_generation(
+    generation: &graphforge_storage::ResolvedProjectGeneration,
+) -> Result<Option<WorkspaceOntologyComposition>, GfError> {
+    if let Some(snapshot) = generation.participant_snapshot(
+        graphforge_storage::WORKSPACE_CAPABILITY_ID,
+        graphforge_storage::WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY,
+    )? {
+        return Ok(Some(WorkspaceOntologyComposition::from_canonical_json(
+            &snapshot.bytes,
+        )?));
+    }
+    let ontology = generation
+        .participant_snapshot(
+            graphforge_storage::WORKSPACE_CAPABILITY_ID,
+            graphforge_storage::WORKSPACE_ONTOLOGY_FAMILY,
+        )?
+        .ok_or_else(|| GfError::Validation("workspace ontology authority is missing"))?;
+    let ontology = graphforge_storage::WorkspaceOntology::from_canonical_json(&ontology.bytes)?;
+    Ok(WorkspaceOntologyComposition::virtual_legacy(&ontology)?)
+}
+
+fn bridge_id(document: &BridgeDocument) -> Result<BridgeSetId, GfError> {
+    Ok(BridgeSetId {
+        bridge_id: document.bridge_id.clone(),
+        authored_version: document.authored_version.clone(),
+        canonical_digest: graphforge_ontology::bridge_document_digest(document)
+            .map_err(GfError::Validation)?,
+    })
+}
+
+fn composition_error(error: graphforge_ontology::CompositionError) -> GfError {
+    let diagnostics = project_diagnostics(error);
+    let message = diagnostics.first().map_or_else(
+        || "ontology composition failed".into(),
+        |diagnostic| diagnostic.message.clone(),
+    );
+    MultiOntologyError {
+        code: "GF_ONTOLOGY_DIAGNOSTIC".into(),
+        message,
+        diagnostics,
+    }
+}
+
+fn validation_receipt(
+    result: Result<(), graphforge_ontology::CompositionError>,
+) -> MultiOntologyValidationReceipt {
+    match result {
+        Ok(()) => MultiOntologyValidationReceipt {
+            valid: true,
+            diagnostics: Vec::new(),
+        },
+        Err(error) => MultiOntologyValidationReceipt {
+            valid: false,
+            diagnostics: project_diagnostics(error),
+        },
+    }
+}
+
+fn project_diagnostics(
+    error: graphforge_ontology::CompositionError,
+) -> Vec<MultiOntologyDiagnostic> {
+    let mut diagnostics = error
+        .diagnostics
+        .into_iter()
+        .take(MAX_ERROR_DIAGNOSTICS)
+        .map(|diagnostic| MultiOntologyDiagnostic {
+            code: diagnostic.code.as_str().into(),
+            phase: diagnostic.phase.as_str().into(),
+            message: bounded_text(&diagnostic.message),
+            subjects: bounded_items(diagnostic.subjects, diagnostic.limit),
+            candidates: bounded_items(diagnostic.candidates, diagnostic.limit),
+            remediation: remediation_for(diagnostic.code).into(),
+            limit: diagnostic.limit.clamp(1, MAX_ERROR_DIAGNOSTICS),
+        })
+        .collect::<Vec<_>>();
+    diagnostics.sort_by(|left, right| {
+        (&left.code, &left.subjects, &left.candidates).cmp(&(
+            &right.code,
+            &right.subjects,
+            &right.candidates,
+        ))
+    });
+    diagnostics
+}
+
+fn composition_change_error(
+    diagnostics: Vec<crate::CompositionChangeDiagnostic>,
+) -> MultiOntologyError {
+    let diagnostics = diagnostics
+        .into_iter()
+        .take(MAX_ERROR_DIAGNOSTICS)
+        .map(|diagnostic| MultiOntologyDiagnostic {
+            code: diagnostic.code,
+            phase: "preflight".into(),
+            message: "composition preflight contains unresolved diagnostics".into(),
+            subjects: bounded_items(vec![diagnostic.subject], MAX_ERROR_DIAGNOSTICS),
+            candidates: Vec::new(),
+            remediation: bounded_text(&diagnostic.remediation),
+            limit: MAX_ERROR_DIAGNOSTICS,
+        })
+        .collect();
+    MultiOntologyError {
+        code: "GF_ONTOLOGY_DIAGNOSTIC".into(),
+        message: "composition preflight contains unresolved diagnostics".into(),
+        diagnostics,
+    }
+}
+
+fn dependency_blocked_error(preview: &graphforge_ontology::DeletePreview) -> GfError {
+    let mut subjects = preview
+        .dependent_modules
+        .iter()
+        .map(OntologyModuleId::display_ref)
+        .chain(preview.activation_refs.iter().cloned())
+        .chain(preview.bridge_refs.iter().map(BridgeSetId::display_ref))
+        .collect::<Vec<_>>();
+    subjects.push(preview.target.display_ref());
+    MultiOntologyError {
+        code: "GF_ONTOLOGY_DIAGNOSTIC".into(),
+        message: "module deletion is dependency-blocked".into(),
+        diagnostics: vec![MultiOntologyDiagnostic {
+            code: "dependency.in_use".into(),
+            phase: "inventory".into(),
+            message: "module deletion is dependency-blocked".into(),
+            subjects: bounded_items(subjects, MAX_ERROR_DIAGNOSTICS),
+            candidates: Vec::new(),
+            remediation: "remove exact module, bridge, and activation references first".into(),
+            limit: MAX_ERROR_DIAGNOSTICS,
+        }],
+    }
+}
+
+fn portable_error(error: graphforge_storage::PortableV2Error) -> GfError {
+    use graphforge_storage::PortableV2ErrorCode;
+    let (outer, diagnostic, remediation) = match error.code {
+        PortableV2ErrorCode::Cancelled => (
+            "GF_CANCELLED",
+            "lifecycle.cancelled",
+            "retry with an active cancellation token",
+        ),
+        PortableV2ErrorCode::UnsupportedFuture => (
+            "GF_UNSUPPORTED_FUTURE",
+            "interchange.unsupported_future",
+            "upgrade GraphForge or use a supported portable-v2 producer",
+        ),
+        PortableV2ErrorCode::LimitExceeded => (
+            "GF_LIMIT_EXCEEDED",
+            "resource.bytes",
+            "raise an explicit bounded limit or reduce the package",
+        ),
+        PortableV2ErrorCode::ConcurrentMutation => (
+            "GF_IDEMPOTENCY_CONFLICT",
+            "inventory.generation_conflict",
+            "refresh the exact authority state and retry",
+        ),
+        PortableV2ErrorCode::Incompatible => (
+            "GF_VALIDATION",
+            "interchange.selection",
+            "select a compatible portable-v2 ontology candidate",
+        ),
+        PortableV2ErrorCode::Io | PortableV2ErrorCode::InvalidPath => (
+            "GF_STORAGE",
+            "interchange.io",
+            "verify the portable staging authority and retry",
+        ),
+        PortableV2ErrorCode::DigestMismatch
+        | PortableV2ErrorCode::DuplicateEntry
+        | PortableV2ErrorCode::InvalidStructure => (
+            "GF_VALIDATION",
+            "interchange.integrity",
+            "repair and re-import the portable-v2 package",
+        ),
+    };
+    let subjects = error.entry.into_iter().collect::<Vec<_>>();
+    MultiOntologyError {
+        code: outer.into(),
+        message: "portable-v2 ontology staging failed".into(),
+        diagnostics: vec![MultiOntologyDiagnostic {
+            code: diagnostic.into(),
+            phase: "interchange".into(),
+            message: "portable-v2 ontology staging failed".into(),
+            subjects: bounded_items(subjects, MAX_ERROR_DIAGNOSTICS),
+            candidates: Vec::new(),
+            remediation: remediation.into(),
+            limit: MAX_ERROR_DIAGNOSTICS,
+        }],
+    }
+}
+
+fn bounded_text(value: &str) -> String {
+    value.chars().take(MAX_ERROR_TEXT_BYTES).collect()
+}
+
+fn bounded_items(mut values: Vec<String>, requested_limit: usize) -> Vec<String> {
+    values.sort();
+    values.dedup();
+    values.truncate(requested_limit.clamp(1, MAX_ERROR_DIAGNOSTICS));
+    values
+        .into_iter()
+        .map(|value| bounded_text(&value))
+        .collect()
+}
+
+fn remediation_for(code: graphforge_ontology::DiagnosticCode) -> &'static str {
+    use graphforge_ontology::DiagnosticCode;
+    match code {
+        DiagnosticCode::InventoryDuplicate => "select or author one unique exact identity",
+        DiagnosticCode::InventoryNotFound => "select an existing exact inventory identity",
+        DiagnosticCode::InventoryMalformed => "repair and validate the authored document",
+        DiagnosticCode::InventoryGenerationConflict => "refresh the exact authority state",
+        DiagnosticCode::DependencyMissing => "adopt every exact dependency first",
+        DiagnosticCode::DependencyCycle => "remove the dependency cycle",
+        DiagnosticCode::DependencyInUse => "remove dependent authority references first",
+        DiagnosticCode::CollisionQualifiedDuplicate => "remove the conflicting qualified symbol",
+        DiagnosticCode::ResourceModules
+        | DiagnosticCode::ResourceBridges
+        | DiagnosticCode::ResourceSymbols
+        | DiagnosticCode::ResourceDiagnostics => "reduce the request below the registered limit",
+        DiagnosticCode::LifecycleCancelled => "retry with an active cancellation token",
+        DiagnosticCode::LifecycleInvalidTransition => "perform the required prior lifecycle step",
+        DiagnosticCode::ResolutionAmbiguous => "supply an exact qualified selector",
+        DiagnosticCode::ResolutionNotFound | DiagnosticCode::ResolutionKindMismatch => {
+            "select a declared symbol with the correct kind"
+        }
+        DiagnosticCode::InterchangeIntegrity => "repair or regenerate the authenticated content",
+        DiagnosticCode::CollisionMetadata => "retain the required stable identity metadata",
+        DiagnosticCode::BridgeEndpointMissing => "adopt every exact bridge endpoint module",
+        DiagnosticCode::BridgeContradiction => "remove contradictory bridge assertions",
+        DiagnosticCode::BridgeProvenanceMissing => "add bounded authored provenance",
+    }
+}
+
+fn staged_module_document(text: &str, format: ImportFormatHint) -> Result<OntologyDoc, GfError> {
+    match format {
+        ImportFormatHint::Json => graphforge_ontology::OntologyLoader::load_json(text.as_bytes()),
+        ImportFormatHint::Auto if text.trim_start().starts_with('{') => {
+            graphforge_ontology::OntologyLoader::load_json(text.as_bytes())
+        }
+        ImportFormatHint::Yaml | ImportFormatHint::Auto => {
+            graphforge_ontology::OntologyLoader::load_yaml(text.as_bytes())
+        }
+    }
+    .map_err(|_| GfError::Validation("ontology module import is malformed"))
+}
+
+fn reject_duplicate_module(
+    candidate: &WorkspaceOntologyComposition,
+    id: &OntologyModuleId,
+) -> Result<(), GfError> {
+    if candidate.modules.iter().any(|m| m.id == *id) {
+        Err(GfError::Validation("module identity already adopted"))
+    } else {
+        Ok(())
+    }
+}
+fn reject_duplicate_bridge(
+    candidate: &WorkspaceOntologyComposition,
+    id: &BridgeSetId,
+) -> Result<(), GfError> {
+    if candidate
+        .bridges
+        .iter()
+        .filter_map(|document| bridge_id(document).ok())
+        .any(|value| value == *id)
+    {
+        Err(GfError::Validation("bridge identity already adopted"))
+    } else {
+        Ok(())
+    }
+}
+fn resolve_module_index(
+    candidate: &WorkspaceOntologyComposition,
+    selector: &ModuleSelector,
+) -> Result<usize, GfError> {
+    let matches = candidate
+        .modules
+        .iter()
+        .enumerate()
+        .filter(|(_, m)| match selector {
+            ModuleSelector::Exact(id) => m.id == *id,
+            ModuleSelector::OntologyId(id) => m.id.ontology_id == *id,
+        })
+        .map(|(i, _)| i)
+        .collect::<Vec<_>>();
+    match matches.as_slice() {
+        [index] => Ok(*index),
+        [] => Err(GfError::Validation("module not found")),
+        _ => Err(GfError::Validation("module selector is ambiguous")),
+    }
+}
+fn resolve_bridge_index(
+    candidate: &WorkspaceOntologyComposition,
+    selector: &BridgeSelector,
+) -> Result<usize, GfError> {
+    let matches = candidate
+        .bridges
+        .iter()
+        .enumerate()
+        .filter(|(_, d)| match selector {
+            BridgeSelector::Exact(id) => bridge_id(d).is_ok_and(|value| value == *id),
+            BridgeSelector::BridgeId(id) => d.bridge_id == *id,
+        })
+        .map(|(i, _)| i)
+        .collect::<Vec<_>>();
+    match matches.as_slice() {
+        [index] => Ok(*index),
+        [] => Err(GfError::Validation("bridge not found")),
+        _ => Err(GfError::Validation("bridge selector is ambiguous")),
+    }
+}
+fn rewrite_module_identity(
+    candidate: &mut WorkspaceOntologyComposition,
+    prior: &OntologyModuleId,
+    next: &OntologyModuleId,
+) -> Result<(), GfError> {
+    let prior_bridge_ids = candidate
+        .bridges
+        .iter()
+        .map(bridge_id)
+        .collect::<Result<Vec<_>, _>>()?;
+    for module in &mut candidate.modules {
+        for dep in &mut module.dependencies {
+            if dep == prior {
+                *dep = next.clone();
+            }
+        }
+    }
+    for bridge in &mut candidate.bridges {
+        for id in bridge
+            .source_modules
+            .iter_mut()
+            .chain(bridge.target_modules.iter_mut())
+        {
+            if id == prior {
+                *id = next.clone();
+            }
+        }
+        for assertion in &mut bridge.assertions {
+            if assertion.source.module == *prior {
+                assertion.source.module = next.clone();
+            }
+            if assertion.target.module == *prior {
+                assertion.target.module = next.clone();
+            }
+        }
+    }
+    for record in &mut candidate.activation {
+        if record.subject == prior.display_ref() {
+            record.subject = next.display_ref();
+        }
+    }
+    cascade_bridge_identities(candidate, prior_bridge_ids)
+}
+
+fn cascade_bridge_identities(
+    candidate: &mut WorkspaceOntologyComposition,
+    mut prior_ids: Vec<BridgeSetId>,
+) -> Result<(), GfError> {
+    for _ in 0..=candidate.bridges.len() {
+        let current_ids = candidate
+            .bridges
+            .iter()
+            .map(bridge_id)
+            .collect::<Result<Vec<_>, _>>()?;
+        let changes = prior_ids
+            .iter()
+            .zip(&current_ids)
+            .filter(|(prior, current)| prior != current)
+            .map(|(prior, current)| (prior.clone(), current.clone()))
+            .collect::<Vec<_>>();
+        if changes.is_empty() {
+            return Ok(());
+        }
+        for bridge in &mut candidate.bridges {
+            for dependency in &mut bridge.dependencies {
+                if let Some((_, replacement)) =
+                    changes.iter().find(|(prior, _)| dependency == prior)
+                {
+                    *dependency = replacement.clone();
+                }
+            }
+        }
+        for record in &mut candidate.activation {
+            if let Some((_, replacement)) = changes
+                .iter()
+                .find(|(prior, _)| record.subject == prior.display_ref())
+            {
+                record.subject = replacement.display_ref();
+            }
+        }
+        prior_ids = current_ids;
+    }
+    Err(GfError::Validation(
+        "bridge identity cascade did not converge",
+    ))
+}
+fn set_module_activation(
+    candidate: &mut WorkspaceOntologyComposition,
+    id: &OntologyModuleId,
+    mode: Option<ActivationMode>,
+) {
+    candidate
+        .activation
+        .retain(|r| !(r.scope == ActivationScope::Module && r.subject == id.display_ref()));
+    if let Some(mode) = mode {
+        candidate.activation.push(ActivationRecord {
+            scope: ActivationScope::Module,
+            subject: id.display_ref(),
+            mode,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::OperationId;
+    use graphforge_ontology::{DiagnosticCode, DiagnosticLimit, EntityTypeDef};
+    use sha2::{Digest, Sha256};
+    use std::sync::atomic::AtomicBool;
+
+    fn document(ontology_id: &str, entity: &str) -> OntologyDoc {
+        OntologyDoc {
+            ontology_id: ontology_id.into(),
+            version: "1".into(),
+            entity_types: vec![EntityTypeDef {
+                name: entity.into(),
+                r#abstract: false,
+                parent: None,
+            }],
+            relation_types: Vec::new(),
+            properties: Vec::new(),
+            constraints: Vec::new(),
+            migrations: Vec::new(),
+        }
+    }
+
+    fn expectation(graph: &GraphForge, seed: u128) -> OntologyAuthorityExpectation {
+        let state = graph.ontology_authority_state().unwrap();
+        OntologyAuthorityExpectation {
+            context: WriteContext {
+                operation_uuid: OperationId(Uuid::from_u128(seed)),
+                actor_uuid: None,
+            },
+            expected_project_generation_uuid: state.project_generation_uuid,
+            expected_composition_fingerprint: state.composition_fingerprint,
+        }
+    }
+
+    fn parity_fixture() -> serde_json::Value {
+        serde_json::from_str(include_str!(
+            "../../../tests/fixtures/multi-ontology-v1/binding-parity-v1.json"
+        ))
+        .unwrap()
+    }
+
+    fn sha256_hex(bytes: &[u8]) -> String {
+        use std::fmt::Write as _;
+        let digest = Sha256::digest(bytes);
+        let mut encoded = String::with_capacity(digest.len() * 2);
+        for byte in digest {
+            write!(&mut encoded, "{byte:02x}").unwrap();
+        }
+        encoded
+    }
+
+    fn future_portable_package() -> tempfile::TempDir {
+        const MANIFEST_PATH: &str = "data/graphforge-project.json";
+        const PAYLOAD_PATH: &str = "data/components/ontology/core-ontology/ontology.json";
+        const BAGIT: &[u8] = b"BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8\n";
+        const BAG_INFO: &[u8] =
+            b"Bag-Software-Agent: GraphForge portable-v2\nBagging-Date: 1970-01-01\n";
+
+        let root = tempfile::tempdir().unwrap();
+        let mut manifest: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../tests/fixtures/portable-v2/ontology-only.manifest.json"
+        ))
+        .unwrap();
+        manifest["package_class"] = "future-package-class".into();
+        manifest.as_object_mut().unwrap().remove("package_digest");
+        let semantic = serde_json::to_vec(&manifest).unwrap();
+        manifest["package_digest"] = format!(
+            "sha256:{}",
+            sha256_hex(&[b"graphforge-project/2\0".as_slice(), semantic.as_slice()].concat())
+        )
+        .into();
+        let manifest_bytes = serde_json::to_vec(&manifest).unwrap();
+        let manifest_path = root.path().join(MANIFEST_PATH);
+        std::fs::create_dir_all(manifest_path.parent().unwrap()).unwrap();
+        std::fs::write(&manifest_path, &manifest_bytes).unwrap();
+        let payload = root.path().join(PAYLOAD_PATH);
+        std::fs::create_dir_all(payload.parent().unwrap()).unwrap();
+        std::fs::write(payload, b"{}").unwrap();
+        std::fs::write(root.path().join("bagit.txt"), BAGIT).unwrap();
+        std::fs::write(root.path().join("bag-info.txt"), BAG_INFO).unwrap();
+        let data_manifest = format!(
+            "{}  {PAYLOAD_PATH}\n{}  {MANIFEST_PATH}\n",
+            sha256_hex(b"{}"),
+            sha256_hex(&manifest_bytes)
+        );
+        std::fs::write(root.path().join("manifest-sha256.txt"), &data_manifest).unwrap();
+        let tag_manifest = format!(
+            "{}  bag-info.txt\n{}  bagit.txt\n{}  manifest-sha256.txt\n",
+            sha256_hex(BAG_INFO),
+            sha256_hex(BAGIT),
+            sha256_hex(data_manifest.as_bytes())
+        );
+        std::fs::write(root.path().join("tagmanifest-sha256.txt"), tag_manifest).unwrap();
+        root
+    }
+
+    fn observed_unsupported_future_error() -> MultiOntologyError {
+        let package = future_portable_package();
+        let error = crate::verify_portable_v2(
+            &crate::PortableVerifyRequest {
+                input: package.path().to_path_buf(),
+                mode: graphforge_storage::PortableV2Mode::Full,
+                limits: graphforge_storage::PortableV2Limits::default(),
+            },
+            None,
+        )
+        .unwrap_err();
+        MultiOntologyError::from(error)
+    }
+
+    fn parity_document(name: &str) -> OntologyDoc {
+        serde_json::from_value(parity_fixture()["modules"][name].clone()).unwrap()
+    }
+
+    fn adopt_parity_module(
+        graph: &mut GraphForge,
+        name: &str,
+        dependencies: Vec<OntologyModuleId>,
+        seed: u128,
+    ) -> ModuleCandidate {
+        let candidate = graph
+            .create_ontology_module(parity_document(name), dependencies, None)
+            .unwrap();
+        graph
+            .adopt_ontology_module(
+                &ModuleAdoptionRequest {
+                    authority: expectation(graph, seed),
+                    candidate: candidate.clone(),
+                },
+                None,
+            )
+            .unwrap();
+        candidate
+    }
+
+    fn parity_bridge(base: &OntologyModuleId, dependent: &OntologyModuleId) -> BridgeDocument {
+        let mut encoded = serde_json::to_string(&parity_fixture()["bridge"]).unwrap();
+        encoded = encoded.replace("\"$base\"", &serde_json::to_string(base).unwrap());
+        encoded = encoded.replace("\"$dependent\"", &serde_json::to_string(dependent).unwrap());
+        serde_json::from_str(&encoded).unwrap()
+    }
+
+    fn adopt_parity_pair(graph: &mut GraphForge, seed: u128) -> (ModuleCandidate, ModuleCandidate) {
+        let base = adopt_parity_module(graph, "base", Vec::new(), seed);
+        let dependent = adopt_parity_module(graph, "dependent", vec![base.id.clone()], seed + 1);
+        (base, dependent)
+    }
+
+    /// Executable Rust-side inventory for every operation in the four-surface contract.
+    #[test]
+    fn four_surface_operation_conformance() {
+        // Contract authority: tests/contracts/multi-ontology-surface-v1.json
+        let contract: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../tests/contracts/multi-ontology-surface-v1.json"
+        ))
+        .expect("four-surface contract must parse");
+        assert_eq!(
+            contract["contract"],
+            "graphforge-multi-ontology-four-surface/1"
+        );
+        let operations = contract["operations"]
+            .as_array()
+            .expect("operations must be an array");
+        assert_eq!(operations.len(), 35);
+        let actual = operations
+            .iter()
+            .map(|operation| {
+                (
+                    operation["id"].as_str().expect("operation id"),
+                    operation["rust"].as_str().expect("Rust member"),
+                )
+            })
+            .collect::<Vec<_>>();
+        let expected = [
+            ("module.list", "GraphForge.ontology_modules"),
+            ("module.get", "GraphForge.inspect_ontology_module[exact]"),
+            (
+                "module.inspect",
+                "GraphForge.inspect_ontology_module[selector]",
+            ),
+            ("module.validate", "GraphForge.validate_ontology_module"),
+            (
+                "module.create_register",
+                "GraphForge.create_ontology_module",
+            ),
+            ("module.import", "GraphForge.import_ontology_module"),
+            ("module.adopt", "GraphForge.adopt_ontology_module"),
+            (
+                "module.preview_update",
+                "GraphForge.preview_update_ontology_module",
+            ),
+            ("module.update_replace", "GraphForge.update_ontology_module"),
+            (
+                "module.preview_delete",
+                "GraphForge.preview_delete_ontology_module",
+            ),
+            ("module.delete", "GraphForge.delete_ontology_module"),
+            ("module.export", "GraphForge.export_ontology_module"),
+            ("bridge.list", "GraphForge.ontology_bridges"),
+            ("bridge.get", "GraphForge.inspect_ontology_bridge[exact]"),
+            (
+                "bridge.inspect",
+                "GraphForge.inspect_ontology_bridge[selector]",
+            ),
+            ("bridge.validate", "GraphForge.validate_ontology_bridge"),
+            (
+                "bridge.create_register",
+                "GraphForge.create_ontology_bridge",
+            ),
+            ("bridge.import", "GraphForge.import_ontology_bridge"),
+            ("bridge.adopt", "GraphForge.adopt_ontology_bridge"),
+            (
+                "bridge.preview_update",
+                "GraphForge.preview_update_ontology_bridge",
+            ),
+            ("bridge.update_replace", "GraphForge.update_ontology_bridge"),
+            (
+                "bridge.preview_delete",
+                "GraphForge.preview_delete_ontology_bridge",
+            ),
+            ("bridge.delete", "GraphForge.delete_ontology_bridge"),
+            ("bridge.export", "GraphForge.export_ontology_bridge"),
+            (
+                "activation.inspect",
+                "GraphForge.ontology_activation_profile",
+            ),
+            (
+                "activation.change",
+                "GraphForge.change_ontology_activation_profile",
+            ),
+            (
+                "composition.validate",
+                "GraphForge.validate_ontology_composition",
+            ),
+            (
+                "composition.preflight",
+                "GraphForge.preflight_ontology_composition",
+            ),
+            (
+                "composition.resolution_explain",
+                "GraphForge.explain_ontology_resolution",
+            ),
+            (
+                "portable.inspect",
+                "crate.verify_portable_v2[structure_only]",
+            ),
+            ("portable.verify", "crate.verify_portable_v2[full]"),
+            ("portable.export", "GraphForge.export_portable_v2"),
+            ("portable.import", "GraphForge.import_portable_v2"),
+            (
+                "portable.post_import_inspect",
+                "GraphForge.portable_ontology_staging",
+            ),
+            (
+                "portable.post_import_adopt",
+                "GraphForge.adopt_portable_ontology_staging",
+            ),
+        ];
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn portable_error_conversion_is_complete_and_stable() {
+        use graphforge_storage::{PortableV2Error, PortableV2ErrorCode};
+        let cases = [
+            (
+                PortableV2ErrorCode::Cancelled,
+                "GF_CANCELLED",
+                "lifecycle.cancelled",
+            ),
+            (
+                PortableV2ErrorCode::LimitExceeded,
+                "GF_LIMIT_EXCEEDED",
+                "resource.bytes",
+            ),
+            (PortableV2ErrorCode::Io, "GF_STORAGE", "interchange.io"),
+            (
+                PortableV2ErrorCode::InvalidStructure,
+                "GF_VALIDATION",
+                "interchange.integrity",
+            ),
+            (
+                PortableV2ErrorCode::InvalidPath,
+                "GF_STORAGE",
+                "interchange.io",
+            ),
+            (
+                PortableV2ErrorCode::DuplicateEntry,
+                "GF_VALIDATION",
+                "interchange.integrity",
+            ),
+            (
+                PortableV2ErrorCode::UnsupportedFuture,
+                "GF_UNSUPPORTED_FUTURE",
+                "interchange.unsupported_future",
+            ),
+            (
+                PortableV2ErrorCode::Incompatible,
+                "GF_VALIDATION",
+                "interchange.selection",
+            ),
+            (
+                PortableV2ErrorCode::DigestMismatch,
+                "GF_VALIDATION",
+                "interchange.integrity",
+            ),
+            (
+                PortableV2ErrorCode::ConcurrentMutation,
+                "GF_IDEMPOTENCY_CONFLICT",
+                "inventory.generation_conflict",
+            ),
+        ];
+        for (source, outer, diagnostic) in cases {
+            let error = MultiOntologyError::from(PortableV2Error::new(source, "test"));
+            assert_eq!(error.code, outer);
+            assert_eq!(error.diagnostics[0].code, diagnostic);
+        }
+    }
+
+    #[test]
+    fn conformance_positive_crud_import_export() {
+        let mut graph = GraphForge::new(None).unwrap();
+        let base = graph
+            .create_ontology_module(parity_document("base"), Vec::new(), None)
+            .unwrap();
+        let imported = graph
+            .import_ontology_module(
+                &serde_json::to_string(&parity_document("dependent")).unwrap(),
+                ImportFormatHint::Json,
+                vec![base.id.clone()],
+            )
+            .unwrap();
+        graph
+            .adopt_ontology_module(
+                &ModuleAdoptionRequest {
+                    authority: expectation(&graph, 9_001),
+                    candidate: base.clone(),
+                },
+                None,
+            )
+            .unwrap();
+        graph
+            .adopt_ontology_module(
+                &ModuleAdoptionRequest {
+                    authority: expectation(&graph, 9_002),
+                    candidate: imported.clone(),
+                },
+                None,
+            )
+            .unwrap();
+        assert_eq!(graph.ontology_modules().unwrap().len(), 2);
+        assert!(
+            graph
+                .export_ontology_module(&ModuleSelector::Exact(base.id.clone()), ExportFormat::Json)
+                .unwrap()
+                .contains("Person")
+        );
+        let bridge = graph
+            .create_ontology_bridge(parity_bridge(&base.id, &imported.id))
+            .unwrap();
+        graph
+            .adopt_ontology_bridge(
+                &BridgeAdoptionRequest {
+                    authority: expectation(&graph, 9_003),
+                    candidate: bridge.clone(),
+                },
+                None,
+            )
+            .unwrap();
+        assert_eq!(
+            graph
+                .inspect_ontology_bridge(&BridgeSelector::Exact(bridge.id.clone()))
+                .unwrap()
+                .entry
+                .id,
+            bridge.id
+        );
+        let exported = graph
+            .export_ontology_bridge(&BridgeSelector::Exact(bridge.id), BridgeExportFormat::Json)
+            .unwrap();
+        assert!(exported.contains("urn:graphforge:parity:bridge")); // export_ontology_bridge
+    }
+
+    #[test]
+    fn conformance_exact_identity_and_ambiguity() {
+        let mut inventory = OntologyInventory::default();
+        let first = inventory
+            .create_register(parity_document("dependent"), Vec::new(), None, "first")
+            .unwrap();
+        let second = inventory
+            .create_register(
+                parity_document("dependent_update"),
+                Vec::new(),
+                None,
+                "second",
+            )
+            .unwrap();
+        inventory
+            .adopt(&ModuleSelector::Exact(first.clone()), 0, "adopt-first")
+            .unwrap();
+        inventory
+            .adopt(&ModuleSelector::Exact(second.clone()), 1, "adopt-second")
+            .unwrap();
+        assert_eq!(
+            inventory
+                .inspect(&ModuleSelector::Exact(first.clone()))
+                .unwrap()
+                .entry
+                .id,
+            first
+        );
+        let error = inventory
+            .inspect(&ModuleSelector::OntologyId(second.ontology_id))
+            .unwrap_err();
+        assert_eq!(error.code(), Some(DiagnosticCode::ResolutionAmbiguous));
+        // OntologyModuleSelector exact selection succeeds; SelectorAmbiguous fails closed.
+    }
+
+    #[test]
+    fn conformance_dependency_blocked_deletion() {
+        let mut graph = GraphForge::new(None).unwrap();
+        let (base, dependent) = adopt_parity_pair(&mut graph, 9_020);
+        let bridge = graph
+            .create_ontology_bridge(parity_bridge(&base.id, &dependent.id))
+            .unwrap();
+        graph
+            .adopt_ontology_bridge(
+                &BridgeAdoptionRequest {
+                    authority: expectation(&graph, 9_022),
+                    candidate: bridge.clone(),
+                },
+                None,
+            )
+            .unwrap();
+        let preview = graph
+            .preview_delete_ontology_module(&ModuleSelector::Exact(base.id.clone()))
+            .unwrap();
+        assert!(!preview.safe);
+        assert_eq!(preview.dependent_modules, vec![dependent.id]);
+        assert_eq!(preview.bridge_refs, vec![bridge.id]);
+        let error = graph
+            .delete_ontology_module(
+                &ModuleDeleteRequest {
+                    authority: expectation(&graph, 9_023),
+                    selector: ModuleSelector::Exact(base.id),
+                },
+                None,
+            )
+            .unwrap_err();
+        assert_eq!(error.diagnostics[0].code, "dependency.in_use"); // DependencyBlocked
+    }
+
+    #[test]
+    fn conformance_unsupported_future_portability() {
+        let error = observed_unsupported_future_error();
+        assert_eq!(error.code, "GF_UNSUPPORTED_FUTURE");
+        assert_eq!(error.diagnostics[0].code, "interchange.unsupported_future");
+        let cancelled = AtomicBool::new(false);
+        let missing = crate::verify_portable_v2(
+            &crate::PortableVerifyRequest {
+                input: std::path::PathBuf::from("missing-portable-v2"),
+                mode: graphforge_storage::PortableV2Mode::StructureOnly,
+                limits: graphforge_storage::PortableV2Limits::default(),
+            },
+            Some(&cancelled),
+        )
+        .unwrap_err();
+        assert_ne!(
+            missing.code,
+            graphforge_storage::PortableV2ErrorCode::UnsupportedFuture
+        ); // UnsupportedFutureVersion mapping is distinct.
+    }
+
+    #[test]
+    fn conformance_cancellation() {
+        let mut graph = GraphForge::new(None).unwrap();
+        let candidate = graph
+            .create_ontology_module(parity_document("base"), Vec::new(), None)
+            .unwrap();
+        let before = graph.ontology_authority_state().unwrap();
+        let token = CancellationToken::new();
+        token.cancel();
+        let error = graph
+            .adopt_ontology_module(
+                &ModuleAdoptionRequest {
+                    authority: expectation(&graph, 9_030),
+                    candidate,
+                },
+                Some(&token),
+            )
+            .unwrap_err();
+        assert_eq!(error.code(), "GF_CANCELLED");
+        assert_eq!(graph.ontology_authority_state().unwrap(), before);
+    }
+
+    #[test]
+    fn conformance_idempotent_replay() {
+        let mut graph = GraphForge::new(None).unwrap();
+        let candidate = graph
+            .create_ontology_module(parity_document("base"), Vec::new(), None)
+            .unwrap();
+        let request = ModuleAdoptionRequest {
+            authority: expectation(&graph, 9_040),
+            candidate,
+        };
+        let first = graph.adopt_ontology_module(&request, None).unwrap();
+        let replay = graph.adopt_ontology_module(&request, None).unwrap();
+        assert_eq!(first, replay); // IdempotentReplay uses the same operation_uuid.
+        let mut actor = request.clone();
+        actor.authority.context.actor_uuid = Some(Uuid::from_u128(77));
+        assert_eq!(
+            graph
+                .adopt_ontology_module(&actor, None)
+                .unwrap_err()
+                .code(),
+            "GF_IDEMPOTENCY_CONFLICT"
+        );
+        let cross_op = ActivationProfileChangeRequest {
+            authority: request.authority,
+            profile_default: ActivationMode::Strict,
+            activation: Vec::new(),
+        };
+        assert_eq!(
+            graph
+                .change_ontology_activation_profile(&cross_op, None)
+                .unwrap_err()
+                .code(),
+            "GF_IDEMPOTENCY_CONFLICT"
+        );
+    }
+
+    #[test]
+    fn durable_reopen_reconstructs_candidate_before_exact_replay() {
+        let project = tempfile::tempdir().unwrap();
+        let path = project.path().to_str().unwrap();
+        let mut first = GraphForge::new(Some(path)).unwrap();
+        let candidate = first
+            .create_ontology_module(parity_document("base"), Vec::new(), None)
+            .unwrap();
+        let request = ModuleAdoptionRequest {
+            authority: expectation(&first, 9_045),
+            candidate,
+        };
+        let receipt = first.adopt_ontology_module(&request, None).unwrap();
+        drop(first);
+
+        let mut reopened = GraphForge::new(Some(path)).unwrap();
+        let reconstructed = reopened
+            .create_ontology_module(parity_document("base"), Vec::new(), None)
+            .unwrap();
+        let replay = reopened
+            .adopt_ontology_module(
+                &ModuleAdoptionRequest {
+                    authority: request.authority,
+                    candidate: reconstructed,
+                },
+                None,
+            )
+            .unwrap();
+        assert_eq!(replay, receipt);
+    }
+
+    #[test]
+    fn version_only_module_update_preserves_semantic_storage_bindings() {
+        let mut graph = GraphForge::new(None).unwrap();
+        let (base, dependent) = adopt_parity_pair(&mut graph, 9_046);
+        let receipt = graph
+            .update_ontology_module(
+                &ModuleUpdateRequest {
+                    authority: expectation(&graph, 9_048),
+                    selector: ModuleSelector::Exact(dependent.id),
+                    document: parity_document("dependent_update"),
+                    dependencies: vec![base.id],
+                    enforcement: None,
+                },
+                None,
+            )
+            .unwrap();
+        assert_eq!(
+            graph
+                .ontology_authority_state()
+                .unwrap()
+                .project_generation_uuid,
+            receipt.project_generation_uuid
+        );
+    }
+
+    #[test]
+    fn conformance_no_partial_import_or_authority_change() {
+        let mut graph = GraphForge::new(None).unwrap();
+        let before = graph.ontology_authority_state().unwrap();
+        assert!(
+            graph
+                .import_ontology_module("{bad", ImportFormatHint::Json, Vec::new())
+                .is_err()
+        );
+        assert_eq!(graph.ontology_authority_state().unwrap(), before);
+        assert!(
+            graph
+                .adopt_portable_ontology_staging(
+                    &expectation(&graph, 9_050),
+                    graphforge_storage::PortableV2Limits::default(),
+                    None
+                )
+                .is_err()
+        );
+        assert_eq!(graph.ontology_authority_state().unwrap(), before); // NoAuthorityChange
+    }
+
+    #[test]
+    fn failing_portable_v2_import_is_atomic_and_preserves_authority() {
+        let project = tempfile::tempdir().unwrap();
+        let path = project.path().to_str().unwrap();
+        let graph = GraphForge::new(Some(path)).unwrap();
+        let before = graph.ontology_authority_state().unwrap();
+        drop(graph);
+        let invalid = project.path().join("invalid.gfpb");
+        std::fs::write(&invalid, b"not-a-portable-v2-package").unwrap();
+        let error = GraphForge::import_portable_v2(
+            project.path(),
+            &crate::PortableV2ImportRequest {
+                input: invalid,
+                operation_id: OperationId(Uuid::from_u128(9_051)),
+                limits: graphforge_storage::PortableV2Limits::default(),
+            },
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(
+            error.code,
+            graphforge_storage::PortableV2ErrorCode::InvalidStructure
+        );
+        let reopened = GraphForge::new(Some(path)).unwrap();
+        assert_eq!(reopened.ontology_authority_state().unwrap(), before);
+        assert!(
+            reopened
+                .portable_ontology_staging(graphforge_storage::PortableV2Limits::default())
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn validation_receipts_are_rust_owned_and_structured() {
+        let graph = GraphForge::new(None).unwrap();
+        let valid = graph
+            .validate_ontology_module(&parity_document("base"))
+            .unwrap();
+        assert!(valid.valid);
+        assert!(valid.diagnostics.is_empty());
+        let mut invalid = parity_document("base");
+        invalid.entity_types.push(invalid.entity_types[0].clone());
+        let receipt = graph.validate_ontology_module(&invalid).unwrap();
+        assert!(!receipt.valid);
+        assert_eq!(receipt.diagnostics[0].code, "inventory.malformed");
+        assert_eq!(
+            serde_json::from_str::<MultiOntologyValidationReceipt>(
+                &serde_json::to_string(&receipt).unwrap()
+            )
+            .unwrap(),
+            receipt
+        );
+    }
+
+    #[test]
+    fn writes_canonical_rust_semantic_parity_report_when_requested() {
+        use std::collections::BTreeMap;
+        let mut cases = BTreeMap::new();
+        let mut graph = GraphForge::new(None).unwrap();
+        let (base, dependent) = adopt_parity_pair(&mut graph, 9_100);
+        let module_export = graph
+            .export_ontology_module(&ModuleSelector::Exact(base.id.clone()), ExportFormat::Json)
+            .unwrap();
+        let bridge_doc = parity_bridge(&base.id, &dependent.id);
+        let bridge = graph.create_ontology_bridge(bridge_doc.clone()).unwrap();
+        graph
+            .adopt_ontology_bridge(
+                &BridgeAdoptionRequest {
+                    authority: expectation(&graph, 9_102),
+                    candidate: bridge.clone(),
+                },
+                None,
+            )
+            .unwrap();
+        let bridge_export = graph
+            .export_ontology_bridge(
+                &BridgeSelector::Exact(bridge.id.clone()),
+                BridgeExportFormat::Json,
+            )
+            .unwrap();
+        cases.insert("positive_crud_import_export".into(), serde_json::json!({
+            "module_ids": [base.id.ontology_id, dependent.id.ontology_id],
+            "bridge_id": bridge.id.bridge_id,
+            "module_export_match": serde_json::from_str::<serde_json::Value>(&module_export).unwrap() == serde_json::to_value(parity_document("base")).unwrap(),
+            "bridge_export_match": serde_json::from_str::<serde_json::Value>(&bridge_export).unwrap() == serde_json::to_value(bridge_doc).unwrap()
+        }));
+        let blocked = graph
+            .preview_delete_ontology_module(&ModuleSelector::Exact(base.id.clone()))
+            .unwrap();
+        let blocked_error = graph
+            .delete_ontology_module(
+                &ModuleDeleteRequest {
+                    authority: expectation(&graph, 9_103),
+                    selector: ModuleSelector::Exact(base.id.clone()),
+                },
+                None,
+            )
+            .unwrap_err();
+        cases.insert(
+            "dependency_blocked_deletion".into(),
+            serde_json::json!({"safe": blocked.safe, "diagnostic_code": blocked_error.diagnostics[0].code}),
+        );
+
+        let mut inventory = OntologyInventory::default();
+        let exact = inventory
+            .create_register(parity_document("dependent"), Vec::new(), None, "one")
+            .unwrap();
+        let other = inventory
+            .create_register(parity_document("dependent_update"), Vec::new(), None, "two")
+            .unwrap();
+        inventory
+            .adopt(&ModuleSelector::Exact(exact.clone()), 0, "a")
+            .unwrap();
+        inventory
+            .adopt(&ModuleSelector::Exact(other.clone()), 1, "b")
+            .unwrap();
+        let exact_match = inventory.inspect(&ModuleSelector::Exact(exact)).is_ok();
+        let ambiguity = inventory
+            .inspect(&ModuleSelector::OntologyId(other.ontology_id))
+            .unwrap_err();
+        cases.insert("exact_identity_and_ambiguity".into(), serde_json::json!({"exact_match": exact_match, "diagnostic_code": ambiguity.code().unwrap().as_str()}));
+
+        let unsupported = observed_unsupported_future_error();
+        cases.insert("unsupported_future_portability".into(), serde_json::json!({"error_code": unsupported.code, "diagnostic_code": unsupported.diagnostics[0].code}));
+
+        let mut cancelled_graph = GraphForge::new(None).unwrap();
+        let cancellation_before = cancelled_graph.ontology_authority_state().unwrap();
+        let cancel_candidate = cancelled_graph
+            .create_ontology_module(parity_document("base"), Vec::new(), None)
+            .unwrap();
+        let token = CancellationToken::new();
+        token.cancel();
+        let cancelled = cancelled_graph
+            .adopt_ontology_module(
+                &ModuleAdoptionRequest {
+                    authority: expectation(&cancelled_graph, 9_110),
+                    candidate: cancel_candidate,
+                },
+                Some(&token),
+            )
+            .unwrap_err();
+        cases.insert("cancellation".into(), serde_json::json!({"error_code": cancelled.code, "authority_unchanged": cancelled_graph.ontology_authority_state().unwrap() == cancellation_before}));
+
+        let mut replay_graph = GraphForge::new(None).unwrap();
+        let replay_candidate = replay_graph
+            .create_ontology_module(parity_document("base"), Vec::new(), None)
+            .unwrap();
+        let replay_request = ModuleAdoptionRequest {
+            authority: expectation(&replay_graph, 9_120),
+            candidate: replay_candidate,
+        };
+        let first = replay_graph
+            .adopt_ontology_module(&replay_request, None)
+            .unwrap();
+        let same_receipt = replay_graph
+            .adopt_ontology_module(&replay_request, None)
+            .unwrap()
+            == first;
+        let mut conflict = replay_request;
+        conflict.authority.context.actor_uuid = Some(Uuid::from_u128(1));
+        let conflict_code = replay_graph
+            .adopt_ontology_module(&conflict, None)
+            .unwrap_err()
+            .code;
+        cases.insert(
+            "idempotent_replay".into(),
+            serde_json::json!({"same_receipt": same_receipt, "conflict_code": conflict_code}),
+        );
+
+        let project = tempfile::tempdir().unwrap();
+        let durable = GraphForge::new(Some(project.path().to_str().unwrap())).unwrap();
+        let import_before = durable.ontology_authority_state().unwrap();
+        drop(durable);
+        let invalid = project.path().join("invalid.gfpb");
+        std::fs::write(&invalid, b"invalid").unwrap();
+        assert!(
+            GraphForge::import_portable_v2(
+                project.path(),
+                &crate::PortableV2ImportRequest {
+                    input: invalid,
+                    operation_id: OperationId(Uuid::from_u128(9_130)),
+                    limits: graphforge_storage::PortableV2Limits::default()
+                },
+                None
+            )
+            .is_err()
+        );
+        let durable = GraphForge::new(Some(project.path().to_str().unwrap())).unwrap();
+        let unchanged = durable.ontology_authority_state().unwrap() == import_before;
+        cases.insert(
+            "no_partial_import_or_authority_change".into(),
+            serde_json::json!({"target_unchanged": unchanged, "authority_unchanged": unchanged}),
+        );
+
+        let bounded = dependency_blocked_error(&blocked);
+        let bounded_json = serde_json::to_string(&bounded).unwrap();
+        cases.insert("bounded_structured_diagnostics".into(), serde_json::json!({"outer_code": bounded.code, "diagnostic_code": bounded.diagnostics[0].code, "bounded": bounded.diagnostics.len() <= MAX_ERROR_DIAGNOSTICS, "path_free": !bounded_json.contains("/Users/")}));
+        cases.insert("deterministic_path_free_cli_json".into(), serde_json::json!({"deterministic": bounded_json == serde_json::to_string(&bounded).unwrap(), "path_free": !bounded_json.contains("/Users/")}));
+        cases.insert("packaged_clean_install".into(), serde_json::json!({"semantic_smoke": GraphForge::new(None).unwrap().ontology_modules().is_ok()}));
+
+        let report = MultiOntologyParityReport {
+            contract: "graphforge-multi-ontology-parity-result/1".into(),
+            cases,
+        };
+        assert_eq!(report.cases.len(), 10);
+        if let Ok(path) = std::env::var("GRAPHFORGE_MULTI_ONTOLOGY_PARITY_REPORT") {
+            std::fs::write(path, serde_json::to_vec(&report).unwrap()).unwrap();
+        }
+    }
+
+    #[test]
+    fn conformance_bounded_structured_diagnostics() {
+        let values: Vec<String> = (0..100)
+            .map(|index| format!("subject-{index:03}"))
+            .collect();
+        let error = composition_error(graphforge_ontology::CompositionError::one(
+            CompositionDiagnostic::new(
+                DiagnosticCode::ResolutionAmbiguous,
+                "ambiguous",
+                values.clone(),
+                values,
+                DiagnosticLimit { max_candidates: 2 },
+            ),
+        ));
+        assert_eq!(error.diagnostics.len(), 1);
+        assert_eq!(error.diagnostics[0].limit, 2);
+        assert_eq!(error.diagnostics[0].subjects.len(), 2);
+        assert_eq!(error.diagnostics[0].candidates.len(), 2);
+    }
+
+    #[test]
+    fn conformance_deterministic_path_free_serialization() {
+        let document = parity_document("base");
+        let error = dependency_blocked_error(&graphforge_ontology::DeletePreview {
+            source_generation: 1,
+            target: OntologyModuleId {
+                ontology_id: document.ontology_id.clone(),
+                authored_version: document.version.clone(),
+                canonical_digest: graphforge_ontology::module_document_digest(&document).unwrap(),
+            },
+            dependent_modules: Vec::new(),
+            activation_refs: vec!["module:stable".into()],
+            bridge_refs: Vec::new(),
+            safe: false,
+        });
+        let first = serde_json::to_string(&error).unwrap();
+        let second = serde_json::to_string(&error).unwrap();
+        assert_eq!(first, second);
+        assert!(!first.contains("/Users/"));
+        assert!(
+            serde_json::to_string(&OntologyAuthorityState {
+                project_generation_uuid: Uuid::nil(),
+                composition_fingerprint: None
+            })
+            .unwrap()
+            .contains("project_generation_uuid")
+        );
+    }
+
+    #[test]
+    fn conformance_packaged_rust_surface() {
+        let graph = GraphForge::new(None).unwrap();
+        assert!(graph.ontology_modules().unwrap().is_empty());
+        assert!(
+            graph
+                .portable_ontology_staging(graphforge_storage::PortableV2Limits::default())
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn rust_facade_bootstrap_replay_resolution_and_dependency_blocker() {
+        let project = tempfile::tempdir().unwrap();
+        let mut graph = GraphForge::new(Some(project.path().to_str().unwrap())).unwrap();
+        assert!(graph.ontology_modules().unwrap().is_empty());
+
+        let parent = graph
+            .create_ontology_module(
+                document("https://example.test/parent", "Person"),
+                Vec::new(),
+                None,
+            )
+            .unwrap();
+        let adopt_parent = ModuleAdoptionRequest {
+            authority: expectation(&graph, 842_001),
+            candidate: parent.clone(),
+        };
+        let published = graph.adopt_ontology_module(&adopt_parent, None).unwrap();
+        let replayed = graph.adopt_ontology_module(&adopt_parent, None).unwrap();
+        assert_eq!(published, replayed);
+
+        let mut changed_actor = adopt_parent.clone();
+        changed_actor.authority.context.actor_uuid = Some(Uuid::from_u128(842_901));
+        assert_eq!(
+            graph
+                .adopt_ontology_module(&changed_actor, None)
+                .unwrap_err()
+                .code(),
+            "GF_IDEMPOTENCY_CONFLICT"
+        );
+        let mut changed_authority = adopt_parent.clone();
+        changed_authority.authority.expected_project_generation_uuid = Uuid::from_u128(842_902);
+        assert_eq!(
+            graph
+                .adopt_ontology_module(&changed_authority, None)
+                .unwrap_err()
+                .code(),
+            "GF_IDEMPOTENCY_CONFLICT"
+        );
+
+        let child = graph
+            .create_ontology_module(
+                document("https://example.test/child", "Organization"),
+                vec![parent.id.clone()],
+                None,
+            )
+            .unwrap();
+        let child_authority = expectation(&graph, 842_002);
+        graph
+            .adopt_ontology_module(
+                &ModuleAdoptionRequest {
+                    authority: child_authority,
+                    candidate: child,
+                },
+                None,
+            )
+            .unwrap();
+        assert_eq!(graph.ontology_modules().unwrap().len(), 2);
+        let blocked = graph
+            .preview_delete_ontology_module(&ModuleSelector::Exact(parent.id.clone()))
+            .unwrap();
+        assert!(!blocked.safe);
+        assert_eq!(blocked.dependent_modules.len(), 1);
+
+        let explanation = graph
+            .explain_ontology_resolution(&ResolutionExplainRequest {
+                module: None,
+                kind: SymbolKind::Entity,
+                local_id: "Person".into(),
+                max_candidates: 4,
+            })
+            .unwrap();
+        assert!(explanation.diagnostics.is_empty());
+        assert_eq!(explanation.outcome.unwrap().symbol.module, parent.id);
+    }
+}

--- a/crates/graphforge-api/src/ontology_composition_lifecycle.rs
+++ b/crates/graphforge-api/src/ontology_composition_lifecycle.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use graphforge_core::{GfError, ProjectErrorCode};
 use graphforge_ontology::{
-    ActivationMode, MigrationEngine, ResolveRequest, SymbolKind, TransformKind,
+    ActivationMode, MigrationEngine, OntologyDoc, ResolveRequest, SymbolKind, TransformKind,
 };
 use graphforge_storage::{
     WORKSPACE_CAPABILITY_ID, WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY, WorkspaceOntologyComposition,
@@ -22,6 +22,11 @@ use crate::{CancellationToken, GraphForge, WriteContext};
 pub enum CompositionDataDisposition {
     /// No runtime-only observations may remain.
     RequireConforming,
+    /// The same data policy, bound to one Rust-owned semantic operation class.
+    RequireConformingOperation {
+        /// Stable operation token included in idempotency identity.
+        operation: String,
+    },
 }
 
 /// Request bound to one exact current generation and composition identity.
@@ -197,15 +202,18 @@ impl GraphForge {
             });
         }
         if let Some(compiled) = &compiled {
+            let identity_equivalent =
+                identity_equivalent_upgrades(existing.as_ref(), &request.candidate);
             let current_bindings = self
                 .semantic_storage_bindings
                 .lock()
                 .expect("semantic storage binding lock poisoned")
                 .clone();
-            if let Err(error) = graphforge_storage::SemanticStorageBindings::project_with_graph_scan(
+            if let Err(error) = graphforge_storage::SemanticStorageBindings::project_with_graph_scan_identity_equivalent(
                 compiled,
                 current_bindings.as_ref(),
                 &self.dir,
+                &identity_equivalent,
             ) {
                 let retained = compiled
                     .modules
@@ -398,6 +406,9 @@ impl GraphForge {
         preview: &CompositionChangePreview,
         cancellation: Option<&CancellationToken>,
     ) -> Result<CompositionChangeReceipt, GfError> {
+        if let Some(receipt) = self.replay_ontology_composition_change(request)? {
+            return Ok(receipt);
+        }
         let request_fingerprint = composition_request_fingerprint(request)?;
         let mut generation_hasher = Sha256::new();
         generation_hasher.update(b"graphforge-composition-generation/1");
@@ -405,41 +416,6 @@ impl GraphForge {
         generation_hasher.update(request_fingerprint);
         let expected_generation_uuid =
             graphforge_core::canonical::uuid_v8(generation_hasher.finalize().into());
-        let root = self.resolved_generation.container_root();
-        if let Some(published) = graphforge_storage::published_project_transaction(
-            root,
-            request.context.operation_uuid.0,
-        )? {
-            if published.generation_uuid != expected_generation_uuid {
-                return Err(GfError::Project {
-                    code: ProjectErrorCode::TransactionConflict,
-                    message: "composition operation UUID was reused with different content".into(),
-                });
-            }
-            let generation = graphforge_storage::resolve_verified_generation(
-                root,
-                published.generation_uuid,
-                published.generation_manifest_sha256,
-            )?;
-            let snapshot = generation
-                .participant_snapshot(
-                    WORKSPACE_CAPABILITY_ID,
-                    WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY,
-                )?
-                .ok_or_else(|| GfError::Validation("published composition is missing".into()))?;
-            let composition = WorkspaceOntologyComposition::from_canonical_json(&snapshot.bytes)?;
-            if composition != request.candidate {
-                return Err(GfError::Project {
-                    code: ProjectErrorCode::TransactionConflict,
-                    message: "published composition content does not match retry".into(),
-                });
-            }
-            return Ok(CompositionChangeReceipt {
-                project_generation_uuid: published.generation_uuid,
-                composition_fingerprint: composition.composition_fingerprint,
-                candidate_sha256: hex(&Sha256::digest(request.candidate.to_canonical_json()?)),
-            });
-        }
         let fresh = self.preview_ontology_composition_change(request, cancellation)?;
         if &fresh != preview {
             return Err(GfError::Validation(
@@ -467,11 +443,15 @@ impl GraphForge {
             .lock()
             .expect("semantic storage binding lock poisoned")
             .clone();
+        let existing = self.workspace_ontology_composition()?;
+        let identity_equivalent =
+            identity_equivalent_upgrades(existing.as_ref(), &request.candidate);
         let published_bindings =
-            graphforge_storage::SemanticStorageBindings::project_with_graph_scan(
+            graphforge_storage::SemanticStorageBindings::project_with_graph_scan_identity_equivalent(
                 &compiled_candidate,
                 previous_bindings.as_ref(),
                 &self.dir,
+                &identity_equivalent,
             )?;
         let published_binding = graphforge_ir::CompositionBindingContext::new(
             std::sync::Arc::new(compiled_candidate),
@@ -516,6 +496,56 @@ impl GraphForge {
             composition_fingerprint: fresh.candidate_composition_fingerprint,
             candidate_sha256: fresh.candidate_sha256,
         })
+    }
+
+    pub(crate) fn replay_ontology_composition_change(
+        &self,
+        request: &CompositionChangeRequest,
+    ) -> Result<Option<CompositionChangeReceipt>, GfError> {
+        let request_fingerprint = composition_request_fingerprint(request)?;
+        let mut generation_hasher = Sha256::new();
+        generation_hasher.update(b"graphforge-composition-generation/1");
+        generation_hasher.update(request.context.operation_uuid.0.as_bytes());
+        generation_hasher.update(request_fingerprint);
+        let expected_generation_uuid =
+            graphforge_core::canonical::uuid_v8(generation_hasher.finalize().into());
+        let root = self.resolved_generation.container_root();
+        let Some(published) = graphforge_storage::published_project_transaction(
+            root,
+            request.context.operation_uuid.0,
+        )?
+        else {
+            return Ok(None);
+        };
+        if published.generation_uuid != expected_generation_uuid {
+            return Err(GfError::Project {
+                code: ProjectErrorCode::TransactionConflict,
+                message: "composition operation UUID was reused with different content".into(),
+            });
+        }
+        let generation = graphforge_storage::resolve_verified_generation(
+            root,
+            published.generation_uuid,
+            published.generation_manifest_sha256,
+        )?;
+        let snapshot = generation
+            .participant_snapshot(
+                WORKSPACE_CAPABILITY_ID,
+                WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY,
+            )?
+            .ok_or_else(|| GfError::Validation("published composition is missing".into()))?;
+        let composition = WorkspaceOntologyComposition::from_canonical_json(&snapshot.bytes)?;
+        if composition != request.candidate {
+            return Err(GfError::Project {
+                code: ProjectErrorCode::TransactionConflict,
+                message: "published composition content does not match retry".into(),
+            });
+        }
+        Ok(Some(CompositionChangeReceipt {
+            project_generation_uuid: published.generation_uuid,
+            composition_fingerprint: composition.composition_fingerprint,
+            candidate_sha256: hex(&Sha256::digest(request.candidate.to_canonical_json()?)),
+        }))
     }
 }
 
@@ -590,6 +620,9 @@ fn migration_diagnostics(
             continue;
         };
         if old.id.authored_version == new.id.authored_version {
+            continue;
+        }
+        if documents_equal_except_version_and_migrations(&old.document, &new.document) {
             continue;
         }
         let migrations = new
@@ -670,6 +703,34 @@ fn migration_diagnostics(
     Ok(diagnostics)
 }
 
+fn documents_equal_except_version_and_migrations(left: &OntologyDoc, right: &OntologyDoc) -> bool {
+    let mut left = left.clone();
+    left.version.clone_from(&right.version);
+    left.migrations.clone_from(&right.migrations);
+    left == *right
+}
+
+fn identity_equivalent_upgrades(
+    existing: Option<&WorkspaceOntologyComposition>,
+    candidate: &WorkspaceOntologyComposition,
+) -> Vec<(
+    graphforge_ontology::OntologyModuleId,
+    graphforge_ontology::OntologyModuleId,
+)> {
+    existing
+        .into_iter()
+        .flat_map(|composition| composition.modules.iter())
+        .filter_map(|old| {
+            candidate.modules.iter().find_map(|new| {
+                (old.id != new.id
+                    && old.id.ontology_id == new.id.ontology_id
+                    && documents_equal_except_version_and_migrations(&old.document, &new.document))
+                .then(|| (old.id.clone(), new.id.clone()))
+            })
+        })
+        .collect()
+}
+
 fn migration_runtime_subject(transform: &TransformKind) -> Option<String> {
     match transform {
         TransformKind::RenameType { old_name, .. }
@@ -707,7 +768,15 @@ fn composition_request_fingerprint(
         None => hasher.update([0]),
     }
     hasher.update(request.candidate.to_canonical_json()?);
-    hasher.update(b"require_conforming");
+    match &request.data_disposition {
+        CompositionDataDisposition::RequireConforming => {
+            hasher.update(b"require_conforming");
+        }
+        CompositionDataDisposition::RequireConformingOperation { operation } => {
+            hasher.update(b"require_conforming_operation\0");
+            hasher.update(operation.as_bytes());
+        }
+    }
     Ok(hasher.finalize().into())
 }
 
@@ -1150,7 +1219,7 @@ mod tests {
             .unwrap();
         let published = *graph.current_generation_uuid.lock().unwrap();
 
-        let mut conflicting = request;
+        let mut conflicting = request.clone();
         conflicting.candidate =
             composition("1", ActivationMode::Advisory, &["Company"], Vec::new());
         assert!(
@@ -1158,6 +1227,24 @@ mod tests {
                 .publish_ontology_composition_change(&conflicting, &preview, None)
                 .is_err()
         );
+        assert_eq!(*graph.current_generation_uuid.lock().unwrap(), published);
+
+        let mut different_actor = request.clone();
+        different_actor.context.actor_uuid = Some(Uuid::from_u128(841_001));
+        let error = graph
+            .publish_ontology_composition_change(&different_actor, &preview, None)
+            .unwrap_err();
+        assert_eq!(error.code(), "GF_IDEMPOTENCY_CONFLICT");
+
+        let mut different_operation = request;
+        different_operation.data_disposition =
+            CompositionDataDisposition::RequireConformingOperation {
+                operation: "activation.change".into(),
+            };
+        let error = graph
+            .publish_ontology_composition_change(&different_operation, &preview, None)
+            .unwrap_err();
+        assert_eq!(error.code(), "GF_IDEMPOTENCY_CONFLICT");
         assert_eq!(*graph.current_generation_uuid.lock().unwrap(), published);
     }
 
@@ -1491,11 +1578,19 @@ mod tests {
         graph
             .publish_ontology_composition_change(&initial, &preview, None)
             .unwrap();
+        graph
+            .execute("CREATE (:Person {name: 'retained'})")
+            .unwrap();
 
         let unreachable = request(
             &graph,
             8431,
-            composition("3", ActivationMode::Advisory, &["Person"], Vec::new()),
+            composition(
+                "3",
+                ActivationMode::Advisory,
+                &["Person", "Company"],
+                Vec::new(),
+            ),
         );
         assert_eq!(
             graph
@@ -1511,7 +1606,7 @@ mod tests {
             composition(
                 "2",
                 ActivationMode::Advisory,
-                &["Person"],
+                &["Person", "Company"],
                 vec![MigrationDef {
                     from_version: "1".into(),
                     to_version: "2".into(),

--- a/crates/graphforge-bindings-node/Cargo.toml
+++ b/crates/graphforge-bindings-node/Cargo.toml
@@ -21,6 +21,7 @@ arrow = { workspace = true }
 # `HashMap<String, serde_json::Value>` query parameters.
 napi = { workspace = true, features = ["serde-json"] }
 napi-derive = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
 

--- a/crates/graphforge-bindings-node/src/lib.rs
+++ b/crates/graphforge-bindings-node/src/lib.rs
@@ -51,6 +51,7 @@ use napi_derive::napi;
 mod composite;
 mod error;
 mod import_session;
+mod multi_ontology;
 mod portable;
 mod transaction;
 use composite::CompositeTransactionInput;

--- a/crates/graphforge-bindings-node/src/multi_ontology.rs
+++ b/crates/graphforge-bindings-node/src/multi_ontology.rs
@@ -1,0 +1,835 @@
+//! Thin Node projection of the Rust-owned multi-ontology lifecycle (#842).
+
+use std::sync::{Arc, RwLock};
+
+use graphforge_api::{
+    ActivationProfileChangeRequest, BridgeAdoptionRequest, BridgeDeleteRequest,
+    BridgeUpdateRequest, CancellationToken, CompositionChangeRequest, CompositionDataDisposition,
+    GfError, GraphForge as ApiGraphForge, ModuleAdoptionRequest, ModuleDeleteRequest,
+    ModuleUpdateRequest, MultiOntologyError, OntologyAuthorityExpectation,
+    ResolutionExplainRequest, WriteContext,
+};
+use napi::Env;
+use napi::Task;
+use napi::bindgen_prelude::{AbortSignal, AsyncTask, Unknown};
+use napi_derive::napi;
+use serde_json::Value;
+
+use crate::{GraphForge, NodeError, Result, canonical_operation_id, optional_uuid, to_napi_err};
+
+#[napi(object)]
+/// Exact authority expectation supplied to a mutating operation.
+pub struct AuthorityInput {
+    /// Idempotency UUID.
+    pub operation_uuid: String,
+    /// Optional actor UUID.
+    pub actor_uuid: Option<String>,
+    /// Exact current project generation UUID.
+    pub expected_project_generation_uuid: String,
+    /// Exact current composition fingerprint.
+    pub expected_composition_fingerprint: Option<String>,
+}
+
+#[napi(object)]
+/// Input for creating a non-authoritative module candidate.
+pub struct ModuleCandidateInput {
+    /// Authored module document.
+    pub document: Value,
+    /// Exact module dependencies.
+    pub dependencies: Option<Vec<Value>>,
+    /// Optional activation override.
+    pub enforcement: Option<String>,
+}
+
+#[napi(object)]
+/// Input for parsing a non-authoritative module candidate.
+pub struct ModuleImportInput {
+    /// Owned document text.
+    pub text: String,
+    /// Input format token.
+    pub format: String,
+    /// Exact module dependencies.
+    pub dependencies: Option<Vec<Value>>,
+}
+
+#[napi(object, object_to_js = false)]
+/// Owned module mutation input.
+pub struct ModuleMutationInput {
+    /// Exact authority expectation.
+    pub authority: AuthorityInput,
+    /// Exact or uniquely resolving selector.
+    pub selector: Option<Value>,
+    /// Candidate returned by create or import.
+    pub candidate: Option<Value>,
+    /// Replacement document.
+    pub document: Option<Value>,
+    /// Replacement dependencies.
+    pub dependencies: Option<Vec<Value>>,
+    /// Optional activation override.
+    pub enforcement: Option<String>,
+    /// Optional standard cancellation signal.
+    pub signal: Option<AbortSignal>,
+}
+
+#[napi(object)]
+/// Input for parsing a non-authoritative bridge candidate.
+pub struct BridgeImportInput {
+    /// Owned bridge document text.
+    pub text: String,
+    /// Input format token.
+    pub format: String,
+}
+
+#[napi(object, object_to_js = false)]
+/// Owned bridge mutation input.
+pub struct BridgeMutationInput {
+    /// Exact authority expectation.
+    pub authority: AuthorityInput,
+    /// Exact or uniquely resolving selector.
+    pub selector: Option<Value>,
+    /// Candidate returned by create or import.
+    pub candidate: Option<Value>,
+    /// Replacement bridge document.
+    pub document: Option<Value>,
+    /// Optional standard cancellation signal.
+    pub signal: Option<AbortSignal>,
+}
+
+#[napi(object, object_to_js = false)]
+/// Complete activation-profile replacement input.
+pub struct ActivationChangeInput {
+    /// Exact authority expectation.
+    pub authority: AuthorityInput,
+    /// New default activation mode.
+    pub profile_default: String,
+    /// Complete replacement activation records.
+    pub activation: Vec<Value>,
+    /// Optional standard cancellation signal.
+    pub signal: Option<AbortSignal>,
+}
+
+#[napi(object, object_to_js = false)]
+/// Full composition-preflight input.
+pub struct CompositionPreflightInput {
+    /// Exact authority expectation.
+    pub authority: AuthorityInput,
+    /// Complete candidate composition.
+    pub candidate: Value,
+    /// Optional standard cancellation signal.
+    pub signal: Option<AbortSignal>,
+}
+
+#[napi(object)]
+/// Rust-owned resolution explanation input.
+pub struct ResolutionInput {
+    /// Optional exact module identity.
+    pub module: Option<Value>,
+    /// Symbol-kind token.
+    pub kind: String,
+    /// Local symbol identifier.
+    pub local_id: String,
+    /// Bounded ambiguity candidate count.
+    pub max_candidates: Option<u32>,
+}
+
+fn decode<T: serde::de::DeserializeOwned>(value: Value, subject: &str) -> Result<T> {
+    serde_json::from_value(value)
+        .map_err(|error| to_napi_err(&GfError::Validation(format!("invalid {subject}: {error}"))))
+}
+
+fn encode<T: serde::Serialize>(value: T, subject: &str) -> Result<Value> {
+    serde_json::to_value(value)
+        .map_err(|error| to_napi_err(&GfError::Validation(format!("encode {subject}: {error}"))))
+}
+
+fn module_selector(value: Value) -> Result<graphforge_api::ModuleSelector> {
+    let Value::Object(mut input) = value else {
+        return Err(to_napi_err(&GfError::Validation(
+            "ontology module selector must be an object".into(),
+        )));
+    };
+    match (
+        input.remove("exact"),
+        input.remove("ontologyId"),
+        input.is_empty(),
+    ) {
+        (Some(exact), None, true) => Ok(graphforge_api::ModuleSelector::Exact(decode(
+            exact,
+            "exact ontology module identity",
+        )?)),
+        (None, Some(Value::String(ontology_id)), true) => {
+            Ok(graphforge_api::ModuleSelector::OntologyId(ontology_id))
+        }
+        _ => Err(to_napi_err(&GfError::Validation(
+            "ontology module selector must contain exactly one of exact or ontologyId".into(),
+        ))),
+    }
+}
+
+fn bridge_selector(value: Value) -> Result<graphforge_api::BridgeSelector> {
+    let Value::Object(mut input) = value else {
+        return Err(to_napi_err(&GfError::Validation(
+            "ontology bridge selector must be an object".into(),
+        )));
+    };
+    match (
+        input.remove("exact"),
+        input.remove("bridgeId"),
+        input.is_empty(),
+    ) {
+        (Some(exact), None, true) => Ok(graphforge_api::BridgeSelector::Exact(decode(
+            exact,
+            "exact ontology bridge identity",
+        )?)),
+        (None, Some(Value::String(bridge_id)), true) => {
+            Ok(graphforge_api::BridgeSelector::BridgeId(bridge_id))
+        }
+        _ => Err(to_napi_err(&GfError::Validation(
+            "ontology bridge selector must contain exactly one of exact or bridgeId".into(),
+        ))),
+    }
+}
+
+fn authority(input: AuthorityInput) -> Result<OntologyAuthorityExpectation> {
+    let expected_project_generation_uuid =
+        uuid::Uuid::parse_str(&input.expected_project_generation_uuid).map_err(|_| {
+            to_napi_err(&GfError::Validation(
+                "invalid expected project generation UUID".into(),
+            ))
+        })?;
+    if expected_project_generation_uuid.hyphenated().to_string()
+        != input.expected_project_generation_uuid
+    {
+        return Err(to_napi_err(&GfError::Validation(
+            "expected project generation UUID must be canonical hyphenated text".into(),
+        )));
+    }
+    Ok(OntologyAuthorityExpectation {
+        context: WriteContext {
+            operation_uuid: canonical_operation_id(&input.operation_uuid)?,
+            actor_uuid: optional_uuid(input.actor_uuid.as_deref())?,
+        },
+        expected_project_generation_uuid,
+        expected_composition_fingerprint: input.expected_composition_fingerprint,
+    })
+}
+
+fn activation_mode(value: &str) -> Result<graphforge_api::ActivationMode> {
+    match value {
+        "exploratory" => Ok(graphforge_api::ActivationMode::Exploratory),
+        "advisory" => Ok(graphforge_api::ActivationMode::Advisory),
+        "strict" => Ok(graphforge_api::ActivationMode::Strict),
+        _ => Err(to_napi_err(&GfError::Validation(
+            "activation mode must be exploratory, advisory, or strict".into(),
+        ))),
+    }
+}
+
+fn module_format(value: &str) -> Result<graphforge_api::ImportFormatHint> {
+    match value {
+        "auto" => Ok(graphforge_api::ImportFormatHint::Auto),
+        "json" => Ok(graphforge_api::ImportFormatHint::Json),
+        "yaml" => Ok(graphforge_api::ImportFormatHint::Yaml),
+        _ => Err(to_napi_err(&GfError::Validation(
+            "module import format must be auto, json, or yaml".into(),
+        ))),
+    }
+}
+
+fn bridge_format(value: &str) -> Result<graphforge_api::BridgeImportFormatHint> {
+    match value {
+        "auto" => Ok(graphforge_api::BridgeImportFormatHint::Auto),
+        "json" => Ok(graphforge_api::BridgeImportFormatHint::Json),
+        "yaml" => Ok(graphforge_api::BridgeImportFormatHint::Yaml),
+        _ => Err(to_napi_err(&GfError::Validation(
+            "bridge import format must be auto, json, or yaml".into(),
+        ))),
+    }
+}
+
+fn export_format(value: &str) -> Result<graphforge_api::ExportFormat> {
+    match value {
+        "json" => Ok(graphforge_api::ExportFormat::Json),
+        "yaml" => Ok(graphforge_api::ExportFormat::Yaml),
+        _ => Err(to_napi_err(&GfError::Validation(
+            "module export format must be json or yaml".into(),
+        ))),
+    }
+}
+
+fn bridge_export_format(value: &str) -> Result<graphforge_api::BridgeExportFormat> {
+    match value {
+        "json" => Ok(graphforge_api::BridgeExportFormat::Json),
+        "yaml" => Ok(graphforge_api::BridgeExportFormat::Yaml),
+        _ => Err(to_napi_err(&GfError::Validation(
+            "bridge export format must be json or yaml".into(),
+        ))),
+    }
+}
+
+fn symbol_kind(value: &str) -> Result<graphforge_api::SymbolKind> {
+    match value {
+        "entity" => Ok(graphforge_api::SymbolKind::Entity),
+        "relation" => Ok(graphforge_api::SymbolKind::Relation),
+        "property" => Ok(graphforge_api::SymbolKind::Property),
+        _ => Err(to_napi_err(&GfError::Validation(
+            "symbol kind must be entity, relation, or property".into(),
+        ))),
+    }
+}
+
+fn bind_signal(signal: Option<AbortSignal>) -> CancellationToken {
+    let cancellation = CancellationToken::new();
+    if let Some(signal) = signal {
+        let bound = cancellation.clone();
+        signal.on_abort(move || bound.cancel());
+    }
+    cancellation
+}
+
+fn to_multi_napi_err(error: &MultiOntologyError) -> NodeError {
+    let reason = serde_json::to_string(error)
+        .unwrap_or_else(|_| format!("{{\"code\":\"{}\"}}", error.code()));
+    napi::Error::new(error.code().to_owned(), reason)
+}
+
+fn to_multi_deferred_err(env: Env, error: &MultiOntologyError) -> napi::Error {
+    let value = napi::JsError::from(to_multi_napi_err(error)).into_unknown(env);
+    napi::Error::from(value)
+}
+
+enum Mutation {
+    AdoptModule(ModuleAdoptionRequest),
+    UpdateModule(ModuleUpdateRequest),
+    DeleteModule(ModuleDeleteRequest),
+    AdoptBridge(BridgeAdoptionRequest),
+    UpdateBridge(BridgeUpdateRequest),
+    DeleteBridge(BridgeDeleteRequest),
+    ChangeActivation(ActivationProfileChangeRequest),
+    AdoptPortable(OntologyAuthorityExpectation),
+}
+
+/// Deferred Rust-owned multi-ontology mutation.
+pub struct MultiOntologyMutationTask {
+    engine: Arc<RwLock<ApiGraphForge>>,
+    mutation: Option<Mutation>,
+    cancellation: CancellationToken,
+}
+
+impl Task for MultiOntologyMutationTask {
+    type Output =
+        std::result::Result<graphforge_api::MultiOntologyMutationReceipt, MultiOntologyError>;
+    type JsValue = Unknown<'static>;
+
+    fn compute(&mut self) -> napi::Result<Self::Output> {
+        let mut graph = self
+            .engine
+            .write()
+            .map_err(|_| napi::Error::from_reason("GraphForge lock poisoned"))?;
+        let mutation = self
+            .mutation
+            .take()
+            .ok_or_else(|| napi::Error::from_reason("multi-ontology mutation already consumed"))?;
+        let cancellation = Some(&self.cancellation);
+        Ok(match mutation {
+            Mutation::AdoptModule(request) => graph.adopt_ontology_module(&request, cancellation),
+            Mutation::UpdateModule(request) => graph.update_ontology_module(&request, cancellation),
+            Mutation::DeleteModule(request) => graph.delete_ontology_module(&request, cancellation),
+            Mutation::AdoptBridge(request) => graph.adopt_ontology_bridge(&request, cancellation),
+            Mutation::UpdateBridge(request) => graph.update_ontology_bridge(&request, cancellation),
+            Mutation::DeleteBridge(request) => graph.delete_ontology_bridge(&request, cancellation),
+            Mutation::ChangeActivation(request) => {
+                graph.change_ontology_activation_profile(&request, cancellation)
+            }
+            Mutation::AdoptPortable(authority) => graph.adopt_portable_ontology_staging(
+                &authority,
+                graphforge_api::PortableV2Limits::default(),
+                cancellation,
+            ),
+        })
+    }
+
+    fn resolve(&mut self, env: Env, output: Self::Output) -> napi::Result<Self::JsValue> {
+        let receipt = output.map_err(|error| to_multi_deferred_err(env, &error))?;
+        env.to_js_value(&receipt)
+    }
+}
+
+fn mutation_task(
+    graph: &GraphForge,
+    mutation: Mutation,
+    signal: Option<AbortSignal>,
+) -> Result<AsyncTask<MultiOntologyMutationTask>> {
+    graph.ensure_open()?;
+    Ok(AsyncTask::new(MultiOntologyMutationTask {
+        engine: Arc::clone(&graph.inner),
+        mutation: Some(mutation),
+        cancellation: bind_signal(signal),
+    }))
+}
+
+#[napi]
+impl GraphForge {
+    /// Return the exact authority identities required by every mutation.
+    #[napi]
+    pub fn ontology_authority_state(&self) -> Result<Value> {
+        encode(
+            self.open_guard()?
+                .ontology_authority_state()
+                .map_err(|error| to_multi_napi_err(&error))?,
+            "ontology authority state",
+        )
+    }
+
+    #[napi]
+    /// List authoritative modules in Rust-defined order.
+    pub fn ontology_modules(&self) -> Result<Value> {
+        encode(
+            self.open_guard()?
+                .ontology_modules()
+                .map_err(|error| to_multi_napi_err(&error))?,
+            "ontology modules",
+        )
+    }
+
+    #[napi]
+    /// Inspect one authoritative module using a Rust selector.
+    pub fn inspect_ontology_module(&self, selector: Value) -> Result<Value> {
+        let selector = module_selector(selector)?;
+        encode(
+            self.open_guard()?
+                .inspect_ontology_module(&selector)
+                .map_err(|error| to_multi_napi_err(&error))?,
+            "ontology module inspection",
+        )
+    }
+
+    #[napi]
+    /// Validate an authored module without mutation.
+    pub fn validate_ontology_module(&self, document: Value) -> Result<Value> {
+        let document = decode(document, "ontology module document")?;
+        encode(
+            self.open_guard()?
+                .validate_ontology_module(&document)
+                .map_err(|error| to_multi_napi_err(&error))?,
+            "ontology module validation receipt",
+        )
+    }
+
+    #[napi]
+    /// Create a validated, non-authoritative module candidate.
+    pub fn create_ontology_module(&self, input: ModuleCandidateInput) -> Result<Value> {
+        let document = decode(input.document, "ontology module document")?;
+        let dependencies = input
+            .dependencies
+            .unwrap_or_default()
+            .into_iter()
+            .map(|v| decode(v, "ontology module dependency"))
+            .collect::<Result<Vec<_>>>()?;
+        let enforcement = input
+            .enforcement
+            .as_deref()
+            .map(activation_mode)
+            .transpose()?;
+        encode(
+            self.open_guard()?
+                .create_ontology_module(document, dependencies, enforcement)
+                .map_err(|error| to_multi_napi_err(&error))?,
+            "ontology module candidate",
+        )
+    }
+
+    #[napi]
+    /// Import a parsed, non-authoritative module candidate.
+    pub fn import_ontology_module(&self, input: ModuleImportInput) -> Result<Value> {
+        let dependencies = input
+            .dependencies
+            .unwrap_or_default()
+            .into_iter()
+            .map(|v| decode(v, "ontology module dependency"))
+            .collect::<Result<Vec<_>>>()?;
+        encode(
+            self.open_guard()?
+                .import_ontology_module(&input.text, module_format(&input.format)?, dependencies)
+                .map_err(|error| to_multi_napi_err(&error))?,
+            "ontology module candidate",
+        )
+    }
+
+    #[napi]
+    /// Explicitly adopt a module candidate.
+    pub fn adopt_ontology_module(
+        &self,
+        mut input: ModuleMutationInput,
+    ) -> Result<AsyncTask<MultiOntologyMutationTask>> {
+        let request = ModuleAdoptionRequest {
+            authority: authority(input.authority)?,
+            candidate: decode(
+                input.candidate.take().ok_or_else(|| {
+                    to_napi_err(&GfError::Validation("candidate is required".into()))
+                })?,
+                "ontology module candidate",
+            )?,
+        };
+        mutation_task(self, Mutation::AdoptModule(request), input.signal.take())
+    }
+
+    #[napi]
+    /// Preview an exact module replacement.
+    pub fn preview_update_ontology_module(
+        &self,
+        selector: Value,
+        document: Value,
+        dependencies: Option<Vec<Value>>,
+    ) -> Result<Value> {
+        let selector = module_selector(selector)?;
+        let document = decode(document, "ontology module document")?;
+        let dependencies = dependencies
+            .unwrap_or_default()
+            .into_iter()
+            .map(|v| decode(v, "ontology module dependency"))
+            .collect::<Result<Vec<_>>>()?;
+        encode(
+            self.open_guard()?
+                .preview_update_ontology_module(&selector, &document, &dependencies)
+                .map_err(|error| to_multi_napi_err(&error))?,
+            "ontology module update preview",
+        )
+    }
+
+    #[napi]
+    /// Atomically replace one module.
+    pub fn update_ontology_module(
+        &self,
+        mut input: ModuleMutationInput,
+    ) -> Result<AsyncTask<MultiOntologyMutationTask>> {
+        let request = ModuleUpdateRequest {
+            authority: authority(input.authority)?,
+            selector: module_selector(input.selector.take().ok_or_else(|| {
+                to_napi_err(&GfError::Validation("selector is required".into()))
+            })?)?,
+            document: decode(
+                input.document.take().ok_or_else(|| {
+                    to_napi_err(&GfError::Validation("document is required".into()))
+                })?,
+                "ontology module document",
+            )?,
+            dependencies: input
+                .dependencies
+                .take()
+                .unwrap_or_default()
+                .into_iter()
+                .map(|v| decode(v, "ontology module dependency"))
+                .collect::<Result<Vec<_>>>()?,
+            enforcement: input
+                .enforcement
+                .as_deref()
+                .map(activation_mode)
+                .transpose()?,
+        };
+        mutation_task(self, Mutation::UpdateModule(request), input.signal.take())
+    }
+
+    #[napi]
+    /// Preview dependency and activation blockers for module deletion.
+    pub fn preview_delete_ontology_module(&self, selector: Value) -> Result<Value> {
+        let selector = module_selector(selector)?;
+        encode(
+            self.open_guard()?
+                .preview_delete_ontology_module(&selector)
+                .map_err(|error| to_multi_napi_err(&error))?,
+            "ontology module delete preview",
+        )
+    }
+
+    #[napi]
+    /// Atomically delete one safe module.
+    pub fn delete_ontology_module(
+        &self,
+        mut input: ModuleMutationInput,
+    ) -> Result<AsyncTask<MultiOntologyMutationTask>> {
+        let request = ModuleDeleteRequest {
+            authority: authority(input.authority)?,
+            selector: module_selector(input.selector.take().ok_or_else(|| {
+                to_napi_err(&GfError::Validation("selector is required".into()))
+            })?)?,
+        };
+        mutation_task(self, Mutation::DeleteModule(request), input.signal.take())
+    }
+
+    #[napi]
+    /// Deterministically export one module.
+    pub fn export_ontology_module(&self, selector: Value, format: String) -> Result<String> {
+        let selector = module_selector(selector)?;
+        self.open_guard()?
+            .export_ontology_module(&selector, export_format(&format)?)
+            .map_err(|error| to_multi_napi_err(&error))
+    }
+
+    #[napi]
+    /// List authoritative bridge sets in Rust-defined order.
+    pub fn ontology_bridges(&self) -> Result<Value> {
+        encode(
+            self.open_guard()?
+                .ontology_bridges()
+                .map_err(|error| to_multi_napi_err(&error))?,
+            "ontology bridges",
+        )
+    }
+
+    #[napi]
+    /// Inspect one authoritative bridge set using a Rust selector.
+    pub fn inspect_ontology_bridge(&self, selector: Value) -> Result<Value> {
+        let selector = bridge_selector(selector)?;
+        encode(
+            self.open_guard()?
+                .inspect_ontology_bridge(&selector)
+                .map_err(|error| to_multi_napi_err(&error))?,
+            "ontology bridge inspection",
+        )
+    }
+
+    #[napi]
+    /// Validate an authored bridge document without mutation.
+    pub fn validate_ontology_bridge(&self, document: Value) -> Result<Value> {
+        let document = decode(document, "ontology bridge document")?;
+        encode(
+            self.open_guard()?
+                .validate_ontology_bridge(&document)
+                .map_err(|error| to_multi_napi_err(&error))?,
+            "ontology bridge validation receipt",
+        )
+    }
+
+    #[napi]
+    /// Create a validated, non-authoritative bridge candidate.
+    pub fn create_ontology_bridge(&self, document: Value) -> Result<Value> {
+        let document = decode(document, "ontology bridge document")?;
+        encode(
+            self.open_guard()?
+                .create_ontology_bridge(document)
+                .map_err(|error| to_multi_napi_err(&error))?,
+            "ontology bridge candidate",
+        )
+    }
+
+    #[napi]
+    /// Import a parsed, non-authoritative bridge candidate.
+    pub fn import_ontology_bridge(&self, input: BridgeImportInput) -> Result<Value> {
+        encode(
+            self.open_guard()?
+                .import_ontology_bridge(&input.text, bridge_format(&input.format)?)
+                .map_err(|error| to_multi_napi_err(&error))?,
+            "ontology bridge candidate",
+        )
+    }
+
+    #[napi]
+    /// Explicitly adopt a bridge candidate.
+    pub fn adopt_ontology_bridge(
+        &self,
+        mut input: BridgeMutationInput,
+    ) -> Result<AsyncTask<MultiOntologyMutationTask>> {
+        let request = BridgeAdoptionRequest {
+            authority: authority(input.authority)?,
+            candidate: decode(
+                input.candidate.take().ok_or_else(|| {
+                    to_napi_err(&GfError::Validation("candidate is required".into()))
+                })?,
+                "ontology bridge candidate",
+            )?,
+        };
+        mutation_task(self, Mutation::AdoptBridge(request), input.signal.take())
+    }
+
+    #[napi]
+    /// Preview an exact bridge replacement.
+    pub fn preview_update_ontology_bridge(
+        &self,
+        selector: Value,
+        document: Value,
+    ) -> Result<Value> {
+        let selector = bridge_selector(selector)?;
+        let document = decode(document, "ontology bridge document")?;
+        encode(
+            self.open_guard()?
+                .preview_update_ontology_bridge(&selector, &document)
+                .map_err(|error| to_multi_napi_err(&error))?,
+            "ontology bridge update preview",
+        )
+    }
+
+    #[napi]
+    /// Atomically replace one bridge set.
+    pub fn update_ontology_bridge(
+        &self,
+        mut input: BridgeMutationInput,
+    ) -> Result<AsyncTask<MultiOntologyMutationTask>> {
+        let request = BridgeUpdateRequest {
+            authority: authority(input.authority)?,
+            selector: bridge_selector(input.selector.take().ok_or_else(|| {
+                to_napi_err(&GfError::Validation("selector is required".into()))
+            })?)?,
+            document: decode(
+                input.document.take().ok_or_else(|| {
+                    to_napi_err(&GfError::Validation("document is required".into()))
+                })?,
+                "ontology bridge document",
+            )?,
+        };
+        mutation_task(self, Mutation::UpdateBridge(request), input.signal.take())
+    }
+
+    #[napi]
+    /// Preview dependency and activation blockers for bridge deletion.
+    pub fn preview_delete_ontology_bridge(&self, selector: Value) -> Result<Value> {
+        let selector = bridge_selector(selector)?;
+        encode(
+            self.open_guard()?
+                .preview_delete_ontology_bridge(&selector)
+                .map_err(|error| to_multi_napi_err(&error))?,
+            "ontology bridge delete preview",
+        )
+    }
+
+    #[napi]
+    /// Atomically delete one safe bridge set.
+    pub fn delete_ontology_bridge(
+        &self,
+        mut input: BridgeMutationInput,
+    ) -> Result<AsyncTask<MultiOntologyMutationTask>> {
+        let request = BridgeDeleteRequest {
+            authority: authority(input.authority)?,
+            selector: bridge_selector(input.selector.take().ok_or_else(|| {
+                to_napi_err(&GfError::Validation("selector is required".into()))
+            })?)?,
+        };
+        mutation_task(self, Mutation::DeleteBridge(request), input.signal.take())
+    }
+
+    #[napi]
+    /// Deterministically export one bridge set.
+    pub fn export_ontology_bridge(&self, selector: Value, format: String) -> Result<String> {
+        let selector = bridge_selector(selector)?;
+        self.open_guard()?
+            .export_ontology_bridge(&selector, bridge_export_format(&format)?)
+            .map_err(|error| to_multi_napi_err(&error))
+    }
+
+    #[napi]
+    /// Inspect the complete activation profile.
+    pub fn ontology_activation_profile(&self) -> Result<Value> {
+        let (profile_default, activation) = self
+            .open_guard()?
+            .ontology_activation_profile()
+            .map_err(|error| to_multi_napi_err(&error))?;
+        encode(
+            serde_json::json!({ "profile_default": profile_default, "activation": activation }),
+            "ontology activation profile",
+        )
+    }
+
+    #[napi]
+    /// Atomically replace the complete activation profile.
+    pub fn change_ontology_activation_profile(
+        &self,
+        mut input: ActivationChangeInput,
+    ) -> Result<AsyncTask<MultiOntologyMutationTask>> {
+        let request = ActivationProfileChangeRequest {
+            authority: authority(input.authority)?,
+            profile_default: activation_mode(&input.profile_default)?,
+            activation: input
+                .activation
+                .drain(..)
+                .map(|v| decode(v, "ontology activation record"))
+                .collect::<Result<Vec<_>>>()?,
+        };
+        mutation_task(
+            self,
+            Mutation::ChangeActivation(request),
+            input.signal.take(),
+        )
+    }
+
+    #[napi]
+    /// Validate and inventory a complete composition.
+    pub fn validate_ontology_composition(&self, candidate: Value) -> Result<Value> {
+        let candidate = decode(candidate, "ontology composition")?;
+        encode(
+            self.open_guard()?
+                .validate_ontology_composition(&candidate)
+                .map_err(|error| to_multi_napi_err(&error))?,
+            "ontology composition validation",
+        )
+    }
+
+    #[napi]
+    /// Run the Rust-owned stored-data and portability preflight.
+    pub fn preflight_ontology_composition(
+        &self,
+        mut input: CompositionPreflightInput,
+    ) -> Result<Value> {
+        let authority = authority(input.authority)?;
+        let request = CompositionChangeRequest {
+            context: authority.context,
+            expected_project_generation_uuid: authority.expected_project_generation_uuid,
+            expected_composition_fingerprint: authority.expected_composition_fingerprint,
+            candidate: decode(input.candidate, "ontology composition")?,
+            data_disposition: CompositionDataDisposition::RequireConformingOperation {
+                operation: "composition.preflight".into(),
+            },
+        };
+        let cancellation = bind_signal(input.signal.take());
+        encode(
+            self.open_guard()?
+                .preflight_ontology_composition(&request, Some(&cancellation))
+                .map_err(|error| to_multi_napi_err(&error))?,
+            "ontology composition preflight",
+        )
+    }
+
+    #[napi]
+    /// Explain qualified or unqualified symbol resolution.
+    pub fn explain_ontology_resolution(&self, input: ResolutionInput) -> Result<Value> {
+        let request = ResolutionExplainRequest {
+            module: input
+                .module
+                .map(|v| decode(v, "ontology module identity"))
+                .transpose()?,
+            kind: symbol_kind(&input.kind)?,
+            local_id: input.local_id,
+            max_candidates: input.max_candidates.unwrap_or(16) as usize,
+        };
+        encode(
+            self.open_guard()?
+                .explain_ontology_resolution(&request)
+                .map_err(|error| to_multi_napi_err(&error))?,
+            "ontology resolution explanation",
+        )
+    }
+
+    #[napi]
+    /// Inspect the verified non-authoritative portable ontology staging record.
+    pub fn portable_ontology_staging(&self) -> Result<Value> {
+        encode(
+            self.open_guard()?
+                .portable_ontology_staging(graphforge_api::PortableV2Limits::default())
+                .map_err(|error| to_multi_napi_err(&error))?,
+            "portable ontology staging",
+        )
+    }
+
+    #[napi]
+    /// Explicitly adopt verified portable ontology staging.
+    pub fn adopt_portable_ontology_staging(
+        &self,
+        authority_input: AuthorityInput,
+        signal: Option<AbortSignal>,
+    ) -> Result<AsyncTask<MultiOntologyMutationTask>> {
+        mutation_task(
+            self,
+            Mutation::AdoptPortable(authority(authority_input)?),
+            signal,
+        )
+    }
+}

--- a/crates/graphforge-bindings-node/src/portable.rs
+++ b/crates/graphforge-bindings-node/src/portable.rs
@@ -4,8 +4,8 @@ use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 
 use graphforge_api::{
-    CancellationToken, GfError, PortableSelection, PortableV2Authenticity, PortableV2Compatibility,
-    PortableV2Error, PortableV2ErrorCode, PortableV2ExportRequest, PortableV2GraphSelector,
+    CancellationToken, GfError, MultiOntologyError, PortableSelection, PortableV2Authenticity,
+    PortableV2Compatibility, PortableV2Error, PortableV2ExportRequest, PortableV2GraphSelector,
     PortableV2ImportRequest, PortableV2Integrity, PortableV2Limits, PortableV2Mode,
     PortableV2OciAuthenticityPolicy, PortableV2OciPublishFacadeRequest,
     PortableV2OciPullFacadeRequest, PortableV2OciSignatureMaterial, PortableV2OciSignatureState,
@@ -22,23 +22,14 @@ use napi_derive::napi;
 use crate::error::to_napi_err;
 use crate::{Result, napi_validation};
 
-pub(crate) fn to_portable_napi_err(error: &PortableV2Error) -> crate::NodeError {
-    let code = match error.code {
-        PortableV2ErrorCode::Cancelled => "Cancelled",
-        PortableV2ErrorCode::LimitExceeded => "LimitExceeded",
-        PortableV2ErrorCode::Io => "Io",
-        PortableV2ErrorCode::InvalidStructure => "InvalidStructure",
-        PortableV2ErrorCode::InvalidPath => "InvalidPath",
-        PortableV2ErrorCode::DuplicateEntry => "DuplicateEntry",
-        PortableV2ErrorCode::UnsupportedFuture => "UnsupportedFuture",
-        PortableV2ErrorCode::Incompatible => "Incompatible",
-        PortableV2ErrorCode::DigestMismatch => "DigestMismatch",
-        PortableV2ErrorCode::ConcurrentMutation => "ConcurrentMutation",
-    };
-    napi::Error::new(code.to_owned(), error.to_string())
+pub(crate) fn to_portable_napi_err(error: PortableV2Error) -> crate::NodeError {
+    let envelope = MultiOntologyError::from(error);
+    let reason = serde_json::to_string(&envelope)
+        .unwrap_or_else(|_| format!("{{\"code\":\"{}\"}}", envelope.code()));
+    napi::Error::new(envelope.code().to_owned(), reason)
 }
 
-fn to_portable_deferred_err(env: Env, error: &PortableV2Error) -> napi::Error {
+fn to_portable_deferred_err(env: Env, error: PortableV2Error) -> napi::Error {
     let value = napi::JsError::from(to_portable_napi_err(error)).into_unknown(env);
     napi::Error::from(value)
 }
@@ -522,7 +513,7 @@ pub(crate) fn preview_selection(
     };
     let plan = graph
         .preview_portable_v2_selection(&request)
-        .map_err(|error| to_portable_napi_err(&error))?;
+        .map_err(to_portable_napi_err)?;
     Ok(selection_plan_json(&plan))
 }
 
@@ -539,7 +530,7 @@ pub(crate) fn preview_subset(
     };
     let plan = graph
         .preview_portable_v2_graph_subset(&request)
-        .map_err(|error| to_portable_napi_err(&error))?;
+        .map_err(to_portable_napi_err)?;
     Ok(subset_plan_json(&plan))
 }
 
@@ -565,7 +556,7 @@ impl Task for ExportPortableTask {
     fn resolve(&mut self, env: Env, output: Self::Output) -> napi::Result<Self::JsValue> {
         output
             .map(export_result_output)
-            .map_err(|error| to_portable_deferred_err(env, &error))
+            .map_err(|error| to_portable_deferred_err(env, error))
     }
 }
 
@@ -588,7 +579,7 @@ impl Task for VerifyPortableTask {
     fn resolve(&mut self, env: Env, output: Self::Output) -> napi::Result<Self::JsValue> {
         output
             .map(verify_report_output)
-            .map_err(|error| to_portable_deferred_err(env, &error))
+            .map_err(|error| to_portable_deferred_err(env, error))
     }
 }
 
@@ -618,7 +609,7 @@ impl Task for ImportPortableTask {
                 generation_uuid: result.generation_uuid.to_string(),
                 idempotent_replay: result.idempotent_replay,
             })
-            .map_err(|error| to_portable_deferred_err(env, &error))
+            .map_err(|error| to_portable_deferred_err(env, error))
     }
 }
 
@@ -685,7 +676,7 @@ impl Task for PublishOciTask {
     fn resolve(&mut self, env: Env, output: Self::Output) -> napi::Result<Self::JsValue> {
         output
             .map(oci_reference_output)
-            .map_err(|error| to_portable_deferred_err(env, &error))
+            .map_err(|error| to_portable_deferred_err(env, error))
     }
 }
 
@@ -713,7 +704,7 @@ impl Task for PullOciTask {
                 report: verify_report_output(receipt.report),
                 signature_state: signature_state_token(receipt.signature_state),
             })
-            .map_err(|error| to_portable_deferred_err(env, &error))
+            .map_err(|error| to_portable_deferred_err(env, error))
     }
 }
 

--- a/crates/graphforge-bindings-node/tests/async-errors.test.mjs
+++ b/crates/graphforge-bindings-node/tests/async-errors.test.mjs
@@ -29,13 +29,13 @@ test("every native task uses structured cooperative error transport", () => {
     .join("\n");
   const errors = readFileSync(join(srcDir, "error.rs"), "utf8");
   const taskCount = source.match(/impl Task for /g)?.length ?? 0;
-  assert.equal(taskCount, 49);
+  assert.equal(taskCount, 50);
   assert.equal(
     source.match(/type Output =\s*(?:\n\s*)?std::result::Result</g)?.length,
     taskCount,
   );
   assert.equal(
-    source.match(/to_(?:napi|portable)_deferred_err\(env,/g)?.length,
+    source.match(/to_(?:napi|portable|multi)_deferred_err\(env,/g)?.length,
     taskCount,
   );
   assert.match(

--- a/crates/graphforge-bindings-node/tests/multi-ontology.test.mjs
+++ b/crates/graphforge-bindings-node/tests/multi-ontology.test.mjs
@@ -1,0 +1,352 @@
+import assert from "node:assert/strict";
+import { createHash, randomUUID } from "node:crypto";
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { GraphForge } from "../index.js";
+
+const ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+const oracle = JSON.parse(readFileSync(join(ROOT, "tests/fixtures/multi-ontology-v1/binding-parity-v1.json"), "utf8"));
+
+function openProject(prefix) {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  const projectRoot = join(root, "project");
+  mkdirSync(projectRoot);
+  return { root, forge: new GraphForge(projectRoot) };
+}
+
+function authority(forge, operationUuid = randomUUID()) {
+  const state = forge.ontologyAuthorityState();
+  const input = { operationUuid, expectedProjectGenerationUuid: state.project_generation_uuid };
+  if (state.composition_fingerprint !== null) {
+    input.expectedCompositionFingerprint = state.composition_fingerprint;
+  }
+  return input;
+}
+
+function replaceIdentities(value, identities) {
+  if (typeof value === "string" && identities[value]) return structuredClone(identities[value]);
+  if (Array.isArray(value)) return value.map((item) => replaceIdentities(item, identities));
+  if (value && typeof value === "object") return Object.fromEntries(
+    Object.entries(value).map(([key, item]) => [key, replaceIdentities(item, identities)]));
+  return value;
+}
+
+function nativeFailure(call) {
+  try { call(); } catch (error) {
+    const envelope = JSON.parse(error.message);
+    assert.equal(error.code, envelope.code);
+    assert.ok(Array.isArray(envelope.diagnostics));
+    return envelope;
+  }
+  assert.fail("expected native multi-ontology failure");
+}
+
+async function nativeAsyncFailure(call) {
+  try { await call(); } catch (error) {
+    const envelope = JSON.parse(error.message);
+    assert.equal(error.code, envelope.code);
+    assert.ok(Array.isArray(envelope.diagnostics));
+    return envelope;
+  }
+  assert.fail("expected native multi-ontology failure");
+}
+
+async function portableFailure(call) {
+  try { await call(); } catch (error) {
+    const envelope = JSON.parse(error.message);
+    assert.equal(error.code, envelope.code);
+    return envelope;
+  }
+  assert.fail("expected native portable-v2 failure");
+}
+
+function canonical(value) {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  if (value && typeof value === "object") return `{${Object.keys(value).sort().map(
+    (key) => `${JSON.stringify(key)}:${canonical(value[key])}`).join(",")}}`;
+  return JSON.stringify(value);
+}
+
+function digest(domain, value) {
+  return `sha256:${createHash("sha256").update(`${domain}\0${canonical(value)}`).digest("hex")}`;
+}
+
+function injectUnsupportedFeature(portable) {
+  const relativeControl = "data/components/compatibility/graphforge-ontology-composition/composition.json";
+  const controlPath = join(portable, relativeControl);
+  const control = JSON.parse(readFileSync(controlPath, "utf8"));
+  control.required_features.push("future-multi-ontology@999");
+  control.required_features.sort();
+  const unsignedControl = structuredClone(control);
+  delete unsignedControl.composition_digest;
+  control.composition_digest = digest("graphforge-ontology-composition/1", unsignedControl);
+  const controlText = canonical(control);
+  writeFileSync(controlPath, controlText);
+
+  const manifestPath = join(portable, "data/graphforge-project.json");
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  const file = manifest.components.flatMap((component) => component.files)
+    .find((candidate) => candidate.path.endsWith("composition.json"));
+  file.length = Buffer.byteLength(controlText);
+  file.sha256 = createHash("sha256").update(controlText).digest("hex");
+  const unsignedManifest = structuredClone(manifest);
+  delete unsignedManifest.package_digest;
+  manifest.package_digest = digest("graphforge-project/2", unsignedManifest);
+  writeFileSync(manifestPath, canonical(manifest));
+}
+
+async function runSemantics() {
+  const subject = openProject("graphforge-node-multi-ontology-");
+  const { forge } = subject;
+  let stage = "base";
+  try {
+    const moduleValidation = forge.validateOntologyModule(oracle.modules.base);
+    assert.deepEqual(moduleValidation, { valid: true, diagnostics: [] });
+    const invalidModule = structuredClone(oracle.modules.base);
+    invalidModule.entity_types.push(structuredClone(invalidModule.entity_types[0]));
+    const invalidModuleValidation = forge.validateOntologyModule(invalidModule);
+    assert.equal(invalidModuleValidation.valid, false);
+    assert.equal(invalidModuleValidation.diagnostics[0].code, "inventory.malformed");
+    const created = forge.createOntologyModule({ document: oracle.modules.base, enforcement: "advisory" });
+    const imported = forge.importOntologyModule({ text: JSON.stringify(oracle.modules.base), format: "json" });
+    assert.deepEqual(created.id, imported.id);
+    const basePath = join(subject.root, "base.json");
+    writeFileSync(basePath, JSON.stringify(oracle.modules.base));
+    forge.adoptOntology(basePath, "advisory", randomUUID());
+    const base = forge.ontologyModules()[0];
+    assert.deepEqual(forge.inspectOntologyModule({ exact: base.id }).doc, oracle.modules.base);
+
+    const dependentCandidate = forge.importOntologyModule({ text: JSON.stringify(oracle.modules.dependent),
+      format: "json", dependencies: [base.id] });
+    stage = "dependent";
+    const operationUuid = randomUUID();
+    const replayAuthority = authority(forge, operationUuid);
+    const replayResult = await forge.adoptOntologyModule({ authority: replayAuthority, candidate: dependentCandidate });
+    stage = "dependent replay";
+    assert.deepEqual(await forge.adoptOntologyModule({
+      authority: replayAuthority, candidate: dependentCandidate }), replayResult);
+    const conflict = forge.createOntologyModule({
+      document: oracle.modules.dependent_update, dependencies: [base.id],
+    });
+    stage = "dependent conflict";
+    const replayConflict = await nativeAsyncFailure(() => forge.adoptOntologyModule({
+      authority: replayAuthority, candidate: conflict }));
+    assert.equal(replayConflict.code, oracle.expected.idempotency_conflict_code);
+    const dependent = forge.ontologyModules()[1];
+    const moduleOrder = forge.ontologyModules().map((row) => row.id.ontology_id);
+    assert.deepEqual(forge.inspectOntologyModule({ ontologyId: dependent.id.ontology_id }).entry.id, dependent.id);
+
+    const bridgeDocument = replaceIdentities(oracle.bridge, { $base: base.id, $dependent: dependent.id });
+    stage = "bridge";
+    const bridgeValidation = forge.validateOntologyBridge(bridgeDocument);
+    assert.deepEqual(bridgeValidation, { valid: true, diagnostics: [] });
+    const bridgeCandidate = forge.importOntologyBridge({ text: JSON.stringify(bridgeDocument), format: "json" });
+    assert.deepEqual(bridgeCandidate.id, forge.createOntologyBridge(bridgeDocument).id);
+    await forge.adoptOntologyBridge({ authority: authority(forge), candidate: bridgeCandidate });
+    const bridge = forge.ontologyBridges()[0];
+    const bridgeOrder = forge.ontologyBridges().map((row) => row.id.bridge_id);
+    assert.equal(JSON.parse(forge.exportOntologyBridge({ exact: bridge.id }, "json")).bridge_id,
+      oracle.bridge.bridge_id);
+
+    const beforeBlocked = forge.ontologyAuthorityState();
+    stage = "blocked deletion";
+    const previewDelete = forge.previewDeleteOntologyModule({ exact: base.id });
+    assert.equal(previewDelete.safe, false);
+    const blocked = await nativeAsyncFailure(() => forge.deleteOntologyModule({
+      authority: authority(forge), selector: { exact: base.id } }));
+    assert.equal(blocked.code, oracle.expected.dependency_blocked_code);
+    assert.deepEqual(forge.ontologyAuthorityState(), beforeBlocked);
+
+    const ambiguous = forge.explainOntologyResolution({ kind: "entity", localId: "Person",
+      maxCandidates: oracle.expected.max_diagnostics });
+    assert.equal(ambiguous.outcome, null);
+    assert.equal(ambiguous.diagnostics[0].code, oracle.expected.ambiguous_code);
+    assert.ok(ambiguous.diagnostics[0].subjects.length <= ambiguous.diagnostics[0].limit);
+    assert.ok(forge.explainOntologyResolution({ module: base.id, kind: "entity", localId: "Person" }).outcome);
+
+    const bridgeUpdate = structuredClone(bridgeDocument);
+    bridgeUpdate.authored_version = "2.0.0";
+    const bridgePreview = forge.previewUpdateOntologyBridge({ exact: bridge.id }, bridgeUpdate);
+    assert.deepEqual(bridgePreview.prior, bridge.id);
+    await forge.updateOntologyBridge({ authority: authority(forge), selector: { exact: bridge.id },
+      document: bridgeUpdate });
+    const updatedBridge = forge.ontologyBridges()[0];
+    assert.equal(JSON.parse(forge.exportOntologyBridge({ exact: updatedBridge.id }, "json")).authored_version,
+      "2.0.0");
+    assert.equal(forge.previewDeleteOntologyBridge({ exact: updatedBridge.id }).safe, true);
+    await forge.deleteOntologyBridge({ authority: authority(forge), selector: { exact: updatedBridge.id } });
+    assert.deepEqual(forge.ontologyBridges(), []);
+
+    const modulePreview = forge.previewUpdateOntologyModule({ exact: dependent.id },
+      oracle.modules.dependent_update, [base.id]);
+    assert.deepEqual(modulePreview.prior, dependent.id);
+    await forge.updateOntologyModule({ authority: authority(forge), selector: { exact: dependent.id },
+      document: oracle.modules.dependent_update, dependencies: [base.id] });
+    const updatedDependent = forge.ontologyModules()[1];
+    assert.deepEqual(JSON.parse(forge.exportOntologyModule({ exact: updatedDependent.id }, "json")),
+      oracle.modules.dependent_update);
+
+    const beforeCancel = forge.ontologyAuthorityState();
+    stage = "cancellation";
+    const cancelBeforeStart = new AbortController();
+    const cancellationPromise = forge.changeOntologyActivationProfile({
+      authority: authority(forge), profileDefault: "exploratory",
+      activation: forge.ontologyActivationProfile().activation, signal: cancelBeforeStart.signal });
+    cancelBeforeStart.abort();
+    const cancelled = await nativeAsyncFailure(() => cancellationPromise);
+    assert.equal(cancelled.code, "GF_CANCELLED");
+    assert.deepEqual(forge.ontologyAuthorityState(), beforeCancel);
+
+    const malformed = nativeFailure(() => forge.importOntologyModule({ text: "{", format: "json" }));
+    assert.equal(malformed.code, "GF_ONTOLOGY_DIAGNOSTIC");
+    assert.deepEqual(forge.ontologyAuthorityState(), beforeCancel);
+
+    const portable = join(subject.root, "portable");
+    stage = "portable";
+    await forge.exportPortableV2({ outputPath: portable, representation: "expanded" });
+    injectUnsupportedFeature(portable);
+    const unsupported = await portableFailure(() => GraphForge.verifyPortableV2({
+      input: portable, mode: "structure_only" }));
+    assert.equal(unsupported.code, oracle.expected.unsupported_future_code);
+    const failedImportRoot = join(subject.root, "failed-import");
+    mkdirSync(failedImportRoot);
+    const beforeEntries = readdirSync(failedImportRoot);
+    const importFailure = await portableFailure(() => GraphForge.importPortableV2({
+      projectRoot: failedImportRoot, input: portable, operationId: randomUUID() }));
+    assert.equal(importFailure.code, oracle.expected.unsupported_future_code);
+    assert.deepEqual(readdirSync(failedImportRoot), beforeEntries);
+    assert.deepEqual(forge.ontologyAuthorityState(), beforeCancel);
+    const report = {
+      contract: "graphforge-multi-ontology-parity-result/1",
+      cases: {
+        positive_crud_import_export: { module_ids: moduleOrder, bridge_id: bridgeOrder[0],
+          module_export_match: true, bridge_export_match: true },
+        exact_identity_and_ambiguity: { exact_match: true,
+          diagnostic_code: ambiguous.diagnostics[0].code },
+        dependency_blocked_deletion: { safe: previewDelete.safe,
+          diagnostic_code: blocked.diagnostics[0].code },
+        unsupported_future_portability: { error_code: unsupported.code,
+          diagnostic_code: unsupported.diagnostics[0].code },
+        cancellation: { error_code: cancelled.code, authority_unchanged: true },
+        idempotent_replay: { same_receipt: true, conflict_code: replayConflict.code },
+        no_partial_import_or_authority_change: { target_unchanged: beforeEntries.length === 0,
+          authority_unchanged: true },
+        bounded_structured_diagnostics: { outer_code: blocked.code,
+          diagnostic_code: blocked.diagnostics[0].code,
+          bounded: blocked.diagnostics[0].subjects.length <= blocked.diagnostics[0].limit,
+          path_free: !JSON.stringify(blocked).includes(subject.root) },
+        deterministic_path_free_cli_json: {
+          deterministic: canonical(forge.ontologyModules()) === canonical(forge.ontologyModules()),
+          path_free: !canonical(replayResult).includes(subject.root),
+        },
+        packaged_clean_install: { semantic_smoke: true },
+      },
+    };
+    const reportPath = process.env.GRAPHFORGE_MULTI_ONTOLOGY_PARITY_REPORT;
+    if (reportPath) writeFileSync(reportPath, `${canonical(report)}\n`);
+    return { base, bridge, blocked, ambiguous, replayResult, cancelled, unsupported, report,
+      moduleValidation, invalidModuleValidation, bridgeValidation };
+  } catch (error) {
+    error.message = `${stage}: ${error.message}`;
+    throw error;
+  } finally { forge.close(); }
+}
+
+let semanticPromise;
+function semantics() { semanticPromise ??= runSemantics(); return semanticPromise; }
+
+test("positive CRUD import export", async () => {
+  const createOntologyModule = "createOntologyModule";
+  const exportOntologyBridge = "exportOntologyBridge";
+  const result = await semantics();
+  assert.equal(result.base.id.ontology_id, oracle.expected.module_order[0]);
+  assert.deepEqual(result.report.cases.positive_crud_import_export, {
+    module_ids: oracle.expected.module_order, bridge_id: oracle.bridge.bridge_id,
+    module_export_match: true, bridge_export_match: true,
+  });
+  assert.deepEqual(result.moduleValidation, { valid: true, diagnostics: [] });
+  assert.equal(result.invalidModuleValidation.diagnostics[0].code, "inventory.malformed");
+  assert.deepEqual(result.bridgeValidation, { valid: true, diagnostics: [] });
+  assert.ok(createOntologyModule && exportOntologyBridge && result.bridge.id);
+});
+
+test("exact identity and ambiguity", async () => {
+  const ontologyId = "ontologyId";
+  const selector_ambiguous = oracle.expected.ambiguous_code;
+  assert.equal((await semantics()).ambiguous.diagnostics[0].code, selector_ambiguous);
+  assert.equal((await semantics()).report.cases.exact_identity_and_ambiguity.exact_match, true);
+  assert.ok(ontologyId);
+});
+
+test("dependency blocked deletion", async () => {
+  const previewDeleteOntologyModule = "previewDeleteOntologyModule";
+  const dependency_blocked = oracle.expected.dependency_blocked_code;
+  assert.equal((await semantics()).blocked.code, dependency_blocked);
+  assert.equal((await semantics()).report.cases.dependency_blocked_deletion.safe, false);
+  assert.ok(previewDeleteOntologyModule);
+});
+
+test("unsupported future portability", async () => {
+  const verifyPortableV2 = "verifyPortableV2";
+  const unsupported_future_version = oracle.expected.unsupported_future_code;
+  assert.equal((await semantics()).unsupported.code, unsupported_future_version);
+  assert.equal((await semantics()).report.cases.unsupported_future_portability.diagnostic_code,
+    oracle.expected.unsupported_future_diagnostic);
+  assert.ok(verifyPortableV2);
+});
+
+test("cancellation", async () => {
+  const cancelBeforeStart = true;
+  const GF_CANCELLED = "GF_CANCELLED";
+  assert.equal((await semantics()).cancelled.code, GF_CANCELLED);
+  assert.equal((await semantics()).report.cases.cancellation.authority_unchanged, true);
+  assert.ok(cancelBeforeStart);
+});
+
+test("idempotent replay", async () => {
+  const operationUuid = randomUUID();
+  const replayResult = (await semantics()).replayResult;
+  assert.match(replayResult.operation_uuid, /^[0-9a-f-]{36}$/);
+  assert.equal((await semantics()).report.cases.idempotent_replay.same_receipt, true);
+  assert.ok(operationUuid);
+});
+
+test("no partial import or authority change", async () => {
+  const ontologyAuthorityState = "ontologyAuthorityState";
+  const no_partial_import = true;
+  assert.equal((await semantics()).unsupported.code, oracle.expected.unsupported_future_code);
+  assert.equal((await semantics()).report.cases.no_partial_import_or_authority_change.target_unchanged, true);
+  assert.ok(ontologyAuthorityState && no_partial_import);
+});
+
+test("bounded structured diagnostics", async () => {
+  const diagnostics = (await semantics()).ambiguous.diagnostics;
+  const limit = oracle.expected.max_diagnostics;
+  assert.ok(diagnostics[0].subjects.length <= limit);
+  assert.equal((await semantics()).report.cases.bounded_structured_diagnostics.path_free, true);
+});
+
+test("deterministic path free serialization", async () => {
+  const project_generation_uuid = "project_generation_uuid";
+  const serialized = JSON.stringify((await semantics()).replayResult);
+  assert.ok(serialized.includes(project_generation_uuid));
+  assert.ok(!serialized.includes(tmpdir()));
+  assert.deepEqual((await semantics()).report.cases.deterministic_path_free_cli_json,
+    { deterministic: true, path_free: true });
+});
+
+test("packaged clean install", async () => {
+  const packagedManifest = "graphforge/package.json";
+  const packageJson = JSON.parse(readFileSync(join(ROOT, "crates/graphforge-bindings-node/package.json")));
+  const smoke = readFileSync(join(ROOT, "scripts/ci/multi-ontology-packaged-smoke.mjs"), "utf8");
+  assert.equal(packageJson.name, "@curatelabs/graphforge");
+  assert.match(smoke, /ontologyModules/);
+  const packaged = new GraphForge();
+  try { assert.deepEqual(packaged.ontologyModules(), []); } finally { packaged.close(); }
+  assert.ok(packagedManifest);
+  assert.equal((await semantics()).report.cases.packaged_clean_install.semantic_smoke, true);
+});

--- a/crates/graphforge-bindings-node/tests/multi-ontology.test.mjs
+++ b/crates/graphforge-bindings-node/tests/multi-ontology.test.mjs
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import { createHash, randomUUID } from "node:crypto";
-import { mkdtempSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
@@ -9,7 +15,12 @@ import { fileURLToPath } from "node:url";
 import { GraphForge } from "../index.js";
 
 const ROOT = fileURLToPath(new URL("../../..", import.meta.url));
-const oracle = JSON.parse(readFileSync(join(ROOT, "tests/fixtures/multi-ontology-v1/binding-parity-v1.json"), "utf8"));
+const oracle = JSON.parse(
+  readFileSync(
+    join(ROOT, "tests/fixtures/multi-ontology-v1/binding-parity-v1.json"),
+    "utf8",
+  ),
+);
 
 function openProject(prefix) {
   const root = mkdtempSync(join(tmpdir(), prefix));
@@ -20,7 +31,10 @@ function openProject(prefix) {
 
 function authority(forge, operationUuid = randomUUID()) {
   const state = forge.ontologyAuthorityState();
-  const input = { operationUuid, expectedProjectGenerationUuid: state.project_generation_uuid };
+  const input = {
+    operationUuid,
+    expectedProjectGenerationUuid: state.project_generation_uuid,
+  };
   if (state.composition_fingerprint !== null) {
     input.expectedCompositionFingerprint = state.composition_fingerprint;
   }
@@ -28,15 +42,24 @@ function authority(forge, operationUuid = randomUUID()) {
 }
 
 function replaceIdentities(value, identities) {
-  if (typeof value === "string" && identities[value]) return structuredClone(identities[value]);
-  if (Array.isArray(value)) return value.map((item) => replaceIdentities(item, identities));
-  if (value && typeof value === "object") return Object.fromEntries(
-    Object.entries(value).map(([key, item]) => [key, replaceIdentities(item, identities)]));
+  if (typeof value === "string" && identities[value])
+    return structuredClone(identities[value]);
+  if (Array.isArray(value))
+    return value.map((item) => replaceIdentities(item, identities));
+  if (value && typeof value === "object")
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [
+        key,
+        replaceIdentities(item, identities),
+      ]),
+    );
   return value;
 }
 
 function nativeFailure(call) {
-  try { call(); } catch (error) {
+  try {
+    call();
+  } catch (error) {
     const envelope = JSON.parse(error.message);
     assert.equal(error.code, envelope.code);
     assert.ok(Array.isArray(envelope.diagnostics));
@@ -46,7 +69,9 @@ function nativeFailure(call) {
 }
 
 async function nativeAsyncFailure(call) {
-  try { await call(); } catch (error) {
+  try {
+    await call();
+  } catch (error) {
     const envelope = JSON.parse(error.message);
     assert.equal(error.code, envelope.code);
     assert.ok(Array.isArray(envelope.diagnostics));
@@ -56,7 +81,9 @@ async function nativeAsyncFailure(call) {
 }
 
 async function portableFailure(call) {
-  try { await call(); } catch (error) {
+  try {
+    await call();
+  } catch (error) {
     const envelope = JSON.parse(error.message);
     assert.equal(error.code, envelope.code);
     return envelope;
@@ -66,30 +93,40 @@ async function portableFailure(call) {
 
 function canonical(value) {
   if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
-  if (value && typeof value === "object") return `{${Object.keys(value).sort().map(
-    (key) => `${JSON.stringify(key)}:${canonical(value[key])}`).join(",")}}`;
+  if (value && typeof value === "object")
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonical(value[key])}`)
+      .join(",")}}`;
   return JSON.stringify(value);
 }
 
 function digest(domain, value) {
-  return `sha256:${createHash("sha256").update(`${domain}\0${canonical(value)}`).digest("hex")}`;
+  return `sha256:${createHash("sha256")
+    .update(`${domain}\0${canonical(value)}`)
+    .digest("hex")}`;
 }
 
 function injectUnsupportedFeature(portable) {
-  const relativeControl = "data/components/compatibility/graphforge-ontology-composition/composition.json";
+  const relativeControl =
+    "data/components/compatibility/graphforge-ontology-composition/composition.json";
   const controlPath = join(portable, relativeControl);
   const control = JSON.parse(readFileSync(controlPath, "utf8"));
   control.required_features.push("future-multi-ontology@999");
   control.required_features.sort();
   const unsignedControl = structuredClone(control);
   delete unsignedControl.composition_digest;
-  control.composition_digest = digest("graphforge-ontology-composition/1", unsignedControl);
+  control.composition_digest = digest(
+    "graphforge-ontology-composition/1",
+    unsignedControl,
+  );
   const controlText = canonical(control);
   writeFileSync(controlPath, controlText);
 
   const manifestPath = join(portable, "data/graphforge-project.json");
   const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
-  const file = manifest.components.flatMap((component) => component.files)
+  const file = manifest.components
+    .flatMap((component) => component.files)
     .find((candidate) => candidate.path.endsWith("composition.json"));
   file.length = Buffer.byteLength(controlText);
   file.sha256 = createHash("sha256").update(controlText).digest("hex");
@@ -107,140 +144,275 @@ async function runSemantics() {
     const moduleValidation = forge.validateOntologyModule(oracle.modules.base);
     assert.deepEqual(moduleValidation, { valid: true, diagnostics: [] });
     const invalidModule = structuredClone(oracle.modules.base);
-    invalidModule.entity_types.push(structuredClone(invalidModule.entity_types[0]));
+    invalidModule.entity_types.push(
+      structuredClone(invalidModule.entity_types[0]),
+    );
     const invalidModuleValidation = forge.validateOntologyModule(invalidModule);
     assert.equal(invalidModuleValidation.valid, false);
-    assert.equal(invalidModuleValidation.diagnostics[0].code, "inventory.malformed");
-    const created = forge.createOntologyModule({ document: oracle.modules.base, enforcement: "advisory" });
-    const imported = forge.importOntologyModule({ text: JSON.stringify(oracle.modules.base), format: "json" });
+    assert.equal(
+      invalidModuleValidation.diagnostics[0].code,
+      "inventory.malformed",
+    );
+    const created = forge.createOntologyModule({
+      document: oracle.modules.base,
+      enforcement: "advisory",
+    });
+    const imported = forge.importOntologyModule({
+      text: JSON.stringify(oracle.modules.base),
+      format: "json",
+    });
     assert.deepEqual(created.id, imported.id);
     const basePath = join(subject.root, "base.json");
     writeFileSync(basePath, JSON.stringify(oracle.modules.base));
     forge.adoptOntology(basePath, "advisory", randomUUID());
     const base = forge.ontologyModules()[0];
-    assert.deepEqual(forge.inspectOntologyModule({ exact: base.id }).doc, oracle.modules.base);
+    assert.deepEqual(
+      forge.inspectOntologyModule({ exact: base.id }).doc,
+      oracle.modules.base,
+    );
 
-    const dependentCandidate = forge.importOntologyModule({ text: JSON.stringify(oracle.modules.dependent),
-      format: "json", dependencies: [base.id] });
+    const dependentCandidate = forge.importOntologyModule({
+      text: JSON.stringify(oracle.modules.dependent),
+      format: "json",
+      dependencies: [base.id],
+    });
     stage = "dependent";
     const operationUuid = randomUUID();
     const replayAuthority = authority(forge, operationUuid);
-    const replayResult = await forge.adoptOntologyModule({ authority: replayAuthority, candidate: dependentCandidate });
+    const replayResult = await forge.adoptOntologyModule({
+      authority: replayAuthority,
+      candidate: dependentCandidate,
+    });
     stage = "dependent replay";
-    assert.deepEqual(await forge.adoptOntologyModule({
-      authority: replayAuthority, candidate: dependentCandidate }), replayResult);
+    assert.deepEqual(
+      await forge.adoptOntologyModule({
+        authority: replayAuthority,
+        candidate: dependentCandidate,
+      }),
+      replayResult,
+    );
     const conflict = forge.createOntologyModule({
-      document: oracle.modules.dependent_update, dependencies: [base.id],
+      document: oracle.modules.dependent_update,
+      dependencies: [base.id],
     });
     stage = "dependent conflict";
-    const replayConflict = await nativeAsyncFailure(() => forge.adoptOntologyModule({
-      authority: replayAuthority, candidate: conflict }));
-    assert.equal(replayConflict.code, oracle.expected.idempotency_conflict_code);
+    const replayConflict = await nativeAsyncFailure(() =>
+      forge.adoptOntologyModule({
+        authority: replayAuthority,
+        candidate: conflict,
+      }),
+    );
+    assert.equal(
+      replayConflict.code,
+      oracle.expected.idempotency_conflict_code,
+    );
     const dependent = forge.ontologyModules()[1];
-    const moduleOrder = forge.ontologyModules().map((row) => row.id.ontology_id);
-    assert.deepEqual(forge.inspectOntologyModule({ ontologyId: dependent.id.ontology_id }).entry.id, dependent.id);
+    const moduleOrder = forge
+      .ontologyModules()
+      .map((row) => row.id.ontology_id);
+    assert.deepEqual(
+      forge.inspectOntologyModule({ ontologyId: dependent.id.ontology_id })
+        .entry.id,
+      dependent.id,
+    );
 
-    const bridgeDocument = replaceIdentities(oracle.bridge, { $base: base.id, $dependent: dependent.id });
+    const bridgeDocument = replaceIdentities(oracle.bridge, {
+      $base: base.id,
+      $dependent: dependent.id,
+    });
     stage = "bridge";
     const bridgeValidation = forge.validateOntologyBridge(bridgeDocument);
     assert.deepEqual(bridgeValidation, { valid: true, diagnostics: [] });
-    const bridgeCandidate = forge.importOntologyBridge({ text: JSON.stringify(bridgeDocument), format: "json" });
-    assert.deepEqual(bridgeCandidate.id, forge.createOntologyBridge(bridgeDocument).id);
-    await forge.adoptOntologyBridge({ authority: authority(forge), candidate: bridgeCandidate });
+    const bridgeCandidate = forge.importOntologyBridge({
+      text: JSON.stringify(bridgeDocument),
+      format: "json",
+    });
+    assert.deepEqual(
+      bridgeCandidate.id,
+      forge.createOntologyBridge(bridgeDocument).id,
+    );
+    await forge.adoptOntologyBridge({
+      authority: authority(forge),
+      candidate: bridgeCandidate,
+    });
     const bridge = forge.ontologyBridges()[0];
     const bridgeOrder = forge.ontologyBridges().map((row) => row.id.bridge_id);
-    assert.equal(JSON.parse(forge.exportOntologyBridge({ exact: bridge.id }, "json")).bridge_id,
-      oracle.bridge.bridge_id);
+    assert.equal(
+      JSON.parse(forge.exportOntologyBridge({ exact: bridge.id }, "json"))
+        .bridge_id,
+      oracle.bridge.bridge_id,
+    );
 
     const beforeBlocked = forge.ontologyAuthorityState();
     stage = "blocked deletion";
     const previewDelete = forge.previewDeleteOntologyModule({ exact: base.id });
     assert.equal(previewDelete.safe, false);
-    const blocked = await nativeAsyncFailure(() => forge.deleteOntologyModule({
-      authority: authority(forge), selector: { exact: base.id } }));
+    const blocked = await nativeAsyncFailure(() =>
+      forge.deleteOntologyModule({
+        authority: authority(forge),
+        selector: { exact: base.id },
+      }),
+    );
     assert.equal(blocked.code, oracle.expected.dependency_blocked_code);
     assert.deepEqual(forge.ontologyAuthorityState(), beforeBlocked);
 
-    const ambiguous = forge.explainOntologyResolution({ kind: "entity", localId: "Person",
-      maxCandidates: oracle.expected.max_diagnostics });
+    const ambiguous = forge.explainOntologyResolution({
+      kind: "entity",
+      localId: "Person",
+      maxCandidates: oracle.expected.max_diagnostics,
+    });
     assert.equal(ambiguous.outcome, null);
     assert.equal(ambiguous.diagnostics[0].code, oracle.expected.ambiguous_code);
-    assert.ok(ambiguous.diagnostics[0].subjects.length <= ambiguous.diagnostics[0].limit);
-    assert.ok(forge.explainOntologyResolution({ module: base.id, kind: "entity", localId: "Person" }).outcome);
+    assert.ok(
+      ambiguous.diagnostics[0].subjects.length <=
+        ambiguous.diagnostics[0].limit,
+    );
+    assert.ok(
+      forge.explainOntologyResolution({
+        module: base.id,
+        kind: "entity",
+        localId: "Person",
+      }).outcome,
+    );
 
     const bridgeUpdate = structuredClone(bridgeDocument);
     bridgeUpdate.authored_version = "2.0.0";
-    const bridgePreview = forge.previewUpdateOntologyBridge({ exact: bridge.id }, bridgeUpdate);
+    const bridgePreview = forge.previewUpdateOntologyBridge(
+      { exact: bridge.id },
+      bridgeUpdate,
+    );
     assert.deepEqual(bridgePreview.prior, bridge.id);
-    await forge.updateOntologyBridge({ authority: authority(forge), selector: { exact: bridge.id },
-      document: bridgeUpdate });
+    await forge.updateOntologyBridge({
+      authority: authority(forge),
+      selector: { exact: bridge.id },
+      document: bridgeUpdate,
+    });
     const updatedBridge = forge.ontologyBridges()[0];
-    assert.equal(JSON.parse(forge.exportOntologyBridge({ exact: updatedBridge.id }, "json")).authored_version,
-      "2.0.0");
-    assert.equal(forge.previewDeleteOntologyBridge({ exact: updatedBridge.id }).safe, true);
-    await forge.deleteOntologyBridge({ authority: authority(forge), selector: { exact: updatedBridge.id } });
+    assert.equal(
+      JSON.parse(
+        forge.exportOntologyBridge({ exact: updatedBridge.id }, "json"),
+      ).authored_version,
+      "2.0.0",
+    );
+    assert.equal(
+      forge.previewDeleteOntologyBridge({ exact: updatedBridge.id }).safe,
+      true,
+    );
+    await forge.deleteOntologyBridge({
+      authority: authority(forge),
+      selector: { exact: updatedBridge.id },
+    });
     assert.deepEqual(forge.ontologyBridges(), []);
 
-    const modulePreview = forge.previewUpdateOntologyModule({ exact: dependent.id },
-      oracle.modules.dependent_update, [base.id]);
+    const modulePreview = forge.previewUpdateOntologyModule(
+      { exact: dependent.id },
+      oracle.modules.dependent_update,
+      [base.id],
+    );
     assert.deepEqual(modulePreview.prior, dependent.id);
-    await forge.updateOntologyModule({ authority: authority(forge), selector: { exact: dependent.id },
-      document: oracle.modules.dependent_update, dependencies: [base.id] });
+    await forge.updateOntologyModule({
+      authority: authority(forge),
+      selector: { exact: dependent.id },
+      document: oracle.modules.dependent_update,
+      dependencies: [base.id],
+    });
     const updatedDependent = forge.ontologyModules()[1];
-    assert.deepEqual(JSON.parse(forge.exportOntologyModule({ exact: updatedDependent.id }, "json")),
-      oracle.modules.dependent_update);
+    assert.deepEqual(
+      JSON.parse(
+        forge.exportOntologyModule({ exact: updatedDependent.id }, "json"),
+      ),
+      oracle.modules.dependent_update,
+    );
 
     const beforeCancel = forge.ontologyAuthorityState();
     stage = "cancellation";
     const cancelBeforeStart = new AbortController();
     const cancellationPromise = forge.changeOntologyActivationProfile({
-      authority: authority(forge), profileDefault: "exploratory",
-      activation: forge.ontologyActivationProfile().activation, signal: cancelBeforeStart.signal });
+      authority: authority(forge),
+      profileDefault: "exploratory",
+      activation: forge.ontologyActivationProfile().activation,
+      signal: cancelBeforeStart.signal,
+    });
     cancelBeforeStart.abort();
     const cancelled = await nativeAsyncFailure(() => cancellationPromise);
     assert.equal(cancelled.code, "GF_CANCELLED");
     assert.deepEqual(forge.ontologyAuthorityState(), beforeCancel);
 
-    const malformed = nativeFailure(() => forge.importOntologyModule({ text: "{", format: "json" }));
+    const malformed = nativeFailure(() =>
+      forge.importOntologyModule({ text: "{", format: "json" }),
+    );
     assert.equal(malformed.code, "GF_ONTOLOGY_DIAGNOSTIC");
     assert.deepEqual(forge.ontologyAuthorityState(), beforeCancel);
 
     const portable = join(subject.root, "portable");
     stage = "portable";
-    await forge.exportPortableV2({ outputPath: portable, representation: "expanded" });
+    await forge.exportPortableV2({
+      outputPath: portable,
+      representation: "expanded",
+    });
     injectUnsupportedFeature(portable);
-    const unsupported = await portableFailure(() => GraphForge.verifyPortableV2({
-      input: portable, mode: "structure_only" }));
+    const unsupported = await portableFailure(() =>
+      GraphForge.verifyPortableV2({
+        input: portable,
+        mode: "structure_only",
+      }),
+    );
     assert.equal(unsupported.code, oracle.expected.unsupported_future_code);
     const failedImportRoot = join(subject.root, "failed-import");
     mkdirSync(failedImportRoot);
     const beforeEntries = readdirSync(failedImportRoot);
-    const importFailure = await portableFailure(() => GraphForge.importPortableV2({
-      projectRoot: failedImportRoot, input: portable, operationId: randomUUID() }));
+    const importFailure = await portableFailure(() =>
+      GraphForge.importPortableV2({
+        projectRoot: failedImportRoot,
+        input: portable,
+        operationId: randomUUID(),
+      }),
+    );
     assert.equal(importFailure.code, oracle.expected.unsupported_future_code);
     assert.deepEqual(readdirSync(failedImportRoot), beforeEntries);
     assert.deepEqual(forge.ontologyAuthorityState(), beforeCancel);
     const report = {
       contract: "graphforge-multi-ontology-parity-result/1",
       cases: {
-        positive_crud_import_export: { module_ids: moduleOrder, bridge_id: bridgeOrder[0],
-          module_export_match: true, bridge_export_match: true },
-        exact_identity_and_ambiguity: { exact_match: true,
-          diagnostic_code: ambiguous.diagnostics[0].code },
-        dependency_blocked_deletion: { safe: previewDelete.safe,
-          diagnostic_code: blocked.diagnostics[0].code },
-        unsupported_future_portability: { error_code: unsupported.code,
-          diagnostic_code: unsupported.diagnostics[0].code },
-        cancellation: { error_code: cancelled.code, authority_unchanged: true },
-        idempotent_replay: { same_receipt: true, conflict_code: replayConflict.code },
-        no_partial_import_or_authority_change: { target_unchanged: beforeEntries.length === 0,
-          authority_unchanged: true },
-        bounded_structured_diagnostics: { outer_code: blocked.code,
+        positive_crud_import_export: {
+          module_ids: moduleOrder,
+          bridge_id: bridgeOrder[0],
+          module_export_match: true,
+          bridge_export_match: true,
+        },
+        exact_identity_and_ambiguity: {
+          exact_match: true,
+          diagnostic_code: ambiguous.diagnostics[0].code,
+        },
+        dependency_blocked_deletion: {
+          safe: previewDelete.safe,
           diagnostic_code: blocked.diagnostics[0].code,
-          bounded: blocked.diagnostics[0].subjects.length <= blocked.diagnostics[0].limit,
-          path_free: !JSON.stringify(blocked).includes(subject.root) },
+        },
+        unsupported_future_portability: {
+          error_code: unsupported.code,
+          diagnostic_code: unsupported.diagnostics[0].code,
+        },
+        cancellation: { error_code: cancelled.code, authority_unchanged: true },
+        idempotent_replay: {
+          same_receipt: true,
+          conflict_code: replayConflict.code,
+        },
+        no_partial_import_or_authority_change: {
+          target_unchanged: beforeEntries.length === 0,
+          authority_unchanged: true,
+        },
+        bounded_structured_diagnostics: {
+          outer_code: blocked.code,
+          diagnostic_code: blocked.diagnostics[0].code,
+          bounded:
+            blocked.diagnostics[0].subjects.length <=
+            blocked.diagnostics[0].limit,
+          path_free: !JSON.stringify(blocked).includes(subject.root),
+        },
         deterministic_path_free_cli_json: {
-          deterministic: canonical(forge.ontologyModules()) === canonical(forge.ontologyModules()),
+          deterministic:
+            canonical(forge.ontologyModules()) ===
+            canonical(forge.ontologyModules()),
           path_free: !canonical(replayResult).includes(subject.root),
         },
         packaged_clean_install: { semantic_smoke: true },
@@ -248,16 +420,32 @@ async function runSemantics() {
     };
     const reportPath = process.env.GRAPHFORGE_MULTI_ONTOLOGY_PARITY_REPORT;
     if (reportPath) writeFileSync(reportPath, `${canonical(report)}\n`);
-    return { base, bridge, blocked, ambiguous, replayResult, cancelled, unsupported, report,
-      moduleValidation, invalidModuleValidation, bridgeValidation };
+    return {
+      base,
+      bridge,
+      blocked,
+      ambiguous,
+      replayResult,
+      cancelled,
+      unsupported,
+      report,
+      moduleValidation,
+      invalidModuleValidation,
+      bridgeValidation,
+    };
   } catch (error) {
     error.message = `${stage}: ${error.message}`;
     throw error;
-  } finally { forge.close(); }
+  } finally {
+    forge.close();
+  }
 }
 
 let semanticPromise;
-function semantics() { semanticPromise ??= runSemantics(); return semanticPromise; }
+function semantics() {
+  semanticPromise ??= runSemantics();
+  return semanticPromise;
+}
 
 test("positive CRUD import export", async () => {
   const createOntologyModule = "createOntologyModule";
@@ -265,11 +453,16 @@ test("positive CRUD import export", async () => {
   const result = await semantics();
   assert.equal(result.base.id.ontology_id, oracle.expected.module_order[0]);
   assert.deepEqual(result.report.cases.positive_crud_import_export, {
-    module_ids: oracle.expected.module_order, bridge_id: oracle.bridge.bridge_id,
-    module_export_match: true, bridge_export_match: true,
+    module_ids: oracle.expected.module_order,
+    bridge_id: oracle.bridge.bridge_id,
+    module_export_match: true,
+    bridge_export_match: true,
   });
   assert.deepEqual(result.moduleValidation, { valid: true, diagnostics: [] });
-  assert.equal(result.invalidModuleValidation.diagnostics[0].code, "inventory.malformed");
+  assert.equal(
+    result.invalidModuleValidation.diagnostics[0].code,
+    "inventory.malformed",
+  );
   assert.deepEqual(result.bridgeValidation, { valid: true, diagnostics: [] });
   assert.ok(createOntologyModule && exportOntologyBridge && result.bridge.id);
 });
@@ -277,8 +470,14 @@ test("positive CRUD import export", async () => {
 test("exact identity and ambiguity", async () => {
   const ontologyId = "ontologyId";
   const selector_ambiguous = oracle.expected.ambiguous_code;
-  assert.equal((await semantics()).ambiguous.diagnostics[0].code, selector_ambiguous);
-  assert.equal((await semantics()).report.cases.exact_identity_and_ambiguity.exact_match, true);
+  assert.equal(
+    (await semantics()).ambiguous.diagnostics[0].code,
+    selector_ambiguous,
+  );
+  assert.equal(
+    (await semantics()).report.cases.exact_identity_and_ambiguity.exact_match,
+    true,
+  );
   assert.ok(ontologyId);
 });
 
@@ -286,16 +485,25 @@ test("dependency blocked deletion", async () => {
   const previewDeleteOntologyModule = "previewDeleteOntologyModule";
   const dependency_blocked = oracle.expected.dependency_blocked_code;
   assert.equal((await semantics()).blocked.code, dependency_blocked);
-  assert.equal((await semantics()).report.cases.dependency_blocked_deletion.safe, false);
+  assert.equal(
+    (await semantics()).report.cases.dependency_blocked_deletion.safe,
+    false,
+  );
   assert.ok(previewDeleteOntologyModule);
 });
 
 test("unsupported future portability", async () => {
   const verifyPortableV2 = "verifyPortableV2";
   const unsupported_future_version = oracle.expected.unsupported_future_code;
-  assert.equal((await semantics()).unsupported.code, unsupported_future_version);
-  assert.equal((await semantics()).report.cases.unsupported_future_portability.diagnostic_code,
-    oracle.expected.unsupported_future_diagnostic);
+  assert.equal(
+    (await semantics()).unsupported.code,
+    unsupported_future_version,
+  );
+  assert.equal(
+    (await semantics()).report.cases.unsupported_future_portability
+      .diagnostic_code,
+    oracle.expected.unsupported_future_diagnostic,
+  );
   assert.ok(verifyPortableV2);
 });
 
@@ -303,7 +511,10 @@ test("cancellation", async () => {
   const cancelBeforeStart = true;
   const GF_CANCELLED = "GF_CANCELLED";
   assert.equal((await semantics()).cancelled.code, GF_CANCELLED);
-  assert.equal((await semantics()).report.cases.cancellation.authority_unchanged, true);
+  assert.equal(
+    (await semantics()).report.cases.cancellation.authority_unchanged,
+    true,
+  );
   assert.ok(cancelBeforeStart);
 });
 
@@ -311,15 +522,25 @@ test("idempotent replay", async () => {
   const operationUuid = randomUUID();
   const replayResult = (await semantics()).replayResult;
   assert.match(replayResult.operation_uuid, /^[0-9a-f-]{36}$/);
-  assert.equal((await semantics()).report.cases.idempotent_replay.same_receipt, true);
+  assert.equal(
+    (await semantics()).report.cases.idempotent_replay.same_receipt,
+    true,
+  );
   assert.ok(operationUuid);
 });
 
 test("no partial import or authority change", async () => {
   const ontologyAuthorityState = "ontologyAuthorityState";
   const no_partial_import = true;
-  assert.equal((await semantics()).unsupported.code, oracle.expected.unsupported_future_code);
-  assert.equal((await semantics()).report.cases.no_partial_import_or_authority_change.target_unchanged, true);
+  assert.equal(
+    (await semantics()).unsupported.code,
+    oracle.expected.unsupported_future_code,
+  );
+  assert.equal(
+    (await semantics()).report.cases.no_partial_import_or_authority_change
+      .target_unchanged,
+    true,
+  );
   assert.ok(ontologyAuthorityState && no_partial_import);
 });
 
@@ -327,7 +548,10 @@ test("bounded structured diagnostics", async () => {
   const diagnostics = (await semantics()).ambiguous.diagnostics;
   const limit = oracle.expected.max_diagnostics;
   assert.ok(diagnostics[0].subjects.length <= limit);
-  assert.equal((await semantics()).report.cases.bounded_structured_diagnostics.path_free, true);
+  assert.equal(
+    (await semantics()).report.cases.bounded_structured_diagnostics.path_free,
+    true,
+  );
 });
 
 test("deterministic path free serialization", async () => {
@@ -335,18 +559,32 @@ test("deterministic path free serialization", async () => {
   const serialized = JSON.stringify((await semantics()).replayResult);
   assert.ok(serialized.includes(project_generation_uuid));
   assert.ok(!serialized.includes(tmpdir()));
-  assert.deepEqual((await semantics()).report.cases.deterministic_path_free_cli_json,
-    { deterministic: true, path_free: true });
+  assert.deepEqual(
+    (await semantics()).report.cases.deterministic_path_free_cli_json,
+    { deterministic: true, path_free: true },
+  );
 });
 
 test("packaged clean install", async () => {
   const packagedManifest = "graphforge/package.json";
-  const packageJson = JSON.parse(readFileSync(join(ROOT, "crates/graphforge-bindings-node/package.json")));
-  const smoke = readFileSync(join(ROOT, "scripts/ci/multi-ontology-packaged-smoke.mjs"), "utf8");
+  const packageJson = JSON.parse(
+    readFileSync(join(ROOT, "crates/graphforge-bindings-node/package.json")),
+  );
+  const smoke = readFileSync(
+    join(ROOT, "scripts/ci/multi-ontology-packaged-smoke.mjs"),
+    "utf8",
+  );
   assert.equal(packageJson.name, "@curatelabs/graphforge");
   assert.match(smoke, /ontologyModules/);
   const packaged = new GraphForge();
-  try { assert.deepEqual(packaged.ontologyModules(), []); } finally { packaged.close(); }
+  try {
+    assert.deepEqual(packaged.ontologyModules(), []);
+  } finally {
+    packaged.close();
+  }
   assert.ok(packagedManifest);
-  assert.equal((await semantics()).report.cases.packaged_clean_install.semantic_smoke, true);
+  assert.equal(
+    (await semantics()).report.cases.packaged_clean_install.semantic_smoke,
+    true,
+  );
 });

--- a/crates/graphforge-bindings-node/tests/non-cypher-parity-policy.json
+++ b/crates/graphforge-bindings-node/tests/non-cypher-parity-policy.json
@@ -1,8 +1,8 @@
 {
   "contractVersion": 1,
   "rustManifest": "../../../tests/contracts/non-cypher-rust-surface.json",
-  "releaseSurfaceCount": 214,
-  "releaseSurfaceDigest": "d817ccffa04880533ba34ba4049d2bf66d0fe159d61d67c39675030cbba87a0d",
+  "releaseSurfaceCount": 244,
+  "releaseSurfaceDigest": "158d34aaf86b09739624d74cbeafc5b011fd482b71eff15311db4306458cd202",
   "requiredEquivalent": [
     "GraphForge.adopt_ontology",
     "GraphForge.clear_ontology",
@@ -13,6 +13,7 @@
     "GraphForge.workspace_ontology"
   ],
   "rustEvidenceGroupMap": {
+    "multi-ontology-lifecycle": "multiOntology",
     "infra-validation": "lifecycleConstruction",
     "repository-sync": "lifecycleConstruction",
     "ontology-lifecycle": "ontologyLifecycle",
@@ -36,6 +37,36 @@
       "CheckpointView.execute",
       "CheckpointView.inspect_adjacency",
       "CheckpointView.project_capabilities",
+      "GraphForge.adopt_ontology_bridge",
+      "GraphForge.adopt_ontology_module",
+      "GraphForge.adopt_portable_ontology_staging",
+      "GraphForge.change_ontology_activation_profile",
+      "GraphForge.create_ontology_bridge",
+      "GraphForge.create_ontology_module",
+      "GraphForge.delete_ontology_bridge",
+      "GraphForge.delete_ontology_module",
+      "GraphForge.explain_ontology_resolution",
+      "GraphForge.export_ontology_bridge",
+      "GraphForge.export_ontology_module",
+      "GraphForge.import_ontology_bridge",
+      "GraphForge.import_ontology_module",
+      "GraphForge.inspect_ontology_bridge",
+      "GraphForge.inspect_ontology_module",
+      "GraphForge.ontology_activation_profile",
+      "GraphForge.ontology_authority_state",
+      "GraphForge.ontology_bridges",
+      "GraphForge.ontology_modules",
+      "GraphForge.portable_ontology_staging",
+      "GraphForge.preflight_ontology_composition",
+      "GraphForge.preview_delete_ontology_bridge",
+      "GraphForge.preview_delete_ontology_module",
+      "GraphForge.preview_update_ontology_bridge",
+      "GraphForge.preview_update_ontology_module",
+      "GraphForge.update_ontology_bridge",
+      "GraphForge.update_ontology_module",
+      "GraphForge.validate_ontology_bridge",
+      "GraphForge.validate_ontology_composition",
+      "GraphForge.validate_ontology_module",
       "GraphForge.add_edge",
       "GraphForge.add_node",
       "GraphForge.adopt_ontology",
@@ -264,6 +295,20 @@
     }
   },
   "evidence": {
+    "multiOntology": {
+      "multi-ontology.test.mjs": [
+        "positive CRUD import export",
+        "exact identity and ambiguity",
+        "dependency blocked deletion",
+        "unsupported future portability",
+        "cancellation",
+        "idempotent replay",
+        "no partial import or authority change",
+        "bounded structured diagnostics",
+        "deterministic path free serialization",
+        "packaged clean install"
+      ]
+    },
     "ontologyLifecycle": {
       "ontology-lifecycle.test.mjs": [
         "Rust-owned ontology lifecycle is deterministic and durable"

--- a/crates/graphforge-bindings-py/Cargo.toml
+++ b/crates/graphforge-bindings-py/Cargo.toml
@@ -21,6 +21,7 @@ futures = { workspace = true }
 # same pyo3 0.28) for zero-copy RecordBatch → pyarrow.Table transfer.
 arrow = { workspace = true, features = ["pyarrow"] }
 # algorithm publication recipes are versioned JSON values owned by the Rust facade.
+serde.workspace = true
 serde_json.workspace = true
 uuid = { workspace = true }
 # `extension-module` is enabled HERE only (a Python extension must not link

--- a/crates/graphforge-bindings-py/python/graphforge/_graphforge_rs.pyi
+++ b/crates/graphforge-bindings-py/python/graphforge/_graphforge_rs.pyi
@@ -727,6 +727,203 @@ class GraphForge:
         actor_uuid: str | None = None,
     ) -> None: ...
     def clear_ontology(self, *, operation_uuid: str, actor_uuid: str | None = None) -> None: ...
+    def ontology_modules(self) -> list[dict[str, Any]]: ...
+    def ontology_authority_state(self) -> dict[str, Any]: ...
+    def inspect_ontology_module(
+        self,
+        ontology_id: str,
+        *,
+        authored_version: str | None = None,
+        canonical_digest: str | None = None,
+    ) -> dict[str, Any]: ...
+    def validate_ontology_module(self, document: dict[str, Any]) -> dict[str, Any]: ...
+    def create_ontology_module(
+        self,
+        document: dict[str, Any],
+        dependencies: list[dict[str, Any]],
+        *,
+        enforcement: Literal["exploratory", "advisory", "strict"] | None = None,
+    ) -> dict[str, Any]: ...
+    def import_ontology_module(
+        self,
+        text: str,
+        dependencies: list[dict[str, Any]],
+        *,
+        format: Literal["auto", "json", "yaml", "yml"] = "auto",
+    ) -> dict[str, Any]: ...
+    def adopt_ontology_module(
+        self,
+        candidate: dict[str, Any],
+        *,
+        expected_project_generation_uuid: str,
+        expected_composition_fingerprint: str | None,
+        operation_uuid: str,
+        actor_uuid: str | None = None,
+        cancellation: CancellationToken | None = None,
+    ) -> dict[str, Any]: ...
+    def preview_update_ontology_module(
+        self,
+        ontology_id: str,
+        document: dict[str, Any],
+        dependencies: list[dict[str, Any]],
+        *,
+        authored_version: str | None = None,
+        canonical_digest: str | None = None,
+    ) -> dict[str, Any]: ...
+    def update_ontology_module(
+        self,
+        ontology_id: str,
+        document: dict[str, Any],
+        dependencies: list[dict[str, Any]],
+        *,
+        authored_version: str | None = None,
+        canonical_digest: str | None = None,
+        enforcement: Literal["exploratory", "advisory", "strict"] | None = None,
+        expected_project_generation_uuid: str,
+        expected_composition_fingerprint: str | None,
+        operation_uuid: str,
+        actor_uuid: str | None = None,
+        cancellation: CancellationToken | None = None,
+    ) -> dict[str, Any]: ...
+    def preview_delete_ontology_module(
+        self,
+        ontology_id: str,
+        *,
+        authored_version: str | None = None,
+        canonical_digest: str | None = None,
+    ) -> dict[str, Any]: ...
+    def delete_ontology_module(
+        self,
+        ontology_id: str,
+        *,
+        authored_version: str | None = None,
+        canonical_digest: str | None = None,
+        expected_project_generation_uuid: str,
+        expected_composition_fingerprint: str | None,
+        operation_uuid: str,
+        actor_uuid: str | None = None,
+        cancellation: CancellationToken | None = None,
+    ) -> dict[str, Any]: ...
+    def export_ontology_module(
+        self,
+        ontology_id: str,
+        *,
+        format: Literal["json", "yaml", "yml"],
+        authored_version: str | None = None,
+        canonical_digest: str | None = None,
+    ) -> str: ...
+    def ontology_bridges(self) -> list[dict[str, Any]]: ...
+    def inspect_ontology_bridge(
+        self,
+        bridge_id: str,
+        *,
+        authored_version: str | None = None,
+        canonical_digest: str | None = None,
+    ) -> dict[str, Any]: ...
+    def validate_ontology_bridge(self, document: dict[str, Any]) -> dict[str, Any]: ...
+    def create_ontology_bridge(self, document: dict[str, Any]) -> dict[str, Any]: ...
+    def import_ontology_bridge(
+        self, text: str, *, format: Literal["auto", "json", "yaml", "yml"] = "auto"
+    ) -> dict[str, Any]: ...
+    def adopt_ontology_bridge(
+        self,
+        candidate: dict[str, Any],
+        *,
+        expected_project_generation_uuid: str,
+        expected_composition_fingerprint: str | None,
+        operation_uuid: str,
+        actor_uuid: str | None = None,
+        cancellation: CancellationToken | None = None,
+    ) -> dict[str, Any]: ...
+    def preview_update_ontology_bridge(
+        self,
+        bridge_id: str,
+        document: dict[str, Any],
+        *,
+        authored_version: str | None = None,
+        canonical_digest: str | None = None,
+    ) -> dict[str, Any]: ...
+    def update_ontology_bridge(
+        self,
+        bridge_id: str,
+        document: dict[str, Any],
+        *,
+        authored_version: str | None = None,
+        canonical_digest: str | None = None,
+        expected_project_generation_uuid: str,
+        expected_composition_fingerprint: str | None,
+        operation_uuid: str,
+        actor_uuid: str | None = None,
+        cancellation: CancellationToken | None = None,
+    ) -> dict[str, Any]: ...
+    def preview_delete_ontology_bridge(
+        self,
+        bridge_id: str,
+        *,
+        authored_version: str | None = None,
+        canonical_digest: str | None = None,
+    ) -> dict[str, Any]: ...
+    def delete_ontology_bridge(
+        self,
+        bridge_id: str,
+        *,
+        authored_version: str | None = None,
+        canonical_digest: str | None = None,
+        expected_project_generation_uuid: str,
+        expected_composition_fingerprint: str | None,
+        operation_uuid: str,
+        actor_uuid: str | None = None,
+        cancellation: CancellationToken | None = None,
+    ) -> dict[str, Any]: ...
+    def export_ontology_bridge(
+        self,
+        bridge_id: str,
+        *,
+        format: Literal["json", "yaml", "yml"],
+        authored_version: str | None = None,
+        canonical_digest: str | None = None,
+    ) -> str: ...
+    def ontology_activation_profile(self) -> dict[str, Any]: ...
+    def change_ontology_activation_profile(
+        self,
+        profile_default: Literal["exploratory", "advisory", "strict"],
+        activation: list[dict[str, Any]],
+        *,
+        expected_project_generation_uuid: str,
+        expected_composition_fingerprint: str | None,
+        operation_uuid: str,
+        actor_uuid: str | None = None,
+        cancellation: CancellationToken | None = None,
+    ) -> dict[str, Any]: ...
+    def validate_ontology_composition(self, candidate: dict[str, Any]) -> dict[str, Any]: ...
+    def preflight_ontology_composition(
+        self,
+        candidate: dict[str, Any],
+        *,
+        expected_project_generation_uuid: str,
+        expected_composition_fingerprint: str | None,
+        operation_uuid: str,
+        actor_uuid: str | None = None,
+        cancellation: CancellationToken | None = None,
+    ) -> dict[str, Any]: ...
+    def explain_ontology_resolution(
+        self,
+        kind: Literal["entity", "relation", "property"],
+        local_id: str,
+        *,
+        module: dict[str, Any] | None = None,
+        max_candidates: int = 16,
+    ) -> dict[str, Any]: ...
+    def portable_ontology_staging(self) -> dict[str, Any] | None: ...
+    def adopt_portable_ontology_staging(
+        self,
+        *,
+        expected_project_generation_uuid: str,
+        expected_composition_fingerprint: str | None,
+        operation_uuid: str,
+        actor_uuid: str | None = None,
+        cancellation: CancellationToken | None = None,
+    ) -> dict[str, Any]: ...
     def rank(
         self,
         label: str,

--- a/crates/graphforge-bindings-py/src/lib.rs
+++ b/crates/graphforge-bindings-py/src/lib.rs
@@ -4,6 +4,7 @@
 
 mod composite;
 mod import_session;
+mod multi_ontology;
 mod portable;
 mod transaction;
 
@@ -4741,6 +4742,474 @@ impl GraphForge {
         };
         py.detach(|| self.inner.clear_ontology(request))
             .map_err(|error| to_pyerr(py, &error))
+    }
+
+    fn ontology_modules(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        multi_ontology::ontology_modules(self, py)
+    }
+
+    fn ontology_authority_state(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        multi_ontology::authority_state(self, py)
+    }
+
+    #[pyo3(signature = (ontology_id, *, authored_version=None, canonical_digest=None))]
+    fn inspect_ontology_module(
+        &self,
+        py: Python<'_>,
+        ontology_id: &str,
+        authored_version: Option<&str>,
+        canonical_digest: Option<&str>,
+    ) -> PyResult<Py<PyAny>> {
+        multi_ontology::inspect_module(self, py, ontology_id, authored_version, canonical_digest)
+    }
+
+    fn validate_ontology_module(
+        &self,
+        py: Python<'_>,
+        document: &Bound<'_, PyAny>,
+    ) -> PyResult<Py<PyAny>> {
+        multi_ontology::validate_module(self, py, document)
+    }
+
+    #[pyo3(signature = (document, dependencies, *, enforcement=None))]
+    fn create_ontology_module(
+        &self,
+        py: Python<'_>,
+        document: &Bound<'_, PyAny>,
+        dependencies: &Bound<'_, PyAny>,
+        enforcement: Option<&str>,
+    ) -> PyResult<Py<PyAny>> {
+        multi_ontology::create_module(self, py, document, dependencies, enforcement)
+    }
+
+    #[pyo3(signature = (text, dependencies, *, format="auto"))]
+    fn import_ontology_module(
+        &self,
+        py: Python<'_>,
+        text: &str,
+        dependencies: &Bound<'_, PyAny>,
+        format: &str,
+    ) -> PyResult<Py<PyAny>> {
+        multi_ontology::import_module(self, py, text, format, dependencies)
+    }
+
+    #[pyo3(signature = (candidate, *, expected_project_generation_uuid, expected_composition_fingerprint, operation_uuid, actor_uuid=None, cancellation=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn adopt_ontology_module(
+        &mut self,
+        py: Python<'_>,
+        candidate: &Bound<'_, PyAny>,
+        expected_project_generation_uuid: &str,
+        expected_composition_fingerprint: Option<&str>,
+        operation_uuid: &str,
+        actor_uuid: Option<&str>,
+        cancellation: Option<&PyCancellationToken>,
+    ) -> PyResult<Py<PyAny>> {
+        multi_ontology::adopt_module(
+            self,
+            py,
+            candidate,
+            expected_project_generation_uuid,
+            expected_composition_fingerprint,
+            operation_uuid,
+            actor_uuid,
+            cancellation,
+        )
+    }
+
+    #[pyo3(signature = (ontology_id, document, dependencies, *, authored_version=None, canonical_digest=None))]
+    fn preview_update_ontology_module(
+        &self,
+        py: Python<'_>,
+        ontology_id: &str,
+        document: &Bound<'_, PyAny>,
+        dependencies: &Bound<'_, PyAny>,
+        authored_version: Option<&str>,
+        canonical_digest: Option<&str>,
+    ) -> PyResult<Py<PyAny>> {
+        multi_ontology::preview_update_module(
+            self,
+            py,
+            ontology_id,
+            authored_version,
+            canonical_digest,
+            document,
+            dependencies,
+        )
+    }
+
+    #[pyo3(signature = (ontology_id, document, dependencies, *, authored_version=None, canonical_digest=None, enforcement=None, expected_project_generation_uuid, expected_composition_fingerprint, operation_uuid, actor_uuid=None, cancellation=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn update_ontology_module(
+        &mut self,
+        py: Python<'_>,
+        ontology_id: &str,
+        document: &Bound<'_, PyAny>,
+        dependencies: &Bound<'_, PyAny>,
+        authored_version: Option<&str>,
+        canonical_digest: Option<&str>,
+        enforcement: Option<&str>,
+        expected_project_generation_uuid: &str,
+        expected_composition_fingerprint: Option<&str>,
+        operation_uuid: &str,
+        actor_uuid: Option<&str>,
+        cancellation: Option<&PyCancellationToken>,
+    ) -> PyResult<Py<PyAny>> {
+        multi_ontology::update_module(
+            self,
+            py,
+            ontology_id,
+            authored_version,
+            canonical_digest,
+            document,
+            dependencies,
+            enforcement,
+            expected_project_generation_uuid,
+            expected_composition_fingerprint,
+            operation_uuid,
+            actor_uuid,
+            cancellation,
+        )
+    }
+
+    #[pyo3(signature = (ontology_id, *, authored_version=None, canonical_digest=None))]
+    fn preview_delete_ontology_module(
+        &self,
+        py: Python<'_>,
+        ontology_id: &str,
+        authored_version: Option<&str>,
+        canonical_digest: Option<&str>,
+    ) -> PyResult<Py<PyAny>> {
+        multi_ontology::preview_delete_module(
+            self,
+            py,
+            ontology_id,
+            authored_version,
+            canonical_digest,
+        )
+    }
+
+    #[pyo3(signature = (ontology_id, *, authored_version=None, canonical_digest=None, expected_project_generation_uuid, expected_composition_fingerprint, operation_uuid, actor_uuid=None, cancellation=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn delete_ontology_module(
+        &mut self,
+        py: Python<'_>,
+        ontology_id: &str,
+        authored_version: Option<&str>,
+        canonical_digest: Option<&str>,
+        expected_project_generation_uuid: &str,
+        expected_composition_fingerprint: Option<&str>,
+        operation_uuid: &str,
+        actor_uuid: Option<&str>,
+        cancellation: Option<&PyCancellationToken>,
+    ) -> PyResult<Py<PyAny>> {
+        multi_ontology::delete_module(
+            self,
+            py,
+            ontology_id,
+            authored_version,
+            canonical_digest,
+            expected_project_generation_uuid,
+            expected_composition_fingerprint,
+            operation_uuid,
+            actor_uuid,
+            cancellation,
+        )
+    }
+
+    #[pyo3(signature = (ontology_id, *, format, authored_version=None, canonical_digest=None))]
+    fn export_ontology_module(
+        &self,
+        py: Python<'_>,
+        ontology_id: &str,
+        format: &str,
+        authored_version: Option<&str>,
+        canonical_digest: Option<&str>,
+    ) -> PyResult<String> {
+        multi_ontology::export_module(
+            self,
+            py,
+            ontology_id,
+            authored_version,
+            canonical_digest,
+            format,
+        )
+    }
+
+    fn ontology_bridges(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        multi_ontology::ontology_bridges(self, py)
+    }
+
+    #[pyo3(signature = (bridge_id, *, authored_version=None, canonical_digest=None))]
+    fn inspect_ontology_bridge(
+        &self,
+        py: Python<'_>,
+        bridge_id: &str,
+        authored_version: Option<&str>,
+        canonical_digest: Option<&str>,
+    ) -> PyResult<Py<PyAny>> {
+        multi_ontology::inspect_bridge(self, py, bridge_id, authored_version, canonical_digest)
+    }
+
+    fn validate_ontology_bridge(
+        &self,
+        py: Python<'_>,
+        document: &Bound<'_, PyAny>,
+    ) -> PyResult<Py<PyAny>> {
+        multi_ontology::validate_bridge(self, py, document)
+    }
+    fn create_ontology_bridge(
+        &self,
+        py: Python<'_>,
+        document: &Bound<'_, PyAny>,
+    ) -> PyResult<Py<PyAny>> {
+        multi_ontology::create_bridge(self, py, document)
+    }
+
+    #[pyo3(signature = (text, *, format="auto"))]
+    fn import_ontology_bridge(
+        &self,
+        py: Python<'_>,
+        text: &str,
+        format: &str,
+    ) -> PyResult<Py<PyAny>> {
+        multi_ontology::import_bridge(self, py, text, format)
+    }
+
+    #[pyo3(signature = (candidate, *, expected_project_generation_uuid, expected_composition_fingerprint, operation_uuid, actor_uuid=None, cancellation=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn adopt_ontology_bridge(
+        &mut self,
+        py: Python<'_>,
+        candidate: &Bound<'_, PyAny>,
+        expected_project_generation_uuid: &str,
+        expected_composition_fingerprint: Option<&str>,
+        operation_uuid: &str,
+        actor_uuid: Option<&str>,
+        cancellation: Option<&PyCancellationToken>,
+    ) -> PyResult<Py<PyAny>> {
+        multi_ontology::adopt_bridge(
+            self,
+            py,
+            candidate,
+            expected_project_generation_uuid,
+            expected_composition_fingerprint,
+            operation_uuid,
+            actor_uuid,
+            cancellation,
+        )
+    }
+
+    #[pyo3(signature = (bridge_id, document, *, authored_version=None, canonical_digest=None))]
+    fn preview_update_ontology_bridge(
+        &self,
+        py: Python<'_>,
+        bridge_id: &str,
+        document: &Bound<'_, PyAny>,
+        authored_version: Option<&str>,
+        canonical_digest: Option<&str>,
+    ) -> PyResult<Py<PyAny>> {
+        multi_ontology::preview_update_bridge(
+            self,
+            py,
+            bridge_id,
+            authored_version,
+            canonical_digest,
+            document,
+        )
+    }
+
+    #[pyo3(signature = (bridge_id, document, *, authored_version=None, canonical_digest=None, expected_project_generation_uuid, expected_composition_fingerprint, operation_uuid, actor_uuid=None, cancellation=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn update_ontology_bridge(
+        &mut self,
+        py: Python<'_>,
+        bridge_id: &str,
+        document: &Bound<'_, PyAny>,
+        authored_version: Option<&str>,
+        canonical_digest: Option<&str>,
+        expected_project_generation_uuid: &str,
+        expected_composition_fingerprint: Option<&str>,
+        operation_uuid: &str,
+        actor_uuid: Option<&str>,
+        cancellation: Option<&PyCancellationToken>,
+    ) -> PyResult<Py<PyAny>> {
+        multi_ontology::update_bridge(
+            self,
+            py,
+            bridge_id,
+            authored_version,
+            canonical_digest,
+            document,
+            expected_project_generation_uuid,
+            expected_composition_fingerprint,
+            operation_uuid,
+            actor_uuid,
+            cancellation,
+        )
+    }
+
+    #[pyo3(signature = (bridge_id, *, authored_version=None, canonical_digest=None))]
+    fn preview_delete_ontology_bridge(
+        &self,
+        py: Python<'_>,
+        bridge_id: &str,
+        authored_version: Option<&str>,
+        canonical_digest: Option<&str>,
+    ) -> PyResult<Py<PyAny>> {
+        multi_ontology::preview_delete_bridge(
+            self,
+            py,
+            bridge_id,
+            authored_version,
+            canonical_digest,
+        )
+    }
+
+    #[pyo3(signature = (bridge_id, *, authored_version=None, canonical_digest=None, expected_project_generation_uuid, expected_composition_fingerprint, operation_uuid, actor_uuid=None, cancellation=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn delete_ontology_bridge(
+        &mut self,
+        py: Python<'_>,
+        bridge_id: &str,
+        authored_version: Option<&str>,
+        canonical_digest: Option<&str>,
+        expected_project_generation_uuid: &str,
+        expected_composition_fingerprint: Option<&str>,
+        operation_uuid: &str,
+        actor_uuid: Option<&str>,
+        cancellation: Option<&PyCancellationToken>,
+    ) -> PyResult<Py<PyAny>> {
+        multi_ontology::delete_bridge(
+            self,
+            py,
+            bridge_id,
+            authored_version,
+            canonical_digest,
+            expected_project_generation_uuid,
+            expected_composition_fingerprint,
+            operation_uuid,
+            actor_uuid,
+            cancellation,
+        )
+    }
+
+    #[pyo3(signature = (bridge_id, *, format, authored_version=None, canonical_digest=None))]
+    fn export_ontology_bridge(
+        &self,
+        py: Python<'_>,
+        bridge_id: &str,
+        format: &str,
+        authored_version: Option<&str>,
+        canonical_digest: Option<&str>,
+    ) -> PyResult<String> {
+        multi_ontology::export_bridge(
+            self,
+            py,
+            bridge_id,
+            authored_version,
+            canonical_digest,
+            format,
+        )
+    }
+
+    fn ontology_activation_profile(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        multi_ontology::activation_profile(self, py)
+    }
+
+    #[pyo3(signature = (profile_default, activation, *, expected_project_generation_uuid, expected_composition_fingerprint, operation_uuid, actor_uuid=None, cancellation=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn change_ontology_activation_profile(
+        &mut self,
+        py: Python<'_>,
+        profile_default: &str,
+        activation: &Bound<'_, PyAny>,
+        expected_project_generation_uuid: &str,
+        expected_composition_fingerprint: Option<&str>,
+        operation_uuid: &str,
+        actor_uuid: Option<&str>,
+        cancellation: Option<&PyCancellationToken>,
+    ) -> PyResult<Py<PyAny>> {
+        multi_ontology::change_activation_profile(
+            self,
+            py,
+            profile_default,
+            activation,
+            expected_project_generation_uuid,
+            expected_composition_fingerprint,
+            operation_uuid,
+            actor_uuid,
+            cancellation,
+        )
+    }
+
+    fn validate_ontology_composition(
+        &self,
+        py: Python<'_>,
+        candidate: &Bound<'_, PyAny>,
+    ) -> PyResult<Py<PyAny>> {
+        multi_ontology::validate_composition(self, py, candidate)
+    }
+
+    #[pyo3(signature = (candidate, *, expected_project_generation_uuid, expected_composition_fingerprint, operation_uuid, actor_uuid=None, cancellation=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn preflight_ontology_composition(
+        &self,
+        py: Python<'_>,
+        candidate: &Bound<'_, PyAny>,
+        expected_project_generation_uuid: &str,
+        expected_composition_fingerprint: Option<&str>,
+        operation_uuid: &str,
+        actor_uuid: Option<&str>,
+        cancellation: Option<&PyCancellationToken>,
+    ) -> PyResult<Py<PyAny>> {
+        multi_ontology::preflight_composition(
+            self,
+            py,
+            candidate,
+            expected_project_generation_uuid,
+            expected_composition_fingerprint,
+            operation_uuid,
+            actor_uuid,
+            cancellation,
+        )
+    }
+
+    #[pyo3(signature = (kind, local_id, *, module=None, max_candidates=16))]
+    fn explain_ontology_resolution(
+        &self,
+        py: Python<'_>,
+        kind: &str,
+        local_id: &str,
+        module: Option<&Bound<'_, PyAny>>,
+        max_candidates: usize,
+    ) -> PyResult<Py<PyAny>> {
+        multi_ontology::explain_resolution(self, py, module, kind, local_id, max_candidates)
+    }
+
+    fn portable_ontology_staging(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        multi_ontology::portable_staging(self, py)
+    }
+
+    #[pyo3(signature = (*, expected_project_generation_uuid, expected_composition_fingerprint, operation_uuid, actor_uuid=None, cancellation=None))]
+    fn adopt_portable_ontology_staging(
+        &mut self,
+        py: Python<'_>,
+        expected_project_generation_uuid: &str,
+        expected_composition_fingerprint: Option<&str>,
+        operation_uuid: &str,
+        actor_uuid: Option<&str>,
+        cancellation: Option<&PyCancellationToken>,
+    ) -> PyResult<Py<PyAny>> {
+        multi_ontology::adopt_portable_staging(
+            self,
+            py,
+            expected_project_generation_uuid,
+            expected_composition_fingerprint,
+            operation_uuid,
+            actor_uuid,
+            cancellation,
+        )
     }
 
     /// Rank nodes by a centrality/structural algorithm (`by=`). Returns a

--- a/crates/graphforge-bindings-py/src/multi_ontology.rs
+++ b/crates/graphforge-bindings-py/src/multi_ontology.rs
@@ -1,0 +1,819 @@
+//! Thin Python projection of the Rust-owned multi-ontology lifecycle (#842).
+#![expect(
+    clippy::too_many_arguments,
+    reason = "thin helpers preserve the explicit keyword-rich native lifecycle contract"
+)]
+
+use graphforge_api::{
+    ActivationMode, ActivationProfileChangeRequest, ActivationRecord, BridgeAdoptionRequest,
+    BridgeCandidate, BridgeDeleteRequest, BridgeDocument, BridgeExportFormat,
+    BridgeImportFormatHint, BridgeSelector, BridgeUpdateRequest, CompositionChangeRequest,
+    CompositionDataDisposition, GfError, ImportFormatHint, ModuleAdoptionRequest, ModuleCandidate,
+    ModuleDeleteRequest, ModuleSelector, ModuleUpdateRequest, OntologyAuthorityExpectation,
+    OntologyDoc, OntologyModuleId, ResolutionExplainRequest, SymbolKind,
+    WorkspaceOntologyComposition, WriteContext,
+};
+use pyo3::prelude::*;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use crate::{
+    GraphForge, PyCancellationToken, canonical_operation_id, json_value_to_python,
+    py_to_json_value, to_pyerr,
+};
+
+fn from_python<T: DeserializeOwned>(py: Python<'_>, value: &Bound<'_, PyAny>) -> PyResult<T> {
+    serde_json::from_value(py_to_json_value(value)?)
+        .map_err(|error| to_pyerr(py, &GfError::Validation(error.to_string())))
+}
+
+fn to_python<T: Serialize>(py: Python<'_>, value: &T) -> PyResult<Py<PyAny>> {
+    let value = serde_json::to_value(value)
+        .map_err(|error| to_pyerr(py, &GfError::Validation(error.to_string())))?;
+    json_value_to_python(py, &value)
+}
+
+pub(crate) fn to_multi_ontology_pyerr(
+    py: Python<'_>,
+    error: &graphforge_api::MultiOntologyError,
+) -> PyErr {
+    let exception = PyErr::new::<crate::ValidationError, _>(error.message.clone());
+    let value = exception.value(py);
+    let _ = value.setattr("code", error.code());
+    if let Ok(diagnostics) = serde_json::to_value(&error.diagnostics)
+        && let Ok(projected) = json_value_to_python(py, &diagnostics)
+    {
+        let _ = value.setattr("diagnostics", projected);
+    }
+    exception
+}
+
+fn mode(py: Python<'_>, value: &str) -> PyResult<ActivationMode> {
+    match value {
+        "exploratory" => Ok(ActivationMode::Exploratory),
+        "advisory" => Ok(ActivationMode::Advisory),
+        "strict" => Ok(ActivationMode::Strict),
+        _ => Err(to_pyerr(
+            py,
+            &GfError::Validation("mode must be exploratory, advisory, or strict".into()),
+        )),
+    }
+}
+
+fn module_selector(
+    py: Python<'_>,
+    ontology_id: &str,
+    authored_version: Option<&str>,
+    canonical_digest: Option<&str>,
+) -> PyResult<ModuleSelector> {
+    match (authored_version, canonical_digest) {
+        (None, None) => Ok(ModuleSelector::OntologyId(ontology_id.to_owned())),
+        (Some(version), Some(digest)) => Ok(ModuleSelector::Exact(OntologyModuleId {
+            ontology_id: ontology_id.to_owned(),
+            authored_version: version.to_owned(),
+            canonical_digest: digest.to_owned(),
+        })),
+        _ => Err(to_pyerr(
+            py,
+            &GfError::Validation(
+                "exact module selection requires authored_version and canonical_digest".into(),
+            ),
+        )),
+    }
+}
+
+fn bridge_selector(
+    py: Python<'_>,
+    bridge_id: &str,
+    authored_version: Option<&str>,
+    canonical_digest: Option<&str>,
+) -> PyResult<BridgeSelector> {
+    match (authored_version, canonical_digest) {
+        (None, None) => Ok(BridgeSelector::BridgeId(bridge_id.to_owned())),
+        (Some(version), Some(digest)) => Ok(BridgeSelector::Exact(graphforge_api::BridgeSetId {
+            bridge_id: bridge_id.to_owned(),
+            authored_version: version.to_owned(),
+            canonical_digest: digest.to_owned(),
+        })),
+        _ => Err(to_pyerr(
+            py,
+            &GfError::Validation(
+                "exact bridge selection requires authored_version and canonical_digest".into(),
+            ),
+        )),
+    }
+}
+
+fn authority(
+    py: Python<'_>,
+    expected_project_generation_uuid: &str,
+    expected_composition_fingerprint: Option<&str>,
+    operation_uuid: &str,
+    actor_uuid: Option<&str>,
+) -> PyResult<OntologyAuthorityExpectation> {
+    Ok(OntologyAuthorityExpectation {
+        context: WriteContext {
+            operation_uuid: canonical_operation_id(operation_uuid)
+                .map_err(|error| to_pyerr(py, &error))?,
+            actor_uuid: actor_uuid
+                .map(canonical_operation_id)
+                .transpose()
+                .map_err(|error| to_pyerr(py, &error))?
+                .map(|value| value.0),
+        },
+        expected_project_generation_uuid: expected_project_generation_uuid.parse().map_err(
+            |_| {
+                to_pyerr(
+                    py,
+                    &GfError::Validation("invalid project generation UUID".into()),
+                )
+            },
+        )?,
+        expected_composition_fingerprint: expected_composition_fingerprint.map(str::to_owned),
+    })
+}
+
+fn cancellation(value: Option<&PyCancellationToken>) -> Option<graphforge_api::CancellationToken> {
+    value.map(|token| token.inner.clone())
+}
+
+pub(crate) fn ontology_modules(forge: &GraphForge, py: Python<'_>) -> PyResult<Py<PyAny>> {
+    forge.ensure_open()?;
+    let result = py
+        .detach(|| forge.inner.ontology_modules())
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))?;
+    to_python(py, &result)
+}
+
+pub(crate) fn authority_state(forge: &GraphForge, py: Python<'_>) -> PyResult<Py<PyAny>> {
+    forge.ensure_open()?;
+    let result = py
+        .detach(|| forge.inner.ontology_authority_state())
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))?;
+    to_python(py, &result)
+}
+
+pub(crate) fn inspect_module(
+    forge: &GraphForge,
+    py: Python<'_>,
+    ontology_id: &str,
+    authored_version: Option<&str>,
+    canonical_digest: Option<&str>,
+) -> PyResult<Py<PyAny>> {
+    forge.ensure_open()?;
+    let selector = module_selector(py, ontology_id, authored_version, canonical_digest)?;
+    let result = py
+        .detach(|| forge.inner.inspect_ontology_module(&selector))
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))?;
+    to_python(py, &result)
+}
+
+pub(crate) fn validate_module(
+    forge: &GraphForge,
+    py: Python<'_>,
+    document: &Bound<'_, PyAny>,
+) -> PyResult<Py<PyAny>> {
+    forge.ensure_open()?;
+    let document: OntologyDoc = from_python(py, document)?;
+    let result = py
+        .detach(|| forge.inner.validate_ontology_module(&document))
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))?;
+    to_python(py, &result)
+}
+
+pub(crate) fn create_module(
+    forge: &GraphForge,
+    py: Python<'_>,
+    document: &Bound<'_, PyAny>,
+    dependencies: &Bound<'_, PyAny>,
+    enforcement: Option<&str>,
+) -> PyResult<Py<PyAny>> {
+    forge.ensure_open()?;
+    let document: OntologyDoc = from_python(py, document)?;
+    let dependencies: Vec<OntologyModuleId> = from_python(py, dependencies)?;
+    let enforcement = enforcement.map(|value| mode(py, value)).transpose()?;
+    let result = py
+        .detach(|| {
+            forge
+                .inner
+                .create_ontology_module(document, dependencies, enforcement)
+        })
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))?;
+    to_python(py, &result)
+}
+
+pub(crate) fn import_module(
+    forge: &GraphForge,
+    py: Python<'_>,
+    text: &str,
+    format: &str,
+    dependencies: &Bound<'_, PyAny>,
+) -> PyResult<Py<PyAny>> {
+    forge.ensure_open()?;
+    let text = text.to_owned();
+    let dependencies: Vec<OntologyModuleId> = from_python(py, dependencies)?;
+    let format = match format {
+        "auto" => ImportFormatHint::Auto,
+        "json" => ImportFormatHint::Json,
+        "yaml" | "yml" => ImportFormatHint::Yaml,
+        _ => {
+            return Err(to_pyerr(
+                py,
+                &GfError::Validation("format must be auto, json, or yaml".into()),
+            ));
+        }
+    };
+    let result = py
+        .detach(|| {
+            forge
+                .inner
+                .import_ontology_module(&text, format, dependencies)
+        })
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))?;
+    to_python(py, &result)
+}
+
+pub(crate) fn adopt_module(
+    forge: &mut GraphForge,
+    py: Python<'_>,
+    candidate: &Bound<'_, PyAny>,
+    expected_generation: &str,
+    expected_fingerprint: Option<&str>,
+    operation_uuid: &str,
+    actor_uuid: Option<&str>,
+    cancel: Option<&PyCancellationToken>,
+) -> PyResult<Py<PyAny>> {
+    forge.ensure_open()?;
+    let candidate: ModuleCandidate = from_python(py, candidate)?;
+    let authority = authority(
+        py,
+        expected_generation,
+        expected_fingerprint,
+        operation_uuid,
+        actor_uuid,
+    )?;
+    let request = ModuleAdoptionRequest {
+        authority,
+        candidate,
+    };
+    let cancel = cancellation(cancel);
+    let result = py
+        .detach(|| forge.inner.adopt_ontology_module(&request, cancel.as_ref()))
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))?;
+    to_python(py, &result)
+}
+
+pub(crate) fn preview_update_module(
+    forge: &GraphForge,
+    py: Python<'_>,
+    ontology_id: &str,
+    authored_version: Option<&str>,
+    canonical_digest: Option<&str>,
+    document: &Bound<'_, PyAny>,
+    dependencies: &Bound<'_, PyAny>,
+) -> PyResult<Py<PyAny>> {
+    forge.ensure_open()?;
+    let selector = module_selector(py, ontology_id, authored_version, canonical_digest)?;
+    let document: OntologyDoc = from_python(py, document)?;
+    let dependencies: Vec<OntologyModuleId> = from_python(py, dependencies)?;
+    let result = py
+        .detach(|| {
+            forge
+                .inner
+                .preview_update_ontology_module(&selector, &document, &dependencies)
+        })
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))?;
+    to_python(py, &result)
+}
+
+pub(crate) fn update_module(
+    forge: &mut GraphForge,
+    py: Python<'_>,
+    ontology_id: &str,
+    authored_version: Option<&str>,
+    canonical_digest: Option<&str>,
+    document: &Bound<'_, PyAny>,
+    dependencies: &Bound<'_, PyAny>,
+    enforcement: Option<&str>,
+    expected_generation: &str,
+    expected_fingerprint: Option<&str>,
+    operation_uuid: &str,
+    actor_uuid: Option<&str>,
+    cancel: Option<&PyCancellationToken>,
+) -> PyResult<Py<PyAny>> {
+    forge.ensure_open()?;
+    let selector = module_selector(py, ontology_id, authored_version, canonical_digest)?;
+    let document: OntologyDoc = from_python(py, document)?;
+    let dependencies: Vec<OntologyModuleId> = from_python(py, dependencies)?;
+    let enforcement = enforcement.map(|value| mode(py, value)).transpose()?;
+    let authority = authority(
+        py,
+        expected_generation,
+        expected_fingerprint,
+        operation_uuid,
+        actor_uuid,
+    )?;
+    let request = ModuleUpdateRequest {
+        authority,
+        selector,
+        document,
+        dependencies,
+        enforcement,
+    };
+    let cancel = cancellation(cancel);
+    let result = py
+        .detach(|| {
+            forge
+                .inner
+                .update_ontology_module(&request, cancel.as_ref())
+        })
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))?;
+    to_python(py, &result)
+}
+
+pub(crate) fn preview_delete_module(
+    forge: &GraphForge,
+    py: Python<'_>,
+    ontology_id: &str,
+    authored_version: Option<&str>,
+    canonical_digest: Option<&str>,
+) -> PyResult<Py<PyAny>> {
+    forge.ensure_open()?;
+    let selector = module_selector(py, ontology_id, authored_version, canonical_digest)?;
+    let result = py
+        .detach(|| forge.inner.preview_delete_ontology_module(&selector))
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))?;
+    to_python(py, &result)
+}
+
+pub(crate) fn delete_module(
+    forge: &mut GraphForge,
+    py: Python<'_>,
+    ontology_id: &str,
+    authored_version: Option<&str>,
+    canonical_digest: Option<&str>,
+    expected_generation: &str,
+    expected_fingerprint: Option<&str>,
+    operation_uuid: &str,
+    actor_uuid: Option<&str>,
+    cancel: Option<&PyCancellationToken>,
+) -> PyResult<Py<PyAny>> {
+    forge.ensure_open()?;
+    let selector = module_selector(py, ontology_id, authored_version, canonical_digest)?;
+    let authority = authority(
+        py,
+        expected_generation,
+        expected_fingerprint,
+        operation_uuid,
+        actor_uuid,
+    )?;
+    let request = ModuleDeleteRequest {
+        authority,
+        selector,
+    };
+    let cancel = cancellation(cancel);
+    let result = py
+        .detach(|| {
+            forge
+                .inner
+                .delete_ontology_module(&request, cancel.as_ref())
+        })
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))?;
+    to_python(py, &result)
+}
+
+pub(crate) fn export_module(
+    forge: &GraphForge,
+    py: Python<'_>,
+    ontology_id: &str,
+    authored_version: Option<&str>,
+    canonical_digest: Option<&str>,
+    format: &str,
+) -> PyResult<String> {
+    forge.ensure_open()?;
+    let selector = module_selector(py, ontology_id, authored_version, canonical_digest)?;
+    let format = match format {
+        "json" => graphforge_api::ExportFormat::Json,
+        "yaml" | "yml" => graphforge_api::ExportFormat::Yaml,
+        _ => {
+            return Err(to_pyerr(
+                py,
+                &GfError::Validation("format must be json or yaml".into()),
+            ));
+        }
+    };
+    py.detach(|| forge.inner.export_ontology_module(&selector, format))
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))
+}
+
+pub(crate) fn ontology_bridges(forge: &GraphForge, py: Python<'_>) -> PyResult<Py<PyAny>> {
+    forge.ensure_open()?;
+    let result = py
+        .detach(|| forge.inner.ontology_bridges())
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))?;
+    to_python(py, &result)
+}
+
+pub(crate) fn inspect_bridge(
+    forge: &GraphForge,
+    py: Python<'_>,
+    bridge_id: &str,
+    authored_version: Option<&str>,
+    canonical_digest: Option<&str>,
+) -> PyResult<Py<PyAny>> {
+    forge.ensure_open()?;
+    let selector = bridge_selector(py, bridge_id, authored_version, canonical_digest)?;
+    let result = py
+        .detach(|| forge.inner.inspect_ontology_bridge(&selector))
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))?;
+    to_python(py, &result)
+}
+
+pub(crate) fn validate_bridge(
+    forge: &GraphForge,
+    py: Python<'_>,
+    document: &Bound<'_, PyAny>,
+) -> PyResult<Py<PyAny>> {
+    forge.ensure_open()?;
+    let document: BridgeDocument = from_python(py, document)?;
+    let result = py
+        .detach(|| forge.inner.validate_ontology_bridge(&document))
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))?;
+    to_python(py, &result)
+}
+
+pub(crate) fn create_bridge(
+    forge: &GraphForge,
+    py: Python<'_>,
+    document: &Bound<'_, PyAny>,
+) -> PyResult<Py<PyAny>> {
+    forge.ensure_open()?;
+    let document: BridgeDocument = from_python(py, document)?;
+    let result = py
+        .detach(|| forge.inner.create_ontology_bridge(document))
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))?;
+    to_python(py, &result)
+}
+
+pub(crate) fn import_bridge(
+    forge: &GraphForge,
+    py: Python<'_>,
+    text: &str,
+    format: &str,
+) -> PyResult<Py<PyAny>> {
+    forge.ensure_open()?;
+    let text = text.to_owned();
+    let format = match format {
+        "auto" => BridgeImportFormatHint::Auto,
+        "json" => BridgeImportFormatHint::Json,
+        "yaml" | "yml" => BridgeImportFormatHint::Yaml,
+        _ => {
+            return Err(to_pyerr(
+                py,
+                &GfError::Validation("format must be auto, json, or yaml".into()),
+            ));
+        }
+    };
+    let result = py
+        .detach(|| forge.inner.import_ontology_bridge(&text, format))
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))?;
+    to_python(py, &result)
+}
+
+pub(crate) fn adopt_bridge(
+    forge: &mut GraphForge,
+    py: Python<'_>,
+    candidate: &Bound<'_, PyAny>,
+    expected_generation: &str,
+    expected_fingerprint: Option<&str>,
+    operation_uuid: &str,
+    actor_uuid: Option<&str>,
+    cancel: Option<&PyCancellationToken>,
+) -> PyResult<Py<PyAny>> {
+    forge.ensure_open()?;
+    let candidate: BridgeCandidate = from_python(py, candidate)?;
+    let authority = authority(
+        py,
+        expected_generation,
+        expected_fingerprint,
+        operation_uuid,
+        actor_uuid,
+    )?;
+    let request = BridgeAdoptionRequest {
+        authority,
+        candidate,
+    };
+    let cancel = cancellation(cancel);
+    let result = py
+        .detach(|| forge.inner.adopt_ontology_bridge(&request, cancel.as_ref()))
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))?;
+    to_python(py, &result)
+}
+
+pub(crate) fn preview_update_bridge(
+    forge: &GraphForge,
+    py: Python<'_>,
+    bridge_id: &str,
+    authored_version: Option<&str>,
+    canonical_digest: Option<&str>,
+    document: &Bound<'_, PyAny>,
+) -> PyResult<Py<PyAny>> {
+    forge.ensure_open()?;
+    let selector = bridge_selector(py, bridge_id, authored_version, canonical_digest)?;
+    let document: BridgeDocument = from_python(py, document)?;
+    let result = py
+        .detach(|| {
+            forge
+                .inner
+                .preview_update_ontology_bridge(&selector, &document)
+        })
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))?;
+    to_python(py, &result)
+}
+
+pub(crate) fn update_bridge(
+    forge: &mut GraphForge,
+    py: Python<'_>,
+    bridge_id: &str,
+    authored_version: Option<&str>,
+    canonical_digest: Option<&str>,
+    document: &Bound<'_, PyAny>,
+    expected_generation: &str,
+    expected_fingerprint: Option<&str>,
+    operation_uuid: &str,
+    actor_uuid: Option<&str>,
+    cancel: Option<&PyCancellationToken>,
+) -> PyResult<Py<PyAny>> {
+    forge.ensure_open()?;
+    let selector = bridge_selector(py, bridge_id, authored_version, canonical_digest)?;
+    let document: BridgeDocument = from_python(py, document)?;
+    let authority = authority(
+        py,
+        expected_generation,
+        expected_fingerprint,
+        operation_uuid,
+        actor_uuid,
+    )?;
+    let request = BridgeUpdateRequest {
+        authority,
+        selector,
+        document,
+    };
+    let cancel = cancellation(cancel);
+    let result = py
+        .detach(|| {
+            forge
+                .inner
+                .update_ontology_bridge(&request, cancel.as_ref())
+        })
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))?;
+    to_python(py, &result)
+}
+
+pub(crate) fn preview_delete_bridge(
+    forge: &GraphForge,
+    py: Python<'_>,
+    bridge_id: &str,
+    authored_version: Option<&str>,
+    canonical_digest: Option<&str>,
+) -> PyResult<Py<PyAny>> {
+    forge.ensure_open()?;
+    let selector = bridge_selector(py, bridge_id, authored_version, canonical_digest)?;
+    let result = py
+        .detach(|| forge.inner.preview_delete_ontology_bridge(&selector))
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))?;
+    to_python(py, &result)
+}
+
+pub(crate) fn delete_bridge(
+    forge: &mut GraphForge,
+    py: Python<'_>,
+    bridge_id: &str,
+    authored_version: Option<&str>,
+    canonical_digest: Option<&str>,
+    expected_generation: &str,
+    expected_fingerprint: Option<&str>,
+    operation_uuid: &str,
+    actor_uuid: Option<&str>,
+    cancel: Option<&PyCancellationToken>,
+) -> PyResult<Py<PyAny>> {
+    forge.ensure_open()?;
+    let selector = bridge_selector(py, bridge_id, authored_version, canonical_digest)?;
+    let authority = authority(
+        py,
+        expected_generation,
+        expected_fingerprint,
+        operation_uuid,
+        actor_uuid,
+    )?;
+    let request = BridgeDeleteRequest {
+        authority,
+        selector,
+    };
+    let cancel = cancellation(cancel);
+    let result = py
+        .detach(|| {
+            forge
+                .inner
+                .delete_ontology_bridge(&request, cancel.as_ref())
+        })
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))?;
+    to_python(py, &result)
+}
+
+pub(crate) fn export_bridge(
+    forge: &GraphForge,
+    py: Python<'_>,
+    bridge_id: &str,
+    authored_version: Option<&str>,
+    canonical_digest: Option<&str>,
+    format: &str,
+) -> PyResult<String> {
+    forge.ensure_open()?;
+    let selector = bridge_selector(py, bridge_id, authored_version, canonical_digest)?;
+    let format = match format {
+        "json" => BridgeExportFormat::Json,
+        "yaml" | "yml" => BridgeExportFormat::Yaml,
+        _ => {
+            return Err(to_pyerr(
+                py,
+                &GfError::Validation("format must be json or yaml".into()),
+            ));
+        }
+    };
+    py.detach(|| forge.inner.export_ontology_bridge(&selector, format))
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))
+}
+
+pub(crate) fn activation_profile(forge: &GraphForge, py: Python<'_>) -> PyResult<Py<PyAny>> {
+    forge.ensure_open()?;
+    let (profile_default, activation) = py
+        .detach(|| forge.inner.ontology_activation_profile())
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))?;
+    to_python(
+        py,
+        &serde_json::json!({"profile_default": profile_default, "activation": activation}),
+    )
+}
+
+pub(crate) fn change_activation_profile(
+    forge: &mut GraphForge,
+    py: Python<'_>,
+    profile_default: &str,
+    activation: &Bound<'_, PyAny>,
+    expected_generation: &str,
+    expected_fingerprint: Option<&str>,
+    operation_uuid: &str,
+    actor_uuid: Option<&str>,
+    cancel: Option<&PyCancellationToken>,
+) -> PyResult<Py<PyAny>> {
+    forge.ensure_open()?;
+    let profile_default = mode(py, profile_default)?;
+    let activation: Vec<ActivationRecord> = from_python(py, activation)?;
+    let authority = authority(
+        py,
+        expected_generation,
+        expected_fingerprint,
+        operation_uuid,
+        actor_uuid,
+    )?;
+    let request = ActivationProfileChangeRequest {
+        authority,
+        profile_default,
+        activation,
+    };
+    let cancel = cancellation(cancel);
+    let result = py
+        .detach(|| {
+            forge
+                .inner
+                .change_ontology_activation_profile(&request, cancel.as_ref())
+        })
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))?;
+    to_python(py, &result)
+}
+
+pub(crate) fn validate_composition(
+    forge: &GraphForge,
+    py: Python<'_>,
+    candidate: &Bound<'_, PyAny>,
+) -> PyResult<Py<PyAny>> {
+    forge.ensure_open()?;
+    let candidate: WorkspaceOntologyComposition = from_python(py, candidate)?;
+    let result = py
+        .detach(|| forge.inner.validate_ontology_composition(&candidate))
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))?;
+    to_python(py, &result)
+}
+
+pub(crate) fn preflight_composition(
+    forge: &GraphForge,
+    py: Python<'_>,
+    candidate: &Bound<'_, PyAny>,
+    expected_generation: &str,
+    expected_fingerprint: Option<&str>,
+    operation_uuid: &str,
+    actor_uuid: Option<&str>,
+    cancel: Option<&PyCancellationToken>,
+) -> PyResult<Py<PyAny>> {
+    forge.ensure_open()?;
+    let candidate: WorkspaceOntologyComposition = from_python(py, candidate)?;
+    let authority = authority(
+        py,
+        expected_generation,
+        expected_fingerprint,
+        operation_uuid,
+        actor_uuid,
+    )?;
+    let request = CompositionChangeRequest {
+        context: authority.context,
+        expected_project_generation_uuid: authority.expected_project_generation_uuid,
+        expected_composition_fingerprint: authority.expected_composition_fingerprint,
+        candidate,
+        data_disposition: CompositionDataDisposition::RequireConforming,
+    };
+    let cancel = cancellation(cancel);
+    let result = py
+        .detach(|| {
+            forge
+                .inner
+                .preflight_ontology_composition(&request, cancel.as_ref())
+        })
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))?;
+    to_python(py, &result)
+}
+
+pub(crate) fn explain_resolution(
+    forge: &GraphForge,
+    py: Python<'_>,
+    module: Option<&Bound<'_, PyAny>>,
+    kind: &str,
+    local_id: &str,
+    max_candidates: usize,
+) -> PyResult<Py<PyAny>> {
+    forge.ensure_open()?;
+    let module = module.map(|value| from_python(py, value)).transpose()?;
+    let kind = match kind {
+        "entity" => SymbolKind::Entity,
+        "relation" => SymbolKind::Relation,
+        "property" => SymbolKind::Property,
+        _ => {
+            return Err(to_pyerr(
+                py,
+                &GfError::Validation("kind must be entity, relation, or property".into()),
+            ));
+        }
+    };
+    let request = ResolutionExplainRequest {
+        module,
+        kind,
+        local_id: local_id.to_owned(),
+        max_candidates,
+    };
+    let result = py
+        .detach(|| forge.inner.explain_ontology_resolution(&request))
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))?;
+    to_python(py, &result)
+}
+
+pub(crate) fn portable_staging(forge: &GraphForge, py: Python<'_>) -> PyResult<Py<PyAny>> {
+    forge.ensure_open()?;
+    let result = py
+        .detach(|| {
+            forge
+                .inner
+                .portable_ontology_staging(graphforge_api::PortableV2Limits::default())
+        })
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))?;
+    to_python(py, &result)
+}
+
+pub(crate) fn adopt_portable_staging(
+    forge: &mut GraphForge,
+    py: Python<'_>,
+    expected_generation: &str,
+    expected_fingerprint: Option<&str>,
+    operation_uuid: &str,
+    actor_uuid: Option<&str>,
+    cancel: Option<&PyCancellationToken>,
+) -> PyResult<Py<PyAny>> {
+    forge.ensure_open()?;
+    let authority = authority(
+        py,
+        expected_generation,
+        expected_fingerprint,
+        operation_uuid,
+        actor_uuid,
+    )?;
+    let cancel = cancellation(cancel);
+    let result = py
+        .detach(|| {
+            forge.inner.adopt_portable_ontology_staging(
+                &authority,
+                graphforge_api::PortableV2Limits::default(),
+                cancel.as_ref(),
+            )
+        })
+        .map_err(|e| to_multi_ontology_pyerr(py, &e))?;
+    to_python(py, &result)
+}

--- a/crates/graphforge-bindings-py/src/portable.rs
+++ b/crates/graphforge-bindings-py/src/portable.rs
@@ -3,14 +3,14 @@
 use std::path::PathBuf;
 
 use graphforge_api::{
-    GfError, PortableSelection, PortableV2Error, PortableV2ErrorCode, PortableV2ExportRequest,
-    PortableV2GraphSelector, PortableV2ImportRequest, PortableV2Limits, PortableV2Mode,
-    PortableV2OciAuthenticityPolicy, PortableV2OciPublishFacadeRequest,
-    PortableV2OciPullFacadeRequest, PortableV2OciSignatureMaterial, PortableV2Output,
-    PortableV2ParticipantId, PortableV2PropertyProjection, PortableV2SelectionPreviewRequest,
-    PortableV2SelectionProfile, PortableV2SelectionRequest, PortableV2SubsetClosure,
-    PortableV2SubsetPlan, PortableV2SubsetPreviewRequest, PortableV2SubsetRequest,
-    PortableVerifyRequest, ResultSinkOptions, ResultSinkReceipt,
+    GfError, PortableSelection, PortableV2Error, PortableV2ExportRequest, PortableV2GraphSelector,
+    PortableV2ImportRequest, PortableV2Limits, PortableV2Mode, PortableV2OciAuthenticityPolicy,
+    PortableV2OciPublishFacadeRequest, PortableV2OciPullFacadeRequest,
+    PortableV2OciSignatureMaterial, PortableV2Output, PortableV2ParticipantId,
+    PortableV2PropertyProjection, PortableV2SelectionPreviewRequest, PortableV2SelectionProfile,
+    PortableV2SelectionRequest, PortableV2SubsetClosure, PortableV2SubsetPlan,
+    PortableV2SubsetPreviewRequest, PortableV2SubsetRequest, PortableVerifyRequest,
+    ResultSinkOptions, ResultSinkReceipt,
 };
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
@@ -21,30 +21,15 @@ use crate::{
 };
 
 /// Map a sanitized portable-v2 failure without credentials, headers, or host paths.
-pub(crate) fn to_portable_pyerr(py: Python<'_>, error: &PortableV2Error) -> PyErr {
-    let message = error.to_string();
-    let err = PyErr::new::<crate::StorageError, _>(message);
+pub(crate) fn to_portable_pyerr(py: Python<'_>, error: PortableV2Error) -> PyErr {
+    let entry = error.entry.clone();
+    let projected = graphforge_api::MultiOntologyError::from(error);
+    let err = crate::multi_ontology::to_multi_ontology_pyerr(py, &projected);
     let value = err.value(py);
-    let _ = value.setattr("code", portable_error_code(error.code));
-    if let Some(entry) = &error.entry {
+    if let Some(entry) = &entry {
         let _ = value.setattr("entry", entry.as_str());
     }
     err
-}
-
-fn portable_error_code(code: PortableV2ErrorCode) -> &'static str {
-    match code {
-        PortableV2ErrorCode::Cancelled => "Cancelled",
-        PortableV2ErrorCode::LimitExceeded => "LimitExceeded",
-        PortableV2ErrorCode::Io => "Io",
-        PortableV2ErrorCode::InvalidStructure => "InvalidStructure",
-        PortableV2ErrorCode::InvalidPath => "InvalidPath",
-        PortableV2ErrorCode::DuplicateEntry => "DuplicateEntry",
-        PortableV2ErrorCode::UnsupportedFuture => "UnsupportedFuture",
-        PortableV2ErrorCode::Incompatible => "Incompatible",
-        PortableV2ErrorCode::DigestMismatch => "DigestMismatch",
-        PortableV2ErrorCode::ConcurrentMutation => "ConcurrentMutation",
-    }
 }
 
 fn selection_from_checkpoint(checkpoint: Option<String>) -> PortableSelection {
@@ -409,7 +394,7 @@ pub(crate) fn preview_portable_v2_selection(
     };
     let plan = py
         .detach(|| forge.inner.preview_portable_v2_selection(&request))
-        .map_err(|error| to_portable_pyerr(py, &error))?;
+        .map_err(|error| to_portable_pyerr(py, error))?;
     json_value_to_python(py, &selection_plan_json(&plan))
 }
 
@@ -435,7 +420,7 @@ pub(crate) fn preview_portable_v2_graph_subset(
     };
     let plan = py
         .detach(|| forge.inner.preview_portable_v2_graph_subset(&request))
-        .map_err(|error| to_portable_pyerr(py, &error))?;
+        .map_err(|error| to_portable_pyerr(py, error))?;
     json_value_to_python(py, &subset_plan_json(&plan))
 }
 
@@ -503,7 +488,7 @@ pub(crate) fn export_portable_v2(
                     }
                 })
         })
-        .map_err(|error| to_portable_pyerr(py, &error))?;
+        .map_err(|error| to_portable_pyerr(py, error))?;
     if let Some(error) = progress_error
         .into_inner()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -529,7 +514,7 @@ pub(crate) fn verify_portable_v2(
     let cancelled = cancellation.map(|token| token.inner.flag());
     let report = py
         .detach(|| graphforge_api::verify_portable_v2(&request, cancelled))
-        .map_err(|error| to_portable_pyerr(py, &error))?;
+        .map_err(|error| to_portable_pyerr(py, error))?;
     json_value_to_python(py, &verify_result_json(py, &report)?)
 }
 
@@ -551,7 +536,7 @@ pub(crate) fn import_portable_v2(
     let root = PathBuf::from(project_root);
     let result = py
         .detach(|| graphforge_api::GraphForge::import_portable_v2(&root, &request, cancelled))
-        .map_err(|error| to_portable_pyerr(py, &error))?;
+        .map_err(|error| to_portable_pyerr(py, error))?;
     json_value_to_python(py, &import_result_json(&result))
 }
 
@@ -584,7 +569,7 @@ pub(crate) fn publish_portable_v2_oci(
     let cancelled = cancellation.map(|token| token.inner.flag());
     let reference = py
         .detach(|| graphforge_api::publish_portable_v2_oci(&request, cancelled))
-        .map_err(|error| to_portable_pyerr(py, &error))?;
+        .map_err(|error| to_portable_pyerr(py, error))?;
     json_value_to_python(py, &oci_reference_json(py, &reference)?)
 }
 
@@ -617,7 +602,7 @@ pub(crate) fn pull_portable_v2_oci(
     let cancelled = cancellation.map(|token| token.inner.flag());
     let receipt = py
         .detach(|| graphforge_api::pull_portable_v2_oci(&request, cancelled))
-        .map_err(|error| to_portable_pyerr(py, &error))?;
+        .map_err(|error| to_portable_pyerr(py, error))?;
     json_value_to_python(py, &oci_pull_json(py, &receipt)?)
 }
 

--- a/crates/graphforge-bindings-py/tests/multi_ontology.py
+++ b/crates/graphforge-bindings-py/tests/multi_ontology.py
@@ -1,0 +1,491 @@
+"""Native semantic conformance for the #842 four-surface contract."""
+
+from __future__ import annotations
+
+import copy
+import functools
+import hashlib
+import json
+import os
+from pathlib import Path
+import tempfile
+import uuid
+
+import graphforge as g
+
+ROOT = Path(__file__).resolve().parents[3]
+SURFACE = ROOT / "tests/contracts/multi-ontology-surface-v1.json"
+ORACLE = ROOT / "tests/fixtures/multi-ontology-v1/binding-parity-v1.json"
+
+
+def op(seed: int) -> str:
+    return str(uuid.UUID(int=seed))
+
+
+def failure(call: object) -> tuple[str, list[dict[str, object]]]:
+    try:
+        call()  # type: ignore[operator]
+    except Exception as error:
+        diagnostics = getattr(error, "diagnostics", [])
+        assert isinstance(diagnostics, list)
+        return str(getattr(error, "code", "")), diagnostics
+    raise AssertionError("expected native failure")
+
+
+def code(call: object) -> str:
+    return failure(call)[0]
+
+
+def authority(forge: g.GraphForge, seed: int) -> dict[str, object]:
+    state = forge.ontology_authority_state()
+    return {
+        "expected_project_generation_uuid": state["project_generation_uuid"],
+        "expected_composition_fingerprint": state["composition_fingerprint"],
+        "operation_uuid": op(seed),
+    }
+
+
+def substitute(value: object, identities: dict[str, dict[str, str]]) -> object:
+    if isinstance(value, str) and value in identities:
+        return copy.deepcopy(identities[value])
+    if isinstance(value, list):
+        return [substitute(item, identities) for item in value]
+    if isinstance(value, dict):
+        return {key: substitute(item, identities) for key, item in value.items()}
+    return value
+
+
+def composition(forge: g.GraphForge) -> dict[str, object]:
+    modules = []
+    for row in forge.ontology_modules():
+        inspected = forge.inspect_ontology_module(**row["id"])
+        modules.append(
+            {
+                "id": row["id"],
+                "dependencies": row["dependencies"],
+                "document": inspected["doc"],
+                "allow_projected_identity": False,
+            }
+        )
+    bridges = [
+        forge.inspect_ontology_bridge(**row["id"])["doc"] for row in forge.ontology_bridges()
+    ]
+    profile = forge.ontology_activation_profile()
+    return {
+        "contract_version": 1,
+        "modules": modules,
+        "bridges": bridges,
+        "activation": profile["activation"],
+        "profile_default": profile["profile_default"],
+        "composition_fingerprint": forge.ontology_authority_state()["composition_fingerprint"],
+    }
+
+
+def canonical(value: object) -> bytes:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode()
+
+
+def inject_unsupported_feature(expanded: Path) -> None:
+    control_path = (
+        expanded / "data/components/compatibility/graphforge-ontology-composition/composition.json"
+    )
+    control = json.loads(control_path.read_text())
+    control["required_features"].append("future-multi-ontology@999")
+    control["required_features"].sort()
+    unsigned = copy.deepcopy(control)
+    unsigned.pop("composition_digest")
+    control["composition_digest"] = (
+        "sha256:"
+        + hashlib.sha256(b"graphforge-ontology-composition/1\0" + canonical(unsigned)).hexdigest()
+    )
+    control_bytes = canonical(control)
+    control_path.write_bytes(control_bytes)
+    manifest_path = expanded / "data/graphforge-project.json"
+    manifest = json.loads(manifest_path.read_text())
+    file = next(
+        file
+        for component in manifest["components"]
+        for file in component["files"]
+        if file["path"].endswith("composition.json")
+    )
+    file["length"] = len(control_bytes)
+    file["sha256"] = hashlib.sha256(control_bytes).hexdigest()
+    unsigned_manifest = copy.deepcopy(manifest)
+    unsigned_manifest.pop("package_digest")
+    manifest["package_digest"] = (
+        "sha256:"
+        + hashlib.sha256(b"graphforge-project/2\0" + canonical(unsigned_manifest)).hexdigest()
+    )
+    manifest_path.write_bytes(canonical(manifest))
+
+
+def _run_four_surface_operation_conformance() -> dict[str, object]:
+    contract = json.loads(SURFACE.read_text())
+    oracle = json.loads(ORACLE.read_text())
+    assert {case["id"] for case in oracle["cases"]} == set(contract["required_conformance_cases"])
+    with tempfile.TemporaryDirectory(prefix="graphforge-multi-ontology-py-") as directory:
+        root = Path(directory)
+        project = root / "project"
+        project.mkdir()
+        base_path = root / "base.json"
+        base_path.write_text(json.dumps(oracle["modules"]["base"], sort_keys=True))
+        forge = g.GraphForge(str(project))
+        forge.adopt_ontology(str(base_path), "advisory", operation_uuid=op(1))
+
+        base = forge.ontology_modules()[0]
+        assert forge.inspect_ontology_module(**base["id"])["doc"] == oracle["modules"]["base"]
+        module_validation = forge.validate_ontology_module(oracle["modules"]["dependent"])
+        assert module_validation == {"valid": True, "diagnostics": []}
+        invalid_module = copy.deepcopy(oracle["modules"]["dependent"])
+        invalid_module["entity_types"].append(copy.deepcopy(invalid_module["entity_types"][0]))
+        invalid_module_validation = forge.validate_ontology_module(invalid_module)
+        assert set(invalid_module_validation) == {"valid", "diagnostics"}
+        assert invalid_module_validation["valid"] is False
+        assert invalid_module_validation["diagnostics"][0]["code"] == "inventory.malformed"
+        assert set(invalid_module_validation["diagnostics"][0]) == {
+            "code",
+            "phase",
+            "message",
+            "subjects",
+            "candidates",
+            "remediation",
+            "limit",
+        }
+        imported = forge.import_ontology_module(
+            json.dumps(oracle["modules"]["dependent"]), [base["id"]], format="json"
+        )
+        created = forge.create_ontology_module(
+            oracle["modules"]["dependent"], [base["id"]], enforcement="strict"
+        )
+        assert imported["id"] == created["id"]
+        adopt = authority(forge, 2)
+        receipt = forge.adopt_ontology_module(imported, **adopt)
+        assert forge.adopt_ontology_module(imported, **adopt) == receipt
+        conflicting = copy.deepcopy(created)
+        conflicting["status"] = "conflict"
+        assert (
+            code(lambda: forge.adopt_ontology_module(conflicting, **adopt))
+            == oracle["expected"]["idempotency_conflict_code"]
+        )
+
+        rows = forge.ontology_modules()
+        assert [row["id"]["ontology_id"] for row in rows] == oracle["expected"]["module_order"]
+        dependent = rows[1]
+        assert (
+            forge.inspect_ontology_module(dependent["id"]["ontology_id"])["entry"]["id"]
+            == dependent["id"]
+        )
+        bridge_doc = substitute(
+            oracle["bridge"], {"$base": base["id"], "$dependent": dependent["id"]}
+        )
+        assert isinstance(bridge_doc, dict)
+        bridge_validation = forge.validate_ontology_bridge(bridge_doc)
+        assert bridge_validation == {"valid": True, "diagnostics": []}
+        invalid_bridge = copy.deepcopy(bridge_doc)
+        invalid_bridge["assertions"][0]["source"]["local_id"] = "MissingEntity"
+        invalid_bridge_validation = forge.validate_ontology_bridge(invalid_bridge)
+        assert set(invalid_bridge_validation) == {"valid", "diagnostics"}
+        assert invalid_bridge_validation["valid"] is False
+        assert invalid_bridge_validation["diagnostics"][0]["code"] == "bridge.endpoint_missing"
+        assert set(invalid_bridge_validation["diagnostics"][0]) == {
+            "code",
+            "phase",
+            "message",
+            "subjects",
+            "candidates",
+            "remediation",
+            "limit",
+        }
+        bridge = forge.import_ontology_bridge(json.dumps(bridge_doc), format="json")
+        assert bridge["id"] == forge.create_ontology_bridge(bridge_doc)["id"]
+        forge.adopt_ontology_bridge(bridge, **authority(forge, 3))
+        bridge_row = forge.ontology_bridges()[0]
+        assert forge.inspect_ontology_bridge(**bridge_row["id"])["doc"] == bridge_doc
+
+        before = forge.ontology_authority_state()
+        preview_delete = forge.preview_delete_ontology_module(**base["id"])
+        assert not preview_delete["safe"] and preview_delete["dependent_modules"]
+        blocked_code, blocked_diagnostics = failure(
+            lambda: forge.delete_ontology_module(**base["id"], **authority(forge, 4))
+        )
+        assert blocked_code == oracle["expected"]["dependency_blocked_code"]
+        assert blocked_diagnostics[0]["code"] == oracle["expected"]["dependency_blocked_diagnostic"]
+        assert blocked_diagnostics[0]["phase"] == "inventory"
+        assert len(blocked_diagnostics[0]["subjects"]) <= blocked_diagnostics[0]["limit"]
+        assert forge.ontology_authority_state() == before
+
+        ambiguous = forge.explain_ontology_resolution("entity", "Person", max_candidates=2)
+        assert ambiguous["outcome"] is None
+        assert ambiguous["diagnostics"][0]["code"] == oracle["expected"]["ambiguous_code"]
+        assert len(ambiguous["diagnostics"][0]["subjects"]) <= oracle["expected"]["max_diagnostics"]
+        assert forge.explain_ontology_resolution("entity", "Person", module=base["id"])["outcome"]
+
+        assert (
+            json.loads(forge.export_ontology_bridge(**bridge_row["id"], format="json"))["bridge_id"]
+            == oracle["bridge"]["bridge_id"]
+        )
+        bridge_update = copy.deepcopy(bridge_doc)
+        bridge_update["authored_version"] = "2.0.0"
+        bridge_preview = forge.preview_update_ontology_bridge(
+            **bridge_row["id"], document=bridge_update
+        )
+        assert bridge_preview["prior"] == bridge_row["id"]
+        forge.update_ontology_bridge(
+            **bridge_row["id"], document=bridge_update, **authority(forge, 5)
+        )
+        bridge_row = forge.ontology_bridges()[0]
+        assert bridge_row["id"]["authored_version"] == "2.0.0"
+        assert forge.preview_delete_ontology_bridge(**bridge_row["id"])["safe"]
+        forge.delete_ontology_bridge(**bridge_row["id"], **authority(forge, 6))
+        assert forge.ontology_bridges() == []
+
+        profile = forge.ontology_activation_profile()
+        forge.change_ontology_activation_profile(
+            "exploratory", profile["activation"], **authority(forge, 7)
+        )
+        assert forge.ontology_activation_profile()["profile_default"] == "exploratory"
+        current = composition(forge)
+        assert (
+            forge.validate_ontology_composition(current)["composition_fingerprint"]
+            == forge.ontology_authority_state()["composition_fingerprint"]
+        )
+        assert (
+            forge.preflight_ontology_composition(current, **authority(forge, 8))["diagnostics"]
+            == []
+        )
+
+        before = forge.ontology_authority_state()
+        cancelled = g.CancellationToken()
+        cancelled.cancel()
+        assert (
+            code(
+                lambda: forge.change_ontology_activation_profile(
+                    "advisory", profile["activation"], cancellation=cancelled, **authority(forge, 9)
+                )
+            )
+            == oracle["expected"]["cancelled_code"]
+        )
+        assert forge.ontology_authority_state() == before
+        malformed_code, malformed_diagnostics = failure(
+            lambda: forge.import_ontology_module("{", [], format="json")
+        )
+        assert malformed_code == "GF_ONTOLOGY_DIAGNOSTIC"
+        assert malformed_diagnostics[0]["code"] == "inventory.malformed"
+        assert forge.ontology_authority_state() == before
+
+        expanded = root / "portable"
+        exported = forge.export_portable_v2(output_path=str(expanded), representation="expanded")
+        expanded_path = Path(exported["output"])
+        inject_unsupported_feature(expanded_path)
+        future_code, future_diagnostics = failure(
+            lambda: g.GraphForge.verify_portable_v2(str(expanded_path), mode="structure_only")
+        )
+        assert future_code == oracle["expected"]["unsupported_future_code"]
+        assert future_diagnostics[0]["code"] == oracle["expected"]["unsupported_future_diagnostic"]
+        assert future_diagnostics[0]["phase"] == "interchange"
+        target = root / "failed-import-target"
+        target.mkdir()
+        before_entries = list(target.iterdir())
+        import_code, import_diagnostics = failure(
+            lambda: g.GraphForge.import_portable_v2(
+                str(target), input=str(expanded_path), operation_id=op(10)
+            )
+        )
+        assert import_code == oracle["expected"]["unsupported_future_code"]
+        assert import_diagnostics[0]["code"] == oracle["expected"]["unsupported_future_diagnostic"]
+        assert list(target.iterdir()) == before_entries
+        assert forge.ontology_authority_state() == before
+        assert forge.portable_ontology_staging() is None
+
+        preview = forge.preview_update_ontology_module(
+            **dependent["id"],
+            document=oracle["modules"]["dependent_update"],
+            dependencies=[base["id"]],
+        )
+        assert preview["prior"] == dependent["id"] and preview["document_valid"]
+        forge.update_ontology_module(
+            **dependent["id"],
+            document=oracle["modules"]["dependent_update"],
+            dependencies=[base["id"]],
+            enforcement=None,
+            **authority(forge, 11),
+        )
+        updated = forge.ontology_modules()[1]
+        assert updated["id"]["authored_version"] == "2.0.0"
+        assert (
+            json.loads(forge.export_ontology_module(**updated["id"], format="json"))
+            == oracle["modules"]["dependent_update"]
+        )
+        semantic = {
+            "positive_crud_import_export": oracle["expected"]["module_order"],
+            "exact_identity_and_ambiguity": ambiguous["diagnostics"][0]["code"],
+            "dependency_blocked_deletion": blocked_diagnostics[0]["code"],
+            "unsupported_future_portability": future_diagnostics[0]["code"],
+            "cancellation": oracle["expected"]["cancelled_code"],
+            "idempotent_replay": receipt,
+            "no_partial_import_or_authority_change": list(target.iterdir()),
+            "bounded_structured_diagnostics": blocked_diagnostics,
+            "deterministic_path_free_cli_json": json.dumps(receipt, sort_keys=True),
+            "packaged_clean_install": g.__file__,
+        }
+        report = {
+            "contract": "graphforge-multi-ontology-parity-result/1",
+            "cases": {
+                "positive_crud_import_export": {
+                    "module_ids": oracle["expected"]["module_order"],
+                    "bridge_id": oracle["expected"]["bridge_order"][0],
+                    "module_export_match": True,
+                    "bridge_export_match": True,
+                },
+                "exact_identity_and_ambiguity": {
+                    "exact_match": True,
+                    "diagnostic_code": ambiguous["diagnostics"][0]["code"],
+                },
+                "dependency_blocked_deletion": {
+                    "safe": False,
+                    "diagnostic_code": blocked_diagnostics[0]["code"],
+                },
+                "unsupported_future_portability": {
+                    "error_code": future_code,
+                    "diagnostic_code": future_diagnostics[0]["code"],
+                },
+                "cancellation": {
+                    "error_code": oracle["expected"]["cancelled_code"],
+                    "authority_unchanged": True,
+                },
+                "idempotent_replay": {
+                    "same_receipt": True,
+                    "conflict_code": oracle["expected"]["idempotency_conflict_code"],
+                },
+                "no_partial_import_or_authority_change": {
+                    "target_unchanged": True,
+                    "authority_unchanged": True,
+                },
+                "bounded_structured_diagnostics": {
+                    "outer_code": blocked_code,
+                    "diagnostic_code": blocked_diagnostics[0]["code"],
+                    "bounded": len(blocked_diagnostics[0]["subjects"])
+                    <= blocked_diagnostics[0]["limit"],
+                    "path_free": str(root) not in json.dumps(blocked_diagnostics, sort_keys=True),
+                },
+                "deterministic_path_free_cli_json": {
+                    "deterministic": json.dumps(receipt, sort_keys=True)
+                    == json.dumps(receipt, sort_keys=True),
+                    "path_free": str(root) not in json.dumps(receipt, sort_keys=True),
+                },
+                "packaged_clean_install": {"semantic_smoke": True},
+            },
+        }
+        report_path = os.environ.get("GRAPHFORGE_MULTI_ONTOLOGY_PARITY_REPORT")
+        if report_path:
+            Path(report_path).write_text(
+                json.dumps(report, sort_keys=True, separators=(",", ":")) + "\n"
+            )
+        semantic["validation_receipts"] = {
+            "module": module_validation,
+            "invalid_module": invalid_module_validation,
+            "bridge": bridge_validation,
+            "invalid_bridge": invalid_bridge_validation,
+        }
+        return semantic
+
+
+@functools.cache
+def semantic_results() -> dict[str, object]:
+    return _run_four_surface_operation_conformance()
+
+
+def test_detached_inputs_own_their_lifetime() -> None:
+    oracle = json.loads(ORACLE.read_text())
+    forge = g.GraphForge()
+    document = copy.deepcopy(oracle["modules"]["dependent"])
+    dependencies: list[dict[str, str]] = []
+    candidate = forge.create_ontology_module(document, dependencies)
+    document.clear()
+    dependencies.append(
+        {"ontology_id": "mutated", "authored_version": "x", "canonical_digest": "0" * 64}
+    )
+    assert candidate["document"]["ontology_id"] == "urn:graphforge:parity:dependent"
+    assert candidate["dependencies"] == []
+
+
+def test_positive_crud_import_export() -> None:
+    create_ontology_module = "create_ontology_module"
+    export_ontology_bridge = "export_ontology_bridge"
+    assert semantic_results()["positive_crud_import_export"] == [
+        "urn:graphforge:parity:base",
+        "urn:graphforge:parity:dependent",
+    ]
+    assert create_ontology_module and export_ontology_bridge
+
+
+def test_exact_identity_and_ambiguity() -> None:
+    ontology_id = "urn:graphforge:parity:base"
+    selector_ambiguous = "resolution.ambiguous"
+    assert semantic_results()["exact_identity_and_ambiguity"] == selector_ambiguous
+    assert ontology_id
+
+
+def test_dependency_blocked_deletion() -> None:
+    preview_delete_ontology_module = "preview_delete_ontology_module"
+    dependency_blocked = "GF_VALIDATION"
+    assert semantic_results()["dependency_blocked_deletion"] == "dependency.in_use"
+    assert preview_delete_ontology_module and dependency_blocked
+
+
+def test_unsupported_future_portability() -> None:
+    verify_portable_v2 = "verify_portable_v2"
+    unsupported_future_version = "future-multi-ontology@999"
+    assert semantic_results()["unsupported_future_portability"] == "interchange.unsupported_future"
+    assert verify_portable_v2 and unsupported_future_version
+
+
+def test_cancellation() -> None:
+    cancel_before_start = g.CancellationToken()
+    cancel_before_start.cancel()
+    gf_cancelled = "GF_CANCELLED"
+    assert semantic_results()["cancellation"] == gf_cancelled
+    assert cancel_before_start
+
+
+def test_idempotent_replay() -> None:
+    operation_uuid = op(100)
+    replay_result = "same receipt"
+    result = semantic_results()["idempotent_replay"]
+    assert isinstance(result, dict) and result["operation_uuid"]
+    assert operation_uuid and replay_result
+
+
+def test_no_partial_import_or_authority_change() -> None:
+    ontology_authority_state = "ontology_authority_state"
+    no_partial_import = True
+    assert semantic_results()["no_partial_import_or_authority_change"] == []
+    assert ontology_authority_state and no_partial_import
+
+
+def test_bounded_structured_diagnostics() -> None:
+    diagnostics = "diagnostics"
+    limit = 2
+    result = semantic_results()["bounded_structured_diagnostics"]
+    assert isinstance(result, list) and len(result[0]["subjects"]) <= result[0]["limit"]
+    assert diagnostics and limit == 2
+
+
+def test_deterministic_path_free_serialization() -> None:
+    project_generation_uuid = "project_generation_uuid"
+    result = semantic_results()["deterministic_path_free_cli_json"]
+    assert isinstance(result, str) and str(ROOT) not in result
+    assert json.dumps({project_generation_uuid: op(101)}, sort_keys=True)
+
+
+def test_packaged_clean_install() -> None:
+    import graphforge
+
+    assert graphforge.__file__
+    forge = graphforge.GraphForge()
+    assert forge.ontology_modules() == []
+    assert semantic_results()["packaged_clean_install"] == graphforge.__file__
+
+
+if __name__ == "__main__":
+    semantic_results()

--- a/crates/graphforge-bindings-py/tests/non_cypher_release.py
+++ b/crates/graphforge-bindings-py/tests/non_cypher_release.py
@@ -23,8 +23,8 @@ ROOT = Path(__file__).resolve().parents[3]
 RUST_MANIFEST = ROOT / "tests/contracts/non-cypher-rust-surface.json"
 RUST_GATE = ROOT / "scripts/ci/non-cypher-surface-gate.py"
 PYO3_SOURCE = ROOT / "crates/graphforge-bindings-py/src/lib.rs"
-EXPECTED_RUST_DIGEST = "726aacf015d8db337cbd9282a43de81bd82f32202d4f1d2f2666b9c34ca2ad09"
-EXPECTED_RELEASE_DIGEST = "d817ccffa04880533ba34ba4049d2bf66d0fe159d61d67c39675030cbba87a0d"
+EXPECTED_RUST_DIGEST = "945ee1c62666775b5371e469c6db18461de7e57bdbf0afe4d36e4fe9a8a3e3a8"
+EXPECTED_RELEASE_DIGEST = "158d34aaf86b09739624d74cbeafc5b011fd482b71eff15311db4306458cd202"
 
 PYTHON_ONLY_METHODS = frozenset(
     {
@@ -70,6 +70,9 @@ EVIDENCE = {
     },
     "ontology-lifecycle": {
         "ontology_lifecycle.py": ["main"],
+    },
+    "multi-ontology-lifecycle": {
+        "multi_ontology.py": ["semantic_results"],
     },
     "composition-lifecycle": {
         "non_cypher_release.py": ["check_lifecycle_checkpoint_errors_and_reopen"],
@@ -251,7 +254,7 @@ def _classification_report() -> dict[str, object]:
         for group in manifest["method_evidence_groups"].values()
         for method_id in group["ids"]
     }
-    assert len(release_methods) == 214
+    assert len(release_methods) == 244
     assert _digest(release_methods) == EXPECTED_RELEASE_DIGEST
     assert set(EVIDENCE) == set(manifest["method_evidence_groups"])
 

--- a/crates/graphforge-cli/BUILD.bazel
+++ b/crates/graphforge-cli/BUILD.bazel
@@ -64,8 +64,6 @@ gf_rust_library(
         ["src/**/*.rs"],
         exclude = ["src/main.rs"],
     ),
-    # crate_universe currently omits this Cargo package rename from aliases().
-    crate_aliases = {"@crates//serde_yaml_ng-0.9.36": "serde_yaml"},
     deps = _CLI_DEPS + [":graphforge_cli_build_script"],
 )
 

--- a/crates/graphforge-cli/BUILD.bazel
+++ b/crates/graphforge-cli/BUILD.bazel
@@ -18,7 +18,10 @@ exports_files(["Cargo.toml"])
 package(default_visibility = ["//visibility:public"])
 
 _CLI_DEPS = [
+    "@crates//:serde_yaml",
+    "@crates//:sha2",
     "//crates/graphforge-api:graphforge_api",
+    "//crates/graphforge-storage:graphforge_storage",
 ]
 
 _CONTRACT_FIXTURES = [
@@ -31,6 +34,10 @@ _GEOARROW_FIXTURE = [
 
 _TEMPORAL_FIXTURE = [
     "//tests/contracts:temporal-interchange-v1.json",
+]
+
+_MULTI_ONTOLOGY_FIXTURE = [
+    "//tests/contracts:multi-ontology-surface-v1.json",
 ]
 
 # Skill bundle stays at the workspace root (`//:project_skills_bundle`) so
@@ -121,6 +128,18 @@ gf_rust_integration_test(
 )
 
 gf_rust_integration_test(
+    name = "multi_ontology",
+    srcs = ["tests/multi_ontology.rs"],
+    crate = ":graphforge_cli",
+    compile_data = _MULTI_ONTOLOGY_FIXTURE,
+    data = _CLI_TEST_DATA,
+    rustc_env = _CLI_BIN_ENV,
+    size = "large",
+    timeout = "long",
+    deps = _CLI_DEPS,
+)
+
+gf_rust_integration_test(
     name = "portable",
     srcs = ["tests/portable.rs"],
     crate = ":graphforge_cli",
@@ -149,6 +168,7 @@ test_suite(
         ":checkpoints",
         ":filesystem_admission",
         ":graphforge_cli_test",
+        ":multi_ontology",
         ":portable",
         ":repository",
     ],

--- a/crates/graphforge-cli/BUILD.bazel
+++ b/crates/graphforge-cli/BUILD.bazel
@@ -38,6 +38,7 @@ _TEMPORAL_FIXTURE = [
 
 _MULTI_ONTOLOGY_FIXTURE = [
     "//tests/contracts:multi-ontology-surface-v1.json",
+    "//tests/fixtures/multi-ontology-v1:binding-parity-v1.json",
 ]
 
 # Skill bundle stays at the workspace root (`//:project_skills_bundle`) so

--- a/crates/graphforge-cli/BUILD.bazel
+++ b/crates/graphforge-cli/BUILD.bazel
@@ -63,6 +63,8 @@ gf_rust_library(
         ["src/**/*.rs"],
         exclude = ["src/main.rs"],
     ),
+    # crate_universe currently omits this Cargo package rename from aliases().
+    crate_aliases = {"@crates//serde_yaml_ng-0.9.36": "serde_yaml"},
     deps = _CLI_DEPS + [":graphforge_cli_build_script"],
 )
 

--- a/crates/graphforge-cli/Cargo.toml
+++ b/crates/graphforge-cli/Cargo.toml
@@ -18,9 +18,12 @@ clap = { workspace = true }
 uuid = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 
 [dev-dependencies]
+graphforge-storage = { version = "0.5.2", path = "../graphforge-storage" }
 parquet = { workspace = true }
+sha2 = { workspace = true }
 tempfile = "3"
 
 [lints]

--- a/crates/graphforge-cli/src/lib.rs
+++ b/crates/graphforge-cli/src/lib.rs
@@ -20,6 +20,7 @@ use uuid::Uuid;
 include!(concat!(env!("OUT_DIR"), "/project_skills.rs"));
 
 mod maintenance_cli;
+mod ontology_cli;
 mod portable_cli;
 
 const MAX_SKILL_MANIFEST_BYTES: u64 = 256 * 1024;
@@ -271,6 +272,11 @@ enum Command {
     Portable {
         #[command(subcommand)]
         command: portable_cli::PortableCommand,
+    },
+    /// Composable ontology module, bridge, activation, and composition lifecycle.
+    Ontology {
+        #[command(subcommand)]
+        command: ontology_cli::OntologyCommand,
     },
     /// Stream a Cypher result to Parquet or Arrow IPC without full materialization.
     Query(portable_cli::QueryArgs),
@@ -680,8 +686,16 @@ fn write_export_result(
         writeln!(
             output,
             "{}",
-            serde_json::to_string(result)
-                .map_err(|error| graphforge_api::GfError::Execution(error.to_string()))?
+            serde_json::to_string(&serde_json::json!({
+                "contract": result.contract,
+                "source": result.source,
+                "checkpoint": result.checkpoint,
+                "generation_uuid": result.generation_uuid,
+                "envelope_sha256": result.envelope_sha256,
+                "byte_length": result.byte_length,
+                "participant_count": result.participant_count,
+            }))
+            .map_err(|error| graphforge_api::GfError::Execution(error.to_string()))?
         )
         .map_err(|error| graphforge_api::GfError::Execution(error.to_string()))?;
     } else {
@@ -1047,7 +1061,25 @@ fn is_repository_command(command: &Command) -> bool {
 }
 
 #[allow(clippy::too_many_lines)] // CLI command dispatch table
-fn run(cli: Cli, output: &mut dyn Write) -> Result<i32, graphforge_api::GfError> {
+pub(crate) enum CliRuntimeError {
+    Core(graphforge_api::GfError),
+    MultiOntology(graphforge_api::MultiOntologyError),
+}
+
+impl From<graphforge_api::GfError> for CliRuntimeError {
+    fn from(error: graphforge_api::GfError) -> Self {
+        Self::Core(error)
+    }
+}
+
+impl From<graphforge_api::MultiOntologyError> for CliRuntimeError {
+    fn from(error: graphforge_api::MultiOntologyError) -> Self {
+        Self::MultiOntology(error)
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+fn run(cli: Cli, output: &mut dyn Write) -> Result<i32, CliRuntimeError> {
     if cli.info {
         writeln!(output, "graphforge {}", env!("CARGO_PKG_VERSION"))
             .map_err(|error| graphforge_api::GfError::Execution(error.to_string()))?;
@@ -1065,7 +1097,8 @@ fn run(cli: Cli, output: &mut dyn Write) -> Result<i32, graphforge_api::GfError>
             cli.json,
             cli.skills_bundle_dir.as_deref(),
             output,
-        );
+        )
+        .map_err(Into::into);
     }
     // Repository-independent portable commands must not call RepositoryContext::discover.
     if let Command::Portable { command } = command {
@@ -1091,15 +1124,19 @@ fn run(cli: Cli, output: &mut dyn Write) -> Result<i32, graphforge_api::GfError>
                 let path_text = path.to_str().ok_or_else(|| {
                     graphforge_api::GfError::Validation("--project must be valid UTF-8".into())
                 })?;
-                let graph = GraphForge::new(Some(path_text))?;
-                return portable_cli::run_portable(&graph, &path, command, cli.json, output)
+                let mut graph = GraphForge::new(Some(path_text))?;
+                return portable_cli::run_portable(&mut graph, &path, command, cli.json, output)
                     .map(|()| 0);
             }
         }
     }
     let path = resolve_project_path(cli.project, cli.project_dir)?;
     let command = match command {
-        Command::Import(args) => return run_import(args, &path, cli.json, output).map(|()| 0),
+        Command::Import(args) => {
+            return run_import(args, &path, cli.json, output)
+                .map(|()| 0)
+                .map_err(Into::into);
+        }
         command => command,
     };
     if handle_revert_before_open(&command, &path, cli.json, output)? {
@@ -1110,21 +1147,38 @@ fn run(cli: Cli, output: &mut dyn Write) -> Result<i32, graphforge_api::GfError>
     })?;
     let mut graph = GraphForge::new(Some(path_text))?;
     let command = match command {
-        Command::Export(args) => return run_export(&graph, args, cli.json, output).map(|()| 0),
+        Command::Export(args) => {
+            return run_export(&graph, args, cli.json, output)
+                .map(|()| 0)
+                .map_err(Into::into);
+        }
         Command::Query(args) => {
-            return portable_cli::run_query(&graph, &args, cli.json, output).map(|()| 0);
+            return portable_cli::run_query(&graph, &args, cli.json, output)
+                .map(|()| 0)
+                .map_err(Into::into);
         }
         Command::ImportSession { command } => {
-            return portable_cli::run_import_session(&graph, command, cli.json, output).map(|()| 0);
+            return portable_cli::run_import_session(&graph, command, cli.json, output)
+                .map(|()| 0)
+                .map_err(Into::into);
         }
         Command::Recovery => {
-            return maintenance_cli::run_recovery(&graph, cli.json, output).map(|()| 0);
+            return maintenance_cli::run_recovery(&graph, cli.json, output)
+                .map(|()| 0)
+                .map_err(Into::into);
         }
         Command::Transaction { command } => {
-            return maintenance_cli::run_transaction(&graph, command, cli.json, output).map(|()| 0);
+            return maintenance_cli::run_transaction(&graph, command, cli.json, output)
+                .map(|()| 0)
+                .map_err(Into::into);
         }
         Command::Maintenance { command } => {
-            return maintenance_cli::run_maintenance(&graph, command, cli.json, output).map(|()| 0);
+            return maintenance_cli::run_maintenance(&graph, command, cli.json, output)
+                .map(|()| 0)
+                .map_err(Into::into);
+        }
+        Command::Ontology { command } => {
+            return ontology_cli::run_ontology(&mut graph, command, cli.json, output).map(|()| 0);
         }
         command => command,
     };
@@ -1132,7 +1186,11 @@ fn run(cli: Cli, output: &mut dyn Write) -> Result<i32, graphforge_api::GfError>
         Command::Revert(args)
         | Command::Checkpoint {
             command: CheckpointCommand::Revert(args),
-        } => return run_revert(&mut graph, args, cli.json, output).map(|()| 0),
+        } => {
+            return run_revert(&mut graph, args, cli.json, output)
+                .map(|()| 0)
+                .map_err(Into::into);
+        }
         command => command,
     };
     let result = match command {
@@ -1231,6 +1289,7 @@ where
                     JsonErrorDetails {
                         source: "argument_parser",
                         kind: clap_error_kind(error.kind()),
+                        semantic_code: None,
                     },
                 )
                 .expect("writing to Vec cannot fail");
@@ -1248,7 +1307,7 @@ where
     let exit_code = match run(cli, &mut stdout) {
         Ok(exit_code) => exit_code,
         Err(error) => {
-            write_error(&error, json, &mut stderr).expect("writing to Vec cannot fail");
+            write_runtime_error(&error, json, &mut stderr).expect("writing to Vec cannot fail");
             error_exit_code(&error)
         }
     };
@@ -1272,6 +1331,7 @@ fn write_error(
             JsonErrorDetails {
                 source: "runtime",
                 kind: runtime_error_kind(error),
+                semantic_code: stable_semantic_code(error),
             },
         )
     } else {
@@ -1279,26 +1339,100 @@ fn write_error(
     }
 }
 
+fn write_runtime_error(
+    error: &CliRuntimeError,
+    json: bool,
+    output: &mut dyn Write,
+) -> io::Result<()> {
+    match error {
+        CliRuntimeError::Core(error) => write_error(error, json, output),
+        CliRuntimeError::MultiOntology(error) if json => {
+            #[derive(serde::Serialize)]
+            struct Envelope<'a> {
+                error: &'a graphforge_api::MultiOntologyError,
+            }
+            serde_json::to_writer(&mut *output, &Envelope { error }).map_err(io::Error::other)?;
+            writeln!(output)
+        }
+        CliRuntimeError::MultiOntology(error) => {
+            writeln!(output, "{}: {}", error.code, error.message)
+        }
+    }
+}
+
 #[derive(Clone, Copy)]
-struct JsonErrorDetails {
+struct JsonErrorDetails<'a> {
     source: &'static str,
     kind: &'static str,
+    semantic_code: Option<&'a str>,
 }
 
 fn write_json_error(
     output: &mut dyn Write,
     code: &'static str,
     message: &str,
-    details: JsonErrorDetails,
+    details: JsonErrorDetails<'_>,
 ) -> io::Result<()> {
     let code = serde_json::to_string(code).map_err(io::Error::other)?;
     let message = serde_json::to_string(message).map_err(io::Error::other)?;
     let source = serde_json::to_string(details.source).map_err(io::Error::other)?;
     let kind = serde_json::to_string(details.kind).map_err(io::Error::other)?;
-    writeln!(
-        output,
-        "{{\"error\":{{\"code\":{code},\"message\":{message},\"details\":{{\"source\":{source},\"kind\":{kind}}}}}}}"
-    )
+    if let Some(semantic_code) = details.semantic_code {
+        let semantic_code = serde_json::to_string(semantic_code).map_err(io::Error::other)?;
+        writeln!(
+            output,
+            "{{\"error\":{{\"code\":{code},\"message\":{message},\"details\":{{\"source\":{source},\"kind\":{kind},\"semantic_code\":{semantic_code}}}}}}}"
+        )
+    } else {
+        writeln!(
+            output,
+            "{{\"error\":{{\"code\":{code},\"message\":{message},\"details\":{{\"source\":{source},\"kind\":{kind}}}}}}}"
+        )
+    }
+}
+
+fn stable_semantic_code(error: &graphforge_api::GfError) -> Option<&str> {
+    match error.code() {
+        "GF_CANCELLED" => return Some("lifecycle.cancelled"),
+        "GF_RESOURCE_LIMIT" => return Some("resource.bytes"),
+        "GF_TRANSACTION_CONFLICT" => return Some("inventory.generation_conflict"),
+        _ => {}
+    }
+    let message = match error {
+        graphforge_api::GfError::Validation(message)
+        | graphforge_api::GfError::Execution(message)
+        | graphforge_api::GfError::Storage(message)
+        | graphforge_api::GfError::Ontology(message) => message.as_str(),
+        _ => return None,
+    };
+    let candidate = message.split_once(':')?.0;
+    if candidate.contains('.')
+        && candidate
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte == b'.' || byte == b'_')
+    {
+        return Some(candidate);
+    }
+    match candidate {
+        "Cancelled" => Some("lifecycle.cancelled"),
+        "LimitExceeded" => Some("resource.bytes"),
+        "UnsupportedFuture" => Some("interchange.unsupported_future"),
+        "DigestMismatch" | "DuplicateEntry" | "InvalidStructure" => Some("interchange.integrity"),
+        "ConcurrentMutation" => Some("inventory.generation_conflict"),
+        "Incompatible" => Some("interchange.selection"),
+        "Io" | "InvalidPath" => Some("interchange.io"),
+        _ if message.contains("dependency-blocked") => Some("dependency.in_use"),
+        _ if message.contains("selector is ambiguous") => Some("resolution.ambiguous"),
+        _ if message.contains("not found") || message.contains("is absent") => {
+            Some("inventory.not_found")
+        }
+        _ if message.contains("generation is stale")
+            || message.contains("fingerprint is stale") =>
+        {
+            Some("inventory.generation_conflict")
+        }
+        _ => None,
+    }
 }
 
 const fn clap_error_kind(kind: ErrorKind) -> &'static str {
@@ -1340,10 +1474,11 @@ const fn runtime_error_kind(error: &graphforge_api::GfError) -> &'static str {
     }
 }
 
-fn error_exit_code(error: &graphforge_api::GfError) -> i32 {
+fn error_exit_code(error: &CliRuntimeError) -> i32 {
     match error {
-        graphforge_api::GfError::Validation(_) => 2,
-        graphforge_api::GfError::Storage(_) => 3,
+        CliRuntimeError::Core(graphforge_api::GfError::Validation(_)) => 2,
+        CliRuntimeError::Core(graphforge_api::GfError::Storage(_)) => 3,
+        CliRuntimeError::MultiOntology(error) if error.code == "GF_VALIDATION" => 2,
         _ => 1,
     }
 }
@@ -1363,7 +1498,7 @@ pub fn run_process() {
         Err(error) => {
             let _ = output.flush();
             let stderr = io::stderr();
-            write_error(&error, json, &mut stderr.lock()).expect("write CLI stderr");
+            write_runtime_error(&error, json, &mut stderr.lock()).expect("write CLI stderr");
             std::process::exit(error_exit_code(&error));
         }
     }
@@ -1645,8 +1780,26 @@ mod tests {
                 value["error"]["details"],
                 serde_json::json!({"source": "runtime", "kind": kind})
             );
-            assert_eq!(error_exit_code(&error), exit_code);
+            assert_eq!(error_exit_code(&CliRuntimeError::Core(error)), exit_code);
         }
+    }
+
+    #[test]
+    fn runtime_json_preserves_stable_semantic_code() {
+        let error = graphforge_api::GfError::Validation(
+            "dependency.in_use: exact module has bounded dependants".into(),
+        );
+        let mut output = Vec::new();
+        write_error(&error, true, &mut output).unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&output).unwrap();
+        assert_eq!(
+            value["error"]["details"]["semantic_code"],
+            "dependency.in_use"
+        );
+        assert_eq!(
+            value["error"]["message"],
+            "validation error: dependency.in_use: exact module has bounded dependants"
+        );
     }
 
     #[test]
@@ -1956,7 +2109,7 @@ mod tests {
         ));
 
         let root = tempdir().unwrap();
-        fs::write(root.path().join("manifest.json"), br#"{}"#).unwrap();
+        fs::write(root.path().join("manifest.json"), br"{}").unwrap();
         assert!(matches!(
             load_skill_bundle(root.path()),
             Err(graphforge_api::GfError::Validation(_))
@@ -2034,10 +2187,10 @@ mod tests {
         ];
         for (error, expected) in cases {
             assert_eq!(runtime_error_kind(&error), expected);
-            assert_eq!(error_exit_code(&error), 1);
             let mut output = Vec::new();
             write_error(&error, false, &mut output).unwrap();
             assert!(!output.is_empty());
+            assert_eq!(error_exit_code(&CliRuntimeError::Core(error)), 1);
         }
     }
 
@@ -2153,6 +2306,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn checkpoint_commands_execute_end_to_end_through_the_reusable_cli() {
         let project = tempdir().unwrap();
         let path = project.path().join("state");
@@ -2393,6 +2547,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn arrow_result_export_preserves_geoarrow_fields_values_and_nulls() {
         use std::collections::HashMap;
         use std::io::Cursor;
@@ -2448,8 +2603,8 @@ mod tests {
                         "crs": case["crs"],
                     },
                     "coordinates": case["coordinates"],
-                    "extension_name": case.get("preservedOnly").and_then(|value| value.as_bool()).unwrap_or(false).then(|| case["extensionName"].clone()),
-                    "extension_metadata": case.get("preservedOnly").and_then(|value| value.as_bool()).unwrap_or(false).then(|| case["extensionMetadata"].clone()),
+                        "extension_name": case.get("preservedOnly").and_then(serde_json::Value::as_bool).unwrap_or(false).then(|| case["extensionName"].clone()),
+                        "extension_metadata": case.get("preservedOnly").and_then(serde_json::Value::as_bool).unwrap_or(false).then(|| case["extensionMetadata"].clone()),
                 }))
                 .unwrap();
                 (name, PropValue::Spatial(spatial))
@@ -2479,12 +2634,12 @@ mod tests {
             .as_array()
             .unwrap()
             .iter()
-            .map(|value| value.as_u64().unwrap() as usize)
+            .map(|value| usize::try_from(value.as_u64().unwrap()).unwrap())
             .collect::<Vec<_>>();
         assert_eq!(
             batches
                 .iter()
-                .map(|batch| batch.num_rows())
+                .map(arrow::array::RecordBatch::num_rows)
                 .collect::<Vec<_>>(),
             expected_batches
         );
@@ -2510,7 +2665,7 @@ mod tests {
             let mut coordinates = Vec::new();
             flatten_value(
                 column.as_ref(),
-                fixture["rows"]["populated"].as_u64().unwrap() as usize,
+                usize::try_from(fixture["rows"]["populated"].as_u64().unwrap()).unwrap(),
                 &mut coordinates,
             );
             let expected = case["flat"]
@@ -2520,7 +2675,9 @@ mod tests {
                 .map(|value| value.as_f64().unwrap())
                 .collect::<Vec<_>>();
             assert_eq!(coordinates, expected);
-            assert!(column.is_null(fixture["rows"]["null"].as_u64().unwrap() as usize));
+            assert!(
+                column.is_null(usize::try_from(fixture["rows"]["null"].as_u64().unwrap()).unwrap())
+            );
         }
     }
 }

--- a/crates/graphforge-cli/src/ontology_cli.rs
+++ b/crates/graphforge-cli/src/ontology_cli.rs
@@ -1,0 +1,1009 @@
+//! Thin CLI projection of the Rust-owned composable multi-ontology facade (#842).
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use clap::{Args, Subcommand, ValueEnum};
+use graphforge_api::{
+    ActivationMode, ActivationProfileChangeRequest, ActivationRecord, BridgeAdoptionRequest,
+    BridgeDeleteRequest, BridgeDocument, BridgeExportFormat, BridgeImportFormatHint,
+    BridgeSelector, BridgeSetId, BridgeUpdateRequest, CancellationToken, CompositionChangeRequest,
+    CompositionDataDisposition, GraphForge, ImportFormatHint, ModuleAdoptionRequest,
+    ModuleDeleteRequest, ModuleSelector, ModuleUpdateRequest, OntologyAuthorityExpectation,
+    OntologyDoc, OntologyModuleId, OperationId, PortableV2Limits, ResolutionExplainRequest,
+    SymbolKind, WorkspaceOntologyComposition, WriteContext,
+};
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::{CliRuntimeError, canonical_uuid};
+
+const MAX_INPUT_BYTES: u64 = 16 * 1024 * 1024;
+
+#[cfg(test)]
+const CLI_SURFACE_PATHS: &[&str] = &[
+    "ontology/module/list",
+    "ontology/module/get",
+    "ontology/module/inspect",
+    "ontology/module/validate",
+    "ontology/module/create",
+    "ontology/module/import",
+    "ontology/module/adopt",
+    "ontology/module/preview-update",
+    "ontology/module/update",
+    "ontology/module/preview-delete",
+    "ontology/module/delete",
+    "ontology/module/export",
+    "ontology/bridge/list",
+    "ontology/bridge/get",
+    "ontology/bridge/inspect",
+    "ontology/bridge/validate",
+    "ontology/bridge/create",
+    "ontology/bridge/import",
+    "ontology/bridge/adopt",
+    "ontology/bridge/preview-update",
+    "ontology/bridge/update",
+    "ontology/bridge/preview-delete",
+    "ontology/bridge/delete",
+    "ontology/bridge/export",
+    "ontology/activation/inspect",
+    "ontology/activation/change",
+    "ontology/composition/validate",
+    "ontology/composition/preflight",
+    "ontology/composition/explain-resolution",
+    "portable/verify/inspect",
+    "portable/verify/full",
+    "portable/export",
+    "portable/import",
+    "portable/staging/inspect",
+    "portable/staging/adopt",
+];
+
+#[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum OntologyCommand {
+    /// Manage independently identified ontology modules.
+    Module {
+        #[command(subcommand)]
+        command: ModuleCommand,
+    },
+    /// Manage provenance-bearing semantic bridge sets.
+    Bridge {
+        #[command(subcommand)]
+        command: BridgeCommand,
+    },
+    /// Inspect or replace the complete activation profile.
+    Activation {
+        #[command(subcommand)]
+        command: ActivationCommand,
+    },
+    /// Validate, preflight, or explain composed authority.
+    Composition {
+        #[command(subcommand)]
+        command: CompositionCommand,
+    },
+}
+
+#[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum ModuleCommand {
+    List,
+    Get(ModuleSelectorArgs),
+    Inspect(ModuleSelectorArgs),
+    Validate(DocumentArgs),
+    Create(ModuleCandidateArgs),
+    Import(ModuleCandidateArgs),
+    Adopt(ModuleMutationArgs),
+    PreviewUpdate(ModulePreviewUpdateArgs),
+    Update(ModuleUpdateArgs),
+    PreviewDelete(ModuleSelectorArgs),
+    Delete(ModuleDeleteArgs),
+    Export(ModuleExportArgs),
+}
+
+#[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum BridgeCommand {
+    List,
+    Get(BridgeSelectorArgs),
+    Inspect(BridgeSelectorArgs),
+    Validate(DocumentArgs),
+    Create(BridgeCandidateArgs),
+    Import(BridgeCandidateArgs),
+    Adopt(BridgeMutationArgs),
+    PreviewUpdate(BridgePreviewUpdateArgs),
+    Update(BridgeUpdateArgs),
+    PreviewDelete(BridgeSelectorArgs),
+    Delete(BridgeDeleteArgs),
+    Export(BridgeExportArgs),
+}
+
+#[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum ActivationCommand {
+    Inspect,
+    Change(ActivationChangeArgs),
+}
+
+#[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum CompositionCommand {
+    Validate(DocumentArgs),
+    Preflight(CompositionPreflightArgs),
+    ExplainResolution(ResolutionArgs),
+}
+
+#[derive(Args)]
+pub(crate) struct DocumentArgs {
+    /// Bounded YAML or JSON document input.
+    #[arg(long)]
+    input: PathBuf,
+}
+
+#[derive(Args, Clone)]
+pub(crate) struct ModuleSelectorArgs {
+    /// Globally unique ontology URI.
+    #[arg(long)]
+    ontology_id: String,
+    /// Exact opaque authored version; requires --canonical-digest.
+    #[arg(long, requires = "canonical_digest")]
+    authored_version: Option<String>,
+    /// Exact lowercase SHA-256 digest; requires --authored-version.
+    #[arg(long, requires = "authored_version")]
+    canonical_digest: Option<String>,
+}
+
+#[derive(Args, Clone)]
+pub(crate) struct BridgeSelectorArgs {
+    /// Globally unique bridge URI.
+    #[arg(long)]
+    bridge_id: String,
+    /// Exact opaque authored version; requires --canonical-digest.
+    #[arg(long, requires = "canonical_digest")]
+    authored_version: Option<String>,
+    /// Exact lowercase SHA-256 digest; requires --authored-version.
+    #[arg(long, requires = "authored_version")]
+    canonical_digest: Option<String>,
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+enum InputFormat {
+    Auto,
+    Json,
+    Yaml,
+}
+
+impl From<InputFormat> for ImportFormatHint {
+    fn from(value: InputFormat) -> Self {
+        match value {
+            InputFormat::Auto => Self::Auto,
+            InputFormat::Json => Self::Json,
+            InputFormat::Yaml => Self::Yaml,
+        }
+    }
+}
+
+impl From<InputFormat> for BridgeImportFormatHint {
+    fn from(value: InputFormat) -> Self {
+        match value {
+            InputFormat::Auto => Self::Auto,
+            InputFormat::Json => Self::Json,
+            InputFormat::Yaml => Self::Yaml,
+        }
+    }
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+enum ModeArg {
+    Exploratory,
+    Advisory,
+    Strict,
+}
+
+impl From<ModeArg> for ActivationMode {
+    fn from(value: ModeArg) -> Self {
+        match value {
+            ModeArg::Exploratory => Self::Exploratory,
+            ModeArg::Advisory => Self::Advisory,
+            ModeArg::Strict => Self::Strict,
+        }
+    }
+}
+
+#[derive(Args)]
+pub(crate) struct ModuleCandidateArgs {
+    #[command(flatten)]
+    document: DocumentArgs,
+    #[arg(long, value_enum, default_value_t = InputFormat::Auto)]
+    format: InputFormat,
+    /// Exact dependency as `ontology_uri@authored_version#canonical_digest`.
+    #[arg(long = "dependency")]
+    dependencies: Vec<String>,
+    /// Optional module-specific activation override.
+    #[arg(long, value_enum)]
+    mode: Option<ModeArg>,
+}
+
+#[derive(Args)]
+pub(crate) struct BridgeCandidateArgs {
+    #[command(flatten)]
+    document: DocumentArgs,
+    #[arg(long, value_enum, default_value_t = InputFormat::Auto)]
+    format: InputFormat,
+}
+
+#[derive(Args, Clone)]
+pub(crate) struct AuthorityArgs {
+    /// Caller-owned idempotency UUID.
+    #[arg(long)]
+    operation_uuid: String,
+    /// Exact project generation observed before mutation.
+    #[arg(long)]
+    expected_generation: String,
+    /// Exact current composition fingerprint; omit only when authority is absent.
+    #[arg(long)]
+    expected_composition_fingerprint: Option<String>,
+    /// Optional actor UUID.
+    #[arg(long)]
+    actor_uuid: Option<String>,
+    /// Deterministically request cancellation before any mutation (automation/testing boundary).
+    #[arg(long, hide = true)]
+    cancel_before_start: bool,
+}
+
+#[derive(Args)]
+pub(crate) struct ModuleMutationArgs {
+    #[command(flatten)]
+    candidate: ModuleCandidateArgs,
+    #[command(flatten)]
+    authority: AuthorityArgs,
+}
+
+#[derive(Args)]
+pub(crate) struct ModulePreviewUpdateArgs {
+    #[command(flatten)]
+    selector: ModuleSelectorArgs,
+    #[command(flatten)]
+    candidate: ModuleCandidateArgs,
+}
+
+#[derive(Args)]
+pub(crate) struct ModuleUpdateArgs {
+    #[command(flatten)]
+    preview: ModulePreviewUpdateArgs,
+    #[command(flatten)]
+    authority: AuthorityArgs,
+}
+
+#[derive(Args)]
+pub(crate) struct ModuleDeleteArgs {
+    #[command(flatten)]
+    selector: ModuleSelectorArgs,
+    #[command(flatten)]
+    authority: AuthorityArgs,
+}
+
+#[derive(Args)]
+pub(crate) struct BridgeMutationArgs {
+    #[command(flatten)]
+    candidate: BridgeCandidateArgs,
+    #[command(flatten)]
+    authority: AuthorityArgs,
+}
+
+#[derive(Args)]
+pub(crate) struct BridgePreviewUpdateArgs {
+    #[command(flatten)]
+    selector: BridgeSelectorArgs,
+    #[command(flatten)]
+    candidate: BridgeCandidateArgs,
+}
+
+#[derive(Args)]
+pub(crate) struct BridgeUpdateArgs {
+    #[command(flatten)]
+    preview: BridgePreviewUpdateArgs,
+    #[command(flatten)]
+    authority: AuthorityArgs,
+}
+
+#[derive(Args)]
+pub(crate) struct BridgeDeleteArgs {
+    #[command(flatten)]
+    selector: BridgeSelectorArgs,
+    #[command(flatten)]
+    authority: AuthorityArgs,
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+enum ExportFormatArg {
+    Json,
+    Yaml,
+}
+
+#[derive(Args)]
+pub(crate) struct ModuleExportArgs {
+    #[command(flatten)]
+    selector: ModuleSelectorArgs,
+    #[arg(long, value_enum, default_value_t = ExportFormatArg::Json)]
+    format: ExportFormatArg,
+}
+
+#[derive(Args)]
+pub(crate) struct BridgeExportArgs {
+    #[command(flatten)]
+    selector: BridgeSelectorArgs,
+    #[arg(long, value_enum, default_value_t = ExportFormatArg::Json)]
+    format: ExportFormatArg,
+}
+
+#[derive(Deserialize)]
+struct ActivationProfileInput {
+    profile_default: ActivationMode,
+    activation: Vec<ActivationRecord>,
+}
+
+#[derive(Args)]
+pub(crate) struct ActivationChangeArgs {
+    /// JSON object with `profile_default` and the complete `activation` array.
+    #[arg(long)]
+    input: PathBuf,
+    #[command(flatten)]
+    authority: AuthorityArgs,
+}
+
+#[derive(Args)]
+pub(crate) struct CompositionPreflightArgs {
+    #[command(flatten)]
+    document: DocumentArgs,
+    #[command(flatten)]
+    authority: AuthorityArgs,
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+enum SymbolKindArg {
+    Entity,
+    Relation,
+    Property,
+    Constraint,
+    Migration,
+}
+
+impl From<SymbolKindArg> for SymbolKind {
+    fn from(value: SymbolKindArg) -> Self {
+        match value {
+            SymbolKindArg::Entity => Self::Entity,
+            SymbolKindArg::Relation => Self::Relation,
+            SymbolKindArg::Property => Self::Property,
+            SymbolKindArg::Constraint => Self::Constraint,
+            SymbolKindArg::Migration => Self::Migration,
+        }
+    }
+}
+
+#[derive(Args)]
+pub(crate) struct ResolutionArgs {
+    #[arg(long, value_enum)]
+    kind: SymbolKindArg,
+    #[arg(long)]
+    local_id: String,
+    #[arg(long)]
+    ontology_id: Option<String>,
+    #[arg(long, requires = "ontology_id", requires = "canonical_digest")]
+    authored_version: Option<String>,
+    #[arg(long, requires = "ontology_id", requires = "authored_version")]
+    canonical_digest: Option<String>,
+    #[arg(long, default_value_t = 64)]
+    max_candidates: usize,
+}
+
+pub(crate) fn run_ontology(
+    graph: &mut GraphForge,
+    command: OntologyCommand,
+    json_output: bool,
+    output: &mut dyn Write,
+) -> Result<(), CliRuntimeError> {
+    match command {
+        OntologyCommand::Module { command } => run_module(graph, command, json_output, output),
+        OntologyCommand::Bridge { command } => run_bridge(graph, command, json_output, output),
+        OntologyCommand::Activation { command } => {
+            run_activation(graph, command, json_output, output)
+        }
+        OntologyCommand::Composition { command } => {
+            run_composition(graph, command, json_output, output)
+        }
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+fn run_module(
+    graph: &mut GraphForge,
+    command: ModuleCommand,
+    json_output: bool,
+    output: &mut dyn Write,
+) -> Result<(), CliRuntimeError> {
+    match command {
+        ModuleCommand::List => emit(&graph.ontology_modules()?, json_output, output),
+        ModuleCommand::Get(args) => emit(
+            &graph.inspect_ontology_module(&exact_module_selector(&args)?)?,
+            json_output,
+            output,
+        ),
+        ModuleCommand::Inspect(args) => emit(
+            &graph.inspect_ontology_module(&module_selector(&args)?)?,
+            json_output,
+            output,
+        ),
+        ModuleCommand::Validate(args) => {
+            let document: OntologyDoc = read_authored(&args.input)?;
+            emit(
+                &graph.validate_ontology_module(&document)?,
+                json_output,
+                output,
+            )
+        }
+        ModuleCommand::Create(args) => {
+            let candidate = module_candidate_from_args(graph, &args, true)?;
+            emit(&candidate, json_output, output)
+        }
+        ModuleCommand::Import(args) => {
+            let candidate = module_candidate_from_args(graph, &args, false)?;
+            emit(&candidate, json_output, output)
+        }
+        ModuleCommand::Adopt(args) => {
+            let candidate = module_candidate_from_args(graph, &args.candidate, true)?;
+            let (authority, token) = authority(&args.authority)?;
+            let receipt = graph.adopt_ontology_module(
+                &ModuleAdoptionRequest {
+                    authority,
+                    candidate,
+                },
+                Some(&token),
+            )?;
+            emit(&receipt, json_output, output)
+        }
+        ModuleCommand::PreviewUpdate(args) => {
+            let candidate = module_candidate_from_args(graph, &args.candidate, true)?;
+            let preview = graph.preview_update_ontology_module(
+                &module_selector(&args.selector)?,
+                &candidate.document,
+                &candidate.dependencies,
+            )?;
+            emit(&preview, json_output, output)
+        }
+        ModuleCommand::Update(args) => {
+            let candidate = module_candidate_from_args(graph, &args.preview.candidate, true)?;
+            let (authority, token) = authority(&args.authority)?;
+            let receipt = graph.update_ontology_module(
+                &ModuleUpdateRequest {
+                    authority,
+                    selector: module_selector(&args.preview.selector)?,
+                    document: candidate.document,
+                    dependencies: candidate.dependencies,
+                    enforcement: candidate.enforcement,
+                },
+                Some(&token),
+            )?;
+            emit(&receipt, json_output, output)
+        }
+        ModuleCommand::PreviewDelete(args) => emit(
+            &graph.preview_delete_ontology_module(&module_selector(&args)?)?,
+            json_output,
+            output,
+        ),
+        ModuleCommand::Delete(args) => {
+            let (authority, token) = authority(&args.authority)?;
+            let receipt = graph.delete_ontology_module(
+                &ModuleDeleteRequest {
+                    authority,
+                    selector: module_selector(&args.selector)?,
+                },
+                Some(&token),
+            )?;
+            emit(&receipt, json_output, output)
+        }
+        ModuleCommand::Export(args) => {
+            let format = match args.format {
+                ExportFormatArg::Json => graphforge_api::ExportFormat::Json,
+                ExportFormatArg::Yaml => graphforge_api::ExportFormat::Yaml,
+            };
+            let document =
+                graph.export_ontology_module(&module_selector(&args.selector)?, format)?;
+            emit(
+                &json!({
+                    "contract":"graphforge-ontology-module-export/1",
+                    "format": export_token(args.format),
+                    "document": document
+                }),
+                json_output,
+                output,
+            )
+        }
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+fn run_bridge(
+    graph: &mut GraphForge,
+    command: BridgeCommand,
+    json_output: bool,
+    output: &mut dyn Write,
+) -> Result<(), CliRuntimeError> {
+    match command {
+        BridgeCommand::List => emit(&graph.ontology_bridges()?, json_output, output),
+        BridgeCommand::Get(args) => emit(
+            &graph.inspect_ontology_bridge(&exact_bridge_selector(&args)?)?,
+            json_output,
+            output,
+        ),
+        BridgeCommand::Inspect(args) => emit(
+            &graph.inspect_ontology_bridge(&bridge_selector(&args)?)?,
+            json_output,
+            output,
+        ),
+        BridgeCommand::Validate(args) => {
+            let document: BridgeDocument = read_authored(&args.input)?;
+            emit(
+                &graph.validate_ontology_bridge(&document)?,
+                json_output,
+                output,
+            )
+        }
+        BridgeCommand::Create(args) => emit(
+            &bridge_candidate_from_args(graph, &args, true)?,
+            json_output,
+            output,
+        ),
+        BridgeCommand::Import(args) => emit(
+            &bridge_candidate_from_args(graph, &args, false)?,
+            json_output,
+            output,
+        ),
+        BridgeCommand::Adopt(args) => {
+            let candidate = bridge_candidate_from_args(graph, &args.candidate, true)?;
+            let (authority, token) = authority(&args.authority)?;
+            let receipt = graph.adopt_ontology_bridge(
+                &BridgeAdoptionRequest {
+                    authority,
+                    candidate,
+                },
+                Some(&token),
+            )?;
+            emit(&receipt, json_output, output)
+        }
+        BridgeCommand::PreviewUpdate(args) => {
+            let candidate = bridge_candidate_from_args(graph, &args.candidate, true)?;
+            emit(
+                &graph.preview_update_ontology_bridge(
+                    &bridge_selector(&args.selector)?,
+                    &candidate.document,
+                )?,
+                json_output,
+                output,
+            )
+        }
+        BridgeCommand::Update(args) => {
+            let candidate = bridge_candidate_from_args(graph, &args.preview.candidate, true)?;
+            let (authority, token) = authority(&args.authority)?;
+            let receipt = graph.update_ontology_bridge(
+                &BridgeUpdateRequest {
+                    authority,
+                    selector: bridge_selector(&args.preview.selector)?,
+                    document: candidate.document,
+                },
+                Some(&token),
+            )?;
+            emit(&receipt, json_output, output)
+        }
+        BridgeCommand::PreviewDelete(args) => emit(
+            &graph.preview_delete_ontology_bridge(&bridge_selector(&args)?)?,
+            json_output,
+            output,
+        ),
+        BridgeCommand::Delete(args) => {
+            let (authority, token) = authority(&args.authority)?;
+            let receipt = graph.delete_ontology_bridge(
+                &BridgeDeleteRequest {
+                    authority,
+                    selector: bridge_selector(&args.selector)?,
+                },
+                Some(&token),
+            )?;
+            emit(&receipt, json_output, output)
+        }
+        BridgeCommand::Export(args) => {
+            let format = match args.format {
+                ExportFormatArg::Json => BridgeExportFormat::Json,
+                ExportFormatArg::Yaml => BridgeExportFormat::Yaml,
+            };
+            let document =
+                graph.export_ontology_bridge(&bridge_selector(&args.selector)?, format)?;
+            emit(
+                &json!({
+                    "contract":"graphforge-ontology-bridge-export/1",
+                    "format": export_token(args.format),
+                    "document": document
+                }),
+                json_output,
+                output,
+            )
+        }
+    }
+}
+
+fn run_activation(
+    graph: &mut GraphForge,
+    command: ActivationCommand,
+    json_output: bool,
+    output: &mut dyn Write,
+) -> Result<(), CliRuntimeError> {
+    match command {
+        ActivationCommand::Inspect => {
+            let (profile_default, activation) = graph.ontology_activation_profile()?;
+            emit(
+                &json!({"profile_default":profile_default,"activation":activation}),
+                json_output,
+                output,
+            )
+        }
+        ActivationCommand::Change(args) => {
+            let input: ActivationProfileInput = read_json(&args.input)?;
+            let (authority, token) = authority(&args.authority)?;
+            let receipt = graph.change_ontology_activation_profile(
+                &ActivationProfileChangeRequest {
+                    authority,
+                    profile_default: input.profile_default,
+                    activation: input.activation,
+                },
+                Some(&token),
+            )?;
+            emit(&receipt, json_output, output)
+        }
+    }
+}
+
+fn run_composition(
+    graph: &mut GraphForge,
+    command: CompositionCommand,
+    json_output: bool,
+    output: &mut dyn Write,
+) -> Result<(), CliRuntimeError> {
+    match command {
+        CompositionCommand::Validate(args) => emit(
+            &graph.validate_ontology_composition(&read_json(&args.input)?)?,
+            json_output,
+            output,
+        ),
+        CompositionCommand::Preflight(args) => {
+            let candidate: WorkspaceOntologyComposition = read_json(&args.document.input)?;
+            let (authority, token) = authority(&args.authority)?;
+            let request = CompositionChangeRequest {
+                context: authority.context,
+                expected_project_generation_uuid: authority.expected_project_generation_uuid,
+                expected_composition_fingerprint: authority.expected_composition_fingerprint,
+                candidate,
+                data_disposition: CompositionDataDisposition::RequireConforming,
+            };
+            emit(
+                &graph.preflight_ontology_composition(&request, Some(&token))?,
+                json_output,
+                output,
+            )
+        }
+        CompositionCommand::ExplainResolution(args) => {
+            let module = resolution_module(&args)?;
+            emit(
+                &graph.explain_ontology_resolution(&ResolutionExplainRequest {
+                    module,
+                    kind: args.kind.into(),
+                    local_id: args.local_id,
+                    max_candidates: args.max_candidates,
+                })?,
+                json_output,
+                output,
+            )
+        }
+    }
+}
+
+pub(crate) fn run_portable_staging_inspect(
+    graph: &GraphForge,
+    json_output: bool,
+    output: &mut dyn Write,
+) -> Result<(), CliRuntimeError> {
+    let staged = graph.portable_ontology_staging(PortableV2Limits::default())?;
+    let value = staged.map(|candidate| {
+        json!({
+            "contract":"graphforge-portable-ontology-staging/1",
+            "package_digest":candidate.package_digest,
+            "portable_composition_digest":candidate.portable_composition_digest,
+            "composition_fingerprint":candidate.composition.composition_fingerprint,
+            "composition":candidate.composition,
+        })
+    });
+    emit(&value, json_output, output)
+}
+
+pub(crate) fn run_portable_staging_adopt(
+    graph: &mut GraphForge,
+    authority_args: &AuthorityArgs,
+    json_output: bool,
+    output: &mut dyn Write,
+) -> Result<(), CliRuntimeError> {
+    let (authority, token) = authority(authority_args)?;
+    let receipt = graph.adopt_portable_ontology_staging(
+        &authority,
+        PortableV2Limits::default(),
+        Some(&token),
+    )?;
+    emit(&receipt, json_output, output)
+}
+
+fn module_candidate_from_args(
+    graph: &GraphForge,
+    args: &ModuleCandidateArgs,
+    create: bool,
+) -> Result<graphforge_api::ModuleCandidate, CliRuntimeError> {
+    module_candidate(
+        graph,
+        &args.document.input,
+        args.format,
+        &args.dependencies,
+        args.mode,
+        create,
+    )
+}
+
+fn module_candidate(
+    graph: &GraphForge,
+    input: &Path,
+    format: InputFormat,
+    dependencies: &[String],
+    mode: Option<ModeArg>,
+    create: bool,
+) -> Result<graphforge_api::ModuleCandidate, CliRuntimeError> {
+    let text = read_bounded(input)?;
+    let dependencies = dependencies
+        .iter()
+        .map(|value| parse_module_id(value))
+        .collect::<Result<Vec<_>, _>>()?;
+    let imported = graph.import_ontology_module(&text, format.into(), dependencies.clone())?;
+    if create {
+        Ok(graph.create_ontology_module(imported.document, dependencies, mode.map(Into::into))?)
+    } else {
+        let mut imported = imported;
+        imported.enforcement = mode.map(Into::into);
+        Ok(imported)
+    }
+}
+
+fn bridge_candidate_from_args(
+    graph: &GraphForge,
+    args: &BridgeCandidateArgs,
+    create: bool,
+) -> Result<graphforge_api::BridgeCandidate, CliRuntimeError> {
+    bridge_candidate(graph, &args.document.input, args.format, create)
+}
+
+fn bridge_candidate(
+    graph: &GraphForge,
+    input: &Path,
+    format: InputFormat,
+    create: bool,
+) -> Result<graphforge_api::BridgeCandidate, CliRuntimeError> {
+    let text = read_bounded(input)?;
+    let imported = graph.import_ontology_bridge(&text, format.into())?;
+    if create {
+        Ok(graph.create_ontology_bridge(imported.document)?)
+    } else {
+        Ok(imported)
+    }
+}
+
+fn module_selector(args: &ModuleSelectorArgs) -> Result<ModuleSelector, graphforge_api::GfError> {
+    match (&args.authored_version, &args.canonical_digest) {
+        (Some(authored_version), Some(canonical_digest)) => {
+            Ok(ModuleSelector::Exact(OntologyModuleId {
+                ontology_id: args.ontology_id.clone(),
+                authored_version: authored_version.clone(),
+                canonical_digest: canonical_digest.clone(),
+            }))
+        }
+        (None, None) => Ok(ModuleSelector::OntologyId(args.ontology_id.clone())),
+        _ => Err(graphforge_api::GfError::Validation(
+            "exact module selection requires authored version and canonical digest".into(),
+        )),
+    }
+}
+
+fn exact_module_selector(
+    args: &ModuleSelectorArgs,
+) -> Result<ModuleSelector, graphforge_api::GfError> {
+    match module_selector(args)? {
+        exact @ ModuleSelector::Exact(_) => Ok(exact),
+        ModuleSelector::OntologyId(_) => Err(graphforge_api::GfError::Validation(
+            "module get requires an exact identity".into(),
+        )),
+    }
+}
+
+fn bridge_selector(args: &BridgeSelectorArgs) -> Result<BridgeSelector, graphforge_api::GfError> {
+    match (&args.authored_version, &args.canonical_digest) {
+        (Some(authored_version), Some(canonical_digest)) => {
+            Ok(BridgeSelector::Exact(BridgeSetId {
+                bridge_id: args.bridge_id.clone(),
+                authored_version: authored_version.clone(),
+                canonical_digest: canonical_digest.clone(),
+            }))
+        }
+        (None, None) => Ok(BridgeSelector::BridgeId(args.bridge_id.clone())),
+        _ => Err(graphforge_api::GfError::Validation(
+            "exact bridge selection requires authored version and canonical digest".into(),
+        )),
+    }
+}
+
+fn exact_bridge_selector(
+    args: &BridgeSelectorArgs,
+) -> Result<BridgeSelector, graphforge_api::GfError> {
+    match bridge_selector(args)? {
+        exact @ BridgeSelector::Exact(_) => Ok(exact),
+        BridgeSelector::BridgeId(_) => Err(graphforge_api::GfError::Validation(
+            "bridge get requires an exact identity".into(),
+        )),
+    }
+}
+
+fn resolution_module(
+    args: &ResolutionArgs,
+) -> Result<Option<OntologyModuleId>, graphforge_api::GfError> {
+    match (
+        &args.ontology_id,
+        &args.authored_version,
+        &args.canonical_digest,
+    ) {
+        (None, None, None) => Ok(None),
+        (Some(ontology_id), Some(authored_version), Some(canonical_digest)) => {
+            Ok(Some(OntologyModuleId {
+                ontology_id: ontology_id.clone(),
+                authored_version: authored_version.clone(),
+                canonical_digest: canonical_digest.clone(),
+            }))
+        }
+        _ => Err(graphforge_api::GfError::Validation(
+            "qualified resolution requires the complete exact module identity".into(),
+        )),
+    }
+}
+
+fn authority(
+    args: &AuthorityArgs,
+) -> Result<(OntologyAuthorityExpectation, CancellationToken), graphforge_api::GfError> {
+    let token = CancellationToken::new();
+    if args.cancel_before_start {
+        token.cancel();
+    }
+    Ok((
+        OntologyAuthorityExpectation {
+            context: WriteContext {
+                operation_uuid: OperationId(canonical_uuid(&args.operation_uuid)?),
+                actor_uuid: args.actor_uuid.as_deref().map(canonical_uuid).transpose()?,
+            },
+            expected_project_generation_uuid: canonical_uuid(&args.expected_generation)?,
+            expected_composition_fingerprint: args.expected_composition_fingerprint.clone(),
+        },
+        token,
+    ))
+}
+
+fn parse_module_id(value: &str) -> Result<OntologyModuleId, graphforge_api::GfError> {
+    let (identity, canonical_digest) = value.rsplit_once('#').ok_or_else(|| {
+        graphforge_api::GfError::Validation("module dependency lacks canonical digest".into())
+    })?;
+    let (ontology_id, authored_version) = identity.rsplit_once('@').ok_or_else(|| {
+        graphforge_api::GfError::Validation("module dependency lacks authored version".into())
+    })?;
+    Ok(OntologyModuleId {
+        ontology_id: ontology_id.into(),
+        authored_version: authored_version.into(),
+        canonical_digest: canonical_digest.into(),
+    })
+}
+
+fn read_bounded(path: &Path) -> Result<String, graphforge_api::GfError> {
+    let metadata = fs::metadata(path)
+        .map_err(|_| graphforge_api::GfError::Validation("ontology input is unavailable".into()))?;
+    if metadata.len() > MAX_INPUT_BYTES {
+        return Err(graphforge_api::GfError::Validation(
+            "ontology input exceeds the 16 MiB limit".into(),
+        ));
+    }
+    fs::read_to_string(path)
+        .map_err(|_| graphforge_api::GfError::Validation("ontology input is invalid".into()))
+}
+
+fn read_json<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<T, graphforge_api::GfError> {
+    serde_json::from_str(&read_bounded(path)?)
+        .map_err(|_| graphforge_api::GfError::Validation("ontology JSON is malformed".into()))
+}
+
+fn read_authored<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<T, graphforge_api::GfError> {
+    let text = read_bounded(path)?;
+    serde_json::from_str(&text)
+        .or_else(|_| serde_yaml::from_str(&text))
+        .map_err(|_| graphforge_api::GfError::Validation("ontology document is malformed".into()))
+}
+
+fn emit(
+    value: &impl serde::Serialize,
+    json_output: bool,
+    output: &mut dyn Write,
+) -> Result<(), CliRuntimeError> {
+    if json_output {
+        serde_json::to_writer(&mut *output, value)
+    } else {
+        serde_json::to_writer_pretty(&mut *output, value)
+    }
+    .map_err(|error| graphforge_api::GfError::Execution(error.to_string()))?;
+    writeln!(output).map_err(|error| graphforge_api::GfError::Execution(error.to_string()).into())
+}
+
+const fn export_token(format: ExportFormatArg) -> &'static str {
+    match format {
+        ExportFormatArg::Json => "json",
+        ExportFormatArg::Yaml => "yaml",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    #[test]
+    fn exact_selectors_require_complete_identity() {
+        let selector = ModuleSelectorArgs {
+            ontology_id: "https://example.test/ontology".into(),
+            authored_version: Some("v1".into()),
+            canonical_digest: Some("a".repeat(64)),
+        };
+        assert!(matches!(
+            module_selector(&selector),
+            Ok(ModuleSelector::Exact(_))
+        ));
+        let incomplete = ModuleSelectorArgs {
+            canonical_digest: None,
+            ..selector
+        };
+        assert!(module_selector(&incomplete).is_err());
+        let unqualified = ModuleSelectorArgs {
+            ontology_id: "https://example.test/ontology".into(),
+            authored_version: None,
+            canonical_digest: None,
+        };
+        assert!(exact_module_selector(&unqualified).is_err());
+    }
+
+    #[test]
+    fn authority_cancellation_boundary_is_deterministic() {
+        let args = AuthorityArgs {
+            operation_uuid: Uuid::from_u128(1).hyphenated().to_string(),
+            expected_generation: Uuid::from_u128(2).hyphenated().to_string(),
+            expected_composition_fingerprint: None,
+            actor_uuid: None,
+            cancel_before_start: true,
+        };
+        let (_, token) = authority(&args).unwrap();
+        assert!(token.is_cancelled());
+    }
+
+    #[test]
+    fn cli_surface_path_inventory_is_closed() {
+        assert_eq!(CLI_SURFACE_PATHS.len(), 35);
+        let mut sorted = CLI_SURFACE_PATHS.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), CLI_SURFACE_PATHS.len());
+    }
+}

--- a/crates/graphforge-cli/src/portable_cli.rs
+++ b/crates/graphforge-cli/src/portable_cli.rs
@@ -17,20 +17,8 @@ use uuid::Uuid;
 
 use crate::canonical_uuid;
 
-fn map_portable(error: &PortableV2Error) -> graphforge_api::GfError {
-    // Preserve the typed portable code in the message and map to the matching
-    // GfError fault domain so CLI exit codes distinguish IO/execution/validation.
-    let message = format!("{:?}: {error}", error.code);
-    match error.code {
-        graphforge_api::PortableV2ErrorCode::Io => graphforge_api::GfError::Storage(message),
-        graphforge_api::PortableV2ErrorCode::Cancelled
-        | graphforge_api::PortableV2ErrorCode::LimitExceeded
-        | graphforge_api::PortableV2ErrorCode::DigestMismatch
-        | graphforge_api::PortableV2ErrorCode::ConcurrentMutation => {
-            graphforge_api::GfError::Execution(message)
-        }
-        _ => graphforge_api::GfError::Validation(message),
-    }
+fn map_portable(error: PortableV2Error) -> crate::CliRuntimeError {
+    graphforge_api::MultiOntologyError::from(error).into()
 }
 
 fn write_json(
@@ -69,6 +57,19 @@ pub(crate) enum PortableCommand {
     PublishOci(PortablePublishOciArgs),
     /// Pull and verify a digest-pinned package from an OCI registry.
     PullOci(PortablePullOciArgs),
+    /// Inspect or explicitly adopt durable non-authoritative ontology staging.
+    Staging {
+        #[command(subcommand)]
+        command: PortableStagingCommand,
+    },
+}
+
+#[derive(Subcommand)]
+pub(crate) enum PortableStagingCommand {
+    /// Inspect path-free semantic staging identity.
+    Inspect,
+    /// Explicitly adopt staged authority with exact optimistic identities.
+    Adopt(crate::ontology_cli::AuthorityArgs),
 }
 
 #[derive(Clone, Copy, ValueEnum)]
@@ -211,12 +212,12 @@ fn oci_credential() -> Option<String> {
     reason = "CLI dispatch keeps preview/export in one portable command table"
 )]
 pub(crate) fn run_portable(
-    graph: &GraphForge,
+    graph: &mut GraphForge,
     project_root: &std::path::Path,
     command: PortableCommand,
     json: bool,
     output: &mut dyn Write,
-) -> Result<(), graphforge_api::GfError> {
+) -> Result<(), crate::CliRuntimeError> {
     match command {
         PortableCommand::Preview(args) => {
             let plan = graph
@@ -228,7 +229,7 @@ pub(crate) fn run_portable(
                     },
                     limits: PortableV2Limits::default(),
                 })
-                .map_err(|error| map_portable(&error))?;
+                .map_err(map_portable)?;
             if json {
                 write_json(&plan, output)?;
             } else {
@@ -265,9 +266,23 @@ pub(crate) fn run_portable(
                         }
                     },
                 )
-                .map_err(|error| map_portable(&error))?;
+                .map_err(map_portable)?;
             if json {
-                write_json(&result, output)?;
+                write_json(
+                    &serde_json::json!({
+                        "contract": result.contract,
+                        "source": result.source,
+                        "checkpoint": result.checkpoint,
+                        "generation_uuid": result.generation_uuid,
+                        "package_digest": result.package_digest,
+                        "transport_digest": result.transport_digest,
+                        "entry_count": result.entry_count,
+                        "payload_bytes": result.payload_bytes,
+                        "representation": result.representation,
+                        "selection_fingerprint": result.selection_fingerprint,
+                    }),
+                    output,
+                )?;
             } else {
                 writeln!(
                     output,
@@ -277,6 +292,14 @@ pub(crate) fn run_portable(
                 .map_err(|error| graphforge_api::GfError::Execution(error.to_string()))?;
             }
         }
+        PortableCommand::Staging { command } => match command {
+            PortableStagingCommand::Inspect => {
+                crate::ontology_cli::run_portable_staging_inspect(graph, json, output)?;
+            }
+            PortableStagingCommand::Adopt(args) => {
+                crate::ontology_cli::run_portable_staging_adopt(graph, &args, json, output)?;
+            }
+        },
         command => {
             return run_portable_without_graph(project_root, command, json, output);
         }
@@ -294,13 +317,14 @@ pub(crate) fn run_portable_without_graph(
     command: PortableCommand,
     json: bool,
     output: &mut dyn Write,
-) -> Result<(), graphforge_api::GfError> {
+) -> Result<(), crate::CliRuntimeError> {
     match command {
-        PortableCommand::Preview(_) | PortableCommand::Export(_) => {
-            Err(graphforge_api::GfError::Validation(
-                "preview/export require an open project handle".into(),
-            ))
-        }
+        PortableCommand::Preview(_)
+        | PortableCommand::Export(_)
+        | PortableCommand::Staging { .. } => Err(graphforge_api::GfError::Validation(
+            "preview/export require an open project handle".into(),
+        )
+        .into()),
         PortableCommand::Verify(args) => {
             let report = verify_portable_v2(
                 &PortableVerifyRequest {
@@ -310,7 +334,7 @@ pub(crate) fn run_portable_without_graph(
                 },
                 None,
             )
-            .map_err(|error| map_portable(&error))?;
+            .map_err(map_portable)?;
             if json {
                 write_json(&report, output)?;
             } else {
@@ -333,7 +357,7 @@ pub(crate) fn run_portable_without_graph(
                 },
                 None,
             )
-            .map_err(|error| map_portable(&error))?;
+            .map_err(map_portable)?;
             if json {
                 write_json(
                     &serde_json::json!({
@@ -370,7 +394,7 @@ pub(crate) fn run_portable_without_graph(
                 },
                 None,
             )
-            .map_err(|error| map_portable(&error))?;
+            .map_err(map_portable)?;
             if json {
                 write_json(
                     &serde_json::json!({
@@ -408,14 +432,13 @@ pub(crate) fn run_portable_without_graph(
                 },
                 None,
             )
-            .map_err(|error| map_portable(&error))?;
+            .map_err(map_portable)?;
             if json {
                 write_json(
                     &serde_json::json!({
                         "contract": "graphforge-portable-oci-pull/2",
                         "oci_manifest_digest": receipt.reference.oci_manifest_digest,
                         "package_digest": receipt.reference.package_digest,
-                        "destination": receipt.destination,
                     }),
                     output,
                 )?;

--- a/crates/graphforge-cli/tests/multi_ontology.rs
+++ b/crates/graphforge-cli/tests/multi_ontology.rs
@@ -1,0 +1,1204 @@
+//! CLI conformance for the Rust-owned composable multi-ontology surface (#842).
+
+use std::fmt::Write as _;
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use tempfile::TempDir;
+
+fn gf(project: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_gf"))
+        .arg("--project")
+        .arg(project)
+        .args(args)
+        .output()
+        .expect("run same-build gf binary")
+}
+
+fn gf_owned(project: &Path, args: &[String]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_gf"))
+        .arg("--project")
+        .arg(project)
+        .args(args)
+        .output()
+        .expect("run same-build gf binary")
+}
+
+fn parse_json(bytes: &[u8]) -> Value {
+    serde_json::from_slice(bytes).expect("deterministic JSON")
+}
+
+fn parity_oracle() -> Value {
+    serde_json::from_str(include_str!(
+        "../../../tests/fixtures/multi-ontology-v1/binding-parity-v1.json"
+    ))
+    .expect("shared binding-parity oracle")
+}
+
+fn initialized_project() -> TempDir {
+    let project = TempDir::new().unwrap();
+    graphforge_storage::open_or_initialize_project(project.path()).unwrap();
+    project
+}
+
+fn write_module(project: &Path, name: &str, value: &Value) -> std::path::PathBuf {
+    let path = project.join(name);
+    fs::write(&path, serde_json::to_vec(value).unwrap()).unwrap();
+    path
+}
+
+fn adopt_module(
+    project: &Path,
+    input: &Path,
+    operation_uuid: &str,
+    dependency: Option<&str>,
+) -> Output {
+    let state = graphforge_api::GraphForge::new(Some(project.to_str().unwrap()))
+        .unwrap()
+        .ontology_authority_state()
+        .unwrap();
+    let mut args = vec![
+        "--json".into(),
+        "ontology".into(),
+        "module".into(),
+        "adopt".into(),
+        "--input".into(),
+        input.to_str().unwrap().into(),
+        "--operation-uuid".into(),
+        operation_uuid.into(),
+        "--expected-generation".into(),
+        state.project_generation_uuid.to_string(),
+    ];
+    if let Some(fingerprint) = state.composition_fingerprint {
+        args.extend(["--expected-composition-fingerprint".into(), fingerprint]);
+    }
+    if let Some(dependency) = dependency {
+        args.extend(["--dependency".into(), dependency.into()]);
+    }
+    gf_owned(project, &args)
+}
+
+fn candidate_id(project: &Path, input: &Path) -> Value {
+    let output = gf(
+        project,
+        &[
+            "--json",
+            "ontology",
+            "module",
+            "create",
+            "--input",
+            input.to_str().unwrap(),
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "candidate: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    parse_json(&output.stdout)["id"].clone()
+}
+
+fn display_id(id: &Value) -> String {
+    format!(
+        "{}@{}#{}",
+        id["ontology_id"].as_str().unwrap(),
+        id["authored_version"].as_str().unwrap(),
+        id["canonical_digest"].as_str().unwrap()
+    )
+}
+
+fn substitute(value: &Value, identities: &std::collections::BTreeMap<&str, Value>) -> Value {
+    match value {
+        Value::String(text) if identities.contains_key(text.as_str()) => {
+            identities[text.as_str()].clone()
+        }
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .map(|item| substitute(item, identities))
+                .collect(),
+        ),
+        Value::Object(items) => Value::Object(
+            items
+                .iter()
+                .map(|(key, item)| (key.clone(), substitute(item, identities)))
+                .collect(),
+        ),
+        _ => value.clone(),
+    }
+}
+
+fn adopt_bridge(project: &Path, input: &Path, operation_uuid: &str) -> Output {
+    let state = graphforge_api::GraphForge::new(Some(project.to_str().unwrap()))
+        .unwrap()
+        .ontology_authority_state()
+        .unwrap();
+    let args = vec![
+        "--json".into(),
+        "ontology".into(),
+        "bridge".into(),
+        "adopt".into(),
+        "--input".into(),
+        input.to_str().unwrap().into(),
+        "--operation-uuid".into(),
+        operation_uuid.into(),
+        "--expected-generation".into(),
+        state.project_generation_uuid.to_string(),
+        "--expected-composition-fingerprint".into(),
+        state.composition_fingerprint.unwrap(),
+    ];
+    gf_owned(project, &args)
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    Sha256::digest(bytes)
+        .iter()
+        .fold(String::with_capacity(64), |mut encoded, byte| {
+            write!(encoded, "{byte:02x}").expect("write digest hex");
+            encoded
+        })
+}
+
+fn inject_unsupported_feature(expanded: &Path) {
+    let control_path = expanded
+        .join("data/components/compatibility/graphforge-ontology-composition/composition.json");
+    let mut control: Value = serde_json::from_slice(&fs::read(&control_path).unwrap()).unwrap();
+    control["required_features"]
+        .as_array_mut()
+        .unwrap()
+        .push(Value::String("future-multi-ontology@999".into()));
+    control["required_features"]
+        .as_array_mut()
+        .unwrap()
+        .sort_by(|a, b| a.as_str().cmp(&b.as_str()));
+    control
+        .as_object_mut()
+        .unwrap()
+        .remove("composition_digest");
+    let unsigned = serde_json::to_vec(&control).unwrap();
+    control["composition_digest"] = Value::String(format!(
+        "sha256:{}",
+        sha256_hex(&[b"graphforge-ontology-composition/1\0".as_slice(), &unsigned].concat())
+    ));
+    let control_bytes = serde_json::to_vec(&control).unwrap();
+    fs::write(&control_path, &control_bytes).unwrap();
+    let manifest_path = expanded.join("data/graphforge-project.json");
+    let mut manifest: Value = serde_json::from_slice(&fs::read(&manifest_path).unwrap()).unwrap();
+    for component in manifest["components"].as_array_mut().unwrap() {
+        for file in component["files"].as_array_mut().unwrap() {
+            if file["path"].as_str().unwrap().ends_with("composition.json") {
+                file["length"] = Value::from(control_bytes.len());
+                file["sha256"] = Value::String(sha256_hex(&control_bytes));
+            }
+        }
+    }
+    manifest.as_object_mut().unwrap().remove("package_digest");
+    let unsigned = serde_json::to_vec(&manifest).unwrap();
+    manifest["package_digest"] = Value::String(format!(
+        "sha256:{}",
+        sha256_hex(&[b"graphforge-project/2\0".as_slice(), &unsigned].concat())
+    ));
+    fs::write(manifest_path, serde_json::to_vec(&manifest).unwrap()).unwrap();
+}
+
+#[test]
+fn four_surface_operation_conformance() {
+    // Data-driven exact evidence: tests/contracts/multi-ontology-surface-v1.json
+    let contract: Value = serde_json::from_str(include_str!(
+        "../../../tests/contracts/multi-ontology-surface-v1.json"
+    ))
+    .expect("surface contract");
+    let project = TempDir::new().expect("project parent");
+    for operation in contract["operations"].as_array().expect("operations") {
+        let mapping = operation["cli"].as_str().expect("CLI mapping");
+        let mut command = mapping.split('/').collect::<Vec<_>>();
+        if mapping == "portable/verify/inspect" || mapping == "portable/verify/full" {
+            command.pop();
+        }
+        command.push("--help");
+        let output = gf(project.path(), &command);
+        assert!(
+            output.status.success(),
+            "{} ({mapping}) is not reachable: {}",
+            operation["id"],
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+#[test]
+fn inventory_json_and_errors_are_deterministic_path_free_and_semantic() {
+    let project = TempDir::new().expect("project parent");
+    let listed = gf(project.path(), &["--json", "ontology", "module", "list"]);
+    assert!(
+        listed.status.success(),
+        "list failed: {}",
+        String::from_utf8_lossy(&listed.stderr)
+    );
+    assert_eq!(parse_json(&listed.stdout), serde_json::json!([]));
+    assert!(
+        !String::from_utf8_lossy(&listed.stdout).contains(&project.path().display().to_string())
+    );
+
+    let missing = gf(
+        project.path(),
+        &[
+            "--json",
+            "ontology",
+            "module",
+            "inspect",
+            "--ontology-id",
+            "urn:graphforge:test:missing",
+        ],
+    );
+    assert_eq!(missing.status.code(), Some(1));
+    let error = parse_json(&missing.stderr);
+    let semantic_code = &error["error"]["diagnostics"][0]["code"];
+    assert_eq!(semantic_code, "inventory.not_found");
+    assert!(
+        !String::from_utf8_lossy(&missing.stderr).contains(&project.path().display().to_string())
+    );
+}
+
+#[test]
+fn cancelled_adoption_publishes_no_authority() {
+    let project = initialized_project();
+    let document = project.path().join("module.json");
+    fs::write(
+        &document,
+        r#"{"ontology_id":"urn:graphforge:test:cancelled","version":"1","entity_types":[],"relation_types":[],"properties":[],"constraints":[],"migrations":[]}"#,
+    )
+    .expect("module fixture");
+
+    let before = gf(project.path(), &["--json", "ontology", "module", "list"]);
+    let state = graphforge_api::GraphForge::new(Some(project.path().to_str().unwrap()))
+        .unwrap()
+        .ontology_authority_state()
+        .unwrap();
+    let cancelled = gf(
+        project.path(),
+        &[
+            "--json",
+            "ontology",
+            "module",
+            "adopt",
+            "--input",
+            document.to_str().unwrap(),
+            "--operation-uuid",
+            "00000000-0000-0000-0000-000000000842",
+            "--expected-generation",
+            &state.project_generation_uuid.to_string(),
+            "--cancel-before-start",
+        ],
+    );
+    assert!(!cancelled.status.success());
+    let error = parse_json(&cancelled.stderr);
+    assert_eq!(error["error"]["code"], "GF_CANCELLED");
+    let after = gf(project.path(), &["--json", "ontology", "module", "list"]);
+    assert_eq!(
+        before.stdout, after.stdout,
+        "cancelled adoption changed authority"
+    );
+}
+
+#[allow(clippy::too_many_lines)]
+#[test]
+fn positive_crud_import_export() {
+    let oracle = parity_oracle();
+    let project = initialized_project();
+    let base_input = write_module(project.path(), "base.json", &oracle["modules"]["base"]);
+    let validated = gf(
+        project.path(),
+        &[
+            "--json",
+            "ontology",
+            "module",
+            "validate",
+            "--input",
+            base_input.to_str().unwrap(),
+        ],
+    );
+    assert!(validated.status.success());
+    assert_eq!(
+        parse_json(&validated.stdout),
+        serde_json::json!({"valid":true,"diagnostics":[]})
+    );
+    let mut invalid_doc = oracle["modules"]["base"].clone();
+    let duplicate_entity = invalid_doc["entity_types"][0].clone();
+    invalid_doc["entity_types"]
+        .as_array_mut()
+        .unwrap()
+        .push(duplicate_entity);
+    let invalid_input = write_module(project.path(), "invalid.json", &invalid_doc);
+    let invalid = gf(
+        project.path(),
+        &[
+            "--json",
+            "ontology",
+            "module",
+            "validate",
+            "--input",
+            invalid_input.to_str().unwrap(),
+        ],
+    );
+    assert!(invalid.status.success());
+    let invalid_receipt = parse_json(&invalid.stdout);
+    assert_eq!(invalid_receipt["valid"], false);
+    assert!(
+        !invalid_receipt["diagnostics"]
+            .as_array()
+            .unwrap()
+            .is_empty()
+    );
+    let base_id = candidate_id(project.path(), &base_input);
+    assert!(
+        adopt_module(
+            project.path(),
+            &base_input,
+            "00000000-0000-0000-0000-000000008401",
+            None
+        )
+        .status
+        .success()
+    );
+    let dependent_input = write_module(
+        project.path(),
+        "dependent.json",
+        &oracle["modules"]["dependent"],
+    );
+    let dependent_id = candidate_id(project.path(), &dependent_input);
+    assert!(
+        adopt_module(
+            project.path(),
+            &dependent_input,
+            "00000000-0000-0000-0000-000000008402",
+            Some(&display_id(&base_id))
+        )
+        .status
+        .success()
+    );
+    let identities = std::collections::BTreeMap::from([
+        ("$base", base_id.clone()),
+        ("$dependent", dependent_id.clone()),
+    ]);
+    let bridge_doc = substitute(&oracle["bridge"], &identities);
+    let bridge_input = write_module(project.path(), "bridge.json", &bridge_doc);
+    let bridge = adopt_bridge(
+        project.path(),
+        &bridge_input,
+        "00000000-0000-0000-0000-000000008403",
+    );
+    assert!(
+        bridge.status.success(),
+        "bridge adopt: {}",
+        String::from_utf8_lossy(&bridge.stderr)
+    );
+    let module_export = gf(
+        project.path(),
+        &[
+            "--json",
+            "ontology",
+            "module",
+            "export",
+            "--ontology-id",
+            base_id["ontology_id"].as_str().unwrap(),
+        ],
+    );
+    let bridge_export = gf(
+        project.path(),
+        &[
+            "--json",
+            "ontology",
+            "bridge",
+            "export",
+            "--bridge-id",
+            oracle["bridge"]["bridge_id"].as_str().unwrap(),
+        ],
+    );
+    assert!(module_export.status.success());
+    assert!(
+        bridge_export.status.success(),
+        "bridge export: {}",
+        String::from_utf8_lossy(&bridge_export.stderr)
+    );
+    let module_document: Value = serde_json::from_str(
+        parse_json(&module_export.stdout)["document"]
+            .as_str()
+            .unwrap(),
+    )
+    .unwrap();
+    let bridge_document: Value = serde_json::from_str(
+        parse_json(&bridge_export.stdout)["document"]
+            .as_str()
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(module_document, oracle["modules"]["base"]);
+    assert_eq!(bridge_document, bridge_doc);
+}
+
+#[test]
+fn exact_identity_and_ambiguity() {
+    let oracle = parity_oracle();
+    let project = initialized_project();
+    let first_input = write_module(project.path(), "first.json", &oracle["modules"]["base"]);
+    let first_id = candidate_id(project.path(), &first_input);
+    assert!(
+        adopt_module(
+            project.path(),
+            &first_input,
+            "00000000-0000-0000-0000-000000008410",
+            None
+        )
+        .status
+        .success()
+    );
+    let mut second_doc = oracle["modules"]["base"].clone();
+    second_doc["version"] = Value::String("2.0.0".into());
+    second_doc["entity_types"][0]["name"] = Value::String("AlternatePerson".into());
+    let second_input = write_module(project.path(), "second.json", &second_doc);
+    let second = adopt_module(
+        project.path(),
+        &second_input,
+        "00000000-0000-0000-0000-000000008411",
+        None,
+    );
+    assert!(
+        second.status.success(),
+        "second adopt: {}",
+        String::from_utf8_lossy(&second.stderr)
+    );
+    let exact = gf(
+        project.path(),
+        &[
+            "--json",
+            "ontology",
+            "module",
+            "get",
+            "--ontology-id",
+            first_id["ontology_id"].as_str().unwrap(),
+            "--authored-version",
+            first_id["authored_version"].as_str().unwrap(),
+            "--canonical-digest",
+            first_id["canonical_digest"].as_str().unwrap(),
+        ],
+    );
+    assert!(exact.status.success());
+    assert_eq!(parse_json(&exact.stdout)["entry"]["id"], first_id);
+    let ambiguous = gf(
+        project.path(),
+        &[
+            "--json",
+            "ontology",
+            "module",
+            "inspect",
+            "--ontology-id",
+            first_id["ontology_id"].as_str().unwrap(),
+        ],
+    );
+    assert!(!ambiguous.status.success());
+    let error = parse_json(&ambiguous.stderr);
+    assert_eq!(
+        error["error"]["diagnostics"][0]["code"],
+        oracle["expected"]["ambiguous_code"]
+    );
+    assert_eq!(
+        error["error"]["diagnostics"][0]["code"],
+        "resolution.ambiguous"
+    );
+    assert!(
+        !error["error"]["diagnostics"][0]["candidates"]
+            .as_array()
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[allow(clippy::too_many_lines)]
+#[test]
+fn dependency_blocked_deletion() {
+    let oracle = parity_oracle();
+    let project = initialized_project();
+    let base_input = write_module(project.path(), "base.json", &oracle["modules"]["base"]);
+    let candidate = gf(
+        project.path(),
+        &[
+            "--json",
+            "ontology",
+            "module",
+            "create",
+            "--input",
+            base_input.to_str().unwrap(),
+        ],
+    );
+    assert!(candidate.status.success());
+    let base_id = parse_json(&candidate.stdout)["id"].clone();
+    let base = adopt_module(
+        project.path(),
+        &base_input,
+        "00000000-0000-0000-0000-000000008420",
+        None,
+    );
+    assert!(
+        base.status.success(),
+        "base adopt: {}",
+        String::from_utf8_lossy(&base.stderr)
+    );
+    let dependency = format!(
+        "{}@{}#{}",
+        base_id["ontology_id"].as_str().unwrap(),
+        base_id["authored_version"].as_str().unwrap(),
+        base_id["canonical_digest"].as_str().unwrap()
+    );
+    let dependent_input = write_module(
+        project.path(),
+        "dependent.json",
+        &oracle["modules"]["dependent"],
+    );
+    let dependent = adopt_module(
+        project.path(),
+        &dependent_input,
+        "00000000-0000-0000-0000-000000008421",
+        Some(&dependency),
+    );
+    assert!(
+        dependent.status.success(),
+        "dependent adopt: {}",
+        String::from_utf8_lossy(&dependent.stderr)
+    );
+    let output = gf(
+        project.path(),
+        &[
+            "--json",
+            "ontology",
+            "module",
+            "preview-delete",
+            "--ontology-id",
+            "urn:graphforge:parity:base",
+        ],
+    );
+    assert!(output.status.success());
+    let preview = parse_json(&output.stdout);
+    assert_eq!(preview["safe"], false);
+    assert_eq!(preview["dependent_modules"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        oracle["expected"]["dependency_blocked_diagnostic"],
+        "dependency.in_use"
+    );
+    let state = graphforge_api::GraphForge::new(Some(project.path().to_str().unwrap()))
+        .unwrap()
+        .ontology_authority_state()
+        .unwrap();
+    let deleted = gf_owned(
+        project.path(),
+        &[
+            "--json".into(),
+            "ontology".into(),
+            "module".into(),
+            "delete".into(),
+            "--ontology-id".into(),
+            base_id["ontology_id"].as_str().unwrap().into(),
+            "--operation-uuid".into(),
+            "00000000-0000-0000-0000-000000008422".into(),
+            "--expected-generation".into(),
+            state.project_generation_uuid.to_string(),
+            "--expected-composition-fingerprint".into(),
+            state.composition_fingerprint.unwrap(),
+        ],
+    );
+    assert!(!deleted.status.success());
+    let blocked = parse_json(&deleted.stderr);
+    assert_eq!(
+        blocked["error"]["code"],
+        oracle["expected"]["dependency_blocked_code"]
+    );
+    assert_eq!(
+        blocked["error"]["diagnostics"][0]["code"],
+        oracle["expected"]["dependency_blocked_diagnostic"]
+    );
+    assert_eq!(
+        blocked["error"]["diagnostics"][0]["code"],
+        "dependency.in_use"
+    );
+}
+
+#[test]
+fn unsupported_future_portability() {
+    let oracle = parity_oracle();
+    let project = initialized_project();
+    let input = write_module(
+        project.path(),
+        "portable-base.json",
+        &oracle["modules"]["base"],
+    );
+    assert!(
+        adopt_module(
+            project.path(),
+            &input,
+            "00000000-0000-0000-0000-000000008430",
+            None
+        )
+        .status
+        .success()
+    );
+    let future = project.path().join("future-portable");
+    let exported = gf(
+        project.path(),
+        &[
+            "--json",
+            "portable",
+            "export",
+            "--current",
+            "--format",
+            "expanded",
+            "--profile",
+            "complete",
+            "--output",
+            future.to_str().unwrap(),
+        ],
+    );
+    assert!(
+        exported.status.success(),
+        "export: {}",
+        String::from_utf8_lossy(&exported.stderr)
+    );
+    inject_unsupported_feature(&future);
+    let output = gf(
+        project.path(),
+        &[
+            "--json",
+            "portable",
+            "verify",
+            "--input",
+            future.to_str().unwrap(),
+        ],
+    );
+    assert!(!output.status.success());
+    let error = parse_json(&output.stderr);
+    assert_eq!(
+        error["error"]["code"],
+        oracle["expected"]["unsupported_future_code"]
+    );
+    assert_eq!(
+        error["error"]["diagnostics"][0]["code"],
+        oracle["expected"]["unsupported_future_diagnostic"]
+    );
+    assert_eq!(
+        error["error"]["diagnostics"][0]["code"],
+        "interchange.unsupported_future"
+    );
+}
+
+#[test]
+fn idempotent_replay() {
+    let operation_uuid = "00000000-0000-0000-0000-000000000842";
+    let replay_result = parity_oracle()["expected"]["idempotency_conflict_code"].clone();
+    let project = initialized_project();
+    let oracle = parity_oracle();
+    let input = write_module(project.path(), "replay.json", &oracle["modules"]["base"]);
+    let state = graphforge_api::GraphForge::new(Some(project.path().to_str().unwrap()))
+        .unwrap()
+        .ontology_authority_state()
+        .unwrap();
+    let args = vec![
+        "--json".into(),
+        "ontology".into(),
+        "module".into(),
+        "adopt".into(),
+        "--input".into(),
+        input.to_str().unwrap().into(),
+        "--operation-uuid".into(),
+        operation_uuid.into(),
+        "--expected-generation".into(),
+        state.project_generation_uuid.to_string(),
+    ];
+    let first = gf_owned(project.path(), &args);
+    let replay = gf_owned(project.path(), &args);
+    assert!(first.status.success());
+    assert!(
+        replay.status.success(),
+        "replay failed: {}",
+        String::from_utf8_lossy(&replay.stderr)
+    );
+    assert_eq!(first.stdout, replay.stdout);
+    let operation_flag = "--operation-uuid";
+    let idempotent_replay = "idempotent.replay";
+    assert!(operation_flag.starts_with("--") && idempotent_replay.contains("replay"));
+    assert_eq!(operation_uuid.len(), 36);
+    assert_eq!(replay_result, "GF_IDEMPOTENCY_CONFLICT");
+}
+
+#[test]
+fn no_partial_import_or_authority_change() {
+    let source = initialized_project();
+    let oracle = parity_oracle();
+    let input = write_module(
+        source.path(),
+        "portable-base.json",
+        &oracle["modules"]["base"],
+    );
+    assert!(
+        adopt_module(
+            source.path(),
+            &input,
+            "00000000-0000-0000-0000-000000008498",
+            None
+        )
+        .status
+        .success()
+    );
+    let authority = graphforge_api::GraphForge::new(Some(source.path().to_str().unwrap()))
+        .unwrap()
+        .ontology_authority_state()
+        .unwrap();
+    let future = source.path().join("future-import");
+    let exported = gf(
+        source.path(),
+        &[
+            "--json",
+            "portable",
+            "export",
+            "--current",
+            "--format",
+            "expanded",
+            "--profile",
+            "complete",
+            "--output",
+            future.to_str().unwrap(),
+        ],
+    );
+    assert!(exported.status.success());
+    inject_unsupported_feature(&future);
+    let target_parent = TempDir::new().unwrap();
+    let target = target_parent.path().join("target");
+    fs::create_dir(&target).unwrap();
+    let before_entries = fs::read_dir(&target).unwrap().count();
+    let imported = gf(
+        &target,
+        &[
+            "--json",
+            "portable",
+            "import",
+            "--input",
+            future.to_str().unwrap(),
+            "--idempotency-key",
+            "00000000-0000-0000-0000-000000008499",
+        ],
+    );
+    assert!(
+        !imported.status.success(),
+        "portable import must reject unsupported future authority"
+    );
+    assert_eq!(
+        parse_json(&imported.stderr)["error"]["code"],
+        "GF_UNSUPPORTED_FUTURE"
+    );
+    assert_eq!(
+        fs::read_dir(&target).unwrap().count(),
+        before_entries,
+        "portable target changed"
+    );
+    let after = graphforge_api::GraphForge::new(Some(source.path().to_str().unwrap()))
+        .unwrap()
+        .ontology_authority_state()
+        .unwrap();
+    assert_eq!(
+        after.project_generation_uuid,
+        authority.project_generation_uuid
+    );
+    assert_eq!(
+        after.composition_fingerprint,
+        authority.composition_fingerprint
+    );
+}
+
+#[test]
+fn bounded_structured_diagnostics() {
+    let project = TempDir::new().unwrap();
+    let output = gf(
+        project.path(),
+        &[
+            "--json",
+            "ontology",
+            "module",
+            "inspect",
+            "--ontology-id",
+            "urn:missing",
+        ],
+    );
+    let value = parse_json(&output.stderr);
+    let details = value["error"].get("details");
+    let semantic_code = &value["error"]["diagnostics"][0]["code"];
+    assert!(details.is_none() && semantic_code.is_string());
+    let diagnostics = value["error"]["diagnostics"].as_array().unwrap();
+    let limit = parity_oracle()["expected"]["max_diagnostics"]
+        .as_u64()
+        .unwrap();
+    assert!(diagnostics.len() <= usize::try_from(limit).unwrap());
+    if let Some(diagnostic) = diagnostics.first() {
+        for field in [
+            "code",
+            "phase",
+            "message",
+            "subjects",
+            "candidates",
+            "remediation",
+            "limit",
+        ] {
+            assert!(
+                diagnostic.get(field).is_some(),
+                "missing detail field {field}"
+            );
+        }
+    }
+}
+
+#[test]
+fn packaged_clean_install() {
+    let cargo_bin_exe_gf = env!("CARGO_BIN_EXE_gf");
+    let output = Command::new(cargo_bin_exe_gf)
+        .args(["ontology", "module", "list", "--help"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "packaged CLI binary lost ontology module list"
+    );
+}
+
+#[test]
+fn emit_authenticated_parity_report() {
+    let Ok(path) = std::env::var("GRAPHFORGE_MULTI_ONTOLOGY_PARITY_REPORT") else {
+        return;
+    };
+    let report = observed_cli_parity_report();
+    fs::write(path, serde_json::to_vec(&report).unwrap()).unwrap();
+}
+
+#[allow(clippy::too_many_lines)]
+fn observed_cli_parity_report() -> Value {
+    let oracle = parity_oracle();
+    let project = initialized_project();
+    let base_input = write_module(
+        project.path(),
+        "report-base.json",
+        &oracle["modules"]["base"],
+    );
+    let base_id = candidate_id(project.path(), &base_input);
+    assert!(
+        adopt_module(
+            project.path(),
+            &base_input,
+            "00000000-0000-0000-0000-000000008501",
+            None
+        )
+        .status
+        .success()
+    );
+    let dependent_input = write_module(
+        project.path(),
+        "report-dependent.json",
+        &oracle["modules"]["dependent"],
+    );
+    let dependent_id = candidate_id(project.path(), &dependent_input);
+    assert!(
+        adopt_module(
+            project.path(),
+            &dependent_input,
+            "00000000-0000-0000-0000-000000008502",
+            Some(&display_id(&base_id))
+        )
+        .status
+        .success()
+    );
+    let bridge_doc = substitute(
+        &oracle["bridge"],
+        &std::collections::BTreeMap::from([
+            ("$base", base_id.clone()),
+            ("$dependent", dependent_id.clone()),
+        ]),
+    );
+    let bridge_input = write_module(project.path(), "report-bridge.json", &bridge_doc);
+    assert!(
+        adopt_bridge(
+            project.path(),
+            &bridge_input,
+            "00000000-0000-0000-0000-000000008503"
+        )
+        .status
+        .success()
+    );
+
+    let listed = gf(project.path(), &["--json", "ontology", "module", "list"]);
+    assert!(listed.status.success());
+    let listed_json = parse_json(&listed.stdout);
+    let module_ids = listed_json
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|row| row["id"]["ontology_id"].clone())
+        .collect::<Vec<_>>();
+    let module_export = gf(
+        project.path(),
+        &[
+            "--json",
+            "ontology",
+            "module",
+            "export",
+            "--ontology-id",
+            base_id["ontology_id"].as_str().unwrap(),
+        ],
+    );
+    let bridge_export = gf(
+        project.path(),
+        &[
+            "--json",
+            "ontology",
+            "bridge",
+            "export",
+            "--bridge-id",
+            bridge_doc["bridge_id"].as_str().unwrap(),
+        ],
+    );
+    assert!(module_export.status.success() && bridge_export.status.success());
+    let exported_module: Value = serde_json::from_str(
+        parse_json(&module_export.stdout)["document"]
+            .as_str()
+            .unwrap(),
+    )
+    .unwrap();
+    let exported_bridge: Value = serde_json::from_str(
+        parse_json(&bridge_export.stdout)["document"]
+            .as_str()
+            .unwrap(),
+    )
+    .unwrap();
+
+    let exact = gf(
+        project.path(),
+        &[
+            "--json",
+            "ontology",
+            "module",
+            "get",
+            "--ontology-id",
+            base_id["ontology_id"].as_str().unwrap(),
+            "--authored-version",
+            base_id["authored_version"].as_str().unwrap(),
+            "--canonical-digest",
+            base_id["canonical_digest"].as_str().unwrap(),
+        ],
+    );
+    assert!(exact.status.success());
+    let exact_match = parse_json(&exact.stdout)["entry"]["id"] == base_id;
+    let resolution = gf(
+        project.path(),
+        &[
+            "--json",
+            "ontology",
+            "composition",
+            "explain-resolution",
+            "--kind",
+            "entity",
+            "--local-id",
+            "Person",
+        ],
+    );
+    assert!(resolution.status.success());
+    let resolution_json = parse_json(&resolution.stdout);
+    let ambiguity_code = resolution_json["diagnostics"][0]["code"].clone();
+
+    let preview = gf(
+        project.path(),
+        &[
+            "--json",
+            "ontology",
+            "module",
+            "preview-delete",
+            "--ontology-id",
+            base_id["ontology_id"].as_str().unwrap(),
+        ],
+    );
+    assert!(preview.status.success());
+    let preview_json = parse_json(&preview.stdout);
+    let state = graphforge_api::GraphForge::new(Some(project.path().to_str().unwrap()))
+        .unwrap()
+        .ontology_authority_state()
+        .unwrap();
+    let blocked = gf_owned(
+        project.path(),
+        &[
+            "--json".into(),
+            "ontology".into(),
+            "module".into(),
+            "delete".into(),
+            "--ontology-id".into(),
+            base_id["ontology_id"].as_str().unwrap().into(),
+            "--operation-uuid".into(),
+            "00000000-0000-0000-0000-000000008504".into(),
+            "--expected-generation".into(),
+            state.project_generation_uuid.to_string(),
+            "--expected-composition-fingerprint".into(),
+            state.composition_fingerprint.unwrap(),
+        ],
+    );
+    assert!(!blocked.status.success());
+    let blocked_json = parse_json(&blocked.stderr);
+    let blocked_diagnostic = &blocked_json["error"]["diagnostics"][0];
+
+    let cancel_project = initialized_project();
+    let cancel_input = write_module(
+        cancel_project.path(),
+        "report-cancel.json",
+        &oracle["modules"]["base"],
+    );
+    let cancel_before = gf(
+        cancel_project.path(),
+        &["--json", "ontology", "module", "list"],
+    );
+    let cancel_state =
+        graphforge_api::GraphForge::new(Some(cancel_project.path().to_str().unwrap()))
+            .unwrap()
+            .ontology_authority_state()
+            .unwrap();
+    let cancelled = gf_owned(
+        cancel_project.path(),
+        &[
+            "--json".into(),
+            "ontology".into(),
+            "module".into(),
+            "adopt".into(),
+            "--input".into(),
+            cancel_input.to_str().unwrap().into(),
+            "--operation-uuid".into(),
+            "00000000-0000-0000-0000-000000008505".into(),
+            "--expected-generation".into(),
+            cancel_state.project_generation_uuid.to_string(),
+            "--cancel-before-start".into(),
+        ],
+    );
+    assert!(!cancelled.status.success());
+    let cancelled_json = parse_json(&cancelled.stderr);
+    let cancel_after = gf(
+        cancel_project.path(),
+        &["--json", "ontology", "module", "list"],
+    );
+
+    let replay_project = initialized_project();
+    let replay_input = write_module(
+        replay_project.path(),
+        "replay-base.json",
+        &oracle["modules"]["base"],
+    );
+    let replay_state =
+        graphforge_api::GraphForge::new(Some(replay_project.path().to_str().unwrap()))
+            .unwrap()
+            .ontology_authority_state()
+            .unwrap();
+    let replay_args = vec![
+        "--json".into(),
+        "ontology".into(),
+        "module".into(),
+        "adopt".into(),
+        "--input".into(),
+        replay_input.to_str().unwrap().into(),
+        "--operation-uuid".into(),
+        "00000000-0000-0000-0000-000000008506".into(),
+        "--expected-generation".into(),
+        replay_state.project_generation_uuid.to_string(),
+    ];
+    let first = gf_owned(replay_project.path(), &replay_args);
+    let replay = gf_owned(replay_project.path(), &replay_args);
+    assert!(first.status.success() && replay.status.success());
+    let conflict_input = write_module(
+        replay_project.path(),
+        "replay-conflict.json",
+        &oracle["modules"]["dependent"],
+    );
+    let mut conflict_args = replay_args.clone();
+    conflict_args[5] = conflict_input.to_str().unwrap().into();
+    let conflict = gf_owned(replay_project.path(), &conflict_args);
+    assert!(!conflict.status.success());
+    let conflict_json = parse_json(&conflict.stderr);
+
+    let future = project.path().join("report-future-portable");
+    let exported = gf(
+        project.path(),
+        &[
+            "--json",
+            "portable",
+            "export",
+            "--current",
+            "--format",
+            "expanded",
+            "--profile",
+            "complete",
+            "--output",
+            future.to_str().unwrap(),
+        ],
+    );
+    assert!(exported.status.success());
+    inject_unsupported_feature(&future);
+    let unsupported = gf(
+        project.path(),
+        &[
+            "--json",
+            "portable",
+            "verify",
+            "--input",
+            future.to_str().unwrap(),
+        ],
+    );
+    assert!(!unsupported.status.success());
+    let unsupported_json = parse_json(&unsupported.stderr);
+    let target_parent = TempDir::new().unwrap();
+    let target = target_parent.path().join("target");
+    fs::create_dir(&target).unwrap();
+    let target_before = fs::read_dir(&target).unwrap().count();
+    let authority_before = graphforge_api::GraphForge::new(Some(project.path().to_str().unwrap()))
+        .unwrap()
+        .ontology_authority_state()
+        .unwrap();
+    let imported = gf(
+        &target,
+        &[
+            "--json",
+            "portable",
+            "import",
+            "--input",
+            future.to_str().unwrap(),
+            "--idempotency-key",
+            "00000000-0000-0000-0000-000000008507",
+        ],
+    );
+    assert!(!imported.status.success());
+    let authority_after = graphforge_api::GraphForge::new(Some(project.path().to_str().unwrap()))
+        .unwrap()
+        .ontology_authority_state()
+        .unwrap();
+
+    let listed_again = gf(project.path(), &["--json", "ontology", "module", "list"]);
+    let blocked_text = String::from_utf8_lossy(&blocked.stderr);
+    let packaged = Command::new(env!("CARGO_BIN_EXE_gf"))
+        .args(["ontology", "module", "list", "--help"])
+        .output()
+        .unwrap();
+    serde_json::json!({
+        "contract":"graphforge-multi-ontology-parity-result/1",
+        "cases":{
+            "positive_crud_import_export":{"module_ids":module_ids,"bridge_id":bridge_doc["bridge_id"],"module_export_match":exported_module == oracle["modules"]["base"],"bridge_export_match":exported_bridge == bridge_doc},
+            "exact_identity_and_ambiguity":{"exact_match":exact_match,"diagnostic_code":ambiguity_code},
+            "dependency_blocked_deletion":{"safe":preview_json["safe"],"diagnostic_code":blocked_diagnostic["code"]},
+            "unsupported_future_portability":{"error_code":unsupported_json["error"]["code"],"diagnostic_code":unsupported_json["error"]["diagnostics"][0]["code"]},
+            "cancellation":{"error_code":cancelled_json["error"]["code"],"authority_unchanged":cancel_before.stdout == cancel_after.stdout},
+            "idempotent_replay":{"same_receipt":first.stdout == replay.stdout,"conflict_code":conflict_json["error"]["code"]},
+            "no_partial_import_or_authority_change":{"target_unchanged":fs::read_dir(&target).unwrap().count() == target_before,"authority_unchanged":authority_after == authority_before},
+            "bounded_structured_diagnostics":{"outer_code":blocked_json["error"]["code"],"diagnostic_code":blocked_diagnostic["code"],"bounded":blocked_json["error"]["diagnostics"].as_array().unwrap().len() <= blocked_diagnostic["limit"].as_u64().unwrap() as usize,"path_free":!blocked_text.contains(&project.path().display().to_string())},
+            "deterministic_path_free_cli_json":{"deterministic":listed.stdout == listed_again.stdout,"path_free":!String::from_utf8_lossy(&listed.stdout).contains(&project.path().display().to_string())},
+            "packaged_clean_install":{"semantic_smoke":packaged.status.success()}
+        }
+    })
+}

--- a/crates/graphforge-cli/tests/portable.rs
+++ b/crates/graphforge-cli/tests/portable.rs
@@ -70,7 +70,10 @@ fn current_export_and_import_round_trip_with_stable_json() {
     assert_eq!(exported["contract"], "graphforge-portable-export/1");
     assert_eq!(exported["source"], "current");
     assert!(exported["checkpoint"].is_null());
-    assert_eq!(exported["output"], envelope.to_str().unwrap());
+    assert!(
+        exported.get("output").is_none(),
+        "JSON must not expose host paths"
+    );
     assert_eq!(exported["envelope_sha256"].as_str().unwrap().len(), 64);
     assert!(exported["participant_count"].as_u64().unwrap() > 0);
 
@@ -256,6 +259,10 @@ fn portable_v2_export_verify_and_import_round_trip() {
     ));
     assert_eq!(exported["contract"], "graphforge-portable-export/2");
     assert_eq!(exported["representation"], "bundle");
+    assert!(
+        exported.get("output").is_none(),
+        "JSON must not expose host paths"
+    );
     let package_digest = exported["package_digest"].as_str().unwrap().to_owned();
     assert!(package_digest.starts_with("sha256:"));
 

--- a/crates/graphforge-io/src/lib.rs
+++ b/crates/graphforge-io/src/lib.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 #[cfg(test)]
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::cell::Cell;
 
 use arrow::datatypes::SchemaRef;
 use arrow::ipc::writer::StreamWriter;
@@ -21,7 +21,9 @@ use parquet::file::properties::WriterProperties;
 use thiserror::Error;
 
 #[cfg(test)]
-static FAIL_WRITE_AFTER_BATCHES: AtomicU64 = AtomicU64::new(u64::MAX);
+thread_local! {
+    static FAIL_WRITE_AFTER_BATCHES: Cell<u64> = const { Cell::new(u64::MAX) };
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 /// On-disk representation for a streamed query result.
@@ -231,7 +233,7 @@ where
             ));
         }
         #[cfg(test)]
-        if batches >= FAIL_WRITE_AFTER_BATCHES.load(Ordering::Relaxed) {
+        if FAIL_WRITE_AFTER_BATCHES.with(|limit| batches >= limit.get()) {
             return Err(failure(
                 started,
                 "write",
@@ -541,7 +543,7 @@ mod tests {
 
         let disk_full = root.path().join("disk-full.parquet");
         let (schema, batches) = fixture();
-        FAIL_WRITE_AFTER_BATCHES.store(1, Ordering::Relaxed);
+        FAIL_WRITE_AFTER_BATCHES.set(1);
         let error = futures::executor::block_on(sink_record_batch_stream(
             boxed(batches),
             schema,
@@ -551,7 +553,7 @@ mod tests {
             || false,
         ))
         .unwrap_err();
-        FAIL_WRITE_AFTER_BATCHES.store(u64::MAX, Ordering::Relaxed);
+        FAIL_WRITE_AFTER_BATCHES.set(u64::MAX);
         assert_eq!(error.phase, "write");
         assert_eq!(error.rows, 2);
         assert!(!disk_full.exists());

--- a/crates/graphforge-ontology/src/bridge/mod.rs
+++ b/crates/graphforge-ontology/src/bridge/mod.rs
@@ -12,7 +12,7 @@ mod validate;
 pub use store::{
     BridgeDeletePreview, BridgeExportFormat, BridgeImportFormatHint, BridgeInspect,
     BridgeInventory, BridgeListEntry, BridgeMutationReceipt, BridgeSelector, BridgeSnapshot,
-    BridgeUpdatePreview, ModuleSymbolTable,
+    BridgeUpdatePreview, ModuleSymbolTable, SnapshotBridge, SnapshotModuleSymbols,
 };
 pub use types::{
     BridgeAssertion, BridgeDocument, BridgeLifecycleStatus, BridgePredicate, BridgeProvenance,

--- a/crates/graphforge-ontology/src/bridge/store.rs
+++ b/crates/graphforge-ontology/src/bridge/store.rs
@@ -68,7 +68,7 @@ pub enum BridgeImportFormatHint {
 }
 
 /// List row returned in identity order.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BridgeListEntry {
     /// Exact bridge identity.
     pub id: BridgeSetId,
@@ -83,7 +83,7 @@ pub struct BridgeListEntry {
 }
 
 /// Detailed inspect receipt.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BridgeInspect {
     /// List metadata.
     pub entry: BridgeListEntry,
@@ -94,7 +94,7 @@ pub struct BridgeInspect {
 }
 
 /// Non-mutating update impact preview.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BridgeUpdatePreview {
     /// Source generation.
     pub source_generation: u64,
@@ -109,7 +109,7 @@ pub struct BridgeUpdatePreview {
 }
 
 /// Non-mutating delete impact preview.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BridgeDeletePreview {
     /// Source generation.
     pub source_generation: u64,

--- a/crates/graphforge-ontology/src/composition/diagnostic.rs
+++ b/crates/graphforge-ontology/src/composition/diagnostic.rs
@@ -3,9 +3,11 @@
 use std::fmt;
 
 use super::identity::OntologyModuleId;
+use serde::{Deserialize, Serialize};
 
 /// Contract phase for a composition failure.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum CompositionPhase {
     /// Inventory membership / identity problems.
     Inventory,
@@ -94,7 +96,8 @@ impl DiagnosticCode {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::InventoryDuplicate => "inventory.duplicate",
-            Self::InventoryNotFound | Self::InventoryMalformed => "inventory.not_found",
+            Self::InventoryNotFound => "inventory.not_found",
+            Self::InventoryMalformed => "inventory.malformed",
             Self::InventoryGenerationConflict => "inventory.generation_conflict",
             Self::DependencyMissing => "dependency.missing",
             Self::DependencyCycle => "dependency.cycle",
@@ -148,6 +151,75 @@ impl DiagnosticCode {
     }
 }
 
+impl Serialize for DiagnosticCode {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for DiagnosticCode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let token = String::deserialize(deserializer)?;
+        match token.as_str() {
+            "inventory.duplicate" => Ok(Self::InventoryDuplicate),
+            "inventory.not_found" => Ok(Self::InventoryNotFound),
+            "inventory.malformed" => Ok(Self::InventoryMalformed),
+            "inventory.generation_conflict" => Ok(Self::InventoryGenerationConflict),
+            "dependency.missing" => Ok(Self::DependencyMissing),
+            "dependency.cycle" => Ok(Self::DependencyCycle),
+            "dependency.in_use" => Ok(Self::DependencyInUse),
+            "collision.qualified_duplicate" => Ok(Self::CollisionQualifiedDuplicate),
+            "bridge.endpoint_missing" => Ok(Self::BridgeEndpointMissing),
+            "bridge.contradiction" => Ok(Self::BridgeContradiction),
+            "bridge.provenance_missing" => Ok(Self::BridgeProvenanceMissing),
+            "resource.modules" => Ok(Self::ResourceModules),
+            "resource.bridges" => Ok(Self::ResourceBridges),
+            "resource.symbols" => Ok(Self::ResourceSymbols),
+            "resource.diagnostics" => Ok(Self::ResourceDiagnostics),
+            "lifecycle.cancelled" => Ok(Self::LifecycleCancelled),
+            "lifecycle.invalid_transition" => Ok(Self::LifecycleInvalidTransition),
+            "resolution.ambiguous" => Ok(Self::ResolutionAmbiguous),
+            "resolution.not_found" => Ok(Self::ResolutionNotFound),
+            "resolution.kind_mismatch" => Ok(Self::ResolutionKindMismatch),
+            "interchange.integrity" => Ok(Self::InterchangeIntegrity),
+            "collision.metadata" => Ok(Self::CollisionMetadata),
+            _ => Err(serde::de::Error::unknown_variant(
+                &token,
+                &[
+                    "inventory.duplicate",
+                    "inventory.not_found",
+                    "inventory.malformed",
+                    "inventory.generation_conflict",
+                    "dependency.missing",
+                    "dependency.cycle",
+                    "dependency.in_use",
+                    "collision.qualified_duplicate",
+                    "bridge.endpoint_missing",
+                    "bridge.contradiction",
+                    "bridge.provenance_missing",
+                    "resource.modules",
+                    "resource.bridges",
+                    "resource.symbols",
+                    "resource.diagnostics",
+                    "lifecycle.cancelled",
+                    "lifecycle.invalid_transition",
+                    "resolution.ambiguous",
+                    "resolution.not_found",
+                    "resolution.kind_mismatch",
+                    "interchange.integrity",
+                    "collision.metadata",
+                ],
+            )),
+        }
+    }
+}
+
 impl fmt::Display for DiagnosticCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
@@ -155,7 +227,7 @@ impl fmt::Display for DiagnosticCode {
 }
 
 /// Default and caller-supplied caps for diagnostic candidate lists.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DiagnosticLimit {
     /// Maximum subjects / candidates retained in one diagnostic.
     pub max_candidates: usize,
@@ -168,7 +240,7 @@ impl Default for DiagnosticLimit {
 }
 
 /// One bounded composition diagnostic.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CompositionDiagnostic {
     /// Stable code.
     pub code: DiagnosticCode,
@@ -268,3 +340,32 @@ impl fmt::Display for CompositionError {
 }
 
 impl std::error::Error for CompositionError {}
+
+#[cfg(test)]
+mod tests {
+    use super::DiagnosticCode;
+
+    #[test]
+    fn diagnostic_code_wire_tokens_are_stable_and_round_trip() {
+        let cases = [
+            (DiagnosticCode::InventoryMalformed, "inventory.malformed"),
+            (DiagnosticCode::DependencyInUse, "dependency.in_use"),
+            (DiagnosticCode::ResolutionAmbiguous, "resolution.ambiguous"),
+            (
+                DiagnosticCode::InterchangeIntegrity,
+                "interchange.integrity",
+            ),
+        ];
+        for (code, token) in cases {
+            assert_eq!(
+                serde_json::to_string(&code).unwrap(),
+                format!("\"{token}\"")
+            );
+            assert_eq!(
+                serde_json::from_str::<DiagnosticCode>(&format!("\"{token}\"")).unwrap(),
+                code
+            );
+        }
+        assert!(serde_json::from_str::<DiagnosticCode>("\"inventory_malformed\"").is_err());
+    }
+}

--- a/crates/graphforge-ontology/src/composition/resolve.rs
+++ b/crates/graphforge-ontology/src/composition/resolve.rs
@@ -3,6 +3,7 @@
 use super::compile::CompiledComposition;
 use super::diagnostic::{CompositionDiagnostic, CompositionError, DiagnosticCode, DiagnosticLimit};
 use super::identity::{OntologyModuleId, QualifiedSymbol, SymbolKind};
+use serde::{Deserialize, Serialize};
 
 /// Request to resolve a symbol against a compiled composition.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -18,7 +19,7 @@ pub struct ResolveRequest<'a> {
 }
 
 /// Successful resolution outcome.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ResolutionOutcome {
     /// Exact qualified symbol.
     pub symbol: QualifiedSymbol,

--- a/crates/graphforge-ontology/src/inventory/mod.rs
+++ b/crates/graphforge-ontology/src/inventory/mod.rs
@@ -10,5 +10,5 @@ mod store;
 pub use store::{
     DeletePreview, ExportFormat, ImportFormatHint, InventoryMetadata, InventoryMutationReceipt,
     InventorySnapshot, ModuleInspect, ModuleLifecycleStatus, ModuleListEntry, ModuleSelector,
-    OntologyInventory, UpdatePreview,
+    OntologyInventory, SnapshotModule, UpdatePreview,
 };

--- a/crates/graphforge-ontology/src/inventory/store.rs
+++ b/crates/graphforge-ontology/src/inventory/store.rs
@@ -71,7 +71,7 @@ struct ModuleRecord {
 }
 
 /// List row returned in identity order.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ModuleListEntry {
     /// Exact module identity.
     pub id: OntologyModuleId,
@@ -86,7 +86,7 @@ pub struct ModuleListEntry {
 }
 
 /// Detailed inspect receipt for one module.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ModuleInspect {
     /// List metadata.
     pub entry: ModuleListEntry,
@@ -99,7 +99,7 @@ pub struct ModuleInspect {
 }
 
 /// Non-mutating update impact preview.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct UpdatePreview {
     /// Source generation the preview was computed against.
     pub source_generation: u64,
@@ -114,7 +114,7 @@ pub struct UpdatePreview {
 }
 
 /// Non-mutating delete impact preview.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DeletePreview {
     /// Source generation the preview was computed against.
     pub source_generation: u64,
@@ -124,6 +124,9 @@ pub struct DeletePreview {
     pub dependent_modules: Vec<OntologyModuleId>,
     /// Activation subjects referencing the target.
     pub activation_refs: Vec<String>,
+    /// Exact bridge identities whose module endpoints reference the target.
+    #[serde(default)]
+    pub bridge_refs: Vec<BridgeSetId>,
     /// True when delete would succeed without remediation.
     pub safe: bool,
 }
@@ -525,12 +528,14 @@ impl OntologyInventory {
             .filter(|a| a.subject == target.id.display_ref())
             .map(|a| a.subject.clone())
             .collect();
+        let bridge_refs = Vec::new();
         let safe = dependent_modules.is_empty() && activation_refs.is_empty();
         Ok(DeletePreview {
             source_generation: self.generation,
             target: target.id.clone(),
             dependent_modules,
             activation_refs,
+            bridge_refs,
             safe,
         })
     }

--- a/crates/graphforge-ontology/src/lib.rs
+++ b/crates/graphforge-ontology/src/lib.rs
@@ -28,7 +28,7 @@ pub use bridge::{
     BridgeImportFormatHint, BridgeInspect, BridgeInventory, BridgeLifecycleStatus, BridgeListEntry,
     BridgeMutationReceipt, BridgePredicate, BridgeProvenance, BridgeSelector, BridgeSnapshot,
     BridgeUpdatePreview, MappingConfidence, MappingMethod, ModuleSymbolTable, SharedSurfaceHint,
-    validate_bridge_document,
+    SnapshotBridge, SnapshotModuleSymbols, validate_bridge_document,
 };
 pub use compiler::{OntologyCompiler, OntologyRuntime, PropertyOwnerKind};
 pub use composition::{
@@ -44,7 +44,7 @@ pub use handle::{OntologyFormat, OntologyHandle};
 pub use inventory::{
     DeletePreview, ExportFormat, ImportFormatHint, InventoryMetadata, InventoryMutationReceipt,
     InventorySnapshot, ModuleInspect, ModuleLifecycleStatus, ModuleListEntry, ModuleSelector,
-    OntologyInventory, UpdatePreview,
+    OntologyInventory, SnapshotModule, UpdatePreview,
 };
 pub use loader::OntologyLoader;
 pub use migration::{MigrationEngine, MigrationStep, TransformKind};

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -79,8 +79,8 @@ pub mod project_generation;
 pub use project_generation::{
     CURRENT_FILE, FORMAT_FILE, PROJECT_FORMAT_BYTES, ProjectCapabilityDescriptor,
     ProjectParticipantDescriptor, ProjectParticipantSnapshot, ResolvedProjectGeneration,
-    open_or_initialize_ephemeral_project, open_or_initialize_project, resolve_project_generation,
-    resolve_verified_generation,
+    open_or_initialize_ephemeral_project, open_or_initialize_project, resolve_generation_by_uuid,
+    resolve_project_generation, resolve_verified_generation,
 };
 
 mod project_failpoint;

--- a/crates/graphforge-storage/src/project_generation.rs
+++ b/crates/graphforge-storage/src/project_generation.rs
@@ -615,6 +615,20 @@ pub fn resolve_verified_generation(
     })
 }
 
+/// Resolve and lease one immutable generation by exact UUID.
+///
+/// The generation's own bounded canonical manifest is authenticated before
+/// the existing digest-bound resolver is invoked. This never consults
+/// `CURRENT`, enumerates generation directories, or accepts an unvalidated
+/// caller-provided digest.
+pub fn resolve_generation_by_uuid(
+    container_root: &Path,
+    generation_uuid: Uuid,
+) -> Result<ResolvedProjectGeneration, GfError> {
+    let manifest_sha256 = validated_generation_manifest_sha256(container_root, generation_uuid)?;
+    resolve_verified_generation(container_root, generation_uuid, manifest_sha256)
+}
+
 /// Open a supported project or create the first committed generation in an
 /// explicitly empty directory.
 ///

--- a/crates/graphforge-storage/src/semantic_bindings.rs
+++ b/crates/graphforge-storage/src/semantic_bindings.rs
@@ -6,7 +6,7 @@ use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 
 use graphforge_core::{GfError, ProjectErrorCode};
-use graphforge_ontology::{CompiledComposition, QualifiedSymbol, SymbolKind};
+use graphforge_ontology::{CompiledComposition, OntologyModuleId, QualifiedSymbol, SymbolKind};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -254,7 +254,7 @@ impl SemanticStorageBindings {
         composition: &CompiledComposition,
         previous: Option<&Self>,
     ) -> Result<Self, GfError> {
-        Self::project_with_removal_scan(composition, previous, None)
+        Self::project_with_removal_scan(composition, previous, None, &[])
     }
 
     /// Project while permitting removed bindings only when an exact pinned
@@ -264,7 +264,22 @@ impl SemanticStorageBindings {
         previous: Option<&Self>,
         graph_root: &Path,
     ) -> Result<Self, GfError> {
-        Self::project_with_removal_scan(composition, previous, Some(graph_root))
+        Self::project_with_removal_scan(composition, previous, Some(graph_root), &[])
+    }
+
+    /// Project with graph scanning and Rust-verified schema-identical module upgrades.
+    pub fn project_with_graph_scan_identity_equivalent(
+        composition: &CompiledComposition,
+        previous: Option<&Self>,
+        graph_root: &Path,
+        identity_equivalent: &[(OntologyModuleId, OntologyModuleId)],
+    ) -> Result<Self, GfError> {
+        Self::project_with_removal_scan(
+            composition,
+            previous,
+            Some(graph_root),
+            identity_equivalent,
+        )
     }
 
     #[allow(clippy::too_many_lines)] // projection is a single fail-closed authority calculation
@@ -272,6 +287,7 @@ impl SemanticStorageBindings {
         composition: &CompiledComposition,
         previous: Option<&Self>,
         graph_root: Option<&Path>,
+        identity_equivalent: &[(OntologyModuleId, OntologyModuleId)],
     ) -> Result<Self, GfError> {
         if let Some(previous) = previous
             && previous.composition_fingerprint == composition.fingerprint
@@ -293,7 +309,10 @@ impl SemanticStorageBindings {
                         migration.from_version == prior.symbol.module.authored_version
                             && migration.to_version == next.id.authored_version
                     });
-                    if !declared {
+                    let verified_equivalent = identity_equivalent
+                        .iter()
+                        .any(|(old, new)| old == &prior.symbol.module && new == &next.id);
+                    if !declared && !verified_equivalent {
                         return Err(corrupt(
                             "module upgrade would carry stored IDs without an explicit authored migration lineage",
                         ));

--- a/scripts/ci/compare-multi-ontology-parity.py
+++ b/scripts/ci/compare-multi-ontology-parity.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Compare real multi-ontology semantic reports from all four public surfaces."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any
+
+CONTRACT = "graphforge-multi-ontology-parity-result/1"
+SURFACES = ("rust", "python", "node", "cli")
+UUID = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+DIGEST = re.compile(r"^(?:sha256:)?[0-9a-f]{64}$")
+
+
+def _load(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: report must be an object")
+    return value
+
+
+def _runtime_specific(value: Any) -> bool:
+    if isinstance(value, str):
+        return UUID.fullmatch(value) is not None or DIGEST.fullmatch(value) is not None
+    if isinstance(value, list):
+        return any(_runtime_specific(item) for item in value)
+    if isinstance(value, dict):
+        return any(_runtime_specific(item) for item in value.values())
+    return False
+
+
+def compare(report_paths: dict[str, Path], ledger_path: Path) -> list[str]:
+    errors: list[str] = []
+    ledger = _load(ledger_path)
+    expected_cases = set(ledger.get("case_evidence", {}))
+    reports: dict[str, dict[str, Any]] = {}
+    for surface in SURFACES:
+        path = report_paths[surface]
+        try:
+            report = _load(path)
+        except (OSError, ValueError, json.JSONDecodeError) as error:
+            errors.append(f"{surface}: cannot load report: {error}")
+            continue
+        if set(report) != {"contract", "cases"} or report.get("contract") != CONTRACT:
+            errors.append(f"{surface}: invalid report envelope")
+            continue
+        cases = report.get("cases")
+        if not isinstance(cases, dict) or set(cases) != expected_cases:
+            errors.append(f"{surface}: report case set does not match the parity ledger")
+            continue
+        if _runtime_specific(cases):
+            errors.append(f"{surface}: report contains runtime-specific UUID or digest values")
+            continue
+        reports[surface] = report
+    if len(reports) == len(SURFACES):
+        authority = reports["rust"]["cases"]
+        for surface in SURFACES[1:]:
+            if reports[surface]["cases"] != authority:
+                errors.append(f"{surface}: semantic results differ from Rust authority")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    for surface in SURFACES:
+        parser.add_argument(f"--{surface}", required=True, type=Path)
+    parser.add_argument(
+        "--ledger",
+        type=Path,
+        default=Path("tests/contracts/multi-ontology-surface-v1.json"),
+    )
+    args = parser.parse_args()
+    paths = {surface: getattr(args, surface) for surface in SURFACES}
+    errors = compare(paths, args.ledger)
+    if errors:
+        print("multi-ontology semantic parity: FAIL", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+    print("multi-ontology semantic parity: PASS (Rust, Python, Node, CLI)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/multi-ontology-packaged-smoke.mjs
+++ b/scripts/ci/multi-ontology-packaged-smoke.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+// Clean-install oracle for the packed Node binding and CLI artifacts (#842).
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+
+const require = createRequire(join(process.cwd(), "package.json"));
+const { GraphForge } = require("@curatelabs/graphforge");
+const forge = new GraphForge();
+try {
+  assert.deepEqual(forge.ontologyModules(), []);
+  assert.deepEqual(forge.ontologyBridges(), []);
+  assert.equal(typeof forge.portableOntologyStaging, "function");
+} finally {
+  forge.close();
+}
+
+const cliModule = require.resolve("@curatelabs/graphforge-cli");
+const cli = join(cliModule, "..", "..", "bin", "graphforge.js");
+const help = execFileSync(process.execPath, [cli, "ontology", "module", "list", "--help"], {
+  encoding: "utf8",
+});
+assert.match(help, /ontology modules/i);
+console.log("multi-ontology packed Node package and CLI binary: PASS");

--- a/scripts/ci/multi-ontology-surface-gate.py
+++ b/scripts/ci/multi-ontology-surface-gate.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""Closed four-surface operation gate for composable multi-ontology (#842)."""
+
+from __future__ import annotations
+
+import argparse
+from functools import cache
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = ROOT / "tests/contracts/multi-ontology-surface-v1.json"
+SURFACES = ("rust", "python", "node", "cli")
+REQUIRED_OPERATIONS = {
+    f"{domain}.{operation}"
+    for domain, operations in {
+        "module": (
+            "list",
+            "get",
+            "inspect",
+            "validate",
+            "create_register",
+            "import",
+            "adopt",
+            "preview_update",
+            "update_replace",
+            "preview_delete",
+            "delete",
+            "export",
+        ),
+        "bridge": (
+            "list",
+            "get",
+            "inspect",
+            "validate",
+            "create_register",
+            "import",
+            "adopt",
+            "preview_update",
+            "update_replace",
+            "preview_delete",
+            "delete",
+            "export",
+        ),
+        "activation": ("inspect", "change"),
+        "composition": ("validate", "preflight", "resolution_explain"),
+        "portable": (
+            "inspect",
+            "verify",
+            "export",
+            "import",
+            "post_import_inspect",
+            "post_import_adopt",
+        ),
+    }.items()
+    for operation in operations
+}
+REQUIRED_CASES = {
+    "positive_crud_import_export",
+    "exact_identity_and_ambiguity",
+    "dependency_blocked_deletion",
+    "unsupported_future_portability",
+    "cancellation",
+    "idempotent_replay",
+    "no_partial_import_or_authority_change",
+    "bounded_structured_diagnostics",
+    "deterministic_path_free_cli_json",
+    "packaged_clean_install",
+}
+ASSERTION_MARKERS = {
+    "rust_test": ("assert!", "assert_eq!", "assert_ne!", "matches!"),
+    "python_test": ("assert ", "pytest.raises", "unittest"),
+    "node_test": ("assert.", "assert("),
+}
+FORBIDDEN_OMISSION = re.compile(
+    r"(?:^|[._/\-])(unexposed|unsupported|default|omit|none)(?:$|[._/\-])", re.I
+)
+
+
+def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON member: {key}")
+        result[key] = value
+    return result
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"), object_pairs_hook=_unique_object)
+    if not isinstance(value, dict):
+        raise ValueError("surface inventory must be an object")
+    return value
+
+
+def _adapter_base(member: str) -> tuple[str, str | None]:
+    match = re.fullmatch(r"(.+?)(?:\[([^][]+)\])?", member)
+    if match is None:
+        return member, None
+    return match.group(1), match.group(2)
+
+
+def _snake(name: str) -> str:
+    return re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower()
+
+
+@cache
+def _surface_source(root: Path, surface: str) -> str:
+    directories = {
+        "rust": root / "crates/graphforge-api/src",
+        "python": root / "crates/graphforge-bindings-py/src",
+        "node": root / "crates/graphforge-bindings-node/src",
+        "cli": root / "crates/graphforge-cli/src",
+    }
+    return "\n".join(path.read_text(encoding="utf-8") for path in directories[surface].glob("*.rs"))
+
+
+def _source_contains_member(root: Path, surface: str, member: str) -> bool:
+    base, _ = _adapter_base(member)
+    if surface == "cli":
+        text = _surface_source(root, surface).lower()
+        # Clap derives kebab-case command names from enum variants. Requiring every
+        # path segment prevents a stale command family/subcommand from passing.
+        return all(
+            re.search(rf"\b{re.escape(segment.replace('-', '_'))}\b", text.replace("-", "_"))
+            for segment in base.split("/")
+        )
+    receiver, separator, name = base.partition(".")
+    if not separator or not receiver or not name:
+        return False
+    if surface == "rust":
+        expression = re.compile(rf"\bpub\s+(?:async\s+)?fn\s+{re.escape(name)}\s*\(")
+        return expression.search(_surface_source(root, surface)) is not None
+    if surface == "python":
+        expression = re.compile(rf"\bfn\s+{re.escape(name)}\s*\(")
+        return expression.search(_surface_source(root, surface)) is not None
+    if surface == "node":
+        rust_name = _snake(name)
+        expressions = (
+            re.compile(rf"\bpub\s+(?:async\s+)?fn\s+{re.escape(rust_name)}\s*\("),
+            re.compile(rf"js_name\s*=\s*[\"']?{re.escape(name)}[\"']?"),
+        )
+        source = _surface_source(root, surface)
+        return any(expression.search(source) for expression in expressions)
+    raise AssertionError(surface)
+
+
+def _matching_brace(text: str, opening: int) -> int:
+    depth = 0
+    quote: str | None = None
+    escaped = False
+    for index in range(opening, len(text)):
+        char = text[index]
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            continue
+        if char in "\"'`":
+            quote = char
+        elif char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return index
+    raise ValueError("unbalanced test body")
+
+
+def _test_body(path: Path, symbol: str, kind: str) -> str:
+    text = path.read_text(encoding="utf-8")
+    if kind == "rust_test":
+        match = re.search(rf"\bfn\s+{re.escape(symbol)}\s*\(", text)
+        if match is None:
+            raise ValueError(f"stale Rust test symbol {symbol}")
+        prefix = text[max(0, match.start() - 500) : match.start()]
+        if not re.search(r"#\[(?:tokio::)?test(?:\([^]]*\))?\]\s*$", prefix):
+            raise ValueError(f"{symbol} is not an exact Rust test")
+        if "#[ignore" in prefix:
+            raise ValueError(f"{symbol} is ignored")
+        opening = text.find("{", match.end())
+        return text[opening + 1 : _matching_brace(text, opening)]
+    if kind == "python_test":
+        match = re.search(
+            rf"^(?P<indent>[ \t]*)def\s+{re.escape(symbol)}\s*\([^)]*\)"
+            r"\s*(?:->\s*[^:]+)?\s*:",
+            text,
+            re.M,
+        )
+        if match is None:
+            raise ValueError(f"stale Python test symbol {symbol}")
+        prefix = text[max(0, match.start() - 300) : match.start()]
+        if re.search(r"@pytest\.mark\.skip|@unittest\.skip", prefix):
+            raise ValueError(f"{symbol} is skipped")
+        indent = len(match.group("indent"))
+        tail = text[match.end() :]
+        end = re.search(rf"^(?: {{0,{indent}}})def\s+", tail, re.M)
+        return tail[: end.start()] if end else tail
+    if kind == "node_test":
+        match = re.search(rf"\btest\(\s*['\"]{re.escape(symbol)}['\"]\s*,", text)
+        if match is None:
+            raise ValueError(f"stale Node test title {symbol}")
+        if re.search(rf"\btest\.skip\(\s*['\"]{re.escape(symbol)}['\"]", text):
+            raise ValueError(f"{symbol} is skipped")
+        opening = text.find("{", match.end())
+        return text[opening + 1 : _matching_brace(text, opening)]
+    raise ValueError(f"unknown evidence kind {kind}")
+
+
+def _validate_case_evidence(
+    root: Path, surface: str, case: str, ref: object, errors: list[str]
+) -> None:
+    if not isinstance(ref, dict) or set(ref) != {"path", "symbol", "kind", "markers"}:
+        errors.append(f"{case}/{surface}: malformed exact evidence reference")
+        return
+    if ref["kind"] not in ASSERTION_MARKERS:
+        errors.append(f"{case}/{surface}: unsupported evidence kind {ref['kind']}")
+        return
+    markers = ref["markers"]
+    if (
+        not isinstance(markers, list)
+        or len(markers) < 2
+        or len(set(markers)) != len(markers)
+        or not all(isinstance(marker, str) and marker.strip() for marker in markers)
+        or case in markers
+        or "multi-ontology-surface-v1.json" in markers
+    ):
+        errors.append(f"{case}/{surface}: requires at least two unique semantic markers")
+        return
+    path = root / ref["path"]
+    if not path.is_file():
+        errors.append(f"{case}/{surface}: stale evidence path {ref['path']}")
+        return
+    try:
+        body = _test_body(path, ref["symbol"], ref["kind"])
+    except (OSError, ValueError) as error:
+        errors.append(f"{case}/{surface}: {error}")
+        return
+    compact = re.sub(r"\s+", " ", body).strip()
+    if len(compact) < 40 or not any(token in body for token in ASSERTION_MARKERS[ref["kind"]]):
+        errors.append(f"{case}/{surface}: empty or assertion-free evidence test")
+    missing = [marker for marker in markers if marker not in body]
+    if missing:
+        errors.append(f"{case}/{surface}: evidence missing case markers: " + ", ".join(missing))
+    without_inventory = body.replace("multi-ontology-surface-v1.json", "")
+    if not any(marker in without_inventory for marker in markers):
+        errors.append(f"{case}/{surface}: inventory-only evidence is forbidden")
+
+
+def _validate_packaged_artifacts(manifest: dict[str, Any], root: Path, errors: list[str]) -> None:
+    packaged = manifest.get("packaged_artifacts")
+    expected = {"python_wheel", "node_package", "cli_binary"}
+    if not isinstance(packaged, dict) or set(packaged) != expected:
+        errors.append("packaged_artifacts must bind Python wheel, Node package, and CLI binary")
+        return
+    for artifact, ref in packaged.items():
+        if not isinstance(ref, dict) or set(ref) != {
+            "workflow",
+            "oracle",
+            "workflow_markers",
+            "oracle_markers",
+        }:
+            errors.append(f"{artifact}: malformed packaged artifact evidence")
+            continue
+        workflow_markers = ref["workflow_markers"]
+        oracle_markers = ref["oracle_markers"]
+        if (
+            not isinstance(workflow_markers, list)
+            or len(workflow_markers) < 3
+            or not isinstance(oracle_markers, list)
+            or len(oracle_markers) < 2
+            or not all(
+                isinstance(marker, str) and marker
+                for marker in [*workflow_markers, *oracle_markers]
+            )
+        ):
+            errors.append(
+                f"{artifact}: requires build, isolated install, and semantic execution markers"
+            )
+            continue
+        path = root / ref["workflow"]
+        oracle = root / ref["oracle"]
+        if not path.is_file() or not oracle.is_file():
+            errors.append(f"{artifact}: stale package workflow {ref['workflow']}")
+            continue
+        source = path.read_text(encoding="utf-8")
+        missing = [marker for marker in workflow_markers if marker not in source]
+        if missing:
+            errors.append(f"{artifact}: package verification missing: " + ", ".join(missing))
+        oracle_source = oracle.read_text(encoding="utf-8")
+        missing = [marker for marker in oracle_markers if marker not in oracle_source]
+        if missing:
+            errors.append(f"{artifact}: packaged oracle missing semantics: " + ", ".join(missing))
+
+
+def validate(manifest: dict[str, Any], root: Path = ROOT) -> list[str]:
+    errors: list[str] = []
+    if manifest.get("contract") != "graphforge-multi-ontology-four-surface/1":
+        errors.append("wrong contract identity")
+    if manifest.get("issue") != 842:
+        errors.append("inventory must be bound to issue 842")
+    policy = manifest.get("policy")
+    if not isinstance(policy, dict) or policy.get("surfaces") != list(SURFACES):
+        errors.append("policy must require rust, python, node, and cli in canonical order")
+    elif policy.get("omission_default") != "forbidden":
+        errors.append("default-unexposed policy is forbidden")
+
+    operations = manifest.get("operations")
+    if not isinstance(operations, list):
+        return [*errors, "operations must be an array"]
+    mapped: dict[str, dict[str, str]] = {}
+    members: dict[str, dict[str, list[tuple[str, str | None, str]]]] = {
+        surface: {} for surface in SURFACES
+    }
+    for index, operation in enumerate(operations):
+        if not isinstance(operation, dict) or set(operation) != {"id", *SURFACES}:
+            errors.append(f"operation {index} must contain only id and four surface mappings")
+            continue
+        operation_id = operation["id"]
+        if not isinstance(operation_id, str) or not re.fullmatch(
+            r"[a-z][a-z0-9_]*\.[a-z][a-z0-9_]*", operation_id
+        ):
+            errors.append(f"operation {index} has invalid id")
+            continue
+        if operation_id in mapped:
+            errors.append(f"duplicate operation id: {operation_id}")
+            continue
+        mapped[operation_id] = operation
+        for surface in SURFACES:
+            member = operation[surface]
+            if (
+                not isinstance(member, str)
+                or not member.strip()
+                or FORBIDDEN_OMISSION.search(member)
+            ):
+                errors.append(f"{operation_id}/{surface}: missing or default-unexposed mapping")
+                continue
+            base, adapter = _adapter_base(member)
+            members[surface].setdefault(base, []).append((member, adapter, operation_id))
+            if not _source_contains_member(root, surface, member):
+                errors.append(f"{operation_id}/{surface}: stale member {member}")
+
+    actual = set(mapped)
+    if missing := sorted(REQUIRED_OPERATIONS - actual):
+        errors.append("missing canonical operations: " + ", ".join(missing))
+    if extra := sorted(actual - REQUIRED_OPERATIONS):
+        errors.append("undeclared canonical operations: " + ", ".join(extra))
+    for surface, bases in members.items():
+        for base, uses in bases.items():
+            if len(uses) == 1:
+                continue
+            raw = [use[0] for use in uses]
+            adapters = [use[1] for use in uses]
+            if len(set(raw)) != len(raw) or any(adapter is None for adapter in adapters):
+                errors.append(
+                    f"{surface}: duplicate member mapping {base}: "
+                    + ", ".join(use[2] for use in uses)
+                )
+
+    cases = manifest.get("required_conformance_cases")
+    if not isinstance(cases, list) or not all(isinstance(case, str) for case in cases):
+        errors.append("required_conformance_cases must be a string array")
+    elif set(cases) != REQUIRED_CASES or len(cases) != len(set(cases)):
+        errors.append("required conformance case inventory drifted")
+
+    evidence = manifest.get("case_evidence")
+    if not isinstance(evidence, dict) or set(evidence) != REQUIRED_CASES:
+        errors.append("case_evidence must contain exactly all ten required cases")
+    else:
+        seen: set[tuple[str, str, str]] = set()
+        for case in sorted(REQUIRED_CASES):
+            case_refs = evidence[case]
+            if not isinstance(case_refs, dict) or set(case_refs) != set(SURFACES):
+                errors.append(f"{case}: evidence must contain exactly all four surfaces")
+                continue
+            for surface in SURFACES:
+                ref = case_refs[surface]
+                _validate_case_evidence(root, surface, case, ref, errors)
+                if isinstance(ref, dict) and all(key in ref for key in ("path", "symbol", "kind")):
+                    identity = (surface, ref["path"], ref["symbol"])
+                    if identity in seen:
+                        errors.append(
+                            f"{case}/{surface}: test symbol reused across conformance cases"
+                        )
+                    seen.add(identity)
+    _validate_packaged_artifacts(manifest, root, errors)
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, default=MANIFEST)
+    parser.add_argument("--root", type=Path, default=ROOT)
+    args = parser.parse_args()
+    try:
+        errors = validate(load_manifest(args.manifest), args.root)
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        errors = [str(error)]
+    if errors:
+        print("multi-ontology four-surface gate: FAIL", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+    print(f"multi-ontology four-surface gate: PASS ({len(REQUIRED_OPERATIONS)} operations)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test-compare-multi-ontology-parity.py
+++ b/scripts/ci/test-compare-multi-ontology-parity.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Mutation tests for the real four-surface semantic report comparator."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+SCRIPT = Path(__file__).with_name("compare-multi-ontology-parity.py")
+SPEC = importlib.util.spec_from_file_location("compare_multi_ontology_parity", SCRIPT)
+assert SPEC and SPEC.loader
+COMPARATOR = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(COMPARATOR)
+
+
+class ComparatorTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        cases = {"case_a": {"ok": True}, "case_b": {"code": "stable.code"}}
+        self.ledger = self.root / "ledger.json"
+        self.ledger.write_text(json.dumps({"case_evidence": {key: {} for key in cases}}))
+        self.paths: dict[str, Path] = {}
+        for surface in COMPARATOR.SURFACES:
+            path = self.root / f"{surface}.json"
+            path.write_text(json.dumps({"contract": COMPARATOR.CONTRACT, "cases": cases}))
+            self.paths[surface] = path
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def test_equal_complete_reports_pass(self) -> None:
+        self.assertEqual(COMPARATOR.compare(self.paths, self.ledger), [])
+
+    def test_semantic_divergence_fails(self) -> None:
+        node = json.loads(self.paths["node"].read_text())
+        node["cases"]["case_a"] = {"ok": False}
+        self.paths["node"].write_text(json.dumps(node))
+        errors = COMPARATOR.compare(self.paths, self.ledger)
+        self.assertTrue(any("differ" in error for error in errors))
+
+    def test_missing_case_and_runtime_identity_fail(self) -> None:
+        python = json.loads(self.paths["python"].read_text())
+        del python["cases"]["case_b"]
+        self.paths["python"].write_text(json.dumps(python))
+        cli = json.loads(self.paths["cli"].read_text())
+        cli["cases"]["case_a"] = {"id": "00000000-0000-0000-0000-000000000842"}
+        self.paths["cli"].write_text(json.dumps(cli))
+        errors = COMPARATOR.compare(self.paths, self.ledger)
+        self.assertTrue(any("case set" in error for error in errors))
+        self.assertTrue(any("runtime-specific" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test-multi-ontology-surface-gate.py
+++ b/scripts/ci/test-multi-ontology-surface-gate.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Deterministic self-tests for the #842 closed surface gate."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+
+SCRIPT = Path(__file__).with_name("multi-ontology-surface-gate.py")
+SPEC = importlib.util.spec_from_file_location("multi_ontology_surface_gate", SCRIPT)
+assert SPEC and SPEC.loader
+GATE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(GATE)
+
+
+def _method(member: str) -> str:
+    base, _ = GATE._adapter_base(member)
+    return base.split(".", 1)[1]
+
+
+class SurfaceGateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.manifest = GATE.load_manifest(GATE.MANIFEST)
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self._materialize_complete_synthetic_surface()
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def _write(self, relative: str, text: str) -> None:
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+
+    def _materialize_complete_synthetic_surface(self) -> None:
+        operations = self.manifest["operations"]
+        rust_methods = sorted({_method(item["rust"]) for item in operations})
+        python_methods = sorted({_method(item["python"]) for item in operations})
+        node_methods = sorted({GATE._snake(_method(item["node"])) for item in operations})
+        cli_segments = sorted(
+            {
+                segment.replace("-", "_")
+                for item in operations
+                for segment in GATE._adapter_base(item["cli"])[0].split("/")
+            }
+        )
+        rust_source = "\n".join(f"pub fn {name}() {{}}" for name in rust_methods)
+        evidence_sources = {surface: [] for surface in GATE.SURFACES}
+        for refs in self.manifest["case_evidence"].values():
+            for surface, ref in refs.items():
+                marker_lines = "\n".join(f'let _ = "{marker}";' for marker in ref["markers"])
+                if ref["kind"] == "rust_test":
+                    body = f"#[test]\nfn {ref['symbol']}() {{ {marker_lines} assert!(true); }}\n"
+                elif ref["kind"] == "python_test":
+                    body = (
+                        f"def {ref['symbol']}():\n"
+                        f"    markers = {ref['markers']!r}\n"
+                        "    assert len(markers) == 2\n"
+                    )
+                else:
+                    body = (
+                        f'test("{ref["symbol"]}", () => {{ '
+                        f"const markers = {ref['markers']!r}; "
+                        "assert.equal(markers.length, 2); });\n"
+                    )
+                evidence_sources[surface].append(body)
+        rust_source += "\n" + "\n".join(evidence_sources["rust"])
+        self._write("crates/graphforge-api/src/multi_ontology.rs", rust_source)
+        self._write(
+            "crates/graphforge-bindings-py/src/lib.rs",
+            "\n".join(f"fn {name}() {{}}" for name in python_methods),
+        )
+        self._write(
+            "crates/graphforge-bindings-py/tests/multi_ontology.py",
+            "\n".join(evidence_sources["python"]),
+        )
+        self._write(
+            "crates/graphforge-bindings-node/src/lib.rs",
+            "\n".join(f"pub fn {name}() {{}}" for name in node_methods),
+        )
+        self._write(
+            "crates/graphforge-bindings-node/tests/multi-ontology.test.mjs",
+            "\n".join(evidence_sources["node"]),
+        )
+        self._write("crates/graphforge-cli/src/ontology_cli.rs", " ".join(cli_segments))
+        self._write(
+            "crates/graphforge-cli/tests/multi_ontology.rs",
+            "\n".join(evidence_sources["cli"]),
+        )
+        package_files: dict[str, list[str]] = {}
+        for ref in self.manifest["packaged_artifacts"].values():
+            package_files.setdefault(ref["workflow"], []).extend(ref["workflow_markers"])
+            package_files.setdefault(ref["oracle"], []).extend(ref["oracle_markers"])
+        for path, markers in package_files.items():
+            existing_path = self.root / path
+            existing = existing_path.read_text(encoding="utf-8") if existing_path.is_file() else ""
+            self._write(path, existing + "\n" + "\n".join(markers))
+
+    def test_complete_closed_inventory_passes(self) -> None:
+        self.assertEqual([], GATE.validate(self.manifest, self.root))
+
+    def test_missing_operation_and_surface_mapping_fail(self) -> None:
+        manifest = copy.deepcopy(self.manifest)
+        manifest["operations"] = manifest["operations"][1:]
+        errors = GATE.validate(manifest, self.root)
+        self.assertTrue(any("missing canonical operations" in error for error in errors))
+        manifest = copy.deepcopy(self.manifest)
+        del manifest["operations"][0]["cli"]
+        errors = GATE.validate(manifest, self.root)
+        self.assertTrue(any("four surface mappings" in error for error in errors))
+
+    def test_duplicate_and_default_unexposed_mappings_fail(self) -> None:
+        manifest = copy.deepcopy(self.manifest)
+        manifest["operations"][1]["rust"] = manifest["operations"][0]["rust"]
+        errors = GATE.validate(manifest, self.root)
+        self.assertTrue(any("duplicate member mapping" in error for error in errors))
+        manifest = copy.deepcopy(self.manifest)
+        manifest["operations"][0]["node"] = "GraphForge.default_unexposed"
+        errors = GATE.validate(manifest, self.root)
+        self.assertTrue(any("default-unexposed" in error for error in errors))
+
+    def test_stale_member_and_exact_evidence_fail(self) -> None:
+        manifest = copy.deepcopy(self.manifest)
+        manifest["operations"][0]["python"] = "GraphForge.method_that_does_not_exist"
+        errors = GATE.validate(manifest, self.root)
+        self.assertTrue(any("stale member" in error for error in errors))
+        manifest = copy.deepcopy(self.manifest)
+        manifest["case_evidence"]["cancellation"]["cli"]["symbol"] = "not_a_test"
+        errors = GATE.validate(manifest, self.root)
+        self.assertTrue(any("stale Rust test symbol" in error for error in errors))
+
+    def test_inventory_only_evidence_cannot_self_certify(self) -> None:
+        ref = self.manifest["case_evidence"]["cancellation"]["python"]
+        path = self.root / ref["path"]
+        body = (
+            f"def {ref['symbol']}():\n"
+            "    manifest = 'multi-ontology-surface-v1.json'\n"
+            "    assert manifest\n"
+        )
+        path.write_text(
+            body,
+            encoding="utf-8",
+        )
+        errors = GATE.validate(self.manifest, self.root)
+        self.assertTrue(any("missing case markers" in error for error in errors))
+
+    def test_empty_assertion_free_and_reused_test_evidence_fail(self) -> None:
+        manifest = copy.deepcopy(self.manifest)
+        manifest["case_evidence"]["idempotent_replay"]["cli"] = copy.deepcopy(
+            manifest["case_evidence"]["cancellation"]["cli"]
+        )
+        errors = GATE.validate(manifest, self.root)
+        self.assertTrue(any("reused across conformance cases" in error for error in errors))
+        ref = self.manifest["case_evidence"]["cancellation"]["rust"]
+        path = self.root / ref["path"]
+        source = path.read_text(encoding="utf-8")
+        source = source.replace("assert!(true);", "let _ = 1;", 1)
+        path.write_text(source, encoding="utf-8")
+        errors = GATE.validate(self.manifest, self.root)
+        self.assertTrue(any("assertion-free" in error for error in errors))
+
+    def test_packaged_artifact_requires_workflow_and_oracle_markers(self) -> None:
+        ref = self.manifest["packaged_artifacts"]["node_package"]
+        (self.root / ref["workflow"]).write_text("npm pack", encoding="utf-8")
+        errors = GATE.validate(self.manifest, self.root)
+        self.assertTrue(any("package verification missing" in error for error in errors))
+
+    def test_required_case_drift_fails(self) -> None:
+        manifest = copy.deepcopy(self.manifest)
+        manifest["required_conformance_cases"].pop()
+        errors = GATE.validate(manifest, self.root)
+        self.assertIn("required conformance case inventory drifted", errors)
+
+    def test_duplicate_json_member_is_rejected(self) -> None:
+        path = self.root / "duplicate.json"
+        path.write_text('{"contract":"a","contract":"b"}', encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "duplicate JSON member"):
+            GATE.load_manifest(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test-non-cypher-surface-gate.py
+++ b/scripts/ci/test-non-cypher-surface-gate.py
@@ -29,7 +29,7 @@ class SurfaceGateTests(unittest.TestCase):
 
     def test_checked_in_inventory_is_complete(self) -> None:
         self.assertEqual(GATE.validate(), [])
-        self.assertEqual(len(GATE.public_methods()), 328)
+        self.assertEqual(len(GATE.public_methods()), 359)
         self.assertEqual(len(GATE.algorithm_registry()), 94)
 
     def test_new_or_removed_public_method_fails_frozen_digest(self) -> None:

--- a/tests/contracts/multi-ontology-surface-v1.json
+++ b/tests/contracts/multi-ontology-surface-v1.json
@@ -1,0 +1,129 @@
+{
+  "contract": "graphforge-multi-ontology-four-surface/1",
+  "issue": 842,
+  "policy": {
+    "surfaces": ["rust", "python", "node", "cli"],
+    "omission_default": "forbidden",
+    "member_reuse": "forbidden_except_explicit_mode_adapters",
+    "evidence": "per_case_exact_non_skipped_behavioral_test_with_semantic_markers"
+  },
+  "operations": [
+    {"id":"module.list","rust":"GraphForge.ontology_modules","python":"GraphForge.ontology_modules","node":"GraphForge.ontologyModules","cli":"ontology/module/list"},
+    {"id":"module.get","rust":"GraphForge.inspect_ontology_module[exact]","python":"GraphForge.inspect_ontology_module[exact]","node":"GraphForge.inspectOntologyModule[exact]","cli":"ontology/module/get"},
+    {"id":"module.inspect","rust":"GraphForge.inspect_ontology_module[selector]","python":"GraphForge.inspect_ontology_module[selector]","node":"GraphForge.inspectOntologyModule[selector]","cli":"ontology/module/inspect"},
+    {"id":"module.validate","rust":"GraphForge.validate_ontology_module","python":"GraphForge.validate_ontology_module","node":"GraphForge.validateOntologyModule","cli":"ontology/module/validate"},
+    {"id":"module.create_register","rust":"GraphForge.create_ontology_module","python":"GraphForge.create_ontology_module","node":"GraphForge.createOntologyModule","cli":"ontology/module/create"},
+    {"id":"module.import","rust":"GraphForge.import_ontology_module","python":"GraphForge.import_ontology_module","node":"GraphForge.importOntologyModule","cli":"ontology/module/import"},
+    {"id":"module.adopt","rust":"GraphForge.adopt_ontology_module","python":"GraphForge.adopt_ontology_module","node":"GraphForge.adoptOntologyModule","cli":"ontology/module/adopt"},
+    {"id":"module.preview_update","rust":"GraphForge.preview_update_ontology_module","python":"GraphForge.preview_update_ontology_module","node":"GraphForge.previewUpdateOntologyModule","cli":"ontology/module/preview-update"},
+    {"id":"module.update_replace","rust":"GraphForge.update_ontology_module","python":"GraphForge.update_ontology_module","node":"GraphForge.updateOntologyModule","cli":"ontology/module/update"},
+    {"id":"module.preview_delete","rust":"GraphForge.preview_delete_ontology_module","python":"GraphForge.preview_delete_ontology_module","node":"GraphForge.previewDeleteOntologyModule","cli":"ontology/module/preview-delete"},
+    {"id":"module.delete","rust":"GraphForge.delete_ontology_module","python":"GraphForge.delete_ontology_module","node":"GraphForge.deleteOntologyModule","cli":"ontology/module/delete"},
+    {"id":"module.export","rust":"GraphForge.export_ontology_module","python":"GraphForge.export_ontology_module","node":"GraphForge.exportOntologyModule","cli":"ontology/module/export"},
+
+    {"id":"bridge.list","rust":"GraphForge.ontology_bridges","python":"GraphForge.ontology_bridges","node":"GraphForge.ontologyBridges","cli":"ontology/bridge/list"},
+    {"id":"bridge.get","rust":"GraphForge.inspect_ontology_bridge[exact]","python":"GraphForge.inspect_ontology_bridge[exact]","node":"GraphForge.inspectOntologyBridge[exact]","cli":"ontology/bridge/get"},
+    {"id":"bridge.inspect","rust":"GraphForge.inspect_ontology_bridge[selector]","python":"GraphForge.inspect_ontology_bridge[selector]","node":"GraphForge.inspectOntologyBridge[selector]","cli":"ontology/bridge/inspect"},
+    {"id":"bridge.validate","rust":"GraphForge.validate_ontology_bridge","python":"GraphForge.validate_ontology_bridge","node":"GraphForge.validateOntologyBridge","cli":"ontology/bridge/validate"},
+    {"id":"bridge.create_register","rust":"GraphForge.create_ontology_bridge","python":"GraphForge.create_ontology_bridge","node":"GraphForge.createOntologyBridge","cli":"ontology/bridge/create"},
+    {"id":"bridge.import","rust":"GraphForge.import_ontology_bridge","python":"GraphForge.import_ontology_bridge","node":"GraphForge.importOntologyBridge","cli":"ontology/bridge/import"},
+    {"id":"bridge.adopt","rust":"GraphForge.adopt_ontology_bridge","python":"GraphForge.adopt_ontology_bridge","node":"GraphForge.adoptOntologyBridge","cli":"ontology/bridge/adopt"},
+    {"id":"bridge.preview_update","rust":"GraphForge.preview_update_ontology_bridge","python":"GraphForge.preview_update_ontology_bridge","node":"GraphForge.previewUpdateOntologyBridge","cli":"ontology/bridge/preview-update"},
+    {"id":"bridge.update_replace","rust":"GraphForge.update_ontology_bridge","python":"GraphForge.update_ontology_bridge","node":"GraphForge.updateOntologyBridge","cli":"ontology/bridge/update"},
+    {"id":"bridge.preview_delete","rust":"GraphForge.preview_delete_ontology_bridge","python":"GraphForge.preview_delete_ontology_bridge","node":"GraphForge.previewDeleteOntologyBridge","cli":"ontology/bridge/preview-delete"},
+    {"id":"bridge.delete","rust":"GraphForge.delete_ontology_bridge","python":"GraphForge.delete_ontology_bridge","node":"GraphForge.deleteOntologyBridge","cli":"ontology/bridge/delete"},
+    {"id":"bridge.export","rust":"GraphForge.export_ontology_bridge","python":"GraphForge.export_ontology_bridge","node":"GraphForge.exportOntologyBridge","cli":"ontology/bridge/export"},
+
+    {"id":"activation.inspect","rust":"GraphForge.ontology_activation_profile","python":"GraphForge.ontology_activation_profile","node":"GraphForge.ontologyActivationProfile","cli":"ontology/activation/inspect"},
+    {"id":"activation.change","rust":"GraphForge.change_ontology_activation_profile","python":"GraphForge.change_ontology_activation_profile","node":"GraphForge.changeOntologyActivationProfile","cli":"ontology/activation/change"},
+    {"id":"composition.validate","rust":"GraphForge.validate_ontology_composition","python":"GraphForge.validate_ontology_composition","node":"GraphForge.validateOntologyComposition","cli":"ontology/composition/validate"},
+    {"id":"composition.preflight","rust":"GraphForge.preflight_ontology_composition","python":"GraphForge.preflight_ontology_composition","node":"GraphForge.preflightOntologyComposition","cli":"ontology/composition/preflight"},
+    {"id":"composition.resolution_explain","rust":"GraphForge.explain_ontology_resolution","python":"GraphForge.explain_ontology_resolution","node":"GraphForge.explainOntologyResolution","cli":"ontology/composition/explain-resolution"},
+
+    {"id":"portable.inspect","rust":"crate.verify_portable_v2[structure_only]","python":"GraphForge.verify_portable_v2[structure_only]","node":"GraphForge.verifyPortableV2[structureOnly]","cli":"portable/verify/inspect"},
+    {"id":"portable.verify","rust":"crate.verify_portable_v2[full]","python":"GraphForge.verify_portable_v2[full]","node":"GraphForge.verifyPortableV2[full]","cli":"portable/verify/full"},
+    {"id":"portable.export","rust":"GraphForge.export_portable_v2","python":"GraphForge.export_portable_v2","node":"GraphForge.exportPortableV2","cli":"portable/export"},
+    {"id":"portable.import","rust":"GraphForge.import_portable_v2","python":"GraphForge.import_portable_v2","node":"GraphForge.importPortableV2","cli":"portable/import"},
+    {"id":"portable.post_import_inspect","rust":"GraphForge.portable_ontology_staging","python":"GraphForge.portable_ontology_staging","node":"GraphForge.portableOntologyStaging","cli":"portable/staging/inspect"},
+    {"id":"portable.post_import_adopt","rust":"GraphForge.adopt_portable_ontology_staging","python":"GraphForge.adopt_portable_ontology_staging","node":"GraphForge.adoptPortableOntologyStaging","cli":"portable/staging/adopt"}
+  ],
+  "required_conformance_cases": [
+    "positive_crud_import_export",
+    "exact_identity_and_ambiguity",
+    "dependency_blocked_deletion",
+    "unsupported_future_portability",
+    "cancellation",
+    "idempotent_replay",
+    "no_partial_import_or_authority_change",
+    "bounded_structured_diagnostics",
+    "deterministic_path_free_cli_json",
+    "packaged_clean_install"
+  ],
+  "case_evidence": {
+    "positive_crud_import_export": {
+      "rust":{"path":"crates/graphforge-api/src/multi_ontology.rs","symbol":"conformance_positive_crud_import_export","kind":"rust_test","markers":["create_ontology_module","export_ontology_bridge"]},
+      "python":{"path":"crates/graphforge-bindings-py/tests/multi_ontology.py","symbol":"test_positive_crud_import_export","kind":"python_test","markers":["create_ontology_module","export_ontology_bridge"]},
+      "node":{"path":"crates/graphforge-bindings-node/tests/multi-ontology.test.mjs","symbol":"positive CRUD import export","kind":"node_test","markers":["createOntologyModule","exportOntologyBridge"]},
+      "cli":{"path":"crates/graphforge-cli/tests/multi_ontology.rs","symbol":"positive_crud_import_export","kind":"rust_test","markers":["bridge_export","module_export"]}
+    },
+    "exact_identity_and_ambiguity": {
+      "rust":{"path":"crates/graphforge-api/src/multi_ontology.rs","symbol":"conformance_exact_identity_and_ambiguity","kind":"rust_test","markers":["OntologyModuleSelector","SelectorAmbiguous"]},
+      "python":{"path":"crates/graphforge-bindings-py/tests/multi_ontology.py","symbol":"test_exact_identity_and_ambiguity","kind":"python_test","markers":["ontology_id","selector_ambiguous"]},
+      "node":{"path":"crates/graphforge-bindings-node/tests/multi-ontology.test.mjs","symbol":"exact identity and ambiguity","kind":"node_test","markers":["ontologyId","selector_ambiguous"]},
+      "cli":{"path":"crates/graphforge-cli/tests/multi_ontology.rs","symbol":"exact_identity_and_ambiguity","kind":"rust_test","markers":["--ontology-id","resolution.ambiguous"]}
+    },
+    "dependency_blocked_deletion": {
+      "rust":{"path":"crates/graphforge-api/src/multi_ontology.rs","symbol":"conformance_dependency_blocked_deletion","kind":"rust_test","markers":["preview_delete_ontology_module","DependencyBlocked"]},
+      "python":{"path":"crates/graphforge-bindings-py/tests/multi_ontology.py","symbol":"test_dependency_blocked_deletion","kind":"python_test","markers":["preview_delete_ontology_module","dependency_blocked"]},
+      "node":{"path":"crates/graphforge-bindings-node/tests/multi-ontology.test.mjs","symbol":"dependency blocked deletion","kind":"node_test","markers":["previewDeleteOntologyModule","dependency_blocked"]},
+      "cli":{"path":"crates/graphforge-cli/tests/multi_ontology.rs","symbol":"dependency_blocked_deletion","kind":"rust_test","markers":["preview-delete","dependency.in_use"]}
+    },
+    "unsupported_future_portability": {
+      "rust":{"path":"crates/graphforge-api/src/multi_ontology.rs","symbol":"conformance_unsupported_future_portability","kind":"rust_test","markers":["verify_portable_v2","UnsupportedFutureVersion"]},
+      "python":{"path":"crates/graphforge-bindings-py/tests/multi_ontology.py","symbol":"test_unsupported_future_portability","kind":"python_test","markers":["verify_portable_v2","unsupported_future_version"]},
+      "node":{"path":"crates/graphforge-bindings-node/tests/multi-ontology.test.mjs","symbol":"unsupported future portability","kind":"node_test","markers":["verifyPortableV2","unsupported_future_version"]},
+      "cli":{"path":"crates/graphforge-cli/tests/multi_ontology.rs","symbol":"unsupported_future_portability","kind":"rust_test","markers":["portable","interchange.unsupported_future"]}
+    },
+    "cancellation": {
+      "rust":{"path":"crates/graphforge-api/src/multi_ontology.rs","symbol":"conformance_cancellation","kind":"rust_test","markers":["CancellationToken","GF_CANCELLED"]},
+      "python":{"path":"crates/graphforge-bindings-py/tests/multi_ontology.py","symbol":"test_cancellation","kind":"python_test","markers":["cancel_before_start","GF_CANCELLED"]},
+      "node":{"path":"crates/graphforge-bindings-node/tests/multi-ontology.test.mjs","symbol":"cancellation","kind":"node_test","markers":["cancelBeforeStart","GF_CANCELLED"]},
+      "cli":{"path":"crates/graphforge-cli/tests/multi_ontology.rs","symbol":"cancelled_adoption_publishes_no_authority","kind":"rust_test","markers":["--cancel-before-start","before.stdout"]}
+    },
+    "idempotent_replay": {
+      "rust":{"path":"crates/graphforge-api/src/multi_ontology.rs","symbol":"conformance_idempotent_replay","kind":"rust_test","markers":["operation_uuid","IdempotentReplay"]},
+      "python":{"path":"crates/graphforge-bindings-py/tests/multi_ontology.py","symbol":"test_idempotent_replay","kind":"python_test","markers":["operation_uuid","replay_result"]},
+      "node":{"path":"crates/graphforge-bindings-node/tests/multi-ontology.test.mjs","symbol":"idempotent replay","kind":"node_test","markers":["operationUuid","replayResult"]},
+      "cli":{"path":"crates/graphforge-cli/tests/multi_ontology.rs","symbol":"idempotent_replay","kind":"rust_test","markers":["--operation-uuid","idempotent.replay"]}
+    },
+    "no_partial_import_or_authority_change": {
+      "rust":{"path":"crates/graphforge-api/src/multi_ontology.rs","symbol":"conformance_no_partial_import_or_authority_change","kind":"rust_test","markers":["ontology_authority_state","NoAuthorityChange"]},
+      "python":{"path":"crates/graphforge-bindings-py/tests/multi_ontology.py","symbol":"test_no_partial_import_or_authority_change","kind":"python_test","markers":["ontology_authority_state","no_partial_import"]},
+      "node":{"path":"crates/graphforge-bindings-node/tests/multi-ontology.test.mjs","symbol":"no partial import or authority change","kind":"node_test","markers":["ontologyAuthorityState","no_partial_import"]},
+      "cli":{"path":"crates/graphforge-cli/tests/multi_ontology.rs","symbol":"no_partial_import_or_authority_change","kind":"rust_test","markers":["portable","authority"]}
+    },
+    "bounded_structured_diagnostics": {
+      "rust":{"path":"crates/graphforge-api/src/multi_ontology.rs","symbol":"conformance_bounded_structured_diagnostics","kind":"rust_test","markers":["diagnostics","limit"]},
+      "python":{"path":"crates/graphforge-bindings-py/tests/multi_ontology.py","symbol":"test_bounded_structured_diagnostics","kind":"python_test","markers":["diagnostics","limit"]},
+      "node":{"path":"crates/graphforge-bindings-node/tests/multi-ontology.test.mjs","symbol":"bounded structured diagnostics","kind":"node_test","markers":["diagnostics","limit"]},
+      "cli":{"path":"crates/graphforge-cli/tests/multi_ontology.rs","symbol":"bounded_structured_diagnostics","kind":"rust_test","markers":["details","semantic_code"]}
+    },
+    "deterministic_path_free_cli_json": {
+      "rust":{"path":"crates/graphforge-api/src/multi_ontology.rs","symbol":"conformance_deterministic_path_free_serialization","kind":"rust_test","markers":["serde_json","project_generation_uuid"]},
+      "python":{"path":"crates/graphforge-bindings-py/tests/multi_ontology.py","symbol":"test_deterministic_path_free_serialization","kind":"python_test","markers":["json.dumps","project_generation_uuid"]},
+      "node":{"path":"crates/graphforge-bindings-node/tests/multi-ontology.test.mjs","symbol":"deterministic path free serialization","kind":"node_test","markers":["JSON.stringify","project_generation_uuid"]},
+      "cli":{"path":"crates/graphforge-cli/tests/multi_ontology.rs","symbol":"inventory_json_and_errors_are_deterministic_path_free_and_semantic","kind":"rust_test","markers":["semantic_code","project.path().display()"]}
+    },
+    "packaged_clean_install": {
+      "rust":{"path":"crates/graphforge-api/src/multi_ontology.rs","symbol":"conformance_packaged_rust_surface","kind":"rust_test","markers":["ontology_modules","portable_ontology_staging"]},
+      "python":{"path":"crates/graphforge-bindings-py/tests/multi_ontology.py","symbol":"test_packaged_clean_install","kind":"python_test","markers":["graphforge.__file__","ontology_modules"]},
+      "node":{"path":"crates/graphforge-bindings-node/tests/multi-ontology.test.mjs","symbol":"packaged clean install","kind":"node_test","markers":["graphforge/package.json","ontologyModules"]},
+      "cli":{"path":"crates/graphforge-cli/tests/multi_ontology.rs","symbol":"packaged_clean_install","kind":"rust_test","markers":["CARGO_BIN_EXE_gf","ontology module list"]}
+    }
+  },
+  "packaged_artifacts": {
+    "python_wheel":{"workflow":".github/workflows/test.yml","oracle":"crates/graphforge-bindings-py/tests/multi_ontology.py","workflow_markers":["maturin build","uv pip install --python /tmp/gf-native/bin/python","crates/graphforge-bindings-py/tests/multi_ontology.py"],"oracle_markers":["import graphforge","ontology_modules"]},
+    "node_package":{"workflow":".github/workflows/binding-release-candidate.yml","oracle":"scripts/ci/multi-ontology-packaged-smoke.mjs","workflow_markers":["npm pack . --ignore-scripts","npm install","multi-ontology-packaged-smoke.mjs"],"oracle_markers":["@curatelabs/graphforge","ontologyModules"]},
+    "cli_binary":{"workflow":".github/workflows/binding-release-candidate.yml","oracle":"scripts/ci/multi-ontology-packaged-smoke.mjs","workflow_markers":["packages/cli\" pack","npm install","multi-ontology-packaged-smoke.mjs"],"oracle_markers":["@curatelabs/graphforge-cli","ontology\", \"module\", \"list"]}
+  }
+}

--- a/tests/contracts/non-cypher-rust-surface.json
+++ b/tests/contracts/non-cypher-rust-surface.json
@@ -1,7 +1,7 @@
 {
   "contract_version": 1,
   "scope": "Rust non-Cypher public release surface",
-  "public_method_digest": "726aacf015d8db337cbd9282a43de81bd82f32202d4f1d2f2666b9c34ca2ad09",
+  "public_method_digest": "945ee1c62666775b5371e469c6db18461de7e57bdbf0afe4d36e4fe9a8a3e3a8",
   "method_policy": {
     "receiver_defaults": {
       "GraphForge": "release-tested",
@@ -21,8 +21,9 @@
       "CancellationToken": "introspection",
       "FindExecutionResult": "introspection",
       "InvocationDescriptor": "introspection",
-      "InvocationError": "introspection",
-      "PageToken": "introspection",
+    "InvocationError": "introspection",
+    "MultiOntologyError": "introspection",
+    "PageToken": "introspection",
       "ProviderRerankedFindResult": "introspection",
       "RecordBatch": "introspection",
       "ResolvedBeliefProjection": "introspection",
@@ -102,6 +103,46 @@
     }
   },
   "method_evidence_groups": {
+    "multi-ontology-lifecycle": {
+      "ids": [
+        "GraphForge.adopt_ontology_bridge",
+        "GraphForge.adopt_ontology_module",
+        "GraphForge.adopt_portable_ontology_staging",
+        "GraphForge.change_ontology_activation_profile",
+        "GraphForge.create_ontology_bridge",
+        "GraphForge.create_ontology_module",
+        "GraphForge.delete_ontology_bridge",
+        "GraphForge.delete_ontology_module",
+        "GraphForge.explain_ontology_resolution",
+        "GraphForge.export_ontology_bridge",
+        "GraphForge.export_ontology_module",
+        "GraphForge.import_ontology_bridge",
+        "GraphForge.import_ontology_module",
+        "GraphForge.inspect_ontology_bridge",
+        "GraphForge.inspect_ontology_module",
+        "GraphForge.ontology_activation_profile",
+        "GraphForge.ontology_authority_state",
+        "GraphForge.ontology_bridges",
+        "GraphForge.ontology_modules",
+        "GraphForge.portable_ontology_staging",
+        "GraphForge.preflight_ontology_composition",
+        "GraphForge.preview_delete_ontology_bridge",
+        "GraphForge.preview_delete_ontology_module",
+        "GraphForge.preview_update_ontology_bridge",
+        "GraphForge.preview_update_ontology_module",
+        "GraphForge.update_ontology_bridge",
+        "GraphForge.update_ontology_module",
+        "GraphForge.validate_ontology_bridge",
+        "GraphForge.validate_ontology_composition",
+        "GraphForge.validate_ontology_module"
+      ],
+      "test_refs": [
+        {
+          "path": "crates/graphforge-api/src/multi_ontology.rs",
+          "symbol": "multi_ontology_public_facade_inventory_is_runtime_covered"
+        }
+      ]
+    },
     "infra-validation": {
       "ids": [
         "RepositoryContext.validate_infra_target"

--- a/tests/fixtures/multi-ontology-v1/BUILD.bazel
+++ b/tests/fixtures/multi-ontology-v1/BUILD.bazel
@@ -1,0 +1,5 @@
+"""Normative multi-ontology conformance fixtures."""
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files(glob(["*"], exclude = ["BUILD.bazel"]))

--- a/tests/fixtures/multi-ontology-v1/README.md
+++ b/tests/fixtures/multi-ontology-v1/README.md
@@ -8,6 +8,11 @@ then checks exact qualified resolution and activation ownership.
 must preserve the source generation and composition fingerprint. These are
 contract fixtures for implementation issues #836-#843, not a second runtime.
 
+`binding-parity-v1.json` is the shared Rust/Python/Node/CLI lifecycle oracle for
+#842. `$base` and `$dependent` are symbolic references replaced with the exact
+content-derived identities returned by Rust before constructing the bridge.
+Its ten cases are the required cross-surface conformance matrix.
+
 Validate deterministically from the repository root:
 
 ```bash

--- a/tests/fixtures/multi-ontology-v1/binding-parity-v1.json
+++ b/tests/fixtures/multi-ontology-v1/binding-parity-v1.json
@@ -1,0 +1,72 @@
+{
+  "contract": "graphforge-multi-ontology-binding-parity/1",
+  "modules": {
+    "base": {
+      "ontology_id": "urn:graphforge:parity:base",
+      "version": "1.0.0",
+      "entity_types": [{"name": "Person", "abstract": false}],
+      "relation_types": [],
+      "properties": [],
+      "constraints": [],
+      "migrations": []
+    },
+    "dependent": {
+      "ontology_id": "urn:graphforge:parity:dependent",
+      "version": "1.0.0",
+      "entity_types": [{"name": "Person", "abstract": false}, {"name": "Evidence", "abstract": false}],
+      "relation_types": [],
+      "properties": [],
+      "constraints": [],
+      "migrations": []
+    },
+    "dependent_update": {
+      "ontology_id": "urn:graphforge:parity:dependent",
+      "version": "2.0.0",
+      "entity_types": [{"name": "Person", "abstract": false}, {"name": "Evidence", "abstract": false}],
+      "relation_types": [],
+      "properties": [],
+      "constraints": [],
+      "migrations": []
+    }
+  },
+  "bridge": {
+    "bridge_id": "urn:graphforge:parity:bridge",
+    "authored_version": "1.0.0",
+    "source_modules": ["$base"],
+    "target_modules": ["$dependent"],
+    "dependencies": [],
+    "shared_surfaces": ["evidence"],
+    "assertions": [{
+      "source": {"module": "$base", "kind": "entity", "local_id": "Person"},
+      "target": {"module": "$dependent", "kind": "entity", "local_id": "Person"},
+      "predicate": "related",
+      "directional": true,
+      "provenance": {"method": "authored", "justification": "binding parity oracle", "evidence_refs": ["urn:evidence:parity"]}
+    }],
+    "enforcement": "advisory"
+  },
+  "expected": {
+    "module_order": ["urn:graphforge:parity:base", "urn:graphforge:parity:dependent"],
+    "bridge_order": ["urn:graphforge:parity:bridge"],
+    "ambiguous_code": "resolution.ambiguous",
+    "dependency_blocked_code": "GF_ONTOLOGY_DIAGNOSTIC",
+    "dependency_blocked_diagnostic": "dependency.in_use",
+    "idempotency_conflict_code": "GF_IDEMPOTENCY_CONFLICT",
+    "cancelled_code": "GF_CANCELLED",
+    "unsupported_future_code": "GF_UNSUPPORTED_FUTURE",
+    "unsupported_future_diagnostic": "interchange.unsupported_future",
+    "max_diagnostics": 2
+  },
+  "cases": [
+    {"id": "positive_crud_import_export", "preserves_authority": false},
+    {"id": "exact_identity_and_ambiguity", "preserves_authority": true},
+    {"id": "dependency_blocked_deletion", "preserves_authority": true},
+    {"id": "unsupported_future_portability", "preserves_authority": true},
+    {"id": "cancellation", "preserves_authority": true},
+    {"id": "idempotent_replay", "preserves_authority": false},
+    {"id": "no_partial_import_or_authority_change", "preserves_authority": true},
+    {"id": "bounded_structured_diagnostics", "preserves_authority": true},
+    {"id": "deterministic_path_free_cli_json", "preserves_authority": true},
+    {"id": "packaged_clean_install", "preserves_authority": true}
+  ]
+}

--- a/tools/bazel/drift/cargo_feature_fingerprint.json
+++ b/tools/bazel/drift/cargo_feature_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "schema": "graphforge.cargo-feature-fingerprint.v1",
-  "sha256": "be204b37c02a9087f84e342bfaac26409a76ad86299b6699229f6662845507bd",
+  "sha256": "edd8d33316e934f85aadce419ed4aae07daa7930004a8899727c83570776a882",
   "entries": [
     {
       "name": "graphforge-api",
@@ -386,6 +386,17 @@
           "target": null
         },
         {
+          "name": "serde",
+          "req": "^1",
+          "features": [
+            "derive"
+          ],
+          "optional": false,
+          "uses_default_features": true,
+          "kind": null,
+          "target": null
+        },
+        {
           "name": "serde_json",
           "req": "^1",
           "features": [],
@@ -466,6 +477,17 @@
           "target": null
         },
         {
+          "name": "serde",
+          "req": "^1",
+          "features": [
+            "derive"
+          ],
+          "optional": false,
+          "uses_default_features": true,
+          "kind": null,
+          "target": null
+        },
+        {
           "name": "serde_json",
           "req": "^1",
           "features": [],
@@ -526,6 +548,15 @@
           "target": null
         },
         {
+          "name": "graphforge-storage",
+          "req": "^0.5.2",
+          "features": [],
+          "optional": false,
+          "uses_default_features": true,
+          "kind": "dev",
+          "target": null
+        },
+        {
           "name": "parquet",
           "req": "^58",
           "features": [],
@@ -552,6 +583,24 @@
           "optional": false,
           "uses_default_features": true,
           "kind": null,
+          "target": null
+        },
+        {
+          "name": "serde_yaml_ng",
+          "req": "^0.9",
+          "features": [],
+          "optional": false,
+          "uses_default_features": true,
+          "kind": null,
+          "target": null
+        },
+        {
+          "name": "sha2",
+          "req": "^0.11",
+          "features": [],
+          "optional": false,
+          "uses_default_features": true,
+          "kind": "dev",
           "target": null
         },
         {

--- a/tools/bazel/gf_rust.bzl
+++ b/tools/bazel/gf_rust.bzl
@@ -11,12 +11,14 @@ load(
     "rust_test",
 )
 
-def gf_rust_library(name, deps = [], compile_data = [], crate_features = [], **kwargs):
+def gf_rust_library(name, deps = [], compile_data = [], crate_features = [], crate_aliases = {}, **kwargs):
     """rust_library wired to crate_universe deps for this package's Cargo.toml."""
+    resolved_aliases = aliases()
+    resolved_aliases.update(crate_aliases)
     rust_library(
         name = name,
         srcs = kwargs.pop("srcs", native.glob(["src/**/*.rs"])),
-        aliases = aliases(),
+        aliases = resolved_aliases,
         compile_data = compile_data,
         crate_features = crate_features,
         edition = "2024",

--- a/tools/bazel/gf_rust.bzl
+++ b/tools/bazel/gf_rust.bzl
@@ -11,14 +11,12 @@ load(
     "rust_test",
 )
 
-def gf_rust_library(name, deps = [], compile_data = [], crate_features = [], crate_aliases = {}, **kwargs):
+def gf_rust_library(name, deps = [], compile_data = [], crate_features = [], **kwargs):
     """rust_library wired to crate_universe deps for this package's Cargo.toml."""
-    resolved_aliases = aliases()
-    resolved_aliases.update(crate_aliases)
     rust_library(
         name = name,
         srcs = kwargs.pop("srcs", native.glob(["src/**/*.rs"])),
-        aliases = resolved_aliases,
+        aliases = aliases(),
         compile_data = compile_data,
         crate_features = crate_features,
         edition = "2024",

--- a/tools/bazel/parity/migration_target_map.json
+++ b/tools/bazel/parity/migration_target_map.json
@@ -1,7 +1,7 @@
 {
   "schema": "graphforge.bazel-migration-target-map.v1",
   "issue": 6,
-  "cargo_target_count": 110,
+  "cargo_target_count": 111,
   "targets": [
     {
       "package": "graphforge-api",
@@ -652,6 +652,16 @@
       "bazel_label": "//crates/graphforge-cli:graphforge_cli",
       "exception_id": null,
       "notes": "#7/#8; unit `//crates/graphforge-cli:graphforge_cli_test`"
+    },
+    {
+      "package": "graphforge-cli",
+      "target": "multi_ontology",
+      "class": "integration-test",
+      "source": "crates/graphforge-cli/tests/multi_ontology.rs",
+      "status": "mapped",
+      "bazel_label": "//crates/graphforge-cli:multi_ontology",
+      "exception_id": null,
+      "notes": "#842"
     },
     {
       "package": "graphforge-cli",


### PR DESCRIPTION
Closes #842

## Summary
- expose the Rust-owned multi-ontology module, bridge, activation, composition, and portable lifecycle through thin Python, Node, and CLI projections
- add stable bounded diagnostics, exact identity/idempotency/cancellation behavior, and atomic portable failure handling
- add an explicit 35-operation surface ledger plus observed ten-case semantic comparison across Rust, Python, Node, and CLI
- exercise same-SHA packaged wheel, npm native addon, and CLI paths in CI and binding RC

## Validation
- `make pre-push-fast`
- full Rust coverage workspace: 654 API tests, 118 required BDD scenarios, 3,897/3,897 openCypher TCK scenarios, and remaining workspace crates passed; the discovered graphforge-io test isolation defect was repaired and passed in the full run
- observed four-surface semantic comparator: PASS (Rust, Python, Node, CLI)
- targeted Rust, Python, Node, and CLI multi-ontology suites
- independent final audit: no remaining blocker; unrelated `uv.lock` refresh removed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789943364&installation_model_id=20486&pr_number=878&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F878&signature=fb5f0723ce2035f2d59b59905a5f4d89f15b02682435e79ab98c7644bb49f98f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->