### PR TITLE
test(scale): qualify Fly filesystem exact path

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.venv
+target
+bazel-*
+build
+dist
+node_modules
+*.env
+.env*
+*.pem
+*.key
+fly-qualification-evidence.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Test CodSpeed nightly policy
         run: python3 scripts/ci/test-codspeed-nightly.py
 
+      - name: Test Fly qualification safety contract
+        run: python3 scripts/ci/test-fly-filesystem-safety-contract.py
+
       - name: Test Repository Policy suite classifier
         run: scripts/ci/test-classify-policy-suites.sh
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -166,7 +166,10 @@ build_test(
 # Deterministic CI target groups (#8 / #1 step 5).
 test_suite(
     name = "unit_tests",
-    tests = [":first_party_lib_tests"],
+    tests = [
+        ":first_party_lib_tests",
+        "//crates/graphforge-api:graphforge_fly_filesystem_smoke_test",
+    ],
 )
 
 test_suite(

--- a/containers/fly-filesystem-qualification/Dockerfile
+++ b/containers/fly-filesystem-qualification/Dockerfile
@@ -1,0 +1,12 @@
+FROM rust:1.90-bookworm AS build
+WORKDIR /source
+COPY . .
+RUN cargo build --locked --release -p graphforge-api --bin graphforge-fly-filesystem-smoke
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates coreutils \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=build /source/target/release/graphforge-fly-filesystem-smoke /usr/local/bin/graphforge-fly-filesystem-smoke
+COPY containers/fly-filesystem-qualification/run-smoke.sh /usr/local/bin/run-fly-filesystem-smoke
+RUN chmod 0555 /usr/local/bin/run-fly-filesystem-smoke /usr/local/bin/graphforge-fly-filesystem-smoke
+ENTRYPOINT ["/usr/local/bin/run-fly-filesystem-smoke"]

--- a/containers/fly-filesystem-qualification/run-smoke.sh
+++ b/containers/fly-filesystem-qualification/run-smoke.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -u
+
+evidence=/work/fly-qualification-evidence.json
+ack=/work/controller-ack
+rm -f "$ack" "$evidence"
+export TMPDIR=/work
+
+set +e
+timeout --signal=TERM --kill-after=30s 930s \
+  /usr/local/bin/graphforge-fly-filesystem-smoke \
+  --work-root /work --evidence-out "$evidence" --timeout-s 900
+status=$?
+set -e
+
+# Keep the auto-destroy Machine available only long enough for retrieval.
+remaining=300
+while [ ! -f "$ack" ] && [ "$remaining" -gt 0 ]; do
+  sleep 1
+  remaining=$((remaining - 1))
+done
+exit "$status"

--- a/containers/fly-filesystem-qualification/run-smoke.sh
+++ b/containers/fly-filesystem-qualification/run-smoke.sh
@@ -1,11 +1,19 @@
 #!/bin/sh
-set -u
+set -eu
 
 evidence=/work/fly-qualification-evidence.json
 ack=/work/controller-ack
-rm -f "$ack" "$evidence"
+temporary=/work/.fly-qualification-evidence.json.tmp
+if [ "$(stat -c %d /work)" = "$(stat -c %d /)" ]; then
+  echo "qualification work root is not an attached mount" >&2
+  exit 3
+fi
+rm -f "$ack" "$evidence" "$temporary"
 export TMPDIR=/work
 
+# Budget chain: 900s probe, 930s TERM backstop plus 30s KILL grace, then a
+# 300s evidence-ack wait. The controller retrieval window must cover the probe
+# and grace; cleanup remains the final bounded backstop.
 set +e
 timeout --signal=TERM --kill-after=30s 930s \
   /usr/local/bin/graphforge-fly-filesystem-smoke \

--- a/crates/graphforge-api/BUILD.bazel
+++ b/crates/graphforge-api/BUILD.bazel
@@ -600,3 +600,9 @@ build_test(
     name = "api_example_bins",
     targets = [":%s" % name for name in _EXAMPLE_NAMES],
 )
+
+gf_rust_binary(
+    name = "graphforge-fly-filesystem-smoke",
+    srcs = ["src/bin/graphforge-fly-filesystem-smoke.rs"],
+    deps = _API_DEPS + [":graphforge_api"],
+)

--- a/crates/graphforge-api/BUILD.bazel
+++ b/crates/graphforge-api/BUILD.bazel
@@ -606,3 +606,10 @@ gf_rust_binary(
     srcs = ["src/bin/graphforge-fly-filesystem-smoke.rs"],
     deps = _API_DEPS + [":graphforge_api"],
 )
+
+gf_rust_integration_test(
+    name = "graphforge_fly_filesystem_smoke_test",
+    srcs = ["src/bin/graphforge-fly-filesystem-smoke.rs"],
+    crate = ":graphforge_api",
+    deps = _API_DEPS,
+)

--- a/crates/graphforge-api/src/bin/graphforge-fly-filesystem-smoke.rs
+++ b/crates/graphforge-api/src/bin/graphforge-fly-filesystem-smoke.rs
@@ -1,0 +1,520 @@
+//! Exact-path durable filesystem qualification for provisioned Fly Machines.
+
+use std::collections::HashMap;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+use graphforge_api::{
+    GfError, GraphForge, OperationId, PortableSelection, PortableV2ExportRequest,
+    PortableV2ImportRequest, PortableV2Limits, PortableV2Mode, PortableV2Output,
+    PortableV2SelectionProfile, PortableVerifyRequest, PropValue, verify_portable_v2,
+};
+use graphforge_core::uuid::Uuid;
+use serde::Serialize;
+
+const SCHEMA: &str = "graphforge-fly-filesystem-qualification/1";
+const PROJECT_NAME: &str = ".graphforge-fly-filesystem-qualification-project";
+
+#[derive(Debug)]
+struct Config {
+    work_root: PathBuf,
+    evidence_out: PathBuf,
+    timeout: Duration,
+    git_sha: String,
+    image_digest: String,
+    region: String,
+}
+
+#[derive(Debug, Serialize)]
+struct Evidence {
+    schema: &'static str,
+    git_sha: String,
+    image_digest: String,
+    provider: &'static str,
+    region: String,
+    host: Host,
+    volume: Volume,
+    admission: Admission,
+    result: &'static str,
+    full_run_authorized: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct Host {
+    os: &'static str,
+    filesystem: String,
+    memory_bytes: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct Volume {
+    mount_role: &'static str,
+    capacity_bytes: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct Admission {
+    status: &'static str,
+    code: Option<String>,
+    cause: Option<String>,
+}
+
+fn main() {
+    let config = parse_config(std::env::args_os().skip(1))
+        .and_then(validate_paths)
+        .unwrap_or_else(|cause| {
+            eprintln!("qualification configuration rejected: {cause}");
+            std::process::exit(2);
+        });
+    let output = config.evidence_out.clone();
+    let timeout = config.timeout;
+    let metadata = (
+        config.git_sha.clone(),
+        config.image_digest.clone(),
+        config.region.clone(),
+    );
+    let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+    std::thread::spawn(move || {
+        let _ = sender.send(qualify(&config));
+    });
+    let evidence = receiver
+        .recv_timeout(timeout)
+        .unwrap_or_else(|_| failed(metadata, "unproven", 1, 1, "GF_RESOURCE_LIMIT", "timeout"));
+    let encoded = serde_json::to_vec(&evidence).expect("serialize evidence");
+    if write_evidence(&output, &encoded).is_err() {
+        eprintln!("qualification evidence write failed");
+        std::process::exit(1);
+    }
+    println!("{}", String::from_utf8(encoded).expect("JSON is UTF-8"));
+    std::process::exit(i32::from(evidence.result != "qualified"));
+}
+
+fn parse_config(args: impl Iterator<Item = std::ffi::OsString>) -> Result<Config, &'static str> {
+    let mut root = std::env::var_os("GF_FLY_QUALIFICATION_WORK_ROOT").map(PathBuf::from);
+    let mut output = std::env::var_os("GF_FLY_QUALIFICATION_EVIDENCE_OUT").map(PathBuf::from);
+    let mut timeout = std::env::var("GF_FLY_QUALIFICATION_TIMEOUT_S")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(900);
+    let mut args = args;
+    while let Some(flag) = args.next() {
+        let value = args.next().ok_or("missing_option_value")?;
+        match flag.to_str() {
+            Some("--work-root") => root = Some(value.into()),
+            Some("--evidence-out") => output = Some(value.into()),
+            Some("--timeout-s") => {
+                timeout = value
+                    .to_str()
+                    .and_then(|v| v.parse().ok())
+                    .ok_or("invalid_timeout")?;
+            }
+            _ => return Err("unknown_option"),
+        }
+    }
+    let work_root = root.ok_or("work_root_required")?;
+    let evidence_out = output.ok_or("evidence_out_required")?;
+    if !work_root.is_absolute() || !evidence_out.is_absolute() {
+        return Err("absolute_path_required");
+    }
+    if timeout == 0 {
+        return Err("invalid_timeout");
+    }
+    let git_sha = std::env::var("GF_FLY_QUALIFICATION_GIT_SHA").map_err(|_| "git_sha_required")?;
+    let image_digest =
+        std::env::var("GF_FLY_QUALIFICATION_IMAGE_DIGEST").map_err(|_| "image_digest_required")?;
+    let region = std::env::var("GF_FLY_QUALIFICATION_REGION").map_err(|_| "region_required")?;
+    validate_metadata(&git_sha, &image_digest, &region)?;
+    Ok(Config {
+        work_root,
+        evidence_out,
+        timeout: Duration::from_secs(timeout),
+        git_sha,
+        image_digest,
+        region,
+    })
+}
+
+fn validate_metadata(sha: &str, digest: &str, region: &str) -> Result<(), &'static str> {
+    let lower_hex = |byte: u8| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase();
+    if sha.len() != 40 || !sha.bytes().all(lower_hex) {
+        return Err("invalid_git_sha");
+    }
+    if digest.len() != 71 || !digest.starts_with("sha256:") || !digest[7..].bytes().all(lower_hex) {
+        return Err("invalid_image_digest");
+    }
+    if !(2..=20).contains(&region.len())
+        || !region
+            .bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+    {
+        return Err("invalid_region");
+    }
+    Ok(())
+}
+
+fn validate_paths(mut config: Config) -> Result<Config, &'static str> {
+    let root = config
+        .work_root
+        .canonicalize()
+        .map_err(|_| "work_root_unavailable")?;
+    if !root.is_dir() {
+        return Err("work_root_unavailable");
+    }
+    let parent = config
+        .evidence_out
+        .parent()
+        .and_then(|p| p.canonicalize().ok())
+        .ok_or("evidence_parent_unavailable")?;
+    if !parent.starts_with(&root) {
+        return Err("evidence_outside_work_root");
+    }
+    config.work_root = root;
+    Ok(config)
+}
+
+#[allow(clippy::too_many_lines)]
+fn qualify(config: &Config) -> Evidence {
+    let project = config.work_root.join(PROJECT_NAME);
+    let package = config
+        .work_root
+        .join(".graphforge-fly-filesystem-qualification.gfpb");
+    let imported = config
+        .work_root
+        .join(".graphforge-fly-filesystem-qualification-imported");
+    let memory = linux_memory_bytes().unwrap_or(1);
+    let capacity = filesystem_capacity_bytes(&config.work_root).unwrap_or(1);
+    if project.exists() || package.exists() || imported.exists() {
+        return failure(
+            config,
+            "unproven",
+            memory,
+            capacity,
+            "GF_VALIDATION",
+            "qualification_state_exists",
+        );
+    }
+    let filesystem =
+        match graphforge_storage::filesystem_admission::filesystem_durability_preflight(&project) {
+            Ok(value) => value.filesystem_class,
+            Err(error) => return gf_failure(config, "unproven", memory, capacity, &error),
+        };
+    let graph = match GraphForge::new(project.to_str()) {
+        Ok(graph) => graph,
+        Err(error) => return gf_failure(config, &filesystem, memory, capacity, &error),
+    };
+    let props = HashMap::from([("marker".into(), PropValue::Str("qualification".into()))]);
+    if let Err(error) = graph.add_node("FlyQualification", &props) {
+        return gf_failure(config, &filesystem, memory, capacity, &error);
+    }
+    drop(graph);
+    let reopened = match GraphForge::new(project.to_str()) {
+        Ok(graph) => graph,
+        Err(error) => return gf_failure(config, &filesystem, memory, capacity, &error),
+    };
+    match reopened.node_count("FlyQualification") {
+        Ok(1) => {}
+        Ok(_) => {
+            return failure(
+                config,
+                &filesystem,
+                memory,
+                capacity,
+                "GF_EXECUTION",
+                "persisted_count_mismatch",
+            );
+        }
+        Err(error) => return gf_failure(config, &filesystem, memory, capacity, &error),
+    }
+    drop(reopened);
+    let limits = PortableV2Limits::default();
+    let source = match GraphForge::new(project.to_str()) {
+        Ok(graph) => graph,
+        Err(error) => return gf_failure(config, &filesystem, memory, capacity, &error),
+    };
+    if source
+        .export_portable_v2(
+            &PortableV2ExportRequest {
+                selection: PortableSelection::Current,
+                output_path: package.clone(),
+                representation: PortableV2Output::Bundle,
+                profile: PortableV2SelectionProfile::Complete,
+                subset: None,
+                limits,
+            },
+            None,
+            |_| {},
+        )
+        .is_err()
+    {
+        return failure(
+            config,
+            &filesystem,
+            memory,
+            capacity,
+            "GF_PORTABLE_V2",
+            "portable_export_failed",
+        );
+    }
+    drop(source);
+    if verify_portable_v2(
+        &PortableVerifyRequest {
+            input: package.clone(),
+            mode: PortableV2Mode::Full,
+            limits,
+        },
+        None,
+    )
+    .is_err()
+    {
+        return failure(
+            config,
+            &filesystem,
+            memory,
+            capacity,
+            "GF_PORTABLE_V2",
+            "portable_verify_failed",
+        );
+    }
+    if GraphForge::import_portable_v2(
+        &imported,
+        &PortableV2ImportRequest {
+            input: package.clone(),
+            operation_id: OperationId(Uuid::from_u128(0x882)),
+            limits,
+        },
+        None,
+    )
+    .is_err()
+    {
+        return failure(
+            config,
+            &filesystem,
+            memory,
+            capacity,
+            "GF_PORTABLE_V2",
+            "portable_import_failed",
+        );
+    }
+    let imported_graph = match GraphForge::new(imported.to_str()) {
+        Ok(graph) => graph,
+        Err(error) => return gf_failure(config, &filesystem, memory, capacity, &error),
+    };
+    if !matches!(imported_graph.node_count("FlyQualification"), Ok(1)) {
+        return failure(
+            config,
+            &filesystem,
+            memory,
+            capacity,
+            "GF_PORTABLE_V2",
+            "portable_reopen_mismatch",
+        );
+    }
+    drop(imported_graph);
+    if fs::remove_dir_all(project).is_err()
+        || fs::remove_dir_all(imported).is_err()
+        || fs::remove_file(package).is_err()
+    {
+        return failure(
+            config,
+            &filesystem,
+            memory,
+            capacity,
+            "GF_IO",
+            "project_cleanup_failed",
+        );
+    }
+    Evidence {
+        schema: SCHEMA,
+        git_sha: config.git_sha.clone(),
+        image_digest: config.image_digest.clone(),
+        provider: "fly.io",
+        region: config.region.clone(),
+        host: Host {
+            os: "Linux",
+            filesystem,
+            memory_bytes: memory,
+        },
+        volume: Volume {
+            mount_role: "process_work_root",
+            capacity_bytes: capacity,
+        },
+        admission: Admission {
+            status: "accepted",
+            code: None,
+            cause: None,
+        },
+        result: "qualified",
+        full_run_authorized: false,
+    }
+}
+
+fn gf_failure(config: &Config, fs: &str, memory: u64, capacity: u64, error: &GfError) -> Evidence {
+    let cause = match error {
+        GfError::Project { message, .. } => safe_cause(message).unwrap_or("project_failure"),
+        _ => "public_facade_failure",
+    };
+    failure(config, fs, memory, capacity, error.code(), cause)
+}
+
+fn safe_cause(message: &str) -> Option<&str> {
+    message
+        .split("cause=")
+        .nth(1)?
+        .split_whitespace()
+        .next()
+        .filter(|value| {
+            !value.is_empty()
+                && value
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b == b'_')
+        })
+}
+
+fn failure(
+    config: &Config,
+    fs: &str,
+    memory: u64,
+    capacity: u64,
+    code: &str,
+    cause: &str,
+) -> Evidence {
+    failed(
+        (
+            config.git_sha.clone(),
+            config.image_digest.clone(),
+            config.region.clone(),
+        ),
+        fs,
+        memory,
+        capacity,
+        code,
+        cause,
+    )
+}
+
+fn failed(
+    meta: (String, String, String),
+    fs: &str,
+    memory: u64,
+    capacity: u64,
+    code: &str,
+    cause: &str,
+) -> Evidence {
+    Evidence {
+        schema: SCHEMA,
+        git_sha: meta.0,
+        image_digest: meta.1,
+        provider: "fly.io",
+        region: meta.2,
+        host: Host {
+            os: "Linux",
+            filesystem: fs.into(),
+            memory_bytes: memory,
+        },
+        volume: Volume {
+            mount_role: "process_work_root",
+            capacity_bytes: capacity,
+        },
+        admission: Admission {
+            status: "rejected",
+            code: Some(code.into()),
+            cause: Some(cause.into()),
+        },
+        result: "disqualified",
+        full_run_authorized: false,
+    }
+}
+
+fn linux_memory_bytes() -> Option<u64> {
+    fs::read_to_string("/proc/meminfo")
+        .ok()?
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("MemTotal:")?
+                .split_whitespace()
+                .next()?
+                .parse::<u64>()
+                .ok()
+                .map(|kib| kib.saturating_mul(1024))
+        })
+}
+
+fn filesystem_capacity_bytes(path: &Path) -> Option<u64> {
+    let output = Command::new("df")
+        .args(["--output=size", "-B1"])
+        .arg(path)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout)
+        .ok()?
+        .lines()
+        .nth(1)?
+        .trim()
+        .parse()
+        .ok()
+}
+
+fn write_evidence(path: &Path, encoded: &[u8]) -> std::io::Result<()> {
+    if path.exists() {
+        return Err(std::io::ErrorKind::AlreadyExists.into());
+    }
+    let name = path.file_name().ok_or(std::io::ErrorKind::InvalidInput)?;
+    let temporary = path.with_file_name(format!(".{}.tmp", name.to_string_lossy()));
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temporary)?;
+    file.write_all(encoded)?;
+    file.sync_all()?;
+    fs::rename(temporary, path)?;
+    File::open(path.parent().unwrap_or_else(|| Path::new(".")))?.sync_all()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn typed_failure_matches_sanitized_schema_shape() {
+        let value = serde_json::to_value(failed(
+            (
+                "a".repeat(40),
+                format!("sha256:{}", "b".repeat(64)),
+                "iad".into(),
+            ),
+            "unproven",
+            1,
+            1,
+            "GF_UNSUPPORTED_FILESYSTEM",
+            "ancestor_cross_volume",
+        ))
+        .unwrap();
+        assert_eq!(value["admission"]["cause"], "ancestor_cross_volume");
+        assert_eq!(value["result"], "disqualified");
+        assert_eq!(value["full_run_authorized"], false);
+        assert!(!value.to_string().contains("/work"));
+    }
+
+    #[test]
+    fn safe_cause_rejects_path_like_diagnostics() {
+        assert_eq!(
+            safe_cause("phase=X cause=ancestor_cross_volume"),
+            Some("ancestor_cross_volume")
+        );
+        assert_eq!(safe_cause("phase=X cause=/work/private"), None);
+    }
+
+    #[test]
+    fn atomic_evidence_write_refuses_overwrite() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("evidence.json");
+        write_evidence(&path, b"{}").unwrap();
+        assert!(write_evidence(&path, b"changed").is_err());
+    }
+}

