### PR TITLE
fix(storage): bound topology rewrite memory

### DIFF
--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -669,7 +669,7 @@ impl IngestHeartbeat {
         let project = project.to_path_buf();
         let spill = spill.to_path_buf();
         let handle = thread::spawn(move || {
-            while !thread_stop.load(Ordering::Relaxed) {
+            loop {
                 let value = json!({
                     "schema": EVIDENCE_SCHEMA,
                     "schema_version": SCHEMA_VERSION,
@@ -690,7 +690,13 @@ impl IngestHeartbeat {
                     "error_class": null,
                 });
                 write_json_atomically(&path, &value);
+                if thread_stop.load(Ordering::Relaxed) {
+                    break;
+                }
                 thread::park_timeout(Duration::from_secs(2));
+                if thread_stop.load(Ordering::Relaxed) {
+                    break;
+                }
             }
         });
         Self {
@@ -699,12 +705,24 @@ impl IngestHeartbeat {
         }
     }
 
-    fn stop(mut self) {
+    fn shutdown(&mut self) -> Option<thread::Result<()>> {
         self.stop.store(true, Ordering::Relaxed);
-        if let Some(handle) = self.handle.take() {
+        self.handle.take().map(|handle| {
             handle.thread().unpark();
-            handle.join().expect("ingest heartbeat");
+            handle.join()
+        })
+    }
+
+    fn stop(mut self) {
+        if let Some(result) = self.shutdown() {
+            result.expect("ingest heartbeat");
         }
+    }
+}
+
+impl Drop for IngestHeartbeat {
+    fn drop(&mut self) {
+        let _ = self.shutdown();
     }
 }
 
@@ -800,9 +818,10 @@ fn run_rung(
         let graph = GraphForge::new(Some(project.to_str().expect("utf8 project")))
             .expect("open GraphForge for ingest");
         graphforge_storage::io_stats::reset();
+        INGEST_CHUNK_INDEX.store(0, Ordering::Relaxed);
+        INGEST_SUBPHASE.store(1, Ordering::Relaxed);
         let heartbeat =
             IngestHeartbeat::start(profile, rung, completed_rungs, &steps, &project, &spill_dir);
-        INGEST_SUBPHASE.store(1, Ordering::Relaxed);
         publish_nodes(&graph, 1u64 << rung.scale, None);
         INGEST_SUBPHASE.store(2, Ordering::Relaxed);
         let mut sink = EdgeSink::new(&graph, None);

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -57,6 +57,8 @@ const TWO_HOP: &str =
     "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN c.node_uuid AS id ORDER BY id LIMIT 1000";
 const COUNT_EDGES: &str = "MATCH ()-[r:LINK]->() RETURN count(r) AS total";
 static JOURNAL_WRITE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+static INGEST_SUBPHASE: AtomicU64 = AtomicU64::new(0);
+static INGEST_CHUNK_INDEX: AtomicU64 = AtomicU64::new(0);
 
 // ---------------------------------------------------------------------------
 // Versioned profile (single source of truth for the ladder).
@@ -611,6 +613,101 @@ fn persist_phase_journal(
     write_json_atomically(&PathBuf::from(path), &value);
 }
 
+fn ingest_subphase() -> &'static str {
+    match INGEST_SUBPHASE.load(Ordering::Relaxed) {
+        1 => "publish_nodes",
+        2 => "merge_edges",
+        3 => "publish_edge_chunk",
+        4 => "edge_chunk_committed",
+        _ => "idle",
+    }
+}
+
+fn storage_io_value() -> Value {
+    let io = graphforge_storage::io_stats::snapshot();
+    json!({
+        "node_full_reads": io.node_full_reads,
+        "node_full_rows": io.node_full_rows,
+        "edge_full_reads": io.edge_full_reads,
+        "edge_full_rows": io.edge_full_rows,
+        "rewrite_commits": io.rewrite_commits,
+        "topology_rewrite_existing_rows": io.topology_rewrite_existing_rows,
+        "topology_rewrite_new_rows": io.topology_rewrite_new_rows,
+        "topology_rewrite_output_rows": io.topology_rewrite_output_rows,
+        "topology_rewrite_peak_batch_rows": io.topology_rewrite_peak_batch_rows,
+    })
+}
+
+struct IngestHeartbeat {
+    stop: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl IngestHeartbeat {
+    fn start(
+        profile: &ScaleProfile,
+        rung: &Rung,
+        completed_rungs: &[Value],
+        steps: &[Value],
+        project: &Path,
+        spill: &Path,
+    ) -> Self {
+        let Ok(path) = std::env::var("GF_G500_LADDER_JOURNAL_OUT") else {
+            return Self {
+                stop: Arc::new(AtomicBool::new(true)),
+                handle: None,
+            };
+        };
+        let stop = Arc::new(AtomicBool::new(false));
+        let thread_stop = Arc::clone(&stop);
+        let path = PathBuf::from(path);
+        let profile_schema = profile.schema.clone();
+        let rung_id = rung.id.clone();
+        let scale = rung.scale;
+        let completed_rungs = completed_rungs.to_vec();
+        let steps = steps.to_vec();
+        let project = project.to_path_buf();
+        let spill = spill.to_path_buf();
+        let handle = thread::spawn(move || {
+            while !thread_stop.load(Ordering::Relaxed) {
+                let value = json!({
+                    "schema": EVIDENCE_SCHEMA,
+                    "schema_version": SCHEMA_VERSION,
+                    "profile_schema": profile_schema,
+                    "run_state": "ingest_heartbeat",
+                    "active_rung": rung_id,
+                    "active_scale": scale,
+                    "active_phase": "ingest",
+                    "active_subphase": ingest_subphase(),
+                    "active_chunk_index": INGEST_CHUNK_INDEX.load(Ordering::Relaxed),
+                    "process_memory": linux_process_memory(),
+                    "storage_io": storage_io_value(),
+                    "disk_used_bytes": directory_bytes(&project).unwrap_or(0)
+                        .saturating_add(directory_bytes(&spill).unwrap_or(0)),
+                    "completed_rungs": completed_rungs,
+                    "active_steps": steps,
+                    "first_failing_phase": null,
+                    "error_class": null,
+                });
+                write_json_atomically(&path, &value);
+                thread::park_timeout(Duration::from_secs(2));
+            }
+        });
+        Self {
+            stop,
+            handle: Some(handle),
+        }
+    }
+
+    fn stop(mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            handle.thread().unpark();
+            handle.join().expect("ingest heartbeat");
+        }
+    }
+}
+
 #[allow(clippy::too_many_lines)]
 fn run_rung(
     profile: &ScaleProfile,
@@ -702,7 +799,12 @@ fn run_rung(
         let ingest_started = Instant::now();
         let graph = GraphForge::new(Some(project.to_str().expect("utf8 project")))
             .expect("open GraphForge for ingest");
+        graphforge_storage::io_stats::reset();
+        let heartbeat =
+            IngestHeartbeat::start(profile, rung, completed_rungs, &steps, &project, &spill_dir);
+        INGEST_SUBPHASE.store(1, Ordering::Relaxed);
         publish_nodes(&graph, 1u64 << rung.scale, None);
+        INGEST_SUBPHASE.store(2, Ordering::Relaxed);
         let mut sink = EdgeSink::new(&graph, None);
         let merge =
             merge_runs(&spill.runs, None, |src, dst| sink.push(src, dst)).expect("rung merge");
@@ -710,6 +812,8 @@ fn run_rung(
         live_unique_edges = merge.live_unique_edges;
         duplicates_rejected = merge.duplicates_rejected;
         input_fingerprint = format!("sha256:{}", hex_encode(sink.finish()));
+        INGEST_SUBPHASE.store(0, Ordering::Relaxed);
+        heartbeat.stop();
         drop(graph);
         ingest_ran = true;
         let ingest_s = ingest_started.elapsed().as_secs_f64();
@@ -1049,9 +1153,15 @@ impl<'a> EdgeSink<'a> {
             batches.push(batch);
             offset = end;
         }
+        INGEST_CHUNK_INDEX.store(
+            u64::try_from(self.chunk_index).unwrap_or(u64::MAX),
+            Ordering::Relaxed,
+        );
+        INGEST_SUBPHASE.store(3, Ordering::Relaxed);
         self.graph
             .publish_bulk_edges(OperationId(uuidv7(0xB100 + self.chunk_index)), &batches)
             .expect("publish_bulk_edges");
+        INGEST_SUBPHASE.store(4, Ordering::Relaxed);
         self.chunk_index += 1;
         self.buf.clear();
     }

--- a/crates/graphforge-storage/src/catalog.rs
+++ b/crates/graphforge-storage/src/catalog.rs
@@ -983,8 +983,6 @@ pub fn read_nodes_filtered_observed(
 /// # Errors
 /// Propagates Parquet / Arrow errors encountered while reading an edge file.
 pub(crate) fn max_edge_id(dir: &Path) -> Result<u64, DataFusionError> {
-    use arrow::array::{Array, UInt64Array};
-
     let edges_dir = dir.join("topology").join("edges");
     let entries = match std::fs::read_dir(&edges_dir) {
         Ok(rd) => rd,
@@ -998,19 +996,51 @@ pub(crate) fn max_edge_id(dir: &Path) -> Result<u64, DataFusionError> {
         if path.extension().and_then(|s| s.to_str()) != Some("parquet") {
             continue;
         }
-        // The `edge_id` column exists in both the typed and exploratory edge
-        // schemas, so the on-disk file schema (discovered) reads it either way.
-        let Some(schema) = discover_parquet_schema(&path) else {
-            continue;
-        };
-        for batch in read_parquet_or_empty(&path, schema)? {
-            if let Some(col) = batch.column_by_name("edge_id")
-                && let Some(ids) = col.as_any().downcast_ref::<UInt64Array>()
-            {
-                for i in 0..ids.len() {
-                    if !ids.is_null(i) {
-                        max = max.max(ids.value(i));
-                    }
+        // Preserve discovery semantics: unrelated/corrupt edge artifacts are
+        // ignored here and rejected by the normal catalog validation path.
+        // Surrogate recovery must still inspect every readable relation stem.
+        if let Ok(candidate) = max_ordered_u64_tail(&path, "edge_id") {
+            max = max.max(candidate);
+        }
+    }
+    Ok(max)
+}
+
+/// Return the largest canonical node surrogate without decoding the complete
+/// node table. Canonical topology keeps surrogate ids strictly increasing, so
+/// only the final bounded Parquet row group is needed.
+pub(crate) fn max_node_id(dir: &Path) -> Result<u64, DataFusionError> {
+    max_ordered_u64_tail(&dir.join("topology/nodes.parquet"), "node_id")
+}
+
+fn max_ordered_u64_tail(path: &Path, column: &str) -> Result<u64, DataFusionError> {
+    use arrow::array::{Array, UInt64Array};
+
+    let input = match File::open(path) {
+        Ok(input) => input,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(error) => return Err(io_err(&error)),
+    };
+    let builder = ParquetRecordBatchReaderBuilder::try_new(input).map_err(parquet_err)?;
+    let row_groups = builder.metadata().num_row_groups();
+    if row_groups == 0 {
+        return Ok(0);
+    }
+    let reader = builder
+        .with_row_groups(vec![row_groups - 1])
+        .with_batch_size(8_192)
+        .build()
+        .map_err(parquet_err)?;
+    let mut max = 0_u64;
+    for batch in reader {
+        let batch = batch.map_err(parquet_err)?;
+        if let Some(values) = batch
+            .column_by_name(column)
+            .and_then(|value| value.as_any().downcast_ref::<UInt64Array>())
+        {
+            for row in 0..values.len() {
+                if !values.is_null(row) {
+                    max = max.max(values.value(row));
                 }
             }
         }

--- a/crates/graphforge-storage/src/io_stats.rs
+++ b/crates/graphforge-storage/src/io_stats.rs
@@ -124,6 +124,10 @@ static NODE_EXACT_ROWS_SELECTED: AtomicU64 = AtomicU64::new(0);
 static NODE_METADATA_FALLBACKS: AtomicU64 = AtomicU64::new(0);
 static NODE_VALIDATION_FALLBACKS: AtomicU64 = AtomicU64::new(0);
 static REWRITE_COMMITS: AtomicU64 = AtomicU64::new(0);
+static TOPOLOGY_REWRITE_EXISTING_ROWS: AtomicU64 = AtomicU64::new(0);
+static TOPOLOGY_REWRITE_NEW_ROWS: AtomicU64 = AtomicU64::new(0);
+static TOPOLOGY_REWRITE_OUTPUT_ROWS: AtomicU64 = AtomicU64::new(0);
+static TOPOLOGY_REWRITE_PEAK_BATCH_ROWS: AtomicU64 = AtomicU64::new(0);
 
 /// A point-in-time copy of the process-global I/O counters. Difference two
 /// snapshots — or [`reset`] then [`snapshot`] — to attribute work to a region.
@@ -174,6 +178,14 @@ pub struct IoSnapshot {
     /// Successful non-empty [`RewriteBatch`](crate::RewriteBatch) commits.
     /// This counts persistence cycles, not the number of files in a batch.
     pub rewrite_commits: u64,
+    /// Existing topology rows decoded and copied by append-style rewrites.
+    pub topology_rewrite_existing_rows: u64,
+    /// New topology rows supplied to append-style rewrites.
+    pub topology_rewrite_new_rows: u64,
+    /// Total topology rows materialized as rewrite outputs.
+    pub topology_rewrite_output_rows: u64,
+    /// Largest decoded or newly supplied batch held by a topology rewrite.
+    pub topology_rewrite_peak_batch_rows: u64,
 }
 
 /// Capture the current process-global counters.
@@ -200,6 +212,10 @@ pub fn snapshot() -> IoSnapshot {
         node_metadata_fallbacks: NODE_METADATA_FALLBACKS.load(Ordering::Relaxed),
         node_validation_fallbacks: NODE_VALIDATION_FALLBACKS.load(Ordering::Relaxed),
         rewrite_commits: REWRITE_COMMITS.load(Ordering::Relaxed),
+        topology_rewrite_existing_rows: TOPOLOGY_REWRITE_EXISTING_ROWS.load(Ordering::Relaxed),
+        topology_rewrite_new_rows: TOPOLOGY_REWRITE_NEW_ROWS.load(Ordering::Relaxed),
+        topology_rewrite_output_rows: TOPOLOGY_REWRITE_OUTPUT_ROWS.load(Ordering::Relaxed),
+        topology_rewrite_peak_batch_rows: TOPOLOGY_REWRITE_PEAK_BATCH_ROWS.load(Ordering::Relaxed),
     }
 }
 
@@ -226,6 +242,10 @@ pub fn reset() {
         &NODE_METADATA_FALLBACKS,
         &NODE_VALIDATION_FALLBACKS,
         &REWRITE_COMMITS,
+        &TOPOLOGY_REWRITE_EXISTING_ROWS,
+        &TOPOLOGY_REWRITE_NEW_ROWS,
+        &TOPOLOGY_REWRITE_OUTPUT_ROWS,
+        &TOPOLOGY_REWRITE_PEAK_BATCH_ROWS,
     ] {
         c.store(0, Ordering::Relaxed);
     }
@@ -280,4 +300,26 @@ pub(crate) fn record_node_pruning(pruning: FilteredReadPruning) {
 
 pub(crate) fn record_rewrite_commit() {
     REWRITE_COMMITS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_topology_rewrite(existing_rows: u64, new_rows: u64) {
+    TOPOLOGY_REWRITE_EXISTING_ROWS.fetch_add(existing_rows, Ordering::Relaxed);
+    TOPOLOGY_REWRITE_NEW_ROWS.fetch_add(new_rows, Ordering::Relaxed);
+    TOPOLOGY_REWRITE_OUTPUT_ROWS
+        .fetch_add(existing_rows.saturating_add(new_rows), Ordering::Relaxed);
+}
+
+pub(crate) fn record_topology_rewrite_batch(rows: u64) {
+    let mut prior = TOPOLOGY_REWRITE_PEAK_BATCH_ROWS.load(Ordering::Relaxed);
+    while rows > prior {
+        match TOPOLOGY_REWRITE_PEAK_BATCH_ROWS.compare_exchange_weak(
+            prior,
+            rows,
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        ) {
+            Ok(_) => break,
+            Err(actual) => prior = actual,
+        }
+    }
 }

--- a/crates/graphforge-storage/src/staging.rs
+++ b/crates/graphforge-storage/src/staging.rs
@@ -33,6 +33,7 @@ use std::path::{Path, PathBuf};
 use arrow::array::RecordBatch;
 use arrow::datatypes::SchemaRef;
 use parquet::arrow::ArrowWriter;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::file::properties::WriterProperties;
 use tempfile::NamedTempFile;
 
@@ -172,6 +173,84 @@ impl RewriteBatch {
         Ok(())
     }
 
+    /// Stage a fixed-schema append without materializing the existing Parquet
+    /// file. Existing row groups are decoded and re-encoded one bounded batch
+    /// at a time, followed by `batch`.
+    ///
+    /// Returns the number of existing rows copied into the replacement.
+    ///
+    /// # Errors
+    /// Returns [`GfError`] on I/O, decode, schema, or encode failure. The prior
+    /// destination remains untouched.
+    pub fn restage_append(
+        &mut self,
+        final_path: &Path,
+        schema: SchemaRef,
+        batch: &RecordBatch,
+    ) -> Result<u64, GfError> {
+        self.restage_append_with(final_path, schema, batch, Ok)
+    }
+
+    /// Like [`Self::restage_append`], applying `normalize` to each bounded
+    /// existing batch before it is written under the destination schema.
+    pub fn restage_append_with(
+        &mut self,
+        final_path: &Path,
+        schema: SchemaRef,
+        batch: &RecordBatch,
+        mut normalize: impl FnMut(RecordBatch) -> Result<RecordBatch, GfError>,
+    ) -> Result<u64, GfError> {
+        let read_path = self
+            .staged_temp(final_path)
+            .map_or_else(|| final_path.to_path_buf(), Path::to_path_buf);
+        let parent = final_path.parent().ok_or_else(|| {
+            GfError::Storage(format!(
+                "staged path {} has no parent directory",
+                final_path.display()
+            ))
+        })?;
+        std::fs::create_dir_all(parent).map_err(|error| io_err(&error))?;
+        let file_name = final_path.file_name().map_or_else(
+            || "staged".to_owned(),
+            |name| name.to_string_lossy().into_owned(),
+        );
+        let tmp = tempfile::Builder::new()
+            .prefix(&format!("{file_name}."))
+            .suffix(".tmp")
+            .tempfile_in(parent)
+            .map_err(|error| io_err(&error))?;
+        let properties = WriterProperties::builder()
+            .set_max_row_group_row_count(Some(ROW_GROUP_SIZE))
+            .build();
+        let mut writer =
+            ArrowWriter::try_new(tmp.as_file(), schema, Some(properties)).map_err(pq_err)?;
+        let mut existing_rows = 0_u64;
+        if read_path.exists() {
+            let input = std::fs::File::open(&read_path).map_err(|error| io_err(&error))?;
+            let reader = ParquetRecordBatchReaderBuilder::try_new(input)
+                .map_err(pq_err)?
+                .with_batch_size(ROW_GROUP_SIZE)
+                .build()
+                .map_err(pq_err)?;
+            for existing in reader {
+                let existing = existing.map_err(pq_err)?;
+                existing_rows = existing_rows.saturating_add(existing.num_rows() as u64);
+                crate::io_stats::record_topology_rewrite_batch(existing.num_rows() as u64);
+                let existing = normalize(existing)?;
+                writer.write(&existing).map_err(pq_err)?;
+            }
+        }
+        crate::io_stats::record_topology_rewrite_batch(batch.num_rows() as u64);
+        writer.write(batch).map_err(pq_err)?;
+        writer.close().map_err(pq_err)?;
+        if let Some(entry) = self.staged.iter_mut().find(|(_, path)| path == final_path) {
+            entry.0 = tmp;
+        } else {
+            self.staged.push((tmp, final_path.to_path_buf()));
+        }
+        Ok(existing_rows)
+    }
+
     /// The staged temp file currently holding `final_path`'s replacement
     /// content, if any. Readers that must see this statement's
     /// already-staged effects (rather than the committed file) read through
@@ -308,6 +387,37 @@ mod tests {
             .filter_map(Result::ok)
             .filter(|e| e.path().extension().is_some_and(|x| x == "tmp"))
             .count()
+    }
+
+    #[test]
+    fn append_rewrite_copies_existing_topology_in_bounded_batches() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("topology/nodes.parquet");
+        let initial_values = (0..(ROW_GROUP_SIZE * 2 + 17))
+            .map(|value| i64::try_from(value).unwrap())
+            .collect::<Vec<_>>();
+        let (schema, initial) = int_batch(&initial_values);
+        let mut first = RewriteBatch::new();
+        first.stage(&path, Arc::clone(&schema), &initial).unwrap();
+        first.commit().unwrap();
+
+        crate::io_stats::reset();
+        let (_, appended) = int_batch(&[900_001, 900_002, 900_003]);
+        let mut rewrite = RewriteBatch::new();
+        let existing = rewrite
+            .restage_append(&path, Arc::clone(&schema), &appended)
+            .unwrap();
+        rewrite.commit().unwrap();
+
+        assert_eq!(existing, initial_values.len() as u64);
+        let io = crate::io_stats::snapshot();
+        assert_eq!(io.topology_rewrite_peak_batch_rows, ROW_GROUP_SIZE as u64);
+        let values = read_values(&path);
+        assert_eq!(&values[..initial_values.len()], initial_values.as_slice());
+        assert_eq!(
+            &values[initial_values.len()..],
+            &[900_001, 900_002, 900_003]
+        );
     }
 
     #[test]

--- a/crates/graphforge-storage/src/writer.rs
+++ b/crates/graphforge-storage/src/writer.rs
@@ -98,26 +98,6 @@ fn pq_err(e: impl fmt::Display) -> GfError {
     GfError::Storage(e.to_string())
 }
 
-/// Largest value of a `UInt64` column named `col` across `batches`, or `0` if
-/// the column is absent/empty. Used to continue surrogate id assignment from
-/// the on-disk maximum.
-fn max_u64_column(batches: &[RecordBatch], col: &str) -> u64 {
-    use arrow::array::Array;
-    let mut max = 0u64;
-    for batch in batches {
-        if let Some(c) = batch.column_by_name(col)
-            && let Some(ids) = c.as_any().downcast_ref::<UInt64Array>()
-        {
-            for i in 0..ids.len() {
-                if !ids.is_null(i) {
-                    max = max.max(ids.value(i));
-                }
-            }
-        }
-    }
-    max
-}
-
 // ---------------------------------------------------------------------------
 // Buffered rows
 // ---------------------------------------------------------------------------
@@ -1243,8 +1223,7 @@ impl GraphWriter {
         // Continue surrogate assignment from the on-disk maximum so a writer
         // opened on an existing project appends rather than colliding with /
         // overwriting prior rows. Absent files → max 0 → start at 1.
-        let max_node_id =
-            max_u64_column(&crate::catalog::read_nodes(dir).map_err(pq_err)?, "node_id");
+        let max_node_id = crate::catalog::max_node_id(dir).map_err(pq_err)?;
         let max_edge_id = crate::catalog::max_edge_id(dir).map_err(pq_err)?;
         Ok(Self {
             dir: dir.to_path_buf(),
@@ -1852,16 +1831,19 @@ impl GraphWriter {
         // accumulate (#733) rather than overwriting. The schema is fixed, so a
         // concat of [existing, new] always succeeds.
         let path = topology.join("nodes.parquet");
-        let read_path = staged
-            .staged_temp(&path)
-            .map_or_else(|| path.clone(), Path::to_path_buf);
-        let existing = crate::catalog::normalize_topology_nodes(
-            crate::catalog::read_parquet_or_empty(&read_path, TOPOLOGY_NODES_SCHEMA.clone())
-                .map_err(pq_err)?,
-        )
-        .map_err(pq_err)?;
-        let merged = concat_with_existing(&TOPOLOGY_NODES_SCHEMA, existing, batch)?;
-        staged.restage(&path, TOPOLOGY_NODES_SCHEMA.clone(), &merged)?;
+        let existing_rows = staged.restage_append_with(
+            &path,
+            TOPOLOGY_NODES_SCHEMA.clone(),
+            &batch,
+            |existing| {
+                crate::catalog::normalize_topology_nodes(vec![existing])
+                    .map_err(pq_err)?
+                    .into_iter()
+                    .next()
+                    .ok_or_else(|| GfError::Storage("node normalization returned no batch".into()))
+            },
+        )?;
+        crate::io_stats::record_topology_rewrite(existing_rows, batch.num_rows() as u64);
         self.nodes.clear();
         Ok(())
     }
@@ -1901,13 +1883,8 @@ impl GraphWriter {
             // Merge with this stem's existing file so appends accumulate (#733);
             // stems not in this buffer are never opened, so they are untouched.
             let path = edges_dir.join(format!("{stem}.parquet"));
-            let read_path = staged
-                .staged_temp(&path)
-                .map_or_else(|| path.clone(), Path::to_path_buf);
-            let existing = crate::catalog::read_parquet_or_empty(&read_path, schema.clone())
-                .map_err(pq_err)?;
-            let merged = concat_with_existing(&schema, existing, batch)?;
-            staged.restage(&path, schema, &merged)?;
+            let existing_rows = staged.restage_append(&path, schema, &batch)?;
+            crate::io_stats::record_topology_rewrite(existing_rows, batch.num_rows() as u64);
         }
         Ok(())
     }
@@ -3930,20 +3907,6 @@ fn read_props_through(staged: &RewriteBatch, path: &Path) -> Result<Vec<RecordBa
 
 use crate::staging::RewriteBatch;
 
-/// Concatenate already-on-disk `existing` batches with the freshly-built `new`
-/// batch under a fixed `schema` (used for the node + typed/exploratory edge
-/// files, whose schema never varies). Zero-row placeholder batches from an
-/// absent file concat harmlessly.
-fn concat_with_existing(
-    schema: &SchemaRef,
-    existing: Vec<RecordBatch>,
-    new: RecordBatch,
-) -> Result<RecordBatch, GfError> {
-    let mut all = existing;
-    all.push(new);
-    arrow::compute::concat_batches(schema, &all).map_err(pq_err)
-}
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -3993,6 +3956,92 @@ mod tests {
         assert_eq!(w.create_node(new_v7(), TypeId(0)).unwrap(), 1);
         assert_eq!(w.create_node(new_v7(), TypeId(0)).unwrap(), 2);
         assert_eq!(w.create_node(new_v7(), TypeId(0)).unwrap(), 3);
+    }
+
+    #[test]
+    fn reopen_recovers_surrogate_tails_without_full_topology_reads() {
+        let dir = TempDir::new().unwrap();
+        let first_node = new_v7();
+        let second_node = new_v7();
+        let mut first = GraphWriter::open_at(dir.path(), OntologyMode::Strict, TS).unwrap();
+        assert_eq!(first.create_node(first_node, TypeId(0)).unwrap(), 1);
+        assert_eq!(first.create_node(second_node, TypeId(0)).unwrap(), 2);
+        assert_eq!(
+            first
+                .create_edge(new_v7(), "KNOWS", &first_node, &second_node)
+                .unwrap(),
+            1
+        );
+        first.flush().unwrap();
+
+        crate::io_stats::reset();
+        let mut reopened = GraphWriter::open_at(dir.path(), OntologyMode::Strict, TS).unwrap();
+        assert_eq!(reopened.create_node(new_v7(), TypeId(0)).unwrap(), 3);
+        reopened.register_existing_node(first_node, 1);
+        reopened.register_existing_node(second_node, 2);
+        assert_eq!(
+            reopened
+                .create_edge(new_v7(), "KNOWS", &first_node, &second_node)
+                .unwrap(),
+            2
+        );
+        let io = crate::io_stats::snapshot();
+        assert_eq!(
+            io.node_full_reads, 0,
+            "writer reopen must use bounded tails"
+        );
+        assert_eq!(
+            io.edge_full_reads, 0,
+            "writer reopen must use bounded tails"
+        );
+    }
+
+    #[test]
+    fn streaming_node_append_normalizes_legacy_scalar_labels() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join("topology")).unwrap();
+        let legacy_schema = Arc::new(Schema::new(vec![
+            uuid_field("node_uuid"),
+            crate::schemas::id_field("node_id"),
+            Field::new("type_id", DataType::UInt32, false),
+            crate::schemas::ts_field("created_at"),
+            crate::schemas::ts_field("updated_at"),
+        ]));
+        let uuid = FixedSizeBinaryArray::try_from_iter([vec![1_u8; 16]].into_iter()).unwrap();
+        let ts = TimestampMicrosecondArray::from(vec![TS])
+            .with_timezone_opt(Some(Arc::<str>::from("UTC")));
+        let legacy = RecordBatch::try_new(
+            legacy_schema,
+            vec![
+                Arc::new(uuid),
+                Arc::new(UInt64Array::from(vec![1_u64])),
+                Arc::new(UInt32Array::from(vec![7_u32])),
+                Arc::new(ts.clone()),
+                Arc::new(ts),
+            ],
+        )
+        .unwrap();
+        let file = File::create(dir.path().join("topology/nodes.parquet")).unwrap();
+        let mut parquet =
+            parquet::arrow::ArrowWriter::try_new(file, legacy.schema(), None).unwrap();
+        parquet.write(&legacy).unwrap();
+        parquet.close().unwrap();
+
+        let mut writer = GraphWriter::open_at(dir.path(), OntologyMode::Strict, TS).unwrap();
+        assert_eq!(writer.create_node(new_v7(), TypeId(9)).unwrap(), 2);
+        writer.flush().unwrap();
+
+        let nodes = crate::catalog::read_nodes(dir.path()).unwrap();
+        assert_eq!(nodes.iter().map(RecordBatch::num_rows).sum::<usize>(), 2);
+        let labels = nodes[0]
+            .column_by_name("type_ids")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<arrow::array::ListArray>()
+            .unwrap();
+        let first = labels.value(0);
+        let first = first.as_any().downcast_ref::<UInt32Array>().unwrap();
+        assert_eq!(first.values(), &[7]);
     }
 
     #[test]

--- a/docs/book/architecture/resumable-import.md
+++ b/docs/book/architecture/resumable-import.md
@@ -22,6 +22,14 @@ Every completed batch advances the versioned manifest. If a process stops
 between the graph flush and manifest replacement, resume recognizes the fully
 present batch as an idempotent replay.
 
+Fixed-schema topology rewrites stream prior Parquet through bounded 64K-row
+batches rather than concatenating the complete accumulated table in Arrow.
+Opening a writer recovers node and edge surrogate maxima from only each file's
+final bounded row group. These bounds prevent resident topology state from
+growing with earlier batches. The current private staging tree still recopies
+prior rows while appending; append-only/shard-staged linear I/O and disk growth
+is the separate #901 close gate and must not be inferred from the memory bound.
+
 `commit` requires every source to be validated. It pins the original generation,
 captures the staged graph, runtime catalog, and UUID indexes, and publishes them
 through one recoverable project-generation transition. Cancellation before

--- a/docs/development/perf-g500-ladder.md
+++ b/docs/development/perf-g500-ladder.md
@@ -107,13 +107,17 @@ stops — no larger rung is attempted and no SCALE-26 pass is claimed.
 > (`vmhwm` | `ps_sampled`) so a `ps_sampled` value is read as a floor. Run
 > provisioned certification rungs on **Linux**.
 
-> Ingest-phase attribution: `publish_bulk_nodes` / `publish_bulk_edges` build an
-> in-memory set of existing identities per call (`bulk_construction.rs`), so RSS
-> during the `ingest` phase grows with the persisted graph, not just the
-> generator buffer. Per-phase `rss_peak_bytes` is recorded on each step, and an
-> `oom` with `first_failing_phase: "ingest"` reflects that upstream
-> bulk-publication cost — **not** a generator-memory regression. Reducing that
-> cost is upstream storage work (a non-goal here), tracked toward #745.
+> Ingest-phase attribution: `publish_bulk_nodes` / `publish_bulk_edges` retain
+> request-sized normalization, identity, endpoint, writer, delta, and receipt
+> state. Existing fixed-schema Parquet is copied through bounded 64K-row batches,
+> and writer reopen reads only final row-group surrogate tails; neither operation
+> materializes accumulated topology. While ingest runs, the atomic journal is
+> refreshed every two seconds with the current subphase, edge-chunk index,
+> anonymous/file RSS, disk usage, and aggregate topology rewrite counters. An
+> `oom` with `first_failing_phase: "ingest"` therefore remains an upstream
+> publication failure, not a generator-memory regression. Append-only linear-I/O
+> construction is tracked separately by #901 and remains required before the
+> billion-edge close gate.
 
 ## Commands
 


### PR DESCRIPTION
## Summary

- recover node and edge surrogate tails from bounded final Parquet row groups instead of full topology scans
- stream fixed-schema topology rewrites through 64K-row batches, including legacy node-label normalization
- journal ingest subphase, chunk, process memory, topology rewrite work, and disk usage during long Graph500 publications
- document that this bounds resident memory but does not solve the cumulative recopy I/O tracked by #901

## Root-cause evidence

With identical 1,048,576-edge publication windows before this repair, S17 peaked at 963,362,816 bytes RSS and S18 at 1,369,128,960 bytes. The second S17 publication copied all existing edges; S18 emitted 10,358,282 cumulative topology rows for about 3.8 million retained edges.

After streaming rewrites and bounded tail reads, the same diagnostics peaked at 675,184,640 bytes for S17 and 819,511,296 bytes for S18; later S18 windows remained about 693, 705, and 561 MB. This removes accumulated-topology RSS growth while leaving the superlinear I/O visible for #901.

## Verification

- `cargo test -p graphforge-storage --lib` (603 passed, 1 contract regression initially exposed; corrected and rerun directly green; 2 ignored)
- `cargo test -p graphforge-storage wave12_max_edge_id_skips_non_parquet_and_corrupt_parquet_entries --lib`
- `cargo test -p graphforge-storage append_rewrite_copies_existing_topology_in_bounded_batches --lib`
- `cargo test -p graphforge-storage reopen_recovers_surrogate_tails_without_full_topology_reads --lib`
- `cargo test -p graphforge-storage streaming_node_append_normalizes_legacy_scalar_labels --lib`
- `cargo test -p graphforge-api --test scale_g500_ladder ci_rung_public_facade_engineering_green -- --exact --nocapture --test-threads=1`
- `cargo clippy -p graphforge-storage -p graphforge-api --lib -- -D warnings`
- `make pre-push-fast`

`cargo clippy ... --tests -- -D warnings` is not a repository gate and reports pre-existing unrelated test lints across the storage crate; no unrelated cleanup is included here.

## Remaining gate

#900 stays open until the exact merged SHA completes S20 on the same 4 GiB Fly class with plateauing anonymous RSS. #901 remains the required append-only / linear-I/O and disk-growth repair before billion-edge certification.

Fixes #902
Refs #900
Refs #901

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790049630&installation_model_id=20486&pr_number=903&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F903&signature=321828709ee1aad6dfe4d6f2ac317112af44c198dfca0f105355e3d4c336fe40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added progress monitoring for large-scale graph ingestion, including phase, chunk, memory, storage, and disk usage details.
  * Added topology rewrite I/O metrics, including row counts and peak batch size.
  * Improved append workflows for existing graph data while preserving ordering and supporting normalization.

* **Performance**
  * Reduced catalog scans by reading only relevant data tails when determining maximum node and edge IDs.
  * Improved bounded processing of existing Parquet data during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->