### PR TITLE
Profile Hub clone as one local workspace job

### DIFF
--- a/crates/graphforge-cli/src/hub_clone.rs
+++ b/crates/graphforge-cli/src/hub_clone.rs
@@ -55,6 +55,7 @@ struct CloneProfile<'a> {
     started: Option<Instant>,
     cursor_ns: u64,
     stages: Vec<JobStage>,
+    handoffs: Vec<ComponentHandoff>,
 }
 
 impl<'a> CloneProfile<'a> {
@@ -64,7 +65,27 @@ impl<'a> CloneProfile<'a> {
             started: None,
             cursor_ns: 0,
             stages: Vec::new(),
+            handoffs: Vec::new(),
         }
+    }
+
+    fn handoff(
+        &mut self,
+        from: ComponentKind,
+        to: ComponentKind,
+        kind: HandoffKind,
+        bytes: Option<u64>,
+    ) {
+        self.handoffs.push(ComponentHandoff {
+            start_offset_ns: self.cursor_ns,
+            from,
+            to,
+            kind,
+            duration_ns: 0,
+            wait_duration_ns: 0,
+            bytes,
+            records: None,
+        });
     }
 
     fn stage<T>(
@@ -153,20 +174,6 @@ impl<'a> CloneProfile<'a> {
             self.cursor_ns = elapsed_ns;
         }
         let failure = result.as_ref().err().map(classify_failure);
-        let handoffs = self
-            .stages
-            .windows(2)
-            .filter(|pair| pair[0].component != pair[1].component)
-            .map(|pair| ComponentHandoff {
-                from: pair[0].component,
-                to: pair[1].component,
-                kind: HandoffKind::Call,
-                duration_ns: 0,
-                wait_duration_ns: 0,
-                bytes: None,
-                records: None,
-            })
-            .collect();
         let _ = self.runtime.record_job(JobSnapshot {
             family: JobFamily::Clone,
             enqueued_ns: 0,
@@ -179,23 +186,47 @@ impl<'a> CloneProfile<'a> {
             },
             failure,
             stages: self.stages,
-            handoffs,
+            handoffs: self.handoffs,
         });
     }
 }
 
 fn classify_failure(error: &graphforge_api::GfError) -> Failure {
-    let rendered = error.to_string();
-    if rendered.contains("hub.network") {
-        Failure::Network
-    } else if rendered.contains("limit") {
-        Failure::ResourceLimit
-    } else {
-        match error {
-            graphforge_api::GfError::Storage(_) => Failure::Storage,
-            graphforge_api::GfError::Validation(_) => Failure::InvalidInput,
-            _ => Failure::Internal,
+    let detail = match error {
+        graphforge_api::GfError::Validation(detail) | graphforge_api::GfError::Storage(detail) => {
+            detail.as_str()
         }
+        _ => return Failure::Internal,
+    };
+    let code = detail.split_once(':').map_or(detail, |(code, _)| code);
+    match code {
+        "hub.network" | "hub.unsafe_location" => Failure::Network,
+        "hub.limit_exceeded" | "hub.package.limit_exceeded" => Failure::ResourceLimit,
+        "hub.invalid_identity"
+        | "hub.malformed_response"
+        | "hub.unsupported_future"
+        | "hub.missing_ref"
+        | "hub.missing_object"
+        | "hub.duplicate"
+        | "hub.destination_conflict"
+        | "hub.concurrent_clone"
+        | "hub.interrupted"
+        | "hub.package.cancelled"
+        | "hub.package.unsupported_future"
+        | "hub.package.incompatible" => Failure::InvalidInput,
+        "hub.integrity"
+        | "hub.integrity_failure"
+        | "hub.package.repository_mismatch"
+        | "hub.package.immutable_version_mismatch"
+        | "hub.package.package_digest_mismatch"
+        | "hub.package.invalid_structure"
+        | "hub.package.invalid_path"
+        | "hub.package.duplicate_entry"
+        | "hub.package.digest_mismatch"
+        | "hub.package.concurrent_mutation" => Failure::InvalidInput,
+        "hub.package.io" => Failure::Storage,
+        _ if matches!(error, graphforge_api::GfError::Storage(_)) => Failure::Storage,
+        _ => Failure::Internal,
     }
 }
 
@@ -700,10 +731,21 @@ fn read_resume(checkpoint: &Path) -> Result<Option<ResumeState>, graphforge_api:
 }
 
 #[allow(clippy::too_many_lines)]
+#[cfg(test)]
 fn download(
     transport: &dyn Transport,
     object: &ObjectDescriptor,
     partial: &Path,
+) -> Result<DownloadReport, graphforge_api::GfError> {
+    download_with_progress(transport, object, partial, &mut DownloadReport::default())
+}
+
+#[allow(clippy::too_many_lines)]
+fn download_with_progress(
+    transport: &dyn Transport,
+    object: &ObjectDescriptor,
+    partial: &Path,
+    progress: &mut DownloadReport,
 ) -> Result<DownloadReport, graphforge_api::GfError> {
     let checkpoint = partial.with_extension("resume.json");
     if object.length > MAX_BUNDLE_BYTES {
@@ -740,10 +782,12 @@ fn download(
     if resumed > 0 && validator.is_none() {
         resumed = 0;
     }
+    progress.resumed_bytes = resumed;
     let mut transferred = 0_u64;
     let mut attempts = 0_u32;
     if resumed < object.length {
         attempts = 1;
+        progress.attempts = attempts;
         let mut response = fetch(
             transport,
             &url,
@@ -783,6 +827,7 @@ fn download(
                 .checked_add(read as u64)
                 .ok_or_else(|| limit_error("object exceeds byte bound"))?;
             transferred = copied;
+            progress.transferred_bytes = transferred;
             if copied > object.length.saturating_sub(resumed) {
                 return Err(limit_error("object exceeds declared size"));
             }
@@ -812,7 +857,7 @@ fn download(
     })
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 struct DownloadReport {
     resumed_bytes: u64,
     transferred_bytes: u64,
@@ -919,8 +964,33 @@ fn run_clone_profiled(
     output: &mut dyn Write,
     runtime: &TelemetryRuntime,
 ) -> Result<(), graphforge_api::GfError> {
+    run_clone_profiled_with_delays(
+        transport,
+        args,
+        json,
+        output,
+        runtime,
+        CloneDelays::default(),
+    )
+}
+
+#[derive(Clone, Copy, Default)]
+struct CloneDelays {
+    verification: Duration,
+    import: Duration,
+    reopen: Duration,
+}
+
+fn run_clone_profiled_with_delays(
+    transport: &dyn Transport,
+    args: CloneArgs,
+    json: bool,
+    output: &mut dyn Write,
+    runtime: &TelemetryRuntime,
+    delays: CloneDelays,
+) -> Result<(), graphforge_api::GfError> {
     let mut profile = CloneProfile::new(runtime);
-    let result = run_clone_job(transport, args, &mut profile)
+    let result = run_clone_job(transport, args, &mut profile, delays)
         .and_then(|result| write_clone_result(&result, json, output));
     profile.finish(&result);
     result
@@ -931,6 +1001,7 @@ fn run_clone_job(
     transport: &dyn Transport,
     args: CloneArgs,
     profile: &mut CloneProfile<'_>,
+    delays: CloneDelays,
 ) -> Result<CloneResult, graphforge_api::GfError> {
     let (identity, base, destination) = profile.stage(
         Stage::IdentityValidation,
@@ -947,9 +1018,15 @@ fn run_clone_job(
             Ok(((identity, base, destination), None, None))
         },
     )?;
+    profile.handoff(
+        ComponentKind::Cli,
+        ComponentKind::NetworkTransport,
+        HandoffKind::Call,
+        None,
+    );
     let refs_bytes = profile.stage(
         Stage::RefsDiscovery,
-        ComponentKind::Discovery,
+        ComponentKind::NetworkTransport,
         ComponentRole::Transfer,
         Some(WaitReason::Network),
         1,
@@ -970,7 +1047,7 @@ fn run_clone_job(
     )?;
     let manifest_bytes = profile.stage(
         Stage::ManifestDiscovery,
-        ComponentKind::Discovery,
+        ComponentKind::NetworkTransport,
         ComponentRole::Transfer,
         Some(WaitReason::Network),
         1,
@@ -994,6 +1071,12 @@ fn run_clone_job(
         max_cumulative_object_bytes: MAX_BUNDLE_BYTES,
         ..DiscoveryLimits::default()
     };
+    profile.handoff(
+        ComponentKind::NetworkTransport,
+        ComponentKind::Discovery,
+        HandoffKind::Return,
+        Some((refs_bytes.len() + manifest_bytes.len()) as u64),
+    );
     let (manifest, staging) = profile.stage(
         Stage::ManifestDiscovery,
         ComponentKind::Discovery,
@@ -1016,22 +1099,38 @@ fn run_clone_job(
     )?;
     let object = select_bundle(&manifest)?;
     let partial = staging.partial.clone();
-    let download = profile.stage(
+    profile.handoff(
+        ComponentKind::Discovery,
+        ComponentKind::NetworkTransport,
+        HandoffKind::Call,
+        None,
+    );
+    let mut download_progress = DownloadReport::default();
+    let download_result = profile.stage(
         Stage::Download,
         ComponentKind::NetworkTransport,
         ComponentRole::Transfer,
         Some(WaitReason::Network),
         1,
         || {
-            let report = download(transport, object, &partial)?;
+            let report =
+                download_with_progress(transport, object, &partial, &mut download_progress)?;
             Ok((report, Some(report.transferred_bytes), None))
         },
-    )?;
+    );
     if let Some(stage) = profile.stages.last_mut() {
-        stage.attempt = download.attempts.max(1);
-        stage.resumed_bytes = Some(download.resumed_bytes);
+        stage.attempt = download_progress.attempts.max(1);
+        stage.bytes = Some(download_progress.transferred_bytes);
+        stage.resumed_bytes = Some(download_progress.resumed_bytes);
     }
+    let download = download_result?;
     let portable_limits = PortableV2Limits::default();
+    profile.handoff(
+        ComponentKind::NetworkTransport,
+        ComponentKind::PortableVerify,
+        HandoffKind::Transfer,
+        Some(download.resumed_bytes + download.transferred_bytes),
+    );
     let verified = profile.stage(
         Stage::PortableVerification,
         ComponentKind::PortableVerify,
@@ -1039,6 +1138,7 @@ fn run_clone_job(
         None,
         1,
         || {
+            std::thread::sleep(delays.verification);
             verify_discovered_portable_v2(&DiscoveryPortableV2Request {
                 manifest_json: &manifest_bytes,
                 refs_json: &refs_bytes,
@@ -1062,6 +1162,12 @@ fn run_clone_job(
         )
         .as_bytes(),
     ));
+    profile.handoff(
+        ComponentKind::PortableVerify,
+        ComponentKind::PortableImport,
+        HandoffKind::Transfer,
+        Some(object.length),
+    );
     let imported = profile.stage(
         Stage::AtomicImport,
         ComponentKind::PortableImport,
@@ -1069,6 +1175,7 @@ fn run_clone_job(
         None,
         1,
         || {
+            std::thread::sleep(delays.import);
             GraphForge::import_portable_v2(
                 &destination,
                 &PortableV2ImportRequest {
@@ -1082,6 +1189,12 @@ fn run_clone_job(
             .map(|imported| (imported, Some(object.length), None))
         },
     )?;
+    profile.handoff(
+        ComponentKind::PortableImport,
+        ComponentKind::Recovery,
+        HandoffKind::Return,
+        Some(object.length),
+    );
     profile.stage(
         Stage::Reopen,
         ComponentKind::Recovery,
@@ -1089,12 +1202,19 @@ fn run_clone_job(
         None,
         1,
         || {
+            std::thread::sleep(delays.reopen);
             let destination = destination.to_str().ok_or_else(|| {
                 validation("hub.destination_conflict", "destination must be UTF-8")
             })?;
             GraphForge::new(Some(destination)).map(|graph| (graph, None, None))
         },
     )?;
+    profile.handoff(
+        ComponentKind::Recovery,
+        ComponentKind::Storage,
+        HandoffKind::Call,
+        None,
+    );
     let staging_root = staging.root.clone();
     drop(staging);
     // The destination is already atomically published; cleanup cannot turn
@@ -1239,6 +1359,12 @@ mod tests {
         fn remaining(&self) -> usize {
             self.0.lock().unwrap().len()
         }
+
+        fn replace_last(&self, response: HttpResponse) {
+            let mut responses = self.0.lock().unwrap();
+            responses.pop_back().unwrap();
+            responses.push_back(response);
+        }
     }
 
     impl Transport for Scripted {
@@ -1250,6 +1376,30 @@ mod tests {
             _limit: u64,
         ) -> Result<HttpResponse, graphforge_api::GfError> {
             Ok(self.0.lock().unwrap().pop_front().unwrap())
+        }
+    }
+
+    struct DelayedTransport {
+        inner: Scripted,
+        discovery: Duration,
+        download: Duration,
+    }
+
+    impl Transport for DelayedTransport {
+        fn get(
+            &self,
+            url: &Url,
+            range: Option<u64>,
+            if_range: Option<&str>,
+            limit: u64,
+        ) -> Result<HttpResponse, graphforge_api::GfError> {
+            let delay = if url.path().contains("/.gf/objects/") || url.path().ends_with(".gfpb") {
+                self.download
+            } else {
+                self.discovery
+            };
+            std::thread::sleep(delay);
+            self.inner.get(url, range, if_range, limit)
         }
     }
 
@@ -1747,8 +1897,73 @@ mod tests {
             .unwrap()
             .duration_ns;
         assert!(verify_ns > download_ns);
-        assert!(slow_download.handoffs.iter().any(|handoff| {
-            handoff.from == ComponentKind::NetworkTransport && handoff.to == ComponentKind::Cli
+        assert!(slow_download.handoffs.is_empty());
+    }
+
+    #[test]
+    fn interrupted_clone_retains_resumed_and_transferred_bytes_once() {
+        let bundle = b"0123456789abcdef";
+        let package_digest = format!("sha256:{}", "b".repeat(64));
+        let transport = clone_script(bundle, &package_digest);
+        let range = format!("bytes 8-{}/{}", bundle.len() - 1, bundle.len());
+        transport.replace_last(response(206, Some(&range), &bundle[8..12]));
+        let root = tempfile::tempdir().unwrap();
+        let destination = root.path().join("clone");
+        let staging = staging_path(&destination).unwrap();
+        std::fs::create_dir(&staging).unwrap();
+        let partial = staging.join("package.part");
+        std::fs::write(&partial, &bundle[..8]).unwrap();
+        let digest = hash_reader(&mut std::io::Cursor::new(bundle)).unwrap();
+        std::fs::write(
+            partial.with_extension("resume.json"),
+            serde_json::to_vec(&ResumeState {
+                digest,
+                length: bundle.len() as u64,
+                location: "https://objects.example/project.gfpb".into(),
+                etag: "\"fixture-1\"".into(),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        let runtime = TelemetryRuntime::new(TelemetryConfig {
+            mode: TelemetryMode::InMemory,
+            ..TelemetryConfig::default()
+        })
+        .unwrap();
+        let error = run_clone_profiled(
+            &transport,
+            CloneArgs {
+                repository: "openalex/openalex".into(),
+                destination: Some(destination),
+                telemetry_endpoint: None,
+            },
+            true,
+            &mut Vec::new(),
+            &runtime,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("hub.interrupted"));
+        assert_eq!(
+            runtime.force_flush(),
+            graphforge_api::telemetry::LifecycleStatus::Complete
+        );
+        let snapshots = runtime.snapshots();
+        assert_eq!(snapshots.len(), 1);
+        let job = snapshots[0].job.as_ref().unwrap();
+        assert_eq!(job.outcome, Outcome::Failed);
+        let stage = job
+            .stages
+            .iter()
+            .find(|stage| stage.stage == Stage::Download)
+            .unwrap();
+        assert_eq!(stage.resumed_bytes, Some(8));
+        assert_eq!(stage.bytes, Some(4));
+        assert_eq!(stage.attempt, 1);
+        assert!(!job.handoffs.iter().any(|handoff| {
+            matches!(
+                handoff.to,
+                ComponentKind::PortableVerify | ComponentKind::PortableImport
+            )
         }));
     }
 
@@ -1825,6 +2040,27 @@ mod tests {
     }
 
     #[test]
+    fn hub_failure_codes_map_through_a_finite_matrix() {
+        for (code, expected) in [
+            ("hub.invalid_identity", Failure::InvalidInput),
+            ("hub.destination_conflict", Failure::InvalidInput),
+            ("hub.unsupported_future", Failure::InvalidInput),
+            ("hub.integrity", Failure::InvalidInput),
+            ("hub.limit_exceeded", Failure::ResourceLimit),
+            ("hub.unsafe_location", Failure::Network),
+            ("hub.network", Failure::Network),
+            ("hub.package.io", Failure::Storage),
+        ] {
+            assert_eq!(classify_failure(&validation(code, "redacted")), expected);
+        }
+        assert_eq!(
+            classify_failure(&validation("hub.unknown", "redacted")),
+            Failure::Internal
+        );
+        assert_eq!(classify_failure(&storage("redacted")), Failure::Storage);
+    }
+
+    #[test]
     fn both_identity_forms_import_and_reopen_the_same_real_project() {
         let root = tempfile::tempdir().unwrap();
         let source = root.path().join("source");
@@ -1854,9 +2090,15 @@ mod tests {
 
         let mut fail_open_results = Vec::new();
         let mut fail_open_elapsed = Vec::new();
+        let mut delayed_jobs = Vec::new();
         for (index, input) in [
             "openalex/openalex",
             "https://graphforge.sh/openalex/openalex",
+            "openalex/openalex",
+            "openalex/openalex",
+            "openalex/openalex",
+            "openalex/openalex",
+            "openalex/openalex",
             "openalex/openalex",
             "openalex/openalex",
         ]
@@ -1885,9 +2127,39 @@ mod tests {
                 })
                 .unwrap(),
             };
+            let transport = DelayedTransport {
+                inner: clone_script(&bundle, &report.package_digest),
+                discovery: if index == 4 {
+                    Duration::from_millis(20)
+                } else {
+                    Duration::ZERO
+                },
+                download: if index == 5 {
+                    Duration::from_millis(20)
+                } else {
+                    Duration::ZERO
+                },
+            };
+            let delays = CloneDelays {
+                verification: if index == 6 {
+                    Duration::from_millis(20)
+                } else {
+                    Duration::ZERO
+                },
+                import: if index == 7 {
+                    Duration::from_millis(20)
+                } else {
+                    Duration::ZERO
+                },
+                reopen: if index == 8 {
+                    Duration::from_millis(20)
+                } else {
+                    Duration::ZERO
+                },
+            };
             let clone_started = Instant::now();
-            run_clone_profiled(
-                &clone_script(&bundle, &report.package_digest),
+            run_clone_profiled_with_delays(
+                &transport,
                 CloneArgs {
                     repository: input.into(),
                     destination: Some(destination.clone()),
@@ -1896,11 +2168,12 @@ mod tests {
                 true,
                 &mut output,
                 &runtime,
+                delays,
             )
             .unwrap();
             let clone_elapsed = clone_started.elapsed();
             let lifecycle = runtime.force_flush();
-            if index < 2 {
+            if index < 2 || index >= 4 {
                 assert_eq!(
                     lifecycle,
                     graphforge_api::telemetry::LifecycleStatus::Complete
@@ -1915,6 +2188,20 @@ mod tests {
                 assert_eq!(job.stages.first().unwrap().stage, Stage::IdentityValidation);
                 assert!(job.stages.iter().any(|stage| stage.stage == Stage::Cleanup));
                 assert!(job.stages.iter().any(|stage| stage.stage == Stage::Reopen));
+                assert!(
+                    job.handoffs
+                        .windows(2)
+                        .all(|pair| { pair[0].start_offset_ns <= pair[1].start_offset_ns })
+                );
+                assert!(job.handoffs.iter().any(|handoff| {
+                    handoff.from == ComponentKind::NetworkTransport
+                        && handoff.to == ComponentKind::PortableVerify
+                        && handoff.kind == HandoffKind::Transfer
+                        && handoff.bytes == Some(bundle.len() as u64)
+                }));
+                if index >= 4 {
+                    delayed_jobs.push(job.clone());
+                }
             }
             let serialized = serde_json::to_string(&snapshots).unwrap();
             for canary in [input, destination.to_str().unwrap(), &report.package_digest] {
@@ -1924,7 +2211,7 @@ mod tests {
             assert_eq!(result["contract"], "graphforge-hub-clone/1");
             assert_eq!(result["package_digest"], report.package_digest);
             GraphForge::new(destination.to_str()).expect("cloned project reopens through facade");
-            if index >= 2 {
+            if (2..=3).contains(&index) {
                 result.as_object_mut().unwrap().remove("destination");
                 fail_open_results.push(result);
                 fail_open_elapsed.push(clone_elapsed);
@@ -1932,5 +2219,20 @@ mod tests {
         }
         assert_eq!(fail_open_results[0], fail_open_results[1]);
         assert!(fail_open_elapsed[1] <= fail_open_elapsed[0] + Duration::from_secs(1));
+        for (job, expected) in delayed_jobs.iter().zip([
+            ComponentKind::NetworkTransport,
+            ComponentKind::NetworkTransport,
+            ComponentKind::PortableVerify,
+            ComponentKind::PortableImport,
+            ComponentKind::Recovery,
+        ]) {
+            let dominant = job
+                .stages
+                .iter()
+                .filter(|stage| stage.stage != Stage::Orchestration)
+                .max_by_key(|stage| stage.duration_ns)
+                .unwrap();
+            assert_eq!(dominant.component, expected);
+        }
     }
 }

--- a/crates/graphforge-cli/src/hub_clone.rs
+++ b/crates/graphforge-cli/src/hub_clone.rs
@@ -432,9 +432,22 @@ fn fetch(
     if_range: Option<&str>,
     limit: u64,
 ) -> Result<HttpResponse, graphforge_api::GfError> {
+    let mut attempts = 0;
+    fetch_with_attempts(transport, start, range, if_range, limit, &mut attempts)
+}
+
+fn fetch_with_attempts(
+    transport: &dyn Transport,
+    start: &Url,
+    range: Option<u64>,
+    if_range: Option<&str>,
+    limit: u64,
+    attempts: &mut u32,
+) -> Result<HttpResponse, graphforge_api::GfError> {
     let mut url = start.clone();
     for hop in 0..=MAX_REDIRECTS {
         transport.validate(&url)?;
+        *attempts = attempts.saturating_add(1);
         let response = transport.get(&url, range, if_range, limit)?;
         if matches!(response.status, 301 | 302 | 303 | 307 | 308) {
             if hop == MAX_REDIRECTS {
@@ -784,16 +797,14 @@ fn download_with_progress(
     }
     progress.resumed_bytes = resumed;
     let mut transferred = 0_u64;
-    let mut attempts = 0_u32;
     if resumed < object.length {
-        attempts = 1;
-        progress.attempts = attempts;
-        let mut response = fetch(
+        let mut response = fetch_with_attempts(
             transport,
             &url,
             (resumed > 0).then_some(resumed),
             validator,
             object.length.saturating_sub(resumed),
+            &mut progress.attempts,
         )?;
         let expected_range = format!("bytes {resumed}-{}/{}", object.length - 1, object.length);
         let append = resumed > 0
@@ -853,7 +864,7 @@ fn download_with_progress(
     Ok(DownloadReport {
         resumed_bytes: resumed,
         transferred_bytes: transferred,
-        attempts,
+        attempts: progress.attempts,
     })
 }
 
@@ -1024,7 +1035,8 @@ fn run_clone_job(
         HandoffKind::Call,
         None,
     );
-    let refs_bytes = profile.stage(
+    let mut refs_attempts = 0;
+    let refs_result = profile.stage(
         Stage::RefsDiscovery,
         ComponentKind::NetworkTransport,
         ComponentRole::Transfer,
@@ -1032,20 +1044,26 @@ fn run_clone_job(
         1,
         || {
             let bytes = read_bounded(
-                fetch(
+                fetch_with_attempts(
                     transport,
                     &endpoint(&base, "refs"),
                     None,
                     None,
                     MAX_METADATA_BYTES as u64,
+                    &mut refs_attempts,
                 )?,
                 MAX_METADATA_BYTES,
             )?;
             let length = bytes.len() as u64;
             Ok((bytes, Some(length), None))
         },
-    )?;
-    let manifest_bytes = profile.stage(
+    );
+    if let Some(stage) = profile.stages.last_mut() {
+        stage.attempt = refs_attempts.max(1);
+    }
+    let refs_bytes = refs_result?;
+    let mut manifest_attempts = 0;
+    let manifest_result = profile.stage(
         Stage::ManifestDiscovery,
         ComponentKind::NetworkTransport,
         ComponentRole::Transfer,
@@ -1053,19 +1071,24 @@ fn run_clone_job(
         1,
         || {
             let bytes = read_bounded(
-                fetch(
+                fetch_with_attempts(
                     transport,
                     &endpoint(&base, "manifest"),
                     None,
                     None,
                     MAX_METADATA_BYTES as u64,
+                    &mut manifest_attempts,
                 )?,
                 MAX_METADATA_BYTES,
             )?;
             let length = bytes.len() as u64;
             Ok((bytes, Some(length), None))
         },
-    )?;
+    );
+    if let Some(stage) = profile.stages.last_mut() {
+        stage.attempt = manifest_attempts.max(1);
+    }
+    let manifest_bytes = manifest_result?;
     let limits = DiscoveryLimits {
         max_response_bytes: MAX_METADATA_BYTES,
         max_cumulative_object_bytes: MAX_BUNDLE_BYTES,
@@ -1164,8 +1187,14 @@ fn run_clone_job(
     ));
     profile.handoff(
         ComponentKind::PortableVerify,
+        ComponentKind::Api,
+        HandoffKind::Call,
+        Some(object.length),
+    );
+    profile.handoff(
+        ComponentKind::Api,
         ComponentKind::PortableImport,
-        HandoffKind::Transfer,
+        HandoffKind::Call,
         Some(object.length),
     );
     let imported = profile.stage(
@@ -1191,9 +1220,27 @@ fn run_clone_job(
     )?;
     profile.handoff(
         ComponentKind::PortableImport,
+        ComponentKind::Storage,
+        HandoffKind::Write,
+        Some(object.length),
+    );
+    profile.handoff(
+        ComponentKind::Storage,
+        ComponentKind::Publication,
+        HandoffKind::Write,
+        Some(object.length),
+    );
+    profile.handoff(
+        ComponentKind::Publication,
+        ComponentKind::Api,
+        HandoffKind::Return,
+        None,
+    );
+    profile.handoff(
+        ComponentKind::Api,
         ComponentKind::Recovery,
         HandoffKind::Return,
-        Some(object.length),
+        None,
     );
     profile.stage(
         Stage::Reopen,
@@ -1524,6 +1571,19 @@ mod tests {
     }
 
     #[test]
+    fn redirect_attempts_count_each_transport_request() {
+        let mut redirect = response(302, None, b"");
+        redirect.location = Some("https://objects.example/final".into());
+        let transport = Scripted::new(vec![redirect, response(200, None, b"ok")]);
+        let start = Url::parse("https://hub.example/start").unwrap();
+        let mut attempts = 0;
+        let response =
+            fetch_with_attempts(&transport, &start, None, None, 1024, &mut attempts).unwrap();
+        assert_eq!(response.status, 200);
+        assert_eq!(attempts, 2);
+    }
+
+    #[test]
     fn interrupted_download_resumes_with_exact_range() {
         let bytes = b"verified portable bytes";
         let descriptor = object(bytes);
@@ -1826,80 +1886,6 @@ mod tests {
         ])
     }
 
-    fn delayed_profile(download_delay: Duration, verify_delay: Duration) -> JobSnapshot {
-        let runtime = TelemetryRuntime::new(TelemetryConfig {
-            mode: TelemetryMode::InMemory,
-            ..TelemetryConfig::default()
-        })
-        .unwrap();
-        let mut profile = CloneProfile::new(&runtime);
-        profile
-            .stage(
-                Stage::Download,
-                ComponentKind::NetworkTransport,
-                ComponentRole::Transfer,
-                Some(WaitReason::Network),
-                1,
-                || {
-                    std::thread::sleep(download_delay);
-                    Ok(((), Some(64), None))
-                },
-            )
-            .unwrap();
-        profile
-            .stage(
-                Stage::PortableVerification,
-                ComponentKind::PortableVerify,
-                ComponentRole::Verification,
-                None,
-                1,
-                || {
-                    std::thread::sleep(verify_delay);
-                    Ok(((), Some(64), None))
-                },
-            )
-            .unwrap();
-        profile.finish(&Ok(()));
-        assert_eq!(
-            runtime.force_flush(),
-            graphforge_api::telemetry::LifecycleStatus::Complete
-        );
-        runtime.snapshots().remove(0).job.unwrap()
-    }
-
-    #[test]
-    fn delayed_fixtures_attribute_the_dominant_clone_component() {
-        let slow_download = delayed_profile(Duration::from_millis(15), Duration::from_millis(1));
-        let download_ns = slow_download
-            .stages
-            .iter()
-            .find(|stage| stage.stage == Stage::Download)
-            .unwrap()
-            .duration_ns;
-        let verify_ns = slow_download
-            .stages
-            .iter()
-            .find(|stage| stage.stage == Stage::PortableVerification)
-            .unwrap()
-            .duration_ns;
-        assert!(download_ns > verify_ns);
-        let slow_verify = delayed_profile(Duration::from_millis(1), Duration::from_millis(15));
-        let download_ns = slow_verify
-            .stages
-            .iter()
-            .find(|stage| stage.stage == Stage::Download)
-            .unwrap()
-            .duration_ns;
-        let verify_ns = slow_verify
-            .stages
-            .iter()
-            .find(|stage| stage.stage == Stage::PortableVerification)
-            .unwrap()
-            .duration_ns;
-        assert!(verify_ns > download_ns);
-        assert!(slow_download.handoffs.is_empty());
-    }
-
     #[test]
     fn interrupted_clone_retains_resumed_and_transferred_bytes_once() {
         let bundle = b"0123456789abcdef";
@@ -2130,29 +2116,29 @@ mod tests {
             let transport = DelayedTransport {
                 inner: clone_script(&bundle, &report.package_digest),
                 discovery: if index == 4 {
-                    Duration::from_millis(20)
+                    Duration::from_secs(2)
                 } else {
                     Duration::ZERO
                 },
                 download: if index == 5 {
-                    Duration::from_millis(20)
+                    Duration::from_secs(2)
                 } else {
                     Duration::ZERO
                 },
             };
             let delays = CloneDelays {
                 verification: if index == 6 {
-                    Duration::from_millis(20)
+                    Duration::from_secs(2)
                 } else {
                     Duration::ZERO
                 },
                 import: if index == 7 {
-                    Duration::from_millis(20)
+                    Duration::from_secs(2)
                 } else {
                     Duration::ZERO
                 },
                 reopen: if index == 8 {
-                    Duration::from_millis(20)
+                    Duration::from_secs(2)
                 } else {
                     Duration::ZERO
                 },
@@ -2180,7 +2166,7 @@ mod tests {
                 );
             }
             let snapshots = runtime.snapshots();
-            if index < 2 {
+            if index < 2 || index >= 4 {
                 assert_eq!(snapshots.len(), 1);
                 let job = snapshots[0].job.as_ref().unwrap();
                 assert_eq!(job.family, JobFamily::Clone);
@@ -2199,6 +2185,30 @@ mod tests {
                         && handoff.kind == HandoffKind::Transfer
                         && handoff.bytes == Some(bundle.len() as u64)
                 }));
+                let path: Vec<_> = job
+                    .handoffs
+                    .iter()
+                    .map(|handoff| (handoff.from, handoff.to))
+                    .collect();
+                assert_eq!(
+                    path,
+                    vec![
+                        (ComponentKind::Cli, ComponentKind::NetworkTransport),
+                        (ComponentKind::NetworkTransport, ComponentKind::Discovery),
+                        (ComponentKind::Discovery, ComponentKind::NetworkTransport),
+                        (
+                            ComponentKind::NetworkTransport,
+                            ComponentKind::PortableVerify
+                        ),
+                        (ComponentKind::PortableVerify, ComponentKind::Api),
+                        (ComponentKind::Api, ComponentKind::PortableImport),
+                        (ComponentKind::PortableImport, ComponentKind::Storage),
+                        (ComponentKind::Storage, ComponentKind::Publication),
+                        (ComponentKind::Publication, ComponentKind::Api),
+                        (ComponentKind::Api, ComponentKind::Recovery),
+                        (ComponentKind::Recovery, ComponentKind::Storage),
+                    ]
+                );
                 if index >= 4 {
                     delayed_jobs.push(job.clone());
                 }
@@ -2219,6 +2229,7 @@ mod tests {
         }
         assert_eq!(fail_open_results[0], fail_open_results[1]);
         assert!(fail_open_elapsed[1] <= fail_open_elapsed[0] + Duration::from_secs(1));
+        assert_eq!(delayed_jobs.len(), 5);
         for (job, expected) in delayed_jobs.iter().zip([
             ComponentKind::NetworkTransport,
             ComponentKind::NetworkTransport,

--- a/crates/graphforge-cli/src/hub_clone.rs
+++ b/crates/graphforge-cli/src/hub_clone.rs
@@ -2,6 +2,11 @@
 
 use clap::Args;
 use fs4::{FileExt, TryLockError};
+use graphforge_api::telemetry::{
+    ComponentHandoff, ComponentKind, ComponentRole, Failure, HandoffKind, JobFamily, JobSnapshot,
+    JobStage, OtlpConfig, Outcome, Stage, TelemetryConfig, TelemetryMode, TelemetryRuntime,
+    WaitReason,
+};
 use graphforge_api::{
     GraphForge, OperationId, PortableV2ImportRequest, PortableV2Limits, PortableV2Mode,
 };
@@ -15,6 +20,7 @@ use graphforge_storage::{
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
+use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::fmt::Write as _;
 use std::fs::{File, OpenOptions};
@@ -23,7 +29,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 #[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt as _;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use ureq::unversioned::resolver::{DefaultResolver, ResolvedSocketAddrs, Resolver};
 use ureq::unversioned::transport::DefaultConnector;
 use url::Url;
@@ -39,6 +45,158 @@ pub(crate) struct CloneArgs {
     pub repository: String,
     /// New project directory; defaults to the repository name.
     pub destination: Option<PathBuf>,
+    /// Explicit local OTLP collector base URL. Clone telemetry is otherwise disabled.
+    #[arg(long)]
+    pub telemetry_endpoint: Option<String>,
+}
+
+struct CloneProfile<'a> {
+    runtime: &'a TelemetryRuntime,
+    started: Option<Instant>,
+    cursor_ns: u64,
+    stages: Vec<JobStage>,
+}
+
+impl<'a> CloneProfile<'a> {
+    fn new(runtime: &'a TelemetryRuntime) -> Self {
+        Self {
+            runtime,
+            started: None,
+            cursor_ns: 0,
+            stages: Vec::new(),
+        }
+    }
+
+    fn stage<T>(
+        &mut self,
+        stage: Stage,
+        component: ComponentKind,
+        role: ComponentRole,
+        wait_reason: Option<WaitReason>,
+        attempt: u32,
+        operation: impl FnOnce() -> Result<(T, Option<u64>, Option<u64>), graphforge_api::GfError>,
+    ) -> Result<T, graphforge_api::GfError> {
+        let origin = *self.started.get_or_insert_with(Instant::now);
+        let operation_start_ns = u64::try_from(origin.elapsed().as_nanos()).unwrap_or(u64::MAX);
+        if !self.stages.is_empty() && operation_start_ns > self.cursor_ns {
+            let duration_ns = operation_start_ns - self.cursor_ns;
+            self.stages.push(JobStage {
+                stage: Stage::Orchestration,
+                component: ComponentKind::Cli,
+                component_role: ComponentRole::Coordination,
+                start_offset_ns: self.cursor_ns,
+                duration_ns,
+                wait_duration_ns: 0,
+                wait_reason: None,
+                attempt: 1,
+                bytes: None,
+                resumed_bytes: None,
+                records: None,
+                outcome: Outcome::Ok,
+            });
+            self.cursor_ns = operation_start_ns;
+        }
+        let started = Instant::now();
+        let result = operation();
+        let duration_ns = u64::try_from(started.elapsed().as_nanos())
+            .unwrap_or(u64::MAX)
+            .max(1);
+        let (bytes, records) = result
+            .as_ref()
+            .map_or((None, None), |(_, bytes, records)| (*bytes, *records));
+        self.stages.push(JobStage {
+            stage,
+            component,
+            component_role: role,
+            start_offset_ns: self.cursor_ns,
+            duration_ns,
+            wait_duration_ns: wait_reason.map_or(0, |_| duration_ns),
+            wait_reason,
+            attempt,
+            bytes,
+            resumed_bytes: None,
+            records,
+            outcome: if result.is_ok() {
+                Outcome::Ok
+            } else {
+                Outcome::Failed
+            },
+        });
+        self.cursor_ns = self.cursor_ns.saturating_add(duration_ns);
+        result.map(|(value, _, _)| value)
+    }
+
+    fn finish(mut self, result: &Result<(), graphforge_api::GfError>) {
+        let elapsed_ns = self.started.map_or(0, |started| {
+            u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX)
+        });
+        if elapsed_ns > self.cursor_ns {
+            let duration_ns = elapsed_ns - self.cursor_ns;
+            self.stages.push(JobStage {
+                stage: Stage::Orchestration,
+                component: ComponentKind::Cli,
+                component_role: ComponentRole::Coordination,
+                start_offset_ns: self.cursor_ns,
+                duration_ns,
+                wait_duration_ns: 0,
+                wait_reason: None,
+                attempt: 1,
+                bytes: None,
+                resumed_bytes: None,
+                records: None,
+                outcome: if result.is_ok() {
+                    Outcome::Ok
+                } else {
+                    Outcome::Failed
+                },
+            });
+            self.cursor_ns = elapsed_ns;
+        }
+        let failure = result.as_ref().err().map(classify_failure);
+        let handoffs = self
+            .stages
+            .windows(2)
+            .filter(|pair| pair[0].component != pair[1].component)
+            .map(|pair| ComponentHandoff {
+                from: pair[0].component,
+                to: pair[1].component,
+                kind: HandoffKind::Call,
+                duration_ns: 0,
+                wait_duration_ns: 0,
+                bytes: None,
+                records: None,
+            })
+            .collect();
+        let _ = self.runtime.record_job(JobSnapshot {
+            family: JobFamily::Clone,
+            enqueued_ns: 0,
+            started_ns: 0,
+            finished_ns: self.cursor_ns,
+            outcome: if result.is_ok() {
+                Outcome::Ok
+            } else {
+                Outcome::Failed
+            },
+            failure,
+            stages: self.stages,
+            handoffs,
+        });
+    }
+}
+
+fn classify_failure(error: &graphforge_api::GfError) -> Failure {
+    let rendered = error.to_string();
+    if rendered.contains("hub.network") {
+        Failure::Network
+    } else if rendered.contains("limit") {
+        Failure::ResourceLimit
+    } else {
+        match error {
+            graphforge_api::GfError::Storage(_) => Failure::Storage,
+            graphforge_api::GfError::Validation(_) => Failure::InvalidInput,
+            _ => Failure::Internal,
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -541,11 +699,12 @@ fn read_resume(checkpoint: &Path) -> Result<Option<ResumeState>, graphforge_api:
     }
 }
 
+#[allow(clippy::too_many_lines)]
 fn download(
     transport: &dyn Transport,
     object: &ObjectDescriptor,
     partial: &Path,
-) -> Result<u64, graphforge_api::GfError> {
+) -> Result<DownloadReport, graphforge_api::GfError> {
     let checkpoint = partial.with_extension("resume.json");
     if object.length > MAX_BUNDLE_BYTES {
         return Err(limit_error("portable bundle exceeds clone byte bound"));
@@ -581,7 +740,10 @@ fn download(
     if resumed > 0 && validator.is_none() {
         resumed = 0;
     }
+    let mut transferred = 0_u64;
+    let mut attempts = 0_u32;
     if resumed < object.length {
+        attempts = 1;
         let mut response = fetch(
             transport,
             &url,
@@ -620,6 +782,7 @@ fn download(
             copied = copied
                 .checked_add(read as u64)
                 .ok_or_else(|| limit_error("object exceeds byte bound"))?;
+            transferred = copied;
             if copied > object.length.saturating_sub(resumed) {
                 return Err(limit_error("object exceeds declared size"));
             }
@@ -642,7 +805,18 @@ fn download(
         let _ = std::fs::remove_file(&checkpoint);
         return Err(validation("hub.integrity", "download digest mismatch"));
     }
-    Ok(resumed)
+    Ok(DownloadReport {
+        resumed_bytes: resumed,
+        transferred_bytes: transferred,
+        attempts,
+    })
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct DownloadReport {
+    resumed_bytes: u64,
+    transferred_bytes: u64,
+    attempts: u32,
 }
 
 #[cfg(unix)]
@@ -707,69 +881,178 @@ pub(crate) fn run_clone(
     json: bool,
     output: &mut dyn Write,
 ) -> Result<(), graphforge_api::GfError> {
-    run_clone_with(&HttpTransport::new(), args, json, output)
+    let runtime = clone_telemetry_runtime(args.telemetry_endpoint.as_deref());
+    let result = run_clone_profiled(&HttpTransport::new(), args, json, output, &runtime);
+    let _ = runtime.shutdown();
+    result
 }
 
+fn clone_telemetry_runtime(endpoint: Option<&str>) -> TelemetryRuntime {
+    let Some(endpoint) = endpoint else {
+        return TelemetryRuntime::default();
+    };
+    TelemetryRuntime::new(TelemetryConfig {
+        mode: TelemetryMode::OtlpHttpJson,
+        otlp: Some(OtlpConfig {
+            endpoint: endpoint.to_owned(),
+            headers: BTreeMap::default(),
+        }),
+        ..TelemetryConfig::default()
+    })
+    .unwrap_or_default()
+}
+
+#[cfg(test)]
 fn run_clone_with(
     transport: &dyn Transport,
     args: CloneArgs,
     json: bool,
     output: &mut dyn Write,
 ) -> Result<(), graphforge_api::GfError> {
-    let (identity, base) = parse_input(&args.repository)?;
-    let destination = args
-        .destination
-        .unwrap_or_else(|| PathBuf::from(&identity.repository));
-    ensure_destination_absent(&destination)?;
-    let refs_bytes = read_bounded(
-        fetch(
-            transport,
-            &endpoint(&base, "refs"),
-            None,
-            None,
-            MAX_METADATA_BYTES as u64,
-        )?,
-        MAX_METADATA_BYTES,
+    run_clone_profiled(transport, args, json, output, &TelemetryRuntime::default())
+}
+
+fn run_clone_profiled(
+    transport: &dyn Transport,
+    args: CloneArgs,
+    json: bool,
+    output: &mut dyn Write,
+    runtime: &TelemetryRuntime,
+) -> Result<(), graphforge_api::GfError> {
+    let mut profile = CloneProfile::new(runtime);
+    let result = run_clone_job(transport, args, &mut profile)
+        .and_then(|result| write_clone_result(&result, json, output));
+    profile.finish(&result);
+    result
+}
+
+#[allow(clippy::too_many_lines)]
+fn run_clone_job(
+    transport: &dyn Transport,
+    args: CloneArgs,
+    profile: &mut CloneProfile<'_>,
+) -> Result<CloneResult, graphforge_api::GfError> {
+    let (identity, base, destination) = profile.stage(
+        Stage::IdentityValidation,
+        ComponentKind::Cli,
+        ComponentRole::Facade,
+        None,
+        1,
+        || {
+            let (identity, base) = parse_input(&args.repository)?;
+            let destination = args
+                .destination
+                .unwrap_or_else(|| PathBuf::from(&identity.repository));
+            ensure_destination_absent(&destination)?;
+            Ok(((identity, base, destination), None, None))
+        },
     )?;
-    let manifest_bytes = read_bounded(
-        fetch(
-            transport,
-            &endpoint(&base, "manifest"),
-            None,
-            None,
-            MAX_METADATA_BYTES as u64,
-        )?,
-        MAX_METADATA_BYTES,
+    let refs_bytes = profile.stage(
+        Stage::RefsDiscovery,
+        ComponentKind::Discovery,
+        ComponentRole::Transfer,
+        Some(WaitReason::Network),
+        1,
+        || {
+            let bytes = read_bounded(
+                fetch(
+                    transport,
+                    &endpoint(&base, "refs"),
+                    None,
+                    None,
+                    MAX_METADATA_BYTES as u64,
+                )?,
+                MAX_METADATA_BYTES,
+            )?;
+            let length = bytes.len() as u64;
+            Ok((bytes, Some(length), None))
+        },
+    )?;
+    let manifest_bytes = profile.stage(
+        Stage::ManifestDiscovery,
+        ComponentKind::Discovery,
+        ComponentRole::Transfer,
+        Some(WaitReason::Network),
+        1,
+        || {
+            let bytes = read_bounded(
+                fetch(
+                    transport,
+                    &endpoint(&base, "manifest"),
+                    None,
+                    None,
+                    MAX_METADATA_BYTES as u64,
+                )?,
+                MAX_METADATA_BYTES,
+            )?;
+            let length = bytes.len() as u64;
+            Ok((bytes, Some(length), None))
+        },
     )?;
     let limits = DiscoveryLimits {
         max_response_bytes: MAX_METADATA_BYTES,
         max_cumulative_object_bytes: MAX_BUNDLE_BYTES,
         ..DiscoveryLimits::default()
     };
-    let refs = RefSet::from_json(&refs_bytes, limits).map_err(|error| protocol_error(&error))?;
-    let manifest = DiscoveryManifest::from_json(&manifest_bytes, limits)
-        .map_err(|error| protocol_error(&error))?;
-    if refs.repository != identity || manifest.repository != identity {
-        return Err(validation("hub.integrity", "discovery repository mismatch"));
-    }
-    refs.validate_manifest(&manifest)
-        .map_err(|error| protocol_error(&error))?;
+    let (manifest, staging) = profile.stage(
+        Stage::ManifestDiscovery,
+        ComponentKind::Discovery,
+        ComponentRole::Verification,
+        None,
+        1,
+        || {
+            let refs =
+                RefSet::from_json(&refs_bytes, limits).map_err(|error| protocol_error(&error))?;
+            let manifest = DiscoveryManifest::from_json(&manifest_bytes, limits)
+                .map_err(|error| protocol_error(&error))?;
+            if refs.repository != identity || manifest.repository != identity {
+                return Err(validation("hub.integrity", "discovery repository mismatch"));
+            }
+            refs.validate_manifest(&manifest)
+                .map_err(|error| protocol_error(&error))?;
+            let staging = acquire_staging(&destination)?;
+            Ok(((manifest, staging), None, None))
+        },
+    )?;
     let object = select_bundle(&manifest)?;
-    let staging = acquire_staging(&destination)?;
     let partial = staging.partial.clone();
-    let resumed_bytes = download(transport, object, &partial)?;
+    let download = profile.stage(
+        Stage::Download,
+        ComponentKind::NetworkTransport,
+        ComponentRole::Transfer,
+        Some(WaitReason::Network),
+        1,
+        || {
+            let report = download(transport, object, &partial)?;
+            Ok((report, Some(report.transferred_bytes), None))
+        },
+    )?;
+    if let Some(stage) = profile.stages.last_mut() {
+        stage.attempt = download.attempts.max(1);
+        stage.resumed_bytes = Some(download.resumed_bytes);
+    }
     let portable_limits = PortableV2Limits::default();
-    let verified = verify_discovered_portable_v2(&DiscoveryPortableV2Request {
-        manifest_json: &manifest_bytes,
-        refs_json: &refs_bytes,
-        expected_repository: &identity,
-        package: &partial,
-        discovery_limits: limits,
-        portable_limits,
-        mode: PortableV2Mode::Full,
-        cancelled: None,
-    })
-    .map_err(portable_error)?;
+    let verified = profile.stage(
+        Stage::PortableVerification,
+        ComponentKind::PortableVerify,
+        ComponentRole::Verification,
+        None,
+        1,
+        || {
+            verify_discovered_portable_v2(&DiscoveryPortableV2Request {
+                manifest_json: &manifest_bytes,
+                refs_json: &refs_bytes,
+                expected_repository: &identity,
+                package: &partial,
+                discovery_limits: limits,
+                portable_limits,
+                mode: PortableV2Mode::Full,
+                cancelled: None,
+            })
+            .map_err(portable_error)
+            .map(|verified| (verified, Some(object.length), None))
+        },
+    )?;
     let operation_id = OperationId(uuid::Uuid::new_v5(
         &uuid::Uuid::NAMESPACE_URL,
         format!(
@@ -779,30 +1062,70 @@ fn run_clone_with(
         )
         .as_bytes(),
     ));
-    let imported = GraphForge::import_portable_v2(
-        &destination,
-        &PortableV2ImportRequest {
-            input: partial.clone(),
-            operation_id,
-            limits: portable_limits,
-        },
+    let imported = profile.stage(
+        Stage::AtomicImport,
+        ComponentKind::PortableImport,
+        ComponentRole::Persistence,
         None,
-    )
-    .map_err(|_| validation("hub.integrity", "portable project import failed"))?;
+        1,
+        || {
+            GraphForge::import_portable_v2(
+                &destination,
+                &PortableV2ImportRequest {
+                    input: partial.clone(),
+                    operation_id,
+                    limits: portable_limits,
+                },
+                None,
+            )
+            .map_err(|_| validation("hub.integrity", "portable project import failed"))
+            .map(|imported| (imported, Some(object.length), None))
+        },
+    )?;
+    profile.stage(
+        Stage::Reopen,
+        ComponentKind::Recovery,
+        ComponentRole::Verification,
+        None,
+        1,
+        || {
+            let destination = destination.to_str().ok_or_else(|| {
+                validation("hub.destination_conflict", "destination must be UTF-8")
+            })?;
+            GraphForge::new(Some(destination)).map(|graph| (graph, None, None))
+        },
+    )?;
     let staging_root = staging.root.clone();
     drop(staging);
     // The destination is already atomically published; cleanup cannot turn
     // success into a reported failure.
-    let _ = std::fs::remove_dir_all(staging_root);
-    let result = CloneResult {
+    profile.stage(
+        Stage::Cleanup,
+        ComponentKind::Storage,
+        ComponentRole::Persistence,
+        None,
+        1,
+        || {
+            let _ = std::fs::remove_dir_all(staging_root);
+            Ok(((), None, None))
+        },
+    )?;
+    Ok(CloneResult {
         contract: "graphforge-hub-clone/1",
         repository: canonical_name(&identity),
         destination: destination.display().to_string(),
         immutable_version: verified.immutable_version,
         package_digest: imported.package_digest,
         generation_uuid: imported.generation_uuid.to_string(),
-        resumed_bytes,
-    };
+        resumed_bytes: download.resumed_bytes,
+    })
+}
+
+fn write_clone_result(
+    result: &CloneResult,
+    json: bool,
+    output: &mut dyn Write,
+) -> Result<(), graphforge_api::GfError> {
     if json {
         serde_json::to_writer(&mut *output, &result)
             .map_err(|e| graphforge_api::GfError::Execution(e.to_string()))?;
@@ -1039,9 +1362,8 @@ mod tests {
         redirect.location = Some("https://127.0.0.1/private".into());
         let transport = Scripted::new(vec![redirect, response(200, None, b"secret")]);
         let start = Url::parse("https://hub.example/repository/.gf/manifest").unwrap();
-        let error = match fetch(&transport, &start, None, None, 1024) {
-            Ok(_) => panic!("private redirect unexpectedly succeeded"),
-            Err(error) => error,
+        let Err(error) = fetch(&transport, &start, None, None, 1024) else {
+            panic!("private redirect unexpectedly succeeded");
         };
         assert!(error.to_string().contains("hub.unsafe_location"));
         assert_eq!(
@@ -1062,7 +1384,14 @@ mod tests {
         assert!(error.to_string().contains("hub.interrupted"));
         let range = format!("bytes 8-{}/{}", bytes.len() - 1, bytes.len());
         let second = Scripted::new(vec![response(206, Some(&range), &bytes[8..])]);
-        assert_eq!(download(&second, &descriptor, &destination).unwrap(), 8);
+        assert_eq!(
+            download(&second, &descriptor, &destination).unwrap(),
+            DownloadReport {
+                resumed_bytes: 8,
+                transferred_bytes: (bytes.len() - 8) as u64,
+                attempts: 1,
+            }
+        );
     }
 
     #[test]
@@ -1074,7 +1403,14 @@ mod tests {
         std::fs::write(&partial, &bytes[..8]).unwrap();
         std::fs::write(partial.with_extension("resume.json"), b"{torn").unwrap();
         let transport = Scripted::new(vec![response(200, None, bytes)]);
-        assert_eq!(download(&transport, &descriptor, &partial).unwrap(), 0);
+        assert_eq!(
+            download(&transport, &descriptor, &partial).unwrap(),
+            DownloadReport {
+                resumed_bytes: 0,
+                transferred_bytes: bytes.len() as u64,
+                attempts: 1,
+            }
+        );
         assert_eq!(std::fs::read(partial).unwrap(), bytes);
     }
 
@@ -1151,7 +1487,14 @@ mod tests {
         let destination = root.path().join("project");
         let transport = LoopbackTransport::new();
         assert!(download(&transport, &descriptor, &destination).is_err());
-        assert_eq!(download(&transport, &descriptor, &destination).unwrap(), 8);
+        assert_eq!(
+            download(&transport, &descriptor, &destination).unwrap(),
+            DownloadReport {
+                resumed_bytes: 8,
+                transferred_bytes: (bytes.len() - 8) as u64,
+                attempts: 1,
+            }
+        );
         server.join().unwrap();
     }
 
@@ -1200,6 +1543,7 @@ mod tests {
             CloneArgs {
                 repository: "openalex/openalex".into(),
                 destination: Some(destination),
+                telemetry_endpoint: None,
             },
             false,
             &mut Vec::new(),
@@ -1289,6 +1633,7 @@ mod tests {
             CloneArgs {
                 repository: "openalex/openalex".into(),
                 destination: Some(root.path().join("project")),
+                telemetry_endpoint: None,
             },
             true,
             &mut Vec::new(),
@@ -1331,6 +1676,154 @@ mod tests {
         ])
     }
 
+    fn delayed_profile(download_delay: Duration, verify_delay: Duration) -> JobSnapshot {
+        let runtime = TelemetryRuntime::new(TelemetryConfig {
+            mode: TelemetryMode::InMemory,
+            ..TelemetryConfig::default()
+        })
+        .unwrap();
+        let mut profile = CloneProfile::new(&runtime);
+        profile
+            .stage(
+                Stage::Download,
+                ComponentKind::NetworkTransport,
+                ComponentRole::Transfer,
+                Some(WaitReason::Network),
+                1,
+                || {
+                    std::thread::sleep(download_delay);
+                    Ok(((), Some(64), None))
+                },
+            )
+            .unwrap();
+        profile
+            .stage(
+                Stage::PortableVerification,
+                ComponentKind::PortableVerify,
+                ComponentRole::Verification,
+                None,
+                1,
+                || {
+                    std::thread::sleep(verify_delay);
+                    Ok(((), Some(64), None))
+                },
+            )
+            .unwrap();
+        profile.finish(&Ok(()));
+        assert_eq!(
+            runtime.force_flush(),
+            graphforge_api::telemetry::LifecycleStatus::Complete
+        );
+        runtime.snapshots().remove(0).job.unwrap()
+    }
+
+    #[test]
+    fn delayed_fixtures_attribute_the_dominant_clone_component() {
+        let slow_download = delayed_profile(Duration::from_millis(15), Duration::from_millis(1));
+        let download_ns = slow_download
+            .stages
+            .iter()
+            .find(|stage| stage.stage == Stage::Download)
+            .unwrap()
+            .duration_ns;
+        let verify_ns = slow_download
+            .stages
+            .iter()
+            .find(|stage| stage.stage == Stage::PortableVerification)
+            .unwrap()
+            .duration_ns;
+        assert!(download_ns > verify_ns);
+        let slow_verify = delayed_profile(Duration::from_millis(1), Duration::from_millis(15));
+        let download_ns = slow_verify
+            .stages
+            .iter()
+            .find(|stage| stage.stage == Stage::Download)
+            .unwrap()
+            .duration_ns;
+        let verify_ns = slow_verify
+            .stages
+            .iter()
+            .find(|stage| stage.stage == Stage::PortableVerification)
+            .unwrap()
+            .duration_ns;
+        assert!(verify_ns > download_ns);
+        assert!(slow_download.handoffs.iter().any(|handoff| {
+            handoff.from == ComponentKind::NetworkTransport && handoff.to == ComponentKind::Cli
+        }));
+    }
+
+    #[test]
+    fn disabled_and_failed_exporters_do_not_change_clone_stage_results() {
+        let execute = |runtime: &TelemetryRuntime| {
+            let mut profile = CloneProfile::new(runtime);
+            let value = profile
+                .stage(
+                    Stage::IdentityValidation,
+                    ComponentKind::Cli,
+                    ComponentRole::Facade,
+                    None,
+                    1,
+                    || Ok((42_u8, None, None)),
+                )
+                .unwrap();
+            profile.finish(&Ok(()));
+            value
+        };
+        let disabled = TelemetryRuntime::default();
+        let failed = TelemetryRuntime::new(TelemetryConfig {
+            mode: TelemetryMode::OtlpHttpJson,
+            export_timeout: Duration::from_millis(5),
+            lifecycle_timeout: Duration::from_millis(20),
+            max_retries: 0,
+            otlp: Some(OtlpConfig {
+                endpoint: "http://127.0.0.1:1/".into(),
+                headers: BTreeMap::default(),
+            }),
+            ..TelemetryConfig::default()
+        })
+        .unwrap();
+        assert_eq!(execute(&disabled), execute(&failed));
+        assert!(matches!(
+            failed.force_flush(),
+            graphforge_api::telemetry::LifecycleStatus::ExportFailed
+                | graphforge_api::telemetry::LifecycleStatus::TimedOut
+        ));
+    }
+
+    #[test]
+    fn invalid_clone_emits_one_normalized_terminal_without_identity() {
+        let runtime = TelemetryRuntime::new(TelemetryConfig {
+            mode: TelemetryMode::InMemory,
+            ..TelemetryConfig::default()
+        })
+        .unwrap();
+        let canary = "not/a/valid/repository-secret-canary";
+        let error = run_clone_profiled(
+            &Scripted::new(vec![]),
+            CloneArgs {
+                repository: canary.into(),
+                destination: None,
+                telemetry_endpoint: None,
+            },
+            true,
+            &mut Vec::new(),
+            &runtime,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("hub.invalid_identity"));
+        assert_eq!(
+            runtime.force_flush(),
+            graphforge_api::telemetry::LifecycleStatus::Complete
+        );
+        let snapshots = runtime.snapshots();
+        assert_eq!(snapshots.len(), 1);
+        let job = snapshots[0].job.as_ref().unwrap();
+        assert_eq!(job.outcome, Outcome::Failed);
+        assert_eq!(job.failure, Some(Failure::InvalidInput));
+        assert_eq!(job.stages[0].stage, Stage::IdentityValidation);
+        assert!(!serde_json::to_string(&snapshots).unwrap().contains(canary));
+    }
+
     #[test]
     fn both_identity_forms_import_and_reopen_the_same_real_project() {
         let root = tempfile::tempdir().unwrap();
@@ -1359,29 +1852,85 @@ mod tests {
         )
         .unwrap();
 
+        let mut fail_open_results = Vec::new();
+        let mut fail_open_elapsed = Vec::new();
         for (index, input) in [
             "openalex/openalex",
             "https://graphforge.sh/openalex/openalex",
+            "openalex/openalex",
+            "openalex/openalex",
         ]
         .into_iter()
         .enumerate()
         {
             let destination = root.path().join(format!("clone-{index}"));
             let mut output = Vec::new();
-            run_clone_with(
+            let runtime = match index {
+                2 => TelemetryRuntime::default(),
+                3 => TelemetryRuntime::new(TelemetryConfig {
+                    mode: TelemetryMode::OtlpHttpJson,
+                    export_timeout: Duration::from_millis(5),
+                    lifecycle_timeout: Duration::from_millis(20),
+                    max_retries: 0,
+                    otlp: Some(OtlpConfig {
+                        endpoint: "http://127.0.0.1:1/".into(),
+                        headers: BTreeMap::default(),
+                    }),
+                    ..TelemetryConfig::default()
+                })
+                .unwrap(),
+                _ => TelemetryRuntime::new(TelemetryConfig {
+                    mode: TelemetryMode::InMemory,
+                    ..TelemetryConfig::default()
+                })
+                .unwrap(),
+            };
+            let clone_started = Instant::now();
+            run_clone_profiled(
                 &clone_script(&bundle, &report.package_digest),
                 CloneArgs {
                     repository: input.into(),
                     destination: Some(destination.clone()),
+                    telemetry_endpoint: None,
                 },
                 true,
                 &mut output,
+                &runtime,
             )
             .unwrap();
-            let result: serde_json::Value = serde_json::from_slice(&output).unwrap();
+            let clone_elapsed = clone_started.elapsed();
+            let lifecycle = runtime.force_flush();
+            if index < 2 {
+                assert_eq!(
+                    lifecycle,
+                    graphforge_api::telemetry::LifecycleStatus::Complete
+                );
+            }
+            let snapshots = runtime.snapshots();
+            if index < 2 {
+                assert_eq!(snapshots.len(), 1);
+                let job = snapshots[0].job.as_ref().unwrap();
+                assert_eq!(job.family, JobFamily::Clone);
+                assert_eq!(job.outcome, Outcome::Ok);
+                assert_eq!(job.stages.first().unwrap().stage, Stage::IdentityValidation);
+                assert!(job.stages.iter().any(|stage| stage.stage == Stage::Cleanup));
+                assert!(job.stages.iter().any(|stage| stage.stage == Stage::Reopen));
+            }
+            let serialized = serde_json::to_string(&snapshots).unwrap();
+            for canary in [input, destination.to_str().unwrap(), &report.package_digest] {
+                assert!(!serialized.contains(canary));
+            }
+            let mut result: serde_json::Value = serde_json::from_slice(&output).unwrap();
             assert_eq!(result["contract"], "graphforge-hub-clone/1");
             assert_eq!(result["package_digest"], report.package_digest);
             GraphForge::new(destination.to_str()).expect("cloned project reopens through facade");
+            if index >= 2 {
+                result.as_object_mut().unwrap().remove("destination");
+                fail_open_results.push(result);
+                fail_open_elapsed.push(clone_elapsed);
+            }
         }
+        assert_eq!(fail_open_results[0], fail_open_results[1]);
+        assert!(fail_open_elapsed[1] <= fail_open_elapsed[0] + Duration::from_secs(1));
     }
 }

--- a/crates/graphforge-cli/src/hub_clone.rs
+++ b/crates/graphforge-cli/src/hub_clone.rs
@@ -213,8 +213,8 @@ fn classify_failure(error: &graphforge_api::GfError) -> Failure {
         | "hub.interrupted"
         | "hub.package.cancelled"
         | "hub.package.unsupported_future"
-        | "hub.package.incompatible" => Failure::InvalidInput,
-        "hub.integrity"
+        | "hub.package.incompatible"
+        | "hub.integrity"
         | "hub.integrity_failure"
         | "hub.package.repository_mismatch"
         | "hub.package.immutable_version_mismatch"
@@ -425,6 +425,7 @@ fn validate_url(url: &Url) -> Result<(), graphforge_api::GfError> {
     Ok(())
 }
 
+#[cfg(test)]
 fn fetch(
     transport: &dyn Transport,
     start: &Url,
@@ -1440,7 +1441,11 @@ mod tests {
             if_range: Option<&str>,
             limit: u64,
         ) -> Result<HttpResponse, graphforge_api::GfError> {
-            let delay = if url.path().contains("/.gf/objects/") || url.path().ends_with(".gfpb") {
+            let delay = if url.path().contains("/.gf/objects/")
+                || std::path::Path::new(url.path())
+                    .extension()
+                    .is_some_and(|extension| extension.eq_ignore_ascii_case("gfpb"))
+            {
                 self.download
             } else {
                 self.discovery
@@ -2047,6 +2052,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn both_identity_forms_import_and_reopen_the_same_real_project() {
         let root = tempfile::tempdir().unwrap();
         let source = root.path().join("source");
@@ -2159,14 +2165,14 @@ mod tests {
             .unwrap();
             let clone_elapsed = clone_started.elapsed();
             let lifecycle = runtime.force_flush();
-            if index < 2 || index >= 4 {
+            if !(2..4).contains(&index) {
                 assert_eq!(
                     lifecycle,
                     graphforge_api::telemetry::LifecycleStatus::Complete
                 );
             }
             let snapshots = runtime.snapshots();
-            if index < 2 || index >= 4 {
+            if !(2..4).contains(&index) {
                 assert_eq!(snapshots.len(), 1);
                 let job = snapshots[0].job.as_ref().unwrap();
                 assert_eq!(job.family, JobFamily::Clone);

--- a/crates/graphforge-cli/tests/multi_ontology.rs
+++ b/crates/graphforge-cli/tests/multi_ontology.rs
@@ -1351,7 +1351,7 @@ fn observed_cli_parity_report() -> Value {
             "cancellation":{"error_code":cancelled_json["error"]["code"],"before_modules":parse_json(&cancel_before.stdout),"after_modules":parse_json(&cancel_after.stdout)},
             "idempotent_replay":{"first_receipt":parse_json(&first.stdout),"replay_receipt":parse_json(&replay.stdout),"conflict_code":conflict_json["error"]["code"]},
             "no_partial_import_or_authority_change":{"before_entries":target_before,"after_entries":target_after,"authority_before":authority_before,"authority_after":authority_after},
-            "bounded_structured_diagnostics":{"outer_code":blocked_json["error"]["code"],"diagnostic_code":blocked_diagnostic["code"],"bounded":blocked_json["error"]["diagnostics"].as_array().unwrap().len() <= blocked_diagnostic["limit"].as_u64().unwrap() as usize,"path_free":!blocked_text.contains(&project.path().display().to_string())},
+            "bounded_structured_diagnostics":{"outer_code":blocked_json["error"]["code"],"diagnostic_code":blocked_diagnostic["code"],"bounded":u64::try_from(blocked_json["error"]["diagnostics"].as_array().unwrap().len()).unwrap() <= blocked_diagnostic["limit"].as_u64().unwrap(),"path_free":!blocked_text.contains(&project.path().display().to_string())},
             "deterministic_path_free_cli_json":{"first_serialized":String::from_utf8(listed.stdout).unwrap(),"second_serialized":String::from_utf8(listed_again.stdout).unwrap(),"forbidden_path":project.path().display().to_string()},
             "packaged_clean_install":{"package_origin":env!("CARGO_BIN_EXE_gf"),"operation":"ontology_modules","module_count":packaged_modules.as_array().unwrap().len()}
         }

--- a/crates/graphforge-observability/src/lib.rs
+++ b/crates/graphforge-observability/src/lib.rs
@@ -377,7 +377,11 @@ impl JobSnapshot {
             handoff.from == handoff.to
                 || handoff.start_offset_ns > active
                 || handoff.wait_duration_ns > handoff.duration_ns
-        }) {
+        }) || self
+            .handoffs
+            .windows(2)
+            .any(|pair| pair[0].start_offset_ns > pair[1].start_offset_ns)
+        {
             return Err(InvalidJobSnapshot);
         }
         Ok(())
@@ -1447,6 +1451,11 @@ mod tests {
             }],
         };
         job.validate().unwrap();
+        let mut reversed = job.clone();
+        let mut earlier = reversed.handoffs[0];
+        earlier.start_offset_ns = 60;
+        reversed.handoffs.push(earlier);
+        assert_eq!(reversed.validate(), Err(InvalidJobSnapshot));
         assert_eq!(
             job.queue_delay_ns() + job.active_duration_ns(),
             job.total_duration_ns()

--- a/crates/graphforge-observability/src/lib.rs
+++ b/crates/graphforge-observability/src/lib.rs
@@ -238,7 +238,11 @@ semantic_enum!(Operation {
 });
 semantic_enum!(Stage {
     Parse => "parse", Bind => "bind", Plan => "plan", Execute => "execute",
-    Commit => "commit", Transfer => "transfer", Recover => "recover"
+    Commit => "commit", Transfer => "transfer", Recover => "recover",
+    IdentityValidation => "identity_validation", RefsDiscovery => "refs_discovery",
+    ManifestDiscovery => "manifest_discovery", Download => "download",
+    PortableVerification => "portable_verification", AtomicImport => "atomic_import",
+    Reopen => "reopen", Cleanup => "cleanup", Orchestration => "orchestration"
 });
 semantic_enum!(Outcome { Ok => "ok", Denied => "denied", Cancelled => "cancelled", Failed => "failed" });
 semantic_enum!(Failure {
@@ -290,6 +294,8 @@ pub struct JobStage {
     pub attempt: u32,
     /// Exact byte count, when the operation already knows it.
     pub bytes: Option<u64>,
+    /// Bytes already present before this attempt, when the operation knows it.
+    pub resumed_bytes: Option<u64>,
     /// Exact record count, when the operation already knows it.
     pub records: Option<u64>,
     /// Normalized stage outcome.
@@ -328,6 +334,8 @@ pub struct JobSnapshot {
     pub finished_ns: u64,
     /// Normalized job outcome.
     pub outcome: Outcome,
+    /// Normalized failure class; raw provider or engine errors are never retained.
+    pub failure: Option<Failure>,
     /// Non-overlapping active intervals in chronological order.
     pub stages: Vec<JobStage>,
     /// Ordered component transfers actually observed.
@@ -1004,6 +1012,9 @@ fn trace_spans(record: &Snapshot, sequence: u64, index: usize, exported_at: u128
         otel_int("graphforge.job.stage_count", job.stages.len() as u64),
         otel_int("graphforge.job.handoff_count", job.handoffs.len() as u64),
     ];
+    if let Some(failure) = job.failure {
+        root_attributes.push(otel_string("graphforge.failure", failure.as_str()));
+    }
     root_attributes.extend(otel_attributes(record.attributes));
     let events = job
         .handoffs
@@ -1055,6 +1066,11 @@ fn trace_spans(record: &Snapshot, sequence: u64, index: usize, exported_at: u128
             attributes.push(otel_string("graphforge.stage.wait_reason", reason.as_str()));
         }
         push_optional_int(&mut attributes, "graphforge.stage.bytes", stage.bytes);
+        push_optional_int(
+            &mut attributes,
+            "graphforge.stage.resumed_bytes",
+            stage.resumed_bytes,
+        );
         push_optional_int(&mut attributes, "graphforge.stage.records", stage.records);
         json!({
             "traceId": trace_id,
@@ -1384,6 +1400,7 @@ mod tests {
             started_ns: 125,
             finished_ns: 225,
             outcome: Outcome::Ok,
+            failure: None,
             stages: vec![
                 JobStage {
                     stage: Stage::Transfer,
@@ -1395,6 +1412,7 @@ mod tests {
                     wait_reason: Some(WaitReason::Network),
                     attempt: 2,
                     bytes: Some(4096),
+                    resumed_bytes: Some(1024),
                     records: None,
                     outcome: Outcome::Ok,
                 },
@@ -1408,6 +1426,7 @@ mod tests {
                     wait_reason: None,
                     attempt: 1,
                     bytes: Some(4096),
+                    resumed_bytes: None,
                     records: Some(8),
                     outcome: Outcome::Ok,
                 },
@@ -1453,6 +1472,7 @@ mod tests {
             wait_reason: None,
             attempt: 1,
             bytes: None,
+            resumed_bytes: None,
             records: None,
             outcome: Outcome::Ok,
         };
@@ -1462,6 +1482,7 @@ mod tests {
             started_ns: 10,
             finished_ns: 50,
             outcome: Outcome::Ok,
+            failure: None,
             stages: vec![stage(ComponentKind::Executor, ComponentRole::Compute, 40)],
             handoffs: vec![],
         };
@@ -1471,6 +1492,7 @@ mod tests {
             started_ns: 10,
             finished_ns: 100,
             outcome: Outcome::Ok,
+            failure: None,
             stages: vec![stage(
                 ComponentKind::Publication,
                 ComponentRole::Persistence,
@@ -1496,6 +1518,7 @@ mod tests {
             started_ns: 0,
             finished_ns: 10,
             outcome: Outcome::Ok,
+            failure: None,
             stages: vec![JobStage {
                 stage: Stage::Execute,
                 component: ComponentKind::Executor,
@@ -1506,6 +1529,7 @@ mod tests {
                 wait_reason: None,
                 attempt: 1,
                 bytes: None,
+                resumed_bytes: None,
                 records: None,
                 outcome: Outcome::Ok,
             }],
@@ -1528,6 +1552,7 @@ mod tests {
                 started_ns: 20,
                 finished_ns: 70,
                 outcome: Outcome::Ok,
+                failure: None,
                 stages: vec![JobStage {
                     stage: Stage::Transfer,
                     component: ComponentKind::NetworkTransport,
@@ -1538,6 +1563,7 @@ mod tests {
                     wait_reason: Some(WaitReason::Network),
                     attempt: 1,
                     bytes: Some(128),
+                    resumed_bytes: Some(64),
                     records: Some(2),
                     outcome: Outcome::Ok,
                 }],
@@ -1558,6 +1584,11 @@ mod tests {
             .as_array()
             .unwrap();
         assert_eq!(spans.len(), 2);
+        let stage_attributes = spans[1]["attributes"].as_array().unwrap();
+        assert!(stage_attributes.iter().any(|attribute| {
+            attribute["key"] == "graphforge.stage.resumed_bytes"
+                && attribute["value"]["intValue"] == "64"
+        }));
         assert_eq!(spans[0]["traceId"].as_str().unwrap().len(), 32);
         assert_eq!(spans[0]["spanId"].as_str().unwrap().len(), 16);
         assert_eq!(spans[1]["spanId"].as_str().unwrap().len(), 16);

--- a/crates/graphforge-observability/src/lib.rs
+++ b/crates/graphforge-observability/src/lib.rs
@@ -305,6 +305,8 @@ pub struct JobStage {
 /// One ordered handoff between components actually used by a job.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 pub struct ComponentHandoff {
+    /// Offset from job start where the boundary was observed.
+    pub start_offset_ns: u64,
     /// Calling component.
     pub from: ComponentKind,
     /// Receiving component.
@@ -372,7 +374,9 @@ impl JobSnapshot {
             return Err(InvalidJobSnapshot);
         }
         if self.handoffs.iter().any(|handoff| {
-            handoff.from == handoff.to || handoff.wait_duration_ns > handoff.duration_ns
+            handoff.from == handoff.to
+                || handoff.start_offset_ns > active
+                || handoff.wait_duration_ns > handoff.duration_ns
         }) {
             return Err(InvalidJobSnapshot);
         }
@@ -1031,7 +1035,7 @@ fn trace_spans(record: &Snapshot, sequence: u64, index: usize, exported_at: u128
             ];
             push_optional_int(&mut attributes, "graphforge.handoff.bytes", handoff.bytes);
             push_optional_int(&mut attributes, "graphforge.handoff.records", handoff.records);
-            json!({"timeUnixNano":active_start.to_string(),"name":"graphforge.component.handoff","attributes":attributes})
+            json!({"timeUnixNano":(active_start + u128::from(handoff.start_offset_ns)).to_string(),"name":"graphforge.component.handoff","attributes":attributes})
         })
         .collect::<Vec<_>>();
     let mut spans = vec![json!({
@@ -1432,6 +1436,7 @@ mod tests {
                 },
             ],
             handoffs: vec![ComponentHandoff {
+                start_offset_ns: 70,
                 from: ComponentKind::NetworkTransport,
                 to: ComponentKind::Storage,
                 kind: HandoffKind::Write,
@@ -1568,6 +1573,7 @@ mod tests {
                     outcome: Outcome::Ok,
                 }],
                 handoffs: vec![ComponentHandoff {
+                    start_offset_ns: 50,
                     from: ComponentKind::NetworkTransport,
                     to: ComponentKind::Storage,
                     kind: HandoffKind::Write,

--- a/docs/engineering/TELEMETRY.md
+++ b/docs/engineering/TELEMETRY.md
@@ -97,3 +97,24 @@ duration, then read the ordered stage and handoff list. The largest stage owns
 the attributable wall time; its wait reason distinguishes blocked time from
 compute. Usage accounting, automatic activation, hosted collection, billing,
 and dashboards are deliberately outside this foundation.
+
+### Hub clone
+
+`gf clone OWNER/REPOSITORY --telemetry-endpoint http://127.0.0.1:4318/`
+emits one `clone` job to an explicitly selected local collector. Without that
+flag clone remains telemetry-disabled. Read the ordered finite stages from
+identity validation through refs/manifest discovery, download, portable
+verification, atomic import, reopen, and cleanup. Network-backed discovery and
+download stages report network wait; `bytes` on download means bytes newly
+received in this run. The separate `resumed_bytes` stage attribute means prior
+partial state and is never added to current transferred bytes. Finite
+`orchestration` intervals account for local time between named operations;
+formatting the already-completed result and bounded exporter shutdown are
+outside the workspace job.
+
+Compare stage durations to locate the bottleneck: a delayed object response is
+owned by `network_transport`/`download`, while CPU or storage verification is
+owned by `portable_verify`/`portable_verification`. Component handoffs include
+only components actually reached. Failed clones end once with `failed` plus a
+finite failure class; raw `hub.*` text and repository, endpoint, destination,
+manifest, digest, UUID, and graph content never enter telemetry.

--- a/docs/engineering/TELEMETRY.md
+++ b/docs/engineering/TELEMETRY.md
@@ -115,6 +115,7 @@ outside the workspace job.
 Compare stage durations to locate the bottleneck: a delayed object response is
 owned by `network_transport`/`download`, while CPU or storage verification is
 owned by `portable_verify`/`portable_verification`. Component handoffs include
-only components actually reached. Failed clones end once with `failed` plus a
+only boundaries actually reached, carry their monotonic job offset, and attach
+byte counts only where a known payload crosses the boundary. Failed clones end once with `failed` plus a
 finite failure class; raw `hub.*` text and repository, endpoint, destination,
 manifest, digest, UUID, and graph content never enter telemetry.


### PR DESCRIPTION
## Summary
- profile Hub clone as one finite, gap-free local workspace job using the Rust-owned telemetry runtime
- report normalized outcomes, component handoffs, attempts, and distinct transferred versus resumed bytes without identity leakage
- keep telemetry disabled by default and fail open across invalid/unavailable exporters with bounded lifecycle handling
- document explicit local OTLP enablement and clone-stage interpretation

## Validation
- `cargo test -p graphforge-cli --lib hub_clone::tests::` (19 passed)
- `cargo test -p graphforge-observability --lib` (13 passed)
- `cargo clippy -p graphforge-observability -p graphforge-cli --lib --bins -- -D warnings`
- `bazel test //crates/graphforge-observability:all //crates/graphforge-cli:graphforge_cli_test` (3 passed)
- `git diff --check`

Full `--all-targets` clippy also reached the existing `cast_possible_truncation` finding in `crates/graphforge-cli/tests/multi_ontology.rs:1354`; the changed lib/bin targets are clean.

Closes #922

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790107506&installation_model_id=20486&pr_number=928&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F928&signature=027886b66d71b086e377c2e07abab8e6d73cddeaa197aa3c81bda4c1d44b455d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->