### PR TITLE
test(storage): serialize process-global I/O counter assertions

### DIFF
--- a/crates/graphforge-storage/src/io_stats.rs
+++ b/crates/graphforge-storage/src/io_stats.rs
@@ -36,6 +36,17 @@
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
+#[cfg(test)]
+static TEST_MEASUREMENT_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Serialize tests that reset and assert the process-global counters.
+#[cfg(test)]
+pub(crate) fn test_measurement_guard() -> std::sync::MutexGuard<'static, ()> {
+    TEST_MEASUREMENT_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 /// Table family involved in one filtered topology read.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[doc(hidden)]

--- a/crates/graphforge-storage/src/staging.rs
+++ b/crates/graphforge-storage/src/staging.rs
@@ -391,6 +391,7 @@ mod tests {
 
     #[test]
     fn append_rewrite_copies_existing_topology_in_bounded_batches() {
+        let _measurement = crate::io_stats::test_measurement_guard();
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("topology/nodes.parquet");
         let initial_values = (0..(ROW_GROUP_SIZE * 2 + 17))

--- a/crates/graphforge-storage/src/writer.rs
+++ b/crates/graphforge-storage/src/writer.rs
@@ -3974,6 +3974,7 @@ mod tests {
         );
         first.flush().unwrap();
 
+        let _measurement = crate::io_stats::test_measurement_guard();
         crate::io_stats::reset();
         let mut reopened = GraphWriter::open_at(dir.path(), OntologyMode::Strict, TS).unwrap();
         assert_eq!(reopened.create_node(new_v7(), TypeId(0)).unwrap(), 3);


### PR DESCRIPTION
Closes #914

## Summary
- add one test-only mutex for process-global I/O counter measurements
- hold it across reset, measured operation, and assertion in both affected tests
- preserve production instrumentation unchanged

## Verification
- `cargo test -p graphforge-storage --lib` (604 passed, 2 ignored)
- `bazelisk test //crates/graphforge-storage:graphforge_storage_test`
- `make pre-push-fast`
- local CodeRabbit review: zero findings

## Failure evidence
PR #911 exact-head run 32650743381 exposed the cross-test reset race (17 observed vs 65536 expected).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790095358&installation_model_id=20486&pr_number=916&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F916&signature=bca88dcf83fc10ca1101748f12aa9f3a8cb1c16c7dace7af431ba319c72a34e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->