### PR TITLE
test(discovery): publish schemas and conformance fixtures

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -183,6 +183,7 @@ test_suite(
         "//crates/graphforge-cli:portable",
         "//crates/graphforge-cli:repository",
         "//crates/graphforge-cypher:corpus",
+        "//crates/graphforge-discovery:contract_artifacts",
         "//crates/graphforge-exec:exec_integration_tests",
         "//crates/graphforge-ir:golden",
         "//crates/graphforge-ontology:integration",

--- a/crates/graphforge-discovery/BUILD.bazel
+++ b/crates/graphforge-discovery/BUILD.bazel
@@ -1,6 +1,6 @@
 """Bazel targets for the Rust-owned GraphForge Hub discovery contract."""
 
-load("//tools/bazel:gf_rust.bzl", "gf_rust_library", "gf_rust_test")
+load("//tools/bazel:gf_rust.bzl", "gf_rust_integration_test", "gf_rust_library", "gf_rust_test")
 
 exports_files(["Cargo.toml"])
 
@@ -13,4 +13,19 @@ gf_rust_library(
 gf_rust_test(
     name = "graphforge_discovery_test",
     crate = ":graphforge_discovery",
+)
+
+gf_rust_integration_test(
+    name = "contract_artifacts",
+    srcs = ["tests/contract_artifacts.rs"],
+    crate = ":graphforge_discovery",
+    compile_data = ["//docs/reference/discovery/v1:artifacts"],
+)
+
+test_suite(
+    name = "discovery_tests",
+    tests = [
+        ":contract_artifacts",
+        ":graphforge_discovery_test",
+    ],
 )

--- a/crates/graphforge-discovery/tests/contract_artifacts.rs
+++ b/crates/graphforge-discovery/tests/contract_artifacts.rs
@@ -1,0 +1,565 @@
+//! Deterministic generator and parity test for public discovery artifacts.
+#![allow(
+    clippy::needless_pass_by_value,
+    clippy::semicolon_if_nothing_returned,
+    clippy::struct_field_names,
+    clippy::too_many_lines,
+    clippy::type_complexity
+)]
+
+use graphforge_discovery::{DiscoveryLimits, DiscoveryManifest, RefSet};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const MANIFEST_SCHEMA: &str =
+    include_str!("../../../docs/reference/discovery/v1/manifest.schema.json");
+const REFS_SCHEMA: &str = include_str!("../../../docs/reference/discovery/v1/refs.schema.json");
+const FIXTURES: &str = include_str!("../../../docs/reference/discovery/v1/conformance.json");
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Corpus {
+    format: String,
+    cases: Vec<Case>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Case {
+    name: String,
+    document: Document,
+    json: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    limits: Option<Limits>,
+    expected: Expected,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum Document {
+    Manifest,
+    Refs,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
+struct Limits {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    max_response_bytes: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    max_refs: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    max_objects: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    max_locations_per_object: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    max_cumulative_object_bytes: Option<u64>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(tag = "result", rename_all = "snake_case")]
+enum Expected {
+    Valid {
+        canonical_json: String,
+    },
+    Invalid {
+        code: String,
+        field: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        version: Option<Value>,
+    },
+}
+
+fn schema(title: &str, required: &[&str], properties: Value, defs: Value) -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": format!("https://graphforge.sh/schemas/discovery/v1/{title}.schema.json"),
+        "title": title,
+        "type": "object",
+        "additionalProperties": false,
+        "required": required,
+        "properties": properties,
+        "$defs": defs
+    })
+}
+
+fn common_defs() -> Value {
+    json!({
+        "digest": {"type":"string","pattern":"^sha256:[0-9a-f]{64}$"},
+        "identity": {"type":"object","additionalProperties":false,"required":["owner","repository"],"properties":{
+            "owner":{"$ref":"#/$defs/slug"},"repository":{"$ref":"#/$defs/slug"}}},
+        "slug": {"type":"string","minLength":1,"maxLength":100,"pattern":"^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$"},
+        "version": {"type":"object","additionalProperties":false,"required":["major","minor"],"properties":{
+            "major":{"type":"integer","minimum":0,"maximum":65535},"minor":{"type":"integer","minimum":0,"maximum":65535}}},
+        "extensions": {"type":"object","maxProperties":256,"propertyNames":{"pattern":"^x-[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$"}}
+    })
+}
+
+fn manifest_schema() -> Value {
+    schema(
+        "manifest",
+        &[
+            "format",
+            "version",
+            "repository",
+            "default_ref",
+            "resolved_ref",
+            "immutable_version",
+            "package",
+            "requirements",
+            "capabilities",
+            "objects",
+        ],
+        json!({
+            "format":{"const":"graphforge-discovery/1"}, "version":{"$ref":"#/$defs/version"},
+            "repository":{"$ref":"#/$defs/identity"}, "default_ref":{"type":"string","minLength":1,"maxLength":4096},
+            "resolved_ref":{"type":"string","minLength":1,"maxLength":4096}, "immutable_version":{"$ref":"#/$defs/digest"},
+            "package":{"type":"object","additionalProperties":false,"required":["format","package_digest"],"properties":{"format":{"const":"graphforge-project/2"},"package_digest":{"$ref":"#/$defs/digest"}}},
+            "requirements":{"type":"array","maxItems":256,"items":{"$ref":"#/$defs/semantic"}},
+            "capabilities":{"type":"array","maxItems":256,"items":{"$ref":"#/$defs/semantic"}},
+            "objects":{"type":"array","minItems":1,"maxItems":1_000_000,"items":{"$ref":"#/$defs/object"}},
+            "extensions":{"$ref":"#/$defs/extensions"}
+        }),
+        {
+            let mut defs = common_defs();
+            let map = defs.as_object_mut().unwrap();
+            map.insert("semantic".into(), json!({"type":"object","additionalProperties":false,"required":["capability","major"],"properties":{"capability":{"type":"string","minLength":1,"maxLength":128},"major":{"type":"integer","minimum":0,"maximum":65535}}}));
+            map.insert("object".into(), json!({"type":"object","additionalProperties":false,"required":["digest","length","media_type","locations"],"properties":{"digest":{"$ref":"#/$defs/digest"},"length":{"type":"integer","minimum":0},"media_type":{"type":"string","minLength":1,"maxLength":4096},"locations":{"type":"array","minItems":1,"maxItems":8,"items":{"type":"string","format":"uri","pattern":"^https://"}}}}));
+            defs
+        },
+    )
+}
+
+fn refs_schema() -> Value {
+    schema(
+        "refs",
+        &["format", "version", "repository", "default_ref", "refs"],
+        json!({
+            "format":{"const":"graphforge-discovery/1"}, "version":{"$ref":"#/$defs/version"},
+            "repository":{"$ref":"#/$defs/identity"}, "default_ref":{"type":"string","minLength":1,"maxLength":4096},
+            "refs":{"type":"array","maxItems":10000,"items":{"$ref":"#/$defs/ref"}}, "extensions":{"$ref":"#/$defs/extensions"}
+        }),
+        {
+            let mut defs = common_defs();
+            defs.as_object_mut().unwrap().insert("ref".into(), json!({"type":"object","additionalProperties":false,"required":["name","target","validator"],"properties":{"name":{"type":"string","minLength":1,"maxLength":4096},"target":{"$ref":"#/$defs/digest"},"validator":{"$ref":"#/$defs/digest"}}}));
+            defs
+        },
+    )
+}
+
+fn digest(c: char) -> String {
+    format!("sha256:{}", c.to_string().repeat(64))
+}
+
+fn base_manifest() -> Value {
+    json!({
+        "format":"graphforge-discovery/1","version":{"major":1,"minor":0},"repository":{"owner":"openalex","repository":"openalex"},
+        "default_ref":"main","resolved_ref":"main","immutable_version":digest('a'),
+        "package":{"format":"graphforge-project/2","package_digest":digest('b')},
+        "requirements":[{"capability":"portable-v2","major":1}],"capabilities":[{"capability":"range-requests","major":1}],
+        "objects":[{"digest":digest('c'),"length":42,"media_type":"application/vnd.graphforge.project","locations":["https://data.graphforge.sh/objects/c"]}],
+        "extensions":{"x-example":{"z":1,"a":true}}
+    })
+}
+
+fn base_refs() -> Value {
+    json!({
+        "format":"graphforge-discovery/1","version":{"major":1,"minor":0},"repository":{"owner":"openalex","repository":"openalex"},
+        "default_ref":"main","refs":[{"name":"main","target":digest('a'),"validator":digest('d')}]
+    })
+}
+
+fn compact(value: &Value) -> String {
+    serde_json::to_string(value).unwrap()
+}
+
+fn valid(name: &str, document: Document, value: Value) -> Case {
+    let canonical_json = match document {
+        Document::Manifest => String::from_utf8(
+            DiscoveryManifest::from_json(compact(&value).as_bytes(), DiscoveryLimits::default())
+                .unwrap()
+                .to_canonical_json()
+                .unwrap(),
+        )
+        .unwrap(),
+        Document::Refs => String::from_utf8(
+            RefSet::from_json(compact(&value).as_bytes(), DiscoveryLimits::default())
+                .unwrap()
+                .to_canonical_json()
+                .unwrap(),
+        )
+        .unwrap(),
+    };
+    Case {
+        name: name.into(),
+        document,
+        json: compact(&value),
+        limits: None,
+        expected: Expected::Valid { canonical_json },
+    }
+}
+
+fn invalid(name: &str, document: Document, value: Value, code: &str, field: Option<&str>) -> Case {
+    Case {
+        name: name.into(),
+        document,
+        json: compact(&value),
+        limits: None,
+        expected: Expected::Invalid {
+            code: code.into(),
+            field: field.map(str::to_owned),
+            version: None,
+        },
+    }
+}
+
+fn invalid_version(
+    name: &str,
+    value: Value,
+    field: &str,
+    subject: &str,
+    supported_major: Option<u16>,
+    requested_major: u16,
+) -> Case {
+    Case {
+        name: name.into(),
+        document: Document::Manifest,
+        json: compact(&value),
+        limits: None,
+        expected: Expected::Invalid {
+            code: "unsupported_future".into(),
+            field: Some(field.into()),
+            version: Some(
+                json!({"subject":subject,"supported_major":supported_major,"requested_major":requested_major}),
+            ),
+        },
+    }
+}
+
+fn corpus() -> Corpus {
+    let mut cases = vec![
+        valid(
+            "manifest-minor-compatible-and-canonical",
+            Document::Manifest,
+            {
+                let mut v = base_manifest();
+                v["version"]["minor"] = json!(99);
+                v
+            },
+        ),
+        valid("refs-canonical", Document::Refs, base_refs()),
+    ];
+    cases.push(invalid_version(
+        "future-protocol",
+        {
+            let mut v = base_manifest();
+            v["version"]["major"] = json!(2);
+            v
+        },
+        "version.major",
+        "protocol",
+        Some(1),
+        2,
+    ));
+    cases.push(invalid_version(
+        "future-package",
+        {
+            let mut v = base_manifest();
+            v["package"]["format"] = json!("graphforge-project/3");
+            v
+        },
+        "package.format",
+        "portable_package",
+        Some(2),
+        3,
+    ));
+    cases.push(invalid_version(
+        "unknown-required-capability",
+        {
+            let mut v = base_manifest();
+            v["requirements"][0]["capability"] = json!("future-fetch");
+            v
+        },
+        "requirements",
+        "capability",
+        None,
+        1,
+    ));
+    cases.push(valid("unknown-optional-capability", Document::Manifest, {
+        let mut v = base_manifest();
+        v["capabilities"][0]["capability"] = json!("future-fetch");
+        v
+    }));
+    let mutations: &[(&str, Document, &str, Option<&str>, fn(&mut Value))] = &[
+        (
+            "invalid-identity",
+            Document::Manifest,
+            "invalid_identity",
+            Some("repository"),
+            |v| v["repository"]["owner"] = json!("OpenAlex"),
+        ),
+        (
+            "invalid-digest",
+            Document::Manifest,
+            "integrity_failure",
+            Some("digest"),
+            |v| v["objects"][0]["digest"] = json!("sha256:ABC"),
+        ),
+        (
+            "unsafe-http-url",
+            Document::Manifest,
+            "unsafe_location",
+            Some("objects.locations"),
+            |v| v["objects"][0]["locations"][0] = json!("http://data.graphforge.sh/object"),
+        ),
+        (
+            "credentialed-url",
+            Document::Manifest,
+            "unsafe_location",
+            Some("objects.locations"),
+            |v| {
+                v["objects"][0]["locations"][0] =
+                    json!("https://user:secret@data.graphforge.sh/object")
+            },
+        ),
+        (
+            "query-url",
+            Document::Manifest,
+            "unsafe_location",
+            Some("objects.locations"),
+            |v| {
+                v["objects"][0]["locations"][0] =
+                    json!("https://data.graphforge.sh/object?token=secret")
+            },
+        ),
+        (
+            "duplicate-object",
+            Document::Manifest,
+            "duplicate",
+            Some("objects.digest"),
+            |v| {
+                let x = v["objects"][0].clone();
+                v["objects"].as_array_mut().unwrap().push(x)
+            },
+        ),
+        (
+            "missing-object",
+            Document::Manifest,
+            "missing_object",
+            Some("objects"),
+            |v| v["objects"] = json!([]),
+        ),
+        (
+            "noncanonical-requirements",
+            Document::Manifest,
+            "duplicate",
+            Some("requirements"),
+            |v| v["requirements"] = json!([{"capability":"portable-v2","major":1},{"capability":"portable-v2","major":1}]),
+        ),
+        (
+            "invalid-ref-name",
+            Document::Refs,
+            "malformed_response",
+            Some("ref"),
+            |v| v["refs"][0]["name"] = json!("bad..ref"),
+        ),
+        (
+            "missing-default-ref",
+            Document::Refs,
+            "missing_ref",
+            Some("default_ref"),
+            |v| v["default_ref"] = json!("trunk"),
+        ),
+        (
+            "invalid-validator",
+            Document::Refs,
+            "integrity_failure",
+            Some("digest"),
+            |v| v["refs"][0]["validator"] = json!("W/\"weak\""),
+        ),
+        (
+            "duplicate-ref",
+            Document::Refs,
+            "duplicate",
+            Some("refs.name"),
+            |v| {
+                let x = v["refs"][0].clone();
+                v["refs"].as_array_mut().unwrap().push(x)
+            },
+        ),
+    ];
+    for (name, doc, code, field, mutate) in mutations {
+        let mut value = match doc {
+            Document::Manifest => base_manifest(),
+            Document::Refs => base_refs(),
+        };
+        mutate(&mut value);
+        cases.push(invalid(name, *doc, value, code, *field));
+    }
+    let mut bounded = invalid(
+        "response-byte-bound",
+        Document::Manifest,
+        base_manifest(),
+        "limit_exceeded",
+        Some("response"),
+    );
+    bounded.limits = Some(Limits {
+        max_response_bytes: Some(1),
+        ..Limits::default()
+    });
+    cases.push(bounded);
+    let mut bounded = invalid(
+        "location-count-bound",
+        Document::Manifest,
+        {
+            let mut v = base_manifest();
+            v["objects"][0]["locations"] = json!(["https://a.example/o", "https://b.example/o"]);
+            v
+        },
+        "limit_exceeded",
+        Some("objects.locations"),
+    );
+    bounded.limits = Some(Limits {
+        max_locations_per_object: Some(1),
+        ..Limits::default()
+    });
+    cases.push(bounded);
+    let mut bounded = invalid(
+        "cumulative-byte-bound",
+        Document::Manifest,
+        base_manifest(),
+        "limit_exceeded",
+        Some("objects.length"),
+    );
+    bounded.limits = Some(Limits {
+        max_cumulative_object_bytes: Some(41),
+        ..Limits::default()
+    });
+    cases.push(bounded);
+    let mut bounded = invalid(
+        "ref-count-bound",
+        Document::Refs,
+        base_refs(),
+        "limit_exceeded",
+        Some("refs"),
+    );
+    bounded.limits = Some(Limits {
+        max_refs: Some(0),
+        ..Limits::default()
+    });
+    cases.push(bounded);
+    cases.push(Case {
+        name: "duplicate-json-member".into(),
+        document: Document::Refs,
+        json: "{\"format\":\"graphforge-discovery/1\",\"format\":\"graphforge-discovery/1\"}"
+            .into(),
+        limits: None,
+        expected: Expected::Invalid {
+            code: "malformed_response".into(),
+            field: None,
+            version: None,
+        },
+    });
+    Corpus {
+        format: "graphforge-discovery-conformance/1".into(),
+        cases,
+    }
+}
+
+fn limits(overrides: Option<Limits>) -> DiscoveryLimits {
+    let mut limits = DiscoveryLimits::default();
+    if let Some(v) = overrides {
+        if let Some(x) = v.max_response_bytes {
+            limits.max_response_bytes = x
+        }
+        if let Some(x) = v.max_refs {
+            limits.max_refs = x
+        }
+        if let Some(x) = v.max_objects {
+            limits.max_objects = x
+        }
+        if let Some(x) = v.max_locations_per_object {
+            limits.max_locations_per_object = x
+        }
+        if let Some(x) = v.max_cumulative_object_bytes {
+            limits.max_cumulative_object_bytes = x
+        }
+    }
+    limits
+}
+fn pretty(value: &impl Serialize) -> Vec<u8> {
+    let mut bytes = serde_json::to_vec_pretty(value).unwrap();
+    bytes.push(b'\n');
+    bytes
+}
+fn root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .unwrap()
+}
+
+#[test]
+fn checked_in_contract_artifacts_match_rust_authority() {
+    let expected = [
+        ("manifest.schema.json", pretty(&manifest_schema())),
+        ("refs.schema.json", pretty(&refs_schema())),
+        ("conformance.json", pretty(&corpus())),
+    ];
+    if std::env::var_os("GRAPHFORGE_UPDATE_DISCOVERY_ARTIFACTS").is_some() {
+        let dir = root().join("docs/reference/discovery/v1");
+        fs::create_dir_all(&dir).unwrap();
+        for (name, bytes) in &expected {
+            fs::write(dir.join(name), bytes).unwrap();
+        }
+        return;
+    }
+    for ((name, expected), actual) in expected
+        .iter()
+        .zip([MANIFEST_SCHEMA, REFS_SCHEMA, FIXTURES])
+    {
+        assert_eq!(
+            actual.as_bytes(),
+            expected,
+            "{name} is stale; regenerate with GRAPHFORGE_UPDATE_DISCOVERY_ARTIFACTS=1 cargo test -p graphforge-discovery --test contract_artifacts"
+        );
+    }
+    let parsed: Corpus = serde_json::from_str(FIXTURES).unwrap();
+    for case in parsed.cases {
+        let result = match case.document {
+            Document::Manifest => {
+                DiscoveryManifest::from_json(case.json.as_bytes(), limits(case.limits))
+                    .map(|v| String::from_utf8(v.to_canonical_json().unwrap()).unwrap())
+            }
+            Document::Refs => RefSet::from_json(case.json.as_bytes(), limits(case.limits))
+                .map(|v| String::from_utf8(v.to_canonical_json().unwrap()).unwrap()),
+        };
+        match (case.expected, result) {
+            (Expected::Valid { canonical_json }, Ok(actual)) => {
+                assert_eq!(actual, canonical_json, "{}", case.name)
+            }
+            (
+                Expected::Invalid {
+                    code,
+                    field,
+                    version,
+                },
+                Err(error),
+            ) => {
+                assert_eq!(
+                    serde_json::to_value(error.code).unwrap(),
+                    Value::String(code),
+                    "{}",
+                    case.name
+                );
+                assert_eq!(error.field.map(str::to_owned), field, "{}", case.name);
+                assert_eq!(
+                    serde_json::to_value(error.version).unwrap(),
+                    version.unwrap_or(Value::Null),
+                    "{}",
+                    case.name
+                )
+            }
+            (_, result) => panic!("{}: unexpected {result:?}", case.name),
+        }
+    }
+}

