### PR TITLE
feat(discovery): verify portable-v2 references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2434,6 +2434,7 @@ dependencies = [
  "fs4 1.1.0",
  "futures",
  "graphforge-core",
+ "graphforge-discovery",
  "graphforge-filesystem",
  "graphforge-ir",
  "graphforge-ontology",

--- a/crates/graphforge-storage/BUILD.bazel
+++ b/crates/graphforge-storage/BUILD.bazel
@@ -8,6 +8,7 @@ package(default_visibility = ["//visibility:public"])
 
 _STORAGE_DEPS = [
     "//crates/graphforge-core:graphforge_core",
+    "//crates/graphforge-discovery:graphforge_discovery",
     "//crates/graphforge-filesystem:graphforge_filesystem",
     "//crates/graphforge-ir:graphforge_ir",
     "//crates/graphforge-ontology:graphforge_ontology",
@@ -45,6 +46,14 @@ gf_rust_integration_test(
     crate = ":graphforge_storage",
     crate_features = ["test-failpoints"],
     size = "medium",
+    deps = _STORAGE_DEPS,
+)
+
+gf_rust_integration_test(
+    name = "discovery_portable_v2",
+    srcs = ["tests/discovery_portable_v2.rs"],
+    crate = ":graphforge_storage",
+    compile_data = ["//tests/fixtures/portable-v2:ontology-only.manifest.json"],
     deps = _STORAGE_DEPS,
 )
 
@@ -97,6 +106,7 @@ test_suite(
     name = "storage_integration_tests",
     tests = [
         ":adjacency_delta_write",
+        ":discovery_portable_v2",
         ":filtered_read",
         ":graph_delta_compaction",
         ":graph_delta_journal",

--- a/crates/graphforge-storage/Cargo.toml
+++ b/crates/graphforge-storage/Cargo.toml
@@ -15,6 +15,7 @@ test-failpoints = []
 
 [dependencies]
 graphforge-core = { version = "0.5.2", path = "../graphforge-core" }
+graphforge-discovery = { version = "0.5.2", path = "../graphforge-discovery" }
 graphforge-filesystem = { version = "0.5.2", path = "../graphforge-filesystem" }
 graphforge-ir = { version = "0.5.2", path = "../graphforge-ir" }
 graphforge-ontology = { version = "0.5.2", path = "../graphforge-ontology" }

--- a/crates/graphforge-storage/src/discovery_portable_v2.rs
+++ b/crates/graphforge-storage/src/discovery_portable_v2.rs
@@ -1,0 +1,135 @@
+//! Verification-first bridge from discovery responses to portable-v2.
+//!
+//! Discovery validates repository/ref selection and names an expected semantic
+//! package digest. This module then delegates package integrity, compatibility,
+//! and authenticity exclusively to [`crate::verify_portable_v2`]. A successful
+//! result is constructed only after both authorities agree.
+
+use crate::{
+    PortableV2Error, PortableV2Limits, PortableV2Mode, PortableV2Report, verify_portable_v2,
+};
+use graphforge_discovery::{
+    DiscoveryError, DiscoveryLimits, DiscoveryManifest, RefSet, RepositoryIdentity,
+};
+use std::fmt;
+use std::path::Path;
+use std::sync::atomic::AtomicBool;
+
+/// Stable cross-contract mismatch classification.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DiscoveryPortableV2Mismatch {
+    /// The response names a repository other than the requested identity.
+    Repository,
+    /// The refs snapshot and manifest select different immutable versions.
+    ImmutableVersion,
+    /// The verified portable package digest differs from the discovery reference.
+    PackageDigest,
+}
+
+/// Failure at one of the explicit discovery-to-package trust boundaries.
+#[derive(Debug)]
+pub enum DiscoveryPortableV2Error {
+    /// The discovery response itself is invalid or unsupported.
+    Discovery(DiscoveryError),
+    /// Valid discovery documents disagree with the requested or verified identity.
+    ReferenceMismatch(DiscoveryPortableV2Mismatch),
+    /// The storage-owned portable-v2 verifier rejected the package.
+    Portable(PortableV2Error),
+}
+
+impl fmt::Display for DiscoveryPortableV2Error {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Discovery(error) => write!(formatter, "{error}"),
+            Self::ReferenceMismatch(kind) => {
+                write!(
+                    formatter,
+                    "discovery portable-v2 reference mismatch: {kind:?}"
+                )
+            }
+            Self::Portable(error) => write!(formatter, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for DiscoveryPortableV2Error {}
+
+/// Fully accepted immutable discovery selection and storage verification report.
+#[derive(Debug)]
+pub struct DiscoveredPortableV2 {
+    /// Canonical repository identity requested by the caller.
+    pub repository: RepositoryIdentity,
+    /// Ref resolved by the discovery manifest.
+    pub resolved_ref: String,
+    /// Immutable repository version selected by the refs snapshot.
+    pub immutable_version: String,
+    /// Report produced by the storage-owned portable-v2 verifier.
+    pub report: PortableV2Report,
+}
+
+/// Inputs for one verification-first discovery/package admission attempt.
+pub struct DiscoveryPortableV2Request<'a> {
+    /// Untrusted discovery manifest bytes.
+    pub manifest_json: &'a [u8],
+    /// Untrusted refs snapshot bytes.
+    pub refs_json: &'a [u8],
+    /// Canonical repository identity requested by the caller.
+    pub expected_repository: &'a RepositoryIdentity,
+    /// Complete downloaded portable-v2 file or expanded directory.
+    pub package: &'a Path,
+    /// Bounds applied while parsing discovery documents.
+    pub discovery_limits: DiscoveryLimits,
+    /// Bounds applied by the portable-v2 verifier.
+    pub portable_limits: PortableV2Limits,
+    /// Portable verification depth.
+    pub mode: PortableV2Mode,
+    /// Optional cooperative cancellation signal.
+    pub cancelled: Option<&'a AtomicBool>,
+}
+
+/// Validate discovery documents, bind their immutable selection, and verify the package.
+///
+/// No partially accepted value is returned: package verification and the final
+/// package-digest comparison complete before [`DiscoveredPortableV2`] exists.
+pub fn verify_discovered_portable_v2(
+    request: &DiscoveryPortableV2Request<'_>,
+) -> Result<DiscoveredPortableV2, DiscoveryPortableV2Error> {
+    let manifest = DiscoveryManifest::from_json(request.manifest_json, request.discovery_limits)
+        .map_err(DiscoveryPortableV2Error::Discovery)?;
+    let refs = RefSet::from_json(request.refs_json, request.discovery_limits)
+        .map_err(DiscoveryPortableV2Error::Discovery)?;
+    if &manifest.repository != request.expected_repository
+        || &refs.repository != request.expected_repository
+    {
+        return Err(DiscoveryPortableV2Error::ReferenceMismatch(
+            DiscoveryPortableV2Mismatch::Repository,
+        ));
+    }
+    refs.validate_manifest(&manifest).map_err(|error| {
+        if error.field == Some("immutable_version") || error.field == Some("resolved_ref") {
+            DiscoveryPortableV2Error::ReferenceMismatch(
+                DiscoveryPortableV2Mismatch::ImmutableVersion,
+            )
+        } else {
+            DiscoveryPortableV2Error::Discovery(error)
+        }
+    })?;
+    let report = verify_portable_v2(
+        request.package,
+        request.mode,
+        request.portable_limits,
+        request.cancelled,
+    )
+    .map_err(DiscoveryPortableV2Error::Portable)?;
+    if report.package_digest != manifest.package.package_digest.0 {
+        return Err(DiscoveryPortableV2Error::ReferenceMismatch(
+            DiscoveryPortableV2Mismatch::PackageDigest,
+        ));
+    }
+    Ok(DiscoveredPortableV2 {
+        repository: manifest.repository,
+        resolved_ref: manifest.resolved_ref,
+        immutable_version: manifest.immutable_version.0,
+        report,
+    })
+}

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -161,6 +161,12 @@ pub use project_portable_v2::{
     materialize_verified_portable_v2, verify_portable_v2,
 };
 
+pub mod discovery_portable_v2;
+pub use discovery_portable_v2::{
+    DiscoveredPortableV2, DiscoveryPortableV2Error, DiscoveryPortableV2Mismatch,
+    DiscoveryPortableV2Request, verify_discovered_portable_v2,
+};
+
 mod project_portable_v2_selection;
 pub use project_portable_v2_selection::{
     PortableV2ParticipantId, PortableV2ProjectedSelectionEntry, PortableV2SelectionEntry,

--- a/crates/graphforge-storage/tests/discovery_portable_v2.rs
+++ b/crates/graphforge-storage/tests/discovery_portable_v2.rs
@@ -1,0 +1,207 @@
+//! End-to-end discovery selection into the storage-owned portable-v2 verifier.
+
+use graphforge_discovery::{
+    DISCOVERY_FORMAT, DiscoveryLimits, DiscoveryManifest, ObjectDescriptor, PORTABLE_V2_FORMAT,
+    PortablePackageReference, ProtocolRequirement, ProtocolVersion, RefSet, RepositoryIdentity,
+    RepositoryRef, Sha256Digest,
+};
+use graphforge_storage::{
+    DiscoveryPortableV2Error, DiscoveryPortableV2Mismatch, DiscoveryPortableV2Request,
+    PortableV2ErrorCode, PortableV2Limits, PortableV2Mode, verify_discovered_portable_v2,
+};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::fs;
+
+const BAGIT: &[u8] = b"BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8\n";
+const BAG_INFO: &[u8] = b"Bag-Software-Agent: GraphForge portable-v2\nBagging-Date: 1970-01-01\n";
+const MANIFEST_PATH: &str = "data/graphforge-project.json";
+
+fn hex(bytes: impl AsRef<[u8]>) -> String {
+    bytes
+        .as_ref()
+        .iter()
+        .fold(String::new(), |mut output, byte| {
+            write!(output, "{byte:02x}").unwrap();
+            output
+        })
+}
+
+fn package() -> (tempfile::TempDir, String) {
+    let root = tempfile::tempdir().unwrap();
+    let mut value: Value = serde_json::from_str(include_str!(
+        "../../../tests/fixtures/portable-v2/ontology-only.manifest.json"
+    ))
+    .unwrap();
+    value.as_object_mut().unwrap().remove("package_digest");
+    let semantic = serde_json::to_vec(&value).unwrap();
+    let package_digest = format!(
+        "sha256:{}",
+        hex(Sha256::digest(
+            [b"graphforge-project/2\0".as_slice(), semantic.as_slice()].concat()
+        ))
+    );
+    value["package_digest"] = Value::String(package_digest.clone());
+    let manifest = serde_json::to_vec(&value).unwrap();
+    let payload_path = "data/components/ontology/core-ontology/ontology.json";
+    let manifest_path = root.path().join(MANIFEST_PATH);
+    fs::create_dir_all(manifest_path.parent().unwrap()).unwrap();
+    fs::write(&manifest_path, &manifest).unwrap();
+    let payload = root.path().join(payload_path);
+    fs::create_dir_all(payload.parent().unwrap()).unwrap();
+    fs::write(payload, b"{}").unwrap();
+    fs::write(root.path().join("bagit.txt"), BAGIT).unwrap();
+    fs::write(root.path().join("bag-info.txt"), BAG_INFO).unwrap();
+    let data_manifest = format!(
+        "{}  {}\n{}  {}\n",
+        hex(Sha256::digest(b"{}")),
+        payload_path,
+        hex(Sha256::digest(&manifest)),
+        MANIFEST_PATH
+    );
+    fs::write(root.path().join("manifest-sha256.txt"), &data_manifest).unwrap();
+    let tag_manifest = format!(
+        "{}  bag-info.txt\n{}  bagit.txt\n{}  manifest-sha256.txt\n",
+        hex(Sha256::digest(BAG_INFO)),
+        hex(Sha256::digest(BAGIT)),
+        hex(Sha256::digest(data_manifest.as_bytes()))
+    );
+    fs::write(root.path().join("tagmanifest-sha256.txt"), tag_manifest).unwrap();
+    (root, package_digest)
+}
+
+fn digest(marker: char) -> Sha256Digest {
+    Sha256Digest(format!("sha256:{}", marker.to_string().repeat(64)))
+}
+
+fn discovery(package_digest: String) -> (DiscoveryManifest, RefSet, RepositoryIdentity) {
+    let repository = RepositoryIdentity::parse("openalex/openalex").unwrap();
+    let immutable_version = digest('a');
+    let manifest = DiscoveryManifest {
+        format: DISCOVERY_FORMAT.into(),
+        version: ProtocolVersion::CURRENT,
+        repository: repository.clone(),
+        default_ref: "main".into(),
+        resolved_ref: "main".into(),
+        immutable_version: immutable_version.clone(),
+        package: PortablePackageReference {
+            format: PORTABLE_V2_FORMAT.into(),
+            package_digest: Sha256Digest(package_digest),
+        },
+        requirements: vec![ProtocolRequirement {
+            capability: "portable-v2".into(),
+            major: 1,
+        }],
+        capabilities: vec![],
+        objects: vec![ObjectDescriptor {
+            digest: digest('c'),
+            length: 1,
+            media_type: "application/vnd.graphforge.project".into(),
+            locations: vec!["https://data.graphforge.sh/object".into()],
+        }],
+        extensions: BTreeMap::default(),
+    };
+    let refs = RefSet {
+        format: DISCOVERY_FORMAT.into(),
+        version: ProtocolVersion::CURRENT,
+        repository: repository.clone(),
+        default_ref: "main".into(),
+        refs: vec![RepositoryRef {
+            name: "main".into(),
+            target: immutable_version,
+            validator: digest('d'),
+        }],
+        extensions: BTreeMap::default(),
+    };
+    (manifest, refs, repository)
+}
+
+fn verify(
+    manifest: &DiscoveryManifest,
+    refs: &RefSet,
+    expected: &RepositoryIdentity,
+    package: &tempfile::TempDir,
+) -> Result<graphforge_storage::DiscoveredPortableV2, DiscoveryPortableV2Error> {
+    let manifest_json = serde_json::to_vec(manifest).unwrap();
+    let refs_json = serde_json::to_vec(refs).unwrap();
+    verify_discovered_portable_v2(&DiscoveryPortableV2Request {
+        manifest_json: &manifest_json,
+        refs_json: &refs_json,
+        expected_repository: expected,
+        package: package.path(),
+        discovery_limits: DiscoveryLimits::default(),
+        portable_limits: PortableV2Limits::default(),
+        mode: PortableV2Mode::Full,
+        cancelled: None,
+    })
+}
+
+#[test]
+fn valid_discovery_maps_to_the_storage_verified_package() {
+    let (package, package_digest) = package();
+    let (manifest, refs, repository) = discovery(package_digest.clone());
+    let accepted = verify(&manifest, &refs, &repository, &package).unwrap();
+    assert_eq!(accepted.repository, repository);
+    assert_eq!(accepted.resolved_ref, "main");
+    assert_eq!(accepted.immutable_version, digest('a').0);
+    assert_eq!(accepted.report.package_digest, package_digest);
+}
+
+#[test]
+fn repository_package_and_version_mismatches_fail_without_acceptance() {
+    let (package, package_digest) = package();
+    let (manifest, refs, repository) = discovery(package_digest);
+    let other = RepositoryIdentity::parse("example/other").unwrap();
+    assert!(matches!(
+        verify(&manifest, &refs, &other, &package),
+        Err(DiscoveryPortableV2Error::ReferenceMismatch(
+            DiscoveryPortableV2Mismatch::Repository
+        ))
+    ));
+
+    let mut wrong_package = manifest.clone();
+    wrong_package.package.package_digest = digest('f');
+    assert!(matches!(
+        verify(&wrong_package, &refs, &repository, &package),
+        Err(DiscoveryPortableV2Error::ReferenceMismatch(
+            DiscoveryPortableV2Mismatch::PackageDigest
+        ))
+    ));
+
+    let mut wrong_version = refs.clone();
+    wrong_version.refs[0].target = digest('e');
+    assert!(matches!(
+        verify(&manifest, &wrong_version, &repository, &package),
+        Err(DiscoveryPortableV2Error::ReferenceMismatch(
+            DiscoveryPortableV2Mismatch::ImmutableVersion
+        ))
+    ));
+}
+
+#[test]
+fn unsupported_future_discovery_stops_before_package_acceptance() {
+    let (package, package_digest) = package();
+    let (mut manifest, refs, repository) = discovery(package_digest);
+    manifest.version.major = 2;
+    assert!(
+        matches!(verify(&manifest, &refs, &repository, &package), Err(DiscoveryPortableV2Error::Discovery(error)) if error.code == graphforge_discovery::DiscoveryErrorCode::UnsupportedFuture)
+    );
+}
+
+#[test]
+fn portable_integrity_failure_is_not_partially_accepted() {
+    let (package, package_digest) = package();
+    let (manifest, refs, repository) = discovery(package_digest);
+    fs::write(
+        package
+            .path()
+            .join("data/components/ontology/core-ontology/ontology.json"),
+        b"tampered",
+    )
+    .unwrap();
+    assert!(
+        matches!(verify(&manifest, &refs, &repository, &package), Err(DiscoveryPortableV2Error::Portable(error)) if error.code == PortableV2ErrorCode::DigestMismatch)
+    );
+}

--- a/docs/development/bazel-migration-ledger.md
+++ b/docs/development/bazel-migration-ledger.md
@@ -160,6 +160,7 @@ Authoritative machine-readable map: `tools/bazel/parity/migration_target_map.jso
 | `graphforge-storage` | `m6_storage` | `bench` | `crates/graphforge-storage/benches/m6_storage.rs` | — | `exception` | RT-codspeed-bench; #782 diagnostic simulation/hardware evidence |
 | `graphforge-storage` | `m6_storage_io` | `bench` | `crates/graphforge-storage/benches/m6_storage_io.rs` | — | `exception` | RT-codspeed-bench; #782 stable-runner walltime evidence |
 | `graphforge-storage` | `adjacency_delta_write` | `integration-test` | `crates/graphforge-storage/tests/adjacency_delta_write.rs` | `//crates/graphforge-storage:adjacency_delta_write` | `mapped` | #8 |
+| `graphforge-storage` | `discovery_portable_v2` | `integration-test` | `crates/graphforge-storage/tests/discovery_portable_v2.rs` | `//crates/graphforge-storage:discovery_portable_v2` | `mapped` | #909; discovery reference to storage verifier boundary |
 | `graphforge-storage` | `filtered_read` | `integration-test` | `crates/graphforge-storage/tests/filtered_read.rs` | `//crates/graphforge-storage:filtered_read` | `mapped` | #8 |
 | `graphforge-storage` | `graph_delta_journal` | `integration-test` | `crates/graphforge-storage/tests/graph_delta_journal.rs` | `//crates/graphforge-storage:graph_delta_journal` | `mapped` | #8 / #752 |
 | `graphforge-storage` | `graph_delta_compaction` | `integration-test` | `crates/graphforge-storage/tests/graph_delta_compaction.rs` | `//crates/graphforge-storage:graph_delta_compaction` | `mapped` | #8 / #753 |

--- a/docs/reference/discovery/v1/README.md
+++ b/docs/reference/discovery/v1/README.md
@@ -24,3 +24,6 @@ adapter. It must not transcribe the schema as hand-written TypeScript protocol
 types or reimplement validation semantics. Rust remains the authority; generated
 TypeScript declarations, if needed, must be treated as disposable build output
 derived from these versioned artifacts.
+
+See [portable-v2-integration.md](portable-v2-integration.md) for the normative
+validation order and the boundary between discovery and package verification.

--- a/docs/reference/discovery/v1/portable-v2-integration.md
+++ b/docs/reference/discovery/v1/portable-v2-integration.md
@@ -1,0 +1,42 @@
+# Discovery v1 to portable-v2 verification
+
+This document defines the trust boundary between repository discovery and a
+downloaded portable-v2 package.
+
+## Required order
+
+1. Parse and validate manifest and refs bytes with `graphforge-discovery`, using
+   explicit response limits.
+2. Require both documents to name the repository identity requested by the
+   caller.
+3. Bind `resolved_ref` through the refs snapshot and require its target to equal
+   the manifest's `immutable_version`.
+4. Download the selected object using a caller-owned HTTP transport. Redirect,
+   host, and credential policy remain transport responsibilities.
+5. Pass the complete local package to `graphforge-storage`'s portable-v2
+   verifier. Only that verifier decides package integrity, compatibility, and
+   authenticity.
+6. Require the verifier's semantic `package_digest` to equal the discovery
+   manifest's `package.package_digest` before returning an accepted selection.
+
+Failure at any step MUST return no accepted repository/package result. Discovery
+object digests protect downloaded object bytes; they do not replace the
+portable-v2 semantic package digest. Likewise, an immutable repository version
+identifies a repository snapshot and is not a portable package identity.
+
+`graphforge-storage::verify_discovered_portable_v2` implements this sequence.
+It does not publish or materialize a project, so a failed cross-contract check
+cannot leave partially accepted project state.
+
+## Hub and TypeScript consumption
+
+The Hub may serve the versioned files in this directory and package them as
+static TypeScript assets. It may use `manifest.schema.json` and
+`refs.schema.json` for early structural diagnostics and `conformance.json` to
+test its HTTP adapter. These files are generated and byte-checked by Rust.
+
+The Hub MUST NOT maintain hand-written TypeScript protocol types or validation
+rules as a competing authority. If TypeScript declarations are useful, generate
+them from the versioned schema during the Hub build, keep them disposable, and
+still treat a Rust validation/verification result as authoritative for protocol
+acceptance.

--- a/tools/bazel/drift/cargo_feature_fingerprint.json
+++ b/tools/bazel/drift/cargo_feature_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "schema": "graphforge.cargo-feature-fingerprint.v1",
-  "sha256": "dc5a6c4e923296113ebb09cecb4b107d10022ab2318c941540c0986be6f1b377",
+  "sha256": "8f9db8617daadff92274ffbfc67ccefb2abe6f337f9f0eaccdeb1b580577f0af",
   "entries": [
     {
       "name": "graphforge-api",
@@ -1817,6 +1817,15 @@
         },
         {
           "name": "graphforge-core",
+          "req": "^0.5.2",
+          "features": [],
+          "optional": false,
+          "uses_default_features": true,
+          "kind": null,
+          "target": null
+        },
+        {
+          "name": "graphforge-discovery",
           "req": "^0.5.2",
           "features": [],
           "optional": false,

--- a/tools/bazel/parity/migration_target_map.json
+++ b/tools/bazel/parity/migration_target_map.json
@@ -1,7 +1,7 @@
 {
   "schema": "graphforge.bazel-migration-target-map.v1",
   "issue": 6,
-  "cargo_target_count": 115,
+  "cargo_target_count": 116,
   "targets": [
     {
       "package": "graphforge-api",
@@ -1092,6 +1092,16 @@
       "bazel_label": "//crates/graphforge-storage:adjacency_delta_write",
       "exception_id": null,
       "notes": "#8"
+    },
+    {
+      "package": "graphforge-storage",
+      "target": "discovery_portable_v2",
+      "class": "integration-test",
+      "source": "crates/graphforge-storage/tests/discovery_portable_v2.rs",
+      "status": "mapped",
+      "bazel_label": "//crates/graphforge-storage:discovery_portable_v2",
+      "exception_id": null,
+      "notes": "#909; discovery reference to storage verifier boundary"
     },
     {
       "package": "graphforge-storage",


### PR DESCRIPTION
## Summary
- add a storage-owned verification bridge that validates discovery repository/ref selection, delegates package verification to the existing portable-v2 authority, and admits a result only after semantic package digests agree
- cover valid selection, repository/package/version mismatches, unsupported future discovery, portable integrity failure, and no partial accepted result
- document the normative discovery/package trust boundary and generated Hub TypeScript artifact consumption without duplicating semantics
- wire Cargo, Bazel, dependency fingerprint, and migration parity for the integration target

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy -p graphforge-storage --test discovery_portable_v2 -- -D warnings`
- `cargo test -p graphforge-storage --test discovery_portable_v2` (4 passed)
- `python3 scripts/ci/bazel-migration-ledger-check.py` (116 targets)
- `python3 scripts/ci/test-bazel-migration-ledger-check.py`
- `python3 scripts/ci/cargo-bazel-drift-check.py`
- `python3 scripts/ci/test-cargo-bazel-parity-check.py`
- Bazel target build was stopped before completion when free disk fell to 1.1 GiB during its cold 1,324-action build; CI will run it in a clean environment

Closes #909

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790095190&installation_model_id=20486&pr_number=915&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F915&signature=a229d40869cce53342044bfb338fb4ddda5eda8f3b454f9acbbbd2bdb6f88fcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->