--- a/crates/graphforge-api/src/bin/graphforge-fly-filesystem-smoke.rs
+++ b/crates/graphforge-api/src/bin/graphforge-fly-filesystem-smoke.rs
@@ -37,6 +37,7 @@ struct Evidence {
     region: String,
     host: Host,
     volume: Volume,
+    phase_peak_rss_bytes: PhasePeakRss,
     admission: Admission,
     result: &'static str,
     full_run_authorized: bool,
@@ -46,13 +47,21 @@ struct Evidence {
 struct Host {
     os: &'static str,
     filesystem: String,
-    memory_bytes: u64,
+    memory_bytes: Option<u64>,
 }
 
 #[derive(Debug, Serialize)]
 struct Volume {
     mount_role: &'static str,
-    capacity_bytes: u64,
+    capacity_bytes: Option<u64>,
+}
+
+#[derive(Debug, Default, Serialize)]
+struct PhasePeakRss {
+    filesystem_admission: Option<u64>,
+    durable_reopen: Option<u64>,
+    portable_verify: Option<u64>,
+    portable_import_reopen: Option<u64>,
 }
 
 #[derive(Debug, Serialize)]
@@ -80,9 +89,16 @@ fn main() {
     std::thread::spawn(move || {
         let _ = sender.send(qualify(&config));
     });
-    let evidence = receiver
-        .recv_timeout(timeout)
-        .unwrap_or_else(|_| failed(metadata, "unproven", 1, 1, "GF_RESOURCE_LIMIT", "timeout"));
+    let evidence = receiver.recv_timeout(timeout).unwrap_or_else(|_| {
+        failed(
+            metadata,
+            "unproven",
+            None,
+            None,
+            "GF_RESOURCE_LIMIT",
+            "timeout",
+        )
+    });
     let encoded = serde_json::to_vec(&evidence).expect("serialize evidence");
     if write_evidence(&output, &encoded).is_err() {
         eprintln!("qualification evidence write failed");
@@ -184,8 +200,9 @@ fn qualify(config: &Config) -> Evidence {
     let imported = config
         .work_root
         .join(".graphforge-fly-filesystem-qualification-imported");
-    let memory = linux_memory_bytes().unwrap_or(1);
-    let capacity = filesystem_capacity_bytes(&config.work_root).unwrap_or(1);
+    let memory = linux_memory_bytes();
+    let capacity = filesystem_capacity_bytes(&config.work_root);
+    let mut phase_peak_rss = PhasePeakRss::default();
     if project.exists() || package.exists() || imported.exists() {
         return failure(
             config,
@@ -201,6 +218,7 @@ fn qualify(config: &Config) -> Evidence {
             Ok(value) => value.filesystem_class,
             Err(error) => return gf_failure(config, "unproven", memory, capacity, &error),
         };
+    phase_peak_rss.filesystem_admission = linux_peak_rss_bytes();
     let graph = match GraphForge::new(project.to_str()) {
         Ok(graph) => graph,
         Err(error) => return gf_failure(config, &filesystem, memory, capacity, &error),
@@ -229,6 +247,7 @@ fn qualify(config: &Config) -> Evidence {
         Err(error) => return gf_failure(config, &filesystem, memory, capacity, &error),
     }
     drop(reopened);
+    phase_peak_rss.durable_reopen = linux_peak_rss_bytes();
     let limits = PortableV2Limits::default();
     let source = match GraphForge::new(project.to_str()) {
         Ok(graph) => graph,
@@ -278,6 +297,7 @@ fn qualify(config: &Config) -> Evidence {
             "portable_verify_failed",
         );
     }
+    phase_peak_rss.portable_verify = linux_peak_rss_bytes();
     if GraphForge::import_portable_v2(
         &imported,
         &PortableV2ImportRequest {
@@ -313,10 +333,11 @@ fn qualify(config: &Config) -> Evidence {
         );
     }
     drop(imported_graph);
-    if fs::remove_dir_all(project).is_err()
-        || fs::remove_dir_all(imported).is_err()
-        || fs::remove_file(package).is_err()
-    {
+    phase_peak_rss.portable_import_reopen = linux_peak_rss_bytes();
+    let project_removed = fs::remove_dir_all(project).is_ok();
+    let imported_removed = fs::remove_dir_all(imported).is_ok();
+    let package_removed = fs::remove_file(package).is_ok();
+    if !(project_removed && imported_removed && package_removed) {
         return failure(
             config,
             &filesystem,
@@ -341,6 +362,7 @@ fn qualify(config: &Config) -> Evidence {
             mount_role: "process_work_root",
             capacity_bytes: capacity,
         },
+        phase_peak_rss_bytes: phase_peak_rss,
         admission: Admission {
             status: "accepted",
             code: None,
@@ -351,7 +373,13 @@ fn qualify(config: &Config) -> Evidence {
     }
 }
 
-fn gf_failure(config: &Config, fs: &str, memory: u64, capacity: u64, error: &GfError) -> Evidence {
+fn gf_failure(
+    config: &Config,
+    fs: &str,
+    memory: Option<u64>,
+    capacity: Option<u64>,
+    error: &GfError,
+) -> Evidence {
     let cause = match error {
         GfError::Project { message, .. } => safe_cause(message).unwrap_or("project_failure"),
         _ => "public_facade_failure",
@@ -376,8 +404,8 @@ fn safe_cause(message: &str) -> Option<&str> {
 fn failure(
     config: &Config,
     fs: &str,
-    memory: u64,
-    capacity: u64,
+    memory: Option<u64>,
+    capacity: Option<u64>,
     code: &str,
     cause: &str,
 ) -> Evidence {
@@ -398,8 +426,8 @@ fn failure(
 fn failed(
     meta: (String, String, String),
     fs: &str,
-    memory: u64,
-    capacity: u64,
+    memory: Option<u64>,
+    capacity: Option<u64>,
     code: &str,
     cause: &str,
 ) -> Evidence {
@@ -418,6 +446,7 @@ fn failed(
             mount_role: "process_work_root",
             capacity_bytes: capacity,
         },
+        phase_peak_rss_bytes: PhasePeakRss::default(),
         admission: Admission {
             status: "rejected",
             code: Some(code.into()),
@@ -440,6 +469,18 @@ fn linux_memory_bytes() -> Option<u64> {
                 .ok()
                 .map(|kib| kib.saturating_mul(1024))
         })
+}
+
+fn linux_peak_rss_bytes() -> Option<u64> {
+    fs::read_to_string("/proc/self/status")
+        .ok()?
+        .lines()
+        .find_map(|line| line.strip_prefix("VmHWM:"))?
+        .split_whitespace()
+        .next()?
+        .parse::<u64>()
+        .ok()?
+        .checked_mul(1024)
 }
 
 fn filesystem_capacity_bytes(path: &Path) -> Option<u64> {
@@ -466,6 +507,11 @@ fn write_evidence(path: &Path, encoded: &[u8]) -> std::io::Result<()> {
     }
     let name = path.file_name().ok_or(std::io::ErrorKind::InvalidInput)?;
     let temporary = path.with_file_name(format!(".{}.tmp", name.to_string_lossy()));
+    match fs::remove_file(&temporary) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
+    }
     let mut file = OpenOptions::new()
         .write(true)
         .create_new(true)
@@ -489,8 +535,8 @@ mod tests {
                 "iad".into(),
             ),
             "unproven",
-            1,
-            1,
+            Some(1),
+            Some(1),
             "GF_UNSUPPORTED_FILESYSTEM",
             "ancestor_cross_volume",
         ))
@@ -516,5 +562,14 @@ mod tests {
         let path = directory.path().join("evidence.json");
         write_evidence(&path, b"{}").unwrap();
         assert!(write_evidence(&path, b"changed").is_err());
+    }
+
+    #[test]
+    fn atomic_evidence_write_recovers_from_stale_temporary_file() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("evidence.json");
+        std::fs::write(directory.path().join(".evidence.json.tmp"), b"stale").unwrap();
+        write_evidence(&path, b"fresh").unwrap();
+        assert_eq!(std::fs::read(path).unwrap(), b"fresh");
     }
 }

--- a/docs/development/evidence/fly-filesystem-qualification.schema.json
+++ b/docs/development/evidence/fly-filesystem-qualification.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://graphforge.dev/evidence/fly-filesystem-qualification.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "git_sha", "image_digest", "provider", "region", "host", "volume", "admission", "result", "full_run_authorized"],
+  "properties": {
+    "schema": {"const": "graphforge-fly-filesystem-qualification/1"},
+    "git_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+    "image_digest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "provider": {"const": "fly.io"},
+    "region": {"type": "string", "pattern": "^[a-z0-9-]{2,20}$"},
+    "host": {
+      "type": "object", "additionalProperties": false,
+      "required": ["os", "filesystem", "memory_bytes"],
+      "properties": {
+        "os": {"const": "Linux"},
+        "filesystem": {"type": "string", "pattern": "^[a-z0-9_-]{2,32}$"},
+        "memory_bytes": {"type": "integer", "minimum": 1}
+      }
+    },
+    "volume": {
+      "type": "object", "additionalProperties": false,
+      "required": ["mount_role", "capacity_bytes"],
+      "properties": {
+        "mount_role": {"const": "process_work_root"},
+        "capacity_bytes": {"type": "integer", "minimum": 1}
+      }
+    },
+    "admission": {
+      "type": "object", "additionalProperties": false,
+      "required": ["status", "code", "cause"],
+      "properties": {
+        "status": {"enum": ["accepted", "rejected"]},
+        "code": {"type": ["string", "null"], "pattern": "^[A-Z0-9_]{2,80}$"},
+        "cause": {"type": ["string", "null"], "pattern": "^[a-z0-9_]{2,80}$"}
+      }
+    },
+    "result": {"enum": ["qualified", "disqualified", "failed"]},
+    "full_run_authorized": {"const": false}
+  }
+}

--- a/docs/development/evidence/fly-filesystem-qualification.schema.json
+++ b/docs/development/evidence/fly-filesystem-qualification.schema.json
@@ -3,7 +3,7 @@
   "$id": "https://graphforge.dev/evidence/fly-filesystem-qualification.schema.json",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema", "git_sha", "image_digest", "provider", "region", "host", "volume", "admission", "result", "full_run_authorized"],
+  "required": ["schema", "git_sha", "image_digest", "provider", "region", "host", "volume", "phase_peak_rss_bytes", "admission", "result", "full_run_authorized"],
   "properties": {
     "schema": {"const": "graphforge-fly-filesystem-qualification/1"},
     "git_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
@@ -16,7 +16,7 @@
       "properties": {
         "os": {"const": "Linux"},
         "filesystem": {"type": "string", "pattern": "^[a-z0-9_-]{2,32}$"},
-        "memory_bytes": {"type": "integer", "minimum": 1}
+        "memory_bytes": {"type": ["integer", "null"], "minimum": 1}
       }
     },
     "volume": {
@@ -24,7 +24,17 @@
       "required": ["mount_role", "capacity_bytes"],
       "properties": {
         "mount_role": {"const": "process_work_root"},
-        "capacity_bytes": {"type": "integer", "minimum": 1}
+        "capacity_bytes": {"type": ["integer", "null"], "minimum": 1}
+      }
+    },
+    "phase_peak_rss_bytes": {
+      "type": "object", "additionalProperties": false,
+      "required": ["filesystem_admission", "durable_reopen", "portable_verify", "portable_import_reopen"],
+      "properties": {
+        "filesystem_admission": {"type": ["integer", "null"], "minimum": 1},
+        "durable_reopen": {"type": ["integer", "null"], "minimum": 1},
+        "portable_verify": {"type": ["integer", "null"], "minimum": 1},
+        "portable_import_reopen": {"type": ["integer", "null"], "minimum": 1}
       }
     },
     "admission": {

--- a/docs/development/fly-filesystem-qualification.md
+++ b/docs/development/fly-filesystem-qualification.md
@@ -1,0 +1,39 @@
+# Fly filesystem qualification
+
+This issue-882 probe answers only whether GraphForge admits a Fly volume as its process work root. It never runs or authorizes S24, S25, SCALE26, or another full certification.
+
+## Prepare and review
+
+Use a clean checkout at the exact commit to test. Build `containers/fly-filesystem-qualification/Dockerfile`, push it to a private registry, and resolve the pushed image to its immutable `sha256` digest. Authenticate `flyctl` without putting a token in a command or artifact.
+
+Review the no-spend plan first (dry-run is the default):
+
+```bash
+python3 scripts/fly-filesystem-qualification.py \
+  --expected-sha "$GIT_SHA" \
+  --image "registry.example/graphforge@sha256:<64-hex-digest>" \
+  --region den --org curatelabs \
+  --app-name gf-fs-qual-<suffix> \
+  --volume-name gf-fs-vol-<suffix> \
+  --machine-name gf-fs-machine-<suffix>
+```
+
+The controller refuses a dirty tree, a different HEAD, a mutable image, a missing fixed region, unsafe names, or an existing app name. The plan has one small volume mounted at `/work`, a small explicitly sized performance Machine (2 CPUs and 4 GiB by default), no service or public port, restart policy `no`, and automatic destruction. The 128 GiB certification ceiling is not a qualification default or a sizing target. A later ladder or SCALE26 Machine must be selected from measured phase-level peak-RSS headroom and plateau evidence; continued material RSS growth with edge count is an architectural failure, not a reason to buy more RAM. The 500 GB certification envelope is expected to be storage/IO constrained and is outside this probe.
+
+## Run the disposable probe
+
+Only after approving the dry-run, repeat the command with `--execute --confirm-disposable`. This creates billable resources. The container bounds the Rust smoke to 900 seconds and remains alive for at most another 300 seconds for evidence retrieval. The controller validates the observed Machine config and sanitized evidence before acknowledging container exit.
+
+Cleanup runs on success and failure in Machine, volume, app order. Repeating cleanup is safe. A rejected admission produces a typed code/cause and a non-zero controller exit; it blocks any full run. The committed artifact `fly-qualification-evidence.json` contains no Fly resource ID/name, secret, credential, or absolute path.
+
+Validate a retrieved artifact independently:
+
+```bash
+python3 scripts/ci/validate-fly-filesystem-qualification.py \
+  fly-qualification-evidence.json \
+  --expected-sha "$GIT_SHA" \
+  --expected-image-digest "sha256:<64-hex-digest>" \
+  --expected-region den
+```
+
+After any interrupted operator session, confirm the disposable app is absent with `flyctl apps list`; if present, destroy its Machine first, then its volume, then the app. Never paste the resulting inventory into evidence because it contains provider identifiers.

--- a/scripts/ci/test-fly-filesystem-qualification.py
+++ b/scripts/ci/test-fly-filesystem-qualification.py
@@ -5,6 +5,7 @@ import argparse
 import importlib.util
 import json
 from pathlib import Path
+import subprocess
 
 import pytest
 
@@ -53,6 +54,12 @@ def evidence(**changes):
         "region": "den",
         "host": {"os": "Linux", "filesystem": "ext4", "memory_bytes": 4_000_000_000},
         "volume": {"mount_role": "process_work_root", "capacity_bytes": 10_000_000_000},
+        "phase_peak_rss_bytes": {
+            "filesystem_admission": 100_000_000,
+            "durable_reopen": 110_000_000,
+            "portable_verify": 120_000_000,
+            "portable_import_reopen": 125_000_000,
+        },
         "admission": {"status": "accepted", "code": None, "cause": None},
         "result": "qualified",
         "full_run_authorized": False,
@@ -81,6 +88,11 @@ def test_refuses_out_of_bounds_machine_and_timeout_values(change, message):
         controller.validate_inputs(args(**change))
 
 
+def test_refuses_missing_evidence_output_parent(tmp_path):
+    with pytest.raises(controller.QualificationError, match="parent directory"):
+        controller.validate_inputs(args(evidence_out=tmp_path / "missing" / "evidence.json"))
+
+
 def test_refuses_dirty_or_non_exact_source(monkeypatch):
     responses = iter(
         [
@@ -103,7 +115,7 @@ def test_refuses_dirty_or_non_exact_source(monkeypatch):
 
 
 def test_launch_has_private_disposable_exact_resources():
-    command = controller.launch_args(args(), "internal-volume-id")
+    command = controller.launch_args(args(), "internal-volume-id", "sha256:" + "b" * 64)
     assert command[2].endswith("@sha256:" + "b" * 64)
     assert [
         command[command.index(flag) + 1]
@@ -126,6 +138,10 @@ def test_observed_config_rejects_service_or_wrong_mount():
         },
     }
     controller.assert_machine_config(machine, args(), "sha256:" + "b" * 64)
+    machine["config"]["mounts"] = [{"path": "/not-work"}]
+    with pytest.raises(controller.QualificationError, match="mounted"):
+        controller.assert_machine_config(machine, args(), "sha256:" + "b" * 64)
+    machine["config"]["mounts"] = [{"path": "/work"}]
     machine["config"]["services"] = [{"ports": [443]}]
     with pytest.raises(controller.QualificationError, match="service"):
         controller.assert_machine_config(machine, args(), "sha256:" + "b" * 64)
@@ -140,6 +156,9 @@ def test_validator_accepts_sanitized_evidence_and_rejects_leakage():
     leaked["host"]["filesystem"] = "/dev/vdc"
     with pytest.raises(validator.EvidenceError):
         validator.validate(leaked, sha="a" * 40, digest="sha256:" + "b" * 64, region="den")
+    for windows_path in (r"\\server\share", r"\rooted\path"):
+        with pytest.raises(validator.EvidenceError, match="absolute path"):
+            validator.reject_sensitive(windows_path)
 
 
 def test_rejection_is_typed_and_never_authorizes_full_run():
@@ -176,6 +195,21 @@ def test_teardown_is_child_first_and_idempotent():
         ["apps", "destroy"],
     ]
     assert fake.calls[-1][:2] == ["apps", "destroy"]
+
+
+def test_teardown_continues_after_each_timeout():
+    class TimingOutFly(FakeFly):
+        def run(self, command, check=True):
+            self.calls.append(command)
+            raise subprocess.TimeoutExpired(command, 120)
+
+    fake = TimingOutFly()
+    controller.cleanup(fake, "gf-qual-app", "machine-internal", "volume-internal")
+    assert [call[:2] for call in fake.calls] == [
+        ["machine", "destroy"],
+        ["volumes", "destroy"],
+        ["apps", "destroy"],
+    ]
 
 
 def test_schema_is_closed_and_committed():

--- a/scripts/ci/test-fly-filesystem-qualification.py
+++ b/scripts/ci/test-fly-filesystem-qualification.py
@@ -88,9 +88,7 @@ def test_refuses_dirty_or_non_exact_source(monkeypatch):
             argparse.Namespace(stdout=""),
         ]
     )
-    monkeypatch.setattr(
-        controller.subprocess, "run", lambda *_args, **_kwargs: next(responses)
-    )
+    monkeypatch.setattr(controller.subprocess, "run", lambda *_args, **_kwargs: next(responses))
     with pytest.raises(controller.QualificationError, match="not the checked-out HEAD"):
         controller.check_source("a" * 40)
 

--- a/scripts/ci/test-fly-filesystem-qualification.py
+++ b/scripts/ci/test-fly-filesystem-qualification.py
@@ -68,6 +68,19 @@ def test_refuses_mutable_image_and_execute_without_confirmation():
         controller.validate_inputs(args(execute=True))
 
 
+@pytest.mark.parametrize(
+    ("change", "message"),
+    [
+        ({"cpus": 0}, "CPU count"),
+        ({"memory_mb": 131073}, "memory"),
+        ({"retrieve_timeout_s": 59}, "retrieval timeout"),
+    ],
+)
+def test_refuses_out_of_bounds_machine_and_timeout_values(change, message):
+    with pytest.raises(controller.QualificationError, match=message):
+        controller.validate_inputs(args(**change))
+
+
 def test_refuses_dirty_or_non_exact_source(monkeypatch):
     responses = iter(
         [

--- a/scripts/ci/test-fly-filesystem-qualification.py
+++ b/scripts/ci/test-fly-filesystem-qualification.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+controller = load(ROOT / "scripts/fly-filesystem-qualification.py", "fly_controller")
+validator = load(ROOT / "scripts/ci/validate-fly-filesystem-qualification.py", "fly_validator")
+
+
+def args(**changes):
+    values = {
+        "expected_sha": "a" * 40,
+        "image": "registry.example/graphforge@sha256:" + "b" * 64,
+        "region": "den",
+        "org": "curate",
+        "app_name": "gf-qual-app",
+        "volume_name": "gf-qual-vol",
+        "machine_name": "gf-qual-machine",
+        "cpus": 2,
+        "memory_mb": 4096,
+        "volume_size_gb": 10,
+        "retrieve_timeout_s": 60,
+        "evidence_out": Path("unused.json"),
+        "execute": False,
+        "confirm_disposable": False,
+    }
+    values.update(changes)
+    return argparse.Namespace(**values)
+
+
+def evidence(**changes):
+    value = {
+        "schema": "graphforge-fly-filesystem-qualification/1",
+        "git_sha": "a" * 40,
+        "image_digest": "sha256:" + "b" * 64,
+        "provider": "fly.io",
+        "region": "den",
+        "host": {"os": "Linux", "filesystem": "ext4", "memory_bytes": 4_000_000_000},
+        "volume": {"mount_role": "process_work_root", "capacity_bytes": 10_000_000_000},
+        "admission": {"status": "accepted", "code": None, "cause": None},
+        "result": "qualified",
+        "full_run_authorized": False,
+    }
+    value.update(changes)
+    return value
+
+
+def test_refuses_mutable_image_and_execute_without_confirmation():
+    with pytest.raises(controller.QualificationError, match="immutable"):
+        controller.validate_inputs(args(image="registry.example/graphforge:latest"))
+    with pytest.raises(controller.QualificationError, match="confirm-disposable"):
+        controller.validate_inputs(args(execute=True))
+
+
+def test_refuses_dirty_or_non_exact_source(monkeypatch):
+    responses = iter(
+        [
+            argparse.Namespace(stdout="b" * 40 + "\n"),
+            argparse.Namespace(stdout=""),
+        ]
+    )
+    monkeypatch.setattr(
+        controller.subprocess, "run", lambda *_args, **_kwargs: next(responses)
+    )
+    with pytest.raises(controller.QualificationError, match="not the checked-out HEAD"):
+        controller.check_source("a" * 40)
+
+    responses = iter(
+        [
+            argparse.Namespace(stdout="a" * 40 + "\n"),
+            argparse.Namespace(stdout="?? unexpected\n"),
+        ]
+    )
+    with pytest.raises(controller.QualificationError, match="not clean"):
+        controller.check_source("a" * 40)
+
+
+def test_launch_has_private_disposable_exact_resources():
+    command = controller.launch_args(args(), "internal-volume-id")
+    assert command[2].endswith("@sha256:" + "b" * 64)
+    assert [
+        command[command.index(flag) + 1]
+        for flag in ("--region", "--restart", "--autostop", "--vm-cpu-kind", "--vm-memory")
+    ] == ["den", "no", "off", "performance", "4096"]
+    assert "--rm" in command and "--skip-dns-registration" in command
+    assert not any(flag in command for flag in ("--port", "--http-service", "--public-ip"))
+
+
+def test_observed_config_rejects_service_or_wrong_mount():
+    machine = {
+        "region": "den",
+        "image_ref": {"digest": "sha256:" + "b" * 64},
+        "config": {
+            "auto_destroy": True,
+            "restart": {"policy": "no"},
+            "guest": {"cpu_kind": "performance", "cpus": 2, "memory_mb": 4096},
+            "mounts": [{"path": "/work"}],
+            "services": [],
+        },
+    }
+    controller.assert_machine_config(machine, args(), "sha256:" + "b" * 64)
+    machine["config"]["services"] = [{"ports": [443]}]
+    with pytest.raises(controller.QualificationError, match="service"):
+        controller.assert_machine_config(machine, args(), "sha256:" + "b" * 64)
+
+
+def test_validator_accepts_sanitized_evidence_and_rejects_leakage():
+    validator.validate(evidence(), sha="a" * 40, digest="sha256:" + "b" * 64, region="den")
+    leaked = evidence(machine_id="9080deadbeef")
+    with pytest.raises(validator.EvidenceError, match="schema violation"):
+        validator.validate(leaked, sha="a" * 40, digest="sha256:" + "b" * 64, region="den")
+    leaked = evidence()
+    leaked["host"]["filesystem"] = "/dev/vdc"
+    with pytest.raises(validator.EvidenceError):
+        validator.validate(leaked, sha="a" * 40, digest="sha256:" + "b" * 64, region="den")
+
+
+def test_rejection_is_typed_and_never_authorizes_full_run():
+    rejected = evidence(
+        admission={
+            "status": "rejected",
+            "code": "GF_UNSUPPORTED_FILESYSTEM",
+            "cause": "filesystem_class_unproven",
+        },
+        result="disqualified",
+    )
+    validator.validate(rejected, sha="a" * 40, digest="sha256:" + "b" * 64, region="den")
+    rejected["full_run_authorized"] = True
+    with pytest.raises(validator.EvidenceError):
+        validator.validate(rejected, sha="a" * 40, digest="sha256:" + "b" * 64, region="den")
+
+
+class FakeFly:
+    def __init__(self):
+        self.calls = []
+
+    def run(self, command, check=True):
+        self.calls.append(command)
+        return argparse.Namespace(returncode=0, stdout="", stderr="")
+
+
+def test_teardown_is_child_first_and_idempotent():
+    fake = FakeFly()
+    controller.cleanup(fake, "gf-qual-app", "machine-internal", "volume-internal")
+    controller.cleanup(fake, "gf-qual-app", None, None)
+    assert [call[:2] for call in fake.calls[:3]] == [
+        ["machine", "destroy"],
+        ["volumes", "destroy"],
+        ["apps", "destroy"],
+    ]
+    assert fake.calls[-1][:2] == ["apps", "destroy"]
+
+
+def test_schema_is_closed_and_committed():
+    schema = json.loads(
+        (ROOT / "docs/development/evidence/fly-filesystem-qualification.schema.json").read_text()
+    )
+    assert schema["additionalProperties"] is False
+    assert schema["properties"]["host"]["additionalProperties"] is False

--- a/scripts/ci/test-fly-filesystem-safety-contract.py
+++ b/scripts/ci/test-fly-filesystem-safety-contract.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Static and mutation tests for the disposable Fly qualification boundary."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+import shutil
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTROLLER = Path("scripts/fly-filesystem-qualification.py")
+VALIDATOR = Path("scripts/ci/validate-fly-filesystem-qualification.py")
+SCHEMA = Path("docs/development/evidence/fly-filesystem-qualification.schema.json")
+DOCKERFILE = Path("containers/fly-filesystem-qualification/Dockerfile")
+ENTRYPOINT = Path("containers/fly-filesystem-qualification/run-smoke.sh")
+
+PUBLIC_SURFACE = re.compile(
+    r"(?:\bEXPOSE\b|\bhttp_service\b|\[\[services\]\]|--(?:port|ports)\b|"
+    r"\bfly(?:ctl)?\s+(?:deploy|launch|ips)\b|\b0\.0\.0\.0\b|"
+    r"allocate-(?:v4|v6)|public[_ -]?ip)",
+    re.IGNORECASE,
+)
+FORBIDDEN_EVIDENCE_KEY = re.compile(
+    r"(?:app|machine|volume|runner|resource|host|absolute)_(?:id|path|name)$|"
+    r"(?:secret|credential|token|password)",
+    re.IGNORECASE,
+)
+
+
+class ContractError(AssertionError):
+    pass
+
+
+def read(root: Path, relative: Path) -> str:
+    path = root / relative
+    if not path.is_file():
+        raise ContractError(f"missing Fly qualification contract file: {relative}")
+    return path.read_text(encoding="utf-8")
+
+
+def property_names(schema: object) -> list[str]:
+    if isinstance(schema, dict):
+        names = list(schema.get("properties", {}))
+        for value in schema.values():
+            names.extend(property_names(value))
+        return names
+    if isinstance(schema, list):
+        return [name for value in schema for name in property_names(value)]
+    return []
+
+
+def validate_contract(root: Path) -> None:
+    controller = read(root, CONTROLLER)
+    validator = read(root, VALIDATOR)
+    dockerfile = read(root, DOCKERFILE)
+    entrypoint = read(root, ENTRYPOINT)
+
+    combined_runtime = "\n".join((controller, dockerfile, entrypoint))
+    match = PUBLIC_SURFACE.search(combined_runtime)
+    if match:
+        raise ContractError(f"Fly qualification may not expose a public service: {match.group(0)}")
+
+    if "machine" not in controller or "run" not in controller:
+        raise ContractError("controller must create the disposable Fly Machine explicitly")
+    if "@" not in controller or "sha256:" not in controller or "{64}" not in controller:
+        raise ContractError("controller must require a full immutable image digest")
+    if "--restart" not in controller or "--rm" not in controller:
+        raise ContractError("machine must be non-restarting and disposable")
+
+    if "finally" not in controller:
+        raise ContractError("cleanup must be protected by a finally block")
+    for resource in ("machine", "volumes", "apps"):
+        if f'["{resource}", "destroy"' not in controller:
+            raise ContractError(f"cleanup must destroy the disposable Fly {resource}")
+
+    try:
+        schema = json.loads(read(root, SCHEMA))
+    except json.JSONDecodeError as error:
+        raise ContractError(f"invalid qualification evidence schema: {error}") from error
+    if schema.get("additionalProperties") is not False:
+        raise ContractError("evidence root must reject additional properties")
+    unsafe = sorted({name for name in property_names(schema) if FORBIDDEN_EVIDENCE_KEY.search(name)})
+    if unsafe:
+        raise ContractError("evidence schema exposes resource IDs or paths: " + ", ".join(unsafe))
+    if "additionalProperties" not in read(root, SCHEMA):
+        raise ContractError("evidence schema must be closed")
+
+    for marker in ("absolute", "id", "path", "secret", "token"):
+        if marker not in validator.lower():
+            raise ContractError(f"validator must fail closed on evidence {marker} leakage")
+
+
+class FlySafetyContractTests(unittest.TestCase):
+    def test_repository_contract(self) -> None:
+        validate_contract(ROOT)
+
+    def test_mutations_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory)
+            for relative in (CONTROLLER, VALIDATOR, SCHEMA, DOCKERFILE, ENTRYPOINT):
+                destination = fixture / relative
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(ROOT / relative, destination)
+
+            mutations = {
+                "public_port": (ENTRYPOINT, "\npython3 -m http.server 8080 --bind 0.0.0.0\n"),
+                "mutable_image": (CONTROLLER, "sha256:"),
+                "missing_cleanup": (CONTROLLER, "finally"),
+                "missing_machine_cleanup": (CONTROLLER, 'fly.run(["machine", "destroy"'),
+                "missing_volume_cleanup": (CONTROLLER, 'fly.run(["volumes", "destroy"'),
+                "missing_app_cleanup": (CONTROLLER, 'fly.run(["apps", "destroy"'),
+                "leaked_id": (SCHEMA, '"properties": {', '"properties": {"machine_id": {"type": "string"},'),
+            }
+            for name, mutation in mutations.items():
+                with self.subTest(name=name):
+                    target = fixture / mutation[0]
+                    original = target.read_text(encoding="utf-8")
+                    if name == "public_port":
+                        target.write_text(original + mutation[1], encoding="utf-8")
+                    elif name == "leaked_id":
+                        target.write_text(original.replace(mutation[1], mutation[2], 1), encoding="utf-8")
+                    else:
+                        self.assertIn(mutation[1], original)
+                        target.write_text(original.replace(mutation[1], ""), encoding="utf-8")
+                    with self.assertRaises(ContractError):
+                        validate_contract(fixture)
+                    target.write_text(original, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test-fly-filesystem-safety-contract.py
+++ b/scripts/ci/test-fly-filesystem-safety-contract.py
@@ -10,7 +10,6 @@ import shutil
 import tempfile
 import unittest
 
-
 ROOT = Path(__file__).resolve().parents[2]
 CONTROLLER = Path("scripts/fly-filesystem-qualification.py")
 VALIDATOR = Path("scripts/ci/validate-fly-filesystem-qualification.py")
@@ -83,7 +82,9 @@ def validate_contract(root: Path) -> None:
         raise ContractError(f"invalid qualification evidence schema: {error}") from error
     if schema.get("additionalProperties") is not False:
         raise ContractError("evidence root must reject additional properties")
-    unsafe = sorted({name for name in property_names(schema) if FORBIDDEN_EVIDENCE_KEY.search(name)})
+    unsafe = sorted(
+        {name for name in property_names(schema) if FORBIDDEN_EVIDENCE_KEY.search(name)}
+    )
     if unsafe:
         raise ContractError("evidence schema exposes resource IDs or paths: " + ", ".join(unsafe))
     if "additionalProperties" not in read(root, SCHEMA):
@@ -113,7 +114,11 @@ class FlySafetyContractTests(unittest.TestCase):
                 "missing_machine_cleanup": (CONTROLLER, 'fly.run(["machine", "destroy"'),
                 "missing_volume_cleanup": (CONTROLLER, 'fly.run(["volumes", "destroy"'),
                 "missing_app_cleanup": (CONTROLLER, 'fly.run(["apps", "destroy"'),
-                "leaked_id": (SCHEMA, '"properties": {', '"properties": {"machine_id": {"type": "string"},'),
+                "leaked_id": (
+                    SCHEMA,
+                    '"properties": {',
+                    '"properties": {"machine_id": {"type": "string"},',
+                ),
             }
             for name, mutation in mutations.items():
                 with self.subTest(name=name):
@@ -122,7 +127,9 @@ class FlySafetyContractTests(unittest.TestCase):
                     if name == "public_port":
                         target.write_text(original + mutation[1], encoding="utf-8")
                     elif name == "leaked_id":
-                        target.write_text(original.replace(mutation[1], mutation[2], 1), encoding="utf-8")
+                        target.write_text(
+                            original.replace(mutation[1], mutation[2], 1), encoding="utf-8"
+                        )
                     else:
                         self.assertIn(mutation[1], original)
                         target.write_text(original.replace(mutation[1], ""), encoding="utf-8")

--- a/scripts/ci/test-fly-filesystem-safety-contract.py
+++ b/scripts/ci/test-fly-filesystem-safety-contract.py
@@ -111,9 +111,9 @@ class FlySafetyContractTests(unittest.TestCase):
                 "public_port": (ENTRYPOINT, "\npython3 -m http.server 8080 --bind 0.0.0.0\n"),
                 "mutable_image": (CONTROLLER, "sha256:"),
                 "missing_cleanup": (CONTROLLER, "finally"),
-                "missing_machine_cleanup": (CONTROLLER, 'fly.run(["machine", "destroy"'),
-                "missing_volume_cleanup": (CONTROLLER, 'fly.run(["volumes", "destroy"'),
-                "missing_app_cleanup": (CONTROLLER, 'fly.run(["apps", "destroy"'),
+                "missing_machine_cleanup": (CONTROLLER, '["machine", "destroy"'),
+                "missing_volume_cleanup": (CONTROLLER, '["volumes", "destroy"'),
+                "missing_app_cleanup": (CONTROLLER, '["apps", "destroy"'),
                 "leaked_id": (
                     SCHEMA,
                     '"properties": {',

--- a/scripts/ci/validate-fly-filesystem-qualification.py
+++ b/scripts/ci/validate-fly-filesystem-qualification.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Validate the small, sanitized Fly filesystem qualification artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA = ROOT / "docs/development/evidence/fly-filesystem-qualification.schema.json"
+FORBIDDEN_KEY = re.compile(r"(?:^|_)(?:id|token|secret|credential|password|path|name)(?:$|_)", re.I)
+ABSOLUTE_PATH = re.compile(r"^(?:/|[A-Za-z]:[\\/])")
+
+
+class EvidenceError(ValueError):
+    pass
+
+
+def reject_sensitive(value: Any, trail: str = "$") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if FORBIDDEN_KEY.search(key):
+                raise EvidenceError(f"forbidden identity, secret, or path field at {trail}.{key}")
+            reject_sensitive(child, f"{trail}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            reject_sensitive(child, f"{trail}[{index}]")
+    elif isinstance(value, str) and ABSOLUTE_PATH.search(value):
+        raise EvidenceError(f"absolute path at {trail}")
+
+
+def validate(evidence: dict[str, Any], *, sha: str, digest: str, region: str) -> None:
+    contract = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    errors = sorted(
+        Draft202012Validator(contract).iter_errors(evidence), key=lambda e: list(e.path)
+    )
+    if errors:
+        location = ".".join(map(str, errors[0].absolute_path)) or "$"
+        raise EvidenceError(f"schema violation at {location}: {errors[0].message}")
+    reject_sensitive(evidence)
+    if evidence["git_sha"] != sha:
+        raise EvidenceError("git_sha does not match the exact source commit")
+    if evidence["image_digest"] != digest:
+        raise EvidenceError("image_digest does not match the launched image")
+    if evidence["region"] != region:
+        raise EvidenceError("region does not match the fixed launch region")
+    accepted = evidence["admission"]["status"] == "accepted"
+    if accepted != (evidence["result"] == "qualified"):
+        raise EvidenceError("admission and result disagree")
+    if accepted and (
+        evidence["admission"]["code"] is not None or evidence["admission"]["cause"] is not None
+    ):
+        raise EvidenceError("accepted admission cannot contain failure classification")
+    if not accepted and (not evidence["admission"]["code"] or not evidence["admission"]["cause"]):
+        raise EvidenceError("rejected admission requires typed code and cause")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("evidence", type=Path)
+    parser.add_argument("--expected-sha", required=True)
+    parser.add_argument("--expected-image-digest", required=True)
+    parser.add_argument("--expected-region", required=True)
+    args = parser.parse_args()
+    try:
+        value = json.loads(args.evidence.read_text(encoding="utf-8"))
+        validate(
+            value,
+            sha=args.expected_sha,
+            digest=args.expected_image_digest,
+            region=args.expected_region,
+        )
+    except (OSError, json.JSONDecodeError, EvidenceError) as error:
+        parser.error(str(error))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/validate-fly-filesystem-qualification.py
+++ b/scripts/ci/validate-fly-filesystem-qualification.py
@@ -14,7 +14,7 @@ from jsonschema import Draft202012Validator
 ROOT = Path(__file__).resolve().parents[2]
 SCHEMA = ROOT / "docs/development/evidence/fly-filesystem-qualification.schema.json"
 FORBIDDEN_KEY = re.compile(r"(?:^|_)(?:id|token|secret|credential|password|path|name)(?:$|_)", re.I)
-ABSOLUTE_PATH = re.compile(r"^(?:/|[A-Za-z]:[\\/])")
+ABSOLUTE_PATH = re.compile(r"^(?:/|\\|[A-Za-z]:[\\/])")
 
 
 class EvidenceError(ValueError):

--- a/scripts/fly-filesystem-qualification.py
+++ b/scripts/fly-filesystem-qualification.py
@@ -10,6 +10,7 @@ import json
 from pathlib import Path
 import re
 import subprocess
+import sys
 import tempfile
 import time
 from typing import Any
@@ -58,7 +59,7 @@ def check_source(expected_sha: str) -> None:
         raise QualificationError("source tree is not clean")
 
 
-def launch_args(args: argparse.Namespace, volume_id: str) -> list[str]:
+def launch_args(args: argparse.Namespace, volume_id: str, digest: str) -> list[str]:
     return [
         "machine",
         "run",
@@ -74,7 +75,7 @@ def launch_args(args: argparse.Namespace, volume_id: str) -> list[str]:
         "--env",
         f"GF_FLY_QUALIFICATION_GIT_SHA={args.expected_sha}",
         "--env",
-        f"GF_FLY_QUALIFICATION_IMAGE_DIGEST={DIGEST_REF.fullmatch(args.image).group('digest')}",
+        f"GF_FLY_QUALIFICATION_IMAGE_DIGEST={digest}",
         "--env",
         f"GF_FLY_QUALIFICATION_REGION={args.region}",
         "--vm-cpu-kind",
@@ -113,6 +114,8 @@ def validate_inputs(args: argparse.Namespace) -> str:
         raise QualificationError("qualification volume must be small (1..20 GiB)")
     if not 60 <= args.retrieve_timeout_s <= 1800:
         raise QualificationError("evidence retrieval timeout must be in 60..1800 seconds")
+    if not args.evidence_out.parent.is_dir():
+        raise QualificationError("evidence output parent directory does not exist")
     if args.execute and not args.confirm_disposable:
         raise QualificationError("--execute requires --confirm-disposable")
     return match.group("digest")
@@ -143,11 +146,17 @@ def assert_machine_config(machine: dict[str, Any], args: argparse.Namespace, dig
 
 def cleanup(fly: Flyctl, app: str, machine_id: str | None, volume_id: str | None) -> None:
     # Child-before-parent cleanup is idempotent; already-absent resources are success.
+    operations = []
     if machine_id:
-        fly.run(["machine", "destroy", machine_id, "--app", app, "--force"], check=False)
+        operations.append(["machine", "destroy", machine_id, "--app", app, "--force"])
     if volume_id:
-        fly.run(["volumes", "destroy", volume_id, "--app", app, "--yes"], check=False)
-    fly.run(["apps", "destroy", app, "--yes"], check=False)
+        operations.append(["volumes", "destroy", volume_id, "--app", app, "--yes"])
+    operations.append(["apps", "destroy", app, "--yes"])
+    for operation in operations:
+        try:
+            fly.run(operation, check=False)
+        except subprocess.SubprocessError:  # noqa: PERF203 - every cleanup must run
+            continue
 
 
 def execute(args: argparse.Namespace, fly: Flyctl, digest: str) -> None:
@@ -178,7 +187,7 @@ def execute(args: argparse.Namespace, fly: Flyctl, digest: str) -> None:
             ]
         )
         volume_id = volume["id"]
-        fly.run(launch_args(args, volume_id))
+        fly.run(launch_args(args, volume_id, digest))
         machines = fly.json(["machine", "list", "--app", args.app_name])
         selected = [item for item in machines if item.get("name") == args.machine_name]
         if len(selected) != 1:
@@ -191,20 +200,23 @@ def execute(args: argparse.Namespace, fly: Flyctl, digest: str) -> None:
             local = Path(directory) / "evidence.json"
             deadline = time.monotonic() + args.retrieve_timeout_s
             while time.monotonic() < deadline:
-                result = fly.run(
-                    [
-                        "ssh",
-                        "sftp",
-                        "get",
-                        "/work/fly-qualification-evidence.json",
-                        str(local),
-                        "--app",
-                        args.app_name,
-                        "--machine",
-                        machine_id,
-                    ],
-                    check=False,
-                )
+                try:
+                    result = fly.run(
+                        [
+                            "ssh",
+                            "sftp",
+                            "get",
+                            "/work/fly-qualification-evidence.json",
+                            str(local),
+                            "--app",
+                            args.app_name,
+                            "--machine",
+                            machine_id,
+                        ],
+                        check=False,
+                    )
+                except subprocess.TimeoutExpired:
+                    continue
                 if result.returncode == 0 and local.is_file():
                     break
                 time.sleep(2)
@@ -297,7 +309,8 @@ def main() -> int:
         KeyError,
         ValueError,
     ) as error:
-        parser().error(str(error))
+        print(f"fly filesystem qualification failed: {error}", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/scripts/fly-filesystem-qualification.py
+++ b/scripts/fly-filesystem-qualification.py
@@ -29,9 +29,7 @@ class QualificationError(RuntimeError):
 class Flyctl:
     """Small injectable flyctl transport; stdout is never copied to evidence."""
 
-    def run(
-        self, args: Sequence[str], *, check: bool = True
-    ) -> subprocess.CompletedProcess[str]:
+    def run(self, args: Sequence[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
             ["flyctl", *args],
             cwd=ROOT,

--- a/scripts/fly-filesystem-qualification.py
+++ b/scripts/fly-filesystem-qualification.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Create one disposable, private Fly Machine for issue #882 qualification."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+import importlib.util
+import json
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+import time
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR_PATH = ROOT / "scripts/ci/validate-fly-filesystem-qualification.py"
+SHA = re.compile(r"^[0-9a-f]{40}$")
+DIGEST_REF = re.compile(r"^[^\s@]+@(?P<digest>sha256:[0-9a-f]{64})$")
+SAFE_NAME = re.compile(r"^[a-z][a-z0-9-]{2,62}$")
+SAFE_REGION = re.compile(r"^[a-z0-9-]{2,20}$")
+
+
+class QualificationError(RuntimeError):
+    pass
+
+
+class Flyctl:
+    """Small injectable flyctl transport; stdout is never copied to evidence."""
+
+    def run(
+        self, args: Sequence[str], *, check: bool = True
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["flyctl", *args],
+            cwd=ROOT,
+            check=check,
+            text=True,
+            capture_output=True,
+            timeout=120,
+        )
+
+    def json(self, args: Sequence[str]) -> Any:
+        return json.loads(self.run([*args, "--json"]).stdout)
+
+
+def check_source(expected_sha: str) -> None:
+    if not SHA.fullmatch(expected_sha):
+        raise QualificationError("--expected-sha must be exact lowercase 40-hex")
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=ROOT, check=True, text=True, stdout=subprocess.PIPE
+    ).stdout.strip()
+    dirty = subprocess.run(
+        ["git", "status", "--porcelain"], cwd=ROOT, check=True, text=True, stdout=subprocess.PIPE
+    ).stdout
+    if head != expected_sha:
+        raise QualificationError("expected SHA is not the checked-out HEAD")
+    if dirty:
+        raise QualificationError("source tree is not clean")
+
+
+def launch_args(args: argparse.Namespace, volume_id: str) -> list[str]:
+    return [
+        "machine",
+        "run",
+        args.image,
+        "--app",
+        args.app_name,
+        "--region",
+        args.region,
+        "--name",
+        args.machine_name,
+        "--volume",
+        f"{volume_id}:/work",
+        "--env",
+        f"GF_FLY_QUALIFICATION_GIT_SHA={args.expected_sha}",
+        "--env",
+        f"GF_FLY_QUALIFICATION_IMAGE_DIGEST={DIGEST_REF.fullmatch(args.image).group('digest')}",
+        "--env",
+        f"GF_FLY_QUALIFICATION_REGION={args.region}",
+        "--vm-cpu-kind",
+        "performance",
+        "--vm-cpus",
+        str(args.cpus),
+        "--vm-memory",
+        str(args.memory_mb),
+        "--restart",
+        "no",
+        "--rm",
+        "--autostop",
+        "off",
+        "--autostart=false",
+        "--skip-dns-registration",
+        "--detach",
+    ]
+
+
+def validate_inputs(args: argparse.Namespace) -> str:
+    match = DIGEST_REF.fullmatch(args.image)
+    if not match:
+        raise QualificationError("--image must be an immutable OCI @sha256 digest reference")
+    if not SHA.fullmatch(args.expected_sha):
+        raise QualificationError("--expected-sha must be exact lowercase 40-hex")
+    if not SAFE_REGION.fullmatch(args.region):
+        raise QualificationError("invalid fixed region")
+    for value in (args.app_name, args.volume_name, args.machine_name):
+        if not SAFE_NAME.fullmatch(value):
+            raise QualificationError("resource names must be explicit safe lowercase names")
+    if not 1 <= args.volume_size_gb <= 20:
+        raise QualificationError("qualification volume must be small (1..20 GiB)")
+    if args.execute and not args.confirm_disposable:
+        raise QualificationError("--execute requires --confirm-disposable")
+    return match.group("digest")
+
+
+def assert_machine_config(machine: dict[str, Any], args: argparse.Namespace, digest: str) -> None:
+    config = machine.get("config", {})
+    guest = config.get("guest", {})
+    image = machine.get("image_ref", {})
+    mounts = config.get("mounts", [])
+    if machine.get("region") != args.region or image.get("digest") != digest:
+        raise QualificationError("observed Machine region/image differs from the pinned plan")
+    if config.get("auto_destroy") is not True or config.get("restart", {}).get("policy") != "no":
+        raise QualificationError("Machine is not disposable")
+    if config.get("services") not in (None, []):
+        raise QualificationError("Machine unexpectedly exposes a service")
+    if (
+        guest.get("cpu_kind") != "performance"
+        or guest.get("cpus") != args.cpus
+        or guest.get("memory_mb") != args.memory_mb
+    ):
+        raise QualificationError("observed Machine resources differ from explicit plan")
+    if len(mounts) != 1 or mounts[0].get("path") != "/work":
+        raise QualificationError(
+            "Machine must have exactly one volume mounted at process work root"
+        )
+
+
+def cleanup(fly: Flyctl, app: str, machine_id: str | None, volume_id: str | None) -> None:
+    # Child-before-parent cleanup is idempotent; already-absent resources are success.
+    if machine_id:
+        fly.run(["machine", "destroy", machine_id, "--app", app, "--force"], check=False)
+    if volume_id:
+        fly.run(["volumes", "destroy", volume_id, "--app", app, "--yes"], check=False)
+    fly.run(["apps", "destroy", app, "--yes"], check=False)
+
+
+def execute(args: argparse.Namespace, fly: Flyctl, digest: str) -> None:
+    app_created = False
+    machine_id = None
+    volume_id = None
+    try:
+        apps = fly.json(["apps", "list"])
+        if any(
+            item.get("Name") == args.app_name or item.get("name") == args.app_name for item in apps
+        ):
+            raise QualificationError("refusing to reuse a non-empty app name")
+        app_created = True
+        fly.run(["apps", "create", args.app_name, "--org", args.org])
+        volume = fly.json(
+            [
+                "volumes",
+                "create",
+                args.volume_name,
+                "--app",
+                args.app_name,
+                "--region",
+                args.region,
+                "--size",
+                str(args.volume_size_gb),
+                "--scheduled-snapshots=false",
+                "--yes",
+            ]
+        )
+        volume_id = volume["id"]
+        fly.run(launch_args(args, volume_id))
+        machines = fly.json(["machine", "list", "--app", args.app_name])
+        selected = [item for item in machines if item.get("name") == args.machine_name]
+        if len(selected) != 1:
+            raise QualificationError("could not identify exactly one qualification Machine")
+        machine = selected[0]
+        machine_id = machine["id"]
+        assert_machine_config(machine, args, digest)
+
+        with tempfile.TemporaryDirectory(prefix="graphforge-fly-evidence-") as directory:
+            local = Path(directory) / "evidence.json"
+            deadline = time.monotonic() + args.retrieve_timeout_s
+            while time.monotonic() < deadline:
+                result = fly.run(
+                    [
+                        "ssh",
+                        "sftp",
+                        "get",
+                        "/work/fly-qualification-evidence.json",
+                        str(local),
+                        "--app",
+                        args.app_name,
+                        "--machine",
+                        machine_id,
+                    ],
+                    check=False,
+                )
+                if result.returncode == 0 and local.is_file():
+                    break
+                time.sleep(2)
+            else:
+                raise QualificationError("timed out retrieving qualification evidence")
+
+            spec = importlib.util.spec_from_file_location("fly_evidence_validator", VALIDATOR_PATH)
+            if spec is None or spec.loader is None:
+                raise QualificationError("cannot load committed evidence validator")
+            validator = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(validator)
+            evidence = json.loads(local.read_text(encoding="utf-8"))
+            validator.validate(evidence, sha=args.expected_sha, digest=digest, region=args.region)
+            args.evidence_out.write_text(
+                json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+            )
+            fly.run(
+                [
+                    "machine",
+                    "exec",
+                    machine_id,
+                    "--app",
+                    args.app_name,
+                    "touch",
+                    "/work/controller-ack",
+                ]
+            )
+            if evidence["result"] != "qualified":
+                raise QualificationError(
+                    "filesystem admission was not qualified; full run remains blocked"
+                )
+    finally:
+        if app_created:
+            cleanup(fly, args.app_name, machine_id, volume_id)
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument("--expected-sha", required=True)
+    result.add_argument("--image", required=True)
+    result.add_argument("--region", required=True)
+    result.add_argument("--org", required=True)
+    result.add_argument("--app-name", required=True)
+    result.add_argument("--volume-name", required=True)
+    result.add_argument("--machine-name", required=True)
+    result.add_argument("--cpus", type=int, default=2, choices=range(1, 17))
+    result.add_argument("--memory-mb", type=int, default=4096, choices=range(1024, 131073))
+    result.add_argument("--volume-size-gb", type=int, default=10)
+    result.add_argument("--retrieve-timeout-s", type=int, default=1200, choices=range(60, 1801))
+    result.add_argument(
+        "--evidence-out", type=Path, default=Path("fly-qualification-evidence.json")
+    )
+    result.add_argument("--execute", action="store_true")
+    result.add_argument("--confirm-disposable", action="store_true")
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        digest = validate_inputs(args)
+        check_source(args.expected_sha)
+        if not args.execute:
+            print(
+                json.dumps(
+                    {
+                        "mode": "dry-run",
+                        "git_sha": args.expected_sha,
+                        "image_digest": digest,
+                        "region": args.region,
+                        "cpu_kind": "performance",
+                        "cpus": args.cpus,
+                        "memory_mb": args.memory_mb,
+                        "volume_size_gb": args.volume_size_gb,
+                        "mount_role": "process_work_root",
+                        "public_services": 0,
+                        "restart": "no",
+                        "auto_destroy": True,
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+            return 0
+        execute(args, Flyctl(), digest)
+    except (
+        QualificationError,
+        subprocess.SubprocessError,
+        json.JSONDecodeError,
+        KeyError,
+        ValueError,
+    ) as error:
+        parser().error(str(error))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fly-filesystem-qualification.py
+++ b/scripts/fly-filesystem-qualification.py
@@ -107,8 +107,14 @@ def validate_inputs(args: argparse.Namespace) -> str:
     for value in (args.app_name, args.volume_name, args.machine_name):
         if not SAFE_NAME.fullmatch(value):
             raise QualificationError("resource names must be explicit safe lowercase names")
+    if not 1 <= args.cpus <= 16:
+        raise QualificationError("qualification CPU count must be in 1..16")
+    if not 1024 <= args.memory_mb <= 131072:
+        raise QualificationError("qualification memory must be in 1024..131072 MiB")
     if not 1 <= args.volume_size_gb <= 20:
         raise QualificationError("qualification volume must be small (1..20 GiB)")
+    if not 60 <= args.retrieve_timeout_s <= 1800:
+        raise QualificationError("evidence retrieval timeout must be in 60..1800 seconds")
     if args.execute and not args.confirm_disposable:
         raise QualificationError("--execute requires --confirm-disposable")
     return match.group("digest")
@@ -246,10 +252,10 @@ def parser() -> argparse.ArgumentParser:
     result.add_argument("--app-name", required=True)
     result.add_argument("--volume-name", required=True)
     result.add_argument("--machine-name", required=True)
-    result.add_argument("--cpus", type=int, default=2, choices=range(1, 17))
-    result.add_argument("--memory-mb", type=int, default=4096, choices=range(1024, 131073))
+    result.add_argument("--cpus", type=int, default=2)
+    result.add_argument("--memory-mb", type=int, default=4096)
     result.add_argument("--volume-size-gb", type=int, default=10)
-    result.add_argument("--retrieve-timeout-s", type=int, default=1200, choices=range(60, 1801))
+    result.add_argument("--retrieve-timeout-s", type=int, default=1200)
     result.add_argument(
         "--evidence-out", type=Path, default=Path("fly-qualification-evidence.json")
     )

--- a/tools/bazel/parity/migration_target_map.json
+++ b/tools/bazel/parity/migration_target_map.json
@@ -1,7 +1,7 @@
 {
   "schema": "graphforge.bazel-migration-target-map.v1",
   "issue": 6,
-  "cargo_target_count": 112,
+  "cargo_target_count": 113,
   "targets": [
     {
       "package": "graphforge-api",

--- a/tools/bazel/parity/migration_target_map.json
+++ b/tools/bazel/parity/migration_target_map.json
@@ -435,6 +435,16 @@
     },
     {
       "package": "graphforge-api",
+      "target": "graphforge-fly-filesystem-smoke",
+      "class": "bin",
+      "source": "crates/graphforge-api/src/bin/graphforge-fly-filesystem-smoke.rs",
+      "status": "mapped",
+      "bazel_label": "//crates/graphforge-api:graphforge-fly-filesystem-smoke",
+      "exception_id": null,
+      "notes": "#882 exact-path Fly filesystem qualification"
+    },
+    {
+      "package": "graphforge-api",
       "target": "public_facade_remaining_conformance",
       "class": "integration-test",
       "source": "crates/graphforge-api/tests/public_facade_remaining_conformance.rs",


### PR DESCRIPTION
Closes #882

## Summary
- add a Rust-owned exact-path durable and portable-v2 qualification probe
- add a dry-run-first disposable Fly Machine controller with private networking and fail-closed cleanup
- add a closed sanitized evidence contract, validator, container, runbook, and mutation safety tests
- keep 128 GiB as the M5 ceiling; default this probe to a small Machine and reserve scale sizing for measured RSS plateau evidence

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p graphforge-api --bin graphforge-fly-filesystem-smoke` (3 passed)
- `cargo clippy -p graphforge-api --bin graphforge-fly-filesystem-smoke -- -D warnings`
- `python3 scripts/ci/cargo-bazel-drift-check.py`
- `uv run --frozen --extra dev pytest -q scripts/ci/test-fly-filesystem-qualification.py` (11 passed)
- `uv run --frozen --extra dev python scripts/ci/test-fly-filesystem-safety-contract.py`
- dry-run plan at exact head (2 performance CPUs, 4 GiB, 10 GiB volume, zero public services)

No Fly resources were provisioned by this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789963819&installation_model_id=20486&pr_number=883&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F883&signature=41cee17a1864bb089d158f01dc34a670cba97d0556752ec49c70737b75df6503"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a disposable Fly filesystem qualification workflow with dry-run support and explicit execution confirmation.
  * Validates filesystem durability, persistence, export/import flows, machine configuration, and evidence integrity.
  * Produces sanitized qualification evidence with clear accepted or rejected outcomes.
  * Automatically cleans up temporary machines, volumes, and applications after execution.
  * Added containerized smoke-test execution with timeout and acknowledgment handling.

* **Tests**
  * Added coverage for evidence validation, safety requirements, cleanup behavior, configuration checks, and rejection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->