### PR TITLE
fix(portable): preserve semantic composition closure

### DIFF
--- a/crates/graphforge-storage/src/project_portable_v2_import.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_import.rs
@@ -423,7 +423,8 @@ fn import_materialized(
             capability_version: capability.capability_version,
         })
         .collect();
-    let mut participants = Vec::with_capacity(runtime.participants.len());
+    let mut participants = Vec::with_capacity(runtime.participants.len() + 2);
+    let mut semantic_composition_fingerprint = None;
     for participant in runtime.participants {
         let source = find_participant_file(stage, &participant.participant_id, limits)?;
         let metadata = fs::metadata(&source).map_err(|_| {
@@ -433,6 +434,18 @@ fn import_materialized(
             )
         })?;
         let content_sha256: [u8; 32] = hash_file(&source, limits.copy_buffer_bytes, cancelled)?;
+        if participant.capability_id == crate::GRAPH_CAPABILITY_ID
+            && participant.record_family_id == crate::GRAPH_SEMANTIC_BINDINGS_FAMILY
+        {
+            let bytes = read_bounded_payload(
+                &source,
+                crate::semantic_bindings::MAX_SEMANTIC_BINDING_BYTES as u64,
+                "semantic bindings",
+            )?;
+            let bindings =
+                crate::SemanticStorageBindings::from_canonical_json(&bytes).map_err(storage)?;
+            semantic_composition_fingerprint = Some(bindings.composition_fingerprint);
+        }
         let encoding = match participant.encoding.as_str() {
             "json" => ProjectParticipantEncoding::Json,
             "parquet" => ProjectParticipantEncoding::Parquet,
@@ -463,9 +476,32 @@ fn import_materialized(
     }
     let staged_composition = if report.ontology_composition.is_some() {
         let (candidate, receipt) = build_staged_composition(stage, report, limits)?;
+        if let Some(expected) = semantic_composition_fingerprint.as_deref() {
+            let staged_bytes = read_bounded_payload(
+                &candidate.source,
+                limits.max_manifest_bytes,
+                "staged composition",
+            )?;
+            let staged =
+                crate::WorkspacePortableOntologyStaging::from_canonical_json(&staged_bytes)
+                    .map_err(storage)?;
+            if staged.composition.composition_fingerprint != expected {
+                return Err(PortableV2Error::new(
+                    PortableV2ErrorCode::Incompatible,
+                    "semantic bindings and portable composition fingerprints disagree",
+                ));
+            }
+            participants.push(persist_composition_authority(stage, &staged.composition)?);
+        }
         participants.push(candidate);
         Some(receipt)
     } else {
+        if semantic_composition_fingerprint.is_some() {
+            return Err(PortableV2Error::new(
+                PortableV2ErrorCode::Incompatible,
+                "semantic bindings require portable composition authority",
+            ));
+        }
         None
     };
     participants.sort_by(|left, right| {
@@ -813,6 +849,43 @@ fn persist_staged_composition(
     Ok((participant, source, bytes))
 }
 
+fn persist_composition_authority(
+    stage: &Path,
+    composition: &crate::WorkspaceOntologyComposition,
+) -> Result<ProjectFileParticipant, PortableV2Error> {
+    let participant = composition.to_project_participant().map_err(storage)?;
+    let bytes = participant.bytes.clone();
+    let source = stage.join("ontology-composition-authority.json");
+    let mut output = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&source)
+        .map_err(|_| {
+            PortableV2Error::new(
+                PortableV2ErrorCode::Io,
+                "cannot stage composition authority",
+            )
+        })?;
+    output.write_all(&bytes).map_err(|_| {
+        PortableV2Error::new(
+            PortableV2ErrorCode::Io,
+            "cannot write composition authority",
+        )
+    })?;
+    output.sync_all().map_err(|_| {
+        PortableV2Error::new(PortableV2ErrorCode::Io, "cannot sync composition authority")
+    })?;
+    Ok(ProjectFileParticipant {
+        participant: ProjectParticipant {
+            bytes: Vec::new(),
+            ..participant
+        },
+        source,
+        byte_length: bytes.len() as u64,
+        content_sha256: Sha256::digest(&bytes).into(),
+    })
+}
+
 fn read_bounded_payload(
     path: &Path,
     limit: u64,
@@ -1018,6 +1091,15 @@ mod tests {
             .unwrap()
             .unwrap();
         let mut participants = crate::empty_workspace_participants().unwrap();
+        participants.push(
+            crate::SemanticStorageBindings::new(
+                composition.composition_fingerprint.clone(),
+                Vec::new(),
+            )
+            .unwrap()
+            .to_project_participant()
+            .unwrap(),
+        );
         participants.push(composition.to_project_participant().unwrap());
         participants.sort_by(|left, right| {
             (&left.capability_id, &left.record_family_id)
@@ -1085,9 +1167,14 @@ mod tests {
                 .participant_snapshots()
                 .unwrap()
                 .iter()
-                .all(|entry| {
-                    entry.record_family_id != crate::WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY
+                .any(|entry| {
+                    entry.record_family_id == crate::WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY
                 })
+        );
+        assert!(
+            crate::semantic_storage_bindings(&reopened)
+                .unwrap()
+                .is_some()
         );
 
         let replay = import_complete_portable_v2(

--- a/crates/graphforge-storage/src/project_portable_v2_selection.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_selection.rs
@@ -251,6 +251,13 @@ pub fn preview_portable_v2_selection(
         }));
     }
     let selected = requested.union(&auto).cloned().collect::<BTreeSet<_>>();
+    let semantic_bindings = PortableV2ParticipantId {
+        capability_id: crate::GRAPH_CAPABILITY_ID.to_owned(),
+        record_family_id: crate::GRAPH_SEMANTIC_BINDINGS_FAMILY.to_owned(),
+    };
+    if selected.contains(&semantic_bindings) {
+        crate::semantic_storage_bindings(generation).map_err(storage)?;
+    }
     validate_settings(generation, &selected, limits)?;
 
     let mut included = Vec::new();
@@ -652,4 +659,104 @@ fn hex(digest: [u8; 32]) -> String {
             write!(output, "{byte:02x}").expect("writing to String cannot fail");
             output
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    fn semantic_generation(
+        composition: Option<crate::WorkspaceOntologyComposition>,
+        binding_fingerprint: String,
+    ) -> (tempfile::TempDir, crate::ResolvedProjectGeneration) {
+        let root = tempfile::tempdir().unwrap();
+        let parent = crate::open_or_initialize_project(root.path()).unwrap();
+        let mut participants = crate::empty_workspace_participants().unwrap();
+        participants.push(
+            crate::SemanticStorageBindings::new(binding_fingerprint, Vec::new())
+                .unwrap()
+                .to_project_participant()
+                .unwrap(),
+        );
+        if let Some(composition) = composition {
+            participants.push(composition.to_project_participant().unwrap());
+        }
+        participants.sort_by(|left, right| {
+            (&left.capability_id, &left.record_family_id)
+                .cmp(&(&right.capability_id, &right.record_family_id))
+        });
+        let request = crate::ProjectGenerationRequest {
+            transaction_uuid: Uuid::new_v4(),
+            generation_uuid: Uuid::new_v4(),
+            capabilities: vec![
+                crate::ProjectCapability {
+                    capability_id: crate::GRAPH_CAPABILITY_ID.into(),
+                    capability_version: crate::GRAPH_CAPABILITY_VERSION,
+                },
+                crate::ProjectCapability {
+                    capability_id: crate::WORKSPACE_CAPABILITY_ID.into(),
+                    capability_version: crate::WORKSPACE_CAPABILITY_VERSION,
+                },
+            ],
+            participants,
+        };
+        let crate::ProjectStageOutcome::Staged(staged) =
+            crate::stage_project_generation(root.path(), &request).unwrap()
+        else {
+            panic!("fresh semantic generation replayed");
+        };
+        staged
+            .validate(|_| Ok(()), |_, _| Ok(()))
+            .unwrap()
+            .publish()
+            .unwrap();
+        drop(parent);
+        let generation = crate::resolve_project_generation(root.path()).unwrap();
+        (root, generation)
+    }
+
+    fn composition() -> crate::WorkspaceOntologyComposition {
+        let legacy = crate::WorkspaceOntology {
+            contract_version: 1,
+            mode: crate::WorkspaceOntologyMode::Strict,
+            source_format: Some(crate::WorkspaceOntologySourceFormat::Json),
+            canonical_ontology_sha256: Some("a".repeat(64)),
+            canonical_ontology: Some(
+                serde_json::to_value(graphforge_ontology::OntologyDoc {
+                    ontology_id: "https://graphforge.dev/ontology/selection-closure".into(),
+                    version: "1".into(),
+                    entity_types: Vec::new(),
+                    relation_types: Vec::new(),
+                    properties: Vec::new(),
+                    constraints: Vec::new(),
+                    migrations: Vec::new(),
+                })
+                .unwrap(),
+            ),
+        };
+        crate::WorkspaceOntologyComposition::virtual_legacy(&legacy)
+            .unwrap()
+            .unwrap()
+    }
+
+    #[test]
+    fn semantic_selection_fails_closed_without_matching_composition_authority() {
+        for (authority, fingerprint) in [
+            (None, "b".repeat(64)),
+            (Some(composition()), "c".repeat(64)),
+        ] {
+            let (_root, generation) = semantic_generation(authority, fingerprint);
+            let error = preview_portable_v2_selection(
+                &generation,
+                &PortableV2SelectionRequest {
+                    profile: PortableV2SelectionProfile::Complete,
+                    strict: false,
+                },
+                PortableV2Limits::default(),
+            )
+            .unwrap_err();
+            assert_eq!(error.code, PortableV2ErrorCode::Io);
+        }
+    }
 }


### PR DESCRIPTION
## Description

Close the portable-v2 semantic dependency gap isolated by #943. Selection now authenticates semantic bindings against the exact persisted workspace composition, while clean import verifies the exported composition fingerprint and reconstructs composition authority in the same generation as the bindings.

This intentionally excludes #940's property-overlay lifecycle coverage; that remains on #940.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✅ Tests (adding or updating tests)

## Related Issues

Fixes #943

## Changes Made

- Fail selection before export when selected graph semantic bindings lack matching authenticated composition authority.
- Validate imported bindings against the staged composition and persist both authorities atomically in one generation.
- Cover missing/mismatched selection authority and successful clean import/reopen with generic storage tests.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] All existing focused tests pass
- [x] Coverage maintained or improved

### Test Commands Run

```bash
cargo fmt --all -- --check
CARGO_TARGET_DIR=/private/tmp/graphforge-940-property-overlay/target cargo clippy -p graphforge-storage --lib -- -D warnings
CARGO_TARGET_DIR=/private/tmp/graphforge-940-property-overlay/target cargo test -p graphforge-storage project_portable_v2_ -- --nocapture
bazelisk test --local_test_jobs=2 //crates/graphforge-storage:graphforge_storage_test
git diff --check
```

## Checklist

### PR Size and Quality

- [x] This PR is small and focused
- [x] This PR addresses one logical change
- [x] The root issue is fixed without bypasses, retries, skips, or weakened assertions
- [x] No commented-out code or skipped tests

### Code Quality

- [x] The code follows the project's style guidelines
- [x] Self-review completed
- [x] The change introduces no new warnings
- [x] No dependency or lockfile changes

### Testing

- [x] Tests prove the fix is effective
- [x] New and existing focused unit tests pass locally

### Documentation

- [x] No public documentation change is needed; this restores the existing portable-v2 authority contract

### Compliance

- [x] No breaking public API changes
- [x] No Cypher or TCK impact

## Performance Impact

- [x] No material performance impact

Selection performs the already-bounded authenticated semantic authority read only when semantic bindings are selected. Import reads the bounded bindings and composition payloads once before publication.

## Breaking Changes

- [x] No breaking changes

## Reviewer Notes

Please focus on fail-closed ordering before export/publication and the atomic reconstruction of composition plus bindings during clean import.

---

**By submitting this PR, I confirm that:**

- [x] I have read and followed the CONTRIBUTING guidelines
- [x] I understand that intentionally submitted contributions are licensed under Apache-2.0
- [x] I am authorized to make these contributions

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790325780&installation_model_id=20486&pr_number=944&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F944&signature=79ae090a9df2a208d79110ed4a6c3a807069a644295ac15fa44beaa992da0a9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved portable project imports by validating semantic bindings against the staged composition.
  - Imports are now rejected when semantic bindings are present without valid composition authority or when fingerprints do not match.
  - Improved project selection reliability by failing safely when semantic storage bindings are missing or inconsistent.

- **Reliability**
  - Validated composition and semantic-binding data now remains available after reopening imported projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->