### PR TITLE
Fix Fly qualification acknowledgement command

### DIFF
--- a/scripts/ci/test-fly-filesystem-qualification.py
+++ b/scripts/ci/test-fly-filesystem-qualification.py
@@ -231,6 +231,53 @@ class FakeFly:
         return argparse.Namespace(returncode=0, stdout="", stderr="")
 
 
+def test_machine_exec_receives_acknowledgement_as_one_remote_command(tmp_path, monkeypatch):
+    fake = FakeFly()
+    fake_json_responses = iter(
+        [
+            [],
+            {"id": "volume-internal"},
+        ]
+    )
+    fake.json = lambda _command: next(fake_json_responses)
+    machine = {
+        "id": "machine-internal",
+        "region": "den",
+        "image_ref": {"digest": "sha256:" + "b" * 64},
+        "config": {
+            "auto_destroy": True,
+            "restart": {"policy": "no"},
+            "guest": {"cpu_kind": "performance", "cpus": 2, "memory_mb": 4096},
+            "mounts": [{"path": "/work"}],
+            "services": [],
+        },
+    }
+    monkeypatch.setattr(controller, "create_machine", lambda *_args: machine)
+    monkeypatch.setattr(controller.time, "monotonic", lambda: 0)
+
+    original_run = fake.run
+
+    def run(command, check=True):
+        result = original_run(command, check)
+        if command[:4] == ["ssh", "sftp", "get", "/work/fly-qualification-evidence.json"]:
+            Path(command[4]).write_text(json.dumps(evidence()) + "\n", encoding="utf-8")
+        return result
+
+    fake.run = run
+    output = tmp_path / "evidence.json"
+    controller.execute(args(evidence_out=output), fake, "sha256:" + "b" * 64)
+
+    assert [
+        "machine",
+        "exec",
+        "machine-internal",
+        "--app",
+        "gf-qual-app",
+        "touch /work/controller-ack",
+    ] in fake.calls
+    assert output.is_file()
+
+
 def test_teardown_is_child_first_and_idempotent():
     fake = FakeFly()
     controller.cleanup(fake, "gf-qual-app", "machine-internal", "volume-internal")

--- a/scripts/fly-filesystem-qualification.py
+++ b/scripts/fly-filesystem-qualification.py
@@ -255,8 +255,7 @@ def execute(args: argparse.Namespace, fly: Flyctl, digest: str) -> None:
                     machine_id,
                     "--app",
                     args.app_name,
-                    "touch",
-                    "/work/controller-ack",
+                    "touch /work/controller-ack",
                 ]
             )
             if evidence["result"] != "qualified":


### PR DESCRIPTION
Closes #894.

Passes the remote acknowledgement to `flyctl machine exec` as the single command string its CLI expects. Adds a controller-level regression test that exercises evidence retrieval, validation, acknowledgement, and cleanup command capture.

Validation:
- `python -m pytest -q scripts/ci/test-fly-filesystem-qualification.py` (23 passed)
- `python -m ruff check scripts/fly-filesystem-qualification.py scripts/ci/test-fly-filesystem-qualification.py`
- `python -m ruff format --check scripts/fly-filesystem-qualification.py scripts/ci/test-fly-filesystem-qualification.py`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790006583&installation_model_id=20486&pr_number=895&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F895&signature=c3ef50df18878fd604f168673209ba4bf723a8a7527a79bcaebc8858bcd13f8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->