### PR TITLE
Cap provisioned Graph500 ladder at authorized rung

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -320,7 +320,9 @@ bench-g500-scale20:  ## Official-parameter SCALE-20 public-facade engineering gr
 	cargo test -p graphforge-api --release --test scale_g500_scale20 scale20_public_facade_engineering_green -- --ignored --nocapture --test-threads=1
 
 bench-g500-ladder:  ## Bounded billion-edge scale ladder S20-S26 first-fail evidence (#736; ignored, provisioned scale-host)
+	@test -n "$$GF_G500_LADDER_MAX_SCALE" || (echo "GF_G500_LADDER_MAX_SCALE is required" && exit 2)
 	GF_G500_LADDER_EVIDENCE_OUT="$(CURDIR)/docs/development/g500-ladder-evidence.json" \
+	GF_G500_LADDER_MAX_SCALE="$$GF_G500_LADDER_MAX_SCALE" \
 	cargo test -p graphforge-api --release --test scale_g500_ladder ladder_public_facade_first_fail_evidence -- --ignored --nocapture --test-threads=1
 
 bench-adjacency-200m:  ## >200M-edge public adjacency build evidence (#336; ignored, scale-host)

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -743,6 +743,24 @@ fn run_ladder(profile: &ScaleProfile, env: RunEnvelope, rungs: &[Rung]) -> Vec<V
     evidence
 }
 
+fn provisioned_rungs_through(profile: &ScaleProfile, max_scale: u32) -> Result<Vec<Rung>, String> {
+    let is_provisioned_max = profile
+        .rungs
+        .iter()
+        .any(|rung| rung.scale == max_scale && rung.tier == "provisioned");
+    if !is_provisioned_max {
+        return Err(format!(
+            "GF_G500_LADDER_MAX_SCALE={max_scale} is not a provisioned profile rung"
+        ));
+    }
+    Ok(profile
+        .rungs
+        .iter()
+        .filter(|rung| rung.tier == "provisioned" && rung.scale <= max_scale)
+        .cloned()
+        .collect())
+}
+
 // ---------------------------------------------------------------------------
 // Streaming edge publisher (bounded by EDGE_PUBLISH_ROWS).
 // ---------------------------------------------------------------------------
@@ -1314,12 +1332,12 @@ fn ci_rung_public_facade_engineering_green() {
 #[ignore = "Provisioned billion-edge scale ladder; make bench-g500-ladder"]
 fn ladder_public_facade_first_fail_evidence() {
     let profile = load_profile();
-    let provisioned: Vec<Rung> = profile
-        .rungs
-        .iter()
-        .filter(|r| r.tier == "provisioned")
-        .cloned()
-        .collect();
+    let max_scale = std::env::var("GF_G500_LADDER_MAX_SCALE")
+        .expect("GF_G500_LADDER_MAX_SCALE must explicitly cap the authorized ladder")
+        .parse::<u32>()
+        .expect("GF_G500_LADDER_MAX_SCALE must be an integer");
+    let provisioned =
+        provisioned_rungs_through(&profile, max_scale).unwrap_or_else(|error| panic!("{error}"));
     let evidence = run_ladder(&profile, profile.envelope.into(), &provisioned);
     assert!(
         !evidence.is_empty(),
@@ -1339,6 +1357,7 @@ fn ladder_public_facade_first_fail_evidence() {
             "schema": EVIDENCE_SCHEMA,
             "schema_version": SCHEMA_VERSION,
             "profile_schema": profile.schema,
+            "authorized_max_scale": max_scale,
             "rungs": evidence,
         }))
         .expect("serialize ladder evidence"),
@@ -1355,6 +1374,19 @@ fn ladder_public_facade_first_fail_evidence() {
             "an evaluated rung must reconcile; got {rec}"
         );
     }
+}
+
+#[test]
+fn provisioned_max_scale_excludes_larger_rungs() {
+    let profile = load_profile();
+    let selected = provisioned_rungs_through(&profile, 25).expect("S25 is provisioned");
+    assert_eq!(
+        selected.iter().map(|rung| rung.scale).collect::<Vec<_>>(),
+        vec![20, 22, 24, 25]
+    );
+    assert!(selected.iter().all(|rung| rung.scale != 26));
+    assert!(provisioned_rungs_through(&profile, 10).is_err());
+    assert!(provisioned_rungs_through(&profile, 23).is_err());
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/development/perf-g500-ladder.md
+++ b/docs/development/perf-g500-ladder.md
@@ -128,10 +128,15 @@ Provisioned full ladder (long; isolate the target dir; **Linux cloud scale-host*
 matching the declared SKU — not a developer laptop for #745 evidence):
 
 ```bash
-CARGO_TARGET_DIR=/tmp/cargo-g500-ladder make bench-g500-ladder
+GF_G500_LADDER_MAX_SCALE=25 CARGO_TARGET_DIR=/tmp/cargo-g500-ladder make bench-g500-ladder
 # override the evidence path:
-GF_G500_LADDER_EVIDENCE_OUT=build/g500-ladder-evidence.json make bench-g500-ladder
+GF_G500_LADDER_MAX_SCALE=25 GF_G500_LADDER_EVIDENCE_OUT=build/g500-ladder-evidence.json make bench-g500-ladder
 ```
+
+`GF_G500_LADDER_MAX_SCALE` is mandatory and must name a provisioned rung in the
+profile. It is an authorization ceiling, not a performance hint: selecting 25
+runs S20, S22, S24, and S25, and excludes S26 even when every smaller rung
+passes.
 
 Default evidence path: `docs/development/g500-ladder-evidence.json`.
 


### PR DESCRIPTION
Closes #896.

Requires an explicit `GF_G500_LADDER_MAX_SCALE` matching a provisioned profile rung. An S25 authorization selects S20/S22/S24/S25 and excludes S26 by construction. The selected ceiling is recorded in evidence.

Validation:
- `cargo fmt --all -- --check`
- `cargo test -p graphforge-api --test scale_g500_ladder` (13 passed, 2 intentionally ignored)
- unset `GF_G500_LADDER_MAX_SCALE` makes `make bench-g500-ladder` fail before execution

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790020947&installation_model_id=20486&pr_number=897&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F897&signature=218c8910f8bd2464a79ceca06da3790cbd0aef5ad6ffa93680957cddfa615ce3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * G500 ladder benchmark runs now require an explicit maximum scale.
  * Benchmark results are limited to the authorized scale, with the selected limit recorded in the evidence output.
  * Added validation to reject unsupported or non-provisioned scale limits and prevent larger rungs from being included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->