### PR TITLE
test(storage): scope durable failpoints to the invoking thread

### DIFF
--- a/crates/graphforge-storage/src/durable_rewrite.rs
+++ b/crates/graphforge-storage/src/durable_rewrite.rs
@@ -665,8 +665,9 @@ pub(crate) fn recovery_required(root: &Path) -> Result<bool, GfError> {
 }
 
 #[cfg(test)]
-static FAIL_AFTER_DURABLE_INTENT: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
+thread_local! {
+    static FAIL_AFTER_DURABLE_INTENT: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
 
 #[allow(clippy::too_many_lines)]
 pub(crate) fn commit(
@@ -816,7 +817,7 @@ pub(crate) fn commit(
     intent.checksum = checksum(&intent)?;
     publish_journal(&guard.directory, &intent)?;
     #[cfg(test)]
-    if FAIL_AFTER_DURABLE_INTENT.swap(false, std::sync::atomic::Ordering::SeqCst) {
+    if FAIL_AFTER_DURABLE_INTENT.replace(false) {
         return Err(storage("injected ordinary error after durable intent"));
     }
     crate::project_failpoint::hit(
@@ -845,8 +846,6 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
-
-    static DURABLE_INTENT_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     fn entry(destination: &str, class: EntryClass) -> Entry {
         Entry {
@@ -888,7 +887,6 @@ mod tests {
     }
 
     fn leave_durable_intent(root: &Path) -> Intent {
-        let _test_guard = DURABLE_INTENT_TEST_LOCK.lock().unwrap();
         let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, false)]));
         let batch = RecordBatch::try_new(
             Arc::clone(&schema),
@@ -899,13 +897,27 @@ mod tests {
         rewrite
             .stage(&root.join("topology/nodes.parquet"), schema, &batch)
             .unwrap();
-        FAIL_AFTER_DURABLE_INTENT.store(true, std::sync::atomic::Ordering::SeqCst);
+        FAIL_AFTER_DURABLE_INTENT.set(true);
         assert!(commit(rewrite, root, true, true, None).is_err());
         let stable = StableDirectory::open(root).unwrap();
         let (bytes, _) = read_journal(&stable).unwrap().unwrap();
         let value: Intent = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(value.state, IntentState::Durable);
         value
+    }
+
+    fn single_value_rewrite(root: &Path, value: i64) -> RewriteBatch {
+        let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, false)]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int64Array::from(vec![value]))],
+        )
+        .unwrap();
+        let mut rewrite = RewriteBatch::new();
+        rewrite
+            .stage(&root.join("topology/nodes.parquet"), schema, &batch)
+            .unwrap();
+        rewrite
     }
 
     fn republish_intent(root: &Path, intent: &mut Intent) {
@@ -1077,6 +1089,33 @@ mod tests {
         );
         assert!(destination.is_file());
         assert!(!root.path().join(JOURNAL).exists());
+    }
+
+    #[test]
+    fn durable_intent_error_injection_is_thread_scoped_and_one_shot() {
+        let armed_root = TempDir::new().unwrap();
+        let unrelated_root = TempDir::new().unwrap();
+        let armed_rewrite = single_value_rewrite(armed_root.path(), 7);
+        let unrelated_rewrite = single_value_rewrite(unrelated_root.path(), 11);
+
+        FAIL_AFTER_DURABLE_INTENT.set(true);
+        let unrelated_path = unrelated_root.path().to_path_buf();
+        std::thread::spawn(move || {
+            commit(unrelated_rewrite, &unrelated_path, true, true, None).unwrap();
+        })
+        .join()
+        .unwrap();
+
+        let error = commit(armed_rewrite, armed_root.path(), true, true, None).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("injected ordinary error after durable intent")
+        );
+        recover(armed_root.path()).unwrap();
+
+        let next = single_value_rewrite(armed_root.path(), 13);
+        commit(next, armed_root.path(), true, true, None).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
Closes #941.

## Summary
- replace the process-global durable-intent test failpoint with thread-local one-shot state
- remove the poisonable shared test mutex
- deterministically prove an unrelated commit cannot steal the injected failure

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p graphforge-storage --lib durable_rewrite::tests:: -- --test-threads=8` (10 passed)
- `cargo test -p graphforge-storage --lib --no-fail-fast` (659 passed, 2 ignored)
- `bazelisk test //crates/graphforge-storage:graphforge_storage_test`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790273139&installation_model_id=20486&pr_number=942&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F942&signature=9a49d7d5bc038c64108249f84f482bd914a77e03cda5ea17c8ab4602771a5622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of durable rewrite failure testing.
  * Ensured simulated failures remain isolated between threads and trigger only once.
  * Verified recovery and successful commits after a simulated failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->