--- a/docs/development/bazel-migration-ledger.md
+++ b/docs/development/bazel-migration-ledger.md
@@ -127,6 +127,7 @@ Authoritative machine-readable map: `tools/bazel/parity/migration_target_map.jso
 | `graphforge-cypher` | `corpus` | `integration-test` | `crates/graphforge-cypher/tests/corpus.rs` | `//crates/graphforge-cypher:corpus` | `mapped` | #8 |
 | `graphforge-cypher` | `compile` | `bench` | `crates/graphforge-cypher/benches/compile.rs` | — | `exception` | RT-codspeed-bench; CodSpeed divan benchmark |
 | `graphforge-discovery` | `graphforge_discovery` | `lib` | `crates/graphforge-discovery/src/lib.rs` | `//crates/graphforge-discovery:graphforge_discovery` | `mapped` | #908; unit tests `//crates/graphforge-discovery:graphforge_discovery_test` |
+| `graphforge-discovery` | `contract_artifacts` | `integration-test` | `crates/graphforge-discovery/tests/contract_artifacts.rs` | `//crates/graphforge-discovery:contract_artifacts` | `mapped` | #910; deterministic schema and conformance fixture parity |
 | `graphforge-exec` | `graphforge_exec` | `lib` | `crates/graphforge-exec/src/lib.rs` | `//crates/graphforge-exec:graphforge_exec` | `mapped` | #9; unit tests `//crates/graphforge-exec:graphforge_exec_test` |
 | `graphforge-exec` | `adjacency_expand` | `integration-test` | `crates/graphforge-exec/tests/adjacency_expand.rs` | `//crates/graphforge-exec:adjacency_expand` | `mapped` | #8 |
 | `graphforge-exec` | `bench_traversal_scaling` | `integration-test` | `crates/graphforge-exec/tests/bench_traversal_scaling.rs` | `//crates/graphforge-exec:bench_traversal_scaling` | `mapped` | #8 |

