### PR TITLE
test(scale): harden SCALE26 certification before dispatch

### DIFF
--- a/.github/workflows/g500-certification.yml
+++ b/.github/workflows/g500-certification.yml
@@ -15,8 +15,16 @@ on:
         description: Provisioned provider recorded in evidence
         required: true
         type: string
+      region:
+        description: Exact provisioned provider region recorded in evidence
+        required: true
+        type: string
       sku:
         description: Provisioned SKU recorded in evidence
+        required: true
+        type: string
+      os_image:
+        description: Immutable resolved OS image identity recorded in evidence
         required: true
         type: string
 
@@ -32,17 +40,35 @@ jobs:
     name: SCALE26 target-live certification
     environment: scale-certification
     runs-on: ${{ inputs.runner_label }}
-    timeout-minutes: 240
+    # The Rust watchdog owns the 240-minute product fail-safe. Keep 30 minutes
+    # of job headroom so failure evidence can still be validated and uploaded.
+    timeout-minutes: 270
     steps:
       - name: Reject branch names and malformed SHAs
         env:
           COMMIT_SHA: ${{ inputs.commit_sha }}
+          PROVIDER: ${{ inputs.provider }}
+          REGION: ${{ inputs.region }}
+          SKU: ${{ inputs.sku }}
+          OS_IMAGE: ${{ inputs.os_image }}
         run: |
           case "$COMMIT_SHA" in
             (????????????????????????????????????????) ;;
             (*) echo "commit_sha must contain exactly 40 characters" >&2; exit 2 ;;
           esac
           case "$COMMIT_SHA" in (*[!0-9a-f]*) echo "commit_sha must be lowercase hex" >&2; exit 2 ;; esac
+          case "$(printf '%s' "$PROVIDER" | tr '[:upper:]' '[:lower:]')" in
+            (""|local|localhost|developer|example|test|unknown) echo "provider must name provisioned cloud infrastructure" >&2; exit 2 ;;
+          esac
+          case "$(printf '%s' "$REGION" | tr '[:upper:]' '[:lower:]')" in
+            (""|local|localhost|default|example|global|test|unknown) echo "region must name the exact provisioned region" >&2; exit 2 ;;
+          esac
+          case "$(printf '%s' "$SKU" | tr '[:upper:]' '[:lower:]')" in
+            (""|local|default|example|generic|test|unknown) echo "sku must name the exact provisioned machine SKU" >&2; exit 2 ;;
+          esac
+          case "$(printf '%s' "$OS_IMAGE" | tr '[:upper:]' '[:lower:]')" in
+            (""|local|default|example|generic|latest|test|unknown|*:latest) echo "os_image must be an immutable resolved image identity" >&2; exit 2 ;;
+          esac
       - name: Checkout exact commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -52,20 +78,29 @@ jobs:
         env:
           COMMIT_SHA: ${{ inputs.commit_sha }}
         run: |
+          mkdir -p "$RUNNER_TEMP/g500-sut-temp"
           test "$(git rev-parse HEAD)" = "$COMMIT_SHA"
           test "$(uname -s)" = Linux
           test "$(awk '/MemTotal/ {print $2 * 1024}' /proc/meminfo)" -ge 137438953472
-          test "$(df --output=size -B1 "$RUNNER_TEMP" | tail -1 | tr -d ' ')" -ge 1099511627776
-          case "$(stat -f -c %T "$RUNNER_TEMP")" in ext2/ext3|xfs|btrfs) ;; (*) exit 2 ;; esac
+          test "$(df --output=size -B1 "$RUNNER_TEMP/g500-sut-temp" | tail -1 | tr -d ' ')" -ge 1099511627776
+          case "$(stat -f -c %T "$RUNNER_TEMP/g500-sut-temp")" in ext2/ext3|xfs|btrfs) ;; (*) exit 2 ;; esac
       - name: Install pinned Rust toolchain
         run: rustup show active-toolchain
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      - name: Prepare pinned evidence validator
+        run: uv run --isolated --no-project --with jsonschema==4.26.0 python -c "import jsonschema"
       - name: Run bounded preflight and provisioned certification
         env:
           CARGO_TARGET_DIR: ${{ runner.temp }}/cargo-g500-certification
+          # tempfile::TempDir follows TMPDIR. This binds the source project,
+          # spills, bundle, and clean import to the exact attested volume.
+          TMPDIR: ${{ runner.temp }}/g500-sut-temp
           GF_G500_CERT_EVIDENCE_OUT: ${{ runner.temp }}/g500-certification-evidence.json
           GF_G500_CERT_JOURNAL_OUT: ${{ runner.temp }}/g500-certification-phase-journal.json
           GF_G500_CERT_PROVIDER: ${{ inputs.provider }}
+          GF_G500_CERT_REGION: ${{ inputs.region }}
           GF_G500_CERT_SKU: ${{ inputs.sku }}
+          GF_G500_CERT_OS_IMAGE: ${{ inputs.os_image }}
           GF_G500_CERT_EXPECTED_SHA: ${{ inputs.commit_sha }}
         run: |
           cargo test -p graphforge-api --release --test scale_g500_ladder certification_lifecycle_journals_equivalent_round_trip_and_drills -- --exact --nocapture
@@ -74,7 +109,11 @@ jobs:
         if: always()
         env:
           COMMIT_SHA: ${{ inputs.commit_sha }}
-        run: python3 scripts/ci/validate-g500-certification.py "$RUNNER_TEMP/g500-certification-evidence.json" --expected-sha "$COMMIT_SHA"
+        run: >-
+          uv run --isolated --no-project --with jsonschema==4.26.0 python
+          scripts/ci/validate-g500-certification.py
+          "$RUNNER_TEMP/g500-certification-evidence.json"
+          --expected-sha "$COMMIT_SHA"
       - name: Upload evidence without project payload
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/g500-certification.yml
+++ b/.github/workflows/g500-certification.yml
@@ -103,6 +103,7 @@ jobs:
           GF_G500_CERT_OS_IMAGE: ${{ inputs.os_image }}
           GF_G500_CERT_EXPECTED_SHA: ${{ inputs.commit_sha }}
         run: |
