### PR TITLE
feat(cli): clone Hub repositories securely

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2229,13 +2229,17 @@ dependencies = [
  "arrow",
  "clap",
  "graphforge-api",
+ "graphforge-discovery",
  "graphforge-storage",
+ "libc",
  "parquet",
  "serde",
  "serde_json",
  "serde_yaml_ng",
  "sha2",
  "tempfile",
+ "ureq",
+ "url",
  "uuid",
 ]
 

--- a/crates/graphforge-cli/BUILD.bazel
+++ b/crates/graphforge-cli/BUILD.bazel
@@ -18,9 +18,16 @@ exports_files(["Cargo.toml"])
 package(default_visibility = ["//visibility:public"])
 
 _CLI_DEPS = [
+    "@crates//:libc",
+    "@crates//:serde",
+    "@crates//:serde_json",
     "@crates//:serde_yaml",
     "@crates//:sha2",
+    "@crates//:tempfile",
+    "@crates//:ureq",
+    "@crates//:url",
     "//crates/graphforge-api:graphforge_api",
+    "//crates/graphforge-discovery:graphforge_discovery",
     "//crates/graphforge-storage:graphforge_storage",
 ]
 

--- a/crates/graphforge-cli/Cargo.toml
+++ b/crates/graphforge-cli/Cargo.toml
@@ -14,17 +14,21 @@ path = "src/main.rs"
 [dependencies]
 arrow = { workspace = true }
 graphforge-api = { version = "0.5.2", path = "../graphforge-api" }
+graphforge-discovery = { version = "0.5.2", path = "../graphforge-discovery" }
+graphforge-storage = { version = "0.5.2", path = "../graphforge-storage" }
 clap = { workspace = true }
 uuid = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
-
-[dev-dependencies]
-graphforge-storage = { version = "0.5.2", path = "../graphforge-storage" }
-parquet = { workspace = true }
 sha2 = { workspace = true }
 tempfile = "3"