--- a/docs/reference/discovery/v1/BUILD.bazel
+++ b/docs/reference/discovery/v1/BUILD.bazel
@@ -1,0 +1,10 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "artifacts",
+    srcs = [
+        "conformance.json",
+        "manifest.schema.json",
+        "refs.schema.json",
+    ],
+)

--- a/docs/reference/discovery/v1/README.md
+++ b/docs/reference/discovery/v1/README.md
@@ -1,0 +1,26 @@
+# Discovery v1 contract artifacts
+
+These checked-in JSON Schemas describe the wire shape of GraphForge discovery
+manifest and refs responses. `conformance.json` supplies valid and invalid
+examples with stable Rust error results. Semantic rules that JSON Schema cannot
+express—canonical ordering, cumulative bounds, safe URLs, capability
+negotiation, and duplicate JSON members—remain authoritative in
+`graphforge-discovery` and are exercised by the corpus.
+
+Regenerate all three artifacts deterministically from the Rust test source:
+
+```bash
+GRAPHFORGE_UPDATE_DISCOVERY_ARTIFACTS=1 \
+  cargo test -p graphforge-discovery --test contract_artifacts
+```
+
+Running the same test without that environment variable compares generated
+bytes with the checked-in files and validates every corpus case through the
+public Rust parser. Cargo and Bazel CI therefore fail when artifacts drift.
+
+Downstream TypeScript may package these JSON files, use a JSON Schema validator
+for early structural feedback, and run the conformance corpus against an HTTP
+adapter. It must not transcribe the schema as hand-written TypeScript protocol
+types or reimplement validation semantics. Rust remains the authority; generated
+TypeScript declarations, if needed, must be treated as disposable build output
+derived from these versioned artifacts.