+          export GF_G500_CERT_STARTED_EPOCH_S="$(date +%s)"
           cargo test -p graphforge-api --release --test scale_g500_ladder certification_lifecycle_journals_equivalent_round_trip_and_drills -- --exact --nocapture
           cargo test -p graphforge-api --release --test scale_g500_ladder certification_target_live_full_lifecycle_evidence -- --ignored --exact --nocapture --test-threads=1
       - name: Validate sanitized durable evidence

--- a/crates/graphforge-api/tests/fixtures/scale_g500_certification.v1.json
+++ b/crates/graphforge-api/tests/fixtures/scale_g500_certification.v1.json
@@ -15,9 +15,43 @@
   "envelope": {
     "rss_bytes": 137438953472,
     "disk_bytes": 1099511627776,
-    "timeout_s": 14400
+    "timeout_s": 14400,
+    "dispatch_timeout_s": 14400,
+    "provisioning_ttl_s": 18000,
+    "timeout_headroom_note": "The four-hour product envelope includes both certification test commands. Provisioning and runner registration happen before dispatch and are bounded separately by the five-hour infrastructure TTL; they are never excluded from billed-cost approval."
   },
   "preflight_scale": 10,
   "provider_decision": "required-at-dispatch",
-  "runner_label": "required-at-dispatch"
+  "runner_label": "required-at-dispatch",
+  "sut": {
+    "provider": "required-at-dispatch",
+    "region": "required-at-dispatch",
+    "sku": "required-at-dispatch",
+    "os_image": "required-at-dispatch-exact-image-identity",
+    "filesystem": "xfs",
+    "workspace_binding": "process TMPDIR and GitHub RUNNER_TEMP must resolve to the same local-NVMe filesystem",
+    "runner_lifecycle": "unique ephemeral repository runner; deregister and destroy after evidence upload"
+  },
+  "authorization": {
+    "preflight_mode": "read-only-no-spend",
+    "required_before_provisioning": [
+      "explicit provider registration authorization",
+      "explicit resource creation and spend ceiling",
+      "approved exact provider, region, SKU, image version, runner label, and teardown owner"
+    ]
+  },
+  "negative_drills": {
+    "scale": "representative-bounded",
+    "required": ["corruption-before-import", "cooperative-cancellation", "resource-limit", "interrupted-finalization"],
+    "invariant": "no partial publication, no addressable partial candidate, and the last complete atomic phase journal remains valid"
+  },
+  "identity_reconciliation": {
+    "source_generation": "distinct durable source generation identity",
+    "semantic_package": "portable-v2 semantic package digest",
+    "transport": "bundle transport digest distinct from semantic package digest",
+    "imported_generation": "distinct durable imported generation identity",
+    "authority": "source and imported ontology/capability fingerprints must match",
+    "project": "source and imported canonical project fingerprints must match",
+    "queries": "source and imported 1-hop and 2-hop observation fingerprints must match"
+  }
 }

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -25,7 +25,7 @@ use std::process::Command;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::thread::{self, JoinHandle};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use arrow::array::{Array, FixedSizeBinaryArray, Int64Array, StringArray, UInt64Array};
 use arrow::record_batch::RecordBatch;
