### PR TITLE
Journal Graph500 ladder phases atomically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -322,6 +322,7 @@ bench-g500-scale20:  ## Official-parameter SCALE-20 public-facade engineering gr
 bench-g500-ladder:  ## Bounded billion-edge scale ladder S20-S26 first-fail evidence (#736; ignored, provisioned scale-host)
 	@test -n "$$GF_G500_LADDER_MAX_SCALE" || (echo "GF_G500_LADDER_MAX_SCALE is required" && exit 2)
 	GF_G500_LADDER_EVIDENCE_OUT="$(CURDIR)/docs/development/g500-ladder-evidence.json" \
+	GF_G500_LADDER_JOURNAL_OUT="$(CURDIR)/build/g500-ladder-journal.json" \
 	GF_G500_LADDER_MAX_SCALE="$$GF_G500_LADDER_MAX_SCALE" \
 	cargo test -p graphforge-api --release --test scale_g500_ladder ladder_public_facade_first_fail_evidence -- --ignored --nocapture --test-threads=1
 

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -56,6 +56,7 @@ const ONE_HOP: &str = "MATCH (a)-[r]->(b) RETURN b.node_uuid AS id ORDER BY id L
 const TWO_HOP: &str =
     "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN c.node_uuid AS id ORDER BY id LIMIT 1000";
 const COUNT_EDGES: &str = "MATCH ()-[r:LINK]->() RETURN count(r) AS total";
+static JOURNAL_WRITE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 // ---------------------------------------------------------------------------
 // Versioned profile (single source of truth for the ladder).