--- a/docs/reference/discovery/v1/conformance.json
+++ b/docs/reference/discovery/v1/conformance.json
@@ -1,0 +1,259 @@
+{
+  "format": "graphforge-discovery-conformance/1",
+  "cases": [
+    {
+      "name": "manifest-minor-compatible-and-canonical",
+      "document": "manifest",
+      "json": "{\"capabilities\":[{\"capability\":\"range-requests\",\"major\":1}],\"default_ref\":\"main\",\"extensions\":{\"x-example\":{\"a\":true,\"z\":1}},\"format\":\"graphforge-discovery/1\",\"immutable_version\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"objects\":[{\"digest\":\"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\",\"length\":42,\"locations\":[\"https://data.graphforge.sh/objects/c\"],\"media_type\":\"application/vnd.graphforge.project\"}],\"package\":{\"format\":\"graphforge-project/2\",\"package_digest\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"},\"repository\":{\"owner\":\"openalex\",\"repository\":\"openalex\"},\"requirements\":[{\"capability\":\"portable-v2\",\"major\":1}],\"resolved_ref\":\"main\",\"version\":{\"major\":1,\"minor\":99}}",
+      "expected": {
+        "result": "valid",
+        "canonical_json": "{\"capabilities\":[{\"capability\":\"range-requests\",\"major\":1}],\"default_ref\":\"main\",\"extensions\":{\"x-example\":{\"a\":true,\"z\":1}},\"format\":\"graphforge-discovery/1\",\"immutable_version\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"objects\":[{\"digest\":\"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\",\"length\":42,\"locations\":[\"https://data.graphforge.sh/objects/c\"],\"media_type\":\"application/vnd.graphforge.project\"}],\"package\":{\"format\":\"graphforge-project/2\",\"package_digest\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"},\"repository\":{\"owner\":\"openalex\",\"repository\":\"openalex\"},\"requirements\":[{\"capability\":\"portable-v2\",\"major\":1}],\"resolved_ref\":\"main\",\"version\":{\"major\":1,\"minor\":99}}"
+      }
+    },
+    {
+      "name": "refs-canonical",
+      "document": "refs",
+      "json": "{\"default_ref\":\"main\",\"format\":\"graphforge-discovery/1\",\"refs\":[{\"name\":\"main\",\"target\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"validator\":\"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\"}],\"repository\":{\"owner\":\"openalex\",\"repository\":\"openalex\"},\"version\":{\"major\":1,\"minor\":0}}",
+      "expected": {
+        "result": "valid",
+        "canonical_json": "{\"default_ref\":\"main\",\"format\":\"graphforge-discovery/1\",\"refs\":[{\"name\":\"main\",\"target\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"validator\":\"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\"}],\"repository\":{\"owner\":\"openalex\",\"repository\":\"openalex\"},\"version\":{\"major\":1,\"minor\":0}}"
+      }
+    },
+    {
+      "name": "future-protocol",
+      "document": "manifest",
+      "json": "{\"capabilities\":[{\"capability\":\"range-requests\",\"major\":1}],\"default_ref\":\"main\",\"extensions\":{\"x-example\":{\"a\":true,\"z\":1}},\"format\":\"graphforge-discovery/1\",\"immutable_version\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"objects\":[{\"digest\":\"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\",\"length\":42,\"locations\":[\"https://data.graphforge.sh/objects/c\"],\"media_type\":\"application/vnd.graphforge.project\"}],\"package\":{\"format\":\"graphforge-project/2\",\"package_digest\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"},\"repository\":{\"owner\":\"openalex\",\"repository\":\"openalex\"},\"requirements\":[{\"capability\":\"portable-v2\",\"major\":1}],\"resolved_ref\":\"main\",\"version\":{\"major\":2,\"minor\":0}}",
+      "expected": {
+        "result": "invalid",
+        "code": "unsupported_future",
+        "field": "version.major",
+        "version": {
+          "requested_major": 2,
+          "subject": "protocol",
+          "supported_major": 1
+        }
+      }
+    },
+    {
+      "name": "future-package",
+      "document": "manifest",
+      "json": "{\"capabilities\":[{\"capability\":\"range-requests\",\"major\":1}],\"default_ref\":\"main\",\"extensions\":{\"x-example\":{\"a\":true,\"z\":1}},\"format\":\"graphforge-discovery/1\",\"immutable_version\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"objects\":[{\"digest\":\"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\",\"length\":42,\"locations\":[\"https://data.graphforge.sh/objects/c\"],\"media_type\":\"application/vnd.graphforge.project\"}],\"package\":{\"format\":\"graphforge-project/3\",\"package_digest\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"},\"repository\":{\"owner\":\"openalex\",\"repository\":\"openalex\"},\"requirements\":[{\"capability\":\"portable-v2\",\"major\":1}],\"resolved_ref\":\"main\",\"version\":{\"major\":1,\"minor\":0}}",
+      "expected": {
+        "result": "invalid",
+        "code": "unsupported_future",
+        "field": "package.format",
+        "version": {
+          "requested_major": 3,
+          "subject": "portable_package",
+          "supported_major": 2
+        }
+      }
+    },
+    {
+      "name": "unknown-required-capability",
+      "document": "manifest",
+      "json": "{\"capabilities\":[{\"capability\":\"range-requests\",\"major\":1}],\"default_ref\":\"main\",\"extensions\":{\"x-example\":{\"a\":true,\"z\":1}},\"format\":\"graphforge-discovery/1\",\"immutable_version\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"objects\":[{\"digest\":\"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\",\"length\":42,\"locations\":[\"https://data.graphforge.sh/objects/c\"],\"media_type\":\"application/vnd.graphforge.project\"}],\"package\":{\"format\":\"graphforge-project/2\",\"package_digest\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"},\"repository\":{\"owner\":\"openalex\",\"repository\":\"openalex\"},\"requirements\":[{\"capability\":\"future-fetch\",\"major\":1}],\"resolved_ref\":\"main\",\"version\":{\"major\":1,\"minor\":0}}",
+      "expected": {
+        "result": "invalid",
+        "code": "unsupported_future",
+        "field": "requirements",
+        "version": {
+          "requested_major": 1,
+          "subject": "capability",
+          "supported_major": null
+        }
+      }
+    },
+    {
+      "name": "unknown-optional-capability",
+      "document": "manifest",
+      "json": "{\"capabilities\":[{\"capability\":\"future-fetch\",\"major\":1}],\"default_ref\":\"main\",\"extensions\":{\"x-example\":{\"a\":true,\"z\":1}},\"format\":\"graphforge-discovery/1\",\"immutable_version\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"objects\":[{\"digest\":\"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\",\"length\":42,\"locations\":[\"https://data.graphforge.sh/objects/c\"],\"media_type\":\"application/vnd.graphforge.project\"}],\"package\":{\"format\":\"graphforge-project/2\",\"package_digest\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"},\"repository\":{\"owner\":\"openalex\",\"repository\":\"openalex\"},\"requirements\":[{\"capability\":\"portable-v2\",\"major\":1}],\"resolved_ref\":\"main\",\"version\":{\"major\":1,\"minor\":0}}",
+      "expected": {
+        "result": "valid",
+        "canonical_json": "{\"capabilities\":[{\"capability\":\"future-fetch\",\"major\":1}],\"default_ref\":\"main\",\"extensions\":{\"x-example\":{\"a\":true,\"z\":1}},\"format\":\"graphforge-discovery/1\",\"immutable_version\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"objects\":[{\"digest\":\"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\",\"length\":42,\"locations\":[\"https://data.graphforge.sh/objects/c\"],\"media_type\":\"application/vnd.graphforge.project\"}],\"package\":{\"format\":\"graphforge-project/2\",\"package_digest\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"},\"repository\":{\"owner\":\"openalex\",\"repository\":\"openalex\"},\"requirements\":[{\"capability\":\"portable-v2\",\"major\":1}],\"resolved_ref\":\"main\",\"version\":{\"major\":1,\"minor\":0}}"
+      }
+    },
+    {
+      "name": "invalid-identity",
+      "document": "manifest",
+      "json": "{\"capabilities\":[{\"capability\":\"range-requests\",\"major\":1}],\"default_ref\":\"main\",\"extensions\":{\"x-example\":{\"a\":true,\"z\":1}},\"format\":\"graphforge-discovery/1\",\"immutable_version\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"objects\":[{\"digest\":\"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\",\"length\":42,\"locations\":[\"https://data.graphforge.sh/objects/c\"],\"media_type\":\"application/vnd.graphforge.project\"}],\"package\":{\"format\":\"graphforge-project/2\",\"package_digest\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"},\"repository\":{\"owner\":\"OpenAlex\",\"repository\":\"openalex\"},\"requirements\":[{\"capability\":\"portable-v2\",\"major\":1}],\"resolved_ref\":\"main\",\"version\":{\"major\":1,\"minor\":0}}",
+      "expected": {
+        "result": "invalid",
+        "code": "invalid_identity",
+        "field": "repository"
+      }
+    },
+    {
+      "name": "invalid-digest",
+      "document": "manifest",
+      "json": "{\"capabilities\":[{\"capability\":\"range-requests\",\"major\":1}],\"default_ref\":\"main\",\"extensions\":{\"x-example\":{\"a\":true,\"z\":1}},\"format\":\"graphforge-discovery/1\",\"immutable_version\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"objects\":[{\"digest\":\"sha256:ABC\",\"length\":42,\"locations\":[\"https://data.graphforge.sh/objects/c\"],\"media_type\":\"application/vnd.graphforge.project\"}],\"package\":{\"format\":\"graphforge-project/2\",\"package_digest\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"},\"repository\":{\"owner\":\"openalex\",\"repository\":\"openalex\"},\"requirements\":[{\"capability\":\"portable-v2\",\"major\":1}],\"resolved_ref\":\"main\",\"version\":{\"major\":1,\"minor\":0}}",
+      "expected": {
+        "result": "invalid",
+        "code": "integrity_failure",
+        "field": "digest"
+      }
+    },
+    {
+      "name": "unsafe-http-url",
+      "document": "manifest",
+      "json": "{\"capabilities\":[{\"capability\":\"range-requests\",\"major\":1}],\"default_ref\":\"main\",\"extensions\":{\"x-example\":{\"a\":true,\"z\":1}},\"format\":\"graphforge-discovery/1\",\"immutable_version\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"objects\":[{\"digest\":\"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\",\"length\":42,\"locations\":[\"http://data.graphforge.sh/object\"],\"media_type\":\"application/vnd.graphforge.project\"}],\"package\":{\"format\":\"graphforge-project/2\",\"package_digest\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"},\"repository\":{\"owner\":\"openalex\",\"repository\":\"openalex\"},\"requirements\":[{\"capability\":\"portable-v2\",\"major\":1}],\"resolved_ref\":\"main\",\"version\":{\"major\":1,\"minor\":0}}",
+      "expected": {
+        "result": "invalid",
+        "code": "unsafe_location",
+        "field": "objects.locations"
+      }
+    },
+    {
+      "name": "credentialed-url",
+      "document": "manifest",
+      "json": "{\"capabilities\":[{\"capability\":\"range-requests\",\"major\":1}],\"default_ref\":\"main\",\"extensions\":{\"x-example\":{\"a\":true,\"z\":1}},\"format\":\"graphforge-discovery/1\",\"immutable_version\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"objects\":[{\"digest\":\"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\",\"length\":42,\"locations\":[\"https://user:secret@data.graphforge.sh/object\"],\"media_type\":\"application/vnd.graphforge.project\"}],\"package\":{\"format\":\"graphforge-project/2\",\"package_digest\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"},\"repository\":{\"owner\":\"openalex\",\"repository\":\"openalex\"},\"requirements\":[{\"capability\":\"portable-v2\",\"major\":1}],\"resolved_ref\":\"main\",\"version\":{\"major\":1,\"minor\":0}}",
+      "expected": {
+        "result": "invalid",
+        "code": "unsafe_location",
+        "field": "objects.locations"
+      }
+    },
+    {
+      "name": "query-url",
+      "document": "manifest",
+      "json": "{\"capabilities\":[{\"capability\":\"range-requests\",\"major\":1}],\"default_ref\":\"main\",\"extensions\":{\"x-example\":{\"a\":true,\"z\":1}},\"format\":\"graphforge-discovery/1\",\"immutable_version\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"objects\":[{\"digest\":\"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\",\"length\":42,\"locations\":[\"https://data.graphforge.sh/object?token=secret\"],\"media_type\":\"application/vnd.graphforge.project\"}],\"package\":{\"format\":\"graphforge-project/2\",\"package_digest\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"},\"repository\":{\"owner\":\"openalex\",\"repository\":\"openalex\"},\"requirements\":[{\"capability\":\"portable-v2\",\"major\":1}],\"resolved_ref\":\"main\",\"version\":{\"major\":1,\"minor\":0}}",
+      "expected": {
+        "result": "invalid",
+        "code": "unsafe_location",
+        "field": "objects.locations"
+      }
+    },
+    {
+      "name": "duplicate-object",
+      "document": "manifest",
+      "json": "{\"capabilities\":[{\"capability\":\"range-requests\",\"major\":1}],\"default_ref\":\"main\",\"extensions\":{\"x-example\":{\"a\":true,\"z\":1}},\"format\":\"graphforge-discovery/1\",\"immutable_version\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"objects\":[{\"digest\":\"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\",\"length\":42,\"locations\":[\"https://data.graphforge.sh/objects/c\"],\"media_type\":\"application/vnd.graphforge.project\"},{\"digest\":\"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\",\"length\":42,\"locations\":[\"https://data.graphforge.sh/objects/c\"],\"media_type\":\"application/vnd.graphforge.project\"}],\"package\":{\"format\":\"graphforge-project/2\",\"package_digest\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"},\"repository\":{\"owner\":\"openalex\",\"repository\":\"openalex\"},\"requirements\":[{\"capability\":\"portable-v2\",\"major\":1}],\"resolved_ref\":\"main\",\"version\":{\"major\":1,\"minor\":0}}",
+      "expected": {
+        "result": "invalid",
+        "code": "duplicate",
+        "field": "objects.digest"
+      }
+    },
+    {
+      "name": "missing-object",
+      "document": "manifest",
+      "json": "{\"capabilities\":[{\"capability\":\"range-requests\",\"major\":1}],\"default_ref\":\"main\",\"extensions\":{\"x-example\":{\"a\":true,\"z\":1}},\"format\":\"graphforge-discovery/1\",\"immutable_version\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"objects\":[],\"package\":{\"format\":\"graphforge-project/2\",\"package_digest\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"},\"repository\":{\"owner\":\"openalex\",\"repository\":\"openalex\"},\"requirements\":[{\"capability\":\"portable-v2\",\"major\":1}],\"resolved_ref\":\"main\",\"version\":{\"major\":1,\"minor\":0}}",
+      "expected": {
+        "result": "invalid",
+        "code": "missing_object",
+        "field": "objects"
+      }
+    },
+    {
+      "name": "noncanonical-requirements",
+      "document": "manifest",
+      "json": "{\"capabilities\":[{\"capability\":\"range-requests\",\"major\":1}],\"default_ref\":\"main\",\"extensions\":{\"x-example\":{\"a\":true,\"z\":1}},\"format\":\"graphforge-discovery/1\",\"immutable_version\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"objects\":[{\"digest\":\"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\",\"length\":42,\"locations\":[\"https://data.graphforge.sh/objects/c\"],\"media_type\":\"application/vnd.graphforge.project\"}],\"package\":{\"format\":\"graphforge-project/2\",\"package_digest\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"},\"repository\":{\"owner\":\"openalex\",\"repository\":\"openalex\"},\"requirements\":[{\"capability\":\"portable-v2\",\"major\":1},{\"capability\":\"portable-v2\",\"major\":1}],\"resolved_ref\":\"main\",\"version\":{\"major\":1,\"minor\":0}}",
+      "expected": {
+        "result": "invalid",
+        "code": "duplicate",
+        "field": "requirements"
+      }
+    },
+    {
+      "name": "invalid-ref-name",
+      "document": "refs",
+      "json": "{\"default_ref\":\"main\",\"format\":\"graphforge-discovery/1\",\"refs\":[{\"name\":\"bad..ref\",\"target\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"validator\":\"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\"}],\"repository\":{\"owner\":\"openalex\",\"repository\":\"openalex\"},\"version\":{\"major\":1,\"minor\":0}}",
+      "expected": {
+        "result": "invalid",
+        "code": "malformed_response",
+        "field": "ref"
+      }
+    },
+    {
+      "name": "missing-default-ref",
+      "document": "refs",
+      "json": "{\"default_ref\":\"trunk\",\"format\":\"graphforge-discovery/1\",\"refs\":[{\"name\":\"main\",\"target\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"validator\":\"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\"}],\"repository\":{\"owner\":\"openalex\",\"repository\":\"openalex\"},\"version\":{\"major\":1,\"minor\":0}}",
+      "expected": {
+        "result": "invalid",
+        "code": "missing_ref",
+        "field": "default_ref"
+      }
+    },
+    {
+      "name": "invalid-validator",
+      "document": "refs",
+      "json": "{\"default_ref\":\"main\",\"format\":\"graphforge-discovery/1\",\"refs\":[{\"name\":\"main\",\"target\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"validator\":\"W/\\\"weak\\\"\"}],\"repository\":{\"owner\":\"openalex\",\"repository\":\"openalex\"},\"version\":{\"major\":1,\"minor\":0}}",
+      "expected": {
+        "result": "invalid",
+        "code": "integrity_failure",
+        "field": "digest"
+      }
+    },
+    {
+      "name": "duplicate-ref",
+      "document": "refs",
+      "json": "{\"default_ref\":\"main\",\"format\":\"graphforge-discovery/1\",\"refs\":[{\"name\":\"main\",\"target\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"validator\":\"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\"},{\"name\":\"main\",\"target\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"validator\":\"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\"}],\"repository\":{\"owner\":\"openalex\",\"repository\":\"openalex\"},\"version\":{\"major\":1,\"minor\":0}}",
+      "expected": {
+        "result": "invalid",
+        "code": "duplicate",
+        "field": "refs.name"
+      }
+    },
+    {
+      "name": "response-byte-bound",
+      "document": "manifest",
+      "json": "{\"capabilities\":[{\"capability\":\"range-requests\",\"major\":1}],\"default_ref\":\"main\",\"extensions\":{\"x-example\":{\"a\":true,\"z\":1}},\"format\":\"graphforge-discovery/1\",\"immutable_version\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"objects\":[{\"digest\":\"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\",\"length\":42,\"locations\":[\"https://data.graphforge.sh/objects/c\"],\"media_type\":\"application/vnd.graphforge.project\"}],\"package\":{\"format\":\"graphforge-project/2\",\"package_digest\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"},\"repository\":{\"owner\":\"openalex\",\"repository\":\"openalex\"},\"requirements\":[{\"capability\":\"portable-v2\",\"major\":1}],\"resolved_ref\":\"main\",\"version\":{\"major\":1,\"minor\":0}}",
+      "limits": {
+        "max_response_bytes": 1
+      },
+      "expected": {
+        "result": "invalid",
+        "code": "limit_exceeded",
+        "field": "response"
+      }
+    },
+    {
+      "name": "location-count-bound",
+      "document": "manifest",
+      "json": "{\"capabilities\":[{\"capability\":\"range-requests\",\"major\":1}],\"default_ref\":\"main\",\"extensions\":{\"x-example\":{\"a\":true,\"z\":1}},\"format\":\"graphforge-discovery/1\",\"immutable_version\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"objects\":[{\"digest\":\"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\",\"length\":42,\"locations\":[\"https://a.example/o\",\"https://b.example/o\"],\"media_type\":\"application/vnd.graphforge.project\"}],\"package\":{\"format\":\"graphforge-project/2\",\"package_digest\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"},\"repository\":{\"owner\":\"openalex\",\"repository\":\"openalex\"},\"requirements\":[{\"capability\":\"portable-v2\",\"major\":1}],\"resolved_ref\":\"main\",\"version\":{\"major\":1,\"minor\":0}}",
+      "limits": {
+        "max_locations_per_object": 1
+      },
+      "expected": {
+        "result": "invalid",
+        "code": "limit_exceeded",
+        "field": "objects.locations"
+      }
+    },
+    {
+      "name": "cumulative-byte-bound",
+      "document": "manifest",
+      "json": "{\"capabilities\":[{\"capability\":\"range-requests\",\"major\":1}],\"default_ref\":\"main\",\"extensions\":{\"x-example\":{\"a\":true,\"z\":1}},\"format\":\"graphforge-discovery/1\",\"immutable_version\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"objects\":[{\"digest\":\"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\",\"length\":42,\"locations\":[\"https://data.graphforge.sh/objects/c\"],\"media_type\":\"application/vnd.graphforge.project\"}],\"package\":{\"format\":\"graphforge-project/2\",\"package_digest\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"},\"repository\":{\"owner\":\"openalex\",\"repository\":\"openalex\"},\"requirements\":[{\"capability\":\"portable-v2\",\"major\":1}],\"resolved_ref\":\"main\",\"version\":{\"major\":1,\"minor\":0}}",
+      "limits": {
+        "max_cumulative_object_bytes": 41
+      },
+      "expected": {
+        "result": "invalid",
+        "code": "limit_exceeded",
+        "field": "objects.length"
+      }
+    },
+    {
+      "name": "ref-count-bound",
+      "document": "refs",
+      "json": "{\"default_ref\":\"main\",\"format\":\"graphforge-discovery/1\",\"refs\":[{\"name\":\"main\",\"target\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"validator\":\"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\"}],\"repository\":{\"owner\":\"openalex\",\"repository\":\"openalex\"},\"version\":{\"major\":1,\"minor\":0}}",
+      "limits": {
+        "max_refs": 0
+      },
+      "expected": {
+        "result": "invalid",
+        "code": "limit_exceeded",
+        "field": "refs"
+      }
+    },
+    {
+      "name": "duplicate-json-member",
+      "document": "refs",
+      "json": "{\"format\":\"graphforge-discovery/1\",\"format\":\"graphforge-discovery/1\"}",
+      "expected": {
+        "result": "invalid",
+        "code": "malformed_response",
+        "field": null
+      }
+    }
+  ]
+}