@@ -1499,6 +1499,7 @@ impl ResourceMonitor {
         let worker_failure = Arc::clone(&failure);
         let worker_workspace = workspace.clone();
         let started = Instant::now();
+        let elapsed_before_process = certification_elapsed_before_process();
         let worker = thread::spawn(move || {
             let mut samples = 0_u8;
             while !worker_stop.load(Ordering::Relaxed) {
@@ -1506,7 +1507,11 @@ impl ResourceMonitor {
                 worker_peak_rss.fetch_max(rss, Ordering::Relaxed);
                 let mut code = if rss > envelope.rss_bytes {
                     1
-                } else if started.elapsed().as_secs() > envelope.timeout_s {
+                } else if elapsed_before_process
+                    .saturating_add(started.elapsed())
+                    .as_secs()
+                    > envelope.timeout_s
+                {
                     3
                 } else {
                     0
@@ -1561,6 +1566,20 @@ impl ResourceMonitor {
             _ => None,
         }
     }
+}
+
+fn certification_elapsed_before_process() -> Duration {
+    let Ok(value) = std::env::var("GF_G500_CERT_STARTED_EPOCH_S") else {
+        return Duration::ZERO;
+    };
+    let started = value
+        .parse::<u64>()
+        .expect("GF_G500_CERT_STARTED_EPOCH_S must be Unix seconds");
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock must be after Unix epoch")
+        .as_secs();
+    Duration::from_secs(now.saturating_sub(started))
 }
 
 fn current_rss_bytes() -> Result<u64, &'static str> {
@@ -2153,6 +2172,7 @@ fn cancellation_stops_merge_and_publication_before_more_work_is_committed() {
 #[test]
 #[ignore = "requires approved 128 GiB / 1 TiB Linux certification host"]
 fn certification_target_live_full_lifecycle_evidence() {
+    let elapsed_before_process = certification_elapsed_before_process();
     let started = Instant::now();
     let profile = load_certification_profile();
     let root = TempDir::new().expect("certification workspace");
@@ -2215,7 +2235,7 @@ fn certification_target_live_full_lifecycle_evidence() {
         "equivalence": { "source_project_fingerprint": lifecycle["source_project_fingerprint"], "imported_project_fingerprint": lifecycle["imported_project_fingerprint"] },
         "authority": { "source_fingerprint": lifecycle["source_authority_fingerprint"], "imported_fingerprint": lifecycle["imported_authority_fingerprint"] },
         "phases": phases,
-        "envelope": { "peak_rss_bytes": peak_rss, "peak_disk_bytes": peak_disk, "wall_time_s": started.elapsed().as_secs_f64() },
+        "envelope": { "peak_rss_bytes": peak_rss, "peak_disk_bytes": peak_disk, "wall_time_s": elapsed_before_process.saturating_add(started.elapsed()).as_secs_f64() },
         "result": "pass", "first_failure": null,
     });
     let out = PathBuf::from(std::env::var("GF_G500_CERT_EVIDENCE_OUT").expect("evidence output"));

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -253,7 +253,11 @@ struct MergeCounts {
 /// K-way merge of sorted runs. Emits each unique undirected pair exactly once
 /// in canonical sorted order and counts every dropped duplicate. Memory is
 /// `O(number_of_runs)`, not `O(total_edges)`.
-fn merge_runs<F: FnMut(u32, u32)>(runs: &[PathBuf], mut emit: F) -> MergeCounts {
+fn merge_runs<F: FnMut(u32, u32)>(
+    runs: &[PathBuf],
+    cancellation: Option<&AtomicBool>,
+    mut emit: F,
+) -> Result<MergeCounts, &'static str> {
     let mut readers: Vec<RunReader> = runs.iter().map(|p| RunReader::open(p)).collect();
     let mut heap: BinaryHeap<Reverse<(u32, u32, usize)>> = BinaryHeap::new();
     for (idx, reader) in readers.iter_mut().enumerate() {
@@ -266,6 +270,9 @@ fn merge_runs<F: FnMut(u32, u32)>(runs: &[PathBuf], mut emit: F) -> MergeCounts 
     let mut duplicates_rejected = 0u64;
     let mut last: Option<(u32, u32)> = None;
     while let Some(Reverse((src, dst, idx))) = heap.pop() {
+        if cancellation.is_some_and(|flag| flag.load(Ordering::SeqCst)) {
+            return Err("merge_cancelled");
+        }
         let pair = (src, dst);
         if Some(pair) == last {
             duplicates_rejected += 1;
@@ -279,10 +286,10 @@ fn merge_runs<F: FnMut(u32, u32)>(runs: &[PathBuf], mut emit: F) -> MergeCounts 
         }
     }
 
-    MergeCounts {
+    Ok(MergeCounts {
         live_unique_edges,
         duplicates_rejected,
-    }
+    })
 }
 
 /// Full reconciled generation summary for a rung.
@@ -323,11 +330,12 @@ fn bounded_generation(
     );
     let mut edges = Vec::new();
     let mut hasher = Sha256::new();
-    let merge = merge_runs(&spill.runs, |src, dst| {
+    let merge = merge_runs(&spill.runs, None, |src, dst| {
         hasher.update(src.to_le_bytes());
         hasher.update(dst.to_le_bytes());
         edges.push((src, dst));
-    });
+    })
+    .expect("bounded merge");
     let summary = GenSummary {
         raw_attempts: spill.raw_attempts,
         self_loops_rejected: spill.self_loops_rejected,
@@ -399,14 +407,15 @@ fn generate_target_live_runs(
         let compact_path = work.join(format!("accumulated-{window:04}.bin"));
         let mut writer = BufWriter::new(File::create(&compact_path).expect("create compact run"));
         let mut digest = Sha256::new();
-        let counts = merge_runs(&combined.runs, |src, dst| {
+        let counts = merge_runs(&combined.runs, Some(cancelled), |src, dst| {
             let src = src.to_le_bytes();
             let dst = dst.to_le_bytes();
             writer.write_all(&src).expect("write compact src");
             writer.write_all(&dst).expect("write compact dst");
             digest.update(src);
             digest.update(dst);
-        });
+        })
+        .expect("target-live merge was cancelled");
         writer.flush().expect("flush compact run");
         drop(writer);
         for obsolete in &combined.runs {
@@ -571,9 +580,10 @@ fn run_rung(
         let ingest_started = Instant::now();
         let graph = GraphForge::new(Some(project.to_str().expect("utf8 project")))
             .expect("open GraphForge for ingest");
-        publish_nodes(&graph, 1u64 << rung.scale);
-        let mut sink = EdgeSink::new(&graph);
-        let merge = merge_runs(&spill.runs, |src, dst| sink.push(src, dst));
+        publish_nodes(&graph, 1u64 << rung.scale, None);
+        let mut sink = EdgeSink::new(&graph, None);
+        let merge =
+            merge_runs(&spill.runs, None, |src, dst| sink.push(src, dst)).expect("rung merge");
         sink.flush();
         live_unique_edges = merge.live_unique_edges;
         duplicates_rejected = merge.duplicates_rejected;
@@ -739,15 +749,17 @@ fn run_ladder(profile: &ScaleProfile, env: RunEnvelope, rungs: &[Rung]) -> Vec<V
 
 struct EdgeSink<'a> {
     graph: &'a GraphForge,
+    cancellation: Option<&'a AtomicBool>,
     buf: Vec<(u32, u32)>,
     chunk_index: u128,
     hasher: Sha256,
 }
 
 impl<'a> EdgeSink<'a> {
-    fn new(graph: &'a GraphForge) -> Self {
+    fn new(graph: &'a GraphForge, cancellation: Option<&'a AtomicBool>) -> Self {
         EdgeSink {
             graph,
+            cancellation,
             buf: Vec::with_capacity(EDGE_PUBLISH_ROWS),
             chunk_index: 0,
             hasher: Sha256::new(),
@@ -755,6 +767,7 @@ impl<'a> EdgeSink<'a> {
     }
 
     fn push(&mut self, src: u32, dst: u32) {
+        self.check_cancellation();
         self.hasher.update(src.to_le_bytes());
         self.hasher.update(dst.to_le_bytes());
         self.buf.push((src, dst));
@@ -764,6 +777,7 @@ impl<'a> EdgeSink<'a> {
     }
 
     fn flush(&mut self) {
+        self.check_cancellation();
         if self.buf.is_empty() {
             return;
         }
@@ -771,6 +785,7 @@ impl<'a> EdgeSink<'a> {
         let mut batches = Vec::new();
         let mut offset = 0usize;
         while offset < self.buf.len() {
+            self.check_cancellation();
             let end = (offset + BATCH_ROWS).min(self.buf.len());
             let slice = &self.buf[offset..end];
             let mut edge_ids = Vec::with_capacity(slice.len());
@@ -814,6 +829,15 @@ impl<'a> EdgeSink<'a> {
         self.buf.clear();
     }
 
+    fn check_cancellation(&self) {
+        assert!(
+            !self
+                .cancellation
+                .is_some_and(|flag| flag.load(Ordering::SeqCst)),
+            "edge publication cancelled"
+        );
+    }
+
     fn finish(mut self) -> String {
         // Any residual edges must already be flushed by the caller.
         debug_assert!(self.buf.is_empty());
@@ -821,15 +845,23 @@ impl<'a> EdgeSink<'a> {
     }
 }
 
-fn publish_nodes(graph: &GraphForge, vertex_count: u64) {
+fn publish_nodes(graph: &GraphForge, vertex_count: u64, cancellation: Option<&AtomicBool>) {
     let total = usize::try_from(vertex_count).expect("vertex count fits usize");
     let schema = bulk_node_input_schema(Vec::new()).expect("node schema");
     let mut offset = 0usize;
     while offset < total {
+        assert!(
+            !cancellation.is_some_and(|flag| flag.load(Ordering::SeqCst)),
+            "node publication cancelled"
+        );
         let chunk_end = (offset + EDGE_PUBLISH_ROWS).min(total);
         let mut batches = Vec::new();
         let mut inner = offset;
         while inner < chunk_end {
+            assert!(
+                !cancellation.is_some_and(|flag| flag.load(Ordering::SeqCst)),
+                "node publication cancelled"
+            );
             let end = (inner + BATCH_ROWS).min(chunk_end);
             let count = end - inner;
             let ids = (inner..end)
@@ -1633,6 +1665,51 @@ fn authority_fingerprint(graph: &GraphForge) -> String {
     format!("sha256:{}", hex_encode(hasher.finalize()))
 }
 
+fn current_generation_uuid(graph: &GraphForge) -> Uuid {
+    let capabilities = graph.project_capabilities().expect("project capabilities");
+    let batch = capabilities
+        .batches
+        .first()
+        .expect("project capabilities contain a generation identity");
+    let generations = batch
+        .column(4)
+        .as_any()
+        .downcast_ref::<FixedSizeBinaryArray>()
+        .expect("generation_uuid capability column");
+    let mut bytes = [0_u8; 16];
+    bytes.copy_from_slice(generations.value(0));
+    Uuid::from_bytes(bytes)
+}
+
+fn create_bounded_drill_package(root: &Path, limits: PortableV2Limits) -> (PathBuf, String) {
+    let project = root.join("drill-source");
+    let package = root.join("drill.gfpb");
+    fs::create_dir_all(&project).expect("bounded drill project");
+    let graph = GraphForge::new(project.to_str()).expect("open bounded drill project");
+    publish_nodes(&graph, 8, None);
+    let mut sink = EdgeSink::new(&graph, None);
+    for edge in [(0, 1), (1, 2), (2, 3), (3, 4)] {
+        sink.push(edge.0, edge.1);
+    }
+    sink.flush();
+    let _ = sink.finish();
+    let receipt = graph
+        .export_portable_v2(
+            &PortableV2ExportRequest {
+                selection: PortableSelection::Current,
+                output_path: package.clone(),
+                representation: PortableV2Output::Bundle,
+                profile: PortableV2SelectionProfile::Complete,
+                subset: None,
+                limits,
+            },
+            None,
+            |_| {},
+        )
+        .expect("export bounded drill package");
+    (package, receipt.package_digest)
+}
+
 #[allow(clippy::too_many_lines)]
 fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value {
     let source = root.join("source");
@@ -1709,23 +1786,27 @@ fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value 
         || target_live_fingerprint.expect("target-live payload fingerprint"),
         |value| value.input_fingerprint.clone(),
     );
-    journal.pass("generate", phase, Some(generation_fingerprint));
+    journal.pass("generate", phase, Some(generation_fingerprint.clone()));
 
     let phase = Instant::now();
     let graph = GraphForge::new(source.to_str()).expect("open certification source");
-    publish_nodes(&graph, 1u64 << scale);
-    let mut sink = EdgeSink::new(&graph);
+    publish_nodes(&graph, 1u64 << scale, Some(journal.cancellation()));
+    let mut sink = EdgeSink::new(&graph, Some(journal.cancellation()));
     if let Some(edges) = edges {
         for (src, dst) in edges {
             sink.push(src, dst);
         }
     } else {
-        merge_runs(&spills.as_ref().expect("target spills").runs, |src, dst| {
-            sink.push(src, dst);
-        });
+        merge_runs(
+            &spills.as_ref().expect("target spills").runs,
+            Some(journal.cancellation()),
+            |src, dst| sink.push(src, dst),
+        )
+        .expect("certification merge was cancelled");
     }
     sink.flush();
     let input_fingerprint = format!("sha256:{}", sink.finish());
+    assert_eq!(input_fingerprint, generation_fingerprint);
     journal.pass("ingest", phase, Some(input_fingerprint));
 
     let phase = Instant::now();
@@ -1744,6 +1825,16 @@ fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value 
     let graph = GraphForge::new(source.to_str()).expect("reopen source");
     let source_nodes = graph.node_count(NODE_LABEL).expect("source nodes");
     let source_edges = scalar_count(&graph.execute(COUNT_EDGES).expect("source edges"));
+    let expected_live_edges = generated_counts.as_ref().map_or_else(
+        || {
+            summary
+                .as_ref()
+                .expect("bounded generation summary")
+                .live_unique_edges
+        },
+        |counts| counts.live_unique_edges,
+    );
+    assert_eq!(source_edges, expected_live_edges);
     journal.pass("source_reopen", phase, None);
     let phase = Instant::now();
     let source_1hop = result_fingerprint(&graph.execute(ONE_HOP).expect("source 1hop"));
@@ -1751,6 +1842,7 @@ fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value 
     let phase = Instant::now();
     let source_2hop = result_fingerprint(&graph.execute(TWO_HOP).expect("source 2hop"));
     let source_authority_fingerprint = authority_fingerprint(&graph);
+    let source_generation = current_generation_uuid(&graph);
     journal.pass("source_query_2hop", phase, Some(source_2hop.clone()));
 
     let phase = Instant::now();
@@ -1768,6 +1860,7 @@ fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value 
             |_| {},
         )
         .expect("portable-v2 export");
+    assert_eq!(source_generation, exported.generation_uuid);
     journal.pass("export", phase, Some(exported.package_digest.clone()));
     let phase = Instant::now();
     let verified = verify_portable_v2(
@@ -1819,6 +1912,10 @@ fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value 
     let phase = Instant::now();
     let imported_2hop = result_fingerprint(&imported_graph.execute(TWO_HOP).expect("import 2hop"));
     let imported_authority_fingerprint = authority_fingerprint(&imported_graph);
+    assert_eq!(
+        current_generation_uuid(&imported_graph),
+        imported_receipt.generation_uuid
+    );
     assert_eq!(source_2hop, imported_2hop);
     assert_eq!(source_authority_fingerprint, imported_authority_fingerprint);
     journal.pass("imported_query_2hop", phase, Some(imported_2hop.clone()));
@@ -1826,8 +1923,19 @@ fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value 
     // Representative drills use the same verifier/import boundaries but never
     // repeat the billion-edge payload.
     let phase = Instant::now();
+    let (drill_package, drill_digest) = create_bounded_drill_package(root, limits);
+    let drill_verified = verify_portable_v2(
+        &PortableVerifyRequest {
+            input: drill_package.clone(),
+            mode: PortableV2Mode::Full,
+            limits,
+        },
+        None,
+    )
+    .expect("bounded drill package verifies before mutation");
+    assert_eq!(drill_verified.package_digest, drill_digest);
     let corrupt = root.join("corrupt.gfpb");
-    fs::copy(&package, &corrupt).expect("copy corrupt drill");
+    fs::copy(&drill_package, &corrupt).expect("copy bounded corrupt drill");
     {
         let mut file = fs::OpenOptions::new()
             .append(true)
@@ -1853,7 +1961,7 @@ fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value 
     assert!(
         verify_portable_v2(
             &PortableVerifyRequest {
-                input: package.clone(),
+                input: drill_package.clone(),
                 mode: PortableV2Mode::Full,
                 limits
             },
@@ -1870,7 +1978,7 @@ fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value 
     assert!(
         verify_portable_v2(
             &PortableVerifyRequest {
-                input: package.clone(),
+                input: drill_package.clone(),
                 mode: PortableV2Mode::Full,
                 limits: tiny
             },
@@ -1885,7 +1993,7 @@ fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value 
         GraphForge::import_portable_v2(
             &interrupted,
             &PortableV2ImportRequest {
-                input: package,
+                input: drill_package,
                 operation_id: OperationId(uuidv7(0x746)),
                 limits,
             },
@@ -1984,10 +2092,11 @@ fn target_live_windows_are_deterministic_bounded_and_reconciled() {
             &cancelled,
         );
         let mut digest = Sha256::new();
-        let replay = merge_runs(&spills.runs, |src, dst| {
+        let replay = merge_runs(&spills.runs, Some(&cancelled), |src, dst| {
             digest.update(src.to_le_bytes());
             digest.update(dst.to_le_bytes());
-        });
+        })
+        .expect("replay merge");
         assert_eq!(counts.live_unique_edges, replay.live_unique_edges);
         assert_eq!(
             spills.raw_attempts,
@@ -2002,6 +2111,43 @@ fn target_live_windows_are_deterministic_bounded_and_reconciled() {
         (counts.live_unique_edges, generated_fingerprint)
     };
     assert_eq!(run(first.path()), run(second.path()));
+}
+
+#[test]
+fn cancellation_stops_merge_and_publication_before_more_work_is_committed() {
+    let profile = load_profile();
+    let spill_root = TempDir::new().expect("cancellation spill root");
+    let spill = generate_spill_runs(
+        8,
+        4,
+        profile.initiator,
+        profile.seed,
+        64,
+        spill_root.path(),
+        None,
+    );
+    let cancelled = AtomicBool::new(true);
+    let mut emitted = 0_u64;
+    assert!(matches!(
+        merge_runs(&spill.runs, Some(&cancelled), |_, _| emitted += 1),
+        Err("merge_cancelled")
+    ));
+    assert_eq!(emitted, 0);
+
+    let project = TempDir::new().expect("cancelled publication project");
+    let graph = GraphForge::new(project.path().to_str()).expect("open publication project");
+    let before = current_generation_uuid(&graph);
+    let stopped = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        publish_nodes(&graph, 8, Some(&cancelled));
+    }));
+    assert!(stopped.is_err());
+    assert_eq!(current_generation_uuid(&graph), before);
+    assert_eq!(
+        graph
+            .node_count(NODE_LABEL)
+            .expect("node count after cancellation"),
+        0
+    );
 }
 
 #[test]
@@ -2043,7 +2189,9 @@ fn certification_target_live_full_lifecycle_evidence() {
         },
         "host": {
             "provider": std::env::var("GF_G500_CERT_PROVIDER").expect("approved provider input"),
+            "region": std::env::var("GF_G500_CERT_REGION").expect("approved region input"),
             "sku": std::env::var("GF_G500_CERT_SKU").expect("approved SKU input"),
+            "os_image": std::env::var("GF_G500_CERT_OS_IMAGE").expect("approved OS image input"),
             "os": command_text("uname", &["-s"]),
             "kernel": command_text("uname", &["-r"]),
             "filesystem": normalized_filesystem(root.path()),

--- a/docs/development/evidence/g500-certification.schema.json
+++ b/docs/development/evidence/g500-certification.schema.json
@@ -12,13 +12,15 @@
     "run": { "type": "object", "additionalProperties": false, "required": ["command", "scale", "edgefactor", "seed", "directionality", "self_loops", "duplicates"], "properties": { "command": { "const": "cargo test -p graphforge-api --release --test scale_g500_ladder certification_target_live_full_lifecycle_evidence -- --ignored --exact --nocapture --test-threads=1" }, "scale": { "const": 26 }, "edgefactor": { "const": 16 }, "seed": { "const": 1 }, "directionality": { "const": "undirected" }, "self_loops": { "const": "drop" }, "duplicates": { "const": "drop" } } },
     "host": {
       "type": "object", "additionalProperties": false,
-      "required": ["provider", "sku", "os", "kernel", "filesystem", "memory_bytes", "nvme_bytes"],
+      "required": ["provider", "region", "sku", "os_image", "os", "kernel", "filesystem", "memory_bytes", "nvme_bytes"],
       "properties": {
-        "provider": { "type": "string", "minLength": 1, "maxLength": 64 },
-        "sku": { "type": "string", "minLength": 1, "maxLength": 128 },
-        "os": { "type": "string", "pattern": "^Linux" },
+        "provider": { "type": "string", "minLength": 1, "maxLength": 64, "description": "Provisioned cloud provider; never local or a mutable resource identifier." },
+        "region": { "type": "string", "minLength": 1, "maxLength": 64, "pattern": "^[A-Za-z0-9._-]+$", "description": "Exact provider region approved for this run." },
+        "sku": { "type": "string", "minLength": 1, "maxLength": 128, "description": "Exact provisioned machine SKU approved for this run." },
+        "os_image": { "type": "string", "minLength": 1, "maxLength": 256, "description": "Immutable Linux image identity including its resolved version; moving aliases are invalid." },
+        "os": { "type": "string", "pattern": "^Linux", "description": "Observed Linux OS family from the provisioned host." },
         "kernel": { "type": "string", "minLength": 1, "maxLength": 128 },
-        "filesystem": { "enum": ["ext4", "xfs", "btrfs"] },
+        "filesystem": { "enum": ["ext4", "xfs", "btrfs"], "description": "Filesystem of the Rust process temp workspace; provisioning proves it is the same local-NVMe device as RUNNER_TEMP." },
         "memory_bytes": { "type": "integer", "minimum": 137438953472 },
         "nvme_bytes": { "type": "integer", "minimum": 1099511627776 }
       }

--- a/docs/development/g500-certification.md
+++ b/docs/development/g500-certification.md
@@ -61,11 +61,12 @@ unique edges.
    immediate teardown. Never retain
    the project, portable bundle, credentials, registry tokens, or spill files.
 
-The workflow has a four-hour outer timeout, and measured certification wall time
-must remain at or below the same 14,400-second product envelope. Both test
-commands, including compilation, share that window and therefore need explicit
-headroom. Provisioning happens before dispatch but remains inside the separately
-approved five-hour billed-resource TTL.
+The workflow records one start timestamp before either test command. The bounded
+preflight and full SCALE26 lifecycle share the 14,400-second product envelope;
+the Rust watchdog includes time already spent in preflight. The job has a
+270-minute outer timeout, leaving 30 minutes after the product fail-safe for
+validation and artifact upload. Provisioning happens before dispatch but remains
+inside the separately approved five-hour billed-resource TTL.
 
 An in-process watchdog samples Linux
 resident memory every 250 ms and allocated workspace bytes every five seconds,

--- a/docs/development/g500-certification.md
+++ b/docs/development/g500-certification.md
@@ -6,6 +6,29 @@ provisioned Linux evidence host. The workflow is manual, protected by the
 A maintainer must approve the provider, exact SKU, ephemeral runner label, cost,
 and teardown before dispatch.
 
+The approved SUT record is immutable for a run. Separate evidence fields record
+provider, region, SKU, and the full Linux image identity with resolved version
+(never a moving `latest` alias); observed fields record OS, kernel, filesystem,
+memory, and local-NVMe capacity. The private provisioning record also retains
+vCPU/NVMe inventory, runner version, and pinned GraphForge toolchain versions.
+Neither record adds absolute host paths or mutable cloud resource identifiers.
+
+## No-spend readiness gate
+
+All checks before explicit cost approval are read-only: confirm the authenticated
+subscription, role, provider-registration state, regional SKU restrictions,
+regional vCPU quota, current on-demand price, GitHub environment policy, and
+unique runner-label availability. Do not register a provider, request quota,
+create resources, generate a runner registration token, or dispatch the workflow
+during this gate.
+
+The approval record names the exact provider/region/SKU/image version,
+on-demand price estimate, hard total spend ceiling, five-hour infrastructure
+TTL, teardown owner, and permission to register required providers and destroy
+the exact ephemeral resources. Spot/low-priority capacity is not valid: an
+uncontrolled eviction cannot be distinguished from the required cancellation
+and interrupted-finalization drills.
+
 The committed profile fixes SCALE 26, seed 1, the Graph500/R-MAT initiator,
 undirected canonicalization, and a **target-live** stopping rule. Deterministic
 attempt windows are externally sorted and merged until a complete merge proves
@@ -16,17 +39,35 @@ unique edges.
 ## Dispatch and abort policy
 
 1. Freeze the exact commit after normal PR CI is green.
-2. Provision a fresh Linux host with at least 128 GiB RAM and 1 TiB local NVMe
-   formatted as ext4, XFS, or Btrfs. Register it with one unique runner label.
-3. Configure required reviewers on the `scale-certification` environment.
-4. Dispatch `Billion-edge certification` with the exact 40-character SHA,
-   runner label, provider, and SKU. Branch names and moving refs are rejected.
-5. Do not retry an unchanged failing tree. Preserve the partial phase journal,
+2. After approval, provision a fresh Linux host with more than 128 GiB
+   advertised RAM (so guest `MemTotal` still clears 128 GiB) and at least 1 TiB
+   local NVMe. Format one local NVMe filesystem as XFS and mount it for the
+   runner's temp and work roots. Durable managed data disks are not substitutes.
+3. Configure the runner service so process `TMPDIR` and GitHub `RUNNER_TEMP`
+   resolve to directories on that same filesystem. Before registration, prove
+   resolved filesystem type, device identity, capacity, and a write/fsync probe;
+   retain paths only in the private provisioning log, never evidence.
+4. Register a repository-scoped ephemeral runner with one unique label. Do not
+   reuse a runner work directory, label, or cloud disk from another attempt.
+5. Configure required reviewers on the `scale-certification` environment.
+6. Dispatch `Billion-edge certification` with the exact 40-character SHA,
+   runner label, provider, region, SKU, and exact OS image identity. Branch
+   names, moving refs, and moving image aliases are rejected.
+7. Do not retry an unchanged failing tree. Preserve the partial phase journal,
    identify the first failed phase, repair the root cause, and certify a new SHA.
-6. Deregister and destroy the host after artifacts are uploaded. Never retain
+8. After both sanitized artifacts upload and validate, deregister the runner and
+   destroy the exact VM, OS disk, NIC, public IP, and resource group created for
+   the run. The independent five-hour TTL is a backstop, not a substitute for
+   immediate teardown. Never retain
    the project, portable bundle, credentials, registry tokens, or spill files.
 
-The workflow has a four-hour outer timeout. An in-process watchdog samples Linux
+The workflow has a four-hour outer timeout, and measured certification wall time
+must remain at or below the same 14,400-second product envelope. Both test
+commands, including compilation, share that window and therefore need explicit
+headroom. Provisioning happens before dispatch but remains inside the separately
+approved five-hour billed-resource TTL.
+
+An in-process watchdog samples Linux
 resident memory every 250 ms and allocated workspace bytes every five seconds,
 sets the shared cooperative-cancellation token on the first RSS, disk, or time
 breach, and records a typed failure at the affected phase. The Rust journal is
@@ -42,6 +83,21 @@ portable-v2 bundle export, full verification, atomic import, imported reopen and
 matching observations, plus representative corruption, cancellation, resource
 limit, and interrupted-finalization drills. Source generation, semantic package,
 transport, and imported generation identities remain distinct and reconciled.
+
+Negative drills use representative bounded data, not a second billion-edge
+payload. Each records its own elapsed/RSS/disk observation and typed outcome:
+corruption is rejected before import mutation; cancellation leaves no published
+partial generation; a resource limit stops at the first breach; and interrupted
+finalization recovers only the last acknowledged durable generation. No partial
+candidate may be addressable, and the last complete atomic journal entry remains
+valid.
+
+Fingerprint reconciliation is explicit: source and imported durable generation
+IDs are distinct; semantic package and transport digests are distinct;
+ontology/capability authority fingerprints match; canonical source/imported
+project fingerprints match; and source/imported 1-hop and 2-hop query
+fingerprints match. Integrity and compatibility verification occurs before any
+clean-import mutation.
 
 Only the sanitized JSON evidence and phase journal may be downloaded and checked
 in. The schema and semantic validator reject missing phases, count or authority

--- a/docs/development/perf-g500-ladder.md
+++ b/docs/development/perf-g500-ladder.md
@@ -66,11 +66,32 @@ hard-code rungs elsewhere.
 | Host capacity | **128 GiB** peak RSS, **1 TiB** local NVMe (declared **Linux cloud** SKU) |
 | Wall-clock fail-safe | **4 h** (`timeout_s: 14400`) end-to-end on that SKU — provisional #745 budget, not a laptop or “overnight is fine” product claim |
 
+Before any provisioned rung, complete the read-only/no-spend checks from the
+[certification runbook](g500-certification.md): subscription and role, provider
+registration state, regional SKU restrictions and quota, current on-demand
+price, protected environment, and unique runner-label availability. Provider
+registration, quota requests, runner-token generation, provisioning, and
+dispatch require recorded resource and spend authorization.
+
+The declared certification filesystem is the filesystem the Rust process
+actually uses. Configure process `TMPDIR` and GitHub `RUNNER_TEMP` on the same
+local-NVMe XFS mount and verify their resolved filesystem/device identity before
+dispatch. Merely attaching NVMe or checking a different runner directory is not
+capacity evidence. Absolute paths stay in the private provisioning log and are
+excluded from sanitized evidence.
+
 The **S10** rung runs in normal CI and deliberately sets `buffer_edges` below
 its own edge count, so the spill/merge path is exercised on every run. S20–S26
 are `#[ignore]` and opt-in on **provisioned Linux cloud / evidence hosts**
 only. Developer laptops (including macOS Air-class machines) must not be used
 as #745 certification SUTs; local runs are dry-runs at best.
+
+Record the full provider/region/SKU and immutable Linux image version for every
+provisioned observation. Use on-demand capacity with a unique ephemeral runner;
+an eviction-prone Spot/low-priority host cannot provide controlled cancellation
+or wall-time evidence. A five-hour infrastructure TTL bounds billing and
+cleanup, while the product certification must still finish within 14,400
+seconds.
 
 ## First-fail ladder
 

--- a/scripts/ci/test-validate-g500-certification.py
+++ b/scripts/ci/test-validate-g500-certification.py
@@ -47,8 +47,10 @@ def evidence():
             "duplicates": "drop",
         },
         "host": {
-            "provider": "example",
-            "sku": "cert",
+            "provider": "Microsoft Azure",
+            "region": "eastus",
+            "sku": "Standard_L64s_v3",
+            "os_image": "Canonical:ubuntu-24_04-lts:server:24.04.202608010",
             "os": "Linux",
             "kernel": "6",
             "filesystem": "xfs",
@@ -121,6 +123,15 @@ def test_accepts_complete_sanitized_evidence():
         "capacity",
         "failed_result",
         "missing_node_count",
+        "extra_top_level",
+        "duplicate_phase",
+        "extra_phase",
+        "out_of_order_phase",
+        "placeholder_sku",
+        "placeholder_region",
+        "mutable_os_image",
+        "provider_whitespace",
+        "malformed_kernel",
     ],
 )
 def test_rejects_incomplete_or_unsafe_evidence(mutation):
@@ -163,6 +174,33 @@ def test_rejects_incomplete_or_unsafe_evidence(mutation):
         value["first_failure"] = "generate"
     if mutation == "missing_node_count":
         value["counts"].pop("source_nodes")
+    if mutation == "extra_top_level":
+        value["unexpected"] = True
+    if mutation == "duplicate_phase":
+        value["phases"][-1]["id"] = value["phases"][-2]["id"]
+    if mutation == "extra_phase":
+        value["phases"].append(
+            {
+                "id": "surprise",
+                "status": "pass",
+                "elapsed_ms": 1,
+                "rss_peak_bytes": 1,
+                "disk_peak_bytes": 1,
+                "fingerprint": DIGEST_A,
+            }
+        )
+    if mutation == "out_of_order_phase":
+        value["phases"][0], value["phases"][1] = value["phases"][1], value["phases"][0]
+    if mutation == "placeholder_sku":
+        value["host"]["sku"] = "default"
+    if mutation == "placeholder_region":
+        value["host"]["region"] = "global"
+    if mutation == "mutable_os_image":
+        value["host"]["os_image"] = "Canonical:ubuntu:server:latest"
+    if mutation == "provider_whitespace":
+        value["host"]["provider"] = " Microsoft Azure"
+    if mutation == "malformed_kernel":
+        value["host"]["kernel"] = "6.8.0\nforged"
     with pytest.raises(VALIDATOR.EvidenceError):
         VALIDATOR.validate(value, SHA)
 

--- a/scripts/ci/validate-g500-certification.py
+++ b/scripts/ci/validate-g500-certification.py
@@ -10,6 +10,9 @@ from pathlib import Path
 import re
 from typing import Any
 
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError, ValidationError
+
 REQUIRED_PHASES = (
     "preflight",
     "generate",
@@ -33,6 +36,7 @@ FORBIDDEN_KEY = re.compile(r"(secret|credential|token|password|host_path|absolut
 ABSOLUTE_PATH = re.compile(r"(?:^|[\s=:])(?:/|[A-Za-z]:[\\/])")
 ROOT = Path(__file__).resolve().parents[2]
 PROFILE = ROOT / "crates/graphforge-api/tests/fixtures/scale_g500_certification.v1.json"
+SCHEMA = ROOT / "docs/development/evidence/g500-certification.schema.json"
 RUN_COMMAND = (
     "cargo test -p graphforge-api --release --test scale_g500_ladder "
     "certification_target_live_full_lifecycle_evidence -- --ignored --exact "
@@ -42,6 +46,18 @@ RUN_COMMAND = (
 
 class EvidenceError(ValueError):
     pass
+
+
+def validate_schema(evidence: dict[str, Any]) -> None:
+    try:
+        contract = json.loads(SCHEMA.read_text(encoding="utf-8"))
+        Draft202012Validator.check_schema(contract)
+        Draft202012Validator(contract).validate(evidence)
+    except (OSError, json.JSONDecodeError, SchemaError) as error:
+        raise EvidenceError(f"committed evidence schema is invalid: {error}") from error
+    except ValidationError as error:
+        location = ".".join(str(item) for item in error.absolute_path) or "$"
+        raise EvidenceError(f"evidence schema violation at {location}: {error.message}") from error
 
 
 def require_mapping(evidence: dict[str, Any], key: str, fields: tuple[str, ...]) -> dict[str, Any]:
@@ -68,6 +84,7 @@ def reject_sensitive(value: Any, trail: str = "$") -> None:
 
 
 def validate(evidence: dict[str, Any], expected_sha: str | None) -> None:
+    validate_schema(evidence)
     reject_sensitive(evidence)
     if evidence.get("schema") != "graphforge-billion-edge-certification-evidence/1":
         raise EvidenceError("unsupported evidence schema")
@@ -154,6 +171,16 @@ def validate(evidence: dict[str, Any], expected_sha: str | None) -> None:
     phases = evidence.get("phases")
     if not isinstance(phases, list):
         raise EvidenceError("phases must be an array")
+    phase_ids = [phase.get("id") for phase in phases if isinstance(phase, dict)]
+    if len(phase_ids) != len(phases):
+        raise EvidenceError("every phase must be an object with an id")
+    if len(set(phase_ids)) != len(phase_ids):
+        raise EvidenceError("duplicate phase ids are forbidden")
+    extras = [phase for phase in phase_ids if phase not in REQUIRED_PHASES]
+    if extras:
+        raise EvidenceError("unexpected phases: " + ", ".join(str(phase) for phase in extras))
+    if tuple(phase_ids) != REQUIRED_PHASES:
+        raise EvidenceError("phases must use the required lifecycle order")
     by_id = {phase.get("id"): phase for phase in phases if isinstance(phase, dict)}
     missing = [phase for phase in REQUIRED_PHASES if phase not in by_id]
     if missing:
@@ -173,10 +200,39 @@ def validate(evidence: dict[str, Any], expected_sha: str | None) -> None:
     if envelope.get("wall_time_s", 2**64) > 14_400:
         raise EvidenceError("wall-time envelope exceeded")
     host = evidence.get("host", {})
-    if not str(host.get("os", "")).startswith("Linux"):
+    if host.get("os") != "Linux":
         raise EvidenceError("certification host must be Linux")
-    if str(host.get("provider", "")).lower() in {"local", "localhost", "developer"}:
+    provider = str(host.get("provider", "")).strip()
+    region = str(host.get("region", "")).strip()
+    sku = str(host.get("sku", "")).strip()
+    os_image = str(host.get("os_image", "")).strip()
+    placeholders = {"", "local", "localhost", "developer", "example", "generic", "test", "unknown"}
+    if provider.casefold() in placeholders:
         raise EvidenceError("certification provider must identify provisioned infrastructure")
+    if region.casefold() in placeholders | {"default", "global"}:
+        raise EvidenceError("certification region must identify the exact provisioned region")
+    if sku.casefold() in placeholders or sku.casefold() == "default":
+        raise EvidenceError("certification SKU must identify the exact provisioned machine class")
+    if os_image.casefold() in placeholders | {"default", "latest"} or os_image.casefold().endswith(
+        ":latest"
+    ):
+        raise EvidenceError("certification OS image must be an immutable resolved identity")
+    declared = (provider, region, sku, os_image)
+    observed = tuple(host.get(key) for key in ("provider", "region", "sku", "os_image"))
+    if declared != observed:
+        raise EvidenceError(
+            "provider, region, SKU, and OS image must not contain surrounding whitespace"
+        )
+    if re.fullmatch(r"[0-9A-Za-z][0-9A-Za-z ._+:/()-]*", provider) is None:
+        raise EvidenceError("certification provider contains unsupported characters")
+    if re.fullmatch(r"[0-9A-Za-z][0-9A-Za-z._+-]*", region) is None:
+        raise EvidenceError("certification region contains unsupported characters")
+    if re.fullmatch(r"[0-9A-Za-z][0-9A-Za-z ._+:/()-]*", sku) is None:
+        raise EvidenceError("certification SKU contains unsupported characters")
+    if re.fullmatch(r"[0-9A-Za-z][0-9A-Za-z ._+:/()@-]*", os_image) is None:
+        raise EvidenceError("certification OS image contains unsupported characters")
+    if re.fullmatch(r"[0-9A-Za-z._+-]+", str(host.get("kernel", ""))) is None:
+        raise EvidenceError("host kernel release is malformed")
     if (
         host.get("memory_bytes", 0) < 137_438_953_472
         or host.get("nvme_bytes", 0) < 1_099_511_627_776


### PR DESCRIPTION
## Summary

- bind the certification workspace to the attested local-NVMe runner filesystem
- measure bounded preflight and SCALE26 under one four-hour product clock while preserving validation/upload headroom
- add cooperative cancellation checkpoints and bounded negative-drill packages
- reconcile generation/ingest and round-trip identities
- validate evidence against the committed JSON Schema with exact phase and structured host identity checks
- document no-spend readiness, ephemeral runner, TTL, and teardown requirements

## Validation

- `cargo fmt --all -- --check`
- `uv run --frozen --with jsonschema==4.26.0 --with pytest python -m pytest -q scripts/ci/test-validate-g500-certification.py` (29 passed)
- focused Rust lifecycle, cancellation, deterministic target-live, and profile tests
- `make pre-push-fast`

## Scope

This PR makes the protected run safe to dispatch. Azure resources and SCALE26 execution remain outside this repair; the separate #745 close gate stays open.

Closes #880