### PR TITLE
feat(storage): publish compact authenticated graph roots

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -952,6 +952,12 @@ jobs:
           cargo test -p graphforge-storage --lib \
             graph_object_store::tests::read_only_lifecycle_rejects_multiple_links \
             -- --exact --nocapture
+          cargo test -p graphforge-storage --lib \
+            graph_object_store::tests::returned_errors_release_every_cas_lock_and_pending_lease_boundary \
+            -- --exact --nocapture
+          cargo test -p graphforge-storage --lib \
+            graph_object_store::tests::publication_and_gc_lifecycles_are_mutually_exclusive \
+            -- --exact --nocapture
 
       - name: Cross-check Windows publication-kill results against the fault oracle
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -940,6 +940,19 @@ jobs:
           cargo test -p graphforge-storage
           filesystem_admission::tests:: --lib --no-fail-fast
 
+      - name: Run Windows read-only CAS lock tests
+        shell: bash
+        run: |
+          cargo test -p graphforge-storage --lib \
+            graph_object_store::tests::pure_reads_require_only_existing_digest_namespace_and_never_create \
+            -- --exact --nocapture
+          cargo test -p graphforge-storage --lib \
+            graph_object_store::tests::read_only_guard_pins_cas_against_gc \
+            -- --exact --nocapture
+          cargo test -p graphforge-storage --lib \
+            graph_object_store::tests::read_only_lifecycle_rejects_multiple_links \
+            -- --exact --nocapture
+
       - name: Cross-check Windows publication-kill results against the fault oracle
         shell: bash
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2310,6 +2310,7 @@ dependencies = [
 name = "graphforge-filesystem"
 version = "0.5.2"
 dependencies = [
+ "fs4 1.1.0",
  "rustix 1.1.4",
  "tempfile",
  "windows-sys 0.61.2",

--- a/crates/graphforge-api/Cargo.toml
+++ b/crates/graphforge-api/Cargo.toml
@@ -38,7 +38,7 @@ uuid = { workspace = true }
 cucumber = { workspace = true }
 tokio = { workspace = true }
 graphforge-cypher = { path = "../graphforge-cypher" }
-graphforge-storage = { path = "../graphforge-storage", features = ["test-failpoints"] }
+graphforge-storage = { path = "../graphforge-storage", features = ["test-failpoints", "test-support"] }
 
 # BDD runner for the public-API + TCK feature files (tests/features/).
 # A custom-harness target (cucumber drives its own main).

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -3761,13 +3761,12 @@ fn hydrate_graph_workspace(
     }
 
     if let Some(files) = files {
-        if files.capability_version != graphforge_storage::GRAPH_CAPABILITY_VERSION
-            || files.record_version != graphforge_storage::GRAPH_FILES_RECORD_VERSION
-            || files.encoding != "json"
-        {
-            return Err(GfError::Validation(
-                "unsupported graph files participant contract".into(),
-            ));
+        validate_graph_files_snapshot(&files)?;
+        if files.record_version == graphforge_storage::GRAPH_FILES_V2_RECORD_VERSION {
+            let inventory = generation
+                .graph_files_inventory()?
+                .ok_or_else(|| GfError::Validation("compact graph root disappeared".into()))?;
+            return hydrate_compact_graph_workspace(generation, &inventory);
         }
         let inventory = graphforge_storage::decode_inventory(&files.bytes)?;
         let tree = generation.graph_tree_root();
@@ -3853,6 +3852,100 @@ fn hydrate_graph_workspace(
     Ok((workspace.path().to_path_buf(), workspace, evidence))
 }
 
+fn validate_graph_files_snapshot(
+    files: &graphforge_storage::ProjectParticipantSnapshot,
+) -> Result<(), GfError> {
+    if files.capability_version != graphforge_storage::GRAPH_CAPABILITY_VERSION
+        || !matches!(
+            files.record_version,
+            graphforge_storage::GRAPH_FILES_RECORD_VERSION
+                | graphforge_storage::GRAPH_FILES_V2_RECORD_VERSION
+        )
+        || files.encoding != "json"
+    {
+        return Err(GfError::Validation(
+            "unsupported graph files participant contract".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn hydrate_compact_graph_workspace(
+    generation: &ResolvedProjectGeneration,
+    inventory: &graphforge_storage::GraphFilesInventory,
+) -> Result<
+    (
+        PathBuf,
+        Arc<tempfile::TempDir>,
+        graphforge_storage::GraphFilesOpenEvidence,
+    ),
+    GfError,
+> {
+    let workspace = Arc::new(
+        tempfile::Builder::new()
+            .prefix("graphforge-graph-workspace-")
+            .tempdir()
+            .map_err(|error| {
+                GfError::Storage(format!("failed to create graph workspace: {error}"))
+            })?,
+    );
+    let evidence = materialize_compact_graph_target(generation, inventory, workspace.path())?;
+    Ok((workspace.path().to_path_buf(), workspace, evidence))
+}
+
+fn materialize_compact_graph_target(
+    generation: &ResolvedProjectGeneration,
+    inventory: &graphforge_storage::GraphFilesInventory,
+    target: &std::path::Path,
+) -> Result<graphforge_storage::GraphFilesOpenEvidence, GfError> {
+    let has_authoritative_deltas = !graphforge_storage::list_delta_runs(
+        inventory,
+        graphforge_storage::GraphDeltaJournalLimits::default(),
+    )?
+    .is_empty();
+    if !has_authoritative_deltas {
+        return graphforge_storage::materialize_graph_objects(
+            generation.container_root(),
+            inventory,
+            target,
+        );
+    }
+    let source = tempfile::Builder::new()
+        .prefix("graphforge-graph-cas-source-")
+        .tempdir()
+        .map_err(|error| {
+            GfError::Storage(format!(
+                "failed to create graph CAS source workspace: {error}"
+            ))
+        })?;
+    let reused = graphforge_storage::materialize_graph_objects(
+        generation.container_root(),
+        inventory,
+        source.path(),
+    )?;
+    let (copied, _replay) = graphforge_storage::materialize_replayed_graph_tree(
+        source.path(),
+        inventory,
+        target,
+        graphforge_storage::GraphDeltaJournalLimits::default(),
+    )?;
+    let evidence = graphforge_storage::GraphFilesOpenEvidence {
+        strategy: graphforge_storage::GraphFilesOpenStrategy::PrivateMaterialize,
+        files_validated: reused
+            .files_validated
+            .saturating_add(copied.files_validated),
+        bytes_validated: reused
+            .bytes_validated
+            .saturating_add(copied.bytes_validated),
+        files_copied: copied.files_copied,
+        bytes_copied: copied.bytes_copied,
+        files_opened_in_place: 0,
+        files_reused: reused.files_reused,
+        bytes_reused: reused.bytes_reused,
+    };
+    Ok(evidence)
+}
+
 pub(crate) fn rematerialize_graph_workspace(
     generation: &ResolvedProjectGeneration,
     target: &std::path::Path,
@@ -3883,12 +3976,24 @@ pub(crate) fn rematerialize_graph_workspace(
             }
         }
     }
-    if let Some(inventory) = generation.graph_files_inventory()? {
-        graphforge_storage::materialize_graph_tree(
-            &generation.graph_tree_root(),
-            &inventory,
-            target,
-        )?;
+    if let Some(files) = generation.participant_snapshot(
+        graphforge_storage::GRAPH_CAPABILITY_ID,
+        graphforge_storage::GRAPH_FILES_FAMILY,
+    )? {
+        validate_graph_files_snapshot(&files)?;
+        if files.record_version == graphforge_storage::GRAPH_FILES_V2_RECORD_VERSION {
+            let inventory = generation
+                .graph_files_inventory()?
+                .ok_or_else(|| GfError::Validation("compact graph root disappeared".into()))?;
+            materialize_compact_graph_target(generation, &inventory, target)?;
+        } else {
+            let inventory = graphforge_storage::decode_inventory(&files.bytes)?;
+            graphforge_storage::materialize_graph_tree(
+                &generation.graph_tree_root(),
+                &inventory,
+                target,
+            )?;
+        }
         return Ok(());
     }
     if let Some(snapshot) = generation.participant_snapshot("graph", "snapshot")? {
@@ -4351,6 +4456,106 @@ mod tests {
     const ABSENT_TARGET_COOKIE: &str = "graphforge-absent-target-open-v1";
     const ABSENT_TARGET_DEADLINE: Duration = Duration::from_secs(10);
 
+    fn regular_files_beneath(root: &Path) -> Vec<PathBuf> {
+        let mut pending = vec![root.to_path_buf()];
+        let mut files = Vec::new();
+        while let Some(directory) = pending.pop() {
+            for entry in std::fs::read_dir(&directory).unwrap() {
+                let entry = entry.unwrap();
+                let kind = entry.file_type().unwrap();
+                if kind.is_dir() {
+                    pending.push(entry.path());
+                } else if kind.is_file() {
+                    files.push(entry.path().strip_prefix(root).unwrap().to_path_buf());
+                }
+            }
+        }
+        files.sort();
+        files
+    }
+
+    fn publish_compact_graph_workspace(project: &Path, workspace: &Path) {
+        use graphforge_core::canonical::{
+            CANONICAL_CONTRACT_VERSION, CanonicalDomain, fingerprint,
+        };
+        use graphforge_storage::{
+            ProjectCapability, ProjectGenerationRequest, ProjectParticipant,
+            ProjectParticipantEncoding, ProjectStageOutcome,
+        };
+
+        let lease = graphforge_storage::begin_graph_object_publication(project).unwrap();
+        let mut state = graphforge_storage::GraphManifestState::empty();
+        let paths = regular_files_beneath(workspace);
+        let (root, _) =
+            graphforge_storage::append_graph_files_v2(&lease, workspace, &mut state, &paths, &[])
+                .unwrap();
+        let participant = ProjectParticipant {
+            capability_id: graphforge_storage::GRAPH_CAPABILITY_ID.into(),
+            capability_version: graphforge_storage::GRAPH_CAPABILITY_VERSION,
+            record_family_id: graphforge_storage::GRAPH_FILES_FAMILY.into(),
+            record_version: graphforge_storage::GRAPH_FILES_V2_RECORD_VERSION,
+            encoding: ProjectParticipantEncoding::Json,
+            schema_fingerprint: fingerprint(
+                CanonicalDomain::Schema,
+                CANONICAL_CONTRACT_VERSION,
+                b"graphforge-graph-files-root/2|root_node_sha256|logical_file_count|logical_byte_length",
+            )
+            .unwrap(),
+            row_count: root.logical_file_count,
+            bytes: graphforge_storage::encode_graph_files_root_v2(&root).unwrap(),
+        };
+        let current = graphforge_storage::resolve_project_generation(project).unwrap();
+        let capabilities = current
+            .capabilities()
+            .into_iter()
+            .map(|capability| ProjectCapability {
+                capability_id: capability.capability_id,
+                capability_version: capability.capability_version,
+            })
+            .collect();
+        let mut participants = current
+            .participant_snapshots()
+            .unwrap()
+            .into_iter()
+            .filter(|snapshot| {
+                snapshot.capability_id != graphforge_storage::GRAPH_CAPABILITY_ID
+                    || snapshot.record_family_id != graphforge_storage::GRAPH_FILES_FAMILY
+            })
+            .map(|snapshot| ProjectParticipant {
+                capability_id: snapshot.capability_id,
+                capability_version: snapshot.capability_version,
+                record_family_id: snapshot.record_family_id,
+                record_version: snapshot.record_version,
+                encoding: match snapshot.encoding.as_str() {
+                    "parquet" => ProjectParticipantEncoding::Parquet,
+                    "arrow" => ProjectParticipantEncoding::Arrow,
+                    "json" => ProjectParticipantEncoding::Json,
+                    other => panic!("unsupported fixture participant encoding {other}"),
+                },
+                schema_fingerprint: snapshot.schema_fingerprint,
+                row_count: snapshot.row_count,
+                bytes: snapshot.bytes,
+            })
+            .collect::<Vec<_>>();
+        participants.push(participant);
+        let request = ProjectGenerationRequest {
+            transaction_uuid: uuid::Uuid::new_v4(),
+            generation_uuid: uuid::Uuid::new_v4(),
+            capabilities,
+            participants,
+        };
+        let ProjectStageOutcome::Staged(staged) =
+            graphforge_storage::stage_project_generation(project, &request).unwrap()
+        else {
+            panic!("compact graph publication unexpectedly replayed");
+        };
+        staged
+            .validate(|_| Ok(()), |_, _| Ok(()))
+            .unwrap()
+            .publish_with_graph_objects(&lease)
+            .unwrap();
+    }
+
     fn spawn_absent_target_child(parent: &Path, child_id: &str) -> Child {
         Command::new(std::env::current_exe().expect("absent-target current test executable"))
             .args(["--exact", ABSENT_TARGET_CHILD, "--nocapture"])
@@ -4457,6 +4662,114 @@ mod tests {
             error.to_string(),
             "validation error: procedure test.bad_width expects 1 fixture columns, found 0"
         );
+    }
+
+    #[test]
+    fn compact_graph_root_reopens_through_ordinary_api_and_rematerializes() {
+        let project = tempfile::tempdir().unwrap();
+        let graph = GraphForge::new(Some(project.path().to_str().unwrap())).unwrap();
+        graph
+            .execute("CREATE (:Person {name: 'Ada'})")
+            .expect("create compact-root fixture");
+        publish_compact_graph_workspace(project.path(), &graph.dir);
+        drop(graph);
+
+        let reopened = GraphForge::new(Some(project.path().to_str().unwrap())).unwrap();
+        let result = reopened
+            .execute("MATCH (n:Person) RETURN n.name AS name")
+            .expect("ordinary query over compact-root generation");
+        assert_eq!(result.stats.rows_produced, 1);
+        assert_eq!(reopened.graph_open_evidence().files_copied, 0);
+        assert!(reopened.graph_open_evidence().files_reused > 0);
+        assert!(!reopened.dir.join("files").exists());
+        assert!(reopened.dir.join("topology").is_dir());
+
+        let resolved = graphforge_storage::resolve_project_generation(project.path()).unwrap();
+        let (read_only_dir, read_only_guard, read_only_evidence) =
+            hydrate_graph_workspace(&resolved, true).unwrap();
+        assert!(read_only_dir.join("topology").is_dir());
+        assert!(read_only_evidence.files_reused > 0);
+        assert_eq!(read_only_evidence.files_opened_in_place, 0);
+
+        let rematerialized_owner = tempfile::tempdir().unwrap();
+        let rematerialized = rematerialized_owner.path().join("workspace");
+        std::fs::create_dir(&rematerialized).unwrap();
+        rematerialize_graph_workspace(&resolved, &rematerialized).unwrap();
+        let (expected, _) = graphforge_storage::capture_graph_files(&reopened.dir).unwrap();
+        let (actual, _) = graphforge_storage::capture_graph_files(&rematerialized).unwrap();
+        assert_eq!(actual, expected);
+
+        let inventory = resolved.graph_files_inventory().unwrap().unwrap();
+        let victim_entry = inventory
+            .files
+            .iter()
+            .find(|entry| entry.byte_length > 0)
+            .expect("compact fixture contains a nonempty graph object");
+        let victim =
+            graphforge_storage::graph_object_path(project.path(), &victim_entry.content_sha256)
+                .unwrap();
+        drop(read_only_guard);
+        drop(reopened);
+        let mut permissions = std::fs::metadata(&victim).unwrap().permissions();
+        permissions.set_readonly(false);
+        std::fs::set_permissions(&victim, permissions).unwrap();
+        std::fs::write(&victim, vec![0_u8; victim_entry.byte_length as usize]).unwrap();
+        assert!(GraphForge::new(Some(project.path().to_str().unwrap())).is_err());
+    }
+
+    #[test]
+    fn compact_graph_root_replays_authoritative_deltas_into_distinct_workspace() {
+        use graphforge_storage::{
+            GraphDeltaJournalLimits, GraphDeltaOp, GraphDeltaOpKind, GraphDeltaPayload,
+            GraphDeltaPublishRequest,
+        };
+
+        let project = tempfile::tempdir().unwrap();
+        let graph = GraphForge::new(Some(project.path().to_str().unwrap())).unwrap();
+        graph.execute("CREATE (:Person {name: 'Ada'})").unwrap();
+        drop(graph);
+        graphforge_storage::publish_graph_delta(
+            project.path(),
+            &GraphDeltaPublishRequest {
+                transaction_uuid: uuid::Uuid::new_v4(),
+                generation_uuid: uuid::Uuid::new_v4(),
+                run_uuid: uuid::Uuid::new_v4(),
+                operations: vec![GraphDeltaOp {
+                    operation_uuid: uuid::Uuid::new_v4(),
+                    kind: GraphDeltaOpKind::UpsertNode,
+                    payload: GraphDeltaPayload::UpsertNodeV2 {
+                        node_uuid: uuid::Uuid::new_v4().hyphenated().to_string(),
+                        node_id: 2,
+                        type_ids: vec![1],
+                        created_at_micros: 2,
+                        updated_at_micros: 2,
+                    },
+                }],
+                limits: GraphDeltaJournalLimits::default(),
+            },
+        )
+        .unwrap();
+        let delta_generation =
+            graphforge_storage::resolve_project_generation(project.path()).unwrap();
+        assert!(delta_generation.graph_tree_root().join("deltas").is_dir());
+        publish_compact_graph_workspace(project.path(), &delta_generation.graph_tree_root());
+        drop(delta_generation);
+
+        let reopened = GraphForge::new(Some(project.path().to_str().unwrap())).unwrap();
+        let result = reopened
+            .execute("MATCH (n) RETURN count(n) AS total")
+            .unwrap();
+        let total = result.batches[0]
+            .column_by_name("total")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap()
+            .value(0);
+        assert_eq!(total, 2);
+        assert!(!reopened.dir.join("deltas").exists());
+        assert!(reopened.graph_open_evidence().files_reused > 0);
+        assert!(reopened.graph_open_evidence().files_copied > 0);
     }
 
     #[test]

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -289,9 +289,9 @@ pub use graphforge_storage::{
     GraphDeltaCompactionLimits, GraphDeltaCompactionPolicy, GraphDeltaCompactionReport,
     GraphDeltaCompactionRequest, GraphDeltaCompactionStatus, GraphDeltaJournalLimits,
     ProjectCleanupDisposition, ProjectCleanupEntry, ProjectCleanupLocation, ProjectCleanupReport,
-    ProjectOpenRecoveryEvidence, ProjectOpenRecoveryKind, ProjectReachabilityReport,
-    ProjectRecoveryDeferral, ProjectRecoveryGenerationClass, ProjectRetentionLimits,
-    ProjectRetentionPolicy,
+    ProjectGraphObjectSweepDisposition, ProjectGraphObjectSweepReport, ProjectOpenRecoveryEvidence,
+    ProjectOpenRecoveryKind, ProjectReachabilityReport, ProjectRecoveryDeferral,
+    ProjectRecoveryGenerationClass, ProjectRetentionLimits, ProjectRetentionPolicy,
 };
 pub use gsi_profiler::{GraphScaleIndexProfile, GsiDirectedness, grade_gsi};
 pub use hypotheses::{

--- a/crates/graphforge-bindings-node/src/transaction.rs
+++ b/crates/graphforge-bindings-node/src/transaction.rs
@@ -97,6 +97,15 @@ pub struct ProjectCleanupEntryOutput {
     pub bytes: BigInt,
 }
 
+/// Graph-object sweep disposition and physical evidence.
+#[napi(object)]
+pub struct ProjectGraphObjectSweepReportOutput {
+    pub disposition: String,
+    pub objects_marked: BigInt,
+    pub objects_removed: BigInt,
+    pub bytes_removed: BigInt,
+}
+
 /// Retention/GC report with lossless 64-bit counters.
 #[napi(object)]
 pub struct ProjectCleanupReportOutput {
@@ -114,6 +123,7 @@ pub struct ProjectCleanupReportOutput {
     pub entries_scanned: BigInt,
     pub work_units: BigInt,
     pub bounded: bool,
+    pub graph_object_sweep: ProjectGraphObjectSweepReportOutput,
     pub elapsed_ms: BigInt,
     pub entries: Vec<ProjectCleanupEntryOutput>,
 }
@@ -281,6 +291,12 @@ fn cleanup_output(report: &ProjectCleanupReport) -> ProjectCleanupReportOutput {
         entries_scanned: u64_bigint(report.entries_scanned),
         work_units: u64_bigint(report.work_units),
         bounded: report.bounded,
+        graph_object_sweep: ProjectGraphObjectSweepReportOutput {
+            disposition: report.graph_object_sweep.disposition.as_str().into(),
+            objects_marked: u64_bigint(report.graph_object_sweep.objects_marked),
+            objects_removed: u64_bigint(report.graph_object_sweep.objects_removed),
+            bytes_removed: u64_bigint(report.graph_object_sweep.bytes_removed),
+        },
         elapsed_ms: u64_bigint(report.elapsed_ms),
         entries: report
             .entries

--- a/crates/graphforge-bindings-node/tests/transaction-parity.test.mjs
+++ b/crates/graphforge-bindings-node/tests/transaction-parity.test.mjs
@@ -75,6 +75,13 @@ test("maintenance preview and execution reconcile candidate identities", async (
     seed.commit();
     const preview = forge.previewProjectCleanup({ retainedAncestors: 2 });
     const executed = forge.executeProjectCleanup({ retainedAncestors: 2 });
+    assert.deepEqual(preview.graphObjectSweep, {
+      disposition: "not_run_dry_run",
+      objectsMarked: 0n,
+      objectsRemoved: 0n,
+      bytesRemoved: 0n,
+    });
+    assert.equal(executed.graphObjectSweep.disposition, "completed");
     assert.equal(preview.candidates, executed.candidates);
     assert.equal(preview.reachableCount, executed.reachableCount);
     assert.deepEqual(

--- a/crates/graphforge-bindings-py/src/transaction.rs
+++ b/crates/graphforge-bindings-py/src/transaction.rs
@@ -338,6 +338,15 @@ fn cleanup_report_dict<'py>(
     dict.set_item("entries_scanned", report.entries_scanned)?;
     dict.set_item("work_units", report.work_units)?;
     dict.set_item("bounded", report.bounded)?;
+    let graph_object_sweep = PyDict::new(py);
+    graph_object_sweep.set_item(
+        "disposition",
+        report.graph_object_sweep.disposition.as_str(),
+    )?;
+    graph_object_sweep.set_item("objects_marked", report.graph_object_sweep.objects_marked)?;
+    graph_object_sweep.set_item("objects_removed", report.graph_object_sweep.objects_removed)?;
+    graph_object_sweep.set_item("bytes_removed", report.graph_object_sweep.bytes_removed)?;
+    dict.set_item("graph_object_sweep", graph_object_sweep)?;
     dict.set_item("elapsed_ms", report.elapsed_ms)?;
     let entries = PyList::empty(py);
     for entry in &report.entries {

--- a/crates/graphforge-bindings-py/tests/transaction_parity.py
+++ b/crates/graphforge-bindings-py/tests/transaction_parity.py
@@ -74,6 +74,13 @@ def check_maintenance_preview_execute_reconcile(project: Path) -> None:
     assert "selected_generation_uuid" in recovery
     preview = forge.preview_project_cleanup(retained_ancestors=2)
     execute = forge.execute_project_cleanup(retained_ancestors=2)
+    assert preview["graph_object_sweep"] == {
+        "disposition": "not_run_dry_run",
+        "objects_marked": 0,
+        "objects_removed": 0,
+        "bytes_removed": 0,
+    }
+    assert execute["graph_object_sweep"]["disposition"] == "completed"
     assert preview["candidates"] == execute["candidates"]
     assert preview["reachable_count"] == execute["reachable_count"]
     assert [entry["generation_uuid"] for entry in preview["entries"]] == [
@@ -114,6 +121,24 @@ def check_cli_parity(project: Path) -> None:
     assert code == 0, stdout
     recovery = json.loads(stdout.decode())
     assert "selected_generation_uuid" in recovery
+    code, stdout, _stderr = _cli_execute(
+        [
+            "gf",
+            "--project",
+            str(project),
+            "--json",
+            "maintenance",
+            "cleanup-preview",
+        ]
+    )
+    assert code == 0, stdout
+    cleanup = json.loads(stdout.decode())
+    assert cleanup["graph_object_sweep"] == {
+        "disposition": "not_run_dry_run",
+        "objects_marked": 0,
+        "objects_removed": 0,
+        "bytes_removed": 0,
+    }
 
 
 def check_certification_observation_parity(project: Path) -> None:

--- a/crates/graphforge-cli/src/maintenance_cli.rs
+++ b/crates/graphforge-cli/src/maintenance_cli.rs
@@ -211,6 +211,12 @@ fn cleanup_json(report: &graphforge_api::ProjectCleanupReport) -> serde_json::Va
         "entries_scanned": report.entries_scanned,
         "work_units": report.work_units,
         "bounded": report.bounded,
+        "graph_object_sweep": {
+            "disposition": report.graph_object_sweep.disposition.as_str(),
+            "objects_marked": report.graph_object_sweep.objects_marked,
+            "objects_removed": report.graph_object_sweep.objects_removed,
+            "bytes_removed": report.graph_object_sweep.bytes_removed,
+        },
         "elapsed_ms": report.elapsed_ms,
         "entries": report.entries.iter().map(|entry| serde_json::json!({
             "generation_uuid": entry.generation_uuid.map(|uuid| uuid.to_string()),

--- a/crates/graphforge-filesystem/BUILD.bazel
+++ b/crates/graphforge-filesystem/BUILD.bazel
@@ -8,6 +8,7 @@ package(default_visibility = ["//visibility:public"])
 
 gf_rust_library(
     name = "graphforge_filesystem",
+    deps = ["@crates//:fs4"],
 )
 
 gf_rust_test(

--- a/crates/graphforge-filesystem/Cargo.toml
+++ b/crates/graphforge-filesystem/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 license-file.workspace = true
 repository.workspace = true
 
+[dependencies]
+fs4 = "1.1"
+
 [target.'cfg(unix)'.dependencies]
 rustix = { version = "1.1", features = ["fs"] }
 

--- a/crates/graphforge-filesystem/src/lib.rs
+++ b/crates/graphforge-filesystem/src/lib.rs
@@ -124,6 +124,18 @@ impl StableDirectory {
         Ok(file)
     }
 
+    /// Create a new regular child whose retained handle permits an atomic
+    /// namespace replacement while it remains open.
+    pub fn create_replaceable_child_file(&self, name: &OsStr) -> io::Result<File> {
+        validate_child_name(name)?;
+        self.revalidate_named()?;
+        let path = self.path.join(name);
+        let file = stable_open_replaceable_child_file(&self.file, &path, name)?;
+        validate_stable_child_file(&file, &path)?;
+        self.revalidate_named()?;
+        Ok(file)
+    }
+
     /// Open an existing regular child for read/write, or create it once.
     pub fn open_or_create_child_file(&self, name: &OsStr) -> io::Result<File> {
         validate_child_name(name)?;
@@ -197,13 +209,20 @@ impl StableDirectory {
                 "atomic temporary child is multiply linked",
             ));
         }
-        let result = match self.open_child_file(target) {
-            Ok(_) => replace_file(&self.file, temporary, target)
-                .map_err(|error| io::Error::other(error.to_string())),
-            Err(error) if error.kind() == io::ErrorKind::NotFound => {
-                install_new_file(&self.file, temporary, target)
+        drop(temporary_file);
+        let target_exists = match self.open_child_file(target) {
+            Ok(target_file) => {
+                drop(target_file);
+                true
             }
-            Err(error) => Err(error),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => false,
+            Err(error) => return Err(error),
+        };
+        let result = if target_exists {
+            replace_file(&self.file, temporary, target)
+                .map_err(|error| io::Error::other(error.to_string()))
+        } else {
+            install_new_file(&self.file, temporary, target)
         };
         result?;
         self.revalidate_named()?;
@@ -306,6 +325,15 @@ fn stable_open_child_file(
 }
 
 #[cfg(unix)]
+fn stable_open_replaceable_child_file(
+    parent: &File,
+    path: &Path,
+    name: &OsStr,
+) -> io::Result<File> {
+    stable_open_child_file(parent, path, name, true)
+}
+
+#[cfg(unix)]
 fn stable_open_or_create_child_file(parent: &File, _path: &Path, name: &OsStr) -> io::Result<File> {
     use rustix::fs::{Mode, OFlags};
     rustix::fs::openat(
@@ -375,8 +403,7 @@ fn stable_unlink_child_if_identity(
     let named =
         rustix::fs::statat(parent, name, AtFlags::SYMLINK_NOFOLLOW).map_err(io::Error::from)?;
     let named_identity = FileIdentity {
-        volume_serial: u64::try_from(named.st_dev)
-            .map_err(|_| io::Error::other("negative device identity"))?,
+        volume_serial: named.st_dev as u64,
         file_id: u128::from(named.st_ino).to_le_bytes(),
     };
     if named_identity != expected {
@@ -432,6 +459,26 @@ fn stable_open_child_file(
         .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
         .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
     options.open(path)
+}
+
+#[cfg(windows)]
+fn stable_open_replaceable_child_file(
+    _parent: &File,
+    path: &Path,
+    _name: &OsStr,
+) -> io::Result<File> {
+    use std::os::windows::fs::OpenOptionsExt as _;
+    const FILE_SHARE_READ: u32 = 0x0000_0001;
+    const FILE_SHARE_WRITE: u32 = 0x0000_0002;
+    const FILE_SHARE_DELETE: u32 = 0x0000_0004;
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)
 }
 
 #[cfg(windows)]
@@ -501,6 +548,15 @@ fn stable_open_child_directory(_parent: &File, _path: &Path, _name: &OsStr) -> i
 
 #[cfg(all(not(unix), not(windows)))]
 fn stable_open_or_create_child_file(
+    _parent: &File,
+    _path: &Path,
+    _name: &OsStr,
+) -> io::Result<File> {
+    stable_open_directory(Path::new(""))
+}
+
+#[cfg(all(not(unix), not(windows)))]
+fn stable_open_replaceable_child_file(
     _parent: &File,
     _path: &Path,
     _name: &OsStr,

--- a/crates/graphforge-filesystem/src/lib.rs
+++ b/crates/graphforge-filesystem/src/lib.rs
@@ -100,6 +100,60 @@ impl StableDirectory {
         Ok(file)
     }
 
+    /// Open an existing regular child for read/write, or create it once.
+    pub fn open_or_create_child_file(&self, name: &OsStr) -> io::Result<File> {
+        validate_child_name(name)?;
+        self.revalidate_named()?;
+        let path = self.path.join(name);
+        let file = stable_open_or_create_child_file(&self.file, &path, name)?;
+        validate_stable_child_file(&file, &path)?;
+        self.revalidate_named()?;
+        Ok(file)
+    }
+
+    /// Enumerate child names while retaining this directory capability.
+    pub fn child_names(&self) -> io::Result<Vec<std::ffi::OsString>> {
+        self.revalidate_named()?;
+        stable_child_names(&self.file, &self.path)
+    }
+
+    /// Create a hard link between retained source and destination directories.
+    pub fn link_child_into(
+        &self,
+        source_name: &OsStr,
+        destination: &Self,
+        destination_name: &OsStr,
+    ) -> io::Result<()> {
+        validate_child_name(source_name)?;
+        validate_child_name(destination_name)?;
+        self.revalidate_named()?;
+        destination.revalidate_named()?;
+        stable_link_child(
+            &self.file,
+            &self.path,
+            source_name,
+            &destination.file,
+            &destination.path,
+            destination_name,
+        )?;
+        self.revalidate_named()?;
+        destination.revalidate_named()
+    }
+
+    /// Remove a child only while its current named identity matches `expected`.
+    pub fn unlink_child_if_identity(&self, name: &OsStr, expected: FileIdentity) -> io::Result<()> {
+        validate_child_name(name)?;
+        self.revalidate_named()?;
+        stable_unlink_child_if_identity(&self.file, &self.path, name, expected)?;
+        self.revalidate_named()
+    }
+
+    /// Return the path used only for diagnostics and guarded Windows syscalls.
+    #[must_use]
+    pub fn diagnostic_path(&self) -> &Path {
+        &self.path
+    }
+
     /// Borrow the retained directory handle.
     #[must_use]
     pub fn file(&self) -> &File {
@@ -196,6 +250,86 @@ fn stable_open_child_file(
         .map_err(io::Error::from)
 }
 
+#[cfg(unix)]
+fn stable_open_or_create_child_file(parent: &File, _path: &Path, name: &OsStr) -> io::Result<File> {
+    use rustix::fs::{Mode, OFlags};
+    rustix::fs::openat(
+        parent,
+        name,
+        OFlags::RDWR | OFlags::CREATE | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+        Mode::from_bits_truncate(0o600),
+    )
+    .map(File::from)
+    .map_err(io::Error::from)
+}
+
+#[cfg(unix)]
+fn stable_child_names(parent: &File, _path: &Path) -> io::Result<Vec<std::ffi::OsString>> {
+    use std::os::unix::ffi::OsStrExt as _;
+    let directory = rustix::fs::Dir::read_from(parent).map_err(io::Error::from)?;
+    directory
+        .map(|entry| {
+            let entry = entry.map_err(io::Error::from)?;
+            let name = OsStr::from_bytes(entry.file_name().to_bytes());
+            Ok(name.to_os_string())
+        })
+        .filter(|entry| {
+            !matches!(entry, Ok(name) if name == OsStr::new(".") || name == OsStr::new(".."))
+        })
+        .collect()
+}
+
+#[cfg(unix)]
+fn stable_link_child(
+    source: &File,
+    _source_path: &Path,
+    source_name: &OsStr,
+    destination: &File,
+    _destination_path: &Path,
+    destination_name: &OsStr,
+) -> io::Result<()> {
+    rustix::fs::linkat(
+        source,
+        source_name,
+        destination,
+        destination_name,
+        rustix::fs::AtFlags::empty(),
+    )
+    .map_err(io::Error::from)
+}
+
+#[cfg(unix)]
+fn stable_unlink_child_if_identity(
+    parent: &File,
+    _path: &Path,
+    name: &OsStr,
+    expected: FileIdentity,
+) -> io::Result<()> {
+    use rustix::fs::{AtFlags, Mode, OFlags};
+    let opened = rustix::fs::openat(
+        parent,
+        name,
+        OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+        Mode::empty(),
+    )
+    .map(File::from)
+    .map_err(io::Error::from)?;
+    if file_identity(&opened)? != expected {
+        return Err(io::Error::other("child identity changed before unlink"));
+    }
+    let named =
+        rustix::fs::statat(parent, name, AtFlags::SYMLINK_NOFOLLOW).map_err(io::Error::from)?;
+    let named_identity = FileIdentity {
+        volume_serial: u64::try_from(named.st_dev)
+            .map_err(|_| io::Error::other("negative device identity"))?,
+        file_id: u128::from(named.st_ino).to_le_bytes(),
+    };
+    if named_identity != expected {
+        return Err(io::Error::other("child identity changed before unlink"));
+    }
+    rustix::fs::unlinkat(parent, name, AtFlags::empty()).map_err(io::Error::from)
+}
+
 #[cfg(windows)]
 fn stable_open_directory(path: &Path) -> io::Result<File> {
     use std::os::windows::fs::OpenOptionsExt as _;
@@ -245,6 +379,61 @@ fn stable_open_child_file(
     options.open(path)
 }
 
+#[cfg(windows)]
+fn stable_open_or_create_child_file(
+    _parent: &File,
+    path: &Path,
+    _name: &OsStr,
+) -> io::Result<File> {
+    use std::os::windows::fs::OpenOptionsExt as _;
+    const FILE_SHARE_READ: u32 = 0x0000_0001;
+    const FILE_SHARE_WRITE: u32 = 0x0000_0002;
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)
+}
+
+#[cfg(windows)]
+fn stable_child_names(_parent: &File, path: &Path) -> io::Result<Vec<std::ffi::OsString>> {
+    std::fs::read_dir(path)?
+        .map(|entry| entry.map(|entry| entry.file_name()))
+        .collect()
+}
+
+#[cfg(windows)]
+fn stable_link_child(
+    _source: &File,
+    source_path: &Path,
+    source_name: &OsStr,
+    _destination: &File,
+    destination_path: &Path,
+    destination_name: &OsStr,
+) -> io::Result<()> {
+    std::fs::hard_link(
+        source_path.join(source_name),
+        destination_path.join(destination_name),
+    )
+}
+
+#[cfg(windows)]
+fn stable_unlink_child_if_identity(
+    _parent: &File,
+    path: &Path,
+    name: &OsStr,
+    expected: FileIdentity,
+) -> io::Result<()> {
+    let child = path.join(name);
+    if path_identity(&child)? != expected {
+        return Err(io::Error::other("child identity changed before unlink"));
+    }
+    std::fs::remove_file(child)
+}
+
 #[cfg(all(not(unix), not(windows)))]
 fn stable_open_directory(_path: &Path) -> io::Result<File> {
     Err(io::Error::new(
@@ -256,6 +445,51 @@ fn stable_open_directory(_path: &Path) -> io::Result<File> {
 #[cfg(all(not(unix), not(windows)))]
 fn stable_open_child_directory(_parent: &File, _path: &Path, _name: &OsStr) -> io::Result<File> {
     stable_open_directory(Path::new(""))
+}
+
+#[cfg(all(not(unix), not(windows)))]
+fn stable_open_or_create_child_file(
+    _parent: &File,
+    _path: &Path,
+    _name: &OsStr,
+) -> io::Result<File> {
+    stable_open_directory(Path::new(""))
+}
+
+#[cfg(all(not(unix), not(windows)))]
+fn stable_child_names(_parent: &File, _path: &Path) -> io::Result<Vec<std::ffi::OsString>> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "stable directories unsupported",
+    ))
+}
+
+#[cfg(all(not(unix), not(windows)))]
+fn stable_link_child(
+    _source: &File,
+    _source_path: &Path,
+    _source_name: &OsStr,
+    _destination: &File,
+    _destination_path: &Path,
+    _destination_name: &OsStr,
+) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "stable directories unsupported",
+    ))
+}
+
+#[cfg(all(not(unix), not(windows)))]
+fn stable_unlink_child_if_identity(
+    _parent: &File,
+    _path: &Path,
+    _name: &OsStr,
+    _expected: FileIdentity,
+) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "stable directories unsupported",
+    ))
 }
 
 #[cfg(all(not(unix), not(windows)))]

--- a/crates/graphforge-filesystem/src/lib.rs
+++ b/crates/graphforge-filesystem/src/lib.rs
@@ -121,13 +121,19 @@ impl StableDirectory {
     pub fn link_child_into(
         &self,
         source_name: &OsStr,
+        source: &File,
+        expected_source: FileIdentity,
         destination: &Self,
         destination_name: &OsStr,
-    ) -> io::Result<()> {
+    ) -> io::Result<(File, FileIdentity)> {
         validate_child_name(source_name)?;
         validate_child_name(destination_name)?;
         self.revalidate_named()?;
         destination.revalidate_named()?;
+        validate_stable_child_file(source, &self.path.join(source_name))?;
+        if file_identity(source)? != expected_source {
+            return Err(io::Error::other("hard-link source identity changed"));
+        }
         stable_link_child(
             &self.file,
             &self.path,
@@ -137,10 +143,17 @@ impl StableDirectory {
             destination_name,
         )?;
         self.revalidate_named()?;
-        destination.revalidate_named()
+        destination.revalidate_named()?;
+        let installed = destination.open_child_file(destination_name)?;
+        let installed_identity = file_identity(&installed)?;
+        if installed_identity != expected_source {
+            return Err(io::Error::other("hard-link destination identity mismatch"));
+        }
+        Ok((installed, installed_identity))
     }
 
-    /// Remove a child only while its current named identity matches `expected`.
+    /// Remove a child under the caller's held cooperative exclusive lifecycle
+    /// guard, only while its current named identity matches `expected`.
     pub fn unlink_child_if_identity(&self, name: &OsStr, expected: FileIdentity) -> io::Result<()> {
         validate_child_name(name)?;
         self.revalidate_named()?;
@@ -148,16 +161,34 @@ impl StableDirectory {
         self.revalidate_named()
     }
 
-    /// Return the path used only for diagnostics and guarded Windows syscalls.
-    #[must_use]
-    pub fn diagnostic_path(&self) -> &Path {
-        &self.path
+    /// Atomically publish a retained temporary child as `target` within this
+    /// retained directory. Cooperative publishers must serialize the target.
+    pub fn replace_child(&self, temporary: &OsStr, target: &OsStr) -> io::Result<()> {
+        validate_child_name(temporary)?;
+        validate_child_name(target)?;
+        self.revalidate_named()?;
+        let temporary_file = self.open_child_file(temporary)?;
+        if file_link_count(&temporary_file)? != 1 {
+            return Err(io::Error::other(
+                "atomic temporary child is multiply linked",
+            ));
+        }
+        let result = match self.open_child_file(target) {
+            Ok(_) => replace_file(&self.file, temporary, target)
+                .map_err(|error| io::Error::other(error.to_string())),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                install_new_file(&self.file, temporary, target)
+            }
+            Err(error) => Err(error),
+        };
+        result?;
+        self.revalidate_named()?;
+        self.open_child_file(target).map(|_| ())
     }
 
-    /// Borrow the retained directory handle.
-    #[must_use]
-    pub fn file(&self) -> &File {
-        &self.file
+    /// Flush this retained directory capability.
+    pub fn sync(&self) -> io::Result<()> {
+        self.file.sync_all()
     }
 
     /// Return the retained native identity.
@@ -428,10 +459,7 @@ fn stable_unlink_child_if_identity(
     expected: FileIdentity,
 ) -> io::Result<()> {
     let child = path.join(name);
-    if path_identity(&child)? != expected {
-        return Err(io::Error::other("child identity changed before unlink"));
-    }
-    std::fs::remove_file(child)
+    windows::delete_file_by_handle(&child, expected)
 }
 
 #[cfg(all(not(unix), not(windows)))]
@@ -966,12 +994,13 @@ mod windows {
     use windows_sys::Win32::Security::{DACL_SECURITY_INFORMATION, OWNER_SECURITY_INFORMATION};
     use windows_sys::Win32::Security::{PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES};
     use windows_sys::Win32::Storage::FileSystem::{
-        BY_HANDLE_FILE_INFORMATION, CreateDirectoryW, DELETE, FILE_FLAG_BACKUP_SEMANTICS,
-        FILE_FLAG_OPEN_REPARSE_POINT, FILE_FLAG_WRITE_THROUGH, FILE_ID_INFO, FILE_NAME_NORMALIZED,
-        FILE_READ_ATTRIBUTES, FILE_RENAME_INFO, FILE_SHARE_DELETE, FILE_SHARE_READ,
-        FILE_SHARE_WRITE, FileIdInfo, FileRenameInfo, FileRenameInfoEx, GetDriveTypeW,
-        GetFileInformationByHandle, GetFileInformationByHandleEx, GetFinalPathNameByHandleW,
-        GetVolumeInformationW, GetVolumePathNameW, SetFileInformationByHandle, VOLUME_NAME_DOS,
+        BY_HANDLE_FILE_INFORMATION, CreateDirectoryW, DELETE, FILE_DISPOSITION_INFO,
+        FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_FLAG_WRITE_THROUGH,
+        FILE_ID_INFO, FILE_NAME_NORMALIZED, FILE_READ_ATTRIBUTES, FILE_RENAME_INFO,
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FileDispositionInfo, FileIdInfo,
+        FileRenameInfo, FileRenameInfoEx, GetDriveTypeW, GetFileInformationByHandle,
+        GetFileInformationByHandleEx, GetFinalPathNameByHandleW, GetVolumeInformationW,
+        GetVolumePathNameW, SetFileInformationByHandle, VOLUME_NAME_DOS,
     };
 
     #[cfg(test)]
@@ -1132,6 +1161,35 @@ mod windows {
             .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
             .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_WRITE_THROUGH)
             .open(path)
+    }
+
+    pub(super) fn delete_file_by_handle(path: &Path, expected: FileIdentity) -> io::Result<()> {
+        let file = std::fs::OpenOptions::new()
+            .access_mode(DELETE | FILE_READ_ATTRIBUTES)
+            .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+            .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_WRITE_THROUGH)
+            .open(path)?;
+        if file_identity(&file)? != expected || identity(path)? != expected {
+            return Err(io::Error::other("child identity changed before unlink"));
+        }
+        let mut disposition = FILE_DISPOSITION_INFO { DeleteFile: true };
+        // SAFETY: `file` is an exact retained handle opened with DELETE access,
+        // and `disposition` is the initialized structure required by
+        // FileDispositionInfo for the duration of the call.
+        let deleted = unsafe {
+            SetFileInformationByHandle(
+                file.as_raw_handle(),
+                FileDispositionInfo,
+                (&mut disposition as *mut FILE_DISPOSITION_INFO).cast(),
+                u32::try_from(std::mem::size_of::<FILE_DISPOSITION_INFO>())
+                    .expect("FILE_DISPOSITION_INFO size fits u32"),
+            )
+        };
+        if deleted == 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
     }
 
     fn rename_handle(
@@ -1943,6 +2001,77 @@ mod tests {
             stable_root
                 .open_child_directory(OsStr::new("objects"))
                 .is_err()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stable_directory_enumerates_and_links_only_retained_regular_source() {
+        use std::io::Write as _;
+
+        let root = tempfile::tempdir().unwrap();
+        let stable = StableDirectory::open(root.path()).unwrap();
+        let source_dir = stable.create_child_directory(OsStr::new("source")).unwrap();
+        let destination = stable
+            .create_child_directory(OsStr::new("destination"))
+            .unwrap();
+        let mut source = source_dir.create_child_file(OsStr::new("payload")).unwrap();
+        source.write_all(b"payload").unwrap();
+        let identity = file_identity(&source).unwrap();
+        assert_eq!(
+            source_dir.child_names().unwrap(),
+            [std::ffi::OsString::from("payload")]
+        );
+        let (installed, installed_identity) = source_dir
+            .link_child_into(
+                OsStr::new("payload"),
+                &source,
+                identity,
+                &destination,
+                OsStr::new("copy"),
+            )
+            .unwrap();
+        assert_eq!(installed_identity, identity);
+        assert_eq!(file_identity(&installed).unwrap(), identity);
+
+        std::fs::rename(
+            root.path().join("source/payload"),
+            root.path().join("source/old"),
+        )
+        .unwrap();
+        std::fs::write(root.path().join("source/payload"), b"replacement").unwrap();
+        assert!(
+            source_dir
+                .link_child_into(
+                    OsStr::new("payload"),
+                    &source,
+                    identity,
+                    &destination,
+                    OsStr::new("bad")
+                )
+                .is_err()
+        );
+        assert!(!root.path().join("destination/bad").exists());
+    }
+
+    #[test]
+    fn stable_directory_rejects_non_child_names_and_identity_mismatch_cleanup() {
+        let root = tempfile::tempdir().unwrap();
+        let stable = StableDirectory::open(root.path()).unwrap();
+        assert!(stable.open_child_file(OsStr::new("../escape")).is_err());
+        let file = stable.create_child_file(OsStr::new("payload")).unwrap();
+        let identity = file_identity(&file).unwrap();
+        drop(file);
+        std::fs::rename(root.path().join("payload"), root.path().join("old")).unwrap();
+        std::fs::write(root.path().join("payload"), b"replacement").unwrap();
+        assert!(
+            stable
+                .unlink_child_if_identity(OsStr::new("payload"), identity)
+                .is_err()
+        );
+        assert_eq!(
+            std::fs::read(root.path().join("payload")).unwrap(),
+            b"replacement"
         );
     }
 }

--- a/crates/graphforge-filesystem/src/lib.rs
+++ b/crates/graphforge-filesystem/src/lib.rs
@@ -27,6 +27,30 @@ pub struct StableDirectory {
 }
 
 impl StableDirectory {
+    /// Acquire a cooperative shared lock on this retained directory inode.
+    pub fn lock_shared(&self) -> io::Result<()> {
+        <File as fs4::FileExt>::lock_shared(&self.file)
+    }
+
+    /// Acquire a cooperative exclusive lock on this retained directory inode.
+    pub fn lock_exclusive(&self) -> io::Result<()> {
+        <File as fs4::FileExt>::lock(&self.file)
+    }
+
+    /// Try to acquire a cooperative exclusive lock on this retained directory inode.
+    pub fn try_lock_exclusive(&self) -> io::Result<bool> {
+        match <File as fs4::FileExt>::try_lock(&self.file) {
+            Ok(()) => Ok(true),
+            Err(fs4::TryLockError::WouldBlock) => Ok(false),
+            Err(fs4::TryLockError::Error(error)) => Err(error),
+        }
+    }
+
+    /// Release this retained directory inode's cooperative lock.
+    pub fn unlock(&self) -> io::Result<()> {
+        <File as fs4::FileExt>::unlock(&self.file)
+    }
+
     /// Open and retain a real directory at `path`.
     pub fn open(path: &Path) -> io::Result<Self> {
         let file = stable_open_directory(path)?;

--- a/crates/graphforge-filesystem/src/lib.rs
+++ b/crates/graphforge-filesystem/src/lib.rs
@@ -245,7 +245,23 @@ impl StableDirectory {
 
     /// Flush this retained directory capability.
     pub fn sync(&self) -> io::Result<()> {
-        self.file.sync_all()
+        self.revalidate_named()?;
+        #[cfg(windows)]
+        {
+            let directory = stable_open_directory_for_sync(&self.path)?;
+            if file_identity(&directory)? != self.identity {
+                return Err(io::Error::other(
+                    "stable directory identity changed before sync",
+                ));
+            }
+            directory.sync_all()?;
+            self.revalidate_named()
+        }
+        #[cfg(not(windows))]
+        {
+            self.file.sync_all()?;
+            self.revalidate_named()
+        }
     }
 
     /// Return the retained native identity.
@@ -444,6 +460,20 @@ fn stable_open_directory(path: &Path) -> io::Result<File> {
     const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
     std::fs::OpenOptions::new()
         .read(true)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)
+}
+
+#[cfg(windows)]
+fn stable_open_directory_for_sync(path: &Path) -> io::Result<File> {
+    use std::os::windows::fs::OpenOptionsExt as _;
+    const FILE_SHARE_READ: u32 = 0x0000_0001;
+    const FILE_SHARE_WRITE: u32 = 0x0000_0002;
+    const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    std::fs::OpenOptions::new()
+        .write(true)
         .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT)
         .open(path)
@@ -2406,5 +2436,13 @@ mod tests {
             b"authenticated"
         );
         assert!(!root.path().join("CURRENT").exists());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn stable_directory_sync_uses_an_identity_checked_write_handle() {
+        let root = tempfile::tempdir().unwrap();
+        let stable = StableDirectory::open(root.path()).unwrap();
+        stable.sync().unwrap();
     }
 }

--- a/crates/graphforge-filesystem/src/lib.rs
+++ b/crates/graphforge-filesystem/src/lib.rs
@@ -325,6 +325,7 @@ fn stable_open_child_file(
     } else {
         OFlags::RDONLY
     } | OFlags::NOFOLLOW
+        | OFlags::NONBLOCK
         | OFlags::CLOEXEC;
     rustix::fs::openat(parent, name, flags, Mode::from_bits_truncate(0o600))
         .map(File::from)
@@ -346,7 +347,7 @@ fn stable_open_or_create_child_file(parent: &File, _path: &Path, name: &OsStr) -
     rustix::fs::openat(
         parent,
         name,
-        OFlags::RDWR | OFlags::CREATE | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+        OFlags::RDWR | OFlags::CREATE | OFlags::NOFOLLOW | OFlags::NONBLOCK | OFlags::CLOEXEC,
         Mode::from_bits_truncate(0o600),
     )
     .map(File::from)
@@ -399,11 +400,14 @@ fn stable_unlink_child_if_identity(
     let opened = rustix::fs::openat(
         parent,
         name,
-        OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+        OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::NONBLOCK | OFlags::CLOEXEC,
         Mode::empty(),
     )
     .map(File::from)
     .map_err(io::Error::from)?;
+    if !opened.metadata()?.is_file() {
+        return Err(io::Error::other("child is not a regular file"));
+    }
     if file_identity(&opened)? != expected {
         return Err(io::Error::other("child identity changed before unlink"));
     }
@@ -828,7 +832,7 @@ fn replace_file_platform(
     let source = openat(
         directory,
         source_name,
-        OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+        OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::NONBLOCK | OFlags::CLOEXEC,
         Mode::empty(),
     )
     .map(File::from)
@@ -837,7 +841,7 @@ fn replace_file_platform(
     let target = openat(
         directory,
         target_name,
-        OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+        OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::NONBLOCK | OFlags::CLOEXEC,
         Mode::empty(),
     )
     .map(File::from)
@@ -859,11 +863,17 @@ fn replace_file_platform(
     let replaced = openat(
         directory,
         target_name,
-        OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+        OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::NONBLOCK | OFlags::CLOEXEC,
         Mode::empty(),
     )
     .map(File::from)
     .map_err(io::Error::from)
+    .map_err(ReplaceFileError::StateUnknown)?;
+    verify_regular_metadata(
+        &replaced
+            .metadata()
+            .map_err(ReplaceFileError::StateUnknown)?,
+    )
     .map_err(ReplaceFileError::StateUnknown)?;
     if unix_identity(&replaced).map_err(ReplaceFileError::StateUnknown)? != source_identity
         || statat(directory, source_name, AtFlags::SYMLINK_NOFOLLOW).is_ok()
@@ -952,7 +962,7 @@ fn install_new_file_platform(
     let source = openat(
         directory,
         source_name,
-        OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+        OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::NONBLOCK | OFlags::CLOEXEC,
         Mode::empty(),
     )
     .map(File::from)
@@ -975,11 +985,12 @@ fn install_new_file_platform(
     let installed = openat(
         directory,
         target_name,
-        OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+        OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::NONBLOCK | OFlags::CLOEXEC,
         Mode::empty(),
     )
     .map(File::from)
     .map_err(io::Error::from)?;
+    verify_regular_metadata(&installed.metadata()?)?;
     if unix_identity(&installed)? != source_identity {
         return Err(io::Error::other("atomic creation state did not reconcile"));
     }
@@ -1979,6 +1990,12 @@ mod windows {
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
+    const FIFO_CHILD_ENV: &str = "GRAPHFORGE_FILESYSTEM_FIFO_CHILD";
+
+    #[cfg(unix)]
+    const FIFO_ROOT_ENV: &str = "GRAPHFORGE_FILESYSTEM_FIFO_ROOT";
+
     pub(super) fn directory_handle(path: &Path) -> File {
         #[cfg(unix)]
         return File::open(path).unwrap();
@@ -1996,6 +2013,133 @@ mod tests {
                 .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
                 .open(path)
                 .unwrap();
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn peerless_fifo_child() {
+        let Ok(operation) = std::env::var(FIFO_CHILD_ENV) else {
+            return;
+        };
+        let root = PathBuf::from(std::env::var_os(FIFO_ROOT_ENV).expect("FIFO test root"));
+        let stable = StableDirectory::open(&root).unwrap();
+        let fifo_identity = path_identity(&root.join("fifo")).unwrap();
+        let regular_identity = path_identity(&root.join("regular")).unwrap();
+        let result = match operation.as_str() {
+            "open" => stable.open_child_file(OsStr::new("fifo")).map(drop),
+            "open-or-create" => stable
+                .open_or_create_child_file(OsStr::new("fifo"))
+                .map(drop),
+            "unlink" => stable.unlink_child_if_identity(OsStr::new("fifo"), fifo_identity),
+            "replace-source" => {
+                stable.replace_child(OsStr::new("fifo"), fifo_identity, OsStr::new("regular"))
+            }
+            "replace-target" => {
+                stable.replace_child(OsStr::new("regular"), regular_identity, OsStr::new("fifo"))
+            }
+            "native-replace-source" => replace_file(
+                &directory_handle(&root),
+                OsStr::new("fifo"),
+                OsStr::new("regular"),
+            )
+            .map_err(|error| io::Error::other(error.to_string())),
+            "native-replace-target" => replace_file(
+                &directory_handle(&root),
+                OsStr::new("regular"),
+                OsStr::new("fifo"),
+            )
+            .map_err(|error| io::Error::other(error.to_string())),
+            "native-install-source" => install_new_file(
+                &directory_handle(&root),
+                OsStr::new("fifo"),
+                OsStr::new("absent"),
+            ),
+            other => panic!("unknown FIFO operation {other}"),
+        };
+        assert!(
+            result.is_err(),
+            "peerless FIFO must fail closed: {operation}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn every_regular_child_operation_rejects_peerless_fifo_without_blocking() {
+        use std::process::{Command, Stdio};
+        use std::time::{Duration, Instant};
+
+        for operation in [
+            "open",
+            "open-or-create",
+            "unlink",
+            "replace-source",
+            "replace-target",
+            "native-replace-source",
+            "native-replace-target",
+            "native-install-source",
+        ] {
+            let root = tempfile::tempdir().unwrap();
+            std::fs::write(root.path().join("regular"), b"regular").unwrap();
+            let status = Command::new("mkfifo")
+                .arg(root.path().join("fifo"))
+                .status()
+                .unwrap();
+            assert!(status.success(), "mkfifo failed for {operation}");
+            let mut child = Command::new(std::env::current_exe().unwrap())
+                .args(["--exact", "tests::peerless_fifo_child", "--nocapture"])
+                .env(FIFO_CHILD_ENV, operation)
+                .env(FIFO_ROOT_ENV, root.path())
+                .stdin(Stdio::null())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .unwrap();
+            let started = Instant::now();
+            loop {
+                if let Some(status) = child.try_wait().unwrap() {
+                    assert!(
+                        status.success(),
+                        "FIFO child failed for {operation}: {status}"
+                    );
+                    break;
+                }
+                if started.elapsed() >= Duration::from_secs(2) {
+                    child.kill().unwrap();
+                    let _ = child.wait();
+                    panic!("regular-child operation blocked on peerless FIFO: {operation}");
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn regular_child_operations_reject_symlinks_and_unix_sockets() {
+        use std::os::unix::fs::symlink;
+        use std::os::unix::net::UnixDatagram;
+
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("regular"), b"regular").unwrap();
+        symlink("regular", root.path().join("linked")).unwrap();
+        let _socket = UnixDatagram::bind(root.path().join("socket")).unwrap();
+        let stable = StableDirectory::open(root.path()).unwrap();
+
+        for special in ["linked", "socket"] {
+            assert!(stable.open_child_file(OsStr::new(special)).is_err());
+            assert!(
+                stable
+                    .open_or_create_child_file(OsStr::new(special))
+                    .is_err()
+            );
+            let identity = path_identity(&root.path().join(special)).unwrap();
+            assert!(
+                stable
+                    .unlink_child_if_identity(OsStr::new(special), identity)
+                    .is_err()
+            );
+            assert!(root.path().join(special).exists());
         }
     }
 

--- a/crates/graphforge-filesystem/src/lib.rs
+++ b/crates/graphforge-filesystem/src/lib.rs
@@ -199,14 +199,21 @@ impl StableDirectory {
 
     /// Atomically publish a retained temporary child as `target` within this
     /// retained directory. Cooperative publishers must serialize the target.
-    pub fn replace_child(&self, temporary: &OsStr, target: &OsStr) -> io::Result<()> {
+    pub fn replace_child(
+        &self,
+        temporary: &OsStr,
+        expected_temporary: FileIdentity,
+        target: &OsStr,
+    ) -> io::Result<()> {
         validate_child_name(temporary)?;
         validate_child_name(target)?;
         self.revalidate_named()?;
         let temporary_file = self.open_child_file(temporary)?;
-        if file_link_count(&temporary_file)? != 1 {
+        if file_identity(&temporary_file)? != expected_temporary
+            || file_link_count(&temporary_file)? != 1
+        {
             return Err(io::Error::other(
-                "atomic temporary child is multiply linked",
+                "atomic temporary child identity or link count changed",
             ));
         }
         drop(temporary_file);
@@ -219,10 +226,10 @@ impl StableDirectory {
             Err(error) => return Err(error),
         };
         let result = if target_exists {
-            replace_file(&self.file, temporary, target)
+            replace_file_platform(&self.file, temporary, target, Some(expected_temporary))
                 .map_err(|error| io::Error::other(error.to_string()))
         } else {
-            install_new_file(&self.file, temporary, target)
+            install_new_file_platform(&self.file, temporary, target, Some(expected_temporary))
         };
         result?;
         self.revalidate_named()?;
@@ -402,8 +409,13 @@ fn stable_unlink_child_if_identity(
     }
     let named =
         rustix::fs::statat(parent, name, AtFlags::SYMLINK_NOFOLLOW).map_err(io::Error::from)?;
+    // `dev_t` is an opaque device bit pattern. It is unsigned on Linux and
+    // signed on Darwin, so preserving the bits requires a target-dependent
+    // no-op/sign cast that Clippy cannot express portably without allowances.
+    #[allow(clippy::cast_sign_loss, clippy::unnecessary_cast)]
+    let volume_serial = named.st_dev as u64;
     let named_identity = FileIdentity {
-        volume_serial: named.st_dev as u64,
+        volume_serial,
         file_id: u128::from(named.st_ino).to_le_bytes(),
     };
     if named_identity != expected {
@@ -735,7 +747,7 @@ pub fn replace_file(
 ) -> Result<(), ReplaceFileError> {
     verify_single_component(source_name).map_err(ReplaceFileError::NotReplaced)?;
     verify_single_component(target_name).map_err(ReplaceFileError::NotReplaced)?;
-    replace_file_platform(directory, source_name, target_name)
+    replace_file_platform(directory, source_name, target_name, None)
 }
 
 /// Atomically install a new regular file without replacing an existing entry.
@@ -749,7 +761,7 @@ pub fn install_new_file(
 ) -> io::Result<()> {
     verify_single_component(source_name)?;
     verify_single_component(target_name)?;
-    install_new_file_platform(directory, source_name, target_name)
+    install_new_file_platform(directory, source_name, target_name, None)
 }
 
 fn verify_single_component(name: &OsStr) -> io::Result<()> {
@@ -809,6 +821,7 @@ fn replace_file_platform(
     directory: &File,
     source_name: &OsStr,
     target_name: &OsStr,
+    expected_source: Option<FileIdentity>,
 ) -> Result<(), ReplaceFileError> {
     use rustix::fs::{AtFlags, Mode, OFlags, openat, renameat, statat};
 
@@ -835,6 +848,11 @@ fn replace_file_platform(
     verify_regular_metadata(&target.metadata().map_err(ReplaceFileError::NotReplaced)?)
         .map_err(ReplaceFileError::NotReplaced)?;
     let source_identity = unix_identity(&source).map_err(ReplaceFileError::NotReplaced)?;
+    if expected_source.is_some_and(|expected| expected != source_identity) {
+        return Err(ReplaceFileError::NotReplaced(io::Error::other(
+            "rename source differs from the retained expected identity",
+        )));
+    }
     renameat(directory, source_name, directory, target_name)
         .map_err(io::Error::from)
         .map_err(ReplaceFileError::NotReplaced)?;
@@ -927,6 +945,7 @@ fn install_new_file_platform(
     directory: &File,
     source_name: &OsStr,
     target_name: &OsStr,
+    expected_source: Option<FileIdentity>,
 ) -> io::Result<()> {
     use rustix::fs::{Mode, OFlags, RenameFlags, openat, renameat_with};
 
@@ -940,6 +959,11 @@ fn install_new_file_platform(
     .map_err(io::Error::from)?;
     verify_regular_metadata(&source.metadata()?)?;
     let source_identity = unix_identity(&source)?;
+    if expected_source.is_some_and(|expected| expected != source_identity) {
+        return Err(io::Error::other(
+            "rename source differs from the retained expected identity",
+        ));
+    }
     renameat_with(
         directory,
         source_name,
@@ -967,8 +991,9 @@ fn replace_file_platform(
     directory: &File,
     source_name: &OsStr,
     target_name: &OsStr,
+    expected_source: Option<FileIdentity>,
 ) -> Result<(), ReplaceFileError> {
-    windows::replace_file(directory, source_name, target_name)
+    windows::replace_file(directory, source_name, target_name, expected_source)
 }
 
 #[cfg(windows)]
@@ -976,10 +1001,11 @@ fn install_new_file_platform(
     directory: &File,
     source_name: &OsStr,
     target_name: &OsStr,
+    expected_source: Option<FileIdentity>,
 ) -> io::Result<()> {
     // The native handle-scoped rename is the race-free no-replace authority;
     // identity reconciliation supplies a stable AlreadyExists class.
-    windows::install_new_file(directory, source_name, target_name)
+    windows::install_new_file(directory, source_name, target_name, expected_source)
 }
 
 #[cfg(windows)]
@@ -992,6 +1018,7 @@ fn replace_file_platform(
     _directory: &File,
     _source_name: &OsStr,
     _target_name: &OsStr,
+    _expected_source: Option<FileIdentity>,
 ) -> Result<(), ReplaceFileError> {
     Err(ReplaceFileError::NotReplaced(io::Error::new(
         io::ErrorKind::Unsupported,
@@ -1004,6 +1031,7 @@ fn install_new_file_platform(
     _directory: &File,
     _source_name: &OsStr,
     _target_name: &OsStr,
+    _expected_source: Option<FileIdentity>,
 ) -> io::Result<()> {
     Err(io::Error::new(
         io::ErrorKind::Unsupported,
@@ -1101,6 +1129,7 @@ mod windows {
         directory: &File,
         source_name: &OsStr,
         target_name: &OsStr,
+        expected_source: Option<FileIdentity>,
     ) -> Result<(), ReplaceFileError> {
         let (_directory_guard, directory_path) =
             guarded_directory_path(directory).map_err(ReplaceFileError::NotReplaced)?;
@@ -1110,6 +1139,11 @@ mod windows {
         verify_open_regular(&source).map_err(ReplaceFileError::NotReplaced)?;
         source.sync_all().map_err(ReplaceFileError::NotReplaced)?;
         let source_before = file_identity(&source).map_err(ReplaceFileError::NotReplaced)?;
+        if expected_source.is_some_and(|expected| expected != source_before) {
+            return Err(ReplaceFileError::NotReplaced(io::Error::other(
+                "rename source differs from the retained expected identity",
+            )));
+        }
         if identity(&source_path).map_err(ReplaceFileError::NotReplaced)? != source_before {
             return Err(ReplaceFileError::NotReplaced(io::Error::other(
                 "rename source identity changed during open",
@@ -1161,14 +1195,16 @@ mod windows {
         directory: &File,
         source_name: &OsStr,
         target_name: &OsStr,
+        expected_source: Option<FileIdentity>,
     ) -> io::Result<()> {
-        install_new_file_before_rename(directory, source_name, target_name, || {})
+        install_new_file_before_rename(directory, source_name, target_name, expected_source, || {})
     }
 
     fn install_new_file_before_rename(
         directory: &File,
         source_name: &OsStr,
         target_name: &OsStr,
+        expected_source: Option<FileIdentity>,
         before_rename: impl FnOnce(),
     ) -> io::Result<()> {
         let (_directory_guard, directory_path) = guarded_directory_path(directory)?;
@@ -1178,6 +1214,11 @@ mod windows {
         verify_open_regular(&source)?;
         source.sync_all()?;
         let source_identity = file_identity(&source)?;
+        if expected_source.is_some_and(|expected| expected != source_identity) {
+            return Err(io::Error::other(
+                "rename source differs from the retained expected identity",
+            ));
+        }
         if identity(&source_path)? != source_identity {
             return Err(io::Error::other(
                 "rename source identity changed during open",
@@ -1817,6 +1858,7 @@ mod windows {
                 &handle,
                 OsStr::new("source"),
                 OsStr::new("target"),
+                None,
                 || std::fs::write(&target, b"contender").unwrap(),
             )
             .unwrap_err();
@@ -1840,7 +1882,7 @@ mod windows {
             let target = directory.path().join(target_name);
             let handle = super::super::tests::directory_handle(directory.path());
 
-            install_new_file(&handle, OsStr::new("source"), target_name).unwrap();
+            install_new_file(&handle, OsStr::new("source"), target_name, None).unwrap();
 
             assert_eq!(std::fs::read(target).unwrap(), b"source");
             assert!(cwd_decoy.path().is_dir());
@@ -1864,6 +1906,7 @@ mod windows {
                 &caller,
                 OsStr::new("source"),
                 OsStr::new("target"),
+                None,
                 || assert!(std::fs::rename(&directory, &moved).is_err()),
             )
             .unwrap();
@@ -1895,12 +1938,39 @@ mod windows {
                 .open(&junction)
                 .unwrap();
 
-            let error = install_new_file(&caller, OsStr::new("source"), OsStr::new("published"))
-                .unwrap_err();
+            let error =
+                install_new_file(&caller, OsStr::new("source"), OsStr::new("published"), None)
+                    .unwrap_err();
 
             assert_eq!(error.kind(), io::ErrorKind::Other);
             assert_eq!(std::fs::read(source).unwrap(), b"source");
             assert!(!published.exists());
+        }
+
+        #[test]
+        fn install_rejects_source_substituted_after_expected_identity_was_recorded() {
+            let directory = tempfile::tempdir().unwrap();
+            let source = directory.path().join("source");
+            let original = directory.path().join("original");
+            let target = directory.path().join("target");
+            std::fs::write(&source, b"authenticated").unwrap();
+            let expected = identity(&source).unwrap();
+            std::fs::rename(&source, &original).unwrap();
+            std::fs::write(&source, b"substitute").unwrap();
+            let handle = super::super::tests::directory_handle(directory.path());
+
+            let error = install_new_file(
+                &handle,
+                OsStr::new("source"),
+                OsStr::new("target"),
+                Some(expected),
+            )
+            .unwrap_err();
+
+            assert_eq!(error.kind(), io::ErrorKind::Other);
+            assert_eq!(std::fs::read(source).unwrap(), b"substitute");
+            assert_eq!(std::fs::read(original).unwrap(), b"authenticated");
+            assert!(!target.exists());
         }
     }
 }
@@ -2153,5 +2223,37 @@ mod tests {
             std::fs::read(root.path().join("payload")).unwrap(),
             b"replacement"
         );
+    }
+
+    #[test]
+    fn stable_directory_rejects_replaced_atomic_temporary_child() {
+        use std::io::Write as _;
+
+        let root = tempfile::tempdir().unwrap();
+        let stable = StableDirectory::open(root.path()).unwrap();
+        let mut temporary = stable
+            .create_replaceable_child_file(OsStr::new("temporary"))
+            .unwrap();
+        temporary.write_all(b"authenticated").unwrap();
+        temporary.sync_all().unwrap();
+        let expected = file_identity(&temporary).unwrap();
+        drop(temporary);
+        std::fs::rename(root.path().join("temporary"), root.path().join("original")).unwrap();
+        std::fs::write(root.path().join("temporary"), b"substitute").unwrap();
+
+        assert!(
+            stable
+                .replace_child(OsStr::new("temporary"), expected, OsStr::new("CURRENT"))
+                .is_err()
+        );
+        assert_eq!(
+            std::fs::read(root.path().join("temporary")).unwrap(),
+            b"substitute"
+        );
+        assert_eq!(
+            std::fs::read(root.path().join("original")).unwrap(),
+            b"authenticated"
+        );
+        assert!(!root.path().join("CURRENT").exists());
     }
 }

--- a/crates/graphforge-filesystem/src/lib.rs
+++ b/crates/graphforge-filesystem/src/lib.rs
@@ -6,7 +6,7 @@
 use std::ffi::OsStr;
 use std::fs::File;
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Stable filesystem identity suitable for Windows and Unix filesystems.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -15,6 +15,265 @@ pub struct FileIdentity {
     pub volume_serial: u64,
     /// Full native file identity (128-bit on Windows; zero-extended inode on Unix).
     pub file_id: [u8; 16],
+}
+
+/// Retained directory capability whose children are opened without following
+/// links or reparse points.
+#[derive(Debug)]
+pub struct StableDirectory {
+    path: PathBuf,
+    file: File,
+    identity: FileIdentity,
+}
+
+impl StableDirectory {
+    /// Open and retain a real directory at `path`.
+    pub fn open(path: &Path) -> io::Result<Self> {
+        let file = stable_open_directory(path)?;
+        let identity = file_identity(&file)?;
+        let directory = Self {
+            path: path.to_path_buf(),
+            file,
+            identity,
+        };
+        directory.revalidate_named()?;
+        Ok(directory)
+    }
+
+    /// Require that the named path still identifies this retained directory.
+    pub fn revalidate_named(&self) -> io::Result<()> {
+        let metadata = std::fs::symlink_metadata(&self.path)?;
+        if !metadata.is_dir() || is_link_or_reparse(&metadata) {
+            return Err(io::Error::other(
+                "stable directory path is linked or special",
+            ));
+        }
+        if path_identity(&self.path)? != self.identity {
+            return Err(io::Error::other("stable directory identity changed"));
+        }
+        Ok(())
+    }
+
+    /// Open one real child directory relative to this capability.
+    pub fn open_child_directory(&self, name: &OsStr) -> io::Result<Self> {
+        validate_child_name(name)?;
+        self.revalidate_named()?;
+        let path = self.path.join(name);
+        let file = stable_open_child_directory(&self.file, &path, name)?;
+        let child = Self {
+            identity: file_identity(&file)?,
+            path,
+            file,
+        };
+        child.revalidate_named()?;
+        self.revalidate_named()?;
+        Ok(child)
+    }
+
+    /// Create one child directory if absent, then retain it.
+    pub fn create_child_directory(&self, name: &OsStr) -> io::Result<Self> {
+        validate_child_name(name)?;
+        self.revalidate_named()?;
+        stable_create_child_directory(&self.file, &self.path.join(name), name)?;
+        self.open_child_directory(name)
+    }
+
+    /// Open one regular child without following links or reparse points.
+    pub fn open_child_file(&self, name: &OsStr) -> io::Result<File> {
+        validate_child_name(name)?;
+        self.revalidate_named()?;
+        let path = self.path.join(name);
+        let file = stable_open_child_file(&self.file, &path, name, false)?;
+        validate_stable_child_file(&file, &path)?;
+        self.revalidate_named()?;
+        Ok(file)
+    }
+
+    /// Create one new regular child without following links or reparse points.
+    pub fn create_child_file(&self, name: &OsStr) -> io::Result<File> {
+        validate_child_name(name)?;
+        self.revalidate_named()?;
+        let path = self.path.join(name);
+        let file = stable_open_child_file(&self.file, &path, name, true)?;
+        validate_stable_child_file(&file, &path)?;
+        self.revalidate_named()?;
+        Ok(file)
+    }
+
+    /// Borrow the retained directory handle.
+    #[must_use]
+    pub fn file(&self) -> &File {
+        &self.file
+    }
+
+    /// Return the retained native identity.
+    #[must_use]
+    pub fn identity(&self) -> FileIdentity {
+        self.identity
+    }
+}
+
+fn validate_child_name(name: &OsStr) -> io::Result<()> {
+    let path = Path::new(name);
+    if name.is_empty()
+        || path.is_absolute()
+        || path.components().count() != 1
+        || matches!(name.to_str(), Some("." | ".."))
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "invalid child name",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_stable_child_file(file: &File, path: &Path) -> io::Result<()> {
+    let metadata = file.metadata()?;
+    let named = std::fs::symlink_metadata(path)?;
+    if !metadata.is_file()
+        || !named.is_file()
+        || is_link_or_reparse(&named)
+        || file_identity(file)? != path_identity(path)?
+    {
+        return Err(io::Error::other(
+            "stable child is linked, special, or substituted",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn stable_open_directory(path: &Path) -> io::Result<File> {
+    use rustix::fs::{Mode, OFlags};
+    rustix::fs::open(
+        path,
+        OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+        Mode::empty(),
+    )
+    .map(File::from)
+    .map_err(io::Error::from)
+}
+
+#[cfg(unix)]
+fn stable_open_child_directory(parent: &File, _path: &Path, name: &OsStr) -> io::Result<File> {
+    use rustix::fs::{Mode, OFlags};
+    rustix::fs::openat(
+        parent,
+        name,
+        OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+        Mode::empty(),
+    )
+    .map(File::from)
+    .map_err(io::Error::from)
+}
+
+#[cfg(unix)]
+fn stable_create_child_directory(parent: &File, _path: &Path, name: &OsStr) -> io::Result<()> {
+    use rustix::fs::Mode;
+    match rustix::fs::mkdirat(parent, name, Mode::from_bits_truncate(0o700)) {
+        Ok(()) | Err(rustix::io::Errno::EXIST) => Ok(()),
+        Err(error) => Err(io::Error::from(error)),
+    }
+}
+
+#[cfg(unix)]
+fn stable_open_child_file(
+    parent: &File,
+    _path: &Path,
+    name: &OsStr,
+    create_new: bool,
+) -> io::Result<File> {
+    use rustix::fs::{Mode, OFlags};
+    let flags = if create_new {
+        OFlags::RDWR | OFlags::CREATE | OFlags::EXCL
+    } else {
+        OFlags::RDONLY
+    } | OFlags::NOFOLLOW
+        | OFlags::CLOEXEC;
+    rustix::fs::openat(parent, name, flags, Mode::from_bits_truncate(0o600))
+        .map(File::from)
+        .map_err(io::Error::from)
+}
+
+#[cfg(windows)]
+fn stable_open_directory(path: &Path) -> io::Result<File> {
+    use std::os::windows::fs::OpenOptionsExt as _;
+    const FILE_SHARE_READ: u32 = 0x0000_0001;
+    const FILE_SHARE_WRITE: u32 = 0x0000_0002;
+    const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    std::fs::OpenOptions::new()
+        .read(true)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)
+}
+
+#[cfg(windows)]
+fn stable_open_child_directory(_parent: &File, path: &Path, _name: &OsStr) -> io::Result<File> {
+    stable_open_directory(path)
+}
+
+#[cfg(windows)]
+fn stable_create_child_directory(_parent: &File, path: &Path, _name: &OsStr) -> io::Result<()> {
+    match create_private_directory(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(windows)]
+fn stable_open_child_file(
+    _parent: &File,
+    path: &Path,
+    _name: &OsStr,
+    create_new: bool,
+) -> io::Result<File> {
+    use std::os::windows::fs::OpenOptionsExt as _;
+    const FILE_SHARE_READ: u32 = 0x0000_0001;
+    const FILE_SHARE_WRITE: u32 = 0x0000_0002;
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    let mut options = std::fs::OpenOptions::new();
+    options
+        .read(true)
+        .write(create_new)
+        .create_new(create_new)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+    options.open(path)
+}
+
+#[cfg(all(not(unix), not(windows)))]
+fn stable_open_directory(_path: &Path) -> io::Result<File> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "stable directories unsupported",
+    ))
+}
+
+#[cfg(all(not(unix), not(windows)))]
+fn stable_open_child_directory(_parent: &File, _path: &Path, _name: &OsStr) -> io::Result<File> {
+    stable_open_directory(Path::new(""))
+}
+
+#[cfg(all(not(unix), not(windows)))]
+fn stable_create_child_directory(_parent: &File, _path: &Path, _name: &OsStr) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "stable directories unsupported",
+    ))
+}
+
+#[cfg(all(not(unix), not(windows)))]
+fn stable_open_child_file(
+    _parent: &File,
+    _path: &Path,
+    _name: &OsStr,
+    _create_new: bool,
+) -> io::Result<File> {
+    stable_open_directory(Path::new(""))
 }
 
 /// Native Windows volume facts needed by the durability admission policy.
@@ -1416,5 +1675,40 @@ mod tests {
                 0o700
             );
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stable_directory_fails_closed_after_named_child_substitution() {
+        let root = tempfile::tempdir().unwrap();
+        let stable_root = StableDirectory::open(root.path()).unwrap();
+        let child = stable_root
+            .create_child_directory(OsStr::new("objects"))
+            .unwrap();
+        let file = child.create_child_file(OsStr::new("payload")).unwrap();
+        drop(file);
+        let displaced = root.path().join("displaced");
+        std::fs::rename(root.path().join("objects"), &displaced).unwrap();
+        std::fs::create_dir(root.path().join("objects")).unwrap();
+
+        assert!(child.revalidate_named().is_err());
+        assert!(child.open_child_file(OsStr::new("payload")).is_err());
+        assert_eq!(std::fs::read(displaced.join("payload")).unwrap(), b"");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stable_directory_rejects_symlink_child() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        symlink(outside.path(), root.path().join("objects")).unwrap();
+        let stable_root = StableDirectory::open(root.path()).unwrap();
+        assert!(
+            stable_root
+                .open_child_directory(OsStr::new("objects"))
+                .is_err()
+        );
     }
 }

--- a/crates/graphforge-filesystem/src/lib.rs
+++ b/crates/graphforge-filesystem/src/lib.rs
@@ -27,17 +27,23 @@ pub struct StableDirectory {
 }
 
 impl StableDirectory {
-    /// Acquire a cooperative shared lock on this retained directory inode.
+    /// Acquire a cooperative shared lock on this retained Unix directory inode.
+    ///
+    /// Windows directory handles cannot be byte-range locked; callers use a
+    /// retained regular coordination file there instead.
+    #[cfg(unix)]
     pub fn lock_shared(&self) -> io::Result<()> {
         <File as fs4::FileExt>::lock_shared(&self.file)
     }
 
-    /// Acquire a cooperative exclusive lock on this retained directory inode.
+    /// Acquire a cooperative exclusive lock on this retained Unix directory inode.
+    #[cfg(unix)]
     pub fn lock_exclusive(&self) -> io::Result<()> {
         <File as fs4::FileExt>::lock(&self.file)
     }
 
-    /// Try to acquire a cooperative exclusive lock on this retained directory inode.
+    /// Try to acquire a cooperative exclusive lock on this retained Unix directory inode.
+    #[cfg(unix)]
     pub fn try_lock_exclusive(&self) -> io::Result<bool> {
         match <File as fs4::FileExt>::try_lock(&self.file) {
             Ok(()) => Ok(true),
@@ -46,7 +52,8 @@ impl StableDirectory {
         }
     }
 
-    /// Release this retained directory inode's cooperative lock.
+    /// Release this retained Unix directory inode's cooperative lock.
+    #[cfg(unix)]
     pub fn unlock(&self) -> io::Result<()> {
         <File as fs4::FileExt>::unlock(&self.file)
     }

--- a/crates/graphforge-storage/BUILD.bazel
+++ b/crates/graphforge-storage/BUILD.bazel
@@ -17,11 +17,15 @@ _STORAGE_DEPS = [
 gf_rust_library(
     name = "graphforge_storage",
     # Enable failpoint hooks so api/cli unit tests that spawn subprocesses can
-    # inject protocol faults. Hooks remain no-ops unless the exact env cookie is
-    # set (same as Cargo `[dev-dependencies] features = ["test-failpoints"]`
-    # unification). Residual vs Cargo release builds: Bazel links the env-gated
-    # bodies instead of the const no-op; document for #6 parity.
-    crate_features = ["test-failpoints"],
+    # inject protocol faults and compile API unit-test compact-root fixtures.
+    # Hooks remain no-ops unless the exact env cookie is set; fixture builders
+    # are not exposed by the host bindings. Cargo's published Rust library does
+    # not enable either dev-only feature. Bazel uses one shared first-party
+    # storage target, so it models Cargo dev-feature unification here.
+    crate_features = [
+        "test-failpoints",
+        "test-support",
+    ],
     deps = _STORAGE_DEPS,
 )
 

--- a/crates/graphforge-storage/Cargo.toml
+++ b/crates/graphforge-storage/Cargo.toml
@@ -12,6 +12,8 @@ default = []
 # Enables the existing cookie-protected subprocess failpoints for higher-level
 # workspace tests. Production consumers do not enable this feature.
 test-failpoints = []
+# Exposes compact-root builders only to higher-level cross-crate tests.
+test-support = []
 
 [dependencies]
 graphforge-core = { version = "0.5.2", path = "../graphforge-core" }

--- a/crates/graphforge-storage/src/filesystem_admission.rs
+++ b/crates/graphforge-storage/src/filesystem_admission.rs
@@ -657,7 +657,7 @@ fn open_lifecycle_lock_file(parent: &LifecycleDirectory, name: &str) -> std::io:
         openat(
             &parent.handle,
             name,
-            OFlags::RDWR | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+            OFlags::RDWR | OFlags::NOFOLLOW | OFlags::NONBLOCK | OFlags::CLOEXEC,
             Mode::empty(),
         )
         .map(File::from)
@@ -668,7 +668,12 @@ fn open_lifecycle_lock_file(parent: &LifecycleDirectory, name: &str) -> std::io:
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => match openat(
             &parent.handle,
             name,
-            OFlags::RDWR | OFlags::CREATE | OFlags::EXCL | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+            OFlags::RDWR
+                | OFlags::CREATE
+                | OFlags::EXCL
+                | OFlags::NOFOLLOW
+                | OFlags::NONBLOCK
+                | OFlags::CLOEXEC,
             Mode::RUSR | Mode::WUSR,
         ) {
             Ok(file) => Ok(File::from(file)),
@@ -1465,7 +1470,7 @@ fn open_regular_non_link(probe: &ProbeDirectory, name: &str) -> Result<File, GfE
 fn open_probe_file(probe: &ProbeDirectory, name: &str, create: bool) -> std::io::Result<File> {
     use rustix::fs::{Mode, OFlags, openat};
 
-    let mut flags = OFlags::RDWR | OFlags::NOFOLLOW | OFlags::CLOEXEC;
+    let mut flags = OFlags::RDWR | OFlags::NOFOLLOW | OFlags::NONBLOCK | OFlags::CLOEXEC;
     if create {
         flags |= OFlags::CREATE | OFlags::EXCL;
     }

--- a/crates/graphforge-storage/src/graph_files.rs
+++ b/crates/graphforge-storage/src/graph_files.rs
@@ -37,6 +37,7 @@ const MAX_GRAPH_FILES: usize = 100_000;
 const HASH_BUFFER_BYTES: usize = 64 * 1024;
 const GRAPH_FILES_SCHEMA_CANONICAL_BYTES: &[u8] =
     b"graphforge-graph-files/1|relative_path|byte_length|content_sha256|role";
+#[cfg(test)]
 const GRAPH_FILES_V2_SCHEMA_CANONICAL_BYTES: &[u8] =
     b"graphforge-graph-files-root/2|root_node_sha256|logical_file_count|logical_byte_length";
 
@@ -88,7 +89,7 @@ pub struct GraphFilesInventory {
 
 /// Explicitly decoded `graph/files` participant generation.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum GraphFilesParticipant {
+pub(crate) enum GraphFilesParticipant {
     /// Expanded generation-owned v1 inventory.
     V1(GraphFilesInventory),
     /// Compact project-object-store v2 manifest root.
@@ -167,7 +168,8 @@ pub fn inventory_participant(
 }
 
 /// Encode a compact v2 root as the registered `graph`/`files` participant.
-pub fn graph_files_root_participant(
+#[cfg(test)]
+pub(crate) fn graph_files_root_participant(
     root: &crate::GraphFilesRootV2,
 ) -> Result<ProjectParticipant, GfError> {
     Ok(ProjectParticipant {
@@ -215,7 +217,9 @@ pub fn decode_inventory(bytes: &[u8]) -> Result<GraphFilesInventory, GfError> {
 
 /// Decode either the legacy expanded inventory or compact v2 root.
 /// Unknown format tags and future versions fail closed.
-pub fn decode_graph_files_participant(bytes: &[u8]) -> Result<GraphFilesParticipant, GfError> {
+pub(crate) fn decode_graph_files_participant(
+    bytes: &[u8],
+) -> Result<GraphFilesParticipant, GfError> {
     let value: serde_json::Value = serde_json::from_slice(bytes)
         .map_err(|error| validation(format!("invalid graph files participant JSON: {error}")))?;
     let format = value
@@ -243,7 +247,7 @@ pub fn decode_graph_files_participant(bytes: &[u8]) -> Result<GraphFilesParticip
 }
 
 /// Decode a participant and enforce the descriptor/payload version pairing.
-pub fn decode_versioned_graph_files_participant(
+pub(crate) fn decode_versioned_graph_files_participant(
     record_version: u32,
     bytes: &[u8],
 ) -> Result<GraphFilesParticipant, GfError> {

--- a/crates/graphforge-storage/src/graph_files.rs
+++ b/crates/graphforge-storage/src/graph_files.rs
@@ -460,19 +460,27 @@ pub fn infer_role(relative: &Path) -> GraphFileRole {
 fn build_inventory(source_root: &Path) -> Result<GraphFilesInventory, GfError> {
     let mut paths = Vec::new();
     collect_source_files(source_root, &mut paths)?;
-    paths.sort();
     if paths.len() > MAX_GRAPH_FILES {
         return Err(resource_limit("graph files count exceeds limit"));
     }
+    let mut paths = paths
+        .into_iter()
+        .map(|path| {
+            let relative = path
+                .strip_prefix(source_root)
+                .map_err(|_| validation("graph file path escaped workspace"))?;
+            validate_relative_path(relative)?;
+            Ok((path_text(relative)?, path))
+        })
+        .collect::<Result<Vec<_>, GfError>>()?;
+    paths.sort_by(|(left, _), (right, _)| left.cmp(right));
     let mut files = Vec::with_capacity(paths.len());
     let mut total = 0_u64;
     let mut seen = HashSet::new();
-    for path in paths {
+    for (relative_text, path) in paths {
         let relative = path
             .strip_prefix(source_root)
             .map_err(|_| validation("graph file path escaped workspace"))?;
-        validate_relative_path(relative)?;
-        let relative_text = path_text(relative)?;
         if !seen.insert(relative_text.clone()) {
             return Err(validation("graph files inventory contains duplicate paths"));
         }
@@ -825,6 +833,34 @@ mod tests {
         assert_eq!(inventory.files[1].relative_path, "topology/nodes.parquet");
         assert_eq!(inventory.files[1].role, GraphFileRole::Topology);
         assert_eq!(participant.record_family_id, GRAPH_FILES_FAMILY);
+        assert_eq!(decode_inventory(&participant.bytes).unwrap(), inventory);
+    }
+
+    #[test]
+    fn legacy_monolith_and_shards_sort_by_canonical_wire_path() {
+        let source = tempfile::tempdir().unwrap();
+        fs::create_dir_all(source.path().join("topology/nodes")).unwrap();
+        fs::write(source.path().join("topology/nodes.parquet"), b"legacy").unwrap();
+        fs::write(
+            source
+                .path()
+                .join("topology/nodes/00000000000000000001.parquet"),
+            b"shard",
+        )
+        .unwrap();
+
+        let (inventory, participant) = capture_graph_files(source.path()).unwrap();
+        assert_eq!(
+            inventory
+                .files
+                .iter()
+                .map(|entry| entry.relative_path.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "topology/nodes.parquet",
+                "topology/nodes/00000000000000000001.parquet",
+            ]
+        );
         assert_eq!(decode_inventory(&participant.bytes).unwrap(), inventory);
     }
 

--- a/crates/graphforge-storage/src/graph_files.rs
+++ b/crates/graphforge-storage/src/graph_files.rs
@@ -26,6 +26,8 @@ pub const GRAPH_CAPABILITY_VERSION: u32 = 1;
 pub const GRAPH_FILES_FAMILY: &str = "files";
 /// Record contract version for [`GRAPH_FILES_FAMILY`].
 pub const GRAPH_FILES_RECORD_VERSION: u32 = 1;
+/// Record version for compact content-addressed graph roots.
+pub const GRAPH_FILES_V2_RECORD_VERSION: u32 = 2;
 /// Generation-owned directory holding graph workspace files.
 pub const GRAPH_TREE_DIR: &str = "graph";
 
@@ -35,6 +37,8 @@ const MAX_GRAPH_FILES: usize = 100_000;
 const HASH_BUFFER_BYTES: usize = 64 * 1024;
 const GRAPH_FILES_SCHEMA_CANONICAL_BYTES: &[u8] =
     b"graphforge-graph-files/1|relative_path|byte_length|content_sha256|role";
+const GRAPH_FILES_V2_SCHEMA_CANONICAL_BYTES: &[u8] =
+    b"graphforge-graph-files-root/2|root_node_sha256|logical_file_count|logical_byte_length";
 
 /// Logical role inferred from a contained relative workspace path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -82,6 +86,15 @@ pub struct GraphFilesInventory {
     pub total_byte_length: u64,
 }
 
+/// Explicitly decoded `graph/files` participant generation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GraphFilesParticipant {
+    /// Expanded generation-owned v1 inventory.
+    V1(GraphFilesInventory),
+    /// Compact project-object-store v2 manifest root.
+    V2(crate::GraphFilesRootV2),
+}
+
 /// Structural evidence recorded while validating or materializing a graph tree.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct GraphFilesOpenEvidence {
@@ -97,6 +110,10 @@ pub struct GraphFilesOpenEvidence {
     pub bytes_copied: u64,
     /// Files opened or mapped in place (no copy).
     pub files_opened_in_place: u64,
+    /// Immutable files reused from the content-addressed object store.
+    pub files_reused: u64,
+    /// Logical bytes represented by reused immutable objects.
+    pub bytes_reused: u64,
 }
 
 /// Open/materialization strategy for a file-backed graph.
@@ -149,6 +166,27 @@ pub fn inventory_participant(
     })
 }
 
+/// Encode a compact v2 root as the registered `graph`/`files` participant.
+pub fn graph_files_root_participant(
+    root: &crate::GraphFilesRootV2,
+) -> Result<ProjectParticipant, GfError> {
+    Ok(ProjectParticipant {
+        capability_id: GRAPH_CAPABILITY_ID.into(),
+        capability_version: GRAPH_CAPABILITY_VERSION,
+        record_family_id: GRAPH_FILES_FAMILY.into(),
+        record_version: GRAPH_FILES_V2_RECORD_VERSION,
+        encoding: ProjectParticipantEncoding::Json,
+        schema_fingerprint: fingerprint(
+            CanonicalDomain::Schema,
+            CANONICAL_CONTRACT_VERSION,
+            GRAPH_FILES_V2_SCHEMA_CANONICAL_BYTES,
+        )
+        .map_err(|error| GfError::Validation(error.to_string()))?,
+        row_count: root.logical_file_count,
+        bytes: crate::encode_graph_files_root_v2(root)?,
+    })
+}
+
 /// Decode and mechanically validate inventory JSON bytes.
 ///
 /// # Errors
@@ -173,6 +211,35 @@ pub fn decode_inventory(bytes: &[u8]) -> Result<GraphFilesInventory, GfError> {
         return Err(validation("graph files inventory is not in canonical form"));
     }
     Ok(inventory)
+}
+
+/// Decode either the legacy expanded inventory or compact v2 root.
+/// Unknown format tags and future versions fail closed.
+pub fn decode_graph_files_participant(bytes: &[u8]) -> Result<GraphFilesParticipant, GfError> {
+    let value: serde_json::Value = serde_json::from_slice(bytes)
+        .map_err(|error| validation(format!("invalid graph files participant JSON: {error}")))?;
+    let format = value
+        .get("format")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| validation("graph files participant format is missing"))?;
+    let version = value
+        .get("format_version")
+        .and_then(serde_json::Value::as_u64)
+        .ok_or_else(|| validation("graph files participant format_version is missing"))?;
+    match (format, version) {
+        (GRAPH_FILES_FORMAT, version) if version == u64::from(GRAPH_FILES_FORMAT_VERSION) => {
+            decode_inventory(bytes).map(GraphFilesParticipant::V1)
+        }
+        (crate::GRAPH_FILES_V2_FORMAT, version)
+            if version == u64::from(crate::GRAPH_FILES_V2_VERSION) =>
+        {
+            crate::decode_graph_files_root_v2(bytes).map(GraphFilesParticipant::V2)
+        }
+        _ => Err(GfError::Project {
+            code: ProjectErrorCode::UnsupportedProjectFormat,
+            message: format!("unsupported graph files participant {format}/{version}"),
+        }),
+    }
 }
 
 /// Encode inventory as one canonical JSON line ending in LF.
@@ -364,6 +431,8 @@ pub fn pinned_open_evidence(inventory: &GraphFilesInventory) -> GraphFilesOpenEv
         files_copied: 0,
         bytes_copied: 0,
         files_opened_in_place: u64::try_from(inventory.files.len()).unwrap_or(u64::MAX),
+        files_reused: 0,
+        bytes_reused: 0,
     }
 }
 
@@ -430,6 +499,25 @@ fn build_inventory(source_root: &Path) -> Result<GraphFilesInventory, GfError> {
         format_version: GRAPH_FILES_FORMAT_VERSION,
         file_count: u64::try_from(files.len()).unwrap_or(u64::MAX),
         total_byte_length: total,
+        files,
+    };
+    validate_inventory_contract(&inventory)?;
+    Ok(inventory)
+}
+
+pub(crate) fn inventory_from_entries(
+    files: Vec<GraphFileEntry>,
+) -> Result<GraphFilesInventory, GfError> {
+    let total_byte_length = files.iter().try_fold(0_u64, |total, entry| {
+        total
+            .checked_add(entry.byte_length)
+            .ok_or_else(|| validation("graph files total size overflow"))
+    })?;
+    let inventory = GraphFilesInventory {
+        format: GRAPH_FILES_FORMAT.into(),
+        format_version: GRAPH_FILES_FORMAT_VERSION,
+        file_count: u64::try_from(files.len()).unwrap_or(u64::MAX),
+        total_byte_length,
         files,
     };
     validate_inventory_contract(&inventory)?;

--- a/crates/graphforge-storage/src/graph_files.rs
+++ b/crates/graphforge-storage/src/graph_files.rs
@@ -242,6 +242,24 @@ pub fn decode_graph_files_participant(bytes: &[u8]) -> Result<GraphFilesParticip
     }
 }
 
+/// Decode a participant and enforce the descriptor/payload version pairing.
+pub fn decode_versioned_graph_files_participant(
+    record_version: u32,
+    bytes: &[u8],
+) -> Result<GraphFilesParticipant, GfError> {
+    let participant = decode_graph_files_participant(bytes)?;
+    if !matches!(
+        (record_version, &participant),
+        (GRAPH_FILES_RECORD_VERSION, GraphFilesParticipant::V1(_))
+            | (GRAPH_FILES_V2_RECORD_VERSION, GraphFilesParticipant::V2(_))
+    ) {
+        return Err(validation(
+            "graph files descriptor version does not match its encoded payload",
+        ));
+    }
+    Ok(participant)
+}
+
 /// Encode inventory as one canonical JSON line ending in LF.
 pub fn encode_inventory(inventory: &GraphFilesInventory) -> Result<Vec<u8>, GfError> {
     validate_inventory_contract(inventory)?;
@@ -1143,5 +1161,27 @@ mod tests {
             row_count: wire.row_count,
             bytes: wire.bytes,
         }
+    }
+
+    #[test]
+    fn descriptor_record_version_must_match_graph_files_payload_version() {
+        let inventory = inventory_from_entries(Vec::new()).unwrap();
+        let v1 = encode_inventory(&inventory).unwrap();
+        let v2 = crate::encode_graph_files_root_v2(&crate::GraphFilesRootV2 {
+            format: crate::GRAPH_FILES_V2_FORMAT.into(),
+            format_version: crate::GRAPH_FILES_V2_VERSION,
+            root_node_sha256: "0".repeat(64),
+            logical_file_count: 0,
+            logical_byte_length: 0,
+        })
+        .unwrap();
+        assert!(decode_versioned_graph_files_participant(GRAPH_FILES_RECORD_VERSION, &v1).is_ok());
+        assert!(
+            decode_versioned_graph_files_participant(GRAPH_FILES_V2_RECORD_VERSION, &v2).is_ok()
+        );
+        assert!(decode_versioned_graph_files_participant(GRAPH_FILES_RECORD_VERSION, &v2).is_err());
+        assert!(
+            decode_versioned_graph_files_participant(GRAPH_FILES_V2_RECORD_VERSION, &v1).is_err()
+        );
     }
 }

--- a/crates/graphforge-storage/src/graph_manifest.rs
+++ b/crates/graphforge-storage/src/graph_manifest.rs
@@ -1,0 +1,453 @@
+//! Fixed-depth content-addressed radix manifest for graph files.
+
+use crate::{GraphFileEntry, GraphFileRole};
+use graphforge_core::GfError;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Canonical v2 compact-root format identifier.
+pub const GRAPH_FILES_V2_FORMAT: &str = "graphforge-graph-files-root";
+/// Supported compact-root format version.
+pub const GRAPH_FILES_V2_VERSION: u32 = 2;
+/// Canonical radix-node format identifier.
+pub const GRAPH_MANIFEST_NODE_FORMAT: &str = "graphforge-graph-manifest-radix-node";
+/// Supported radix-node format version.
+pub const GRAPH_MANIFEST_NODE_VERSION: u32 = 1;
+/// Number of SHA-256 nibbles consumed by the fixed-depth trie.
+pub const GRAPH_RADIX_DEPTH: u8 = 64;
+
+/// Generation participant root naming one immutable radix root and its totals.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GraphFilesRootV2 {
+    /// Contract format identifier.
+    pub format: String,
+    /// Contract format version.
+    pub format_version: u32,
+    /// SHA-256 address of the root radix node.
+    pub root_node_sha256: String,
+    /// Total live logical files.
+    pub logical_file_count: u64,
+    /// Total live logical payload bytes.
+    pub logical_byte_length: u64,
+}
+
+/// One immutable, canonically encoded radix node.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GraphManifestNode {
+    /// Node contract identifier.
+    pub format: String,
+    /// Node contract version.
+    pub format_version: u32,
+    /// SHA-256 nibble depth represented by this node.
+    pub depth: u8,
+    #[serde(flatten)]
+    /// Branch or collision-leaf payload.
+    pub kind: GraphManifestNodeKind,
+}
+
+/// Canonical radix-node payload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum GraphManifestNodeKind {
+    /// Hex-nibble child references.
+    Branch {
+        /// Canonically ordered nibble to child-object digest map.
+        children: BTreeMap<String, String>,
+    },
+    /// Terminal exact-path collision bucket.
+    Leaf {
+        /// Full SHA-256 digest shared by every colliding exact path.
+        path_sha256: String,
+        /// Exact logical entries ordered by relative path.
+        entries: Vec<GraphFileEntry>,
+    },
+}
+
+/// Admission bounds for resolving an untrusted radix manifest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GraphManifestLimits {
+    /// Maximum distinct radix objects examined.
+    pub max_segments: usize,
+    /// Maximum live logical entries resolved.
+    pub max_entries: usize,
+}
+impl Default for GraphManifestLimits {
+    fn default() -> Self {
+        Self {
+            max_segments: 6_500_000,
+            max_entries: 100_000,
+        }
+    }
+}
+
+/// Deterministic work evidence from manifest resolution.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GraphManifestResolveEvidence {
+    /// Distinct radix nodes examined.
+    pub segments_examined: u64,
+    /// Terminal logical entries examined.
+    pub entries_examined: u64,
+}
+
+/// Encode one validated node as canonical JSON-line bytes.
+pub fn encode_node(node: &GraphManifestNode) -> Result<Vec<u8>, GfError> {
+    validate_node(node)?;
+    canonical_line(node, "graph manifest radix node")
+}
+/// Decode and validate canonical JSON-line node bytes.
+pub fn decode_node(bytes: &[u8]) -> Result<GraphManifestNode, GfError> {
+    decode_canonical_line(bytes, "graph manifest radix node", validate_node)
+}
+/// Encode one validated compact root as canonical JSON-line bytes.
+pub fn encode_root(root: &GraphFilesRootV2) -> Result<Vec<u8>, GfError> {
+    validate_root(root)?;
+    canonical_line(root, "graph files v2 root")
+}
+/// Decode and validate canonical JSON-line compact-root bytes.
+pub fn decode_root(bytes: &[u8]) -> Result<GraphFilesRootV2, GfError> {
+    decode_canonical_line(bytes, "graph files v2 root", validate_root)
+}
+#[must_use]
+/// Return the lowercase SHA-256 address of exact object bytes.
+pub fn object_digest(bytes: &[u8]) -> String {
+    hex_digest(Sha256::digest(bytes).into())
+}
+#[must_use]
+/// Hash canonical logical-path UTF-8 bytes for radix routing.
+pub fn logical_path_digest(path: &str) -> [u8; 32] {
+    Sha256::digest(path.as_bytes()).into()
+}
+#[must_use]
+/// Select one high/low SHA-256 nibble at `depth`.
+pub const fn radix_nibble(digest: &[u8; 32], depth: u8) -> u8 {
+    let byte = digest[(depth / 2) as usize];
+    if depth.is_multiple_of(2) {
+        byte >> 4
+    } else {
+        byte & 15
+    }
+}
+/// Verify declared object length and SHA-256 identity.
+pub fn verify_object_bytes(expected: &str, length: u64, bytes: &[u8]) -> Result<(), GfError> {
+    validate_digest(expected)?;
+    if u64::try_from(bytes.len()).unwrap_or(u64::MAX) != length {
+        return Err(validation("graph object length does not match manifest"));
+    }
+    if object_digest(bytes) != expected {
+        return Err(validation("graph object digest does not match manifest"));
+    }
+    Ok(())
+}
+
+/// Resolve a compact radix root into its authenticated logical inventory.
+pub fn resolve_manifest<F>(
+    root: &GraphFilesRootV2,
+    limits: GraphManifestLimits,
+    mut load: F,
+) -> Result<(Vec<GraphFileEntry>, GraphManifestResolveEvidence), GfError>
+where
+    F: FnMut(&str) -> Result<Vec<u8>, GfError>,
+{
+    validate_root(root)?;
+    if limits.max_segments == 0 || limits.max_entries == 0 {
+        return Err(validation("graph manifest limits must be positive"));
+    }
+    let mut stack = vec![(root.root_node_sha256.clone(), 0_u8)];
+    let mut visited = BTreeSet::new();
+    let mut files = BTreeMap::new();
+    let mut evidence = GraphManifestResolveEvidence::default();
+    while let Some((digest, expected_depth)) = stack.pop() {
+        if visited.len() >= limits.max_segments {
+            return Err(validation("graph manifest node limit exceeded"));
+        }
+        if !visited.insert(digest.clone()) {
+            return Err(validation(
+                "graph manifest node cycle or duplicate reference detected",
+            ));
+        }
+        let bytes = load(&digest)?;
+        if object_digest(&bytes) != digest {
+            return Err(validation("graph manifest node digest mismatch"));
+        }
+        let node = decode_node(&bytes)?;
+        if node.depth != expected_depth {
+            return Err(validation("graph manifest radix depth mismatch"));
+        }
+        evidence.segments_examined = evidence.segments_examined.saturating_add(1);
+        match node.kind {
+            GraphManifestNodeKind::Branch { children } => {
+                if expected_depth >= GRAPH_RADIX_DEPTH {
+                    return Err(validation("graph manifest branch exceeds radix depth"));
+                }
+                for (nibble, child) in children.into_iter().rev() {
+                    validate_nibble(&nibble)?;
+                    stack.push((child, expected_depth + 1));
+                }
+            }
+            GraphManifestNodeKind::Leaf {
+                path_sha256,
+                entries,
+            } => {
+                if expected_depth != GRAPH_RADIX_DEPTH {
+                    return Err(validation("graph manifest leaf is not terminal"));
+                }
+                for entry in entries {
+                    if hex_digest(logical_path_digest(&entry.relative_path)) != path_sha256 {
+                        return Err(validation("graph manifest leaf path digest mismatch"));
+                    }
+                    evidence.entries_examined = evidence.entries_examined.saturating_add(1);
+                    if files.insert(entry.relative_path.clone(), entry).is_some() {
+                        return Err(validation("graph manifest contains duplicate logical path"));
+                    }
+                    if files.len() > limits.max_entries {
+                        return Err(validation("graph manifest entry limit exceeded"));
+                    }
+                }
+            }
+        }
+    }
+    let files: Vec<_> = files.into_values().collect();
+    let bytes = files.iter().try_fold(0_u64, |n, e| {
+        n.checked_add(e.byte_length)
+            .ok_or_else(|| validation("graph manifest byte total overflow"))
+    })?;
+    if u64::try_from(files.len()).unwrap_or(u64::MAX) != root.logical_file_count
+        || bytes != root.logical_byte_length
+    {
+        return Err(validation(
+            "graph files v2 root totals do not match resolved manifest",
+        ));
+    }
+    Ok((files, evidence))
+}
+
+fn validate_root(root: &GraphFilesRootV2) -> Result<(), GfError> {
+    if root.format != GRAPH_FILES_V2_FORMAT || root.format_version != GRAPH_FILES_V2_VERSION {
+        return Err(validation("unsupported graph files v2 root contract"));
+    }
+    validate_digest(&root.root_node_sha256)
+}
+fn validate_node(node: &GraphManifestNode) -> Result<(), GfError> {
+    if node.format != GRAPH_MANIFEST_NODE_FORMAT
+        || node.format_version != GRAPH_MANIFEST_NODE_VERSION
+    {
+        return Err(validation("unsupported graph manifest radix node contract"));
+    }
+    if node.depth > GRAPH_RADIX_DEPTH {
+        return Err(validation("graph manifest radix depth exceeds limit"));
+    }
+    match &node.kind {
+        GraphManifestNodeKind::Branch { children } => {
+            if node.depth >= GRAPH_RADIX_DEPTH {
+                return Err(validation("terminal graph manifest node must be a leaf"));
+            }
+            for (nibble, digest) in children {
+                validate_nibble(nibble)?;
+                validate_digest(digest)?;
+            }
+        }
+        GraphManifestNodeKind::Leaf {
+            path_sha256,
+            entries,
+        } => {
+            if node.depth != GRAPH_RADIX_DEPTH || entries.is_empty() {
+                return Err(validation("graph manifest leaf shape is invalid"));
+            }
+            validate_digest(path_sha256)?;
+            let mut previous: Option<&str> = None;
+            for entry in entries {
+                validate_entry(entry)?;
+                if previous.is_some_and(|p| p >= entry.relative_path.as_str()) {
+                    return Err(validation("graph manifest collision leaf is not canonical"));
+                }
+                if hex_digest(logical_path_digest(&entry.relative_path)) != *path_sha256 {
+                    return Err(validation("graph manifest leaf path digest mismatch"));
+                }
+                previous = Some(&entry.relative_path);
+            }
+        }
+    }
+    Ok(())
+}
+fn validate_entry(entry: &GraphFileEntry) -> Result<(), GfError> {
+    validate_path(&entry.relative_path)?;
+    validate_digest(&entry.content_sha256)?;
+    match entry.role {
+        GraphFileRole::Topology
+        | GraphFileRole::Properties
+        | GraphFileRole::Index
+        | GraphFileRole::Delta
+        | GraphFileRole::Catalog
+        | GraphFileRole::Other => {}
+    }
+    Ok(())
+}
+fn validate_path(value: &str) -> Result<(), GfError> {
+    let path = std::path::Path::new(value);
+    if path.as_os_str().is_empty()
+        || path.is_absolute()
+        || path
+            .components()
+            .any(|c| !matches!(c, std::path::Component::Normal(_)))
+    {
+        return Err(validation("invalid graph manifest relative path"));
+    }
+    if path
+        .components()
+        .next()
+        .is_some_and(|component| component.as_os_str() == std::ffi::OsStr::new(".graphforge-cache"))
+    {
+        return Err(validation("derived cache path cannot be authoritative"));
+    }
+    Ok(())
+}
+fn validate_digest(value: &str) -> Result<(), GfError> {
+    if value.len() != 64
+        || !value
+            .bytes()
+            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+    {
+        return Err(validation(
+            "graph manifest digest must be 64 lowercase hex characters",
+        ));
+    }
+    Ok(())
+}
+fn validate_nibble(value: &str) -> Result<(), GfError> {
+    if value.len() != 1
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(validation(
+            "graph manifest child nibble is not canonical lowercase hex",
+        ));
+    }
+    Ok(())
+}
+fn canonical_line<T: Serialize>(value: &T, label: &str) -> Result<Vec<u8>, GfError> {
+    let mut bytes = serde_json::to_vec(value)
+        .map_err(|e| validation(format!("failed to encode {label}: {e}")))?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+fn decode_canonical_line<T, V>(bytes: &[u8], label: &str, validate: V) -> Result<T, GfError>
+where
+    T: for<'de> Deserialize<'de> + Serialize,
+    V: FnOnce(&T) -> Result<(), GfError>,
+{
+    if !bytes.ends_with(b"\n") || bytes[..bytes.len().saturating_sub(1)].contains(&b'\n') {
+        return Err(validation(format!(
+            "{label} must be one canonical JSON line"
+        )));
+    }
+    let value: T = serde_json::from_slice(bytes)
+        .map_err(|e| validation(format!("invalid {label} JSON: {e}")))?;
+    validate(&value)?;
+    if canonical_line(&value, label)? != bytes {
+        return Err(validation(format!("{label} is not canonical")));
+    }
+    Ok(value)
+}
+fn hex_digest(digest: [u8; 32]) -> String {
+    use std::fmt::Write as _;
+    digest.iter().fold(String::with_capacity(64), |mut s, b| {
+        let _ = write!(s, "{b:02x}");
+        s
+    })
+}
+fn validation(message: impl Into<String>) -> GfError {
+    GfError::Validation(message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn branch(depth: u8, children: BTreeMap<String, String>) -> GraphManifestNode {
+        GraphManifestNode {
+            format: GRAPH_MANIFEST_NODE_FORMAT.into(),
+            format_version: GRAPH_MANIFEST_NODE_VERSION,
+            depth,
+            kind: GraphManifestNodeKind::Branch { children },
+        }
+    }
+
+    #[test]
+    fn unknown_versions_unsafe_paths_and_noncanonical_nibbles_fail_closed() {
+        let future = b"{\"format\":\"graphforge-graph-files-root\",\"format_version\":3,\"root_node_sha256\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"logical_file_count\":0,\"logical_byte_length\":0}\n";
+        assert!(decode_root(future).is_err());
+
+        let mut children = BTreeMap::new();
+        children.insert("A".into(), "0".repeat(64));
+        assert!(encode_node(&branch(0, children)).is_err());
+
+        let digest = "0".repeat(64);
+        for path in ["../escape", "/absolute", ".graphforge-cache/index"] {
+            let node = GraphManifestNode {
+                format: GRAPH_MANIFEST_NODE_FORMAT.into(),
+                format_version: GRAPH_MANIFEST_NODE_VERSION,
+                depth: GRAPH_RADIX_DEPTH,
+                kind: GraphManifestNodeKind::Leaf {
+                    path_sha256: digest.clone(),
+                    entries: vec![GraphFileEntry {
+                        relative_path: path.into(),
+                        byte_length: 0,
+                        content_sha256: digest.clone(),
+                        role: GraphFileRole::Other,
+                    }],
+                },
+            };
+            assert!(encode_node(&node).is_err());
+        }
+    }
+
+    #[test]
+    fn duplicate_references_depth_mismatch_and_corruption_fail_closed() {
+        let child_bytes = encode_node(&branch(1, BTreeMap::new())).unwrap();
+        let child_digest = object_digest(&child_bytes);
+        let mut children = BTreeMap::new();
+        children.insert("0".into(), child_digest.clone());
+        children.insert("1".into(), child_digest.clone());
+        let root_bytes = encode_node(&branch(0, children)).unwrap();
+        let root_digest = object_digest(&root_bytes);
+        let root = GraphFilesRootV2 {
+            format: GRAPH_FILES_V2_FORMAT.into(),
+            format_version: GRAPH_FILES_V2_VERSION,
+            root_node_sha256: root_digest.clone(),
+            logical_file_count: 0,
+            logical_byte_length: 0,
+        };
+        let load = |digest: &str| {
+            if digest == root_digest {
+                Ok(root_bytes.clone())
+            } else if digest == child_digest {
+                Ok(child_bytes.clone())
+            } else {
+                Err(validation("missing test object"))
+            }
+        };
+        assert!(resolve_manifest(&root, GraphManifestLimits::default(), load).is_err());
+
+        let wrong_depth = encode_node(&branch(1, BTreeMap::new())).unwrap();
+        let wrong_digest = object_digest(&wrong_depth);
+        let wrong_root = GraphFilesRootV2 {
+            root_node_sha256: wrong_digest,
+            ..root.clone()
+        };
+        assert!(
+            resolve_manifest(&wrong_root, GraphManifestLimits::default(), |_| {
+                Ok(wrong_depth.clone())
+            })
+            .is_err()
+        );
+
+        assert!(
+            resolve_manifest(&root, GraphManifestLimits::default(), |_| {
+                Ok(b"corrupt\n".to_vec())
+            })
+            .is_err()
+        );
+    }
+}

--- a/crates/graphforge-storage/src/graph_manifest.rs
+++ b/crates/graphforge-storage/src/graph_manifest.rs
@@ -1,4 +1,4 @@
-//! Fixed-depth content-addressed radix manifest for graph files.
+//! Canonical content-addressed Patricia manifest for graph files.
 
 use crate::{GraphFileEntry, GraphFileRole};
 use graphforge_core::GfError;
@@ -13,8 +13,8 @@ pub const GRAPH_FILES_V2_VERSION: u32 = 2;
 /// Canonical radix-node format identifier.
 pub const GRAPH_MANIFEST_NODE_FORMAT: &str = "graphforge-graph-manifest-radix-node";
 /// Supported radix-node format version.
-pub const GRAPH_MANIFEST_NODE_VERSION: u32 = 1;
-/// Number of SHA-256 nibbles consumed by the fixed-depth trie.
+pub const GRAPH_MANIFEST_NODE_VERSION: u32 = 2;
+/// Number of SHA-256 nibbles consumed by the Patricia trie.
 pub const GRAPH_RADIX_DEPTH: u8 = 64;
 
 /// Generation participant root naming one immutable radix root and its totals.
@@ -41,6 +41,8 @@ pub struct GraphManifestNode {
     pub format_version: u32,
     /// SHA-256 nibble depth represented by this node.
     pub depth: u8,
+    /// Lowercase hex path compressed between `depth` and this node's payload.
+    pub prefix: String,
     #[serde(flatten)]
     /// Branch or collision-leaf payload.
     pub kind: GraphManifestNodeKind,
@@ -79,12 +81,12 @@ pub struct GraphManifestLimits {
 impl Default for GraphManifestLimits {
     fn default() -> Self {
         Self {
-            // A 100k-entry fixed-depth radix contains about 6.0m nodes once
-            // random SHA-256 prefixes share their compact upper levels.
-            max_segments: 6_100_000,
+            // A non-empty canonical Patricia tree has at most 2F-1 nodes for
+            // F distinct path digests. The empty inventory has one root node.
+            max_segments: 200_000,
             max_entries: 100_000,
-            max_decoded_bytes: 1_610_612_736,
-            max_work_units: 12_300_000,
+            max_decoded_bytes: 1024 * 1024 * 1024,
+            max_work_units: 500_000,
         }
     }
 }
@@ -153,6 +155,7 @@ pub fn verify_object_bytes(expected: &str, length: u64, bytes: &[u8]) -> Result<
 }
 
 /// Resolve a compact radix root into its authenticated logical inventory.
+#[allow(clippy::too_many_lines)]
 pub fn resolve_manifest<F>(
     root: &GraphFilesRootV2,
     limits: GraphManifestLimits,
@@ -172,17 +175,30 @@ where
     if root.logical_file_count > u64::try_from(limits.max_entries).unwrap_or(u64::MAX) {
         return Err(validation("graph manifest declared entry limit exceeded"));
     }
-    let mut stack = vec![(root.root_node_sha256.clone(), 0_u8)];
+    let structural_node_bound = if root.logical_file_count == 0 {
+        1
+    } else {
+        root.logical_file_count
+            .checked_mul(2)
+            .and_then(|value| value.checked_sub(1))
+            .ok_or_else(|| validation("graph manifest structural bound overflow"))?
+    };
+    let mut stack = vec![(root.root_node_sha256.clone(), 0_u8, String::new())];
     let mut visited = BTreeSet::new();
     let mut files = BTreeMap::new();
     let mut evidence = GraphManifestResolveEvidence::default();
-    while let Some((digest, expected_depth)) = stack.pop() {
+    while let Some((digest, expected_depth, route)) = stack.pop() {
         if visited.len() >= limits.max_segments {
             return Err(validation("graph manifest node limit exceeded"));
         }
         if !visited.insert(digest.clone()) {
             return Err(validation(
                 "graph manifest node cycle or duplicate reference detected",
+            ));
+        }
+        if u64::try_from(visited.len()).unwrap_or(u64::MAX) > structural_node_bound {
+            return Err(validation(
+                "graph manifest exceeds canonical Patricia node bound",
             ));
         }
         let bytes = load(&digest)?;
@@ -200,11 +216,19 @@ where
         if node.depth != expected_depth {
             return Err(validation("graph manifest radix depth mismatch"));
         }
+        let payload_depth = node
+            .depth
+            .checked_add(u8::try_from(node.prefix.len()).map_err(|_| {
+                validation("graph manifest compressed prefix length exceeds radix depth")
+            })?)
+            .ok_or_else(|| validation("graph manifest compressed depth overflow"))?;
+        let mut node_route = route;
+        node_route.push_str(&node.prefix);
         evidence.segments_examined = evidence.segments_examined.saturating_add(1);
         admit_work(&mut evidence, limits, 1)?;
         match node.kind {
             GraphManifestNodeKind::Branch { children } => {
-                if expected_depth >= GRAPH_RADIX_DEPTH {
+                if payload_depth >= GRAPH_RADIX_DEPTH {
                     return Err(validation("graph manifest branch exceeds radix depth"));
                 }
                 admit_work(
@@ -214,14 +238,16 @@ where
                 )?;
                 for (nibble, child) in children.into_iter().rev() {
                     validate_nibble(&nibble)?;
-                    stack.push((child, expected_depth + 1));
+                    let mut child_route = node_route.clone();
+                    child_route.push_str(&nibble);
+                    stack.push((child, payload_depth + 1, child_route));
                 }
             }
             GraphManifestNodeKind::Leaf {
                 path_sha256,
                 entries,
             } => {
-                if expected_depth != GRAPH_RADIX_DEPTH {
+                if payload_depth != GRAPH_RADIX_DEPTH || node_route != path_sha256 {
                     return Err(validation("graph manifest leaf is not terminal"));
                 }
                 admit_work(
@@ -286,27 +312,49 @@ fn validate_node(node: &GraphManifestNode) -> Result<(), GfError> {
     {
         return Err(validation("unsupported graph manifest radix node contract"));
     }
-    if node.depth > GRAPH_RADIX_DEPTH {
+    validate_prefix(&node.prefix)?;
+    let payload_depth = node
+        .depth
+        .checked_add(u8::try_from(node.prefix.len()).map_err(|_| {
+            validation("graph manifest compressed prefix length exceeds radix depth")
+        })?)
+        .ok_or_else(|| validation("graph manifest compressed depth overflow"))?;
+    if payload_depth > GRAPH_RADIX_DEPTH {
         return Err(validation("graph manifest radix depth exceeds limit"));
     }
     match &node.kind {
         GraphManifestNodeKind::Branch { children } => {
-            if node.depth >= GRAPH_RADIX_DEPTH {
+            if payload_depth >= GRAPH_RADIX_DEPTH {
                 return Err(validation("terminal graph manifest node must be a leaf"));
+            }
+            if children.len() == 1 {
+                return Err(validation("graph manifest unary branch is not canonical"));
+            }
+            let mut child_digests = BTreeSet::new();
+            if children.is_empty() && (node.depth != 0 || !node.prefix.is_empty()) {
+                return Err(validation("only the root may be an empty branch"));
             }
             for (nibble, digest) in children {
                 validate_nibble(nibble)?;
                 validate_digest(digest)?;
+                if !child_digests.insert(digest) {
+                    return Err(validation(
+                        "graph manifest branch contains duplicate child references",
+                    ));
+                }
             }
         }
         GraphManifestNodeKind::Leaf {
             path_sha256,
             entries,
         } => {
-            if node.depth != GRAPH_RADIX_DEPTH || entries.is_empty() {
+            if payload_depth != GRAPH_RADIX_DEPTH || entries.is_empty() {
                 return Err(validation("graph manifest leaf shape is invalid"));
             }
             validate_digest(path_sha256)?;
+            if node.prefix != path_sha256[usize::from(node.depth)..] {
+                return Err(validation("graph manifest leaf compressed route mismatch"));
+            }
             let mut previous: Option<&str> = None;
             for entry in entries {
                 validate_entry(entry)?;
@@ -378,6 +426,17 @@ fn validate_nibble(value: &str) -> Result<(), GfError> {
     }
     Ok(())
 }
+fn validate_prefix(value: &str) -> Result<(), GfError> {
+    if !value
+        .bytes()
+        .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(validation(
+            "graph manifest compressed prefix is not canonical lowercase hex",
+        ));
+    }
+    Ok(())
+}
 fn canonical_line<T: Serialize>(value: &T, label: &str) -> Result<Vec<u8>, GfError> {
     let mut bytes = serde_json::to_vec(value)
         .map_err(|e| validation(format!("failed to encode {label}: {e}")))?;
@@ -422,6 +481,7 @@ mod tests {
             format: GRAPH_MANIFEST_NODE_FORMAT.into(),
             format_version: GRAPH_MANIFEST_NODE_VERSION,
             depth,
+            prefix: String::new(),
             kind: GraphManifestNodeKind::Branch { children },
         }
     }
@@ -441,6 +501,7 @@ mod tests {
                 format: GRAPH_MANIFEST_NODE_FORMAT.into(),
                 format_version: GRAPH_MANIFEST_NODE_VERSION,
                 depth: GRAPH_RADIX_DEPTH,
+                prefix: String::new(),
                 kind: GraphManifestNodeKind::Leaf {
                     path_sha256: digest.clone(),
                     entries: vec![GraphFileEntry {
@@ -457,11 +518,14 @@ mod tests {
 
     #[test]
     fn duplicate_references_depth_mismatch_and_corruption_fail_closed() {
-        let child_bytes = encode_node(&branch(1, BTreeMap::new())).unwrap();
-        let child_digest = object_digest(&child_bytes);
         let mut children = BTreeMap::new();
-        children.insert("0".into(), child_digest.clone());
-        children.insert("1".into(), child_digest.clone());
+        children.insert("0".into(), "1".repeat(64));
+        children.insert("1".into(), "1".repeat(64));
+        assert!(encode_node(&branch(0, children)).is_err());
+
+        let mut children = BTreeMap::new();
+        children.insert("0".into(), "1".repeat(64));
+        children.insert("1".into(), "2".repeat(64));
         let root_bytes = encode_node(&branch(0, children)).unwrap();
         let root_digest = object_digest(&root_bytes);
         let root = GraphFilesRootV2 {
@@ -474,15 +538,17 @@ mod tests {
         let load = |digest: &str| {
             if digest == root_digest {
                 Ok(root_bytes.clone())
-            } else if digest == child_digest {
-                Ok(child_bytes.clone())
             } else {
                 Err(validation("missing test object"))
             }
         };
         assert!(resolve_manifest(&root, GraphManifestLimits::default(), load).is_err());
 
-        let wrong_depth = encode_node(&branch(1, BTreeMap::new())).unwrap();
+        let wrong_depth = encode_node(&branch(
+            1,
+            BTreeMap::from([("0".into(), "1".repeat(64)), ("1".into(), "2".repeat(64))]),
+        ))
+        .unwrap();
         let wrong_digest = object_digest(&wrong_depth);
         let wrong_root = GraphFilesRootV2 {
             root_node_sha256: wrong_digest,
@@ -521,7 +587,7 @@ mod tests {
         assert!(resolve_manifest(&empty_root, byte_limits, |_| Ok(empty_bytes.clone())).is_err());
 
         let children = (0_u8..16)
-            .map(|nibble| (format!("{nibble:x}"), "0".repeat(64)))
+            .map(|nibble| (format!("{nibble:x}"), format!("{nibble:064x}")))
             .collect();
         let wide_bytes = encode_node(&branch(0, children)).unwrap();
         let wide_digest = object_digest(&wide_bytes);
@@ -551,5 +617,53 @@ mod tests {
             resolve_manifest(&root, GraphManifestLimits::default(), |_| Ok(bytes.clone())).unwrap();
         assert_eq!(evidence.decoded_bytes, bytes.len() as u64);
         assert_eq!(evidence.work_units, 1);
+    }
+
+    #[test]
+    fn node_v1_unary_and_wrong_compressed_routes_fail_closed() {
+        let old = b"{\"format\":\"graphforge-graph-manifest-radix-node\",\"format_version\":1,\"depth\":0,\"kind\":\"branch\",\"children\":{}}\n";
+        assert!(decode_node(old).is_err());
+
+        let unary = branch(0, BTreeMap::from([("0".into(), "1".repeat(64))]));
+        assert!(encode_node(&unary).is_err());
+
+        let path = "topology/nodes/a.parquet";
+        let path_sha256 = hex_digest(logical_path_digest(path));
+        let entry = GraphFileEntry {
+            relative_path: path.into(),
+            byte_length: 1,
+            content_sha256: "a".repeat(64),
+            role: GraphFileRole::Topology,
+        };
+        let node = GraphManifestNode {
+            format: GRAPH_MANIFEST_NODE_FORMAT.into(),
+            format_version: GRAPH_MANIFEST_NODE_VERSION,
+            depth: 0,
+            prefix: path_sha256.clone(),
+            kind: GraphManifestNodeKind::Leaf {
+                path_sha256,
+                entries: vec![entry],
+            },
+        };
+        let bytes = encode_node(&node).unwrap();
+        let digest = object_digest(&bytes);
+        let root = GraphFilesRootV2 {
+            format: GRAPH_FILES_V2_FORMAT.into(),
+            format_version: GRAPH_FILES_V2_VERSION,
+            root_node_sha256: digest,
+            logical_file_count: 1,
+            logical_byte_length: 1,
+        };
+        let mut wrong = node;
+        wrong
+            .prefix
+            .replace_range(..1, if &wrong.prefix[..1] == "0" { "1" } else { "0" });
+        let wrong_bytes = encode_node(&wrong).unwrap_err();
+        assert!(matches!(wrong_bytes, GfError::Validation(_)));
+        // Correctly routed leaf resolves; changing its authenticated bytes or
+        // route changes the address and cannot satisfy this root.
+        let (entries, _) =
+            resolve_manifest(&root, GraphManifestLimits::default(), |_| Ok(bytes.clone())).unwrap();
+        assert_eq!(entries.len(), 1);
     }
 }

--- a/crates/graphforge-storage/src/graph_manifest.rs
+++ b/crates/graphforge-storage/src/graph_manifest.rs
@@ -71,12 +71,20 @@ pub struct GraphManifestLimits {
     pub max_segments: usize,
     /// Maximum live logical entries resolved.
     pub max_entries: usize,
+    /// Maximum aggregate encoded bytes decoded across all radix objects.
+    pub max_decoded_bytes: u64,
+    /// Maximum aggregate node, child-reference, and entry work admitted.
+    pub max_work_units: u64,
 }
 impl Default for GraphManifestLimits {
     fn default() -> Self {
         Self {
-            max_segments: 6_500_000,
+            // A 100k-entry fixed-depth radix contains about 6.0m nodes once
+            // random SHA-256 prefixes share their compact upper levels.
+            max_segments: 6_100_000,
             max_entries: 100_000,
+            max_decoded_bytes: 1_610_612_736,
+            max_work_units: 12_300_000,
         }
     }
 }
@@ -88,6 +96,10 @@ pub struct GraphManifestResolveEvidence {
     pub segments_examined: u64,
     /// Terminal logical entries examined.
     pub entries_examined: u64,
+    /// Aggregate encoded bytes admitted for decoding.
+    pub decoded_bytes: u64,
+    /// Aggregate node, child-reference, and entry work performed.
+    pub work_units: u64,
 }
 
 /// Encode one validated node as canonical JSON-line bytes.
@@ -150,8 +162,15 @@ where
     F: FnMut(&str) -> Result<Vec<u8>, GfError>,
 {
     validate_root(root)?;
-    if limits.max_segments == 0 || limits.max_entries == 0 {
+    if limits.max_segments == 0
+        || limits.max_entries == 0
+        || limits.max_decoded_bytes == 0
+        || limits.max_work_units == 0
+    {
         return Err(validation("graph manifest limits must be positive"));
+    }
+    if root.logical_file_count > u64::try_from(limits.max_entries).unwrap_or(u64::MAX) {
+        return Err(validation("graph manifest declared entry limit exceeded"));
     }
     let mut stack = vec![(root.root_node_sha256.clone(), 0_u8)];
     let mut visited = BTreeSet::new();
@@ -167,6 +186,13 @@ where
             ));
         }
         let bytes = load(&digest)?;
+        evidence.decoded_bytes = evidence
+            .decoded_bytes
+            .checked_add(u64::try_from(bytes.len()).unwrap_or(u64::MAX))
+            .ok_or_else(|| validation("graph manifest decoded byte total overflow"))?;
+        if evidence.decoded_bytes > limits.max_decoded_bytes {
+            return Err(validation("graph manifest decoded byte limit exceeded"));
+        }
         if object_digest(&bytes) != digest {
             return Err(validation("graph manifest node digest mismatch"));
         }
@@ -175,11 +201,17 @@ where
             return Err(validation("graph manifest radix depth mismatch"));
         }
         evidence.segments_examined = evidence.segments_examined.saturating_add(1);
+        admit_work(&mut evidence, limits, 1)?;
         match node.kind {
             GraphManifestNodeKind::Branch { children } => {
                 if expected_depth >= GRAPH_RADIX_DEPTH {
                     return Err(validation("graph manifest branch exceeds radix depth"));
                 }
+                admit_work(
+                    &mut evidence,
+                    limits,
+                    u64::try_from(children.len()).unwrap_or(u64::MAX),
+                )?;
                 for (nibble, child) in children.into_iter().rev() {
                     validate_nibble(&nibble)?;
                     stack.push((child, expected_depth + 1));
@@ -192,6 +224,11 @@ where
                 if expected_depth != GRAPH_RADIX_DEPTH {
                     return Err(validation("graph manifest leaf is not terminal"));
                 }
+                admit_work(
+                    &mut evidence,
+                    limits,
+                    u64::try_from(entries.len()).unwrap_or(u64::MAX),
+                )?;
                 for entry in entries {
                     if hex_digest(logical_path_digest(&entry.relative_path)) != path_sha256 {
                         return Err(validation("graph manifest leaf path digest mismatch"));
@@ -220,6 +257,21 @@ where
         ));
     }
     Ok((files, evidence))
+}
+
+fn admit_work(
+    evidence: &mut GraphManifestResolveEvidence,
+    limits: GraphManifestLimits,
+    units: u64,
+) -> Result<(), GfError> {
+    evidence.work_units = evidence
+        .work_units
+        .checked_add(units)
+        .ok_or_else(|| validation("graph manifest work total overflow"))?;
+    if evidence.work_units > limits.max_work_units {
+        return Err(validation("graph manifest work limit exceeded"));
+    }
+    Ok(())
 }
 
 fn validate_root(root: &GraphFilesRootV2) -> Result<(), GfError> {
@@ -449,5 +501,55 @@ mod tests {
             })
             .is_err()
         );
+    }
+
+    #[test]
+    fn aggregate_decode_and_work_limits_reject_hostile_roots() {
+        let empty_bytes = encode_node(&branch(0, BTreeMap::new())).unwrap();
+        let empty_digest = object_digest(&empty_bytes);
+        let empty_root = GraphFilesRootV2 {
+            format: GRAPH_FILES_V2_FORMAT.into(),
+            format_version: GRAPH_FILES_V2_VERSION,
+            root_node_sha256: empty_digest.clone(),
+            logical_file_count: 0,
+            logical_byte_length: 0,
+        };
+        let byte_limits = GraphManifestLimits {
+            max_decoded_bytes: u64::try_from(empty_bytes.len() - 1).unwrap(),
+            ..GraphManifestLimits::default()
+        };
+        assert!(resolve_manifest(&empty_root, byte_limits, |_| Ok(empty_bytes.clone())).is_err());
+
+        let children = (0_u8..16)
+            .map(|nibble| (format!("{nibble:x}"), "0".repeat(64)))
+            .collect();
+        let wide_bytes = encode_node(&branch(0, children)).unwrap();
+        let wide_digest = object_digest(&wide_bytes);
+        let wide_root = GraphFilesRootV2 {
+            root_node_sha256: wide_digest,
+            ..empty_root
+        };
+        let work_limits = GraphManifestLimits {
+            max_work_units: 16,
+            ..GraphManifestLimits::default()
+        };
+        assert!(resolve_manifest(&wide_root, work_limits, |_| Ok(wide_bytes.clone())).is_err());
+    }
+
+    #[test]
+    fn successful_resolution_reports_aggregate_admission_evidence() {
+        let bytes = encode_node(&branch(0, BTreeMap::new())).unwrap();
+        let digest = object_digest(&bytes);
+        let root = GraphFilesRootV2 {
+            format: GRAPH_FILES_V2_FORMAT.into(),
+            format_version: GRAPH_FILES_V2_VERSION,
+            root_node_sha256: digest,
+            logical_file_count: 0,
+            logical_byte_length: 0,
+        };
+        let (_, evidence) =
+            resolve_manifest(&root, GraphManifestLimits::default(), |_| Ok(bytes.clone())).unwrap();
+        assert_eq!(evidence.decoded_bytes, bytes.len() as u64);
+        assert_eq!(evidence.work_units, 1);
     }
 }

--- a/crates/graphforge-storage/src/graph_manifest.rs
+++ b/crates/graphforge-storage/src/graph_manifest.rs
@@ -67,6 +67,7 @@ pub enum GraphManifestNodeKind {
 }
 
 /// Admission bounds for resolving an untrusted radix manifest.
+#[allow(clippy::struct_field_names)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GraphManifestLimits {
     /// Maximum distinct radix objects examined.

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -1498,31 +1498,25 @@ fn materialize_from_cas(
         )
     })?;
     let path = Path::new(&entry.relative_path);
-    let mut parent = target
-        .create_child_directory(std::ffi::OsStr::new("files"))
-        .map_err(|error| {
-            storage(
-                "create stable materialization files root",
-                &cas.diagnostic_root,
-                error,
-            )
-        })?;
+    let mut parent: Option<StableDirectory> = None;
     let mut components = path.components().peekable();
     while let Some(component) = components.next() {
         let Component::Normal(name) = component else {
             return Err(validation("invalid materialization path component"));
         };
         if components.peek().is_some() {
-            parent = parent.create_child_directory(name).map_err(|error| {
+            let directory = parent.as_ref().unwrap_or(target);
+            parent = Some(directory.create_child_directory(name).map_err(|error| {
                 storage(
                     "create stable materialization directory",
                     &cas.diagnostic_root,
                     error,
                 )
-            })?;
+            })?);
         } else {
+            let parent = parent.as_ref().unwrap_or(target);
             let (installed, installed_identity) = bucket
-                .link_child_into(source_name, &source, source_identity, &parent, name)
+                .link_child_into(source_name, &source, source_identity, parent, name)
                 .map_err(|error| {
                     storage(
                         "install stable materialized object",
@@ -2678,6 +2672,33 @@ mod tests {
             .is_err()
         );
         assert!(!outside.path().join("payload.bin").exists());
+    }
+
+    #[test]
+    fn materialization_preserves_ordinary_workspace_relative_paths() {
+        let root = tempfile::tempdir().unwrap();
+        let payload = b"ordinary topology payload";
+        let (digest, _) = install_graph_object_bytes(root.path(), payload).unwrap();
+        let inventory = crate::graph_files::inventory_from_entries(vec![crate::GraphFileEntry {
+            relative_path: "topology/edges/knows.parquet".into(),
+            byte_length: payload.len() as u64,
+            content_sha256: digest,
+            role: crate::GraphFileRole::Topology,
+        }])
+        .unwrap();
+        let owner = tempfile::tempdir().unwrap();
+        let target = owner.path().join("workspace");
+
+        let evidence = materialize_graph_objects(root.path(), &inventory, &target).unwrap();
+
+        assert_eq!(
+            fs::read(target.join("topology/edges/knows.parquet")).unwrap(),
+            payload
+        );
+        assert!(!target.join("files").exists());
+        assert_eq!(evidence.files_reused, 1);
+        assert_eq!(evidence.bytes_reused, payload.len() as u64);
+        assert_eq!(evidence.files_copied, 0);
     }
 
     #[cfg(unix)]

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -143,6 +143,7 @@ impl CasRoot {
 impl Drop for GraphObjectGcGuard {
     fn drop(&mut self) {
         let _ = crate::file_lock::unlock(&self.cas.lifecycle);
+        let _ = self.cas.objects.unlock();
     }
 }
 
@@ -154,6 +155,7 @@ impl Drop for GraphObjectPublicationLease {
             .active
             .unlink_child_if_identity(&self.lease_name, self.lease_identity);
         let _ = crate::file_lock::unlock(&self.cas.lifecycle);
+        let _ = self.cas.objects.unlock();
     }
 }
 
@@ -181,7 +183,13 @@ impl GraphObjectPublicationLease {
 /// Begin a CAS installation attempt and hold its lease through CURRENT.
 pub fn begin_graph_object_publication(root: &Path) -> Result<GraphObjectPublicationLease, GfError> {
     let cas = CasRoot::open(root)?;
+    cas.objects
+        .lock_shared()
+        .map_err(|error| storage("lock graph object directory for publication", root, error))?;
     crate::file_lock::lock_shared(&cas.lifecycle)
+        .inspect_err(|_| {
+            let _ = cas.objects.unlock();
+        })
         .map_err(|error| storage("lock graph object publication lifecycle", root, error))?;
     cas.revalidate_named()?;
     let lease_name = std::ffi::OsString::from(format!("{}.lock", Uuid::new_v4().hyphenated()));
@@ -314,7 +322,13 @@ pub fn gc_graph_objects(
 #[cfg(test)]
 pub(crate) fn begin_graph_object_gc(root: &Path) -> Result<GraphObjectGcGuard, GfError> {
     let cas = CasRoot::open(root)?;
+    cas.objects
+        .lock_exclusive()
+        .map_err(|error| storage("lock graph object directory for GC", root, error))?;
     crate::file_lock::lock_exclusive(&cas.lifecycle)
+        .inspect_err(|_| {
+            let _ = cas.objects.unlock();
+        })
         .map_err(|error| storage("lock graph object GC lifecycle", root, error))?;
     cas.revalidate_named()?;
     Ok(GraphObjectGcGuard { cas })
@@ -324,9 +338,17 @@ pub(crate) fn try_begin_graph_object_gc(
     root: &Path,
 ) -> Result<Option<GraphObjectGcGuard>, GfError> {
     let cas = CasRoot::open(root)?;
+    if !cas
+        .objects
+        .try_lock_exclusive()
+        .map_err(|error| storage("try graph object directory for GC", root, error))?
+    {
+        return Ok(None);
+    }
     if !crate::file_lock::try_lock_exclusive(&cas.lifecycle)
         .map_err(|error| storage("try graph object GC lifecycle", root, error))?
     {
+        let _ = cas.objects.unlock();
         return Ok(None);
     }
     cas.revalidate_named()?;
@@ -1721,10 +1743,7 @@ mod tests {
         fs::write(object_root.join(LIFECYCLE_LOCK), b"").unwrap();
 
         assert!(lease.revalidate_for_publish().is_err());
-        assert!(matches!(
-            try_begin_graph_object_gc(root.path()),
-            Ok(Some(_))
-        ));
+        assert!(matches!(try_begin_graph_object_gc(root.path()), Ok(None)));
 
         let other_root = tempfile::tempdir().unwrap();
         let lease = begin_graph_object_publication(other_root.path()).unwrap();

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -27,6 +27,8 @@ const BUFFER_BYTES: usize = 64 * 1024;
 /// Kernel-visible lease protecting CAS objects installed by one publication.
 pub struct GraphObjectPublicationLease {
     root: PathBuf,
+    coordination_directory: File,
+    coordination_directory_path: PathBuf,
     path: PathBuf,
     file: File,
     lifecycle_directory: File,
@@ -38,6 +40,8 @@ pub struct GraphObjectPublicationLease {
 /// Exclusive guard spanning GC root discovery through sweep.
 pub(crate) struct GraphObjectGcGuard {
     root: PathBuf,
+    coordination_directory: File,
+    coordination_directory_path: PathBuf,
     lifecycle_directory: File,
     lifecycle_directory_path: PathBuf,
     lifecycle: File,
@@ -48,6 +52,7 @@ impl Drop for GraphObjectGcGuard {
     fn drop(&mut self) {
         let _ = crate::file_lock::unlock(&self.lifecycle);
         let _ = crate::file_lock::unlock(&self.lifecycle_directory);
+        let _ = crate::file_lock::unlock(&self.coordination_directory);
     }
 }
 
@@ -57,11 +62,40 @@ impl Drop for GraphObjectPublicationLease {
         let _ = fs::remove_file(&self.path);
         let _ = crate::file_lock::unlock(&self.lifecycle);
         let _ = crate::file_lock::unlock(&self.lifecycle_directory);
+        let _ = crate::file_lock::unlock(&self.coordination_directory);
+    }
+}
+
+impl GraphObjectPublicationLease {
+    /// Revalidate the stable CAS root immediately before publishing `CURRENT`.
+    pub fn revalidate_for_publish(&self) -> Result<(), GfError> {
+        validate_publication_identity(self)
+    }
+
+    pub(crate) fn revalidate_for_root(&self, root: &Path) -> Result<(), GfError> {
+        let lease_root = crate::filesystem_admission::open_directory_handle(&self.root)
+            .map_err(|error| storage("open leased graph object root", &self.root, error))?;
+        let requested_root = crate::filesystem_admission::open_directory_handle(root)
+            .map_err(|error| storage("open requested graph object root", root, error))?;
+        if graphforge_filesystem::file_identity(&lease_root)
+            .map_err(|error| storage("inspect leased graph object root", &self.root, error))?
+            != graphforge_filesystem::file_identity(&requested_root)
+                .map_err(|error| storage("inspect requested graph object root", root, error))?
+        {
+            return Err(validation(
+                "graph object lease belongs to a different project",
+            ));
+        }
+        self.revalidate_for_publish()
     }
 }
 
 /// Begin a CAS installation attempt and hold its lease through CURRENT.
 pub fn begin_graph_object_publication(root: &Path) -> Result<GraphObjectPublicationLease, GfError> {
+    let (coordination_directory, coordination_directory_path) = open_coordination_lock(root)?;
+    crate::file_lock::lock_shared(&coordination_directory)
+        .map_err(|error| storage("lock graph object coordination file", root, error))?;
+    validate_lock_identity(&coordination_directory, &coordination_directory_path)?;
     let object_root = root.join(GRAPH_OBJECTS_DIR);
     fs::create_dir_all(&object_root)
         .map_err(|error| storage("create graph object directory", &object_root, error))?;
@@ -94,6 +128,8 @@ pub fn begin_graph_object_publication(root: &Path) -> Result<GraphObjectPublicat
     sync_directory(&active)?;
     Ok(GraphObjectPublicationLease {
         root: root.to_path_buf(),
+        coordination_directory,
+        coordination_directory_path,
         path,
         file,
         lifecycle_directory,
@@ -224,6 +260,10 @@ pub fn gc_graph_objects(
 
 #[cfg(test)]
 pub(crate) fn begin_graph_object_gc(root: &Path) -> Result<GraphObjectGcGuard, GfError> {
+    let (coordination_directory, coordination_directory_path) = open_coordination_lock(root)?;
+    crate::file_lock::lock_exclusive(&coordination_directory)
+        .map_err(|error| storage("lock graph object GC coordination file", root, error))?;
+    validate_lock_identity(&coordination_directory, &coordination_directory_path)?;
     let (root, lifecycle_directory, lifecycle, lifecycle_path) = open_graph_object_lifecycle(root)?;
     crate::file_lock::lock_exclusive(&lifecycle_directory)
         .map_err(|error| storage("lock graph object GC directory", &root, error))?;
@@ -234,6 +274,8 @@ pub(crate) fn begin_graph_object_gc(root: &Path) -> Result<GraphObjectGcGuard, G
     let lifecycle_directory_path = root.join(GRAPH_OBJECTS_DIR);
     Ok(GraphObjectGcGuard {
         root,
+        coordination_directory,
+        coordination_directory_path,
         lifecycle_directory,
         lifecycle_directory_path,
         lifecycle,
@@ -244,6 +286,13 @@ pub(crate) fn begin_graph_object_gc(root: &Path) -> Result<GraphObjectGcGuard, G
 pub(crate) fn try_begin_graph_object_gc(
     root: &Path,
 ) -> Result<Option<GraphObjectGcGuard>, GfError> {
+    let (coordination_directory, coordination_directory_path) = open_coordination_lock(root)?;
+    if !crate::file_lock::try_lock_exclusive(&coordination_directory)
+        .map_err(|error| storage("try graph object GC coordination file", root, error))?
+    {
+        return Ok(None);
+    }
+    validate_lock_identity(&coordination_directory, &coordination_directory_path)?;
     let (root, lifecycle_directory, lifecycle, lifecycle_path) = open_graph_object_lifecycle(root)?;
     if !crate::file_lock::try_lock_exclusive(&lifecycle_directory)
         .map_err(|error| storage("try graph object GC directory", &root, error))?
@@ -261,6 +310,8 @@ pub(crate) fn try_begin_graph_object_gc(
     let lifecycle_directory_path = root.join(GRAPH_OBJECTS_DIR);
     Ok(Some(GraphObjectGcGuard {
         root,
+        coordination_directory,
+        coordination_directory_path,
         lifecycle_directory,
         lifecycle_directory_path,
         lifecycle,
@@ -274,6 +325,65 @@ fn open_graph_object_lifecycle(root: &Path) -> Result<(PathBuf, File, File, Path
         .map_err(|error| storage("create graph object directory", &object_root, error))?;
     let (directory, lifecycle, lifecycle_path) = open_lifecycle_lock(&object_root)?;
     Ok((root.to_path_buf(), directory, lifecycle, lifecycle_path))
+}
+
+fn coordination_lock_path(root: &Path) -> Result<PathBuf, GfError> {
+    let parent = root
+        .parent()
+        .ok_or_else(|| validation("graph object root has no coordination parent"))?;
+    let name = root
+        .file_name()
+        .and_then(std::ffi::OsStr::to_str)
+        .ok_or_else(|| validation("graph object root name is not UTF-8"))?;
+    Ok(parent.join(format!(".graphforge-cas-{name}.lock")))
+}
+
+#[cfg(unix)]
+fn open_coordination_lock(root: &Path) -> Result<(File, PathBuf), GfError> {
+    use std::os::unix::fs::OpenOptionsExt as _;
+
+    let path = coordination_lock_path(root)?;
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(&path)
+        .map_err(|error| storage("open graph object coordination lock", &path, error))?;
+    validate_lock_identity(&file, &path)?;
+    file.sync_all()
+        .map_err(|error| storage("sync graph object coordination lock", &path, error))?;
+    Ok((file, path))
+}
+
+#[cfg(windows)]
+fn open_coordination_lock(root: &Path) -> Result<(File, PathBuf), GfError> {
+    use std::os::windows::fs::OpenOptionsExt as _;
+    const FILE_SHARE_READ: u32 = 0x0000_0001;
+    const FILE_SHARE_WRITE: u32 = 0x0000_0002;
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    const FILE_FLAG_WRITE_THROUGH: u32 = 0x8000_0000;
+    let path = coordination_lock_path(root)?;
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_WRITE_THROUGH)
+        .open(&path)
+        .map_err(|error| storage("open graph object coordination lock", &path, error))?;
+    validate_lock_identity(&file, &path)?;
+    file.sync_all()
+        .map_err(|error| storage("sync graph object coordination lock", &path, error))?;
+    Ok((file, path))
+}
+
+#[cfg(all(not(unix), not(windows)))]
+fn open_coordination_lock(_root: &Path) -> Result<(File, PathBuf), GfError> {
+    Err(validation(
+        "graph object coordination locks are unsupported on this platform",
+    ))
 }
 
 #[cfg(unix)]
@@ -319,16 +429,40 @@ fn open_lifecycle_lock(object_root: &Path) -> Result<(File, File, PathBuf), GfEr
     Ok((directory, file, object_root.join(LIFECYCLE_LOCK)))
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
 fn open_lifecycle_lock(object_root: &Path) -> Result<(File, File, PathBuf), GfError> {
+    use std::os::windows::fs::OpenOptionsExt as _;
+
+    const FILE_SHARE_READ: u32 = 0x0000_0001;
+    const FILE_SHARE_WRITE: u32 = 0x0000_0002;
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    const FILE_FLAG_WRITE_THROUGH: u32 = 0x8000_0000;
     let path = object_root.join(LIFECYCLE_LOCK);
-    let file = crate::project_publication::open_regular_lock(&path)?;
+    let directory = crate::filesystem_admission::open_directory_handle(object_root)
+        .map_err(|error| storage("open graph object lock directory", object_root, error))?;
+    validate_directory_identity(&directory, object_root)?;
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_WRITE_THROUGH)
+        .open(&path)
+        .map_err(|error| storage("open graph object lifecycle lock", &path, error))?;
+    validate_lock_identity(&file, &path)?;
     file.sync_all()
         .map_err(|error| storage("sync graph object lifecycle lock", &path, error))?;
-    sync_directory(object_root)?;
-    let directory = File::open(object_root)
-        .map_err(|error| storage("open graph object lock directory", object_root, error))?;
+    directory
+        .sync_all()
+        .map_err(|error| storage("sync graph object lock directory", object_root, error))?;
     Ok((directory, file, path))
+}
+
+#[cfg(all(not(unix), not(windows)))]
+fn open_lifecycle_lock(_object_root: &Path) -> Result<(File, File, PathBuf), GfError> {
+    Err(validation(
+        "graph object lifecycle locks are unsupported on this platform",
+    ))
 }
 
 fn validate_lock_identity(file: &File, path: &Path) -> Result<(), GfError> {
@@ -349,6 +483,26 @@ fn validate_lock_identity(file: &File, path: &Path) -> Result<(), GfError> {
             || descriptor.ino() != named.ino()
             || descriptor.nlink() != 1
             || named.nlink() != 1
+        {
+            return Err(validation("graph object lifecycle lock identity changed"));
+        }
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt as _;
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+        let descriptor_identity = graphforge_filesystem::file_identity(file)
+            .map_err(|error| storage("inspect lifecycle lock identity", path, error))?;
+        let named_identity = graphforge_filesystem::path_identity(path)
+            .map_err(|error| storage("inspect lifecycle lock identity", path, error))?;
+        if named.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+            || descriptor_identity != named_identity
+            || graphforge_filesystem::file_link_count(file)
+                .map_err(|error| storage("inspect lifecycle lock links", path, error))?
+                != 1
+            || graphforge_filesystem::path_link_count(path)
+                .map_err(|error| storage("inspect lifecycle lock links", path, error))?
+                != 1
         {
             return Err(validation("graph object lifecycle lock identity changed"));
         }
@@ -376,7 +530,31 @@ fn validate_directory_identity(file: &File, path: &Path) -> Result<(), GfError> 
             ));
         }
     }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt as _;
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+        if named.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+            || graphforge_filesystem::file_identity(file)
+                .map_err(|error| storage("inspect lifecycle directory identity", path, error))?
+                != graphforge_filesystem::path_identity(path)
+                    .map_err(|error| storage("inspect lifecycle directory identity", path, error))?
+        {
+            return Err(validation(
+                "graph object lifecycle directory identity changed",
+            ));
+        }
+    }
     Ok(())
+}
+
+fn validate_publication_identity(lease: &GraphObjectPublicationLease) -> Result<(), GfError> {
+    validate_lock_identity(
+        &lease.coordination_directory,
+        &lease.coordination_directory_path,
+    )?;
+    validate_directory_identity(&lease.lifecycle_directory, &lease.lifecycle_directory_path)?;
+    validate_lock_identity(&lease.lifecycle, &lease.lifecycle_path)
 }
 
 pub(crate) fn gc_graph_objects_guarded(
@@ -384,6 +562,10 @@ pub(crate) fn gc_graph_objects_guarded(
     roots: &[GraphFilesRootV2],
     limits: crate::GraphManifestLimits,
 ) -> Result<GraphObjectGcEvidence, GfError> {
+    validate_lock_identity(
+        &guard.coordination_directory,
+        &guard.coordination_directory_path,
+    )?;
     validate_directory_identity(&guard.lifecycle_directory, &guard.lifecycle_directory_path)?;
     validate_lock_identity(&guard.lifecycle, &guard.lifecycle_path)?;
     let root = &guard.root;
@@ -468,8 +650,7 @@ pub fn append_graph_files_v2(
     sealed_paths: &[PathBuf],
     tombstones: &[String],
 ) -> Result<(GraphFilesRootV2, GraphFilesAppendEvidence), GfError> {
-    validate_directory_identity(&lease.lifecycle_directory, &lease.lifecycle_directory_path)?;
-    validate_lock_identity(&lease.lifecycle, &lease.lifecycle_path)?;
+    validate_publication_identity(lease)?;
     let root = &lease.root;
     let mut additions = Vec::with_capacity(sealed_paths.len());
     let mut evidence = GraphFilesAppendEvidence::default();
@@ -571,8 +752,7 @@ pub fn migrate_graph_files_v1_to_v2(
     graph_root: &Path,
     inventory: &GraphFilesInventory,
 ) -> Result<(GraphFilesRootV2, GraphFilesMigrationEvidence), GfError> {
-    validate_directory_identity(&lease.lifecycle_directory, &lease.lifecycle_directory_path)?;
-    validate_lock_identity(&lease.lifecycle, &lease.lifecycle_path)?;
+    validate_publication_identity(lease)?;
     let root = &lease.root;
     let mut evidence = GraphFilesMigrationEvidence::default();
     for entry in &inventory.files {
@@ -878,6 +1058,7 @@ pub fn materialize_graph_objects(
     inventory: &GraphFilesInventory,
     target: &Path,
 ) -> Result<GraphFilesOpenEvidence, GfError> {
+    let lease = begin_graph_object_publication(root)?;
     let target_directory = open_empty_materialization_target(target)?;
     let mut evidence = GraphFilesOpenEvidence {
         strategy: GraphFilesOpenStrategy::PrivateMaterialize,
@@ -897,6 +1078,7 @@ pub fn materialize_graph_objects(
         evidence.files_reused = evidence.files_reused.saturating_add(1);
         evidence.bytes_reused = evidence.bytes_reused.saturating_add(entry.byte_length);
     }
+    lease.revalidate_for_publish()?;
     Ok(evidence)
 }
 
@@ -1080,15 +1262,35 @@ fn link_materialized_object(
     Err(validation("graph object logical path is empty"))
 }
 
-#[cfg(not(unix))]
-fn open_empty_materialization_target(target: &Path) -> Result<PathBuf, GfError> {
-    if let Ok(metadata) = fs::symlink_metadata(target)
-        && (metadata.file_type().is_symlink() || !metadata.is_dir())
-    {
-        return Err(validation("graph object target is not a real directory"));
+#[cfg(windows)]
+struct WindowsMaterializationTarget {
+    path: PathBuf,
+    _guards: Vec<File>,
+}
+
+#[cfg(windows)]
+fn open_empty_materialization_target(
+    target: &Path,
+) -> Result<WindowsMaterializationTarget, GfError> {
+    let parent = target
+        .parent()
+        .ok_or_else(|| validation("graph object target has no parent"))?;
+    let mut guards = windows_directory_guards(parent)?;
+    match fs::create_dir(target) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(error) => {
+            return Err(storage(
+                "create graph object materialization target",
+                target,
+                error,
+            ));
+        }
     }
-    fs::create_dir_all(target)
-        .map_err(|error| storage("create graph object materialization target", target, error))?;
+    let target_handle = crate::filesystem_admission::open_directory_handle(target)
+        .map_err(|error| storage("open graph object materialization target", target, error))?;
+    validate_directory_identity(&target_handle, target)?;
+    guards.push(target_handle);
     if target
         .read_dir()
         .map_err(|error| storage("read graph object target", target, error))?
@@ -1099,42 +1301,169 @@ fn open_empty_materialization_target(target: &Path) -> Result<PathBuf, GfError> 
             "graph object materialization target is not empty",
         ));
     }
-    Ok(target.to_path_buf())
+    Ok(WindowsMaterializationTarget {
+        path: target.to_path_buf(),
+        _guards: guards,
+    })
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+fn windows_directory_guards(path: &Path) -> Result<Vec<File>, GfError> {
+    use std::os::windows::fs::MetadataExt as _;
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+    let mut paths = path.ancestors().collect::<Vec<_>>();
+    paths.reverse();
+    let mut guards = Vec::with_capacity(paths.len());
+    for component in paths {
+        let metadata = fs::symlink_metadata(component)
+            .map_err(|error| storage("inspect materialization directory", component, error))?;
+        if !metadata.is_dir() || metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            return Err(validation("materialization path contains a reparse point"));
+        }
+        let guard = crate::filesystem_admission::open_directory_handle(component)
+            .map_err(|error| storage("retain materialization directory", component, error))?;
+        validate_directory_identity(&guard, component)?;
+        guards.push(guard);
+    }
+    Ok(guards)
+}
+
+#[cfg(windows)]
+fn windows_create_guarded_directories(
+    root: &Path,
+    relative_parent: &Path,
+) -> Result<Vec<File>, GfError> {
+    let mut path = root.to_path_buf();
+    let mut guards = Vec::new();
+    for component in relative_parent.components() {
+        let Component::Normal(name) = component else {
+            return Err(validation("invalid materialization directory component"));
+        };
+        path.push(name);
+        match fs::create_dir(&path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(error) => return Err(storage("create materialization directory", &path, error)),
+        }
+        let guard = crate::filesystem_admission::open_directory_handle(&path)
+            .map_err(|error| storage("retain materialization directory", &path, error))?;
+        validate_directory_identity(&guard, &path)?;
+        guards.push(guard);
+    }
+    Ok(guards)
+}
+
+#[cfg(all(not(unix), not(windows)))]
+fn open_empty_materialization_target(target: &Path) -> Result<PathBuf, GfError> {
+    let _ = target;
+    Err(validation(
+        "graph object materialization is unsupported on this platform",
+    ))
+}
+
+#[cfg(windows)]
 fn link_materialized_object(
-    target: &PathBuf,
+    target: &WindowsMaterializationTarget,
     source: &Path,
     relative: &str,
     expected_digest: &str,
     expected_length: u64,
 ) -> Result<(), GfError> {
-    let destination = target.join(relative);
-    if let Some(parent) = destination.parent() {
-        fs::create_dir_all(parent)
-            .map_err(|error| storage("create logical graph object directory", parent, error))?;
+    use std::os::windows::fs::OpenOptionsExt as _;
+    const FILE_SHARE_READ: u32 = 0x0000_0001;
+    const FILE_SHARE_WRITE: u32 = 0x0000_0002;
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    let destination = target.path.join(relative);
+    let relative_parent = Path::new(relative)
+        .parent()
+        .ok_or_else(|| validation("materialized object has no parent"))?;
+    let _guards = windows_create_guarded_directories(&target.path, relative_parent)?;
+    let source_file = OpenOptions::new()
+        .read(true)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(source)
+        .map_err(|error| {
+            storage(
+                "open graph object source without following reparse points",
+                source,
+                error,
+            )
+        })?;
+    let source_identity = graphforge_filesystem::file_identity(&source_file)
+        .map_err(|error| storage("inspect graph object source identity", source, error))?;
+    if source_identity
+        != graphforge_filesystem::path_identity(source)
+            .map_err(|error| storage("inspect graph object source identity", source, error))?
+    {
+        return Err(validation("graph object source identity changed"));
     }
     fs::hard_link(source, &destination)
         .map_err(|error| storage("link logical graph object", &destination, error))?;
-    let verified = fs::symlink_metadata(&destination)
-        .map_err(|error| storage("inspect materialized object", &destination, error))
-        .and_then(|metadata| {
-            if !metadata.is_file()
-                || metadata.file_type().is_symlink()
-                || metadata.len() != expected_length
-            {
-                return Err(validation("materialized graph object identity is invalid"));
+    let verified = (|| {
+        let mut linked = OpenOptions::new()
+            .read(true)
+            .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+            .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+            .open(&destination)
+            .map_err(|error| storage("open materialized object", &destination, error))?;
+        let metadata = linked
+            .metadata()
+            .map_err(|error| storage("inspect materialized object", &destination, error))?;
+        if !metadata.is_file()
+            || metadata.file_type().is_symlink()
+            || metadata.len() != expected_length
+        {
+            return Err(validation("materialized graph object identity is invalid"));
+        }
+        let linked_identity = graphforge_filesystem::file_identity(&linked).map_err(|error| {
+            storage("inspect materialized object identity", &destination, error)
+        })?;
+        if linked_identity != source_identity
+            || linked_identity
+                != graphforge_filesystem::path_identity(&destination).map_err(|error| {
+                    storage("inspect materialized object identity", &destination, error)
+                })?
+            || source_identity
+                != graphforge_filesystem::path_identity(source).map_err(|error| {
+                    storage("revalidate graph object source identity", source, error)
+                })?
+        {
+            return Err(validation("materialized graph object identity changed"));
+        }
+        let mut hasher = Sha256::new();
+        let mut buffer = vec![0_u8; BUFFER_BYTES];
+        loop {
+            let read = linked
+                .read(&mut buffer)
+                .map_err(|error| storage("verify materialized object", &destination, error))?;
+            if read == 0 {
+                break;
             }
-            (hex_digest(hash_regular_file(&destination)?) == expected_digest)
-                .then_some(())
-                .ok_or_else(|| validation("materialized graph object digest mismatch"))
-        });
+            hasher.update(&buffer[..read]);
+        }
+        (hex_digest(hasher.finalize().into()) == expected_digest)
+            .then_some(())
+            .ok_or_else(|| validation("materialized graph object digest mismatch"))
+    })();
     if let Err(error) = verified {
         let _ = fs::remove_file(&destination);
         return Err(error);
     }
     Ok(())
+}
+
+#[cfg(all(not(unix), not(windows)))]
+fn link_materialized_object(
+    _target: &PathBuf,
+    _source: &Path,
+    _relative: &str,
+    _expected_digest: &str,
+    _expected_length: u64,
+) -> Result<(), GfError> {
+    Err(validation(
+        "graph object materialization is unsupported on this platform",
+    ))
 }
 
 /// Read an object whose digest is known before its declared logical length.
@@ -1251,8 +1580,16 @@ fn create_new(path: &Path) -> Result<File, GfError> {
         .map_err(|error| storage("create temporary graph object", path, error))
 }
 
+#[cfg(not(windows))]
 fn sync_directory(path: &Path) -> Result<(), GfError> {
     File::open(path)
+        .and_then(|file| file.sync_all())
+        .map_err(|error| storage("fsync graph object directory", path, error))
+}
+
+#[cfg(windows)]
+fn sync_directory(path: &Path) -> Result<(), GfError> {
+    crate::filesystem_admission::open_directory_handle(path)
         .and_then(|file| file.sync_all())
         .map_err(|error| storage("fsync graph object directory", path, error))
 }
@@ -1362,6 +1699,38 @@ mod tests {
             )
             .is_err()
         );
+        assert!(matches!(
+            try_begin_graph_object_gc(other_root.path()),
+            Ok(None)
+        ));
+        assert!(lease.revalidate_for_publish().is_err());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_lifecycle_handles_deny_coordination_path_replacement() {
+        let root = tempfile::tempdir().unwrap();
+        let lease = begin_graph_object_publication(root.path()).unwrap();
+        let replacement = lease
+            .coordination_directory_path
+            .with_extension("replacement");
+        assert!(fs::rename(&lease.coordination_directory_path, replacement).is_err());
+        lease.revalidate_for_publish().unwrap();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_materialization_rejects_regular_cas_substitution() {
+        let objects = tempfile::tempdir().unwrap();
+        let (digest, _) = install_graph_object_bytes(objects.path(), b"payload").unwrap();
+        let source = graph_object_path(objects.path(), &digest).unwrap();
+        fs::remove_file(&source).unwrap();
+        fs::write(&source, b"hostile").unwrap();
+        let owner = tempfile::tempdir().unwrap();
+        let target_path = owner.path().join("materialized");
+        let target = open_empty_materialization_target(&target_path).unwrap();
+        assert!(link_materialized_object(&target, &source, "payload.bin", &digest, 7).is_err());
+        assert!(!target_path.join("payload.bin").exists());
     }
 
     #[test]

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -3,9 +3,9 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
-use graphforge_core::GfError;
+use graphforge_core::{GfError, ProjectErrorCode};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
@@ -21,6 +21,7 @@ pub const GRAPH_OBJECTS_DIR: &str = "graph-objects";
 const SHA256_DIR: &str = "sha256";
 const TEMP_DIR: &str = "tmp";
 const ACTIVE_DIR: &str = "active";
+const LIFECYCLE_LOCK: &str = "lifecycle.lock";
 const BUFFER_BYTES: usize = 64 * 1024;
 
 /// Kernel-visible lease protecting CAS objects installed by one publication.
@@ -28,18 +29,59 @@ pub struct GraphObjectPublicationLease {
     root: PathBuf,
     path: PathBuf,
     file: File,
+    lifecycle: File,
+}
+
+/// Exclusive guard spanning GC root discovery through sweep.
+pub(crate) struct GraphObjectGcGuard {
+    root: PathBuf,
+    lifecycle: File,
+}
+
+impl Drop for GraphObjectGcGuard {
+    fn drop(&mut self) {
+        let _ = crate::file_lock::unlock(&self.lifecycle);
+    }
 }
 
 impl Drop for GraphObjectPublicationLease {
     fn drop(&mut self) {
         let _ = crate::file_lock::unlock(&self.file);
         let _ = fs::remove_file(&self.path);
+        let _ = crate::file_lock::unlock(&self.lifecycle);
     }
 }
 
 /// Begin a CAS installation attempt and hold its lease through CURRENT.
 pub fn begin_graph_object_publication(root: &Path) -> Result<GraphObjectPublicationLease, GfError> {
-    let active = root.join(GRAPH_OBJECTS_DIR).join(ACTIVE_DIR);
+    let object_root = root.join(GRAPH_OBJECTS_DIR);
+    fs::create_dir_all(&object_root)
+        .map_err(|error| storage("create graph object directory", &object_root, error))?;
+    let lifecycle_path = object_root.join(LIFECYCLE_LOCK);
+    if !lifecycle_path.exists() {
+        let created = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&lifecycle_path)
+            .map_err(|error| {
+                storage("create graph object lifecycle lock", &lifecycle_path, error)
+            })?;
+        created
+            .sync_all()
+            .map_err(|error| storage("sync graph object lifecycle lock", &lifecycle_path, error))?;
+        sync_directory(&object_root)?;
+    }
+    let lifecycle = crate::project_publication::open_regular_lock(&lifecycle_path)?;
+    crate::file_lock::lock_shared(&lifecycle).map_err(|error| {
+        storage(
+            "lock graph object publication lifecycle",
+            &lifecycle_path,
+            error,
+        )
+    })?;
+    let active = object_root.join(ACTIVE_DIR);
     fs::create_dir_all(&active)
         .map_err(|error| storage("create graph object active directory", &active, error))?;
     let path = active.join(format!("{}.lock", Uuid::new_v4().hyphenated()));
@@ -58,6 +100,7 @@ pub fn begin_graph_object_publication(root: &Path) -> Result<GraphObjectPublicat
         root: root.to_path_buf(),
         path,
         file,
+        lifecycle,
     })
 }
 
@@ -173,6 +216,54 @@ pub fn gc_graph_objects(
     roots: &[GraphFilesRootV2],
     limits: crate::GraphManifestLimits,
 ) -> Result<GraphObjectGcEvidence, GfError> {
+    let guard = try_begin_graph_object_gc(root)?.ok_or_else(|| GfError::Project {
+        code: ProjectErrorCode::WriterBusy,
+        message: "phase=GRAPH_OBJECT_GC committed=false cause=live_publication".into(),
+    })?;
+    gc_graph_objects_guarded(&guard, roots, limits)
+}
+
+#[cfg(test)]
+pub(crate) fn begin_graph_object_gc(root: &Path) -> Result<GraphObjectGcGuard, GfError> {
+    let (root, lifecycle, lifecycle_path) = open_graph_object_lifecycle(root)?;
+    crate::file_lock::lock_exclusive(&lifecycle)
+        .map_err(|error| storage("lock graph object GC lifecycle", &lifecycle_path, error))?;
+    Ok(GraphObjectGcGuard { root, lifecycle })
+}
+
+pub(crate) fn try_begin_graph_object_gc(
+    root: &Path,
+) -> Result<Option<GraphObjectGcGuard>, GfError> {
+    let (root, lifecycle, lifecycle_path) = open_graph_object_lifecycle(root)?;
+    if !crate::file_lock::try_lock_exclusive(&lifecycle)
+        .map_err(|error| storage("try graph object GC lifecycle", &lifecycle_path, error))?
+    {
+        return Ok(None);
+    }
+    Ok(Some(GraphObjectGcGuard { root, lifecycle }))
+}
+
+fn open_graph_object_lifecycle(root: &Path) -> Result<(PathBuf, File, PathBuf), GfError> {
+    let object_root = root.join(GRAPH_OBJECTS_DIR);
+    fs::create_dir_all(&object_root)
+        .map_err(|error| storage("create graph object directory", &object_root, error))?;
+    let lifecycle_path = object_root.join(LIFECYCLE_LOCK);
+    let lifecycle = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&lifecycle_path)
+        .map_err(|error| storage("open graph object lifecycle lock", &lifecycle_path, error))?;
+    Ok((root.to_path_buf(), lifecycle, lifecycle_path))
+}
+
+pub(crate) fn gc_graph_objects_guarded(
+    guard: &GraphObjectGcGuard,
+    roots: &[GraphFilesRootV2],
+    limits: crate::GraphManifestLimits,
+) -> Result<GraphObjectGcEvidence, GfError> {
+    let root = &guard.root;
     let mut marked = BTreeSet::new();
     for graph_root in roots {
         let mut segment_digests = Vec::new();
@@ -660,19 +751,7 @@ pub fn materialize_graph_objects(
     inventory: &GraphFilesInventory,
     target: &Path,
 ) -> Result<GraphFilesOpenEvidence, GfError> {
-    if target.exists()
-        && target
-            .read_dir()
-            .map_err(|error| storage("read graph object target", target, error))?
-            .next()
-            .is_some()
-    {
-        return Err(validation(
-            "graph object materialization target is not empty",
-        ));
-    }
-    fs::create_dir_all(target)
-        .map_err(|error| storage("create graph object materialization target", target, error))?;
+    let target_directory = open_empty_materialization_target(target)?;
     let mut evidence = GraphFilesOpenEvidence {
         strategy: GraphFilesOpenStrategy::PrivateMaterialize,
         files_validated: inventory.file_count,
@@ -681,17 +760,186 @@ pub fn materialize_graph_objects(
     };
     for entry in &inventory.files {
         let source = graph_object_path(root, &entry.content_sha256)?;
-        let destination = target.join(&entry.relative_path);
-        if let Some(parent) = destination.parent() {
-            fs::create_dir_all(parent)
-                .map_err(|error| storage("create logical graph object directory", parent, error))?;
-        }
-        fs::hard_link(&source, &destination)
-            .map_err(|error| storage("link logical graph object", &destination, error))?;
+        link_materialized_object(&target_directory, &source, &entry.relative_path)?;
         evidence.files_reused = evidence.files_reused.saturating_add(1);
         evidence.bytes_reused = evidence.bytes_reused.saturating_add(entry.byte_length);
     }
     Ok(evidence)
+}
+
+#[cfg(unix)]
+fn open_empty_materialization_target(target: &Path) -> Result<std::os::fd::OwnedFd, GfError> {
+    use rustix::fs::{Mode, OFlags};
+
+    let parent = target
+        .parent()
+        .ok_or_else(|| validation("graph object target has no parent"))?;
+    let name = target
+        .file_name()
+        .ok_or_else(|| validation("graph object target has no final component"))?;
+    let canonical_parent = parent
+        .canonicalize()
+        .map_err(|error| storage("resolve graph object target parent", parent, error))?;
+    let parent_fd = open_directory_no_follow(&canonical_parent)?;
+    match rustix::fs::mkdirat(&parent_fd, name, Mode::from_bits_truncate(0o700)) {
+        Ok(()) | Err(rustix::io::Errno::EXIST) => {}
+        Err(error) => return Err(storage("create graph object target", target, error)),
+    }
+    let directory = rustix::fs::openat(
+        &parent_fd,
+        name,
+        OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+        Mode::empty(),
+    )
+    .map_err(|error| {
+        storage(
+            "open graph object target without following links",
+            target,
+            error,
+        )
+    })?;
+    if target
+        .read_dir()
+        .map_err(|error| storage("read graph object target", target, error))?
+        .next()
+        .is_some()
+    {
+        return Err(validation(
+            "graph object materialization target is not empty",
+        ));
+    }
+    Ok(directory)
+}
+
+#[cfg(unix)]
+fn open_directory_no_follow(path: &Path) -> Result<std::os::fd::OwnedFd, GfError> {
+    use rustix::fs::{Mode, OFlags};
+
+    let mut directory = rustix::fs::open(
+        if path.is_absolute() {
+            Path::new("/")
+        } else {
+            Path::new(".")
+        },
+        OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+        Mode::empty(),
+    )
+    .map_err(|error| storage("open graph object directory root", path, error))?;
+    for component in path.components() {
+        let Component::Normal(name) = component else {
+            continue;
+        };
+        directory = rustix::fs::openat(
+            &directory,
+            name,
+            OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+            Mode::empty(),
+        )
+        .map_err(|error| {
+            storage(
+                "open graph object directory without following links",
+                path,
+                error,
+            )
+        })?;
+    }
+    Ok(directory)
+}
+
+#[cfg(unix)]
+fn link_materialized_object(
+    target: &std::os::fd::OwnedFd,
+    source: &Path,
+    relative: &str,
+) -> Result<(), GfError> {
+    use rustix::fs::{AtFlags, Mode, OFlags};
+
+    let path = Path::new(relative);
+    validate_logical_path(path)?;
+    let mut directory = target
+        .try_clone()
+        .map_err(|error| storage("clone graph object target", path, error))?;
+    let mut components = path
+        .components()
+        .filter_map(|component| match component {
+            Component::Normal(name) => Some(name),
+            _ => None,
+        })
+        .peekable();
+    while let Some(component) = components.next() {
+        if components.peek().is_none() {
+            rustix::fs::linkat(
+                rustix::fs::CWD,
+                source,
+                &directory,
+                component,
+                AtFlags::empty(),
+            )
+            .map_err(|error| storage("link logical graph object", path, error))?;
+            return Ok(());
+        }
+        match rustix::fs::mkdirat(&directory, component, Mode::from_bits_truncate(0o700)) {
+            Ok(()) | Err(rustix::io::Errno::EXIST) => {}
+            Err(error) => {
+                return Err(storage(
+                    "create logical graph object directory",
+                    path,
+                    error,
+                ));
+            }
+        }
+        directory = rustix::fs::openat(
+            &directory,
+            component,
+            OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+            Mode::empty(),
+        )
+        .map_err(|error| {
+            storage(
+                "open logical graph object directory without following links",
+                path,
+                error,
+            )
+        })?;
+    }
+    Err(validation("graph object logical path is empty"))
+}
+
+#[cfg(not(unix))]
+fn open_empty_materialization_target(target: &Path) -> Result<PathBuf, GfError> {
+    if let Ok(metadata) = fs::symlink_metadata(target)
+        && (metadata.file_type().is_symlink() || !metadata.is_dir())
+    {
+        return Err(validation("graph object target is not a real directory"));
+    }
+    fs::create_dir_all(target)
+        .map_err(|error| storage("create graph object materialization target", target, error))?;
+    if target
+        .read_dir()
+        .map_err(|error| storage("read graph object target", target, error))?
+        .next()
+        .is_some()
+    {
+        return Err(validation(
+            "graph object materialization target is not empty",
+        ));
+    }
+    Ok(target.to_path_buf())
+}
+
+#[cfg(not(unix))]
+fn link_materialized_object(
+    target: &PathBuf,
+    source: &Path,
+    relative: &str,
+) -> Result<(), GfError> {
+    let destination = target.join(relative);
+    if let Some(parent) = destination.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|error| storage("create logical graph object directory", parent, error))?;
+    }
+    fs::hard_link(source, &destination)
+        .map_err(|error| storage("link logical graph object", &destination, error))
 }
 
 /// Read an object whose digest is known before its declared logical length.
@@ -884,6 +1132,80 @@ fn storage(action: &str, path: &Path, error: impl std::fmt::Display) -> GfError 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn publication_and_gc_lifecycles_are_mutually_exclusive() {
+        use std::sync::mpsc::{self, TryRecvError};
+        use std::time::Duration;
+
+        let root = tempfile::tempdir().unwrap();
+        let publication = begin_graph_object_publication(root.path()).unwrap();
+        assert!(matches!(
+            gc_graph_objects(root.path(), &[], crate::GraphManifestLimits::default()),
+            Err(GfError::Project {
+                code: ProjectErrorCode::WriterBusy,
+                ..
+            })
+        ));
+        let path = root.path().to_path_buf();
+        let (gc_tx, gc_rx) = mpsc::channel();
+        let gc_thread = std::thread::spawn(move || {
+            let guard = begin_graph_object_gc(&path).unwrap();
+            gc_tx.send(guard).unwrap();
+        });
+        assert!(matches!(gc_rx.try_recv(), Err(TryRecvError::Empty)));
+        drop(publication);
+        let gc = gc_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        gc_thread.join().unwrap();
+
+        let path = root.path().to_path_buf();
+        let (publish_tx, publish_rx) = mpsc::channel();
+        let publish_thread = std::thread::spawn(move || {
+            let lease = begin_graph_object_publication(&path).unwrap();
+            publish_tx.send(lease).unwrap();
+        });
+        assert!(matches!(publish_rx.try_recv(), Err(TryRecvError::Empty)));
+        drop(gc);
+        let publication = publish_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        publish_thread.join().unwrap();
+        drop(publication);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn materialization_rejects_target_and_intermediate_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let objects = tempfile::tempdir().unwrap();
+        let (digest, _) = install_graph_object_bytes(objects.path(), b"payload").unwrap();
+        let entry = crate::GraphFileEntry {
+            relative_path: "nested/payload.bin".into(),
+            byte_length: 7,
+            content_sha256: digest,
+            role: crate::GraphFileRole::Other,
+        };
+        let inventory = crate::graph_files::inventory_from_entries(vec![entry.clone()]).unwrap();
+
+        let owner = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let linked_target = owner.path().join("linked-target");
+        symlink(outside.path(), &linked_target).unwrap();
+        assert!(materialize_graph_objects(objects.path(), &inventory, &linked_target).is_err());
+        assert!(!outside.path().join("nested/payload.bin").exists());
+
+        let target = owner.path().join("real-target");
+        let directory = open_empty_materialization_target(&target).unwrap();
+        symlink(outside.path(), target.join("nested")).unwrap();
+        assert!(
+            link_materialized_object(
+                &directory,
+                &graph_object_path(objects.path(), &entry.content_sha256).unwrap(),
+                &entry.relative_path,
+            )
+            .is_err()
+        );
+        assert!(!outside.path().join("payload.bin").exists());
+    }
 
     #[test]
     fn installs_once_reuses_exact_object_and_rejects_tampering() {
@@ -1085,6 +1407,7 @@ mod tests {
         let (root, _) =
             append_graph_files_v2(&lease, workspace.path(), None, &mut live, &[relative], &[])
                 .unwrap();
+        drop(lease);
         let (orphan, _) = install_graph_object_bytes(container.path(), b"orphan").unwrap();
         let evidence = gc_graph_objects(
             container.path(),

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -1170,7 +1170,7 @@ fn link_materialized_object(
                 let linked = rustix::fs::openat(
                     &directory,
                     component,
-                    OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+                    OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::NONBLOCK | OFlags::CLOEXEC,
                     Mode::empty(),
                 )
                 .map_err(|error| {

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -25,6 +25,7 @@ const BUFFER_BYTES: usize = 64 * 1024;
 
 /// Kernel-visible lease protecting CAS objects installed by one publication.
 pub struct GraphObjectPublicationLease {
+    root: PathBuf,
     path: PathBuf,
     file: File,
 }
@@ -53,7 +54,11 @@ pub fn begin_graph_object_publication(root: &Path) -> Result<GraphObjectPublicat
     file.sync_all()
         .map_err(|error| storage("sync graph object publication lease", &path, error))?;
     sync_directory(&active)?;
-    Ok(GraphObjectPublicationLease { path, file })
+    Ok(GraphObjectPublicationLease {
+        root: root.to_path_buf(),
+        path,
+        file,
+    })
 }
 
 /// Return true when any live CAS publication lease prevents safe sweeping.
@@ -242,13 +247,14 @@ pub fn gc_graph_objects(
 
 /// Seal only changed logical files into a structurally shared radix manifest.
 pub fn append_graph_files_v2(
-    root: &Path,
+    lease: &GraphObjectPublicationLease,
     workspace: &Path,
     previous_root: Option<&GraphFilesRootV2>,
     live_entries: &mut BTreeMap<String, crate::GraphFileEntry>,
     sealed_paths: &[PathBuf],
     tombstones: &[String],
 ) -> Result<(GraphFilesRootV2, GraphFilesAppendEvidence), GfError> {
+    let root = &lease.root;
     let mut additions = Vec::with_capacity(sealed_paths.len());
     let mut evidence = GraphFilesAppendEvidence::default();
     let mut logical_byte_length = previous_root.map_or(0, |root| root.logical_byte_length);
@@ -345,10 +351,11 @@ pub fn append_graph_files_v2(
 
 /// Import a verified v1 graph tree into a self-contained v2 radix root.
 pub fn migrate_graph_files_v1_to_v2(
-    root: &Path,
+    lease: &GraphObjectPublicationLease,
     graph_root: &Path,
     inventory: &GraphFilesInventory,
 ) -> Result<(GraphFilesRootV2, GraphFilesMigrationEvidence), GfError> {
+    let root = &lease.root;
     let mut evidence = GraphFilesMigrationEvidence::default();
     for entry in &inventory.files {
         let installed = install_graph_object_file(
@@ -949,8 +956,9 @@ mod tests {
         )
         .unwrap();
         let (inventory, _) = crate::capture_graph_files(graph.path()).unwrap();
+        let lease = begin_graph_object_publication(container.path()).unwrap();
         let (root, evidence) =
-            migrate_graph_files_v1_to_v2(container.path(), graph.path(), &inventory).unwrap();
+            migrate_graph_files_v1_to_v2(&lease, graph.path(), &inventory).unwrap();
         assert_eq!(evidence.payload_objects, 1);
         assert_eq!(evidence.payload_bytes_hashed, 4);
         let (files, _) =
@@ -965,6 +973,7 @@ mod tests {
     fn repeated_v2_appends_examine_only_changed_descriptors() {
         let container = tempfile::tempdir().unwrap();
         let workspace = tempfile::tempdir().unwrap();
+        let lease = begin_graph_object_publication(container.path()).unwrap();
         let mut live = BTreeMap::new();
         let mut previous = None;
         for ordinal in 0_u8..8 {
@@ -975,7 +984,7 @@ mod tests {
             fs::create_dir_all(path.parent().unwrap()).unwrap();
             fs::write(&path, [ordinal]).unwrap();
             let (root, evidence) = append_graph_files_v2(
-                container.path(),
+                &lease,
                 workspace.path(),
                 previous.as_ref(),
                 &mut live,
@@ -998,7 +1007,7 @@ mod tests {
 
         let deleted = "topology/edges/knows/00000000000000000003-00000000000000000003.parquet";
         let (root, delete_evidence) = append_graph_files_v2(
-            container.path(),
+            &lease,
             workspace.path(),
             Some(&root),
             &mut live,
@@ -1034,9 +1043,10 @@ mod tests {
         }
 
         let first = tempfile::tempdir().unwrap();
+        let first_lease = begin_graph_object_publication(first.path()).unwrap();
         let mut first_live = BTreeMap::new();
         let (first_root, _) = append_graph_files_v2(
-            first.path(),
+            &first_lease,
             workspace.path(),
             None,
             &mut first_live,
@@ -1046,11 +1056,12 @@ mod tests {
         .unwrap();
 
         let second = tempfile::tempdir().unwrap();
+        let second_lease = begin_graph_object_publication(second.path()).unwrap();
         let mut reversed = paths.clone();
         reversed.reverse();
         let mut second_live = BTreeMap::new();
         let (second_root, _) = append_graph_files_v2(
-            second.path(),
+            &second_lease,
             workspace.path(),
             None,
             &mut second_live,
@@ -1065,20 +1076,15 @@ mod tests {
     fn gc_traces_segment_and_payload_roots_before_sweeping() {
         let container = tempfile::tempdir().unwrap();
         let workspace = tempfile::tempdir().unwrap();
+        let lease = begin_graph_object_publication(container.path()).unwrap();
         let relative = PathBuf::from("topology/nodes/1-1.parquet");
         let source = workspace.path().join(&relative);
         fs::create_dir_all(source.parent().unwrap()).unwrap();
         fs::write(&source, b"node").unwrap();
         let mut live = BTreeMap::new();
-        let (root, _) = append_graph_files_v2(
-            container.path(),
-            workspace.path(),
-            None,
-            &mut live,
-            &[relative],
-            &[],
-        )
-        .unwrap();
+        let (root, _) =
+            append_graph_files_v2(&lease, workspace.path(), None, &mut live, &[relative], &[])
+                .unwrap();
         let (orphan, _) = install_graph_object_bytes(container.path(), b"orphan").unwrap();
         let evidence = gc_graph_objects(
             container.path(),

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -57,8 +57,10 @@ pub struct GraphObjectPublicationLease {
 }
 
 struct HeldCasLocks<'a> {
+    #[cfg(unix)]
     objects: &'a StableDirectory,
     lifecycle: &'a File,
+    #[cfg(unix)]
     objects_locked: bool,
     lifecycle_locked: bool,
 }
@@ -66,7 +68,10 @@ struct HeldCasLocks<'a> {
 impl HeldCasLocks<'_> {
     fn disarm(mut self) {
         self.lifecycle_locked = false;
-        self.objects_locked = false;
+        #[cfg(unix)]
+        {
+            self.objects_locked = false;
+        }
     }
 }
 
@@ -75,6 +80,7 @@ impl Drop for HeldCasLocks<'_> {
         if self.lifecycle_locked {
             let _ = crate::file_lock::unlock(self.lifecycle);
         }
+        #[cfg(unix)]
         if self.objects_locked {
             let _ = self.objects.unlock();
         }
@@ -139,6 +145,7 @@ fn lock_cas_shared<'a>(
     root: &Path,
     action: &str,
 ) -> Result<HeldCasLocks<'a>, GfError> {
+    #[cfg(unix)]
     objects.lock_shared().map_err(|error| {
         storage(
             &format!("lock graph object directory for {action}"),
@@ -147,12 +154,14 @@ fn lock_cas_shared<'a>(
         )
     })?;
     let mut held = HeldCasLocks {
+        #[cfg(unix)]
         objects,
         lifecycle,
+        #[cfg(unix)]
         objects_locked: true,
         lifecycle_locked: false,
     };
-    #[cfg(test)]
+    #[cfg(all(test, unix))]
     returned_error_boundary(&format!("{action}:objects-lock"))?;
     crate::file_lock::lock_shared(lifecycle).map_err(|error| {
         storage(
@@ -172,21 +181,40 @@ fn lock_cas_exclusive<'a>(
     lifecycle: &'a File,
     root: &Path,
 ) -> Result<HeldCasLocks<'a>, GfError> {
+    #[cfg(unix)]
     objects
         .lock_exclusive()
         .map_err(|error| storage("lock graph object directory for GC", root, error))?;
     let mut held = HeldCasLocks {
+        #[cfg(unix)]
         objects,
         lifecycle,
+        #[cfg(unix)]
         objects_locked: true,
         lifecycle_locked: false,
     };
+    #[cfg(all(test, unix))]
     returned_error_boundary("gc:objects-lock")?;
     crate::file_lock::lock_exclusive(lifecycle)
         .map_err(|error| storage("lock graph object GC lifecycle", root, error))?;
     held.lifecycle_locked = true;
     returned_error_boundary("gc:lifecycle-lock")?;
     Ok(held)
+}
+
+fn revalidate_lifecycle(
+    objects: &StableDirectory,
+    lifecycle: &File,
+    expected_identity: graphforge_filesystem::FileIdentity,
+) -> std::io::Result<()> {
+    if graphforge_filesystem::file_link_count(lifecycle)? != 1 {
+        return Err(std::io::Error::other("lifecycle lock is multiply linked"));
+    }
+    let named = objects.open_child_file(std::ffi::OsStr::new(LIFECYCLE_LOCK))?;
+    if graphforge_filesystem::file_identity(&named)? != expected_identity {
+        return Err(std::io::Error::other("lifecycle identity changed"));
+    }
+    Ok(())
 }
 
 impl CasRoot {
@@ -236,13 +264,7 @@ impl CasRoot {
             .and_then(|()| self.tmp.revalidate_named())
             .and_then(|()| self.active.revalidate_named())
             .and_then(|()| {
-                self.objects
-                    .open_child_file(std::ffi::OsStr::new(LIFECYCLE_LOCK))
-                    .and_then(|file| {
-                        (graphforge_filesystem::file_identity(&file)? == self.lifecycle_identity)
-                            .then_some(())
-                            .ok_or_else(|| std::io::Error::other("lifecycle identity changed"))
-                    })
+                revalidate_lifecycle(&self.objects, &self.lifecycle, self.lifecycle_identity)
             })
             .map_err(|error| {
                 storage(
@@ -323,13 +345,7 @@ impl ReadOnlyCasRoot {
             .and_then(|()| self.objects.revalidate_named())
             .and_then(|()| self.sha256.revalidate_named())
             .and_then(|()| {
-                self.objects
-                    .open_child_file(std::ffi::OsStr::new(LIFECYCLE_LOCK))
-                    .and_then(|file| {
-                        (graphforge_filesystem::file_identity(&file)? == self.lifecycle_identity)
-                            .then_some(())
-                            .ok_or_else(|| std::io::Error::other("lifecycle identity changed"))
-                    })
+                revalidate_lifecycle(&self.objects, &self.lifecycle, self.lifecycle_identity)
             })
             .map_err(|error| {
                 storage(
@@ -364,6 +380,7 @@ impl Drop for ReadOnlyCasRoot {
     fn drop(&mut self) {
         if self.locks_held {
             let _ = crate::file_lock::unlock(&self.lifecycle);
+            #[cfg(unix)]
             let _ = self.objects.unlock();
         }
     }
@@ -372,6 +389,7 @@ impl Drop for ReadOnlyCasRoot {
 impl Drop for GraphObjectGcGuard {
     fn drop(&mut self) {
         let _ = crate::file_lock::unlock(&self.cas.lifecycle);
+        #[cfg(unix)]
         let _ = self.cas.objects.unlock();
     }
 }
@@ -388,6 +406,7 @@ impl Drop for GraphObjectPublicationLease {
             .unlink_child_if_identity(&self.lease_name, self.lease_identity);
         let _ = self.cas.active.sync();
         let _ = crate::file_lock::unlock(&self.cas.lifecycle);
+        #[cfg(unix)]
         let _ = self.cas.objects.unlock();
     }
 }
@@ -644,6 +663,7 @@ pub(crate) fn try_begin_graph_object_gc(
     root: &Path,
 ) -> Result<Option<GraphObjectGcGuard>, GfError> {
     let cas = CasRoot::open_mutable(root)?;
+    #[cfg(unix)]
     if !cas
         .objects
         .try_lock_exclusive()
@@ -652,11 +672,14 @@ pub(crate) fn try_begin_graph_object_gc(
         return Ok(None);
     }
     let mut locks = HeldCasLocks {
+        #[cfg(unix)]
         objects: &cas.objects,
         lifecycle: &cas.lifecycle,
+        #[cfg(unix)]
         objects_locked: true,
         lifecycle_locked: false,
     };
+    #[cfg(all(test, unix))]
     returned_error_boundary("try-gc:objects-lock")?;
     if !crate::file_lock::try_lock_exclusive(&cas.lifecycle)
         .map_err(|error| storage("try graph object GC lifecycle", root, error))?
@@ -2189,11 +2212,16 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         drop(begin_graph_object_publication(root.path()).unwrap());
 
-        for boundary in [
+        #[cfg(unix)]
+        let reading_boundaries = [
             "reading:objects-lock",
             "reading:lifecycle-lock",
             "reading:revalidate",
-        ] {
+        ]
+        .as_slice();
+        #[cfg(not(unix))]
+        let reading_boundaries = ["reading:lifecycle-lock", "reading:revalidate"].as_slice();
+        for &boundary in reading_boundaries {
             inject_returned_error(Some(boundary));
             let error = ReadOnlyCasRoot::open(root.path()).err().unwrap();
             assert_injected_error(error, boundary);
@@ -2201,7 +2229,11 @@ mod tests {
             drop(try_begin_graph_object_gc(root.path()).unwrap().unwrap());
         }
 
-        for boundary in ["gc:objects-lock", "gc:lifecycle-lock", "gc:revalidate"] {
+        #[cfg(unix)]
+        let gc_boundaries = ["gc:objects-lock", "gc:lifecycle-lock", "gc:revalidate"].as_slice();
+        #[cfg(not(unix))]
+        let gc_boundaries = ["gc:lifecycle-lock", "gc:revalidate"].as_slice();
+        for &boundary in gc_boundaries {
             inject_returned_error(Some(boundary));
             let error = begin_graph_object_gc(root.path()).err().unwrap();
             assert_injected_error(error, boundary);
@@ -2209,11 +2241,16 @@ mod tests {
             drop(try_begin_graph_object_gc(root.path()).unwrap().unwrap());
         }
 
-        for boundary in [
+        #[cfg(unix)]
+        let try_gc_boundaries = [
             "try-gc:objects-lock",
             "try-gc:lifecycle-lock",
             "try-gc:revalidate",
-        ] {
+        ]
+        .as_slice();
+        #[cfg(not(unix))]
+        let try_gc_boundaries = ["try-gc:lifecycle-lock", "try-gc:revalidate"].as_slice();
+        for &boundary in try_gc_boundaries {
             inject_returned_error(Some(boundary));
             let error = try_begin_graph_object_gc(root.path()).err().unwrap();
             assert_injected_error(error, boundary);
@@ -2221,7 +2258,8 @@ mod tests {
             drop(try_begin_graph_object_gc(root.path()).unwrap().unwrap());
         }
 
-        for boundary in [
+        #[cfg(unix)]
+        let publication_boundaries = [
             "publication:objects-lock",
             "publication:lifecycle-lock",
             "publication:revalidate",
@@ -2230,7 +2268,20 @@ mod tests {
             "publication:lease-lock",
             "publication:lease-sync",
             "publication:active-sync",
-        ] {
+        ]
+        .as_slice();
+        #[cfg(not(unix))]
+        let publication_boundaries = [
+            "publication:lifecycle-lock",
+            "publication:revalidate",
+            "publication:lease-create",
+            "publication:lease-identity",
+            "publication:lease-lock",
+            "publication:lease-sync",
+            "publication:active-sync",
+        ]
+        .as_slice();
+        for &boundary in publication_boundaries {
             inject_returned_error(Some(boundary));
             let error = begin_graph_object_publication(root.path()).err().unwrap();
             assert_injected_error(error, boundary);

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -1,8 +1,10 @@
 //! Project-level immutable content-addressed graph objects.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Write};
+#[cfg(windows)]
+use std::fs::OpenOptions;
+use std::fs::{self, File};
+use std::io::{Read, Seek, Write};
 use std::path::{Component, Path, PathBuf};
 
 use graphforge_core::{GfError, ProjectErrorCode};
@@ -15,6 +17,7 @@ use crate::{
     GRAPH_MANIFEST_NODE_VERSION, GRAPH_RADIX_DEPTH, GraphFilesInventory, GraphFilesOpenEvidence,
     GraphFilesOpenStrategy, GraphFilesRootV2, GraphManifestNode, GraphManifestNodeKind,
 };
+use graphforge_filesystem::StableDirectory;
 
 /// Project-relative root of immutable graph objects.
 pub const GRAPH_OBJECTS_DIR: &str = "graph-objects";
@@ -26,43 +29,131 @@ const BUFFER_BYTES: usize = 64 * 1024;
 
 /// Kernel-visible lease protecting CAS objects installed by one publication.
 pub struct GraphObjectPublicationLease {
-    root: PathBuf,
-    coordination_directory: File,
-    coordination_directory_path: PathBuf,
-    path: PathBuf,
+    cas: CasRoot,
+    lease_name: std::ffi::OsString,
+    lease_identity: graphforge_filesystem::FileIdentity,
     file: File,
-    lifecycle_directory: File,
-    lifecycle_directory_path: PathBuf,
-    lifecycle: File,
-    lifecycle_path: PathBuf,
 }
 
 /// Exclusive guard spanning GC root discovery through sweep.
 pub(crate) struct GraphObjectGcGuard {
-    root: PathBuf,
-    coordination_directory: File,
-    coordination_directory_path: PathBuf,
-    lifecycle_directory: File,
-    lifecycle_directory_path: PathBuf,
+    cas: CasRoot,
+}
+
+struct CasRoot {
+    diagnostic_root: PathBuf,
+    project: StableDirectory,
+    objects: StableDirectory,
+    sha256: StableDirectory,
+    tmp: StableDirectory,
+    active: StableDirectory,
     lifecycle: File,
-    lifecycle_path: PathBuf,
+    lifecycle_identity: graphforge_filesystem::FileIdentity,
+}
+
+impl CasRoot {
+    fn open(root: &Path) -> Result<Self, GfError> {
+        let project = StableDirectory::open(root)
+            .map_err(|error| storage("open stable project root", root, error))?;
+        let objects = project
+            .create_child_directory(std::ffi::OsStr::new(GRAPH_OBJECTS_DIR))
+            .map_err(|error| storage("open stable graph object root", root, error))?;
+        let sha256 = objects
+            .create_child_directory(std::ffi::OsStr::new(SHA256_DIR))
+            .map_err(|error| storage("open stable graph object digest root", root, error))?;
+        let tmp = objects
+            .create_child_directory(std::ffi::OsStr::new(TEMP_DIR))
+            .map_err(|error| storage("open stable graph object temporary root", root, error))?;
+        let active = objects
+            .create_child_directory(std::ffi::OsStr::new(ACTIVE_DIR))
+            .map_err(|error| storage("open stable graph object active root", root, error))?;
+        let lifecycle = objects
+            .open_or_create_child_file(std::ffi::OsStr::new(LIFECYCLE_LOCK))
+            .map_err(|error| storage("open stable graph object lifecycle", root, error))?;
+        if graphforge_filesystem::file_link_count(&lifecycle)
+            .map_err(|error| storage("inspect graph object lifecycle links", root, error))?
+            != 1
+        {
+            return Err(validation("graph object lifecycle lock is multiply linked"));
+        }
+        let lifecycle_identity = graphforge_filesystem::file_identity(&lifecycle)
+            .map_err(|error| storage("inspect graph object lifecycle identity", root, error))?;
+        Ok(Self {
+            diagnostic_root: root.to_path_buf(),
+            project,
+            objects,
+            sha256,
+            tmp,
+            active,
+            lifecycle,
+            lifecycle_identity,
+        })
+    }
+
+    fn revalidate_named(&self) -> Result<(), GfError> {
+        self.project
+            .revalidate_named()
+            .and_then(|()| self.objects.revalidate_named())
+            .and_then(|()| self.sha256.revalidate_named())
+            .and_then(|()| self.tmp.revalidate_named())
+            .and_then(|()| self.active.revalidate_named())
+            .and_then(|()| {
+                self.objects
+                    .open_child_file(std::ffi::OsStr::new(LIFECYCLE_LOCK))
+                    .and_then(|file| {
+                        (graphforge_filesystem::file_identity(&file)? == self.lifecycle_identity)
+                            .then_some(())
+                            .ok_or_else(|| std::io::Error::other("lifecycle identity changed"))
+                    })
+            })
+            .map_err(|error| {
+                storage(
+                    "revalidate stable graph object root",
+                    &self.diagnostic_root,
+                    error,
+                )
+            })
+    }
+
+    fn digest_bucket(&self, digest: &str, create: bool) -> Result<StableDirectory, GfError> {
+        validate_digest(digest)?;
+        let name = std::ffi::OsStr::new(&digest[..2]);
+        let result = if create {
+            self.sha256.create_child_directory(name)
+        } else {
+            self.sha256.open_child_directory(name)
+        };
+        result.map_err(|error| {
+            storage(
+                "open stable graph object bucket",
+                &self.diagnostic_root,
+                error,
+            )
+        })
+    }
+
+    fn open_digest(&self, digest: &str) -> Result<File, GfError> {
+        let bucket = self.digest_bucket(digest, false)?;
+        bucket
+            .open_child_file(std::ffi::OsStr::new(&digest[2..]))
+            .map_err(|error| storage("open stable graph object", &self.diagnostic_root, error))
+    }
 }
 
 impl Drop for GraphObjectGcGuard {
     fn drop(&mut self) {
-        let _ = crate::file_lock::unlock(&self.lifecycle);
-        let _ = crate::file_lock::unlock(&self.lifecycle_directory);
-        let _ = crate::file_lock::unlock(&self.coordination_directory);
+        let _ = crate::file_lock::unlock(&self.cas.lifecycle);
     }
 }
 
 impl Drop for GraphObjectPublicationLease {
     fn drop(&mut self) {
         let _ = crate::file_lock::unlock(&self.file);
-        let _ = fs::remove_file(&self.path);
-        let _ = crate::file_lock::unlock(&self.lifecycle);
-        let _ = crate::file_lock::unlock(&self.lifecycle_directory);
-        let _ = crate::file_lock::unlock(&self.coordination_directory);
+        let _ = self
+            .cas
+            .active
+            .unlink_child_if_identity(&self.lease_name, self.lease_identity);
+        let _ = crate::file_lock::unlock(&self.cas.lifecycle);
     }
 }
 
@@ -73,12 +164,9 @@ impl GraphObjectPublicationLease {
     }
 
     pub(crate) fn revalidate_for_root(&self, root: &Path) -> Result<(), GfError> {
-        let lease_root = crate::filesystem_admission::open_directory_handle(&self.root)
-            .map_err(|error| storage("open leased graph object root", &self.root, error))?;
         let requested_root = crate::filesystem_admission::open_directory_handle(root)
             .map_err(|error| storage("open requested graph object root", root, error))?;
-        if graphforge_filesystem::file_identity(&lease_root)
-            .map_err(|error| storage("inspect leased graph object root", &self.root, error))?
+        if self.cas.project.identity()
             != graphforge_filesystem::file_identity(&requested_root)
                 .map_err(|error| storage("inspect requested graph object root", root, error))?
         {
@@ -92,50 +180,29 @@ impl GraphObjectPublicationLease {
 
 /// Begin a CAS installation attempt and hold its lease through CURRENT.
 pub fn begin_graph_object_publication(root: &Path) -> Result<GraphObjectPublicationLease, GfError> {
-    let (coordination_directory, coordination_directory_path) = open_coordination_lock(root)?;
-    crate::file_lock::lock_shared(&coordination_directory)
-        .map_err(|error| storage("lock graph object coordination file", root, error))?;
-    validate_lock_identity(&coordination_directory, &coordination_directory_path)?;
-    let object_root = root.join(GRAPH_OBJECTS_DIR);
-    fs::create_dir_all(&object_root)
-        .map_err(|error| storage("create graph object directory", &object_root, error))?;
-    let (lifecycle_directory, lifecycle, lifecycle_path) = open_lifecycle_lock(&object_root)?;
-    crate::file_lock::lock_shared(&lifecycle_directory)
-        .map_err(|error| storage("lock graph object lifecycle directory", &object_root, error))?;
-    crate::file_lock::lock_shared(&lifecycle).map_err(|error| {
-        storage(
-            "lock graph object publication lifecycle",
-            &lifecycle_path,
-            error,
-        )
-    })?;
-    validate_directory_identity(&lifecycle_directory, &object_root)?;
-    validate_lock_identity(&lifecycle, &lifecycle_path)?;
-    let active = object_root.join(ACTIVE_DIR);
-    fs::create_dir_all(&active)
-        .map_err(|error| storage("create graph object active directory", &active, error))?;
-    let path = active.join(format!("{}.lock", Uuid::new_v4().hyphenated()));
-    let file = OpenOptions::new()
-        .create_new(true)
-        .read(true)
-        .write(true)
-        .open(&path)
-        .map_err(|error| storage("create graph object publication lease", &path, error))?;
+    let cas = CasRoot::open(root)?;
+    crate::file_lock::lock_shared(&cas.lifecycle)
+        .map_err(|error| storage("lock graph object publication lifecycle", root, error))?;
+    cas.revalidate_named()?;
+    let lease_name = std::ffi::OsString::from(format!("{}.lock", Uuid::new_v4().hyphenated()));
+    let file = cas
+        .active
+        .create_child_file(&lease_name)
+        .map_err(|error| storage("create graph object publication lease", root, error))?;
+    let lease_identity = graphforge_filesystem::file_identity(&file)
+        .map_err(|error| storage("inspect graph object publication lease", root, error))?;
     crate::file_lock::lock_exclusive(&file)
-        .map_err(|error| storage("lock graph object publication lease", &path, error))?;
+        .map_err(|error| storage("lock graph object publication lease", root, error))?;
     file.sync_all()
-        .map_err(|error| storage("sync graph object publication lease", &path, error))?;
-    sync_directory(&active)?;
+        .map_err(|error| storage("sync graph object publication lease", root, error))?;
+    cas.active
+        .sync()
+        .map_err(|error| storage("sync graph object active directory", root, error))?;
     Ok(GraphObjectPublicationLease {
-        root: root.to_path_buf(),
-        coordination_directory,
-        coordination_directory_path,
-        path,
+        cas,
+        lease_name,
+        lease_identity,
         file,
-        lifecycle_directory,
-        lifecycle_directory_path: object_root,
-        lifecycle,
-        lifecycle_path,
     })
 }
 
@@ -143,24 +210,15 @@ pub fn begin_graph_object_publication(root: &Path) -> Result<GraphObjectPublicat
 /// Unlocked lease files are crash residue and are removed while the caller
 /// holds the project writer/recovery lock.
 pub fn graph_object_publication_is_live(root: &Path) -> Result<bool, GfError> {
-    let active = root.join(GRAPH_OBJECTS_DIR).join(ACTIVE_DIR);
-    let entries = match fs::read_dir(&active) {
-        Ok(entries) => entries,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
-        Err(error) => {
-            return Err(storage(
-                "read graph object active directory",
-                &active,
-                error,
-            ));
-        }
-    };
+    let cas = CasRoot::open(root)?;
+    let entries = cas
+        .active
+        .child_names()
+        .map_err(|error| storage("read graph object active directory", root, error))?;
     let mut live = false;
     for entry in entries {
-        let entry = entry.map_err(|error| storage("read graph object lease", &active, error))?;
-        let path = entry.path();
         let name = entry
-            .file_name()
+            .clone()
             .into_string()
             .map_err(|_| validation("graph object lease name is not UTF-8"))?;
         let uuid_text = name
@@ -171,25 +229,20 @@ pub fn graph_object_publication_is_live(root: &Path) -> Result<bool, GfError> {
         if uuid.hyphenated().to_string() != uuid_text {
             return Err(validation("graph object lease name is not canonical"));
         }
-        let metadata = fs::symlink_metadata(&path)
-            .map_err(|error| storage("inspect graph object lease", &path, error))?;
-        if !metadata.is_file() || metadata.file_type().is_symlink() {
-            return Err(validation(
-                "graph object active directory contains an invalid entry",
-            ));
-        }
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(&path)
-            .map_err(|error| storage("open graph object lease", &path, error))?;
+        let file = cas
+            .active
+            .open_child_file(&entry)
+            .map_err(|error| storage("open graph object lease", root, error))?;
+        let identity = graphforge_filesystem::file_identity(&file)
+            .map_err(|error| storage("inspect graph object lease", root, error))?;
         if crate::file_lock::try_lock_exclusive(&file)
-            .map_err(|error| storage("probe graph object lease", &path, error))?
+            .map_err(|error| storage("probe graph object lease", root, error))?
         {
             crate::file_lock::unlock(&file)
-                .map_err(|error| storage("unlock graph object lease", &path, error))?;
-            fs::remove_file(&path)
-                .map_err(|error| storage("remove stale graph object lease", &path, error))?;
+                .map_err(|error| storage("unlock graph object lease", root, error))?;
+            cas.active
+                .unlink_child_if_identity(&entry, identity)
+                .map_err(|error| storage("remove stale graph object lease", root, error))?;
         } else {
             live = true;
         }
@@ -260,211 +313,27 @@ pub fn gc_graph_objects(
 
 #[cfg(test)]
 pub(crate) fn begin_graph_object_gc(root: &Path) -> Result<GraphObjectGcGuard, GfError> {
-    let (coordination_directory, coordination_directory_path) = open_coordination_lock(root)?;
-    crate::file_lock::lock_exclusive(&coordination_directory)
-        .map_err(|error| storage("lock graph object GC coordination file", root, error))?;
-    validate_lock_identity(&coordination_directory, &coordination_directory_path)?;
-    let (root, lifecycle_directory, lifecycle, lifecycle_path) = open_graph_object_lifecycle(root)?;
-    crate::file_lock::lock_exclusive(&lifecycle_directory)
-        .map_err(|error| storage("lock graph object GC directory", &root, error))?;
-    crate::file_lock::lock_exclusive(&lifecycle)
-        .map_err(|error| storage("lock graph object GC lifecycle", &lifecycle_path, error))?;
-    validate_directory_identity(&lifecycle_directory, &root.join(GRAPH_OBJECTS_DIR))?;
-    validate_lock_identity(&lifecycle, &lifecycle_path)?;
-    let lifecycle_directory_path = root.join(GRAPH_OBJECTS_DIR);
-    Ok(GraphObjectGcGuard {
-        root,
-        coordination_directory,
-        coordination_directory_path,
-        lifecycle_directory,
-        lifecycle_directory_path,
-        lifecycle,
-        lifecycle_path,
-    })
+    let cas = CasRoot::open(root)?;
+    crate::file_lock::lock_exclusive(&cas.lifecycle)
+        .map_err(|error| storage("lock graph object GC lifecycle", root, error))?;
+    cas.revalidate_named()?;
+    Ok(GraphObjectGcGuard { cas })
 }
 
 pub(crate) fn try_begin_graph_object_gc(
     root: &Path,
 ) -> Result<Option<GraphObjectGcGuard>, GfError> {
-    let (coordination_directory, coordination_directory_path) = open_coordination_lock(root)?;
-    if !crate::file_lock::try_lock_exclusive(&coordination_directory)
-        .map_err(|error| storage("try graph object GC coordination file", root, error))?
+    let cas = CasRoot::open(root)?;
+    if !crate::file_lock::try_lock_exclusive(&cas.lifecycle)
+        .map_err(|error| storage("try graph object GC lifecycle", root, error))?
     {
         return Ok(None);
     }
-    validate_lock_identity(&coordination_directory, &coordination_directory_path)?;
-    let (root, lifecycle_directory, lifecycle, lifecycle_path) = open_graph_object_lifecycle(root)?;
-    if !crate::file_lock::try_lock_exclusive(&lifecycle_directory)
-        .map_err(|error| storage("try graph object GC directory", &root, error))?
-    {
-        return Ok(None);
-    }
-    if !crate::file_lock::try_lock_exclusive(&lifecycle)
-        .map_err(|error| storage("try graph object GC lifecycle", &lifecycle_path, error))?
-    {
-        let _ = crate::file_lock::unlock(&lifecycle_directory);
-        return Ok(None);
-    }
-    validate_directory_identity(&lifecycle_directory, &root.join(GRAPH_OBJECTS_DIR))?;
-    validate_lock_identity(&lifecycle, &lifecycle_path)?;
-    let lifecycle_directory_path = root.join(GRAPH_OBJECTS_DIR);
-    Ok(Some(GraphObjectGcGuard {
-        root,
-        coordination_directory,
-        coordination_directory_path,
-        lifecycle_directory,
-        lifecycle_directory_path,
-        lifecycle,
-        lifecycle_path,
-    }))
-}
-
-fn open_graph_object_lifecycle(root: &Path) -> Result<(PathBuf, File, File, PathBuf), GfError> {
-    let object_root = root.join(GRAPH_OBJECTS_DIR);
-    fs::create_dir_all(&object_root)
-        .map_err(|error| storage("create graph object directory", &object_root, error))?;
-    let (directory, lifecycle, lifecycle_path) = open_lifecycle_lock(&object_root)?;
-    Ok((root.to_path_buf(), directory, lifecycle, lifecycle_path))
-}
-
-fn coordination_lock_path(root: &Path) -> Result<PathBuf, GfError> {
-    let parent = root
-        .parent()
-        .ok_or_else(|| validation("graph object root has no coordination parent"))?;
-    let name = root
-        .file_name()
-        .and_then(std::ffi::OsStr::to_str)
-        .ok_or_else(|| validation("graph object root name is not UTF-8"))?;
-    Ok(parent.join(format!(".graphforge-cas-{name}.lock")))
-}
-
-#[cfg(unix)]
-fn open_coordination_lock(root: &Path) -> Result<(File, PathBuf), GfError> {
-    use std::os::unix::fs::OpenOptionsExt as _;
-
-    let path = coordination_lock_path(root)?;
-    let file = OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(true)
-        .mode(0o600)
-        .custom_flags(libc::O_NOFOLLOW)
-        .open(&path)
-        .map_err(|error| storage("open graph object coordination lock", &path, error))?;
-    validate_lock_identity(&file, &path)?;
-    file.sync_all()
-        .map_err(|error| storage("sync graph object coordination lock", &path, error))?;
-    Ok((file, path))
+    cas.revalidate_named()?;
+    Ok(Some(GraphObjectGcGuard { cas }))
 }
 
 #[cfg(windows)]
-fn open_coordination_lock(root: &Path) -> Result<(File, PathBuf), GfError> {
-    use std::os::windows::fs::OpenOptionsExt as _;
-    const FILE_SHARE_READ: u32 = 0x0000_0001;
-    const FILE_SHARE_WRITE: u32 = 0x0000_0002;
-    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
-    const FILE_FLAG_WRITE_THROUGH: u32 = 0x8000_0000;
-    let path = coordination_lock_path(root)?;
-    let file = OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(true)
-        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
-        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_WRITE_THROUGH)
-        .open(&path)
-        .map_err(|error| storage("open graph object coordination lock", &path, error))?;
-    validate_lock_identity(&file, &path)?;
-    file.sync_all()
-        .map_err(|error| storage("sync graph object coordination lock", &path, error))?;
-    Ok((file, path))
-}
-
-#[cfg(all(not(unix), not(windows)))]
-fn open_coordination_lock(_root: &Path) -> Result<(File, PathBuf), GfError> {
-    Err(validation(
-        "graph object coordination locks are unsupported on this platform",
-    ))
-}
-
-#[cfg(unix)]
-fn open_lifecycle_lock(object_root: &Path) -> Result<(File, File, PathBuf), GfError> {
-    use rustix::fs::{AtFlags, Mode, OFlags};
-
-    let directory = rustix::fs::open(
-        object_root,
-        OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
-        Mode::empty(),
-    )
-    .map_err(|error| storage("open graph object lock directory", object_root, error))?;
-    let descriptor = rustix::fs::openat(
-        &directory,
-        LIFECYCLE_LOCK,
-        OFlags::RDWR | OFlags::CREATE | OFlags::NOFOLLOW | OFlags::CLOEXEC,
-        Mode::from_bits_truncate(0o600),
-    )
-    .map_err(|error| storage("open graph object lifecycle lock", object_root, error))?;
-    let descriptor_stat = rustix::fs::fstat(&descriptor).map_err(|error| {
-        storage(
-            "inspect graph object lifecycle descriptor",
-            object_root,
-            error,
-        )
-    })?;
-    let path_stat = rustix::fs::statat(&directory, LIFECYCLE_LOCK, AtFlags::SYMLINK_NOFOLLOW)
-        .map_err(|error| storage("inspect graph object lifecycle path", object_root, error))?;
-    if descriptor_stat.st_dev != path_stat.st_dev
-        || descriptor_stat.st_ino != path_stat.st_ino
-        || descriptor_stat.st_nlink != 1
-        || path_stat.st_nlink != 1
-    {
-        return Err(validation(
-            "graph object lifecycle lock identity is unstable",
-        ));
-    }
-    let file: File = descriptor.into();
-    let directory: File = directory.into();
-    file.sync_all()
-        .map_err(|error| storage("sync graph object lifecycle lock", object_root, error))?;
-    sync_directory(object_root)?;
-    Ok((directory, file, object_root.join(LIFECYCLE_LOCK)))
-}
-
-#[cfg(windows)]
-fn open_lifecycle_lock(object_root: &Path) -> Result<(File, File, PathBuf), GfError> {
-    use std::os::windows::fs::OpenOptionsExt as _;
-
-    const FILE_SHARE_READ: u32 = 0x0000_0001;
-    const FILE_SHARE_WRITE: u32 = 0x0000_0002;
-    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
-    const FILE_FLAG_WRITE_THROUGH: u32 = 0x8000_0000;
-    let path = object_root.join(LIFECYCLE_LOCK);
-    let directory = crate::filesystem_admission::open_directory_handle(object_root)
-        .map_err(|error| storage("open graph object lock directory", object_root, error))?;
-    validate_directory_identity(&directory, object_root)?;
-    let file = OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(true)
-        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
-        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_WRITE_THROUGH)
-        .open(&path)
-        .map_err(|error| storage("open graph object lifecycle lock", &path, error))?;
-    validate_lock_identity(&file, &path)?;
-    file.sync_all()
-        .map_err(|error| storage("sync graph object lifecycle lock", &path, error))?;
-    directory
-        .sync_all()
-        .map_err(|error| storage("sync graph object lock directory", object_root, error))?;
-    Ok((directory, file, path))
-}
-
-#[cfg(all(not(unix), not(windows)))]
-fn open_lifecycle_lock(_object_root: &Path) -> Result<(File, File, PathBuf), GfError> {
-    Err(validation(
-        "graph object lifecycle locks are unsupported on this platform",
-    ))
-}
-
 fn validate_lock_identity(file: &File, path: &Path) -> Result<(), GfError> {
     let descriptor = file
         .metadata()
@@ -510,6 +379,7 @@ fn validate_lock_identity(file: &File, path: &Path) -> Result<(), GfError> {
     Ok(())
 }
 
+#[cfg(windows)]
 fn validate_directory_identity(file: &File, path: &Path) -> Result<(), GfError> {
     let descriptor = file
         .metadata()
@@ -549,82 +419,95 @@ fn validate_directory_identity(file: &File, path: &Path) -> Result<(), GfError> 
 }
 
 fn validate_publication_identity(lease: &GraphObjectPublicationLease) -> Result<(), GfError> {
-    validate_lock_identity(
-        &lease.coordination_directory,
-        &lease.coordination_directory_path,
-    )?;
-    validate_directory_identity(&lease.lifecycle_directory, &lease.lifecycle_directory_path)?;
-    validate_lock_identity(&lease.lifecycle, &lease.lifecycle_path)
+    lease.cas.revalidate_named()
 }
 
+#[allow(clippy::too_many_lines)]
 pub(crate) fn gc_graph_objects_guarded(
     guard: &GraphObjectGcGuard,
     roots: &[GraphFilesRootV2],
     limits: crate::GraphManifestLimits,
 ) -> Result<GraphObjectGcEvidence, GfError> {
-    validate_lock_identity(
-        &guard.coordination_directory,
-        &guard.coordination_directory_path,
-    )?;
-    validate_directory_identity(&guard.lifecycle_directory, &guard.lifecycle_directory_path)?;
-    validate_lock_identity(&guard.lifecycle, &guard.lifecycle_path)?;
-    let root = &guard.root;
+    guard.cas.revalidate_named()?;
     let mut marked = BTreeSet::new();
     for graph_root in roots {
         let mut segment_digests = Vec::new();
         let (files, _) = crate::resolve_graph_manifest(graph_root, limits, |digest| {
             segment_digests.push(digest.to_owned());
-            read_graph_object_by_digest(root, digest, 64 * 1024 * 1024)
+            read_graph_object_by_digest_from_cas(&guard.cas, digest, 64 * 1024 * 1024)
         })?;
         marked.extend(segment_digests);
         marked.extend(files.into_iter().map(|entry| entry.content_sha256));
     }
     let mut candidates = Vec::new();
-    let sha_root = root.join(GRAPH_OBJECTS_DIR).join(SHA256_DIR);
-    if sha_root.exists() {
-        for prefix in fs::read_dir(&sha_root)
-            .map_err(|error| storage("read graph object prefixes", &sha_root, error))?
+    for prefix in guard.cas.sha256.child_names().map_err(|error| {
+        storage(
+            "read stable graph object prefixes",
+            &guard.cas.diagnostic_root,
+            error,
+        )
+    })? {
+        let prefix_text = prefix
+            .to_str()
+            .ok_or_else(|| validation("graph object prefix is not UTF-8"))?;
+        if prefix_text.len() != 2
+            || !prefix_text
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
         {
-            let prefix =
-                prefix.map_err(|error| storage("read graph object prefix", &sha_root, error))?;
-            if !prefix
-                .file_type()
-                .map_err(|error| storage("inspect graph object prefix", &prefix.path(), error))?
-                .is_dir()
-            {
+            return Err(validation("graph object prefix is not canonical"));
+        }
+        let bucket = guard
+            .cas
+            .sha256
+            .open_child_directory(&prefix)
+            .map_err(|error| {
+                storage(
+                    "open stable graph object bucket",
+                    &guard.cas.diagnostic_root,
+                    error,
+                )
+            })?;
+        for object in bucket.child_names().map_err(|error| {
+            storage(
+                "read stable graph object bucket",
+                &guard.cas.diagnostic_root,
+                error,
+            )
+        })? {
+            let suffix = object
+                .to_str()
+                .ok_or_else(|| validation("graph object name is not UTF-8"))?;
+            let digest = format!("{prefix_text}{suffix}");
+            validate_digest(&digest)?;
+            let file = bucket.open_child_file(&object).map_err(|error| {
+                storage(
+                    "open stable graph object candidate",
+                    &guard.cas.diagnostic_root,
+                    error,
+                )
+            })?;
+            let metadata = file.metadata().map_err(|error| {
+                storage(
+                    "inspect stable graph object candidate",
+                    &guard.cas.diagnostic_root,
+                    error,
+                )
+            })?;
+            if !metadata.is_file() {
                 return Err(validation(
-                    "graph object store contains a non-directory prefix",
+                    "graph object bucket contains a non-regular object",
                 ));
             }
-            let prefix_name = prefix
-                .file_name()
-                .into_string()
-                .map_err(|_| validation("graph object prefix is not UTF-8"))?;
-            for object in fs::read_dir(prefix.path())
-                .map_err(|error| storage("read graph object bucket", &prefix.path(), error))?
-            {
-                let object = object
-                    .map_err(|error| storage("read graph object entry", &prefix.path(), error))?;
-                let file_type = object
-                    .file_type()
-                    .map_err(|error| storage("inspect graph object type", &object.path(), error))?;
-                if !file_type.is_file() || file_type.is_symlink() {
-                    return Err(validation(
-                        "graph object bucket contains a non-regular object",
-                    ));
-                }
-                let metadata = object.metadata().map_err(|error| {
-                    storage("inspect graph object entry", &object.path(), error)
+            if !marked.contains(&digest) {
+                let identity = graphforge_filesystem::file_identity(&file).map_err(|error| {
+                    storage(
+                        "identify graph object candidate",
+                        &guard.cas.diagnostic_root,
+                        error,
+                    )
                 })?;
-                let suffix = object
-                    .file_name()
-                    .into_string()
-                    .map_err(|_| validation("graph object name is not UTF-8"))?;
-                let digest = format!("{prefix_name}{suffix}");
-                validate_digest(&digest)?;
-                if !marked.contains(&digest) {
-                    candidates.push((object.path(), metadata.len()));
-                }
+                candidates.push((prefix.clone(), object, identity, metadata.len()));
             }
         }
     }
@@ -632,9 +515,27 @@ pub(crate) fn gc_graph_objects_guarded(
         objects_marked: u64::try_from(marked.len()).unwrap_or(u64::MAX),
         ..GraphObjectGcEvidence::default()
     };
-    for (path, bytes) in candidates {
-        fs::remove_file(&path)
-            .map_err(|error| storage("remove unreachable graph object", &path, error))?;
+    for (prefix, object, identity, bytes) in candidates {
+        let bucket = guard
+            .cas
+            .sha256
+            .open_child_directory(&prefix)
+            .map_err(|error| {
+                storage(
+                    "reopen stable graph object bucket",
+                    &guard.cas.diagnostic_root,
+                    error,
+                )
+            })?;
+        bucket
+            .unlink_child_if_identity(&object, identity)
+            .map_err(|error| {
+                storage(
+                    "remove unreachable stable graph object",
+                    &guard.cas.diagnostic_root,
+                    error,
+                )
+            })?;
         evidence.objects_removed = evidence.objects_removed.saturating_add(1);
         evidence.bytes_removed = evidence.bytes_removed.saturating_add(bytes);
     }
@@ -651,7 +552,6 @@ pub fn append_graph_files_v2(
     tombstones: &[String],
 ) -> Result<(GraphFilesRootV2, GraphFilesAppendEvidence), GfError> {
     validate_publication_identity(lease)?;
-    let root = &lease.root;
     let mut additions = Vec::with_capacity(sealed_paths.len());
     let mut evidence = GraphFilesAppendEvidence::default();
     let mut logical_byte_length = previous_root.map_or(0, |root| root.logical_byte_length);
@@ -665,7 +565,8 @@ pub fn append_graph_files_v2(
         }
         let digest = hash_regular_file(&source)?;
         let digest = hex_digest(digest);
-        let installed = install_graph_object_file(root, &source, &digest, metadata.len())?;
+        let installed =
+            install_graph_object_file_with_lease(lease, &source, &digest, metadata.len())?;
         evidence.payload_bytes_hashed = evidence
             .payload_bytes_hashed
             .saturating_add(metadata.len())
@@ -705,12 +606,12 @@ pub fn append_graph_files_v2(
         u64::try_from(additions.len().saturating_add(tombstones.len())).unwrap_or(u64::MAX);
     let mut root_digest = match previous_root {
         Some(previous) => previous.root_node_sha256.clone(),
-        None => install_manifest_node(root, &empty_branch(0), &mut evidence.bytes_installed)?,
+        None => install_manifest_node(lease, &empty_branch(0), &mut evidence.bytes_installed)?,
     };
     for entry in additions {
         let relative_path = entry.relative_path.clone();
         root_digest = update_manifest_path(
-            root,
+            lease,
             Some(&root_digest),
             0,
             &relative_path,
@@ -721,7 +622,7 @@ pub fn append_graph_files_v2(
     }
     for path in tombstones {
         root_digest = update_manifest_path(
-            root,
+            lease,
             Some(&root_digest),
             0,
             &path,
@@ -729,7 +630,7 @@ pub fn append_graph_files_v2(
             &mut evidence.bytes_installed,
         )?
         .unwrap_or(install_manifest_node(
-            root,
+            lease,
             &empty_branch(0),
             &mut evidence.bytes_installed,
         )?);
@@ -753,11 +654,10 @@ pub fn migrate_graph_files_v1_to_v2(
     inventory: &GraphFilesInventory,
 ) -> Result<(GraphFilesRootV2, GraphFilesMigrationEvidence), GfError> {
     validate_publication_identity(lease)?;
-    let root = &lease.root;
     let mut evidence = GraphFilesMigrationEvidence::default();
     for entry in &inventory.files {
-        let installed = install_graph_object_file(
-            root,
+        let installed = install_graph_object_file_with_lease(
+            lease,
             &graph_root.join(&entry.relative_path),
             &entry.content_sha256,
             entry.byte_length,
@@ -771,10 +671,10 @@ pub fn migrate_graph_files_v1_to_v2(
             .saturating_add(installed.bytes_installed);
     }
     let mut root_digest =
-        install_manifest_node(root, &empty_branch(0), &mut evidence.bytes_installed)?;
+        install_manifest_node(lease, &empty_branch(0), &mut evidence.bytes_installed)?;
     for entry in &inventory.files {
         root_digest = update_manifest_path(
-            root,
+            lease,
             Some(&root_digest),
             0,
             &entry.relative_path,
@@ -807,22 +707,22 @@ fn empty_branch(depth: u8) -> GraphManifestNode {
 }
 
 fn install_manifest_node(
-    root: &Path,
+    lease: &GraphObjectPublicationLease,
     node: &GraphManifestNode,
     bytes_installed: &mut u64,
 ) -> Result<String, GfError> {
     let bytes = crate::encode_graph_manifest_node(node)?;
-    let (digest, evidence) = install_graph_object_bytes(root, &bytes)?;
+    let (digest, evidence) = install_graph_object_bytes_with_lease(lease, &bytes)?;
     *bytes_installed = bytes_installed.saturating_add(evidence.bytes_installed);
     Ok(digest)
 }
 
 fn load_manifest_node(
-    root: &Path,
+    lease: &GraphObjectPublicationLease,
     digest: &str,
     expected_depth: u8,
 ) -> Result<GraphManifestNode, GfError> {
-    let bytes = read_graph_object_by_digest(root, digest, 64 * 1024 * 1024)?;
+    let bytes = read_graph_object_by_digest_from_cas(&lease.cas, digest, 64 * 1024 * 1024)?;
     let node = crate::decode_graph_manifest_node(&bytes)?;
     if node.depth != expected_depth {
         return Err(validation(
@@ -833,7 +733,7 @@ fn load_manifest_node(
 }
 
 fn update_manifest_path(
-    root: &Path,
+    lease: &GraphObjectPublicationLease,
     current_digest: Option<&str>,
     depth: u8,
     path: &str,
@@ -843,7 +743,7 @@ fn update_manifest_path(
     let path_digest = crate::graph_manifest::logical_path_digest(path);
     if depth == GRAPH_RADIX_DEPTH {
         let mut entries = match current_digest {
-            Some(digest) => match load_manifest_node(root, digest, depth)?.kind {
+            Some(digest) => match load_manifest_node(lease, digest, depth)?.kind {
                 GraphManifestNodeKind::Leaf {
                     path_sha256,
                     entries,
@@ -884,11 +784,11 @@ fn update_manifest_path(
                 entries,
             },
         };
-        return install_manifest_node(root, &node, bytes_installed).map(Some);
+        return install_manifest_node(lease, &node, bytes_installed).map(Some);
     }
 
     let mut children = match current_digest {
-        Some(digest) => match load_manifest_node(root, digest, depth)?.kind {
+        Some(digest) => match load_manifest_node(lease, digest, depth)?.kind {
             GraphManifestNodeKind::Branch { children } => children,
             GraphManifestNodeKind::Leaf { .. } => {
                 return Err(validation(
@@ -903,7 +803,7 @@ fn update_manifest_path(
         crate::graph_manifest::radix_nibble(&path_digest, depth)
     );
     let child = update_manifest_path(
-        root,
+        lease,
         children.get(&nibble).map(String::as_str),
         depth + 1,
         path,
@@ -922,7 +822,7 @@ fn update_manifest_path(
         return Ok(None);
     }
     install_manifest_node(
-        root,
+        lease,
         &GraphManifestNode {
             format: GRAPH_MANIFEST_NODE_FORMAT.into(),
             format_version: GRAPH_MANIFEST_NODE_VERSION,
@@ -949,14 +849,31 @@ pub fn install_graph_object_bytes(
     root: &Path,
     bytes: &[u8],
 ) -> Result<(String, GraphObjectInstallEvidence), GfError> {
+    let lease = begin_graph_object_publication(root)?;
+    install_graph_object_bytes_with_lease(&lease, bytes)
+}
+
+fn install_graph_object_bytes_with_lease(
+    lease: &GraphObjectPublicationLease,
+    bytes: &[u8],
+) -> Result<(String, GraphObjectInstallEvidence), GfError> {
     let digest = hex_digest(Sha256::digest(bytes).into());
     let expected_length = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
-    install_object(root, &digest, expected_length, |temporary| {
-        let mut file = create_new(temporary)?;
-        file.write_all(bytes)
-            .map_err(|error| storage("write temporary graph object", temporary, error))?;
-        file.sync_all()
-            .map_err(|error| storage("fsync temporary graph object", temporary, error))?;
+    install_object(&lease.cas, &digest, expected_length, |file| {
+        file.write_all(bytes).map_err(|error| {
+            storage(
+                "write temporary graph object",
+                &lease.cas.diagnostic_root,
+                error,
+            )
+        })?;
+        file.sync_all().map_err(|error| {
+            storage(
+                "fsync temporary graph object",
+                &lease.cas.diagnostic_root,
+                error,
+            )
+        })?;
         Ok(expected_length)
     })
     .map(|evidence| (digest, evidence))
@@ -965,6 +882,16 @@ pub fn install_graph_object_bytes(
 /// Stream, hash, and install a new payload object from a regular source file.
 pub fn install_graph_object_file(
     root: &Path,
+    source: &Path,
+    expected_digest: &str,
+    expected_length: u64,
+) -> Result<GraphObjectInstallEvidence, GfError> {
+    let lease = begin_graph_object_publication(root)?;
+    install_graph_object_file_with_lease(&lease, source, expected_digest, expected_length)
+}
+
+fn install_graph_object_file_with_lease(
+    lease: &GraphObjectPublicationLease,
     source: &Path,
     expected_digest: &str,
     expected_length: u64,
@@ -978,10 +905,9 @@ pub fn install_graph_object_file(
             "graph object source is not the declared regular file",
         ));
     }
-    install_object(root, expected_digest, expected_length, |temporary| {
+    install_object(&lease.cas, expected_digest, expected_length, |output| {
         let mut input = File::open(source)
             .map_err(|error| storage("open graph object source", source, error))?;
-        let mut output = create_new(temporary)?;
         let mut hasher = Sha256::new();
         let mut total = 0_u64;
         let mut buffer = vec![0_u8; BUFFER_BYTES];
@@ -992,9 +918,13 @@ pub fn install_graph_object_file(
             if read == 0 {
                 break;
             }
-            output
-                .write_all(&buffer[..read])
-                .map_err(|error| storage("write temporary graph object", temporary, error))?;
+            output.write_all(&buffer[..read]).map_err(|error| {
+                storage(
+                    "write temporary graph object",
+                    &lease.cas.diagnostic_root,
+                    error,
+                )
+            })?;
             hasher.update(&buffer[..read]);
             total = total.saturating_add(u64::try_from(read).unwrap_or(u64::MAX));
         }
@@ -1003,9 +933,13 @@ pub fn install_graph_object_file(
                 "graph object source digest or length changed during install",
             ));
         }
-        output
-            .sync_all()
-            .map_err(|error| storage("fsync temporary graph object", temporary, error))?;
+        output.sync_all().map_err(|error| {
+            storage(
+                "fsync temporary graph object",
+                &lease.cas.diagnostic_root,
+                error,
+            )
+        })?;
         Ok(total)
     })
 }
@@ -1016,39 +950,33 @@ pub fn read_graph_object(
     digest: &str,
     expected_length: u64,
 ) -> Result<Vec<u8>, GfError> {
-    let path = graph_object_path(root, digest)?;
-    let bytes = fs::read(&path).map_err(|error| storage("read graph object", &path, error))?;
+    let cas = CasRoot::open(root)?;
+    let mut file = cas.open_digest(digest)?;
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)
+        .map_err(|error| storage("read stable graph object", root, error))?;
     verify_object_bytes(digest, expected_length, &bytes)?;
     Ok(bytes)
 }
 
 /// Stream-verify a payload object without retaining it in memory.
 pub fn verify_graph_object(root: &Path, digest: &str, expected_length: u64) -> Result<(), GfError> {
-    let path = graph_object_path(root, digest)?;
-    let metadata = fs::symlink_metadata(&path)
-        .map_err(|error| storage("inspect graph object", &path, error))?;
-    if !metadata.is_file() || metadata.file_type().is_symlink() || metadata.len() != expected_length
-    {
-        return Err(validation(
-            "graph object path is not the declared regular file",
-        ));
-    }
-    let mut file = File::open(&path).map_err(|error| storage("open graph object", &path, error))?;
-    let mut hasher = Sha256::new();
-    let mut buffer = vec![0_u8; BUFFER_BYTES];
-    loop {
-        let read = file
-            .read(&mut buffer)
-            .map_err(|error| storage("read graph object", &path, error))?;
-        if read == 0 {
-            break;
-        }
-        hasher.update(&buffer[..read]);
-    }
-    if hex_digest(hasher.finalize().into()) != digest {
-        return Err(validation("graph object digest does not match its address"));
-    }
-    Ok(())
+    let cas = CasRoot::open(root)?;
+    verify_file(cas.open_digest(digest)?, digest, expected_length, root)
+}
+
+pub(crate) fn verify_graph_object_with_lease(
+    lease: &GraphObjectPublicationLease,
+    digest: &str,
+    expected_length: u64,
+) -> Result<(), GfError> {
+    lease.cas.revalidate_named()?;
+    verify_file(
+        lease.cas.open_digest(digest)?,
+        digest,
+        expected_length,
+        &lease.cas.diagnostic_root,
+    )
 }
 
 /// Materialize a verified logical inventory as hard links to immutable CAS
@@ -1059,7 +987,9 @@ pub fn materialize_graph_objects(
     target: &Path,
 ) -> Result<GraphFilesOpenEvidence, GfError> {
     let lease = begin_graph_object_publication(root)?;
-    let target_directory = open_empty_materialization_target(target)?;
+    let _target_guard = open_empty_materialization_target(target)?;
+    let target_directory = StableDirectory::open(target)
+        .map_err(|error| storage("retain stable materialization target", target, error))?;
     let mut evidence = GraphFilesOpenEvidence {
         strategy: GraphFilesOpenStrategy::PrivateMaterialize,
         files_validated: inventory.file_count,
@@ -1067,19 +997,85 @@ pub fn materialize_graph_objects(
         ..GraphFilesOpenEvidence::default()
     };
     for entry in &inventory.files {
-        let source = graph_object_path(root, &entry.content_sha256)?;
-        link_materialized_object(
-            &target_directory,
-            &source,
-            &entry.relative_path,
-            &entry.content_sha256,
-            entry.byte_length,
-        )?;
+        materialize_from_cas(&lease.cas, &target_directory, entry)?;
         evidence.files_reused = evidence.files_reused.saturating_add(1);
         evidence.bytes_reused = evidence.bytes_reused.saturating_add(entry.byte_length);
     }
     lease.revalidate_for_publish()?;
     Ok(evidence)
+}
+
+fn materialize_from_cas(
+    cas: &CasRoot,
+    target: &StableDirectory,
+    entry: &crate::GraphFileEntry,
+) -> Result<(), GfError> {
+    validate_logical_path(Path::new(&entry.relative_path))?;
+    let bucket = cas.digest_bucket(&entry.content_sha256, false)?;
+    let source_name = std::ffi::OsStr::new(&entry.content_sha256[2..]);
+    let source = bucket
+        .open_child_file(source_name)
+        .map_err(|error| storage("open materialization source", &cas.diagnostic_root, error))?;
+    verify_file(
+        source.try_clone().map_err(|error| {
+            storage("clone materialization source", &cas.diagnostic_root, error)
+        })?,
+        &entry.content_sha256,
+        entry.byte_length,
+        &cas.diagnostic_root,
+    )?;
+    let source_identity = graphforge_filesystem::file_identity(&source).map_err(|error| {
+        storage(
+            "identify materialization source",
+            &cas.diagnostic_root,
+            error,
+        )
+    })?;
+    let path = Path::new(&entry.relative_path);
+    let mut parent = target
+        .create_child_directory(std::ffi::OsStr::new("files"))
+        .map_err(|error| {
+            storage(
+                "create stable materialization files root",
+                &cas.diagnostic_root,
+                error,
+            )
+        })?;
+    let mut components = path.components().peekable();
+    while let Some(component) = components.next() {
+        let Component::Normal(name) = component else {
+            return Err(validation("invalid materialization path component"));
+        };
+        if components.peek().is_some() {
+            parent = parent.create_child_directory(name).map_err(|error| {
+                storage(
+                    "create stable materialization directory",
+                    &cas.diagnostic_root,
+                    error,
+                )
+            })?;
+        } else {
+            let (installed, installed_identity) = bucket
+                .link_child_into(source_name, &source, source_identity, &parent, name)
+                .map_err(|error| {
+                    storage(
+                        "install stable materialized object",
+                        &cas.diagnostic_root,
+                        error,
+                    )
+                })?;
+            if let Err(error) = verify_file(
+                installed,
+                &entry.content_sha256,
+                entry.byte_length,
+                &cas.diagnostic_root,
+            ) {
+                let _ = parent.unlink_child_if_identity(name, installed_identity);
+                return Err(error);
+            }
+        }
+    }
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -1162,6 +1158,7 @@ fn open_directory_no_follow(path: &Path) -> Result<std::os::fd::OwnedFd, GfError
 }
 
 #[cfg(unix)]
+#[allow(dead_code)]
 fn link_materialized_object(
     target: &std::os::fd::OwnedFd,
     source: &Path,
@@ -1362,6 +1359,7 @@ fn open_empty_materialization_target(target: &Path) -> Result<PathBuf, GfError> 
 }
 
 #[cfg(windows)]
+#[allow(dead_code)]
 fn link_materialized_object(
     target: &WindowsMaterializationTarget,
     source: &Path,
@@ -1454,6 +1452,7 @@ fn link_materialized_object(
 }
 
 #[cfg(all(not(unix), not(windows)))]
+#[allow(dead_code)]
 fn link_materialized_object(
     _target: &PathBuf,
     _source: &Path,
@@ -1473,71 +1472,126 @@ pub fn read_graph_object_by_digest(
     digest: &str,
     max_length: u64,
 ) -> Result<Vec<u8>, GfError> {
-    let path = graph_object_path(root, digest)?;
-    let metadata = fs::symlink_metadata(&path)
-        .map_err(|error| storage("inspect graph object", &path, error))?;
-    if !metadata.is_file() || metadata.file_type().is_symlink() || metadata.len() > max_length {
+    let cas = CasRoot::open(root)?;
+    read_graph_object_by_digest_from_cas(&cas, digest, max_length)
+}
+
+fn read_graph_object_by_digest_from_cas(
+    cas: &CasRoot,
+    digest: &str,
+    max_length: u64,
+) -> Result<Vec<u8>, GfError> {
+    let mut file = cas.open_digest(digest)?;
+    let metadata = file
+        .metadata()
+        .map_err(|error| storage("inspect stable graph object", &cas.diagnostic_root, error))?;
+    if !metadata.is_file() || metadata.len() > max_length {
         return Err(validation(
             "graph object exceeds admitted length or is not regular",
         ));
     }
-    let bytes = fs::read(&path).map_err(|error| storage("read graph object", &path, error))?;
+    let mut bytes = Vec::with_capacity(usize::try_from(metadata.len()).unwrap_or(0));
+    file.read_to_end(&mut bytes)
+        .map_err(|error| storage("read stable graph object", &cas.diagnostic_root, error))?;
     if hex_digest(Sha256::digest(&bytes).into()) != digest {
         return Err(validation("graph object digest does not match its address"));
     }
     Ok(bytes)
 }
 
+pub(crate) fn read_graph_object_by_digest_with_lease(
+    lease: &GraphObjectPublicationLease,
+    digest: &str,
+    max_length: u64,
+) -> Result<Vec<u8>, GfError> {
+    lease.cas.revalidate_named()?;
+    read_graph_object_by_digest_from_cas(&lease.cas, digest, max_length)
+}
+
 fn install_object<F>(
-    root: &Path,
+    cas: &CasRoot,
     digest: &str,
     expected_length: u64,
     write_temporary: F,
 ) -> Result<GraphObjectInstallEvidence, GfError>
 where
-    F: FnOnce(&Path) -> Result<u64, GfError>,
+    F: FnOnce(&mut File) -> Result<u64, GfError>,
 {
-    let destination = graph_object_path(root, digest)?;
-    if destination.exists() {
-        verify_existing(&destination, digest, expected_length)?;
+    validate_digest(digest)?;
+    let bucket = cas.digest_bucket(digest, true)?;
+    let destination_name = std::ffi::OsStr::new(&digest[2..]);
+    if let Ok(file) = bucket.open_child_file(destination_name) {
+        verify_file(file, digest, expected_length, &cas.diagnostic_root)?;
         return Ok(GraphObjectInstallEvidence {
             reused_existing: true,
             ..GraphObjectInstallEvidence::default()
         });
     }
-    let temporary_root = root.join(GRAPH_OBJECTS_DIR).join(TEMP_DIR);
-    fs::create_dir_all(&temporary_root).map_err(|error| {
+    let temporary_name = std::ffi::OsString::from(Uuid::new_v4().hyphenated().to_string());
+    let mut temporary = cas
+        .tmp
+        .create_child_file(&temporary_name)
+        .map_err(|error| {
+            storage(
+                "create stable temporary graph object",
+                &cas.diagnostic_root,
+                error,
+            )
+        })?;
+    let temporary_identity = graphforge_filesystem::file_identity(&temporary).map_err(|error| {
         storage(
-            "create graph object temporary directory",
-            &temporary_root,
+            "inspect temporary graph object",
+            &cas.diagnostic_root,
             error,
         )
     })?;
-    let temporary = temporary_root.join(Uuid::new_v4().hyphenated().to_string());
-    let bytes_hashed = write_temporary(&temporary)?;
-    verify_existing(&temporary, digest, expected_length)?;
-    let parent = destination
-        .parent()
-        .ok_or_else(|| validation("graph object destination has no parent"))?;
-    fs::create_dir_all(parent)
-        .map_err(|error| storage("create graph object digest directory", parent, error))?;
-    let installed = match fs::hard_link(&temporary, &destination) {
-        Ok(()) => true,
-        Err(_) if destination.exists() => {
-            verify_existing(&destination, digest, expected_length)?;
-            false
-        }
-        Err(error) => {
-            return Err(storage(
-                "atomically install graph object",
-                &destination,
+    let bytes_hashed = write_temporary(&mut temporary)?;
+    temporary
+        .rewind()
+        .map_err(|error| storage("rewind temporary graph object", &cas.diagnostic_root, error))?;
+    verify_file(
+        temporary.try_clone().map_err(|error| {
+            storage("clone temporary graph object", &cas.diagnostic_root, error)
+        })?,
+        digest,
+        expected_length,
+        &cas.diagnostic_root,
+    )?;
+    let installed = if let Ok((_installed, _identity)) = cas.tmp.link_child_into(
+        &temporary_name,
+        &temporary,
+        temporary_identity,
+        &bucket,
+        destination_name,
+    ) {
+        true
+    } else {
+        let existing = bucket.open_child_file(destination_name).map_err(|error| {
+            storage(
+                "open concurrently installed graph object",
+                &cas.diagnostic_root,
                 error,
-            ));
-        }
+            )
+        })?;
+        verify_file(existing, digest, expected_length, &cas.diagnostic_root)?;
+        false
     };
-    fs::remove_file(&temporary)
-        .map_err(|error| storage("remove temporary graph object", &temporary, error))?;
-    sync_directory(parent)?;
+    cas.tmp
+        .unlink_child_if_identity(&temporary_name, temporary_identity)
+        .map_err(|error| {
+            storage(
+                "remove stable temporary graph object",
+                &cas.diagnostic_root,
+                error,
+            )
+        })?;
+    bucket.sync().map_err(|error| {
+        storage(
+            "sync stable graph object bucket",
+            &cas.diagnostic_root,
+            error,
+        )
+    })?;
     Ok(GraphObjectInstallEvidence {
         bytes_hashed,
         bytes_installed: if installed { expected_length } else { 0 },
@@ -1545,22 +1599,26 @@ where
     })
 }
 
-fn verify_existing(path: &Path, digest: &str, expected_length: u64) -> Result<(), GfError> {
-    let metadata =
-        fs::symlink_metadata(path).map_err(|error| storage("inspect graph object", path, error))?;
-    if !metadata.is_file() || metadata.file_type().is_symlink() || metadata.len() != expected_length
-    {
+fn verify_file(
+    mut file: File,
+    digest: &str,
+    expected_length: u64,
+    diagnostic: &Path,
+) -> Result<(), GfError> {
+    let metadata = file
+        .metadata()
+        .map_err(|error| storage("inspect graph object handle", diagnostic, error))?;
+    if !metadata.is_file() || metadata.len() != expected_length {
         return Err(validation(
-            "graph object path is not the declared regular file",
+            "graph object handle is not the declared regular file",
         ));
     }
-    let mut file = File::open(path).map_err(|error| storage("open graph object", path, error))?;
     let mut hasher = Sha256::new();
     let mut buffer = vec![0_u8; BUFFER_BYTES];
     loop {
         let read = file
             .read(&mut buffer)
-            .map_err(|error| storage("read graph object", path, error))?;
+            .map_err(|error| storage("read graph object handle", diagnostic, error))?;
         if read == 0 {
             break;
         }
@@ -1570,28 +1628,6 @@ fn verify_existing(path: &Path, digest: &str, expected_length: u64) -> Result<()
         return Err(validation("graph object digest does not match its address"));
     }
     Ok(())
-}
-
-fn create_new(path: &Path) -> Result<File, GfError> {
-    OpenOptions::new()
-        .create_new(true)
-        .write(true)
-        .open(path)
-        .map_err(|error| storage("create temporary graph object", path, error))
-}
-
-#[cfg(not(windows))]
-fn sync_directory(path: &Path) -> Result<(), GfError> {
-    File::open(path)
-        .and_then(|file| file.sync_all())
-        .map_err(|error| storage("fsync graph object directory", path, error))
-}
-
-#[cfg(windows)]
-fn sync_directory(path: &Path) -> Result<(), GfError> {
-    crate::filesystem_admission::open_directory_handle(path)
-        .and_then(|file| file.sync_all())
-        .map_err(|error| storage("fsync graph object directory", path, error))
 }
 
 fn hash_regular_file(path: &Path) -> Result<[u8; 32], GfError> {
@@ -1684,24 +1720,21 @@ mod tests {
         fs::rename(object_root.join(LIFECYCLE_LOCK), &displaced).unwrap();
         fs::write(object_root.join(LIFECYCLE_LOCK), b"").unwrap();
 
-        assert!(validate_lock_identity(&lease.lifecycle, &lease.lifecycle_path).is_err());
-        assert!(matches!(try_begin_graph_object_gc(root.path()), Ok(None)));
+        assert!(lease.revalidate_for_publish().is_err());
+        assert!(matches!(
+            try_begin_graph_object_gc(root.path()),
+            Ok(Some(_))
+        ));
 
         let other_root = tempfile::tempdir().unwrap();
         let lease = begin_graph_object_publication(other_root.path()).unwrap();
         let object_root = other_root.path().join(GRAPH_OBJECTS_DIR);
         fs::rename(&object_root, other_root.path().join("displaced-objects")).unwrap();
         fs::create_dir(&object_root).unwrap();
-        assert!(
-            validate_directory_identity(
-                &lease.lifecycle_directory,
-                &lease.lifecycle_directory_path,
-            )
-            .is_err()
-        );
+        assert!(lease.revalidate_for_publish().is_err());
         assert!(matches!(
             try_begin_graph_object_gc(other_root.path()),
-            Ok(None)
+            Ok(Some(_))
         ));
         assert!(lease.revalidate_for_publish().is_err());
     }
@@ -1711,10 +1744,9 @@ mod tests {
     fn windows_lifecycle_handles_deny_coordination_path_replacement() {
         let root = tempfile::tempdir().unwrap();
         let lease = begin_graph_object_publication(root.path()).unwrap();
-        let replacement = lease
-            .coordination_directory_path
-            .with_extension("replacement");
-        assert!(fs::rename(&lease.coordination_directory_path, replacement).is_err());
+        let lifecycle = root.path().join(GRAPH_OBJECTS_DIR).join(LIFECYCLE_LOCK);
+        let replacement = lifecycle.with_extension("replacement");
+        assert!(fs::rename(&lifecycle, replacement).is_err());
         lease.revalidate_for_publish().unwrap();
     }
 

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -736,6 +736,9 @@ pub fn migrate_graph_files_v1_to_v2(
     graph_root: &Path,
     inventory: &GraphFilesInventory,
 ) -> Result<(GraphFilesRootV2, GraphFilesMigrationEvidence), GfError> {
+    // Authenticate the complete expanded contract before installing even one
+    // payload object; malformed caller-owned structs cannot create partial CAS.
+    crate::encode_inventory(inventory)?;
     validate_publication_identity(lease)?;
     let mut evidence = GraphFilesMigrationEvidence::default();
     for entry in &inventory.files {
@@ -2127,6 +2130,42 @@ mod tests {
             })
             .unwrap();
         assert_eq!(files, inventory.files);
+    }
+
+    #[test]
+    fn migration_rejects_noncanonical_v1_before_installing_objects() {
+        let graph = tempfile::tempdir().unwrap();
+        fs::write(graph.path().join("a.parquet"), b"a").unwrap();
+        fs::write(graph.path().join("b.parquet"), b"bb").unwrap();
+        let (valid, _) = crate::capture_graph_files(graph.path()).unwrap();
+        let mut invalid = Vec::new();
+        let mut wrong_count = valid.clone();
+        wrong_count.file_count += 1;
+        invalid.push(wrong_count);
+        let mut wrong_total = valid.clone();
+        wrong_total.total_byte_length += 1;
+        invalid.push(wrong_total);
+        let mut unordered = valid.clone();
+        unordered.files.reverse();
+        invalid.push(unordered);
+        let mut duplicate = valid.clone();
+        duplicate.files[1] = duplicate.files[0].clone();
+        duplicate.total_byte_length = duplicate.files.iter().map(|entry| entry.byte_length).sum();
+        invalid.push(duplicate);
+
+        for inventory in invalid {
+            let container = tempfile::tempdir().unwrap();
+            let lease = begin_graph_object_publication(container.path()).unwrap();
+            assert!(migrate_graph_files_v1_to_v2(&lease, graph.path(), &inventory,).is_err());
+            let digest_root = container.path().join(GRAPH_OBJECTS_DIR).join(SHA256_DIR);
+            assert_eq!(
+                fs::read_dir(digest_root)
+                    .unwrap()
+                    .map(Result::unwrap)
+                    .count(),
+                0
+            );
+        }
     }
 
     #[test]

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -280,18 +280,75 @@ pub struct GraphFilesMigrationEvidence {
     pub bytes_installed: u64,
 }
 
-/// Exact incremental publication work; prior manifest entries are supplied by
-/// the owning facade's pinned cache and are never enumerated here.
+/// Exact publication work, including authentication of the caller's prior cache.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct GraphFilesAppendEvidence {
     /// New/replaced and tombstoned descriptors examined.
     pub changed_entries_examined: u64,
-    /// Prior descriptors examined by publication (always zero).
+    /// Prior descriptors authenticated before publication.
     pub prior_entries_examined: u64,
     /// New/replaced payload bytes hashed, including verification passes.
     pub payload_bytes_hashed: u64,
     /// New physical object bytes installed.
     pub bytes_installed: u64,
+}
+
+/// Storage-owned, root-bound state for a sequence of path-copy publications.
+///
+/// Opening an existing root authenticates its inventory exactly once. Callers
+/// cannot replace the cached inventory independently of the root.
+#[derive(Debug, Clone, Default)]
+pub struct GraphManifestState {
+    project_identity: Option<graphforge_filesystem::FileIdentity>,
+    root: Option<GraphFilesRootV2>,
+    entries: BTreeMap<String, crate::GraphFileEntry>,
+}
+
+impl GraphManifestState {
+    /// Start an empty authenticated publication sequence.
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self {
+            project_identity: None,
+            root: None,
+            entries: BTreeMap::new(),
+        }
+    }
+
+    /// Authenticate an existing root once, then retain its exact inventory.
+    pub fn open(
+        lease: &GraphObjectPublicationLease,
+        root: GraphFilesRootV2,
+        limits: crate::GraphManifestLimits,
+    ) -> Result<(Self, crate::GraphManifestResolveEvidence), GfError> {
+        validate_publication_identity(lease)?;
+        let (entries, evidence) = crate::resolve_graph_manifest(&root, limits, |digest| {
+            read_graph_object_by_digest_from_cas(&lease.cas, digest, 64 * 1024 * 1024)
+        })?;
+        Ok((
+            Self {
+                project_identity: Some(lease.cas.project.identity()),
+                root: Some(root),
+                entries: entries
+                    .into_iter()
+                    .map(|entry| (entry.relative_path.clone(), entry))
+                    .collect(),
+            },
+            evidence,
+        ))
+    }
+
+    /// Current authenticated compact root, if one has been published.
+    #[must_use]
+    pub const fn root(&self) -> Option<&GraphFilesRootV2> {
+        self.root.as_ref()
+    }
+
+    /// Current entries in canonical logical-path order.
+    #[must_use]
+    pub fn entries(&self) -> impl ExactSizeIterator<Item = &crate::GraphFileEntry> {
+        self.entries.values()
+    }
 }
 
 /// Mark/sweep evidence for project-level graph objects.
@@ -519,20 +576,50 @@ pub(crate) fn gc_graph_objects_guarded(
 }
 
 /// Seal only changed logical files into a structurally shared radix manifest.
+#[allow(clippy::too_many_lines)]
 pub fn append_graph_files_v2(
     lease: &GraphObjectPublicationLease,
     workspace: &Path,
-    previous_root: Option<&GraphFilesRootV2>,
-    live_entries: &mut BTreeMap<String, crate::GraphFileEntry>,
+    state: &mut GraphManifestState,
     sealed_paths: &[PathBuf],
     tombstones: &[String],
 ) -> Result<(GraphFilesRootV2, GraphFilesAppendEvidence), GfError> {
     validate_publication_identity(lease)?;
+    if state
+        .project_identity
+        .is_some_and(|identity| identity != lease.cas.project.identity())
+    {
+        return Err(validation(
+            "graph manifest state belongs to a different project",
+        ));
+    }
     let mut additions = Vec::with_capacity(sealed_paths.len());
     let mut evidence = GraphFilesAppendEvidence::default();
-    let mut logical_byte_length = previous_root.map_or(0, |root| root.logical_byte_length);
+    let mut sealed_names = BTreeSet::new();
     for relative in sealed_paths {
         validate_logical_path(relative)?;
+        let name = relative
+            .to_str()
+            .ok_or_else(|| validation("sealed graph path is not UTF-8"))?;
+        if !sealed_names.insert(name.to_owned()) {
+            return Err(validation("sealed graph paths contain a duplicate"));
+        }
+    }
+    let mut tombstone_names = BTreeSet::new();
+    for path in tombstones {
+        validate_logical_path(Path::new(path))?;
+        if !tombstone_names.insert(path.clone()) {
+            return Err(validation("graph tombstones contain a duplicate"));
+        }
+        if sealed_names.contains(path) {
+            return Err(validation("graph path is both sealed and tombstoned"));
+        }
+    }
+    let mut logical_byte_length = state
+        .root
+        .as_ref()
+        .map_or(0, |root| root.logical_byte_length);
+    for relative in sealed_paths {
         let source = workspace.join(relative);
         let metadata = fs::symlink_metadata(&source)
             .map_err(|error| storage("inspect sealed graph file", &source, error))?;
@@ -560,7 +647,7 @@ pub fn append_graph_files_v2(
             content_sha256: digest,
             role: crate::graph_files::infer_role(relative),
         };
-        if let Some(previous) = live_entries.insert(relative_path, entry.clone()) {
+        if let Some(previous) = state.entries.get(&relative_path) {
             logical_byte_length = logical_byte_length.saturating_sub(previous.byte_length);
         }
         logical_byte_length = logical_byte_length
@@ -571,37 +658,35 @@ pub fn append_graph_files_v2(
     additions.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
     let mut tombstones = tombstones.to_vec();
     tombstones.sort();
-    tombstones.dedup();
     for path in &tombstones {
-        validate_logical_path(Path::new(path))?;
-        if let Some(previous) = live_entries.remove(path) {
+        if let Some(previous) = state.entries.get(path) {
             logical_byte_length = logical_byte_length.saturating_sub(previous.byte_length);
         }
     }
     evidence.changed_entries_examined =
         u64::try_from(additions.len().saturating_add(tombstones.len())).unwrap_or(u64::MAX);
-    let mut root_digest = match previous_root {
+    let mut root_digest = match state.root.as_ref() {
         Some(previous) => previous.root_node_sha256.clone(),
         None => install_manifest_node(lease, &empty_branch(0), &mut evidence.bytes_installed)?,
     };
-    for entry in additions {
+    for entry in &additions {
         let relative_path = entry.relative_path.clone();
         root_digest = update_manifest_path(
             lease,
             Some(&root_digest),
             0,
             &relative_path,
-            Some(entry),
+            Some(entry.clone()),
             &mut evidence.bytes_installed,
         )?
         .ok_or_else(|| validation("radix update unexpectedly removed the root"))?;
     }
-    for path in tombstones {
+    for path in &tombstones {
         root_digest = update_manifest_path(
             lease,
             Some(&root_digest),
             0,
-            &path,
+            path,
             None,
             &mut evidence.bytes_installed,
         )?
@@ -611,16 +696,38 @@ pub fn append_graph_files_v2(
             &mut evidence.bytes_installed,
         )?);
     }
-    Ok((
-        GraphFilesRootV2 {
-            format: GRAPH_FILES_V2_FORMAT.into(),
-            format_version: GRAPH_FILES_V2_VERSION,
-            root_node_sha256: root_digest,
-            logical_file_count: u64::try_from(live_entries.len()).unwrap_or(u64::MAX),
-            logical_byte_length,
-        },
-        evidence,
-    ))
+    let added_new = additions
+        .iter()
+        .filter(|entry| !state.entries.contains_key(&entry.relative_path))
+        .count();
+    let removed_existing = tombstones
+        .iter()
+        .filter(|path| state.entries.contains_key(path.as_str()))
+        .count();
+    let logical_file_count = state
+        .entries
+        .len()
+        .checked_add(added_new)
+        .and_then(|count| count.checked_sub(removed_existing))
+        .ok_or_else(|| validation("graph files v2 file total overflow"))?;
+    let root = GraphFilesRootV2 {
+        format: GRAPH_FILES_V2_FORMAT.into(),
+        format_version: GRAPH_FILES_V2_VERSION,
+        root_node_sha256: root_digest,
+        logical_file_count: u64::try_from(logical_file_count).unwrap_or(u64::MAX),
+        logical_byte_length,
+    };
+    // Commit the root-bound cache only after every payload and Patricia node
+    // operation succeeded. An error above leaves both fields unchanged.
+    for entry in additions {
+        state.entries.insert(entry.relative_path.clone(), entry);
+    }
+    for path in tombstones {
+        state.entries.remove(&path);
+    }
+    state.root = Some(root.clone());
+    state.project_identity = Some(lease.cas.project.identity());
+    Ok((root, evidence))
 }
 
 /// Import a verified v1 graph tree into a self-contained v2 radix root.
@@ -676,6 +783,7 @@ fn empty_branch(depth: u8) -> GraphManifestNode {
         format: GRAPH_MANIFEST_NODE_FORMAT.into(),
         format_version: GRAPH_MANIFEST_NODE_VERSION,
         depth,
+        prefix: String::new(),
         kind: GraphManifestNodeKind::Branch {
             children: BTreeMap::new(),
         },
@@ -716,98 +824,193 @@ fn update_manifest_path(
     replacement: Option<crate::GraphFileEntry>,
     bytes_installed: &mut u64,
 ) -> Result<Option<String>, GfError> {
-    let path_digest = crate::graph_manifest::logical_path_digest(path);
-    if depth == GRAPH_RADIX_DEPTH {
-        let mut entries = match current_digest {
-            Some(digest) => match load_manifest_node(lease, digest, depth)?.kind {
-                GraphManifestNodeKind::Leaf {
-                    path_sha256,
-                    entries,
-                } => {
-                    if path_sha256 != hex_digest(path_digest) {
-                        return Err(validation("graph manifest collision leaf digest mismatch"));
-                    }
-                    entries
-                }
-                GraphManifestNodeKind::Branch { .. } => {
-                    return Err(validation("graph manifest terminal node is not a leaf"));
-                }
-            },
-            None => Vec::new(),
-        };
-        match entries.binary_search_by(|entry| entry.relative_path.as_str().cmp(path)) {
-            Ok(index) => match replacement {
-                Some(entry) => entries[index] = entry,
-                None => {
-                    entries.remove(index);
-                }
-            },
-            Err(index) => {
-                if let Some(entry) = replacement {
-                    entries.insert(index, entry);
-                }
-            }
-        }
-        if entries.is_empty() {
-            return Ok(None);
-        }
-        let node = GraphManifestNode {
-            format: GRAPH_MANIFEST_NODE_FORMAT.into(),
-            format_version: GRAPH_MANIFEST_NODE_VERSION,
-            depth,
-            kind: GraphManifestNodeKind::Leaf {
-                path_sha256: hex_digest(path_digest),
-                entries,
-            },
-        };
-        return install_manifest_node(lease, &node, bytes_installed).map(Some);
-    }
-
-    let mut children = match current_digest {
-        Some(digest) => match load_manifest_node(lease, digest, depth)?.kind {
-            GraphManifestNodeKind::Branch { children } => children,
-            GraphManifestNodeKind::Leaf { .. } => {
-                return Err(validation(
-                    "graph manifest non-terminal node is not a branch",
-                ));
-            }
-        },
-        None => BTreeMap::new(),
-    };
-    let nibble = format!(
-        "{:x}",
-        crate::graph_manifest::radix_nibble(&path_digest, depth)
-    );
-    let child = update_manifest_path(
+    let path_digest = hex_digest(crate::graph_manifest::logical_path_digest(path));
+    update_manifest_digest(
         lease,
-        children.get(&nibble).map(String::as_str),
-        depth + 1,
+        current_digest,
+        depth,
         path,
+        &path_digest,
         replacement,
         bytes_installed,
-    )?;
-    match child {
-        Some(digest) => {
-            children.insert(nibble, digest);
-        }
-        None => {
-            children.remove(&nibble);
-        }
-    }
-    if children.is_empty() && depth != 0 {
-        return Ok(None);
-    }
-    install_manifest_node(
-        lease,
-        &GraphManifestNode {
-            format: GRAPH_MANIFEST_NODE_FORMAT.into(),
-            format_version: GRAPH_MANIFEST_NODE_VERSION,
-            depth,
-            kind: GraphManifestNodeKind::Branch { children },
-        },
-        bytes_installed,
     )
-    .map(Some)
+}
+
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+fn update_manifest_digest(
+    lease: &GraphObjectPublicationLease,
+    current_digest: Option<&str>,
+    depth: u8,
+    path: &str,
+    path_digest: &str,
+    replacement: Option<crate::GraphFileEntry>,
+    bytes_installed: &mut u64,
+) -> Result<Option<String>, GfError> {
+    let Some(current_digest) = current_digest else {
+        return replacement
+            .map(|entry| {
+                install_manifest_node(
+                    lease,
+                    &leaf_node(
+                        depth,
+                        &path_digest[usize::from(depth)..],
+                        path_digest,
+                        vec![entry],
+                    ),
+                    bytes_installed,
+                )
+            })
+            .transpose();
+    };
+    let mut node = load_manifest_node(lease, current_digest, depth)?;
+    let start = usize::from(depth);
+    let common = node
+        .prefix
+        .bytes()
+        .zip(path_digest.as_bytes()[start..].iter().copied())
+        .take_while(|(left, right)| left == right)
+        .count();
+    if common != node.prefix.len() {
+        let Some(entry) = replacement else {
+            return Ok(Some(current_digest.to_owned()));
+        };
+        let split_depth = depth
+            .checked_add(u8::try_from(common).map_err(|_| validation("Patricia split overflow"))?)
+            .ok_or_else(|| validation("Patricia split overflow"))?;
+        let old_edge = node.prefix[common..=common].to_owned();
+        node.depth = split_depth + 1;
+        node.prefix = node.prefix[common + 1..].to_owned();
+        let old_digest = install_manifest_node(lease, &node, bytes_installed)?;
+        let new_edge = path_digest[usize::from(split_depth)..=usize::from(split_depth)].to_owned();
+        if old_edge == new_edge {
+            return Err(validation("Patricia split did not diverge"));
+        }
+        let new_digest = install_manifest_node(
+            lease,
+            &leaf_node(
+                split_depth + 1,
+                &path_digest[usize::from(split_depth) + 1..],
+                path_digest,
+                vec![entry],
+            ),
+            bytes_installed,
+        )?;
+        let children = BTreeMap::from([(old_edge, old_digest), (new_edge, new_digest)]);
+        return install_manifest_node(
+            lease,
+            &branch_node(depth, &path_digest[start..start + common], children),
+            bytes_installed,
+        )
+        .map(Some);
+    }
+    let payload_depth = depth
+        .checked_add(
+            u8::try_from(node.prefix.len()).map_err(|_| validation("Patricia depth overflow"))?,
+        )
+        .ok_or_else(|| validation("Patricia depth overflow"))?;
+    match node.kind {
+        GraphManifestNodeKind::Leaf {
+            path_sha256,
+            mut entries,
+        } => {
+            if path_sha256 != path_digest {
+                return Err(validation("Patricia leaf route mismatch"));
+            }
+            match entries.binary_search_by(|entry| entry.relative_path.as_str().cmp(path)) {
+                Ok(index) => match replacement {
+                    Some(entry) => entries[index] = entry,
+                    None => {
+                        entries.remove(index);
+                    }
+                },
+                Err(index) => {
+                    if let Some(entry) = replacement {
+                        entries.insert(index, entry);
+                    } else {
+                        return Ok(Some(current_digest.to_owned()));
+                    }
+                }
+            }
+            if entries.is_empty() {
+                Ok(None)
+            } else {
+                install_manifest_node(
+                    lease,
+                    &leaf_node(depth, &node.prefix, path_digest, entries),
+                    bytes_installed,
+                )
+                .map(Some)
+            }
+        }
+        GraphManifestNodeKind::Branch { mut children } => {
+            if payload_depth >= GRAPH_RADIX_DEPTH {
+                return Err(validation("Patricia branch exceeds digest route"));
+            }
+            let edge =
+                path_digest[usize::from(payload_depth)..=usize::from(payload_depth)].to_owned();
+            let child = update_manifest_digest(
+                lease,
+                children.get(&edge).map(String::as_str),
+                payload_depth + 1,
+                path,
+                path_digest,
+                replacement,
+                bytes_installed,
+            )?;
+            match child {
+                Some(digest) => {
+                    children.insert(edge, digest);
+                }
+                None => {
+                    children.remove(&edge);
+                }
+            }
+            match children.len() {
+                0 => Ok(None),
+                1 => {
+                    let (edge, child_digest) = children.into_iter().next().expect("one child");
+                    let mut child = load_manifest_node(lease, &child_digest, payload_depth + 1)?;
+                    child.depth = depth;
+                    child.prefix = format!("{}{}{}", node.prefix, edge, child.prefix);
+                    install_manifest_node(lease, &child, bytes_installed).map(Some)
+                }
+                _ => install_manifest_node(
+                    lease,
+                    &branch_node(depth, &node.prefix, children),
+                    bytes_installed,
+                )
+                .map(Some),
+            }
+        }
+    }
+}
+
+fn branch_node(depth: u8, prefix: &str, children: BTreeMap<String, String>) -> GraphManifestNode {
+    GraphManifestNode {
+        format: GRAPH_MANIFEST_NODE_FORMAT.into(),
+        format_version: GRAPH_MANIFEST_NODE_VERSION,
+        depth,
+        prefix: prefix.to_owned(),
+        kind: GraphManifestNodeKind::Branch { children },
+    }
+}
+
+fn leaf_node(
+    depth: u8,
+    prefix: &str,
+    path_sha256: &str,
+    entries: Vec<crate::GraphFileEntry>,
+) -> GraphManifestNode {
+    GraphManifestNode {
+        format: GRAPH_MANIFEST_NODE_FORMAT.into(),
+        format_version: GRAPH_MANIFEST_NODE_VERSION,
+        depth,
+        prefix: prefix.to_owned(),
+        kind: GraphManifestNodeKind::Leaf {
+            path_sha256: path_sha256.to_owned(),
+            entries,
+        },
+    }
 }
 
 /// Resolve a digest to its admitted project-level object path.
@@ -1931,8 +2134,7 @@ mod tests {
         let container = tempfile::tempdir().unwrap();
         let workspace = tempfile::tempdir().unwrap();
         let lease = begin_graph_object_publication(container.path()).unwrap();
-        let mut live = BTreeMap::new();
-        let mut previous = None;
+        let mut state = GraphManifestState::empty();
         for ordinal in 0_u8..8 {
             let relative = PathBuf::from(format!(
                 "topology/edges/knows/{ordinal:020}-{ordinal:020}.parquet"
@@ -1940,20 +2142,14 @@ mod tests {
             let path = workspace.path().join(&relative);
             fs::create_dir_all(path.parent().unwrap()).unwrap();
             fs::write(&path, [ordinal]).unwrap();
-            let (root, evidence) = append_graph_files_v2(
-                &lease,
-                workspace.path(),
-                previous.as_ref(),
-                &mut live,
-                &[relative],
-                &[],
-            )
-            .unwrap();
+            let (root, evidence) =
+                append_graph_files_v2(&lease, workspace.path(), &mut state, &[relative], &[])
+                    .unwrap();
             assert_eq!(evidence.changed_entries_examined, 1);
             assert_eq!(evidence.prior_entries_examined, 0);
-            previous = Some(root);
+            assert_eq!(state.root(), Some(&root));
         }
-        let root = previous.unwrap();
+        let root = state.root().unwrap().clone();
         let (resolved, evidence) =
             crate::resolve_graph_manifest(&root, crate::GraphManifestLimits::default(), |digest| {
                 read_graph_object_by_digest(container.path(), digest, 1024 * 1024)
@@ -1963,15 +2159,9 @@ mod tests {
         assert!(evidence.segments_examined <= 1 + u64::from(GRAPH_RADIX_DEPTH) * 8);
 
         let deleted = "topology/edges/knows/00000000000000000003-00000000000000000003.parquet";
-        let (root, delete_evidence) = append_graph_files_v2(
-            &lease,
-            workspace.path(),
-            Some(&root),
-            &mut live,
-            &[],
-            &[deleted.into()],
-        )
-        .unwrap();
+        let (root, delete_evidence) =
+            append_graph_files_v2(&lease, workspace.path(), &mut state, &[], &[deleted.into()])
+                .unwrap();
         assert_eq!(delete_evidence.changed_entries_examined, 1);
         assert_eq!(delete_evidence.prior_entries_examined, 0);
         let (resolved, _) =
@@ -2001,12 +2191,11 @@ mod tests {
 
         let first = tempfile::tempdir().unwrap();
         let first_lease = begin_graph_object_publication(first.path()).unwrap();
-        let mut first_live = BTreeMap::new();
+        let mut first_state = GraphManifestState::empty();
         let (first_root, _) = append_graph_files_v2(
             &first_lease,
             workspace.path(),
-            None,
-            &mut first_live,
+            &mut first_state,
             &paths,
             &[],
         )
@@ -2016,17 +2205,171 @@ mod tests {
         let second_lease = begin_graph_object_publication(second.path()).unwrap();
         let mut reversed = paths.clone();
         reversed.reverse();
-        let mut second_live = BTreeMap::new();
+        let mut second_state = GraphManifestState::empty();
         let (second_root, _) = append_graph_files_v2(
             &second_lease,
             workspace.path(),
-            None,
-            &mut second_live,
+            &mut second_state,
             &reversed,
             &[],
         )
         .unwrap();
         assert_eq!(first_root, second_root);
+    }
+
+    #[test]
+    fn patricia_delete_collapse_and_readd_converge_to_fresh_roots() {
+        let workspace = tempfile::tempdir().unwrap();
+        let paths = [PathBuf::from("a.parquet"), PathBuf::from("b.parquet")];
+        for (ordinal, path) in paths.iter().enumerate() {
+            fs::write(
+                workspace.path().join(path),
+                [u8::try_from(ordinal).unwrap()],
+            )
+            .unwrap();
+        }
+        let container = tempfile::tempdir().unwrap();
+        let lease = begin_graph_object_publication(container.path()).unwrap();
+        let mut state = GraphManifestState::empty();
+        let (both, _) =
+            append_graph_files_v2(&lease, workspace.path(), &mut state, &paths, &[]).unwrap();
+        let (survivor, _) = append_graph_files_v2(
+            &lease,
+            workspace.path(),
+            &mut state,
+            &[],
+            &["b.parquet".into()],
+        )
+        .unwrap();
+
+        let fresh = tempfile::tempdir().unwrap();
+        let fresh_lease = begin_graph_object_publication(fresh.path()).unwrap();
+        let mut fresh_state = GraphManifestState::empty();
+        let (fresh_survivor, _) = append_graph_files_v2(
+            &fresh_lease,
+            workspace.path(),
+            &mut fresh_state,
+            &paths[..1],
+            &[],
+        )
+        .unwrap();
+        assert_eq!(survivor, fresh_survivor);
+
+        let (readded, _) =
+            append_graph_files_v2(&lease, workspace.path(), &mut state, &paths[1..], &[]).unwrap();
+        assert_eq!(readded, both);
+    }
+
+    #[test]
+    fn root_bound_state_opens_once_and_failed_append_is_transactional() {
+        let container = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        fs::write(workspace.path().join("a.parquet"), b"a").unwrap();
+        fs::write(workspace.path().join("b.parquet"), b"b").unwrap();
+        let lease = begin_graph_object_publication(container.path()).unwrap();
+        let mut initial = GraphManifestState::empty();
+        let (root, _) = append_graph_files_v2(
+            &lease,
+            workspace.path(),
+            &mut initial,
+            &[PathBuf::from("a.parquet")],
+            &[],
+        )
+        .unwrap();
+        let (mut reopened, open_evidence) =
+            GraphManifestState::open(&lease, root.clone(), crate::GraphManifestLimits::default())
+                .unwrap();
+        assert_eq!(open_evidence.entries_examined, 1);
+        let (_, append_evidence) = append_graph_files_v2(
+            &lease,
+            workspace.path(),
+            &mut reopened,
+            &[PathBuf::from("b.parquet")],
+            &[],
+        )
+        .unwrap();
+        assert_eq!(append_evidence.prior_entries_examined, 0);
+
+        let before_root = reopened.root().unwrap().clone();
+        let before_entries = reopened.entries().cloned().collect::<Vec<_>>();
+        fs::remove_file(
+            graph_object_path(container.path(), &before_root.root_node_sha256).unwrap(),
+        )
+        .unwrap();
+        fs::write(workspace.path().join("c.parquet"), b"c").unwrap();
+        assert!(
+            append_graph_files_v2(
+                &lease,
+                workspace.path(),
+                &mut reopened,
+                &[PathBuf::from("c.parquet")],
+                &[],
+            )
+            .is_err()
+        );
+        assert_eq!(reopened.root(), Some(&before_root));
+        assert_eq!(
+            reopened.entries().cloned().collect::<Vec<_>>(),
+            before_entries
+        );
+    }
+
+    #[test]
+    fn patricia_s20_inventory_has_linear_resolve_work() {
+        const FILES: usize = 277;
+        let container = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let paths = (0..FILES)
+            .map(|ordinal| PathBuf::from(format!("shards/{ordinal:06}.parquet")))
+            .collect::<Vec<_>>();
+        fs::create_dir_all(workspace.path().join("shards")).unwrap();
+        for (ordinal, path) in paths.iter().enumerate() {
+            fs::write(workspace.path().join(path), ordinal.to_le_bytes()).unwrap();
+        }
+        let lease = begin_graph_object_publication(container.path()).unwrap();
+        let mut state = GraphManifestState::empty();
+        let (root, _) =
+            append_graph_files_v2(&lease, workspace.path(), &mut state, &paths, &[]).unwrap();
+        let (resolved, evidence) =
+            crate::resolve_graph_manifest(&root, crate::GraphManifestLimits::default(), |digest| {
+                read_graph_object_by_digest(container.path(), digest, 1024 * 1024)
+            })
+            .unwrap();
+        assert_eq!(resolved.len(), FILES);
+        assert!(evidence.segments_examined <= (2 * FILES - 1) as u64);
+        assert!(evidence.work_units <= (4 * FILES - 2) as u64);
+    }
+
+    #[test]
+    fn duplicate_and_conflicting_delta_inputs_fail_before_publication() {
+        let container = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        fs::write(workspace.path().join("a.parquet"), b"a").unwrap();
+        let lease = begin_graph_object_publication(container.path()).unwrap();
+        let mut state = GraphManifestState::empty();
+        let path = PathBuf::from("a.parquet");
+        assert!(
+            append_graph_files_v2(
+                &lease,
+                workspace.path(),
+                &mut state,
+                &[path.clone(), path.clone()],
+                &[],
+            )
+            .is_err()
+        );
+        assert!(state.root().is_none());
+        assert!(
+            append_graph_files_v2(
+                &lease,
+                workspace.path(),
+                &mut state,
+                &[path],
+                &["a.parquet".into()],
+            )
+            .is_err()
+        );
+        assert!(state.root().is_none());
     }
 
     #[test]
@@ -2038,10 +2381,9 @@ mod tests {
         let source = workspace.path().join(&relative);
         fs::create_dir_all(source.parent().unwrap()).unwrap();
         fs::write(&source, b"node").unwrap();
-        let mut live = BTreeMap::new();
+        let mut state = GraphManifestState::empty();
         let (root, _) =
-            append_graph_files_v2(&lease, workspace.path(), None, &mut live, &[relative], &[])
-                .unwrap();
+            append_graph_files_v2(&lease, workspace.path(), &mut state, &[relative], &[]).unwrap();
         drop(lease);
         let (orphan, _) = install_graph_object_bytes(container.path(), b"orphan").unwrap();
         let evidence = gc_graph_objects(
@@ -2050,9 +2392,9 @@ mod tests {
             crate::GraphManifestLimits::default(),
         )
         .unwrap();
-        assert_eq!(evidence.objects_marked, u64::from(GRAPH_RADIX_DEPTH) + 2);
+        assert_eq!(evidence.objects_marked, 2);
         // The initial empty root and the explicit orphan are both unreachable.
-        assert_eq!(evidence.objects_removed, 2);
+        assert_eq!(evidence.objects_removed, 3);
         assert!(
             !graph_object_path(container.path(), &orphan)
                 .unwrap()

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -356,52 +356,6 @@ pub(crate) fn try_begin_graph_object_gc(
 }
 
 #[cfg(windows)]
-fn validate_lock_identity(file: &File, path: &Path) -> Result<(), GfError> {
-    let descriptor = file
-        .metadata()
-        .map_err(|error| storage("inspect lifecycle lock descriptor", path, error))?;
-    let named = fs::symlink_metadata(path)
-        .map_err(|error| storage("inspect lifecycle lock path", path, error))?;
-    if !descriptor.is_file() || !named.is_file() || named.file_type().is_symlink() {
-        return Err(validation(
-            "graph object lifecycle lock is not a regular file",
-        ));
-    }
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::MetadataExt;
-        if descriptor.dev() != named.dev()
-            || descriptor.ino() != named.ino()
-            || descriptor.nlink() != 1
-            || named.nlink() != 1
-        {
-            return Err(validation("graph object lifecycle lock identity changed"));
-        }
-    }
-    #[cfg(windows)]
-    {
-        use std::os::windows::fs::MetadataExt as _;
-        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
-        let descriptor_identity = graphforge_filesystem::file_identity(file)
-            .map_err(|error| storage("inspect lifecycle lock identity", path, error))?;
-        let named_identity = graphforge_filesystem::path_identity(path)
-            .map_err(|error| storage("inspect lifecycle lock identity", path, error))?;
-        if named.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
-            || descriptor_identity != named_identity
-            || graphforge_filesystem::file_link_count(file)
-                .map_err(|error| storage("inspect lifecycle lock links", path, error))?
-                != 1
-            || graphforge_filesystem::path_link_count(path)
-                .map_err(|error| storage("inspect lifecycle lock links", path, error))?
-                != 1
-        {
-            return Err(validation("graph object lifecycle lock identity changed"));
-        }
-    }
-    Ok(())
-}
-
-#[cfg(windows)]
 fn validate_directory_identity(file: &File, path: &Path) -> Result<(), GfError> {
     let descriptor = file
         .metadata()

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -139,6 +139,7 @@ struct ReadOnlyCasRoot {
     locks_held: bool,
 }
 
+#[cfg_attr(windows, allow(unused_variables))]
 fn lock_cas_shared<'a>(
     objects: &'a StableDirectory,
     lifecycle: &'a File,
@@ -176,6 +177,7 @@ fn lock_cas_shared<'a>(
     Ok(held)
 }
 
+#[cfg_attr(windows, allow(unused_variables))]
 fn lock_cas_exclusive<'a>(
     objects: &'a StableDirectory,
     lifecycle: &'a File,

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -29,18 +29,25 @@ pub struct GraphObjectPublicationLease {
     root: PathBuf,
     path: PathBuf,
     file: File,
+    lifecycle_directory: File,
+    lifecycle_directory_path: PathBuf,
     lifecycle: File,
+    lifecycle_path: PathBuf,
 }
 
 /// Exclusive guard spanning GC root discovery through sweep.
 pub(crate) struct GraphObjectGcGuard {
     root: PathBuf,
+    lifecycle_directory: File,
+    lifecycle_directory_path: PathBuf,
     lifecycle: File,
+    lifecycle_path: PathBuf,
 }
 
 impl Drop for GraphObjectGcGuard {
     fn drop(&mut self) {
         let _ = crate::file_lock::unlock(&self.lifecycle);
+        let _ = crate::file_lock::unlock(&self.lifecycle_directory);
     }
 }
 
@@ -49,6 +56,7 @@ impl Drop for GraphObjectPublicationLease {
         let _ = crate::file_lock::unlock(&self.file);
         let _ = fs::remove_file(&self.path);
         let _ = crate::file_lock::unlock(&self.lifecycle);
+        let _ = crate::file_lock::unlock(&self.lifecycle_directory);
     }
 }
 
@@ -57,23 +65,9 @@ pub fn begin_graph_object_publication(root: &Path) -> Result<GraphObjectPublicat
     let object_root = root.join(GRAPH_OBJECTS_DIR);
     fs::create_dir_all(&object_root)
         .map_err(|error| storage("create graph object directory", &object_root, error))?;
-    let lifecycle_path = object_root.join(LIFECYCLE_LOCK);
-    if !lifecycle_path.exists() {
-        let created = OpenOptions::new()
-            .create(true)
-            .truncate(false)
-            .read(true)
-            .write(true)
-            .open(&lifecycle_path)
-            .map_err(|error| {
-                storage("create graph object lifecycle lock", &lifecycle_path, error)
-            })?;
-        created
-            .sync_all()
-            .map_err(|error| storage("sync graph object lifecycle lock", &lifecycle_path, error))?;
-        sync_directory(&object_root)?;
-    }
-    let lifecycle = crate::project_publication::open_regular_lock(&lifecycle_path)?;
+    let (lifecycle_directory, lifecycle, lifecycle_path) = open_lifecycle_lock(&object_root)?;
+    crate::file_lock::lock_shared(&lifecycle_directory)
+        .map_err(|error| storage("lock graph object lifecycle directory", &object_root, error))?;
     crate::file_lock::lock_shared(&lifecycle).map_err(|error| {
         storage(
             "lock graph object publication lifecycle",
@@ -81,6 +75,8 @@ pub fn begin_graph_object_publication(root: &Path) -> Result<GraphObjectPublicat
             error,
         )
     })?;
+    validate_directory_identity(&lifecycle_directory, &object_root)?;
+    validate_lock_identity(&lifecycle, &lifecycle_path)?;
     let active = object_root.join(ACTIVE_DIR);
     fs::create_dir_all(&active)
         .map_err(|error| storage("create graph object active directory", &active, error))?;
@@ -100,7 +96,10 @@ pub fn begin_graph_object_publication(root: &Path) -> Result<GraphObjectPublicat
         root: root.to_path_buf(),
         path,
         file,
+        lifecycle_directory,
+        lifecycle_directory_path: object_root,
         lifecycle,
+        lifecycle_path,
     })
 }
 
@@ -225,37 +224,159 @@ pub fn gc_graph_objects(
 
 #[cfg(test)]
 pub(crate) fn begin_graph_object_gc(root: &Path) -> Result<GraphObjectGcGuard, GfError> {
-    let (root, lifecycle, lifecycle_path) = open_graph_object_lifecycle(root)?;
+    let (root, lifecycle_directory, lifecycle, lifecycle_path) = open_graph_object_lifecycle(root)?;
+    crate::file_lock::lock_exclusive(&lifecycle_directory)
+        .map_err(|error| storage("lock graph object GC directory", &root, error))?;
     crate::file_lock::lock_exclusive(&lifecycle)
         .map_err(|error| storage("lock graph object GC lifecycle", &lifecycle_path, error))?;
-    Ok(GraphObjectGcGuard { root, lifecycle })
+    validate_directory_identity(&lifecycle_directory, &root.join(GRAPH_OBJECTS_DIR))?;
+    validate_lock_identity(&lifecycle, &lifecycle_path)?;
+    let lifecycle_directory_path = root.join(GRAPH_OBJECTS_DIR);
+    Ok(GraphObjectGcGuard {
+        root,
+        lifecycle_directory,
+        lifecycle_directory_path,
+        lifecycle,
+        lifecycle_path,
+    })
 }
 
 pub(crate) fn try_begin_graph_object_gc(
     root: &Path,
 ) -> Result<Option<GraphObjectGcGuard>, GfError> {
-    let (root, lifecycle, lifecycle_path) = open_graph_object_lifecycle(root)?;
-    if !crate::file_lock::try_lock_exclusive(&lifecycle)
-        .map_err(|error| storage("try graph object GC lifecycle", &lifecycle_path, error))?
+    let (root, lifecycle_directory, lifecycle, lifecycle_path) = open_graph_object_lifecycle(root)?;
+    if !crate::file_lock::try_lock_exclusive(&lifecycle_directory)
+        .map_err(|error| storage("try graph object GC directory", &root, error))?
     {
         return Ok(None);
     }
-    Ok(Some(GraphObjectGcGuard { root, lifecycle }))
+    if !crate::file_lock::try_lock_exclusive(&lifecycle)
+        .map_err(|error| storage("try graph object GC lifecycle", &lifecycle_path, error))?
+    {
+        let _ = crate::file_lock::unlock(&lifecycle_directory);
+        return Ok(None);
+    }
+    validate_directory_identity(&lifecycle_directory, &root.join(GRAPH_OBJECTS_DIR))?;
+    validate_lock_identity(&lifecycle, &lifecycle_path)?;
+    let lifecycle_directory_path = root.join(GRAPH_OBJECTS_DIR);
+    Ok(Some(GraphObjectGcGuard {
+        root,
+        lifecycle_directory,
+        lifecycle_directory_path,
+        lifecycle,
+        lifecycle_path,
+    }))
 }
 
-fn open_graph_object_lifecycle(root: &Path) -> Result<(PathBuf, File, PathBuf), GfError> {
+fn open_graph_object_lifecycle(root: &Path) -> Result<(PathBuf, File, File, PathBuf), GfError> {
     let object_root = root.join(GRAPH_OBJECTS_DIR);
     fs::create_dir_all(&object_root)
         .map_err(|error| storage("create graph object directory", &object_root, error))?;
-    let lifecycle_path = object_root.join(LIFECYCLE_LOCK);
-    let lifecycle = OpenOptions::new()
-        .create(true)
-        .truncate(false)
-        .read(true)
-        .write(true)
-        .open(&lifecycle_path)
-        .map_err(|error| storage("open graph object lifecycle lock", &lifecycle_path, error))?;
-    Ok((root.to_path_buf(), lifecycle, lifecycle_path))
+    let (directory, lifecycle, lifecycle_path) = open_lifecycle_lock(&object_root)?;
+    Ok((root.to_path_buf(), directory, lifecycle, lifecycle_path))
+}
+
+#[cfg(unix)]
+fn open_lifecycle_lock(object_root: &Path) -> Result<(File, File, PathBuf), GfError> {
+    use rustix::fs::{AtFlags, Mode, OFlags};
+
+    let directory = rustix::fs::open(
+        object_root,
+        OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+        Mode::empty(),
+    )
+    .map_err(|error| storage("open graph object lock directory", object_root, error))?;
+    let descriptor = rustix::fs::openat(
+        &directory,
+        LIFECYCLE_LOCK,
+        OFlags::RDWR | OFlags::CREATE | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+        Mode::from_bits_truncate(0o600),
+    )
+    .map_err(|error| storage("open graph object lifecycle lock", object_root, error))?;
+    let descriptor_stat = rustix::fs::fstat(&descriptor).map_err(|error| {
+        storage(
+            "inspect graph object lifecycle descriptor",
+            object_root,
+            error,
+        )
+    })?;
+    let path_stat = rustix::fs::statat(&directory, LIFECYCLE_LOCK, AtFlags::SYMLINK_NOFOLLOW)
+        .map_err(|error| storage("inspect graph object lifecycle path", object_root, error))?;
+    if descriptor_stat.st_dev != path_stat.st_dev
+        || descriptor_stat.st_ino != path_stat.st_ino
+        || descriptor_stat.st_nlink != 1
+        || path_stat.st_nlink != 1
+    {
+        return Err(validation(
+            "graph object lifecycle lock identity is unstable",
+        ));
+    }
+    let file: File = descriptor.into();
+    let directory: File = directory.into();
+    file.sync_all()
+        .map_err(|error| storage("sync graph object lifecycle lock", object_root, error))?;
+    sync_directory(object_root)?;
+    Ok((directory, file, object_root.join(LIFECYCLE_LOCK)))
+}
+
+#[cfg(not(unix))]
+fn open_lifecycle_lock(object_root: &Path) -> Result<(File, File, PathBuf), GfError> {
+    let path = object_root.join(LIFECYCLE_LOCK);
+    let file = crate::project_publication::open_regular_lock(&path)?;
+    file.sync_all()
+        .map_err(|error| storage("sync graph object lifecycle lock", &path, error))?;
+    sync_directory(object_root)?;
+    let directory = File::open(object_root)
+        .map_err(|error| storage("open graph object lock directory", object_root, error))?;
+    Ok((directory, file, path))
+}
+
+fn validate_lock_identity(file: &File, path: &Path) -> Result<(), GfError> {
+    let descriptor = file
+        .metadata()
+        .map_err(|error| storage("inspect lifecycle lock descriptor", path, error))?;
+    let named = fs::symlink_metadata(path)
+        .map_err(|error| storage("inspect lifecycle lock path", path, error))?;
+    if !descriptor.is_file() || !named.is_file() || named.file_type().is_symlink() {
+        return Err(validation(
+            "graph object lifecycle lock is not a regular file",
+        ));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if descriptor.dev() != named.dev()
+            || descriptor.ino() != named.ino()
+            || descriptor.nlink() != 1
+            || named.nlink() != 1
+        {
+            return Err(validation("graph object lifecycle lock identity changed"));
+        }
+    }
+    Ok(())
+}
+
+fn validate_directory_identity(file: &File, path: &Path) -> Result<(), GfError> {
+    let descriptor = file
+        .metadata()
+        .map_err(|error| storage("inspect lifecycle directory descriptor", path, error))?;
+    let named = fs::symlink_metadata(path)
+        .map_err(|error| storage("inspect lifecycle directory path", path, error))?;
+    if !descriptor.is_dir() || !named.is_dir() || named.file_type().is_symlink() {
+        return Err(validation(
+            "graph object lifecycle directory is not a real directory",
+        ));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if descriptor.dev() != named.dev() || descriptor.ino() != named.ino() {
+            return Err(validation(
+                "graph object lifecycle directory identity changed",
+            ));
+        }
+    }
+    Ok(())
 }
 
 pub(crate) fn gc_graph_objects_guarded(
@@ -263,6 +384,8 @@ pub(crate) fn gc_graph_objects_guarded(
     roots: &[GraphFilesRootV2],
     limits: crate::GraphManifestLimits,
 ) -> Result<GraphObjectGcEvidence, GfError> {
+    validate_directory_identity(&guard.lifecycle_directory, &guard.lifecycle_directory_path)?;
+    validate_lock_identity(&guard.lifecycle, &guard.lifecycle_path)?;
     let root = &guard.root;
     let mut marked = BTreeSet::new();
     for graph_root in roots {
@@ -345,6 +468,8 @@ pub fn append_graph_files_v2(
     sealed_paths: &[PathBuf],
     tombstones: &[String],
 ) -> Result<(GraphFilesRootV2, GraphFilesAppendEvidence), GfError> {
+    validate_directory_identity(&lease.lifecycle_directory, &lease.lifecycle_directory_path)?;
+    validate_lock_identity(&lease.lifecycle, &lease.lifecycle_path)?;
     let root = &lease.root;
     let mut additions = Vec::with_capacity(sealed_paths.len());
     let mut evidence = GraphFilesAppendEvidence::default();
@@ -446,6 +571,8 @@ pub fn migrate_graph_files_v1_to_v2(
     graph_root: &Path,
     inventory: &GraphFilesInventory,
 ) -> Result<(GraphFilesRootV2, GraphFilesMigrationEvidence), GfError> {
+    validate_directory_identity(&lease.lifecycle_directory, &lease.lifecycle_directory_path)?;
+    validate_lock_identity(&lease.lifecycle, &lease.lifecycle_path)?;
     let root = &lease.root;
     let mut evidence = GraphFilesMigrationEvidence::default();
     for entry in &inventory.files {
@@ -760,7 +887,13 @@ pub fn materialize_graph_objects(
     };
     for entry in &inventory.files {
         let source = graph_object_path(root, &entry.content_sha256)?;
-        link_materialized_object(&target_directory, &source, &entry.relative_path)?;
+        link_materialized_object(
+            &target_directory,
+            &source,
+            &entry.relative_path,
+            &entry.content_sha256,
+            entry.byte_length,
+        )?;
         evidence.files_reused = evidence.files_reused.saturating_add(1);
         evidence.bytes_reused = evidence.bytes_reused.saturating_add(entry.byte_length);
     }
@@ -851,6 +984,8 @@ fn link_materialized_object(
     target: &std::os::fd::OwnedFd,
     source: &Path,
     relative: &str,
+    expected_digest: &str,
+    expected_length: u64,
 ) -> Result<(), GfError> {
     use rustix::fs::{AtFlags, Mode, OFlags};
 
@@ -876,7 +1011,47 @@ fn link_materialized_object(
                 AtFlags::empty(),
             )
             .map_err(|error| storage("link logical graph object", path, error))?;
-            return Ok(());
+            let verified = (|| {
+                let linked = rustix::fs::openat(
+                    &directory,
+                    component,
+                    OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+                    Mode::empty(),
+                )
+                .map_err(|error| {
+                    storage(
+                        "open materialized object without following links",
+                        path,
+                        error,
+                    )
+                })?;
+                let mut file: File = linked.into();
+                let metadata = file
+                    .metadata()
+                    .map_err(|error| storage("inspect materialized object", path, error))?;
+                if !metadata.is_file() || metadata.len() != expected_length {
+                    return Err(validation("materialized graph object identity is invalid"));
+                }
+                let mut hasher = Sha256::new();
+                let mut buffer = vec![0_u8; BUFFER_BYTES];
+                loop {
+                    let read = file
+                        .read(&mut buffer)
+                        .map_err(|error| storage("verify materialized object", path, error))?;
+                    if read == 0 {
+                        break;
+                    }
+                    hasher.update(&buffer[..read]);
+                }
+                if hex_digest(hasher.finalize().into()) != expected_digest {
+                    return Err(validation("materialized graph object digest mismatch"));
+                }
+                Ok(())
+            })();
+            if verified.is_err() {
+                let _ = rustix::fs::unlinkat(&directory, component, AtFlags::empty());
+            }
+            return verified;
         }
         match rustix::fs::mkdirat(&directory, component, Mode::from_bits_truncate(0o700)) {
             Ok(()) | Err(rustix::io::Errno::EXIST) => {}
@@ -932,6 +1107,8 @@ fn link_materialized_object(
     target: &PathBuf,
     source: &Path,
     relative: &str,
+    expected_digest: &str,
+    expected_length: u64,
 ) -> Result<(), GfError> {
     let destination = target.join(relative);
     if let Some(parent) = destination.parent() {
@@ -939,7 +1116,25 @@ fn link_materialized_object(
             .map_err(|error| storage("create logical graph object directory", parent, error))?;
     }
     fs::hard_link(source, &destination)
-        .map_err(|error| storage("link logical graph object", &destination, error))
+        .map_err(|error| storage("link logical graph object", &destination, error))?;
+    let verified = fs::symlink_metadata(&destination)
+        .map_err(|error| storage("inspect materialized object", &destination, error))
+        .and_then(|metadata| {
+            if !metadata.is_file()
+                || metadata.file_type().is_symlink()
+                || metadata.len() != expected_length
+            {
+                return Err(validation("materialized graph object identity is invalid"));
+            }
+            (hex_digest(hash_regular_file(&destination)?) == expected_digest)
+                .then_some(())
+                .ok_or_else(|| validation("materialized graph object digest mismatch"))
+        });
+    if let Err(error) = verified {
+        let _ = fs::remove_file(&destination);
+        return Err(error);
+    }
+    Ok(())
 }
 
 /// Read an object whose digest is known before its declared logical length.
@@ -1133,6 +1328,42 @@ fn storage(action: &str, path: &Path, error: impl std::fmt::Display) -> GfError 
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
+    #[test]
+    fn lifecycle_lock_rejects_symlink_and_pathname_substitution() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let object_root = root.path().join(GRAPH_OBJECTS_DIR);
+        fs::create_dir_all(&object_root).unwrap();
+        let outside = root.path().join("outside.lock");
+        fs::write(&outside, b"").unwrap();
+        symlink(&outside, object_root.join(LIFECYCLE_LOCK)).unwrap();
+        assert!(begin_graph_object_publication(root.path()).is_err());
+
+        fs::remove_file(object_root.join(LIFECYCLE_LOCK)).unwrap();
+        let lease = begin_graph_object_publication(root.path()).unwrap();
+        let displaced = object_root.join("displaced.lock");
+        fs::rename(object_root.join(LIFECYCLE_LOCK), &displaced).unwrap();
+        fs::write(object_root.join(LIFECYCLE_LOCK), b"").unwrap();
+
+        assert!(validate_lock_identity(&lease.lifecycle, &lease.lifecycle_path).is_err());
+        assert!(matches!(try_begin_graph_object_gc(root.path()), Ok(None)));
+
+        let other_root = tempfile::tempdir().unwrap();
+        let lease = begin_graph_object_publication(other_root.path()).unwrap();
+        let object_root = other_root.path().join(GRAPH_OBJECTS_DIR);
+        fs::rename(&object_root, other_root.path().join("displaced-objects")).unwrap();
+        fs::create_dir(&object_root).unwrap();
+        assert!(
+            validate_directory_identity(
+                &lease.lifecycle_directory,
+                &lease.lifecycle_directory_path,
+            )
+            .is_err()
+        );
+    }
+
     #[test]
     fn publication_and_gc_lifecycles_are_mutually_exclusive() {
         use std::sync::mpsc::{self, TryRecvError};
@@ -1201,10 +1432,40 @@ mod tests {
                 &directory,
                 &graph_object_path(objects.path(), &entry.content_sha256).unwrap(),
                 &entry.relative_path,
+                &entry.content_sha256,
+                entry.byte_length,
             )
             .is_err()
         );
         assert!(!outside.path().join("payload.bin").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn materialization_rejects_substituted_cas_source_and_removes_destination() {
+        use std::os::unix::fs::symlink;
+
+        let objects = tempfile::tempdir().unwrap();
+        let (digest, _) = install_graph_object_bytes(objects.path(), b"payload").unwrap();
+        let source = graph_object_path(objects.path(), &digest).unwrap();
+        let target_root = tempfile::tempdir().unwrap();
+        let target = target_root.path().join("materialized");
+
+        let original = source.with_extension("original");
+        fs::rename(&source, &original).unwrap();
+        let malicious = objects.path().join("malicious");
+        fs::write(&malicious, b"hostile").unwrap();
+        symlink(&malicious, &source).unwrap();
+        let directory = open_empty_materialization_target(&target).unwrap();
+        assert!(link_materialized_object(&directory, &source, "payload.bin", &digest, 7).is_err());
+        assert!(!target.join("payload.bin").exists());
+
+        fs::remove_file(&source).unwrap();
+        fs::write(&source, b"hostile").unwrap();
+        let second_target = target_root.path().join("materialized-regular");
+        let directory = open_empty_materialization_target(&second_target).unwrap();
+        assert!(link_materialized_object(&directory, &source, "payload.bin", &digest, 7).is_err());
+        assert!(!second_target.join("payload.bin").exists());
     }
 
     #[test]

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -27,12 +27,84 @@ const ACTIVE_DIR: &str = "active";
 const LIFECYCLE_LOCK: &str = "lifecycle.lock";
 const BUFFER_BYTES: usize = 64 * 1024;
 
+#[cfg(test)]
+thread_local! {
+    static RETURNED_ERROR_BOUNDARY: std::cell::RefCell<Option<String>> = const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(test)]
+fn returned_error_boundary(name: &str) -> Result<(), GfError> {
+    if RETURNED_ERROR_BOUNDARY.with(|boundary| boundary.borrow().as_deref() == Some(name)) {
+        return Err(GfError::Storage(format!(
+            "injected graph object returned error at {name}"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(not(test))]
+#[allow(clippy::unnecessary_wraps)]
+fn returned_error_boundary(_name: &str) -> Result<(), GfError> {
+    Ok(())
+}
+
 /// Kernel-visible lease protecting CAS objects installed by one publication.
 pub struct GraphObjectPublicationLease {
     cas: CasRoot,
     lease_name: std::ffi::OsString,
     lease_identity: graphforge_filesystem::FileIdentity,
-    file: File,
+    file: Option<File>,
+}
+
+struct HeldCasLocks<'a> {
+    objects: &'a StableDirectory,
+    lifecycle: &'a File,
+    objects_locked: bool,
+    lifecycle_locked: bool,
+}
+
+impl HeldCasLocks<'_> {
+    fn disarm(mut self) {
+        self.lifecycle_locked = false;
+        self.objects_locked = false;
+    }
+}
+
+impl Drop for HeldCasLocks<'_> {
+    fn drop(&mut self) {
+        if self.lifecycle_locked {
+            let _ = crate::file_lock::unlock(self.lifecycle);
+        }
+        if self.objects_locked {
+            let _ = self.objects.unlock();
+        }
+    }
+}
+
+struct PendingPublication<'a> {
+    cas: &'a CasRoot,
+    lease_name: std::ffi::OsString,
+    lease_identity: Option<graphforge_filesystem::FileIdentity>,
+    file: Option<File>,
+    lease_locked: bool,
+}
+
+impl Drop for PendingPublication<'_> {
+    fn drop(&mut self) {
+        if self.lease_locked
+            && let Some(file) = self.file.as_ref()
+        {
+            let _ = crate::file_lock::unlock(file);
+        }
+        self.file.take();
+        if let Some(identity) = self.lease_identity {
+            let _ = self
+                .cas
+                .active
+                .unlink_child_if_identity(&self.lease_name, identity);
+            let _ = self.cas.active.sync();
+        }
+    }
 }
 
 /// Exclusive guard spanning GC root discovery through sweep.
@@ -58,6 +130,63 @@ struct ReadOnlyCasRoot {
     sha256: StableDirectory,
     lifecycle: File,
     lifecycle_identity: graphforge_filesystem::FileIdentity,
+    locks_held: bool,
+}
+
+fn lock_cas_shared<'a>(
+    objects: &'a StableDirectory,
+    lifecycle: &'a File,
+    root: &Path,
+    action: &str,
+) -> Result<HeldCasLocks<'a>, GfError> {
+    objects.lock_shared().map_err(|error| {
+        storage(
+            &format!("lock graph object directory for {action}"),
+            root,
+            error,
+        )
+    })?;
+    let mut held = HeldCasLocks {
+        objects,
+        lifecycle,
+        objects_locked: true,
+        lifecycle_locked: false,
+    };
+    #[cfg(test)]
+    returned_error_boundary(&format!("{action}:objects-lock"))?;
+    crate::file_lock::lock_shared(lifecycle).map_err(|error| {
+        storage(
+            &format!("lock graph object {action} lifecycle"),
+            root,
+            error,
+        )
+    })?;
+    held.lifecycle_locked = true;
+    #[cfg(test)]
+    returned_error_boundary(&format!("{action}:lifecycle-lock"))?;
+    Ok(held)
+}
+
+fn lock_cas_exclusive<'a>(
+    objects: &'a StableDirectory,
+    lifecycle: &'a File,
+    root: &Path,
+) -> Result<HeldCasLocks<'a>, GfError> {
+    objects
+        .lock_exclusive()
+        .map_err(|error| storage("lock graph object directory for GC", root, error))?;
+    let mut held = HeldCasLocks {
+        objects,
+        lifecycle,
+        objects_locked: true,
+        lifecycle_locked: false,
+    };
+    returned_error_boundary("gc:objects-lock")?;
+    crate::file_lock::lock_exclusive(lifecycle)
+        .map_err(|error| storage("lock graph object GC lifecycle", root, error))?;
+    held.lifecycle_locked = true;
+    returned_error_boundary("gc:lifecycle-lock")?;
+    Ok(held)
 }
 
 impl CasRoot {
@@ -170,14 +299,6 @@ impl ReadOnlyCasRoot {
         }
         let lifecycle_identity = graphforge_filesystem::file_identity(&lifecycle)
             .map_err(|error| storage("inspect graph object lifecycle identity", root, error))?;
-        objects
-            .lock_shared()
-            .map_err(|error| storage("lock graph object directory for reading", root, error))?;
-        crate::file_lock::lock_shared(&lifecycle)
-            .inspect_err(|_| {
-                let _ = objects.unlock();
-            })
-            .map_err(|error| storage("lock graph object read lifecycle", root, error))?;
         let cas = Self {
             diagnostic_root: root.to_path_buf(),
             project,
@@ -185,8 +306,14 @@ impl ReadOnlyCasRoot {
             sha256,
             lifecycle,
             lifecycle_identity,
+            locks_held: false,
         };
+        let locks = lock_cas_shared(&cas.objects, &cas.lifecycle, root, "reading")?;
         cas.revalidate_named()?;
+        returned_error_boundary("reading:revalidate")?;
+        locks.disarm();
+        let mut cas = cas;
+        cas.locks_held = true;
         Ok(cas)
     }
 
@@ -235,8 +362,10 @@ impl ReadOnlyCasRoot {
 
 impl Drop for ReadOnlyCasRoot {
     fn drop(&mut self) {
-        let _ = crate::file_lock::unlock(&self.lifecycle);
-        let _ = self.objects.unlock();
+        if self.locks_held {
+            let _ = crate::file_lock::unlock(&self.lifecycle);
+            let _ = self.objects.unlock();
+        }
     }
 }
 
@@ -249,11 +378,15 @@ impl Drop for GraphObjectGcGuard {
 
 impl Drop for GraphObjectPublicationLease {
     fn drop(&mut self) {
-        let _ = crate::file_lock::unlock(&self.file);
+        if let Some(file) = self.file.take() {
+            let _ = crate::file_lock::unlock(&file);
+            drop(file);
+        }
         let _ = self
             .cas
             .active
             .unlink_child_if_identity(&self.lease_name, self.lease_identity);
+        let _ = self.cas.active.sync();
         let _ = crate::file_lock::unlock(&self.cas.lifecycle);
         let _ = self.cas.objects.unlock();
     }
@@ -283,34 +416,51 @@ impl GraphObjectPublicationLease {
 /// Begin a CAS installation attempt and hold its lease through CURRENT.
 pub fn begin_graph_object_publication(root: &Path) -> Result<GraphObjectPublicationLease, GfError> {
     let cas = CasRoot::open_mutable(root)?;
-    cas.objects
-        .lock_shared()
-        .map_err(|error| storage("lock graph object directory for publication", root, error))?;
-    crate::file_lock::lock_shared(&cas.lifecycle)
-        .inspect_err(|_| {
-            let _ = cas.objects.unlock();
-        })
-        .map_err(|error| storage("lock graph object publication lifecycle", root, error))?;
+    let locks = lock_cas_shared(&cas.objects, &cas.lifecycle, root, "publication")?;
     cas.revalidate_named()?;
+    returned_error_boundary("publication:revalidate")?;
     let lease_name = std::ffi::OsString::from(format!("{}.lock", Uuid::new_v4().hyphenated()));
     let file = cas
         .active
         .create_child_file(&lease_name)
         .map_err(|error| storage("create graph object publication lease", root, error))?;
-    let lease_identity = graphforge_filesystem::file_identity(&file)
+    let mut pending = PendingPublication {
+        cas: &cas,
+        lease_name: lease_name.clone(),
+        lease_identity: None,
+        file: Some(file),
+        lease_locked: false,
+    };
+    returned_error_boundary("publication:lease-create")?;
+    let lease_identity = graphforge_filesystem::file_identity(pending.file.as_ref().unwrap())
         .map_err(|error| storage("inspect graph object publication lease", root, error))?;
-    crate::file_lock::lock_exclusive(&file)
+    pending.lease_identity = Some(lease_identity);
+    returned_error_boundary("publication:lease-identity")?;
+    crate::file_lock::lock_exclusive(pending.file.as_ref().unwrap())
         .map_err(|error| storage("lock graph object publication lease", root, error))?;
-    file.sync_all()
+    pending.lease_locked = true;
+    returned_error_boundary("publication:lease-lock")?;
+    pending
+        .file
+        .as_ref()
+        .unwrap()
+        .sync_all()
         .map_err(|error| storage("sync graph object publication lease", root, error))?;
+    returned_error_boundary("publication:lease-sync")?;
     cas.active
         .sync()
         .map_err(|error| storage("sync graph object active directory", root, error))?;
+    returned_error_boundary("publication:active-sync")?;
+    let file = pending.file.take().unwrap();
+    pending.lease_locked = false;
+    pending.lease_identity = None;
+    drop(pending);
+    locks.disarm();
     Ok(GraphObjectPublicationLease {
         cas,
         lease_name,
         lease_identity,
-        file,
+        file: Some(file),
     })
 }
 
@@ -348,9 +498,13 @@ pub fn graph_object_publication_is_live(root: &Path) -> Result<bool, GfError> {
         {
             crate::file_lock::unlock(&file)
                 .map_err(|error| storage("unlock graph object lease", root, error))?;
+            drop(file);
             cas.active
                 .unlink_child_if_identity(&entry, identity)
                 .map_err(|error| storage("remove stale graph object lease", root, error))?;
+            cas.active
+                .sync()
+                .map_err(|error| storage("sync graph object active directory", root, error))?;
         } else {
             live = true;
         }
@@ -479,15 +633,10 @@ pub fn gc_graph_objects(
 #[cfg(test)]
 pub(crate) fn begin_graph_object_gc(root: &Path) -> Result<GraphObjectGcGuard, GfError> {
     let cas = CasRoot::open_mutable(root)?;
-    cas.objects
-        .lock_exclusive()
-        .map_err(|error| storage("lock graph object directory for GC", root, error))?;
-    crate::file_lock::lock_exclusive(&cas.lifecycle)
-        .inspect_err(|_| {
-            let _ = cas.objects.unlock();
-        })
-        .map_err(|error| storage("lock graph object GC lifecycle", root, error))?;
+    let locks = lock_cas_exclusive(&cas.objects, &cas.lifecycle, root)?;
     cas.revalidate_named()?;
+    returned_error_boundary("gc:revalidate")?;
+    locks.disarm();
     Ok(GraphObjectGcGuard { cas })
 }
 
@@ -502,13 +651,23 @@ pub(crate) fn try_begin_graph_object_gc(
     {
         return Ok(None);
     }
+    let mut locks = HeldCasLocks {
+        objects: &cas.objects,
+        lifecycle: &cas.lifecycle,
+        objects_locked: true,
+        lifecycle_locked: false,
+    };
+    returned_error_boundary("try-gc:objects-lock")?;
     if !crate::file_lock::try_lock_exclusive(&cas.lifecycle)
         .map_err(|error| storage("try graph object GC lifecycle", root, error))?
     {
-        let _ = cas.objects.unlock();
         return Ok(None);
     }
+    locks.lifecycle_locked = true;
+    returned_error_boundary("try-gc:lifecycle-lock")?;
     cas.revalidate_named()?;
+    returned_error_boundary("try-gc:revalidate")?;
+    locks.disarm();
     Ok(Some(GraphObjectGcGuard { cas }))
 }
 
@@ -2008,6 +2167,93 @@ fn storage(action: &str, path: &Path, error: impl std::fmt::Display) -> GfError 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn inject_returned_error(boundary: Option<&str>) {
+        RETURNED_ERROR_BOUNDARY.with(|current| {
+            *current.borrow_mut() = boundary.map(str::to_owned);
+        });
+    }
+
+    fn assert_injected_error(error: GfError, boundary: &str) {
+        match error {
+            GfError::Storage(message) => assert_eq!(
+                message,
+                format!("injected graph object returned error at {boundary}")
+            ),
+            other => panic!("unexpected injected error: {other}"),
+        }
+    }
+
+    #[test]
+    fn returned_errors_release_every_cas_lock_and_pending_lease_boundary() {
+        let root = tempfile::tempdir().unwrap();
+        drop(begin_graph_object_publication(root.path()).unwrap());
+
+        for boundary in [
+            "reading:objects-lock",
+            "reading:lifecycle-lock",
+            "reading:revalidate",
+        ] {
+            inject_returned_error(Some(boundary));
+            let error = ReadOnlyCasRoot::open(root.path()).err().unwrap();
+            assert_injected_error(error, boundary);
+            inject_returned_error(None);
+            drop(try_begin_graph_object_gc(root.path()).unwrap().unwrap());
+        }
+
+        for boundary in ["gc:objects-lock", "gc:lifecycle-lock", "gc:revalidate"] {
+            inject_returned_error(Some(boundary));
+            let error = begin_graph_object_gc(root.path()).err().unwrap();
+            assert_injected_error(error, boundary);
+            inject_returned_error(None);
+            drop(try_begin_graph_object_gc(root.path()).unwrap().unwrap());
+        }
+
+        for boundary in [
+            "try-gc:objects-lock",
+            "try-gc:lifecycle-lock",
+            "try-gc:revalidate",
+        ] {
+            inject_returned_error(Some(boundary));
+            let error = try_begin_graph_object_gc(root.path()).err().unwrap();
+            assert_injected_error(error, boundary);
+            inject_returned_error(None);
+            drop(try_begin_graph_object_gc(root.path()).unwrap().unwrap());
+        }
+
+        for boundary in [
+            "publication:objects-lock",
+            "publication:lifecycle-lock",
+            "publication:revalidate",
+            "publication:lease-create",
+            "publication:lease-identity",
+            "publication:lease-lock",
+            "publication:lease-sync",
+            "publication:active-sync",
+        ] {
+            inject_returned_error(Some(boundary));
+            let error = begin_graph_object_publication(root.path()).err().unwrap();
+            assert_injected_error(error, boundary);
+            inject_returned_error(None);
+            let residue_count = fs::read_dir(root.path().join(GRAPH_OBJECTS_DIR).join(ACTIVE_DIR))
+                .unwrap()
+                .count();
+            assert_eq!(
+                residue_count,
+                usize::from(boundary == "publication:lease-create")
+            );
+            assert!(!graph_object_publication_is_live(root.path()).unwrap());
+            assert_eq!(
+                fs::read_dir(root.path().join(GRAPH_OBJECTS_DIR).join(ACTIVE_DIR))
+                    .unwrap()
+                    .count(),
+                0
+            );
+            drop(begin_graph_object_publication(root.path()).unwrap());
+            drop(try_begin_graph_object_gc(root.path()).unwrap().unwrap());
+            drop(ReadOnlyCasRoot::open(root.path()).unwrap());
+        }
+    }
 
     #[test]
     fn pure_reads_require_only_existing_digest_namespace_and_never_create() {

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -1,0 +1,1118 @@
+//! Project-level immutable content-addressed graph objects.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use graphforge_core::GfError;
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::graph_manifest::verify_object_bytes;
+use crate::{
+    GRAPH_FILES_V2_FORMAT, GRAPH_FILES_V2_VERSION, GRAPH_MANIFEST_NODE_FORMAT,
+    GRAPH_MANIFEST_NODE_VERSION, GRAPH_RADIX_DEPTH, GraphFilesInventory, GraphFilesOpenEvidence,
+    GraphFilesOpenStrategy, GraphFilesRootV2, GraphManifestNode, GraphManifestNodeKind,
+};
+
+/// Project-relative root of immutable graph objects.
+pub const GRAPH_OBJECTS_DIR: &str = "graph-objects";
+const SHA256_DIR: &str = "sha256";
+const TEMP_DIR: &str = "tmp";
+const ACTIVE_DIR: &str = "active";
+const BUFFER_BYTES: usize = 64 * 1024;
+
+/// Kernel-visible lease protecting CAS objects installed by one publication.
+pub struct GraphObjectPublicationLease {
+    path: PathBuf,
+    file: File,
+}
+
+impl Drop for GraphObjectPublicationLease {
+    fn drop(&mut self) {
+        let _ = crate::file_lock::unlock(&self.file);
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+/// Begin a CAS installation attempt and hold its lease through CURRENT.
+pub fn begin_graph_object_publication(root: &Path) -> Result<GraphObjectPublicationLease, GfError> {
+    let active = root.join(GRAPH_OBJECTS_DIR).join(ACTIVE_DIR);
+    fs::create_dir_all(&active)
+        .map_err(|error| storage("create graph object active directory", &active, error))?;
+    let path = active.join(format!("{}.lock", Uuid::new_v4().hyphenated()));
+    let file = OpenOptions::new()
+        .create_new(true)
+        .read(true)
+        .write(true)
+        .open(&path)
+        .map_err(|error| storage("create graph object publication lease", &path, error))?;
+    crate::file_lock::lock_exclusive(&file)
+        .map_err(|error| storage("lock graph object publication lease", &path, error))?;
+    file.sync_all()
+        .map_err(|error| storage("sync graph object publication lease", &path, error))?;
+    sync_directory(&active)?;
+    Ok(GraphObjectPublicationLease { path, file })
+}
+
+/// Return true when any live CAS publication lease prevents safe sweeping.
+/// Unlocked lease files are crash residue and are removed while the caller
+/// holds the project writer/recovery lock.
+pub fn graph_object_publication_is_live(root: &Path) -> Result<bool, GfError> {
+    let active = root.join(GRAPH_OBJECTS_DIR).join(ACTIVE_DIR);
+    let entries = match fs::read_dir(&active) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => {
+            return Err(storage(
+                "read graph object active directory",
+                &active,
+                error,
+            ));
+        }
+    };
+    let mut live = false;
+    for entry in entries {
+        let entry = entry.map_err(|error| storage("read graph object lease", &active, error))?;
+        let path = entry.path();
+        let name = entry
+            .file_name()
+            .into_string()
+            .map_err(|_| validation("graph object lease name is not UTF-8"))?;
+        let uuid_text = name
+            .strip_suffix(".lock")
+            .ok_or_else(|| validation("graph object lease name is not canonical"))?;
+        let uuid = Uuid::parse_str(uuid_text)
+            .map_err(|_| validation("graph object lease name is not canonical"))?;
+        if uuid.hyphenated().to_string() != uuid_text {
+            return Err(validation("graph object lease name is not canonical"));
+        }
+        let metadata = fs::symlink_metadata(&path)
+            .map_err(|error| storage("inspect graph object lease", &path, error))?;
+        if !metadata.is_file() || metadata.file_type().is_symlink() {
+            return Err(validation(
+                "graph object active directory contains an invalid entry",
+            ));
+        }
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&path)
+            .map_err(|error| storage("open graph object lease", &path, error))?;
+        if crate::file_lock::try_lock_exclusive(&file)
+            .map_err(|error| storage("probe graph object lease", &path, error))?
+        {
+            crate::file_lock::unlock(&file)
+                .map_err(|error| storage("unlock graph object lease", &path, error))?;
+            fs::remove_file(&path)
+                .map_err(|error| storage("remove stale graph object lease", &path, error))?;
+        } else {
+            live = true;
+        }
+    }
+    Ok(live)
+}
+
+/// Exact physical work for one object installation.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GraphObjectInstallEvidence {
+    /// Source payload bytes read and hashed.
+    pub bytes_hashed: u64,
+    /// New physical bytes installed into the object store.
+    pub bytes_installed: u64,
+    /// Whether an already installed exact object satisfied the request.
+    pub reused_existing: bool,
+}
+
+/// One-time v1 expanded-tree to v2 object-store migration evidence.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GraphFilesMigrationEvidence {
+    /// Payload objects examined.
+    pub payload_objects: u64,
+    /// Source payload bytes hashed.
+    pub payload_bytes_hashed: u64,
+    /// New physical payload and segment bytes installed.
+    pub bytes_installed: u64,
+}
+
+/// Exact incremental publication work; prior manifest entries are supplied by
+/// the owning facade's pinned cache and are never enumerated here.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GraphFilesAppendEvidence {
+    /// New/replaced and tombstoned descriptors examined.
+    pub changed_entries_examined: u64,
+    /// Prior descriptors examined by publication (always zero).
+    pub prior_entries_examined: u64,
+    /// New/replaced payload bytes hashed, including verification passes.
+    pub payload_bytes_hashed: u64,
+    /// New physical object bytes installed.
+    pub bytes_installed: u64,
+}
+
+/// Mark/sweep evidence for project-level graph objects.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GraphObjectGcEvidence {
+    /// Reachable segment and payload objects marked.
+    pub objects_marked: u64,
+    /// Unreachable objects removed.
+    pub objects_removed: u64,
+    /// Physical unreachable bytes removed.
+    pub bytes_removed: u64,
+}
+
+/// Trace compact generation roots, then sweep unreachable CAS objects.
+/// Marking completes successfully before any deletion begins.
+pub fn gc_graph_objects(
+    root: &Path,
+    roots: &[GraphFilesRootV2],
+    limits: crate::GraphManifestLimits,
+) -> Result<GraphObjectGcEvidence, GfError> {
+    let mut marked = BTreeSet::new();
+    for graph_root in roots {
+        let mut segment_digests = Vec::new();
+        let (files, _) = crate::resolve_graph_manifest(graph_root, limits, |digest| {
+            segment_digests.push(digest.to_owned());
+            read_graph_object_by_digest(root, digest, 64 * 1024 * 1024)
+        })?;
+        marked.extend(segment_digests);
+        marked.extend(files.into_iter().map(|entry| entry.content_sha256));
+    }
+    let mut candidates = Vec::new();
+    let sha_root = root.join(GRAPH_OBJECTS_DIR).join(SHA256_DIR);
+    if sha_root.exists() {
+        for prefix in fs::read_dir(&sha_root)
+            .map_err(|error| storage("read graph object prefixes", &sha_root, error))?
+        {
+            let prefix =
+                prefix.map_err(|error| storage("read graph object prefix", &sha_root, error))?;
+            if !prefix
+                .file_type()
+                .map_err(|error| storage("inspect graph object prefix", &prefix.path(), error))?
+                .is_dir()
+            {
+                return Err(validation(
+                    "graph object store contains a non-directory prefix",
+                ));
+            }
+            let prefix_name = prefix
+                .file_name()
+                .into_string()
+                .map_err(|_| validation("graph object prefix is not UTF-8"))?;
+            for object in fs::read_dir(prefix.path())
+                .map_err(|error| storage("read graph object bucket", &prefix.path(), error))?
+            {
+                let object = object
+                    .map_err(|error| storage("read graph object entry", &prefix.path(), error))?;
+                let file_type = object
+                    .file_type()
+                    .map_err(|error| storage("inspect graph object type", &object.path(), error))?;
+                if !file_type.is_file() || file_type.is_symlink() {
+                    return Err(validation(
+                        "graph object bucket contains a non-regular object",
+                    ));
+                }
+                let metadata = object.metadata().map_err(|error| {
+                    storage("inspect graph object entry", &object.path(), error)
+                })?;
+                let suffix = object
+                    .file_name()
+                    .into_string()
+                    .map_err(|_| validation("graph object name is not UTF-8"))?;
+                let digest = format!("{prefix_name}{suffix}");
+                validate_digest(&digest)?;
+                if !marked.contains(&digest) {
+                    candidates.push((object.path(), metadata.len()));
+                }
+            }
+        }
+    }
+    let mut evidence = GraphObjectGcEvidence {
+        objects_marked: u64::try_from(marked.len()).unwrap_or(u64::MAX),
+        ..GraphObjectGcEvidence::default()
+    };
+    for (path, bytes) in candidates {
+        fs::remove_file(&path)
+            .map_err(|error| storage("remove unreachable graph object", &path, error))?;
+        evidence.objects_removed = evidence.objects_removed.saturating_add(1);
+        evidence.bytes_removed = evidence.bytes_removed.saturating_add(bytes);
+    }
+    Ok(evidence)
+}
+
+/// Seal only changed logical files into a structurally shared radix manifest.
+pub fn append_graph_files_v2(
+    root: &Path,
+    workspace: &Path,
+    previous_root: Option<&GraphFilesRootV2>,
+    live_entries: &mut BTreeMap<String, crate::GraphFileEntry>,
+    sealed_paths: &[PathBuf],
+    tombstones: &[String],
+) -> Result<(GraphFilesRootV2, GraphFilesAppendEvidence), GfError> {
+    let mut additions = Vec::with_capacity(sealed_paths.len());
+    let mut evidence = GraphFilesAppendEvidence::default();
+    let mut logical_byte_length = previous_root.map_or(0, |root| root.logical_byte_length);
+    for relative in sealed_paths {
+        validate_logical_path(relative)?;
+        let source = workspace.join(relative);
+        let metadata = fs::symlink_metadata(&source)
+            .map_err(|error| storage("inspect sealed graph file", &source, error))?;
+        if !metadata.is_file() || metadata.file_type().is_symlink() {
+            return Err(validation("sealed graph path is not a regular file"));
+        }
+        let digest = hash_regular_file(&source)?;
+        let digest = hex_digest(digest);
+        let installed = install_graph_object_file(root, &source, &digest, metadata.len())?;
+        evidence.payload_bytes_hashed = evidence
+            .payload_bytes_hashed
+            .saturating_add(metadata.len())
+            .saturating_add(installed.bytes_hashed);
+        evidence.bytes_installed = evidence
+            .bytes_installed
+            .saturating_add(installed.bytes_installed);
+        let relative_path = relative
+            .to_str()
+            .ok_or_else(|| validation("sealed graph path is not UTF-8"))?
+            .to_owned();
+        let entry = crate::GraphFileEntry {
+            relative_path: relative_path.clone(),
+            byte_length: metadata.len(),
+            content_sha256: digest,
+            role: crate::graph_files::infer_role(relative),
+        };
+        if let Some(previous) = live_entries.insert(relative_path, entry.clone()) {
+            logical_byte_length = logical_byte_length.saturating_sub(previous.byte_length);
+        }
+        logical_byte_length = logical_byte_length
+            .checked_add(entry.byte_length)
+            .ok_or_else(|| validation("graph files v2 byte total overflow"))?;
+        additions.push(entry);
+    }
+    additions.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    let mut tombstones = tombstones.to_vec();
+    tombstones.sort();
+    tombstones.dedup();
+    for path in &tombstones {
+        validate_logical_path(Path::new(path))?;
+        if let Some(previous) = live_entries.remove(path) {
+            logical_byte_length = logical_byte_length.saturating_sub(previous.byte_length);
+        }
+    }
+    evidence.changed_entries_examined =
+        u64::try_from(additions.len().saturating_add(tombstones.len())).unwrap_or(u64::MAX);
+    let mut root_digest = match previous_root {
+        Some(previous) => previous.root_node_sha256.clone(),
+        None => install_manifest_node(root, &empty_branch(0), &mut evidence.bytes_installed)?,
+    };
+    for entry in additions {
+        let relative_path = entry.relative_path.clone();
+        root_digest = update_manifest_path(
+            root,
+            Some(&root_digest),
+            0,
+            &relative_path,
+            Some(entry),
+            &mut evidence.bytes_installed,
+        )?
+        .ok_or_else(|| validation("radix update unexpectedly removed the root"))?;
+    }
+    for path in tombstones {
+        root_digest = update_manifest_path(
+            root,
+            Some(&root_digest),
+            0,
+            &path,
+            None,
+            &mut evidence.bytes_installed,
+        )?
+        .unwrap_or(install_manifest_node(
+            root,
+            &empty_branch(0),
+            &mut evidence.bytes_installed,
+        )?);
+    }
+    Ok((
+        GraphFilesRootV2 {
+            format: GRAPH_FILES_V2_FORMAT.into(),
+            format_version: GRAPH_FILES_V2_VERSION,
+            root_node_sha256: root_digest,
+            logical_file_count: u64::try_from(live_entries.len()).unwrap_or(u64::MAX),
+            logical_byte_length,
+        },
+        evidence,
+    ))
+}
+
+/// Import a verified v1 graph tree into a self-contained v2 radix root.
+pub fn migrate_graph_files_v1_to_v2(
+    root: &Path,
+    graph_root: &Path,
+    inventory: &GraphFilesInventory,
+) -> Result<(GraphFilesRootV2, GraphFilesMigrationEvidence), GfError> {
+    let mut evidence = GraphFilesMigrationEvidence::default();
+    for entry in &inventory.files {
+        let installed = install_graph_object_file(
+            root,
+            &graph_root.join(&entry.relative_path),
+            &entry.content_sha256,
+            entry.byte_length,
+        )?;
+        evidence.payload_objects = evidence.payload_objects.saturating_add(1);
+        evidence.payload_bytes_hashed = evidence
+            .payload_bytes_hashed
+            .saturating_add(installed.bytes_hashed);
+        evidence.bytes_installed = evidence
+            .bytes_installed
+            .saturating_add(installed.bytes_installed);
+    }
+    let mut root_digest =
+        install_manifest_node(root, &empty_branch(0), &mut evidence.bytes_installed)?;
+    for entry in &inventory.files {
+        root_digest = update_manifest_path(
+            root,
+            Some(&root_digest),
+            0,
+            &entry.relative_path,
+            Some(entry.clone()),
+            &mut evidence.bytes_installed,
+        )?
+        .ok_or_else(|| validation("radix migration unexpectedly removed the root"))?;
+    }
+    Ok((
+        GraphFilesRootV2 {
+            format: GRAPH_FILES_V2_FORMAT.into(),
+            format_version: GRAPH_FILES_V2_VERSION,
+            root_node_sha256: root_digest,
+            logical_file_count: inventory.file_count,
+            logical_byte_length: inventory.total_byte_length,
+        },
+        evidence,
+    ))
+}
+
+fn empty_branch(depth: u8) -> GraphManifestNode {
+    GraphManifestNode {
+        format: GRAPH_MANIFEST_NODE_FORMAT.into(),
+        format_version: GRAPH_MANIFEST_NODE_VERSION,
+        depth,
+        kind: GraphManifestNodeKind::Branch {
+            children: BTreeMap::new(),
+        },
+    }
+}
+
+fn install_manifest_node(
+    root: &Path,
+    node: &GraphManifestNode,
+    bytes_installed: &mut u64,
+) -> Result<String, GfError> {
+    let bytes = crate::encode_graph_manifest_node(node)?;
+    let (digest, evidence) = install_graph_object_bytes(root, &bytes)?;
+    *bytes_installed = bytes_installed.saturating_add(evidence.bytes_installed);
+    Ok(digest)
+}
+
+fn load_manifest_node(
+    root: &Path,
+    digest: &str,
+    expected_depth: u8,
+) -> Result<GraphManifestNode, GfError> {
+    let bytes = read_graph_object_by_digest(root, digest, 64 * 1024 * 1024)?;
+    let node = crate::decode_graph_manifest_node(&bytes)?;
+    if node.depth != expected_depth {
+        return Err(validation(
+            "graph manifest radix depth mismatch during update",
+        ));
+    }
+    Ok(node)
+}
+
+fn update_manifest_path(
+    root: &Path,
+    current_digest: Option<&str>,
+    depth: u8,
+    path: &str,
+    replacement: Option<crate::GraphFileEntry>,
+    bytes_installed: &mut u64,
+) -> Result<Option<String>, GfError> {
+    let path_digest = crate::graph_manifest::logical_path_digest(path);
+    if depth == GRAPH_RADIX_DEPTH {
+        let mut entries = match current_digest {
+            Some(digest) => match load_manifest_node(root, digest, depth)?.kind {
+                GraphManifestNodeKind::Leaf {
+                    path_sha256,
+                    entries,
+                } => {
+                    if path_sha256 != hex_digest(path_digest) {
+                        return Err(validation("graph manifest collision leaf digest mismatch"));
+                    }
+                    entries
+                }
+                GraphManifestNodeKind::Branch { .. } => {
+                    return Err(validation("graph manifest terminal node is not a leaf"));
+                }
+            },
+            None => Vec::new(),
+        };
+        match entries.binary_search_by(|entry| entry.relative_path.as_str().cmp(path)) {
+            Ok(index) => match replacement {
+                Some(entry) => entries[index] = entry,
+                None => {
+                    entries.remove(index);
+                }
+            },
+            Err(index) => {
+                if let Some(entry) = replacement {
+                    entries.insert(index, entry);
+                }
+            }
+        }
+        if entries.is_empty() {
+            return Ok(None);
+        }
+        let node = GraphManifestNode {
+            format: GRAPH_MANIFEST_NODE_FORMAT.into(),
+            format_version: GRAPH_MANIFEST_NODE_VERSION,
+            depth,
+            kind: GraphManifestNodeKind::Leaf {
+                path_sha256: hex_digest(path_digest),
+                entries,
+            },
+        };
+        return install_manifest_node(root, &node, bytes_installed).map(Some);
+    }
+
+    let mut children = match current_digest {
+        Some(digest) => match load_manifest_node(root, digest, depth)?.kind {
+            GraphManifestNodeKind::Branch { children } => children,
+            GraphManifestNodeKind::Leaf { .. } => {
+                return Err(validation(
+                    "graph manifest non-terminal node is not a branch",
+                ));
+            }
+        },
+        None => BTreeMap::new(),
+    };
+    let nibble = format!(
+        "{:x}",
+        crate::graph_manifest::radix_nibble(&path_digest, depth)
+    );
+    let child = update_manifest_path(
+        root,
+        children.get(&nibble).map(String::as_str),
+        depth + 1,
+        path,
+        replacement,
+        bytes_installed,
+    )?;
+    match child {
+        Some(digest) => {
+            children.insert(nibble, digest);
+        }
+        None => {
+            children.remove(&nibble);
+        }
+    }
+    if children.is_empty() && depth != 0 {
+        return Ok(None);
+    }
+    install_manifest_node(
+        root,
+        &GraphManifestNode {
+            format: GRAPH_MANIFEST_NODE_FORMAT.into(),
+            format_version: GRAPH_MANIFEST_NODE_VERSION,
+            depth,
+            kind: GraphManifestNodeKind::Branch { children },
+        },
+        bytes_installed,
+    )
+    .map(Some)
+}
+
+/// Resolve a digest to its admitted project-level object path.
+pub fn graph_object_path(root: &Path, digest: &str) -> Result<PathBuf, GfError> {
+    validate_digest(digest)?;
+    Ok(root
+        .join(GRAPH_OBJECTS_DIR)
+        .join(SHA256_DIR)
+        .join(&digest[..2])
+        .join(&digest[2..]))
+}
+
+/// Install exact in-memory bytes under their SHA-256 identity.
+pub fn install_graph_object_bytes(
+    root: &Path,
+    bytes: &[u8],
+) -> Result<(String, GraphObjectInstallEvidence), GfError> {
+    let digest = hex_digest(Sha256::digest(bytes).into());
+    let expected_length = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
+    install_object(root, &digest, expected_length, |temporary| {
+        let mut file = create_new(temporary)?;
+        file.write_all(bytes)
+            .map_err(|error| storage("write temporary graph object", temporary, error))?;
+        file.sync_all()
+            .map_err(|error| storage("fsync temporary graph object", temporary, error))?;
+        Ok(expected_length)
+    })
+    .map(|evidence| (digest, evidence))
+}
+
+/// Stream, hash, and install a new payload object from a regular source file.
+pub fn install_graph_object_file(
+    root: &Path,
+    source: &Path,
+    expected_digest: &str,
+    expected_length: u64,
+) -> Result<GraphObjectInstallEvidence, GfError> {
+    validate_digest(expected_digest)?;
+    let metadata = fs::symlink_metadata(source)
+        .map_err(|error| storage("inspect graph object source", source, error))?;
+    if !metadata.is_file() || metadata.file_type().is_symlink() || metadata.len() != expected_length
+    {
+        return Err(validation(
+            "graph object source is not the declared regular file",
+        ));
+    }
+    install_object(root, expected_digest, expected_length, |temporary| {
+        let mut input = File::open(source)
+            .map_err(|error| storage("open graph object source", source, error))?;
+        let mut output = create_new(temporary)?;
+        let mut hasher = Sha256::new();
+        let mut total = 0_u64;
+        let mut buffer = vec![0_u8; BUFFER_BYTES];
+        loop {
+            let read = input
+                .read(&mut buffer)
+                .map_err(|error| storage("read graph object source", source, error))?;
+            if read == 0 {
+                break;
+            }
+            output
+                .write_all(&buffer[..read])
+                .map_err(|error| storage("write temporary graph object", temporary, error))?;
+            hasher.update(&buffer[..read]);
+            total = total.saturating_add(u64::try_from(read).unwrap_or(u64::MAX));
+        }
+        if total != expected_length || hex_digest(hasher.finalize().into()) != expected_digest {
+            return Err(validation(
+                "graph object source digest or length changed during install",
+            ));
+        }
+        output
+            .sync_all()
+            .map_err(|error| storage("fsync temporary graph object", temporary, error))?;
+        Ok(total)
+    })
+}
+
+/// Read and cryptographically verify an immutable object.
+pub fn read_graph_object(
+    root: &Path,
+    digest: &str,
+    expected_length: u64,
+) -> Result<Vec<u8>, GfError> {
+    let path = graph_object_path(root, digest)?;
+    let bytes = fs::read(&path).map_err(|error| storage("read graph object", &path, error))?;
+    verify_object_bytes(digest, expected_length, &bytes)?;
+    Ok(bytes)
+}
+
+/// Stream-verify a payload object without retaining it in memory.
+pub fn verify_graph_object(root: &Path, digest: &str, expected_length: u64) -> Result<(), GfError> {
+    let path = graph_object_path(root, digest)?;
+    let metadata = fs::symlink_metadata(&path)
+        .map_err(|error| storage("inspect graph object", &path, error))?;
+    if !metadata.is_file() || metadata.file_type().is_symlink() || metadata.len() != expected_length
+    {
+        return Err(validation(
+            "graph object path is not the declared regular file",
+        ));
+    }
+    let mut file = File::open(&path).map_err(|error| storage("open graph object", &path, error))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = vec![0_u8; BUFFER_BYTES];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .map_err(|error| storage("read graph object", &path, error))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    if hex_digest(hasher.finalize().into()) != digest {
+        return Err(validation("graph object digest does not match its address"));
+    }
+    Ok(())
+}
+
+/// Materialize a verified logical inventory as hard links to immutable CAS
+/// objects. The target must be empty.
+pub fn materialize_graph_objects(
+    root: &Path,
+    inventory: &GraphFilesInventory,
+    target: &Path,
+) -> Result<GraphFilesOpenEvidence, GfError> {
+    if target.exists()
+        && target
+            .read_dir()
+            .map_err(|error| storage("read graph object target", target, error))?
+            .next()
+            .is_some()
+    {
+        return Err(validation(
+            "graph object materialization target is not empty",
+        ));
+    }
+    fs::create_dir_all(target)
+        .map_err(|error| storage("create graph object materialization target", target, error))?;
+    let mut evidence = GraphFilesOpenEvidence {
+        strategy: GraphFilesOpenStrategy::PrivateMaterialize,
+        files_validated: inventory.file_count,
+        bytes_validated: inventory.total_byte_length,
+        ..GraphFilesOpenEvidence::default()
+    };
+    for entry in &inventory.files {
+        let source = graph_object_path(root, &entry.content_sha256)?;
+        let destination = target.join(&entry.relative_path);
+        if let Some(parent) = destination.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|error| storage("create logical graph object directory", parent, error))?;
+        }
+        fs::hard_link(&source, &destination)
+            .map_err(|error| storage("link logical graph object", &destination, error))?;
+        evidence.files_reused = evidence.files_reused.saturating_add(1);
+        evidence.bytes_reused = evidence.bytes_reused.saturating_add(entry.byte_length);
+    }
+    Ok(evidence)
+}
+
+/// Read an object whose digest is known before its declared logical length.
+/// `max_length` bounds allocation for untrusted manifest objects.
+pub fn read_graph_object_by_digest(
+    root: &Path,
+    digest: &str,
+    max_length: u64,
+) -> Result<Vec<u8>, GfError> {
+    let path = graph_object_path(root, digest)?;
+    let metadata = fs::symlink_metadata(&path)
+        .map_err(|error| storage("inspect graph object", &path, error))?;
+    if !metadata.is_file() || metadata.file_type().is_symlink() || metadata.len() > max_length {
+        return Err(validation(
+            "graph object exceeds admitted length or is not regular",
+        ));
+    }
+    let bytes = fs::read(&path).map_err(|error| storage("read graph object", &path, error))?;
+    if hex_digest(Sha256::digest(&bytes).into()) != digest {
+        return Err(validation("graph object digest does not match its address"));
+    }
+    Ok(bytes)
+}
+
+fn install_object<F>(
+    root: &Path,
+    digest: &str,
+    expected_length: u64,
+    write_temporary: F,
+) -> Result<GraphObjectInstallEvidence, GfError>
+where
+    F: FnOnce(&Path) -> Result<u64, GfError>,
+{
+    let destination = graph_object_path(root, digest)?;
+    if destination.exists() {
+        verify_existing(&destination, digest, expected_length)?;
+        return Ok(GraphObjectInstallEvidence {
+            reused_existing: true,
+            ..GraphObjectInstallEvidence::default()
+        });
+    }
+    let temporary_root = root.join(GRAPH_OBJECTS_DIR).join(TEMP_DIR);
+    fs::create_dir_all(&temporary_root).map_err(|error| {
+        storage(
+            "create graph object temporary directory",
+            &temporary_root,
+            error,
+        )
+    })?;
+    let temporary = temporary_root.join(Uuid::new_v4().hyphenated().to_string());
+    let bytes_hashed = write_temporary(&temporary)?;
+    verify_existing(&temporary, digest, expected_length)?;
+    let parent = destination
+        .parent()
+        .ok_or_else(|| validation("graph object destination has no parent"))?;
+    fs::create_dir_all(parent)
+        .map_err(|error| storage("create graph object digest directory", parent, error))?;
+    let installed = match fs::hard_link(&temporary, &destination) {
+        Ok(()) => true,
+        Err(_) if destination.exists() => {
+            verify_existing(&destination, digest, expected_length)?;
+            false
+        }
+        Err(error) => {
+            return Err(storage(
+                "atomically install graph object",
+                &destination,
+                error,
+            ));
+        }
+    };
+    fs::remove_file(&temporary)
+        .map_err(|error| storage("remove temporary graph object", &temporary, error))?;
+    sync_directory(parent)?;
+    Ok(GraphObjectInstallEvidence {
+        bytes_hashed,
+        bytes_installed: if installed { expected_length } else { 0 },
+        reused_existing: !installed,
+    })
+}
+
+fn verify_existing(path: &Path, digest: &str, expected_length: u64) -> Result<(), GfError> {
+    let metadata =
+        fs::symlink_metadata(path).map_err(|error| storage("inspect graph object", path, error))?;
+    if !metadata.is_file() || metadata.file_type().is_symlink() || metadata.len() != expected_length
+    {
+        return Err(validation(
+            "graph object path is not the declared regular file",
+        ));
+    }
+    let mut file = File::open(path).map_err(|error| storage("open graph object", path, error))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = vec![0_u8; BUFFER_BYTES];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .map_err(|error| storage("read graph object", path, error))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    if hex_digest(hasher.finalize().into()) != digest {
+        return Err(validation("graph object digest does not match its address"));
+    }
+    Ok(())
+}
+
+fn create_new(path: &Path) -> Result<File, GfError> {
+    OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(path)
+        .map_err(|error| storage("create temporary graph object", path, error))
+}
+
+fn sync_directory(path: &Path) -> Result<(), GfError> {
+    File::open(path)
+        .and_then(|file| file.sync_all())
+        .map_err(|error| storage("fsync graph object directory", path, error))
+}
+
+fn hash_regular_file(path: &Path) -> Result<[u8; 32], GfError> {
+    let mut file =
+        File::open(path).map_err(|error| storage("open sealed graph file", path, error))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = vec![0_u8; BUFFER_BYTES];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .map_err(|error| storage("read sealed graph file", path, error))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(hasher.finalize().into())
+}
+
+fn validate_logical_path(path: &Path) -> Result<(), GfError> {
+    if path.as_os_str().is_empty()
+        || path.is_absolute()
+        || path
+            .components()
+            .any(|component| !matches!(component, std::path::Component::Normal(_)))
+    {
+        return Err(validation("invalid graph object logical path"));
+    }
+    if path
+        .components()
+        .next()
+        .is_some_and(|component| component.as_os_str() == std::ffi::OsStr::new(".graphforge-cache"))
+    {
+        return Err(validation("derived cache path cannot be sealed"));
+    }
+    Ok(())
+}
+
+fn validate_digest(digest: &str) -> Result<(), GfError> {
+    if digest.len() != 64
+        || !digest
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+    {
+        return Err(validation(
+            "graph object digest must be 64 lowercase hex characters",
+        ));
+    }
+    Ok(())
+}
+
+fn hex_digest(digest: [u8; 32]) -> String {
+    use std::fmt::Write as _;
+    digest
+        .iter()
+        .fold(String::with_capacity(64), |mut out, byte| {
+            let _ = write!(out, "{byte:02x}");
+            out
+        })
+}
+
+fn validation(message: impl Into<String>) -> GfError {
+    GfError::Validation(message.into())
+}
+
+fn storage(action: &str, path: &Path, error: impl std::fmt::Display) -> GfError {
+    GfError::Storage(format!("{action} at {}: {error}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn installs_once_reuses_exact_object_and_rejects_tampering() {
+        let root = tempfile::tempdir().unwrap();
+        let (digest, first) = install_graph_object_bytes(root.path(), b"payload").unwrap();
+        assert_eq!(first.bytes_hashed, 7);
+        assert_eq!(first.bytes_installed, 7);
+        assert!(!first.reused_existing);
+        let (_, second) = install_graph_object_bytes(root.path(), b"payload").unwrap();
+        assert!(second.reused_existing);
+        assert_eq!(
+            read_graph_object(root.path(), &digest, 7).unwrap(),
+            b"payload"
+        );
+
+        fs::write(graph_object_path(root.path(), &digest).unwrap(), b"corrupt").unwrap();
+        assert!(install_graph_object_bytes(root.path(), b"payload").is_err());
+    }
+
+    #[test]
+    fn rejects_unsafe_digest_and_source_mismatch() {
+        let root = tempfile::tempdir().unwrap();
+        assert!(graph_object_path(root.path(), "../escape").is_err());
+        let source = root.path().join("source");
+        fs::write(&source, b"payload").unwrap();
+        assert!(install_graph_object_file(root.path(), &source, &"0".repeat(64), 7).is_err());
+        assert!(
+            install_graph_object_file(
+                root.path(),
+                &source,
+                &hex_digest(Sha256::digest(b"payload").into()),
+                8
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn publication_lease_blocks_sweep_probe_and_stale_residue_is_reclaimed() {
+        let root = tempfile::tempdir().unwrap();
+        let lease = begin_graph_object_publication(root.path()).unwrap();
+        assert!(graph_object_publication_is_live(root.path()).unwrap());
+        let active = root.path().join(GRAPH_OBJECTS_DIR).join(ACTIVE_DIR);
+        drop(lease);
+        let stale = active.join("00000000-0000-0000-0000-000000000000.lock");
+        fs::write(&stale, []).unwrap();
+        assert!(!graph_object_publication_is_live(root.path()).unwrap());
+        assert!(!stale.exists());
+    }
+
+    #[test]
+    fn publication_lease_probe_fails_closed_on_noncanonical_residue() {
+        let root = tempfile::tempdir().unwrap();
+        let active = root.path().join(GRAPH_OBJECTS_DIR).join(ACTIVE_DIR);
+        fs::create_dir_all(&active).unwrap();
+        let hostile = active.join("caller-owned");
+        fs::write(&hostile, b"preserve").unwrap();
+        assert!(graph_object_publication_is_live(root.path()).is_err());
+        assert_eq!(fs::read(&hostile).unwrap(), b"preserve");
+    }
+
+    #[test]
+    fn migrates_v1_tree_once_and_reopens_from_compact_root() {
+        let container = tempfile::tempdir().unwrap();
+        let graph = tempfile::tempdir().unwrap();
+        fs::create_dir_all(graph.path().join("topology/edges/knows")).unwrap();
+        fs::write(
+            graph.path().join("topology/edges/knows/1-1.parquet"),
+            b"edge",
+        )
+        .unwrap();
+        let (inventory, _) = crate::capture_graph_files(graph.path()).unwrap();
+        let (root, evidence) =
+            migrate_graph_files_v1_to_v2(container.path(), graph.path(), &inventory).unwrap();
+        assert_eq!(evidence.payload_objects, 1);
+        assert_eq!(evidence.payload_bytes_hashed, 4);
+        let (files, _) =
+            crate::resolve_graph_manifest(&root, crate::GraphManifestLimits::default(), |digest| {
+                read_graph_object_by_digest(container.path(), digest, 1024 * 1024)
+            })
+            .unwrap();
+        assert_eq!(files, inventory.files);
+    }
+
+    #[test]
+    fn repeated_v2_appends_examine_only_changed_descriptors() {
+        let container = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let mut live = BTreeMap::new();
+        let mut previous = None;
+        for ordinal in 0_u8..8 {
+            let relative = PathBuf::from(format!(
+                "topology/edges/knows/{ordinal:020}-{ordinal:020}.parquet"
+            ));
+            let path = workspace.path().join(&relative);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(&path, [ordinal]).unwrap();
+            let (root, evidence) = append_graph_files_v2(
+                container.path(),
+                workspace.path(),
+                previous.as_ref(),
+                &mut live,
+                &[relative],
+                &[],
+            )
+            .unwrap();
+            assert_eq!(evidence.changed_entries_examined, 1);
+            assert_eq!(evidence.prior_entries_examined, 0);
+            previous = Some(root);
+        }
+        let root = previous.unwrap();
+        let (resolved, evidence) =
+            crate::resolve_graph_manifest(&root, crate::GraphManifestLimits::default(), |digest| {
+                read_graph_object_by_digest(container.path(), digest, 1024 * 1024)
+            })
+            .unwrap();
+        assert_eq!(resolved.len(), 8);
+        assert!(evidence.segments_examined <= 1 + u64::from(GRAPH_RADIX_DEPTH) * 8);
+
+        let deleted = "topology/edges/knows/00000000000000000003-00000000000000000003.parquet";
+        let (root, delete_evidence) = append_graph_files_v2(
+            container.path(),
+            workspace.path(),
+            Some(&root),
+            &mut live,
+            &[],
+            &[deleted.into()],
+        )
+        .unwrap();
+        assert_eq!(delete_evidence.changed_entries_examined, 1);
+        assert_eq!(delete_evidence.prior_entries_examined, 0);
+        let (resolved, _) =
+            crate::resolve_graph_manifest(&root, crate::GraphManifestLimits::default(), |digest| {
+                read_graph_object_by_digest(container.path(), digest, 1024 * 1024)
+            })
+            .unwrap();
+        assert_eq!(resolved.len(), 7);
+        assert!(!resolved.iter().any(|entry| entry.relative_path == deleted));
+    }
+
+    #[test]
+    fn radix_root_is_deterministic_across_descriptor_order() {
+        let workspace = tempfile::tempdir().unwrap();
+        let paths: Vec<_> = (0_u8..12)
+            .map(|ordinal| {
+                PathBuf::from(format!(
+                    "topology/nodes/{ordinal:020}-{ordinal:020}.parquet"
+                ))
+            })
+            .collect();
+        for (ordinal, relative) in paths.iter().enumerate() {
+            let source = workspace.path().join(relative);
+            fs::create_dir_all(source.parent().unwrap()).unwrap();
+            fs::write(source, [u8::try_from(ordinal).unwrap()]).unwrap();
+        }
+
+        let first = tempfile::tempdir().unwrap();
+        let mut first_live = BTreeMap::new();
+        let (first_root, _) = append_graph_files_v2(
+            first.path(),
+            workspace.path(),
+            None,
+            &mut first_live,
+            &paths,
+            &[],
+        )
+        .unwrap();
+
+        let second = tempfile::tempdir().unwrap();
+        let mut reversed = paths.clone();
+        reversed.reverse();
+        let mut second_live = BTreeMap::new();
+        let (second_root, _) = append_graph_files_v2(
+            second.path(),
+            workspace.path(),
+            None,
+            &mut second_live,
+            &reversed,
+            &[],
+        )
+        .unwrap();
+        assert_eq!(first_root, second_root);
+    }
+
+    #[test]
+    fn gc_traces_segment_and_payload_roots_before_sweeping() {
+        let container = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let relative = PathBuf::from("topology/nodes/1-1.parquet");
+        let source = workspace.path().join(&relative);
+        fs::create_dir_all(source.parent().unwrap()).unwrap();
+        fs::write(&source, b"node").unwrap();
+        let mut live = BTreeMap::new();
+        let (root, _) = append_graph_files_v2(
+            container.path(),
+            workspace.path(),
+            None,
+            &mut live,
+            &[relative],
+            &[],
+        )
+        .unwrap();
+        let (orphan, _) = install_graph_object_bytes(container.path(), b"orphan").unwrap();
+        let evidence = gc_graph_objects(
+            container.path(),
+            std::slice::from_ref(&root),
+            crate::GraphManifestLimits::default(),
+        )
+        .unwrap();
+        assert_eq!(evidence.objects_marked, u64::from(GRAPH_RADIX_DEPTH) + 2);
+        // The initial empty root and the explicit orphan are both unreachable.
+        assert_eq!(evidence.objects_removed, 2);
+        assert!(
+            !graph_object_path(container.path(), &orphan)
+                .unwrap()
+                .exists()
+        );
+
+        let (another_orphan, _) = install_graph_object_bytes(container.path(), b"another").unwrap();
+        fs::write(
+            graph_object_path(container.path(), &root.root_node_sha256).unwrap(),
+            b"tampered",
+        )
+        .unwrap();
+        assert!(
+            gc_graph_objects(
+                container.path(),
+                &[root],
+                crate::GraphManifestLimits::default()
+            )
+            .is_err()
+        );
+        assert!(
+            graph_object_path(container.path(), &another_orphan)
+                .unwrap()
+                .exists()
+        );
+    }
+}

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -51,8 +51,17 @@ struct CasRoot {
     lifecycle_identity: graphforge_filesystem::FileIdentity,
 }
 
+struct ReadOnlyCasRoot {
+    diagnostic_root: PathBuf,
+    project: StableDirectory,
+    objects: StableDirectory,
+    sha256: StableDirectory,
+    lifecycle: File,
+    lifecycle_identity: graphforge_filesystem::FileIdentity,
+}
+
 impl CasRoot {
-    fn open(root: &Path) -> Result<Self, GfError> {
+    fn open_mutable(root: &Path) -> Result<Self, GfError> {
         let project = StableDirectory::open(root)
             .map_err(|error| storage("open stable project root", root, error))?;
         let objects = project
@@ -140,6 +149,97 @@ impl CasRoot {
     }
 }
 
+impl ReadOnlyCasRoot {
+    fn open(root: &Path) -> Result<Self, GfError> {
+        let project = StableDirectory::open(root)
+            .map_err(|error| storage("open stable project root", root, error))?;
+        let objects = project
+            .open_child_directory(std::ffi::OsStr::new(GRAPH_OBJECTS_DIR))
+            .map_err(|error| storage("open existing graph object root", root, error))?;
+        let sha256 = objects
+            .open_child_directory(std::ffi::OsStr::new(SHA256_DIR))
+            .map_err(|error| storage("open existing graph object digest root", root, error))?;
+        let lifecycle = objects
+            .open_child_file(std::ffi::OsStr::new(LIFECYCLE_LOCK))
+            .map_err(|error| storage("open existing graph object lifecycle", root, error))?;
+        if graphforge_filesystem::file_link_count(&lifecycle)
+            .map_err(|error| storage("inspect graph object lifecycle links", root, error))?
+            != 1
+        {
+            return Err(validation("graph object lifecycle lock is multiply linked"));
+        }
+        let lifecycle_identity = graphforge_filesystem::file_identity(&lifecycle)
+            .map_err(|error| storage("inspect graph object lifecycle identity", root, error))?;
+        objects
+            .lock_shared()
+            .map_err(|error| storage("lock graph object directory for reading", root, error))?;
+        crate::file_lock::lock_shared(&lifecycle)
+            .inspect_err(|_| {
+                let _ = objects.unlock();
+            })
+            .map_err(|error| storage("lock graph object read lifecycle", root, error))?;
+        let cas = Self {
+            diagnostic_root: root.to_path_buf(),
+            project,
+            objects,
+            sha256,
+            lifecycle,
+            lifecycle_identity,
+        };
+        cas.revalidate_named()?;
+        Ok(cas)
+    }
+
+    fn revalidate_named(&self) -> Result<(), GfError> {
+        self.project
+            .revalidate_named()
+            .and_then(|()| self.objects.revalidate_named())
+            .and_then(|()| self.sha256.revalidate_named())
+            .and_then(|()| {
+                self.objects
+                    .open_child_file(std::ffi::OsStr::new(LIFECYCLE_LOCK))
+                    .and_then(|file| {
+                        (graphforge_filesystem::file_identity(&file)? == self.lifecycle_identity)
+                            .then_some(())
+                            .ok_or_else(|| std::io::Error::other("lifecycle identity changed"))
+                    })
+            })
+            .map_err(|error| {
+                storage(
+                    "revalidate read-only graph object root",
+                    &self.diagnostic_root,
+                    error,
+                )
+            })
+    }
+
+    fn digest_bucket(&self, digest: &str) -> Result<StableDirectory, GfError> {
+        validate_digest(digest)?;
+        self.sha256
+            .open_child_directory(std::ffi::OsStr::new(&digest[..2]))
+            .map_err(|error| {
+                storage(
+                    "open stable graph object bucket",
+                    &self.diagnostic_root,
+                    error,
+                )
+            })
+    }
+
+    fn open_digest(&self, digest: &str) -> Result<File, GfError> {
+        self.digest_bucket(digest)?
+            .open_child_file(std::ffi::OsStr::new(&digest[2..]))
+            .map_err(|error| storage("open stable graph object", &self.diagnostic_root, error))
+    }
+}
+
+impl Drop for ReadOnlyCasRoot {
+    fn drop(&mut self) {
+        let _ = crate::file_lock::unlock(&self.lifecycle);
+        let _ = self.objects.unlock();
+    }
+}
+
 impl Drop for GraphObjectGcGuard {
     fn drop(&mut self) {
         let _ = crate::file_lock::unlock(&self.cas.lifecycle);
@@ -182,7 +282,7 @@ impl GraphObjectPublicationLease {
 
 /// Begin a CAS installation attempt and hold its lease through CURRENT.
 pub fn begin_graph_object_publication(root: &Path) -> Result<GraphObjectPublicationLease, GfError> {
-    let cas = CasRoot::open(root)?;
+    let cas = CasRoot::open_mutable(root)?;
     cas.objects
         .lock_shared()
         .map_err(|error| storage("lock graph object directory for publication", root, error))?;
@@ -218,7 +318,7 @@ pub fn begin_graph_object_publication(root: &Path) -> Result<GraphObjectPublicat
 /// Unlocked lease files are crash residue and are removed while the caller
 /// holds the project writer/recovery lock.
 pub fn graph_object_publication_is_live(root: &Path) -> Result<bool, GfError> {
-    let cas = CasRoot::open(root)?;
+    let cas = CasRoot::open_mutable(root)?;
     let entries = cas
         .active
         .child_names()
@@ -378,7 +478,7 @@ pub fn gc_graph_objects(
 
 #[cfg(test)]
 pub(crate) fn begin_graph_object_gc(root: &Path) -> Result<GraphObjectGcGuard, GfError> {
-    let cas = CasRoot::open(root)?;
+    let cas = CasRoot::open_mutable(root)?;
     cas.objects
         .lock_exclusive()
         .map_err(|error| storage("lock graph object directory for GC", root, error))?;
@@ -394,7 +494,7 @@ pub(crate) fn begin_graph_object_gc(root: &Path) -> Result<GraphObjectGcGuard, G
 pub(crate) fn try_begin_graph_object_gc(
     root: &Path,
 ) -> Result<Option<GraphObjectGcGuard>, GfError> {
-    let cas = CasRoot::open(root)?;
+    let cas = CasRoot::open_mutable(root)?;
     if !cas
         .objects
         .try_lock_exclusive()
@@ -1132,7 +1232,7 @@ pub fn read_graph_object(
     digest: &str,
     expected_length: u64,
 ) -> Result<Vec<u8>, GfError> {
-    let cas = CasRoot::open(root)?;
+    let cas = ReadOnlyCasRoot::open(root)?;
     let mut file = cas.open_digest(digest)?;
     let mut bytes = Vec::new();
     file.read_to_end(&mut bytes)
@@ -1143,7 +1243,7 @@ pub fn read_graph_object(
 
 /// Stream-verify a payload object without retaining it in memory.
 pub fn verify_graph_object(root: &Path, digest: &str, expected_length: u64) -> Result<(), GfError> {
-    let cas = CasRoot::open(root)?;
+    let cas = ReadOnlyCasRoot::open(root)?;
     verify_file(cas.open_digest(digest)?, digest, expected_length, root)
 }
 
@@ -1654,8 +1754,21 @@ pub fn read_graph_object_by_digest(
     digest: &str,
     max_length: u64,
 ) -> Result<Vec<u8>, GfError> {
-    let cas = CasRoot::open(root)?;
-    read_graph_object_by_digest_from_cas(&cas, digest, max_length)
+    let cas = ReadOnlyCasRoot::open(root)?;
+    read_graph_object_by_digest_from_read_only_cas(&cas, digest, max_length)
+}
+
+fn read_graph_object_by_digest_from_read_only_cas(
+    cas: &ReadOnlyCasRoot,
+    digest: &str,
+    max_length: u64,
+) -> Result<Vec<u8>, GfError> {
+    read_graph_object_by_digest_file(
+        cas.open_digest(digest)?,
+        digest,
+        max_length,
+        &cas.diagnostic_root,
+    )
 }
 
 fn read_graph_object_by_digest_from_cas(
@@ -1663,10 +1776,23 @@ fn read_graph_object_by_digest_from_cas(
     digest: &str,
     max_length: u64,
 ) -> Result<Vec<u8>, GfError> {
-    let mut file = cas.open_digest(digest)?;
+    read_graph_object_by_digest_file(
+        cas.open_digest(digest)?,
+        digest,
+        max_length,
+        &cas.diagnostic_root,
+    )
+}
+
+fn read_graph_object_by_digest_file(
+    mut file: File,
+    digest: &str,
+    max_length: u64,
+    diagnostic_root: &Path,
+) -> Result<Vec<u8>, GfError> {
     let metadata = file
         .metadata()
-        .map_err(|error| storage("inspect stable graph object", &cas.diagnostic_root, error))?;
+        .map_err(|error| storage("inspect stable graph object", diagnostic_root, error))?;
     if !metadata.is_file() || metadata.len() > max_length {
         return Err(validation(
             "graph object exceeds admitted length or is not regular",
@@ -1674,7 +1800,7 @@ fn read_graph_object_by_digest_from_cas(
     }
     let mut bytes = Vec::with_capacity(usize::try_from(metadata.len()).unwrap_or(0));
     file.read_to_end(&mut bytes)
-        .map_err(|error| storage("read stable graph object", &cas.diagnostic_root, error))?;
+        .map_err(|error| storage("read stable graph object", diagnostic_root, error))?;
     if hex_digest(Sha256::digest(&bytes).into()) != digest {
         return Err(validation("graph object digest does not match its address"));
     }
@@ -1882,6 +2008,241 @@ fn storage(action: &str, path: &Path, error: impl std::fmt::Display) -> GfError 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pure_reads_require_only_existing_digest_namespace_and_never_create() {
+        let root = tempfile::tempdir().unwrap();
+        let payload = b"read-only payload";
+        let digest = hex_digest(Sha256::digest(payload).into());
+        let objects = root.path().join(GRAPH_OBJECTS_DIR);
+        let sha256 = objects.join(SHA256_DIR);
+        let bucket = sha256.join(&digest[..2]);
+        fs::create_dir_all(&bucket).unwrap();
+        fs::write(bucket.join(&digest[2..]), payload).unwrap();
+        fs::write(objects.join(LIFECYCLE_LOCK), b"").unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            fs::set_permissions(bucket.join(&digest[2..]), fs::Permissions::from_mode(0o400))
+                .unwrap();
+            fs::set_permissions(
+                objects.join(LIFECYCLE_LOCK),
+                fs::Permissions::from_mode(0o400),
+            )
+            .unwrap();
+            fs::set_permissions(&bucket, fs::Permissions::from_mode(0o500)).unwrap();
+            fs::set_permissions(&sha256, fs::Permissions::from_mode(0o500)).unwrap();
+            fs::set_permissions(&objects, fs::Permissions::from_mode(0o500)).unwrap();
+        }
+
+        let namespace_before = fs::read_dir(&objects)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect::<BTreeSet<_>>();
+        let digest_namespace_before = fs::read_dir(&sha256)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect::<BTreeSet<_>>();
+        let bucket_namespace_before = fs::read_dir(&bucket)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            read_graph_object(root.path(), &digest, payload.len() as u64).unwrap(),
+            payload
+        );
+        verify_graph_object(root.path(), &digest, payload.len() as u64).unwrap();
+        assert_eq!(
+            read_graph_object_by_digest(root.path(), &digest, 1024).unwrap(),
+            payload
+        );
+        let namespace_after = fs::read_dir(&objects)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(namespace_after, namespace_before);
+        assert_eq!(
+            namespace_after,
+            BTreeSet::from([SHA256_DIR.into(), LIFECYCLE_LOCK.into()])
+        );
+        assert_eq!(
+            fs::read_dir(&sha256)
+                .unwrap()
+                .map(|entry| entry.unwrap().file_name())
+                .collect::<BTreeSet<_>>(),
+            digest_namespace_before
+        );
+        assert_eq!(
+            fs::read_dir(&bucket)
+                .unwrap()
+                .map(|entry| entry.unwrap().file_name())
+                .collect::<BTreeSet<_>>(),
+            bucket_namespace_before
+        );
+        assert_eq!(fs::read(bucket.join(&digest[2..])).unwrap(), payload);
+
+        #[cfg(windows)]
+        {
+            let lifecycle = objects.join(LIFECYCLE_LOCK);
+            let object = bucket.join(&digest[2..]);
+            let mut permissions = fs::metadata(&lifecycle).unwrap().permissions();
+            permissions.set_readonly(true);
+            fs::set_permissions(&lifecycle, permissions).unwrap();
+            let mut permissions = fs::metadata(&object).unwrap().permissions();
+            permissions.set_readonly(true);
+            fs::set_permissions(&object, permissions).unwrap();
+            verify_graph_object(root.path(), &digest, payload.len() as u64).unwrap();
+            let mut permissions = fs::metadata(&lifecycle).unwrap().permissions();
+            permissions.set_readonly(false);
+            fs::set_permissions(&lifecycle, permissions).unwrap();
+            let mut permissions = fs::metadata(&object).unwrap().permissions();
+            permissions.set_readonly(false);
+            fs::set_permissions(&object, permissions).unwrap();
+        }
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let target_owner = tempfile::tempdir().unwrap();
+            let inventory = GraphFilesInventory {
+                format: "graphforge-graph-files".into(),
+                format_version: 1,
+                files: vec![crate::GraphFileEntry {
+                    relative_path: "payload.bin".into(),
+                    byte_length: payload.len() as u64,
+                    content_sha256: digest.clone(),
+                    role: crate::GraphFileRole::Other,
+                }],
+                file_count: 1,
+                total_byte_length: payload.len() as u64,
+            };
+            assert!(
+                materialize_graph_objects(
+                    root.path(),
+                    &inventory,
+                    &target_owner.path().join("readonly-target")
+                )
+                .is_err()
+            );
+            assert_eq!(
+                fs::read_dir(&objects)
+                    .unwrap()
+                    .map(|entry| entry.unwrap().file_name())
+                    .collect::<BTreeSet<_>>(),
+                namespace_before
+            );
+            fs::set_permissions(&objects, fs::Permissions::from_mode(0o700)).unwrap();
+            fs::set_permissions(
+                objects.join(LIFECYCLE_LOCK),
+                fs::Permissions::from_mode(0o600),
+            )
+            .unwrap();
+            fs::set_permissions(&sha256, fs::Permissions::from_mode(0o700)).unwrap();
+            fs::set_permissions(&bucket, fs::Permissions::from_mode(0o700)).unwrap();
+            fs::set_permissions(bucket.join(&digest[2..]), fs::Permissions::from_mode(0o600))
+                .unwrap();
+            materialize_graph_objects(
+                root.path(),
+                &inventory,
+                &target_owner.path().join("writable-target"),
+            )
+            .unwrap();
+            assert!(objects.join(TEMP_DIR).is_dir());
+            assert!(objects.join(ACTIVE_DIR).is_dir());
+            assert!(objects.join(LIFECYCLE_LOCK).is_file());
+        }
+
+        let missing = tempfile::tempdir().unwrap();
+        assert!(read_graph_object(missing.path(), &digest, payload.len() as u64).is_err());
+        assert!(!missing.path().join(GRAPH_OBJECTS_DIR).exists());
+    }
+
+    #[test]
+    fn read_only_guard_pins_cas_against_gc() {
+        let root = tempfile::tempdir().unwrap();
+        let lease = begin_graph_object_publication(root.path()).unwrap();
+        drop(lease);
+        let reader = ReadOnlyCasRoot::open(root.path()).unwrap();
+        assert!(matches!(try_begin_graph_object_gc(root.path()), Ok(None)));
+        drop(reader);
+        assert!(matches!(
+            try_begin_graph_object_gc(root.path()),
+            Ok(Some(_))
+        ));
+    }
+
+    #[test]
+    fn read_only_lifecycle_rejects_multiple_links() {
+        let root = tempfile::tempdir().unwrap();
+        let objects = root.path().join(GRAPH_OBJECTS_DIR);
+        fs::create_dir_all(objects.join(SHA256_DIR)).unwrap();
+        let outside = root.path().join("outside");
+        fs::write(&outside, b"").unwrap();
+        fs::hard_link(&outside, objects.join(LIFECYCLE_LOCK)).unwrap();
+        assert!(ReadOnlyCasRoot::open(root.path()).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_only_lifecycle_rejects_links_fifos_and_sockets_without_blocking() {
+        use std::os::unix::fs::symlink;
+        use std::os::unix::net::UnixListener;
+        use std::process::Command;
+
+        let prepare = || {
+            let root = tempfile::tempdir().unwrap();
+            let objects = root.path().join(GRAPH_OBJECTS_DIR);
+            fs::create_dir_all(objects.join(SHA256_DIR)).unwrap();
+            (root, objects)
+        };
+
+        const FIFO_HELPER: &str = "GRAPHFORGE_READ_ONLY_CAS_FIFO_HELPER";
+        if std::env::var_os(FIFO_HELPER).is_some() {
+            let (root, objects) = prepare();
+            assert!(
+                Command::new("mkfifo")
+                    .arg(objects.join(LIFECYCLE_LOCK))
+                    .status()
+                    .unwrap()
+                    .success()
+            );
+            assert!(ReadOnlyCasRoot::open(root.path()).is_err());
+            return;
+        }
+
+        let (root, objects) = prepare();
+        let outside = root.path().join("outside");
+        fs::write(&outside, b"").unwrap();
+        symlink(&outside, objects.join(LIFECYCLE_LOCK)).unwrap();
+        assert!(ReadOnlyCasRoot::open(root.path()).is_err());
+
+        let mut child = Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "graph_object_store::tests::read_only_lifecycle_rejects_links_fifos_and_sockets_without_blocking",
+                "--nocapture",
+            ])
+            .env(FIFO_HELPER, "1")
+            .spawn()
+            .unwrap();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        loop {
+            if let Some(status) = child.try_wait().unwrap() {
+                assert!(status.success());
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                child.kill().unwrap();
+                panic!("read-only lifecycle FIFO open blocked");
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+
+        let (root, objects) = prepare();
+        let _socket = UnixListener::bind(objects.join(LIFECYCLE_LOCK)).unwrap();
+        assert!(ReadOnlyCasRoot::open(root.path()).is_err());
+    }
 
     #[cfg(unix)]
     #[test]

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -162,10 +162,10 @@ pub mod project_retention;
 pub use project_retention::{
     DEFAULT_RETENTION_CLEANUP_BATCH, DEFAULT_RETENTION_MAX_BYTES, DEFAULT_RETENTION_MAX_ENTRIES,
     DEFAULT_RETENTION_MAX_WORK_UNITS, ProjectCleanupDisposition, ProjectCleanupEntry,
-    ProjectCleanupLocation, ProjectCleanupReport, ProjectReachabilityReport,
-    ProjectRetentionLimits, ProjectRetentionPolicy, execute_project_cleanup,
-    execute_project_cleanup_with_mode, inspect_project_reachability,
-    inspect_project_reachability_with_mode, preview_project_cleanup,
+    ProjectCleanupLocation, ProjectCleanupReport, ProjectGraphObjectSweepDisposition,
+    ProjectGraphObjectSweepReport, ProjectReachabilityReport, ProjectRetentionLimits,
+    ProjectRetentionPolicy, execute_project_cleanup, execute_project_cleanup_with_mode,
+    inspect_project_reachability, inspect_project_reachability_with_mode, preview_project_cleanup,
     preview_project_cleanup_with_mode,
 };
 

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -45,8 +45,8 @@ pub(crate) use graph_files::{GraphFilesParticipant, decode_versioned_graph_files
     reason = "private node-v2 construction is consumed by the staged #932 integration"
 )]
 mod graph_manifest;
-#[cfg(test)]
-pub(crate) use graph_manifest::encode_root as encode_graph_files_root_v2;
+#[cfg(any(test, feature = "test-support"))]
+pub use graph_manifest::encode_root as encode_graph_files_root_v2;
 pub(crate) use graph_manifest::{
     GRAPH_FILES_V2_FORMAT, GRAPH_FILES_V2_VERSION, GRAPH_MANIFEST_NODE_FORMAT,
     GRAPH_MANIFEST_NODE_VERSION, GRAPH_RADIX_DEPTH, GraphFilesRootV2, GraphManifestLimits,
@@ -60,14 +60,19 @@ pub(crate) use graph_manifest::{
     reason = "private CAS construction is consumed by the staged #932 integration"
 )]
 mod graph_object_store;
-#[cfg(test)]
-pub(crate) use graph_object_store::{
+pub use graph_object_store::materialize_graph_objects;
+#[cfg(any(test, feature = "test-support"))]
+pub use graph_object_store::{
     GraphManifestState, append_graph_files_v2, install_graph_object_bytes, read_graph_object,
 };
 pub(crate) use graph_object_store::{
-    GraphObjectPublicationLease, begin_graph_object_publication, graph_object_path,
-    graph_object_publication_is_live, read_graph_object_by_digest, verify_graph_object,
+    GraphObjectPublicationLease, graph_object_publication_is_live, read_graph_object_by_digest,
+    verify_graph_object,
 };
+#[cfg(not(any(test, feature = "test-support")))]
+pub(crate) use graph_object_store::{begin_graph_object_publication, graph_object_path};
+#[cfg(any(test, feature = "test-support"))]
+pub use graph_object_store::{begin_graph_object_publication, graph_object_path};
 
 pub mod semantic_bindings;
 pub use semantic_bindings::{

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -39,25 +39,32 @@ pub use graph_files::{
     stage_graph_tree, verify_graph_tree,
 };
 
-pub mod graph_manifest;
-pub use graph_manifest::{
+#[allow(
+    dead_code,
+    reason = "private node-v2 construction is consumed by the staged #932 integration"
+)]
+mod graph_manifest;
+pub(crate) use graph_manifest::{
     GRAPH_FILES_V2_FORMAT, GRAPH_FILES_V2_VERSION, GRAPH_MANIFEST_NODE_FORMAT,
     GRAPH_MANIFEST_NODE_VERSION, GRAPH_RADIX_DEPTH, GraphFilesRootV2, GraphManifestLimits,
     GraphManifestNode, GraphManifestNodeKind, GraphManifestResolveEvidence,
     decode_node as decode_graph_manifest_node, decode_root as decode_graph_files_root_v2,
     encode_node as encode_graph_manifest_node, encode_root as encode_graph_files_root_v2,
-    object_digest as graph_object_digest, resolve_manifest as resolve_graph_manifest,
-    verify_object_bytes as verify_graph_object_bytes,
+    resolve_manifest as resolve_graph_manifest,
 };
 
-pub mod graph_object_store;
-pub use graph_object_store::{
-    GRAPH_OBJECTS_DIR, GraphFilesAppendEvidence, GraphFilesMigrationEvidence, GraphManifestState,
-    GraphObjectGcEvidence, GraphObjectInstallEvidence, GraphObjectPublicationLease,
-    append_graph_files_v2, begin_graph_object_publication, gc_graph_objects, graph_object_path,
-    graph_object_publication_is_live, install_graph_object_bytes, install_graph_object_file,
-    materialize_graph_objects, migrate_graph_files_v1_to_v2, read_graph_object,
-    read_graph_object_by_digest, verify_graph_object,
+#[allow(
+    dead_code,
+    reason = "private CAS construction is consumed by the staged #932 integration"
+)]
+mod graph_object_store;
+#[cfg(test)]
+pub(crate) use graph_object_store::{
+    GraphManifestState, append_graph_files_v2, install_graph_object_bytes, read_graph_object,
+};
+pub(crate) use graph_object_store::{
+    GraphObjectPublicationLease, begin_graph_object_publication, graph_object_path,
+    graph_object_publication_is_live, read_graph_object_by_digest, verify_graph_object,
 };
 
 pub mod semantic_bindings;

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -33,9 +33,10 @@ pub use graph_files::{
     GRAPH_CAPABILITY_ID, GRAPH_CAPABILITY_VERSION, GRAPH_FILES_FAMILY, GRAPH_FILES_RECORD_VERSION,
     GRAPH_FILES_V2_RECORD_VERSION, GRAPH_TREE_DIR, GraphFileEntry, GraphFileRole,
     GraphFilesInventory, GraphFilesOpenEvidence, GraphFilesOpenStrategy, GraphFilesParticipant,
-    capture_graph_files, decode_graph_files_participant, decode_inventory, encode_inventory,
-    graph_files_root_participant, graph_tree_root, inventory_participant, materialize_graph_tree,
-    pinned_open_evidence, stage_graph_tree, verify_graph_tree,
+    capture_graph_files, decode_graph_files_participant, decode_inventory,
+    decode_versioned_graph_files_participant, encode_inventory, graph_files_root_participant,
+    graph_tree_root, inventory_participant, materialize_graph_tree, pinned_open_evidence,
+    stage_graph_tree, verify_graph_tree,
 };
 
 pub mod graph_manifest;
@@ -51,7 +52,7 @@ pub use graph_manifest::{
 
 pub mod graph_object_store;
 pub use graph_object_store::{
-    GRAPH_OBJECTS_DIR, GraphFilesAppendEvidence, GraphFilesMigrationEvidence,
+    GRAPH_OBJECTS_DIR, GraphFilesAppendEvidence, GraphFilesMigrationEvidence, GraphManifestState,
     GraphObjectGcEvidence, GraphObjectInstallEvidence, GraphObjectPublicationLease,
     append_graph_files_v2, begin_graph_object_publication, gc_graph_objects, graph_object_path,
     graph_object_publication_is_live, install_graph_object_bytes, install_graph_object_file,

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -29,28 +29,30 @@ pub use graph_projection::{
 };
 
 pub mod graph_files;
+#[cfg(test)]
+pub(crate) use graph_files::graph_files_root_participant;
 pub use graph_files::{
     GRAPH_CAPABILITY_ID, GRAPH_CAPABILITY_VERSION, GRAPH_FILES_FAMILY, GRAPH_FILES_RECORD_VERSION,
     GRAPH_FILES_V2_RECORD_VERSION, GRAPH_TREE_DIR, GraphFileEntry, GraphFileRole,
-    GraphFilesInventory, GraphFilesOpenEvidence, GraphFilesOpenStrategy, GraphFilesParticipant,
-    capture_graph_files, decode_graph_files_participant, decode_inventory,
-    decode_versioned_graph_files_participant, encode_inventory, graph_files_root_participant,
-    graph_tree_root, inventory_participant, materialize_graph_tree, pinned_open_evidence,
-    stage_graph_tree, verify_graph_tree,
+    GraphFilesInventory, GraphFilesOpenEvidence, GraphFilesOpenStrategy, capture_graph_files,
+    decode_inventory, encode_inventory, graph_tree_root, inventory_participant,
+    materialize_graph_tree, pinned_open_evidence, stage_graph_tree, verify_graph_tree,
 };
+pub(crate) use graph_files::{GraphFilesParticipant, decode_versioned_graph_files_participant};
 
 #[allow(
     dead_code,
     reason = "private node-v2 construction is consumed by the staged #932 integration"
 )]
 mod graph_manifest;
+#[cfg(test)]
+pub(crate) use graph_manifest::encode_root as encode_graph_files_root_v2;
 pub(crate) use graph_manifest::{
     GRAPH_FILES_V2_FORMAT, GRAPH_FILES_V2_VERSION, GRAPH_MANIFEST_NODE_FORMAT,
     GRAPH_MANIFEST_NODE_VERSION, GRAPH_RADIX_DEPTH, GraphFilesRootV2, GraphManifestLimits,
     GraphManifestNode, GraphManifestNodeKind, GraphManifestResolveEvidence,
     decode_node as decode_graph_manifest_node, decode_root as decode_graph_files_root_v2,
-    encode_node as encode_graph_manifest_node, encode_root as encode_graph_files_root_v2,
-    resolve_manifest as resolve_graph_manifest,
+    encode_node as encode_graph_manifest_node, resolve_manifest as resolve_graph_manifest,
 };
 
 #[allow(

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -31,10 +31,32 @@ pub use graph_projection::{
 pub mod graph_files;
 pub use graph_files::{
     GRAPH_CAPABILITY_ID, GRAPH_CAPABILITY_VERSION, GRAPH_FILES_FAMILY, GRAPH_FILES_RECORD_VERSION,
-    GRAPH_TREE_DIR, GraphFileEntry, GraphFileRole, GraphFilesInventory, GraphFilesOpenEvidence,
-    GraphFilesOpenStrategy, capture_graph_files, decode_inventory, encode_inventory,
-    graph_tree_root, inventory_participant, materialize_graph_tree, pinned_open_evidence,
-    stage_graph_tree, verify_graph_tree,
+    GRAPH_FILES_V2_RECORD_VERSION, GRAPH_TREE_DIR, GraphFileEntry, GraphFileRole,
+    GraphFilesInventory, GraphFilesOpenEvidence, GraphFilesOpenStrategy, GraphFilesParticipant,
+    capture_graph_files, decode_graph_files_participant, decode_inventory, encode_inventory,
+    graph_files_root_participant, graph_tree_root, inventory_participant, materialize_graph_tree,
+    pinned_open_evidence, stage_graph_tree, verify_graph_tree,
+};
+
+pub mod graph_manifest;
+pub use graph_manifest::{
+    GRAPH_FILES_V2_FORMAT, GRAPH_FILES_V2_VERSION, GRAPH_MANIFEST_NODE_FORMAT,
+    GRAPH_MANIFEST_NODE_VERSION, GRAPH_RADIX_DEPTH, GraphFilesRootV2, GraphManifestLimits,
+    GraphManifestNode, GraphManifestNodeKind, GraphManifestResolveEvidence,
+    decode_node as decode_graph_manifest_node, decode_root as decode_graph_files_root_v2,
+    encode_node as encode_graph_manifest_node, encode_root as encode_graph_files_root_v2,
+    object_digest as graph_object_digest, resolve_manifest as resolve_graph_manifest,
+    verify_object_bytes as verify_graph_object_bytes,
+};
+
+pub mod graph_object_store;
+pub use graph_object_store::{
+    GRAPH_OBJECTS_DIR, GraphFilesAppendEvidence, GraphFilesMigrationEvidence,
+    GraphObjectGcEvidence, GraphObjectInstallEvidence, GraphObjectPublicationLease,
+    append_graph_files_v2, begin_graph_object_publication, gc_graph_objects, graph_object_path,
+    graph_object_publication_is_live, install_graph_object_bytes, install_graph_object_file,
+    materialize_graph_objects, migrate_graph_files_v1_to_v2, read_graph_object,
+    read_graph_object_by_digest, verify_graph_object,
 };
 
 pub mod semantic_bindings;

--- a/crates/graphforge-storage/src/project_checkpoints.rs
+++ b/crates/graphforge-storage/src/project_checkpoints.rs
@@ -579,6 +579,10 @@ where
     let admission = admit_existing_project(container_root.as_ref(), mode)?;
     let root = canonical_project_root(admission.root())?;
     let transaction_uuid = revert_transaction_uuid(request.operation_uuid);
+    // Global lifecycle order is CAS -> writer -> checkpoint. Retain the
+    // shared CAS publication guard before acquiring either mutation lock;
+    // compact sources need it through CURRENT, while v1 holds it unused.
+    let graph_object_lease = crate::begin_graph_object_publication(&root)?;
     let mut locks = acquire_mutation_locks(&root)?;
     let checkpoint_root = checkpoint_root(&root)?;
     recover_pair(&checkpoint_root)?;
@@ -761,9 +765,6 @@ where
         Some(crate::GraphFilesParticipant::V1(_))
     )
     .then_some(source_graph_tree.as_path());
-    let graph_object_lease = compact_graph_objects
-        .then(|| crate::begin_graph_object_publication(&root))
-        .transpose()?;
     let receipt = match stage_project_generation_with_lock(
         identity,
         root.clone(),
@@ -815,9 +816,10 @@ where
                         Ok(())
                     },
                 )?;
-            match graph_object_lease.as_ref() {
-                Some(lease) => validated.publish_with_graph_objects(lease)?,
-                None => validated.publish()?,
+            if compact_graph_objects {
+                validated.publish_with_graph_objects(&graph_object_lease)?
+            } else {
+                validated.publish()?
             }
         }
     };
@@ -2558,6 +2560,55 @@ mod tests {
         )
         .unwrap();
         assert_eq!(bytes, b"checkpoint");
+
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(3));
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let revert_root = directory.path().to_path_buf();
+        let revert_barrier = barrier.clone();
+        let revert_sender = sender.clone();
+        let revert_thread = std::thread::spawn(move || {
+            revert_barrier.wait();
+            let result = revert_checkpoint(
+                &revert_root,
+                &CheckpointRevertRequest {
+                    operation_uuid: Uuid::from_u128(142),
+                    name: "Compact".into(),
+                    reason: "concurrent compact restore".into(),
+                    actor_uuid: None,
+                },
+                || Ok(1_720_000_000_123_457),
+                |_| Ok(()),
+            );
+            revert_sender.send(("revert", result.map(|_| ()))).unwrap();
+        });
+        let cleanup_root = directory.path().to_path_buf();
+        let cleanup_barrier = barrier.clone();
+        let cleanup_sender = sender.clone();
+        let cleanup_thread = std::thread::spawn(move || {
+            cleanup_barrier.wait();
+            let result = crate::execute_project_cleanup(
+                &cleanup_root,
+                crate::ProjectRetentionPolicy::default(),
+                crate::ProjectRetentionLimits::default(),
+            );
+            cleanup_sender
+                .send(("cleanup", result.map(|_| ())))
+                .unwrap();
+        });
+        barrier.wait();
+        let mut outcomes = BTreeMap::new();
+        for _ in 0..2 {
+            let (operation, result) = receiver
+                .recv_timeout(Duration::from_secs(5))
+                .expect("compact revert/retention lock ordering deadlocked");
+            outcomes.insert(operation, result);
+        }
+        revert_thread.join().unwrap();
+        cleanup_thread.join().unwrap();
+        outcomes.remove("revert").unwrap().unwrap();
+        if let Err(error) = outcomes.remove("cleanup").unwrap() {
+            assert_eq!(error.code(), "GF_WRITER_BUSY");
+        }
     }
 
     #[test]

--- a/crates/graphforge-storage/src/project_checkpoints.rs
+++ b/crates/graphforge-storage/src/project_checkpoints.rs
@@ -1317,7 +1317,7 @@ fn read_regular_bounded(path: &Path, max: u64) -> Result<Vec<u8>, GfError> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::OpenOptionsExt;
-        options.custom_flags(libc::O_NOFOLLOW);
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
     }
     let file = options.open(path).map_err(|_| {
         registry_corrupt("checkpoint registry file could not be opened without following links")

--- a/crates/graphforge-storage/src/project_checkpoints.rs
+++ b/crates/graphforge-storage/src/project_checkpoints.rs
@@ -751,14 +751,19 @@ where
     // the parent's tree (CURRENT) would verify the restored inventory against
     // post-checkpoint mutations and fail closed with length/digest mismatch.
     let source_graph_tree = source.graph_tree_root();
-    let graph_tree = publication
-        .participants
-        .iter()
-        .any(|participant| {
-            participant.capability_id == crate::GRAPH_CAPABILITY_ID
-                && participant.record_family_id == crate::GRAPH_FILES_FAMILY
-        })
-        .then_some(source_graph_tree.as_path());
+    let source_graph_files = source.declared_graph_files_participant()?;
+    let compact_graph_objects = matches!(
+        source_graph_files,
+        Some(crate::GraphFilesParticipant::V2(_))
+    );
+    let graph_tree = matches!(
+        source_graph_files,
+        Some(crate::GraphFilesParticipant::V1(_))
+    )
+    .then_some(source_graph_tree.as_path());
+    let graph_object_lease = compact_graph_objects
+        .then(|| crate::begin_graph_object_publication(&root))
+        .transpose()?;
     let receipt = match stage_project_generation_with_lock(
         identity,
         root.clone(),
@@ -770,7 +775,7 @@ where
     )? {
         ProjectStageOutcome::AlreadyPublished(receipt) => receipt,
         ProjectStageOutcome::Staged(staged) => {
-            staged
+            let validated = staged
                 .validate(
                     |rows| {
                         let actual = rows
@@ -809,8 +814,11 @@ where
                         }
                         Ok(())
                     },
-                )?
-                .publish()?
+                )?;
+            match graph_object_lease.as_ref() {
+                Some(lease) => validated.publish_with_graph_objects(lease)?,
+                None => validated.publish()?,
+            }
         }
     };
     let resolved = resolve_verified_generation(
@@ -2459,6 +2467,97 @@ mod tests {
             "action=revert published-replay conflict return",
             false,
         );
+    }
+
+    #[test]
+    fn compact_graph_checkpoint_revert_reopens_without_a_graph_tree() {
+        let directory = tempdir().unwrap();
+        crate::open_or_initialize_project(directory.path()).unwrap();
+
+        let publish_compact = |payload: &[u8]| {
+            let selected = crate::resolve_project_generation(directory.path()).unwrap();
+            let workspace = tempdir().unwrap();
+            let relative = PathBuf::from("topology/nodes/000001.parquet");
+            fs::create_dir_all(workspace.path().join(relative.parent().unwrap())).unwrap();
+            fs::write(workspace.path().join(&relative), payload).unwrap();
+            let lease = crate::begin_graph_object_publication(directory.path()).unwrap();
+            let mut state = crate::GraphManifestState::empty();
+            let (graph_root, _) = crate::append_graph_files_v2(
+                &lease,
+                workspace.path(),
+                &mut state,
+                &[relative],
+                &[],
+            )
+            .unwrap();
+            let mut participants = selected
+                .participant_snapshots()
+                .unwrap()
+                .into_iter()
+                .filter(|entry| {
+                    !(entry.capability_id == crate::GRAPH_CAPABILITY_ID
+                        && entry.record_family_id == crate::GRAPH_FILES_FAMILY)
+                })
+                .map(snapshot_to_participant)
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap();
+            participants.push(crate::graph_files_root_participant(&graph_root).unwrap());
+            let request = crate::ProjectGenerationRequest {
+                transaction_uuid: Uuid::now_v7(),
+                generation_uuid: Uuid::now_v7(),
+                capabilities: selected
+                    .capabilities()
+                    .into_iter()
+                    .map(|entry| crate::ProjectCapability {
+                        capability_id: entry.capability_id,
+                        capability_version: entry.capability_version,
+                    })
+                    .collect(),
+                participants,
+            };
+            let crate::ProjectStageOutcome::Staged(staged) =
+                crate::stage_project_generation(directory.path(), &request).unwrap()
+            else {
+                panic!("fresh compact publication replayed")
+            };
+            staged
+                .validate(|_| Ok(()), |_, _| Ok(()))
+                .unwrap()
+                .publish_with_graph_objects(&lease)
+                .unwrap();
+            request.generation_uuid
+        };
+
+        let checkpoint_generation = publish_compact(b"checkpoint");
+        create_checkpoint(
+            directory.path(),
+            &create_request(Uuid::from_u128(140), "Compact"),
+        )
+        .unwrap();
+        let newer_generation = publish_compact(b"newer");
+        assert_ne!(checkpoint_generation, newer_generation);
+        let (_, restored) = revert_checkpoint(
+            directory.path(),
+            &CheckpointRevertRequest {
+                operation_uuid: Uuid::from_u128(141),
+                name: "Compact".into(),
+                reason: "restore compact root".into(),
+                actor_uuid: None,
+            },
+            || Ok(1_720_000_000_123_456),
+            |_| Ok(()),
+        )
+        .unwrap();
+        assert!(!restored.graph_tree_root().exists());
+        let inventory = restored.graph_files_inventory().unwrap().unwrap();
+        assert_eq!(inventory.files.len(), 1);
+        let bytes = crate::read_graph_object(
+            directory.path(),
+            &inventory.files[0].content_sha256,
+            inventory.files[0].byte_length,
+        )
+        .unwrap();
+        assert_eq!(bytes, b"checkpoint");
     }
 
     #[test]

--- a/crates/graphforge-storage/src/project_generation.rs
+++ b/crates/graphforge-storage/src/project_generation.rs
@@ -148,22 +148,86 @@ impl ResolvedProjectGeneration {
     /// Returns structured validation/corruption errors for unsupported
     /// contracts or inventory/tree mismatch.
     pub fn graph_files_inventory(&self) -> Result<Option<crate::GraphFilesInventory>, GfError> {
+        let Some(participant) = self.declared_graph_files_participant()? else {
+            return Ok(None);
+        };
+        match participant {
+            crate::GraphFilesParticipant::V1(inventory) => {
+                crate::verify_graph_tree(&self.graph_tree_root(), &inventory)?;
+                Ok(Some(inventory))
+            }
+            crate::GraphFilesParticipant::V2(root) => {
+                const MAX_SEGMENT_BYTES: u64 = 64 * 1024 * 1024;
+                let (files, _) = crate::resolve_graph_manifest(
+                    &root,
+                    crate::GraphManifestLimits::default(),
+                    |digest| {
+                        crate::read_graph_object_by_digest(
+                            self.container_root(),
+                            digest,
+                            MAX_SEGMENT_BYTES,
+                        )
+                    },
+                )?;
+                for entry in &files {
+                    let path =
+                        crate::graph_object_path(self.container_root(), &entry.content_sha256)?;
+                    let metadata = std::fs::symlink_metadata(&path).map_err(|error| {
+                        GfError::Storage(format!(
+                            "inspect graph payload object at {}: {error}",
+                            path.display()
+                        ))
+                    })?;
+                    if !metadata.is_file() || metadata.len() != entry.byte_length {
+                        return Err(GfError::Validation(
+                            "graph payload object length does not match manifest".into(),
+                        ));
+                    }
+                    crate::verify_graph_object(
+                        self.container_root(),
+                        &entry.content_sha256,
+                        entry.byte_length,
+                    )?;
+                }
+                crate::graph_files::inventory_from_entries(files).map(Some)
+            }
+        }
+    }
+
+    /// Decode the manifest-authenticated graph inventory without rereading
+    /// graph payload bytes. Publication uses this only to reuse digests for
+    /// immutable files proven to retain the same filesystem identity.
+    pub fn declared_graph_files_inventory(
+        &self,
+    ) -> Result<Option<crate::GraphFilesInventory>, GfError> {
+        match self.declared_graph_files_participant()? {
+            Some(crate::GraphFilesParticipant::V1(inventory)) => Ok(Some(inventory)),
+            Some(crate::GraphFilesParticipant::V2(_)) | None => Ok(None),
+        }
+    }
+
+    /// Decode the explicitly versioned graph-files participant without
+    /// resolving payload objects.
+    pub fn declared_graph_files_participant(
+        &self,
+    ) -> Result<Option<crate::GraphFilesParticipant>, GfError> {
         let Some(snapshot) =
             self.participant_snapshot(crate::GRAPH_CAPABILITY_ID, crate::GRAPH_FILES_FAMILY)?
         else {
             return Ok(None);
         };
         if snapshot.capability_version != crate::GRAPH_CAPABILITY_VERSION
-            || snapshot.record_version != crate::GRAPH_FILES_RECORD_VERSION
+            || !matches!(
+                snapshot.record_version,
+                crate::GRAPH_FILES_RECORD_VERSION | crate::GRAPH_FILES_V2_RECORD_VERSION
+            )
             || snapshot.encoding != "json"
         {
             return Err(GfError::Validation(
                 "unsupported graph files participant contract".into(),
             ));
         }
-        let inventory = crate::decode_inventory(&snapshot.bytes)?;
-        crate::verify_graph_tree(&self.graph_tree_root(), &inventory)?;
-        Ok(Some(inventory))
+        crate::decode_graph_files_participant(&snapshot.bytes).map(Some)
     }
 
     /// SHA-256 over the exact selected `manifest.json` bytes.

--- a/crates/graphforge-storage/src/project_generation.rs
+++ b/crates/graphforge-storage/src/project_generation.rs
@@ -227,7 +227,8 @@ impl ResolvedProjectGeneration {
                 "unsupported graph files participant contract".into(),
             ));
         }
-        crate::decode_graph_files_participant(&snapshot.bytes).map(Some)
+        crate::decode_versioned_graph_files_participant(snapshot.record_version, &snapshot.bytes)
+            .map(Some)
     }
 
     /// SHA-256 over the exact selected `manifest.json` bytes.

--- a/crates/graphforge-storage/src/project_generation.rs
+++ b/crates/graphforge-storage/src/project_generation.rs
@@ -208,7 +208,7 @@ impl ResolvedProjectGeneration {
 
     /// Decode the explicitly versioned graph-files participant without
     /// resolving payload objects.
-    pub fn declared_graph_files_participant(
+    pub(crate) fn declared_graph_files_participant(
         &self,
     ) -> Result<Option<crate::GraphFilesParticipant>, GfError> {
         let Some(snapshot) =

--- a/crates/graphforge-storage/src/project_portable.rs
+++ b/crates/graphforge-storage/src/project_portable.rs
@@ -752,7 +752,7 @@ pub(crate) fn open_regular_nofollow(path: &Path) -> std::io::Result<std::fs::Fil
 
     std::fs::OpenOptions::new()
         .read(true)
-        .custom_flags(libc::O_NOFOLLOW)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
         .open(path)
 }
 

--- a/crates/graphforge-storage/src/project_portable_v2_export.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_export.rs
@@ -1801,7 +1801,10 @@ pub(crate) fn open_source_no_follow(path: &Path) -> Result<File, ExportError> {
     let descriptor = rustix::fs::openat(
         &directory,
         *last,
-        rustix::fs::OFlags::RDONLY | rustix::fs::OFlags::NOFOLLOW | rustix::fs::OFlags::CLOEXEC,
+        rustix::fs::OFlags::RDONLY
+            | rustix::fs::OFlags::NOFOLLOW
+            | rustix::fs::OFlags::NONBLOCK
+            | rustix::fs::OFlags::CLOEXEC,
         rustix::fs::Mode::empty(),
     )
     .map_err(storage)?;

--- a/crates/graphforge-storage/src/project_publication.rs
+++ b/crates/graphforge-storage/src/project_publication.rs
@@ -31,6 +31,7 @@ const PARTICIPANTS_DIR: &str = "participants";
 const LEASE_FILE: &str = "lease.lock";
 const MANIFEST_FILE: &str = "manifest.json";
 const MAX_JOURNAL_BYTES: u64 = 1024 * 1024;
+const MAX_GRAPH_MANIFEST_SEGMENT_BYTES: u64 = 64 * 1024 * 1024;
 
 /// Persisted participant encoding.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -1021,7 +1022,10 @@ fn stage_optional_graph_tree(
         return Ok(());
     };
     if files_participant.capability_version != crate::GRAPH_CAPABILITY_VERSION
-        || files_participant.record_version != crate::GRAPH_FILES_RECORD_VERSION
+        || !matches!(
+            files_participant.record_version,
+            crate::GRAPH_FILES_RECORD_VERSION | crate::GRAPH_FILES_V2_RECORD_VERSION
+        )
         || files_participant.encoding != ProjectParticipantEncoding::Json.extension()
     {
         return Err(project_error(
@@ -1032,8 +1036,23 @@ fn stage_optional_graph_tree(
     let inventory_path = generation_root
         .join(PARTICIPANTS_DIR)
         .join(&files_participant.relative_path);
-    let inventory =
-        crate::decode_inventory(&std::fs::read(inventory_path).map_err(publication_io)?)?;
+    let participant = crate::decode_graph_files_participant(
+        &std::fs::read(inventory_path).map_err(publication_io)?,
+    )?;
+    let inventory = match participant {
+        crate::GraphFilesParticipant::V1(inventory) => inventory,
+        crate::GraphFilesParticipant::V2(root) => {
+            if graph_tree.is_some() {
+                return Err(project_error(
+                    ProjectErrorCode::PublicationFailed,
+                    "graph/files v2 root must reference project objects, not a generation graph tree",
+                ));
+            }
+            verify_compact_graph_root(parent.container_root(), &root)?;
+            sync_directory(generation_root)?;
+            return Ok(());
+        }
+    };
     let parent_tree = parent.graph_tree_root();
     let source = match graph_tree {
         Some(path) => path,
@@ -1056,6 +1075,7 @@ fn stage_optional_graph_tree(
 fn verify_optional_graph_tree(
     generation_root: &Path,
     participants: &[StagedParticipant],
+    container_root: &Path,
 ) -> Result<(), GfError> {
     let Some(files) = participants.iter().find(|participant| {
         participant.capability_id == crate::GRAPH_CAPABILITY_ID
@@ -1067,8 +1087,30 @@ fn verify_optional_graph_tree(
         .join(PARTICIPANTS_DIR)
         .join(&files.relative_path);
     let bytes = std::fs::read(&path).map_err(publication_io)?;
-    let inventory = crate::decode_inventory(&bytes)?;
-    crate::verify_graph_tree(&crate::graph_tree_root(generation_root), &inventory)
+    match crate::decode_graph_files_participant(&bytes)? {
+        crate::GraphFilesParticipant::V1(inventory) => {
+            crate::verify_graph_tree(&crate::graph_tree_root(generation_root), &inventory)
+        }
+        crate::GraphFilesParticipant::V2(root) => verify_compact_graph_root(container_root, &root),
+    }
+}
+
+fn verify_compact_graph_root(
+    container_root: &Path,
+    root: &crate::GraphFilesRootV2,
+) -> Result<(), GfError> {
+    let (files, _) =
+        crate::resolve_graph_manifest(root, crate::GraphManifestLimits::default(), |digest| {
+            crate::read_graph_object_by_digest(
+                container_root,
+                digest,
+                MAX_GRAPH_MANIFEST_SEGMENT_BYTES,
+            )
+        })?;
+    for entry in files {
+        crate::verify_graph_object(container_root, &entry.content_sha256, entry.byte_length)?;
+    }
+    Ok(())
 }
 
 fn stage_participant_files(
@@ -1185,7 +1227,11 @@ impl StagedProjectGeneration {
                 participant,
             )?;
         }
-        verify_optional_graph_tree(&self.generation_root, &self.participants)?;
+        verify_optional_graph_tree(
+            &self.generation_root,
+            &self.participants,
+            self.parent.container_root(),
+        )?;
         domain_validation(&self.participants)?;
         project_failpoint::hit(
             "project.after_domain_validation",
@@ -1408,7 +1454,11 @@ fn make_generation_durable(staged: &StagedProjectGeneration) -> Result<[u8; 32],
             participant,
         )?;
     }
-    verify_optional_graph_tree(&staged.generation_root, &staged.participants)?;
+    verify_optional_graph_tree(
+        &staged.generation_root,
+        &staged.participants,
+        staged.parent.container_root(),
+    )?;
     verify_exact_file(&manifest_path, &manifest_bytes)?;
     sync_participant_directories(
         &staged.generation_root.join(PARTICIPANTS_DIR),
@@ -2601,6 +2651,61 @@ mod tests {
             .unwrap()
             .publish()
             .unwrap()
+    }
+
+    #[test]
+    fn publishes_and_reopens_compact_graph_files_v2_root() {
+        let root = project();
+        let workspace = tempfile::tempdir().unwrap();
+        let relative = std::path::PathBuf::from("topology/edges/knows.parquet");
+        fs::create_dir_all(workspace.path().join(relative.parent().unwrap())).unwrap();
+        fs::write(
+            workspace.path().join(&relative),
+            b"immutable topology payload",
+        )
+        .unwrap();
+        let mut live = std::collections::BTreeMap::new();
+        let (files_root, _) = crate::append_graph_files_v2(
+            root.path(),
+            workspace.path(),
+            None,
+            &mut live,
+            &[relative],
+            &[],
+        )
+        .unwrap();
+        let request = request(vec![
+            crate::graph_files_root_participant(&files_root).unwrap(),
+        ]);
+        publish(root.path(), request);
+
+        let reopened = resolve_project_generation(root.path()).unwrap();
+        let inventory = reopened.graph_files_inventory().unwrap().unwrap();
+        assert_eq!(inventory.files, live.into_values().collect::<Vec<_>>());
+        assert!(!reopened.graph_tree_root().exists());
+    }
+
+    #[test]
+    fn corrupt_compact_root_never_advances_current() {
+        let root = project();
+        let prior = resolve_project_generation(root.path())
+            .unwrap()
+            .generation_uuid();
+        let compact = crate::GraphFilesRootV2 {
+            format: crate::GRAPH_FILES_V2_FORMAT.into(),
+            format_version: crate::GRAPH_FILES_V2_VERSION,
+            root_node_sha256: "0".repeat(64),
+            logical_file_count: 1,
+            logical_byte_length: 1,
+        };
+        let request = request(vec![crate::graph_files_root_participant(&compact).unwrap()]);
+        assert!(stage_project_generation(root.path(), &request).is_err());
+        assert_eq!(
+            resolve_project_generation(root.path())
+                .unwrap()
+                .generation_uuid(),
+            prior
+        );
     }
 
     fn journal_path(root: &Path, transaction_uuid: Uuid) -> PathBuf {

--- a/crates/graphforge-storage/src/project_publication.rs
+++ b/crates/graphforge-storage/src/project_publication.rs
@@ -1036,7 +1036,8 @@ fn stage_optional_graph_tree(
     let inventory_path = generation_root
         .join(PARTICIPANTS_DIR)
         .join(&files_participant.relative_path);
-    let participant = crate::decode_graph_files_participant(
+    let participant = crate::decode_versioned_graph_files_participant(
+        files_participant.record_version,
         &std::fs::read(inventory_path).map_err(publication_io)?,
     )?;
     let inventory = match participant {
@@ -1087,7 +1088,7 @@ fn verify_optional_graph_tree(
         .join(PARTICIPANTS_DIR)
         .join(&files.relative_path);
     let bytes = std::fs::read(&path).map_err(publication_io)?;
-    match crate::decode_graph_files_participant(&bytes)? {
+    match crate::decode_versioned_graph_files_participant(files.record_version, &bytes)? {
         crate::GraphFilesParticipant::V1(inventory) => {
             crate::verify_graph_tree(&crate::graph_tree_root(generation_root), &inventory)
         }
@@ -1110,7 +1111,7 @@ fn verify_optional_graph_tree_with_lease(
         .join(PARTICIPANTS_DIR)
         .join(&files.relative_path);
     let bytes = std::fs::read(&path).map_err(publication_io)?;
-    match crate::decode_graph_files_participant(&bytes)? {
+    match crate::decode_versioned_graph_files_participant(files.record_version, &bytes)? {
         crate::GraphFilesParticipant::V1(inventory) => {
             crate::verify_graph_tree(&crate::graph_tree_root(generation_root), &inventory)
         }
@@ -1482,7 +1483,7 @@ fn has_compact_graph_participant(staged: &StagedProjectGeneration) -> Result<boo
         .join(&files.relative_path);
     let bytes = std::fs::read(&path).map_err(publication_io)?;
     if matches!(
-        crate::decode_graph_files_participant(&bytes)?,
+        crate::decode_versioned_graph_files_participant(files.record_version, &bytes)?,
         crate::GraphFilesParticipant::V2(_)
     ) {
         Ok(true)
@@ -2837,17 +2838,11 @@ mod tests {
             b"immutable topology payload",
         )
         .unwrap();
-        let mut live = std::collections::BTreeMap::new();
+        let mut state = crate::GraphManifestState::empty();
         let lease = crate::begin_graph_object_publication(root.path()).unwrap();
-        let (files_root, _) = crate::append_graph_files_v2(
-            &lease,
-            workspace.path(),
-            None,
-            &mut live,
-            &[relative],
-            &[],
-        )
-        .unwrap();
+        let (files_root, _) =
+            crate::append_graph_files_v2(&lease, workspace.path(), &mut state, &[relative], &[])
+                .unwrap();
         let request = request(vec![
             crate::graph_files_root_participant(&files_root).unwrap(),
         ]);
@@ -2865,7 +2860,10 @@ mod tests {
 
         let reopened = resolve_project_generation(root.path()).unwrap();
         let inventory = reopened.graph_files_inventory().unwrap().unwrap();
-        assert_eq!(inventory.files, live.into_values().collect::<Vec<_>>());
+        assert_eq!(
+            inventory.files,
+            state.entries().cloned().collect::<Vec<_>>()
+        );
         assert!(!reopened.graph_tree_root().exists());
     }
 

--- a/crates/graphforge-storage/src/project_publication.rs
+++ b/crates/graphforge-storage/src/project_publication.rs
@@ -2466,7 +2466,7 @@ fn publish_atomic_bytes_in(
         let _namespace_guard = namespace_lock
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        directory.replace_child(&temp_name, target_name)?;
+        directory.replace_child(&temp_name, temp_identity, target_name)?;
         crate::file_lock::unlock(&temp)?;
         Ok(())
     };

--- a/crates/graphforge-storage/src/project_publication.rs
+++ b/crates/graphforge-storage/src/project_publication.rs
@@ -1095,6 +1095,31 @@ fn verify_optional_graph_tree(
     }
 }
 
+fn verify_optional_graph_tree_with_lease(
+    generation_root: &Path,
+    participants: &[StagedParticipant],
+    lease: &crate::GraphObjectPublicationLease,
+) -> Result<(), GfError> {
+    let Some(files) = participants.iter().find(|participant| {
+        participant.capability_id == crate::GRAPH_CAPABILITY_ID
+            && participant.record_family_id == crate::GRAPH_FILES_FAMILY
+    }) else {
+        return Ok(());
+    };
+    let path = generation_root
+        .join(PARTICIPANTS_DIR)
+        .join(&files.relative_path);
+    let bytes = std::fs::read(&path).map_err(publication_io)?;
+    match crate::decode_graph_files_participant(&bytes)? {
+        crate::GraphFilesParticipant::V1(inventory) => {
+            crate::verify_graph_tree(&crate::graph_tree_root(generation_root), &inventory)
+        }
+        crate::GraphFilesParticipant::V2(root) => {
+            verify_compact_graph_root_with_lease(lease, &root)
+        }
+    }
+}
+
 fn verify_compact_graph_root(
     container_root: &Path,
     root: &crate::GraphFilesRootV2,
@@ -1109,6 +1134,28 @@ fn verify_compact_graph_root(
         })?;
     for entry in files {
         crate::verify_graph_object(container_root, &entry.content_sha256, entry.byte_length)?;
+    }
+    Ok(())
+}
+
+fn verify_compact_graph_root_with_lease(
+    lease: &crate::GraphObjectPublicationLease,
+    root: &crate::GraphFilesRootV2,
+) -> Result<(), GfError> {
+    let (files, _) =
+        crate::resolve_graph_manifest(root, crate::GraphManifestLimits::default(), |digest| {
+            crate::graph_object_store::read_graph_object_by_digest_with_lease(
+                lease,
+                digest,
+                MAX_GRAPH_MANIFEST_SEGMENT_BYTES,
+            )
+        })?;
+    for entry in files {
+        crate::graph_object_store::verify_graph_object_with_lease(
+            lease,
+            &entry.content_sha256,
+            entry.byte_length,
+        )?;
     }
     Ok(())
 }
@@ -1396,14 +1443,14 @@ impl ValidatedProjectGeneration {
         }
         let manifest_sha256 = make_generation_durable(staged)?;
         if let Some(lease) = graph_object_lease {
-            verify_optional_graph_tree(
+            verify_optional_graph_tree_with_lease(
                 &staged.generation_root,
                 &staged.participants,
-                staged.parent.container_root(),
+                lease,
             )?;
             lease.revalidate_for_root(staged.parent.container_root())?;
         }
-        replace_current(staged, manifest_sha256)?;
+        replace_current(staged, manifest_sha256, graph_object_lease)?;
         finish_published_generation(staged, manifest_sha256)?;
         Ok(ProjectPublicationReceipt {
             transaction_uuid: staged.transaction_uuid,
@@ -1584,6 +1631,7 @@ fn promote_optimistic_generation(staged: &StagedProjectGeneration) -> Result<(),
 fn replace_current(
     staged: &StagedProjectGeneration,
     manifest_sha256: [u8; 32],
+    graph_object_lease: Option<&crate::GraphObjectPublicationLease>,
 ) -> Result<(), GfError> {
     let current = CurrentRecord {
         format: "graphforge-project".into(),
@@ -1593,8 +1641,12 @@ fn replace_current(
     };
     let current_bytes = canonical_line(&current)?;
     let current_path = staged.root.join(CURRENT_FILE);
-    let replace_result = publish_atomic_bytes(
+    let stable_root =
+        graphforge_filesystem::StableDirectory::open(&staged.root).map_err(publication_io)?;
+    let replace_result = publish_atomic_bytes_in(
+        &stable_root,
         &current_path,
+        std::ffi::OsStr::new(CURRENT_FILE),
         &current_bytes,
         || {
             failpoint_as_io(
@@ -1621,7 +1673,17 @@ fn replace_current(
                 staged.generation_uuid,
                 "CURRENT",
                 false,
-            )
+            )?;
+            staged
+                .admission
+                .revalidate_identity()
+                .map_err(std::io::Error::other)?;
+            if let Some(lease) = graph_object_lease {
+                lease
+                    .revalidate_for_root(staged.parent.container_root())
+                    .map_err(std::io::Error::other)?;
+            }
+            Ok(())
         },
     );
     if let Err(error) = replace_result {
@@ -2359,6 +2421,43 @@ pub(crate) fn publish_atomic_bytes(
     let result = publish();
     if result.is_err() {
         let _ = std::fs::remove_file(&temp_path);
+    }
+    result
+}
+
+fn publish_atomic_bytes_in(
+    directory: &graphforge_filesystem::StableDirectory,
+    diagnostic_path: &Path,
+    target_name: &std::ffi::OsStr,
+    bytes: &[u8],
+    after_write: impl FnOnce() -> std::io::Result<()>,
+    after_sync: impl FnOnce() -> std::io::Result<()>,
+    before_replace: impl FnOnce() -> std::io::Result<()>,
+) -> Result<(), AtomicPublishError> {
+    let target_text = target_name
+        .to_str()
+        .ok_or_else(|| std::io::Error::other("atomic publication target is not UTF-8"))?;
+    let temp_name = std::ffi::OsString::from(unique_atomic_temp_name(target_text));
+    let mut temp = directory.create_child_file(&temp_name)?;
+    let temp_identity = graphforge_filesystem::file_identity(&temp)?;
+    let publish = || -> Result<(), AtomicPublishError> {
+        crate::file_lock::lock_exclusive(&temp)?;
+        temp.write_all(bytes)?;
+        after_write()?;
+        temp.sync_all()?;
+        after_sync()?;
+        before_replace()?;
+        let namespace_lock = lock_atomic_publish_target(diagnostic_path);
+        let _namespace_guard = namespace_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        directory.replace_child(&temp_name, target_name)?;
+        crate::file_lock::unlock(&temp)?;
+        Ok(())
+    };
+    let result = publish();
+    if result.is_err() {
+        let _ = directory.unlink_child_if_identity(&temp_name, temp_identity);
     }
     result
 }

--- a/crates/graphforge-storage/src/project_publication.rs
+++ b/crates/graphforge-storage/src/project_publication.rs
@@ -1073,10 +1073,9 @@ fn stage_optional_graph_tree(
     Ok(())
 }
 
-fn verify_optional_graph_tree(
+fn verify_optional_generation_graph_tree(
     generation_root: &Path,
     participants: &[StagedParticipant],
-    container_root: &Path,
 ) -> Result<(), GfError> {
     let Some(files) = participants.iter().find(|participant| {
         participant.capability_id == crate::GRAPH_CAPABILITY_ID
@@ -1092,7 +1091,11 @@ fn verify_optional_graph_tree(
         crate::GraphFilesParticipant::V1(inventory) => {
             crate::verify_graph_tree(&crate::graph_tree_root(generation_root), &inventory)
         }
-        crate::GraphFilesParticipant::V2(root) => verify_compact_graph_root(container_root, &root),
+        // Compact payloads live outside this generation. Staging verifies the
+        // complete named root once, and publication repeats that verification
+        // while holding the CAS lease immediately before CURRENT. Intermediate
+        // generation validation must not re-read every immutable payload byte.
+        crate::GraphFilesParticipant::V2(_) => Ok(()),
     }
 }
 
@@ -1275,11 +1278,7 @@ impl StagedProjectGeneration {
                 participant,
             )?;
         }
-        verify_optional_graph_tree(
-            &self.generation_root,
-            &self.participants,
-            self.parent.container_root(),
-        )?;
+        verify_optional_generation_graph_tree(&self.generation_root, &self.participants)?;
         domain_validation(&self.participants)?;
         project_failpoint::hit(
             "project.after_domain_validation",
@@ -1569,11 +1568,7 @@ fn make_generation_durable(staged: &StagedProjectGeneration) -> Result<[u8; 32],
             participant,
         )?;
     }
-    verify_optional_graph_tree(
-        &staged.generation_root,
-        &staged.participants,
-        staged.parent.container_root(),
-    )?;
+    verify_optional_generation_graph_tree(&staged.generation_root, &staged.participants)?;
     verify_exact_file(&manifest_path, &manifest_bytes)?;
     sync_participant_directories(
         &staged.generation_root.join(PARTICIPANTS_DIR),
@@ -2888,6 +2883,112 @@ mod tests {
                 .generation_uuid(),
             prior
         );
+    }
+
+    #[test]
+    fn compact_payload_is_reverified_only_at_the_lease_backed_commit_boundary() {
+        let root = project();
+        let parent = resolve_project_generation(root.path())
+            .unwrap()
+            .generation_uuid();
+        let workspace = tempfile::tempdir().unwrap();
+        let relative = std::path::PathBuf::from("topology/edges/knows.parquet");
+        fs::create_dir_all(workspace.path().join(relative.parent().unwrap())).unwrap();
+        fs::write(
+            workspace.path().join(&relative),
+            b"immutable topology payload",
+        )
+        .unwrap();
+        let mut state = crate::GraphManifestState::empty();
+        let lease = crate::begin_graph_object_publication(root.path()).unwrap();
+        let (files_root, _) =
+            crate::append_graph_files_v2(&lease, workspace.path(), &mut state, &[relative], &[])
+                .unwrap();
+        let payload_digest = state
+            .entries()
+            .next()
+            .expect("one compact payload")
+            .content_sha256
+            .clone();
+        let request = request(vec![
+            crate::graph_files_root_participant(&files_root).unwrap(),
+        ]);
+        let ProjectStageOutcome::Staged(staged) =
+            stage_project_generation(root.path(), &request).unwrap()
+        else {
+            panic!("new request unexpectedly replayed");
+        };
+
+        fs::write(
+            crate::graph_object_path(root.path(), &payload_digest).unwrap(),
+            b"corrupt",
+        )
+        .unwrap();
+        let validated = staged
+            .validate(|_| Ok(()), |_, _| Ok(()))
+            .expect("intermediate validation must not rehash compact payloads");
+        let error = validated
+            .publish_with_graph_objects(&lease)
+            .expect_err("final lease-backed verification must reject corruption");
+        assert_eq!(error.code(), "GF_PUBLICATION_FAILED");
+        assert_eq!(
+            resolve_project_generation(root.path())
+                .unwrap()
+                .generation_uuid(),
+            parent
+        );
+        assert!(
+            root.path()
+                .join(GENERATIONS_DIR)
+                .join(request.generation_uuid.hyphenated().to_string())
+                .exists()
+        );
+
+        drop(lease);
+        let report = crate::recover_project_transactions(root.path()).unwrap();
+        assert_eq!(report.aborted_journals, 1);
+        assert_eq!(report.removed_generations, 1);
+        assert!(
+            !root
+                .path()
+                .join(GENERATIONS_DIR)
+                .join(request.generation_uuid.hyphenated().to_string())
+                .exists()
+        );
+        assert_eq!(
+            resolve_project_generation(root.path())
+                .unwrap()
+                .generation_uuid(),
+            parent
+        );
+    }
+
+    #[test]
+    fn expanded_graph_tree_corruption_still_fails_intermediate_validation() {
+        let root = project();
+        let workspace = tempfile::tempdir().unwrap();
+        let relative = std::path::PathBuf::from("topology/edges/knows.parquet");
+        fs::create_dir_all(workspace.path().join(relative.parent().unwrap())).unwrap();
+        fs::write(workspace.path().join(&relative), b"expanded graph payload").unwrap();
+        let (_, files) = crate::capture_graph_files(workspace.path()).unwrap();
+        let request = request(vec![files]);
+        let ProjectStageOutcome::Staged(staged) =
+            stage_project_generation_with_graph_tree(root.path(), &request, Some(workspace.path()))
+                .unwrap()
+        else {
+            panic!("new request unexpectedly replayed");
+        };
+        fs::write(
+            crate::graph_tree_root(&staged.generation_root).join(relative),
+            b"corrupt",
+        )
+        .unwrap();
+
+        let error = match staged.validate(|_| Ok(()), |_, _| Ok(())) {
+            Ok(_) => panic!("expanded generation tree must remain verified"),
+            Err(error) => error,
+        };
+        assert_eq!(error.code(), "GF_PROJECT_CORRUPT");
     }
 
     fn journal_path(root: &Path, transaction_uuid: Uuid) -> PathBuf {

--- a/crates/graphforge-storage/src/project_publication.rs
+++ b/crates/graphforge-storage/src/project_publication.rs
@@ -1307,6 +1307,22 @@ impl ValidatedProjectGeneration {
     /// Returns a stable publication error whose diagnostic states whether the
     /// commit point was crossed.
     pub fn publish(mut self) -> Result<ProjectPublicationReceipt, GfError> {
+        self.publish_with_optional_graph_objects(None)
+    }
+
+    /// Publish a compact graph generation while holding its CAS lease through
+    /// the final closure and named-root validation immediately before CURRENT.
+    pub fn publish_with_graph_objects(
+        mut self,
+        lease: &crate::GraphObjectPublicationLease,
+    ) -> Result<ProjectPublicationReceipt, GfError> {
+        self.publish_with_optional_graph_objects(Some(lease))
+    }
+
+    fn publish_with_optional_graph_objects(
+        &mut self,
+        graph_object_lease: Option<&crate::GraphObjectPublicationLease>,
+    ) -> Result<ProjectPublicationReceipt, GfError> {
         self.0.admission.revalidate_identity()?;
         let lifecycle_admission = self.0.admission.readmit_for_publish()?;
         let commit_lock = self.prepare_commit_lock()?;
@@ -1315,7 +1331,7 @@ impl ValidatedProjectGeneration {
         } else {
             self.0.admission.revalidate_identity()?;
         }
-        let result = self.publish_inner().map_err(|error| {
+        let result = self.publish_inner(graph_object_lease).map_err(|error| {
             if matches!(error, GfError::Project { .. }) {
                 error
             } else {
@@ -1363,9 +1379,30 @@ impl ValidatedProjectGeneration {
         Ok(Some(writer_lock))
     }
 
-    fn publish_inner(&self) -> Result<ProjectPublicationReceipt, GfError> {
+    fn publish_inner(
+        &self,
+        graph_object_lease: Option<&crate::GraphObjectPublicationLease>,
+    ) -> Result<ProjectPublicationReceipt, GfError> {
         let staged = &self.0;
+        let compact_graph = has_compact_graph_participant(staged)?;
+        if compact_graph && graph_object_lease.is_none() {
+            return Err(project_error(
+                ProjectErrorCode::PublicationFailed,
+                "compact graph publication requires its graph object lease through CURRENT",
+            ));
+        }
+        if let Some(lease) = graph_object_lease {
+            lease.revalidate_for_root(staged.parent.container_root())?;
+        }
         let manifest_sha256 = make_generation_durable(staged)?;
+        if let Some(lease) = graph_object_lease {
+            verify_optional_graph_tree(
+                &staged.generation_root,
+                &staged.participants,
+                staged.parent.container_root(),
+            )?;
+            lease.revalidate_for_root(staged.parent.container_root())?;
+        }
         replace_current(staged, manifest_sha256)?;
         finish_published_generation(staged, manifest_sha256)?;
         Ok(ProjectPublicationReceipt {
@@ -1374,6 +1411,28 @@ impl ValidatedProjectGeneration {
             generation_manifest_sha256: manifest_sha256,
             idempotent_replay: false,
         })
+    }
+}
+
+fn has_compact_graph_participant(staged: &StagedProjectGeneration) -> Result<bool, GfError> {
+    let Some(files) = staged.participants.iter().find(|participant| {
+        participant.capability_id == crate::GRAPH_CAPABILITY_ID
+            && participant.record_family_id == crate::GRAPH_FILES_FAMILY
+    }) else {
+        return Ok(false);
+    };
+    let path = staged
+        .generation_root
+        .join(PARTICIPANTS_DIR)
+        .join(&files.relative_path);
+    let bytes = std::fs::read(&path).map_err(publication_io)?;
+    if matches!(
+        crate::decode_graph_files_participant(&bytes)?,
+        crate::GraphFilesParticipant::V2(_)
+    ) {
+        Ok(true)
+    } else {
+        Ok(false)
     }
 }
 
@@ -2678,7 +2737,16 @@ mod tests {
         let request = request(vec![
             crate::graph_files_root_participant(&files_root).unwrap(),
         ]);
-        publish(root.path(), request);
+        let ProjectStageOutcome::Staged(staged) =
+            stage_project_generation(root.path(), &request).unwrap()
+        else {
+            panic!("new request unexpectedly replayed");
+        };
+        staged
+            .validate(|_| Ok(()), |_, _| Ok(()))
+            .unwrap()
+            .publish_with_graph_objects(&lease)
+            .unwrap();
         drop(lease);
 
         let reopened = resolve_project_generation(root.path()).unwrap();

--- a/crates/graphforge-storage/src/project_publication.rs
+++ b/crates/graphforge-storage/src/project_publication.rs
@@ -1378,19 +1378,21 @@ impl ValidatedProjectGeneration {
         } else {
             self.0.admission.revalidate_identity()?;
         }
-        let result = self.publish_inner(graph_object_lease).map_err(|error| {
-            if matches!(error, GfError::Project { .. }) {
-                error
-            } else {
-                publication_error_from_parts(
-                    self.0.transaction_uuid,
-                    self.0.generation_uuid,
-                    "DURABLE",
-                    false,
-                    &error.to_string(),
-                )
-            }
-        });
+        let result = self
+            .publish_inner(graph_object_lease, lifecycle_admission.as_ref())
+            .map_err(|error| {
+                if matches!(error, GfError::Project { .. }) {
+                    error
+                } else {
+                    publication_error_from_parts(
+                        self.0.transaction_uuid,
+                        self.0.generation_uuid,
+                        "DURABLE",
+                        false,
+                        &error.to_string(),
+                    )
+                }
+            });
         drop(commit_lock);
         drop(lifecycle_admission);
         result
@@ -1429,6 +1431,7 @@ impl ValidatedProjectGeneration {
     fn publish_inner(
         &self,
         graph_object_lease: Option<&crate::GraphObjectPublicationLease>,
+        lifecycle_admission: Option<&crate::filesystem_admission::ProjectLifecycleAdmission>,
     ) -> Result<ProjectPublicationReceipt, GfError> {
         let staged = &self.0;
         let compact_graph = has_compact_graph_participant(staged)?;
@@ -1450,7 +1453,12 @@ impl ValidatedProjectGeneration {
             )?;
             lease.revalidate_for_root(staged.parent.container_root())?;
         }
-        replace_current(staged, manifest_sha256, graph_object_lease)?;
+        replace_current(
+            staged,
+            manifest_sha256,
+            graph_object_lease,
+            lifecycle_admission,
+        )?;
         finish_published_generation(staged, manifest_sha256)?;
         Ok(ProjectPublicationReceipt {
             transaction_uuid: staged.transaction_uuid,
@@ -1632,6 +1640,7 @@ fn replace_current(
     staged: &StagedProjectGeneration,
     manifest_sha256: [u8; 32],
     graph_object_lease: Option<&crate::GraphObjectPublicationLease>,
+    lifecycle_admission: Option<&crate::filesystem_admission::ProjectLifecycleAdmission>,
 ) -> Result<(), GfError> {
     let current = CurrentRecord {
         format: "graphforge-project".into(),
@@ -1674,10 +1683,16 @@ fn replace_current(
                 "CURRENT",
                 false,
             )?;
-            staged
-                .admission
-                .revalidate_identity()
-                .map_err(std::io::Error::other)?;
+            if let Some(admission) = lifecycle_admission {
+                admission
+                    .revalidate_identity()
+                    .map_err(std::io::Error::other)?;
+            } else {
+                staged
+                    .admission
+                    .revalidate_identity()
+                    .map_err(std::io::Error::other)?;
+            }
             if let Some(lease) = graph_object_lease {
                 lease
                     .revalidate_for_root(staged.parent.container_root())
@@ -2438,7 +2453,7 @@ fn publish_atomic_bytes_in(
         .to_str()
         .ok_or_else(|| std::io::Error::other("atomic publication target is not UTF-8"))?;
     let temp_name = std::ffi::OsString::from(unique_atomic_temp_name(target_text));
-    let mut temp = directory.create_child_file(&temp_name)?;
+    let mut temp = directory.create_replaceable_child_file(&temp_name)?;
     let temp_identity = graphforge_filesystem::file_identity(&temp)?;
     let publish = || -> Result<(), AtomicPublishError> {
         crate::file_lock::lock_exclusive(&temp)?;

--- a/crates/graphforge-storage/src/project_publication.rs
+++ b/crates/graphforge-storage/src/project_publication.rs
@@ -2665,8 +2665,9 @@ mod tests {
         )
         .unwrap();
         let mut live = std::collections::BTreeMap::new();
+        let lease = crate::begin_graph_object_publication(root.path()).unwrap();
         let (files_root, _) = crate::append_graph_files_v2(
-            root.path(),
+            &lease,
             workspace.path(),
             None,
             &mut live,
@@ -2678,6 +2679,7 @@ mod tests {
             crate::graph_files_root_participant(&files_root).unwrap(),
         ]);
         publish(root.path(), request);
+        drop(lease);
 
         let reopened = resolve_project_generation(root.path()).unwrap();
         let inventory = reopened.graph_files_inventory().unwrap().unwrap();

--- a/crates/graphforge-storage/src/project_retention.rs
+++ b/crates/graphforge-storage/src/project_retention.rs
@@ -410,6 +410,14 @@ fn run_cleanup(
     let root = admission.root();
     let policy = policy.validate()?;
     let limits = limits.validate()?;
+    // Lifecycle lock order is CAS lifecycle -> project writer everywhere.
+    // Publishers already hold the shared lifecycle guard before acquiring the
+    // writer for CURRENT; cleanup must acquire its exclusive guard first to
+    // avoid a writer/lifecycle inversion deadlock.
+    let graph_gc_guard = (!dry_run)
+        .then(|| crate::graph_object_store::try_begin_graph_object_gc(root))
+        .transpose()?
+        .flatten();
     let writer_lock = acquire_recovery_lock(root)?;
     let selected = resolve_project_generation(root).map_err(map_recovery_resolution)?;
     let checkpoint_roots = checkpoint_retention_roots_after_writer_lock(root)?;
@@ -424,6 +432,9 @@ fn run_cleanup(
 
     let mut removed = 0_u64;
     let mut skipped_live = classification.skipped_live;
+    if !dry_run && graph_gc_guard.is_none() {
+        skipped_live = skipped_live.saturating_add(1);
+    }
     let mut bounded = classification.bounded;
     if !dry_run {
         let batch_limit = if limits.cleanup_batch == 0 {
@@ -453,8 +464,8 @@ fn run_cleanup(
                 GenerationCleanupOutcome::Retained | GenerationCleanupOutcome::Absent => {}
             }
         }
-        if !bounded {
-            sweep_unreachable_graph_objects(root)?;
+        if !bounded && let Some(gc_guard) = graph_gc_guard.as_ref() {
+            sweep_unreachable_graph_objects(root, gc_guard)?;
         }
     }
 
@@ -484,7 +495,10 @@ fn run_cleanup(
     })
 }
 
-fn sweep_unreachable_graph_objects(root: &Path) -> Result<(), GfError> {
+fn sweep_unreachable_graph_objects(
+    root: &Path,
+    gc_guard: &crate::graph_object_store::GraphObjectGcGuard,
+) -> Result<(), GfError> {
     if crate::graph_object_publication_is_live(root)? {
         return Ok(());
     }
@@ -531,7 +545,11 @@ fn sweep_unreachable_graph_objects(root: &Path) -> Result<(), GfError> {
             }
         }
     }
-    crate::gc_graph_objects(root, &graph_roots, crate::GraphManifestLimits::default())?;
+    crate::graph_object_store::gc_graph_objects_guarded(
+        gc_guard,
+        &graph_roots,
+        crate::GraphManifestLimits::default(),
+    )?;
     Ok(())
 }
 
@@ -1270,7 +1288,13 @@ mod tests {
         open_or_initialize_project(root.path()).unwrap();
         let lease = crate::begin_graph_object_publication(root.path()).unwrap();
         let (digest, _) = crate::install_graph_object_bytes(root.path(), b"staged").unwrap();
-        execute_project_cleanup(root.path(), policy(2), ProjectRetentionLimits::default()).unwrap();
+        let report =
+            execute_project_cleanup(root.path(), policy(2), ProjectRetentionLimits::default())
+                .unwrap();
+        assert_eq!(
+            report.skipped_live, 1,
+            "live CAS publication skip is evidenced"
+        );
         assert!(
             crate::graph_object_path(root.path(), &digest)
                 .unwrap()

--- a/crates/graphforge-storage/src/project_retention.rs
+++ b/crates/graphforge-storage/src/project_retention.rs
@@ -172,6 +172,71 @@ pub struct ProjectCleanupEntry {
     pub bytes: u64,
 }
 
+/// Terminal disposition of the project graph-object sweep for one cleanup pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProjectGraphObjectSweepDisposition {
+    /// Preview classified generations but intentionally did not mutate graph objects.
+    NotRunDryRun,
+    /// Bounded generation cleanup left work outstanding, so graph objects remain untouched.
+    DeferredBoundedCleanup,
+    /// Another graph-object lifecycle operation held the exclusive GC guard.
+    DeferredGcGuardBusy,
+    /// A live graph-object publication lease made unrooted objects potentially reachable.
+    DeferredLivePublication,
+    /// A staged project-publication attempt may still reference uncommitted graph objects.
+    DeferredActiveAttempt,
+    /// Root tracing and the bounded graph-object sweep completed.
+    Completed,
+}
+
+impl ProjectGraphObjectSweepDisposition {
+    /// Stable machine-readable disposition token.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::NotRunDryRun => "not_run_dry_run",
+            Self::DeferredBoundedCleanup => "deferred_bounded_cleanup",
+            Self::DeferredGcGuardBusy => "deferred_gc_guard_busy",
+            Self::DeferredLivePublication => "deferred_live_publication",
+            Self::DeferredActiveAttempt => "deferred_active_attempt",
+            Self::Completed => "completed",
+        }
+    }
+}
+
+/// Outcome and physical evidence for the project graph-object sweep.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProjectGraphObjectSweepReport {
+    /// Why the sweep completed or was not run.
+    pub disposition: ProjectGraphObjectSweepDisposition,
+    /// Reachable segment and payload objects marked by a completed sweep.
+    pub objects_marked: u64,
+    /// Unreachable graph objects removed by a completed sweep.
+    pub objects_removed: u64,
+    /// Physical unreachable graph-object bytes removed by a completed sweep.
+    pub bytes_removed: u64,
+}
+
+impl ProjectGraphObjectSweepReport {
+    const fn without_sweep(disposition: ProjectGraphObjectSweepDisposition) -> Self {
+        Self {
+            disposition,
+            objects_marked: 0,
+            objects_removed: 0,
+            bytes_removed: 0,
+        }
+    }
+
+    const fn completed(evidence: &crate::graph_object_store::GraphObjectGcEvidence) -> Self {
+        Self {
+            disposition: ProjectGraphObjectSweepDisposition::Completed,
+            objects_marked: evidence.objects_marked,
+            objects_removed: evidence.objects_removed,
+            bytes_removed: evidence.bytes_removed,
+        }
+    }
+}
+
 /// Reachability inspection report.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProjectReachabilityReport {
@@ -224,6 +289,8 @@ pub struct ProjectCleanupReport {
     pub work_units: u64,
     /// True when a bound stopped further work before the tree was exhausted.
     pub bounded: bool,
+    /// Separate status and physical evidence for project graph-object collection.
+    pub graph_object_sweep: ProjectGraphObjectSweepReport,
     /// Classified entries (capped by work units).
     pub entries: Vec<ProjectCleanupEntry>,
     /// Elapsed wall time in milliseconds.
@@ -432,9 +499,6 @@ fn run_cleanup(
 
     let mut removed = 0_u64;
     let mut skipped_live = classification.skipped_live;
-    if !dry_run && graph_gc_guard.is_none() {
-        skipped_live = skipped_live.saturating_add(1);
-    }
     let mut bounded = classification.bounded;
     if !dry_run {
         let batch_limit = if limits.cleanup_batch == 0 {
@@ -464,10 +528,27 @@ fn run_cleanup(
                 GenerationCleanupOutcome::Retained | GenerationCleanupOutcome::Absent => {}
             }
         }
-        if !bounded && let Some(gc_guard) = graph_gc_guard.as_ref() {
-            sweep_unreachable_graph_objects(root, gc_guard)?;
-        }
     }
+
+    let graph_object_sweep = if dry_run {
+        ProjectGraphObjectSweepReport::without_sweep(
+            ProjectGraphObjectSweepDisposition::NotRunDryRun,
+        )
+    } else if bounded {
+        ProjectGraphObjectSweepReport::without_sweep(
+            ProjectGraphObjectSweepDisposition::DeferredBoundedCleanup,
+        )
+    } else if let Some(gc_guard) = graph_gc_guard.as_ref() {
+        sweep_unreachable_graph_objects(root, gc_guard)?
+    } else if crate::graph_object_publication_is_live(root)? {
+        ProjectGraphObjectSweepReport::without_sweep(
+            ProjectGraphObjectSweepDisposition::DeferredLivePublication,
+        )
+    } else {
+        ProjectGraphObjectSweepReport::without_sweep(
+            ProjectGraphObjectSweepDisposition::DeferredGcGuardBusy,
+        )
+    };
 
     let remaining_bytes = remaining_project_bytes(root, limits)?;
 
@@ -490,6 +571,7 @@ fn run_cleanup(
         entries_scanned: classification.entries_scanned,
         work_units: classification.work_units,
         bounded,
+        graph_object_sweep,
         entries: classification.entries,
         elapsed_ms: elapsed_ms(started),
     })
@@ -498,9 +580,11 @@ fn run_cleanup(
 fn sweep_unreachable_graph_objects(
     root: &Path,
     gc_guard: &crate::graph_object_store::GraphObjectGcGuard,
-) -> Result<(), GfError> {
+) -> Result<ProjectGraphObjectSweepReport, GfError> {
     if crate::graph_object_publication_is_live(root)? {
-        return Ok(());
+        return Ok(ProjectGraphObjectSweepReport::without_sweep(
+            ProjectGraphObjectSweepDisposition::DeferredLivePublication,
+        ));
     }
     let attempts = root.join(ATTEMPTS_DIR);
     if attempts.exists()
@@ -512,7 +596,9 @@ fn sweep_unreachable_graph_objects(
             .map_err(storage_io)?
             .is_some()
     {
-        return Ok(());
+        return Ok(ProjectGraphObjectSweepReport::without_sweep(
+            ProjectGraphObjectSweepDisposition::DeferredActiveAttempt,
+        ));
     }
     let generations = root.join(GENERATIONS_DIR);
     let mut graph_roots = Vec::new();
@@ -545,12 +631,12 @@ fn sweep_unreachable_graph_objects(
             }
         }
     }
-    crate::graph_object_store::gc_graph_objects_guarded(
+    let evidence = crate::graph_object_store::gc_graph_objects_guarded(
         gc_guard,
         &graph_roots,
         crate::GraphManifestLimits::default(),
     )?;
-    Ok(())
+    Ok(ProjectGraphObjectSweepReport::completed(&evidence))
 }
 
 struct Classification {
@@ -991,6 +1077,14 @@ mod tests {
         assert_eq!(execute.selected_generation_uuid, current);
         assert!(preview.dry_run);
         assert!(!execute.dry_run);
+        assert_eq!(
+            preview.graph_object_sweep.disposition,
+            ProjectGraphObjectSweepDisposition::NotRunDryRun
+        );
+        assert_eq!(
+            execute.graph_object_sweep.disposition,
+            ProjectGraphObjectSweepDisposition::Completed
+        );
         assert_eq!(preview.reachable_count, execute.reachable_count);
         assert!(preview.candidates >= 1);
         assert_eq!(preview.candidates, execute.candidates);
@@ -1292,8 +1386,12 @@ mod tests {
             execute_project_cleanup(root.path(), policy(2), ProjectRetentionLimits::default())
                 .unwrap();
         assert_eq!(
-            report.skipped_live, 1,
-            "live CAS publication skip is evidenced"
+            report.skipped_live, 0,
+            "only generation entries are counted"
+        );
+        assert_eq!(
+            report.graph_object_sweep.disposition,
+            ProjectGraphObjectSweepDisposition::DeferredLivePublication
         );
         assert!(
             crate::graph_object_path(root.path(), &digest)
@@ -1317,7 +1415,13 @@ mod tests {
         let (digest, _) = crate::install_graph_object_bytes(root.path(), b"attempt").unwrap();
         let attempt = root.path().join(ATTEMPTS_DIR).join("active-attempt");
         fs::create_dir_all(&attempt).unwrap();
-        execute_project_cleanup(root.path(), policy(2), ProjectRetentionLimits::default()).unwrap();
+        let deferred =
+            execute_project_cleanup(root.path(), policy(2), ProjectRetentionLimits::default())
+                .unwrap();
+        assert_eq!(
+            deferred.graph_object_sweep.disposition,
+            ProjectGraphObjectSweepDisposition::DeferredActiveAttempt
+        );
         assert!(
             crate::graph_object_path(root.path(), &digest)
                 .unwrap()
@@ -1325,7 +1429,99 @@ mod tests {
         );
 
         fs::remove_dir(&attempt).unwrap();
-        execute_project_cleanup(root.path(), policy(2), ProjectRetentionLimits::default()).unwrap();
+        let completed =
+            execute_project_cleanup(root.path(), policy(2), ProjectRetentionLimits::default())
+                .unwrap();
+        assert_eq!(
+            completed.graph_object_sweep.disposition,
+            ProjectGraphObjectSweepDisposition::Completed
+        );
+        assert_eq!(completed.graph_object_sweep.objects_removed, 1);
+        assert!(
+            !crate::graph_object_path(root.path(), &digest)
+                .unwrap()
+                .exists()
+        );
+    }
+
+    #[test]
+    fn busy_graph_object_gc_guard_has_distinct_entry_neutral_report() {
+        let root = tempfile::tempdir().unwrap();
+        open_or_initialize_project(root.path()).unwrap();
+        let guard = crate::graph_object_store::begin_graph_object_gc(root.path()).unwrap();
+        let report =
+            execute_project_cleanup(root.path(), policy(2), ProjectRetentionLimits::default())
+                .unwrap();
+        assert_eq!(
+            report.graph_object_sweep.disposition,
+            ProjectGraphObjectSweepDisposition::DeferredGcGuardBusy
+        );
+        assert_eq!(report.skipped_live, 0);
+        assert_eq!(
+            report.candidates
+                + report.skipped_live
+                + report.quarantined
+                + report.unknown
+                + report
+                    .entries
+                    .iter()
+                    .filter(|entry| { entry.disposition == ProjectCleanupDisposition::Reachable })
+                    .count() as u64,
+            report.entries.len() as u64
+        );
+        drop(guard);
+    }
+
+    #[test]
+    fn bounded_generation_cleanup_defers_graph_object_sweep() {
+        let root = tempfile::tempdir().unwrap();
+        open_or_initialize_project(root.path()).unwrap();
+        for _ in 0..3 {
+            publish_one(root.path());
+        }
+        let (digest, _) = crate::install_graph_object_bytes(root.path(), b"bounded").unwrap();
+        let report = execute_project_cleanup(
+            root.path(),
+            policy(0),
+            limits(
+                DEFAULT_RETENTION_MAX_ENTRIES,
+                DEFAULT_RETENTION_MAX_BYTES,
+                DEFAULT_RETENTION_MAX_WORK_UNITS,
+                1,
+            ),
+        )
+        .unwrap();
+        assert!(report.bounded);
+        assert_eq!(
+            report.graph_object_sweep.disposition,
+            ProjectGraphObjectSweepDisposition::DeferredBoundedCleanup
+        );
+        assert!(
+            crate::graph_object_path(root.path(), &digest)
+                .unwrap()
+                .exists()
+        );
+    }
+
+    #[test]
+    fn completed_graph_object_sweep_reports_physical_evidence() {
+        let root = tempfile::tempdir().unwrap();
+        open_or_initialize_project(root.path()).unwrap();
+        let payload = b"unreachable-object";
+        let (digest, _) = crate::install_graph_object_bytes(root.path(), payload).unwrap();
+        let report =
+            execute_project_cleanup(root.path(), policy(2), ProjectRetentionLimits::default())
+                .unwrap();
+        assert_eq!(
+            report.graph_object_sweep.disposition,
+            ProjectGraphObjectSweepDisposition::Completed
+        );
+        assert_eq!(report.graph_object_sweep.objects_marked, 0);
+        assert_eq!(report.graph_object_sweep.objects_removed, 1);
+        assert_eq!(
+            report.graph_object_sweep.bytes_removed,
+            payload.len() as u64
+        );
         assert!(
             !crate::graph_object_path(root.path(), &digest)
                 .unwrap()

--- a/crates/graphforge-storage/src/project_retention.rs
+++ b/crates/graphforge-storage/src/project_retention.rs
@@ -16,7 +16,7 @@ use uuid::Uuid;
 
 use crate::project_checkpoints::checkpoint_retention_roots_after_writer_lock;
 use crate::project_generation::{resolve_project_generation, validated_generation_manifest_sha256};
-use crate::project_publication::{GENERATIONS_DIR, open_regular_lock};
+use crate::project_publication::{ATTEMPTS_DIR, GENERATIONS_DIR, open_regular_lock};
 use crate::project_recovery::{
     DEFAULT_RETAINED_ANCESTORS, GenerationCleanupOutcome, MAX_RETAINED_ANCESTORS, TRASH_DIR,
     acquire_recovery_lock, bounded_directory_entries, cleanup_trash_generation,
@@ -453,6 +453,9 @@ fn run_cleanup(
                 GenerationCleanupOutcome::Retained | GenerationCleanupOutcome::Absent => {}
             }
         }
+        if !bounded {
+            sweep_unreachable_graph_objects(root)?;
+        }
     }
 
     let remaining_bytes = remaining_project_bytes(root, limits)?;
@@ -479,6 +482,57 @@ fn run_cleanup(
         entries: classification.entries,
         elapsed_ms: elapsed_ms(started),
     })
+}
+
+fn sweep_unreachable_graph_objects(root: &Path) -> Result<(), GfError> {
+    if crate::graph_object_publication_is_live(root)? {
+        return Ok(());
+    }
+    let attempts = root.join(ATTEMPTS_DIR);
+    if attempts.exists()
+        && attempts
+            .read_dir()
+            .map_err(storage_io)?
+            .next()
+            .transpose()
+            .map_err(storage_io)?
+            .is_some()
+    {
+        return Ok(());
+    }
+    let generations = root.join(GENERATIONS_DIR);
+    let mut graph_roots = Vec::new();
+    if generations.exists() {
+        let mut entries = generations
+            .read_dir()
+            .map_err(storage_io)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(storage_io)?;
+        entries.sort_by_key(std::fs::DirEntry::file_name);
+        for entry in entries {
+            let file_type = entry.file_type().map_err(storage_io)?;
+            if !file_type.is_dir() || file_type.is_symlink() {
+                continue;
+            }
+            let name = entry.file_name().into_string().map_err(|_| {
+                project_error(
+                    ProjectErrorCode::ProjectCorrupt,
+                    "generation name is not UTF-8",
+                )
+            })?;
+            let Some(uuid) = parse_canonical_uuid(&name) else {
+                continue;
+            };
+            let generation = crate::resolve_generation_by_uuid(root, uuid)?;
+            if let Some(crate::GraphFilesParticipant::V2(graph_root)) =
+                generation.declared_graph_files_participant()?
+            {
+                graph_roots.push(graph_root);
+            }
+        }
+    }
+    crate::gc_graph_objects(root, &graph_roots, crate::GraphManifestLimits::default())?;
+    Ok(())
 }
 
 struct Classification {
@@ -1208,5 +1262,50 @@ mod tests {
         }
         let root = PathBuf::from(std::env::var("GRAPHFORGE_TEST_PROJECT_ROOT").unwrap());
         let _ = execute_project_cleanup(&root, policy(2), ProjectRetentionLimits::default());
+    }
+
+    #[test]
+    fn live_cas_publication_lease_preserves_unrooted_object() {
+        let root = tempfile::tempdir().unwrap();
+        open_or_initialize_project(root.path()).unwrap();
+        let lease = crate::begin_graph_object_publication(root.path()).unwrap();
+        let (digest, _) = crate::install_graph_object_bytes(root.path(), b"staged").unwrap();
+        execute_project_cleanup(root.path(), policy(2), ProjectRetentionLimits::default()).unwrap();
+        assert!(
+            crate::graph_object_path(root.path(), &digest)
+                .unwrap()
+                .exists()
+        );
+
+        drop(lease);
+        execute_project_cleanup(root.path(), policy(2), ProjectRetentionLimits::default()).unwrap();
+        assert!(
+            !crate::graph_object_path(root.path(), &digest)
+                .unwrap()
+                .exists()
+        );
+    }
+
+    #[test]
+    fn active_publication_attempt_defers_object_sweep() {
+        let root = tempfile::tempdir().unwrap();
+        open_or_initialize_project(root.path()).unwrap();
+        let (digest, _) = crate::install_graph_object_bytes(root.path(), b"attempt").unwrap();
+        let attempt = root.path().join(ATTEMPTS_DIR).join("active-attempt");
+        fs::create_dir_all(&attempt).unwrap();
+        execute_project_cleanup(root.path(), policy(2), ProjectRetentionLimits::default()).unwrap();
+        assert!(
+            crate::graph_object_path(root.path(), &digest)
+                .unwrap()
+                .exists()
+        );
+
+        fs::remove_dir(&attempt).unwrap();
+        execute_project_cleanup(root.path(), policy(2), ProjectRetentionLimits::default()).unwrap();
+        assert!(
+            !crate::graph_object_path(root.path(), &digest)
+                .unwrap()
+                .exists()
+        );
     }
 }

--- a/docs/adr/0013-project-generation-protocol.md
+++ b/docs/adr/0013-project-generation-protocol.md
@@ -367,6 +367,21 @@ does not rewrite participant or manifest bytes.
 
 ### Retention and garbage collection
 
+Graph inventory participants may use the compact version-2 authenticated root.
+Its immutable payloads and fixed-depth manifest nodes live in the project
+content-addressed object store, while the generation stores only the root
+digest and logical totals. Publication resolves the entire bounded manifest
+and verifies all payload digests before the atomic `CURRENT` transition.
+Interrupted installation therefore leaves the prior generation authoritative;
+an acknowledged transition survives reopen without copying unchanged objects.
+
+Object collection runs only after generation reachability is established. It
+marks roots from every remaining generation, including checkpoint-retained and
+live-lease-retained generations, and defers while a publication attempt or
+object-installation lease is active. Marking and validation finish before any
+object deletion. Malformed, cyclic, oversized, duplicate-reference, traversal,
+and wrong-digest manifests fail closed and do not grant deletion authority.
+
 The current generation is always reachable. The default retention set also
 contains its two most recent valid ancestors, determined only from verified
 `parent_generation_uuid` links. A configured larger finite retention count may

--- a/docs/adr/0013-project-generation-protocol.md
+++ b/docs/adr/0013-project-generation-protocol.md
@@ -395,7 +395,9 @@ expanded graph-files-v1 inventory writes node-v2 objects only.
 The participant descriptor is paired exactly with its payload: record version
 1 admits only an expanded v1 inventory and record version 2 admits only this
 Patricia root. Checkpoint revert retains the same representation, uses the CAS
-publication lease for v2, and never synthesizes a generation graph tree.
+publication lease for v2, and never synthesizes a generation graph tree. Revert
+acquires the CAS lifecycle guard before the project writer and checkpoint locks,
+matching retention's global `CAS -> writer -> checkpoint` order.
 
 CAS publication, reads, materialization, and collection retain directory and
 file capabilities and address children relative to those capabilities. The

--- a/docs/adr/0013-project-generation-protocol.md
+++ b/docs/adr/0013-project-generation-protocol.md
@@ -368,7 +368,7 @@ does not rewrite participant or manifest bytes.
 ### Retention and garbage collection
 
 Graph inventory participants may use the compact version-2 authenticated root.
-Its immutable payloads and fixed-depth manifest nodes live in the project
+Its immutable payloads and canonical Patricia/radix manifest nodes live in the project
 content-addressed object store, while the generation stores only the root
 digest and logical totals. Publication resolves the entire bounded manifest
 and verifies all payload digests before the atomic `CURRENT` transition.
@@ -381,6 +381,21 @@ live-lease-retained generations, and defers while a publication attempt or
 object-installation lease is active. Marking and validation finish before any
 object deletion. Malformed, cyclic, oversized, duplicate-reference, traversal,
 and wrong-digest manifests fail closed and do not grant deletion authority.
+
+Manifest node version 2 compresses every maximal shared lowercase-hex SHA-256
+path prefix. A branch consumes its compressed prefix and one child nibble and
+has at least two children; unary branches are noncanonical. A leaf consumes the
+complete remaining digest and retains the canonically path-ordered collision
+bucket. The empty inventory alone uses one empty root branch. Consequently a
+nonempty inventory with `F` distinct path digests has at most `2F - 1` manifest
+nodes (the empty inventory has one), and resolution work is linear in the live
+inventory. Old node-v1, mixed-version, malformed-prefix, wrong-route, cyclic,
+duplicate-reference, and noncanonical trees fail closed. Migration from an
+expanded graph-files-v1 inventory writes node-v2 objects only.
+The participant descriptor is paired exactly with its payload: record version
+1 admits only an expanded v1 inventory and record version 2 admits only this
+Patricia root. Checkpoint revert retains the same representation, uses the CAS
+publication lease for v2, and never synthesizes a generation graph tree.
 
 CAS publication, reads, materialization, and collection retain directory and
 file capabilities and address children relative to those capabilities. The

--- a/docs/adr/0013-project-generation-protocol.md
+++ b/docs/adr/0013-project-generation-protocol.md
@@ -382,6 +382,18 @@ object-installation lease is active. Marking and validation finish before any
 object deletion. Malformed, cyclic, oversized, duplicate-reference, traversal,
 and wrong-digest manifests fail closed and do not grant deletion authority.
 
+CAS publication, reads, materialization, and collection retain directory and
+file capabilities and address children relative to those capabilities. The
+named project, object root, digest buckets, lifecycle lock, and complete object
+closure are revalidated immediately before `CURRENT`, which is replaced
+relative to the retained project directory. This coordinates concurrent
+GraphForge processes and fails closed when namespace substitution is detected.
+The operational boundary does not claim atomic protection against an actively
+malicious same-identity process racing the final Unix namespace syscall;
+deployments requiring that adversarial isolation must use OS ownership or
+sandbox boundaries. Identity-conditional Unix cleanup likewise runs only under
+GraphForge's cooperative exclusive lifecycle guard.
+
 The current generation is always reachable. The default retention set also
 contains its two most recent valid ancestors, determined only from verified
 `parent_generation_uuid` links. A configured larger finite retention count may

--- a/docs/book/architecture/concurrency-recovery.md
+++ b/docs/book/architecture/concurrency-recovery.md
@@ -167,6 +167,14 @@ There are four CI surfaces for concurrency and durability contracts:
    reachability oracle as recovery: CURRENT, configured ancestors, and checkpoint
    roots. Live leases skip without waiting; concurrent publication returns
    `GF_WRITER_BUSY`; unknown or linked paths are quarantined and never deleted.
+   Generation-entry classification and project graph-object sweeping have
+   separate evidence. `skipped_live` counts only generation entries. The
+   graph-object sweep reports whether it completed or did not run because the
+   request was a dry run, generation cleanup remained bounded, the GC guard was
+   busy, a graph-object publication was live, or a project publication attempt
+   remained active. Completed sweeps also report objects marked, objects
+   removed, and physical bytes removed; deferred sweeps retain objects and
+   report zero physical-work counters.
    Graph delta compaction (`compact_graph_delta` / `preview_graph_delta_compaction`)
    publishes a new Parquet generation through the same CURRENT path and reclaims
    subsumed inputs only after acknowledgement via that shared oracle.

--- a/docs/book/architecture/storage.md
+++ b/docs/book/architecture/storage.md
@@ -137,7 +137,16 @@ data. New publications store graph workspace files under the generation-owned
 `graph/` tree with a `graph`/`files` inventory participant; legacy
 `graph`/`snapshot` Arrow envelopes remain readable. Root YAML/JSON and
 environment settings are inputs only and cannot override the selected
-generation. Authoritative small-write delta runs, when present, live under
+generation. Version 2 of `graph`/`files` replaces the expanded per-generation
+inventory with a compact authenticated radix root. Immutable payload and
+manifest objects are addressed by SHA-256 in the project object store, so an
+update writes only changed payloads and the bounded root path while unchanged
+objects are reused byte-for-byte. Open resolves the bounded manifest and
+verifies every selected payload before exposing the generation. Version 1
+expanded inventories remain readable and can be migrated without changing
+`CURRENT` until the complete version-2 generation is durable.
+
+Authoritative small-write delta runs, when present, live under
 `graph/deltas/` inside the same generation and are inventory-verified
 ([ADR 0019](../../adr/0019-authoritative-graph-delta-journal.md)). Compaction
 and ordinary opens decode the compact base from these canonical Parquet files;

--- a/docs/book/architecture/storage.md
+++ b/docs/book/architecture/storage.md
@@ -151,8 +151,14 @@ expanded inventories remain readable and can be migrated without changing
 
 Pure CAS reads open the existing `graph-objects/sha256` namespace and existing
 `lifecycle.lock` with read-only capabilities. They create neither lifecycle
-state nor `tmp`/`active`, and shared directory/lifecycle locks pin the immutable
-objects against collection for the read guard's lifetime. Publication,
+state nor `tmp`/`active`. The authenticated regular `lifecycle.lock` is the
+cross-platform coordination authority: reads and publications hold it shared,
+while collection holds it exclusively. On Unix, the same operations also lock
+the retained `graph-objects` directory so replacing the still-open lifecycle
+pathname cannot split cooperative coordination. Windows instead relies on the
+retained lifecycle handle's delete/rename denial because directory handles do
+not support byte-range locking. Post-lock identity and link validation closes
+namespace substitution races on both platforms. Publication,
 materialization, lease cleanup, and GC use the distinct mutable open-or-create
 capability; materialization remains there because installing hard links mutates
 the source inode's link state.

--- a/docs/book/architecture/storage.md
+++ b/docs/book/architecture/storage.md
@@ -144,8 +144,13 @@ update writes only changed payloads and the compressed path-copy root path while
 unchanged objects are reused byte-for-byte. A storage-owned root-bound state
 authenticates an existing inventory once per publication sequence; individual
 updates cannot substitute a caller-owned cache and do not rescan all prior
-descriptors. Open resolves the bounded manifest and
-verifies every selected payload before exposing the generation. Version 1
+descriptors. Open resolves the bounded manifest and verifies every selected
+payload before exposing the generation. Ordinary API open and restore dispatch
+on the declared participant version: version 1 keeps its pinned-tree/copy
+behavior, while version 2 materializes authenticated CAS objects at the same
+workspace-relative paths and replays authoritative deltas into a distinct
+private workspace so immutable CAS hard links are never modified in place.
+Version 1
 expanded inventories remain readable and can be migrated without changing
 `CURRENT` until the complete version-2 generation is durable.
 

--- a/docs/book/architecture/storage.md
+++ b/docs/book/architecture/storage.md
@@ -138,13 +138,25 @@ data. New publications store graph workspace files under the generation-owned
 `graph`/`snapshot` Arrow envelopes remain readable. Root YAML/JSON and
 environment settings are inputs only and cannot override the selected
 generation. Version 2 of `graph`/`files` replaces the expanded per-generation
-inventory with a compact authenticated radix root. Immutable payload and
+inventory with a compact authenticated Patricia/radix root. Immutable payload and
 manifest objects are addressed by SHA-256 in the project object store, so an
-update writes only changed payloads and the bounded root path while unchanged
-objects are reused byte-for-byte. Open resolves the bounded manifest and
+update writes only changed payloads and the compressed path-copy root path while
+unchanged objects are reused byte-for-byte. A storage-owned root-bound state
+authenticates an existing inventory once per publication sequence; individual
+updates cannot substitute a caller-owned cache and do not rescan all prior
+descriptors. Open resolves the bounded manifest and
 verifies every selected payload before exposing the generation. Version 1
 expanded inventories remain readable and can be migrated without changing
 `CURRENT` until the complete version-2 generation is durable.
+
+The node-v2 canonical shape has no unary branches: maximal lowercase-hex digest
+prefixes are compressed into nodes, branches have at least two distinct nibble
+children, and leaves contain the full-digest collision bucket in logical-path
+order. Empty inventory is the sole one-node empty-branch exception. Therefore
+`F > 0` distinct path digests require at most `2F - 1` manifest objects instead
+of one object per hash nibble. Resolver admission derives its structural bound
+from the authenticated root totals and rejects v1/mixed/future nodes, malformed
+or nonmaximal shapes, wrong routes, duplicate references, and corrupt objects.
 
 Authoritative small-write delta runs, when present, live under
 `graph/deltas/` inside the same generation and are inventory-verified

--- a/docs/book/architecture/storage.md
+++ b/docs/book/architecture/storage.md
@@ -149,6 +149,14 @@ verifies every selected payload before exposing the generation. Version 1
 expanded inventories remain readable and can be migrated without changing
 `CURRENT` until the complete version-2 generation is durable.
 
+Pure CAS reads open the existing `graph-objects/sha256` namespace and existing
+`lifecycle.lock` with read-only capabilities. They create neither lifecycle
+state nor `tmp`/`active`, and shared directory/lifecycle locks pin the immutable
+objects against collection for the read guard's lifetime. Publication,
+materialization, lease cleanup, and GC use the distinct mutable open-or-create
+capability; materialization remains there because installing hard links mutates
+the source inode's link state.
+
 The node-v2 canonical shape has no unary branches: maximal lowercase-hex digest
 prefixes are compressed into nodes, branches have at least two distinct nibble
 children, and leaves contain the full-digest collision bucket in logical-path

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -3775,6 +3775,16 @@ Busy writers, resource limits, and conflicts map to the same typed project
 error codes across surfaces. Node reports 64-bit counts and sizes as `bigint`
 so values above `Number.MAX_SAFE_INTEGER` stay exact.
 
+Cleanup reports keep generation-entry accounting separate from project
+graph-object collection. `skipped_live` counts only classified generation
+entries with a live lease. The nested `graph_object_sweep` report has one
+terminal `disposition`: `not_run_dry_run`, `deferred_bounded_cleanup`,
+`deferred_gc_guard_busy`, `deferred_live_publication`,
+`deferred_active_attempt`, or `completed`. Its `objects_marked`,
+`objects_removed`, and `bytes_removed` counters are physical evidence from a
+completed sweep and are zero when no sweep ran. A completed sweep may
+legitimately report all-zero counters.
+
 ```text
 gf --project PATH --json recovery
 gf --project PATH --json transaction commit --operation-uuid UUID --cypher 'CREATE (:Person {name: "A"})'

--- a/tools/bazel/drift/cargo_feature_fingerprint.json
+++ b/tools/bazel/drift/cargo_feature_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "schema": "graphforge.cargo-feature-fingerprint.v1",
-  "sha256": "abee5518fa5758615df53d8fad39a8e5b082e50d14a9e1c3c6b4562d7d457e41",
+  "sha256": "578c0de5c055fbdfe3406ebbcbff82dc48187ffb212dabdf291a61e8bd583f51",
   "entries": [
     {
       "name": "graphforge-api",
@@ -1067,6 +1067,15 @@
       "version": "0.5.2",
       "features": [],
       "dependencies": [
+        {
+          "name": "fs4",
+          "req": "^1.1",
+          "features": [],
+          "optional": false,
+          "uses_default_features": true,
+          "kind": null,
+          "target": null
+        },
         {
           "name": "rustix",
           "req": "^1.1",

--- a/tools/bazel/drift/cargo_feature_fingerprint.json
+++ b/tools/bazel/drift/cargo_feature_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "schema": "graphforge.cargo-feature-fingerprint.v1",
-  "sha256": "578c0de5c055fbdfe3406ebbcbff82dc48187ffb212dabdf291a61e8bd583f51",
+  "sha256": "b3be2fa948ad685b8e34b042fd7da99037da33e4edb464242913107d4e4baf61",
   "entries": [
     {
       "name": "graphforge-api",
@@ -175,7 +175,8 @@
           "name": "graphforge-storage",
           "req": "*",
           "features": [
-            "test-failpoints"
+            "test-failpoints",
+            "test-support"
           ],
           "optional": false,
           "uses_default_features": true,
@@ -1863,7 +1864,8 @@
       "version": "0.5.2",
       "features": [
         "default",
-        "test-failpoints"
+        "test-failpoints",
+        "test-support"
       ],
       "dependencies": [
         {


### PR DESCRIPTION
## Description

Adds retained filesystem and storage capabilities for compact authenticated graph roots. Immutable payloads and bounded-fanout radix nodes are content-addressed once at project scope; generations publish only canonical root participants, and readers authenticate manifests and payloads before use.

Closes #930

## Changes

- add canonical, bounded, fail-closed graph-root and radix-node contracts
- retain authenticated project, graph-object, lifecycle, and temporary-file identities across publication operations
- perform no-follow handle-relative CAS reads, installs, materialization, GC, and CURRENT replacement on Unix and Windows
- serialize publishers and GC against the retained graph-object directory authority
- preserve optimistic multi-process publication while revalidating the retained lifecycle admission
- migrate v1 inventories, trace retained generation roots, and defer GC around live attempts and leases
- document the compact-root publication, substitution threat model, and retention protocol
- add `fs4` to `graphforge-filesystem`; update `Cargo.lock` and Bazel dependency metadata/fingerprint

## Verification

- focused compact-root, retained-directory, substitution, optimistic-publication, and storage tests
- `cargo clippy -p graphforge-filesystem --all-targets -- -D warnings`
- `python3 scripts/ci/cargo-bazel-drift-check.py`
- `bazelisk test //crates/graphforge-filesystem:graphforge_filesystem_test`
- `cargo fmt --all -- --check`
- exact-head GitHub CI, including native Windows replacement and macOS durability lanes

Local Windows runtime execution is not claimed because this host lacks the MinGW compiler; the native Windows CI lane is the runtime authority.

## Reviewer focus

Please focus on retained identity admission, exact-handle CURRENT replacement, optimistic publication lifecycle, pre-CURRENT full verification, and mark-before-sweep reachability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a secure, content-addressed storage system for graph files.
  - Added graph-files v2 manifests with deterministic layouts, validation, and bounded resolution.
  - Added migration, incremental updates, verified reads, hard-link materialization, and garbage collection.
  - Added publication leases and lifecycle safeguards for safe concurrent updates and cleanup.
  - Added support for stable directory operations that prevent symlink and file-substitution issues.

- **Bug Fixes**
  - Improved protection against corrupted, tampered, substituted, or invalid graph files during publication and retrieval.
  - Ensured cleanup defers removal when active publication work could still reference stored objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->