### PR TITLE
fix(scale): accept Fly-valid volume names

### DIFF
--- a/docs/development/fly-filesystem-qualification.md
+++ b/docs/development/fly-filesystem-qualification.md
@@ -14,7 +14,7 @@ python3 scripts/fly-filesystem-qualification.py \
   --image "registry.example/graphforge@sha256:<64-hex-digest>" \
   --region den --org curatelabs \
   --app-name gf-fs-qual-<suffix> \
-  --volume-name gf-fs-vol-<suffix> \
+  --volume-name gf_fs_vol_<suffix> \
   --machine-name gf-fs-machine-<suffix>
 ```
 

--- a/scripts/ci/test-fly-filesystem-qualification.py
+++ b/scripts/ci/test-fly-filesystem-qualification.py
@@ -31,7 +31,7 @@ def args(**changes):
         "region": "den",
         "org": "curate",
         "app_name": "gf-qual-app",
-        "volume_name": "gf-qual-vol",
+        "volume_name": "gf_qual_vol",
         "machine_name": "gf-qual-machine",
         "cpus": 2,
         "memory_mb": 4096,
@@ -73,6 +73,28 @@ def test_refuses_mutable_image_and_execute_without_confirmation():
         controller.validate_inputs(args(image="registry.example/graphforge:latest"))
     with pytest.raises(controller.QualificationError, match="confirm-disposable"):
         controller.validate_inputs(args(execute=True))
+
+
+@pytest.mark.parametrize("volume_name", ["v", "v" + "0" * 29, "gf_qual_vol"])
+def test_accepts_fly_valid_volume_names(volume_name):
+    controller.validate_inputs(args(volume_name=volume_name))
+
+
+@pytest.mark.parametrize(
+    "volume_name",
+    ["gf-qual-vol", "GF_QUAL_VOL", "_gf_qual_vol", "v" + "0" * 30],
+)
+def test_refuses_fly_invalid_volume_names(volume_name):
+    with pytest.raises(controller.QualificationError, match="volume name"):
+        controller.validate_inputs(args(volume_name=volume_name))
+
+
+def test_volume_create_command_uses_valid_name_and_exact_resources():
+    command = controller.volume_create_args(args())
+    assert command[:3] == ["volumes", "create", "gf_qual_vol"]
+    assert command[command.index("--region") + 1] == "den"
+    assert command[command.index("--size") + 1] == "10"
+    assert "--scheduled-snapshots=false" in command
 
 
 @pytest.mark.parametrize(

--- a/scripts/fly-filesystem-qualification.py
+++ b/scripts/fly-filesystem-qualification.py
@@ -19,7 +19,8 @@ ROOT = Path(__file__).resolve().parents[1]
 VALIDATOR_PATH = ROOT / "scripts/ci/validate-fly-filesystem-qualification.py"
 SHA = re.compile(r"^[0-9a-f]{40}$")
 DIGEST_REF = re.compile(r"^[^\s@]+@(?P<digest>sha256:[0-9a-f]{64})$")
-SAFE_NAME = re.compile(r"^[a-z][a-z0-9-]{2,62}$")
+SAFE_APP_MACHINE_NAME = re.compile(r"^[a-z][a-z0-9-]{2,62}$")
+SAFE_VOLUME_NAME = re.compile(r"^[a-z][a-z0-9_]{0,29}$")
 SAFE_REGION = re.compile(r"^[a-z0-9-]{2,20}$")
 
 
@@ -95,6 +96,22 @@ def launch_args(args: argparse.Namespace, volume_id: str, digest: str) -> list[s
     ]
 
 
+def volume_create_args(args: argparse.Namespace) -> list[str]:
+    return [
+        "volumes",
+        "create",
+        args.volume_name,
+        "--app",
+        args.app_name,
+        "--region",
+        args.region,
+        "--size",
+        str(args.volume_size_gb),
+        "--scheduled-snapshots=false",
+        "--yes",
+    ]
+
+
 def validate_inputs(args: argparse.Namespace) -> str:
     match = DIGEST_REF.fullmatch(args.image)
     if not match:
@@ -103,9 +120,13 @@ def validate_inputs(args: argparse.Namespace) -> str:
         raise QualificationError("--expected-sha must be exact lowercase 40-hex")
     if not SAFE_REGION.fullmatch(args.region):
         raise QualificationError("invalid fixed region")
-    for value in (args.app_name, args.volume_name, args.machine_name):
-        if not SAFE_NAME.fullmatch(value):
-            raise QualificationError("resource names must be explicit safe lowercase names")
+    for value in (args.app_name, args.machine_name):
+        if not SAFE_APP_MACHINE_NAME.fullmatch(value):
+            raise QualificationError("app and Machine names must be safe lowercase names")
+    if not SAFE_VOLUME_NAME.fullmatch(args.volume_name):
+        raise QualificationError(
+            "volume name must be 1..30 lowercase alphanumeric/underscore characters"
+        )
     if not 1 <= args.cpus <= 16:
         raise QualificationError("qualification CPU count must be in 1..16")
     if not 1024 <= args.memory_mb <= 131072:
@@ -171,21 +192,7 @@ def execute(args: argparse.Namespace, fly: Flyctl, digest: str) -> None:
             raise QualificationError("refusing to reuse a non-empty app name")
         app_created = True
         fly.run(["apps", "create", args.app_name, "--org", args.org])
-        volume = fly.json(
-            [
-                "volumes",
-                "create",
-                args.volume_name,
-                "--app",
-                args.app_name,
-                "--region",
-                args.region,
-                "--size",
-                str(args.volume_size_gb),
-                "--scheduled-snapshots=false",
-                "--yes",
-            ]
-        )
+        volume = fly.json(volume_create_args(args))
         volume_id = volume["id"]
         fly.run(launch_args(args, volume_id, digest))
         machines = fly.json(["machine", "list", "--app", args.app_name])


### PR DESCRIPTION
Closes #884

## Summary

- validate Fly app/Machine and volume names against their distinct provider constraints
- accept only lowercase alphanumeric/underscore volume names up to 30 characters
- cover valid/invalid boundaries and the exact volume-create command
- update the runbook example to a provider-valid volume name

## Verification

- `uv run pytest -q scripts/ci/test-fly-filesystem-qualification.py` (21 passed)
- `python3 scripts/ci/test-fly-filesystem-safety-contract.py` (2 passed)
- `uv run ruff format --check scripts/fly-filesystem-qualification.py scripts/ci/test-fly-filesystem-qualification.py`
- `uv run ruff check scripts/fly-filesystem-qualification.py scripts/ci/test-fly-filesystem-qualification.py`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789993585&installation_model_id=20486&pr_number=885&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F885&signature=bec4b665bbf41ae618c806aac856b211d9715cda3486d170e93ff714cc1a9863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->