### PR TITLE
fix(api): make provider refresh completion deterministic

### DIFF
--- a/crates/graphforge-api/src/embedding_refresh.rs
+++ b/crates/graphforge-api/src/embedding_refresh.rs
@@ -212,12 +212,13 @@ impl GraphForge {
     }
 
     fn drive_ready_provider_refreshes(&self) {
+        self.drive_ready_provider_refreshes_at(self.embedding_refresh_epoch.elapsed());
+    }
+
+    pub(crate) fn drive_ready_provider_refreshes_at(&self, now: Duration) {
         loop {
             let lease = match self.embedding_refresh_scheduler.lock() {
-                Ok(mut scheduler) => scheduler
-                    .claim_ready(self.embedding_refresh_epoch.elapsed(), || Ok(()))
-                    .ok()
-                    .flatten(),
+                Ok(mut scheduler) => scheduler.claim_ready(now, || Ok(())).ok().flatten(),
                 Err(_) => None,
             };
             let Some(lease) = lease else {

--- a/crates/graphforge-api/src/embedding_refresh.rs
+++ b/crates/graphforge-api/src/embedding_refresh.rs
@@ -233,15 +233,16 @@ impl GraphForge {
                         .find(|runtime| runtime.compatibility_id() == lease.compatibility_id())
                         .cloned()
                 });
-            let completion = match runtime {
+            let (completion, covered_source) = match runtime {
                 Some(runtime) => {
                     let result = runtime.refresh(self);
-                    ConfiguredProviderRefreshRuntime::completion(&result)
+                    let completion = ConfiguredProviderRefreshRuntime::completion(&result);
+                    (completion, result.ok())
                 }
-                None => graphforge_search::EmbeddingRefreshCompletion::Failed,
+                None => (graphforge_search::EmbeddingRefreshCompletion::Failed, None),
             };
             if let Ok(mut scheduler) = self.embedding_refresh_scheduler.lock() {
-                let _ = scheduler.complete(lease, completion, || Ok(()));
+                let _ = scheduler.complete_through(lease, completion, covered_source, || Ok(()));
             }
         }
     }

--- a/crates/graphforge-api/src/provider_session.rs
+++ b/crates/graphforge-api/src/provider_session.rs
@@ -475,7 +475,9 @@ mod tests {
 
     use super::*;
 
-    fn failing_refresh_session() -> (OpenRouterProviderSession, thread::JoinHandle<()>) {
+    fn refresh_session(
+        refresh_succeeds: bool,
+    ) -> (OpenRouterProviderSession, thread::JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let origin = format!("http://{}", listener.local_addr().unwrap());
         let server = thread::spawn(move || {
@@ -516,6 +518,25 @@ mod tests {
                         "data":[
                             {"index":0,"embedding":[1.0,0.0]},
                             {"index":1,"embedding":[0.0,1.0]}
+                        ]
+                    }))
+                    .unwrap();
+                    write!(
+                        stream,
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                        response.len()
+                    )
+                    .unwrap();
+                    stream.write_all(&response).unwrap();
+                } else if refresh_succeeds {
+                    assert_eq!(payload["input"].as_array().unwrap().len(), 4);
+                    let response = serde_json::to_vec(&json!({
+                        "model":"vendor/model",
+                        "data":[
+                            {"index":0,"embedding":[1.0,0.0]},
+                            {"index":1,"embedding":[0.0,1.0]},
+                            {"index":2,"embedding":[0.5,0.5]},
+                            {"index":3,"embedding":[0.25,0.75]}
                         ]
                     }))
                     .unwrap();
@@ -586,7 +607,7 @@ mod tests {
 
     #[test]
     fn proactive_failure_completion_is_driven_without_wall_clock_polling() {
-        let (session, server) = failing_refresh_session();
+        let (session, server) = refresh_session(false);
         let graph = GraphForge::new(None).unwrap();
         for title in ["First", "Second"] {
             graph
@@ -654,6 +675,123 @@ mod tests {
             .unwrap();
         assert_eq!(active.generation_id, original.generation_id);
         assert_eq!(active.vector_count, original.vector_count);
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn proactive_success_coalesces_real_mutations_without_wall_clock_polling() {
+        let (session, server) = refresh_session(true);
+        let graph = GraphForge::new(None).unwrap();
+        for title in ["First", "Second"] {
+            graph
+                .add_node(
+                    "Paper",
+                    &HashMap::from([("title".into(), crate::PropValue::Str(title.into()))]),
+                )
+                .unwrap();
+        }
+        let request = ProviderEmbeddingPlanRequest {
+            display_name: "semantic".into(),
+            label: "Paper".into(),
+            properties: vec!["title".into()],
+            contract: session.contract().clone(),
+            dimensions: 2,
+            normalization: crate::ProviderEmbeddingNormalization::None,
+            distance: crate::ProviderEmbeddingDistance::Cosine,
+            request_limits: ProviderRequestLimits::default(),
+            batch_limits: crate::ProviderBatchLimits::default(),
+            execution_limits: session.config.execution_limits,
+            replace_alias: false,
+        };
+        session.publish_embeddings(&graph, &request).unwrap();
+        let initial_generation = graph
+            .embedding_space(Some("semantic"))
+            .unwrap()
+            .active
+            .unwrap()
+            .generation_id;
+
+        // Own the driver token before either mutation so both notices are
+        // deterministically observed inside one debounce window. The real
+        // scheduler queue is then driven at an injected monotonic instant.
+        graph
+            .provider_refresh_driver_active
+            .store(true, Ordering::Release);
+        for title in ["Third", "Fourth"] {
+            graph
+                .add_node(
+                    "Paper",
+                    &HashMap::from([("title".into(), crate::PropValue::Str(title.into()))]),
+                )
+                .unwrap();
+        }
+        let queued = graph.inspect_embedding_refresh(Some("semantic")).unwrap();
+        assert!(queued.worker.selected_lineage_queued);
+        assert!(!queued.worker.selected_lineage_in_flight);
+        assert_eq!(queued.worker.coalesced_notices, 1);
+        assert_eq!(queued.worker.succeeded, 0);
+        assert_eq!(queued.worker.failed, 0);
+
+        graph.drive_ready_provider_refreshes_at(Duration::MAX);
+
+        let refreshed = graph.inspect_embedding_refresh(Some("semantic")).unwrap();
+        assert!(!refreshed.worker.selected_lineage_queued);
+        assert!(!refreshed.worker.selected_lineage_in_flight);
+        assert_eq!(refreshed.worker.coalesced_notices, 1);
+        assert_eq!(refreshed.worker.succeeded, 1);
+        assert_eq!(refreshed.worker.failed, 0);
+        assert!(matches!(
+            refreshed.last_outcome.map(|outcome| outcome.status),
+            Some(graphforge_storage::EmbeddingRefreshOutcomeStatus::Succeeded)
+        ));
+        let active = graph
+            .embedding_space(Some("semantic"))
+            .unwrap()
+            .active
+            .unwrap();
+        assert_eq!(active.vector_count, 4);
+        assert_ne!(active.generation_id, initial_generation);
+
+        graph
+            .add_node(
+                "Other",
+                &HashMap::from([("note".into(), crate::PropValue::Str("Unrelated".into()))]),
+            )
+            .unwrap();
+        graph
+            .execute("MATCH (n:Other) SET n.note = 'still not selected'")
+            .unwrap();
+        let unrelated = graph.inspect_embedding_refresh(Some("semantic")).unwrap();
+        assert!(!unrelated.worker.selected_lineage_queued);
+        assert_eq!(unrelated.worker.succeeded, 1);
+        assert_eq!(unrelated.worker.failed, 0);
+
+        graph
+            .set_embedding_refresh_project_policy(
+                graphforge_storage::EmbeddingRefreshProjectPolicy {
+                    proactive: false,
+                    debounce: Duration::from_millis(500),
+                    max_concurrent_jobs: 2,
+                },
+            )
+            .unwrap();
+        graph
+            .add_node(
+                "Paper",
+                &HashMap::from([("title".into(), crate::PropValue::Str("Fifth".into()))]),
+            )
+            .unwrap();
+        let disabled = graph.inspect_embedding_refresh(Some("semantic")).unwrap();
+        assert!(!disabled.worker.selected_lineage_queued);
+        assert_eq!(disabled.worker.succeeded, 0);
+        assert_eq!(disabled.worker.failed, 0);
+        assert!(matches!(
+            disabled.freshness.map(|freshness| freshness.state),
+            Some(crate::EmbeddingSpaceFreshnessState::SubstantiallyStale)
+        ));
+        graph
+            .provider_refresh_driver_active
+            .store(false, Ordering::Release);
         server.join().unwrap();
     }
 

--- a/crates/graphforge-api/src/provider_session.rs
+++ b/crates/graphforge-api/src/provider_session.rs
@@ -464,9 +464,198 @@ fn validation(message: impl Into<String>) -> GfError {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::atomic::Ordering;
+    use std::thread;
+
     use graphforge_search::{ProviderCapability, ProviderFailureClass};
+    use serde_json::{Value, json};
 
     use super::*;
+
+    fn failing_refresh_session() -> (OpenRouterProviderSession, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let origin = format!("http://{}", listener.local_addr().unwrap());
+        let server = thread::spawn(move || {
+            for call in 0..2 {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut received = Vec::new();
+                let (headers_end, content_length) = loop {
+                    let mut chunk = [0_u8; 1024];
+                    let count = stream.read(&mut chunk).unwrap();
+                    assert!(count > 0);
+                    received.extend_from_slice(&chunk[..count]);
+                    let Some(headers_end) =
+                        received.windows(4).position(|part| part == b"\r\n\r\n")
+                    else {
+                        continue;
+                    };
+                    let headers = String::from_utf8_lossy(&received[..headers_end]);
+                    let content_length = headers
+                        .lines()
+                        .find_map(|line| {
+                            line.to_ascii_lowercase()
+                                .strip_prefix("content-length: ")
+                                .map(str::to_owned)
+                        })
+                        .unwrap()
+                        .parse::<usize>()
+                        .unwrap();
+                    if received.len() >= headers_end + 4 + content_length {
+                        break (headers_end, content_length);
+                    }
+                };
+                let body = &received[headers_end + 4..headers_end + 4 + content_length];
+                let payload: Value = serde_json::from_slice(body).unwrap();
+                if call == 0 {
+                    assert_eq!(payload["input"].as_array().unwrap().len(), 2);
+                    let response = serde_json::to_vec(&json!({
+                        "model":"vendor/model",
+                        "data":[
+                            {"index":0,"embedding":[1.0,0.0]},
+                            {"index":1,"embedding":[0.0,1.0]}
+                        ]
+                    }))
+                    .unwrap();
+                    write!(
+                        stream,
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                        response.len()
+                    )
+                    .unwrap();
+                    stream.write_all(&response).unwrap();
+                } else {
+                    assert_eq!(payload["input"].as_array().unwrap().len(), 3);
+                    let response = br#"{"error":"temporarily unavailable"}"#;
+                    write!(
+                        stream,
+                        "HTTP/1.1 503 Service Unavailable\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                        response.len()
+                    )
+                    .unwrap();
+                    stream.write_all(response).unwrap();
+                }
+            }
+        });
+        let contract = ProviderModelContract::remote(
+            None,
+            "vendor/model",
+            "revision",
+            "v1",
+            ProviderCapabilities::new([
+                ProviderCapability::DocumentEmbeddings,
+                ProviderCapability::QueryEmbeddings,
+                ProviderCapability::CandidateReranking,
+            ])
+            .unwrap(),
+            TokenizerIdentity {
+                identifier: TOKENIZER_IDENTIFIER.into(),
+                version: TOKENIZER_VERSION.into(),
+                count_class: TokenCountClass::Approximate,
+                max_input_tokens: 10_000,
+                normalization: TOKENIZER_NORMALIZATION.into(),
+            },
+            None,
+        )
+        .unwrap();
+        let session = OpenRouterProviderSession {
+            config: OpenRouterProviderSessionConfig {
+                origin,
+                model: "vendor/model".into(),
+                revision: "revision".into(),
+                response_contract_version: "v1".into(),
+                capabilities: contract.capabilities().clone(),
+                max_input_tokens: 10_000,
+                chunking: None,
+                wire_limits: OpenRouterWireLimits::default(),
+                request_limits: ProviderRequestLimits::default(),
+                execution_limits: ProviderExecutionLimits {
+                    retries: 0,
+                    ..ProviderExecutionLimits::default()
+                },
+                transport_timeout: Duration::from_secs(2),
+                estimated_cost_microunits_per_token: 1,
+            },
+            bearer_credential: "test-secret".into(),
+            contract,
+        };
+        (session, server)
+    }
+
+    #[test]
+    fn proactive_failure_completion_is_driven_without_wall_clock_polling() {
+        let (session, server) = failing_refresh_session();
+        let graph = GraphForge::new(None).unwrap();
+        for title in ["First", "Second"] {
+            graph
+                .add_node(
+                    "Paper",
+                    &HashMap::from([("title".into(), crate::PropValue::Str(title.into()))]),
+                )
+                .unwrap();
+        }
+        let request = ProviderEmbeddingPlanRequest {
+            display_name: "semantic".into(),
+            label: "Paper".into(),
+            properties: vec!["title".into()],
+            contract: session.contract().clone(),
+            dimensions: 2,
+            normalization: crate::ProviderEmbeddingNormalization::None,
+            distance: crate::ProviderEmbeddingDistance::Cosine,
+            request_limits: ProviderRequestLimits::default(),
+            batch_limits: crate::ProviderBatchLimits::default(),
+            execution_limits: session.config.execution_limits,
+            replace_alias: false,
+        };
+        session.publish_embeddings(&graph, &request).unwrap();
+        let original = graph
+            .embedding_space(Some("semantic"))
+            .unwrap()
+            .active
+            .unwrap();
+
+        // Own the driver token so the mutation queues real proactive work but
+        // cannot race a detached worker. Drive that exact queue synchronously
+        // at a monotonic time beyond every valid debounce deadline.
+        graph
+            .provider_refresh_driver_active
+            .store(true, Ordering::Release);
+        graph
+            .add_node(
+                "Paper",
+                &HashMap::from([("title".into(), crate::PropValue::Str("Third".into()))]),
+            )
+            .unwrap();
+        let queued = graph.inspect_embedding_refresh(Some("semantic")).unwrap();
+        assert!(queued.worker.selected_lineage_queued);
+        assert_eq!(queued.worker.failed, 0);
+        graph.drive_ready_provider_refreshes_at(Duration::MAX);
+        graph
+            .provider_refresh_driver_active
+            .store(false, Ordering::Release);
+
+        let failed = graph.inspect_embedding_refresh(Some("semantic")).unwrap();
+        assert!(!failed.worker.selected_lineage_queued);
+        assert!(!failed.worker.selected_lineage_in_flight);
+        assert_eq!(failed.worker.failed, 1);
+        assert_eq!(failed.worker.succeeded, 0);
+        assert!(matches!(
+            failed.last_outcome.map(|outcome| outcome.status),
+            Some(graphforge_storage::EmbeddingRefreshOutcomeStatus::Failed(
+                graphforge_storage::EmbeddingRefreshFailureClass::Provider
+            ))
+        ));
+        let active = graph
+            .embedding_space(Some("semantic"))
+            .unwrap()
+            .active
+            .unwrap();
+        assert_eq!(active.generation_id, original.generation_id);
+        assert_eq!(active.vector_count, original.vector_count);
+        server.join().unwrap();
+    }
 
     #[test]
     fn cost_estimates_fail_closed_on_overflow() {

--- a/crates/graphforge-api/src/provider_session.rs
+++ b/crates/graphforge-api/src/provider_session.rs
@@ -95,16 +95,27 @@ impl ConfiguredProviderRefreshRuntime {
     pub(crate) fn refresh(
         &self,
         graph: &GraphForge,
-    ) -> Result<(), ProviderEmbeddingExecutionError> {
+    ) -> Result<EmbeddingSourceState, ProviderEmbeddingExecutionError> {
         self.session
-            .execute_refresh_embeddings(graph, &self.request)
+            .execute_refresh_embeddings(graph, &self.request)?;
+        let (_, lineage) = graph
+            .resolve_embedding_space_lineage(Some(&self.request.display_name))
+            .map_err(ProviderEmbeddingExecutionError::Api)?;
+        lineage
+            .active()
+            .map(|active| active.manifest.source())
+            .ok_or_else(|| {
+                ProviderEmbeddingExecutionError::Api(GfError::Validation(
+                    "successful provider refresh did not publish an active generation".into(),
+                ))
+            })
     }
 
-    pub(crate) fn completion(
-        result: &Result<(), ProviderEmbeddingExecutionError>,
+    pub(crate) fn completion<T>(
+        result: &Result<T, ProviderEmbeddingExecutionError>,
     ) -> EmbeddingRefreshCompletion {
         match result {
-            Ok(()) => EmbeddingRefreshCompletion::Succeeded,
+            Ok(_) => EmbeddingRefreshCompletion::Succeeded,
             Err(
                 ProviderEmbeddingExecutionError::Plan(ProviderEmbeddingPlanError::Artifact(
                     SearchArtifactError::Cancelled,

--- a/crates/graphforge-api/src/provider_session.rs
+++ b/crates/graphforge-api/src/provider_session.rs
@@ -538,12 +538,12 @@ mod tests {
             ),
         ] {
             assert_eq!(
-                ConfiguredProviderRefreshRuntime::completion(&Err(error)),
+                ConfiguredProviderRefreshRuntime::completion::<()>(&Err(error)),
                 EmbeddingRefreshCompletion::Cancelled
             );
         }
         assert_eq!(
-            ConfiguredProviderRefreshRuntime::completion(&Err(
+            ConfiguredProviderRefreshRuntime::completion::<()>(&Err(
                 ProviderEmbeddingExecutionError::Api(GfError::Validation("invalid".into()))
             )),
             EmbeddingRefreshCompletion::Failed

--- a/crates/graphforge-api/tests/provider_session.rs
+++ b/crates/graphforge-api/tests/provider_session.rs
@@ -80,49 +80,6 @@ fn mock_openrouter() -> (String, thread::JoinHandle<()>) {
     (origin, server)
 }
 
-fn mock_failing_refresh() -> (String, thread::JoinHandle<()>) {
-    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-    let origin = format!("http://{}", listener.local_addr().unwrap());
-    let server = thread::spawn(move || {
-        for call in 0..2 {
-            let (mut stream, _) = listener.accept().unwrap();
-            let request = read_request(&mut stream);
-            let (headers, body) = request.split_once("\r\n\r\n").unwrap();
-            assert!(headers.starts_with("POST /api/v1/embeddings HTTP/1.1"));
-            let payload: Value = serde_json::from_str(body).unwrap();
-            if call == 0 {
-                assert_eq!(payload["input"].as_array().unwrap().len(), 2);
-                let response = serde_json::to_vec(&json!({
-                    "model":"vendor/model",
-                    "data":[
-                        {"index":0,"embedding":[1.0,0.0]},
-                        {"index":1,"embedding":[0.0,1.0]}
-                    ]
-                }))
-                .unwrap();
-                write!(
-                    stream,
-                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-                    response.len()
-                )
-                .unwrap();
-                stream.write_all(&response).unwrap();
-            } else {
-                assert_eq!(payload["input"].as_array().unwrap().len(), 3);
-                let response = br#"{"error":"temporarily unavailable"}"#;
-                write!(
-                    stream,
-                    "HTTP/1.1 503 Service Unavailable\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-                    response.len()
-                )
-                .unwrap();
-                stream.write_all(response).unwrap();
-            }
-        }
-    });
-    (origin, server)
-}
-
 fn read_request(stream: &mut impl Read) -> String {
     let mut received = Vec::new();
     loop {
@@ -371,65 +328,4 @@ fn configuration_failures_are_redacted_before_transport() {
     let rendered = error.to_string();
     assert!(!rendered.contains("credential"));
     assert!(!rendered.contains("private"));
-}
-
-#[test]
-fn proactive_provider_failure_preserves_the_active_generation() {
-    let (origin, server) = mock_failing_refresh();
-    let mut provider_config = config(origin);
-    provider_config.execution_limits.retries = 0;
-    let execution_limits = provider_config.execution_limits;
-    let session =
-        OpenRouterProviderSession::new(provider_config, "test-secret".to_owned()).unwrap();
-    let graph = GraphForge::new(None).unwrap();
-    node(&graph, "First");
-    node(&graph, "Second");
-    let request = ProviderEmbeddingPlanRequest {
-        display_name: "semantic".to_owned(),
-        label: "Paper".to_owned(),
-        properties: vec!["title".to_owned()],
-        contract: session.contract().clone(),
-        dimensions: 2,
-        normalization: ProviderEmbeddingNormalization::None,
-        distance: ProviderEmbeddingDistance::Cosine,
-        request_limits: ProviderRequestLimits::default(),
-        batch_limits: ProviderBatchLimits::default(),
-        execution_limits,
-        replace_alias: false,
-    };
-    session.publish_embeddings(&graph, &request).unwrap();
-    let original = graph
-        .embedding_space(Some("semantic"))
-        .unwrap()
-        .active
-        .unwrap();
-
-    node(&graph, "Third");
-    let deadline = std::time::Instant::now() + Duration::from_secs(3);
-    let failed = loop {
-        let inspection = graph.inspect_embedding_refresh(Some("semantic")).unwrap();
-        if inspection.worker.failed == 1 {
-            break inspection;
-        }
-        assert!(
-            std::time::Instant::now() < deadline,
-            "proactive provider failure was not recorded"
-        );
-        thread::sleep(Duration::from_millis(25));
-    };
-    assert_eq!(failed.worker.succeeded, 0);
-    assert!(matches!(
-        failed.last_outcome.map(|outcome| outcome.status),
-        Some(graphforge_api::EmbeddingRefreshOutcomeStatus::Failed(
-            graphforge_api::EmbeddingRefreshFailureClass::Provider
-        ))
-    ));
-    let active = graph
-        .embedding_space(Some("semantic"))
-        .unwrap()
-        .active
-        .unwrap();
-    assert_eq!(active.generation_id, original.generation_id);
-    assert_eq!(active.vector_count, original.vector_count);
-    server.join().unwrap();
 }

--- a/crates/graphforge-api/tests/provider_session.rs
+++ b/crates/graphforge-api/tests/provider_session.rs
@@ -21,7 +21,7 @@ fn mock_openrouter() -> (String, thread::JoinHandle<()>) {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let origin = format!("http://{}", listener.local_addr().unwrap());
     let server = thread::spawn(move || {
-        for call in 0..4 {
+        for call in 0..3 {
             let (mut stream, _) = listener.accept().unwrap();
             let request = read_request(&mut stream);
             let (headers, body) = request.split_once("\r\n\r\n").unwrap();
@@ -53,16 +53,6 @@ fn mock_openrouter() -> (String, thread::JoinHandle<()>) {
                     json!({"model":"vendor/model","results":[
                         {"index":0,"relevance_score":0.1},
                         {"index":1,"relevance_score":0.9}
-                    ]})
-                }
-                3 => {
-                    assert!(headers.starts_with("POST /api/v1/embeddings HTTP/1.1"));
-                    assert_eq!(payload["input"].as_array().unwrap().len(), 4);
-                    json!({"model":"vendor/model","data":[
-                        {"index":0,"embedding":[1.0,0.0]},
-                        {"index":1,"embedding":[0.0,1.0]},
-                        {"index":2,"embedding":[0.5,0.5]},
-                        {"index":3,"embedding":[0.25,0.75]}
                     ]})
                 }
                 _ => unreachable!(),
@@ -249,72 +239,7 @@ fn configured_session_composes_embedding_query_rerank_and_advisory() {
         .unwrap();
     assert_eq!(uuids.value(0), second);
     assert_eq!(uuids.value(1), first);
-
-    let initial_generation = graph
-        .embedding_space(Some("semantic"))
-        .unwrap()
-        .active
-        .unwrap()
-        .generation_id;
-    node(&graph, "Third");
-    node(&graph, "Fourth");
-    let deadline = std::time::Instant::now() + Duration::from_secs(3);
-    let refreshed = loop {
-        let inspection = graph.inspect_embedding_refresh(Some("semantic")).unwrap();
-        if inspection.worker.succeeded == 1 {
-            break inspection;
-        }
-        assert!(
-            std::time::Instant::now() < deadline,
-            "proactive provider refresh did not complete"
-        );
-        thread::sleep(Duration::from_millis(25));
-    };
-    assert!(refreshed.worker.coalesced_notices >= 1);
-    assert_eq!(refreshed.worker.failed, 0);
-    assert!(matches!(
-        refreshed.last_outcome.map(|outcome| outcome.status),
-        Some(graphforge_api::EmbeddingRefreshOutcomeStatus::Succeeded)
-    ));
-    let active = graph
-        .embedding_space(Some("semantic"))
-        .unwrap()
-        .active
-        .unwrap();
-    assert_eq!(active.vector_count, 4);
-    assert_ne!(active.generation_id, initial_generation);
     server.join().unwrap();
-
-    graph
-        .add_node(
-            "Other",
-            &HashMap::from([("note".to_owned(), PropValue::Str("Unrelated".to_owned()))]),
-        )
-        .unwrap();
-    graph
-        .execute("MATCH (n:Other) SET n.note = 'still not selected'")
-        .unwrap();
-    thread::sleep(Duration::from_millis(600));
-    let unrelated = graph.inspect_embedding_refresh(Some("semantic")).unwrap();
-    assert_eq!(unrelated.worker.succeeded, 1);
-    assert_eq!(unrelated.worker.failed, 0);
-
-    graph
-        .set_embedding_refresh_project_policy(graphforge_api::EmbeddingRefreshProjectPolicy {
-            proactive: false,
-            debounce: Duration::from_millis(500),
-            max_concurrent_jobs: 2,
-        })
-        .unwrap();
-    node(&graph, "Fifth");
-    thread::sleep(Duration::from_millis(600));
-    let disabled = graph.inspect_embedding_refresh(Some("semantic")).unwrap();
-    assert_eq!(disabled.worker.succeeded, 0);
-    assert_eq!(disabled.worker.failed, 0);
-    assert!(matches!(
-        disabled.freshness.map(|freshness| freshness.state),
-        Some(graphforge_api::EmbeddingSpaceFreshnessState::SubstantiallyStale)
-    ));
 }
 
 #[test]

--- a/crates/graphforge-search/src/embedding_scheduler.rs
+++ b/crates/graphforge-search/src/embedding_scheduler.rs
@@ -344,6 +344,33 @@ impl EmbeddingRefreshScheduler {
         &mut self,
         lease: EmbeddingRefreshLease,
         completion: EmbeddingRefreshCompletion,
+        checkpoint: C,
+    ) -> Result<(), SearchArtifactError>
+    where
+        C: FnMut() -> Result<(), SearchArtifactError>,
+    {
+        let covered_source =
+            (completion == EmbeddingRefreshCompletion::Succeeded).then_some(lease.source);
+        self.complete_through(lease, completion, covered_source, checkpoint)
+    }
+
+    /// Release one exact active lease and acknowledge the newest source covered
+    /// by a successful refresh.
+    ///
+    /// A provider may publish a source newer than the source originally leased
+    /// because mutations can coalesce while provider work is in flight. Any
+    /// follow-up already covered by that exact published source is discarded;
+    /// genuinely newer work remains queued. Failed and cancelled leases do not
+    /// claim source coverage and retain their follow-up.
+    ///
+    /// # Errors
+    /// As [`Self::complete`], and rejects missing/regressed/conflicting success
+    /// coverage or coverage attached to a non-success completion.
+    pub fn complete_through<C>(
+        &mut self,
+        lease: EmbeddingRefreshLease,
+        completion: EmbeddingRefreshCompletion,
+        covered_source: Option<EmbeddingSourceState>,
         mut checkpoint: C,
     ) -> Result<(), SearchArtifactError>
     where
@@ -359,6 +386,34 @@ impl EmbeddingRefreshScheduler {
                 "does not match the active lease",
             ));
         }
+        let retained_follow_up = match (completion, covered_source) {
+            (EmbeddingRefreshCompletion::Succeeded, Some(covered)) => {
+                validate_source_progress(lease.source, covered)?;
+                active
+                    .follow_up
+                    .map(|follow_up| retain_follow_up_after_coverage(follow_up, covered))
+                    .transpose()?
+                    .flatten()
+            }
+            (EmbeddingRefreshCompletion::Succeeded, None) => {
+                return Err(invalid(
+                    "embedding scheduler completion coverage",
+                    "is required for success",
+                ));
+            }
+            (EmbeddingRefreshCompletion::Failed | EmbeddingRefreshCompletion::Cancelled, None) => {
+                active.follow_up
+            }
+            (
+                EmbeddingRefreshCompletion::Failed | EmbeddingRefreshCompletion::Cancelled,
+                Some(_),
+            ) => {
+                return Err(invalid(
+                    "embedding scheduler completion coverage",
+                    "is only valid for success",
+                ));
+            }
+        };
         let completed = match completion {
             EmbeddingRefreshCompletion::Succeeded => {
                 next_counter(self.succeeded, "embedding_scheduler_succeeded")?
@@ -370,8 +425,7 @@ impl EmbeddingRefreshScheduler {
                 next_counter(self.cancelled, "embedding_scheduler_cancelled")?
             }
         };
-        let active = self
-            .active
+        self.active
             .remove(&lease.compatibility_id)
             .expect("validated active lease must remain present");
         match completion {
@@ -380,7 +434,7 @@ impl EmbeddingRefreshScheduler {
             EmbeddingRefreshCompletion::Cancelled => self.cancelled = completed,
         }
         if self.state == EmbeddingSchedulerState::Running
-            && let Some(follow_up) = active.follow_up
+            && let Some(follow_up) = retained_follow_up
         {
             self.queued.insert(lease.compatibility_id, follow_up);
         }
@@ -460,6 +514,25 @@ impl EmbeddingRefreshScheduler {
             ));
         }
         Ok(())
+    }
+}
+
+fn retain_follow_up_after_coverage(
+    follow_up: QueuedRefresh,
+    covered: EmbeddingSourceState,
+) -> Result<Option<QueuedRefresh>, SearchArtifactError> {
+    match follow_up
+        .source
+        .graph_generation()
+        .cmp(&covered.graph_generation())
+    {
+        std::cmp::Ordering::Less => Ok(None),
+        std::cmp::Ordering::Equal if follow_up.source == covered => Ok(None),
+        std::cmp::Ordering::Equal => Err(invalid(
+            "embedding scheduler completion coverage",
+            "conflicts with queued source at the same graph generation",
+        )),
+        std::cmp::Ordering::Greater => Ok(Some(follow_up)),
     }
 }
 
@@ -685,6 +758,54 @@ mod tests {
             source(12, 3)
         );
         assert_eq!(scheduler.snapshot().unwrap().failed, 1);
+    }
+
+    #[test]
+    fn successful_refresh_discards_only_follow_up_covered_by_published_source() {
+        let mut covered = new_scheduler();
+        covered
+            .enqueue(id(1), source(10, 1), Duration::ZERO, || Ok(()))
+            .unwrap();
+        let lease = covered
+            .claim_ready(Duration::from_millis(10), || Ok(()))
+            .unwrap()
+            .unwrap();
+        covered
+            .enqueue(id(1), source(11, 2), Duration::from_millis(11), || Ok(()))
+            .unwrap();
+        covered
+            .complete_through(
+                lease,
+                EmbeddingRefreshCompletion::Succeeded,
+                Some(source(11, 2)),
+                || Ok(()),
+            )
+            .unwrap();
+        let snapshot = covered.snapshot().unwrap();
+        assert!(snapshot.queued.is_empty());
+        assert!(snapshot.in_flight.is_empty());
+        assert_eq!(snapshot.succeeded, 1);
+
+        let mut newer = new_scheduler();
+        newer
+            .enqueue(id(1), source(10, 1), Duration::ZERO, || Ok(()))
+            .unwrap();
+        let lease = newer
+            .claim_ready(Duration::from_millis(10), || Ok(()))
+            .unwrap()
+            .unwrap();
+        newer
+            .enqueue(id(1), source(12, 3), Duration::from_millis(12), || Ok(()))
+            .unwrap();
+        newer
+            .complete_through(
+                lease,
+                EmbeddingRefreshCompletion::Succeeded,
+                Some(source(11, 2)),
+                || Ok(()),
+            )
+            .unwrap();
+        assert_eq!(newer.snapshot().unwrap().queued[0].source, source(12, 3));
     }
 
     #[test]


### PR DESCRIPTION
Closes #945

## What changed
- acknowledge the exact published embedding source when completing proactive refresh work
- retain only genuinely newer coalesced follow-ups and reject invalid completion coverage with typed errors
- expose an injected monotonic driver for crate-owned deterministic tests
- replace wall-clock polling in provider success/failure coverage with real queue ownership and synchronous draining

## Validation
- `bazelisk test --local_test_jobs=2 //crates/graphforge-search:graphforge_search_test //crates/graphforge-api:graphforge_api_test //crates/graphforge-api:provider_session`
- `bazelisk test --local_test_jobs=2 //:ci_rust_tests` (97/97)
- `CARGO_TARGET_DIR=/private/tmp/graphforge-940-property-overlay-target cargo clippy -p graphforge-search -p graphforge-api --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790328358&installation_model_id=20486&pr_number=946&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F946&signature=e31eaafd801489bfa955781c12eed7eaa5eaf3c8bd9fe510ed468d16fd86c9a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->