@@ -553,6 +554,7 @@ fn phase_journal_value(
     phase: &str,
     state: &str,
     steps: &[Value],
+    failure: Option<(&str, &str)>,
 ) -> Value {
     json!({
         "schema": EVIDENCE_SCHEMA,
@@ -565,19 +567,29 @@ fn phase_journal_value(
         "process_memory": linux_process_memory(),
         "completed_rungs": completed_rungs,
         "active_steps": steps,
+        "first_failing_phase": failure.map(|(phase, _)| phase),
+        "error_class": failure.map(|(_, class)| class),
     })
 }
 
 fn write_json_atomically(path: &Path, value: &Value) {
     let parent = path.parent().expect("journal parent");
     fs::create_dir_all(parent).expect("journal parent");
-    let temporary = path.with_extension("json.tmp");
+    let sequence = JOURNAL_WRITE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let file_name = path
+        .file_name()
+        .expect("journal file name")
+        .to_string_lossy();
+    let temporary = parent.join(format!(
+        ".{file_name}.{}.{}.tmp",
+        std::process::id(),
+        sequence
+    ));
     let mut file = fs::File::create(&temporary).expect("create journal temporary");
     serde_json::to_writer_pretty(&mut file, value).expect("serialize journal");
-    use std::io::Write;
     file.write_all(b"\n").expect("terminate journal");
     file.sync_all().expect("sync journal temporary");
-    fs::rename(&temporary, &path).expect("publish journal");
+    fs::rename(&temporary, path).expect("publish journal");
     fs::File::open(parent)
         .and_then(|directory| directory.sync_all())
         .expect("sync journal parent");
@@ -590,11 +602,12 @@ fn persist_phase_journal(
     phase: &str,
     state: &str,
     steps: &[Value],
+    failure: Option<(&str, &str)>,
 ) {
     let Ok(path) = std::env::var("GF_G500_LADDER_JOURNAL_OUT") else {
         return;
     };
-    let value = phase_journal_value(profile, rung, completed_rungs, phase, state, steps);
+    let value = phase_journal_value(profile, rung, completed_rungs, phase, state, steps, failure);
     write_json_atomically(&PathBuf::from(path), &value);
 }
 
@@ -626,6 +639,7 @@ fn run_rung(
         "generate",
         "running",
         &steps,
+        None,
     );
     let gen_started = Instant::now();
     let spill = generate_spill_runs(
@@ -661,8 +675,13 @@ fn run_rung(
         rung,
         completed_rungs,
         "generate",
-        "phase_completed",
+        if gen_violation.is_some() {
+            "phase_failed"
+        } else {
+            "phase_completed"
+        },
         &steps,
+        first_failing_phase.zip(error_class),
     );
 
     // ---- ingest (merge + publish through the public facade) ----
@@ -671,7 +690,15 @@ fn run_rung(
     let mut input_fingerprint = String::from("sha256:");
     let mut ingest_ran = false;
     if first_failing_phase.is_none() {
-        persist_phase_journal(profile, rung, completed_rungs, "ingest", "running", &steps);
+        persist_phase_journal(
+            profile,
+            rung,
+            completed_rungs,
+            "ingest",
+            "running",
+            &steps,
+            None,
+        );
         let ingest_started = Instant::now();
         let graph = GraphForge::new(Some(project.to_str().expect("utf8 project")))
             .expect("open GraphForge for ingest");
@@ -710,8 +737,13 @@ fn run_rung(
             rung,
             completed_rungs,
             "ingest",
-            "phase_completed",
+            if ingest_violation.is_some() {
+                "phase_failed"
+            } else {
+                "phase_completed"
+            },
             &steps,
+            first_failing_phase.zip(error_class),
         );
     }
 
@@ -720,7 +752,15 @@ fn run_rung(
     let mut edge_count = 0u64;
     let mut gsi = String::new();
     if first_failing_phase.is_none() {
-        persist_phase_journal(profile, rung, completed_rungs, "reopen", "running", &steps);
+        persist_phase_journal(
+            profile,
+            rung,
+            completed_rungs,
+            "reopen",
+            "running",
+            &steps,
+            None,
+        );
         let reopen_started = Instant::now();
         let graph = GraphForge::new(Some(project.to_str().expect("utf8 project")))
             .expect("reopen GraphForge");
@@ -728,9 +768,14 @@ fn run_rung(
         edge_count = scalar_count(&graph.execute(COUNT_EDGES).expect("edge count"));
         let reopen_s = reopen_started.elapsed().as_secs_f64();
         gsi = gsi_undirected(node_count, edge_count);
+        let reopen_violation = envelope_violation(&env, ladder_started, &project, &spill_dir);
+        if let Some(class) = reopen_violation {
+            first_failing_phase = Some("reopen");
+            error_class = Some(class);
+        }
         steps.push(json!({
             "id": "reopen",
-            "pass": true,
+            "pass": reopen_violation.is_none(),
             "wall_time_s": reopen_s,
             "rss_peak_bytes": rss_value(),
             "detail": { "node_count": node_count, "edge_count": edge_count, "gsi": gsi }
@@ -740,44 +785,65 @@ fn run_rung(
             rung,
             completed_rungs,
             "reopen",
-            "phase_completed",
+            if reopen_violation.is_some() {
+                "phase_failed"
+            } else {
+                "phase_completed"
+            },
             &steps,
+            first_failing_phase.zip(error_class),
         );
 
         // ---- deterministic LIMIT queries ----
-        let hop1_started = Instant::now();
-        persist_phase_journal(profile, rung, completed_rungs, "query", "running", &steps);
-        let hop1 = graph.execute(ONE_HOP).expect("one-hop LIMIT");
-        let hop1_rows = row_count(&hop1);
-        steps.push(json!({
-            "id": "cypher_limit_1hop",
-            "pass": hop1_rows <= 1_000,
-            "wall_time_s": hop1_started.elapsed().as_secs_f64(),
-            "detail": { "rows": hop1_rows }
-        }));
+        if first_failing_phase.is_none() {
+            let hop1_started = Instant::now();
+            persist_phase_journal(
+                profile,
+                rung,
+                completed_rungs,
+                "query",
+                "running",
+                &steps,
+                None,
+            );
+            let hop1 = graph.execute(ONE_HOP).expect("one-hop LIMIT");
+            let hop1_rows = row_count(&hop1);
+            steps.push(json!({
+                "id": "cypher_limit_1hop",
+                "pass": hop1_rows <= 1_000,
+                "wall_time_s": hop1_started.elapsed().as_secs_f64(),
+                "detail": { "rows": hop1_rows }
+            }));
 
-        let hop2_started = Instant::now();
-        let hop2 = graph.execute(TWO_HOP).expect("two-hop LIMIT");
-        let hop2_rows = row_count(&hop2);
-        steps.push(json!({
-            "id": "cypher_limit_2hop",
-            "pass": hop2_rows <= 1_000,
-            "wall_time_s": hop2_started.elapsed().as_secs_f64(),
-            "detail": { "rows": hop2_rows }
-        }));
-        drop(graph);
-        if let Some(class) = envelope_violation(&env, ladder_started, &project, &spill_dir) {
-            first_failing_phase = Some("query");
-            error_class = Some(class);
+            let hop2_started = Instant::now();
+            let hop2 = graph.execute(TWO_HOP).expect("two-hop LIMIT");
+            let hop2_rows = row_count(&hop2);
+            steps.push(json!({
+                "id": "cypher_limit_2hop",
+                "pass": hop2_rows <= 1_000,
+                "wall_time_s": hop2_started.elapsed().as_secs_f64(),
+                "detail": { "rows": hop2_rows }
+            }));
+            let query_violation = envelope_violation(&env, ladder_started, &project, &spill_dir);
+            if let Some(class) = query_violation {
+                first_failing_phase = Some("query");
+                error_class = Some(class);
+            }
+            persist_phase_journal(
+                profile,
+                rung,
+                completed_rungs,
+                "query",
+                if query_violation.is_some() {
+                    "phase_failed"
+                } else {
+                    "phase_completed"
+                },
+                &steps,
+                first_failing_phase.zip(error_class),
+            );
         }
-        persist_phase_journal(
-            profile,
-            rung,
-            completed_rungs,
-            "query",
-            "phase_completed",
-            &steps,
-        );
+        drop(graph);
     }
 
     let disk_used_bytes =
@@ -864,7 +930,21 @@ fn run_ladder(profile: &ScaleProfile, env: RunEnvelope, rungs: &[Rung]) -> Vec<V
         );
         let passed = outcome.passed;
         evidence.push(outcome.evidence);
-        persist_phase_journal(profile, rung, &evidence, "rung", "rung_completed", &[]);
+        let first_failing_phase = evidence
+            .last()
+            .and_then(|rung| rung["first_failing_phase"].as_str());
+        let error_class = evidence
+            .last()
+            .and_then(|rung| rung["error_class"].as_str());
+        persist_phase_journal(
+            profile,
+            rung,
+            &evidence,
+            "rung",
+            "rung_completed",
+            &[],
+            first_failing_phase.zip(error_class),
+        );
         if !passed {
             break;
         }
@@ -1530,11 +1610,21 @@ fn phase_journal_atomically_preserves_completed_rungs_and_active_state() {
         .expect("S22 rung");
     let completed = vec![json!({"rung": "S20", "pass": true})];
     let steps = vec![json!({"id": "generate", "pass": true})];
-    let journal = phase_journal_value(&profile, rung, &completed, "ingest", "running", &steps);
+    let journal = phase_journal_value(
+        &profile,
+        rung,
+        &completed,
+        "ingest",
+        "phase_failed",
+        &steps,
+        Some(("ingest", "disk_limit")),
+    );
     assert_eq!(journal["completed_rungs"], json!(completed));
     assert_eq!(journal["active_rung"], "S22");
     assert_eq!(journal["active_phase"], "ingest");
-    assert_eq!(journal["run_state"], "running");
+    assert_eq!(journal["run_state"], "phase_failed");
+    assert_eq!(journal["first_failing_phase"], "ingest");
+    assert_eq!(journal["error_class"], "disk_limit");
 
     let directory = TempDir::new().expect("journal directory");
     let path = directory.path().join("journal.json");
@@ -1544,7 +1634,13 @@ fn phase_journal_atomically_preserves_completed_rungs_and_active_state() {
             .expect("valid journal"),
         journal
     );
-    assert!(!path.with_extension("json.tmp").exists());
+    assert_eq!(
+        fs::read_dir(directory.path())
+            .expect("list journal directory")
+            .count(),
+        1,
+        "atomic publication must not leave a temporary file"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -521,6 +521,83 @@ fn rss_value() -> Value {
     peak_rss().map_or(Value::Null, |(bytes, _)| json!(bytes))
 }
 
+fn linux_process_memory() -> Value {
+    let Ok(contents) = fs::read_to_string("/proc/self/status") else {
+        return Value::Null;
+    };
+    let read_bytes = |name: &str| {
+        contents.lines().find_map(|line| {
+            line.strip_prefix(name).and_then(|value| {
+                value
+                    .trim()
+                    .trim_end_matches(" kB")
+                    .trim()
+                    .parse::<u64>()
+                    .ok()
+                    .map(|kb| kb.saturating_mul(1024))
+            })
+        })
+    };
+    json!({
+        "vmhwm_bytes": read_bytes("VmHWM:"),
+        "vmrss_bytes": read_bytes("VmRSS:"),
+        "rss_anon_bytes": read_bytes("RssAnon:"),
+        "rss_file_bytes": read_bytes("RssFile:"),
+    })
+}
+
+fn phase_journal_value(
+    profile: &ScaleProfile,
+    rung: &Rung,
+    completed_rungs: &[Value],
+    phase: &str,
+    state: &str,
+    steps: &[Value],
+) -> Value {
+    json!({
+        "schema": EVIDENCE_SCHEMA,
+        "schema_version": SCHEMA_VERSION,
+        "profile_schema": profile.schema,
+        "run_state": state,
+        "active_rung": rung.id,
+        "active_scale": rung.scale,
+        "active_phase": phase,
+        "process_memory": linux_process_memory(),
+        "completed_rungs": completed_rungs,
+        "active_steps": steps,
+    })
+}
+
+fn write_json_atomically(path: &Path, value: &Value) {
+    let parent = path.parent().expect("journal parent");
+    fs::create_dir_all(parent).expect("journal parent");
+    let temporary = path.with_extension("json.tmp");
+    let mut file = fs::File::create(&temporary).expect("create journal temporary");
+    serde_json::to_writer_pretty(&mut file, value).expect("serialize journal");
+    use std::io::Write;
+    file.write_all(b"\n").expect("terminate journal");
+    file.sync_all().expect("sync journal temporary");
+    fs::rename(&temporary, &path).expect("publish journal");
+    fs::File::open(parent)
+        .and_then(|directory| directory.sync_all())
+        .expect("sync journal parent");
+}
+
+fn persist_phase_journal(
+    profile: &ScaleProfile,
+    rung: &Rung,
+    completed_rungs: &[Value],
+    phase: &str,
+    state: &str,
+    steps: &[Value],
+) {
+    let Ok(path) = std::env::var("GF_G500_LADDER_JOURNAL_OUT") else {
+        return;
+    };
+    let value = phase_journal_value(profile, rung, completed_rungs, phase, state, steps);
+    write_json_atomically(&PathBuf::from(path), &value);
+}
+
 #[allow(clippy::too_many_lines)]
 fn run_rung(
     profile: &ScaleProfile,
@@ -528,6 +605,7 @@ fn run_rung(
     env: RunEnvelope,
     edge_factor: u32,
     ladder_started: Instant,
+    completed_rungs: &[Value],
 ) -> RungOutcome {
     let started = Instant::now();
     let workspace = TempDir::new().expect("rung workspace");
@@ -541,6 +619,14 @@ fn run_rung(
     let mut error_class: Option<&'static str> = None;
 
     // ---- generate ----
+    persist_phase_journal(
+        profile,
+        rung,
+        completed_rungs,
+        "generate",
+        "running",
+        &steps,
+    );
     let gen_started = Instant::now();
     let spill = generate_spill_runs(
         rung.scale,
@@ -570,6 +656,14 @@ fn run_rung(
             "run_count": spill.runs.len(),
         }
     }));
+    persist_phase_journal(
+        profile,
+        rung,
+        completed_rungs,
+        "generate",
+        "phase_completed",
+        &steps,
+    );
 
     // ---- ingest (merge + publish through the public facade) ----
     let mut live_unique_edges = 0u64;
@@ -577,6 +671,7 @@ fn run_rung(
     let mut input_fingerprint = String::from("sha256:");
     let mut ingest_ran = false;
     if first_failing_phase.is_none() {
+        persist_phase_journal(profile, rung, completed_rungs, "ingest", "running", &steps);
         let ingest_started = Instant::now();
         let graph = GraphForge::new(Some(project.to_str().expect("utf8 project")))
             .expect("open GraphForge for ingest");
@@ -610,6 +705,14 @@ fn run_rung(
                 "input_fingerprint": input_fingerprint,
             }
         }));
+        persist_phase_journal(
+            profile,
+            rung,
+            completed_rungs,
+            "ingest",
+            "phase_completed",
+            &steps,
+        );
     }
 
     // ---- reopen + recount ----
@@ -617,6 +720,7 @@ fn run_rung(
     let mut edge_count = 0u64;
     let mut gsi = String::new();
     if first_failing_phase.is_none() {
+        persist_phase_journal(profile, rung, completed_rungs, "reopen", "running", &steps);
         let reopen_started = Instant::now();
         let graph = GraphForge::new(Some(project.to_str().expect("utf8 project")))
             .expect("reopen GraphForge");
@@ -631,9 +735,18 @@ fn run_rung(
             "rss_peak_bytes": rss_value(),
             "detail": { "node_count": node_count, "edge_count": edge_count, "gsi": gsi }
         }));
+        persist_phase_journal(
+            profile,
+            rung,
+            completed_rungs,
+            "reopen",
+            "phase_completed",
+            &steps,
+        );
 
         // ---- deterministic LIMIT queries ----
         let hop1_started = Instant::now();
+        persist_phase_journal(profile, rung, completed_rungs, "query", "running", &steps);
         let hop1 = graph.execute(ONE_HOP).expect("one-hop LIMIT");
         let hop1_rows = row_count(&hop1);
         steps.push(json!({
@@ -657,6 +770,14 @@ fn run_rung(
             first_failing_phase = Some("query");
             error_class = Some(class);
         }
+        persist_phase_journal(
+            profile,
+            rung,
+            completed_rungs,
+            "query",
+            "phase_completed",
+            &steps,
+        );
     }
 
     let disk_used_bytes =
@@ -733,9 +854,17 @@ fn run_ladder(profile: &ScaleProfile, env: RunEnvelope, rungs: &[Rung]) -> Vec<V
     let ladder_started = Instant::now();
     let mut evidence = Vec::new();
     for rung in rungs {
-        let outcome = run_rung(profile, rung, env, profile.edgefactor, ladder_started);
+        let outcome = run_rung(
+            profile,
+            rung,
+            env,
+            profile.edgefactor,
+            ladder_started,
+            &evidence,
+        );
         let passed = outcome.passed;
         evidence.push(outcome.evidence);
+        persist_phase_journal(profile, rung, &evidence, "rung", "rung_completed", &[]);
         if !passed {
             break;
         }
@@ -1274,6 +1403,7 @@ fn first_fail_stops_at_envelope_violation() {
         tiny_env,
         profile.edgefactor,
         Instant::now(),
+        &[],
     );
     assert!(!outcome.passed, "a violated envelope must not pass");
     assert_eq!(outcome.evidence["first_failing_phase"], "generate");
@@ -1305,6 +1435,7 @@ fn ci_rung_public_facade_engineering_green() {
         profile.envelope.into(),
         profile.edgefactor,
         Instant::now(),
+        &[],
     );
     assert!(outcome.passed, "CI rung must pass: {:#}", outcome.evidence);
     let ev = &outcome.evidence;
@@ -1387,6 +1518,33 @@ fn provisioned_max_scale_excludes_larger_rungs() {
     assert!(selected.iter().all(|rung| rung.scale != 26));
     assert!(provisioned_rungs_through(&profile, 10).is_err());
     assert!(provisioned_rungs_through(&profile, 23).is_err());
+}
+
+#[test]
+fn phase_journal_atomically_preserves_completed_rungs_and_active_state() {
+    let profile = load_profile();
+    let rung = profile
+        .rungs
+        .iter()
+        .find(|rung| rung.scale == 22)
+        .expect("S22 rung");
+    let completed = vec![json!({"rung": "S20", "pass": true})];
+    let steps = vec![json!({"id": "generate", "pass": true})];
+    let journal = phase_journal_value(&profile, rung, &completed, "ingest", "running", &steps);
+    assert_eq!(journal["completed_rungs"], json!(completed));
+    assert_eq!(journal["active_rung"], "S22");
+    assert_eq!(journal["active_phase"], "ingest");
+    assert_eq!(journal["run_state"], "running");
+
+    let directory = TempDir::new().expect("journal directory");
+    let path = directory.path().join("journal.json");
+    write_json_atomically(&path, &journal);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&fs::read(&path).expect("read journal"))
+            .expect("valid journal"),
+        journal
+    );
+    assert!(!path.with_extension("json.tmp").exists());
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/development/perf-g500-ladder.md
+++ b/docs/development/perf-g500-ladder.md
@@ -139,6 +139,13 @@ runs S20, S22, S24, and S25, and excludes S26 even when every smaller rung
 passes.
 
 Default evidence path: `docs/development/g500-ladder-evidence.json`.
+The runner also atomically updates `build/g500-ladder-journal.json` before and
+after every phase and after every rung. Retrieve the journal after an OOM,
+ENOSPC, timeout, or operator safety stop; `completed_rungs` remain valid, while
+`active_rung`, `active_phase`, and `run_state` describe the interrupted work and
+must not be presented as a pass. On Linux, each journal observation separates
+process `VmHWM`, current RSS, anonymous RSS, and file-backed RSS so filesystem
+cache is not mistaken for GraphForge heap growth.
 
 ## Evidence JSON
 


### PR DESCRIPTION
Closes #898.

Atomically journals before and after every ladder phase and after each rung, preserving completed-rung evidence across host-level interruption. Linux observations separate `VmHWM`, current RSS, anonymous RSS, and file-backed RSS so page cache is not mistaken for GraphForge heap growth.

Validation:
- `cargo fmt --all -- --check`
- `cargo test -p graphforge-api --test scale_g500_ladder` (14 passed, 2 intentionally ignored)
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790025254&installation_model_id=20486&pr_number=899&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F899&signature=004f2f593d044b7dac22e171e9f6b2135320a66d5e5aeb10c6d3066e8bd869d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable progress journaling for the G500 ladder benchmark.
  * Journal records now capture active phases, completed rungs, and Linux process-memory metrics.
  * Progress is saved atomically before and after each benchmark phase and rung.

* **Tests**
  * Added coverage for journal serialization, atomic updates, and state preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->