+libc = "0.2"
+ureq = { workspace = true }
+url = { workspace = true }
+
+[dev-dependencies]
+parquet = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/graphforge-cli/src/hub_clone.rs
+++ b/crates/graphforge-cli/src/hub_clone.rs
@@ -1,0 +1,1056 @@
+//! Secure Hub discovery, download, and atomic portable-v2 import.
+
+use clap::Args;
+use graphforge_api::{
+    GraphForge, OperationId, PortableV2ImportRequest, PortableV2Limits, PortableV2Mode,
+};
+use graphforge_discovery::{
+    DiscoveryError, DiscoveryErrorCode, DiscoveryLimits, DiscoveryManifest, ObjectDescriptor,
+    RefSet, RepositoryIdentity,
+};
+use graphforge_storage::{DiscoveryPortableV2Request, verify_discovered_portable_v2};
+use serde::Serialize;
+use sha2::{Digest as _, Sha256};
+use std::fmt::Debug;
+use std::fmt::Write as _;
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use ureq::unversioned::resolver::{DefaultResolver, ResolvedSocketAddrs, Resolver};
+use ureq::unversioned::transport::DefaultConnector;
+use url::Url;
+
+const DEFAULT_HUB: &str = "https://graphforge.sh";
+const MAX_METADATA_BYTES: usize = 16 * 1024 * 1024;
+const MAX_BUNDLE_BYTES: u64 = 100 * 1024 * 1024 * 1024;
+const MAX_REDIRECTS: usize = 4;
+
+#[derive(Args)]
+pub(crate) struct CloneArgs {
+    /// Canonical owner/repository name or an HTTPS Hub repository URL.
+    pub repository: String,
+    /// New project directory; defaults to the repository name.
+    pub destination: Option<PathBuf>,
+}
+
+#[derive(Serialize)]
+struct CloneResult {
+    contract: &'static str,
+    repository: String,
+    destination: String,
+    immutable_version: String,
+    package_digest: String,
+    generation_uuid: String,
+    resumed_bytes: u64,
+}
+
+#[derive(Debug)]
+struct PublicResolver(DefaultResolver);
+
+impl Resolver for PublicResolver {
+    fn resolve(
+        &self,
+        uri: &ureq::http::Uri,
+        config: &ureq::config::Config,
+        timeout: ureq::unversioned::transport::NextTimeout,
+    ) -> Result<ResolvedSocketAddrs, ureq::Error> {
+        let addresses = self.0.resolve(uri, config, timeout)?;
+        let mut approved = self.empty();
+        for address in addresses
+            .iter()
+            .copied()
+            .filter(|address| public_ip(address.ip()))
+        {
+            approved.push(address);
+        }
+        if approved.is_empty() {
+            Err(ureq::Error::HostNotFound)
+        } else {
+            Ok(approved)
+        }
+    }
+}
+
+fn public_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => public_v4(ip),
+        IpAddr::V6(ip) => {
+            if let Some(v4) = ip.to_ipv4_mapped() {
+                return public_v4(v4);
+            }
+            !(ip.is_unspecified()
+                || ip.is_loopback()
+                || ip.is_multicast()
+                || in_v6(ip, "fc00::".parse().unwrap(), 7)
+                || in_v6(ip, "fe80::".parse().unwrap(), 10)
+                || in_v6(ip, "2001:db8::".parse().unwrap(), 32))
+        }
+    }
+}
+
+fn public_v4(ip: Ipv4Addr) -> bool {
+    let value = u32::from(ip);
+    let blocked = [
+        ("0.0.0.0", 8),
+        ("10.0.0.0", 8),
+        ("100.64.0.0", 10),
+        ("127.0.0.0", 8),
+        ("169.254.0.0", 16),
+        ("172.16.0.0", 12),
+        ("192.0.0.0", 24),
+        ("192.0.2.0", 24),
+        ("192.168.0.0", 16),
+        ("198.18.0.0", 15),
+        ("198.51.100.0", 24),
+        ("203.0.113.0", 24),
+        ("224.0.0.0", 4),
+        ("240.0.0.0", 4),
+    ];
+    !blocked.iter().any(|(base, bits)| {
+        let base = u32::from(base.parse::<Ipv4Addr>().unwrap());
+        let mask = u32::MAX.checked_shl(32 - bits).unwrap_or(0);
+        value & mask == base & mask
+    })
+}
+
+fn in_v6(ip: Ipv6Addr, base: Ipv6Addr, bits: u32) -> bool {
+    let mask = u128::MAX.checked_shl(128 - bits).unwrap_or(0);
+    u128::from(ip) & mask == u128::from(base) & mask
+}
+
+struct HttpResponse {
+    status: u16,
+    location: Option<String>,
+    content_range: Option<String>,
+    body: Box<dyn Read + Send>,
+}
+
+trait Transport {
+    fn validate(&self, url: &Url) -> Result<(), graphforge_api::GfError> {
+        validate_url(url)
+    }
+
+    fn get(
+        &self,
+        url: &Url,
+        range: Option<u64>,
+        limit: u64,
+    ) -> Result<HttpResponse, graphforge_api::GfError>;
+}
+
+struct HttpTransport {
+    agent: ureq::Agent,
+}
+
+impl HttpTransport {
+    fn new() -> Self {
+        let config = ureq::Agent::config_builder()
+            .https_only(true)
+            .http_status_as_error(false)
+            .max_redirects(0)
+            .proxy(None)
+            .timeout_global(Some(Duration::from_mins(1)))
+            .timeout_connect(Some(Duration::from_secs(10)))
+            .build();
+        Self {
+            agent: ureq::Agent::with_parts(
+                config,
+                DefaultConnector::new(),
+                PublicResolver(DefaultResolver::default()),
+            ),
+        }
+    }
+}
+
+impl Transport for HttpTransport {
+    fn get(
+        &self,
+        url: &Url,
+        range: Option<u64>,
+        limit: u64,
+    ) -> Result<HttpResponse, graphforge_api::GfError> {
+        let mut request = self.agent.get(url.as_str());
+        if let Some(offset) = range {
+            request = request.header("Range", format!("bytes={offset}-"));
+        }
+        let response = request.call().map_err(|_| network("request failed"))?;
+        let status = response.status().as_u16();
+        let location = response
+            .headers()
+            .get("location")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned);
+        let content_range = response
+            .headers()
+            .get("content-range")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned);
+        let (_, body) = response.into_parts();
+        Ok(HttpResponse {
+            status,
+            location,
+            content_range,
+            body: Box::new(body.into_reader().take(limit.saturating_add(1))),
+        })
+    }
+}
+
+fn validate_url(url: &Url) -> Result<(), graphforge_api::GfError> {
+    if url.scheme() != "https"
+        || url.username() != ""
+        || url.password().is_some()
+        || url.host_str().is_none()
+        || url.fragment().is_some()
+    {
+        return Err(validation(
+            "hub.unsafe_location",
+            "URL must be credential-free HTTPS",
+        ));
+    }
+    if let Some(host) = url.host_str()
+        && host.parse::<IpAddr>().is_ok_and(|ip| !public_ip(ip))
+    {
+        return Err(validation("hub.unsafe_location", "URL host is not public"));
+    }
+    Ok(())
+}
+
+fn fetch(
+    transport: &dyn Transport,
+    start: &Url,
+    range: Option<u64>,
+    limit: u64,
+) -> Result<HttpResponse, graphforge_api::GfError> {
+    let mut url = start.clone();
+    for hop in 0..=MAX_REDIRECTS {
+        transport.validate(&url)?;
+        let response = transport.get(&url, range, limit)?;
+        if matches!(response.status, 301 | 302 | 303 | 307 | 308) {
+            if hop == MAX_REDIRECTS {
+                return Err(network("redirect limit exceeded"));
+            }
+            let location = response
+                .location
+                .as_deref()
+                .ok_or_else(|| network("redirect is missing Location"))?;
+            url = url
+                .join(location)
+                .map_err(|_| validation("hub.unsafe_location", "invalid redirect URL"))?;
+            continue;
+        }
+        if !(200..300).contains(&response.status) {
+            return Err(network("Hub returned an unsuccessful status"));
+        }
+        return Ok(response);
+    }
+    unreachable!()
+}
+
+fn read_bounded(
+    mut response: HttpResponse,
+    limit: usize,
+) -> Result<Vec<u8>, graphforge_api::GfError> {
+    let mut bytes = Vec::new();
+    response
+        .body
+        .read_to_end(&mut bytes)
+        .map_err(|_| network("response read failed"))?;
+    if bytes.len() > limit {
+        return Err(limit_error("response exceeds byte bound"));
+    }
+    Ok(bytes)
+}
+
+fn parse_input(value: &str) -> Result<(RepositoryIdentity, Url), graphforge_api::GfError> {
+    if !value.contains("://") {
+        let identity = RepositoryIdentity::parse(value)
+            .map_err(|_| validation("hub.invalid_identity", "invalid repository identity"))?;
+        let base = Url::parse(&format!(
+            "{DEFAULT_HUB}/{}/{}",
+            identity.owner, identity.repository
+        ))
+        .unwrap();
+        return Ok((identity, base));
+    }
+    let base = Url::parse(value)
+        .map_err(|_| validation("hub.invalid_identity", "invalid repository URL"))?;
+    validate_url(&base)?;
+    if base.query().is_some() || base.path().ends_with('/') {
+        return Err(validation(
+            "hub.invalid_identity",
+            "repository URL must end in owner/repository",
+        ));
+    }
+    let segments: Vec<_> = base.path_segments().into_iter().flatten().collect();
+    if segments.len() != 2 {
+        return Err(validation(
+            "hub.invalid_identity",
+            "repository URL must end in owner/repository",
+        ));
+    }
+    let identity = RepositoryIdentity::parse(&format!("{}/{}", segments[0], segments[1]))
+        .map_err(|_| validation("hub.invalid_identity", "invalid repository identity"))?;
+    Ok((identity, base))
+}
+
+fn endpoint(base: &Url, name: &str) -> Url {
+    let mut endpoint = base.clone();
+    endpoint.set_path(&format!("{}/.gf/{name}", base.path().trim_end_matches('/')));
+    endpoint
+}
+
+fn select_bundle(
+    manifest: &DiscoveryManifest,
+) -> Result<&ObjectDescriptor, graphforge_api::GfError> {
+    manifest
+        .package_object()
+        .map_err(|error| protocol_error(&error))
+}
+
+fn partial_path(destination: &Path, digest: &str) -> Result<PathBuf, graphforge_api::GfError> {
+    let parent = destination.parent().unwrap_or_else(|| Path::new("."));
+    let name = destination
+        .file_name()
+        .and_then(|v| v.to_str())
+        .ok_or_else(|| {
+            validation(
+                "hub.destination_conflict",
+                "destination must have a UTF-8 name",
+            )
+        })?;
+    Ok(parent.join(format!(
+        ".{name}.gfclone-{}.partial",
+        digest.trim_start_matches("sha256:")
+    )))
+}
+
+fn download(
+    transport: &dyn Transport,
+    object: &ObjectDescriptor,
+    destination: &Path,
+) -> Result<u64, graphforge_api::GfError> {
+    let partial = partial_path(destination, &object.digest.0)?;
+    if object.length > MAX_BUNDLE_BYTES {
+        return Err(limit_error("portable bundle exceeds clone byte bound"));
+    }
+    let mut resumed = match std::fs::symlink_metadata(&partial) {
+        Ok(metadata) if metadata.is_file() && !metadata.file_type().is_symlink() => metadata.len(),
+        Ok(_) => {
+            return Err(validation(
+                "hub.destination_conflict",
+                "resume path is not a regular file",
+            ));
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => 0,
+        Err(error) => return Err(storage(error)),
+    };
+    if resumed > object.length {
+        open_partial_nofollow(&partial, false).map_err(storage)?;
+        resumed = 0;
+    }
+    let location = object
+        .locations
+        .first()
+        .ok_or_else(|| validation("hub.missing_object", "portable bundle has no location"))?;
+    let url = Url::parse(location)
+        .map_err(|_| validation("hub.unsafe_location", "invalid object URL"))?;
+    if resumed < object.length {
+        let mut response = fetch(
+            transport,
+            &url,
+            (resumed > 0).then_some(resumed),
+            object.length.saturating_sub(resumed),
+        )?;
+        let expected_range = format!("bytes {resumed}-{}/{}", object.length - 1, object.length);
+        let append = resumed > 0
+            && response.status == 206
+            && response.content_range.as_deref() == Some(expected_range.as_str());
+        if resumed > 0 && response.status == 206 && !append {
+            let _ = std::fs::remove_file(&partial);
+            return Err(validation(
+                "hub.integrity",
+                "range response does not match the requested object",
+            ));
+        }
+        if resumed > 0 && !append {
+            resumed = 0;
+        }
+        let mut file = open_partial_nofollow(&partial, append).map_err(storage)?;
+        let mut copied = 0_u64;
+        let mut buffer = vec![0_u8; 64 * 1024].into_boxed_slice();
+        loop {
+            let read = response
+                .body
+                .read(&mut buffer)
+                .map_err(|_| network("object read failed"))?;
+            if read == 0 {
+                break;
+            }
+            copied = copied
+                .checked_add(read as u64)
+                .ok_or_else(|| limit_error("object exceeds byte bound"))?;
+            if copied > object.length.saturating_sub(resumed) {
+                return Err(limit_error("object exceeds declared size"));
+            }
+            file.write_all(&buffer[..read]).map_err(storage)?;
+        }
+        file.sync_all().map_err(storage)?;
+    }
+    let mut file = open_read_nofollow(&partial).map_err(storage)?;
+    let length = file.metadata().map_err(storage)?.len();
+    if length != object.length {
+        return Err(validation(
+            "hub.interrupted",
+            "download is incomplete; rerun to resume",
+        ));
+    }
+    file.seek(SeekFrom::Start(0)).map_err(storage)?;
+    let actual = hash_reader(&mut file)?;
+    if actual != object.digest.0 {
+        let _ = std::fs::remove_file(&partial);
+        return Err(validation("hub.integrity", "download digest mismatch"));
+    }
+    Ok(resumed)
+}
+
+#[cfg(unix)]
+fn open_partial_nofollow(path: &Path, append: bool) -> std::io::Result<File> {
+    use std::os::unix::fs::OpenOptionsExt as _;
+
+    OpenOptions::new()
+        .create(true)
+        .write(true)
+        .append(append)
+        .truncate(!append)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+}
+
+#[cfg(unix)]
+fn open_read_nofollow(path: &Path) -> std::io::Result<File> {
+    use std::os::unix::fs::OpenOptionsExt as _;
+
+    OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+}
+
+#[cfg(not(unix))]
+fn open_read_nofollow(path: &Path) -> std::io::Result<File> {
+    let file = File::open(path)?;
+    if !file.metadata()?.is_file() {
+        return Err(std::io::Error::other("resume path is not a regular file"));
+    }
+    Ok(file)
+}
+
+fn ensure_destination_absent(destination: &Path) -> Result<(), graphforge_api::GfError> {
+    match std::fs::symlink_metadata(destination) {
+        Ok(_) => Err(validation(
+            "hub.destination_conflict",
+            "destination already exists",
+        )),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(storage(error)),
+    }
+}
+
+#[cfg(not(unix))]
+fn open_partial_nofollow(path: &Path, append: bool) -> std::io::Result<File> {
+    let file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .append(append)
+        .truncate(!append)
+        .open(path)?;
+    if !file.metadata()?.is_file() {
+        return Err(std::io::Error::other("resume path is not a regular file"));
+    }
+    Ok(file)
+}
+
+pub(crate) fn run_clone(
+    args: CloneArgs,
+    json: bool,
+    output: &mut dyn Write,
+) -> Result<(), graphforge_api::GfError> {
+    run_clone_with(&HttpTransport::new(), args, json, output)
+}
+
+fn run_clone_with(
+    transport: &dyn Transport,
+    args: CloneArgs,
+    json: bool,
+    output: &mut dyn Write,
+) -> Result<(), graphforge_api::GfError> {
+    let (identity, base) = parse_input(&args.repository)?;
+    let destination = args
+        .destination
+        .unwrap_or_else(|| PathBuf::from(&identity.repository));
+    ensure_destination_absent(&destination)?;
+    let refs_bytes = read_bounded(
+        fetch(
+            transport,
+            &endpoint(&base, "refs"),
+            None,
+            MAX_METADATA_BYTES as u64,
+        )?,
+        MAX_METADATA_BYTES,
+    )?;
+    let manifest_bytes = read_bounded(
+        fetch(
+            transport,
+            &endpoint(&base, "manifest"),
+            None,
+            MAX_METADATA_BYTES as u64,
+        )?,
+        MAX_METADATA_BYTES,
+    )?;
+    let limits = DiscoveryLimits {
+        max_response_bytes: MAX_METADATA_BYTES,
+        max_cumulative_object_bytes: MAX_BUNDLE_BYTES,
+        ..DiscoveryLimits::default()
+    };
+    let refs = RefSet::from_json(&refs_bytes, limits).map_err(|error| protocol_error(&error))?;
+    let manifest = DiscoveryManifest::from_json(&manifest_bytes, limits)
+        .map_err(|error| protocol_error(&error))?;
+    if refs.repository != identity || manifest.repository != identity {
+        return Err(validation("hub.integrity", "discovery repository mismatch"));
+    }
+    refs.validate_manifest(&manifest)
+        .map_err(|error| protocol_error(&error))?;
+    let object = select_bundle(&manifest)?;
+    let partial = partial_path(&destination, &object.digest.0)?;
+    let resumed_bytes = download(transport, object, &destination)?;
+    let portable_limits = PortableV2Limits::default();
+    let verified = verify_discovered_portable_v2(&DiscoveryPortableV2Request {
+        manifest_json: &manifest_bytes,
+        refs_json: &refs_bytes,
+        expected_repository: &identity,
+        package: &partial,
+        discovery_limits: limits,
+        portable_limits,
+        mode: PortableV2Mode::Full,
+        cancelled: None,
+    })
+    .map_err(|_| validation("hub.integrity", "portable project verification failed"))?;
+    let operation_id = OperationId(uuid::Uuid::new_v5(
+        &uuid::Uuid::NAMESPACE_URL,
+        format!(
+            "{}:{}",
+            canonical_name(&identity),
+            verified.immutable_version
+        )
+        .as_bytes(),
+    ));
+    let imported = GraphForge::import_portable_v2(
+        &destination,
+        &PortableV2ImportRequest {
+            input: partial.clone(),
+            operation_id,
+            limits: portable_limits,
+        },
+        None,
+    )
+    .map_err(|_| validation("hub.integrity", "portable project import failed"))?;
+    std::fs::remove_file(&partial).map_err(storage)?;
+    let result = CloneResult {
+        contract: "graphforge-hub-clone/1",
+        repository: canonical_name(&identity),
+        destination: destination.display().to_string(),
+        immutable_version: verified.immutable_version,
+        package_digest: imported.package_digest,
+        generation_uuid: imported.generation_uuid.to_string(),
+        resumed_bytes,
+    };
+    if json {
+        serde_json::to_writer(&mut *output, &result)
+            .map_err(|e| graphforge_api::GfError::Execution(e.to_string()))?;
+        writeln!(output).map_err(storage)?;
+    } else {
+        writeln!(
+            output,
+            "Cloned {} to {}",
+            result.repository, result.destination
+        )
+        .map_err(storage)?;
+    }
+    Ok(())
+}
+
+fn validation(code: &str, message: &str) -> graphforge_api::GfError {
+    graphforge_api::GfError::Validation(format!("{code}: {message}"))
+}
+fn canonical_name(identity: &RepositoryIdentity) -> String {
+    identity.canonical_name()
+}
+fn protocol_error(error: &DiscoveryError) -> graphforge_api::GfError {
+    let code = match error.code {
+        DiscoveryErrorCode::InvalidIdentity => "hub.invalid_identity",
+        DiscoveryErrorCode::MalformedResponse => "hub.malformed_response",
+        DiscoveryErrorCode::UnsupportedFuture => "hub.unsupported_future",
+        DiscoveryErrorCode::MissingRef => "hub.missing_ref",
+        DiscoveryErrorCode::MissingObject => "hub.missing_object",
+        DiscoveryErrorCode::IntegrityFailure => "hub.integrity_failure",
+        DiscoveryErrorCode::UnsafeLocation => "hub.unsafe_location",
+        DiscoveryErrorCode::LimitExceeded => "hub.limit_exceeded",
+        DiscoveryErrorCode::Duplicate => "hub.duplicate",
+    };
+    validation(code, error.detail())
+}
+fn network(message: &str) -> graphforge_api::GfError {
+    graphforge_api::GfError::Storage(format!("hub.network: {message}"))
+}
+fn limit_error(message: &str) -> graphforge_api::GfError {
+    validation("hub.limit_exceeded", message)
+}
+fn storage(error: impl std::fmt::Display) -> graphforge_api::GfError {
+    graphforge_api::GfError::Storage(error.to_string())
+}
+fn hash_reader(reader: &mut impl Read) -> Result<String, graphforge_api::GfError> {
+    let mut hash = Sha256::new();
+    let mut buffer = vec![0_u8; 64 * 1024].into_boxed_slice();
+    loop {
+        let read = reader.read(&mut buffer).map_err(storage)?;
+        if read == 0 {
+            break;
+        }
+        hash.update(&buffer[..read]);
+    }
+    let digest = hash.finalize();
+    let hex = digest
+        .iter()
+        .fold(String::with_capacity(64), |mut hex, byte| {
+            write!(hex, "{byte:02x}").expect("writing to a string cannot fail");
+            hex
+        });
+    Ok(format!("sha256:{hex}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+    use std::io::{BufRead as _, BufReader};
+    use std::net::TcpListener;
+    use std::sync::Mutex;
+    use std::sync::atomic::AtomicBool;
+
+    struct Scripted(Mutex<VecDeque<HttpResponse>>);
+
+    impl Scripted {
+        fn new(responses: Vec<HttpResponse>) -> Self {
+            Self(Mutex::new(responses.into()))
+        }
+
+        fn remaining(&self) -> usize {
+            self.0.lock().unwrap().len()
+        }
+    }
+
+    impl Transport for Scripted {
+        fn get(
+            &self,
+            _url: &Url,
+            _range: Option<u64>,
+            _limit: u64,
+        ) -> Result<HttpResponse, graphforge_api::GfError> {
+            Ok(self.0.lock().unwrap().pop_front().unwrap())
+        }
+    }
+
+    struct LoopbackTransport(HttpTransport);
+
+    impl LoopbackTransport {
+        fn new() -> Self {
+            let config = ureq::Agent::config_builder()
+                .https_only(false)
+                .http_status_as_error(false)
+                .max_redirects(0)
+                .proxy(None)
+                .timeout_global(Some(Duration::from_secs(2)))
+                .build();
+            Self(HttpTransport {
+                agent: ureq::Agent::with_parts(
+                    config,
+                    DefaultConnector::new(),
+                    DefaultResolver::default(),
+                ),
+            })
+        }
+    }
+
+    impl Transport for LoopbackTransport {
+        fn validate(&self, url: &Url) -> Result<(), graphforge_api::GfError> {
+            if url.scheme() == "http"
+                && url
+                    .host_str()
+                    .and_then(|host| host.parse::<IpAddr>().ok())
+                    .is_some_and(|address| address.is_loopback())
+            {
+                Ok(())
+            } else {
+                Err(validation(
+                    "hub.unsafe_location",
+                    "test URL is not loopback HTTP",
+                ))
+            }
+        }
+
+        fn get(
+            &self,
+            url: &Url,
+            range: Option<u64>,
+            limit: u64,
+        ) -> Result<HttpResponse, graphforge_api::GfError> {
+            self.0.get(url, range, limit)
+        }
+    }
+
+    fn response(status: u16, content_range: Option<&str>, body: &[u8]) -> HttpResponse {
+        HttpResponse {
+            status,
+            location: None,
+            content_range: content_range.map(str::to_owned),
+            body: Box::new(std::io::Cursor::new(body.to_vec())),
+        }
+    }
+
+    fn object(bytes: &[u8]) -> ObjectDescriptor {
+        let mut cursor = std::io::Cursor::new(bytes);
+        ObjectDescriptor {
+            digest: graphforge_discovery::Sha256Digest(hash_reader(&mut cursor).unwrap()),
+            length: bytes.len() as u64,
+            media_type: graphforge_discovery::PORTABLE_V2_MEDIA_TYPE.into(),
+            locations: vec!["https://objects.example/project.gfpb".into()],
+        }
+    }
+    #[test]
+    fn identity_forms_are_equivalent() {
+        let (short, _) = parse_input("openalex/openalex").unwrap();
+        let (url, _) = parse_input("https://graphforge.sh/openalex/openalex").unwrap();
+        assert_eq!(short, url);
+    }
+    #[test]
+    fn rejects_non_public_address_classes() {
+        for ip in [
+            "127.0.0.1",
+            "10.0.0.1",
+            "169.254.169.254",
+            "100.64.0.1",
+            "192.0.2.1",
+            "::1",
+            "fc00::1",
+            "fe80::1",
+            "2001:db8::1",
+        ] {
+            assert!(!public_ip(ip.parse().unwrap()), "{ip}");
+        }
+        assert!(public_ip("1.1.1.1".parse().unwrap()));
+        assert!(public_ip("2606:4700:4700::1111".parse().unwrap()));
+    }
+    #[test]
+    fn rejects_credentials_and_non_https() {
+        for url in [
+            "http://example.com/a/b",
+            "https://user@example.com/a/b",
+            "https://127.0.0.1/a/b",
+        ] {
+            assert!(parse_input(url).is_err());
+        }
+    }
+
+    #[test]
+    fn rejects_redirect_to_private_network_before_following_it() {
+        let mut redirect = response(302, None, b"");
+        redirect.location = Some("https://127.0.0.1/private".into());
+        let transport = Scripted::new(vec![redirect, response(200, None, b"secret")]);
+        let start = Url::parse("https://hub.example/repository/.gf/manifest").unwrap();
+        let error = match fetch(&transport, &start, None, 1024) {
+            Ok(_) => panic!("private redirect unexpectedly succeeded"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("hub.unsafe_location"));
+        assert_eq!(
+            transport.remaining(),
+            1,
+            "private target was never requested"
+        );
+    }
+
+    #[test]
+    fn interrupted_download_resumes_with_exact_range() {
+        let bytes = b"verified portable bytes";
+        let descriptor = object(bytes);
+        let root = tempfile::tempdir().unwrap();
+        let destination = root.path().join("project");
+        let first = Scripted::new(vec![response(200, None, &bytes[..8])]);
+        let error = download(&first, &descriptor, &destination).unwrap_err();
+        assert!(error.to_string().contains("hub.interrupted"));
+        let range = format!("bytes 8-{}/{}", bytes.len() - 1, bytes.len());
+        let second = Scripted::new(vec![response(206, Some(&range), &bytes[8..])]);
+        assert_eq!(download(&second, &descriptor, &destination).unwrap(), 8);
+    }
+
+    #[test]
+    fn real_http_interruption_resumes_with_range() {
+        let bytes = b"verified portable bytes".to_vec();
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server_bytes = bytes.clone();
+        let server = std::thread::spawn(move || {
+            for attempt in 0..2 {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut reader = BufReader::new(stream.try_clone().unwrap());
+                let mut request = String::new();
+                loop {
+                    let mut line = String::new();
+                    reader.read_line(&mut line).unwrap();
+                    if line == "\r\n" || line.is_empty() {
+                        break;
+                    }
+                    request.push_str(&line);
+                }
+                if attempt == 0 {
+                    write!(
+                        stream,
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                        server_bytes.len()
+                    )
+                    .unwrap();
+                    stream.write_all(&server_bytes[..8]).unwrap();
+                } else {
+                    assert!(
+                        request.to_ascii_lowercase().contains("range: bytes=8-"),
+                        "{request}"
+                    );
+                    write!(
+                        stream,
+                        "HTTP/1.1 206 Partial Content\r\nContent-Length: {}\r\nContent-Range: bytes 8-{}/{}\r\nConnection: close\r\n\r\n",
+                        server_bytes.len() - 8,
+                        server_bytes.len() - 1,
+                        server_bytes.len()
+                    )
+                    .unwrap();
+                    stream.write_all(&server_bytes[8..]).unwrap();
+                }
+            }
+        });
+        let mut descriptor = object(&bytes);
+        descriptor.locations = vec![format!("http://{address}/project.gfpb")];
+        let root = tempfile::tempdir().unwrap();
+        let destination = root.path().join("project");
+        let transport = LoopbackTransport::new();
+        assert!(download(&transport, &descriptor, &destination).is_err());
+        assert_eq!(download(&transport, &descriptor, &destination).unwrap(), 8);
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn corrupt_download_is_removed_and_never_published() {
+        let descriptor = object(b"expected");
+        let root = tempfile::tempdir().unwrap();
+        let destination = root.path().join("project");
+        let transport = Scripted::new(vec![response(200, None, b"corrupt!")]);
+        let error = download(&transport, &descriptor, &destination).unwrap_err();
+        assert!(error.to_string().contains("hub.integrity"));
+        assert!(!destination.exists());
+        assert!(
+            !partial_path(&destination, &descriptor.digest.0)
+                .unwrap()
+                .exists()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resume_path_symlink_is_never_followed() {
+        use std::os::unix::fs::symlink;
+
+        let bytes = b"verified portable bytes";
+        let descriptor = object(bytes);
+        let root = tempfile::tempdir().unwrap();
+        let destination = root.path().join("project");
+        let victim = root.path().join("victim");
+        std::fs::write(&victim, b"keep me").unwrap();
+        symlink(
+            &victim,
+            partial_path(&destination, &descriptor.digest.0).unwrap(),
+        )
+        .unwrap();
+        let transport = Scripted::new(vec![response(200, None, bytes)]);
+        let error = download(&transport, &descriptor, &destination).unwrap_err();
+        assert!(error.to_string().contains("hub.destination_conflict"));
+        assert_eq!(std::fs::read(&victim).unwrap(), b"keep me");
+        assert_eq!(transport.remaining(), 1, "object was never requested");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dangling_destination_symlink_is_a_conflict() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let destination = root.path().join("project");
+        symlink(root.path().join("missing"), &destination).unwrap();
+        let transport = Scripted::new(vec![]);
+        let error = run_clone_with(
+            &transport,
+            CloneArgs {
+                repository: "openalex/openalex".into(),
+                destination: Some(destination),
+            },
+            false,
+            &mut Vec::new(),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("hub.destination_conflict"));
+        assert_eq!(transport.remaining(), 0, "discovery was never requested");
+    }
+
+    #[test]
+    fn endpoint_does_not_duplicate_repository_path() {
+        let base = Url::parse("https://graphforge.sh/openalex/openalex").unwrap();
+        assert_eq!(
+            endpoint(&base, "refs").as_str(),
+            "https://graphforge.sh/openalex/openalex/.gf/refs"
+        );
+    }
+
+    #[test]
+    fn unsupported_future_manifest_stops_before_object_access() {
+        let repository = serde_json::json!({"owner":"openalex","repository":"openalex"});
+        let immutable = format!("sha256:{}", "a".repeat(64));
+        let refs = serde_json::to_vec(&serde_json::json!({
+            "format":"graphforge-discovery/1","version":{"major":1,"minor":0},
+            "repository":repository.clone(),"default_ref":"main",
+            "refs":[{"name":"main","target":immutable,"validator":format!("sha256:{}", "d".repeat(64))}]
+        }))
+        .unwrap();
+        let manifest = serde_json::to_vec(&serde_json::json!({
+            "format":"graphforge-discovery/1","version":{"major":2,"minor":0},
+            "repository":repository,"default_ref":"main","resolved_ref":"main",
+            "immutable_version":format!("sha256:{}", "a".repeat(64)),
+            "package":{
+                "format":"graphforge-project/2",
+                "package_digest":format!("sha256:{}", "b".repeat(64)),
+                "object_digest":format!("sha256:{}", "c".repeat(64))
+            },
+            "requirements":[],"capabilities":[],
+            "objects":[{
+                "digest":format!("sha256:{}", "c".repeat(64)),"length":1,
+                "media_type":graphforge_discovery::PORTABLE_V2_MEDIA_TYPE,
+                "locations":["https://objects.example/project.gfpb"]
+            }]
+        }))
+        .unwrap();
+        let transport = Scripted::new(vec![
+            response(200, None, &refs),
+            response(200, None, &manifest),
+            response(200, None, b"must not be read"),
+        ]);
+        let root = tempfile::tempdir().unwrap();
+        let error = run_clone_with(
+            &transport,
+            CloneArgs {
+                repository: "openalex/openalex".into(),
+                destination: Some(root.path().join("project")),
+            },
+            true,
+            &mut Vec::new(),
+        )
+        .unwrap_err();
+        assert!(
+            error.to_string().contains("hub.unsupported_future"),
+            "{error}"
+        );
+        assert_eq!(
+            transport.remaining(),
+            1,
+            "object endpoint was never requested"
+        );
+    }
+
+    fn clone_script(bundle: &[u8], package_digest: &str) -> Scripted {
+        let object_digest = hash_reader(&mut std::io::Cursor::new(bundle)).unwrap();
+        let repository = serde_json::json!({"owner":"openalex","repository":"openalex"});
+        let immutable = format!("sha256:{}", "a".repeat(64));
+        let validator = format!("sha256:{}", "d".repeat(64));
+        let refs = serde_json::to_vec(&serde_json::json!({
+            "format":"graphforge-discovery/1","version":{"major":1,"minor":0},
+            "repository":repository.clone(),"default_ref":"main",
+            "refs":[{"name":"main","target":immutable.clone(),"validator":validator}]
+        }))
+        .unwrap();
+        let manifest = serde_json::to_vec(&serde_json::json!({
+            "format":"graphforge-discovery/1","version":{"major":1,"minor":0},
+            "repository":repository,"default_ref":"main","resolved_ref":"main",
+            "immutable_version":immutable,
+            "package":{"format":"graphforge-project/2","package_digest":package_digest,"object_digest":object_digest},
+            "requirements":[{"capability":"portable-v2","major":1}],"capabilities":[{"capability":"range-requests","major":1}],
+            "objects":[{"digest":object_digest,"length":bundle.len(),"media_type":graphforge_discovery::PORTABLE_V2_MEDIA_TYPE,"locations":["https://objects.example/project.gfpb"]}]
+        })).unwrap();
+        Scripted::new(vec![
+            response(200, None, &refs),
+            response(200, None, &manifest),
+            response(200, None, bundle),
+        ])
+    }
+
+    #[test]
+    fn both_identity_forms_import_and_reopen_the_same_real_project() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        std::fs::create_dir(&source).unwrap();
+        GraphForge::new(source.to_str()).unwrap();
+        let generation = graphforge_storage::resolve_project_generation(&source).unwrap();
+        let limits = PortableV2Limits::default();
+        let plan = graphforge_storage::plan_complete_portable_v2(&generation, limits).unwrap();
+        let bundle_path = root.path().join("complete.gfpb");
+        graphforge_storage::export_complete_portable_v2(
+            &plan,
+            &bundle_path,
+            graphforge_storage::PortableV2Output::Bundle,
+            limits,
+            &AtomicBool::new(false),
+            |_| {},
+        )
+        .unwrap();
+        let bundle = std::fs::read(&bundle_path).unwrap();
+        let report = graphforge_storage::verify_portable_v2(
+            &bundle_path,
+            PortableV2Mode::Full,
+            limits,
+            None,
+        )
+        .unwrap();
+
+        for (index, input) in [
+            "openalex/openalex",
+            "https://graphforge.sh/openalex/openalex",
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let destination = root.path().join(format!("clone-{index}"));
+            let mut output = Vec::new();
+            run_clone_with(
+                &clone_script(&bundle, &report.package_digest),
+                CloneArgs {
+                    repository: input.into(),
+                    destination: Some(destination.clone()),
+                },
+                true,
+                &mut output,
+            )
+            .unwrap();
+            let result: serde_json::Value = serde_json::from_slice(&output).unwrap();
+            assert_eq!(result["contract"], "graphforge-hub-clone/1");
+            assert_eq!(result["package_digest"], report.package_digest);
+            GraphForge::new(destination.to_str()).expect("cloned project reopens through facade");
+        }
+    }
+}

--- a/crates/graphforge-cli/src/lib.rs
+++ b/crates/graphforge-cli/src/lib.rs
@@ -19,6 +19,7 @@ use uuid::Uuid;
 
 include!(concat!(env!("OUT_DIR"), "/project_skills.rs"));
 
+mod hub_clone;
 mod maintenance_cli;
 mod ontology_cli;
 mod portable_cli;
@@ -241,6 +242,8 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
+    /// Clone a verified portable project from GraphForge Hub.
+    Clone(hub_clone::CloneArgs),
     /// Initialize repository-local GraphForge definitions and state.
     Init(InitArgs),
     /// Compare or reconcile declared definitions and source digests without ingesting data.
@@ -1099,6 +1102,11 @@ fn run(cli: Cli, output: &mut dyn Write) -> Result<i32, CliRuntimeError> {
             output,
         )
         .map_err(Into::into);
+    }
+    if let Command::Clone(args) = command {
+        return hub_clone::run_clone(args, cli.json, output)
+            .map(|()| 0)
+            .map_err(Into::into);
     }
     // Repository-independent portable commands must not call RepositoryContext::discover.
     if let Command::Portable { command } = command {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -30,12 +30,37 @@ npx @curatelabs/graphforge-cli skills remove
 npx @curatelabs/graphforge-cli config validate
 npx @curatelabs/graphforge-cli config resolve --json
 npx @curatelabs/graphforge-cli infra validate --target production --json
+npx @curatelabs/graphforge-cli clone openalex/openalex
+npx @curatelabs/graphforge-cli clone https://graphforge.sh/openalex/openalex openalex-copy
 ```
 
 The package is a thin launcher for the Rust-owned CLI exposed by
 `@curatelabs/graphforge`. It does not parse commands or implement GraphForge behavior
 in JavaScript. Command names, flags, JSON output, errors, and exit codes are the
 same as the native `gf` executable.
+
+`clone` treats `owner/repository` as the canonical
+`https://graphforge.sh/owner/repository` identity. The optional second argument
+is a new destination directory and defaults to the repository name. Clone reads
+only the versioned `/.gf/refs` and `/.gf/manifest` control documents from that
+identity; package bytes come only from the content-addressed HTTPS location in
+the validated manifest. Existing destinations are never overwritten.
+
+Downloads use finite response, object, redirect, connection, and operation
+limits. An interrupted download leaves only a digest-named partial file beside
+the requested destination and a retry resumes it when the server returns an
+exact matching range. A complete destination is published only after transport
+size and SHA-256 checks, full portable-v2 verification, semantic package
+identity comparison, atomic import, and reopen through the GraphForge facade.
+Redirects and DNS answers are rechecked against the public-network-only policy;
+HTTP, credential-bearing URLs, private/link-local/loopback addresses, corrupt
+objects, and ambiguous package references fail closed. JSON mode returns the
+`graphforge-hub-clone/1` result contract and stable `hub.*` semantic errors.
+
+Clone does not initialize or contact a telemetry exporter. The future opt-in
+GraphForge OpenTelemetry lifecycle will remain Rust-owned and must not attach
+repository names, URLs, local paths, credentials, manifests, or graph data to
+clone signals.
 
 Use `--project-dir` to select a repository explicitly and `--json` for
 machine-readable results. Mutating commands accept caller-owned operation and

--- a/tools/bazel/drift/cargo_feature_fingerprint.json
+++ b/tools/bazel/drift/cargo_feature_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "schema": "graphforge.cargo-feature-fingerprint.v1",
-  "sha256": "8f9db8617daadff92274ffbfc67ccefb2abe6f337f9f0eaccdeb1b580577f0af",
+  "sha256": "5ff3723a7f6129ef022656f3303b5ac29f629b7f2d37a225509a6258430d989f",
   "entries": [
     {
       "name": "graphforge-api",
@@ -548,12 +548,30 @@
           "target": null
         },
         {
+          "name": "graphforge-discovery",
+          "req": "^0.5.2",
+          "features": [],
+          "optional": false,
+          "uses_default_features": true,
+          "kind": null,
+          "target": null
+        },
+        {
           "name": "graphforge-storage",
           "req": "^0.5.2",
           "features": [],
           "optional": false,
           "uses_default_features": true,
-          "kind": "dev",
+          "kind": null,
+          "target": null
+        },
+        {
+          "name": "libc",
+          "req": "^0.2",
+          "features": [],
+          "optional": false,
+          "uses_default_features": true,
+          "kind": null,
           "target": null
         },
         {
@@ -600,7 +618,7 @@
           "features": [],
           "optional": false,
           "uses_default_features": true,
-          "kind": "dev",
+          "kind": null,
           "target": null
         },
         {
@@ -609,7 +627,29 @@
           "features": [],
           "optional": false,
           "uses_default_features": true,
-          "kind": "dev",
+          "kind": null,
+          "target": null
+        },
+        {
+          "name": "ureq",
+          "req": "=3.4.0",
+          "features": [
+            "rustls"
+          ],
+          "optional": false,
+          "uses_default_features": false,
+          "kind": null,
+          "target": null
+        },
+        {
+          "name": "url",
+          "req": "^2",
+          "features": [
+            "serde"
+          ],
+          "optional": false,
+          "uses_default_features": true,
+          "kind": null,
           "target": null
         },
         {


### PR DESCRIPTION
## Summary

- add Rust-owned `gf clone` for canonical short identities and GraphForge Hub HTTPS URLs
- consume the canonical `graphforge-discovery` refs/manifest/package-object authority
- stream content-addressed portable-v2 objects with bounded HTTPS/public-network policy, exact range resume, digest/size verification, and symlink-safe partial state
- verify and atomically import through the real GraphForge portable-v2 facade
- expose stable text/JSON results and `hub.*` errors, with security and local HTTP regression coverage

## Verification

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/graphforge-target-905 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p graphforge-cli --lib hub_clone` (12 passed)
- `CARGO_TARGET_DIR=/tmp/graphforge-target-905 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy -p graphforge-cli --lib -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/graphforge-target-905 CARGO_PROFILE_DEV_DEBUG=0 make pre-push-fast`

Closes #923

#905 intentionally remains open: its OTel emission criterion is isolated in native sub-issue #922, which is blocked by the Rust-owned telemetry lifecycle #886.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790100349&installation_model_id=20486&pr_number=924&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F924&signature=0c6630654f75f2aa8ae2126d85ec1a97a9a6f62ce1566e2a91861e09c57a9c24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->