--- a/docs/reference/discovery/v1/manifest.schema.json
+++ b/docs/reference/discovery/v1/manifest.schema.json
@@ -1,0 +1,193 @@
+{
+  "$defs": {
+    "digest": {
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "extensions": {
+      "maxProperties": 256,
+      "propertyNames": {
+        "pattern": "^x-[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$"
+      },
+      "type": "object"
+    },
+    "identity": {
+      "additionalProperties": false,
+      "properties": {
+        "owner": {
+          "$ref": "#/$defs/slug"
+        },
+        "repository": {
+          "$ref": "#/$defs/slug"
+        }
+      },
+      "required": [
+        "owner",
+        "repository"
+      ],
+      "type": "object"
+    },
+    "object": {
+      "additionalProperties": false,
+      "properties": {
+        "digest": {
+          "$ref": "#/$defs/digest"
+        },
+        "length": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "locations": {
+          "items": {
+            "format": "uri",
+            "pattern": "^https://",
+            "type": "string"
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "type": "array"
+        },
+        "media_type": {
+          "maxLength": 4096,
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "digest",
+        "length",
+        "media_type",
+        "locations"
+      ],
+      "type": "object"
+    },
+    "semantic": {
+      "additionalProperties": false,
+      "properties": {
+        "capability": {
+          "maxLength": 128,
+          "minLength": 1,
+          "type": "string"
+        },
+        "major": {
+          "maximum": 65535,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "capability",
+        "major"
+      ],
+      "type": "object"
+    },
+    "slug": {
+      "maxLength": 100,
+      "minLength": 1,
+      "pattern": "^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$",
+      "type": "string"
+    },
+    "version": {
+      "additionalProperties": false,
+      "properties": {
+        "major": {
+          "maximum": 65535,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "minor": {
+          "maximum": 65535,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "major",
+        "minor"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://graphforge.sh/schemas/discovery/v1/manifest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "capabilities": {
+      "items": {
+        "$ref": "#/$defs/semantic"
+      },
+      "maxItems": 256,
+      "type": "array"
+    },
+    "default_ref": {
+      "maxLength": 4096,
+      "minLength": 1,
+      "type": "string"
+    },
+    "extensions": {
+      "$ref": "#/$defs/extensions"
+    },
+    "format": {
+      "const": "graphforge-discovery/1"
+    },
+    "immutable_version": {
+      "$ref": "#/$defs/digest"
+    },
+    "objects": {
+      "items": {
+        "$ref": "#/$defs/object"
+      },
+      "maxItems": 1000000,
+      "minItems": 1,
+      "type": "array"
+    },
+    "package": {
+      "additionalProperties": false,
+      "properties": {
+        "format": {
+          "const": "graphforge-project/2"
+        },
+        "package_digest": {
+          "$ref": "#/$defs/digest"
+        }
+      },
+      "required": [
+        "format",
+        "package_digest"
+      ],
+      "type": "object"
+    },
+    "repository": {
+      "$ref": "#/$defs/identity"
+    },
+    "requirements": {
+      "items": {
+        "$ref": "#/$defs/semantic"
+      },
+      "maxItems": 256,
+      "type": "array"
+    },
+    "resolved_ref": {
+      "maxLength": 4096,
+      "minLength": 1,
+      "type": "string"
+    },
+    "version": {
+      "$ref": "#/$defs/version"
+    }
+  },
+  "required": [
+    "format",
+    "version",
+    "repository",
+    "default_ref",
+    "resolved_ref",
+    "immutable_version",
+    "package",
+    "requirements",
+    "capabilities",
+    "objects"
+  ],
+  "title": "manifest",
+  "type": "object"
+}

--- a/docs/reference/discovery/v1/refs.schema.json
+++ b/docs/reference/discovery/v1/refs.schema.json
@@ -1,0 +1,117 @@
+{
+  "$defs": {
+    "digest": {
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "extensions": {
+      "maxProperties": 256,
+      "propertyNames": {
+        "pattern": "^x-[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$"
+      },
+      "type": "object"
+    },
+    "identity": {
+      "additionalProperties": false,
+      "properties": {
+        "owner": {
+          "$ref": "#/$defs/slug"
+        },
+        "repository": {
+          "$ref": "#/$defs/slug"
+        }
+      },
+      "required": [
+        "owner",
+        "repository"
+      ],
+      "type": "object"
+    },
+    "ref": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "maxLength": 4096,
+          "minLength": 1,
+          "type": "string"
+        },
+        "target": {
+          "$ref": "#/$defs/digest"
+        },
+        "validator": {
+          "$ref": "#/$defs/digest"
+        }
+      },
+      "required": [
+        "name",
+        "target",
+        "validator"
+      ],
+      "type": "object"
+    },
+    "slug": {
+      "maxLength": 100,
+      "minLength": 1,
+      "pattern": "^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$",
+      "type": "string"
+    },
+    "version": {
+      "additionalProperties": false,
+      "properties": {
+        "major": {
+          "maximum": 65535,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "minor": {
+          "maximum": 65535,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "major",
+        "minor"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://graphforge.sh/schemas/discovery/v1/refs.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "default_ref": {
+      "maxLength": 4096,
+      "minLength": 1,
+      "type": "string"
+    },
+    "extensions": {
+      "$ref": "#/$defs/extensions"
+    },
+    "format": {
+      "const": "graphforge-discovery/1"
+    },
+    "refs": {
+      "items": {
+        "$ref": "#/$defs/ref"
+      },
+      "maxItems": 10000,
+      "type": "array"
+    },
+    "repository": {
+      "$ref": "#/$defs/identity"
+    },
+    "version": {
+      "$ref": "#/$defs/version"
+    }
+  },
+  "required": [
+    "format",
+    "version",
+    "repository",
+    "default_ref",
+    "refs"
+  ],
+  "title": "refs",
+  "type": "object"
+}

--- a/tools/bazel/parity/migration_target_map.json
+++ b/tools/bazel/parity/migration_target_map.json
@@ -1,7 +1,7 @@
 {
   "schema": "graphforge.bazel-migration-target-map.v1",
   "issue": 6,
-  "cargo_target_count": 114,
+  "cargo_target_count": 115,
   "targets": [
     {
       "package": "graphforge-api",
@@ -762,6 +762,16 @@
       "bazel_label": "//crates/graphforge-discovery:graphforge_discovery",
       "exception_id": null,
       "notes": "#908; unit tests `//crates/graphforge-discovery:graphforge_discovery_test`"
+    },
+    {
+      "package": "graphforge-discovery",
+      "target": "contract_artifacts",
+      "class": "integration-test",
+      "source": "crates/graphforge-discovery/tests/contract_artifacts.rs",
+      "status": "mapped",
+      "bazel_label": "//crates/graphforge-discovery:contract_artifacts",
+      "exception_id": null,
+      "notes": "#910; deterministic schema and conformance fixture parity"
     },
     {
       "package": "graphforge-exec",


### PR DESCRIPTION
## Summary
- publish deterministic manifest and refs JSON Schemas under the public discovery v1 contract docs
- add a Rust-generated conformance corpus covering compatibility, canonicalization, bounds, URLs, capabilities, digests, refs, and every stable error family
- run byte-for-byte artifact drift and semantic fixture parity under both Cargo and Bazel
- document TypeScript artifact consumption without transferring semantic authority from Rust

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy -p graphforge-discovery --all-targets -- -D warnings`
- `cargo test -p graphforge-discovery`
- `bazelisk test //crates/graphforge-discovery:discovery_tests`
- `python3 scripts/ci/bazel-migration-ledger-check.py`
- `python3 scripts/ci/cargo-bazel-drift-check.py`
- `make pre-push-fast`
- `make pre-push` preflight blocked before compilation: 9 GiB available versus 80 GiB cold-cache estimate

Closes #910

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/913"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790092878&installation_model_id=20486&pr_number=913&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F913&signature=32db79bf96bba48cebe7535129e66a4b53410f5c3cfca2f97e9b198dc2fbccc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->