### PR TITLE
feat(api): add resumable bounded graph construction

### DIFF
--- a/crates/graphforge-api/BUILD.bazel
+++ b/crates/graphforge-api/BUILD.bazel
@@ -58,6 +58,14 @@ gf_rust_test(
     deps = _API_DEPS,
 )
 
+gf_rust_integration_test(
+    name = "resumable_construction_surface",
+    srcs = ["tests/resumable_construction_surface.rs"],
+    crate = ":graphforge_api",
+    size = "small",
+    deps = [],
+)
+
 _API_TEST_DATA = [
     "//docs/contracts/examples:fixtures",
     "//docs/reference:schema_inventory_fixtures",

--- a/crates/graphforge-api/BUILD.bazel
+++ b/crates/graphforge-api/BUILD.bazel
@@ -545,6 +545,7 @@ test_suite(
         ":public_facade_remaining_conformance",
         ":public_lifecycle_conformance",
         ":release_load_construction",
+        ":resumable_construction_surface",
         ":scale_g500_ladder",
         ":scale_g500_scale20",
         ":strict_runtime_properties",

--- a/crates/graphforge-api/src/bulk_construction.rs
+++ b/crates/graphforge-api/src/bulk_construction.rs
@@ -1765,35 +1765,7 @@ fn validate_property_type(
 }
 
 fn property_data_type_supported(data_type: &DataType) -> bool {
-    (match data_type {
-        DataType::List(field) | DataType::LargeList(field) => {
-            property_data_type_supported(field.data_type())
-        }
-        _ => matches!(
-            data_type,
-            DataType::Boolean
-                | DataType::Int8
-                | DataType::Int16
-                | DataType::Int32
-                | DataType::Int64
-                | DataType::UInt8
-                | DataType::UInt16
-                | DataType::UInt32
-                | DataType::Float32
-                | DataType::Float64
-                | DataType::Utf8
-                | DataType::LargeUtf8
-                | DataType::Time64(arrow::datatypes::TimeUnit::Nanosecond)
-        ),
-    }) || {
-        matches!(data_type, DataType::Timestamp(arrow::datatypes::TimeUnit::Microsecond, zone) if zone.as_deref() == Some("UTC"))
-            || matches!(data_type, DataType::Struct(fields)
-        if fields == &graphforge_storage::schemas::duration_struct_fields()
-            || fields == &graphforge_storage::schemas::date_struct_fields()
-            || fields == &graphforge_storage::schemas::localdatetime_struct_fields()
-            || fields == &graphforge_storage::schemas::time_struct_fields()
-            || fields == &graphforge_storage::schemas::datetime_struct_fields())
-    }
+    graphforge_storage::schemas::property_data_type_supported(data_type)
 }
 
 fn validate_identifier(

--- a/crates/graphforge-api/src/bulk_construction.rs
+++ b/crates/graphforge-api/src/bulk_construction.rs
@@ -1816,11 +1816,7 @@ fn validate_identifier(
 }
 
 fn validate_identifier_parts(value: &str) -> bool {
-    let mut characters = value.chars();
-    characters
-        .next()
-        .is_some_and(|first| first == '_' || first.is_alphabetic())
-        && characters.all(|character| character == '_' || character.is_alphanumeric())
+    graphforge_core::identifier::is_graph_identifier(value)
 }
 
 fn uuid_column<'a>(
@@ -3528,6 +3524,24 @@ mod tests {
             assert_eq!(field.reason, BulkValidationReason::InvalidIdentifier);
             assert_eq!(field.field.as_deref(), Some(identifier));
         }
+        let at_limit = format!("A{}", "é".repeat(127));
+        let over_limit = format!("A{}x", "é".repeat(127));
+        assert_eq!(at_limit.len(), 255);
+        assert_eq!(over_limit.len(), 256);
+        assert!(validate_identifier(BulkInputKind::Node, 0, "label", &at_limit).is_ok());
+        assert!(validate_property_name(BulkInputKind::Node, &at_limit).is_ok());
+        assert_eq!(
+            validate_identifier(BulkInputKind::Edge, 7, "rel_type", &over_limit)
+                .unwrap_err()
+                .reason,
+            BulkValidationReason::InvalidIdentifier
+        );
+        assert_eq!(
+            validate_property_name(BulkInputKind::Edge, &over_limit)
+                .unwrap_err()
+                .reason,
+            BulkValidationReason::InvalidIdentifier
+        );
 
         let compatible = [
             (PropertyValueType::Utf8, DataType::LargeUtf8),

--- a/crates/graphforge-api/src/construction.rs
+++ b/crates/graphforge-api/src/construction.rs
@@ -190,12 +190,7 @@ impl GraphForge {
 }
 
 fn validate_identifier(kind: &str, name: &str) -> Result<(), GfError> {
-    let mut characters = name.chars();
-    let valid = characters
-        .next()
-        .is_some_and(|first| first == '_' || first.is_alphabetic())
-        && characters.all(|character| character == '_' || character.is_alphanumeric());
-    if valid {
+    if graphforge_core::identifier::is_graph_identifier(name) {
         Ok(())
     } else {
         Err(validation(format!("invalid node {kind} {name:?}")))

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -50,6 +50,10 @@ pub use graphforge_ontology::{
 use graphforge_ontology::{OntologyCompiler, OntologyHandle, OntologyLoader};
 use graphforge_storage::GraphCatalog;
 use graphforge_storage::ResolvedProjectGeneration;
+pub use graphforge_storage::{
+    CONSTRUCTION_EDGE_SCHEMA, CONSTRUCTION_NODE_SCHEMA, ConstructionChunkReceipt,
+    GraphConstructionBudgets, GraphConstructionEvidence, GraphConstructionState,
+};
 use sha2::{Digest, Sha256};
 
 #[cfg(test)]

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -125,6 +125,7 @@ mod provider_rerank;
 mod provider_session;
 mod repository;
 mod resource_policy;
+mod resumable_construction;
 #[cfg(test)]
 mod same_process_concurrency_tests;
 #[cfg(test)]
@@ -169,6 +170,9 @@ pub use repository::{
     RepositoryInitReceipt, RepositoryRemoveReceipt, RepositorySourceDigest, RepositorySyncRequest,
     RepositorySyncResult, RepositorySyncStatus, SkillBundle, SkillBundleFile, SkillMutationReceipt,
     SkillStatus, SkillStatusReceipt,
+};
+pub use resumable_construction::{
+    GraphConstructionProgress, GraphConstructionPublicationReceipt, GraphConstructionSession,
 };
 
 // Re-export the foundational types callers need alongside the facade, so a

--- a/crates/graphforge-api/src/resumable_construction.rs
+++ b/crates/graphforge-api/src/resumable_construction.rs
@@ -256,21 +256,37 @@ impl GraphConstructionSession<'_> {
             || cancellation.is_some_and(crate::CancellationToken::is_cancelled),
         )?;
 
-        let root = self.graph.resolved_generation.container_root();
-        let resolved = graphforge_storage::resolve_project_generation(root)?;
-        if resolved.generation_uuid() != published.generation_uuid {
-            return Err(GfError::Storage(
-                "construction publication did not resolve its exact generation".into(),
-            ));
-        }
-        let (prepared_dir, prepared_guard, _) = super::hydrate_graph_workspace(&resolved, false)?;
-        let runtime_catalog = super::load_runtime_catalog(&prepared_dir)?;
-        let property_inventory = std::sync::Arc::new(
-            graphforge_storage::AuthenticatedPropertyInventory::from_resolved_generation(
-                &resolved,
-            )?,
-        );
-        replace_workspace(&prepared_dir, &self.graph.dir)?;
+        let refresh = (|| {
+            let root = self.graph.resolved_generation.container_root();
+            let resolved = graphforge_storage::resolve_project_generation(root)?;
+            if resolved.generation_uuid() != published.generation_uuid {
+                return Err(GfError::Storage(
+                    "construction publication did not resolve its exact generation".into(),
+                ));
+            }
+            let (prepared_dir, prepared_guard, _) =
+                super::hydrate_graph_workspace(&resolved, false)?;
+            let runtime_catalog = super::load_runtime_catalog(&prepared_dir)?;
+            let property_inventory = std::sync::Arc::new(
+                graphforge_storage::AuthenticatedPropertyInventory::from_resolved_generation(
+                    &resolved,
+                )?,
+            );
+            replace_workspace(&prepared_dir, &self.graph.dir)?;
+            Ok((
+                resolved,
+                prepared_guard,
+                runtime_catalog,
+                property_inventory,
+            ))
+        })();
+        let (resolved, prepared_guard, runtime_catalog, property_inventory) =
+            refresh.map_err(|error: GfError| {
+                GfError::Storage(format!(
+                    "phase=POST_PUBLICATION_REFRESH committed=true generation_uuid={} recovery=reopen_or_resume cause={error}",
+                    published.generation_uuid
+                ))
+            })?;
         drop(prepared_guard);
         *self
             .graph
@@ -506,6 +522,31 @@ mod tests {
                 .generation_uuid(),
             parent
         );
+    }
+
+    #[test]
+    fn post_publication_refresh_failure_reports_committed_authority() {
+        let graph = GraphForge::new(None).unwrap();
+        let root = graph.resolved_generation.container_root().to_path_buf();
+        let mut session = graph.begin_graph_construction(Default::default()).unwrap();
+        session
+            .append_nodes("nodes", &nodes(&[Uuid::now_v7()]))
+            .unwrap();
+
+        REFRESH_FAILURE.with(|failure| failure.set(Some(RefreshBoundary::BeforeMove)));
+        let error = session.seal_and_publish().unwrap_err();
+        REFRESH_FAILURE.with(|failure| failure.set(None));
+
+        let progress = session.progress();
+        assert!(progress.publication_committed);
+        let committed = graphforge_storage::resolve_project_generation(&root)
+            .unwrap()
+            .generation_uuid();
+        let message = error.to_string();
+        assert!(message.contains("phase=POST_PUBLICATION_REFRESH"));
+        assert!(message.contains("committed=true"));
+        assert!(message.contains(&format!("generation_uuid={committed}")));
+        assert!(message.contains("recovery=reopen_or_resume"));
     }
 
     #[test]

--- a/crates/graphforge-api/src/resumable_construction.rs
+++ b/crates/graphforge-api/src/resumable_construction.rs
@@ -496,11 +496,10 @@ mod tests {
             )
             .unwrap();
         cancellation.cancel();
-        assert!(
-            session
-                .seal_and_publish_with_cancellation(&cancellation)
-                .is_err()
-        );
+        let error = session
+            .seal_and_publish_with_cancellation(&cancellation)
+            .unwrap_err();
+        assert_eq!(error.code(), "GF_CANCELLED");
         assert_eq!(
             graphforge_storage::resolve_project_generation(&root)
                 .unwrap()

--- a/crates/graphforge-api/src/resumable_construction.rs
+++ b/crates/graphforge-api/src/resumable_construction.rs
@@ -246,9 +246,12 @@ impl GraphConstructionSession<'_> {
         }
         let target = derived_uuid(self.session_uuid, b"generation");
         let transaction = derived_uuid(self.session_uuid, b"transaction");
-        let published = self
-            .inner
-            .publish_canonical(&encoding, target, transaction)?;
+        let published = self.inner.publish_canonical_with_cancellation(
+            &encoding,
+            target,
+            transaction,
+            || cancellation.is_some_and(crate::CancellationToken::is_cancelled),
+        )?;
 
         let root = self.graph.resolved_generation.container_root();
         let resolved = graphforge_storage::resolve_project_generation(root)?;
@@ -476,10 +479,19 @@ mod tests {
             .unwrap()
             .generation_uuid();
         let mut session = graph.begin_graph_construction(Default::default()).unwrap();
-        session
-            .append_nodes("nodes", &nodes(&[Uuid::now_v7()]))
-            .unwrap();
+        let first = Uuid::now_v7();
+        let second = Uuid::now_v7();
         let cancellation = crate::CancellationToken::new();
+        session
+            .append_nodes_with_cancellation("nodes", &nodes(&[first, second]), &cancellation)
+            .unwrap();
+        session
+            .append_edges_with_cancellation(
+                "edges",
+                &edges(&[Uuid::now_v7()], &[(first, second)]),
+                &cancellation,
+            )
+            .unwrap();
         cancellation.cancel();
         assert!(
             session

--- a/crates/graphforge-api/src/resumable_construction.rs
+++ b/crates/graphforge-api/src/resumable_construction.rs
@@ -1,0 +1,369 @@
+//! Public Rust facade for resumable, bounded, disk-owned graph construction.
+
+use arrow::record_batch::RecordBatch;
+use graphforge_core::uuid::Uuid;
+use sha2::{Digest, Sha256};
+
+use crate::{GfError, GraphForge, OntologyMode};
+
+/// Content-free durable progress for one construction session.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GraphConstructionProgress {
+    /// Durable session identifier required to resume after interruption.
+    pub session_uuid: Uuid,
+    /// Private lifecycle state; sealing does not imply publication.
+    pub state: graphforge_storage::GraphConstructionState,
+    /// Topology generation pinned when the session began.
+    pub parent_topology_generation: u64,
+    /// Number of durably accepted chunks.
+    pub accepted_chunks: u64,
+    /// Storage-measured bounded-work evidence.
+    pub evidence: graphforge_storage::GraphConstructionEvidence,
+}
+
+/// Receipt for the sole project-generation transition owned by a session.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GraphConstructionPublicationReceipt {
+    /// Published project generation.
+    pub generation_uuid: Uuid,
+    /// Whether the same durable publication was returned on retry.
+    pub idempotent_replay: bool,
+}
+
+/// Owned resumable construction handle. Arrow chunks remain storage-owned.
+pub struct GraphConstructionSession<'a> {
+    graph: &'a GraphForge,
+    session_uuid: Uuid,
+    inner: graphforge_storage::GraphConstructionSession,
+}
+
+impl GraphForge {
+    /// Begin a bounded construction pinned to the current committed graph.
+    pub fn begin_graph_construction(
+        &self,
+        budgets: graphforge_storage::GraphConstructionBudgets,
+    ) -> Result<GraphConstructionSession<'_>, GfError> {
+        self.open_graph_construction(Uuid::now_v7(), budgets, false)
+    }
+
+    /// Resume a construction using the opaque durable identifier returned at begin.
+    pub fn resume_graph_construction(
+        &self,
+        session_uuid: Uuid,
+        budgets: graphforge_storage::GraphConstructionBudgets,
+    ) -> Result<GraphConstructionSession<'_>, GfError> {
+        self.open_graph_construction(session_uuid, budgets, true)
+    }
+
+    fn open_graph_construction(
+        &self,
+        session_uuid: Uuid,
+        budgets: graphforge_storage::GraphConstructionBudgets,
+        resume: bool,
+    ) -> Result<GraphConstructionSession<'_>, GfError> {
+        if self.read_only {
+            return Err(validation("historical graph views cannot construct"));
+        }
+        let parent_topology_generation = graphforge_storage::read_topology_generation(&self.dir)?;
+        let project = self.resolved_generation.container_root();
+        let inner = if self.ontology_mode == OntologyMode::Exploratory {
+            if resume {
+                graphforge_storage::GraphConstructionSession::resume_with_mode_and_lifecycle_from_graph(
+                    project,
+                    &self.dir,
+                    session_uuid,
+                    self.ontology_mode,
+                    budgets,
+                    self.lifecycle_mode,
+                )?
+            } else {
+                graphforge_storage::GraphConstructionSession::open_with_mode_and_lifecycle_from_graph(
+                    project,
+                    &self.dir,
+                    session_uuid,
+                    parent_topology_generation,
+                    self.ontology_mode,
+                    budgets,
+                    self.lifecycle_mode,
+                )?
+            }
+        } else {
+            let composition = self
+                .workspace_ontology_composition()?
+                .ok_or_else(|| validation("construction semantic composition is absent"))?;
+            let bindings = self
+                .semantic_storage_bindings
+                .lock()
+                .expect("semantic storage binding lock poisoned")
+                .clone()
+                .ok_or_else(|| validation("construction semantic bindings are absent"))?;
+            let authority = graphforge_storage::ConstructionSemanticAuthority {
+                composition,
+                bindings,
+            };
+            if resume {
+                graphforge_storage::GraphConstructionSession::resume_with_semantic_authority_and_lifecycle_from_graph(
+                    project,
+                    &self.dir,
+                    session_uuid,
+                    self.ontology_mode,
+                    budgets,
+                    authority,
+                    self.lifecycle_mode,
+                )?
+            } else {
+                graphforge_storage::GraphConstructionSession::open_with_semantic_authority_and_lifecycle_from_graph(
+                    project,
+                    &self.dir,
+                    session_uuid,
+                    parent_topology_generation,
+                    self.ontology_mode,
+                    budgets,
+                    authority,
+                    self.lifecycle_mode,
+                )?
+            }
+        };
+        Ok(GraphConstructionSession {
+            graph: self,
+            session_uuid,
+            inner,
+        })
+    }
+}
+
+impl GraphConstructionSession<'_> {
+    /// Durable opaque identifier used to reopen this session.
+    #[must_use]
+    pub const fn session_uuid(&self) -> Uuid {
+        self.session_uuid
+    }
+
+    /// Append one canonical node Arrow chunk.
+    pub fn append_nodes(
+        &mut self,
+        chunk_id: &str,
+        batch: &RecordBatch,
+    ) -> Result<graphforge_storage::ConstructionChunkReceipt, GfError> {
+        self.inner.append(
+            graphforge_storage::ConstructionChunkKind::Node,
+            chunk_id,
+            batch,
+        )
+    }
+
+    /// Append one canonical edge Arrow chunk after all node chunks.
+    pub fn append_edges(
+        &mut self,
+        chunk_id: &str,
+        batch: &RecordBatch,
+    ) -> Result<graphforge_storage::ConstructionChunkReceipt, GfError> {
+        self.inner.append(
+            graphforge_storage::ConstructionChunkKind::Edge,
+            chunk_id,
+            batch,
+        )
+    }
+
+    /// Return durable content-free lifecycle and bounded-work progress.
+    #[must_use]
+    pub fn progress(&self) -> GraphConstructionProgress {
+        GraphConstructionProgress {
+            session_uuid: self.session_uuid,
+            state: self.inner.state(),
+            parent_topology_generation: self.inner.parent_topology_generation(),
+            accepted_chunks: self.inner.accepted_chunks(),
+            evidence: self.inner.evidence().clone(),
+        }
+    }
+
+    /// Seal, shape, encode, and atomically publish exactly one generation.
+    pub fn seal_and_publish(&mut self) -> Result<GraphConstructionPublicationReceipt, GfError> {
+        let _visibility = self.graph.graph_visibility.lock()?;
+        if self.inner.state() == graphforge_storage::GraphConstructionState::Staging {
+            self.inner.seal()?;
+        }
+        let topology_generation = self.inner.parent_topology_generation().saturating_add(1);
+        let encoding = self.inner.prepare_canonical_encoding(topology_generation)?;
+        let target = derived_uuid(self.session_uuid, b"generation");
+        let transaction = derived_uuid(self.session_uuid, b"transaction");
+        let published = self
+            .inner
+            .publish_canonical(&encoding, target, transaction)?;
+
+        let root = self.graph.resolved_generation.container_root();
+        let resolved = graphforge_storage::resolve_project_generation(root)?;
+        if resolved.generation_uuid() != published.generation_uuid {
+            return Err(GfError::Storage(
+                "construction publication did not resolve its exact generation".into(),
+            ));
+        }
+        super::rematerialize_graph_workspace(&resolved, &self.graph.dir)?;
+        *self
+            .graph
+            .runtime_catalog
+            .lock()
+            .expect("runtime catalog poisoned") = super::load_runtime_catalog(&self.graph.dir)?;
+        self.graph.install_property_generation(&resolved)?;
+        *self
+            .graph
+            .uuid_membership_index
+            .lock()
+            .expect("UUID membership lock poisoned") = None;
+        self.graph.adjacency_provider.invalidate();
+        Ok(GraphConstructionPublicationReceipt {
+            generation_uuid: published.generation_uuid,
+            idempotent_replay: published.idempotent_replay,
+        })
+    }
+
+    /// Abort an unsealed session without changing project authority.
+    pub fn abort(&mut self) -> Result<(), GfError> {
+        self.inner.abort()
+    }
+}
+
+fn derived_uuid(operation: Uuid, domain: &[u8]) -> Uuid {
+    let mut digest = Sha256::new();
+    digest.update(b"graphforge-construction-publication/v1\0");
+    digest.update(operation.as_bytes());
+    digest.update(domain);
+    graphforge_core::canonical::uuid_v8(digest.finalize().into())
+}
+
+fn validation(message: impl Into<String>) -> GfError {
+    GfError::Validation(message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::array::{ArrayRef, FixedSizeBinaryArray, StringArray};
+    use arrow::record_batch::RecordBatch;
+
+    use super::*;
+
+    fn nodes(ids: &[Uuid]) -> RecordBatch {
+        let uuids =
+            FixedSizeBinaryArray::try_from_iter(ids.iter().map(|uuid| uuid.as_bytes().as_slice()))
+                .unwrap();
+        RecordBatch::try_new(
+            graphforge_storage::CONSTRUCTION_NODE_SCHEMA.clone(),
+            vec![
+                Arc::new(uuids) as ArrayRef,
+                Arc::new(StringArray::from(vec!["Person"; ids.len()])) as ArrayRef,
+            ],
+        )
+        .unwrap()
+    }
+
+    fn edges(ids: &[Uuid], endpoints: &[(Uuid, Uuid)]) -> RecordBatch {
+        let edge_uuids =
+            FixedSizeBinaryArray::try_from_iter(ids.iter().map(|uuid| uuid.as_bytes().as_slice()))
+                .unwrap();
+        let sources = FixedSizeBinaryArray::try_from_iter(
+            endpoints
+                .iter()
+                .map(|(source, _)| source.as_bytes().as_slice()),
+        )
+        .unwrap();
+        let targets = FixedSizeBinaryArray::try_from_iter(
+            endpoints
+                .iter()
+                .map(|(_, target)| target.as_bytes().as_slice()),
+        )
+        .unwrap();
+        RecordBatch::try_new(
+            graphforge_storage::CONSTRUCTION_EDGE_SCHEMA.clone(),
+            vec![
+                Arc::new(edge_uuids) as ArrayRef,
+                Arc::new(StringArray::from(vec!["KNOWS"; ids.len()])) as ArrayRef,
+                Arc::new(sources) as ArrayRef,
+                Arc::new(targets) as ArrayRef,
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn graphforge_multi_chunk_construction_publishes_once_and_reopens() {
+        let graph = GraphForge::new(None).unwrap();
+        let root = graph.resolved_generation.container_root().to_path_buf();
+        let parent = graphforge_storage::resolve_project_generation(&root)
+            .unwrap()
+            .generation_uuid();
+        let budgets = graphforge_storage::GraphConstructionBudgets::default();
+        let mut aborted = graph.begin_graph_construction(budgets).unwrap();
+        aborted.abort().unwrap();
+        assert_eq!(
+            aborted.progress().state,
+            graphforge_storage::GraphConstructionState::Aborted
+        );
+        assert_eq!(
+            graphforge_storage::resolve_project_generation(&root)
+                .unwrap()
+                .generation_uuid(),
+            parent
+        );
+        drop(aborted);
+
+        let node_ids = [Uuid::now_v7(), Uuid::now_v7(), Uuid::now_v7()];
+        let edge_ids = [Uuid::now_v7(), Uuid::now_v7()];
+
+        let mut session = graph.begin_graph_construction(budgets).unwrap();
+        let session_uuid = session.session_uuid();
+        session
+            .append_nodes("nodes-a", &nodes(&node_ids[..2]))
+            .unwrap();
+        session
+            .append_nodes("nodes-b", &nodes(&node_ids[2..]))
+            .unwrap();
+        session
+            .append_edges(
+                "edges",
+                &edges(
+                    &edge_ids,
+                    &[(node_ids[0], node_ids[1]), (node_ids[1], node_ids[2])],
+                ),
+            )
+            .unwrap();
+        let progress = session.progress();
+        assert_eq!(progress.session_uuid, session_uuid);
+        assert_eq!(progress.accepted_chunks, 3);
+        assert_eq!(progress.evidence.input_rows, 5);
+
+        let first = session.seal_and_publish().unwrap();
+        assert!(!first.idempotent_replay);
+        assert_ne!(first.generation_uuid, parent);
+        assert_eq!(
+            graphforge_storage::resolve_project_generation(&root)
+                .unwrap()
+                .generation_uuid(),
+            first.generation_uuid
+        );
+        drop(session);
+
+        let mut resumed = graph
+            .resume_graph_construction(session_uuid, budgets)
+            .unwrap();
+        let replay = resumed.seal_and_publish().unwrap();
+        assert_eq!(replay.generation_uuid, first.generation_uuid);
+        assert!(replay.idempotent_replay);
+        assert_eq!(
+            graphforge_storage::resolve_project_generation(&root)
+                .unwrap()
+                .generation_uuid(),
+            first.generation_uuid
+        );
+        drop(resumed);
+
+        let index = graphforge_storage::UuidMembershipIndex::open(&graph.dir).unwrap();
+        assert_eq!(index.count(graphforge_storage::UuidIndexKind::Node), 3);
+        assert_eq!(index.count(graphforge_storage::UuidIndexKind::Edge), 2);
+        let catalog = graph.runtime_catalog.lock().unwrap();
+        assert!(catalog.contains_entity_type("Person"));
+        assert!(catalog.contains_relation_type("KNOWS"));
+        drop(catalog);
+    }
+}

--- a/crates/graphforge-api/src/resumable_construction.rs
+++ b/crates/graphforge-api/src/resumable_construction.rs
@@ -3,8 +3,12 @@
 use arrow::record_batch::RecordBatch;
 use graphforge_core::uuid::Uuid;
 use sha2::{Digest, Sha256};
+use std::path::Path;
 
-use crate::{GfError, GraphForge, OntologyMode};
+use crate::{
+    ConstructionChunkReceipt, GfError, GraphConstructionBudgets, GraphConstructionEvidence,
+    GraphConstructionState, GraphForge, OntologyMode,
+};
 
 /// Content-free durable progress for one construction session.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -12,13 +16,13 @@ pub struct GraphConstructionProgress {
     /// Durable session identifier required to resume after interruption.
     pub session_uuid: Uuid,
     /// Private lifecycle state; sealing does not imply publication.
-    pub state: graphforge_storage::GraphConstructionState,
+    pub state: GraphConstructionState,
     /// Topology generation pinned when the session began.
     pub parent_topology_generation: u64,
     /// Number of durably accepted chunks.
     pub accepted_chunks: u64,
     /// Storage-measured bounded-work evidence.
-    pub evidence: graphforge_storage::GraphConstructionEvidence,
+    pub evidence: GraphConstructionEvidence,
 }
 
 /// Receipt for the sole project-generation transition owned by a session.
@@ -41,7 +45,7 @@ impl GraphForge {
     /// Begin a bounded construction pinned to the current committed graph.
     pub fn begin_graph_construction(
         &self,
-        budgets: graphforge_storage::GraphConstructionBudgets,
+        budgets: GraphConstructionBudgets,
     ) -> Result<GraphConstructionSession<'_>, GfError> {
         self.open_graph_construction(Uuid::now_v7(), budgets, false)
     }
@@ -50,7 +54,7 @@ impl GraphForge {
     pub fn resume_graph_construction(
         &self,
         session_uuid: Uuid,
-        budgets: graphforge_storage::GraphConstructionBudgets,
+        budgets: GraphConstructionBudgets,
     ) -> Result<GraphConstructionSession<'_>, GfError> {
         self.open_graph_construction(session_uuid, budgets, true)
     }
@@ -58,7 +62,7 @@ impl GraphForge {
     fn open_graph_construction(
         &self,
         session_uuid: Uuid,
-        budgets: graphforge_storage::GraphConstructionBudgets,
+        budgets: GraphConstructionBudgets,
         resume: bool,
     ) -> Result<GraphConstructionSession<'_>, GfError> {
         if self.read_only {
@@ -144,7 +148,7 @@ impl GraphConstructionSession<'_> {
         &mut self,
         chunk_id: &str,
         batch: &RecordBatch,
-    ) -> Result<graphforge_storage::ConstructionChunkReceipt, GfError> {
+    ) -> Result<ConstructionChunkReceipt, GfError> {
         self.inner.append(
             graphforge_storage::ConstructionChunkKind::Node,
             chunk_id,
@@ -157,7 +161,7 @@ impl GraphConstructionSession<'_> {
         &mut self,
         chunk_id: &str,
         batch: &RecordBatch,
-    ) -> Result<graphforge_storage::ConstructionChunkReceipt, GfError> {
+    ) -> Result<ConstructionChunkReceipt, GfError> {
         self.inner.append(
             graphforge_storage::ConstructionChunkKind::Edge,
             chunk_id,
@@ -180,7 +184,7 @@ impl GraphConstructionSession<'_> {
     /// Seal, shape, encode, and atomically publish exactly one generation.
     pub fn seal_and_publish(&mut self) -> Result<GraphConstructionPublicationReceipt, GfError> {
         let _visibility = self.graph.graph_visibility.lock()?;
-        if self.inner.state() == graphforge_storage::GraphConstructionState::Staging {
+        if self.inner.state() == GraphConstructionState::Staging {
             self.inner.seal()?;
         }
         let topology_generation = self.inner.parent_topology_generation().saturating_add(1);
@@ -198,13 +202,33 @@ impl GraphConstructionSession<'_> {
                 "construction publication did not resolve its exact generation".into(),
             ));
         }
-        super::rematerialize_graph_workspace(&resolved, &self.graph.dir)?;
+        let (prepared_dir, prepared_guard, _) = super::hydrate_graph_workspace(&resolved, false)?;
+        let runtime_catalog = super::load_runtime_catalog(&prepared_dir)?;
+        let property_inventory = std::sync::Arc::new(
+            graphforge_storage::AuthenticatedPropertyInventory::from_resolved_generation(
+                &resolved,
+            )?,
+        );
+        replace_workspace(&prepared_dir, &self.graph.dir)?;
+        drop(prepared_guard);
         *self
             .graph
             .runtime_catalog
             .lock()
-            .expect("runtime catalog poisoned") = super::load_runtime_catalog(&self.graph.dir)?;
-        self.graph.install_property_generation(&resolved)?;
+            .expect("runtime catalog poisoned") = runtime_catalog;
+        *self
+            .graph
+            .property_authority
+            .lock()
+            .expect("property authority lock poisoned") = super::GenerationPropertyAuthority {
+            generation_uuid: resolved.generation_uuid(),
+            inventory: property_inventory,
+        };
+        *self
+            .graph
+            .current_generation_uuid
+            .lock()
+            .expect("generation UUID lock poisoned") = resolved.generation_uuid();
         *self
             .graph
             .uuid_membership_index
@@ -221,6 +245,80 @@ impl GraphConstructionSession<'_> {
     pub fn abort(&mut self) -> Result<(), GfError> {
         self.inner.abort()
     }
+}
+
+fn replace_workspace(prepared: &Path, target: &Path) -> Result<(), GfError> {
+    refresh_boundary(RefreshBoundary::BeforeMove)?;
+    let parent = target.parent().ok_or_else(|| {
+        GfError::Storage("graph workspace has no parent for atomic replacement".into())
+    })?;
+    let backup = parent.join(format!(".graphforge-workspace-backup-{}", Uuid::now_v7()));
+    std::fs::rename(target, &backup).map_err(|error| {
+        GfError::Storage(format!("failed to preserve graph workspace: {error}"))
+    })?;
+    if let Err(error) = refresh_boundary(RefreshBoundary::AfterOldMoved) {
+        restore_workspace(&backup, target, None)?;
+        return Err(error);
+    }
+    if let Err(error) = std::fs::rename(prepared, target) {
+        restore_workspace(&backup, target, None)?;
+        return Err(GfError::Storage(format!(
+            "failed to install prepared graph workspace: {error}"
+        )));
+    }
+    if let Err(error) = refresh_boundary(RefreshBoundary::AfterNewInstalled) {
+        restore_workspace(&backup, target, Some(prepared))?;
+        return Err(error);
+    }
+    // The backup is no longer authoritative. Failure to reclaim it cannot make
+    // the already-installed workspace or in-memory replacement state invalid.
+    let _ = std::fs::remove_dir_all(backup);
+    Ok(())
+}
+
+fn restore_workspace(backup: &Path, target: &Path, prepared: Option<&Path>) -> Result<(), GfError> {
+    if let Some(prepared) = prepared {
+        std::fs::rename(target, prepared).map_err(|error| {
+            GfError::Storage(format!(
+                "failed to withdraw prepared graph workspace during rollback: {error}"
+            ))
+        })?;
+    }
+    std::fs::rename(backup, target).map_err(|error| {
+        GfError::Storage(format!("failed to restore prior graph workspace: {error}"))
+    })
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RefreshBoundary {
+    BeforeMove,
+    AfterOldMoved,
+    AfterNewInstalled,
+}
+
+#[cfg(not(test))]
+#[allow(
+    clippy::unnecessary_wraps,
+    reason = "test and production boundary hooks intentionally share one fallible signature"
+)]
+fn refresh_boundary(_: RefreshBoundary) -> Result<(), GfError> {
+    Ok(())
+}
+
+#[cfg(test)]
+fn refresh_boundary(boundary: RefreshBoundary) -> Result<(), GfError> {
+    let requested = REFRESH_FAILURE.with(std::cell::Cell::get);
+    if requested == Some(boundary) {
+        return Err(GfError::Storage(format!(
+            "injected construction refresh failure at {boundary:?}"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+thread_local! {
+    static REFRESH_FAILURE: std::cell::Cell<Option<RefreshBoundary>> = const { std::cell::Cell::new(None) };
 }
 
 fn derived_uuid(operation: Uuid, domain: &[u8]) -> Uuid {
@@ -243,6 +341,35 @@ mod tests {
     use arrow::record_batch::RecordBatch;
 
     use super::*;
+
+    #[test]
+    fn refresh_boundaries_preserve_the_prior_workspace_on_failure() {
+        for boundary in [
+            RefreshBoundary::BeforeMove,
+            RefreshBoundary::AfterOldMoved,
+            RefreshBoundary::AfterNewInstalled,
+        ] {
+            let parent = tempfile::tempdir().unwrap();
+            let target = parent.path().join("live");
+            let prepared = parent.path().join("prepared");
+            std::fs::create_dir(&target).unwrap();
+            std::fs::create_dir(&prepared).unwrap();
+            std::fs::write(target.join("generation"), b"old").unwrap();
+            std::fs::write(prepared.join("generation"), b"new").unwrap();
+
+            REFRESH_FAILURE.with(|failure| failure.set(Some(boundary)));
+            let error = replace_workspace(&prepared, &target).unwrap_err();
+            REFRESH_FAILURE.with(|failure| failure.set(None));
+
+            assert!(
+                error
+                    .to_string()
+                    .contains("injected construction refresh failure")
+            );
+            assert_eq!(std::fs::read(target.join("generation")).unwrap(), b"old");
+            assert_eq!(std::fs::read(prepared.join("generation")).unwrap(), b"new");
+        }
+    }
 
     fn nodes(ids: &[Uuid]) -> RecordBatch {
         let uuids =
@@ -365,5 +492,83 @@ mod tests {
         assert!(catalog.contains_entity_type("Person"));
         assert!(catalog.contains_relation_type("KNOWS"));
         drop(catalog);
+
+        let first_inventory = graphforge_storage::resolve_project_generation(&root)
+            .unwrap()
+            .graph_files_inventory()
+            .unwrap()
+            .unwrap();
+        let mut rejected = graph.begin_graph_construction(budgets).unwrap();
+        rejected
+            .append_nodes("duplicate-parent-node", &nodes(&node_ids[..1]))
+            .unwrap();
+        assert!(rejected.seal_and_publish().is_err());
+        assert_eq!(
+            graphforge_storage::resolve_project_generation(&root)
+                .unwrap()
+                .generation_uuid(),
+            first.generation_uuid
+        );
+        drop(rejected);
+
+        let added_node = Uuid::now_v7();
+        let added_edge = Uuid::now_v7();
+        let mut child = graph.begin_graph_construction(budgets).unwrap();
+        let child_session_uuid = child.session_uuid();
+        child
+            .append_nodes("child-node", &nodes(&[added_node]))
+            .unwrap();
+        child
+            .append_edges(
+                "child-edge",
+                &edges(&[added_edge], &[(node_ids[2], added_node)]),
+            )
+            .unwrap();
+        let child_receipt = child.seal_and_publish().unwrap();
+        assert_ne!(child_receipt.generation_uuid, first.generation_uuid);
+        drop(child);
+
+        let resolved_child = graphforge_storage::resolve_project_generation(&root).unwrap();
+        assert_eq!(
+            resolved_child.generation_uuid(),
+            child_receipt.generation_uuid
+        );
+        let child_inventory = resolved_child.graph_files_inventory().unwrap().unwrap();
+        assert!(first_inventory.files.iter().any(|parent_entry| {
+            child_inventory.files.iter().any(|child_entry| {
+                parent_entry.content_sha256 == child_entry.content_sha256
+                    && parent_entry.byte_length == child_entry.byte_length
+            })
+        }));
+
+        let child_index = graphforge_storage::UuidMembershipIndex::open(&graph.dir).unwrap();
+        assert_eq!(
+            child_index.count(graphforge_storage::UuidIndexKind::Node),
+            4
+        );
+        assert_eq!(
+            child_index.count(graphforge_storage::UuidIndexKind::Edge),
+            3
+        );
+        let child_catalog = graph.runtime_catalog.lock().unwrap();
+        assert!(child_catalog.contains_entity_type("Person"));
+        assert!(child_catalog.contains_relation_type("KNOWS"));
+        drop(child_catalog);
+
+        let mut child_replay = graph
+            .resume_graph_construction(child_session_uuid, budgets)
+            .unwrap();
+        let replay_receipt = child_replay.seal_and_publish().unwrap();
+        assert_eq!(
+            replay_receipt.generation_uuid,
+            child_receipt.generation_uuid
+        );
+        assert!(replay_receipt.idempotent_replay);
+        assert_eq!(
+            graphforge_storage::resolve_project_generation(&root)
+                .unwrap()
+                .generation_uuid(),
+            child_receipt.generation_uuid
+        );
     }
 }

--- a/crates/graphforge-api/src/resumable_construction.rs
+++ b/crates/graphforge-api/src/resumable_construction.rs
@@ -21,6 +21,8 @@ pub struct GraphConstructionProgress {
     pub parent_topology_generation: u64,
     /// Number of durably accepted chunks.
     pub accepted_chunks: u64,
+    /// Whether the sole project publication commit point was crossed.
+    pub publication_committed: bool,
     /// Storage-measured bounded-work evidence.
     pub evidence: GraphConstructionEvidence,
 }
@@ -207,6 +209,7 @@ impl GraphConstructionSession<'_> {
             state: self.inner.state(),
             parent_topology_generation: self.inner.parent_topology_generation(),
             accepted_chunks: self.inner.accepted_chunks(),
+            publication_committed: self.inner.publication_committed(),
             evidence: self.inner.evidence().clone(),
         }
     }

--- a/crates/graphforge-api/src/resumable_construction.rs
+++ b/crates/graphforge-api/src/resumable_construction.rs
@@ -156,6 +156,21 @@ impl GraphConstructionSession<'_> {
         )
     }
 
+    /// Append one node chunk while polling cooperative cancellation.
+    pub fn append_nodes_with_cancellation(
+        &mut self,
+        chunk_id: &str,
+        batch: &RecordBatch,
+        cancellation: &crate::CancellationToken,
+    ) -> Result<ConstructionChunkReceipt, GfError> {
+        self.inner.append_with_cancellation(
+            graphforge_storage::ConstructionChunkKind::Node,
+            chunk_id,
+            batch,
+            || cancellation.is_cancelled(),
+        )
+    }
+
     /// Append one canonical edge Arrow chunk after all node chunks.
     pub fn append_edges(
         &mut self,
@@ -166,6 +181,21 @@ impl GraphConstructionSession<'_> {
             graphforge_storage::ConstructionChunkKind::Edge,
             chunk_id,
             batch,
+        )
+    }
+
+    /// Append one edge chunk while polling cooperative cancellation.
+    pub fn append_edges_with_cancellation(
+        &mut self,
+        chunk_id: &str,
+        batch: &RecordBatch,
+        cancellation: &crate::CancellationToken,
+    ) -> Result<ConstructionChunkReceipt, GfError> {
+        self.inner.append_with_cancellation(
+            graphforge_storage::ConstructionChunkKind::Edge,
+            chunk_id,
+            batch,
+            || cancellation.is_cancelled(),
         )
     }
 
@@ -183,12 +213,37 @@ impl GraphConstructionSession<'_> {
 
     /// Seal, shape, encode, and atomically publish exactly one generation.
     pub fn seal_and_publish(&mut self) -> Result<GraphConstructionPublicationReceipt, GfError> {
+        self.seal_and_publish_inner(None)
+    }
+
+    /// Seal and publish while polling cooperative cancellation before `CURRENT`.
+    pub fn seal_and_publish_with_cancellation(
+        &mut self,
+        cancellation: &crate::CancellationToken,
+    ) -> Result<GraphConstructionPublicationReceipt, GfError> {
+        self.seal_and_publish_inner(Some(cancellation))
+    }
+
+    fn seal_and_publish_inner(
+        &mut self,
+        cancellation: Option<&crate::CancellationToken>,
+    ) -> Result<GraphConstructionPublicationReceipt, GfError> {
+        if let Some(token) = cancellation {
+            token.checkpoint()?;
+        }
         let _visibility = self.graph.graph_visibility.lock()?;
         if self.inner.state() == GraphConstructionState::Staging {
             self.inner.seal()?;
         }
         let topology_generation = self.inner.parent_topology_generation().saturating_add(1);
-        let encoding = self.inner.prepare_canonical_encoding(topology_generation)?;
+        let encoding = self
+            .inner
+            .prepare_canonical_encoding_with_cancellation(topology_generation, || {
+                cancellation.is_some_and(crate::CancellationToken::is_cancelled)
+            })?;
+        if let Some(token) = cancellation {
+            token.checkpoint()?;
+        }
         let target = derived_uuid(self.session_uuid, b"generation");
         let transaction = derived_uuid(self.session_uuid, b"transaction");
         let published = self
@@ -411,6 +466,32 @@ mod tests {
             ],
         )
         .unwrap()
+    }
+
+    #[test]
+    fn cancelled_public_construction_preserves_current() {
+        let graph = GraphForge::new(None).unwrap();
+        let root = graph.resolved_generation.container_root().to_path_buf();
+        let parent = graphforge_storage::resolve_project_generation(&root)
+            .unwrap()
+            .generation_uuid();
+        let mut session = graph.begin_graph_construction(Default::default()).unwrap();
+        session
+            .append_nodes("nodes", &nodes(&[Uuid::now_v7()]))
+            .unwrap();
+        let cancellation = crate::CancellationToken::new();
+        cancellation.cancel();
+        assert!(
+            session
+                .seal_and_publish_with_cancellation(&cancellation)
+                .is_err()
+        );
+        assert_eq!(
+            graphforge_storage::resolve_project_generation(&root)
+                .unwrap()
+                .generation_uuid(),
+            parent
+        );
     }
 
     #[test]

--- a/crates/graphforge-api/tests/resumable_construction_surface.rs
+++ b/crates/graphforge-api/tests/resumable_construction_surface.rs
@@ -1,0 +1,27 @@
+//! External-crate proof that construction contracts are owned by `graphforge-api`.
+
+use graphforge_api::{
+    CONSTRUCTION_EDGE_SCHEMA, CONSTRUCTION_NODE_SCHEMA, ConstructionChunkReceipt,
+    GraphConstructionBudgets, GraphConstructionEvidence, GraphConstructionProgress,
+    GraphConstructionState,
+};
+
+#[test]
+fn construction_contract_is_nameable_from_graphforge_api_alone() {
+    let budgets = GraphConstructionBudgets::default();
+    let evidence = GraphConstructionEvidence::default();
+    let state = GraphConstructionState::Staging;
+    let node_schema = CONSTRUCTION_NODE_SCHEMA.clone();
+    let edge_schema = CONSTRUCTION_EDGE_SCHEMA.clone();
+
+    fn accepts_receipt(_: Option<ConstructionChunkReceipt>) {}
+    fn accepts_progress(_: Option<GraphConstructionProgress>) {}
+
+    accepts_receipt(None);
+    accepts_progress(None);
+    assert!(budgets.max_batch_rows > 0);
+    assert_eq!(evidence.input_rows, 0);
+    assert_eq!(state, GraphConstructionState::Staging);
+    assert_eq!(node_schema.fields().len(), 2);
+    assert_eq!(edge_schema.fields().len(), 4);
+}

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -30,10 +30,10 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use arrow::array::{Array, FixedSizeBinaryArray, Int64Array, StringArray, UInt64Array};
 use arrow::record_batch::RecordBatch;
 use graphforge_api::{
-    CancellationToken, GraphForge, OperationId, PortableSelection, PortableV2ExportRequest,
-    PortableV2ImportRequest, PortableV2Limits, PortableV2Mode, PortableV2Output,
-    PortableV2SelectionProfile, PortableVerifyRequest, bulk_edge_input_schema,
-    bulk_node_input_schema, verify_portable_v2,
+    CONSTRUCTION_EDGE_SCHEMA, CONSTRUCTION_NODE_SCHEMA, CancellationToken,
+    GraphConstructionBudgets, GraphConstructionSession, GraphForge, OperationId, PortableSelection,
+    PortableV2ExportRequest, PortableV2ImportRequest, PortableV2Limits, PortableV2Mode,
+    PortableV2Output, PortableV2SelectionProfile, PortableVerifyRequest, verify_portable_v2,
 };
 use graphforge_core::uuid::Uuid;
 use serde::Deserialize;
@@ -597,6 +597,36 @@ fn write_json_atomically(path: &Path, value: &Value) {
         .expect("sync journal parent");
 }
 
+fn open_persisted_construction<'a>(
+    graph: &'a GraphForge,
+    path: &Path,
+) -> GraphConstructionSession<'a> {
+    if path.exists() {
+        let opaque = fs::read_to_string(path).expect("read construction session identifier");
+        let session_uuid =
+            Uuid::parse_str(opaque.trim()).expect("parse construction session identifier");
+        return graph
+            .resume_graph_construction(session_uuid, GraphConstructionBudgets::default())
+            .expect("resume persisted construction session");
+    }
+    let session = graph
+        .begin_graph_construction(GraphConstructionBudgets::default())
+        .expect("begin persisted construction session");
+    let parent = path.parent().expect("construction session parent");
+    fs::create_dir_all(parent).expect("construction session parent");
+    let temporary = parent.join(".construction-session.uuid.tmp");
+    let mut file = File::create(&temporary).expect("create construction session identifier");
+    writeln!(file, "{}", session.session_uuid().hyphenated())
+        .expect("write construction session identifier");
+    file.sync_all()
+        .expect("sync construction session identifier");
+    fs::rename(&temporary, path).expect("publish construction session identifier");
+    File::open(parent)
+        .and_then(|directory| directory.sync_all())
+        .expect("sync construction session parent");
+    session
+}
+
 fn persist_phase_journal(
     profile: &ScaleProfile,
     rung: &Rung,
@@ -822,15 +852,21 @@ fn run_rung(
         INGEST_SUBPHASE.store(1, Ordering::Relaxed);
         let heartbeat =
             IngestHeartbeat::start(profile, rung, completed_rungs, &steps, &project, &spill_dir);
-        publish_nodes(&graph, 1u64 << rung.scale, None);
+        let mut construction =
+            open_persisted_construction(&graph, &spill_dir.join("construction-session.uuid"));
+        publish_nodes(&mut construction, 1u64 << rung.scale, None);
         INGEST_SUBPHASE.store(2, Ordering::Relaxed);
-        let mut sink = EdgeSink::new(&graph, None);
+        let mut sink = EdgeSink::new(&mut construction, None);
         let merge =
             merge_runs(&spill.runs, None, |src, dst| sink.push(src, dst)).expect("rung merge");
         sink.flush();
         live_unique_edges = merge.live_unique_edges;
         duplicates_rejected = merge.duplicates_rejected;
         input_fingerprint = format!("sha256:{}", hex_encode(sink.finish()));
+        let construction_evidence = construction.progress().evidence;
+        construction
+            .seal_and_publish()
+            .expect("publish rung construction");
         INGEST_SUBPHASE.store(0, Ordering::Relaxed);
         heartbeat.stop();
         drop(graph);
@@ -845,14 +881,22 @@ fn run_rung(
             "id": "ingest",
             "pass": ingest_violation.is_none(),
             "wall_time_s": ingest_s,
-            // NOTE: ingest RSS includes the upstream bulk-publication identity
-            // set (see runbook), so an ingest-phase `oom` is not a generator
-            // bottleneck. Recorded here so consumers can attribute it.
             "rss_peak_bytes": rss_value(),
+            "disk_used_bytes": directory_bytes(&project).unwrap_or(0)
+                .saturating_add(directory_bytes(&spill_dir).unwrap_or(0)),
             "detail": {
                 "live_unique_edges": live_unique_edges,
                 "duplicates_rejected": duplicates_rejected,
                 "input_fingerprint": input_fingerprint,
+                "construction": {
+                    "input_rows": construction_evidence.input_rows,
+                    "input_batches": construction_evidence.input_batches,
+                    "parquet_shards": construction_evidence.parquet_shards,
+                    "write_bytes": construction_evidence.write_bytes,
+                    "write_operations": construction_evidence.write_operations,
+                    "authentication_read_bytes": construction_evidence.authentication_read_bytes,
+                    "authentication_read_operations": construction_evidence.authentication_read_operations,
+                },
             }
         }));
         persist_phase_journal(
@@ -1097,18 +1141,21 @@ fn provisioned_rungs_through(profile: &ScaleProfile, max_scale: u32) -> Result<V
 // Streaming edge publisher (bounded by EDGE_PUBLISH_ROWS).
 // ---------------------------------------------------------------------------
 
-struct EdgeSink<'a> {
-    graph: &'a GraphForge,
+struct EdgeSink<'a, 'graph> {
+    session: &'a mut GraphConstructionSession<'graph>,
     cancellation: Option<&'a AtomicBool>,
     buf: Vec<(u32, u32)>,
     chunk_index: u128,
     hasher: Sha256,
 }
 
-impl<'a> EdgeSink<'a> {
-    fn new(graph: &'a GraphForge, cancellation: Option<&'a AtomicBool>) -> Self {
+impl<'a, 'graph> EdgeSink<'a, 'graph> {
+    fn new(
+        session: &'a mut GraphConstructionSession<'graph>,
+        cancellation: Option<&'a AtomicBool>,
+    ) -> Self {
         EdgeSink {
-            graph,
+            session,
             cancellation,
             buf: Vec::with_capacity(EDGE_PUBLISH_ROWS),
             chunk_index: 0,
@@ -1131,8 +1178,6 @@ impl<'a> EdgeSink<'a> {
         if self.buf.is_empty() {
             return;
         }
-        let schema = bulk_edge_input_schema(Vec::new()).expect("edge schema");
-        let mut batches = Vec::new();
         let mut offset = 0usize;
         while offset < self.buf.len() {
             self.check_cancellation();
@@ -1151,7 +1196,7 @@ impl<'a> EdgeSink<'a> {
                 targets.push(uuidv7(u128::from(dst) + 1));
             }
             let batch = RecordBatch::try_new(
-                schema.clone(),
+                CONSTRUCTION_EDGE_SCHEMA.clone(),
                 vec![
                     Arc::new(
                         FixedSizeBinaryArray::try_from_iter(edge_ids.iter().map(Uuid::as_bytes))
@@ -1169,7 +1214,12 @@ impl<'a> EdgeSink<'a> {
                 ],
             )
             .expect("edge batch");
-            batches.push(batch);
+            self.session
+                .append_edges(
+                    &format!("edges-{:016x}-{:08x}", self.chunk_index, offset),
+                    &batch,
+                )
+                .expect("append construction edge chunk");
             offset = end;
         }
         INGEST_CHUNK_INDEX.store(
@@ -1177,9 +1227,6 @@ impl<'a> EdgeSink<'a> {
             Ordering::Relaxed,
         );
         INGEST_SUBPHASE.store(3, Ordering::Relaxed);
-        self.graph
-            .publish_bulk_edges(OperationId(uuidv7(0xB100 + self.chunk_index)), &batches)
-            .expect("publish_bulk_edges");
         INGEST_SUBPHASE.store(4, Ordering::Relaxed);
         self.chunk_index += 1;
         self.buf.clear();
@@ -1201,9 +1248,12 @@ impl<'a> EdgeSink<'a> {
     }
 }
 
-fn publish_nodes(graph: &GraphForge, vertex_count: u64, cancellation: Option<&AtomicBool>) {
+fn publish_nodes(
+    session: &mut GraphConstructionSession<'_>,
+    vertex_count: u64,
+    cancellation: Option<&AtomicBool>,
+) {
     let total = usize::try_from(vertex_count).expect("vertex count fits usize");
-    let schema = bulk_node_input_schema(Vec::new()).expect("node schema");
     let mut offset = 0usize;
     while offset < total {
         assert!(
@@ -1211,7 +1261,6 @@ fn publish_nodes(graph: &GraphForge, vertex_count: u64, cancellation: Option<&At
             "node publication cancelled"
         );
         let chunk_end = (offset + EDGE_PUBLISH_ROWS).min(total);
-        let mut batches = Vec::new();
         let mut inner = offset;
         while inner < chunk_end {
             assert!(
@@ -1224,7 +1273,7 @@ fn publish_nodes(graph: &GraphForge, vertex_count: u64, cancellation: Option<&At
                 .map(|index| uuidv7(u128::try_from(index + 1).expect("node seed")))
                 .collect::<Vec<_>>();
             let batch = RecordBatch::try_new(
-                schema.clone(),
+                CONSTRUCTION_NODE_SCHEMA.clone(),
                 vec![
                     Arc::new(
                         FixedSizeBinaryArray::try_from_iter(ids.iter().map(Uuid::as_bytes))
@@ -1234,12 +1283,11 @@ fn publish_nodes(graph: &GraphForge, vertex_count: u64, cancellation: Option<&At
                 ],
             )
             .expect("node batch");
-            batches.push(batch);
+            session
+                .append_nodes(&format!("nodes-{inner:016x}"), &batch)
+                .expect("append construction node chunk");
             inner = end;
         }
-        graph
-            .publish_bulk_nodes(OperationId(uuidv7(0xB001_0000 + offset as u128)), &batches)
-            .expect("publish_bulk_nodes");
         offset = chunk_end;
     }
 }
@@ -2120,13 +2168,22 @@ fn create_bounded_drill_package(root: &Path, limits: PortableV2Limits) -> (PathB
     let package = root.join("drill.gfpb");
     fs::create_dir_all(&project).expect("bounded drill project");
     let graph = GraphForge::new(project.to_str()).expect("open bounded drill project");
-    publish_nodes(&graph, 8, None);
-    let mut sink = EdgeSink::new(&graph, None);
+    let mut construction = graph
+        .begin_graph_construction(Default::default())
+        .expect("begin bounded drill construction");
+    publish_nodes(&mut construction, 8, None);
+    let mut sink = EdgeSink::new(&mut construction, None);
     for edge in [(0, 1), (1, 2), (2, 3), (3, 4)] {
         sink.push(edge.0, edge.1);
     }
     sink.flush();
     let _ = sink.finish();
+    construction
+        .seal_and_publish()
+        .expect("publish bounded drill construction");
+    drop(construction);
+    drop(graph);
+    let graph = GraphForge::new(project.to_str()).expect("reopen bounded drill project");
     let receipt = graph
         .export_portable_v2(
             &PortableV2ExportRequest {
@@ -2224,8 +2281,15 @@ fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value 
 
     let phase = Instant::now();
     let graph = GraphForge::new(source.to_str()).expect("open certification source");
-    publish_nodes(&graph, 1u64 << scale, Some(journal.cancellation()));
-    let mut sink = EdgeSink::new(&graph, Some(journal.cancellation()));
+    let mut construction = graph
+        .begin_graph_construction(Default::default())
+        .expect("begin certification construction");
+    publish_nodes(
+        &mut construction,
+        1u64 << scale,
+        Some(journal.cancellation()),
+    );
+    let mut sink = EdgeSink::new(&mut construction, Some(journal.cancellation()));
     if let Some(edges) = edges {
         for (src, dst) in edges {
             sink.push(src, dst);
@@ -2241,6 +2305,9 @@ fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value 
     sink.flush();
     let input_fingerprint = format!("sha256:{}", sink.finish());
     assert_eq!(input_fingerprint, generation_fingerprint);
+    construction
+        .seal_and_publish()
+        .expect("publish certification construction");
     journal.pass("ingest", phase, Some(input_fingerprint));
 
     let phase = Instant::now();
@@ -2571,8 +2638,11 @@ fn cancellation_stops_merge_and_publication_before_more_work_is_committed() {
     let project = TempDir::new().expect("cancelled publication project");
     let graph = GraphForge::new(project.path().to_str()).expect("open publication project");
     let before = current_generation_uuid(&graph);
+    let mut construction = graph
+        .begin_graph_construction(Default::default())
+        .expect("begin cancelled construction");
     let stopped = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        publish_nodes(&graph, 8, Some(&cancelled));
+        publish_nodes(&mut construction, 8, Some(&cancelled));
     }));
     assert!(stopped.is_err());
     assert_eq!(current_generation_uuid(&graph), before);
@@ -2582,6 +2652,54 @@ fn cancellation_stops_merge_and_publication_before_more_work_is_committed() {
             .expect("node count after cancellation"),
         0
     );
+}
+
+#[test]
+fn graph500_driver_has_no_bulk_publication_escape_hatch() {
+    let forbidden = ["publish", "bulk"].join("_");
+    assert!(!include_str!("scale_g500_ladder.rs").contains(&forbidden));
+}
+
+#[test]
+fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
+    for factor in [1_u64, 2, 4] {
+        let project = TempDir::new().expect("tiny construction project");
+        let graph = GraphForge::new(project.path().to_str()).expect("open tiny project");
+        let before = current_generation_uuid(&graph);
+        let session_file = project.path().join("session.uuid");
+        let session_uuid = {
+            let mut session = open_persisted_construction(&graph, &session_file);
+            publish_nodes(&mut session, 8 * factor, None);
+            session.session_uuid()
+        };
+        let mut resumed = graph
+            .resume_graph_construction(session_uuid, GraphConstructionBudgets::default())
+            .expect("resume tiny construction");
+        let mut sink = EdgeSink::new(&mut resumed, None);
+        for node in 0..u32::try_from(8 * factor - 1).expect("tiny vertex count") {
+            sink.push(node, node + 1);
+        }
+        sink.flush();
+        let _ = sink.finish();
+        let progress = resumed.progress();
+        assert_eq!(progress.evidence.input_rows, 16 * factor - 1);
+        assert!(progress.evidence.input_batches <= 2 * factor + 1);
+        assert!(progress.evidence.parquet_shards <= progress.evidence.input_batches);
+        let receipt = resumed
+            .seal_and_publish()
+            .expect("publish tiny construction");
+        assert_ne!(receipt.generation_uuid, before);
+        assert_eq!(current_generation_uuid(&graph), receipt.generation_uuid);
+        drop(resumed);
+        let replay = graph
+            .resume_graph_construction(session_uuid, GraphConstructionBudgets::default())
+            .expect("resume published tiny construction")
+            .seal_and_publish()
+            .expect("replay tiny publication");
+        assert!(replay.idempotent_replay);
+        assert_eq!(replay.generation_uuid, receipt.generation_uuid);
+        assert_eq!(current_generation_uuid(&graph), receipt.generation_uuid);
+    }
 }
 
 #[test]

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -870,15 +870,27 @@ fn run_rung(
             IngestHeartbeat::start(profile, rung, completed_rungs, &steps, &project, &spill_dir);
         let mut construction =
             open_persisted_construction(&graph, &spill_dir.join("construction-session.uuid"));
-        publish_nodes(&mut construction, 1u64 << rung.scale, None);
-        INGEST_SUBPHASE.store(2, Ordering::Relaxed);
-        let mut sink = EdgeSink::new(&mut construction, None);
-        let merge =
-            merge_runs(&spill.runs, None, |src, dst| sink.push(src, dst)).expect("rung merge");
-        sink.flush();
-        live_unique_edges = merge.live_unique_edges;
-        duplicates_rejected = merge.duplicates_rejected;
-        input_fingerprint = format!("sha256:{}", hex_encode(sink.finish()));
+        if construction.progress().publication_committed {
+            let mut fingerprint = Sha256::new();
+            let merge = merge_runs(&spill.runs, None, |src, dst| {
+                fingerprint.update(src.to_le_bytes());
+                fingerprint.update(dst.to_le_bytes());
+            })
+            .expect("reconcile already-published rung");
+            live_unique_edges = merge.live_unique_edges;
+            duplicates_rejected = merge.duplicates_rejected;
+            input_fingerprint = format!("sha256:{}", hex_encode(fingerprint.finalize()));
+        } else {
+            publish_nodes(&mut construction, 1u64 << rung.scale, None);
+            INGEST_SUBPHASE.store(2, Ordering::Relaxed);
+            let mut sink = EdgeSink::new(&mut construction, None);
+            let merge =
+                merge_runs(&spill.runs, None, |src, dst| sink.push(src, dst)).expect("rung merge");
+            sink.flush();
+            live_unique_edges = merge.live_unique_edges;
+            duplicates_rejected = merge.duplicates_rejected;
+            input_fingerprint = format!("sha256:{}", hex_encode(sink.finish()));
+        }
         construction
             .seal_and_publish()
             .expect("publish rung construction");
@@ -2820,6 +2832,12 @@ fn construction_session_reenters_across_processes() {
                 let _ = sink.finish();
                 session.seal_and_publish().expect("child publish");
             }
+            Ok("recover") => {
+                let receipt = session
+                    .seal_and_publish()
+                    .expect("recover publication receipt");
+                assert!(receipt.idempotent_replay);
+            }
             _ => panic!("unknown re-entry phase"),
         }
         return;
@@ -2842,6 +2860,11 @@ fn construction_session_reenters_across_processes() {
     run_child("nodes");
     run_child("edges");
     let graph = GraphForge::new(workspace.path().join("project").to_str()).expect("reopen result");
+    let published = current_generation_uuid(&graph);
+    drop(graph);
+    run_child("recover");
+    let graph = GraphForge::new(workspace.path().join("project").to_str()).expect("reopen result");
+    assert_eq!(current_generation_uuid(&graph), published);
     assert_eq!(graph.node_count(NODE_LABEL).unwrap(), 8);
     assert_eq!(scalar_count(&graph.execute(COUNT_EDGES).unwrap()), 2);
 }

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -769,7 +769,17 @@ fn run_rung(
     let temporary_workspace;
     let workspace = if let Ok(root) = std::env::var("GF_G500_LADDER_WORKSPACE") {
         PathBuf::from(root).join(&rung.id)
+    } else if let Ok(journal) = std::env::var("GF_G500_LADDER_JOURNAL_OUT") {
+        PathBuf::from(journal)
+            .parent()
+            .expect("ladder journal parent")
+            .join("workspace")
+            .join(&rung.id)
     } else {
+        assert_ne!(
+            rung.tier, "provisioned",
+            "provisioned rungs require GF_G500_LADDER_WORKSPACE or GF_G500_LADDER_JOURNAL_OUT"
+        );
         temporary_workspace = TempDir::new().expect("rung workspace");
         temporary_workspace.path().to_path_buf()
     };
@@ -2740,6 +2750,51 @@ fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
         assert_eq!(replay.generation_uuid, receipt.generation_uuid);
         assert_eq!(current_generation_uuid(&graph), receipt.generation_uuid);
     }
+}
+
+#[test]
+fn construction_session_reenters_across_processes() {
+    if let Ok(workspace) = std::env::var("GF_G500_REENTRY_CHILD") {
+        let workspace = PathBuf::from(workspace);
+        let project = workspace.join("project");
+        fs::create_dir_all(&project).expect("child project");
+        let graph = GraphForge::new(project.to_str()).expect("child graph");
+        let session_file = workspace.join("construction-session.uuid");
+        let mut session = open_persisted_construction(&graph, &session_file);
+        match std::env::var("GF_G500_REENTRY_PHASE").as_deref() {
+            Ok("nodes") => publish_nodes(&mut session, 8, None),
+            Ok("edges") => {
+                let mut sink = EdgeSink::new(&mut session, None);
+                sink.push(0, 1);
+                sink.push(1, 2);
+                sink.flush();
+                let _ = sink.finish();
+                session.seal_and_publish().expect("child publish");
+            }
+            _ => panic!("unknown re-entry phase"),
+        }
+        return;
+    }
+
+    let workspace = TempDir::new().expect("re-entry workspace");
+    let run_child = |phase: &str| {
+        let status = Command::new(std::env::current_exe().expect("test executable"))
+            .args([
+                "--exact",
+                "construction_session_reenters_across_processes",
+                "--nocapture",
+            ])
+            .env("GF_G500_REENTRY_CHILD", workspace.path())
+            .env("GF_G500_REENTRY_PHASE", phase)
+            .status()
+            .expect("run re-entry child");
+        assert!(status.success(), "re-entry child {phase} failed");
+    };
+    run_child("nodes");
+    run_child("edges");
+    let graph = GraphForge::new(workspace.path().join("project").to_str()).expect("reopen result");
+    assert_eq!(graph.node_count(NODE_LABEL).unwrap(), 8);
+    assert_eq!(scalar_count(&graph.execute(COUNT_EDGES).unwrap()), 2);
 }
 
 #[test]

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -2748,8 +2748,13 @@ fn cancellation_stops_merge_and_publication_before_more_work_is_committed() {
 
 #[test]
 fn graph500_driver_has_no_bulk_publication_escape_hatch() {
-    let forbidden = ["publish", "bulk"].join("_");
-    assert!(!include_str!("scale_g500_ladder.rs").contains(&forbidden));
+    let source = include_str!("scale_g500_ladder.rs");
+    for forbidden in [["publish", "bulk"].join("_"), ["bulk", "publish"].join("_")] {
+        assert!(
+            !source.contains(&forbidden),
+            "bulk publication escape hatch reintroduced: {forbidden}"
+        );
+    }
 }
 
 #[test]

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -766,9 +766,15 @@ fn run_rung(
     completed_rungs: &[Value],
 ) -> RungOutcome {
     let started = Instant::now();
-    let workspace = TempDir::new().expect("rung workspace");
-    let spill_dir = workspace.path().join("spill");
-    let project = workspace.path().join("project");
+    let temporary_workspace;
+    let workspace = if let Ok(root) = std::env::var("GF_G500_LADDER_WORKSPACE") {
+        PathBuf::from(root).join(&rung.id)
+    } else {
+        temporary_workspace = TempDir::new().expect("rung workspace");
+        temporary_workspace.path().to_path_buf()
+    };
+    let spill_dir = workspace.join("spill");
+    let project = workspace.join("project");
     fs::create_dir_all(&spill_dir).expect("spill dir");
     fs::create_dir_all(&project).expect("project dir");
 
@@ -863,10 +869,10 @@ fn run_rung(
         live_unique_edges = merge.live_unique_edges;
         duplicates_rejected = merge.duplicates_rejected;
         input_fingerprint = format!("sha256:{}", hex_encode(sink.finish()));
-        let construction_evidence = construction.progress().evidence;
         construction
             .seal_and_publish()
             .expect("publish rung construction");
+        let construction_evidence = construction.progress().evidence;
         INGEST_SUBPHASE.store(0, Ordering::Relaxed);
         heartbeat.stop();
         drop(graph);
@@ -896,6 +902,23 @@ fn run_rung(
                     "write_operations": construction_evidence.write_operations,
                     "authentication_read_bytes": construction_evidence.authentication_read_bytes,
                     "authentication_read_operations": construction_evidence.authentication_read_operations,
+                    "peak_batch_rows": construction_evidence.peak_batch_rows,
+                    "peak_batch_bytes": construction_evidence.peak_batch_bytes,
+                    "peak_accounted_live_bytes": construction_evidence.peak_accounted_live_bytes,
+                    "peak_run_records": construction_evidence.peak_run_records,
+                    "merge_read_records": construction_evidence.merge_read_records,
+                    "merge_written_records": construction_evidence.merge_written_records,
+                    "merge_groups": construction_evidence.merge_groups,
+                    "peak_merge_inputs": construction_evidence.peak_merge_inputs,
+                    "merge_read_bytes": construction_evidence.merge_read_bytes,
+                    "merge_written_bytes": construction_evidence.merge_written_bytes,
+                    "merge_fsync_operations": construction_evidence.merge_fsync_operations,
+                    "parquet_read_bytes": construction_evidence.parquet_read_bytes,
+                    "parquet_read_operations": construction_evidence.parquet_read_operations,
+                    "parquet_write_bytes": construction_evidence.parquet_write_bytes,
+                    "parquet_write_operations": construction_evidence.parquet_write_operations,
+                    "retained_probe_read_bytes": construction_evidence.retained_probe_read_bytes,
+                    "retained_probe_block_loads": construction_evidence.retained_probe_block_loads,
                 },
             }
         }));
@@ -1154,11 +1177,12 @@ impl<'a, 'graph> EdgeSink<'a, 'graph> {
         session: &'a mut GraphConstructionSession<'graph>,
         cancellation: Option<&'a AtomicBool>,
     ) -> Self {
+        let chunk_index = u128::from(session.progress().accepted_chunks);
         EdgeSink {
             session,
             cancellation,
             buf: Vec::with_capacity(EDGE_PUBLISH_ROWS),
-            chunk_index: 0,
+            chunk_index,
             hasher: Sha256::new(),
         }
     }
@@ -2675,8 +2699,16 @@ fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
         let mut resumed = graph
             .resume_graph_construction(session_uuid, GraphConstructionBudgets::default())
             .expect("resume tiny construction");
+        let mut first_edge = EdgeSink::new(&mut resumed, None);
+        first_edge.push(0, 1);
+        first_edge.flush();
+        let _ = first_edge.finish();
+        drop(resumed);
+        let mut resumed = graph
+            .resume_graph_construction(session_uuid, GraphConstructionBudgets::default())
+            .expect("resume after durable edge chunk");
         let mut sink = EdgeSink::new(&mut resumed, None);
-        for node in 0..u32::try_from(8 * factor - 1).expect("tiny vertex count") {
+        for node in 1..u32::try_from(8 * factor - 1).expect("tiny vertex count") {
             sink.push(node, node + 1);
         }
         sink.flush();

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -2217,6 +2217,49 @@ fn create_bounded_drill_package(root: &Path, limits: PortableV2Limits) -> (PathB
     drop(construction);
     drop(graph);
     let graph = GraphForge::new(project.to_str()).expect("reopen bounded drill project");
+    let expanded = root.join("drill-expanded");
+    graph
+        .export_portable_v2(
+            &PortableV2ExportRequest {
+                selection: PortableSelection::Current,
+                output_path: expanded.clone(),
+                representation: PortableV2Output::Expanded,
+                profile: PortableV2SelectionProfile::Complete,
+                subset: None,
+                limits,
+            },
+            None,
+            |_| {},
+        )
+        .expect("export compact drill expanded package");
+    verify_portable_v2(
+        &PortableVerifyRequest {
+            input: expanded,
+            mode: PortableV2Mode::Full,
+            limits,
+        },
+        None,
+    )
+    .expect("verify compact drill expanded package");
+    let cancelled = AtomicBool::new(true);
+    let cancelled_path = root.join("drill-cancelled.gfpb");
+    assert!(
+        graph
+            .export_portable_v2(
+                &PortableV2ExportRequest {
+                    selection: PortableSelection::Current,
+                    output_path: cancelled_path.clone(),
+                    representation: PortableV2Output::Bundle,
+                    profile: PortableV2SelectionProfile::Complete,
+                    subset: None,
+                    limits,
+                },
+                Some(&cancelled),
+                |_| {},
+            )
+            .is_err()
+    );
+    assert!(!cancelled_path.exists());
     let receipt = graph
         .export_portable_v2(
             &PortableV2ExportRequest {
@@ -2734,7 +2777,13 @@ fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
         assert!(progress.evidence.input_batches <= 2 * factor + 1);
         assert!(progress.evidence.parquet_shards <= progress.evidence.input_batches);
         assert!(progress.evidence.peak_batch_rows <= BATCH_ROWS as u64);
-        assert!(progress.evidence.peak_accounted_live_bytes > 0);
+        assert!(progress.evidence.peak_accounted_live_bytes <= 64 * 1024 * 1024);
+        assert!(progress.evidence.peak_run_records <= BATCH_ROWS as u64);
+        assert!(progress.evidence.peak_merge_inputs <= 64);
+        assert!(progress.evidence.peak_merge_name_slots <= 64);
+        assert!(progress.evidence.peak_resolved_endpoint_name_slots <= 64);
+        assert!(progress.evidence.peak_catalog_entries <= 64);
+        assert!(progress.evidence.peak_catalog_identifier_bytes <= 64 * 1024);
         assert!(progress.evidence.merge_read_records <= 1_024 * factor);
         assert!(progress.evidence.merge_written_records <= 1_024 * factor);
         assert!(progress.evidence.parquet_write_operations > 0);

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -600,17 +600,18 @@ fn write_json_atomically(path: &Path, value: &Value) {
 fn open_persisted_construction<'a>(
     graph: &'a GraphForge,
     path: &Path,
+    budgets: GraphConstructionBudgets,
 ) -> GraphConstructionSession<'a> {
     if path.exists() {
         let opaque = fs::read_to_string(path).expect("read construction session identifier");
         let session_uuid =
             Uuid::parse_str(opaque.trim()).expect("parse construction session identifier");
         return graph
-            .resume_graph_construction(session_uuid, GraphConstructionBudgets::default())
+            .resume_graph_construction(session_uuid, budgets)
             .expect("resume persisted construction session");
     }
     let session = graph
-        .begin_graph_construction(GraphConstructionBudgets::default())
+        .begin_graph_construction(budgets)
         .expect("begin persisted construction session");
     let parent = path.parent().expect("construction session parent");
     fs::create_dir_all(parent).expect("construction session parent");
@@ -868,8 +869,11 @@ fn run_rung(
         INGEST_SUBPHASE.store(1, Ordering::Relaxed);
         let heartbeat =
             IngestHeartbeat::start(profile, rung, completed_rungs, &steps, &project, &spill_dir);
-        let mut construction =
-            open_persisted_construction(&graph, &spill_dir.join("construction-session.uuid"));
+        let mut construction = open_persisted_construction(
+            &graph,
+            &spill_dir.join("construction-session.uuid"),
+            GraphConstructionBudgets::default(),
+        );
         if construction.progress().publication_committed {
             let mut fingerprint = Sha256::new();
             let merge = merge_runs(&spill.runs, None, |src, dst| {
@@ -2750,6 +2754,13 @@ fn graph500_driver_has_no_bulk_publication_escape_hatch() {
 
 #[test]
 fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
+    let budgets = GraphConstructionBudgets {
+        max_batch_rows: BATCH_ROWS,
+        max_run_records: 4 * BATCH_ROWS,
+        merge_fan_in: 2,
+        ..GraphConstructionBudgets::default()
+    };
+    let base_nodes = BATCH_ROWS as u64;
     let mut baseline_peaks: Option<[u64; 11]> = None;
     for factor in [1_u64, 2, 4] {
         let project = TempDir::new().expect("tiny construction project");
@@ -2757,12 +2768,12 @@ fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
         let before = current_generation_uuid(&graph);
         let session_file = project.path().join("session.uuid");
         let session_uuid = {
-            let mut session = open_persisted_construction(&graph, &session_file);
-            publish_nodes(&mut session, 8 * factor, None);
+            let mut session = open_persisted_construction(&graph, &session_file, budgets);
+            publish_nodes(&mut session, base_nodes * factor, None);
             session.session_uuid()
         };
         let mut resumed = graph
-            .resume_graph_construction(session_uuid, GraphConstructionBudgets::default())
+            .resume_graph_construction(session_uuid, budgets)
             .expect("resume tiny construction");
         let mut first_edge = EdgeSink::new(&mut resumed, None);
         first_edge.push(0, 1);
@@ -2770,14 +2781,14 @@ fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
         let _ = first_edge.finish();
         drop(resumed);
         let mut resumed = graph
-            .resume_graph_construction(session_uuid, GraphConstructionBudgets::default())
+            .resume_graph_construction(session_uuid, budgets)
             .expect("resume after durable edge chunk");
         let mut sink = EdgeSink::new(&mut resumed, None);
         // Replay the acknowledged chunk from the deterministic input cursor;
         // append authenticates it idempotently instead of minting new IDs.
         sink.push(0, 1);
         sink.flush();
-        for node in 1..u32::try_from(8 * factor - 1).expect("tiny vertex count") {
+        for node in 1..u32::try_from(base_nodes * factor - 1).expect("tiny vertex count") {
             sink.push(node, node + 1);
         }
         sink.flush();
@@ -2786,12 +2797,12 @@ fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
             .seal_and_publish()
             .expect("publish tiny construction");
         let progress = resumed.progress();
-        assert_eq!(progress.evidence.input_rows, 16 * factor - 1);
+        assert_eq!(progress.evidence.input_rows, 2 * base_nodes * factor - 1);
         assert!(progress.evidence.input_batches <= 2 * factor + 1);
         assert!(progress.evidence.parquet_shards <= progress.evidence.input_batches);
         assert!(progress.evidence.peak_batch_rows <= BATCH_ROWS as u64);
         assert!(progress.evidence.peak_accounted_live_bytes <= 64 * 1024 * 1024);
-        assert!(progress.evidence.peak_run_records <= BATCH_ROWS as u64);
+        assert!(progress.evidence.peak_run_records <= budgets.max_run_records as u64);
         assert!(progress.evidence.peak_merge_inputs <= 64);
         assert!(progress.evidence.peak_merge_name_slots <= 64);
         assert!(progress.evidence.peak_resolved_endpoint_name_slots <= 64);
@@ -2811,45 +2822,46 @@ fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
             progress.evidence.peak_catalog_decoded_batch_bytes,
         ];
         if let Some(baseline) = baseline_peaks {
-            // Input batches can fill by at most one fixed public chunk and
-            // shaping can retain at most one fixed merge/encoding window.
-            // Catalog/name cardinality is data-shape bound and must be equal;
-            // decoded catalog bytes may fill one fixed 64-KiB decode window.
-            let additive_tolerance = [
-                BATCH_ROWS as u64,
-                64 * 1024 * 1024,
-                BATCH_ROWS as u64,
-                1,
-                1024 * 1024,
-                64 * 1024 * 1024,
-                0,
-                0,
-                0,
-                0,
-                64 * 1024,
-            ];
+            // Arrow buffer accounting includes small alignment/offset metadata
+            // differences; the N rung's edge set is N-1 (eight fixed run
+            // records below its window). All other saturated windows plateau.
+            let allocator_tolerance = [0, 1_024, 8, 0, 0, 4_096, 0, 4, 0, 0, 0];
             for (index, ((observed, base), tolerance)) in observed_peaks
                 .iter()
                 .zip(baseline)
-                .zip(additive_tolerance)
+                .zip(allocator_tolerance)
                 .enumerate()
             {
+                if index == 4 {
+                    assert!(
+                        *observed <= base.saturating_mul(factor).saturating_add(4 * 1024 * 1024),
+                        "disk-backed merge footprint exceeded linear work: baseline={base} observed={observed} factor={factor}"
+                    );
+                    continue;
+                }
+                if index == 6 {
+                    assert!(
+                        *observed <= 64,
+                        "merge scheduler name slots exceeded fixed bound"
+                    );
+                    continue;
+                }
                 assert!(
                     *observed <= base.saturating_add(tolerance),
-                    "peak field {index} grew with scale: baseline={base} observed={observed} tolerance={tolerance}"
+                    "saturated peak field {index} grew with scale: baseline={base} observed={observed} tolerance={tolerance}"
                 );
             }
         } else {
             baseline_peaks = Some(observed_peaks);
         }
-        assert!(progress.evidence.merge_read_records <= 1_024 * factor);
-        assert!(progress.evidence.merge_written_records <= 1_024 * factor);
+        assert!(progress.evidence.merge_read_records <= 128 * base_nodes * factor);
+        assert!(progress.evidence.merge_written_records <= 128 * base_nodes * factor);
         assert!(progress.evidence.parquet_write_operations > 0);
         assert_ne!(receipt.generation_uuid, before);
         assert_eq!(current_generation_uuid(&graph), receipt.generation_uuid);
         drop(resumed);
         let replay = graph
-            .resume_graph_construction(session_uuid, GraphConstructionBudgets::default())
+            .resume_graph_construction(session_uuid, budgets)
             .expect("resume published tiny construction")
             .seal_and_publish()
             .expect("replay tiny publication");
@@ -2867,7 +2879,8 @@ fn construction_session_reenters_across_processes() {
         fs::create_dir_all(&project).expect("child project");
         let graph = GraphForge::new(project.to_str()).expect("child graph");
         let session_file = workspace.join("construction-session.uuid");
-        let mut session = open_persisted_construction(&graph, &session_file);
+        let mut session =
+            open_persisted_construction(&graph, &session_file, GraphConstructionBudgets::default());
         match std::env::var("GF_G500_REENTRY_PHASE").as_deref() {
             Ok("nodes") => publish_nodes(&mut session, 8, None),
             Ok("edges") => {

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -1177,12 +1177,11 @@ impl<'a, 'graph> EdgeSink<'a, 'graph> {
         session: &'a mut GraphConstructionSession<'graph>,
         cancellation: Option<&'a AtomicBool>,
     ) -> Self {
-        let chunk_index = u128::from(session.progress().accepted_chunks);
         EdgeSink {
             session,
             cancellation,
             buf: Vec::with_capacity(EDGE_PUBLISH_ROWS),
-            chunk_index,
+            chunk_index: 0,
             hasher: Sha256::new(),
         }
     }
@@ -2708,18 +2707,27 @@ fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
             .resume_graph_construction(session_uuid, GraphConstructionBudgets::default())
             .expect("resume after durable edge chunk");
         let mut sink = EdgeSink::new(&mut resumed, None);
+        // Replay the acknowledged chunk from the deterministic input cursor;
+        // append authenticates it idempotently instead of minting new IDs.
+        sink.push(0, 1);
+        sink.flush();
         for node in 1..u32::try_from(8 * factor - 1).expect("tiny vertex count") {
             sink.push(node, node + 1);
         }
         sink.flush();
         let _ = sink.finish();
+        let receipt = resumed
+            .seal_and_publish()
+            .expect("publish tiny construction");
         let progress = resumed.progress();
         assert_eq!(progress.evidence.input_rows, 16 * factor - 1);
         assert!(progress.evidence.input_batches <= 2 * factor + 1);
         assert!(progress.evidence.parquet_shards <= progress.evidence.input_batches);
-        let receipt = resumed
-            .seal_and_publish()
-            .expect("publish tiny construction");
+        assert!(progress.evidence.peak_batch_rows <= BATCH_ROWS as u64);
+        assert!(progress.evidence.peak_accounted_live_bytes > 0);
+        assert!(progress.evidence.merge_read_records <= 1_024 * factor);
+        assert!(progress.evidence.merge_written_records <= 1_024 * factor);
+        assert!(progress.evidence.parquet_write_operations > 0);
         assert_ne!(receipt.generation_uuid, before);
         assert_eq!(current_generation_uuid(&graph), receipt.generation_uuid);
         drop(resumed);

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -2750,6 +2750,7 @@ fn graph500_driver_has_no_bulk_publication_escape_hatch() {
 
 #[test]
 fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
+    let mut baseline_peaks: Option<[u64; 11]> = None;
     for factor in [1_u64, 2, 4] {
         let project = TempDir::new().expect("tiny construction project");
         let graph = GraphForge::new(project.path().to_str()).expect("open tiny project");
@@ -2796,6 +2797,51 @@ fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
         assert!(progress.evidence.peak_resolved_endpoint_name_slots <= 64);
         assert!(progress.evidence.peak_catalog_entries <= 64);
         assert!(progress.evidence.peak_catalog_identifier_bytes <= 64 * 1024);
+        let observed_peaks = [
+            progress.evidence.peak_batch_rows,
+            progress.evidence.peak_batch_bytes,
+            progress.evidence.peak_run_records,
+            progress.evidence.peak_merge_inputs,
+            progress.evidence.peak_merge_temporary_bytes,
+            progress.evidence.peak_accounted_live_bytes,
+            progress.evidence.peak_merge_name_slots,
+            progress.evidence.peak_resolved_endpoint_name_slots,
+            progress.evidence.peak_catalog_entries,
+            progress.evidence.peak_catalog_identifier_bytes,
+            progress.evidence.peak_catalog_decoded_batch_bytes,
+        ];
+        if let Some(baseline) = baseline_peaks {
+            // Input batches can fill by at most one fixed public chunk and
+            // shaping can retain at most one fixed merge/encoding window.
+            // Catalog/name cardinality is data-shape bound and must be equal;
+            // decoded catalog bytes may fill one fixed 64-KiB decode window.
+            let additive_tolerance = [
+                BATCH_ROWS as u64,
+                64 * 1024 * 1024,
+                BATCH_ROWS as u64,
+                1,
+                1024 * 1024,
+                64 * 1024 * 1024,
+                0,
+                0,
+                0,
+                0,
+                64 * 1024,
+            ];
+            for (index, ((observed, base), tolerance)) in observed_peaks
+                .iter()
+                .zip(baseline)
+                .zip(additive_tolerance)
+                .enumerate()
+            {
+                assert!(
+                    *observed <= base.saturating_add(tolerance),
+                    "peak field {index} grew with scale: baseline={base} observed={observed} tolerance={tolerance}"
+                );
+            }
+        } else {
+            baseline_peaks = Some(observed_peaks);
+        }
         assert!(progress.evidence.merge_read_records <= 1_024 * factor);
         assert!(progress.evidence.merge_written_records <= 1_024 * factor);
         assert!(progress.evidence.parquet_write_operations > 0);

--- a/crates/graphforge-bindings-node/tests/non-cypher-parity-policy.json
+++ b/crates/graphforge-bindings-node/tests/non-cypher-parity-policy.json
@@ -1,8 +1,8 @@
 {
   "contractVersion": 1,
   "rustManifest": "../../../tests/contracts/non-cypher-rust-surface.json",
-  "releaseSurfaceCount": 247,
-  "releaseSurfaceDigest": "fa31f90944981d9e850cb115e70beb0c987ba36cedd71c681a51b122d59954fb",
+  "releaseSurfaceCount": 257,
+  "releaseSurfaceDigest": "bb7d3f89204eb3115fd425081d45e874251a20de9759355e867d87e005063219",
   "requiredEquivalent": [
     "GraphForge.adopt_ontology",
     "GraphForge.clear_ontology",
@@ -29,6 +29,7 @@
     "compatibility": "arrowIpc",
     "transaction-maintenance": "transactionMaintenance",
     "resumable-import": "importSession",
+    "resumable-construction": "resumableConstruction",
     "semantic-generation-diff": "semanticGenerationDiff",
     "portable-v2-facade": "portableV2"
   },
@@ -292,6 +293,7 @@
     },
     "notExposedDefaults": {
       "CheckpointView": "Node checkpoint views expose the bounded pinned read surface; unsupported Rust checkpoint operations require an explicit parity decision.",
+      "GraphConstructionSession": "Resumable graph construction is not yet shipped through the Node product facade; all session operations remain explicitly Rust-only.",
       "GraphForge": "No shipped Node member exists for this Rust facade entry; adding one requires an explicit parity decision.",
       "OpenRouterProviderSession": "Rust provider sessions are not exported; Node owns a configured native provider adapter instead.",
       "RepositoryContext": "Rust owns repository lifecycle behavior; the Node command wrapper parity is delivered by issue #226."
@@ -454,6 +456,11 @@
     "importSession": {
       "import_session.test.mjs": [
         "import session begin checkpoint resume abort lifecycle"
+      ]
+    },
+    "resumableConstruction": {
+      "non-cypher-release-parity.test.mjs": [
+        "the Node classification is total, frozen, and backed by non-skipped native tests"
       ]
     }
   }

--- a/crates/graphforge-bindings-py/tests/non_cypher_release.py
+++ b/crates/graphforge-bindings-py/tests/non_cypher_release.py
@@ -23,8 +23,8 @@ ROOT = Path(__file__).resolve().parents[3]
 RUST_MANIFEST = ROOT / "tests/contracts/non-cypher-rust-surface.json"
 RUST_GATE = ROOT / "scripts/ci/non-cypher-surface-gate.py"
 PYO3_SOURCE = ROOT / "crates/graphforge-bindings-py/src/lib.rs"
-EXPECTED_RUST_DIGEST = "2d86746c592716a79fe12cb5471f1c9b90ce8e91bfca772b19110cdfafa468d1"
-EXPECTED_RELEASE_DIGEST = "fa31f90944981d9e850cb115e70beb0c987ba36cedd71c681a51b122d59954fb"
+EXPECTED_RUST_DIGEST = "71c92e47b6e43da553be7288724d522e303da5d4677e60f51e7ea8d9f8a41b99"
+EXPECTED_RELEASE_DIGEST = "bb7d3f89204eb3115fd425081d45e874251a20de9759355e867d87e005063219"
 
 PYTHON_ONLY_METHODS = frozenset(
     {
@@ -140,6 +140,9 @@ EVIDENCE = {
     "resumable-import": {
         "import_session_lifecycle.py": ["check_import_session_lifecycle"],
     },
+    "resumable-construction": {
+        "non_cypher_release.py": ["check_surface_projection"],
+    },
     "semantic-generation-diff": {
         "generation_diff.py": ["check_generation_diff"],
     },
@@ -254,7 +257,7 @@ def _classification_report() -> dict[str, object]:
         for group in manifest["method_evidence_groups"].values()
         for method_id in group["ids"]
     }
-    assert len(release_methods) == 247
+    assert len(release_methods) == 257
     assert _digest(release_methods) == EXPECTED_RELEASE_DIGEST
     assert set(EVIDENCE) == set(manifest["method_evidence_groups"])
 
@@ -326,6 +329,14 @@ def _classification_report() -> dict[str, object]:
             classification = "not-exposed"
             reason = (
                 "the Python historical view exposes a deliberately smaller read-only projection"
+            )
+        elif rust_id.startswith("GraphConstructionSession.") or rust_id in {
+            "GraphForge.begin_graph_construction",
+            "GraphForge.resume_graph_construction",
+        }:
+            classification = "not-exposed"
+            reason = (
+                "resumable graph construction is not yet shipped through the Python product facade"
             )
         else:
             classification = "not-exposed"

--- a/crates/graphforge-core/src/identifier.rs
+++ b/crates/graphforge-core/src/identifier.rs
@@ -1,0 +1,32 @@
+//! Canonical graph identifier contract shared by every Rust surface.
+
+/// Maximum encoded UTF-8 bytes in a graph label, relationship, or property name.
+pub const MAX_GRAPH_IDENTIFIER_BYTES: usize = 255;
+
+/// Whether `value` is a canonical bounded Unicode graph identifier.
+#[must_use]
+pub fn is_graph_identifier(value: &str) -> bool {
+    if value.len() > MAX_GRAPH_IDENTIFIER_BYTES {
+        return false;
+    }
+    let mut characters = value.chars();
+    characters
+        .next()
+        .is_some_and(|first| first == '_' || first.is_alphabetic())
+        && characters.all(|character| character == '_' || character.is_alphanumeric())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unicode_identifier_limit_is_encoded_bytes() {
+        let at_limit = format!("A{}", "é".repeat(127));
+        let over_limit = format!("A{}x", "é".repeat(127));
+        assert_eq!(at_limit.len(), 255);
+        assert_eq!(over_limit.len(), 256);
+        assert!(is_graph_identifier(&at_limit));
+        assert!(!is_graph_identifier(&over_limit));
+    }
+}

--- a/crates/graphforge-core/src/lib.rs
+++ b/crates/graphforge-core/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod algorithms;
 pub mod canonical;
 pub mod embedding_options;
+pub mod identifier;
 pub mod manifest;
 pub mod uuid;
 

--- a/crates/graphforge-filesystem/src/lib.rs
+++ b/crates/graphforge-filesystem/src/lib.rs
@@ -259,6 +259,37 @@ impl StableDirectory {
         self.open_child_file(target).map(|_| ())
     }
 
+    /// Atomically install a retained temporary child without replacing an
+    /// existing target. This is the creation authority for durable control
+    /// records whose first publication must never overwrite competing state.
+    ///
+    /// # Errors
+    /// Returns an I/O error when either name is invalid, the retained source
+    /// identity changed, the target already exists, or durable installation
+    /// and identity revalidation fail.
+    pub fn install_child(
+        &self,
+        temporary: &OsStr,
+        expected_temporary: FileIdentity,
+        target: &OsStr,
+    ) -> io::Result<()> {
+        validate_child_name(temporary)?;
+        validate_child_name(target)?;
+        self.revalidate_named()?;
+        let temporary_file = self.open_child_file(temporary)?;
+        if file_identity(&temporary_file)? != expected_temporary
+            || file_link_count(&temporary_file)? != 1
+        {
+            return Err(io::Error::other(
+                "atomic temporary child identity or link count changed",
+            ));
+        }
+        drop(temporary_file);
+        install_new_file_platform(&self.file, temporary, target, Some(expected_temporary))?;
+        self.revalidate_named()?;
+        self.open_child_file(target).map(|_| ())
+    }
+
     /// Flush this retained directory capability.
     pub fn sync(&self) -> io::Result<()> {
         self.revalidate_named()?;

--- a/crates/graphforge-filesystem/src/lib.rs
+++ b/crates/graphforge-filesystem/src/lib.rs
@@ -1211,10 +1211,10 @@ mod windows {
         FILE_DISPOSITION_FLAG_IGNORE_READONLY_ATTRIBUTE, FILE_DISPOSITION_INFO_EX,
         FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_FLAG_WRITE_THROUGH,
         FILE_ID_INFO, FILE_NAME_NORMALIZED, FILE_READ_ATTRIBUTES, FILE_RENAME_INFO,
-        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FileDispositionInfoEx, FileIdInfo,
-        FileRenameInfo, FileRenameInfoEx, GetDriveTypeW, GetFileInformationByHandle,
-        GetFileInformationByHandleEx, GetFinalPathNameByHandleW, GetVolumeInformationW,
-        GetVolumePathNameW, SetFileInformationByHandle, VOLUME_NAME_DOS,
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FILE_WRITE_ATTRIBUTES,
+        FileDispositionInfoEx, FileIdInfo, FileRenameInfo, FileRenameInfoEx, GetDriveTypeW,
+        GetFileInformationByHandle, GetFileInformationByHandleEx, GetFinalPathNameByHandleW,
+        GetVolumeInformationW, GetVolumePathNameW, SetFileInformationByHandle, VOLUME_NAME_DOS,
     };
 
     #[cfg(test)]
@@ -1392,7 +1392,9 @@ mod windows {
 
     pub(super) fn delete_file_by_handle(path: &Path, expected: FileIdentity) -> io::Result<()> {
         let file = std::fs::OpenOptions::new()
-            .access_mode(DELETE | FILE_READ_ATTRIBUTES)
+            // IGNORE_READONLY_ATTRIBUTE requires FILE_WRITE_ATTRIBUTES even
+            // though the operation does not clear the shared attribute.
+            .access_mode(DELETE | FILE_READ_ATTRIBUTES | FILE_WRITE_ATTRIBUTES)
             .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
             .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_WRITE_THROUGH)
             .open(path)?;

--- a/crates/graphforge-filesystem/src/lib.rs
+++ b/crates/graphforge-filesystem/src/lib.rs
@@ -1204,10 +1204,11 @@ mod windows {
     use windows_sys::Win32::Security::{DACL_SECURITY_INFORMATION, OWNER_SECURITY_INFORMATION};
     use windows_sys::Win32::Security::{PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES};
     use windows_sys::Win32::Storage::FileSystem::{
-        BY_HANDLE_FILE_INFORMATION, CreateDirectoryW, DELETE, FILE_DISPOSITION_INFO,
+        BY_HANDLE_FILE_INFORMATION, CreateDirectoryW, DELETE, FILE_DISPOSITION_FLAG_DELETE,
+        FILE_DISPOSITION_FLAG_IGNORE_READONLY_ATTRIBUTE, FILE_DISPOSITION_INFO_EX,
         FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_FLAG_WRITE_THROUGH,
         FILE_ID_INFO, FILE_NAME_NORMALIZED, FILE_READ_ATTRIBUTES, FILE_RENAME_INFO,
-        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FileDispositionInfo, FileIdInfo,
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FileDispositionInfoEx, FileIdInfo,
         FileRenameInfo, FileRenameInfoEx, GetDriveTypeW, GetFileInformationByHandle,
         GetFileInformationByHandleEx, GetFinalPathNameByHandleW, GetVolumeInformationW,
         GetVolumePathNameW, SetFileInformationByHandle, VOLUME_NAME_DOS,
@@ -1395,17 +1396,21 @@ mod windows {
         if file_identity(&file)? != expected || identity(path)? != expected {
             return Err(io::Error::other("child identity changed before unlink"));
         }
-        let mut disposition = FILE_DISPOSITION_INFO { DeleteFile: true };
+        let mut disposition = FILE_DISPOSITION_INFO_EX {
+            Flags: FILE_DISPOSITION_FLAG_DELETE | FILE_DISPOSITION_FLAG_IGNORE_READONLY_ATTRIBUTE,
+        };
         // SAFETY: `file` is an exact retained handle opened with DELETE access,
         // and `disposition` is the initialized structure required by
-        // FileDispositionInfo for the duration of the call.
+        // FileDispositionInfoEx for the duration of the call. Ignoring the
+        // readonly attribute removes only this name without mutating attributes
+        // shared by another hard link to the same file.
         let deleted = unsafe {
             SetFileInformationByHandle(
                 file.as_raw_handle(),
-                FileDispositionInfo,
-                (&mut disposition as *mut FILE_DISPOSITION_INFO).cast(),
-                u32::try_from(std::mem::size_of::<FILE_DISPOSITION_INFO>())
-                    .expect("FILE_DISPOSITION_INFO size fits u32"),
+                FileDispositionInfoEx,
+                (&mut disposition as *mut FILE_DISPOSITION_INFO_EX).cast(),
+                u32::try_from(std::mem::size_of::<FILE_DISPOSITION_INFO_EX>())
+                    .expect("FILE_DISPOSITION_INFO_EX size fits u32"),
             )
         };
         if deleted == 0 {
@@ -2489,6 +2494,26 @@ mod tests {
             std::fs::read(root.path().join("payload")).unwrap(),
             b"replacement"
         );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn stable_directory_unlinks_exact_readonly_child_without_clearing_attributes() {
+        let root = tempfile::tempdir().unwrap();
+        let stable = StableDirectory::open(root.path()).unwrap();
+        let path = root.path().join("readonly");
+        std::fs::write(&path, b"sealed").unwrap();
+        let identity = path_identity(&path).unwrap();
+        let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+        permissions.set_readonly(true);
+        std::fs::set_permissions(&path, permissions).unwrap();
+        assert!(std::fs::metadata(&path).unwrap().permissions().readonly());
+
+        stable
+            .unlink_child_if_identity(OsStr::new("readonly"), identity)
+            .unwrap();
+
+        assert!(!path.exists());
     }
 
     #[test]

--- a/crates/graphforge-filesystem/src/lib.rs
+++ b/crates/graphforge-filesystem/src/lib.rs
@@ -2560,6 +2560,7 @@ mod tests {
                 .permissions()
                 .readonly()
         );
+        drop(temporary);
 
         stable
             .unlink_child_if_identity(OsStr::new("temporary"), identity)

--- a/crates/graphforge-filesystem/src/lib.rs
+++ b/crates/graphforge-filesystem/src/lib.rs
@@ -1192,7 +1192,10 @@ mod windows {
     use std::os::windows::io::AsRawHandle as _;
     use std::path::{Path, PathBuf};
 
-    use windows_sys::Win32::Foundation::{GENERIC_WRITE, LocalFree};
+    use windows_sys::Win32::Foundation::{
+        ERROR_INVALID_FUNCTION, ERROR_INVALID_PARAMETER, ERROR_NOT_SUPPORTED, GENERIC_WRITE,
+        LocalFree,
+    };
     #[cfg(test)]
     use windows_sys::Win32::Security::Authorization::{
         ConvertSecurityDescriptorToStringSecurityDescriptorW, GetNamedSecurityInfoW, SE_FILE_OBJECT,
@@ -1414,9 +1417,30 @@ mod windows {
             )
         };
         if deleted == 0 {
-            Err(io::Error::last_os_error())
+            Err(readonly_safe_delete_error(io::Error::last_os_error()))
         } else {
             Ok(())
+        }
+    }
+
+    fn readonly_safe_delete_error(error: io::Error) -> io::Error {
+        let unsupported = [
+            ERROR_INVALID_FUNCTION as i32,
+            ERROR_NOT_SUPPORTED as i32,
+            ERROR_INVALID_PARAMETER as i32,
+        ];
+        if error
+            .raw_os_error()
+            .is_some_and(|code| unsupported.contains(&code))
+        {
+            io::Error::new(
+                io::ErrorKind::Unsupported,
+                format!(
+                    "readonly-safe child deletion requires Windows 10 version 1709 or Windows Server version 1709 or newer: {error}"
+                ),
+            )
+        } else {
+            error
         }
     }
 
@@ -1844,6 +1868,19 @@ mod windows {
                 ),
                 ReplaceFileError::StateUnknown(_)
             ));
+        }
+
+        #[test]
+        fn readonly_safe_delete_maps_unsupported_platform_errors_actionably() {
+            let unsupported = readonly_safe_delete_error(io::Error::from_raw_os_error(
+                ERROR_NOT_SUPPORTED as i32,
+            ));
+            assert_eq!(unsupported.kind(), io::ErrorKind::Unsupported);
+            assert!(unsupported.to_string().contains("Windows 10 version 1709"));
+
+            let denied = readonly_safe_delete_error(io::Error::from_raw_os_error(5));
+            assert_eq!(denied.kind(), io::ErrorKind::PermissionDenied);
+            assert_eq!(denied.raw_os_error(), Some(5));
         }
 
         #[test]
@@ -2498,22 +2535,40 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn stable_directory_unlinks_exact_readonly_child_without_clearing_attributes() {
+    fn stable_directory_unlinks_exact_readonly_child_without_unsealing_hard_link() {
+        use std::io::Write as _;
+
         let root = tempfile::tempdir().unwrap();
         let stable = StableDirectory::open(root.path()).unwrap();
-        let path = root.path().join("readonly");
-        std::fs::write(&path, b"sealed").unwrap();
-        let identity = path_identity(&path).unwrap();
-        let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+        let temporary_path = root.path().join("temporary");
+        let installed_path = root.path().join("installed");
+        let mut temporary = stable.create_child_file(OsStr::new("temporary")).unwrap();
+        temporary.write_all(b"sealed").unwrap();
+        temporary.sync_all().unwrap();
+        let identity = file_identity(&temporary).unwrap();
+        std::fs::hard_link(&temporary_path, &installed_path).unwrap();
+        assert_eq!(path_identity(&installed_path).unwrap(), identity);
+        let mut permissions = temporary.metadata().unwrap().permissions();
         permissions.set_readonly(true);
-        std::fs::set_permissions(&path, permissions).unwrap();
-        assert!(std::fs::metadata(&path).unwrap().permissions().readonly());
+        temporary.set_permissions(permissions).unwrap();
+        assert!(temporary.metadata().unwrap().permissions().readonly());
+        assert!(
+            std::fs::metadata(&installed_path)
+                .unwrap()
+                .permissions()
+                .readonly()
+        );
 
         stable
-            .unlink_child_if_identity(OsStr::new("readonly"), identity)
+            .unlink_child_if_identity(OsStr::new("temporary"), identity)
             .unwrap();
 
-        assert!(!path.exists());
+        assert!(!temporary_path.exists());
+        assert_eq!(std::fs::read(&installed_path).unwrap(), b"sealed");
+        assert_eq!(path_identity(&installed_path).unwrap(), identity);
+        let installed = File::open(&installed_path).unwrap();
+        assert!(installed.metadata().unwrap().permissions().readonly());
+        assert_eq!(file_link_count(&installed).unwrap(), 1);
     }
 
     #[test]

--- a/crates/graphforge-ir/src/catalog.rs
+++ b/crates/graphforge-ir/src/catalog.rs
@@ -565,7 +565,7 @@ impl RuntimeCatalog {
                 if name.is_empty()
                     || observation_count == 0
                     || first_seen > last_seen
-                    || (kind == EntryKind::Property) != owner_label.is_some()
+                    || (kind != EntryKind::Property && owner_label.is_some())
                 {
                     return Err(storage_err("runtime_catalog row is not canonical"));
                 }
@@ -912,6 +912,38 @@ mod tests {
             .find(|&r| kinds.value(r) == "entity_type")
             .unwrap();
         assert_eq!(counts.value(person_row), 3);
+    }
+
+    #[test]
+    fn roundtrip_preserves_global_unowned_properties() {
+        let mut catalog = RuntimeCatalog::new();
+        let expected = catalog.intern_property("score", None);
+
+        let restored = RuntimeCatalog::from_record_batch(&catalog.to_record_batch()).unwrap();
+        assert!(restored.contains_property("score", None));
+        assert_eq!(restored.property_name(expected), Some("score"));
+        assert_eq!(
+            restored
+                .to_record_batch()
+                .column(6)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap()
+                .null_count(),
+            1
+        );
+    }
+
+    #[test]
+    fn persisted_catalog_rejects_owner_on_non_property_rows() {
+        let mut catalog = RuntimeCatalog::new();
+        catalog.intern_label("Person");
+        let good = catalog.to_record_batch();
+        let mut columns = good.columns().to_vec();
+        columns[6] = Arc::new(StringArray::from(vec![Some("invalid-owner")]));
+        let malformed = RecordBatch::try_new(RUNTIME_CATALOG_SCHEMA.clone(), columns).unwrap();
+
+        assert!(RuntimeCatalog::from_record_batch(&malformed).is_err());
     }
 
     #[test]

--- a/crates/graphforge-ir/src/catalog.rs
+++ b/crates/graphforge-ir/src/catalog.rs
@@ -186,7 +186,11 @@ impl RuntimeCatalog {
     /// If `name` has been seen before the observation count is incremented and
     /// the existing ID is returned unchanged.
     pub fn intern_label(&mut self, name: &str) -> RuntimeTypeId {
-        let now = now_micros();
+        self.intern_label_at(name, now_micros())
+    }
+
+    /// Interns an entity label at a caller-authoritative timestamp.
+    pub fn intern_label_at(&mut self, name: &str, now: i64) -> RuntimeTypeId {
         if let Some(&idx) = self.entity_types.get(name) {
             let entry = &mut self.entries[idx];
             entry.observation_count += 1;
@@ -211,7 +215,11 @@ impl RuntimeCatalog {
 
     /// Interns a relation type name and returns a stable [`RuntimeTypeId`].
     pub fn intern_relation_type(&mut self, name: &str) -> RuntimeTypeId {
-        let now = now_micros();
+        self.intern_relation_type_at(name, now_micros())
+    }
+
+    /// Interns a relation type at a caller-authoritative timestamp.
+    pub fn intern_relation_type_at(&mut self, name: &str, now: i64) -> RuntimeTypeId {
         if let Some(&idx) = self.relation_types.get(name) {
             let entry = &mut self.entries[idx];
             entry.observation_count += 1;
@@ -239,7 +247,16 @@ impl RuntimeCatalog {
     /// Properties are keyed by `(name, owner_label)` so the same property name
     /// observed on different labels gets independent IDs.
     pub fn intern_property(&mut self, name: &str, owner_label: Option<&str>) -> RuntimePropId {
-        let now = now_micros();
+        self.intern_property_at(name, owner_label, now_micros())
+    }
+
+    /// Interns a property at a caller-authoritative timestamp.
+    pub fn intern_property_at(
+        &mut self,
+        name: &str,
+        owner_label: Option<&str>,
+        now: i64,
+    ) -> RuntimePropId {
         let key = (name.to_owned(), owner_label.map(str::to_owned));
         if let Some(&idx) = self.properties.get(&key) {
             let entry = &mut self.entries[idx];
@@ -559,6 +576,27 @@ mod tests {
         let id1 = cat.intern_label("Person");
         let id2 = cat.intern_label("Person");
         assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn caller_authoritative_timestamp_is_preserved_for_every_catalog_kind() {
+        let mut catalog = RuntimeCatalog::new();
+        catalog.intern_label_at("Person", 42);
+        catalog.intern_relation_type_at("KNOWS", 42);
+        catalog.intern_property_at("score", Some("Person"), 42);
+        let batch = catalog.to_record_batch();
+        let first = batch
+            .column(4)
+            .as_any()
+            .downcast_ref::<TimestampMicrosecondArray>()
+            .unwrap();
+        let last = batch
+            .column(5)
+            .as_any()
+            .downcast_ref::<TimestampMicrosecondArray>()
+            .unwrap();
+        assert_eq!(first.values(), &[42, 42, 42]);
+        assert_eq!(last.values(), &[42, 42, 42]);
     }
 
     #[test]

--- a/crates/graphforge-ir/src/catalog.rs
+++ b/crates/graphforge-ir/src/catalog.rs
@@ -181,6 +181,22 @@ impl RuntimeCatalog {
         Self::default()
     }
 
+    /// Number of retained catalog entries.
+    #[must_use]
+    pub fn entry_count(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Exact UTF-8 bytes retained by entry names and property owners.
+    #[must_use]
+    pub fn retained_identifier_bytes(&self) -> usize {
+        self.entries.iter().fold(0_usize, |bytes, entry| {
+            bytes
+                .saturating_add(entry.name.len())
+                .saturating_add(entry.owner_label.as_ref().map_or(0, String::len))
+        })
+    }
+
     /// Interns an entity label and returns a stable [`RuntimeTypeId`].
     ///
     /// If `name` has been seen before the observation count is incremented and
@@ -284,6 +300,19 @@ impl RuntimeCatalog {
     #[must_use]
     pub fn contains_entity_type(&self, name: &str) -> bool {
         self.entity_types.contains_key(name)
+    }
+
+    /// Returns `true` if `name` has been interned as a relation type.
+    #[must_use]
+    pub fn contains_relation_type(&self, name: &str) -> bool {
+        self.relation_types.contains_key(name)
+    }
+
+    /// Returns `true` if the owner-scoped property has been interned.
+    #[must_use]
+    pub fn contains_property(&self, name: &str, owner_label: Option<&str>) -> bool {
+        self.properties
+            .contains_key(&(name.to_owned(), owner_label.map(str::to_owned)))
     }
 
     /// Returns all interned entity type names (order unspecified).
@@ -442,11 +471,23 @@ impl RuntimeCatalog {
     pub fn from_record_batches<'a>(
         batches: impl IntoIterator<Item = &'a RecordBatch>,
     ) -> Result<Self, GfError> {
+        Self::decode_record_batches_at(batches, 0, 0)
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn decode_record_batches_at<'a>(
+        batches: impl IntoIterator<Item = &'a RecordBatch>,
+        initial_type_id: u32,
+        initial_prop_id: u32,
+    ) -> Result<Self, GfError> {
         let storage_err = |msg: &str| GfError::Storage(msg.to_owned());
         let mut catalog = Self::new();
-        let mut max_type_id: u32 = 0;
-        let mut max_prop_id: u32 = 0;
+        let mut next_type_id = initial_type_id;
+        let mut next_prop_id = initial_prop_id;
         for batch in batches {
+            if batch.schema().as_ref() != RUNTIME_CATALOG_SCHEMA.as_ref() {
+                return Err(storage_err("runtime_catalog schema is not canonical"));
+            }
             let kinds = batch
                 .column(0)
                 .as_any()
@@ -489,6 +530,16 @@ impl RuntimeCatalog {
                 .downcast_ref::<StringArray>()
                 .ok_or_else(|| storage_err("runtime_catalog col 6 (owner_label) not Utf8"))?;
 
+            if kinds.null_count() != 0
+                || names.null_count() != 0
+                || ids.null_count() != 0
+                || counts.null_count() != 0
+                || first_seens.null_count() != 0
+                || last_seens.null_count() != 0
+            {
+                return Err(storage_err("runtime_catalog required column contains null"));
+            }
+
             for row in 0..batch.num_rows() {
                 let kind = match kinds.value(row) {
                     "entity_type" => EntryKind::EntityType,
@@ -511,6 +562,26 @@ impl RuntimeCatalog {
                     Some(owners.value(row).to_owned())
                 };
 
+                if name.is_empty()
+                    || observation_count == 0
+                    || first_seen > last_seen
+                    || (kind == EntryKind::Property) != owner_label.is_some()
+                {
+                    return Err(storage_err("runtime_catalog row is not canonical"));
+                }
+                let expected_id = match kind {
+                    EntryKind::EntityType | EntryKind::RelationType => &mut next_type_id,
+                    EntryKind::Property => &mut next_prop_id,
+                };
+                if runtime_id != *expected_id {
+                    return Err(storage_err(
+                        "runtime_catalog IDs are not unique and contiguous in insertion order",
+                    ));
+                }
+                *expected_id = expected_id.checked_add(1).ok_or_else(|| {
+                    storage_err("runtime_catalog persisted ID exceeds supported range")
+                })?;
+
                 let idx = catalog.entries.len();
                 catalog.entries.push(CatalogEntry {
                     kind,
@@ -529,7 +600,6 @@ impl RuntimeCatalog {
                                 "runtime_catalog contains duplicate entity type",
                             ));
                         }
-                        max_type_id = max_type_id.max(runtime_id + 1);
                     }
                     EntryKind::RelationType => {
                         if catalog.relation_types.insert(name, idx).is_some() {
@@ -537,7 +607,6 @@ impl RuntimeCatalog {
                                 "runtime_catalog contains duplicate relation type",
                             ));
                         }
-                        max_type_id = max_type_id.max(runtime_id + 1);
                     }
                     EntryKind::Property => {
                         if catalog
@@ -547,14 +616,13 @@ impl RuntimeCatalog {
                         {
                             return Err(storage_err("runtime_catalog contains duplicate property"));
                         }
-                        max_prop_id = max_prop_id.max(runtime_id + 1);
                     }
                 }
             }
         }
 
-        catalog.next_type_id = max_type_id;
-        catalog.next_prop_id = max_prop_id;
+        catalog.next_type_id = next_type_id;
+        catalog.next_prop_id = next_prop_id;
         Ok(catalog)
     }
 
@@ -562,7 +630,13 @@ impl RuntimeCatalog {
     /// observations. The caller may therefore decode a Parquet catalog in
     /// bounded windows rather than concatenating it in memory.
     pub fn extend_from_record_batch(&mut self, batch: &RecordBatch) -> Result<(), GfError> {
-        let incoming = Self::from_record_batch(batch)?;
+        let incoming = Self::decode_record_batches_at(
+            std::iter::once(batch),
+            self.next_type_id,
+            self.next_prop_id,
+        )?;
+        let mut expected_type_id = self.next_type_id;
+        let mut expected_prop_id = self.next_prop_id;
         for entry in &incoming.entries {
             let duplicate = match entry.kind {
                 EntryKind::EntityType => self.entity_types.contains_key(&entry.name),
@@ -576,7 +650,16 @@ impl RuntimeCatalog {
                     "runtime_catalog contains a duplicate persisted entry".to_owned(),
                 ));
             }
-            entry.runtime_id.checked_add(1).ok_or_else(|| {
+            let expected = match entry.kind {
+                EntryKind::EntityType | EntryKind::RelationType => &mut expected_type_id,
+                EntryKind::Property => &mut expected_prop_id,
+            };
+            if entry.runtime_id != *expected {
+                return Err(GfError::Storage(
+                    "runtime_catalog persisted IDs do not continue prior authority".to_owned(),
+                ));
+            }
+            *expected = expected.checked_add(1).ok_or_else(|| {
                 GfError::Storage("runtime_catalog persisted ID overflow".to_owned())
             })?;
         }
@@ -585,16 +668,28 @@ impl RuntimeCatalog {
             match entry.kind {
                 EntryKind::EntityType => {
                     self.entity_types.insert(entry.name.clone(), idx);
-                    self.next_type_id = self.next_type_id.max(entry.runtime_id + 1);
+                    self.next_type_id =
+                        self.next_type_id
+                            .max(entry.runtime_id.checked_add(1).ok_or_else(|| {
+                                GfError::Storage("runtime_catalog persisted ID overflow".to_owned())
+                            })?);
                 }
                 EntryKind::RelationType => {
                     self.relation_types.insert(entry.name.clone(), idx);
-                    self.next_type_id = self.next_type_id.max(entry.runtime_id + 1);
+                    self.next_type_id =
+                        self.next_type_id
+                            .max(entry.runtime_id.checked_add(1).ok_or_else(|| {
+                                GfError::Storage("runtime_catalog persisted ID overflow".to_owned())
+                            })?);
                 }
                 EntryKind::Property => {
                     let key = (entry.name.clone(), entry.owner_label.clone());
                     self.properties.insert(key, idx);
-                    self.next_prop_id = self.next_prop_id.max(entry.runtime_id + 1);
+                    self.next_prop_id =
+                        self.next_prop_id
+                            .max(entry.runtime_id.checked_add(1).ok_or_else(|| {
+                                GfError::Storage("runtime_catalog persisted ID overflow".to_owned())
+                            })?);
                 }
             }
             self.entries.push(entry);
@@ -851,5 +946,29 @@ mod tests {
             matches!(result, Err(GfError::Storage(_))),
             "expected Storage error for unknown entry_kind"
         );
+    }
+
+    #[test]
+    fn persisted_catalog_rejects_noncanonical_schema_without_panicking() {
+        let mut cat = RuntimeCatalog::new();
+        cat.intern_label("X");
+        let good = cat.to_record_batch();
+        let shortened = RecordBatch::try_new(
+            Arc::new(Schema::new(RUNTIME_CATALOG_SCHEMA.fields()[..6].to_vec())),
+            good.columns()[..6].to_vec(),
+        )
+        .unwrap();
+        assert!(RuntimeCatalog::from_record_batch(&shortened).is_err());
+    }
+
+    #[test]
+    fn persisted_catalog_rejects_maximum_id_before_overflow() {
+        let mut cat = RuntimeCatalog::new();
+        cat.intern_label("X");
+        let good = cat.to_record_batch();
+        let mut columns = good.columns().to_vec();
+        columns[2] = Arc::new(UInt32Array::from(vec![u32::MAX]));
+        let malformed = RecordBatch::try_new(RUNTIME_CATALOG_SCHEMA.clone(), columns).unwrap();
+        assert!(RuntimeCatalog::from_record_batch(&malformed).is_err());
     }
 }

--- a/crates/graphforge-ir/src/catalog.rs
+++ b/crates/graphforge-ir/src/catalog.rs
@@ -433,97 +433,122 @@ impl RuntimeCatalog {
     /// Returns [`GfError::Storage`] if any column has the wrong type or an
     /// unknown `entry_kind` value is encountered.
     pub fn from_record_batch(batch: &RecordBatch) -> Result<Self, GfError> {
+        Self::from_record_batches(std::iter::once(batch))
+    }
+
+    /// Restores a catalog from a bounded stream of persisted Arrow batches
+    /// without concatenating or retaining those batches.
+    #[allow(clippy::too_many_lines)] // One persisted schema decoder; splitting obscures row authority.
+    pub fn from_record_batches<'a>(
+        batches: impl IntoIterator<Item = &'a RecordBatch>,
+    ) -> Result<Self, GfError> {
         let storage_err = |msg: &str| GfError::Storage(msg.to_owned());
-
-        let kinds = batch
-            .column(0)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .ok_or_else(|| storage_err("runtime_catalog col 0 (entry_kind) not Utf8"))?;
-        let names = batch
-            .column(1)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .ok_or_else(|| storage_err("runtime_catalog col 1 (name) not Utf8"))?;
-        let ids = batch
-            .column(2)
-            .as_any()
-            .downcast_ref::<UInt32Array>()
-            .ok_or_else(|| storage_err("runtime_catalog col 2 (runtime_id) not UInt32"))?;
-        let counts = batch
-            .column(3)
-            .as_any()
-            .downcast_ref::<UInt64Array>()
-            .ok_or_else(|| storage_err("runtime_catalog col 3 (observation_count) not UInt64"))?;
-        let first_seens = batch
-            .column(4)
-            .as_any()
-            .downcast_ref::<TimestampMicrosecondArray>()
-            .ok_or_else(|| {
-                storage_err("runtime_catalog col 4 (first_seen) not TimestampMicrosecond")
-            })?;
-        let last_seens = batch
-            .column(5)
-            .as_any()
-            .downcast_ref::<TimestampMicrosecondArray>()
-            .ok_or_else(|| {
-                storage_err("runtime_catalog col 5 (last_seen) not TimestampMicrosecond")
-            })?;
-        let owners = batch
-            .column(6)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .ok_or_else(|| storage_err("runtime_catalog col 6 (owner_label) not Utf8"))?;
-
         let mut catalog = Self::new();
         let mut max_type_id: u32 = 0;
         let mut max_prop_id: u32 = 0;
+        for batch in batches {
+            let kinds = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .ok_or_else(|| storage_err("runtime_catalog col 0 (entry_kind) not Utf8"))?;
+            let names = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .ok_or_else(|| storage_err("runtime_catalog col 1 (name) not Utf8"))?;
+            let ids = batch
+                .column(2)
+                .as_any()
+                .downcast_ref::<UInt32Array>()
+                .ok_or_else(|| storage_err("runtime_catalog col 2 (runtime_id) not UInt32"))?;
+            let counts = batch
+                .column(3)
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .ok_or_else(|| {
+                    storage_err("runtime_catalog col 3 (observation_count) not UInt64")
+                })?;
+            let first_seens = batch
+                .column(4)
+                .as_any()
+                .downcast_ref::<TimestampMicrosecondArray>()
+                .ok_or_else(|| {
+                    storage_err("runtime_catalog col 4 (first_seen) not TimestampMicrosecond")
+                })?;
+            let last_seens = batch
+                .column(5)
+                .as_any()
+                .downcast_ref::<TimestampMicrosecondArray>()
+                .ok_or_else(|| {
+                    storage_err("runtime_catalog col 5 (last_seen) not TimestampMicrosecond")
+                })?;
+            let owners = batch
+                .column(6)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .ok_or_else(|| storage_err("runtime_catalog col 6 (owner_label) not Utf8"))?;
 
-        for row in 0..batch.num_rows() {
-            let kind = match kinds.value(row) {
-                "entity_type" => EntryKind::EntityType,
-                "relation_type" => EntryKind::RelationType,
-                "property" => EntryKind::Property,
-                other => {
-                    return Err(GfError::Storage(format!(
-                        "runtime_catalog: unknown entry_kind '{other}'"
-                    )));
-                }
-            };
-            let name = names.value(row).to_owned();
-            let runtime_id = ids.value(row);
-            let observation_count = counts.value(row);
-            let first_seen = first_seens.value(row);
-            let last_seen = last_seens.value(row);
-            let owner_label = if owners.is_null(row) {
-                None
-            } else {
-                Some(owners.value(row).to_owned())
-            };
+            for row in 0..batch.num_rows() {
+                let kind = match kinds.value(row) {
+                    "entity_type" => EntryKind::EntityType,
+                    "relation_type" => EntryKind::RelationType,
+                    "property" => EntryKind::Property,
+                    other => {
+                        return Err(GfError::Storage(format!(
+                            "runtime_catalog: unknown entry_kind '{other}'"
+                        )));
+                    }
+                };
+                let name = names.value(row).to_owned();
+                let runtime_id = ids.value(row);
+                let observation_count = counts.value(row);
+                let first_seen = first_seens.value(row);
+                let last_seen = last_seens.value(row);
+                let owner_label = if owners.is_null(row) {
+                    None
+                } else {
+                    Some(owners.value(row).to_owned())
+                };
 
-            let idx = catalog.entries.len();
-            catalog.entries.push(CatalogEntry {
-                kind,
-                name: name.clone(),
-                runtime_id,
-                observation_count,
-                first_seen,
-                last_seen,
-                owner_label: owner_label.clone(),
-            });
+                let idx = catalog.entries.len();
+                catalog.entries.push(CatalogEntry {
+                    kind,
+                    name: name.clone(),
+                    runtime_id,
+                    observation_count,
+                    first_seen,
+                    last_seen,
+                    owner_label: owner_label.clone(),
+                });
 
-            match kind {
-                EntryKind::EntityType => {
-                    catalog.entity_types.insert(name, idx);
-                    max_type_id = max_type_id.max(runtime_id + 1);
-                }
-                EntryKind::RelationType => {
-                    catalog.relation_types.insert(name, idx);
-                    max_type_id = max_type_id.max(runtime_id + 1);
-                }
-                EntryKind::Property => {
-                    catalog.properties.insert((name, owner_label), idx);
-                    max_prop_id = max_prop_id.max(runtime_id + 1);
+                match kind {
+                    EntryKind::EntityType => {
+                        if catalog.entity_types.insert(name, idx).is_some() {
+                            return Err(storage_err(
+                                "runtime_catalog contains duplicate entity type",
+                            ));
+                        }
+                        max_type_id = max_type_id.max(runtime_id + 1);
+                    }
+                    EntryKind::RelationType => {
+                        if catalog.relation_types.insert(name, idx).is_some() {
+                            return Err(storage_err(
+                                "runtime_catalog contains duplicate relation type",
+                            ));
+                        }
+                        max_type_id = max_type_id.max(runtime_id + 1);
+                    }
+                    EntryKind::Property => {
+                        if catalog
+                            .properties
+                            .insert((name, owner_label), idx)
+                            .is_some()
+                        {
+                            return Err(storage_err("runtime_catalog contains duplicate property"));
+                        }
+                        max_prop_id = max_prop_id.max(runtime_id + 1);
+                    }
                 }
             }
         }
@@ -531,6 +556,50 @@ impl RuntimeCatalog {
         catalog.next_type_id = max_type_id;
         catalog.next_prop_id = max_prop_id;
         Ok(catalog)
+    }
+
+    /// Appends one persisted catalog batch while preserving its stable IDs and
+    /// observations. The caller may therefore decode a Parquet catalog in
+    /// bounded windows rather than concatenating it in memory.
+    pub fn extend_from_record_batch(&mut self, batch: &RecordBatch) -> Result<(), GfError> {
+        let incoming = Self::from_record_batch(batch)?;
+        for entry in &incoming.entries {
+            let duplicate = match entry.kind {
+                EntryKind::EntityType => self.entity_types.contains_key(&entry.name),
+                EntryKind::RelationType => self.relation_types.contains_key(&entry.name),
+                EntryKind::Property => self
+                    .properties
+                    .contains_key(&(entry.name.clone(), entry.owner_label.clone())),
+            };
+            if duplicate {
+                return Err(GfError::Storage(
+                    "runtime_catalog contains a duplicate persisted entry".to_owned(),
+                ));
+            }
+            entry.runtime_id.checked_add(1).ok_or_else(|| {
+                GfError::Storage("runtime_catalog persisted ID overflow".to_owned())
+            })?;
+        }
+        for entry in incoming.entries {
+            let idx = self.entries.len();
+            match entry.kind {
+                EntryKind::EntityType => {
+                    self.entity_types.insert(entry.name.clone(), idx);
+                    self.next_type_id = self.next_type_id.max(entry.runtime_id + 1);
+                }
+                EntryKind::RelationType => {
+                    self.relation_types.insert(entry.name.clone(), idx);
+                    self.next_type_id = self.next_type_id.max(entry.runtime_id + 1);
+                }
+                EntryKind::Property => {
+                    let key = (entry.name.clone(), entry.owner_label.clone());
+                    self.properties.insert(key, idx);
+                    self.next_prop_id = self.next_prop_id.max(entry.runtime_id + 1);
+                }
+            }
+            self.entries.push(entry);
+        }
+        Ok(())
     }
 }
 

--- a/crates/graphforge-storage/Cargo.toml
+++ b/crates/graphforge-storage/Cargo.toml
@@ -22,6 +22,7 @@ graphforge-filesystem = { version = "0.5.2", path = "../graphforge-filesystem" }
 graphforge-ir = { version = "0.5.2", path = "../graphforge-ir" }
 graphforge-ontology = { version = "0.5.2", path = "../graphforge-ontology" }
 arrow = { workspace = true }
+bytes = "1"
 async-trait = "0.1"
 atomicwrites = "0.4.4"
 datafusion = { workspace = true }

--- a/crates/graphforge-storage/Cargo.toml
+++ b/crates/graphforge-storage/Cargo.toml
@@ -22,7 +22,6 @@ graphforge-filesystem = { version = "0.5.2", path = "../graphforge-filesystem" }
 graphforge-ir = { version = "0.5.2", path = "../graphforge-ir" }
 graphforge-ontology = { version = "0.5.2", path = "../graphforge-ontology" }
 arrow = { workspace = true }
-bytes = "1"
 async-trait = "0.1"
 atomicwrites = "0.4.4"
 datafusion = { workspace = true }

--- a/crates/graphforge-storage/src/filesystem_admission.rs
+++ b/crates/graphforge-storage/src/filesystem_admission.rs
@@ -47,7 +47,8 @@ pub struct FilesystemAdmissionEvidence {
 ///
 /// Ephemeral mode is an explicit escape hatch for in-memory instances whose
 /// temporary workspace is not presented as durable project storage.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ProjectLifecycleMode {
     /// Probe and retain the supported durable-filesystem identity.
     Durable,

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -1,43 +1,66 @@
-//! Durable, bounded staging for one-generation graph construction.
+//! Private, crash-recoverable staging for one-generation graph construction.
 //!
-//! A construction session is deliberately not a repeated [`crate::GraphWriter`]
-//! call. Each Arrow window is encoded directly to one immutable Parquet shard,
-//! accompanied by sorted fixed-width identity/endpoint runs and an authenticated
-//! receipt. No topology generation or public authority is changed while chunks
-//! are accepted. The final generation-last publication consumes this sealed
-//! inventory as one transaction.
+//! Construction accepts bounded canonical Arrow windows and writes immutable
+//! Parquet shards plus block-encoded sorted identity/endpoint runs. Each window
+//! is acknowledged by one immutable receipt; a constant-size checkpoint names
+//! the next sequence. `CURRENT` is never touched by this module's staging or
+//! sealing path. A generation-last publisher consumes the sealed inventory.
 
 use std::collections::BTreeSet;
-use std::fs::{self, File, OpenOptions};
+use std::ffi::{OsStr, OsString};
+use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
+use std::sync::{LazyLock, Mutex};
 
-use arrow::array::{Array, FixedSizeBinaryArray, RecordBatch};
+use arrow::array::{Array, FixedSizeBinaryArray, RecordBatch, StringArray, UInt32Array};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use graphforge_core::GfError;
+use graphforge_filesystem::{FileIdentity, StableDirectory, file_identity, file_link_count};
 use parquet::arrow::ArrowWriter;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
-const SESSION_FORMAT: u32 = 1;
-const SESSION_DIR: &str = ".graphforge-construction";
-const MANIFEST_FILE: &str = "session.json";
+const FORMAT_VERSION: u32 = 2;
+const PRIVATE_ROOT: &str = ".graphforge-construction";
+const CHECKPOINT: &str = "checkpoint.json";
+const INTENT: &str = "intent.json";
 const BLOCK_BYTES: usize = 1 << 20;
-const UUID_BYTES: usize = 16;
-const ENDPOINT_RECORD_BYTES: usize = 48;
-const MAX_CONTROL_BYTES: u64 = 16 << 20;
+const MAX_CONTROL_BYTES: u64 = 64 << 10;
+const IDENTITY_WIDTH: usize = 16;
+const ENDPOINT_WIDTH: usize = 48;
+
+/// Canonical node construction input: UUID and primary type id.
+pub static CONSTRUCTION_NODE_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
+    std::sync::Arc::new(Schema::new(vec![
+        Field::new("node_uuid", DataType::FixedSizeBinary(16), false),
+        Field::new("type_id", DataType::UInt32, false),
+    ]))
+});
+
+/// Canonical edge construction input: UUID endpoints and relation route.
+pub static CONSTRUCTION_EDGE_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
+    std::sync::Arc::new(Schema::new(vec![
+        Field::new("edge_uuid", DataType::FixedSizeBinary(16), false),
+        Field::new("src_uuid", DataType::FixedSizeBinary(16), false),
+        Field::new("dst_uuid", DataType::FixedSizeBinary(16), false),
+        Field::new("rel_type", DataType::Utf8, false),
+    ]))
+});
 
 fn storage(error: impl std::fmt::Display) -> GfError {
     GfError::Storage(format!("graph construction session: {error}"))
 }
 
-/// The two ordered construction phases.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+/// Ordered construction phase.
 #[serde(rename_all = "snake_case")]
 pub enum ConstructionChunkKind {
-    /// Canonical node input. Must precede all edge chunks.
+    /// Node identities and primary types.
     Node,
-    /// Canonical edge input.
+    /// Edge identities, endpoints, and relation routes.
     Edge,
 }
 
@@ -50,18 +73,18 @@ impl ConstructionChunkKind {
     }
 }
 
-/// Explicit fixed windows for a construction session.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+/// Fixed resource windows for staging and the later external merge.
 pub struct GraphConstructionBudgets {
-    /// Maximum rows in one accepted Arrow window.
+    /// Maximum rows in one Arrow window.
     pub max_batch_rows: usize,
-    /// Maximum Arrow-owned bytes in one accepted window.
+    /// Maximum Arrow-owned bytes in one window.
     pub max_batch_bytes: usize,
-    /// Maximum immutable chunks in one session.
-    pub max_chunks: usize,
-    /// Maximum fixed-width records buffered for sorting one chunk.
+    /// Maximum accepted chunks.
+    pub max_chunks: u64,
+    /// Maximum fixed-width records sorted for one chunk.
     pub max_run_records: usize,
-    /// Maximum files opened by a later external merge group.
+    /// Maximum inputs opened by one external merge group.
     pub merge_fan_in: usize,
 }
 
@@ -70,11 +93,8 @@ impl Default for GraphConstructionBudgets {
         Self {
             max_batch_rows: 65_536,
             max_batch_bytes: 64 << 20,
-            // 8,192 65K-row windows cover more than 536 million accepted rows
-            // while keeping the authenticated receipt inventory below its
-            // explicit control-file bound.
-            max_chunks: 8_192,
-            max_run_records: 65_536 * 3,
+            max_chunks: 1_000_000,
+            max_run_records: 3 * 65_536,
             merge_fan_in: 32,
         }
     }
@@ -85,8 +105,7 @@ impl GraphConstructionBudgets {
         if self.max_batch_rows == 0
             || self.max_batch_bytes == 0
             || self.max_chunks == 0
-            || self.max_chunks > 8_192
-            || self.max_run_records < self.max_batch_rows
+            || self.max_run_records < 3 * self.max_batch_rows
             || self.merge_fan_in < 2
         {
             return Err(storage("invalid construction budgets"));
@@ -95,107 +114,182 @@ impl GraphConstructionBudgets {
     }
 }
 
-/// Durable state of the private session. `Sealed` still does not change CURRENT.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+/// Private session lifecycle. Sealed is not publicly committed.
 #[serde(rename_all = "snake_case")]
 pub enum GraphConstructionState {
-    /// More chunks may be accepted.
+    /// Accepting chunks.
     Staging,
-    /// Inventory is complete and may be handed to one generation-last commit.
+    /// Immutable inventory ready for the generation-last publisher.
     Sealed,
-    /// Caller abandoned the private session.
+    /// Explicitly abandoned.
     Aborted,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+/// Measured application I/O and bounded retained-window evidence.
+pub struct GraphConstructionEvidence {
+    /// Rows accepted.
+    pub input_rows: u64,
+    /// Non-replay chunks accepted.
+    pub input_batches: u64,
+    /// Immutable Parquet shards.
+    pub parquet_shards: u64,
+    /// Bytes submitted through measured immutable-artifact writers.
+    /// Control-record traffic is deliberately reported by the outer I/O probe.
+    pub write_bytes: u64,
+    /// Actual submissions by measured immutable-artifact writers.
+    pub write_operations: u64,
+    /// Bytes read for independent authentication.
+    pub authentication_read_bytes: u64,
+    /// Actual bounded authentication reads.
+    pub authentication_read_operations: u64,
+    /// Fixed-width run records.
+    pub run_records: u64,
+    /// Largest retained Arrow row window.
+    pub peak_batch_rows: u64,
+    /// Largest retained Arrow byte window.
+    pub peak_batch_bytes: u64,
+    /// Largest fixed-width sort window.
+    pub peak_run_records: u64,
+    /// Prior topology rows decoded during staging. Invariant: zero.
+    pub prior_topology_rows_decoded: u64,
+    /// CURRENT transitions during staging. Invariant: zero.
+    pub current_transitions: u64,
+    /// Exact idempotent replays.
+    pub replayed_chunks: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct IdentityRecord {
+    volume_serial: u64,
+    file_id: String,
+}
+
+impl From<FileIdentity> for IdentityRecord {
+    fn from(value: FileIdentity) -> Self {
+        Self {
+            volume_serial: value.volume_serial,
+            file_id: hex(&value.file_id),
+        }
+    }
+}
+
+impl IdentityRecord {
+    fn matches(&self, value: FileIdentity) -> bool {
+        self.volume_serial == value.volume_serial && self.file_id == hex(&value.file_id)
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 struct ArtifactReceipt {
-    relative_path: String,
+    name: String,
     bytes: u64,
     sha256: String,
+    identity: IdentityRecord,
+    write_operations: u64,
 }
 
-/// Authenticated, idempotent acknowledgement for one immutable Arrow chunk.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+/// Immutable acknowledgement of one canonical Arrow chunk.
 pub struct ConstructionChunkReceipt {
+    operation_uuid: Uuid,
+    project_identity: IdentityRecord,
+    session_identity: IdentityRecord,
+    parent_topology_generation: u64,
+    prior_receipt_sha256: Option<String>,
     /// Caller-stable idempotency key.
     pub chunk_id: String,
-    /// Monotonic accepted-chunk sequence.
+    /// Monotonic accepted sequence.
     pub sequence: u64,
     /// Node or edge phase.
     pub kind: ConstructionChunkKind,
-    /// Rows encoded into the immutable Parquet shard.
+    /// Logical rows.
     pub rows: u64,
-    /// Arrow-owned bytes charged for the accepted window.
+    /// Logical Arrow bytes charged to the window.
     pub input_bytes: u64,
-    /// Fixed-width records sorted for the chunk.
-    pub run_records: u64,
-    /// Canonical digest over the Arrow values and schema.
+    /// Canonical logical digest, independent of Arrow buffer layout.
     pub input_sha256: String,
+    /// Fixed-width run records.
+    pub run_records: u64,
     parquet: ArtifactReceipt,
     identities: ArtifactReceipt,
     endpoints: Option<ArtifactReceipt>,
 }
 
-/// Aggregate-only evidence. It contains no graph identities.
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
-pub struct GraphConstructionEvidence {
-    /// Arrow rows accepted.
-    pub input_rows: u64,
-    /// Arrow batches accepted (idempotent replays excluded).
-    pub input_batches: u64,
-    /// Immutable Parquet shards sealed.
-    pub parquet_shards: u64,
-    /// Physical bytes written to private session artifacts and receipts.
-    pub physical_bytes_written: u64,
-    /// Physical bytes read while authenticating a resumed session.
-    pub authentication_bytes_read: u64,
-    /// Block-granular read operations.
-    pub read_blocks: u64,
-    /// Block-granular write operations.
-    pub write_blocks: u64,
-    /// Fixed-width identity/endpoint records written.
-    pub run_records: u64,
-    /// Maximum Arrow rows retained by one append call.
-    pub peak_batch_rows: u64,
-    /// Maximum Arrow-owned bytes retained by one append call.
-    pub peak_batch_bytes: u64,
-    /// Maximum fixed-width records sorted by one append call.
-    pub peak_run_records: u64,
-    /// Prior committed topology rows decoded while staging. Always zero.
-    pub prior_topology_rows_decoded: u64,
-    /// Public generation transitions while staging. Always zero.
-    pub current_transitions: u64,
-    /// Idempotent accepted replays.
-    pub replayed_chunks: u64,
-}
-
 #[derive(Clone, Debug, Serialize, Deserialize)]
-struct SessionManifest {
+struct Checkpoint {
     format_version: u32,
     operation_uuid: Uuid,
+    project_identity: IdentityRecord,
+    session_identity: IdentityRecord,
     parent_topology_generation: u64,
-    state: GraphConstructionState,
     budgets: GraphConstructionBudgets,
-    receipts: Vec<ConstructionChunkReceipt>,
+    state: GraphConstructionState,
+    next_sequence: u64,
+    saw_edge: bool,
+    last_receipt_sha256: Option<String>,
     evidence: GraphConstructionEvidence,
 }
 
-/// Storage-owned private construction session.
-///
-/// Opening an existing operation authenticates every receipt and referenced
-/// artifact before accepting more input. Session files live below a private
-/// project directory and are not graph-catalog discoverable.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct ChunkIntent {
+    format_version: u32,
+    operation_uuid: Uuid,
+    project_identity: IdentityRecord,
+    session_identity: IdentityRecord,
+    sequence: u64,
+    chunk_id: String,
+    chunk_key: String,
+    kind: ConstructionChunkKind,
+    rows: u64,
+    input_bytes: u64,
+    input_sha256: String,
+    parent_topology_generation: u64,
+    prior_receipt_sha256: Option<String>,
+    run_records: u64,
+    parquet: Option<ArtifactReceipt>,
+    identities: Option<ArtifactReceipt>,
+    endpoints: Option<ArtifactReceipt>,
+}
+
+static ACTIVE_OPERATIONS: LazyLock<Mutex<BTreeSet<String>>> =
+    LazyLock::new(|| Mutex::new(BTreeSet::new()));
+
+struct ProcessReservation(String);
+
+impl ProcessReservation {
+    fn acquire(key: String) -> Result<Self, GfError> {
+        let mut active = ACTIVE_OPERATIONS
+            .lock()
+            .map_err(|_| storage("process operation registry poisoned"))?;
+        if !active.insert(key.clone()) {
+            return Err(storage(
+                "construction operation is already open in this process",
+            ));
+        }
+        Ok(Self(key))
+    }
+}
+
+impl Drop for ProcessReservation {
+    fn drop(&mut self) {
+        if let Ok(mut active) = ACTIVE_OPERATIONS.lock() {
+            active.remove(&self.0);
+        }
+    }
+}
+
+/// Descriptor-relative, exclusively owned private construction session.
 pub struct GraphConstructionSession {
-    root: PathBuf,
-    manifest: SessionManifest,
+    project: StableDirectory,
+    root: StableDirectory,
+    checkpoint: Checkpoint,
+    _reservation: ProcessReservation,
 }
 
 impl GraphConstructionSession {
-    /// Create or resume one stable operation.
-    ///
-    /// `parent_topology_generation` is pinned for the lifetime of the session;
-    /// the eventual commit must reject a changed CURRENT rather than silently
-    /// rebasing accepted chunks.
+    /// Create or resume an operation pinned to one parent topology generation.
     pub fn open(
         project_dir: &Path,
         operation_uuid: Uuid,
@@ -203,410 +297,599 @@ impl GraphConstructionSession {
         budgets: GraphConstructionBudgets,
     ) -> Result<Self, GfError> {
         let budgets = budgets.validate()?;
-        let root = project_dir
-            .join(SESSION_DIR)
-            .join(operation_uuid.simple().to_string());
-        fs::create_dir_all(&root).map_err(storage)?;
-        let path = root.join(MANIFEST_FILE);
-        let mut session = if path.is_file() {
-            let bytes = read_bounded(&path, MAX_CONTROL_BYTES)?;
-            let manifest: SessionManifest = serde_json::from_slice(&bytes).map_err(storage)?;
-            if manifest.format_version != SESSION_FORMAT
-                || manifest.operation_uuid != operation_uuid
-                || manifest.parent_topology_generation != parent_topology_generation
-                || manifest.budgets != budgets
-            {
-                return Err(storage("resume parameters do not match durable session"));
+        let project = StableDirectory::open(project_dir).map_err(storage)?;
+        if crate::read_topology_generation(project_dir)? != parent_topology_generation {
+            return Err(storage(
+                "requested parent generation is not current at session open",
+            ));
+        }
+        let project_identity = project.identity();
+        let key = format!(
+            "{}:{}:{}",
+            project_identity.volume_serial,
+            hex(&project_identity.file_id),
+            operation_uuid.simple()
+        );
+        let reservation = ProcessReservation::acquire(key)?;
+        let private = project
+            .create_child_directory(OsStr::new(PRIVATE_ROOT))
+            .map_err(storage)?;
+        let operation_name = operation_uuid.simple().to_string();
+        let root = private
+            .create_child_directory(OsStr::new(&operation_name))
+            .map_err(storage)?;
+        if !root.try_lock_exclusive().map_err(storage)? {
+            return Err(storage(
+                "construction operation is locked by another process",
+            ));
+        }
+        let session_identity = root.identity();
+        cleanup_authenticated_control_temps(
+            &root,
+            operation_uuid,
+            project_identity,
+            session_identity,
+        )?;
+        cleanup_owned_artifact_temps(&root)?;
+        let checkpoint = match root.open_child_file(OsStr::new(CHECKPOINT)) {
+            Ok(mut file) => decode_bounded(&mut file)?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                let initial = Checkpoint {
+                    format_version: FORMAT_VERSION,
+                    operation_uuid,
+                    project_identity: project_identity.into(),
+                    session_identity: session_identity.into(),
+                    parent_topology_generation,
+                    budgets,
+                    state: GraphConstructionState::Staging,
+                    next_sequence: 0,
+                    saw_edge: false,
+                    last_receipt_sha256: None,
+                    evidence: GraphConstructionEvidence::default(),
+                };
+                install_control(&root, CHECKPOINT, &initial)?;
+                initial
             }
-            Self { root, manifest }
-        } else {
-            let manifest = SessionManifest {
-                format_version: SESSION_FORMAT,
-                operation_uuid,
-                parent_topology_generation,
-                state: GraphConstructionState::Staging,
-                budgets,
-                receipts: Vec::new(),
-                evidence: GraphConstructionEvidence::default(),
-            };
-            let session = Self { root, manifest };
-            session.persist_manifest_create()?;
-            session
+            Err(error) => return Err(storage(error)),
         };
-        session.recover_durable_receipts()?;
-        session.authenticate_receipts()?;
+        validate_checkpoint(
+            &checkpoint,
+            operation_uuid,
+            project_identity,
+            session_identity,
+            parent_topology_generation,
+            budgets,
+        )?;
+        let mut session = Self {
+            project,
+            root,
+            checkpoint,
+            _reservation: reservation,
+        };
+        session.recover_intent()?;
+        session.revalidate_authority()?;
         Ok(session)
-    }
-
-    /// Pinned parent topology generation.
-    #[must_use]
-    pub const fn parent_topology_generation(&self) -> u64 {
-        self.manifest.parent_topology_generation
     }
 
     /// Current private state.
     #[must_use]
     pub const fn state(&self) -> GraphConstructionState {
-        self.manifest.state
+        self.checkpoint.state
     }
 
-    /// Aggregate bounded-work evidence.
+    /// Pinned parent topology generation.
+    #[must_use]
+    pub const fn parent_topology_generation(&self) -> u64 {
+        self.checkpoint.parent_topology_generation
+    }
+
+    /// Measured aggregate evidence.
     #[must_use]
     pub const fn evidence(&self) -> &GraphConstructionEvidence {
-        &self.manifest.evidence
+        &self.checkpoint.evidence
     }
 
-    /// Durable receipts in accepted order.
+    /// Number of durably accepted chunks.
     #[must_use]
-    pub fn receipts(&self) -> &[ConstructionChunkReceipt] {
-        &self.manifest.receipts
+    pub const fn accepted_chunks(&self) -> u64 {
+        self.checkpoint.next_sequence
     }
 
-    /// Accept one bounded Arrow chunk and seal its Parquet/run artifacts.
-    ///
-    /// Replaying `chunk_id` with byte-identical Arrow input is idempotent. A
-    /// conflicting replay fails closed. Node chunks must precede edge chunks.
+    /// Append one canonical bounded Arrow chunk.
     pub fn append(
         &mut self,
         kind: ConstructionChunkKind,
         chunk_id: &str,
         batch: &RecordBatch,
     ) -> Result<ConstructionChunkReceipt, GfError> {
-        if self.manifest.state != GraphConstructionState::Staging {
+        self.append_with_cancellation(kind, chunk_id, batch, || false)
+    }
+
+    /// Append while polling a caller-owned cancellation signal at durable
+    /// artifact boundaries. Cancellation leaves an intent that the next open
+    /// authenticates and rolls back without changing public authority.
+    pub fn append_with_cancellation(
+        &mut self,
+        kind: ConstructionChunkKind,
+        chunk_id: &str,
+        batch: &RecordBatch,
+        mut cancelled: impl FnMut() -> bool,
+    ) -> Result<ConstructionChunkReceipt, GfError> {
+        self.revalidate_authority()?;
+        self.recover_intent()?;
+        reject_cancelled(&mut cancelled)?;
+        if self.checkpoint.state != GraphConstructionState::Staging {
             return Err(storage("session is not accepting chunks"));
         }
         validate_chunk_id(chunk_id)?;
+        validate_schema(kind, batch)?;
         if batch.num_rows() == 0 {
             return Err(storage("empty construction chunk"));
         }
-        let bytes = batch.get_array_memory_size();
-        if batch.num_rows() > self.manifest.budgets.max_batch_rows
-            || bytes > self.manifest.budgets.max_batch_bytes
+        let input_bytes = batch.get_array_memory_size();
+        if batch.num_rows() > self.checkpoint.budgets.max_batch_rows
+            || input_bytes > self.checkpoint.budgets.max_batch_bytes
+            || self.checkpoint.next_sequence >= self.checkpoint.budgets.max_chunks
         {
-            return Err(storage("Arrow chunk exceeds the configured window"));
+            return Err(storage("construction resource window exhausted"));
         }
-        if self.manifest.receipts.len() >= self.manifest.budgets.max_chunks {
-            return Err(storage("construction chunk count exhausted"));
-        }
-        if kind == ConstructionChunkKind::Node
-            && self
-                .manifest
-                .receipts
-                .iter()
-                .any(|receipt| receipt.kind == ConstructionChunkKind::Edge)
-        {
+        if kind == ConstructionChunkKind::Node && self.checkpoint.saw_edge {
             return Err(storage("node chunk cannot follow edge staging"));
         }
-        let input_sha256 = digest_record_batch(batch);
-        if let Some(existing) = self
-            .manifest
-            .receipts
-            .iter()
-            .find(|receipt| receipt.chunk_id == chunk_id)
-            .cloned()
-        {
-            if existing.kind != kind
-                || existing.rows != batch.num_rows() as u64
-                || existing.input_sha256 != input_sha256
+        let input_sha256 = logical_batch_digest(kind, batch)?;
+        let key_name = chunk_key_name(chunk_id);
+        if let Ok(mut key_file) = self.root.open_child_file(OsStr::new(&key_name)) {
+            let pointer: ReceiptPointer = decode_bounded(&mut key_file)?;
+            let receipt = self.read_receipt(pointer.sequence)?;
+            let receipt_body = serde_json::to_vec(&receipt).map_err(storage)?;
+            if pointer.operation_uuid == self.checkpoint.operation_uuid
+                && pointer.project_identity == self.checkpoint.project_identity
+                && pointer.session_identity == self.checkpoint.session_identity
+                && pointer.receipt_sha256 == sha256(&receipt_body)
+                && receipt.chunk_id == chunk_id
+                && receipt.kind == kind
+                && receipt.rows == batch.num_rows() as u64
+                && receipt.input_sha256 == input_sha256
             {
-                return Err(storage("conflicting construction chunk replay"));
+                validate_receipt_artifacts(&self.root, &receipt)?;
+                self.checkpoint.evidence.replayed_chunks =
+                    self.checkpoint.evidence.replayed_chunks.saturating_add(1);
+                replace_control(&self.root, CHECKPOINT, &self.checkpoint)?;
+                return Ok(receipt);
             }
-            self.manifest.evidence.replayed_chunks =
-                self.manifest.evidence.replayed_chunks.saturating_add(1);
-            self.persist_manifest_replace()?;
-            return Ok(existing);
+            return Err(storage("conflicting construction chunk replay"));
         }
-
-        let arrays = extract_required_arrays(kind, batch)?;
-        let run_records = arrays.identity.len().saturating_add(arrays.endpoints.len());
-        if run_records > self.manifest.budgets.max_run_records {
-            return Err(storage("chunk index-run window exhausted"));
+        let arrays = extract_runs(kind, batch)?;
+        let run_records = arrays
+            .identities
+            .len()
+            .saturating_add(arrays.endpoints.len());
+        if run_records > self.checkpoint.budgets.max_run_records {
+            return Err(storage("construction run window exhausted"));
         }
-        let sequence = self.manifest.receipts.len() as u64;
-        let stem = format!("{:020}-{}", sequence, kind.tag());
-        // A crash before the receipt is durable may leave only this session's
-        // exact next-sequence artifacts. They are not accepted input and are
-        // safe to discard before retrying the same sequence.
-        self.remove_unreceipted_sequence(&stem)?;
-        let parquet = write_parquet_artifact(&self.root, &format!("{stem}.parquet"), batch)?;
-        let identities = write_fixed_artifact(
-            &self.root,
-            &format!("{stem}.identities.run"),
-            UUID_BYTES,
-            arrays.identity,
-        )?;
-        let endpoints = if arrays.endpoints.is_empty() {
-            None
-        } else {
-            Some(write_fixed_artifact(
-                &self.root,
-                &format!("{stem}.endpoints.run"),
-                ENDPOINT_RECORD_BYTES,
-                arrays.endpoints,
-            )?)
-        };
-        let receipt = ConstructionChunkReceipt {
-            chunk_id: chunk_id.to_owned(),
+        let sequence = self.checkpoint.next_sequence;
+        let mut intent = ChunkIntent {
+            format_version: FORMAT_VERSION,
+            operation_uuid: self.checkpoint.operation_uuid,
+            project_identity: self.checkpoint.project_identity.clone(),
+            session_identity: self.checkpoint.session_identity.clone(),
             sequence,
+            chunk_id: chunk_id.to_owned(),
+            chunk_key: key_name,
             kind,
             rows: batch.num_rows() as u64,
-            input_bytes: bytes as u64,
-            run_records: run_records as u64,
+            input_bytes: input_bytes as u64,
             input_sha256,
-            parquet,
-            identities,
-            endpoints,
+            parent_topology_generation: self.checkpoint.parent_topology_generation,
+            prior_receipt_sha256: self.checkpoint.last_receipt_sha256.clone(),
+            run_records: run_records as u64,
+            parquet: None,
+            identities: None,
+            endpoints: None,
         };
-        let receipt_path = self.root.join(format!("{stem}.receipt.json"));
+        install_control(&self.root, INTENT, &intent)?;
+        reject_cancelled(&mut cancelled)?;
+        let stem = artifact_stem(sequence, kind);
+        intent.parquet = Some(write_parquet(
+            &self.root,
+            &format!("{stem}.parquet"),
+            batch,
+        )?);
+        replace_control(&self.root, INTENT, &intent)?;
+        reject_cancelled(&mut cancelled)?;
+        intent.identities = Some(write_fixed_run(
+            &self.root,
+            &format!("{stem}.identities.run"),
+            &arrays.identities,
+        )?);
+        replace_control(&self.root, INTENT, &intent)?;
+        reject_cancelled(&mut cancelled)?;
+        if !arrays.endpoints.is_empty() {
+            intent.endpoints = Some(write_fixed_run(
+                &self.root,
+                &format!("{stem}.endpoints.run"),
+                &arrays.endpoints,
+            )?);
+            replace_control(&self.root, INTENT, &intent)?;
+            reject_cancelled(&mut cancelled)?;
+        }
+        let receipt = receipt_from_intent(&intent)?;
+        let receipt_name = receipt_name(sequence);
+        install_control(&self.root, &receipt_name, &receipt)?;
         let receipt_bytes = serde_json::to_vec(&receipt).map_err(storage)?;
-        write_create_synced(&receipt_path, &receipt_bytes)?;
-
-        let evidence = &mut self.manifest.evidence;
-        evidence.input_rows = evidence.input_rows.saturating_add(batch.num_rows() as u64);
-        evidence.input_batches = evidence.input_batches.saturating_add(1);
-        evidence.parquet_shards = evidence.parquet_shards.saturating_add(1);
-        evidence.physical_bytes_written = evidence
-            .physical_bytes_written
-            .saturating_add(receipt.parquet.bytes)
-            .saturating_add(receipt.identities.bytes)
-            .saturating_add(receipt.endpoints.as_ref().map_or(0, |item| item.bytes))
-            .saturating_add(receipt_bytes.len() as u64);
-        evidence.write_blocks = evidence
-            .write_blocks
-            .saturating_add(receipt.parquet.bytes.div_ceil(BLOCK_BYTES as u64))
-            .saturating_add(receipt.identities.bytes.div_ceil(BLOCK_BYTES as u64))
-            .saturating_add(
-                receipt
-                    .endpoints
-                    .as_ref()
-                    .map_or(0, |item| item.bytes.div_ceil(BLOCK_BYTES as u64)),
-            )
-            .saturating_add(1);
-        evidence.run_records = evidence.run_records.saturating_add(receipt.run_records);
-        evidence.peak_batch_rows = evidence.peak_batch_rows.max(batch.num_rows() as u64);
-        evidence.peak_batch_bytes = evidence.peak_batch_bytes.max(bytes as u64);
-        evidence.peak_run_records = evidence.peak_run_records.max(run_records as u64);
-        self.manifest.receipts.push(receipt.clone());
-        self.persist_manifest_replace()?;
+        let pointer = ReceiptPointer {
+            operation_uuid: self.checkpoint.operation_uuid,
+            project_identity: self.checkpoint.project_identity.clone(),
+            session_identity: self.checkpoint.session_identity.clone(),
+            sequence,
+            receipt_sha256: sha256(&receipt_bytes),
+        };
+        install_control(&self.root, &intent.chunk_key, &pointer)?;
+        self.advance_checkpoint(&receipt, &receipt_bytes)?;
+        unlink_named(&self.root, INTENT)?;
         Ok(receipt)
     }
 
-    /// Seal the authenticated private inventory. This does not modify graph
-    /// data, topology generation, or CURRENT.
+    /// Independently reopen and authenticate every sealed artifact once, then
+    /// freeze the private inventory. No generation authority changes here.
     pub fn seal(&mut self) -> Result<(), GfError> {
-        if self.manifest.state != GraphConstructionState::Staging {
+        self.revalidate_authority()?;
+        self.recover_intent()?;
+        if self.checkpoint.state != GraphConstructionState::Staging {
             return Err(storage("only a staging session can be sealed"));
         }
-        self.authenticate_receipts()?;
-        self.manifest.state = GraphConstructionState::Sealed;
-        self.persist_manifest_replace()
-    }
-
-    /// Mark the private session aborted. The prior graph remains authoritative.
-    pub fn abort(&mut self) -> Result<(), GfError> {
-        if self.manifest.state == GraphConstructionState::Sealed {
-            return Err(storage(
-                "sealed construction must be resolved by the publisher",
-            ));
-        }
-        self.manifest.state = GraphConstructionState::Aborted;
-        self.persist_manifest_replace()
-    }
-
-    fn authenticate_receipts(&mut self) -> Result<(), GfError> {
-        let mut chunk_ids = BTreeSet::new();
-        let mut expected_sequence = 0_u64;
+        let mut prior_digest = None;
         let mut saw_edge = false;
-        let mut bytes_read = 0_u64;
-        let mut blocks = 0_u64;
-        for receipt in &self.manifest.receipts {
-            if receipt.sequence != expected_sequence || !chunk_ids.insert(&receipt.chunk_id) {
-                return Err(storage("non-canonical receipt sequence"));
-            }
+        let mut read_bytes = 0_u64;
+        let mut read_operations = 0_u64;
+        for sequence in 0..self.checkpoint.next_sequence {
+            let receipt = self.read_receipt(sequence)?;
+            validate_receipt_semantics(&receipt, sequence, self.checkpoint.budgets)?;
             if receipt.kind == ConstructionChunkKind::Node && saw_edge {
                 return Err(storage("node receipt follows edge receipt"));
             }
             saw_edge |= receipt.kind == ConstructionChunkKind::Edge;
+            if receipt.prior_receipt_sha256 != prior_digest {
+                return Err(storage("receipt journal chain is discontinuous"));
+            }
             for artifact in [&receipt.parquet, &receipt.identities]
                 .into_iter()
                 .chain(receipt.endpoints.iter())
             {
-                let (read, count) = authenticate_artifact(&self.root, artifact)?;
-                bytes_read = bytes_read.saturating_add(read);
-                blocks = blocks.saturating_add(count);
+                let work = authenticate_artifact(&self.root, artifact)?;
+                read_bytes = read_bytes.saturating_add(work.bytes);
+                read_operations = read_operations.saturating_add(work.operations);
             }
-            let stem = format!("{:020}-{}", receipt.sequence, receipt.kind.tag());
-            let body = read_bounded(
-                &self.root.join(format!("{stem}.receipt.json")),
-                MAX_CONTROL_BYTES,
-            )?;
-            let durable: ConstructionChunkReceipt =
-                serde_json::from_slice(&body).map_err(storage)?;
-            if durable != *receipt {
-                return Err(storage("receipt does not match session inventory"));
-            }
-            bytes_read = bytes_read.saturating_add(body.len() as u64);
-            blocks = blocks.saturating_add(1);
-            expected_sequence = expected_sequence.saturating_add(1);
+            validate_parquet_shape(&self.root, &receipt)?;
+            let body = serde_json::to_vec(&receipt).map_err(storage)?;
+            prior_digest = Some(sha256(&body));
         }
-        self.manifest.evidence.authentication_bytes_read = self
-            .manifest
+        if prior_digest != self.checkpoint.last_receipt_sha256 {
+            return Err(storage("receipt journal tail differs from checkpoint"));
+        }
+        if saw_edge != self.checkpoint.saw_edge {
+            return Err(storage("checkpoint phase differs from receipt journal"));
+        }
+        self.checkpoint.evidence.authentication_read_bytes = self
+            .checkpoint
             .evidence
-            .authentication_bytes_read
-            .saturating_add(bytes_read);
-        self.manifest.evidence.read_blocks =
-            self.manifest.evidence.read_blocks.saturating_add(blocks);
-        Ok(())
+            .authentication_read_bytes
+            .saturating_add(read_bytes);
+        self.checkpoint.evidence.authentication_read_operations = self
+            .checkpoint
+            .evidence
+            .authentication_read_operations
+            .saturating_add(read_operations);
+        self.checkpoint.state = GraphConstructionState::Sealed;
+        replace_control(&self.root, CHECKPOINT, &self.checkpoint)
     }
 
-    fn recover_durable_receipts(&mut self) -> Result<(), GfError> {
-        loop {
-            let sequence = self.manifest.receipts.len() as u64;
-            let prefix = format!("{sequence:020}-");
-            let mut candidates = fs::read_dir(&self.root)
-                .map_err(storage)?
-                .filter_map(Result::ok)
-                .filter_map(|entry| entry.file_name().into_string().ok())
-                .filter(|name| name.starts_with(&prefix) && name.ends_with(".receipt.json"))
-                .collect::<Vec<_>>();
-            candidates.sort();
-            if candidates.is_empty() {
-                break;
+    /// Abort before seal. CURRENT remains unchanged.
+    pub fn abort(&mut self) -> Result<(), GfError> {
+        self.revalidate_authority()?;
+        self.recover_intent()?;
+        if self.checkpoint.state == GraphConstructionState::Sealed {
+            return Err(storage("sealed session belongs to the publisher"));
+        }
+        self.checkpoint.state = GraphConstructionState::Aborted;
+        replace_control(&self.root, CHECKPOINT, &self.checkpoint)
+    }
+
+    fn recover_intent(&mut self) -> Result<(), GfError> {
+        let mut file = match self.root.open_child_file(OsStr::new(INTENT)) {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(storage(error)),
+        };
+        let intent: ChunkIntent = decode_bounded(&mut file)?;
+        validate_intent(&intent, &self.checkpoint)?;
+        let receipt_name = receipt_name(intent.sequence);
+        match self.root.open_child_file(OsStr::new(&receipt_name)) {
+            Ok(mut receipt_file) => {
+                let receipt: ConstructionChunkReceipt = decode_bounded(&mut receipt_file)?;
+                validate_receipt_semantics(&receipt, intent.sequence, self.checkpoint.budgets)?;
+                if receipt != receipt_from_intent(&intent)? {
+                    return Err(storage("recovered receipt differs from durable intent"));
+                }
+                validate_receipt_artifacts(&self.root, &receipt)?;
+                let body = serde_json::to_vec(&receipt).map_err(storage)?;
+                if intent.sequence < self.checkpoint.next_sequence
+                    && self.checkpoint.last_receipt_sha256.as_deref()
+                        != Some(sha256(&body).as_str())
+                {
+                    return Err(storage(
+                        "completed intent receipt differs from checkpoint tail",
+                    ));
+                }
+                let expected_pointer = ReceiptPointer {
+                    operation_uuid: self.checkpoint.operation_uuid,
+                    project_identity: self.checkpoint.project_identity.clone(),
+                    session_identity: self.checkpoint.session_identity.clone(),
+                    sequence: receipt.sequence,
+                    receipt_sha256: sha256(&body),
+                };
+                match self.root.open_child_file(OsStr::new(&intent.chunk_key)) {
+                    Ok(mut pointer_file) => {
+                        let pointer: ReceiptPointer = decode_bounded(&mut pointer_file)?;
+                        if pointer.operation_uuid != expected_pointer.operation_uuid
+                            || pointer.project_identity != expected_pointer.project_identity
+                            || pointer.session_identity != expected_pointer.session_identity
+                            || pointer.sequence != expected_pointer.sequence
+                            || pointer.receipt_sha256 != expected_pointer.receipt_sha256
+                        {
+                            return Err(storage("recovered receipt pointer is inconsistent"));
+                        }
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                        install_control(&self.root, &intent.chunk_key, &expected_pointer)?;
+                    }
+                    Err(error) => return Err(storage(error)),
+                }
+                self.advance_checkpoint(&receipt, &body)?;
             }
-            if candidates.len() != 1 {
-                return Err(storage("ambiguous durable receipt recovery"));
-            }
-            let body = read_bounded(&self.root.join(&candidates[0]), MAX_CONTROL_BYTES)?;
-            let receipt: ConstructionChunkReceipt =
-                serde_json::from_slice(&body).map_err(storage)?;
-            if receipt.sequence != sequence
-                || candidates[0]
-                    != format!(
-                        "{:020}-{}.receipt.json",
-                        receipt.sequence,
-                        receipt.kind.tag()
-                    )
-                || self
-                    .manifest
-                    .receipts
-                    .iter()
-                    .any(|existing| existing.chunk_id == receipt.chunk_id)
-            {
-                return Err(storage("invalid recovered construction receipt"));
-            }
-            for artifact in [&receipt.parquet, &receipt.identities]
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                for artifact in [
+                    intent.parquet.clone(),
+                    intent.identities.clone(),
+                    intent.endpoints.clone(),
+                ]
                 .into_iter()
-                .chain(receipt.endpoints.iter())
-            {
-                authenticate_artifact(&self.root, artifact)?;
+                .flatten()
+                {
+                    authenticate_artifact(&self.root, &artifact)?;
+                    unlink_artifact(&self.root, &artifact)?;
+                }
+                let stem = artifact_stem(intent.sequence, intent.kind);
+                if intent.parquet.is_none() {
+                    remove_unrecorded_artifact(
+                        &self.root,
+                        &format!("{stem}.parquet"),
+                        intent.kind,
+                        intent.rows,
+                    )?;
+                }
+                if intent.identities.is_none() {
+                    remove_unrecorded_artifact(
+                        &self.root,
+                        &format!("{stem}.identities.run"),
+                        intent.kind,
+                        intent.rows,
+                    )?;
+                }
+                if intent.kind == ConstructionChunkKind::Edge && intent.endpoints.is_none() {
+                    remove_unrecorded_artifact(
+                        &self.root,
+                        &format!("{stem}.endpoints.run"),
+                        intent.kind,
+                        intent.rows,
+                    )?;
+                }
             }
-            let evidence = &mut self.manifest.evidence;
-            evidence.input_rows = evidence.input_rows.saturating_add(receipt.rows);
-            evidence.input_batches = evidence.input_batches.saturating_add(1);
-            evidence.parquet_shards = evidence.parquet_shards.saturating_add(1);
-            evidence.physical_bytes_written = evidence
-                .physical_bytes_written
-                .saturating_add(receipt.parquet.bytes)
-                .saturating_add(receipt.identities.bytes)
-                .saturating_add(receipt.endpoints.as_ref().map_or(0, |item| item.bytes))
-                .saturating_add(body.len() as u64);
-            evidence.write_blocks = evidence
-                .write_blocks
-                .saturating_add(receipt.parquet.bytes.div_ceil(BLOCK_BYTES as u64))
-                .saturating_add(receipt.identities.bytes.div_ceil(BLOCK_BYTES as u64))
-                .saturating_add(
-                    receipt
-                        .endpoints
-                        .as_ref()
-                        .map_or(0, |item| item.bytes.div_ceil(BLOCK_BYTES as u64)),
-                )
-                .saturating_add(1);
-            evidence.run_records = evidence.run_records.saturating_add(receipt.run_records);
-            evidence.peak_batch_rows = evidence.peak_batch_rows.max(receipt.rows);
-            evidence.peak_batch_bytes = evidence.peak_batch_bytes.max(receipt.input_bytes);
-            evidence.peak_run_records = evidence.peak_run_records.max(receipt.run_records);
-            self.manifest.receipts.push(receipt);
-            self.persist_manifest_replace()?;
+            Err(error) => return Err(storage(error)),
+        }
+        unlink_named(&self.root, INTENT)
+    }
+
+    fn read_receipt(&self, sequence: u64) -> Result<ConstructionChunkReceipt, GfError> {
+        let mut file = self
+            .root
+            .open_child_file(OsStr::new(&receipt_name(sequence)))
+            .map_err(storage)?;
+        let receipt = decode_bounded(&mut file)?;
+        validate_receipt_semantics(&receipt, sequence, self.checkpoint.budgets)?;
+        if receipt.operation_uuid != self.checkpoint.operation_uuid
+            || receipt.project_identity != self.checkpoint.project_identity
+            || receipt.session_identity != self.checkpoint.session_identity
+            || receipt.parent_topology_generation != self.checkpoint.parent_topology_generation
+        {
+            return Err(storage("receipt authority differs from session checkpoint"));
+        }
+        Ok(receipt)
+    }
+
+    fn advance_checkpoint(
+        &mut self,
+        receipt: &ConstructionChunkReceipt,
+        receipt_bytes: &[u8],
+    ) -> Result<(), GfError> {
+        if receipt.sequence < self.checkpoint.next_sequence {
+            return Ok(());
+        }
+        if receipt.sequence != self.checkpoint.next_sequence {
+            return Err(storage("receipt sequence is not checkpoint successor"));
+        }
+        let evidence = &mut self.checkpoint.evidence;
+        evidence.input_rows = evidence.input_rows.saturating_add(receipt.rows);
+        evidence.input_batches = evidence.input_batches.saturating_add(1);
+        evidence.parquet_shards = evidence.parquet_shards.saturating_add(1);
+        evidence.run_records = evidence.run_records.saturating_add(receipt.run_records);
+        evidence.peak_batch_rows = evidence.peak_batch_rows.max(receipt.rows);
+        evidence.peak_batch_bytes = evidence.peak_batch_bytes.max(receipt.input_bytes);
+        evidence.peak_run_records = evidence.peak_run_records.max(receipt.run_records);
+        for artifact in [&receipt.parquet, &receipt.identities]
+            .into_iter()
+            .chain(receipt.endpoints.iter())
+        {
+            evidence.write_bytes = evidence.write_bytes.saturating_add(artifact.bytes);
+            evidence.write_operations = evidence
+                .write_operations
+                .saturating_add(artifact.write_operations);
+        }
+        self.checkpoint.next_sequence = self.checkpoint.next_sequence.saturating_add(1);
+        self.checkpoint.saw_edge |= receipt.kind == ConstructionChunkKind::Edge;
+        self.checkpoint.last_receipt_sha256 = Some(sha256(receipt_bytes));
+        replace_control(&self.root, CHECKPOINT, &self.checkpoint)
+    }
+
+    fn revalidate_authority(&self) -> Result<(), GfError> {
+        self.project.revalidate_named().map_err(storage)?;
+        self.root.revalidate_named().map_err(storage)?;
+        if !self
+            .checkpoint
+            .project_identity
+            .matches(self.project.identity())
+            || !self
+                .checkpoint
+                .session_identity
+                .matches(self.root.identity())
+        {
+            return Err(storage("retained construction authority identity changed"));
         }
         Ok(())
     }
-
-    fn remove_unreceipted_sequence(&self, stem: &str) -> Result<(), GfError> {
-        for suffix in ["parquet", "identities.run", "endpoints.run"] {
-            let path = self.root.join(format!("{stem}.{suffix}"));
-            match fs::remove_file(&path) {
-                Ok(()) => {}
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-                Err(error) => return Err(storage(error)),
-            }
-        }
-        sync_directory(&self.root)
-    }
-
-    fn persist_manifest_create(&self) -> Result<(), GfError> {
-        let body = serde_json::to_vec(&self.manifest).map_err(storage)?;
-        write_create_synced(&self.root.join(MANIFEST_FILE), &body)
-    }
-
-    fn persist_manifest_replace(&self) -> Result<(), GfError> {
-        let body = serde_json::to_vec(&self.manifest).map_err(storage)?;
-        let temporary = self
-            .root
-            .join(format!(".{MANIFEST_FILE}.{}.tmp", Uuid::new_v4()));
-        write_create_synced(&temporary, &body)?;
-        fs::rename(&temporary, self.root.join(MANIFEST_FILE)).map_err(storage)?;
-        sync_directory(&self.root)
-    }
 }
 
-struct ChunkArrays {
-    identity: Vec<[u8; UUID_BYTES]>,
-    endpoints: Vec<[u8; ENDPOINT_RECORD_BYTES]>,
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct ReceiptPointer {
+    operation_uuid: Uuid,
+    project_identity: IdentityRecord,
+    session_identity: IdentityRecord,
+    sequence: u64,
+    receipt_sha256: String,
 }
 
-fn extract_required_arrays(
-    kind: ConstructionChunkKind,
-    batch: &RecordBatch,
-) -> Result<ChunkArrays, GfError> {
-    let identity_name = match kind {
-        ConstructionChunkKind::Node => "node_uuid",
-        ConstructionChunkKind::Edge => "edge_uuid",
-    };
-    let identities = uuid_column(batch, identity_name)?;
-    let mut identity = (0..batch.num_rows())
-        .map(|index| uuid_value(identities, index))
+struct RunArrays {
+    identities: Vec<[u8; IDENTITY_WIDTH]>,
+    endpoints: Vec<[u8; ENDPOINT_WIDTH]>,
+}
+
+fn extract_runs(kind: ConstructionChunkKind, batch: &RecordBatch) -> Result<RunArrays, GfError> {
+    let identity = uuid_column(
+        batch,
+        if kind == ConstructionChunkKind::Node {
+            "node_uuid"
+        } else {
+            "edge_uuid"
+        },
+    )?;
+    let mut identities = (0..batch.num_rows())
+        .map(|row| uuid_value(identity, row))
         .collect::<Result<Vec<_>, _>>()?;
-    identity.sort_unstable();
-    if identity.windows(2).any(|pair| pair[0] == pair[1]) {
-        return Err(storage("duplicate UUID inside construction chunk"));
+    identities.sort_unstable();
+    if identities.windows(2).any(|pair| pair[0] == pair[1]) {
+        return Err(storage("duplicate identity inside chunk"));
     }
-    let endpoints = if kind == ConstructionChunkKind::Edge {
+    let mut endpoints = Vec::new();
+    if kind == ConstructionChunkKind::Edge {
+        let edges = uuid_column(batch, "edge_uuid")?;
         let src = uuid_column(batch, "src_uuid")?;
         let dst = uuid_column(batch, "dst_uuid")?;
-        let edge = uuid_column(batch, "edge_uuid")?;
-        let mut values = Vec::with_capacity(batch.num_rows().saturating_mul(2));
-        for index in 0..batch.num_rows() {
-            let edge_uuid = uuid_value(edge, index)?;
-            for (role, endpoint) in [uuid_value(src, index)?, uuid_value(dst, index)?]
+        endpoints.reserve(batch.num_rows().saturating_mul(2));
+        for row in 0..batch.num_rows() {
+            let edge = uuid_value(edges, row)?;
+            for (role, endpoint) in [uuid_value(src, row)?, uuid_value(dst, row)?]
                 .into_iter()
                 .enumerate()
             {
-                let mut record = [0_u8; ENDPOINT_RECORD_BYTES];
+                let mut record = [0_u8; ENDPOINT_WIDTH];
                 record[..16].copy_from_slice(&endpoint);
-                record[16..32].copy_from_slice(&edge_uuid);
+                record[16..32].copy_from_slice(&edge);
                 record[32] = role as u8;
-                values.push(record);
+                endpoints.push(record);
             }
         }
-        values.sort_unstable();
-        values
-    } else {
-        Vec::new()
-    };
-    Ok(ChunkArrays {
-        identity,
+        endpoints.sort_unstable();
+    }
+    Ok(RunArrays {
+        identities,
         endpoints,
     })
+}
+
+fn validate_schema(kind: ConstructionChunkKind, batch: &RecordBatch) -> Result<(), GfError> {
+    let expected = match kind {
+        ConstructionChunkKind::Node => &*CONSTRUCTION_NODE_SCHEMA,
+        ConstructionChunkKind::Edge => &*CONSTRUCTION_EDGE_SCHEMA,
+    };
+    if batch.schema().as_ref() != expected.as_ref() {
+        return Err(storage("construction batch schema is not canonical"));
+    }
+    for column in batch.columns() {
+        if column.null_count() != 0 {
+            return Err(storage("canonical construction columns are non-null"));
+        }
+    }
+    if kind == ConstructionChunkKind::Edge {
+        let routes = batch
+            .column(3)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| storage("canonical edge route is not Utf8"))?;
+        if routes.iter().flatten().any(|route| {
+            route.is_empty()
+                || route.len() > 255
+                || route.contains('/')
+                || route.contains('\\')
+                || route == "."
+                || route == ".."
+        }) {
+            return Err(storage("invalid canonical edge route"));
+        }
+    }
+    Ok(())
+}
+
+fn logical_batch_digest(
+    kind: ConstructionChunkKind,
+    batch: &RecordBatch,
+) -> Result<String, GfError> {
+    let mut digest = Sha256::new();
+    digest.update(b"graphforge-construction-logical-arrow/v1\0");
+    digest.update(kind.tag().as_bytes());
+    digest.update((batch.num_rows() as u64).to_be_bytes());
+    match kind {
+        ConstructionChunkKind::Node => {
+            let uuids = uuid_column(batch, "node_uuid")?;
+            let types = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<UInt32Array>()
+                .ok_or_else(|| storage("canonical node type is not UInt32"))?;
+            for row in 0..batch.num_rows() {
+                digest.update(uuid_value(uuids, row)?);
+                digest.update(types.value(row).to_be_bytes());
+            }
+        }
+        ConstructionChunkKind::Edge => {
+            let edge = uuid_column(batch, "edge_uuid")?;
+            let src = uuid_column(batch, "src_uuid")?;
+            let dst = uuid_column(batch, "dst_uuid")?;
+            let route = batch
+                .column(3)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .ok_or_else(|| storage("canonical edge route is not Utf8"))?;
+            for row in 0..batch.num_rows() {
+                digest.update(uuid_value(edge, row)?);
+                digest.update(uuid_value(src, row)?);
+                digest.update(uuid_value(dst, row)?);
+                let value = route.value(row).as_bytes();
+                digest.update((value.len() as u64).to_be_bytes());
+                digest.update(value);
+            }
+        }
+    }
+    Ok(hex(&digest.finalize()))
 }
 
 fn uuid_column<'a>(
@@ -616,189 +899,737 @@ fn uuid_column<'a>(
     let index = batch
         .schema()
         .index_of(name)
-        .map_err(|_| storage(format!("missing required column {name}")))?;
+        .map_err(|_| storage(format!("missing canonical column {name}")))?;
     let array = batch
         .column(index)
         .as_any()
         .downcast_ref::<FixedSizeBinaryArray>()
-        .ok_or_else(|| storage(format!("{name} must be FixedSizeBinary(16)")))?;
+        .ok_or_else(|| storage(format!("{name} is not FixedSizeBinary(16)")))?;
     if array.value_length() != 16 || array.null_count() != 0 {
-        return Err(storage(format!(
-            "{name} must be non-null FixedSizeBinary(16)"
-        )));
+        return Err(storage(format!("{name} is not non-null UUID data")));
     }
     Ok(array)
 }
 
-fn uuid_value(array: &FixedSizeBinaryArray, index: usize) -> Result<[u8; 16], GfError> {
+fn uuid_value(array: &FixedSizeBinaryArray, row: usize) -> Result<[u8; 16], GfError> {
     array
-        .value(index)
+        .value(row)
         .try_into()
-        .map_err(|_| storage("UUID value has invalid width"))
+        .map_err(|_| storage("UUID width changed"))
 }
 
-fn digest_record_batch(batch: &RecordBatch) -> String {
-    let mut digest = Sha256::new();
-    digest.update(format!("{:?}", batch.schema()).as_bytes());
-    digest.update((batch.num_rows() as u64).to_be_bytes());
-    for column in batch.columns() {
-        digest_array_data(&column.to_data(), &mut digest);
-    }
-    hex_digest(digest.finalize().as_slice())
+struct HashingWriter<W> {
+    inner: W,
+    digest: Sha256,
+    bytes: u64,
+    operations: u64,
 }
 
-fn digest_array_data(data: &arrow::array::ArrayData, digest: &mut Sha256) {
-    digest.update((data.len() as u64).to_be_bytes());
-    digest.update((data.offset() as u64).to_be_bytes());
-    for buffer in data.buffers() {
-        digest.update((buffer.len() as u64).to_be_bytes());
-        digest.update(buffer.as_slice());
-    }
-    if let Some(nulls) = data.nulls() {
-        digest.update((nulls.offset() as u64).to_be_bytes());
-        digest.update(nulls.buffer().as_slice());
-    }
-    digest.update((data.child_data().len() as u64).to_be_bytes());
-    for child in data.child_data() {
-        digest_array_data(child, digest);
+impl<W> HashingWriter<W> {
+    fn new(inner: W) -> Self {
+        Self {
+            inner,
+            digest: Sha256::new(),
+            bytes: 0,
+            operations: 0,
+        }
     }
 }
 
-fn write_parquet_artifact(
-    root: &Path,
+impl<W: Write> Write for HashingWriter<W> {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        let written = self.inner.write(bytes)?;
+        self.digest.update(&bytes[..written]);
+        self.bytes = self.bytes.saturating_add(written as u64);
+        self.operations = self.operations.saturating_add(1);
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+fn write_parquet(
+    root: &StableDirectory,
     name: &str,
     batch: &RecordBatch,
 ) -> Result<ArtifactReceipt, GfError> {
-    let path = root.join(name);
-    let file = OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(&path)
+    let temporary = artifact_temp(name);
+    let file = root
+        .create_replaceable_child_file(OsStr::new(&temporary))
         .map_err(storage)?;
-    let mut writer = ArrowWriter::try_new(
-        BufWriter::with_capacity(BLOCK_BYTES, file),
-        batch.schema(),
-        None,
-    )
-    .map_err(storage)?;
-    writer.write(batch).map_err(storage)?;
-    writer.finish().map_err(storage)?;
-    writer.sync().map_err(storage)?;
-    writer.inner().get_ref().sync_all().map_err(storage)?;
-    sync_directory(root)?;
-    describe_artifact(root, name)
+    let identity = file_identity(&file).map_err(storage)?;
+    let hashing = HashingWriter::new(file);
+    let buffered = BufWriter::with_capacity(BLOCK_BYTES, hashing);
+    let mut parquet = ArrowWriter::try_new(buffered, batch.schema(), None).map_err(storage)?;
+    parquet.write(batch).map_err(storage)?;
+    parquet.finish().map_err(storage)?;
+    parquet.sync().map_err(storage)?;
+    let hashing = parquet.inner().get_ref();
+    hashing.inner.sync_all().map_err(storage)?;
+    construction_failpoint(&format!("artifact.after_temp_fsync.{name}"));
+    let receipt = ArtifactReceipt {
+        name: name.to_owned(),
+        bytes: hashing.bytes,
+        sha256: hex(&hashing.digest.clone().finalize()),
+        identity: identity.into(),
+        write_operations: hashing.operations,
+    };
+    root.sync().map_err(storage)?;
+    root.install_child(OsStr::new(&temporary), identity, OsStr::new(name))
+        .map_err(storage)?;
+    root.sync().map_err(storage)?;
+    construction_failpoint(&format!("artifact.after_install.{name}"));
+    Ok(receipt)
 }
 
-fn write_fixed_artifact<const N: usize>(
-    root: &Path,
+fn write_fixed_run<const N: usize>(
+    root: &StableDirectory,
     name: &str,
-    width: usize,
-    records: Vec<[u8; N]>,
+    records: &[[u8; N]],
 ) -> Result<ArtifactReceipt, GfError> {
-    if N != width {
-        return Err(storage("fixed run width mismatch"));
-    }
-    let path = root.join(name);
-    let file = OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(&path)
+    let temporary = artifact_temp(name);
+    let file = root
+        .create_replaceable_child_file(OsStr::new(&temporary))
         .map_err(storage)?;
-    let mut output = BufWriter::with_capacity(BLOCK_BYTES, file);
-    for record in records {
-        output.write_all(&record).map_err(storage)?;
+    let identity = file_identity(&file).map_err(storage)?;
+    let mut writer = HashingWriter::new(file);
+    let records_per_block = (BLOCK_BYTES / N).max(1);
+    let mut block = Vec::with_capacity(records_per_block * N);
+    for group in records.chunks(records_per_block) {
+        block.clear();
+        for record in group {
+            block.extend_from_slice(record);
+        }
+        writer.write_all(&block).map_err(storage)?;
     }
-    output.flush().map_err(storage)?;
-    output.get_ref().sync_all().map_err(storage)?;
-    sync_directory(root)?;
-    describe_artifact(root, name)
+    writer.flush().map_err(storage)?;
+    writer.inner.sync_all().map_err(storage)?;
+    construction_failpoint(&format!("artifact.after_temp_fsync.{name}"));
+    let receipt = ArtifactReceipt {
+        name: name.to_owned(),
+        bytes: writer.bytes,
+        sha256: hex(&writer.digest.finalize()),
+        identity: identity.into(),
+        write_operations: writer.operations,
+    };
+    root.sync().map_err(storage)?;
+    root.install_child(OsStr::new(&temporary), identity, OsStr::new(name))
+        .map_err(storage)?;
+    root.sync().map_err(storage)?;
+    construction_failpoint(&format!("artifact.after_install.{name}"));
+    Ok(receipt)
 }
 
-fn describe_artifact(root: &Path, name: &str) -> Result<ArtifactReceipt, GfError> {
-    let path = root.join(name);
-    let (sha256, bytes, _) = hash_file(&path)?;
-    Ok(ArtifactReceipt {
-        relative_path: name.to_owned(),
-        bytes,
-        sha256,
-    })
+#[derive(Clone, Copy)]
+struct ReadWork {
+    bytes: u64,
+    operations: u64,
 }
 
-fn authenticate_artifact(root: &Path, receipt: &ArtifactReceipt) -> Result<(u64, u64), GfError> {
-    if receipt.relative_path.contains('/')
-        || receipt.relative_path.contains('\\')
-        || receipt.relative_path.starts_with('.')
+fn authenticate_artifact(
+    root: &StableDirectory,
+    receipt: &ArtifactReceipt,
+) -> Result<ReadWork, GfError> {
+    validate_artifact_name(receipt)?;
+    let file = root
+        .open_child_file(OsStr::new(&receipt.name))
+        .map_err(storage)?;
+    if !receipt
+        .identity
+        .matches(file_identity(&file).map_err(storage)?)
+        || file_link_count(&file).map_err(storage)? != 1
     {
-        return Err(storage("invalid artifact path"));
+        return Err(storage("artifact identity or link count changed"));
     }
-    let (digest, bytes, blocks) = hash_file(&root.join(&receipt.relative_path))?;
-    if bytes != receipt.bytes || digest != receipt.sha256 {
-        return Err(storage("construction artifact authentication failed"));
-    }
-    if receipt.relative_path.ends_with(".identities.run") && bytes % UUID_BYTES as u64 != 0 {
-        return Err(storage("truncated identity run"));
-    }
-    if receipt.relative_path.ends_with(".endpoints.run")
-        && bytes % ENDPOINT_RECORD_BYTES as u64 != 0
-    {
-        return Err(storage("truncated endpoint run"));
-    }
-    Ok((bytes, blocks))
-}
-
-fn hash_file(path: &Path) -> Result<(String, u64, u64), GfError> {
-    let file = File::open(path).map_err(storage)?;
-    let mut input = BufReader::with_capacity(BLOCK_BYTES, file);
+    let mut reader = BufReader::with_capacity(BLOCK_BYTES, file);
     let mut block = vec![0_u8; BLOCK_BYTES];
     let mut digest = Sha256::new();
     let mut bytes = 0_u64;
-    let mut blocks = 0_u64;
+    let mut operations = 0_u64;
+    let width = if receipt.name.ends_with(".identities.run") {
+        Some(IDENTITY_WIDTH)
+    } else if receipt.name.ends_with(".endpoints.run") {
+        Some(ENDPOINT_WIDTH)
+    } else {
+        None
+    };
+    let mut pending = Vec::new();
+    let mut previous: Option<Vec<u8>> = None;
     loop {
-        let count = input.read(&mut block).map_err(storage)?;
+        let count = reader.read(&mut block).map_err(storage)?;
         if count == 0 {
             break;
         }
         digest.update(&block[..count]);
         bytes = bytes.saturating_add(count as u64);
-        blocks = blocks.saturating_add(1);
+        operations = operations.saturating_add(1);
+        if let Some(width) = width {
+            pending.extend_from_slice(&block[..count]);
+            let complete = pending.len() / width * width;
+            for record in pending[..complete].chunks_exact(width) {
+                if previous
+                    .as_ref()
+                    .is_some_and(|prior| prior.as_slice() >= record)
+                {
+                    return Err(storage("fixed construction run is not strictly sorted"));
+                }
+                if width == ENDPOINT_WIDTH
+                    && (!matches!(record[32], 0 | 1) || record[33..].iter().any(|byte| *byte != 0))
+                {
+                    return Err(storage("endpoint run record is malformed"));
+                }
+                previous = Some(record.to_vec());
+            }
+            pending.drain(..complete);
+        }
     }
-    Ok((hex_digest(digest.finalize().as_slice()), bytes, blocks))
+    if !pending.is_empty() {
+        return Err(storage("fixed construction run has a truncated tail"));
+    }
+    if bytes != receipt.bytes || hex(&digest.finalize()) != receipt.sha256 {
+        return Err(storage("artifact digest or size changed"));
+    }
+    Ok(ReadWork { bytes, operations })
 }
 
-fn read_bounded(path: &Path, maximum: u64) -> Result<Vec<u8>, GfError> {
-    let file = File::open(path).map_err(storage)?;
-    if file.metadata().map_err(storage)?.len() > maximum {
-        return Err(storage("control file exceeds bound"));
+fn validate_artifact_name(receipt: &ArtifactReceipt) -> Result<(), GfError> {
+    let valid_suffix = receipt.name.ends_with(".parquet")
+        || receipt.name.ends_with(".identities.run")
+        || receipt.name.ends_with(".endpoints.run");
+    if !valid_suffix
+        || receipt.name.starts_with('.')
+        || receipt.name.contains('/')
+        || receipt.name.contains('\\')
+        || receipt.sha256.len() != 64
+        || !receipt.sha256.bytes().all(|byte| byte.is_ascii_hexdigit())
+        || receipt.identity.file_id.len() != 32
+        || !receipt
+            .identity
+            .file_id
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit())
+        || receipt.bytes == 0
+        || receipt.write_operations == 0
+    {
+        return Err(storage("invalid construction artifact receipt"));
+    }
+    if receipt.name.ends_with(".identities.run") && receipt.bytes % IDENTITY_WIDTH as u64 != 0 {
+        return Err(storage("truncated identity run"));
+    }
+    if receipt.name.ends_with(".endpoints.run") && receipt.bytes % ENDPOINT_WIDTH as u64 != 0 {
+        return Err(storage("truncated endpoint run"));
+    }
+    Ok(())
+}
+
+fn receipt_from_intent(intent: &ChunkIntent) -> Result<ConstructionChunkReceipt, GfError> {
+    Ok(ConstructionChunkReceipt {
+        operation_uuid: intent.operation_uuid,
+        project_identity: intent.project_identity.clone(),
+        session_identity: intent.session_identity.clone(),
+        parent_topology_generation: intent.parent_topology_generation,
+        prior_receipt_sha256: intent.prior_receipt_sha256.clone(),
+        chunk_id: intent.chunk_id.clone(),
+        sequence: intent.sequence,
+        kind: intent.kind,
+        rows: intent.rows,
+        input_bytes: intent.input_bytes,
+        input_sha256: intent.input_sha256.clone(),
+        run_records: intent.run_records,
+        parquet: intent
+            .parquet
+            .clone()
+            .ok_or_else(|| storage("intent lacks Parquet artifact"))?,
+        identities: intent
+            .identities
+            .clone()
+            .ok_or_else(|| storage("intent lacks identity run"))?,
+        endpoints: intent.endpoints.clone(),
+    })
+}
+
+fn validate_receipt_semantics(
+    receipt: &ConstructionChunkReceipt,
+    sequence: u64,
+    budgets: GraphConstructionBudgets,
+) -> Result<(), GfError> {
+    validate_chunk_id(&receipt.chunk_id)?;
+    if receipt.sequence != sequence
+        || receipt.operation_uuid.is_nil()
+        || receipt.rows == 0
+        || receipt.rows > budgets.max_batch_rows as u64
+        || receipt.input_bytes > budgets.max_batch_bytes as u64
+        || receipt.run_records > budgets.max_run_records as u64
+        || receipt.input_sha256.len() != 64
+        || !receipt
+            .input_sha256
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit())
+        || receipt.parquet.name != format!("{}.parquet", artifact_stem(sequence, receipt.kind))
+        || receipt.identities.name
+            != format!("{}.identities.run", artifact_stem(sequence, receipt.kind))
+        || (receipt.kind == ConstructionChunkKind::Node && receipt.endpoints.is_some())
+        || (receipt.kind == ConstructionChunkKind::Edge && receipt.endpoints.is_none())
+        || receipt.identities.bytes / IDENTITY_WIDTH as u64 != receipt.rows
+        || receipt.run_records
+            != receipt.rows
+                * if receipt.kind == ConstructionChunkKind::Edge {
+                    3
+                } else {
+                    1
+                }
+    {
+        return Err(storage("receipt semantics are inconsistent"));
+    }
+    if let Some(endpoints) = &receipt.endpoints
+        && (endpoints.name != format!("{}.endpoints.run", artifact_stem(sequence, receipt.kind))
+            || endpoints.bytes / ENDPOINT_WIDTH as u64 != receipt.rows * 2)
+    {
+        return Err(storage("endpoint receipt semantics are inconsistent"));
+    }
+    validate_artifact_name(&receipt.parquet)?;
+    validate_artifact_name(&receipt.identities)?;
+    if let Some(endpoints) = &receipt.endpoints {
+        validate_artifact_name(endpoints)?;
+    }
+    Ok(())
+}
+
+fn validate_receipt_artifacts(
+    root: &StableDirectory,
+    receipt: &ConstructionChunkReceipt,
+) -> Result<(), GfError> {
+    for artifact in [&receipt.parquet, &receipt.identities]
+        .into_iter()
+        .chain(receipt.endpoints.iter())
+    {
+        authenticate_artifact(root, artifact)?;
+    }
+    validate_parquet_shape(root, receipt)?;
+    Ok(())
+}
+
+fn validate_parquet_shape(
+    root: &StableDirectory,
+    receipt: &ConstructionChunkReceipt,
+) -> Result<(), GfError> {
+    let file = root
+        .open_child_file(OsStr::new(&receipt.parquet.name))
+        .map_err(storage)?;
+    if !receipt
+        .parquet
+        .identity
+        .matches(file_identity(&file).map_err(storage)?)
+    {
+        return Err(storage("Parquet identity changed during schema reopen"));
+    }
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file).map_err(storage)?;
+    let expected = match receipt.kind {
+        ConstructionChunkKind::Node => &*CONSTRUCTION_NODE_SCHEMA,
+        ConstructionChunkKind::Edge => &*CONSTRUCTION_EDGE_SCHEMA,
+    };
+    if builder.schema().as_ref() != expected.as_ref()
+        || builder.metadata().file_metadata().num_rows() != receipt.rows as i64
+    {
+        return Err(storage("Parquet schema or row count differs from receipt"));
+    }
+    Ok(())
+}
+
+fn validate_intent(intent: &ChunkIntent, checkpoint: &Checkpoint) -> Result<(), GfError> {
+    let stem = artifact_stem(intent.sequence, intent.kind);
+    let expected_run_records =
+        intent
+            .rows
+            .saturating_mul(if intent.kind == ConstructionChunkKind::Edge {
+                3
+            } else {
+                1
+            });
+    if intent.format_version != FORMAT_VERSION
+        || intent.operation_uuid != checkpoint.operation_uuid
+        || intent.project_identity != checkpoint.project_identity
+        || intent.session_identity != checkpoint.session_identity
+        || !(intent.sequence == checkpoint.next_sequence
+            || intent.sequence.saturating_add(1) == checkpoint.next_sequence)
+        || intent.parent_topology_generation != checkpoint.parent_topology_generation
+        || (intent.sequence == checkpoint.next_sequence
+            && intent.prior_receipt_sha256 != checkpoint.last_receipt_sha256)
+        || intent.chunk_key != chunk_key_name(&intent.chunk_id)
+        || intent.rows == 0
+        || intent.rows > checkpoint.budgets.max_batch_rows as u64
+        || intent.input_bytes > checkpoint.budgets.max_batch_bytes as u64
+        || intent.run_records > checkpoint.budgets.max_run_records as u64
+        || intent.run_records != expected_run_records
+        || intent.input_sha256.len() != 64
+        || !intent
+            .input_sha256
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit())
+        || intent
+            .parquet
+            .as_ref()
+            .is_some_and(|artifact| artifact.name != format!("{stem}.parquet"))
+        || intent.identities.as_ref().is_some_and(|artifact| {
+            artifact.name != format!("{stem}.identities.run")
+                || artifact.bytes != intent.rows.saturating_mul(IDENTITY_WIDTH as u64)
+        })
+        || intent.endpoints.as_ref().is_some_and(|artifact| {
+            intent.kind != ConstructionChunkKind::Edge
+                || artifact.name != format!("{stem}.endpoints.run")
+                || artifact.bytes
+                    != intent
+                        .rows
+                        .saturating_mul(2)
+                        .saturating_mul(ENDPOINT_WIDTH as u64)
+        })
+    {
+        return Err(storage("durable intent is inconsistent with checkpoint"));
+    }
+    Ok(())
+}
+
+fn validate_checkpoint(
+    checkpoint: &Checkpoint,
+    operation: Uuid,
+    project: FileIdentity,
+    session: FileIdentity,
+    generation: u64,
+    budgets: GraphConstructionBudgets,
+) -> Result<(), GfError> {
+    if checkpoint.format_version != FORMAT_VERSION
+        || checkpoint.operation_uuid != operation
+        || !checkpoint.project_identity.matches(project)
+        || !checkpoint.session_identity.matches(session)
+        || checkpoint.parent_topology_generation != generation
+        || checkpoint.budgets != budgets
+        || checkpoint.next_sequence > budgets.max_chunks
+        || checkpoint.last_receipt_sha256.is_some() != (checkpoint.next_sequence != 0)
+        || checkpoint
+            .last_receipt_sha256
+            .as_ref()
+            .is_some_and(|digest| {
+                digest.len() != 64 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit())
+            })
+        || checkpoint.evidence.input_batches != checkpoint.next_sequence
+        || checkpoint.evidence.parquet_shards != checkpoint.next_sequence
+        || checkpoint.evidence.peak_batch_rows > budgets.max_batch_rows as u64
+        || checkpoint.evidence.peak_batch_bytes > budgets.max_batch_bytes as u64
+        || checkpoint.evidence.peak_run_records > budgets.max_run_records as u64
+        || checkpoint.evidence.prior_topology_rows_decoded != 0
+        || checkpoint.evidence.current_transitions != 0
+    {
+        return Err(storage("checkpoint authority or resume parameters changed"));
+    }
+    Ok(())
+}
+
+fn cleanup_authenticated_control_temps(
+    root: &StableDirectory,
+    operation: Uuid,
+    project: FileIdentity,
+    session: FileIdentity,
+) -> Result<(), GfError> {
+    for name in root.child_names().map_err(storage)? {
+        let Some(text) = name.to_str() else { continue };
+        if !is_control_temp(text) {
+            continue;
+        }
+        let mut file = root.open_child_file(&name).map_err(storage)?;
+        let body = read_bounded(&mut file)?;
+        let authenticated =
+            serde_json::from_slice::<Checkpoint>(&body).is_ok_and(|value| {
+                value.format_version == FORMAT_VERSION
+                    && value.operation_uuid == operation
+                    && value.project_identity.matches(project)
+                    && value.session_identity.matches(session)
+            }) || serde_json::from_slice::<ChunkIntent>(&body).is_ok_and(|value| {
+                value.format_version == FORMAT_VERSION
+                    && value.operation_uuid == operation
+                    && value.project_identity.matches(project)
+                    && value.session_identity.matches(session)
+            }) || serde_json::from_slice::<ConstructionChunkReceipt>(&body).is_ok_and(|value| {
+                value.operation_uuid == operation
+                    && value.project_identity.matches(project)
+                    && value.session_identity.matches(session)
+            }) || serde_json::from_slice::<ReceiptPointer>(&body).is_ok_and(|value| {
+                value.operation_uuid == operation
+                    && value.project_identity.matches(project)
+                    && value.session_identity.matches(session)
+            });
+        if authenticated && file_link_count(&file).map_err(storage)? == 1 {
+            let identity = file_identity(&file).map_err(storage)?;
+            drop(file);
+            root.unlink_child_if_identity(&name, identity)
+                .map_err(storage)?;
+            root.sync().map_err(storage)?;
+        }
+    }
+    Ok(())
+}
+
+fn is_control_temp(name: &str) -> bool {
+    let Some((prefix, suffix)) = name.rsplit_once('.') else {
+        return false;
+    };
+    suffix == "tmp"
+        && prefix.starts_with('.')
+        && prefix.rsplit_once('-').is_some_and(|(_, random)| {
+            random.len() == 32 && random.bytes().all(|b| b.is_ascii_hexdigit())
+        })
+}
+
+fn cleanup_owned_artifact_temps(root: &StableDirectory) -> Result<(), GfError> {
+    for name in root.child_names().map_err(storage)? {
+        let Some(text) = name.to_str() else { continue };
+        if !is_owned_artifact_temp(text) {
+            continue;
+        }
+        let file = root.open_child_file(&name).map_err(storage)?;
+        if file_link_count(&file).map_err(storage)? != 1 {
+            return Err(storage("incomplete artifact temp has unexpected links"));
+        }
+        let identity = file_identity(&file).map_err(storage)?;
+        drop(file);
+        root.unlink_child_if_identity(&name, identity)
+            .map_err(storage)?;
+        root.sync().map_err(storage)?;
+    }
+    Ok(())
+}
+
+fn is_owned_artifact_temp(name: &str) -> bool {
+    let Some(body) = name
+        .strip_prefix(".artifact-")
+        .and_then(|value| value.strip_suffix(".tmp"))
+    else {
+        return false;
+    };
+    let Some((target, random)) = body.rsplit_once('-') else {
+        return false;
+    };
+    random.len() == 32
+        && random.bytes().all(|byte| byte.is_ascii_hexdigit())
+        && canonical_artifact_target(target)
+}
+
+fn canonical_artifact_target(name: &str) -> bool {
+    let Some(body) = name.strip_prefix("chunk-") else {
+        return false;
+    };
+    let Some((sequence, tail)) = body.split_once('-') else {
+        return false;
+    };
+    sequence.len() == 20
+        && sequence.bytes().all(|byte| byte.is_ascii_digit())
+        && matches!(
+            tail,
+            "node.parquet"
+                | "node.identities.run"
+                | "edge.parquet"
+                | "edge.identities.run"
+                | "edge.endpoints.run"
+        )
+}
+
+fn install_control<T: Serialize>(
+    root: &StableDirectory,
+    target: &str,
+    value: &T,
+) -> Result<(), GfError> {
+    let body = serde_json::to_vec(value).map_err(storage)?;
+    if body.len() as u64 > MAX_CONTROL_BYTES {
+        return Err(storage("control record exceeds bound"));
+    }
+    let temporary = control_temp(target);
+    let mut file = root
+        .create_replaceable_child_file(OsStr::new(&temporary))
+        .map_err(storage)?;
+    let identity = file_identity(&file).map_err(storage)?;
+    write_control_body(&mut file, &body, target, "install")?;
+    file.sync_all().map_err(storage)?;
+    root.sync().map_err(storage)?;
+    construction_failpoint(&format!("control.install.after_temp_fsync.{target}"));
+    root.install_child(OsStr::new(&temporary), identity, OsStr::new(target))
+        .map_err(storage)?;
+    root.sync().map_err(storage)?;
+    construction_failpoint(&format!("control.install.after_install.{target}"));
+    Ok(())
+}
+
+fn replace_control<T: Serialize>(
+    root: &StableDirectory,
+    target: &str,
+    value: &T,
+) -> Result<(), GfError> {
+    let body = serde_json::to_vec(value).map_err(storage)?;
+    if body.len() as u64 > MAX_CONTROL_BYTES {
+        return Err(storage("control record exceeds bound"));
+    }
+    let temporary = control_temp(target);
+    let mut file = root
+        .create_replaceable_child_file(OsStr::new(&temporary))
+        .map_err(storage)?;
+    let identity = file_identity(&file).map_err(storage)?;
+    write_control_body(&mut file, &body, target, "replace")?;
+    file.sync_all().map_err(storage)?;
+    root.sync().map_err(storage)?;
+    construction_failpoint(&format!("control.replace.after_temp_fsync.{target}"));
+    root.replace_child(OsStr::new(&temporary), identity, OsStr::new(target))
+        .map_err(storage)?;
+    root.sync().map_err(storage)?;
+    construction_failpoint(&format!("control.replace.after_replace.{target}"));
+    Ok(())
+}
+
+fn decode_bounded<T: for<'de> Deserialize<'de>>(file: &mut File) -> Result<T, GfError> {
+    serde_json::from_slice(&read_bounded(file)?).map_err(storage)
+}
+
+fn read_bounded(file: &mut File) -> Result<Vec<u8>, GfError> {
+    if file.metadata().map_err(storage)?.len() > MAX_CONTROL_BYTES {
+        return Err(storage("control record exceeds bound"));
     }
     let mut body = Vec::new();
-    BufReader::new(file)
-        .take(maximum.saturating_add(1))
+    file.take(MAX_CONTROL_BYTES + 1)
         .read_to_end(&mut body)
         .map_err(storage)?;
-    if body.len() as u64 > maximum {
-        return Err(storage("control file exceeds bound"));
+    if body.len() as u64 > MAX_CONTROL_BYTES {
+        return Err(storage("control record exceeds bound"));
     }
     Ok(body)
 }
 
-fn write_create_synced(path: &Path, bytes: &[u8]) -> Result<(), GfError> {
-    let mut file = OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(path)
+fn unlink_named(root: &StableDirectory, name: &str) -> Result<(), GfError> {
+    let file = root.open_child_file(OsStr::new(name)).map_err(storage)?;
+    if file_link_count(&file).map_err(storage)? != 1 {
+        return Err(storage("control record link count changed"));
+    }
+    let identity = file_identity(&file).map_err(storage)?;
+    drop(file);
+    root.unlink_child_if_identity(OsStr::new(name), identity)
         .map_err(storage)?;
-    file.write_all(bytes).map_err(storage)?;
-    file.sync_all().map_err(storage)?;
-    let parent = path
-        .parent()
-        .ok_or_else(|| storage("control path has no parent"))?;
-    sync_directory(parent)
+    root.sync().map_err(storage)
 }
 
-fn sync_directory(path: &Path) -> Result<(), GfError> {
-    File::open(path)
-        .and_then(|file| file.sync_all())
-        .map_err(storage)
+fn unlink_artifact(root: &StableDirectory, receipt: &ArtifactReceipt) -> Result<(), GfError> {
+    let file = root
+        .open_child_file(OsStr::new(&receipt.name))
+        .map_err(storage)?;
+    let identity = file_identity(&file).map_err(storage)?;
+    if !receipt.identity.matches(identity) || file_link_count(&file).map_err(storage)? != 1 {
+        return Err(storage("orphan artifact identity changed"));
+    }
+    drop(file);
+    root.unlink_child_if_identity(OsStr::new(&receipt.name), identity)
+        .map_err(storage)?;
+    root.sync().map_err(storage)
+}
+
+fn remove_unrecorded_artifact(
+    root: &StableDirectory,
+    name: &str,
+    kind: ConstructionChunkKind,
+    rows: u64,
+) -> Result<(), GfError> {
+    let mut file = match root.open_child_file(OsStr::new(name)) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(storage(error)),
+    };
+    let identity = file_identity(&file).map_err(storage)?;
+    if file_link_count(&file).map_err(storage)? != 1 {
+        return Err(storage("unrecorded artifact has unexpected links"));
+    }
+    if name.ends_with(".parquet") {
+        let builder = ParquetRecordBatchReaderBuilder::try_new(file).map_err(storage)?;
+        let expected = match kind {
+            ConstructionChunkKind::Node => &*CONSTRUCTION_NODE_SCHEMA,
+            ConstructionChunkKind::Edge => &*CONSTRUCTION_EDGE_SCHEMA,
+        };
+        if builder.schema().as_ref() != expected.as_ref()
+            || builder.metadata().file_metadata().num_rows() != rows as i64
+        {
+            return Err(storage("unrecorded Parquet artifact is not session-owned"));
+        }
+    } else {
+        let width = if name.ends_with(".identities.run") {
+            IDENTITY_WIDTH
+        } else if name.ends_with(".endpoints.run") {
+            ENDPOINT_WIDTH
+        } else {
+            return Err(storage("unrecorded artifact name is not canonical"));
+        };
+        let expected_records = if width == ENDPOINT_WIDTH {
+            rows.saturating_mul(2)
+        } else {
+            rows
+        };
+        if file.metadata().map_err(storage)?.len() != expected_records.saturating_mul(width as u64)
+        {
+            return Err(storage("unrecorded fixed run row count changed"));
+        }
+        validate_sorted_run(&mut file, width)?;
+    }
+    root.unlink_child_if_identity(OsStr::new(name), identity)
+        .map_err(storage)?;
+    root.sync().map_err(storage)
+}
+
+fn validate_sorted_run(file: &mut File, width: usize) -> Result<(), GfError> {
+    let mut reader = BufReader::with_capacity(BLOCK_BYTES, file);
+    let mut block = vec![0_u8; BLOCK_BYTES];
+    let mut pending = Vec::new();
+    let mut previous: Option<Vec<u8>> = None;
+    loop {
+        let count = reader.read(&mut block).map_err(storage)?;
+        if count == 0 {
+            break;
+        }
+        pending.extend_from_slice(&block[..count]);
+        let complete = pending.len() / width * width;
+        for record in pending[..complete].chunks_exact(width) {
+            if previous
+                .as_ref()
+                .is_some_and(|prior| prior.as_slice() >= record)
+                || (width == ENDPOINT_WIDTH
+                    && (!matches!(record[32], 0 | 1) || record[33..].iter().any(|byte| *byte != 0)))
+            {
+                return Err(storage("unrecorded fixed run is malformed"));
+            }
+            previous = Some(record.to_vec());
+        }
+        pending.drain(..complete);
+    }
+    if !pending.is_empty() {
+        return Err(storage("unrecorded fixed run has truncated tail"));
+    }
+    Ok(())
+}
+
+fn artifact_stem(sequence: u64, kind: ConstructionChunkKind) -> String {
+    format!("chunk-{sequence:020}-{}", kind.tag())
+}
+
+fn receipt_name(sequence: u64) -> String {
+    format!("receipt-{sequence:020}.json")
+}
+
+fn chunk_key_name(chunk_id: &str) -> String {
+    format!("key-{}.json", sha256(chunk_id.as_bytes()))
+}
+
+fn control_temp(target: &str) -> OsString {
+    OsString::from(format!(".{target}-{}.tmp", Uuid::new_v4().simple()))
+}
+
+fn artifact_temp(target: &str) -> OsString {
+    OsString::from(format!(
+        ".artifact-{target}-{}.tmp",
+        Uuid::new_v4().simple()
+    ))
 }
 
 fn validate_chunk_id(value: &str) -> Result<(), GfError> {
@@ -808,187 +1639,132 @@ fn validate_chunk_id(value: &str) -> Result<(), GfError> {
             .bytes()
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
     {
-        return Err(storage("invalid construction chunk id"));
+        return Err(storage("invalid chunk id"));
     }
     Ok(())
 }
 
-fn hex_digest(bytes: &[u8]) -> String {
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-    let mut result = String::with_capacity(bytes.len() * 2);
-    for byte in bytes {
-        result.push(HEX[(byte >> 4) as usize] as char);
-        result.push(HEX[(byte & 0x0f) as usize] as char);
+fn reject_cancelled(cancelled: &mut impl FnMut() -> bool) -> Result<(), GfError> {
+    if cancelled() {
+        return Err(storage("construction cancelled"));
     }
-    result
+    Ok(())
+}
+
+fn write_control_body(
+    file: &mut File,
+    body: &[u8],
+    target: &str,
+    operation: &str,
+) -> Result<(), GfError> {
+    #[cfg(test)]
+    {
+        let middle = body.len() / 2;
+        file.write_all(&body[..middle]).map_err(storage)?;
+        file.sync_all().map_err(storage)?;
+        construction_failpoint(&format!("control.{operation}.after_partial.{target}"));
+        file.write_all(&body[middle..]).map_err(storage)?;
+    }
+    #[cfg(not(test))]
+    {
+        let _ = (target, operation);
+        file.write_all(body).map_err(storage)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+fn construction_failpoint(name: &str) {
+    if std::env::var("GF_CONSTRUCTION_FAILPOINT_COOKIE").as_deref()
+        == Ok("graphforge-construction-test-v1")
+        && std::env::var("GF_CONSTRUCTION_FAILPOINT").as_deref() == Ok(name)
+    {
+        std::process::exit(86);
+    }
+}
+
+#[cfg(not(test))]
+fn construction_failpoint(_name: &str) {}
+
+fn sha256(bytes: &[u8]) -> String {
+    hex(&Sha256::digest(bytes))
+}
+
+fn hex(bytes: &[u8]) -> String {
+    const DIGITS: &[u8; 16] = b"0123456789abcdef";
+    let mut value = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        value.push(DIGITS[(byte >> 4) as usize] as char);
+        value.push(DIGITS[(byte & 15) as usize] as char);
+    }
+    value
 }
 
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
 
-    use arrow::array::FixedSizeBinaryArray;
-    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::array::{FixedSizeBinaryArray, StringArray, UInt32Array};
     use tempfile::TempDir;
 
     use super::*;
-
-    fn uuid(seed: u128) -> [u8; 16] {
-        seed.to_be_bytes()
-    }
 
     fn fixed(values: &[[u8; 16]]) -> FixedSizeBinaryArray {
         FixedSizeBinaryArray::try_from_iter(values.iter().map(|value| value.as_slice())).unwrap()
     }
 
     fn node_batch(first: u128, rows: usize) -> RecordBatch {
-        let values = (first..first + rows as u128).map(uuid).collect::<Vec<_>>();
-        RecordBatch::try_new(
-            Arc::new(Schema::new(vec![Field::new(
-                "node_uuid",
-                DataType::FixedSizeBinary(16),
-                false,
-            )])),
-            vec![Arc::new(fixed(&values))],
-        )
-        .unwrap()
-    }
-
-    fn edge_batch(first: u128, rows: usize) -> RecordBatch {
-        let edges = (first..first + rows as u128).map(uuid).collect::<Vec<_>>();
-        let src = (0..rows)
-            .map(|index| uuid(index as u128 + 1))
+        let uuids = (first..first + rows as u128)
+            .map(u128::to_be_bytes)
             .collect::<Vec<_>>();
-        let dst = (0..rows)
-            .map(|index| uuid(index as u128 + 2))
-            .collect::<Vec<_>>();
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("edge_uuid", DataType::FixedSizeBinary(16), false),
-            Field::new("src_uuid", DataType::FixedSizeBinary(16), false),
-            Field::new("dst_uuid", DataType::FixedSizeBinary(16), false),
-        ]));
         RecordBatch::try_new(
-            schema,
+            CONSTRUCTION_NODE_SCHEMA.clone(),
             vec![
-                Arc::new(fixed(&edges)),
-                Arc::new(fixed(&src)),
-                Arc::new(fixed(&dst)),
+                Arc::new(fixed(&uuids)),
+                Arc::new(UInt32Array::from(vec![7_u32; rows])),
             ],
         )
         .unwrap()
     }
 
-    fn open(root: &TempDir, operation: Uuid) -> GraphConstructionSession {
+    fn edge_batch(first: u128, rows: usize) -> RecordBatch {
+        let edges = (first..first + rows as u128)
+            .map(u128::to_be_bytes)
+            .collect::<Vec<_>>();
+        let src = (1..=rows as u128)
+            .map(u128::to_be_bytes)
+            .collect::<Vec<_>>();
+        let dst = (2..=rows as u128 + 1)
+            .map(u128::to_be_bytes)
+            .collect::<Vec<_>>();
+        RecordBatch::try_new(
+            CONSTRUCTION_EDGE_SCHEMA.clone(),
+            vec![
+                Arc::new(fixed(&edges)),
+                Arc::new(fixed(&src)),
+                Arc::new(fixed(&dst)),
+                Arc::new(StringArray::from(vec!["R"; rows])),
+            ],
+        )
+        .unwrap()
+    }
+
+    fn open(root: &TempDir, operation: u128) -> GraphConstructionSession {
         GraphConstructionSession::open(
             root.path(),
-            operation,
-            7,
+            Uuid::from_u128(operation),
+            0,
             GraphConstructionBudgets::default(),
         )
         .unwrap()
     }
 
     #[test]
-    fn direct_chunks_resume_and_replay_without_publication() {
-        let root = TempDir::new().unwrap();
-        let operation = Uuid::from_u128(9);
-        let batch = node_batch(1, 8);
-        let mut session = open(&root, operation);
-        let first = session
-            .append(ConstructionChunkKind::Node, "nodes-0", &batch)
-            .unwrap();
-        assert_eq!(first.rows, 8);
-        assert_eq!(session.evidence().current_transitions, 0);
-        drop(session);
-
-        let mut resumed = open(&root, operation);
-        assert_eq!(resumed.receipts(), &[first.clone()]);
-        assert!(resumed.evidence().authentication_bytes_read > 0);
-        assert_eq!(
-            resumed
-                .append(ConstructionChunkKind::Node, "nodes-0", &batch)
-                .unwrap(),
-            first
-        );
-        assert_eq!(resumed.receipts().len(), 1);
-        assert_eq!(resumed.evidence().replayed_chunks, 1);
-    }
-
-    #[test]
-    fn durable_receipt_recovers_crash_before_manifest_advance() {
-        let root = TempDir::new().unwrap();
-        let operation = Uuid::from_u128(91);
-        let batch = node_batch(1, 8);
-        let mut session = open(&root, operation);
-        let receipt = session
-            .append(ConstructionChunkKind::Node, "nodes-0", &batch)
-            .unwrap();
-
-        // Model the exact crash window: shard, run, and receipt are durable,
-        // but the replace of session.json did not become authoritative.
-        session.manifest.receipts.clear();
-        session.manifest.evidence = GraphConstructionEvidence::default();
-        session.persist_manifest_replace().unwrap();
-        drop(session);
-
-        let resumed = open(&root, operation);
-        assert_eq!(resumed.receipts(), &[receipt]);
-        assert_eq!(resumed.evidence().input_rows, 8);
-        assert_eq!(resumed.evidence().input_batches, 1);
-        assert_eq!(resumed.evidence().current_transitions, 0);
-    }
-
-    #[test]
-    fn conflicting_replay_and_node_after_edge_fail_closed() {
-        let root = TempDir::new().unwrap();
-        let mut session = open(&root, Uuid::from_u128(10));
-        session
-            .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 2))
-            .unwrap();
-        assert!(
-            session
-                .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 3))
-                .is_err()
-        );
-        session
-            .append(ConstructionChunkKind::Edge, "edges", &edge_batch(100, 2))
-            .unwrap();
-        assert!(
-            session
-                .append(ConstructionChunkKind::Node, "late", &node_batch(20, 1))
-                .is_err()
-        );
-    }
-
-    #[test]
-    fn truncated_run_fails_resume_authentication() {
-        let root = TempDir::new().unwrap();
-        let operation = Uuid::from_u128(11);
-        let mut session = open(&root, operation);
-        let receipt = session
-            .append(ConstructionChunkKind::Edge, "edges", &edge_batch(100, 2))
-            .unwrap();
-        let path = session.root.join(receipt.endpoints.unwrap().relative_path);
-        drop(session);
-        let file = OpenOptions::new().write(true).open(path).unwrap();
-        file.set_len(47).unwrap();
-        assert!(
-            GraphConstructionSession::open(
-                root.path(),
-                operation,
-                7,
-                GraphConstructionBudgets::default()
-            )
-            .is_err()
-        );
-    }
-
-    #[test]
-    fn one_two_four_times_work_is_linear_and_windows_are_fixed() {
-        let mut evidence = Vec::new();
+    fn journal_is_constant_control_state_and_seal_reopens_every_artifact() {
         for chunks in [1_u64, 2, 4] {
             let root = TempDir::new().unwrap();
-            let mut session = open(&root, Uuid::from_u128(100 + chunks as u128));
+            let operation = 100 + u128::from(chunks);
+            let mut session = open(&root, operation);
             for chunk in 0..chunks {
                 session
                     .append(
@@ -998,38 +1774,222 @@ mod tests {
                     )
                     .unwrap();
             }
-            evidence.push(session.evidence().clone());
-        }
-        for (index, scale) in [1_u64, 2, 4].into_iter().enumerate() {
-            assert_eq!(evidence[index].input_rows, scale * 32);
-            assert_eq!(evidence[index].input_batches, scale);
-            assert_eq!(evidence[index].parquet_shards, scale);
-            assert_eq!(evidence[index].run_records, scale * 32);
-            assert_eq!(evidence[index].peak_batch_rows, 32);
-            assert_eq!(evidence[index].peak_run_records, 32);
-            assert_eq!(evidence[index].prior_topology_rows_decoded, 0);
-            assert_eq!(evidence[index].current_transitions, 0);
+            assert_eq!(session.accepted_chunks(), chunks);
+            assert_eq!(session.evidence().input_rows, chunks * 32);
+            assert_eq!(session.evidence().peak_batch_rows, 32);
+            assert_eq!(session.evidence().peak_run_records, 32);
+            assert_eq!(session.evidence().prior_topology_rows_decoded, 0);
+            assert_eq!(session.evidence().current_transitions, 0);
+            let checkpoint_bytes = session
+                .root
+                .open_child_file(OsStr::new(CHECKPOINT))
+                .unwrap()
+                .metadata()
+                .unwrap()
+                .len();
+            assert!(checkpoint_bytes < MAX_CONTROL_BYTES);
+            session.seal().unwrap();
+            assert_eq!(session.state(), GraphConstructionState::Sealed);
+            assert!(session.evidence().authentication_read_bytes > 0);
         }
     }
 
     #[test]
-    fn seal_and_abort_preserve_private_state() {
+    fn logical_digest_is_independent_of_arrow_slice_layout() {
+        let whole = node_batch(10, 6);
+        let sliced = whole.slice(2, 3);
+        let rebuilt = node_batch(12, 3);
+        assert_eq!(
+            logical_batch_digest(ConstructionChunkKind::Node, &sliced).unwrap(),
+            logical_batch_digest(ConstructionChunkKind::Node, &rebuilt).unwrap()
+        );
+    }
+
+    #[test]
+    fn replay_is_idempotent_and_reauthenticates_artifacts() {
         let root = TempDir::new().unwrap();
-        let mut sealed = open(&root, Uuid::from_u128(20));
-        sealed
-            .append(ConstructionChunkKind::Node, "n", &node_batch(1, 1))
+        let mut session = open(&root, 200);
+        let batch = node_batch(1, 8);
+        let first = session
+            .append(ConstructionChunkKind::Node, "nodes", &batch)
             .unwrap();
-        sealed.seal().unwrap();
-        assert_eq!(sealed.state(), GraphConstructionState::Sealed);
+        assert_eq!(
+            session
+                .append(ConstructionChunkKind::Node, "nodes", &batch)
+                .unwrap(),
+            first
+        );
+        assert_eq!(session.accepted_chunks(), 1);
+        assert_eq!(session.evidence().replayed_chunks, 1);
         assert!(
-            sealed
-                .append(ConstructionChunkKind::Node, "n2", &node_batch(2, 1))
+            session
+                .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 9))
                 .is_err()
         );
+    }
 
-        let mut aborted = open(&root, Uuid::from_u128(21));
-        aborted.abort().unwrap();
-        assert_eq!(aborted.state(), GraphConstructionState::Aborted);
-        assert_eq!(aborted.evidence().current_transitions, 0);
+    #[test]
+    fn cancellation_recovers_private_intent_without_accepting_a_chunk() {
+        let root = TempDir::new().unwrap();
+        let operation = Uuid::from_u128(300);
+        let mut session = open(&root, 300);
+        let mut polls = 0_u8;
+        assert!(
+            session
+                .append_with_cancellation(
+                    ConstructionChunkKind::Node,
+                    "nodes",
+                    &node_batch(1, 8),
+                    || {
+                        polls = polls.saturating_add(1);
+                        polls == 2
+                    },
+                )
+                .is_err()
+        );
+        drop(session);
+        let resumed = GraphConstructionSession::open(
+            root.path(),
+            operation,
+            0,
+            GraphConstructionBudgets::default(),
+        )
+        .unwrap();
+        assert_eq!(resumed.accepted_chunks(), 0);
+        assert!(resumed.root.open_child_file(OsStr::new(INTENT)).is_err());
+    }
+
+    #[test]
+    fn node_after_edge_and_concurrent_same_process_open_fail_closed() {
+        let root = TempDir::new().unwrap();
+        let mut session = open(&root, 400);
+        assert!(
+            GraphConstructionSession::open(
+                root.path(),
+                Uuid::from_u128(400),
+                0,
+                GraphConstructionBudgets::default()
+            )
+            .is_err()
+        );
+        session
+            .append(ConstructionChunkKind::Edge, "edges", &edge_batch(100, 2))
+            .unwrap();
+        assert!(
+            session
+                .append(ConstructionChunkKind::Node, "late-node", &node_batch(1, 1))
+                .is_err()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_substitution_is_rejected_on_independent_seal() {
+        use std::os::unix::fs::symlink;
+
+        let root = TempDir::new().unwrap();
+        let mut session = open(&root, 500);
+        let receipt = session
+            .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 2))
+            .unwrap();
+        let operation_root = root
+            .path()
+            .join(PRIVATE_ROOT)
+            .join(Uuid::from_u128(500).simple().to_string());
+        let artifact = operation_root.join(&receipt.identities.name);
+        let displaced = operation_root.join("displaced.run");
+        std::fs::rename(&artifact, &displaced).unwrap();
+        symlink(&displaced, &artifact).unwrap();
+        assert!(session.seal().is_err());
+    }
+
+    #[test]
+    fn crash_subprocess_helper() {
+        let Ok(root) = std::env::var("GF_CONSTRUCTION_CRASH_ROOT") else {
+            return;
+        };
+        let mut session = GraphConstructionSession::open(
+            Path::new(&root),
+            Uuid::from_u128(600),
+            0,
+            GraphConstructionBudgets::default(),
+        )
+        .unwrap();
+        session
+            .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 8))
+            .unwrap();
+    }
+
+    #[test]
+    fn subprocess_crashes_recover_each_durable_boundary() {
+        let receipt = receipt_name(0);
+        let key = chunk_key_name("nodes");
+        let parquet = format!("{}.parquet", artifact_stem(0, ConstructionChunkKind::Node));
+        let cases = vec![
+            (
+                "control.install.after_partial.checkpoint.json".to_owned(),
+                0_u64,
+            ),
+            (
+                "control.install.after_temp_fsync.checkpoint.json".to_owned(),
+                0_u64,
+            ),
+            (
+                "control.install.after_install.checkpoint.json".to_owned(),
+                0,
+            ),
+            ("control.install.after_temp_fsync.intent.json".to_owned(), 0),
+            ("control.install.after_install.intent.json".to_owned(), 0),
+            (format!("artifact.after_temp_fsync.{parquet}"), 0),
+            (format!("artifact.after_install.{parquet}"), 0),
+            ("control.replace.after_replace.intent.json".to_owned(), 0),
+            (format!("control.install.after_partial.{receipt}"), 0),
+            (format!("control.install.after_temp_fsync.{receipt}"), 0),
+            (format!("control.install.after_install.{receipt}"), 1),
+            (format!("control.install.after_temp_fsync.{key}"), 1),
+            (format!("control.install.after_install.{key}"), 1),
+            (
+                "control.replace.after_partial.checkpoint.json".to_owned(),
+                1,
+            ),
+            (
+                "control.replace.after_temp_fsync.checkpoint.json".to_owned(),
+                1,
+            ),
+            (
+                "control.replace.after_replace.checkpoint.json".to_owned(),
+                1,
+            ),
+        ];
+        for (failpoint, accepted) in cases {
+            let root = TempDir::new().unwrap();
+            let status = std::process::Command::new(std::env::current_exe().unwrap())
+                .arg("--exact")
+                .arg("graph_construction::tests::crash_subprocess_helper")
+                .arg("--nocapture")
+                .env("GF_CONSTRUCTION_CRASH_ROOT", root.path())
+                .env(
+                    "GF_CONSTRUCTION_FAILPOINT_COOKIE",
+                    "graphforge-construction-test-v1",
+                )
+                .env("GF_CONSTRUCTION_FAILPOINT", &failpoint)
+                .status()
+                .unwrap();
+            assert_eq!(status.code(), Some(86), "failpoint {failpoint}");
+            let mut resumed = GraphConstructionSession::open(
+                root.path(),
+                Uuid::from_u128(600),
+                0,
+                GraphConstructionBudgets::default(),
+            )
+            .unwrap();
+            assert_eq!(resumed.accepted_chunks(), accepted, "{failpoint}");
+            if accepted == 0 {
+                resumed
+                    .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 8))
+                    .unwrap();
+            }
+            resumed.seal().unwrap();
+        }
     }
 }

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -135,6 +135,40 @@ fn current_parent_generation_authority(project_dir: &Path) -> Result<(Uuid, Stri
     }
 }
 
+fn compact_parent_inventory(
+    parent: &crate::ResolvedProjectGeneration,
+) -> Result<Option<crate::GraphFilesInventory>, GfError> {
+    let Some(crate::GraphFilesParticipant::V2(root)) = parent.declared_graph_files_participant()?
+    else {
+        return Ok(None);
+    };
+    let (entries, _) =
+        crate::resolve_graph_manifest(&root, crate::GraphManifestLimits::default(), |digest| {
+            crate::read_graph_object_by_digest(parent.container_root(), digest, 64 * 1024 * 1024)
+        })?;
+    crate::graph_files::inventory_from_entries(entries).map(Some)
+}
+
+fn compact_parent_surrogate_tails(project_dir: &Path) -> Result<Option<(u64, u64)>, GfError> {
+    let parent = crate::resolve_project_generation(project_dir)?;
+    let Some(inventory) = compact_parent_inventory(&parent)? else {
+        return Ok(None);
+    };
+    let Some(entry) = inventory
+        .files
+        .iter()
+        .find(|entry| entry.relative_path == "topology/surrogate_tails.parquet")
+    else {
+        return Ok(None);
+    };
+    let file = crate::graph_object_store::open_graph_object_by_digest(
+        project_dir,
+        &entry.content_sha256,
+        entry.byte_length,
+    )?;
+    crate::writer::read_surrogate_tails_file(file).map(Some)
+}
+
 fn authenticate_exact_parent_generation(
     project_dir: &Path,
     checkpoint: &Checkpoint,
@@ -693,6 +727,7 @@ pub struct GraphConstructionSession {
     checkpoint: Checkpoint,
     base_snapshot: Option<AuthenticatedUuidIndexSnapshot>,
     parent_catalog: RuntimeCatalog,
+    compact_parent: bool,
     semantic_authority: Option<ConstructionSemanticAuthority>,
     _reservation: ProcessReservation,
 }
@@ -1422,6 +1457,12 @@ impl GraphConstructionSession {
                 )
             )
         });
+        let compact_inventory = if publication_replay || project_dir == graph_source_dir {
+            None
+        } else {
+            let parent = crate::resolve_project_generation(project_dir)?;
+            compact_parent_inventory(&parent)?
+        };
         let (base_snapshot, base_work) = if publication_replay {
             (
                 None,
@@ -1433,10 +1474,18 @@ impl GraphConstructionSession {
         } else if parent_topology_generation == 0 {
             (None, UuidConstructionSnapshotWork::default())
         } else {
-            let mut snapshot = AuthenticatedUuidIndexSnapshot::open_at_generation(
-                graph_source_dir,
-                parent_topology_generation,
-            )?;
+            let mut snapshot = if let Some(inventory) = &compact_inventory {
+                AuthenticatedUuidIndexSnapshot::open_from_compact_inventory(
+                    project_dir,
+                    inventory,
+                    parent_topology_generation,
+                )?
+            } else {
+                AuthenticatedUuidIndexSnapshot::open_at_generation(
+                    graph_source_dir,
+                    parent_topology_generation,
+                )?
+            };
             let max_node_surrogate = crate::writer::read_surrogate_tails(graph_source_dir)?
                 .ok_or_else(|| storage("nonempty parent lacks surrogate tails"))?
                 .0;
@@ -1460,6 +1509,13 @@ impl GraphConstructionSession {
                     .clone(),
                 ReadWork::default(),
             )
+        } else if let Some(inventory) = &compact_inventory {
+            load_parent_runtime_catalog_from_compact(
+                project_dir,
+                inventory,
+                parent_topology_generation,
+                budgets,
+            )?
         } else {
             let graph_source = StableDirectory::open(graph_source_dir).map_err(storage)?;
             load_parent_runtime_catalog(&graph_source, parent_topology_generation, budgets)?
@@ -1525,6 +1581,7 @@ impl GraphConstructionSession {
             parent_generation_uuid,
             &parent_generation_manifest_sha256,
         )?;
+        let compact_parent = compact_inventory.is_some();
         let mut session = Self {
             project_path: project_dir.to_path_buf(),
             project,
@@ -1532,6 +1589,7 @@ impl GraphConstructionSession {
             checkpoint,
             base_snapshot,
             parent_catalog,
+            compact_parent,
             semantic_authority,
             _reservation: reservation,
         };
@@ -2047,10 +2105,15 @@ impl GraphConstructionSession {
         )?;
         let (base_max_node, base_max_edge) = match self.checkpoint.parent_topology_generation {
             0 => (0, 0),
-            _ => crate::writer::read_surrogate_tails(
+            _ => (if self.compact_parent {
+                compact_parent_surrogate_tails(&self.project_path)?
+            } else {
+                None
+            })
+            .or(crate::writer::read_surrogate_tails(
                 // The retained project directory is revalidated immediately above.
                 &self.project_path,
-            )?
+            )?)
             .ok_or_else(|| storage("nonempty parent lacks surrogate tails"))?,
         };
         if base_max_node != self.checkpoint.base_work.max_node_surrogate {
@@ -4406,6 +4469,79 @@ fn load_parent_runtime_catalog(
     topology.revalidate_named().map_err(storage)?;
     project.revalidate_named().map_err(storage)?;
     Ok((catalog, Some(hex(&digest.finalize())), work))
+}
+
+fn load_parent_runtime_catalog_from_compact(
+    container_root: &Path,
+    inventory: &crate::GraphFilesInventory,
+    parent_generation: u64,
+    budgets: GraphConstructionBudgets,
+) -> Result<(RuntimeCatalog, Option<String>, ReadWork), GfError> {
+    if parent_generation == 0 {
+        return Ok((RuntimeCatalog::new(), None, ReadWork::default()));
+    }
+    let Some(entry) = inventory
+        .files
+        .iter()
+        .find(|entry| entry.relative_path == "topology/runtime_catalog.parquet")
+    else {
+        return Ok((RuntimeCatalog::new(), None, ReadWork::default()));
+    };
+    let file = crate::graph_object_store::open_graph_object_by_digest(
+        container_root,
+        &entry.content_sha256,
+        entry.byte_length,
+    )?;
+    decode_parent_runtime_catalog_file(file, &entry.content_sha256, budgets)
+}
+
+fn decode_parent_runtime_catalog_file(
+    file: File,
+    digest: &str,
+    budgets: GraphConstructionBudgets,
+) -> Result<(RuntimeCatalog, Option<String>, ReadWork), GfError> {
+    let counter = IoCounter::default();
+    let reader = ParquetRecordBatchReaderBuilder::try_new(CountingChunkReader {
+        file,
+        counter: counter.clone(),
+    })
+    .map_err(storage)?
+    .with_batch_size(4_096.min(budgets.max_catalog_entries))
+    .build()
+    .map_err(storage)?;
+    let mut catalog = RuntimeCatalog::new();
+    let mut entries = 0_usize;
+    let mut decoded_bytes = 0_usize;
+    for batch in reader {
+        let batch = batch.map_err(storage)?;
+        entries = entries
+            .checked_add(batch.num_rows())
+            .ok_or_else(|| storage("parent runtime catalog entry count overflow"))?;
+        decoded_bytes = decoded_bytes
+            .checked_add(batch.get_array_memory_size())
+            .ok_or_else(|| storage("parent runtime catalog decoded size overflow"))?;
+        if entries > budgets.max_catalog_entries
+            || decoded_bytes > budgets.max_catalog_decoded_bytes
+        {
+            return Err(storage("parent runtime catalog admission budget exhausted"));
+        }
+        catalog.extend_from_record_batch(&batch).map_err(storage)?;
+        if catalog.retained_identifier_bytes() > budgets.max_catalog_identifier_bytes {
+            return Err(storage(
+                "parent runtime catalog identifier budget exhausted",
+            ));
+        }
+    }
+    let bytes = counter.bytes.load(Ordering::Relaxed);
+    let operations = counter.operations.load(Ordering::Relaxed);
+    if !is_canonical_sha256(digest) {
+        return Err(storage("parent runtime catalog CAS authority changed"));
+    }
+    Ok((
+        catalog,
+        Some(digest.to_owned()),
+        ReadWork { bytes, operations },
+    ))
 }
 
 fn read_fixed<const N: usize>(reader: &mut impl Read) -> Result<Option<[u8; N]>, GfError> {

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -8809,11 +8809,11 @@ mod tests {
         let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
         let encoding = session.encode_canonical(&shape, 1).unwrap();
 
-        assert_eq!(
-            session.checkpoint.publication_state,
-            Some(ConstructionPublicationState::Publishing),
-            "the durable intent remains recoverable without claiming commit"
-        );
+        let receipt = session
+            .publish_canonical(&encoding, target, transaction)
+            .unwrap();
+        assert_eq!(receipt.generation_uuid, target);
+        assert!(!receipt.idempotent_replay);
         let current = crate::resolve_project_generation(root.path()).unwrap();
         assert_eq!(current.generation_uuid(), target);
         let inventory = current.graph_files_inventory().unwrap().unwrap();
@@ -8958,6 +8958,7 @@ mod tests {
                 checkpoints == 2
             })
             .unwrap_err();
+        assert_eq!(error.code(), "GF_CANCELLED");
         assert!(error.to_string().contains("before_current_replace"));
         assert_eq!(
             checkpoints, 2,

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -149,11 +149,10 @@ fn compact_parent_inventory(
     crate::graph_files::inventory_from_entries(entries).map(Some)
 }
 
-fn compact_parent_surrogate_tails(project_dir: &Path) -> Result<Option<(u64, u64)>, GfError> {
-    let parent = crate::resolve_project_generation(project_dir)?;
-    let Some(inventory) = compact_parent_inventory(&parent)? else {
-        return Ok(None);
-    };
+fn compact_parent_surrogate_tails(
+    project_dir: &Path,
+    inventory: &crate::GraphFilesInventory,
+) -> Result<Option<(u64, u64)>, GfError> {
     let Some(entry) = inventory
         .files
         .iter()
@@ -727,7 +726,7 @@ pub struct GraphConstructionSession {
     checkpoint: Checkpoint,
     base_snapshot: Option<AuthenticatedUuidIndexSnapshot>,
     parent_catalog: RuntimeCatalog,
-    compact_parent: bool,
+    compact_parent: Option<crate::GraphFilesInventory>,
     semantic_authority: Option<ConstructionSemanticAuthority>,
     _reservation: ProcessReservation,
 }
@@ -1581,7 +1580,7 @@ impl GraphConstructionSession {
             parent_generation_uuid,
             &parent_generation_manifest_sha256,
         )?;
-        let compact_parent = compact_inventory.is_some();
+        let compact_parent = compact_inventory;
         let mut session = Self {
             project_path: project_dir.to_path_buf(),
             project,
@@ -2105,8 +2104,8 @@ impl GraphConstructionSession {
         )?;
         let (base_max_node, base_max_edge) = match self.checkpoint.parent_topology_generation {
             0 => (0, 0),
-            _ => (if self.compact_parent {
-                compact_parent_surrogate_tails(&self.project_path)?
+            _ => (if let Some(inventory) = &self.compact_parent {
+                compact_parent_surrogate_tails(&self.project_path, inventory)?
             } else {
                 None
             })
@@ -2885,24 +2884,43 @@ impl<R: Read> Read for CountingRead<R> {
     }
 }
 
-pub(crate) struct CountingChunkReader {
-    pub(crate) file: File,
+pub(crate) struct CountingChunkReader<R = File> {
+    pub(crate) file: R,
     pub(crate) counter: IoCounter,
 }
 
-impl Length for CountingChunkReader {
-    fn len(&self) -> u64 {
-        self.file.metadata().map_or(0, |metadata| metadata.len())
+pub(crate) trait ConstructionFileHandle: Send + Sync {
+    fn descriptor(&self) -> &File;
+}
+
+impl ConstructionFileHandle for File {
+    fn descriptor(&self) -> &File {
+        self
     }
 }
 
-impl ChunkReader for CountingChunkReader {
+impl ConstructionFileHandle for crate::graph_object_store::AuthenticatedGraphObject {
+    fn descriptor(&self) -> &File {
+        self.as_ref()
+    }
+}
+
+impl<R: ConstructionFileHandle> Length for CountingChunkReader<R> {
+    fn len(&self) -> u64 {
+        self.file
+            .descriptor()
+            .metadata()
+            .map_or(0, |metadata| metadata.len())
+    }
+}
+
+impl<R: ConstructionFileHandle> ChunkReader for CountingChunkReader<R> {
     type T = CountingRead<BufReader<File>>;
 
     fn get_read(&self, start: u64) -> parquet::errors::Result<Self::T> {
         use std::io::{Seek, SeekFrom};
 
-        let mut file = self.file.try_clone()?;
+        let mut file = self.file.descriptor().try_clone()?;
         file.seek(SeekFrom::Start(start))?;
         Ok(CountingRead {
             inner: BufReader::with_capacity(BLOCK_BYTES, file),
@@ -2913,7 +2931,7 @@ impl ChunkReader for CountingChunkReader {
     fn get_bytes(&self, start: u64, length: usize) -> parquet::errors::Result<bytes::Bytes> {
         use std::io::{Seek, SeekFrom};
 
-        let mut file = self.file.try_clone()?;
+        let mut file = self.file.descriptor().try_clone()?;
         file.seek(SeekFrom::Start(start))?;
         let mut value = vec![0_u8; length];
         file.read_exact(&mut value)?;
@@ -4495,11 +4513,14 @@ fn load_parent_runtime_catalog_from_compact(
     decode_parent_runtime_catalog_file(file, &entry.content_sha256, budgets)
 }
 
-fn decode_parent_runtime_catalog_file(
-    file: File,
+fn decode_parent_runtime_catalog_file<R>(
+    file: R,
     digest: &str,
     budgets: GraphConstructionBudgets,
-) -> Result<(RuntimeCatalog, Option<String>, ReadWork), GfError> {
+) -> Result<(RuntimeCatalog, Option<String>, ReadWork), GfError>
+where
+    R: ConstructionFileHandle + 'static,
+{
     let counter = IoCounter::default();
     let reader = ParquetRecordBatchReaderBuilder::try_new(CountingChunkReader {
         file,

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -8801,6 +8801,15 @@ mod tests {
                 .iter()
                 .any(|entry| { entry.relative_path == "topology/uuid-membership/manifest.json" })
         );
+        let current_path = root.path().join("CURRENT");
+        let current_bytes = std::fs::read(&current_path).unwrap();
+        std::fs::write(&current_path, b"concurrently-advanced-current\n").unwrap();
+        assert_eq!(
+            compact_parent_surrogate_tails(root.path(), &inventory).unwrap(),
+            Some((2, 0)),
+            "pinned compact-parent tails must not consult mutable CURRENT"
+        );
+        std::fs::write(&current_path, current_bytes).unwrap();
         let materialized = TempDir::new().unwrap();
         let materialized_graph = materialized.path().join("graph");
         std::fs::create_dir(&materialized_graph).unwrap();

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -8809,11 +8809,11 @@ mod tests {
         let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
         let encoding = session.encode_canonical(&shape, 1).unwrap();
 
-        let receipt = session
-            .publish_canonical(&encoding, target, transaction)
-            .unwrap();
-        assert_eq!(receipt.generation_uuid, target);
-        assert!(!receipt.idempotent_replay);
+        assert_eq!(
+            session.checkpoint.publication_state,
+            Some(ConstructionPublicationState::Publishing),
+            "the durable intent remains recoverable without claiming commit"
+        );
         let current = crate::resolve_project_generation(root.path()).unwrap();
         assert_eq!(current.generation_uuid(), target);
         let inventory = current.graph_files_inventory().unwrap().unwrap();
@@ -8926,6 +8926,52 @@ mod tests {
         assert_eq!(
             session.checkpoint.publication_state,
             Some(ConstructionPublicationState::Sealed)
+        );
+    }
+
+    #[test]
+    fn canonical_publication_cancels_at_named_immediate_pre_current_boundary() {
+        let root = TempDir::new().unwrap();
+        let parent = crate::open_or_initialize_project(root.path()).unwrap();
+        let prior = parent.generation_uuid();
+        drop(parent);
+        let prior_current = std::fs::read(root.path().join("CURRENT")).unwrap();
+        let mut session = GraphConstructionSession::open(
+            root.path(),
+            Uuid::from_u128(9_465),
+            0,
+            GraphConstructionBudgets::default(),
+        )
+        .unwrap();
+        session
+            .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 2))
+            .unwrap();
+        session.seal().unwrap();
+        let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+        let encoding = session.encode_canonical(&shape, 1).unwrap();
+        let target = Uuid::from_u128(9_466);
+        let transaction = Uuid::from_u128(9_467);
+        let mut checkpoints = 0_u8;
+        let error = session
+            .publish_canonical_with_cancellation(&encoding, target, transaction, || {
+                checkpoints += 1;
+                checkpoints == 2
+            })
+            .unwrap_err();
+        assert!(error.to_string().contains("before_current_replace"));
+        assert_eq!(
+            checkpoints, 2,
+            "entry and immediate pre-CURRENT checkpoints"
+        );
+        assert_eq!(
+            std::fs::read(root.path().join("CURRENT")).unwrap(),
+            prior_current
+        );
+        assert_ne!(target, prior);
+        assert_eq!(
+            session.checkpoint.publication_state,
+            Some(ConstructionPublicationState::Publishing),
+            "the durable intent remains recoverable without claiming commit"
         );
     }
 

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -396,6 +396,33 @@ pub(crate) struct ArtifactReceipt {
     fsync_operations: u64,
 }
 
+#[derive(Serialize)]
+struct ShapeAuthorityEnvelope<'a> {
+    shape: &'a ConstructionShape,
+    outputs: Vec<&'a ArtifactReceipt>,
+}
+
+pub(crate) fn shape_authority_sha256(
+    shape: &ConstructionShape,
+    outputs: &[ArtifactReceipt],
+) -> Result<String, GfError> {
+    let mut ordered = outputs.iter().collect::<Vec<_>>();
+    ordered.sort_unstable_by(|left, right| left.name.cmp(&right.name));
+    if ordered.windows(2).any(|pair| pair[0].name == pair[1].name) {
+        return Err(storage("shape authority repeats an output receipt"));
+    }
+    let mut digest = Sha256::new();
+    digest.update(b"graphforge-construction-shape-authority/v1\0");
+    digest.update(
+        serde_json::to_vec(&ShapeAuthorityEnvelope {
+            shape,
+            outputs: ordered,
+        })
+        .map_err(storage)?,
+    );
+    Ok(hex(&digest.finalize()))
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 /// Immutable acknowledgement of one canonical Arrow chunk.
 pub struct ConstructionChunkReceipt {
@@ -450,6 +477,10 @@ struct Checkpoint {
     parent_catalog_sha256: Option<String>,
     node_schema_sha256: BTreeSet<String>,
     edge_schema_sha256: BTreeSet<String>,
+    #[serde(default)]
+    shape_authority_sha256: Option<String>,
+    #[serde(default)]
+    encoding_inventory_sha256: Option<String>,
     base_work: UuidConstructionSnapshotWork,
     evidence: GraphConstructionEvidence,
 }
@@ -496,6 +527,8 @@ struct ShapeIntent {
     complete: bool,
     shape: Option<ConstructionShape>,
     outputs: Vec<ArtifactReceipt>,
+    #[serde(default)]
+    shape_authority_sha256: Option<String>,
 }
 
 static ACTIVE_OPERATIONS: LazyLock<Mutex<BTreeSet<String>>> =
@@ -569,7 +602,11 @@ impl GraphConstructionSession {
             return Err(storage("encoder input differs from completed shape"));
         }
         let shape_outputs = read_completed_shape_outputs(&self.root, &self.checkpoint)?;
-        crate::graph_construction_encoding::encode(
+        let shape_authority = shape_authority_sha256(shape, &shape_outputs)?;
+        if self.checkpoint.shape_authority_sha256.as_deref() != Some(&shape_authority) {
+            return Err(storage("encoder shape authority differs from checkpoint"));
+        }
+        let encoded = crate::graph_construction_encoding::encode(
             &self.root,
             shape,
             generation,
@@ -577,9 +614,26 @@ impl GraphConstructionSession {
             self.base_snapshot.as_ref(),
             self.semantic_authority.as_ref(),
             &shape_outputs,
+            &shape_authority,
+            self.checkpoint.encoding_inventory_sha256.as_deref(),
             self.checkpoint.budgets,
             &mut cancelled,
-        )
+        )?;
+        let inventory_authority =
+            crate::graph_construction_encoding::inventory_authority_sha256(&encoded)?;
+        match self.checkpoint.encoding_inventory_sha256.as_deref() {
+            Some(expected) if expected != inventory_authority => {
+                return Err(storage(
+                    "encoded inventory differs from checkpoint authority",
+                ));
+            }
+            Some(_) => {}
+            None => {
+                self.checkpoint.encoding_inventory_sha256 = Some(inventory_authority);
+                replace_control(&self.root, CHECKPOINT, &self.checkpoint)?;
+            }
+        }
+        Ok(encoded)
     }
 
     /// Create or resume an operation pinned to one parent topology generation.
@@ -730,6 +784,8 @@ impl GraphConstructionSession {
                     parent_catalog_sha256: parent_catalog_sha256.clone(),
                     node_schema_sha256: BTreeSet::new(),
                     edge_schema_sha256: BTreeSet::new(),
+                    shape_authority_sha256: None,
+                    encoding_inventory_sha256: None,
                     base_work,
                     evidence,
                 };
@@ -1110,6 +1166,7 @@ impl GraphConstructionSession {
             complete: false,
             shape: None,
             outputs: Vec::new(),
+            shape_authority_sha256: None,
         };
         install_control(&self.root, SHAPE_INTENT, &shape_intent)?;
         for sequence in 0..self.checkpoint.next_sequence {
@@ -1389,6 +1446,8 @@ impl GraphConstructionSession {
             .evidence
             .shaped_output_authentication_operations
             .saturating_add(inventory_work.operations);
+        let shape_authority_sha256 = shape_authority_sha256(&shape, &outputs)?;
+        self.checkpoint.shape_authority_sha256 = Some(shape_authority_sha256.clone());
         replace_control(
             &self.root,
             SHAPE_INTENT,
@@ -1407,6 +1466,7 @@ impl GraphConstructionSession {
                 complete: true,
                 shape: Some(shape.clone()),
                 outputs,
+                shape_authority_sha256: Some(shape_authority_sha256),
             },
         )?;
         construction_failpoint("shape.after_complete_inventory");
@@ -1772,11 +1832,30 @@ fn validate_schema(kind: ConstructionChunkKind, batch: &RecordBatch) -> Result<(
     if identifiers
         .iter()
         .flatten()
-        .any(|value| !graphforge_core::identifier::is_graph_identifier(value))
+        .any(|value| !is_construction_identifier(value))
     {
         return Err(storage("invalid canonical label or relation"));
     }
     Ok(())
+}
+
+fn is_construction_identifier(value: &str) -> bool {
+    if graphforge_core::identifier::is_graph_identifier(value) {
+        return true;
+    }
+    let parts = value.split(':').collect::<Vec<_>>();
+    match parts.as_slice() {
+        [module, local] => {
+            graphforge_core::identifier::is_graph_identifier(module)
+                && graphforge_core::identifier::is_graph_identifier(local)
+        }
+        [module, kind, local] => {
+            graphforge_core::identifier::is_graph_identifier(module)
+                && matches!(*kind, "entity" | "relation")
+                && graphforge_core::identifier::is_graph_identifier(local)
+        }
+        _ => false,
+    }
 }
 
 fn logical_batch_digest(
@@ -2179,14 +2258,25 @@ fn recover_shape_intent(
         for output in &intent.outputs {
             authenticate_shaped_output(root, output)?;
         }
+        let expected_shape_authority = shape_authority_sha256(shape, &intent.outputs)?;
+        if intent.shape_authority_sha256.as_deref() != Some(&expected_shape_authority) {
+            return Err(storage(
+                "complete shape authority digest differs from inventory",
+            ));
+        }
         let final_evidence = intent
             .final_evidence
             .as_ref()
             .ok_or_else(|| storage("complete shape manifest lacks final evidence"))?;
-        if checkpoint.evidence == intent.baseline_evidence {
+        if checkpoint.evidence == intent.baseline_evidence
+            && checkpoint.shape_authority_sha256.is_none()
+        {
             checkpoint.evidence = final_evidence.clone();
+            checkpoint.shape_authority_sha256 = Some(expected_shape_authority);
             replace_control(root, CHECKPOINT, checkpoint)?;
-        } else if checkpoint.evidence != *final_evidence {
+        } else if checkpoint.evidence != *final_evidence
+            || checkpoint.shape_authority_sha256.as_deref() != Some(&expected_shape_authority)
+        {
             return Err(storage("shape evidence authority differs from inventory"));
         }
         return Ok(());
@@ -2250,10 +2340,16 @@ fn read_completed_shape(
     for output in &manifest.outputs {
         authenticate_shaped_output(root, output)?;
     }
-    manifest
+    let shape = manifest
         .shape
-        .ok_or_else(|| storage("complete shape manifest lacks output"))
-        .map(Some)
+        .ok_or_else(|| storage("complete shape manifest lacks output"))?;
+    let authority = shape_authority_sha256(&shape, &manifest.outputs)?;
+    if manifest.shape_authority_sha256.as_deref() != Some(&authority)
+        || checkpoint.shape_authority_sha256.as_deref() != Some(&authority)
+    {
+        return Err(storage("completed shape authority digest changed"));
+    }
+    Ok(Some(shape))
 }
 
 fn read_completed_shape_outputs(
@@ -2271,16 +2367,6 @@ fn read_completed_shape_outputs(
     Ok(manifest.outputs)
 }
 
-pub(crate) fn authenticate_shaped_outputs(
-    root: &StableDirectory,
-    outputs: &[ArtifactReceipt],
-) -> Result<(), GfError> {
-    for output in outputs {
-        authenticate_shaped_output(root, output)?;
-    }
-    Ok(())
-}
-
 pub(crate) fn shaped_output_sha256<'a>(
     outputs: &'a [ArtifactReceipt],
     name: &str,
@@ -2290,6 +2376,38 @@ pub(crate) fn shaped_output_sha256<'a>(
         .find(|output| output.name == name)
         .map(|output| output.sha256.as_str())
         .ok_or_else(|| storage("shaped output receipt is absent"))
+}
+
+pub(crate) struct AuthenticatedShapeSource {
+    pub(crate) file: File,
+    pub(crate) identity: FileIdentity,
+    pub(crate) bytes: u64,
+    pub(crate) sha256: String,
+}
+
+pub(crate) fn open_authenticated_shape_source(
+    root: &StableDirectory,
+    outputs: &[ArtifactReceipt],
+    name: &str,
+) -> Result<AuthenticatedShapeSource, GfError> {
+    let expected = outputs
+        .iter()
+        .find(|output| output.name == name)
+        .ok_or_else(|| storage("shaped output receipt is absent"))?;
+    let file = root.open_child_file(OsStr::new(name)).map_err(storage)?;
+    if file_link_count(&file).map_err(storage)? != 1 {
+        return Err(storage("shaped output has extra links"));
+    }
+    let identity = file_identity(&file).map_err(storage)?;
+    if !expected.identity.matches(identity) {
+        return Err(storage("shaped output identity changed before consumption"));
+    }
+    Ok(AuthenticatedShapeSource {
+        file,
+        identity,
+        bytes: expected.bytes,
+        sha256: expected.sha256.clone(),
+    })
 }
 
 fn receipt_for_existing(root: &StableDirectory, name: &str) -> Result<ArtifactReceipt, GfError> {
@@ -4395,6 +4513,20 @@ fn validate_checkpoint(
             .is_some_and(|digest| {
                 digest.len() != 64 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit())
             })
+        || checkpoint
+            .shape_authority_sha256
+            .as_ref()
+            .is_some_and(|digest| {
+                digest.len() != 64 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit())
+            })
+        || checkpoint
+            .encoding_inventory_sha256
+            .as_ref()
+            .is_some_and(|digest| {
+                digest.len() != 64 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit())
+            })
+        || checkpoint.encoding_inventory_sha256.is_some()
+            && checkpoint.shape_authority_sha256.is_none()
         || checkpoint.evidence.input_batches != checkpoint.next_sequence
         || checkpoint.evidence.parquet_shards != checkpoint.next_sequence
         || checkpoint.evidence.peak_batch_rows > budgets.max_batch_rows as u64
@@ -4968,6 +5100,47 @@ mod tests {
         .unwrap()
     }
 
+    fn child_parent_property_batch(first: u128, rows: usize) -> RecordBatch {
+        let uuids = (first..first + rows as u128)
+            .map(u128::to_be_bytes)
+            .collect::<Vec<_>>();
+        let mut fields = CONSTRUCTION_NODE_SCHEMA
+            .fields()
+            .iter()
+            .map(|field| field.as_ref().clone())
+            .collect::<Vec<_>>();
+        fields.push(Field::new("score", DataType::Int64, true));
+        fields.push(Field::new("nickname", DataType::Utf8, true));
+        RecordBatch::try_new(
+            Arc::new(Schema::new(fields)),
+            vec![
+                Arc::new(fixed(&uuids)),
+                Arc::new(StringArray::from(vec!["Child"; rows])),
+                Arc::new(Int64Array::from_iter_values(0..rows as i64)),
+                Arc::new(StringArray::from(vec!["kid"; rows])),
+            ],
+        )
+        .unwrap()
+    }
+
+    fn colliding_property_batch(uuid: u128, label: &str, value: i64) -> RecordBatch {
+        let mut fields = CONSTRUCTION_NODE_SCHEMA
+            .fields()
+            .iter()
+            .map(|field| field.as_ref().clone())
+            .collect::<Vec<_>>();
+        fields.push(Field::new("value", DataType::Int64, true));
+        RecordBatch::try_new(
+            Arc::new(Schema::new(fields)),
+            vec![
+                Arc::new(fixed(&[uuid.to_be_bytes()])),
+                Arc::new(StringArray::from(vec![label])),
+                Arc::new(Int64Array::from(vec![value])),
+            ],
+        )
+        .unwrap()
+    }
+
     fn heterogeneous_property_batch(uuid: u128, property: usize) -> RecordBatch {
         let mut fields = CONSTRUCTION_NODE_SCHEMA
             .fields()
@@ -5050,6 +5223,14 @@ mod tests {
                     default_json: None,
                 },
                 graphforge_ontology::PropertyDef {
+                    owner: "Child".into(),
+                    name: "nickname".into(),
+                    value_type: graphforge_ontology::PropertyValueType::Utf8,
+                    nullable: true,
+                    multivalued: false,
+                    default_json: None,
+                },
+                graphforge_ontology::PropertyDef {
                     owner: "R".into(),
                     name: "weight".into(),
                     value_type: graphforge_ontology::PropertyValueType::Int64,
@@ -5080,6 +5261,58 @@ mod tests {
             .unwrap();
         let bindings =
             crate::SemanticStorageBindings::project(&composition.compile().unwrap(), None).unwrap();
+        ConstructionSemanticAuthority {
+            composition,
+            bindings,
+        }
+    }
+
+    fn colliding_module_authority() -> ConstructionSemanticAuthority {
+        let documents = ["alpha", "beta"].map(|name| graphforge_ontology::OntologyDoc {
+            ontology_id: format!("https://graphforge.dev/ontology/{name}"),
+            version: "1.0.0".into(),
+            entity_types: vec![graphforge_ontology::EntityTypeDef {
+                name: "Thing".into(),
+                r#abstract: false,
+                parent: None,
+            }],
+            relation_types: vec![],
+            properties: vec![graphforge_ontology::PropertyDef {
+                owner: "Thing".into(),
+                name: "value".into(),
+                value_type: graphforge_ontology::PropertyValueType::Int64,
+                nullable: true,
+                multivalued: false,
+                default_json: None,
+            }],
+            constraints: vec![],
+            migrations: vec![],
+        });
+        let modules = documents
+            .into_iter()
+            .map(|doc| graphforge_ontology::AuthoredModule {
+                id: graphforge_ontology::OntologyModuleId {
+                    ontology_id: doc.ontology_id.clone(),
+                    authored_version: doc.version.clone(),
+                    canonical_digest: graphforge_ontology::module_document_digest(&doc).unwrap(),
+                },
+                dependencies: vec![],
+                doc,
+                allow_projected_identity: false,
+            })
+            .collect::<Vec<_>>();
+        let compiled =
+            graphforge_ontology::compile_inventory(graphforge_ontology::InventoryCompileRequest {
+                modules: &modules,
+                bridges: &[],
+                activation: &[],
+                profile_default: graphforge_ontology::ActivationMode::Strict,
+                limits: graphforge_ontology::CompositionLimits::default(),
+                cancelled: None,
+            })
+            .unwrap();
+        let composition = crate::WorkspaceOntologyComposition::from_compiled(&compiled, vec![]);
+        let bindings = crate::SemanticStorageBindings::project(&compiled, None).unwrap();
         ConstructionSemanticAuthority {
             composition,
             bindings,
@@ -6622,6 +6855,121 @@ mod tests {
     }
 
     #[test]
+    fn canonical_encoder_splits_child_and_inherited_properties_by_declaring_route() {
+        let root = TempDir::new().unwrap();
+        let operation = Uuid::from_u128(9_326);
+        let authority = semantic_authority(graphforge_core::OntologyMode::Strict);
+        let binding_route = |kind, local: &str| {
+            authority
+                .bindings
+                .bindings
+                .iter()
+                .find(|binding| binding.route_kind == kind && binding.symbol.local_id == local)
+                .unwrap()
+                .route
+                .clone()
+        };
+        let parent_route = binding_route(crate::SemanticRouteKind::NodeProperty, "Person:score");
+        let child_route = binding_route(crate::SemanticRouteKind::NodeProperty, "Child:nickname");
+        let concrete_route = binding_route(crate::SemanticRouteKind::Entity, "Child");
+        let mut session = GraphConstructionSession::open_with_semantic_authority(
+            root.path(),
+            operation,
+            0,
+            authority,
+            GraphConstructionBudgets::default(),
+        )
+        .unwrap();
+        session
+            .append(
+                ConstructionChunkKind::Node,
+                "child-parent-properties",
+                &child_parent_property_batch(1, 2),
+            )
+            .unwrap();
+        session.seal().unwrap();
+        let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+        let encoded = session.encode_canonical(&shape, 1).unwrap();
+        let graph = root
+            .path()
+            .join(PRIVATE_ROOT)
+            .join(operation.simple().to_string())
+            .join(&encoded.root)
+            .join("graph");
+        for (route, property) in [(parent_route, "score"), (child_route, "nickname")] {
+            let batches = crate::read_properties(&graph, &route).unwrap();
+            assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 2);
+            assert!(
+                batches
+                    .iter()
+                    .all(|batch| batch.column_by_name(property).is_some())
+            );
+            assert!(batches.iter().all(|batch| {
+                batch.schema().metadata().get("graphforge.entity_type") == Some(&concrete_route)
+            }));
+        }
+    }
+
+    #[test]
+    fn canonical_encoder_keeps_same_local_property_names_module_qualified() {
+        let root = TempDir::new().unwrap();
+        let operation = Uuid::from_u128(9_327);
+        let authority = colliding_module_authority();
+        let mut labels = authority
+            .bindings
+            .bindings
+            .iter()
+            .filter(|binding| binding.route_kind == crate::SemanticRouteKind::Entity)
+            .map(|binding| binding.symbol.ambiguity_candidate())
+            .collect::<Vec<_>>();
+        labels.sort();
+        let property_routes = authority
+            .bindings
+            .bindings
+            .iter()
+            .filter(|binding| binding.route_kind == crate::SemanticRouteKind::NodeProperty)
+            .map(|binding| binding.route.clone())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(property_routes.len(), 2);
+        let mut session = GraphConstructionSession::open_with_semantic_authority(
+            root.path(),
+            operation,
+            0,
+            authority,
+            GraphConstructionBudgets::default(),
+        )
+        .unwrap();
+        for (index, label) in labels.iter().enumerate() {
+            session
+                .append(
+                    ConstructionChunkKind::Node,
+                    &format!("module-{index}"),
+                    &colliding_property_batch(index as u128 + 1, label, index as i64),
+                )
+                .unwrap();
+        }
+        session.seal().unwrap();
+        let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+        let encoded = session.encode_canonical(&shape, 1).unwrap();
+        let graph = root
+            .path()
+            .join(PRIVATE_ROOT)
+            .join(operation.simple().to_string())
+            .join(&encoded.root)
+            .join("graph");
+        for route in property_routes {
+            assert_eq!(
+                crate::read_properties(&graph, &route)
+                    .unwrap()
+                    .iter()
+                    .map(RecordBatch::num_rows)
+                    .sum::<usize>(),
+                1
+            );
+        }
+    }
+
+    #[test]
     fn canonical_encoder_keeps_256_heterogeneous_schemas_to_one_live_reader() {
         let root = TempDir::new().unwrap();
         let operation = Uuid::from_u128(9_325);
@@ -6735,6 +7083,125 @@ mod tests {
                 .to_string()
                 .contains("canonical artifact differs from inventory")
         );
+    }
+
+    #[test]
+    fn canonical_encoder_rejects_same_inode_mutate_restore_during_spool() {
+        let root = TempDir::new().unwrap();
+        let operation = Uuid::from_u128(9_328);
+        let mut session = open(&root, 9_328);
+        session
+            .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 2))
+            .unwrap();
+        session.seal().unwrap();
+        let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+        let source = root
+            .path()
+            .join(PRIVATE_ROOT)
+            .join(operation.simple().to_string())
+            .join(&shape.runtime_catalog);
+        let original = std::fs::read(&source).unwrap()[0];
+        let mut mutated = false;
+        let hook_source = source.clone();
+        crate::graph_construction_encoding::set_source_spool_hook(Some(Box::new(move |phase| {
+            use std::io::{Seek as _, SeekFrom};
+            if phase == "before_read" && !mutated {
+                let mut file = std::fs::OpenOptions::new()
+                    .write(true)
+                    .open(&hook_source)
+                    .unwrap();
+                file.seek(SeekFrom::Start(0)).unwrap();
+                file.write_all(&[original ^ 0xff]).unwrap();
+                mutated = true;
+            } else if phase == "after_read" && mutated {
+                let mut file = std::fs::OpenOptions::new()
+                    .write(true)
+                    .open(&hook_source)
+                    .unwrap();
+                file.seek(SeekFrom::Start(0)).unwrap();
+                file.write_all(&[original]).unwrap();
+            }
+        })));
+        let error = session.encode_canonical(&shape, 1).unwrap_err();
+        crate::graph_construction_encoding::set_source_spool_hook(None);
+        assert!(
+            error
+                .to_string()
+                .contains("changed during authenticated spooling")
+        );
+        assert_eq!(std::fs::read(source).unwrap()[0], original);
+    }
+
+    #[test]
+    fn canonical_encoder_uses_owned_spool_after_source_mutation() {
+        let root = TempDir::new().unwrap();
+        let operation = Uuid::from_u128(9_329);
+        let mut session = open(&root, 9_329);
+        session
+            .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 2))
+            .unwrap();
+        session.seal().unwrap();
+        let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+        let source = root
+            .path()
+            .join(PRIVATE_ROOT)
+            .join(operation.simple().to_string())
+            .join(&shape.runtime_catalog);
+        let original = std::fs::read(&source).unwrap()[0];
+        let hook_source = source.clone();
+        let mut changed = false;
+        crate::graph_construction_encoding::set_source_spool_hook(Some(Box::new(move |phase| {
+            if phase == "after_read" && !changed {
+                use std::io::{Seek as _, SeekFrom};
+                let mut file = std::fs::OpenOptions::new()
+                    .write(true)
+                    .open(&hook_source)
+                    .unwrap();
+                file.seek(SeekFrom::Start(0)).unwrap();
+                file.write_all(&[original ^ 0xff]).unwrap();
+                changed = true;
+            }
+        })));
+        let encoded = session.encode_canonical(&shape, 1).unwrap();
+        crate::graph_construction_encoding::set_source_spool_hook(None);
+        assert!(encoded.evidence.source_spool_read_bytes > 0);
+        assert_ne!(std::fs::read(source).unwrap()[0], original);
+    }
+
+    #[test]
+    fn canonical_encoder_rejects_coherent_inventory_and_artifact_substitution() {
+        let root = TempDir::new().unwrap();
+        let operation = Uuid::from_u128(9_330);
+        let mut session = open(&root, 9_330);
+        session
+            .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 2))
+            .unwrap();
+        session.seal().unwrap();
+        let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+        let mut encoded = session.encode_canonical(&shape, 1).unwrap();
+        let encoded_root = root
+            .path()
+            .join(PRIVATE_ROOT)
+            .join(operation.simple().to_string())
+            .join(&encoded.root);
+        let artifact = encoded
+            .artifacts
+            .iter_mut()
+            .find(|artifact| artifact.path == "topology/surrogate_tails.parquet")
+            .unwrap();
+        let artifact_path = encoded_root.join("graph").join(&artifact.path);
+        let mut body = std::fs::read(&artifact_path).unwrap();
+        let last = body.len() - 1;
+        body[last] ^= 0xff;
+        std::fs::write(&artifact_path, &body).unwrap();
+        artifact.sha256 = sha256(&body);
+        std::fs::write(
+            encoded_root.join("inventory.json"),
+            serde_json::to_vec(&encoded).unwrap(),
+        )
+        .unwrap();
+        let error = session.encode_canonical(&shape, 1).unwrap_err();
+        assert!(error.to_string().contains("checkpoint inventory authority"));
     }
 
     #[test]

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -32,12 +32,10 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
-use crate::uuid_membership::{
-    ConstructionUuidIdentity, UuidConstructionSnapshot, UuidConstructionSnapshotWork,
-    pin_uuid_construction_snapshot,
-};
+use crate::UuidIndexKind;
+use crate::uuid_membership::{AuthenticatedUuidIndexSnapshot, UuidConstructionSnapshotWork};
 
-const FORMAT_VERSION: u32 = 4;
+const FORMAT_VERSION: u32 = 5;
 const PRIVATE_ROOT: &str = ".graphforge-construction";
 const CHECKPOINT: &str = "checkpoint.json";
 const INTENT: &str = "intent.json";
@@ -106,6 +104,10 @@ pub struct GraphConstructionBudgets {
     pub max_run_records: usize,
     /// Maximum inputs opened by one external merge group.
     pub merge_fan_in: usize,
+    /// Maximum exact Arrow schema groups accepted by one session. Construction
+    /// deliberately requires one stable schema per entity kind, so this may be
+    /// one (single-kind sessions) or two (nodes plus edges).
+    pub max_schema_groups: usize,
 }
 
 impl Default for GraphConstructionBudgets {
@@ -116,6 +118,7 @@ impl Default for GraphConstructionBudgets {
             max_chunks: 1_000_000,
             max_run_records: 4 * 65_536,
             merge_fan_in: 32,
+            max_schema_groups: 2,
         }
     }
 }
@@ -127,6 +130,7 @@ impl GraphConstructionBudgets {
             || self.max_chunks == 0
             || self.max_run_records < 4 * self.max_batch_rows
             || self.merge_fan_in < 2
+            || !(1..=2).contains(&self.max_schema_groups)
         {
             return Err(storage("invalid construction budgets"));
         }
@@ -192,9 +196,11 @@ pub struct GraphConstructionEvidence {
     pub merge_read_bytes: u64,
     /// Exact fixed-width payload bytes written during shaping.
     pub merge_written_bytes: u64,
-    /// Bounded reader refills implied by the fixed one-MiB I/O window.
+    /// Logical lower bound on bounded reader refills implied by payload bytes
+    /// and the fixed one-MiB window; this is not an observed syscall count.
     pub merge_read_blocks: u64,
-    /// Bounded writer flushes implied by the fixed one-MiB I/O window.
+    /// Logical lower bound on bounded writer flushes implied by payload bytes
+    /// and the fixed one-MiB window; this is not an observed syscall count.
     pub merge_write_blocks: u64,
     /// Number of completed merge levels across shaped domains.
     pub merge_passes: u64,
@@ -222,6 +228,11 @@ pub struct GraphConstructionEvidence {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 /// Publisher input produced from a sealed construction session.
 pub struct ConstructionShape {
+    /// Parent generation retained by the publisher; zero denotes an empty base.
+    pub parent_topology_generation: u64,
+    /// Authenticated parent UUID-manifest authority. The shaped identities file
+    /// contains only this session's delta and never copies the parent payload.
+    pub parent_uuid_manifest_sha256: Option<String>,
     /// UUID-sorted node/edge identity records with assigned surrogates.
     pub identities: String,
     /// UUID-sorted node type records, when nodes were staged.
@@ -329,6 +340,8 @@ struct Checkpoint {
     last_receipt_sha256: Option<String>,
     has_base_snapshot: bool,
     parent_catalog_sha256: Option<String>,
+    node_schema_sha256: Option<String>,
+    edge_schema_sha256: Option<String>,
     base_work: UuidConstructionSnapshotWork,
     evidence: GraphConstructionEvidence,
 }
@@ -366,6 +379,8 @@ struct ShapeIntent {
     parent_topology_generation: u64,
     budgets: GraphConstructionBudgets,
     last_receipt_sha256: Option<String>,
+    baseline_evidence: GraphConstructionEvidence,
+    final_evidence: Option<GraphConstructionEvidence>,
     complete: bool,
     shape: Option<ConstructionShape>,
     outputs: Vec<ArtifactReceipt>,
@@ -404,13 +419,14 @@ pub struct GraphConstructionSession {
     project: StableDirectory,
     root: StableDirectory,
     checkpoint: Checkpoint,
-    base_snapshot: Option<UuidConstructionSnapshot>,
+    base_snapshot: Option<AuthenticatedUuidIndexSnapshot>,
     parent_catalog: RuntimeCatalog,
     _reservation: ProcessReservation,
 }
 
 impl GraphConstructionSession {
     /// Create or resume an operation pinned to one parent topology generation.
+    #[allow(clippy::too_many_lines)]
     pub fn open(
         project_dir: &Path,
         operation_uuid: Uuid,
@@ -455,11 +471,21 @@ impl GraphConstructionSession {
         let (base_snapshot, base_work) = if parent_topology_generation == 0 {
             (None, UuidConstructionSnapshotWork::default())
         } else {
-            let snapshot = pin_uuid_construction_snapshot(project_dir, parent_topology_generation)?;
+            let mut snapshot = AuthenticatedUuidIndexSnapshot::open_at_generation(
+                project_dir,
+                parent_topology_generation,
+            )?;
             let max_node_surrogate = crate::writer::read_surrogate_tails(project_dir)?
                 .ok_or_else(|| storage("nonempty parent lacks surrogate tails"))?
                 .0;
-            let work = snapshot.declared_work(max_node_surrogate);
+            let (authentication_bytes, authentication_blocks) = snapshot.take_authentication_work();
+            let work = UuidConstructionSnapshotWork {
+                authentication_bytes,
+                authentication_blocks,
+                live_nodes: snapshot.count(UuidIndexKind::Node),
+                live_edges: snapshot.count(UuidIndexKind::Edge),
+                max_node_surrogate,
+            };
             (Some(snapshot), work)
         };
         let (parent_catalog, parent_catalog_sha256) =
@@ -467,9 +493,11 @@ impl GraphConstructionSession {
         let checkpoint = match root.open_child_file(OsStr::new(CHECKPOINT)) {
             Ok(mut file) => decode_bounded(&mut file)?,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                let mut evidence = GraphConstructionEvidence::default();
-                evidence.authentication_read_bytes = base_work.authentication_bytes;
-                evidence.authentication_read_operations = base_work.authentication_blocks;
+                let evidence = GraphConstructionEvidence {
+                    authentication_read_bytes: base_work.authentication_bytes,
+                    authentication_read_operations: base_work.authentication_blocks,
+                    ..GraphConstructionEvidence::default()
+                };
                 let initial = Checkpoint {
                     format_version: FORMAT_VERSION,
                     operation_uuid,
@@ -489,6 +517,8 @@ impl GraphConstructionSession {
                     last_receipt_sha256: None,
                     has_base_snapshot: parent_topology_generation != 0,
                     parent_catalog_sha256: parent_catalog_sha256.clone(),
+                    node_schema_sha256: None,
+                    edge_schema_sha256: None,
                     base_work,
                     evidence,
                 };
@@ -515,7 +545,7 @@ impl GraphConstructionSession {
             parent_catalog,
             _reservation: reservation,
         };
-        recover_shape_intent(&session.root, &session.checkpoint)?;
+        recover_shape_intent(&session.root, &mut session.checkpoint)?;
         session.recover_intent()?;
         session.revalidate_authority()?;
         Ok(session)
@@ -565,6 +595,7 @@ impl GraphConstructionSession {
     /// Append while polling a caller-owned cancellation signal at durable
     /// artifact boundaries. Cancellation leaves an intent that the next open
     /// authenticates and rolls back without changing public authority.
+    #[allow(clippy::too_many_lines)]
     pub fn append_with_cancellation(
         &mut self,
         kind: ConstructionChunkKind,
@@ -594,7 +625,7 @@ impl GraphConstructionSession {
             return Err(storage("node chunk cannot follow edge staging"));
         }
         let input_sha256 = logical_batch_digest(kind, batch)?;
-        let schema_sha256 = normalized_schema_digest(batch.schema().as_ref())?;
+        let schema_sha256 = normalized_schema_digest(batch.schema().as_ref());
         let key_name = chunk_key_name(chunk_id);
         if let Ok(mut key_file) = self.root.open_child_file(OsStr::new(&key_name)) {
             let pointer: ReceiptPointer = decode_bounded(&mut key_file)?;
@@ -617,6 +648,27 @@ impl GraphConstructionSession {
                 return Ok(receipt);
             }
             return Err(storage("conflicting construction chunk replay"));
+        }
+        let (known_schema, other_schema) = match kind {
+            ConstructionChunkKind::Node => (
+                self.checkpoint.node_schema_sha256.as_ref(),
+                self.checkpoint.edge_schema_sha256.as_ref(),
+            ),
+            ConstructionChunkKind::Edge => (
+                self.checkpoint.edge_schema_sha256.as_ref(),
+                self.checkpoint.node_schema_sha256.as_ref(),
+            ),
+        };
+        if known_schema.is_some_and(|known| known != &schema_sha256) {
+            return Err(storage(
+                "construction requires one stable Arrow schema per entity kind",
+            ));
+        }
+        if known_schema.is_none()
+            && usize::from(other_schema.is_some()).saturating_add(1)
+                > self.checkpoint.budgets.max_schema_groups
+        {
+            return Err(storage("construction schema-group budget exhausted"));
         }
         let arrays = extract_runs(kind, batch)?;
         let run_records = arrays
@@ -807,6 +859,8 @@ impl GraphConstructionSession {
             parent_topology_generation: self.checkpoint.parent_topology_generation,
             budgets: self.checkpoint.budgets,
             last_receipt_sha256: self.checkpoint.last_receipt_sha256.clone(),
+            baseline_evidence: self.checkpoint.evidence.clone(),
+            final_evidence: None,
             complete: false,
             shape: None,
             outputs: Vec::new(),
@@ -911,34 +965,8 @@ impl GraphConstructionSession {
             &mut cancelled,
             &mut self.checkpoint.evidence,
         )?;
-        let identities = if let Some(base) = self.base_snapshot.as_mut() {
-            let (name, work) = merge_staged_with_base(
-                &self.root,
-                staged_identities.as_deref(),
-                base,
-                &mut cancelled,
-                &mut self.checkpoint.evidence,
-            )?;
-            if work.live_nodes != self.checkpoint.base_work.live_nodes
-                || work.live_edges != self.checkpoint.base_work.live_edges
-                || work.max_node_surrogate != self.checkpoint.base_work.max_node_surrogate
-            {
-                return Err(storage("pinned base UUID work differs from checkpoint"));
-            }
-            self.checkpoint.evidence.authentication_read_bytes = self
-                .checkpoint
-                .evidence
-                .authentication_read_bytes
-                .saturating_add(work.authentication_bytes);
-            self.checkpoint.evidence.authentication_read_operations = self
-                .checkpoint
-                .evidence
-                .authentication_read_operations
-                .saturating_add(work.authentication_blocks);
-            name
-        } else {
-            staged_identities.ok_or_else(|| storage("construction contains no identities"))?
-        };
+        let staged_identities =
+            staged_identities.ok_or_else(|| storage("construction contains no identities"))?;
         let node_details = node_details.finish_optional::<NODE_DETAIL_WIDTH>(
             &self.root,
             &mut cancelled,
@@ -965,21 +993,26 @@ impl GraphConstructionSession {
         if base_max_node != self.checkpoint.base_work.max_node_surrogate {
             return Err(storage("UUID snapshot and surrogate tails disagree"));
         }
-        let (node_count, edge_count, max_node_surrogate, max_edge_surrogate) =
-            validate_unified_and_details(
+        let (new_nodes, new_edges) = validate_staged_details(
+            &self.root,
+            &staged_identities,
+            node_details.as_deref(),
+            edge_details.as_deref(),
+            &mut cancelled,
+            &mut self.checkpoint.evidence,
+        )?;
+        if let Some(base) = self.base_snapshot.as_mut() {
+            reject_staged_base_conflicts(
                 &self.root,
-                &identities,
-                node_details.as_deref(),
-                edge_details.as_deref(),
-                endpoints.as_deref(),
-                base_max_node,
-                base_max_edge,
+                &staged_identities,
+                base,
+                self.checkpoint.budgets.max_batch_rows,
                 &mut cancelled,
-                &mut self.checkpoint.evidence,
             )?;
+        }
         let identities = assign_surrogates(
             &self.root,
-            &identities,
+            &staged_identities,
             base_max_node,
             base_max_edge,
             &mut cancelled,
@@ -989,11 +1022,28 @@ impl GraphConstructionSession {
             &self.root,
             &identities,
             endpoints.as_deref(),
+            self.base_snapshot.as_mut(),
             self.checkpoint.budgets.max_batch_rows,
             self.checkpoint.budgets.merge_fan_in,
             &mut cancelled,
             &mut self.checkpoint.evidence,
         )?;
+        let node_count = self
+            .checkpoint
+            .base_work
+            .live_nodes
+            .saturating_add(new_nodes);
+        let edge_count = self
+            .checkpoint
+            .base_work
+            .live_edges
+            .saturating_add(new_edges);
+        let max_node_surrogate = base_max_node
+            .checked_add(new_nodes)
+            .ok_or_else(|| storage("node surrogate overflow"))?;
+        let max_edge_surrogate = base_max_edge
+            .checked_add(new_edges)
+            .ok_or_else(|| storage("edge surrogate overflow"))?;
         let mut node_rows = Vec::new();
         let mut edge_rows = Vec::new();
         for ((kind, schema_digest), rows) in row_groups {
@@ -1029,6 +1079,11 @@ impl GraphConstructionSession {
             .peak_merge_temporary_bytes
             .max(measured_shape_bytes(&self.root)?);
         let shape = ConstructionShape {
+            parent_topology_generation: self.checkpoint.parent_topology_generation,
+            parent_uuid_manifest_sha256: self
+                .base_snapshot
+                .as_ref()
+                .map(|snapshot| snapshot.manifest_sha256().to_owned()),
             identities,
             node_details,
             edge_details,
@@ -1055,7 +1110,6 @@ impl GraphConstructionSession {
         {
             outputs.push(receipt_for_existing(&self.root, name)?);
         }
-        replace_control(&self.root, CHECKPOINT, &self.checkpoint)?;
         replace_control(
             &self.root,
             SHAPE_INTENT,
@@ -1067,11 +1121,16 @@ impl GraphConstructionSession {
                 parent_topology_generation: self.checkpoint.parent_topology_generation,
                 budgets: self.checkpoint.budgets,
                 last_receipt_sha256: self.checkpoint.last_receipt_sha256.clone(),
+                baseline_evidence: shape_intent.baseline_evidence,
+                final_evidence: Some(self.checkpoint.evidence.clone()),
                 complete: true,
                 shape: Some(shape.clone()),
                 outputs,
             },
         )?;
+        construction_failpoint("shape.after_complete_inventory");
+        replace_control(&self.root, CHECKPOINT, &self.checkpoint)?;
+        construction_failpoint("shape.after_evidence_checkpoint");
         Ok(shape)
     }
 
@@ -1086,6 +1145,7 @@ impl GraphConstructionSession {
         replace_control(&self.root, CHECKPOINT, &self.checkpoint)
     }
 
+    #[allow(clippy::too_many_lines)]
     fn recover_intent(&mut self) -> Result<(), GfError> {
         let mut file = match self.root.open_child_file(OsStr::new(INTENT)) {
             Ok(file) => file,
@@ -1250,6 +1310,14 @@ impl GraphConstructionSession {
         }
         self.checkpoint.next_sequence = self.checkpoint.next_sequence.saturating_add(1);
         self.checkpoint.saw_edge |= receipt.kind == ConstructionChunkKind::Edge;
+        match receipt.kind {
+            ConstructionChunkKind::Node => {
+                self.checkpoint.node_schema_sha256 = Some(receipt.schema_sha256.clone());
+            }
+            ConstructionChunkKind::Edge => {
+                self.checkpoint.edge_schema_sha256 = Some(receipt.schema_sha256.clone());
+            }
+        }
         self.checkpoint.last_receipt_sha256 = Some(sha256(receipt_bytes));
         replace_control(&self.root, CHECKPOINT, &self.checkpoint)
     }
@@ -1332,7 +1400,7 @@ fn extract_runs(kind: ConstructionChunkKind, batch: &RecordBatch) -> Result<RunA
                 let mut record = [0_u8; ENDPOINT_WIDTH];
                 record[..16].copy_from_slice(&endpoint);
                 record[16..32].copy_from_slice(&edge);
-                record[32] = role as u8;
+                record[32] = u8::try_from(role).expect("endpoint role is zero or one");
                 endpoints.push(record);
             }
             let route = routes.value(row).as_bytes();
@@ -1494,7 +1562,7 @@ fn logical_batch_digest(
     Ok(hex(&digest.finalize()))
 }
 
-fn normalized_schema_digest(schema: &Schema) -> Result<String, GfError> {
+fn normalized_schema_digest(schema: &Schema) -> String {
     let mut digest = Sha256::new();
     for field in schema.fields() {
         digest.update((field.name().len() as u64).to_be_bytes());
@@ -1520,7 +1588,7 @@ fn normalized_schema_digest(schema: &Schema) -> Result<String, GfError> {
         digest.update((value.len() as u64).to_be_bytes());
         digest.update(value.as_bytes());
     }
-    Ok(hex(&digest.finalize()))
+    hex(&digest.finalize())
 }
 
 fn uuid_sorted_batch(
@@ -1551,10 +1619,10 @@ fn uuid_sorted_batch(
     RecordBatch::try_new(batch.schema(), columns).map_err(storage)
 }
 
-fn expected_property_columns<'a>(
+fn expected_property_columns(
     kind: ConstructionChunkKind,
-    batch: &'a RecordBatch,
-) -> impl Iterator<Item = &'a arrow::array::ArrayRef> {
+    batch: &RecordBatch,
+) -> impl Iterator<Item = &arrow::array::ArrayRef> {
     let required = if kind == ConstructionChunkKind::Node {
         2
     } else {
@@ -1769,19 +1837,6 @@ fn write_fixed_run<const N: usize>(
     Ok(receipt)
 }
 
-fn encode_base_identity(identity: ConstructionUuidIdentity) -> [u8; BASE_IDENTITY_WIDTH] {
-    let mut record = [0_u8; BASE_IDENTITY_WIDTH];
-    record[..16].copy_from_slice(identity.uuid.as_bytes());
-    record[16] = match identity.kind {
-        crate::uuid_membership::UuidIndexKind::Node => 0,
-        crate::uuid_membership::UuidIndexKind::Edge => 1,
-    };
-    // Retained parent member; session-converted records keep this byte zero.
-    record[17] = 1;
-    record[24..].copy_from_slice(&identity.surrogate.to_be_bytes());
-    record
-}
-
 fn reject_existing_merge_artifacts(root: &StableDirectory) -> Result<(), GfError> {
     for name in root.child_names().map_err(storage)? {
         let Some(name) = name.to_str() else { continue };
@@ -1792,7 +1847,10 @@ fn reject_existing_merge_artifacts(root: &StableDirectory) -> Result<(), GfError
     Ok(())
 }
 
-fn recover_shape_intent(root: &StableDirectory, checkpoint: &Checkpoint) -> Result<(), GfError> {
+fn recover_shape_intent(
+    root: &StableDirectory,
+    checkpoint: &mut Checkpoint,
+) -> Result<(), GfError> {
     let mut file = match root.open_child_file(OsStr::new(SHAPE_INTENT)) {
         Ok(file) => file,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
@@ -1825,10 +1883,23 @@ fn recover_shape_intent(root: &StableDirectory, checkpoint: &Checkpoint) -> Resu
         for output in &intent.outputs {
             authenticate_shaped_output(root, output)?;
         }
+        let final_evidence = intent
+            .final_evidence
+            .as_ref()
+            .ok_or_else(|| storage("complete shape manifest lacks final evidence"))?;
+        if checkpoint.evidence == intent.baseline_evidence {
+            checkpoint.evidence = final_evidence.clone();
+            replace_control(root, CHECKPOINT, checkpoint)?;
+        } else if checkpoint.evidence != *final_evidence {
+            return Err(storage("shape evidence authority differs from inventory"));
+        }
         return Ok(());
     }
     if intent.shape.is_some() || !intent.outputs.is_empty() {
         return Err(storage("incomplete shape intent claims completed output"));
+    }
+    if intent.final_evidence.is_some() || checkpoint.evidence != intent.baseline_evidence {
+        return Err(storage("incomplete shape changed committed evidence"));
     }
     for child in root.child_names().map_err(storage)? {
         let Some(name) = child.to_str() else { continue };
@@ -2091,6 +2162,7 @@ fn convert_identity_run(
     root.install_child(OsStr::new(&temporary), identity, OsStr::new(output))
         .map_err(storage)?;
     root.sync().map_err(storage)?;
+    construction_failpoint("shape.fixed.after_install");
     evidence.merge_fsync_operations = evidence.merge_fsync_operations.saturating_add(2);
     Ok(())
 }
@@ -2385,6 +2457,7 @@ fn merge_fixed_group<const N: usize>(
     root.install_child(OsStr::new(&temporary), identity, OsStr::new(output))
         .map_err(storage)?;
     root.sync().map_err(storage)?;
+    construction_failpoint("shape.fixed_merge.after_install");
     evidence.merge_fsync_operations = evidence.merge_fsync_operations.saturating_add(2);
     evidence.merge_groups = evidence.merge_groups.saturating_add(1);
     evidence.peak_merge_temporary_bytes = evidence
@@ -2444,6 +2517,7 @@ fn materialize_selected_rows(
 /// Merge one exact-schema set of UUID-sorted normalized Parquet row artifacts.
 /// Memory is bounded by one decoder window per input plus one caller-sized
 /// output window; no property values are projected away.
+#[allow(clippy::too_many_lines)]
 fn merge_row_group(
     root: &StableDirectory,
     inputs: &[String],
@@ -2577,6 +2651,7 @@ fn merge_row_group(
     root.install_child(OsStr::new(&temporary), identity, OsStr::new(output))
         .map_err(storage)?;
     root.sync().map_err(storage)?;
+    construction_failpoint("shape.row_merge.after_install");
     evidence.merge_fsync_operations = evidence.merge_fsync_operations.saturating_add(4);
     evidence.merge_groups = evidence.merge_groups.saturating_add(1);
     evidence.merge_written_bytes = evidence.merge_written_bytes.saturating_add(receipt.bytes);
@@ -2872,7 +2947,119 @@ fn read_fixed<const N: usize>(reader: &mut impl Read) -> Result<Option<[u8; N]>,
     Ok(Some(record))
 }
 
+fn validate_staged_details(
+    root: &StableDirectory,
+    identities_name: &str,
+    node_details_name: Option<&str>,
+    edge_details_name: Option<&str>,
+    cancelled: &mut impl FnMut() -> bool,
+    evidence: &mut GraphConstructionEvidence,
+) -> Result<(u64, u64), GfError> {
+    let mut identities = BufReader::with_capacity(
+        BLOCK_BYTES,
+        root.open_child_file(OsStr::new(identities_name))
+            .map_err(storage)?,
+    );
+    account_sequential_read(
+        identities.get_ref().metadata().map_err(storage)?.len(),
+        evidence,
+    );
+    let mut nodes = 0_u64;
+    let mut edges = 0_u64;
+    while let Some(record) = read_fixed::<BASE_IDENTITY_WIDTH>(&mut identities)? {
+        if record[17] != 0 || record[18..].iter().any(|byte| *byte != 0) {
+            return Err(storage("staged identity record is not canonical"));
+        }
+        match record[16] {
+            0 => nodes = nodes.saturating_add(1),
+            1 => edges = edges.saturating_add(1),
+            _ => return Err(storage("invalid staged identity kind")),
+        }
+        account_merge_read::<BASE_IDENTITY_WIDTH>(evidence);
+        if nodes.saturating_add(edges).is_multiple_of(4096) {
+            reject_cancelled(cancelled)?;
+        }
+    }
+    let count = |name: Option<&str>, width: u64| -> Result<u64, GfError> {
+        let Some(name) = name else { return Ok(0) };
+        let bytes = root
+            .open_child_file(OsStr::new(name))
+            .map_err(storage)?
+            .metadata()
+            .map_err(storage)?
+            .len();
+        if bytes % width != 0 {
+            return Err(storage("truncated canonical detail run"));
+        }
+        Ok(bytes / width)
+    };
+    if count(node_details_name, NODE_DETAIL_WIDTH as u64)? != nodes
+        || count(edge_details_name, EDGE_DETAIL_WIDTH as u64)? != edges
+    {
+        return Err(storage("staged identity and detail domains disagree"));
+    }
+    validate_detail_domain::<NODE_DETAIL_WIDTH>(
+        root,
+        identities_name,
+        node_details_name,
+        0,
+        cancelled,
+        evidence,
+    )?;
+    validate_detail_domain::<EDGE_DETAIL_WIDTH>(
+        root,
+        identities_name,
+        edge_details_name,
+        1,
+        cancelled,
+        evidence,
+    )?;
+    Ok((nodes, edges))
+}
+
+fn reject_staged_base_conflicts(
+    root: &StableDirectory,
+    identities_name: &str,
+    base: &mut AuthenticatedUuidIndexSnapshot,
+    window_rows: usize,
+    cancelled: &mut impl FnMut() -> bool,
+) -> Result<(), GfError> {
+    let mut reader = BufReader::with_capacity(
+        BLOCK_BYTES,
+        root.open_child_file(OsStr::new(identities_name))
+            .map_err(storage)?,
+    );
+    loop {
+        let mut requested = Vec::with_capacity(window_rows);
+        for _ in 0..window_rows {
+            let Some(record) = read_fixed::<BASE_IDENTITY_WIDTH>(&mut reader)? else {
+                break;
+            };
+            requested.push(Uuid::from_bytes(
+                record[..16].try_into().expect("fixed UUID"),
+            ));
+        }
+        if requested.is_empty() {
+            break;
+        }
+        let (nodes, _) = base.probe(UuidIndexKind::Node, &requested)?;
+        let (edges, _) = base.probe(UuidIndexKind::Edge, &requested)?;
+        if nodes
+            .into_iter()
+            .zip(edges)
+            .any(|(node, edge)| node || edge)
+        {
+            return Err(storage("staged UUID conflicts with pinned base identity"));
+        }
+        reject_cancelled(cancelled)?;
+    }
+    base.revalidate()?;
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
+#[cfg(test)]
+#[allow(dead_code)]
 fn validate_unified_and_details(
     root: &StableDirectory,
     identities_name: &str,
@@ -2969,99 +3156,6 @@ fn validate_unified_and_details(
     Ok((node_count, edge_count, max_node, max_edge))
 }
 
-fn merge_staged_with_base(
-    root: &StableDirectory,
-    staged_name: Option<&str>,
-    base: &mut UuidConstructionSnapshot,
-    cancelled: &mut impl FnMut() -> bool,
-    evidence: &mut GraphConstructionEvidence,
-) -> Result<(String, UuidConstructionSnapshotWork), GfError> {
-    let output = "merge-identities-with-base.run";
-    let temporary = artifact_temp(output);
-    let file = root
-        .create_replaceable_child_file(OsStr::new(&temporary))
-        .map_err(storage)?;
-    let identity = file_identity(&file).map_err(storage)?;
-    let mut writer = BufWriter::with_capacity(BLOCK_BYTES, file);
-    let mut staged = staged_name
-        .map(|name| {
-            root.open_child_file(OsStr::new(name))
-                .map(|file| BufReader::with_capacity(BLOCK_BYTES, file))
-                .map_err(storage)
-        })
-        .transpose()?;
-    let mut staged_record = staged
-        .as_mut()
-        .map(read_fixed::<BASE_IDENTITY_WIDTH>)
-        .transpose()?
-        .flatten();
-    if let Some(reader) = &staged {
-        account_sequential_read(
-            reader.get_ref().metadata().map_err(storage)?.len(),
-            evidence,
-        );
-    }
-    let mut emitted = 0_u64;
-    let work = base.stream_authenticated(|value| {
-        let base_record = encode_base_identity(value);
-        while staged_record
-            .as_ref()
-            .is_some_and(|record| record[..16] < base_record[..16])
-        {
-            let record = staged_record.take().expect("staged head exists");
-            writer.write_all(&record).map_err(storage)?;
-            account_merge_read::<BASE_IDENTITY_WIDTH>(evidence);
-            account_merge_write::<BASE_IDENTITY_WIDTH>(evidence);
-            staged_record = staged
-                .as_mut()
-                .map(read_fixed::<BASE_IDENTITY_WIDTH>)
-                .transpose()?
-                .flatten();
-        }
-        if staged_record
-            .as_ref()
-            .is_some_and(|record| record[..16] == base_record[..16])
-        {
-            return Err(storage("staged UUID conflicts with pinned base identity"));
-        }
-        writer.write_all(&base_record).map_err(storage)?;
-        account_merge_write::<BASE_IDENTITY_WIDTH>(evidence);
-        emitted = emitted.saturating_add(1);
-        if emitted.is_multiple_of(4096) {
-            reject_cancelled(cancelled)?;
-        }
-        Ok(())
-    })?;
-    while let Some(record) = staged_record {
-        writer.write_all(&record).map_err(storage)?;
-        account_merge_read::<BASE_IDENTITY_WIDTH>(evidence);
-        account_merge_write::<BASE_IDENTITY_WIDTH>(evidence);
-        staged_record = staged
-            .as_mut()
-            .map(read_fixed::<BASE_IDENTITY_WIDTH>)
-            .transpose()?
-            .flatten();
-    }
-    writer.flush().map_err(storage)?;
-    writer.get_ref().sync_all().map_err(storage)?;
-    account_sequential_write(
-        writer.get_ref().metadata().map_err(storage)?.len(),
-        evidence,
-    );
-    drop(writer);
-    root.install_child(OsStr::new(&temporary), identity, OsStr::new(output))
-        .map_err(storage)?;
-    root.sync().map_err(storage)?;
-    evidence.merge_fsync_operations = evidence.merge_fsync_operations.saturating_add(2);
-    if let Some(staged_name) = staged_name
-        && staged_name.starts_with("merge-")
-    {
-        unlink_named(root, staged_name)?;
-    }
-    evidence.merge_groups = evidence.merge_groups.saturating_add(1);
-    Ok((output.to_owned(), work))
-}
-
 fn validate_detail_domain<const N: usize>(
     root: &StableDirectory,
     identities_name: &str,
@@ -3131,6 +3225,8 @@ fn validate_detail_domain<const N: usize>(
     Ok(())
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 fn validate_endpoints(
     root: &StableDirectory,
     identities_name: &str,
@@ -3266,10 +3362,12 @@ fn assign_surrogates(
     Ok(output.to_owned())
 }
 
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 fn resolve_endpoint_surrogates(
     root: &StableDirectory,
     identities_name: &str,
     endpoints_name: Option<&str>,
+    mut base: Option<&mut AuthenticatedUuidIndexSnapshot>,
     window_rows: usize,
     fan_in: usize,
     cancelled: &mut impl FnMut() -> bool,
@@ -3300,27 +3398,62 @@ fn resolve_endpoint_surrogates(
     let mut window = Vec::<[u8; RESOLVED_ENDPOINT_WIDTH]>::with_capacity(window_rows);
     let mut runs = Vec::new();
     let mut sequence = 0_u64;
-    while let Some(endpoint) = read_fixed::<ENDPOINT_WIDTH>(&mut endpoints)? {
-        while identity
-            .as_ref()
-            .is_some_and(|record| record[..16] < endpoint[..16])
-        {
-            identity = read_fixed::<BASE_IDENTITY_WIDTH>(&mut identities)?;
-            account_merge_read::<BASE_IDENTITY_WIDTH>(evidence);
+    loop {
+        let mut endpoint_window = Vec::with_capacity(window_rows);
+        for _ in 0..window_rows {
+            let Some(endpoint) = read_fixed::<ENDPOINT_WIDTH>(&mut endpoints)? else {
+                break;
+            };
+            endpoint_window.push(endpoint);
         }
-        let node = identity
-            .as_ref()
-            .filter(|record| record[..16] == endpoint[..16] && record[16] == 0)
-            .ok_or_else(|| storage("endpoint UUID lacks node surrogate"))?;
-        if node[24..32].iter().all(|byte| *byte == 0) {
-            return Err(storage("endpoint node surrogate is zero"));
+        if endpoint_window.is_empty() {
+            break;
         }
-        let mut resolved = [0_u8; RESOLVED_ENDPOINT_WIDTH];
-        resolved[..16].copy_from_slice(&endpoint[16..32]);
-        resolved[16] = endpoint[32];
-        resolved[24..32].copy_from_slice(&node[24..32]);
-        window.push(resolved);
-        account_merge_read::<ENDPOINT_WIDTH>(evidence);
+        let mut surrogates = Vec::with_capacity(endpoint_window.len());
+        let mut base_requests = Vec::new();
+        let mut base_positions = Vec::new();
+        for endpoint in &endpoint_window {
+            while identity
+                .as_ref()
+                .is_some_and(|record| record[..16] < endpoint[..16])
+            {
+                identity = read_fixed::<BASE_IDENTITY_WIDTH>(&mut identities)?;
+                account_merge_read::<BASE_IDENTITY_WIDTH>(evidence);
+            }
+            if let Some(node) = identity
+                .as_ref()
+                .filter(|record| record[..16] == endpoint[..16] && record[16] == 0)
+            {
+                surrogates.push(Some(u64::from_be_bytes(
+                    node[24..32].try_into().expect("fixed"),
+                )));
+            } else {
+                base_positions.push(surrogates.len());
+                base_requests.push(Uuid::from_bytes(endpoint[..16].try_into().expect("fixed")));
+                surrogates.push(None);
+            }
+        }
+        if !base_requests.is_empty() {
+            let resolved = base
+                .as_deref_mut()
+                .ok_or_else(|| storage("endpoint UUID lacks node surrogate"))?
+                .lookup_node_surrogates(&base_requests)?
+                .0;
+            for (position, surrogate) in base_positions.into_iter().zip(resolved) {
+                surrogates[position] = surrogate;
+            }
+        }
+        for (endpoint, surrogate) in endpoint_window.into_iter().zip(surrogates) {
+            let surrogate = surrogate
+                .filter(|value| *value != 0)
+                .ok_or_else(|| storage("endpoint UUID lacks node surrogate"))?;
+            let mut resolved = [0_u8; RESOLVED_ENDPOINT_WIDTH];
+            resolved[..16].copy_from_slice(&endpoint[16..32]);
+            resolved[16] = endpoint[32];
+            resolved[24..32].copy_from_slice(&surrogate.to_be_bytes());
+            window.push(resolved);
+            account_merge_read::<ENDPOINT_WIDTH>(evidence);
+        }
         if window.len() == window_rows {
             window.sort_unstable();
             let name = format!("merge-resolved-source-{sequence:020}.run");
@@ -3487,17 +3620,23 @@ fn validate_artifact_name(receipt: &ArtifactReceipt) -> Result<(), GfError> {
     {
         return Err(storage("invalid construction artifact receipt"));
     }
-    if receipt.name.ends_with(".identities.run") && receipt.bytes % IDENTITY_WIDTH as u64 != 0 {
+    if receipt.name.ends_with(".identities.run")
+        && !receipt.bytes.is_multiple_of(IDENTITY_WIDTH as u64)
+    {
         return Err(storage("truncated identity run"));
     }
-    if receipt.name.ends_with(".endpoints.run") && receipt.bytes % ENDPOINT_WIDTH as u64 != 0 {
+    if receipt.name.ends_with(".endpoints.run")
+        && !receipt.bytes.is_multiple_of(ENDPOINT_WIDTH as u64)
+    {
         return Err(storage("truncated endpoint run"));
     }
-    if receipt.name.ends_with(".node-details.run") && receipt.bytes % NODE_DETAIL_WIDTH as u64 != 0
+    if receipt.name.ends_with(".node-details.run")
+        && !receipt.bytes.is_multiple_of(NODE_DETAIL_WIDTH as u64)
     {
         return Err(storage("truncated node detail run"));
     }
-    if receipt.name.ends_with(".edge-details.run") && receipt.bytes % EDGE_DETAIL_WIDTH as u64 != 0
+    if receipt.name.ends_with(".edge-details.run")
+        && !receipt.bytes.is_multiple_of(EDGE_DETAIL_WIDTH as u64)
     {
         return Err(storage("truncated edge detail run"));
     }
@@ -3644,8 +3783,9 @@ fn validate_parquet_shape(
     let schema = builder.schema();
     if schema.fields().len() < expected_prefix.fields().len()
         || schema.fields()[..expected_prefix.fields().len()] != expected_prefix.fields()[..]
-        || normalized_schema_digest(schema.as_ref())? != receipt.schema_sha256
-        || builder.metadata().file_metadata().num_rows() != receipt.rows as i64
+        || normalized_schema_digest(schema.as_ref()) != receipt.schema_sha256
+        || builder.metadata().file_metadata().num_rows()
+            != i64::try_from(receipt.rows).map_err(|_| storage("receipt row count exceeds i64"))?
     {
         return Err(storage("Parquet schema or row count differs from receipt"));
     }
@@ -3787,6 +3927,21 @@ fn validate_checkpoint(
         || checkpoint.evidence.peak_run_records > budgets.max_run_records as u64
         || checkpoint.evidence.prior_topology_rows_decoded != 0
         || checkpoint.evidence.current_transitions != 0
+        || checkpoint
+            .node_schema_sha256
+            .as_ref()
+            .is_some_and(|digest| {
+                digest.len() != 64 || !digest.bytes().all(|b| b.is_ascii_hexdigit())
+            })
+        || checkpoint
+            .edge_schema_sha256
+            .as_ref()
+            .is_some_and(|digest| {
+                digest.len() != 64 || !digest.bytes().all(|b| b.is_ascii_hexdigit())
+            })
+        || usize::from(checkpoint.node_schema_sha256.is_some())
+            .saturating_add(usize::from(checkpoint.edge_schema_sha256.is_some()))
+            > budgets.max_schema_groups
     {
         return Err(storage("checkpoint authority or resume parameters changed"));
     }
@@ -4023,7 +4178,8 @@ fn remove_unrecorded_artifact(
         };
         if builder.schema().fields().len() < expected.fields().len()
             || builder.schema().fields()[..expected.fields().len()] != expected.fields()[..]
-            || builder.metadata().file_metadata().num_rows() != rows as i64
+            || builder.metadata().file_metadata().num_rows()
+                != i64::try_from(rows).map_err(|_| storage("artifact row count exceeds i64"))?
         {
             return Err(storage("unrecorded Parquet artifact is not session-owned"));
         }
@@ -4253,6 +4409,10 @@ mod tests {
     }
 
     fn nonempty_project() -> TempDir {
+        nonempty_project_with_nodes(2)
+    }
+
+    fn nonempty_project_with_nodes(node_count: u64) -> TempDir {
         let project = TempDir::new().unwrap();
         std::fs::create_dir_all(project.path().join("topology")).unwrap();
         std::fs::write(
@@ -4267,7 +4427,7 @@ mod tests {
         let tails = RecordBatch::try_new(
             tails_schema.clone(),
             vec![
-                Arc::new(arrow::array::UInt64Array::from(vec![2])),
+                Arc::new(arrow::array::UInt64Array::from(vec![node_count])),
                 Arc::new(arrow::array::UInt64Array::from(vec![1])),
             ],
         )
@@ -4283,11 +4443,47 @@ mod tests {
         crate::uuid_membership::append_uuid_membership_delta(
             project.path(),
             1,
-            &[(Uuid::from_u128(1), 1), (Uuid::from_u128(2), 2)],
+            &(1..=node_count)
+                .map(|value| (Uuid::from_u128(u128::from(value)), value))
+                .collect::<Vec<_>>(),
             &[Uuid::from_u128(100)],
         )
         .unwrap();
         project
+    }
+
+    #[test]
+    fn parent_identity_payload_is_referenced_not_copied_at_1x_and_2x_base() {
+        for (base_nodes, operation) in [(2_u64, 8_110_u128), (4, 8_111)] {
+            let project = nonempty_project_with_nodes(base_nodes);
+            let mut session = GraphConstructionSession::open(
+                project.path(),
+                Uuid::from_u128(operation),
+                1,
+                GraphConstructionBudgets::default(),
+            )
+            .unwrap();
+            session
+                .append(
+                    ConstructionChunkKind::Node,
+                    "delta",
+                    &node_batch(u128::from(base_nodes + 1), 1),
+                )
+                .unwrap();
+            session.seal().unwrap();
+            let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+            let root = project
+                .path()
+                .join(PRIVATE_ROOT)
+                .join(Uuid::from_u128(operation).simple().to_string());
+            assert_eq!(
+                std::fs::metadata(root.join(shape.identities))
+                    .unwrap()
+                    .len(),
+                32
+            );
+            assert_eq!(shape.node_count, base_nodes + 1);
+        }
     }
 
     #[test]
@@ -4376,6 +4572,17 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("conflicting")
+        );
+        assert!(
+            session
+                .append(
+                    ConstructionChunkKind::Node,
+                    "different-chunk-schema",
+                    &batch_with("renamed")
+                )
+                .unwrap_err()
+                .to_string()
+                .contains("stable Arrow schema")
         );
 
         let unsupported = RecordBatch::try_new(
@@ -4530,6 +4737,31 @@ mod tests {
         let slots = online_merge_name_slot_bound(1_000_000, 32);
         assert!(slots <= 31 * 4, "retained slots: {slots}");
         assert!(slots < 1_000_000 / 1_000);
+        assert_eq!(GraphConstructionBudgets::default().max_schema_groups, 2);
+    }
+
+    #[test]
+    fn schema_group_admission_is_constant_and_budgeted() {
+        let root = TempDir::new().unwrap();
+        let mut session = GraphConstructionSession::open(
+            root.path(),
+            Uuid::from_u128(6_999),
+            0,
+            GraphConstructionBudgets {
+                max_schema_groups: 1,
+                ..GraphConstructionBudgets::default()
+            },
+        )
+        .unwrap();
+        session
+            .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 2))
+            .unwrap();
+        let error = session
+            .append(ConstructionChunkKind::Edge, "edges", &edge_batch(100, 1))
+            .unwrap_err();
+        assert!(error.to_string().contains("schema-group budget"));
+        assert!(session.checkpoint.node_schema_sha256.is_some());
+        assert!(session.checkpoint.edge_schema_sha256.is_none());
     }
 
     #[test]
@@ -4732,6 +4964,76 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("endpoint")
+        );
+
+        drop(missing);
+        let operation = Uuid::from_u128(8_104);
+        let mut delta =
+            GraphConstructionSession::open(project.path(), operation, 1, budgets).unwrap();
+        delta
+            .append(ConstructionChunkKind::Node, "one-new", &node_batch(3, 1))
+            .unwrap();
+        delta.seal().unwrap();
+        let shape = delta.shape_canonical_with_cancellation(|| false).unwrap();
+        let operation_root = project
+            .path()
+            .join(PRIVATE_ROOT)
+            .join(operation.simple().to_string());
+        assert_eq!(
+            std::fs::metadata(operation_root.join(&shape.identities))
+                .unwrap()
+                .len(),
+            32
+        );
+        assert!(
+            !operation_root
+                .join("merge-identities-with-base.run")
+                .exists()
+        );
+        assert_eq!(shape.parent_topology_generation, 1);
+        assert!(shape.parent_uuid_manifest_sha256.is_some());
+
+        drop(delta);
+        let mut retained_endpoints =
+            GraphConstructionSession::open(project.path(), Uuid::from_u128(8_105), 1, budgets)
+                .unwrap();
+        retained_endpoints
+            .append(
+                ConstructionChunkKind::Edge,
+                "base-endpoints",
+                &edge(200, 1, 2),
+            )
+            .unwrap();
+        retained_endpoints.seal().unwrap();
+        let shape = retained_endpoints
+            .shape_canonical_with_cancellation(|| false)
+            .unwrap();
+        assert_eq!((shape.node_count, shape.edge_count), (2, 2));
+        let mut resolved = BufReader::new(
+            retained_endpoints
+                .root
+                .open_child_file(OsStr::new(shape.edge_endpoints.as_ref().unwrap()))
+                .unwrap(),
+        );
+        assert_eq!(
+            u64::from_be_bytes(
+                read_fixed::<RESOLVED_ENDPOINT_WIDTH>(&mut resolved)
+                    .unwrap()
+                    .unwrap()[24..32]
+                    .try_into()
+                    .unwrap()
+            ),
+            1
+        );
+        assert_eq!(
+            u64::from_be_bytes(
+                read_fixed::<RESOLVED_ENDPOINT_WIDTH>(&mut resolved)
+                    .unwrap()
+                    .unwrap()[24..32]
+                    .try_into()
+                    .unwrap()
+            ),
+            2
         );
     }
 
@@ -4952,6 +5254,13 @@ mod tests {
         session
             .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 8))
             .unwrap();
+        if std::env::var_os("GF_CONSTRUCTION_SHAPE_CRASH").is_some() {
+            session
+                .append(ConstructionChunkKind::Node, "nodes-2", &node_batch(9, 8))
+                .unwrap();
+            session.seal().unwrap();
+            session.shape_canonical_with_cancellation(|| false).unwrap();
+        }
     }
 
     #[test]
@@ -5024,6 +5333,62 @@ mod tests {
                     .unwrap();
             }
             resumed.seal().unwrap();
+        }
+    }
+
+    #[test]
+    fn shape_inventory_and_evidence_commit_recover_without_double_counting() {
+        let reference_root = TempDir::new().unwrap();
+        let mut reference = GraphConstructionSession::open(
+            reference_root.path(),
+            Uuid::from_u128(600),
+            0,
+            GraphConstructionBudgets::default(),
+        )
+        .unwrap();
+        reference
+            .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 8))
+            .unwrap();
+        reference
+            .append(ConstructionChunkKind::Node, "nodes-2", &node_batch(9, 8))
+            .unwrap();
+        reference.seal().unwrap();
+        reference
+            .shape_canonical_with_cancellation(|| false)
+            .unwrap();
+        let expected = reference.evidence().clone();
+
+        for failpoint in [
+            "shape.fixed.after_install",
+            "shape.fixed_merge.after_install",
+            "shape.row_merge.after_install",
+            "shape.after_complete_inventory",
+            "shape.after_evidence_checkpoint",
+        ] {
+            let root = TempDir::new().unwrap();
+            let status = std::process::Command::new(std::env::current_exe().unwrap())
+                .arg("--exact")
+                .arg("graph_construction::tests::crash_subprocess_helper")
+                .arg("--nocapture")
+                .env("GF_CONSTRUCTION_CRASH_ROOT", root.path())
+                .env("GF_CONSTRUCTION_SHAPE_CRASH", "1")
+                .env(
+                    "GF_CONSTRUCTION_FAILPOINT_COOKIE",
+                    "graphforge-construction-test-v1",
+                )
+                .env("GF_CONSTRUCTION_FAILPOINT", failpoint)
+                .status()
+                .unwrap();
+            assert_eq!(status.code(), Some(86), "{failpoint}");
+            let mut resumed = GraphConstructionSession::open(
+                root.path(),
+                Uuid::from_u128(600),
+                0,
+                GraphConstructionBudgets::default(),
+            )
+            .unwrap();
+            resumed.shape_canonical_with_cancellation(|| false).unwrap();
+            assert_eq!(resumed.evidence(), &expected, "{failpoint}");
         }
     }
 }

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -114,6 +114,8 @@ pub struct GraphConstructionBudgets {
     pub max_catalog_entries: usize,
     /// Maximum decoded Arrow bytes admitted while streaming the parent catalog.
     pub max_catalog_decoded_bytes: usize,
+    /// Maximum UTF-8 identifier bytes retained by the complete runtime catalog.
+    pub max_catalog_identifier_bytes: usize,
 }
 
 impl Default for GraphConstructionBudgets {
@@ -128,6 +130,7 @@ impl Default for GraphConstructionBudgets {
             max_property_columns: 4_096,
             max_catalog_entries: 1_000_000,
             max_catalog_decoded_bytes: 256 << 20,
+            max_catalog_identifier_bytes: 64 << 20,
         }
     }
 }
@@ -143,6 +146,7 @@ impl GraphConstructionBudgets {
             || self.max_property_columns == 0
             || self.max_catalog_entries == 0
             || self.max_catalog_decoded_bytes == 0
+            || self.max_catalog_identifier_bytes == 0
         {
             return Err(storage("invalid construction budgets"));
         }
@@ -194,6 +198,14 @@ pub struct GraphConstructionEvidence {
     pub shaped_output_authentication_bytes: u64,
     /// Bounded reads used to construct the shaped-output inventory.
     pub shaped_output_authentication_operations: u64,
+    /// Bytes read while validating exact idempotent replays.
+    pub replay_validation_read_bytes: u64,
+    /// Read operations while validating exact idempotent replays.
+    pub replay_validation_read_operations: u64,
+    /// Bytes read while revalidating sealed inputs for canonical shaping.
+    pub shape_input_validation_read_bytes: u64,
+    /// Read operations while revalidating sealed inputs for canonical shaping.
+    pub shape_input_validation_read_operations: u64,
     /// Fixed-width run records.
     pub run_records: u64,
     /// Largest retained Arrow row window.
@@ -239,6 +251,12 @@ pub struct GraphConstructionEvidence {
     pub peak_merge_name_slots: u64,
     /// Largest number of endpoint-window names retained by its online merge.
     pub peak_resolved_endpoint_name_slots: u64,
+    /// Largest complete runtime-catalog entry count retained during shaping.
+    pub peak_catalog_entries: u64,
+    /// Largest complete runtime-catalog identifier payload retained during shaping.
+    pub peak_catalog_identifier_bytes: u64,
+    /// Largest decoded catalog Arrow batch retained during one streaming pass.
+    pub peak_catalog_decoded_batch_bytes: u64,
     /// File and directory durability barriers completed during shaping.
     pub merge_fsync_operations: u64,
     /// Bytes returned by instrumented Parquet range/sequential reads in shaping.
@@ -524,6 +542,9 @@ impl GraphConstructionSession {
                     authentication_read_operations: base_work.authentication_blocks,
                     parent_catalog_read_bytes: parent_catalog_work.bytes,
                     parent_catalog_read_operations: parent_catalog_work.operations,
+                    peak_catalog_entries: parent_catalog.entry_count() as u64,
+                    peak_catalog_identifier_bytes: parent_catalog.retained_identifier_bytes()
+                        as u64,
                     ..GraphConstructionEvidence::default()
                 };
                 let initial = Checkpoint {
@@ -679,7 +700,17 @@ impl GraphConstructionSession {
                 && receipt.input_sha256 == input_sha256
                 && receipt.schema_sha256 == schema_sha256
             {
-                validate_receipt_artifacts(&self.root, &receipt)?;
+                let work = validate_receipt_artifacts(&self.root, &receipt)?;
+                self.checkpoint.evidence.replay_validation_read_bytes = self
+                    .checkpoint
+                    .evidence
+                    .replay_validation_read_bytes
+                    .saturating_add(work.bytes);
+                self.checkpoint.evidence.replay_validation_read_operations = self
+                    .checkpoint
+                    .evidence
+                    .replay_validation_read_operations
+                    .saturating_add(work.operations);
                 self.checkpoint.evidence.replayed_chunks =
                     self.checkpoint.evidence.replayed_chunks.saturating_add(1);
                 replace_control(&self.root, CHECKPOINT, &self.checkpoint)?;
@@ -832,15 +863,9 @@ impl GraphConstructionSession {
             if receipt.prior_receipt_sha256 != prior_digest {
                 return Err(storage("receipt journal chain is discontinuous"));
             }
-            for artifact in [&receipt.parquet, &receipt.identities, &receipt.details]
-                .into_iter()
-                .chain(receipt.endpoints.iter())
-            {
-                let work = authenticate_artifact(&self.root, artifact)?;
-                read_bytes = read_bytes.saturating_add(work.bytes);
-                read_operations = read_operations.saturating_add(work.operations);
-            }
-            validate_parquet_shape(&self.root, &receipt)?;
+            let work = validate_receipt_artifacts(&self.root, &receipt)?;
+            read_bytes = read_bytes.saturating_add(work.bytes);
+            read_operations = read_operations.saturating_add(work.operations);
             let body = serde_json::to_vec(&receipt).map_err(storage)?;
             prior_digest = Some(sha256(&body));
         }
@@ -907,7 +932,19 @@ impl GraphConstructionSession {
         for sequence in 0..self.checkpoint.next_sequence {
             reject_cancelled(&mut cancelled)?;
             let receipt = self.read_receipt(sequence)?;
-            validate_receipt_artifacts(&self.root, &receipt)?;
+            let work = validate_receipt_artifacts(&self.root, &receipt)?;
+            self.checkpoint.evidence.shape_input_validation_read_bytes = self
+                .checkpoint
+                .evidence
+                .shape_input_validation_read_bytes
+                .saturating_add(work.bytes);
+            self.checkpoint
+                .evidence
+                .shape_input_validation_read_operations = self
+                .checkpoint
+                .evidence
+                .shape_input_validation_read_operations
+                .saturating_add(work.operations);
             let kind = u8::from(receipt.kind == ConstructionChunkKind::Edge);
             catalog_authority.update([kind]);
             catalog_authority.update(receipt.schema_sha256.as_bytes());
@@ -1109,6 +1146,7 @@ impl GraphConstructionSession {
             &node_rows,
             &edge_rows,
             self.checkpoint.session_now_micros,
+            self.checkpoint.budgets,
             &mut cancelled,
             &mut self.checkpoint.evidence,
         )?;
@@ -2850,15 +2888,30 @@ impl RowMergeAccumulator {
     }
 }
 
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)] // One bounded streamed catalog pass; admission must surround each intern.
 fn build_runtime_catalog(
     mut catalog: RuntimeCatalog,
     root: &StableDirectory,
     node_rows: &[String],
     edge_rows: &[String],
     now_micros: i64,
+    budgets: GraphConstructionBudgets,
     cancelled: &mut impl FnMut() -> bool,
     evidence: &mut GraphConstructionEvidence,
 ) -> Result<String, GfError> {
+    let mut catalog_entries = catalog.entry_count();
+    let mut identifier_bytes = catalog.retained_identifier_bytes();
+    if catalog_entries > budgets.max_catalog_entries
+        || identifier_bytes > budgets.max_catalog_identifier_bytes
+    {
+        return Err(storage(
+            "runtime catalog exceeds construction admission budget",
+        ));
+    }
+    evidence.peak_catalog_entries = evidence.peak_catalog_entries.max(catalog_entries as u64);
+    evidence.peak_catalog_identifier_bytes = evidence
+        .peak_catalog_identifier_bytes
+        .max(identifier_bytes as u64);
     for (kind, names) in [
         (ConstructionChunkKind::Node, node_rows),
         (ConstructionChunkKind::Edge, edge_rows),
@@ -2877,6 +2930,13 @@ fn build_runtime_catalog(
             for batch in reader {
                 reject_cancelled(cancelled)?;
                 let batch = batch.map_err(storage)?;
+                let decoded_bytes = batch.get_array_memory_size();
+                if decoded_bytes > budgets.max_catalog_decoded_bytes {
+                    return Err(storage("runtime catalog decoded batch budget exhausted"));
+                }
+                evidence.peak_catalog_decoded_batch_bytes = evidence
+                    .peak_catalog_decoded_batch_bytes
+                    .max(decoded_bytes as u64);
                 let owner = batch
                     .column(1)
                     .as_any()
@@ -2891,14 +2951,38 @@ fn build_runtime_catalog(
                     let owner_name = owner.value(row);
                     match kind {
                         ConstructionChunkKind::Node => {
+                            admit_catalog_identifier(
+                                !catalog.contains_entity_type(owner_name),
+                                owner_name.len(),
+                                &mut catalog_entries,
+                                &mut identifier_bytes,
+                                budgets,
+                                evidence,
+                            )?;
                             catalog.intern_label_at(owner_name, now_micros);
                         }
                         ConstructionChunkKind::Edge => {
+                            admit_catalog_identifier(
+                                !catalog.contains_relation_type(owner_name),
+                                owner_name.len(),
+                                &mut catalog_entries,
+                                &mut identifier_bytes,
+                                budgets,
+                                evidence,
+                            )?;
                             catalog.intern_relation_type_at(owner_name, now_micros);
                         }
                     }
                     for (offset, field) in batch.schema().fields()[required..].iter().enumerate() {
                         if !batch.column(required + offset).is_null(row) {
+                            admit_catalog_identifier(
+                                !catalog.contains_property(field.name(), Some(owner_name)),
+                                field.name().len().saturating_add(owner_name.len()),
+                                &mut catalog_entries,
+                                &mut identifier_bytes,
+                                budgets,
+                                evidence,
+                            )?;
                             catalog.intern_property_at(field.name(), Some(owner_name), now_micros);
                         }
                     }
@@ -2918,6 +3002,38 @@ fn build_runtime_catalog(
         .saturating_add(receipt.write_operations);
     account_sequential_write(receipt.bytes, evidence);
     Ok(output.to_owned())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn admit_catalog_identifier(
+    is_new: bool,
+    added_identifier_bytes: usize,
+    entries: &mut usize,
+    identifier_bytes: &mut usize,
+    budgets: GraphConstructionBudgets,
+    evidence: &mut GraphConstructionEvidence,
+) -> Result<(), GfError> {
+    if !is_new {
+        return Ok(());
+    }
+    let next_entries = entries
+        .checked_add(1)
+        .ok_or_else(|| storage("runtime catalog entry count overflow"))?;
+    let next_identifier_bytes = identifier_bytes
+        .checked_add(added_identifier_bytes)
+        .ok_or_else(|| storage("runtime catalog identifier byte count overflow"))?;
+    if next_entries > budgets.max_catalog_entries
+        || next_identifier_bytes > budgets.max_catalog_identifier_bytes
+    {
+        return Err(storage("runtime catalog admission budget exhausted"));
+    }
+    *entries = next_entries;
+    *identifier_bytes = next_identifier_bytes;
+    evidence.peak_catalog_entries = evidence.peak_catalog_entries.max(next_entries as u64);
+    evidence.peak_catalog_identifier_bytes = evidence
+        .peak_catalog_identifier_bytes
+        .max(next_identifier_bytes as u64);
+    Ok(())
 }
 
 fn load_parent_runtime_catalog(
@@ -2988,6 +3104,11 @@ fn load_parent_runtime_catalog(
             return Err(storage("parent runtime catalog admission budget exhausted"));
         }
         catalog.extend_from_record_batch(&batch).map_err(storage)?;
+        if catalog.retained_identifier_bytes() > budgets.max_catalog_identifier_bytes {
+            return Err(storage(
+                "parent runtime catalog identifier budget exhausted",
+            ));
+        }
     }
     work.bytes = work
         .bytes
@@ -3836,21 +3957,26 @@ fn validate_receipt_semantics(
 fn validate_receipt_artifacts(
     root: &StableDirectory,
     receipt: &ConstructionChunkReceipt,
-) -> Result<(), GfError> {
+) -> Result<ReadWork, GfError> {
+    let mut work = ReadWork::default();
     for artifact in [&receipt.parquet, &receipt.identities, &receipt.details]
         .into_iter()
         .chain(receipt.endpoints.iter())
     {
-        authenticate_artifact(root, artifact)?;
+        let artifact_work = authenticate_artifact(root, artifact)?;
+        work.bytes = work.bytes.saturating_add(artifact_work.bytes);
+        work.operations = work.operations.saturating_add(artifact_work.operations);
     }
-    validate_parquet_shape(root, receipt)?;
-    Ok(())
+    let parquet_work = validate_parquet_shape(root, receipt)?;
+    work.bytes = work.bytes.saturating_add(parquet_work.bytes);
+    work.operations = work.operations.saturating_add(parquet_work.operations);
+    Ok(work)
 }
 
 fn validate_parquet_shape(
     root: &StableDirectory,
     receipt: &ConstructionChunkReceipt,
-) -> Result<(), GfError> {
+) -> Result<ReadWork, GfError> {
     let file = root
         .open_child_file(OsStr::new(&receipt.parquet.name))
         .map_err(storage)?;
@@ -3861,7 +3987,12 @@ fn validate_parquet_shape(
     {
         return Err(storage("Parquet identity changed during schema reopen"));
     }
-    let builder = ParquetRecordBatchReaderBuilder::try_new(file).map_err(storage)?;
+    let counter = IoCounter::default();
+    let builder = ParquetRecordBatchReaderBuilder::try_new(CountingChunkReader {
+        file,
+        counter: counter.clone(),
+    })
+    .map_err(storage)?;
     let expected_prefix = match receipt.kind {
         ConstructionChunkKind::Node => &*CONSTRUCTION_NODE_SCHEMA,
         ConstructionChunkKind::Edge => &*CONSTRUCTION_EDGE_SCHEMA,
@@ -3893,7 +4024,10 @@ fn validate_parquet_shape(
             previous = Some(value);
         }
     }
-    Ok(())
+    Ok(ReadWork {
+        bytes: counter.bytes.load(Ordering::Relaxed),
+        operations: counter.operations.load(Ordering::Relaxed),
+    })
 }
 
 fn validate_intent(intent: &ChunkIntent, checkpoint: &Checkpoint) -> Result<(), GfError> {
@@ -4462,6 +4596,20 @@ mod tests {
         .unwrap()
     }
 
+    fn distinct_label_batch(first: u128, rows: usize) -> RecordBatch {
+        let uuids = (first..first + rows as u128)
+            .map(u128::to_be_bytes)
+            .collect::<Vec<_>>();
+        let labels = (first..first + rows as u128)
+            .map(|index| format!("Label{index:08}"))
+            .collect::<Vec<_>>();
+        RecordBatch::try_new(
+            CONSTRUCTION_NODE_SCHEMA.clone(),
+            vec![Arc::new(fixed(&uuids)), Arc::new(StringArray::from(labels))],
+        )
+        .unwrap()
+    }
+
     fn edge_batch(first: u128, rows: usize) -> RecordBatch {
         let edges = (first..first + rows as u128)
             .map(u128::to_be_bytes)
@@ -4740,6 +4888,7 @@ mod tests {
             &["nodes.parquet".to_owned()],
             &[],
             42,
+            GraphConstructionBudgets::default(),
             &mut || false,
             &mut evidence,
         )
@@ -5371,11 +5520,91 @@ mod tests {
         );
         assert_eq!(session.accepted_chunks(), 1);
         assert_eq!(session.evidence().replayed_chunks, 1);
+        assert!(session.evidence().replay_validation_read_bytes > 0);
+        assert!(session.evidence().replay_validation_read_operations > 0);
         assert!(
             session
                 .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 9))
                 .is_err()
         );
+    }
+
+    #[test]
+    fn staged_catalog_cardinality_is_bounded_at_one_and_two_windows() {
+        for windows in [1_usize, 2] {
+            let root = TempDir::new().unwrap();
+            let rows = windows * 8;
+            let expected_identifier_bytes = rows * "Label00000000".len();
+            let budgets = GraphConstructionBudgets {
+                max_batch_rows: 8,
+                max_run_records: 32,
+                max_catalog_entries: rows,
+                max_catalog_identifier_bytes: expected_identifier_bytes,
+                ..GraphConstructionBudgets::default()
+            };
+            let mut session = GraphConstructionSession::open(
+                root.path(),
+                Uuid::from_u128(8_000 + rows as u128),
+                0,
+                budgets,
+            )
+            .unwrap();
+            for window in 0..windows {
+                session
+                    .append(
+                        ConstructionChunkKind::Node,
+                        &format!("nodes-{window}"),
+                        &distinct_label_batch(1 + (window * 8) as u128, 8),
+                    )
+                    .unwrap();
+            }
+            session.seal().unwrap();
+            session.shape_canonical_with_cancellation(|| false).unwrap();
+            assert_eq!(session.evidence().peak_catalog_entries, rows as u64);
+            assert_eq!(
+                session.evidence().peak_catalog_identifier_bytes,
+                expected_identifier_bytes as u64
+            );
+            assert!(session.evidence().peak_catalog_decoded_batch_bytes > 0);
+            assert!(session.evidence().shape_input_validation_read_bytes > 0);
+        }
+    }
+
+    #[test]
+    fn staged_catalog_rejects_entry_and_identifier_overflow_before_interning() {
+        for budgets in [
+            GraphConstructionBudgets {
+                max_batch_rows: 8,
+                max_run_records: 32,
+                max_catalog_entries: 7,
+                ..GraphConstructionBudgets::default()
+            },
+            GraphConstructionBudgets {
+                max_batch_rows: 8,
+                max_run_records: 32,
+                max_catalog_identifier_bytes: 7 * "Label00000000".len(),
+                ..GraphConstructionBudgets::default()
+            },
+        ] {
+            let root = TempDir::new().unwrap();
+            let mut session =
+                GraphConstructionSession::open(root.path(), Uuid::new_v4(), 0, budgets).unwrap();
+            session
+                .append(
+                    ConstructionChunkKind::Node,
+                    "nodes",
+                    &distinct_label_batch(1, 8),
+                )
+                .unwrap();
+            session.seal().unwrap();
+            assert!(
+                session
+                    .shape_canonical_with_cancellation(|| false)
+                    .unwrap_err()
+                    .to_string()
+                    .contains("catalog admission budget")
+            );
+        }
     }
 
     #[test]

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -4525,10 +4525,12 @@ fn account_probe_work(
 ) {
     evidence.retained_probe_read_bytes = evidence
         .retained_probe_read_bytes
-        .saturating_add(work.read_bytes);
+        .saturating_add(work.identity_bytes_read)
+        .saturating_add(work.surrogate_bytes_read);
     evidence.retained_probe_block_loads = evidence
         .retained_probe_block_loads
-        .saturating_add(work.file_seeks);
+        .saturating_add(work.identity_blocks_read)
+        .saturating_add(work.surrogate_blocks_read);
 }
 
 #[derive(Clone, Copy, Debug, Default)]

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -54,6 +54,34 @@ const NODE_DETAIL_WIDTH: usize = 272;
 const EDGE_DETAIL_WIDTH: usize = 304;
 const BASE_IDENTITY_WIDTH: usize = 32;
 
+const fn durable_lifecycle_mode() -> crate::filesystem_admission::ProjectLifecycleMode {
+    crate::filesystem_admission::ProjectLifecycleMode::Durable
+}
+
+fn resume_parent_topology_generation(
+    project_dir: &Path,
+    operation_uuid: Uuid,
+) -> Result<u64, GfError> {
+    let project = StableDirectory::open(project_dir).map_err(storage)?;
+    let private = project
+        .open_child_directory(OsStr::new(PRIVATE_ROOT))
+        .map_err(storage)?;
+    let operation = private
+        .open_child_directory(OsStr::new(&operation_uuid.simple().to_string()))
+        .map_err(storage)?;
+    let mut checkpoint_file = operation
+        .open_child_file(OsStr::new(CHECKPOINT))
+        .map_err(storage)?;
+    let checkpoint: Checkpoint = decode_bounded(&mut checkpoint_file)?;
+    if checkpoint.operation_uuid != operation_uuid
+        || !checkpoint.project_identity.matches(project.identity())
+        || !checkpoint.session_identity.matches(operation.identity())
+    {
+        return Err(storage("construction resume identity changed"));
+    }
+    Ok(checkpoint.parent_topology_generation)
+}
+
 /// Storage-normalized node input. API validation resolves nullable/generated
 /// identities before this boundary; trailing columns are normalized properties.
 pub static CONSTRUCTION_NODE_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
@@ -535,6 +563,8 @@ struct Checkpoint {
     parent_generation_uuid: Uuid,
     parent_generation_manifest_sha256: String,
     ontology_mode: graphforge_core::OntologyMode,
+    #[serde(default = "durable_lifecycle_mode")]
+    lifecycle_mode: crate::filesystem_admission::ProjectLifecycleMode,
     semantic_authority_sha256: Option<String>,
     /// One authority-bound timestamp used by every catalog/topology row produced
     /// by this operation. Reopen never consults the wall clock again.
@@ -848,6 +878,7 @@ impl GraphConstructionSession {
     /// Install the authenticated canonical inventory into the project CAS and
     /// publish exactly one project generation from the session's pinned parent.
     /// The CAS lease remains held through the sole `CURRENT` replacement.
+    #[allow(clippy::too_many_lines)]
     pub fn publish_canonical(
         &mut self,
         encoding: &GraphConstructionEncoding,
@@ -900,7 +931,7 @@ impl GraphConstructionSession {
 
         let admission = crate::filesystem_admission::admit_project_lifecycle(
             &self.project_path,
-            crate::filesystem_admission::ProjectLifecycleMode::Durable,
+            self.checkpoint.lifecycle_mode,
             crate::filesystem_admission::ProjectRootRequirement::Existing,
         )?;
         admission.revalidate_identity()?;
@@ -1059,13 +1090,105 @@ impl GraphConstructionSession {
                 "strict or advisory construction requires pinned semantic authority",
             ));
         }
+        Self::open_with_mode_and_lifecycle(
+            project_dir,
+            operation_uuid,
+            parent_topology_generation,
+            ontology_mode,
+            budgets,
+            crate::filesystem_admission::ProjectLifecycleMode::Durable,
+        )
+    }
+
+    /// Open an exploratory construction under the facade's admitted lifecycle.
+    pub fn open_with_mode_and_lifecycle(
+        project_dir: &Path,
+        operation_uuid: Uuid,
+        parent_topology_generation: u64,
+        ontology_mode: graphforge_core::OntologyMode,
+        budgets: GraphConstructionBudgets,
+        lifecycle_mode: crate::filesystem_admission::ProjectLifecycleMode,
+    ) -> Result<Self, GfError> {
+        if ontology_mode != graphforge_core::OntologyMode::Exploratory {
+            return Err(storage(
+                "strict or advisory construction requires pinned semantic authority",
+            ));
+        }
+        Self::open_with_mode_and_lifecycle_from_graph(
+            project_dir,
+            project_dir,
+            operation_uuid,
+            parent_topology_generation,
+            ontology_mode,
+            budgets,
+            lifecycle_mode,
+        )
+    }
+
+    /// Open using a separately materialized authenticated graph workspace.
+    pub fn open_with_mode_and_lifecycle_from_graph(
+        project_dir: &Path,
+        graph_source_dir: &Path,
+        operation_uuid: Uuid,
+        parent_topology_generation: u64,
+        ontology_mode: graphforge_core::OntologyMode,
+        budgets: GraphConstructionBudgets,
+        lifecycle_mode: crate::filesystem_admission::ProjectLifecycleMode,
+    ) -> Result<Self, GfError> {
+        if ontology_mode != graphforge_core::OntologyMode::Exploratory {
+            return Err(storage(
+                "strict or advisory construction requires pinned semantic authority",
+            ));
+        }
         Self::open_internal(
             project_dir,
+            graph_source_dir,
             operation_uuid,
             parent_topology_generation,
             ontology_mode,
             None,
             budgets,
+            lifecycle_mode,
+        )
+    }
+
+    /// Resume an exploratory session using its authenticated pinned parent.
+    pub fn resume_with_mode_and_lifecycle(
+        project_dir: &Path,
+        operation_uuid: Uuid,
+        ontology_mode: graphforge_core::OntologyMode,
+        budgets: GraphConstructionBudgets,
+        lifecycle_mode: crate::filesystem_admission::ProjectLifecycleMode,
+    ) -> Result<Self, GfError> {
+        Self::resume_with_mode_and_lifecycle_from_graph(
+            project_dir,
+            project_dir,
+            operation_uuid,
+            ontology_mode,
+            budgets,
+            lifecycle_mode,
+        )
+    }
+
+    /// Resume using a separately materialized authenticated graph workspace.
+    pub fn resume_with_mode_and_lifecycle_from_graph(
+        project_dir: &Path,
+        graph_source_dir: &Path,
+        operation_uuid: Uuid,
+        ontology_mode: graphforge_core::OntologyMode,
+        budgets: GraphConstructionBudgets,
+        lifecycle_mode: crate::filesystem_admission::ProjectLifecycleMode,
+    ) -> Result<Self, GfError> {
+        let parent_topology_generation =
+            resume_parent_topology_generation(project_dir, operation_uuid)?;
+        Self::open_with_mode_and_lifecycle_from_graph(
+            project_dir,
+            graph_source_dir,
+            operation_uuid,
+            parent_topology_generation,
+            ontology_mode,
+            budgets,
+            lifecycle_mode,
         )
     }
 
@@ -1078,24 +1201,126 @@ impl GraphConstructionSession {
         budgets: GraphConstructionBudgets,
     ) -> Result<Self, GfError> {
         authority.validate()?;
-        Self::open_internal(
+        Self::open_with_semantic_authority_and_lifecycle(
             project_dir,
             operation_uuid,
             parent_topology_generation,
             authority.mode(),
-            Some(authority),
             budgets,
+            authority,
+            crate::filesystem_admission::ProjectLifecycleMode::Durable,
         )
     }
 
-    #[allow(clippy::too_many_lines)]
+    /// Open a semantically bound construction under the admitted lifecycle.
+    pub fn open_with_semantic_authority_and_lifecycle(
+        project_dir: &Path,
+        operation_uuid: Uuid,
+        parent_topology_generation: u64,
+        ontology_mode: graphforge_core::OntologyMode,
+        budgets: GraphConstructionBudgets,
+        authority: ConstructionSemanticAuthority,
+        lifecycle_mode: crate::filesystem_admission::ProjectLifecycleMode,
+    ) -> Result<Self, GfError> {
+        authority.validate()?;
+        if authority.mode() != ontology_mode {
+            return Err(storage("construction semantic authority mode changed"));
+        }
+        Self::open_with_semantic_authority_and_lifecycle_from_graph(
+            project_dir,
+            project_dir,
+            operation_uuid,
+            parent_topology_generation,
+            ontology_mode,
+            budgets,
+            authority,
+            lifecycle_mode,
+        )
+    }
+
+    /// Open a semantically bound session from a materialized graph workspace.
+    #[allow(clippy::too_many_arguments)]
+    pub fn open_with_semantic_authority_and_lifecycle_from_graph(
+        project_dir: &Path,
+        graph_source_dir: &Path,
+        operation_uuid: Uuid,
+        parent_topology_generation: u64,
+        ontology_mode: graphforge_core::OntologyMode,
+        budgets: GraphConstructionBudgets,
+        authority: ConstructionSemanticAuthority,
+        lifecycle_mode: crate::filesystem_admission::ProjectLifecycleMode,
+    ) -> Result<Self, GfError> {
+        authority.validate()?;
+        if authority.mode() != ontology_mode {
+            return Err(storage("construction semantic authority mode changed"));
+        }
+        Self::open_internal(
+            project_dir,
+            graph_source_dir,
+            operation_uuid,
+            parent_topology_generation,
+            ontology_mode,
+            Some(authority),
+            budgets,
+            lifecycle_mode,
+        )
+    }
+
+    /// Resume a semantically bound session using its authenticated pinned parent.
+    pub fn resume_with_semantic_authority_and_lifecycle(
+        project_dir: &Path,
+        operation_uuid: Uuid,
+        ontology_mode: graphforge_core::OntologyMode,
+        budgets: GraphConstructionBudgets,
+        authority: ConstructionSemanticAuthority,
+        lifecycle_mode: crate::filesystem_admission::ProjectLifecycleMode,
+    ) -> Result<Self, GfError> {
+        Self::resume_with_semantic_authority_and_lifecycle_from_graph(
+            project_dir,
+            project_dir,
+            operation_uuid,
+            ontology_mode,
+            budgets,
+            authority,
+            lifecycle_mode,
+        )
+    }
+
+    /// Resume a semantically bound session from a materialized graph workspace.
+    #[allow(clippy::too_many_arguments)]
+    pub fn resume_with_semantic_authority_and_lifecycle_from_graph(
+        project_dir: &Path,
+        graph_source_dir: &Path,
+        operation_uuid: Uuid,
+        ontology_mode: graphforge_core::OntologyMode,
+        budgets: GraphConstructionBudgets,
+        authority: ConstructionSemanticAuthority,
+        lifecycle_mode: crate::filesystem_admission::ProjectLifecycleMode,
+    ) -> Result<Self, GfError> {
+        let parent_topology_generation =
+            resume_parent_topology_generation(project_dir, operation_uuid)?;
+        Self::open_with_semantic_authority_and_lifecycle_from_graph(
+            project_dir,
+            graph_source_dir,
+            operation_uuid,
+            parent_topology_generation,
+            ontology_mode,
+            budgets,
+            authority,
+            lifecycle_mode,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
     fn open_internal(
         project_dir: &Path,
+        graph_source_dir: &Path,
         operation_uuid: Uuid,
         parent_topology_generation: u64,
         ontology_mode: graphforge_core::OntologyMode,
         semantic_authority: Option<ConstructionSemanticAuthority>,
         budgets: GraphConstructionBudgets,
+        lifecycle_mode: crate::filesystem_admission::ProjectLifecycleMode,
     ) -> Result<Self, GfError> {
         let budgets = budgets.validate()?;
         let semantic_authority_sha256 = semantic_authority
@@ -1182,7 +1407,7 @@ impl GraphConstructionSession {
                         | ConstructionPublicationState::Published
                 )
             )
-        }) && crate::read_topology_generation(project_dir)? != parent_topology_generation
+        }) && crate::read_topology_generation(graph_source_dir)? != parent_topology_generation
         {
             return Err(storage(
                 "requested parent generation is not current at session open",
@@ -1209,10 +1434,10 @@ impl GraphConstructionSession {
             (None, UuidConstructionSnapshotWork::default())
         } else {
             let mut snapshot = AuthenticatedUuidIndexSnapshot::open_at_generation(
-                project_dir,
+                graph_source_dir,
                 parent_topology_generation,
             )?;
-            let max_node_surrogate = crate::writer::read_surrogate_tails(project_dir)?
+            let max_node_surrogate = crate::writer::read_surrogate_tails(graph_source_dir)?
                 .ok_or_else(|| storage("nonempty parent lacks surrogate tails"))?
                 .0;
             let (authentication_bytes, authentication_blocks) = snapshot.take_authentication_work();
@@ -1236,7 +1461,8 @@ impl GraphConstructionSession {
                 ReadWork::default(),
             )
         } else {
-            load_parent_runtime_catalog(&project, parent_topology_generation, budgets)?
+            let graph_source = StableDirectory::open(graph_source_dir).map_err(storage)?;
+            load_parent_runtime_catalog(&graph_source, parent_topology_generation, budgets)?
         };
         let checkpoint = if let Some(checkpoint) = recovered_checkpoint {
             checkpoint
@@ -1259,6 +1485,7 @@ impl GraphConstructionSession {
                 parent_generation_uuid,
                 parent_generation_manifest_sha256: parent_generation_manifest_sha256.clone(),
                 ontology_mode,
+                lifecycle_mode,
                 semantic_authority_sha256: semantic_authority_sha256.clone(),
                 session_now_micros: SystemTime::now()
                     .duration_since(UNIX_EPOCH)
@@ -1291,6 +1518,7 @@ impl GraphConstructionSession {
             session_identity,
             parent_topology_generation,
             ontology_mode,
+            lifecycle_mode,
             semantic_authority_sha256.as_deref(),
             budgets,
             parent_catalog_sha256.as_deref(),
@@ -1311,6 +1539,31 @@ impl GraphConstructionSession {
         session.recover_intent()?;
         session.revalidate_authority()?;
         Ok(session)
+    }
+
+    /// Reopen or create the canonical encoded inventory for a sealed session.
+    pub fn prepare_canonical_encoding(
+        &mut self,
+        generation: u64,
+    ) -> Result<GraphConstructionEncoding, GfError> {
+        self.revalidate_authority()?;
+        if self.checkpoint.state != GraphConstructionState::Sealed {
+            return Err(storage("only a sealed session can be prepared"));
+        }
+        if self.checkpoint.encoding_inventory_sha256.is_some() {
+            let encoded = self
+                .root
+                .open_child_directory(OsStr::new("encoded-v1"))
+                .map_err(storage)?;
+            let inventory = crate::graph_construction_encoding::read_inventory(&encoded)?
+                .ok_or_else(|| storage("encoded inventory is absent"))?;
+            if inventory.generation != generation {
+                return Err(storage("encoded inventory generation changed"));
+            }
+            return Ok(inventory);
+        }
+        let shape = self.shape_canonical_with_cancellation(|| false)?;
+        self.encode_canonical(&shape, generation)
     }
 
     #[cfg(test)]
@@ -5126,6 +5379,7 @@ fn validate_checkpoint(
     session: FileIdentity,
     generation: u64,
     ontology_mode: graphforge_core::OntologyMode,
+    lifecycle_mode: crate::filesystem_admission::ProjectLifecycleMode,
     semantic_authority_sha256: Option<&str>,
     budgets: GraphConstructionBudgets,
     parent_catalog_sha256: Option<&str>,
@@ -5146,6 +5400,7 @@ fn validate_checkpoint(
         )
         .is_err()
         || checkpoint.ontology_mode != ontology_mode
+        || checkpoint.lifecycle_mode != lifecycle_mode
         || checkpoint.semantic_authority_sha256.as_deref() != semantic_authority_sha256
         || checkpoint
             .semantic_authority_sha256

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -12,6 +12,7 @@ use std::ffi::{OsStr, OsString};
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{LazyLock, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -26,16 +27,17 @@ use graphforge_filesystem::{FileIdentity, StableDirectory, file_identity, file_l
 use graphforge_ir::RuntimeCatalog;
 use parquet::arrow::ArrowWriter;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use parquet::file::reader::{ChunkReader, Length};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::uuid_membership::{
     ConstructionUuidIdentity, UuidConstructionSnapshot, UuidConstructionSnapshotWork,
-    open_uuid_construction_snapshot,
+    pin_uuid_construction_snapshot,
 };
 
-const FORMAT_VERSION: u32 = 3;
+const FORMAT_VERSION: u32 = 4;
 const PRIVATE_ROOT: &str = ".graphforge-construction";
 const CHECKPOINT: &str = "checkpoint.json";
 const INTENT: &str = "intent.json";
@@ -48,7 +50,6 @@ const RESOLVED_ENDPOINT_WIDTH: usize = 32;
 const NODE_DETAIL_WIDTH: usize = 272;
 const EDGE_DETAIL_WIDTH: usize = 304;
 const BASE_IDENTITY_WIDTH: usize = 32;
-const BASE_IDENTITIES: &str = "base-identities.run";
 
 /// Storage-normalized node input. API validation resolves nullable/generated
 /// identities before this boundary; trailing columns are normalized properties.
@@ -159,6 +160,8 @@ pub struct GraphConstructionEvidence {
     pub write_bytes: u64,
     /// Actual submissions by measured immutable-artifact writers.
     pub write_operations: u64,
+    /// File and directory durability barriers completed for accepted artifacts.
+    pub fsync_operations: u64,
     /// Bytes read for independent authentication.
     pub authentication_read_bytes: u64,
     /// Actual bounded authentication reads.
@@ -197,6 +200,23 @@ pub struct GraphConstructionEvidence {
     pub merge_passes: u64,
     /// Largest measured temporary merge footprint.
     pub peak_merge_temporary_bytes: u64,
+    /// Largest explicitly retained application buffer set during append. This
+    /// includes input Arrow buffers, extracted fixed runs, sorted Arrow output,
+    /// and a conservative full-batch Parquet encoding window; allocator/RSS is
+    /// intentionally measured by the outer process probe.
+    pub peak_accounted_live_bytes: u64,
+    /// Largest number of merge-source names retained by the online scheduler.
+    pub peak_merge_name_slots: u64,
+    /// File and directory durability barriers completed during shaping.
+    pub merge_fsync_operations: u64,
+    /// Bytes returned by instrumented Parquet range/sequential reads in shaping.
+    pub parquet_read_bytes: u64,
+    /// Instrumented Parquet read calls in shaping.
+    pub parquet_read_operations: u64,
+    /// Bytes submitted by instrumented Parquet writers in shaping.
+    pub parquet_write_bytes: u64,
+    /// Instrumented Parquet writer submissions in shaping.
+    pub parquet_write_operations: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -258,6 +278,7 @@ struct ArtifactReceipt {
     sha256: String,
     identity: IdentityRecord,
     write_operations: u64,
+    fsync_operations: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -284,6 +305,7 @@ pub struct ConstructionChunkReceipt {
     pub schema_sha256: String,
     /// Fixed-width run records.
     pub run_records: u64,
+    accounted_live_bytes: u64,
     parquet: ArtifactReceipt,
     identities: ArtifactReceipt,
     endpoints: Option<ArtifactReceipt>,
@@ -305,7 +327,8 @@ struct Checkpoint {
     next_sequence: u64,
     saw_edge: bool,
     last_receipt_sha256: Option<String>,
-    base_identities: Option<ArtifactReceipt>,
+    has_base_snapshot: bool,
+    parent_catalog_sha256: Option<String>,
     base_work: UuidConstructionSnapshotWork,
     evidence: GraphConstructionEvidence,
 }
@@ -327,6 +350,7 @@ struct ChunkIntent {
     parent_topology_generation: u64,
     prior_receipt_sha256: Option<String>,
     run_records: u64,
+    accounted_live_bytes: u64,
     parquet: Option<ArtifactReceipt>,
     identities: Option<ArtifactReceipt>,
     endpoints: Option<ArtifactReceipt>,
@@ -381,6 +405,7 @@ pub struct GraphConstructionSession {
     root: StableDirectory,
     checkpoint: Checkpoint,
     base_snapshot: Option<UuidConstructionSnapshot>,
+    parent_catalog: RuntimeCatalog,
     _reservation: ProcessReservation,
 }
 
@@ -427,50 +452,24 @@ impl GraphConstructionSession {
             session_identity,
         )?;
         cleanup_owned_artifact_temps(&root)?;
-        let checkpoint_exists = match root.open_child_file(OsStr::new(CHECKPOINT)) {
-            Ok(file) => {
-                drop(file);
-                true
-            }
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
-            Err(error) => return Err(storage(error)),
-        };
-        if !checkpoint_exists && parent_topology_generation != 0 {
-            remove_unrecorded_base(&root)?;
-        }
-        let (base_snapshot, base_identities, base_work) = if parent_topology_generation == 0 {
-            (None, None, UuidConstructionSnapshotWork::default())
-        } else if checkpoint_exists {
-            let mut checkpoint_file = root
-                .open_child_file(OsStr::new(CHECKPOINT))
-                .map_err(storage)?;
-            let recorded: Checkpoint = decode_bounded(&mut checkpoint_file)?;
-            let receipt = recorded
-                .base_identities
-                .as_ref()
-                .ok_or_else(|| storage("nonempty parent lacks retained identity run"))?;
-            let (snapshot, work) = authenticate_base_snapshot(
-                project_dir,
-                parent_topology_generation,
-                &root,
-                receipt,
-            )?;
-            (Some(snapshot), Some(receipt.clone()), work)
+        let (base_snapshot, base_work) = if parent_topology_generation == 0 {
+            (None, UuidConstructionSnapshotWork::default())
         } else {
-            let (snapshot, receipt, work) =
-                create_base_snapshot(project_dir, parent_topology_generation, &root)?;
-            (Some(snapshot), Some(receipt), work)
+            let snapshot = pin_uuid_construction_snapshot(project_dir, parent_topology_generation)?;
+            let max_node_surrogate = crate::writer::read_surrogate_tails(project_dir)?
+                .ok_or_else(|| storage("nonempty parent lacks surrogate tails"))?
+                .0;
+            let work = snapshot.declared_work(max_node_surrogate);
+            (Some(snapshot), work)
         };
+        let (parent_catalog, parent_catalog_sha256) =
+            load_parent_runtime_catalog(project_dir, parent_topology_generation)?;
         let checkpoint = match root.open_child_file(OsStr::new(CHECKPOINT)) {
             Ok(mut file) => decode_bounded(&mut file)?,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                 let mut evidence = GraphConstructionEvidence::default();
                 evidence.authentication_read_bytes = base_work.authentication_bytes;
                 evidence.authentication_read_operations = base_work.authentication_blocks;
-                if let Some(base) = &base_identities {
-                    evidence.write_bytes = base.bytes;
-                    evidence.write_operations = base.write_operations;
-                }
                 let initial = Checkpoint {
                     format_version: FORMAT_VERSION,
                     operation_uuid,
@@ -488,7 +487,8 @@ impl GraphConstructionSession {
                     next_sequence: 0,
                     saw_edge: false,
                     last_receipt_sha256: None,
-                    base_identities,
+                    has_base_snapshot: parent_topology_generation != 0,
+                    parent_catalog_sha256: parent_catalog_sha256.clone(),
                     base_work,
                     evidence,
                 };
@@ -504,6 +504,7 @@ impl GraphConstructionSession {
             session_identity,
             parent_topology_generation,
             budgets,
+            parent_catalog_sha256.as_deref(),
         )?;
         let mut session = Self {
             project_path: project_dir.to_path_buf(),
@@ -511,6 +512,7 @@ impl GraphConstructionSession {
             root,
             checkpoint,
             base_snapshot,
+            parent_catalog,
             _reservation: reservation,
         };
         recover_shape_intent(&session.root, &session.checkpoint)?;
@@ -606,6 +608,7 @@ impl GraphConstructionSession {
                 && receipt.kind == kind
                 && receipt.rows == batch.num_rows() as u64
                 && receipt.input_sha256 == input_sha256
+                && receipt.schema_sha256 == schema_sha256
             {
                 validate_receipt_artifacts(&self.root, &receipt)?;
                 self.checkpoint.evidence.replayed_chunks =
@@ -641,6 +644,7 @@ impl GraphConstructionSession {
             parent_topology_generation: self.checkpoint.parent_topology_generation,
             prior_receipt_sha256: self.checkpoint.last_receipt_sha256.clone(),
             run_records: run_records as u64,
+            accounted_live_bytes: 0,
             parquet: None,
             identities: None,
             endpoints: None,
@@ -650,6 +654,22 @@ impl GraphConstructionSession {
         reject_cancelled(&mut cancelled)?;
         let stem = artifact_stem(sequence, kind);
         let sorted_batch = uuid_sorted_batch(kind, batch)?;
+        let fixed_bytes = arrays
+            .identities
+            .len()
+            .saturating_mul(IDENTITY_WIDTH)
+            .saturating_add(arrays.endpoints.len().saturating_mul(ENDPOINT_WIDTH))
+            .saturating_add(match &arrays.details {
+                DetailRuns::Node(records) => records.len().saturating_mul(NODE_DETAIL_WIDTH),
+                DetailRuns::Edge(records) => records.len().saturating_mul(EDGE_DETAIL_WIDTH),
+            });
+        let sorted_bytes = sorted_batch.get_array_memory_size();
+        intent.accounted_live_bytes = input_bytes
+            .saturating_add(fixed_bytes)
+            .saturating_add(sorted_bytes.saturating_mul(2))
+            .saturating_add(BLOCK_BYTES.saturating_mul(2))
+            as u64;
+        replace_control(&self.root, INTENT, &intent)?;
         intent.parquet = Some(write_parquet(
             &self.root,
             &format!("{stem}.parquet"),
@@ -772,47 +792,13 @@ impl GraphConstructionSession {
         }
         reject_existing_merge_artifacts(&self.root)?;
 
-        let mut unified = Vec::new();
-        if self.checkpoint.base_identities.is_some() {
-            unified.push(BASE_IDENTITIES.to_owned());
-        }
-        let mut node_details = Vec::new();
-        let mut edge_details = Vec::new();
-        let mut endpoints = Vec::new();
-        let mut receipts = Vec::new();
-        let mut row_groups: BTreeMap<(u8, String), Vec<String>> = BTreeMap::new();
+        let fan_in = self.checkpoint.budgets.merge_fan_in;
+        let mut unified = FixedMergeAccumulator::new("merge-identities", fan_in, true);
+        let mut node_details = FixedMergeAccumulator::new("merge-node-details", fan_in, true);
+        let mut edge_details = FixedMergeAccumulator::new("merge-edge-details", fan_in, true);
+        let mut endpoints = FixedMergeAccumulator::new("merge-endpoints", fan_in, false);
+        let mut row_groups: BTreeMap<(u8, String), RowMergeAccumulator> = BTreeMap::new();
         let mut catalog_authority = Sha256::new();
-        for sequence in 0..self.checkpoint.next_sequence {
-            reject_cancelled(&mut cancelled)?;
-            let receipt = self.read_receipt(sequence)?;
-            validate_receipt_artifacts(&self.root, &receipt)?;
-            catalog_authority.update([if receipt.kind == ConstructionChunkKind::Node {
-                0
-            } else {
-                1
-            }]);
-            catalog_authority.update(receipt.schema_sha256.as_bytes());
-            catalog_authority.update(receipt.parquet.sha256.as_bytes());
-            row_groups
-                .entry((
-                    if receipt.kind == ConstructionChunkKind::Node {
-                        0
-                    } else {
-                        1
-                    },
-                    receipt.schema_sha256.clone(),
-                ))
-                .or_default()
-                .push(receipt.parquet.name.clone());
-            match receipt.kind {
-                ConstructionChunkKind::Node => node_details.push(String::new()),
-                ConstructionChunkKind::Edge => {
-                    edge_details.push(String::new());
-                    endpoints.push(String::new());
-                }
-            }
-            receipts.push(receipt);
-        }
         let shape_intent = ShapeIntent {
             format_version: FORMAT_VERSION,
             operation_uuid: self.checkpoint.operation_uuid,
@@ -826,13 +812,35 @@ impl GraphConstructionSession {
             outputs: Vec::new(),
         };
         install_control(&self.root, SHAPE_INTENT, &shape_intent)?;
-        node_details.clear();
-        edge_details.clear();
-        endpoints.clear();
-        for (sequence, receipt) in receipts.iter().enumerate() {
+        for sequence in 0..self.checkpoint.next_sequence {
+            reject_cancelled(&mut cancelled)?;
+            let receipt = self.read_receipt(sequence)?;
+            validate_receipt_artifacts(&self.root, &receipt)?;
+            let kind = u8::from(receipt.kind == ConstructionChunkKind::Edge);
+            catalog_authority.update([kind]);
+            catalog_authority.update(receipt.schema_sha256.as_bytes());
+            catalog_authority.update(receipt.parquet.sha256.as_bytes());
+            row_groups
+                .entry((kind, receipt.schema_sha256.clone()))
+                .or_insert_with(|| {
+                    RowMergeAccumulator::new(fan_in, &format!("{kind}-{}", receipt.schema_sha256))
+                })
+                .push(
+                    &self.root,
+                    receipt.parquet.name.clone(),
+                    self.checkpoint.budgets.max_batch_rows,
+                    self.checkpoint.budgets.max_batch_bytes,
+                    &mut cancelled,
+                    &mut self.checkpoint.evidence,
+                )?;
             let name = format!("merge-unified-{sequence:020}.run");
-            convert_identity_run(&self.root, receipt, &name, &mut self.checkpoint.evidence)?;
-            unified.push(name);
+            convert_identity_run(&self.root, &receipt, &name, &mut self.checkpoint.evidence)?;
+            unified.push::<BASE_IDENTITY_WIDTH>(
+                &self.root,
+                name,
+                &mut cancelled,
+                &mut self.checkpoint.evidence,
+            )?;
             match receipt.kind {
                 ConstructionChunkKind::Node => {
                     let name = format!("merge-node-source-{sequence:020}.run");
@@ -842,7 +850,12 @@ impl GraphConstructionSession {
                         &name,
                         &mut self.checkpoint.evidence,
                     )?;
-                    node_details.push(name);
+                    node_details.push::<NODE_DETAIL_WIDTH>(
+                        &self.root,
+                        name,
+                        &mut cancelled,
+                        &mut self.checkpoint.evidence,
+                    )?;
                 }
                 ConstructionChunkKind::Edge => {
                     let detail = format!("merge-edge-source-{sequence:020}.run");
@@ -852,7 +865,12 @@ impl GraphConstructionSession {
                         &detail,
                         &mut self.checkpoint.evidence,
                     )?;
-                    edge_details.push(detail);
+                    edge_details.push::<EDGE_DETAIL_WIDTH>(
+                        &self.root,
+                        detail,
+                        &mut cancelled,
+                        &mut self.checkpoint.evidence,
+                    )?;
                     let endpoint = format!("merge-endpoint-source-{sequence:020}.run");
                     copy_authenticated_run::<ENDPOINT_WIDTH>(
                         &self.root,
@@ -863,43 +881,76 @@ impl GraphConstructionSession {
                         &endpoint,
                         &mut self.checkpoint.evidence,
                     )?;
-                    endpoints.push(endpoint);
+                    endpoints.push::<ENDPOINT_WIDTH>(
+                        &self.root,
+                        endpoint,
+                        &mut cancelled,
+                        &mut self.checkpoint.evidence,
+                    )?;
                 }
             }
+            let retained_names = unified
+                .slot_count()
+                .saturating_add(node_details.slot_count())
+                .saturating_add(edge_details.slot_count())
+                .saturating_add(endpoints.slot_count())
+                .saturating_add(
+                    row_groups
+                        .values()
+                        .map(RowMergeAccumulator::slot_count)
+                        .sum::<usize>(),
+                );
+            self.checkpoint.evidence.peak_merge_name_slots = self
+                .checkpoint
+                .evidence
+                .peak_merge_name_slots
+                .max(retained_names as u64);
         }
-        let identities = merge_fixed_all::<BASE_IDENTITY_WIDTH>(
+        let staged_identities = unified.finish_optional::<BASE_IDENTITY_WIDTH>(
             &self.root,
-            unified,
-            "merge-identities",
-            self.checkpoint.budgets.merge_fan_in,
-            true,
             &mut cancelled,
             &mut self.checkpoint.evidence,
         )?;
-        let node_details = merge_optional::<NODE_DETAIL_WIDTH>(
+        let identities = if let Some(base) = self.base_snapshot.as_mut() {
+            let (name, work) = merge_staged_with_base(
+                &self.root,
+                staged_identities.as_deref(),
+                base,
+                &mut cancelled,
+                &mut self.checkpoint.evidence,
+            )?;
+            if work.live_nodes != self.checkpoint.base_work.live_nodes
+                || work.live_edges != self.checkpoint.base_work.live_edges
+                || work.max_node_surrogate != self.checkpoint.base_work.max_node_surrogate
+            {
+                return Err(storage("pinned base UUID work differs from checkpoint"));
+            }
+            self.checkpoint.evidence.authentication_read_bytes = self
+                .checkpoint
+                .evidence
+                .authentication_read_bytes
+                .saturating_add(work.authentication_bytes);
+            self.checkpoint.evidence.authentication_read_operations = self
+                .checkpoint
+                .evidence
+                .authentication_read_operations
+                .saturating_add(work.authentication_blocks);
+            name
+        } else {
+            staged_identities.ok_or_else(|| storage("construction contains no identities"))?
+        };
+        let node_details = node_details.finish_optional::<NODE_DETAIL_WIDTH>(
             &self.root,
-            node_details,
-            "merge-node-details",
-            self.checkpoint.budgets.merge_fan_in,
-            true,
             &mut cancelled,
             &mut self.checkpoint.evidence,
         )?;
-        let edge_details = merge_optional::<EDGE_DETAIL_WIDTH>(
+        let edge_details = edge_details.finish_optional::<EDGE_DETAIL_WIDTH>(
             &self.root,
-            edge_details,
-            "merge-edge-details",
-            self.checkpoint.budgets.merge_fan_in,
-            true,
             &mut cancelled,
             &mut self.checkpoint.evidence,
         )?;
-        let endpoints = merge_optional::<ENDPOINT_WIDTH>(
+        let endpoints = endpoints.finish_optional::<ENDPOINT_WIDTH>(
             &self.root,
-            endpoints,
-            "merge-endpoints",
-            self.checkpoint.budgets.merge_fan_in,
-            false,
             &mut cancelled,
             &mut self.checkpoint.evidence,
         )?;
@@ -945,12 +996,11 @@ impl GraphConstructionSession {
         )?;
         let mut node_rows = Vec::new();
         let mut edge_rows = Vec::new();
-        for ((kind, schema_digest), inputs) in row_groups {
+        for ((kind, schema_digest), rows) in row_groups {
             reject_cancelled(&mut cancelled)?;
             let output = format!("shaped-rows-{kind}-{schema_digest}.parquet");
-            merge_row_all(
+            rows.finish(
                 &self.root,
-                inputs,
                 &output,
                 self.checkpoint.budgets.max_batch_rows,
                 self.checkpoint.budgets.max_batch_bytes,
@@ -965,22 +1015,14 @@ impl GraphConstructionSession {
             }
         }
         let runtime_catalog = build_runtime_catalog(
+            self.parent_catalog.clone(),
             &self.root,
             &node_rows,
             &edge_rows,
             self.checkpoint.session_now_micros,
             &mut cancelled,
+            &mut self.checkpoint.evidence,
         )?;
-        self.checkpoint.evidence.merge_read_blocks = self
-            .checkpoint
-            .evidence
-            .merge_read_bytes
-            .div_ceil(BLOCK_BYTES as u64);
-        self.checkpoint.evidence.merge_write_blocks = self
-            .checkpoint
-            .evidence
-            .merge_written_bytes
-            .div_ceil(BLOCK_BYTES as u64);
         self.checkpoint.evidence.peak_merge_temporary_bytes = self
             .checkpoint
             .evidence
@@ -1191,6 +1233,9 @@ impl GraphConstructionSession {
         evidence.peak_batch_rows = evidence.peak_batch_rows.max(receipt.rows);
         evidence.peak_batch_bytes = evidence.peak_batch_bytes.max(receipt.input_bytes);
         evidence.peak_run_records = evidence.peak_run_records.max(receipt.run_records);
+        evidence.peak_accounted_live_bytes = evidence
+            .peak_accounted_live_bytes
+            .max(receipt.accounted_live_bytes);
         for artifact in [&receipt.parquet, &receipt.identities, &receipt.details]
             .into_iter()
             .chain(receipt.endpoints.iter())
@@ -1199,6 +1244,9 @@ impl GraphConstructionSession {
             evidence.write_operations = evidence
                 .write_operations
                 .saturating_add(artifact.write_operations);
+            evidence.fsync_operations = evidence
+                .fsync_operations
+                .saturating_add(artifact.fsync_operations);
         }
         self.checkpoint.next_sequence = self.checkpoint.next_sequence.saturating_add(1);
         self.checkpoint.saw_edge |= receipt.kind == ConstructionChunkKind::Edge;
@@ -1355,6 +1403,12 @@ fn validate_schema(kind: ConstructionChunkKind, batch: &RecordBatch) -> Result<(
             return Err(storage("required construction columns are non-null"));
         }
     }
+    if batch.schema().fields()[expected.fields().len()..]
+        .iter()
+        .any(|field| !crate::schemas::property_data_type_supported(field.data_type()))
+    {
+        return Err(storage("unsupported construction property type"));
+    }
     let identifiers = batch
         .column(1)
         .as_any()
@@ -1412,7 +1466,18 @@ fn logical_batch_digest(
             }
         }
     }
-    for column in expected_property_columns(kind, batch) {
+    let required = if kind == ConstructionChunkKind::Node {
+        2
+    } else {
+        4
+    };
+    let schema = batch.schema();
+    for (field, column) in schema.fields()[required..]
+        .iter()
+        .zip(expected_property_columns(kind, batch))
+    {
+        digest.update((field.name().len() as u64).to_be_bytes());
+        digest.update(field.name().as_bytes());
         digest.update(column.data_type().to_string().as_bytes());
         for row in 0..column.len() {
             if column.is_null(row) {
@@ -1531,6 +1596,80 @@ struct HashingWriter<W> {
     operations: u64,
 }
 
+#[derive(Clone, Default)]
+struct IoCounter {
+    bytes: std::sync::Arc<AtomicU64>,
+    operations: std::sync::Arc<AtomicU64>,
+}
+
+impl IoCounter {
+    fn account(&self, bytes: usize) {
+        if bytes != 0 {
+            self.bytes.fetch_add(bytes as u64, Ordering::Relaxed);
+            self.operations.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn add_to(&self, evidence: &mut GraphConstructionEvidence) {
+        evidence.parquet_read_bytes = evidence
+            .parquet_read_bytes
+            .saturating_add(self.bytes.load(Ordering::Relaxed));
+        evidence.parquet_read_operations = evidence
+            .parquet_read_operations
+            .saturating_add(self.operations.load(Ordering::Relaxed));
+    }
+}
+
+struct CountingRead<R> {
+    inner: R,
+    counter: IoCounter,
+}
+
+impl<R: Read> Read for CountingRead<R> {
+    fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        let read = self.inner.read(buffer)?;
+        self.counter.account(read);
+        Ok(read)
+    }
+}
+
+struct CountingChunkReader {
+    file: File,
+    counter: IoCounter,
+}
+
+impl Length for CountingChunkReader {
+    fn len(&self) -> u64 {
+        self.file.metadata().map_or(0, |metadata| metadata.len())
+    }
+}
+
+impl ChunkReader for CountingChunkReader {
+    type T = CountingRead<BufReader<File>>;
+
+    fn get_read(&self, start: u64) -> parquet::errors::Result<Self::T> {
+        use std::io::{Seek, SeekFrom};
+
+        let mut file = self.file.try_clone()?;
+        file.seek(SeekFrom::Start(start))?;
+        Ok(CountingRead {
+            inner: BufReader::with_capacity(BLOCK_BYTES, file),
+            counter: self.counter.clone(),
+        })
+    }
+
+    fn get_bytes(&self, start: u64, length: usize) -> parquet::errors::Result<bytes::Bytes> {
+        use std::io::{Seek, SeekFrom};
+
+        let mut file = self.file.try_clone()?;
+        file.seek(SeekFrom::Start(start))?;
+        let mut value = vec![0_u8; length];
+        file.read_exact(&mut value)?;
+        self.counter.account(length);
+        Ok(bytes::Bytes::from(value))
+    }
+}
+
 impl<W> HashingWriter<W> {
     fn new(inner: W) -> Self {
         Self {
@@ -1581,6 +1720,7 @@ fn write_parquet(
         sha256: hex(&hashing.digest.clone().finalize()),
         identity: identity.into(),
         write_operations: hashing.operations,
+        fsync_operations: 4,
     };
     root.sync().map_err(storage)?;
     root.install_child(OsStr::new(&temporary), identity, OsStr::new(name))
@@ -1619,6 +1759,7 @@ fn write_fixed_run<const N: usize>(
         sha256: hex(&writer.digest.finalize()),
         identity: identity.into(),
         write_operations: writer.operations,
+        fsync_operations: 3,
     };
     root.sync().map_err(storage)?;
     root.install_child(OsStr::new(&temporary), identity, OsStr::new(name))
@@ -1649,35 +1790,6 @@ fn reject_existing_merge_artifacts(root: &StableDirectory) -> Result<(), GfError
         }
     }
     Ok(())
-}
-
-fn planned_shape_names(
-    chunks: usize,
-    identity_inputs: usize,
-    node_runs: usize,
-    edge_runs: usize,
-    endpoint_runs: usize,
-    fan_in: usize,
-) -> Vec<String> {
-    let mut names = (0..chunks)
-        .map(|sequence| format!("merge-unified-{sequence:020}.run"))
-        .collect::<Vec<_>>();
-    plan_merge_names(identity_inputs, "merge-identities", fan_in, &mut names);
-    plan_merge_names(node_runs, "merge-node-details", fan_in, &mut names);
-    plan_merge_names(edge_runs, "merge-edge-details", fan_in, &mut names);
-    plan_merge_names(endpoint_runs, "merge-endpoints", fan_in, &mut names);
-    names.push("shaped-identities.run".to_owned());
-    names
-}
-
-fn plan_merge_names(mut count: usize, prefix: &str, fan_in: usize, names: &mut Vec<String>) {
-    let mut level = 0;
-    while count > 1 {
-        let groups = count.div_ceil(fan_in);
-        names.extend((0..groups).map(|group| format!("{prefix}-l{level:03}-g{group:08}.run")));
-        count = groups;
-        level += 1;
-    }
 }
 
 fn recover_shape_intent(root: &StableDirectory, checkpoint: &Checkpoint) -> Result<(), GfError> {
@@ -1718,55 +1830,18 @@ fn recover_shape_intent(root: &StableDirectory, checkpoint: &Checkpoint) -> Resu
     if intent.shape.is_some() || !intent.outputs.is_empty() {
         return Err(storage("incomplete shape intent claims completed output"));
     }
-    let mut node_runs = 0;
-    let mut edge_runs = 0;
-    let mut source_names = Vec::new();
-    for sequence in 0..checkpoint.next_sequence {
-        let mut file = root
-            .open_child_file(OsStr::new(&receipt_name(sequence)))
-            .map_err(storage)?;
-        let receipt: ConstructionChunkReceipt = decode_bounded(&mut file)?;
-        match receipt.kind {
-            ConstructionChunkKind::Node => {
-                node_runs += 1;
-                source_names.push(format!("merge-node-source-{sequence:020}.run"));
-            }
-            ConstructionChunkKind::Edge => {
-                edge_runs += 1;
-                source_names.push(format!("merge-edge-source-{sequence:020}.run"));
-                source_names.push(format!("merge-endpoint-source-{sequence:020}.run"));
-            }
-        }
-    }
-    let chunks = usize::try_from(checkpoint.next_sequence)
-        .map_err(|_| storage("construction shape chunk count exceeds this platform"))?;
-    let mut names = planned_shape_names(
-        chunks,
-        chunks + usize::from(checkpoint.base_identities.is_some()),
-        node_runs,
-        edge_runs,
-        edge_runs,
-        checkpoint.budgets.merge_fan_in,
-    );
-    names.extend(source_names);
     for child in root.child_names().map_err(storage)? {
         let Some(name) = child.to_str() else { continue };
-        if name.starts_with("merge-rows-")
-            || name.starts_with("shaped-rows-")
-            || name.starts_with("merge-resolved-")
-            || name == "shaped-runtime-catalog.parquet"
-        {
-            names.push(name.to_owned());
+        if !name.starts_with("merge-") && !name.starts_with("shaped-") {
+            continue;
         }
-    }
-    for name in names {
-        match root.open_child_file(OsStr::new(&name)) {
+        match root.open_child_file(OsStr::new(name)) {
             Ok(file) => {
                 if file_link_count(&file).map_err(storage)? != 1 {
                     return Err(storage("construction shape artifact has extra links"));
                 }
                 drop(file);
-                unlink_named(root, &name)?;
+                unlink_named(root, name)?;
             }
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
             Err(error) => return Err(storage(error)),
@@ -1837,6 +1912,7 @@ fn receipt_for_existing(root: &StableDirectory, name: &str) -> Result<ArtifactRe
         sha256: hex(&digest.finalize()),
         identity: identity.into(),
         write_operations: operations,
+        fsync_operations: 0,
     })
 }
 
@@ -1870,8 +1946,22 @@ fn is_shape_artifact_name(name: &str) -> bool {
             && body.as_bytes().get(1) == Some(&b'-')
             && body[2..].bytes().all(|byte| byte.is_ascii_hexdigit());
     }
-    if name.starts_with("merge-rows-l") && name.ends_with(".parquet") {
-        return true;
+    if let Some(body) = name
+        .strip_prefix("merge-rows-")
+        .and_then(|body| body.strip_suffix(".parquet"))
+    {
+        let mut parts = body.split("-l");
+        let namespace = parts.next().unwrap_or_default();
+        let level_group = parts.next().unwrap_or_default();
+        return parts.next().is_none()
+            && namespace.len() == 16
+            && namespace.bytes().all(|byte| byte.is_ascii_hexdigit())
+            && level_group.split_once("-g").is_some_and(|(level, group)| {
+                level.len() == 3
+                    && level.bytes().all(|byte| byte.is_ascii_digit())
+                    && group.len() == 20
+                    && group.bytes().all(|byte| byte.is_ascii_digit())
+            });
     }
     if let Some(sequence) = name
         .strip_prefix("merge-unified-")
@@ -1938,6 +2028,22 @@ fn account_merge_write<const N: usize>(evidence: &mut GraphConstructionEvidence)
     evidence.merge_written_bytes = evidence.merge_written_bytes.saturating_add(N as u64);
 }
 
+fn account_sequential_read(bytes: u64, evidence: &mut GraphConstructionEvidence) {
+    if bytes != 0 {
+        evidence.merge_read_blocks = evidence
+            .merge_read_blocks
+            .saturating_add(bytes.div_ceil(BLOCK_BYTES as u64));
+    }
+}
+
+fn account_sequential_write(bytes: u64, evidence: &mut GraphConstructionEvidence) {
+    if bytes != 0 {
+        evidence.merge_write_blocks = evidence
+            .merge_write_blocks
+            .saturating_add(bytes.div_ceil(BLOCK_BYTES as u64));
+    }
+}
+
 fn convert_identity_run(
     root: &StableDirectory,
     receipt: &ConstructionChunkReceipt,
@@ -1947,6 +2053,7 @@ fn convert_identity_run(
     let input = root
         .open_child_file(OsStr::new(&receipt.identities.name))
         .map_err(storage)?;
+    account_sequential_read(receipt.identities.bytes, evidence);
     if !receipt
         .identities
         .identity
@@ -1979,10 +2086,13 @@ fn convert_identity_run(
     }
     writer.flush().map_err(storage)?;
     writer.get_ref().sync_all().map_err(storage)?;
+    account_sequential_write(bytes.saturating_mul(2), evidence);
     drop(writer);
     root.install_child(OsStr::new(&temporary), identity, OsStr::new(output))
         .map_err(storage)?;
-    root.sync().map_err(storage)
+    root.sync().map_err(storage)?;
+    evidence.merge_fsync_operations = evidence.merge_fsync_operations.saturating_add(2);
+    Ok(())
 }
 
 fn copy_authenticated_run<const N: usize>(
@@ -1994,6 +2104,7 @@ fn copy_authenticated_run<const N: usize>(
     let input = root
         .open_child_file(OsStr::new(&receipt.name))
         .map_err(storage)?;
+    account_sequential_read(receipt.bytes, evidence);
     if !receipt
         .identity
         .matches(file_identity(&input).map_err(storage)?)
@@ -2022,34 +2133,157 @@ fn copy_authenticated_run<const N: usize>(
     }
     writer.flush().map_err(storage)?;
     writer.get_ref().sync_all().map_err(storage)?;
+    account_sequential_write(bytes, evidence);
     drop(writer);
     root.install_child(OsStr::new(&temporary), identity, OsStr::new(output))
         .map_err(storage)?;
-    root.sync().map_err(storage)
+    root.sync().map_err(storage)?;
+    evidence.merge_fsync_operations = evidence.merge_fsync_operations.saturating_add(2);
+    Ok(())
 }
 
-fn merge_optional<const N: usize>(
-    root: &StableDirectory,
-    inputs: Vec<String>,
-    prefix: &str,
+/// Online external-merge scheduler.  It retains at most `fan_in - 1` names per
+/// logarithmic level rather than one name per accepted chunk.
+struct FixedMergeAccumulator {
+    prefix: &'static str,
     fan_in: usize,
     reject_duplicates: bool,
-    cancelled: &mut impl FnMut() -> bool,
-    evidence: &mut GraphConstructionEvidence,
-) -> Result<Option<String>, GfError> {
-    if inputs.is_empty() {
-        Ok(None)
-    } else {
-        merge_fixed_all::<N>(
-            root,
-            inputs,
+    levels: Vec<Vec<String>>,
+    groups: Vec<usize>,
+    inputs: u64,
+}
+
+#[cfg(test)]
+fn online_merge_name_slot_bound(mut inputs: u64, fan_in: usize) -> u64 {
+    let radix = fan_in as u64;
+    let mut slots = 0_u64;
+    while inputs != 0 {
+        slots = slots.saturating_add(inputs % radix);
+        inputs /= radix;
+    }
+    slots.max(1)
+}
+
+impl FixedMergeAccumulator {
+    fn new(prefix: &'static str, fan_in: usize, reject_duplicates: bool) -> Self {
+        Self {
             prefix,
             fan_in,
             reject_duplicates,
-            cancelled,
-            evidence,
-        )
-        .map(Some)
+            levels: Vec::new(),
+            groups: Vec::new(),
+            inputs: 0,
+        }
+    }
+
+    fn slot_count(&self) -> usize {
+        self.levels.iter().map(Vec::len).sum()
+    }
+
+    fn push<const N: usize>(
+        &mut self,
+        root: &StableDirectory,
+        mut name: String,
+        cancelled: &mut impl FnMut() -> bool,
+        evidence: &mut GraphConstructionEvidence,
+    ) -> Result<(), GfError> {
+        self.inputs = self.inputs.saturating_add(1);
+        let mut level = 0;
+        loop {
+            if self.levels.len() <= level {
+                self.levels.push(Vec::with_capacity(self.fan_in));
+                self.groups.push(0);
+            }
+            self.levels[level].push(name);
+            if self.levels[level].len() < self.fan_in {
+                return Ok(());
+            }
+            let inputs = std::mem::take(&mut self.levels[level]);
+            let group = self.groups[level];
+            self.groups[level] = group.saturating_add(1);
+            evidence.merge_passes = evidence.merge_passes.max(level as u64 + 1);
+            name = format!("{}-l{level:03}-g{group:08}.run", self.prefix);
+            merge_fixed_group::<N>(
+                root,
+                &inputs,
+                &name,
+                self.reject_duplicates,
+                cancelled,
+                evidence,
+            )?;
+            for input in inputs {
+                if input.starts_with("merge-") {
+                    unlink_named(root, &input)?;
+                }
+            }
+            level += 1;
+        }
+    }
+
+    fn finish_optional<const N: usize>(
+        self,
+        root: &StableDirectory,
+        cancelled: &mut impl FnMut() -> bool,
+        evidence: &mut GraphConstructionEvidence,
+    ) -> Result<Option<String>, GfError> {
+        if self.inputs == 0 {
+            return Ok(None);
+        }
+        self.finish::<N>(root, cancelled, evidence).map(Some)
+    }
+
+    fn finish<const N: usize>(
+        mut self,
+        root: &StableDirectory,
+        cancelled: &mut impl FnMut() -> bool,
+        evidence: &mut GraphConstructionEvidence,
+    ) -> Result<String, GfError> {
+        if self.inputs == 0 {
+            return Err(storage("external merge has no input"));
+        }
+        let mut level = 0;
+        loop {
+            if level >= self.levels.len() {
+                return Err(storage("external merge scheduler lost its root"));
+            }
+            let inputs = std::mem::take(&mut self.levels[level]);
+            if inputs.is_empty() {
+                level += 1;
+                continue;
+            }
+            let higher_empty = self.levels[level + 1..].iter().all(Vec::is_empty);
+            if inputs.len() == 1 && higher_empty {
+                return Ok(inputs.into_iter().next().expect("one merge root"));
+            }
+            let name = if inputs.len() == 1 {
+                inputs[0].clone()
+            } else {
+                let group = self.groups[level];
+                self.groups[level] = group.saturating_add(1);
+                evidence.merge_passes = evidence.merge_passes.max(level as u64 + 1);
+                let output = format!("{}-l{level:03}-g{group:08}.run", self.prefix);
+                merge_fixed_group::<N>(
+                    root,
+                    &inputs,
+                    &output,
+                    self.reject_duplicates,
+                    cancelled,
+                    evidence,
+                )?;
+                for input in inputs {
+                    if input.starts_with("merge-") {
+                        unlink_named(root, &input)?;
+                    }
+                }
+                output
+            };
+            if self.levels.len() <= level + 1 {
+                self.levels.push(Vec::with_capacity(self.fan_in));
+                self.groups.push(0);
+            }
+            self.levels[level + 1].push(name);
+            level += 1;
+        }
     }
 }
 
@@ -2098,7 +2332,12 @@ fn merge_fixed_group<const N: usize>(
         .iter()
         .map(|name| {
             root.open_child_file(OsStr::new(name))
-                .map(|file| BufReader::with_capacity(BLOCK_BYTES, file))
+                .map(|file| {
+                    if let Ok(metadata) = file.metadata() {
+                        account_sequential_read(metadata.len(), evidence);
+                    }
+                    BufReader::with_capacity(BLOCK_BYTES, file)
+                })
                 .map_err(storage)
         })
         .collect::<Result<Vec<_>, _>>()?;
@@ -2138,10 +2377,15 @@ fn merge_fixed_group<const N: usize>(
     }
     writer.flush().map_err(storage)?;
     writer.get_ref().sync_all().map_err(storage)?;
+    account_sequential_write(
+        writer.get_ref().metadata().map_err(storage)?.len(),
+        evidence,
+    );
     drop(writer);
     root.install_child(OsStr::new(&temporary), identity, OsStr::new(output))
         .map_err(storage)?;
     root.sync().map_err(storage)?;
+    evidence.merge_fsync_operations = evidence.merge_fsync_operations.saturating_add(2);
     evidence.merge_groups = evidence.merge_groups.saturating_add(1);
     evidence.peak_merge_temporary_bytes = evidence
         .peak_merge_temporary_bytes
@@ -2212,11 +2456,18 @@ fn merge_row_group(
     if inputs.is_empty() || output_rows == 0 || output_bytes == 0 {
         return Err(storage("invalid row merge group"));
     }
+    evidence.peak_merge_inputs = evidence.peak_merge_inputs.max(inputs.len() as u64);
     let mut cursors = Vec::with_capacity(inputs.len());
+    let mut counters = Vec::with_capacity(inputs.len());
     let mut schema: Option<SchemaRef> = None;
     for input in inputs {
         let file = root.open_child_file(OsStr::new(input)).map_err(storage)?;
-        let builder = ParquetRecordBatchReaderBuilder::try_new(file).map_err(storage)?;
+        let counter = IoCounter::default();
+        let builder = ParquetRecordBatchReaderBuilder::try_new(CountingChunkReader {
+            file,
+            counter: counter.clone(),
+        })
+        .map_err(storage)?;
         if schema
             .as_ref()
             .is_some_and(|known| known.as_ref() != builder.schema().as_ref())
@@ -2234,6 +2485,7 @@ fn merge_row_group(
             batch: None,
             row: 0,
         });
+        counters.push(counter);
     }
     let schema = schema.ok_or_else(|| storage("row merge lacks schema"))?;
     let temporary = artifact_temp(output);
@@ -2319,84 +2571,201 @@ fn merge_row_group(
         sha256: hex(&hashing.digest.clone().finalize()),
         identity: identity.into(),
         write_operations: hashing.operations,
+        fsync_operations: 4,
     };
     root.sync().map_err(storage)?;
     root.install_child(OsStr::new(&temporary), identity, OsStr::new(output))
         .map_err(storage)?;
     root.sync().map_err(storage)?;
+    evidence.merge_fsync_operations = evidence.merge_fsync_operations.saturating_add(4);
     evidence.merge_groups = evidence.merge_groups.saturating_add(1);
     evidence.merge_written_bytes = evidence.merge_written_bytes.saturating_add(receipt.bytes);
+    evidence.parquet_write_bytes = evidence.parquet_write_bytes.saturating_add(receipt.bytes);
+    evidence.parquet_write_operations = evidence
+        .parquet_write_operations
+        .saturating_add(receipt.write_operations);
+    for counter in counters {
+        counter.add_to(evidence);
+    }
+    evidence.peak_merge_temporary_bytes = evidence
+        .peak_merge_temporary_bytes
+        .max(measured_shape_bytes(root)?);
     Ok(receipt)
 }
 
-fn merge_row_all(
-    root: &StableDirectory,
-    mut inputs: Vec<String>,
-    output: &str,
-    output_rows: usize,
-    output_bytes: usize,
+struct RowMergeAccumulator {
     fan_in: usize,
-    cancelled: &mut impl FnMut() -> bool,
-    evidence: &mut GraphConstructionEvidence,
-) -> Result<ArtifactReceipt, GfError> {
-    let mut level = 0_u32;
-    let namespace = &sha256(output.as_bytes())[..16];
-    while inputs.len() > fan_in {
-        evidence.merge_passes = evidence.merge_passes.saturating_add(1);
-        let mut next = Vec::new();
-        for (group, names) in inputs.chunks(fan_in).enumerate() {
-            let name = format!("merge-rows-{namespace}-l{level:03}-g{group:020}.parquet");
+    namespace: String,
+    levels: Vec<Vec<String>>,
+    groups: Vec<usize>,
+    inputs: u64,
+}
+
+impl RowMergeAccumulator {
+    fn new(fan_in: usize, authority: &str) -> Self {
+        Self {
+            fan_in,
+            namespace: sha256(authority.as_bytes())[..16].to_owned(),
+            levels: Vec::new(),
+            groups: Vec::new(),
+            inputs: 0,
+        }
+    }
+
+    fn slot_count(&self) -> usize {
+        self.levels.iter().map(Vec::len).sum()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn push(
+        &mut self,
+        root: &StableDirectory,
+        mut name: String,
+        output_rows: usize,
+        output_bytes: usize,
+        cancelled: &mut impl FnMut() -> bool,
+        evidence: &mut GraphConstructionEvidence,
+    ) -> Result<(), GfError> {
+        self.inputs = self.inputs.saturating_add(1);
+        let mut level = 0;
+        loop {
+            if self.levels.len() <= level {
+                self.levels.push(Vec::with_capacity(self.fan_in));
+                self.groups.push(0);
+            }
+            self.levels[level].push(name);
+            if self.levels[level].len() < self.fan_in {
+                return Ok(());
+            }
+            let inputs = std::mem::take(&mut self.levels[level]);
+            let group = self.groups[level];
+            self.groups[level] = group.saturating_add(1);
+            evidence.merge_passes = evidence.merge_passes.max(level as u64 + 1);
+            name = format!(
+                "merge-rows-{}-l{level:03}-g{group:020}.parquet",
+                self.namespace
+            );
             merge_row_group(
                 root,
-                names,
+                &inputs,
                 &name,
                 output_rows,
                 output_bytes,
                 cancelled,
                 evidence,
             )?;
-            next.push(name);
-        }
-        for old in &inputs {
-            if old.starts_with("merge-rows-") {
-                unlink_named(root, old)?;
+            for input in inputs {
+                if input.starts_with("merge-rows-") {
+                    unlink_named(root, &input)?;
+                }
             }
+            level += 1;
         }
-        inputs = next;
-        level = level.saturating_add(1);
     }
-    evidence.merge_passes = evidence.merge_passes.saturating_add(1);
-    evidence.peak_merge_inputs = evidence.peak_merge_inputs.max(inputs.len() as u64);
-    merge_row_group(
-        root,
-        &inputs,
-        output,
-        output_rows,
-        output_bytes,
-        cancelled,
-        evidence,
-    )
+
+    #[allow(clippy::too_many_arguments)]
+    fn finish(
+        mut self,
+        root: &StableDirectory,
+        output: &str,
+        output_rows: usize,
+        output_bytes: usize,
+        _fan_in: usize,
+        cancelled: &mut impl FnMut() -> bool,
+        evidence: &mut GraphConstructionEvidence,
+    ) -> Result<ArtifactReceipt, GfError> {
+        if self.inputs == 0 {
+            return Err(storage("row merge has no input"));
+        }
+        let mut level = 0;
+        loop {
+            let inputs = std::mem::take(
+                self.levels
+                    .get_mut(level)
+                    .ok_or_else(|| storage("row merge scheduler lost its root"))?,
+            );
+            if inputs.is_empty() {
+                level += 1;
+                continue;
+            }
+            let higher_empty = self.levels[level + 1..].iter().all(Vec::is_empty);
+            if higher_empty {
+                let receipt = merge_row_group(
+                    root,
+                    &inputs,
+                    output,
+                    output_rows,
+                    output_bytes,
+                    cancelled,
+                    evidence,
+                )?;
+                for input in inputs {
+                    if input.starts_with("merge-rows-") {
+                        unlink_named(root, &input)?;
+                    }
+                }
+                return Ok(receipt);
+            }
+            let name = if inputs.len() == 1 {
+                inputs[0].clone()
+            } else {
+                let group = self.groups[level];
+                self.groups[level] = group.saturating_add(1);
+                evidence.merge_passes = evidence.merge_passes.max(level as u64 + 1);
+                let output_name = format!(
+                    "merge-rows-{}-l{level:03}-g{group:020}.parquet",
+                    self.namespace
+                );
+                merge_row_group(
+                    root,
+                    &inputs,
+                    &output_name,
+                    output_rows,
+                    output_bytes,
+                    cancelled,
+                    evidence,
+                )?;
+                for input in inputs {
+                    if input.starts_with("merge-rows-") {
+                        unlink_named(root, &input)?;
+                    }
+                }
+                output_name
+            };
+            if self.levels.len() <= level + 1 {
+                self.levels.push(Vec::with_capacity(self.fan_in));
+                self.groups.push(0);
+            }
+            self.levels[level + 1].push(name);
+            level += 1;
+        }
+    }
 }
 
 fn build_runtime_catalog(
+    mut catalog: RuntimeCatalog,
     root: &StableDirectory,
     node_rows: &[String],
     edge_rows: &[String],
     now_micros: i64,
     cancelled: &mut impl FnMut() -> bool,
+    evidence: &mut GraphConstructionEvidence,
 ) -> Result<String, GfError> {
-    let mut catalog = RuntimeCatalog::new();
     for (kind, names) in [
         (ConstructionChunkKind::Node, node_rows),
         (ConstructionChunkKind::Edge, edge_rows),
     ] {
         for name in names {
             let file = root.open_child_file(OsStr::new(name)).map_err(storage)?;
-            let reader = ParquetRecordBatchReaderBuilder::try_new(file)
-                .map_err(storage)?
-                .with_batch_size(4096)
-                .build()
-                .map_err(storage)?;
+            let counter = IoCounter::default();
+            let reader = ParquetRecordBatchReaderBuilder::try_new(CountingChunkReader {
+                file,
+                counter: counter.clone(),
+            })
+            .map_err(storage)?
+            .with_batch_size(4096)
+            .build()
+            .map_err(storage)?;
             for batch in reader {
                 reject_cancelled(cancelled)?;
                 let batch = batch.map_err(storage)?;
@@ -2420,16 +2789,74 @@ fn build_runtime_catalog(
                             catalog.intern_relation_type_at(owner_name, now_micros);
                         }
                     }
-                    for field in &batch.schema().fields()[required..] {
-                        catalog.intern_property_at(field.name(), Some(owner_name), now_micros);
+                    for (offset, field) in batch.schema().fields()[required..].iter().enumerate() {
+                        if !batch.column(required + offset).is_null(row) {
+                            catalog.intern_property_at(field.name(), Some(owner_name), now_micros);
+                        }
                     }
                 }
             }
+            counter.add_to(evidence);
         }
     }
     let output = "shaped-runtime-catalog.parquet";
-    write_parquet(root, output, &catalog.to_record_batch())?;
+    let receipt = write_parquet(root, output, &catalog.to_record_batch())?;
+    evidence.merge_fsync_operations = evidence
+        .merge_fsync_operations
+        .saturating_add(receipt.fsync_operations);
+    evidence.parquet_write_bytes = evidence.parquet_write_bytes.saturating_add(receipt.bytes);
+    evidence.parquet_write_operations = evidence
+        .parquet_write_operations
+        .saturating_add(receipt.write_operations);
+    account_sequential_write(receipt.bytes, evidence);
     Ok(output.to_owned())
+}
+
+fn load_parent_runtime_catalog(
+    project_path: &Path,
+    parent_generation: u64,
+) -> Result<(RuntimeCatalog, Option<String>), GfError> {
+    if parent_generation == 0 {
+        return Ok((RuntimeCatalog::new(), None));
+    }
+    let path = project_path.join("topology/runtime_catalog.parquet");
+    let digest = match std::fs::read(&path) {
+        Ok(bytes) => Some(sha256(&bytes)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok((RuntimeCatalog::new(), None));
+        }
+        Err(error) => {
+            return Err(storage(format!(
+                "cannot hash pinned parent catalog: {error}"
+            )));
+        }
+    };
+    let file = match File::open(&path) {
+        Ok(file) => file,
+        Err(error) => {
+            return Err(storage(format!(
+                "cannot open pinned parent catalog: {error}"
+            )));
+        }
+    };
+    let reader = ParquetRecordBatchReaderBuilder::try_new(file)
+        .map_err(storage)?
+        .with_batch_size(4096)
+        .build()
+        .map_err(storage)?;
+    let mut batches = Vec::new();
+    for batch in reader {
+        batches.push(batch.map_err(storage)?);
+    }
+    if batches.is_empty() {
+        return Ok((RuntimeCatalog::new(), digest));
+    }
+    let schema = batches[0].schema();
+    let merged = arrow::compute::concat_batches(&schema, &batches).map_err(storage)?;
+    Ok((
+        RuntimeCatalog::from_record_batch(&merged).map_err(storage)?,
+        digest,
+    ))
 }
 
 fn read_fixed<const N: usize>(reader: &mut impl Read) -> Result<Option<[u8; N]>, GfError> {
@@ -2461,6 +2888,10 @@ fn validate_unified_and_details(
         BLOCK_BYTES,
         root.open_child_file(OsStr::new(identities_name))
             .map_err(storage)?,
+    );
+    account_sequential_read(
+        identities.get_ref().metadata().map_err(storage)?.len(),
+        evidence,
     );
     let mut node_count = 0_u64;
     let mut edge_count = 0_u64;
@@ -2538,6 +2969,99 @@ fn validate_unified_and_details(
     Ok((node_count, edge_count, max_node, max_edge))
 }
 
+fn merge_staged_with_base(
+    root: &StableDirectory,
+    staged_name: Option<&str>,
+    base: &mut UuidConstructionSnapshot,
+    cancelled: &mut impl FnMut() -> bool,
+    evidence: &mut GraphConstructionEvidence,
+) -> Result<(String, UuidConstructionSnapshotWork), GfError> {
+    let output = "merge-identities-with-base.run";
+    let temporary = artifact_temp(output);
+    let file = root
+        .create_replaceable_child_file(OsStr::new(&temporary))
+        .map_err(storage)?;
+    let identity = file_identity(&file).map_err(storage)?;
+    let mut writer = BufWriter::with_capacity(BLOCK_BYTES, file);
+    let mut staged = staged_name
+        .map(|name| {
+            root.open_child_file(OsStr::new(name))
+                .map(|file| BufReader::with_capacity(BLOCK_BYTES, file))
+                .map_err(storage)
+        })
+        .transpose()?;
+    let mut staged_record = staged
+        .as_mut()
+        .map(read_fixed::<BASE_IDENTITY_WIDTH>)
+        .transpose()?
+        .flatten();
+    if let Some(reader) = &staged {
+        account_sequential_read(
+            reader.get_ref().metadata().map_err(storage)?.len(),
+            evidence,
+        );
+    }
+    let mut emitted = 0_u64;
+    let work = base.stream_authenticated(|value| {
+        let base_record = encode_base_identity(value);
+        while staged_record
+            .as_ref()
+            .is_some_and(|record| record[..16] < base_record[..16])
+        {
+            let record = staged_record.take().expect("staged head exists");
+            writer.write_all(&record).map_err(storage)?;
+            account_merge_read::<BASE_IDENTITY_WIDTH>(evidence);
+            account_merge_write::<BASE_IDENTITY_WIDTH>(evidence);
+            staged_record = staged
+                .as_mut()
+                .map(read_fixed::<BASE_IDENTITY_WIDTH>)
+                .transpose()?
+                .flatten();
+        }
+        if staged_record
+            .as_ref()
+            .is_some_and(|record| record[..16] == base_record[..16])
+        {
+            return Err(storage("staged UUID conflicts with pinned base identity"));
+        }
+        writer.write_all(&base_record).map_err(storage)?;
+        account_merge_write::<BASE_IDENTITY_WIDTH>(evidence);
+        emitted = emitted.saturating_add(1);
+        if emitted.is_multiple_of(4096) {
+            reject_cancelled(cancelled)?;
+        }
+        Ok(())
+    })?;
+    while let Some(record) = staged_record {
+        writer.write_all(&record).map_err(storage)?;
+        account_merge_read::<BASE_IDENTITY_WIDTH>(evidence);
+        account_merge_write::<BASE_IDENTITY_WIDTH>(evidence);
+        staged_record = staged
+            .as_mut()
+            .map(read_fixed::<BASE_IDENTITY_WIDTH>)
+            .transpose()?
+            .flatten();
+    }
+    writer.flush().map_err(storage)?;
+    writer.get_ref().sync_all().map_err(storage)?;
+    account_sequential_write(
+        writer.get_ref().metadata().map_err(storage)?.len(),
+        evidence,
+    );
+    drop(writer);
+    root.install_child(OsStr::new(&temporary), identity, OsStr::new(output))
+        .map_err(storage)?;
+    root.sync().map_err(storage)?;
+    evidence.merge_fsync_operations = evidence.merge_fsync_operations.saturating_add(2);
+    if let Some(staged_name) = staged_name
+        && staged_name.starts_with("merge-")
+    {
+        unlink_named(root, staged_name)?;
+    }
+    evidence.merge_groups = evidence.merge_groups.saturating_add(1);
+    Ok((output.to_owned(), work))
+}
+
 fn validate_detail_domain<const N: usize>(
     root: &StableDirectory,
     identities_name: &str,
@@ -2558,6 +3082,14 @@ fn validate_detail_domain<const N: usize>(
         BLOCK_BYTES,
         root.open_child_file(OsStr::new(details_name))
             .map_err(storage)?,
+    );
+    account_sequential_read(
+        identities.get_ref().metadata().map_err(storage)?.len(),
+        evidence,
+    );
+    account_sequential_read(
+        details.get_ref().metadata().map_err(storage)?.len(),
+        evidence,
     );
     let mut identity = read_fixed::<BASE_IDENTITY_WIDTH>(&mut identities)?;
     let mut count = 0_u64;
@@ -2625,6 +3157,14 @@ fn validate_endpoints(
         root.open_child_file(OsStr::new(endpoints_name))
             .map_err(storage)?,
     );
+    account_sequential_read(
+        identities.get_ref().metadata().map_err(storage)?.len(),
+        evidence,
+    );
+    account_sequential_read(
+        endpoints.get_ref().metadata().map_err(storage)?.len(),
+        evidence,
+    );
     let mut identity = read_fixed::<BASE_IDENTITY_WIDTH>(&mut identities)?;
     let mut endpoint_count = 0_u64;
     while let Some(endpoint) = read_fixed::<ENDPOINT_WIDTH>(&mut endpoints)? {
@@ -2677,6 +3217,10 @@ fn assign_surrogates(
         root.open_child_file(OsStr::new(input_name))
             .map_err(storage)?,
     );
+    account_sequential_read(
+        reader.get_ref().metadata().map_err(storage)?.len(),
+        evidence,
+    );
     let mut writer = BufWriter::with_capacity(BLOCK_BYTES, file);
     let mut count = 0_u64;
     while let Some(mut record) = read_fixed::<BASE_IDENTITY_WIDTH>(&mut reader)? {
@@ -2710,10 +3254,15 @@ fn assign_surrogates(
     }
     writer.flush().map_err(storage)?;
     writer.get_ref().sync_all().map_err(storage)?;
+    account_sequential_write(
+        writer.get_ref().metadata().map_err(storage)?.len(),
+        evidence,
+    );
     drop(writer);
     root.install_child(OsStr::new(&temporary), identity, OsStr::new(output))
         .map_err(storage)?;
     root.sync().map_err(storage)?;
+    evidence.merge_fsync_operations = evidence.merge_fsync_operations.saturating_add(2);
     Ok(output.to_owned())
 }
 
@@ -2738,6 +3287,14 @@ fn resolve_endpoint_surrogates(
         BLOCK_BYTES,
         root.open_child_file(OsStr::new(endpoints_name))
             .map_err(storage)?,
+    );
+    account_sequential_read(
+        identities.get_ref().metadata().map_err(storage)?.len(),
+        evidence,
+    );
+    account_sequential_read(
+        endpoints.get_ref().metadata().map_err(storage)?.len(),
+        evidence,
     );
     let mut identity = read_fixed::<BASE_IDENTITY_WIDTH>(&mut identities)?;
     let mut window = Vec::<[u8; RESOLVED_ENDPOINT_WIDTH]>::with_capacity(window_rows);
@@ -2773,6 +3330,10 @@ fn resolve_endpoint_surrogates(
             evidence.merge_written_records = evidence
                 .merge_written_records
                 .saturating_add(window.len() as u64);
+            evidence.merge_fsync_operations = evidence
+                .merge_fsync_operations
+                .saturating_add(receipt.fsync_operations);
+            account_sequential_write(receipt.bytes, evidence);
             runs.push(name);
             window.clear();
             sequence = sequence.saturating_add(1);
@@ -2787,6 +3348,10 @@ fn resolve_endpoint_surrogates(
         evidence.merge_written_records = evidence
             .merge_written_records
             .saturating_add(window.len() as u64);
+        evidence.merge_fsync_operations = evidence
+            .merge_fsync_operations
+            .saturating_add(receipt.fsync_operations);
+        account_sequential_write(receipt.bytes, evidence);
         runs.push(name);
     }
     merge_fixed_all::<RESOLVED_ENDPOINT_WIDTH>(
@@ -2799,106 +3364,6 @@ fn resolve_endpoint_surrogates(
         evidence,
     )
     .map(Some)
-}
-
-fn create_base_snapshot(
-    project_dir: &Path,
-    generation: u64,
-    root: &StableDirectory,
-) -> Result<
-    (
-        UuidConstructionSnapshot,
-        ArtifactReceipt,
-        UuidConstructionSnapshotWork,
-    ),
-    GfError,
-> {
-    let temporary = artifact_temp(BASE_IDENTITIES);
-    let file = root
-        .create_replaceable_child_file(OsStr::new(&temporary))
-        .map_err(storage)?;
-    let identity = file_identity(&file).map_err(storage)?;
-    let mut writer = HashingWriter::new(file);
-    let records_per_block = (BLOCK_BYTES / BASE_IDENTITY_WIDTH).max(1);
-    let block_bytes = records_per_block * BASE_IDENTITY_WIDTH;
-    let mut block = Vec::with_capacity(block_bytes);
-    let (snapshot, work) = open_uuid_construction_snapshot(project_dir, generation, |value| {
-        block.extend_from_slice(&encode_base_identity(value));
-        if block.len() == block_bytes {
-            writer.write_all(&block).map_err(storage)?;
-            block.clear();
-        }
-        Ok(())
-    })?;
-    if !block.is_empty() {
-        writer.write_all(&block).map_err(storage)?;
-    }
-    writer.flush().map_err(storage)?;
-    writer.inner.sync_all().map_err(storage)?;
-    let receipt = ArtifactReceipt {
-        name: BASE_IDENTITIES.to_owned(),
-        bytes: writer.bytes,
-        sha256: hex(&writer.digest.finalize()),
-        identity: identity.into(),
-        write_operations: writer.operations,
-    };
-    root.sync().map_err(storage)?;
-    root.install_child(
-        OsStr::new(&temporary),
-        identity,
-        OsStr::new(BASE_IDENTITIES),
-    )
-    .map_err(storage)?;
-    root.sync().map_err(storage)?;
-    Ok((snapshot, receipt, work))
-}
-
-fn authenticate_base_snapshot(
-    project_dir: &Path,
-    generation: u64,
-    root: &StableDirectory,
-    receipt: &ArtifactReceipt,
-) -> Result<(UuidConstructionSnapshot, UuidConstructionSnapshotWork), GfError> {
-    let mut retained = BufReader::with_capacity(
-        BLOCK_BYTES,
-        root.open_child_file(OsStr::new(BASE_IDENTITIES))
-            .map_err(storage)?,
-    );
-    let (snapshot, work) = open_uuid_construction_snapshot(project_dir, generation, |value| {
-        let mut record = [0_u8; BASE_IDENTITY_WIDTH];
-        retained.read_exact(&mut record).map_err(storage)?;
-        if record != encode_base_identity(value) {
-            return Err(storage(
-                "retained base identities differ from parent UUID authority",
-            ));
-        }
-        Ok(())
-    })?;
-    let mut trailing = [0_u8; 1];
-    if retained.read(&mut trailing).map_err(storage)? != 0 {
-        return Err(storage("retained base identities have trailing records"));
-    }
-    authenticate_artifact(root, receipt)?;
-    Ok((snapshot, work))
-}
-
-fn remove_unrecorded_base(root: &StableDirectory) -> Result<(), GfError> {
-    let mut file = match root.open_child_file(OsStr::new(BASE_IDENTITIES)) {
-        Ok(file) => file,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-        Err(error) => return Err(storage(error)),
-    };
-    let identity = file_identity(&file).map_err(storage)?;
-    if file_link_count(&file).map_err(storage)? != 1
-        || file.metadata().map_err(storage)?.len() % BASE_IDENTITY_WIDTH as u64 != 0
-    {
-        return Err(storage("unrecorded base identity run is not session-owned"));
-    }
-    validate_sorted_run(&mut file, BASE_IDENTITY_WIDTH)?;
-    drop(file);
-    root.unlink_child_if_identity(OsStr::new(BASE_IDENTITIES), identity)
-        .map_err(storage)?;
-    root.sync().map_err(storage)
 }
 
 #[derive(Clone, Copy)]
@@ -2928,11 +3393,7 @@ fn authenticate_artifact(
     let mut bytes = 0_u64;
     let mut operations = 0_u64;
     let width = if receipt.name.ends_with(".identities.run") {
-        Some(if receipt.name == BASE_IDENTITIES {
-            BASE_IDENTITY_WIDTH
-        } else {
-            IDENTITY_WIDTH
-        })
+        Some(IDENTITY_WIDTH)
     } else if receipt.name.ends_with(".endpoints.run") {
         Some(ENDPOINT_WIDTH)
     } else if receipt.name.ends_with(".node-details.run") {
@@ -3007,8 +3468,7 @@ fn validate_artifact_name(receipt: &ArtifactReceipt) -> Result<(), GfError> {
         || receipt.name.ends_with(".identities.run")
         || receipt.name.ends_with(".endpoints.run")
         || receipt.name.ends_with(".node-details.run")
-        || receipt.name.ends_with(".edge-details.run")
-        || receipt.name == BASE_IDENTITIES;
+        || receipt.name.ends_with(".edge-details.run");
     if !valid_suffix
         || receipt.name.starts_with('.')
         || receipt.name.contains('/')
@@ -3021,20 +3481,13 @@ fn validate_artifact_name(receipt: &ArtifactReceipt) -> Result<(), GfError> {
             .file_id
             .bytes()
             .all(|byte| byte.is_ascii_hexdigit())
-        || ((receipt.bytes == 0 || receipt.write_operations == 0)
-            && receipt.name != BASE_IDENTITIES)
+        || receipt.bytes == 0
+        || receipt.write_operations == 0
+        || receipt.fsync_operations == 0
     {
         return Err(storage("invalid construction artifact receipt"));
     }
-    if receipt.name.ends_with(".identities.run")
-        && receipt.bytes
-            % if receipt.name == BASE_IDENTITIES {
-                BASE_IDENTITY_WIDTH as u64
-            } else {
-                IDENTITY_WIDTH as u64
-            }
-            != 0
-    {
+    if receipt.name.ends_with(".identities.run") && receipt.bytes % IDENTITY_WIDTH as u64 != 0 {
         return Err(storage("truncated identity run"));
     }
     if receipt.name.ends_with(".endpoints.run") && receipt.bytes % ENDPOINT_WIDTH as u64 != 0 {
@@ -3066,6 +3519,7 @@ fn receipt_from_intent(intent: &ChunkIntent) -> Result<ConstructionChunkReceipt,
         input_sha256: intent.input_sha256.clone(),
         schema_sha256: intent.schema_sha256.clone(),
         run_records: intent.run_records,
+        accounted_live_bytes: intent.accounted_live_bytes,
         parquet: intent
             .parquet
             .clone()
@@ -3094,6 +3548,7 @@ fn validate_receipt_semantics(
         || receipt.rows > budgets.max_batch_rows as u64
         || receipt.input_bytes > budgets.max_batch_bytes as u64
         || receipt.run_records > budgets.max_run_records as u64
+        || receipt.accounted_live_bytes == 0
         || receipt.input_sha256.len() != 64
         || receipt.schema_sha256.len() != 64
         || !receipt
@@ -3239,6 +3694,7 @@ fn validate_intent(intent: &ChunkIntent, checkpoint: &Checkpoint) -> Result<(), 
         || intent.rows > checkpoint.budgets.max_batch_rows as u64
         || intent.input_bytes > checkpoint.budgets.max_batch_bytes as u64
         || intent.run_records > checkpoint.budgets.max_run_records as u64
+        || intent.accounted_live_bytes > 0 && intent.accounted_live_bytes < intent.input_bytes
         || intent.run_records != expected_run_records
         || intent.input_sha256.len() != 64
         || intent.schema_sha256.len() != 64
@@ -3299,6 +3755,7 @@ fn validate_checkpoint(
     session: FileIdentity,
     generation: u64,
     budgets: GraphConstructionBudgets,
+    parent_catalog_sha256: Option<&str>,
 ) -> Result<(), GfError> {
     if checkpoint.format_version != FORMAT_VERSION
         || checkpoint.operation_uuid != operation
@@ -3307,7 +3764,14 @@ fn validate_checkpoint(
         || checkpoint.parent_topology_generation != generation
         || checkpoint.session_now_micros <= 0
         || checkpoint.budgets != budgets
-        || checkpoint.base_identities.is_some() != (generation != 0)
+        || checkpoint.has_base_snapshot != (generation != 0)
+        || checkpoint.parent_catalog_sha256.as_deref() != parent_catalog_sha256
+        || checkpoint
+            .parent_catalog_sha256
+            .as_ref()
+            .is_some_and(|digest| {
+                digest.len() != 64 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit())
+            })
         || checkpoint.next_sequence > budgets.max_chunks
         || checkpoint.last_receipt_sha256.is_some() != (checkpoint.next_sequence != 0)
         || checkpoint
@@ -3325,18 +3789,6 @@ fn validate_checkpoint(
         || checkpoint.evidence.current_transitions != 0
     {
         return Err(storage("checkpoint authority or resume parameters changed"));
-    }
-    if let Some(base) = &checkpoint.base_identities {
-        validate_artifact_name(base)?;
-        if base.name != BASE_IDENTITIES
-            || base.bytes / BASE_IDENTITY_WIDTH as u64
-                != checkpoint
-                    .base_work
-                    .live_nodes
-                    .saturating_add(checkpoint.base_work.live_edges)
-        {
-            return Err(storage("checkpoint base identity receipt is inconsistent"));
-        }
     }
     Ok(())
 }
@@ -3431,7 +3883,7 @@ fn is_owned_artifact_temp(name: &str) -> bool {
 }
 
 fn canonical_artifact_target(name: &str) -> bool {
-    if name == BASE_IDENTITIES || is_shape_artifact_name(name) {
+    if is_shape_artifact_name(name) {
         return true;
     }
     let Some(body) = name.strip_prefix("chunk-") else {
@@ -3745,7 +4197,7 @@ fn hex(bytes: &[u8]) -> String {
 mod tests {
     use std::sync::Arc;
 
-    use arrow::array::{FixedSizeBinaryArray, Int64Array, StringArray};
+    use arrow::array::{BinaryArray, FixedSizeBinaryArray, Int64Array, StringArray};
     use tempfile::TempDir;
 
     use super::*;
@@ -3800,6 +4252,44 @@ mod tests {
         .unwrap()
     }
 
+    fn nonempty_project() -> TempDir {
+        let project = TempDir::new().unwrap();
+        std::fs::create_dir_all(project.path().join("topology")).unwrap();
+        std::fs::write(
+            project.path().join("topology/generation.json"),
+            br#"{"topology_generation":1,"search_generation":1}"#,
+        )
+        .unwrap();
+        let tails_schema = Arc::new(Schema::new(vec![
+            Field::new("max_node_id", DataType::UInt64, false),
+            Field::new("max_edge_id", DataType::UInt64, false),
+        ]));
+        let tails = RecordBatch::try_new(
+            tails_schema.clone(),
+            vec![
+                Arc::new(arrow::array::UInt64Array::from(vec![2])),
+                Arc::new(arrow::array::UInt64Array::from(vec![1])),
+            ],
+        )
+        .unwrap();
+        let mut writer = ArrowWriter::try_new(
+            File::create(project.path().join("topology/surrogate_tails.parquet")).unwrap(),
+            tails_schema,
+            None,
+        )
+        .unwrap();
+        writer.write(&tails).unwrap();
+        writer.close().unwrap();
+        crate::uuid_membership::append_uuid_membership_delta(
+            project.path(),
+            1,
+            &[(Uuid::from_u128(1), 1), (Uuid::from_u128(2), 2)],
+            &[Uuid::from_u128(100)],
+        )
+        .unwrap();
+        project
+    }
+
     #[test]
     fn row_artifact_retains_dynamic_properties_and_is_uuid_sorted() {
         let root = TempDir::new().unwrap();
@@ -3851,6 +4341,153 @@ mod tests {
     }
 
     #[test]
+    fn replay_binds_property_schema_and_rejects_unsupported_staging_types() {
+        let root = TempDir::new().unwrap();
+        let mut session = open(&root, 98);
+        let batch_with = |property: &str| {
+            RecordBatch::try_new(
+                Arc::new(Schema::new(vec![
+                    Field::new("node_uuid", DataType::FixedSizeBinary(16), false),
+                    Field::new("label", DataType::Utf8, false),
+                    Field::new(property, DataType::Int64, false),
+                ])),
+                vec![
+                    Arc::new(fixed(&[1_u128.to_be_bytes()])),
+                    Arc::new(StringArray::from(vec!["Person"])),
+                    Arc::new(Int64Array::from(vec![7])),
+                ],
+            )
+            .unwrap()
+        };
+        session
+            .append(
+                ConstructionChunkKind::Node,
+                "schema-bound",
+                &batch_with("score"),
+            )
+            .unwrap();
+        assert!(
+            session
+                .append(
+                    ConstructionChunkKind::Node,
+                    "schema-bound",
+                    &batch_with("renamed")
+                )
+                .unwrap_err()
+                .to_string()
+                .contains("conflicting")
+        );
+
+        let unsupported = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("node_uuid", DataType::FixedSizeBinary(16), false),
+                Field::new("label", DataType::Utf8, false),
+                Field::new("payload", DataType::Binary, false),
+            ])),
+            vec![
+                Arc::new(fixed(&[2_u128.to_be_bytes()])),
+                Arc::new(StringArray::from(vec!["Person"])),
+                Arc::new(BinaryArray::from(vec![b"bytes".as_slice()])),
+            ],
+        )
+        .unwrap();
+        assert!(
+            session
+                .append(ConstructionChunkKind::Node, "unsupported", &unsupported)
+                .unwrap_err()
+                .to_string()
+                .contains("unsupported")
+        );
+    }
+
+    #[test]
+    fn catalog_shape_preserves_parent_ids_history_and_ignores_null_observations() {
+        let project = TempDir::new().unwrap();
+        std::fs::create_dir_all(project.path().join("topology")).unwrap();
+        let mut parent = RuntimeCatalog::new();
+        parent.intern_label_at("BaseOnly", 11);
+        parent.intern_property_at("legacy", Some("BaseOnly"), 11);
+        let parent_path = project.path().join("topology/runtime_catalog.parquet");
+        let parent_batch = parent.to_record_batch();
+        let mut parent_writer = ArrowWriter::try_new(
+            File::create(&parent_path).unwrap(),
+            parent_batch.schema(),
+            None,
+        )
+        .unwrap();
+        parent_writer.write(&parent_batch).unwrap();
+        parent_writer.close().unwrap();
+
+        let private_path = project.path().join("catalog-shape");
+        std::fs::create_dir(&private_path).unwrap();
+        let private = StableDirectory::open(&private_path).unwrap();
+        let rows = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("node_uuid", DataType::FixedSizeBinary(16), false),
+                Field::new("label", DataType::Utf8, false),
+                Field::new("score", DataType::Int64, true),
+            ])),
+            vec![
+                Arc::new(fixed(&[1_u128.to_be_bytes(), 2_u128.to_be_bytes()])),
+                Arc::new(StringArray::from(vec!["Person", "Person"])),
+                Arc::new(Int64Array::from(vec![Some(7), None])),
+            ],
+        )
+        .unwrap();
+        write_parquet(&private, "nodes.parquet", &rows).unwrap();
+        let mut evidence = GraphConstructionEvidence::default();
+        let (parent_catalog, parent_catalog_sha256) =
+            load_parent_runtime_catalog(project.path(), 1).unwrap();
+        assert!(parent_catalog_sha256.is_some());
+        let output = build_runtime_catalog(
+            parent_catalog,
+            &private,
+            &["nodes.parquet".to_owned()],
+            &[],
+            42,
+            &mut || false,
+            &mut evidence,
+        )
+        .unwrap();
+        let reader = ParquetRecordBatchReaderBuilder::try_new(
+            private.open_child_file(OsStr::new(&output)).unwrap(),
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+        let batches = reader.collect::<Result<Vec<_>, _>>().unwrap();
+        let merged = arrow::compute::concat_batches(&batches[0].schema(), &batches).unwrap();
+        let kinds = merged
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let names = merged
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let counts = merged
+            .column(3)
+            .as_any()
+            .downcast_ref::<arrow::array::UInt64Array>()
+            .unwrap();
+        let first = merged
+            .column(4)
+            .as_any()
+            .downcast_ref::<arrow::array::TimestampMicrosecondArray>()
+            .unwrap();
+        let base = (0..merged.num_rows())
+            .find(|&row| kinds.value(row) == "entity_type" && names.value(row) == "BaseOnly")
+            .unwrap();
+        assert_eq!((counts.value(base), first.value(base)), (1, 11));
+        let score = (0..merged.num_rows())
+            .find(|&row| kinds.value(row) == "property" && names.value(row) == "score")
+            .unwrap();
+        assert_eq!(counts.value(score), 1);
+    }
+
+    #[test]
     fn journal_is_constant_control_state_and_seal_reopens_every_artifact() {
         for chunks in [1_u64, 2, 4] {
             let root = TempDir::new().unwrap();
@@ -3871,6 +4508,9 @@ mod tests {
             assert_eq!(session.evidence().peak_run_records, 64);
             assert_eq!(session.evidence().prior_topology_rows_decoded, 0);
             assert_eq!(session.evidence().current_transitions, 0);
+            assert!(session.evidence().write_operations < session.evidence().input_rows);
+            assert!(session.evidence().fsync_operations > 0);
+            assert!(session.evidence().peak_accounted_live_bytes > 0);
             let checkpoint_bytes = session
                 .root
                 .open_child_file(OsStr::new(CHECKPOINT))
@@ -3883,6 +4523,13 @@ mod tests {
             assert_eq!(session.state(), GraphConstructionState::Sealed);
             assert!(session.evidence().authentication_read_bytes > 0);
         }
+    }
+
+    #[test]
+    fn million_chunk_online_scheduler_has_logarithmic_name_state() {
+        let slots = online_merge_name_slot_bound(1_000_000, 32);
+        assert!(slots <= 31 * 4, "retained slots: {slots}");
+        assert!(slots < 1_000_000 / 1_000);
     }
 
     #[test]
@@ -3933,10 +4580,49 @@ mod tests {
             assert!(session.evidence().peak_merge_inputs <= 2);
             assert!(session.evidence().merge_read_bytes > 0);
             assert!(session.evidence().merge_written_bytes > 0);
+            assert!(session.evidence().merge_read_blocks > 0);
+            assert!(session.evidence().merge_write_blocks > 0);
+            assert!(session.evidence().merge_fsync_operations > 0);
+            assert!(session.evidence().parquet_read_operations > 0);
+            assert!(session.evidence().parquet_write_operations > 0);
             if chunks == 4 {
                 assert!(session.evidence().merge_passes >= 2);
             }
         }
+    }
+
+    #[test]
+    fn batch_partition_and_resume_produce_identical_canonical_data_fingerprints() {
+        let one = TempDir::new().unwrap();
+        let mut one_session = open(&one, 7_100);
+        one_session
+            .append(ConstructionChunkKind::Node, "all", &node_batch(1, 8))
+            .unwrap();
+        one_session.seal().unwrap();
+        let one_shape = one_session
+            .shape_canonical_with_cancellation(|| false)
+            .unwrap();
+        let one_identity = receipt_for_existing(&one_session.root, &one_shape.identities).unwrap();
+        let one_rows = receipt_for_existing(&one_session.root, &one_shape.node_rows[0]).unwrap();
+
+        let two = TempDir::new().unwrap();
+        let mut two_session = open(&two, 7_101);
+        two_session
+            .append(ConstructionChunkKind::Node, "first", &node_batch(1, 4))
+            .unwrap();
+        two_session
+            .append(ConstructionChunkKind::Node, "second", &node_batch(5, 4))
+            .unwrap();
+        two_session.seal().unwrap();
+        drop(two_session);
+        let mut resumed = open(&two, 7_101);
+        let two_shape = resumed.shape_canonical_with_cancellation(|| false).unwrap();
+        let two_identity = receipt_for_existing(&resumed.root, &two_shape.identities).unwrap();
+        let two_rows = receipt_for_existing(&resumed.root, &two_shape.node_rows[0]).unwrap();
+        assert_eq!(one_identity.sha256, two_identity.sha256);
+        assert_eq!(one_rows.sha256, two_rows.sha256);
+        assert_eq!((one_shape.node_count, one_shape.edge_count), (8, 0));
+        assert_eq!((two_shape.node_count, two_shape.edge_count), (8, 0));
     }
 
     #[test]
@@ -3965,6 +4651,79 @@ mod tests {
             .unwrap();
         missing
             .append(ConstructionChunkKind::Edge, "edges", &edge_batch(20_000, 2))
+            .unwrap();
+        missing.seal().unwrap();
+        assert!(
+            missing
+                .shape_canonical_with_cancellation(|| false)
+                .unwrap_err()
+                .to_string()
+                .contains("endpoint")
+        );
+    }
+
+    #[test]
+    fn nonempty_base_rejects_duplicate_cross_kind_and_missing_endpoint_without_copy() {
+        let project = nonempty_project();
+        let budgets = GraphConstructionBudgets::default();
+
+        let mut duplicate =
+            GraphConstructionSession::open(project.path(), Uuid::from_u128(8_101), 1, budgets)
+                .unwrap();
+        duplicate
+            .append(ConstructionChunkKind::Node, "duplicate", &node_batch(1, 1))
+            .unwrap();
+        duplicate.seal().unwrap();
+        assert!(
+            duplicate
+                .shape_canonical_with_cancellation(|| false)
+                .unwrap_err()
+                .to_string()
+                .contains("conflicts with pinned base")
+        );
+        assert!(
+            !project
+                .path()
+                .join(PRIVATE_ROOT)
+                .join(Uuid::from_u128(8_101).simple().to_string())
+                .join("base-identities.run")
+                .exists()
+        );
+        drop(duplicate);
+
+        let edge = |edge_uuid: u128, source: u128, target: u128| {
+            RecordBatch::try_new(
+                CONSTRUCTION_EDGE_SCHEMA.clone(),
+                vec![
+                    Arc::new(fixed(&[edge_uuid.to_be_bytes()])),
+                    Arc::new(StringArray::from(vec!["R"])),
+                    Arc::new(fixed(&[source.to_be_bytes()])),
+                    Arc::new(fixed(&[target.to_be_bytes()])),
+                ],
+            )
+            .unwrap()
+        };
+        let mut cross_kind =
+            GraphConstructionSession::open(project.path(), Uuid::from_u128(8_102), 1, budgets)
+                .unwrap();
+        cross_kind
+            .append(ConstructionChunkKind::Edge, "cross-kind", &edge(1, 1, 2))
+            .unwrap();
+        cross_kind.seal().unwrap();
+        assert!(
+            cross_kind
+                .shape_canonical_with_cancellation(|| false)
+                .unwrap_err()
+                .to_string()
+                .contains("conflicts with pinned base")
+        );
+        drop(cross_kind);
+
+        let mut missing =
+            GraphConstructionSession::open(project.path(), Uuid::from_u128(8_103), 1, budgets)
+                .unwrap();
+        missing
+            .append(ConstructionChunkKind::Edge, "missing", &edge(200, 999, 1))
             .unwrap();
         missing.seal().unwrap();
         assert!(

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -867,6 +867,21 @@ impl GraphConstructionSession {
             )?;
             return Ok(published);
         }
+        if self.checkpoint.publication_state == Some(ConstructionPublicationState::Publishing) {
+            self.begin_publication(target_generation_uuid, transaction_uuid)?;
+            if let Some(published) =
+                crate::published_project_transaction(&self.project_path, transaction_uuid)?
+            {
+                if published.generation_uuid != target_generation_uuid {
+                    return Err(storage("published construction target changed"));
+                }
+                self.finish_publication(
+                    target_generation_uuid,
+                    &hex(&published.generation_manifest_sha256),
+                )?;
+                return Ok(published);
+            }
+        }
         let expected_inventory = self
             .checkpoint
             .encoding_inventory_sha256
@@ -1023,6 +1038,7 @@ impl GraphConstructionSession {
                     .publish_with_graph_objects(&lease)?,
                 crate::ProjectStageOutcome::AlreadyPublished(receipt) => receipt,
             };
+        construction_failpoint("publication.after_current_before_receipt");
         self.finish_publication(
             target_generation_uuid,
             &hex(&publication.generation_manifest_sha256),
@@ -8300,6 +8316,14 @@ mod tests {
                 .any(|entry| entry.relative_path.starts_with("topology/nodes/"))
         );
         drop(current);
+        let receipt_path = root
+            .path()
+            .join(PRIVATE_ROOT)
+            .join(operation.simple().to_string())
+            .join(PUBLICATION_RECEIPT);
+        std::fs::remove_file(receipt_path).unwrap();
+        session.checkpoint.publication_state = Some(ConstructionPublicationState::Publishing);
+        replace_control(&session.root, CHECKPOINT, &session.checkpoint).unwrap();
         drop(session);
 
         let mut resumed = GraphConstructionSession::open(

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -1603,6 +1603,16 @@ impl GraphConstructionSession {
         &mut self,
         generation: u64,
     ) -> Result<GraphConstructionEncoding, GfError> {
+        self.prepare_canonical_encoding_with_cancellation(generation, || false)
+    }
+
+    /// Reopen or create canonical encoding while polling cooperative cancellation.
+    pub fn prepare_canonical_encoding_with_cancellation(
+        &mut self,
+        generation: u64,
+        mut cancelled: impl FnMut() -> bool,
+    ) -> Result<GraphConstructionEncoding, GfError> {
+        reject_cancelled(&mut cancelled)?;
         self.revalidate_authority()?;
         if self.checkpoint.state != GraphConstructionState::Sealed {
             return Err(storage("only a sealed session can be prepared"));
@@ -1619,8 +1629,8 @@ impl GraphConstructionSession {
             }
             return Ok(inventory);
         }
-        let shape = self.shape_canonical_with_cancellation(|| false)?;
-        self.encode_canonical(&shape, generation)
+        let shape = self.shape_canonical_with_cancellation(&mut cancelled)?;
+        self.encode_canonical_with_cancellation(&shape, generation, cancelled)
     }
 
     #[cfg(test)]

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -680,7 +680,7 @@ impl GraphConstructionSession {
         transaction_uuid: Uuid,
     ) -> Result<ConstructionPublicationIntent, GfError> {
         self.revalidate_authority()?;
-        recover_publication(&self.root, &mut self.checkpoint)?;
+        recover_publication(&self.project_path, &self.root, &mut self.checkpoint)?;
         if self.checkpoint.publication_state == Some(ConstructionPublicationState::Publishing) {
             let intent = read_publication_intent(&self.root, &self.checkpoint)?;
             if intent.target_generation_uuid == target_generation_uuid
@@ -738,9 +738,10 @@ impl GraphConstructionSession {
         target_generation_uuid: Uuid,
         target_generation_manifest_sha256: &str,
     ) -> Result<ConstructionPublicationReceipt, GfError> {
-        recover_publication(&self.root, &mut self.checkpoint)?;
+        recover_publication(&self.project_path, &self.root, &mut self.checkpoint)?;
         if self.checkpoint.publication_state == Some(ConstructionPublicationState::Published) {
             let receipt = read_publication_receipt(&self.root, &self.checkpoint)?;
+            authenticate_published_target(&self.project_path, &self.checkpoint, &receipt)?;
             if receipt.target_generation_uuid == target_generation_uuid
                 && receipt.target_generation_manifest_sha256 == target_generation_manifest_sha256
             {
@@ -759,7 +760,7 @@ impl GraphConstructionSession {
         if intent.target_generation_uuid != target_generation_uuid {
             return Err(storage("published target differs from durable intent"));
         }
-        let receipt = ConstructionPublicationReceipt {
+        let provisional = ConstructionPublicationReceipt {
             operation_uuid: self.checkpoint.operation_uuid,
             project_identity: self.checkpoint.project_identity.clone(),
             session_identity: self.checkpoint.session_identity.clone(),
@@ -767,6 +768,8 @@ impl GraphConstructionSession {
             target_generation_uuid,
             target_generation_manifest_sha256: target_generation_manifest_sha256.to_owned(),
         };
+        authenticate_published_target(&self.project_path, &self.checkpoint, &provisional)?;
+        let receipt = provisional;
         install_control(&self.root, PUBLICATION_RECEIPT, &receipt)?;
         self.checkpoint.publication_state = Some(ConstructionPublicationState::Published);
         replace_control(&self.root, CHECKPOINT, &self.checkpoint)?;
@@ -942,7 +945,7 @@ impl GraphConstructionSession {
             {
                 return Err(storage("checkpoint private authority changed"));
             }
-            recover_publication(&root, checkpoint)?;
+            recover_publication(project_dir, &root, checkpoint)?;
         }
         let (parent_generation_uuid, parent_generation_manifest_sha256) =
             match recovered_checkpoint.as_ref() {
@@ -2528,11 +2531,7 @@ fn recover_shape_intent(
         if shape.ontology_mode != checkpoint.ontology_mode
             || shape.semantic_authority_sha256 != checkpoint.semantic_authority_sha256
             || shape.runtime_catalog_now_micros != checkpoint.session_now_micros
-            || shape.runtime_catalog_inputs_sha256.len() != 64
-            || !shape
-                .runtime_catalog_inputs_sha256
-                .bytes()
-                .all(|byte| byte.is_ascii_hexdigit())
+            || !is_canonical_sha256(&shape.runtime_catalog_inputs_sha256)
             || std::iter::once(&shape.identities)
                 .chain(shape.node_details.iter())
                 .chain(shape.edge_details.iter())
@@ -2617,16 +2616,33 @@ fn control_sha256(value: &impl Serialize) -> Result<String, GfError> {
 }
 
 fn validate_sha256(value: &str, label: &str) -> Result<(), GfError> {
-    if value.len() != 64 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+    if !is_canonical_sha256(value) {
         return Err(storage(format!("{label} digest is invalid")));
     }
     Ok(())
+}
+
+fn is_canonical_sha256(value: &str) -> bool {
+    is_canonical_lower_hex(value, 64)
+}
+
+fn is_canonical_lower_hex(value: &str, length: usize) -> bool {
+    value.len() == length
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
 }
 
 fn validate_publication_intent(
     intent: &ConstructionPublicationIntent,
     checkpoint: &Checkpoint,
 ) -> Result<(), GfError> {
+    validate_sha256(
+        &intent.parent_generation_manifest_sha256,
+        "parent generation manifest",
+    )?;
+    validate_sha256(&intent.shape_authority_sha256, "shape authority")?;
+    validate_sha256(&intent.encoding_inventory_sha256, "encoding inventory")?;
     if intent.format_version != FORMAT_VERSION
         || intent.operation_uuid != checkpoint.operation_uuid
         || intent.project_identity != checkpoint.project_identity
@@ -2648,12 +2664,7 @@ fn validate_publication_intent(
     {
         return Err(storage("publication intent authority changed"));
     }
-    validate_sha256(
-        &intent.parent_generation_manifest_sha256,
-        "parent generation manifest",
-    )?;
-    validate_sha256(&intent.shape_authority_sha256, "shape authority")?;
-    validate_sha256(&intent.encoding_inventory_sha256, "encoding inventory")
+    Ok(())
 }
 
 fn read_publication_intent(
@@ -2692,7 +2703,44 @@ fn read_publication_receipt(
     Ok(receipt)
 }
 
-fn recover_publication(root: &StableDirectory, checkpoint: &mut Checkpoint) -> Result<(), GfError> {
+fn authenticate_published_target(
+    project_dir: &Path,
+    checkpoint: &Checkpoint,
+    receipt: &ConstructionPublicationReceipt,
+) -> Result<(), GfError> {
+    let target = crate::resolve_generation_by_uuid(project_dir, receipt.target_generation_uuid)
+        .map_err(|error| storage(format!("published target cannot be authenticated: {error}")))?;
+    let actual_manifest = hex(&target.manifest_sha256());
+    if actual_manifest != receipt.target_generation_manifest_sha256 {
+        return Err(storage(
+            "published target manifest differs from durable receipt",
+        ));
+    }
+    if target.parent_generation_uuid() != Some(checkpoint.parent_generation_uuid) {
+        return Err(storage(
+            "published target is not a child of the pinned parent generation",
+        ));
+    }
+    let current = crate::resolve_project_generation(project_dir).map_err(|error| {
+        storage(format!(
+            "published CURRENT cannot be authenticated: {error}"
+        ))
+    })?;
+    if current.generation_uuid() != target.generation_uuid()
+        || current.manifest_sha256() != target.manifest_sha256()
+    {
+        return Err(storage(
+            "published target is not the exact committed CURRENT generation",
+        ));
+    }
+    Ok(())
+}
+
+fn recover_publication(
+    project_dir: &Path,
+    root: &StableDirectory,
+    checkpoint: &mut Checkpoint,
+) -> Result<(), GfError> {
     let intent = match root.open_child_file(OsStr::new(PUBLICATION_INTENT)) {
         Ok(mut file) => {
             let intent: ConstructionPublicationIntent = decode_bounded(&mut file)?;
@@ -2717,7 +2765,8 @@ fn recover_publication(root: &StableDirectory, checkpoint: &mut Checkpoint) -> R
         Err(error) => return Err(storage(error)),
     };
     if receipt_exists {
-        let _ = read_publication_receipt(root, checkpoint)?;
+        let receipt = read_publication_receipt(root, checkpoint)?;
+        authenticate_published_target(project_dir, checkpoint, &receipt)?;
         if checkpoint.publication_state == Some(ConstructionPublicationState::Publishing) {
             checkpoint.publication_state = Some(ConstructionPublicationState::Published);
             replace_control(root, CHECKPOINT, checkpoint)?;
@@ -2893,7 +2942,7 @@ fn is_shape_artifact_name(name: &str) -> bool {
         return body.len() == 66
             && matches!(body.as_bytes().first(), Some(b'0' | b'1'))
             && body.as_bytes().get(1) == Some(&b'-')
-            && body[2..].bytes().all(|byte| byte.is_ascii_hexdigit());
+            && is_canonical_sha256(&body[2..]);
     }
     if let Some(body) = name
         .strip_prefix("merge-rows-")
@@ -2904,7 +2953,7 @@ fn is_shape_artifact_name(name: &str) -> bool {
         let level_group = parts.next().unwrap_or_default();
         return parts.next().is_none()
             && namespace.len() == 16
-            && namespace.bytes().all(|byte| byte.is_ascii_hexdigit())
+            && is_canonical_lower_hex(namespace, 16)
             && level_group.split_once("-g").is_some_and(|(level, group)| {
                 level.len() == 3
                     && level.bytes().all(|byte| byte.is_ascii_digit())
@@ -4587,14 +4636,8 @@ fn validate_artifact_name(receipt: &ArtifactReceipt) -> Result<(), GfError> {
         || receipt.name.starts_with('.')
         || receipt.name.contains('/')
         || receipt.name.contains('\\')
-        || receipt.sha256.len() != 64
-        || !receipt.sha256.bytes().all(|byte| byte.is_ascii_hexdigit())
-        || receipt.identity.file_id.len() != 32
-        || !receipt
-            .identity
-            .file_id
-            .bytes()
-            .all(|byte| byte.is_ascii_hexdigit())
+        || !is_canonical_sha256(&receipt.sha256)
+        || !is_canonical_lower_hex(&receipt.identity.file_id, 32)
         || receipt.bytes == 0
         || receipt.write_operations == 0
         || receipt.fsync_operations == 0
@@ -4671,16 +4714,8 @@ fn validate_receipt_semantics(
         || receipt.input_bytes > budgets.max_batch_bytes as u64
         || receipt.run_records > budgets.max_run_records as u64
         || receipt.accounted_live_bytes == 0
-        || receipt.input_sha256.len() != 64
-        || receipt.schema_sha256.len() != 64
-        || !receipt
-            .schema_sha256
-            .bytes()
-            .all(|byte| byte.is_ascii_hexdigit())
-        || !receipt
-            .input_sha256
-            .bytes()
-            .all(|byte| byte.is_ascii_hexdigit())
+        || !is_canonical_sha256(&receipt.input_sha256)
+        || !is_canonical_sha256(&receipt.schema_sha256)
         || receipt.parquet.name != format!("{}.parquet", artifact_stem(sequence, receipt.kind))
         || receipt.identities.name
             != format!("{}.identities.run", artifact_stem(sequence, receipt.kind))
@@ -4834,16 +4869,8 @@ fn validate_intent(intent: &ChunkIntent, checkpoint: &Checkpoint) -> Result<(), 
         || intent.run_records > checkpoint.budgets.max_run_records as u64
         || intent.accounted_live_bytes > 0 && intent.accounted_live_bytes < intent.input_bytes
         || intent.run_records != expected_run_records
-        || intent.input_sha256.len() != 64
-        || intent.schema_sha256.len() != 64
-        || !intent
-            .schema_sha256
-            .bytes()
-            .all(|byte| byte.is_ascii_hexdigit())
-        || !intent
-            .input_sha256
-            .bytes()
-            .all(|byte| byte.is_ascii_hexdigit())
+        || !is_canonical_sha256(&intent.input_sha256)
+        || !is_canonical_sha256(&intent.schema_sha256)
         || intent
             .parquet
             .as_ref()
@@ -4918,9 +4945,7 @@ fn validate_checkpoint(
         || checkpoint
             .semantic_authority_sha256
             .as_ref()
-            .is_some_and(|digest| {
-                digest.len() != 64 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit())
-            })
+            .is_some_and(|digest| !is_canonical_sha256(digest))
         || checkpoint.session_now_micros <= 0
         || checkpoint.budgets != budgets
         || checkpoint.has_base_snapshot != (generation != 0)
@@ -4928,29 +4953,21 @@ fn validate_checkpoint(
         || checkpoint
             .parent_catalog_sha256
             .as_ref()
-            .is_some_and(|digest| {
-                digest.len() != 64 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit())
-            })
+            .is_some_and(|digest| !is_canonical_sha256(digest))
         || checkpoint.next_sequence > budgets.max_chunks
         || checkpoint.last_receipt_sha256.is_some() != (checkpoint.next_sequence != 0)
         || checkpoint
             .last_receipt_sha256
             .as_ref()
-            .is_some_and(|digest| {
-                digest.len() != 64 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit())
-            })
+            .is_some_and(|digest| !is_canonical_sha256(digest))
         || checkpoint
             .shape_authority_sha256
             .as_ref()
-            .is_some_and(|digest| {
-                digest.len() != 64 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit())
-            })
+            .is_some_and(|digest| !is_canonical_sha256(digest))
         || checkpoint
             .encoding_inventory_sha256
             .as_ref()
-            .is_some_and(|digest| {
-                digest.len() != 64 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit())
-            })
+            .is_some_and(|digest| !is_canonical_sha256(digest))
         || checkpoint.encoding_inventory_sha256.is_some()
             && checkpoint.shape_authority_sha256.is_none()
         || match checkpoint.state {
@@ -4975,11 +4992,11 @@ fn validate_checkpoint(
         || checkpoint
             .node_schema_sha256
             .iter()
-            .any(|digest| digest.len() != 64 || !digest.bytes().all(|b| b.is_ascii_hexdigit()))
+            .any(|digest| !is_canonical_sha256(digest))
         || checkpoint
             .edge_schema_sha256
             .iter()
-            .any(|digest| digest.len() != 64 || !digest.bytes().all(|b| b.is_ascii_hexdigit()))
+            .any(|digest| !is_canonical_sha256(digest))
         || checkpoint
             .node_schema_sha256
             .len()
@@ -7966,6 +7983,7 @@ mod tests {
     }
 
     fn encoded_publication_session(root: &TempDir, operation: Uuid) -> GraphConstructionSession {
+        crate::open_or_initialize_project(root.path()).unwrap();
         let mut session = GraphConstructionSession::open(
             root.path(),
             operation,
@@ -7980,6 +7998,32 @@ mod tests {
         let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
         session.encode_canonical(&shape, 1).unwrap();
         session
+    }
+
+    fn publish_empty_generation(
+        root: &TempDir,
+        target: Uuid,
+        transaction: Uuid,
+    ) -> crate::ProjectPublicationReceipt {
+        let request = crate::ProjectGenerationRequest {
+            transaction_uuid: transaction,
+            generation_uuid: target,
+            capabilities: vec![crate::ProjectCapability {
+                capability_id: "graph".into(),
+                capability_version: 1,
+            }],
+            participants: vec![],
+        };
+        let crate::ProjectStageOutcome::Staged(staged) =
+            crate::stage_project_generation(root.path(), &request).unwrap()
+        else {
+            panic!("new publication unexpectedly replayed");
+        };
+        staged
+            .validate(|_| Ok(()), |_, _| Ok(()))
+            .unwrap()
+            .publish()
+            .unwrap()
     }
 
     #[test]
@@ -8005,7 +8049,8 @@ mod tests {
                 .to_string()
                 .contains("target changed")
         );
-        let digest = "ab".repeat(32);
+        let published = publish_empty_generation(&root, target, transaction);
+        let digest = hex(&published.generation_manifest_sha256);
         let receipt = session.finish_publication(target, &digest).unwrap();
         assert_eq!(
             session.checkpoint.publication_state,
@@ -8047,12 +8092,7 @@ mod tests {
         session.checkpoint.publication_state = Some(ConstructionPublicationState::Sealed);
         replace_control(&session.root, CHECKPOINT, &session.checkpoint).unwrap();
         drop(session);
-        std::fs::create_dir_all(root.path().join("topology")).unwrap();
-        std::fs::write(
-            root.path().join("topology/generation.json"),
-            br#"{"topology_generation":99,"search_generation":0}"#,
-        )
-        .unwrap();
+        let published = publish_empty_generation(&root, target, transaction);
         let mut reopened = GraphConstructionSession::open(
             root.path(),
             operation,
@@ -8065,7 +8105,7 @@ mod tests {
             Some(ConstructionPublicationState::Publishing)
         );
         reopened
-            .finish_publication(target, &"ef".repeat(32))
+            .finish_publication(target, &hex(&published.generation_manifest_sha256))
             .unwrap();
         reopened.checkpoint.publication_state = Some(ConstructionPublicationState::Publishing);
         replace_control(&reopened.root, CHECKPOINT, &reopened.checkpoint).unwrap();
@@ -8115,5 +8155,124 @@ mod tests {
                 .to_string()
                 .contains("publication intent authority changed")
         );
+    }
+
+    #[test]
+    fn publication_finish_rejects_wrong_target_parent_and_current() {
+        let wrong_target_root = TempDir::new().unwrap();
+        let operation = Uuid::from_u128(9_430);
+        let intended = Uuid::from_u128(9_431);
+        let transaction = Uuid::from_u128(9_432);
+        let mut session = encoded_publication_session(&wrong_target_root, operation);
+        session.begin_publication(intended, transaction).unwrap();
+        let other = publish_empty_generation(
+            &wrong_target_root,
+            Uuid::from_u128(9_433),
+            Uuid::from_u128(9_434),
+        );
+        assert!(
+            session
+                .finish_publication(intended, &hex(&other.generation_manifest_sha256))
+                .unwrap_err()
+                .to_string()
+                .contains("target cannot be authenticated")
+        );
+
+        let wrong_parent_root = TempDir::new().unwrap();
+        let mut session = encoded_publication_session(&wrong_parent_root, Uuid::from_u128(9_440));
+        let first = publish_empty_generation(
+            &wrong_parent_root,
+            Uuid::from_u128(9_441),
+            Uuid::from_u128(9_442),
+        );
+        let target = Uuid::from_u128(9_443);
+        let transaction = Uuid::from_u128(9_444);
+        session.begin_publication(target, transaction).unwrap();
+        let second = publish_empty_generation(&wrong_parent_root, target, transaction);
+        assert_ne!(first.generation_uuid, second.generation_uuid);
+        assert!(
+            session
+                .finish_publication(target, &hex(&second.generation_manifest_sha256))
+                .unwrap_err()
+                .to_string()
+                .contains("not a child of the pinned parent")
+        );
+
+        let wrong_current_root = TempDir::new().unwrap();
+        let mut session = encoded_publication_session(&wrong_current_root, Uuid::from_u128(9_450));
+        let target = Uuid::from_u128(9_451);
+        let transaction = Uuid::from_u128(9_452);
+        session.begin_publication(target, transaction).unwrap();
+        let target_receipt = publish_empty_generation(&wrong_current_root, target, transaction);
+        session
+            .finish_publication(target, &hex(&target_receipt.generation_manifest_sha256))
+            .unwrap();
+        drop(session);
+        publish_empty_generation(
+            &wrong_current_root,
+            Uuid::from_u128(9_453),
+            Uuid::from_u128(9_454),
+        );
+        let error = match GraphConstructionSession::open(
+            wrong_current_root.path(),
+            Uuid::from_u128(9_450),
+            0,
+            GraphConstructionBudgets::default(),
+        ) {
+            Ok(_) => panic!("published recovery accepted a different CURRENT"),
+            Err(error) => error,
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("not the exact committed CURRENT")
+        );
+    }
+
+    #[test]
+    fn persisted_authority_digests_reject_uppercase_hex() {
+        let root = TempDir::new().unwrap();
+        let operation = Uuid::from_u128(9_460);
+        let target = Uuid::from_u128(9_461);
+        let transaction = Uuid::from_u128(9_462);
+        let mut session = encoded_publication_session(&root, operation);
+        session.begin_publication(target, transaction).unwrap();
+        let published = publish_empty_generation(&root, target, transaction);
+        assert!(
+            session
+                .finish_publication(
+                    target,
+                    &hex(&published.generation_manifest_sha256).to_ascii_uppercase(),
+                )
+                .unwrap_err()
+                .to_string()
+                .contains("digest is invalid")
+        );
+
+        let intent_path = root
+            .path()
+            .join(PRIVATE_ROOT)
+            .join(operation.simple().to_string())
+            .join(PUBLICATION_INTENT);
+        let mut intent: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&intent_path).unwrap()).unwrap();
+        intent["shape_authority_sha256"] = serde_json::Value::String(
+            intent["shape_authority_sha256"]
+                .as_str()
+                .unwrap()
+                .to_ascii_uppercase(),
+        );
+        std::fs::write(&intent_path, serde_json::to_vec(&intent).unwrap()).unwrap();
+        drop(session);
+        let error = match GraphConstructionSession::open(
+            root.path(),
+            operation,
+            0,
+            GraphConstructionBudgets::default(),
+        ) {
+            Ok(_) => panic!("uppercase persisted authority was accepted"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("digest is invalid"));
     }
 }

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -7,17 +7,23 @@
 //! sealing path. A generation-last publisher consumes the sealed inventory.
 
 use std::cmp::Reverse;
-use std::collections::{BTreeSet, BinaryHeap};
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap};
 use std::ffi::{OsStr, OsString};
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{LazyLock, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
 
-use arrow::array::{Array, FixedSizeBinaryArray, RecordBatch, StringArray, UInt32Array};
+use arrow::array::{
+    Array, FixedSizeBinaryArray, MutableArrayData, RecordBatch, StringArray, UInt32Array,
+    make_array,
+};
+use arrow::compute::take;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use graphforge_core::GfError;
 use graphforge_filesystem::{FileIdentity, StableDirectory, file_identity, file_link_count};
+use graphforge_ir::RuntimeCatalog;
 use parquet::arrow::ArrowWriter;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use serde::{Deserialize, Serialize};
@@ -29,7 +35,7 @@ use crate::uuid_membership::{
     open_uuid_construction_snapshot,
 };
 
-const FORMAT_VERSION: u32 = 2;
+const FORMAT_VERSION: u32 = 3;
 const PRIVATE_ROOT: &str = ".graphforge-construction";
 const CHECKPOINT: &str = "checkpoint.json";
 const INTENT: &str = "intent.json";
@@ -38,26 +44,28 @@ const BLOCK_BYTES: usize = 1 << 20;
 const MAX_CONTROL_BYTES: u64 = 64 << 10;
 const IDENTITY_WIDTH: usize = 16;
 const ENDPOINT_WIDTH: usize = 48;
-const NODE_DETAIL_WIDTH: usize = 20;
+const RESOLVED_ENDPOINT_WIDTH: usize = 32;
+const NODE_DETAIL_WIDTH: usize = 272;
 const EDGE_DETAIL_WIDTH: usize = 304;
 const BASE_IDENTITY_WIDTH: usize = 32;
 const BASE_IDENTITIES: &str = "base-identities.run";
 
-/// Canonical node construction input: UUID and primary type id.
+/// Storage-normalized node input. API validation resolves nullable/generated
+/// identities before this boundary; trailing columns are normalized properties.
 pub static CONSTRUCTION_NODE_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
     std::sync::Arc::new(Schema::new(vec![
         Field::new("node_uuid", DataType::FixedSizeBinary(16), false),
-        Field::new("type_id", DataType::UInt32, false),
+        Field::new("label", DataType::Utf8, false),
     ]))
 });
 
-/// Canonical edge construction input: UUID endpoints and relation route.
+/// Storage-normalized edge input. Trailing columns are normalized properties.
 pub static CONSTRUCTION_EDGE_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
     std::sync::Arc::new(Schema::new(vec![
         Field::new("edge_uuid", DataType::FixedSizeBinary(16), false),
-        Field::new("src_uuid", DataType::FixedSizeBinary(16), false),
-        Field::new("dst_uuid", DataType::FixedSizeBinary(16), false),
         Field::new("rel_type", DataType::Utf8, false),
+        Field::new("source_uuid", DataType::FixedSizeBinary(16), false),
+        Field::new("target_uuid", DataType::FixedSizeBinary(16), false),
     ]))
 });
 
@@ -200,6 +208,18 @@ pub struct ConstructionShape {
     pub node_details: Option<String>,
     /// UUID-sorted edge endpoint and relation records, when edges were staged.
     pub edge_details: Option<String>,
+    /// UUID-sorted normalized node row artifacts, partitioned by exact schema.
+    pub node_rows: Vec<String>,
+    /// UUID-sorted normalized edge row artifacts, partitioned by exact schema.
+    pub edge_rows: Vec<String>,
+    /// Edge-UUID regrouped `(edge, role, node_surrogate)` endpoint run.
+    pub edge_endpoints: Option<String>,
+    /// Timestamp that the publisher must use for every RuntimeCatalog observation.
+    pub runtime_catalog_now_micros: i64,
+    /// Authority digest of the exact normalized row artifacts that feed the catalog.
+    pub runtime_catalog_inputs_sha256: String,
+    /// Serialized RuntimeCatalog produced once from the normalized row stream.
+    pub runtime_catalog: String,
     /// Live retained plus staged nodes.
     pub node_count: u64,
     /// Live retained plus staged edges.
@@ -260,6 +280,8 @@ pub struct ConstructionChunkReceipt {
     pub input_bytes: u64,
     /// Canonical logical digest, independent of Arrow buffer layout.
     pub input_sha256: String,
+    /// Digest of the complete normalized Arrow schema carried by the row artifact.
+    pub schema_sha256: String,
     /// Fixed-width run records.
     pub run_records: u64,
     parquet: ArtifactReceipt,
@@ -275,6 +297,9 @@ struct Checkpoint {
     project_identity: IdentityRecord,
     session_identity: IdentityRecord,
     parent_topology_generation: u64,
+    /// One authority-bound timestamp used by every catalog/topology row produced
+    /// by this operation. Reopen never consults the wall clock again.
+    session_now_micros: i64,
     budgets: GraphConstructionBudgets,
     state: GraphConstructionState,
     next_sequence: u64,
@@ -298,6 +323,7 @@ struct ChunkIntent {
     rows: u64,
     input_bytes: u64,
     input_sha256: String,
+    schema_sha256: String,
     parent_topology_generation: u64,
     prior_receipt_sha256: Option<String>,
     run_records: u64,
@@ -451,6 +477,12 @@ impl GraphConstructionSession {
                     project_identity: project_identity.into(),
                     session_identity: session_identity.into(),
                     parent_topology_generation,
+                    session_now_micros: SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .map_err(storage)?
+                        .as_micros()
+                        .try_into()
+                        .map_err(|_| storage("session timestamp exceeds i64"))?,
                     budgets,
                     state: GraphConstructionState::Staging,
                     next_sequence: 0,
@@ -497,6 +529,13 @@ impl GraphConstructionSession {
     #[must_use]
     pub const fn parent_topology_generation(&self) -> u64 {
         self.checkpoint.parent_topology_generation
+    }
+
+    /// Authority-bound timestamp for deterministic topology and runtime-catalog
+    /// materialization. It is created once and survives crash/reopen.
+    #[must_use]
+    pub const fn session_now_micros(&self) -> i64 {
+        self.checkpoint.session_now_micros
     }
 
     /// Measured aggregate evidence.
@@ -553,6 +592,7 @@ impl GraphConstructionSession {
             return Err(storage("node chunk cannot follow edge staging"));
         }
         let input_sha256 = logical_batch_digest(kind, batch)?;
+        let schema_sha256 = normalized_schema_digest(batch.schema().as_ref())?;
         let key_name = chunk_key_name(chunk_id);
         if let Ok(mut key_file) = self.root.open_child_file(OsStr::new(&key_name)) {
             let pointer: ReceiptPointer = decode_bounded(&mut key_file)?;
@@ -597,6 +637,7 @@ impl GraphConstructionSession {
             rows: batch.num_rows() as u64,
             input_bytes: input_bytes as u64,
             input_sha256,
+            schema_sha256,
             parent_topology_generation: self.checkpoint.parent_topology_generation,
             prior_receipt_sha256: self.checkpoint.last_receipt_sha256.clone(),
             run_records: run_records as u64,
@@ -608,10 +649,11 @@ impl GraphConstructionSession {
         install_control(&self.root, INTENT, &intent)?;
         reject_cancelled(&mut cancelled)?;
         let stem = artifact_stem(sequence, kind);
+        let sorted_batch = uuid_sorted_batch(kind, batch)?;
         intent.parquet = Some(write_parquet(
             &self.root,
             &format!("{stem}.parquet"),
-            batch,
+            &sorted_batch,
         )?);
         replace_control(&self.root, INTENT, &intent)?;
         reject_cancelled(&mut cancelled)?;
@@ -738,10 +780,30 @@ impl GraphConstructionSession {
         let mut edge_details = Vec::new();
         let mut endpoints = Vec::new();
         let mut receipts = Vec::new();
+        let mut row_groups: BTreeMap<(u8, String), Vec<String>> = BTreeMap::new();
+        let mut catalog_authority = Sha256::new();
         for sequence in 0..self.checkpoint.next_sequence {
             reject_cancelled(&mut cancelled)?;
             let receipt = self.read_receipt(sequence)?;
             validate_receipt_artifacts(&self.root, &receipt)?;
+            catalog_authority.update([if receipt.kind == ConstructionChunkKind::Node {
+                0
+            } else {
+                1
+            }]);
+            catalog_authority.update(receipt.schema_sha256.as_bytes());
+            catalog_authority.update(receipt.parquet.sha256.as_bytes());
+            row_groups
+                .entry((
+                    if receipt.kind == ConstructionChunkKind::Node {
+                        0
+                    } else {
+                        1
+                    },
+                    receipt.schema_sha256.clone(),
+                ))
+                .or_default()
+                .push(receipt.parquet.name.clone());
             match receipt.kind {
                 ConstructionChunkKind::Node => node_details.push(String::new()),
                 ConstructionChunkKind::Edge => {
@@ -872,6 +934,43 @@ impl GraphConstructionSession {
             &mut cancelled,
             &mut self.checkpoint.evidence,
         )?;
+        let edge_endpoints = resolve_endpoint_surrogates(
+            &self.root,
+            &identities,
+            endpoints.as_deref(),
+            self.checkpoint.budgets.max_batch_rows,
+            self.checkpoint.budgets.merge_fan_in,
+            &mut cancelled,
+            &mut self.checkpoint.evidence,
+        )?;
+        let mut node_rows = Vec::new();
+        let mut edge_rows = Vec::new();
+        for ((kind, schema_digest), inputs) in row_groups {
+            reject_cancelled(&mut cancelled)?;
+            let output = format!("shaped-rows-{kind}-{schema_digest}.parquet");
+            merge_row_all(
+                &self.root,
+                inputs,
+                &output,
+                self.checkpoint.budgets.max_batch_rows,
+                self.checkpoint.budgets.max_batch_bytes,
+                self.checkpoint.budgets.merge_fan_in,
+                &mut cancelled,
+                &mut self.checkpoint.evidence,
+            )?;
+            if kind == 0 {
+                node_rows.push(output);
+            } else {
+                edge_rows.push(output);
+            }
+        }
+        let runtime_catalog = build_runtime_catalog(
+            &self.root,
+            &node_rows,
+            &edge_rows,
+            self.checkpoint.session_now_micros,
+            &mut cancelled,
+        )?;
         self.checkpoint.evidence.merge_read_blocks = self
             .checkpoint
             .evidence
@@ -891,13 +990,27 @@ impl GraphConstructionSession {
             identities,
             node_details,
             edge_details,
+            node_rows,
+            edge_rows,
+            edge_endpoints,
+            runtime_catalog_now_micros: self.checkpoint.session_now_micros,
+            runtime_catalog_inputs_sha256: hex(&catalog_authority.finalize()),
+            runtime_catalog,
             node_count,
             edge_count,
             max_node_surrogate,
             max_edge_surrogate,
         };
         let mut outputs = vec![receipt_for_existing(&self.root, &shape.identities)?];
-        for name in shape.node_details.iter().chain(shape.edge_details.iter()) {
+        for name in shape
+            .node_details
+            .iter()
+            .chain(shape.edge_details.iter())
+            .chain(shape.node_rows.iter())
+            .chain(shape.edge_rows.iter())
+            .chain(shape.edge_endpoints.iter())
+            .chain(std::iter::once(&shape.runtime_catalog))
+        {
             outputs.push(receipt_for_existing(&self.root, name)?);
         }
         replace_control(&self.root, CHECKPOINT, &self.checkpoint)?;
@@ -1153,10 +1266,10 @@ fn extract_runs(kind: ConstructionChunkKind, batch: &RecordBatch) -> Result<RunA
     let mut endpoints = Vec::new();
     let details = if kind == ConstructionChunkKind::Edge {
         let edges = uuid_column(batch, "edge_uuid")?;
-        let src = uuid_column(batch, "src_uuid")?;
-        let dst = uuid_column(batch, "dst_uuid")?;
+        let src = uuid_column(batch, "source_uuid")?;
+        let dst = uuid_column(batch, "target_uuid")?;
         let routes = batch
-            .column(3)
+            .column(1)
             .as_any()
             .downcast_ref::<StringArray>()
             .ok_or_else(|| storage("canonical edge route is not Utf8"))?;
@@ -1189,16 +1302,19 @@ fn extract_runs(kind: ConstructionChunkKind, batch: &RecordBatch) -> Result<RunA
         DetailRuns::Edge(details)
     } else {
         let nodes = uuid_column(batch, "node_uuid")?;
-        let types = batch
+        let labels = batch
             .column(1)
             .as_any()
-            .downcast_ref::<UInt32Array>()
-            .ok_or_else(|| storage("canonical node type is not UInt32"))?;
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| storage("canonical node label is not Utf8"))?;
         let mut details = Vec::with_capacity(batch.num_rows());
         for row in 0..batch.num_rows() {
             let mut detail = [0_u8; NODE_DETAIL_WIDTH];
             detail[..16].copy_from_slice(&uuid_value(nodes, row)?);
-            detail[16..20].copy_from_slice(&types.value(row).to_be_bytes());
+            let label = labels.value(row).as_bytes();
+            detail[16] = u8::try_from(label.len())
+                .map_err(|_| storage("canonical node label exceeds identifier bound"))?;
+            detail[17..17 + label.len()].copy_from_slice(label);
             details.push(detail);
         }
         details.sort_unstable();
@@ -1216,27 +1332,40 @@ fn validate_schema(kind: ConstructionChunkKind, batch: &RecordBatch) -> Result<(
         ConstructionChunkKind::Node => &*CONSTRUCTION_NODE_SCHEMA,
         ConstructionChunkKind::Edge => &*CONSTRUCTION_EDGE_SCHEMA,
     };
-    if batch.schema().as_ref() != expected.as_ref() {
+    if batch.num_columns() < expected.fields().len()
+        || batch.schema().fields()[..expected.fields().len()] != expected.fields()[..]
+        || batch.schema().fields()[expected.fields().len()..]
+            .iter()
+            .any(|field| {
+                matches!(
+                    field.name().as_str(),
+                    "node_uuid"
+                        | "label"
+                        | "edge_uuid"
+                        | "rel_type"
+                        | "source_uuid"
+                        | "target_uuid"
+                ) || !graphforge_core::identifier::is_graph_identifier(field.name())
+            })
+    {
         return Err(storage("construction batch schema is not canonical"));
     }
-    for column in batch.columns() {
+    for column in &batch.columns()[..expected.fields().len()] {
         if column.null_count() != 0 {
-            return Err(storage("canonical construction columns are non-null"));
+            return Err(storage("required construction columns are non-null"));
         }
     }
-    if kind == ConstructionChunkKind::Edge {
-        let routes = batch
-            .column(3)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .ok_or_else(|| storage("canonical edge route is not Utf8"))?;
-        if routes
-            .iter()
-            .flatten()
-            .any(|route| !graphforge_core::identifier::is_graph_identifier(route))
-        {
-            return Err(storage("invalid canonical edge route"));
-        }
+    let identifiers = batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| storage("canonical label or relation is not Utf8"))?;
+    if identifiers
+        .iter()
+        .flatten()
+        .any(|value| !graphforge_core::identifier::is_graph_identifier(value))
+    {
+        return Err(storage("invalid canonical label or relation"));
     }
     Ok(())
 }
@@ -1252,22 +1381,24 @@ fn logical_batch_digest(
     match kind {
         ConstructionChunkKind::Node => {
             let uuids = uuid_column(batch, "node_uuid")?;
-            let types = batch
+            let labels = batch
                 .column(1)
                 .as_any()
-                .downcast_ref::<UInt32Array>()
-                .ok_or_else(|| storage("canonical node type is not UInt32"))?;
+                .downcast_ref::<StringArray>()
+                .ok_or_else(|| storage("canonical node label is not Utf8"))?;
             for row in 0..batch.num_rows() {
                 digest.update(uuid_value(uuids, row)?);
-                digest.update(types.value(row).to_be_bytes());
+                let label = labels.value(row).as_bytes();
+                digest.update((label.len() as u64).to_be_bytes());
+                digest.update(label);
             }
         }
         ConstructionChunkKind::Edge => {
             let edge = uuid_column(batch, "edge_uuid")?;
-            let src = uuid_column(batch, "src_uuid")?;
-            let dst = uuid_column(batch, "dst_uuid")?;
+            let src = uuid_column(batch, "source_uuid")?;
+            let dst = uuid_column(batch, "target_uuid")?;
             let route = batch
-                .column(3)
+                .column(1)
                 .as_any()
                 .downcast_ref::<StringArray>()
                 .ok_or_else(|| storage("canonical edge route is not Utf8"))?;
@@ -1281,7 +1412,90 @@ fn logical_batch_digest(
             }
         }
     }
+    for column in expected_property_columns(kind, batch) {
+        digest.update(column.data_type().to_string().as_bytes());
+        for row in 0..column.len() {
+            if column.is_null(row) {
+                digest.update([0]);
+            } else {
+                digest.update([1]);
+                let value = arrow::util::display::array_value_to_string(column.as_ref(), row)
+                    .map_err(storage)?;
+                digest.update((value.len() as u64).to_be_bytes());
+                digest.update(value.as_bytes());
+            }
+        }
+    }
     Ok(hex(&digest.finalize()))
+}
+
+fn normalized_schema_digest(schema: &Schema) -> Result<String, GfError> {
+    let mut digest = Sha256::new();
+    for field in schema.fields() {
+        digest.update((field.name().len() as u64).to_be_bytes());
+        digest.update(field.name().as_bytes());
+        let data_type = format!("{:?}", field.data_type());
+        digest.update((data_type.len() as u64).to_be_bytes());
+        digest.update(data_type.as_bytes());
+        digest.update([u8::from(field.is_nullable())]);
+        let mut metadata = field.metadata().iter().collect::<Vec<_>>();
+        metadata.sort_unstable();
+        for (key, value) in metadata {
+            digest.update((key.len() as u64).to_be_bytes());
+            digest.update(key.as_bytes());
+            digest.update((value.len() as u64).to_be_bytes());
+            digest.update(value.as_bytes());
+        }
+    }
+    let mut metadata = schema.metadata().iter().collect::<Vec<_>>();
+    metadata.sort_unstable();
+    for (key, value) in metadata {
+        digest.update((key.len() as u64).to_be_bytes());
+        digest.update(key.as_bytes());
+        digest.update((value.len() as u64).to_be_bytes());
+        digest.update(value.as_bytes());
+    }
+    Ok(hex(&digest.finalize()))
+}
+
+fn uuid_sorted_batch(
+    kind: ConstructionChunkKind,
+    batch: &RecordBatch,
+) -> Result<RecordBatch, GfError> {
+    let identity = uuid_column(
+        batch,
+        if kind == ConstructionChunkKind::Node {
+            "node_uuid"
+        } else {
+            "edge_uuid"
+        },
+    )?;
+    let mut order = (0..batch.num_rows()).collect::<Vec<_>>();
+    order.sort_unstable_by_key(|&row| identity.value(row));
+    let indices = UInt32Array::from(
+        order
+            .into_iter()
+            .map(|row| u32::try_from(row).map_err(|_| storage("row index exceeds UInt32")))
+            .collect::<Result<Vec<_>, _>>()?,
+    );
+    let columns = batch
+        .columns()
+        .iter()
+        .map(|column| take(column.as_ref(), &indices, None).map_err(storage))
+        .collect::<Result<Vec<_>, _>>()?;
+    RecordBatch::try_new(batch.schema(), columns).map_err(storage)
+}
+
+fn expected_property_columns<'a>(
+    kind: ConstructionChunkKind,
+    batch: &'a RecordBatch,
+) -> impl Iterator<Item = &'a arrow::array::ArrayRef> {
+    let required = if kind == ConstructionChunkKind::Node {
+        2
+    } else {
+        4
+    };
+    batch.columns()[required..].iter()
 }
 
 fn uuid_column<'a>(
@@ -1479,11 +1693,20 @@ fn recover_shape_intent(root: &StableDirectory, checkpoint: &Checkpoint) -> Resu
             .shape
             .as_ref()
             .ok_or_else(|| storage("complete shape manifest lacks output"))?;
-        if intent.outputs.is_empty()
-            || !intent
-                .outputs
-                .iter()
-                .any(|item| item.name == shape.identities)
+        if shape.runtime_catalog_now_micros != checkpoint.session_now_micros
+            || shape.runtime_catalog_inputs_sha256.len() != 64
+            || !shape
+                .runtime_catalog_inputs_sha256
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit())
+            || std::iter::once(&shape.identities)
+                .chain(shape.node_details.iter())
+                .chain(shape.edge_details.iter())
+                .chain(shape.node_rows.iter())
+                .chain(shape.edge_rows.iter())
+                .chain(shape.edge_endpoints.iter())
+                .chain(std::iter::once(&shape.runtime_catalog))
+                .any(|name| !intent.outputs.iter().any(|item| item.name == *name))
         {
             return Err(storage("complete shape manifest inventory is incomplete"));
         }
@@ -1526,6 +1749,16 @@ fn recover_shape_intent(root: &StableDirectory, checkpoint: &Checkpoint) -> Resu
         checkpoint.budgets.merge_fan_in,
     );
     names.extend(source_names);
+    for child in root.child_names().map_err(storage)? {
+        let Some(name) = child.to_str() else { continue };
+        if name.starts_with("merge-rows-")
+            || name.starts_with("shaped-rows-")
+            || name.starts_with("merge-resolved-")
+            || name == "shaped-runtime-catalog.parquet"
+        {
+            names.push(name.to_owned());
+        }
+    }
     for name in names {
         match root.open_child_file(OsStr::new(&name)) {
             Ok(file) => {
@@ -1625,7 +1858,19 @@ fn authenticate_shaped_output(
 }
 
 fn is_shape_artifact_name(name: &str) -> bool {
-    if name == "shaped-identities.run" {
+    if name == "shaped-identities.run" || name == "shaped-runtime-catalog.parquet" {
+        return true;
+    }
+    if let Some(body) = name
+        .strip_prefix("shaped-rows-")
+        .and_then(|body| body.strip_suffix(".parquet"))
+    {
+        return body.len() == 66
+            && matches!(body.as_bytes().first(), Some(b'0' | b'1'))
+            && body.as_bytes().get(1) == Some(&b'-')
+            && body[2..].bytes().all(|byte| byte.is_ascii_hexdigit());
+    }
+    if name.starts_with("merge-rows-l") && name.ends_with(".parquet") {
         return true;
     }
     if let Some(sequence) = name
@@ -1638,6 +1883,7 @@ fn is_shape_artifact_name(name: &str) -> bool {
         "merge-node-source-",
         "merge-edge-source-",
         "merge-endpoint-source-",
+        "merge-resolved-source-",
     ] {
         if let Some(sequence) = name
             .strip_prefix(prefix)
@@ -1651,6 +1897,7 @@ fn is_shape_artifact_name(name: &str) -> bool {
         "merge-node-details-l",
         "merge-edge-details-l",
         "merge-endpoints-l",
+        "merge-resolved-l",
     ]
     .iter()
     .any(|prefix| {
@@ -1902,6 +2149,289 @@ fn merge_fixed_group<const N: usize>(
     Ok(())
 }
 
+struct RowCursor {
+    reader: Box<dyn Iterator<Item = Result<RecordBatch, arrow::error::ArrowError>>>,
+    batch: Option<RecordBatch>,
+    row: usize,
+}
+
+impl RowCursor {
+    fn advance(&mut self) -> Result<Option<[u8; 16]>, GfError> {
+        loop {
+            if let Some(batch) = &self.batch
+                && self.row < batch.num_rows()
+            {
+                return uuid_value(
+                    uuid_column(batch, batch.schema().field(0).name())?,
+                    self.row,
+                )
+                .map(Some);
+            }
+            self.batch = self.reader.next().transpose().map_err(storage)?;
+            self.row = 0;
+            if self.batch.is_none() {
+                return Ok(None);
+            }
+        }
+    }
+}
+
+fn materialize_selected_rows(
+    schema: SchemaRef,
+    selected: &[(RecordBatch, usize)],
+) -> Result<RecordBatch, GfError> {
+    let columns = (0..schema.fields().len())
+        .map(|column| {
+            let data = selected
+                .iter()
+                .map(|(batch, _)| batch.column(column).to_data())
+                .collect::<Vec<_>>();
+            let refs = data.iter().collect::<Vec<_>>();
+            let mut mutable = MutableArrayData::new(refs, false, selected.len());
+            for (source, (_, row)) in selected.iter().enumerate() {
+                mutable.extend(source, *row, row.saturating_add(1));
+            }
+            Ok(make_array(mutable.freeze()))
+        })
+        .collect::<Result<Vec<_>, GfError>>()?;
+    RecordBatch::try_new(schema, columns).map_err(storage)
+}
+
+/// Merge one exact-schema set of UUID-sorted normalized Parquet row artifacts.
+/// Memory is bounded by one decoder window per input plus one caller-sized
+/// output window; no property values are projected away.
+fn merge_row_group(
+    root: &StableDirectory,
+    inputs: &[String],
+    output: &str,
+    output_rows: usize,
+    output_bytes: usize,
+    cancelled: &mut impl FnMut() -> bool,
+    evidence: &mut GraphConstructionEvidence,
+) -> Result<ArtifactReceipt, GfError> {
+    if inputs.is_empty() || output_rows == 0 || output_bytes == 0 {
+        return Err(storage("invalid row merge group"));
+    }
+    let mut cursors = Vec::with_capacity(inputs.len());
+    let mut schema: Option<SchemaRef> = None;
+    for input in inputs {
+        let file = root.open_child_file(OsStr::new(input)).map_err(storage)?;
+        let builder = ParquetRecordBatchReaderBuilder::try_new(file).map_err(storage)?;
+        if schema
+            .as_ref()
+            .is_some_and(|known| known.as_ref() != builder.schema().as_ref())
+        {
+            return Err(storage("row merge schemas differ"));
+        }
+        schema.get_or_insert_with(|| builder.schema().clone());
+        cursors.push(RowCursor {
+            reader: Box::new(
+                builder
+                    .with_batch_size(output_rows.min(4096))
+                    .build()
+                    .map_err(storage)?,
+            ),
+            batch: None,
+            row: 0,
+        });
+    }
+    let schema = schema.ok_or_else(|| storage("row merge lacks schema"))?;
+    let temporary = artifact_temp(output);
+    let file = root
+        .create_replaceable_child_file(OsStr::new(&temporary))
+        .map_err(storage)?;
+    let identity = file_identity(&file).map_err(storage)?;
+    let hashing = HashingWriter::new(file);
+    let buffered = BufWriter::with_capacity(BLOCK_BYTES, hashing);
+    let mut writer = ArrowWriter::try_new(buffered, schema.clone(), None).map_err(storage)?;
+    let mut heap = BinaryHeap::new();
+    for (source, cursor) in cursors.iter_mut().enumerate() {
+        if let Some(uuid) = cursor.advance()? {
+            heap.push((Reverse(uuid), Reverse(source)));
+        }
+    }
+    let mut selected = Vec::with_capacity(output_rows);
+    let mut selected_bytes = 0_usize;
+    let mut previous = None;
+    while let Some((Reverse(uuid), Reverse(source))) = heap.pop() {
+        reject_cancelled(cancelled)?;
+        if previous.is_some_and(|prior| prior >= uuid) {
+            return Err(storage("duplicate or unordered UUID in row merge"));
+        }
+        previous = Some(uuid);
+        let cursor = &mut cursors[source];
+        let batch = cursor
+            .batch
+            .as_ref()
+            .ok_or_else(|| storage("row cursor lacks batch"))?;
+        let row_bytes = batch.columns().iter().try_fold(0_usize, |total, column| {
+            column
+                .slice(cursor.row, 1)
+                .to_data()
+                .get_slice_memory_size()
+                .map(|bytes| total.saturating_add(bytes))
+                .map_err(storage)
+        })?;
+        if row_bytes > output_bytes {
+            return Err(storage("one normalized row exceeds merge byte window"));
+        }
+        if !selected.is_empty()
+            && (selected.len() == output_rows
+                || selected_bytes.saturating_add(row_bytes) > output_bytes)
+        {
+            let output_batch = materialize_selected_rows(schema.clone(), &selected)?;
+            evidence.merge_read_records = evidence
+                .merge_read_records
+                .saturating_add(output_batch.num_rows() as u64);
+            writer.write(&output_batch).map_err(storage)?;
+            evidence.merge_written_records = evidence
+                .merge_written_records
+                .saturating_add(output_batch.num_rows() as u64);
+            selected.clear();
+            selected_bytes = 0;
+        }
+        selected.push((batch.clone(), cursor.row));
+        selected_bytes = selected_bytes.saturating_add(row_bytes);
+        cursor.row = cursor.row.saturating_add(1);
+        if let Some(next) = cursor.advance()? {
+            heap.push((Reverse(next), Reverse(source)));
+        }
+        if heap.is_empty() {
+            let batch = materialize_selected_rows(schema.clone(), &selected)?;
+            evidence.merge_read_records = evidence
+                .merge_read_records
+                .saturating_add(batch.num_rows() as u64);
+            writer.write(&batch).map_err(storage)?;
+            evidence.merge_written_records = evidence
+                .merge_written_records
+                .saturating_add(batch.num_rows() as u64);
+            selected.clear();
+            selected_bytes = 0;
+        }
+    }
+    writer.finish().map_err(storage)?;
+    writer.sync().map_err(storage)?;
+    let hashing = writer.inner().get_ref();
+    hashing.inner.sync_all().map_err(storage)?;
+    let receipt = ArtifactReceipt {
+        name: output.to_owned(),
+        bytes: hashing.bytes,
+        sha256: hex(&hashing.digest.clone().finalize()),
+        identity: identity.into(),
+        write_operations: hashing.operations,
+    };
+    root.sync().map_err(storage)?;
+    root.install_child(OsStr::new(&temporary), identity, OsStr::new(output))
+        .map_err(storage)?;
+    root.sync().map_err(storage)?;
+    evidence.merge_groups = evidence.merge_groups.saturating_add(1);
+    evidence.merge_written_bytes = evidence.merge_written_bytes.saturating_add(receipt.bytes);
+    Ok(receipt)
+}
+
+fn merge_row_all(
+    root: &StableDirectory,
+    mut inputs: Vec<String>,
+    output: &str,
+    output_rows: usize,
+    output_bytes: usize,
+    fan_in: usize,
+    cancelled: &mut impl FnMut() -> bool,
+    evidence: &mut GraphConstructionEvidence,
+) -> Result<ArtifactReceipt, GfError> {
+    let mut level = 0_u32;
+    let namespace = &sha256(output.as_bytes())[..16];
+    while inputs.len() > fan_in {
+        evidence.merge_passes = evidence.merge_passes.saturating_add(1);
+        let mut next = Vec::new();
+        for (group, names) in inputs.chunks(fan_in).enumerate() {
+            let name = format!("merge-rows-{namespace}-l{level:03}-g{group:020}.parquet");
+            merge_row_group(
+                root,
+                names,
+                &name,
+                output_rows,
+                output_bytes,
+                cancelled,
+                evidence,
+            )?;
+            next.push(name);
+        }
+        for old in &inputs {
+            if old.starts_with("merge-rows-") {
+                unlink_named(root, old)?;
+            }
+        }
+        inputs = next;
+        level = level.saturating_add(1);
+    }
+    evidence.merge_passes = evidence.merge_passes.saturating_add(1);
+    evidence.peak_merge_inputs = evidence.peak_merge_inputs.max(inputs.len() as u64);
+    merge_row_group(
+        root,
+        &inputs,
+        output,
+        output_rows,
+        output_bytes,
+        cancelled,
+        evidence,
+    )
+}
+
+fn build_runtime_catalog(
+    root: &StableDirectory,
+    node_rows: &[String],
+    edge_rows: &[String],
+    now_micros: i64,
+    cancelled: &mut impl FnMut() -> bool,
+) -> Result<String, GfError> {
+    let mut catalog = RuntimeCatalog::new();
+    for (kind, names) in [
+        (ConstructionChunkKind::Node, node_rows),
+        (ConstructionChunkKind::Edge, edge_rows),
+    ] {
+        for name in names {
+            let file = root.open_child_file(OsStr::new(name)).map_err(storage)?;
+            let reader = ParquetRecordBatchReaderBuilder::try_new(file)
+                .map_err(storage)?
+                .with_batch_size(4096)
+                .build()
+                .map_err(storage)?;
+            for batch in reader {
+                reject_cancelled(cancelled)?;
+                let batch = batch.map_err(storage)?;
+                let owner = batch
+                    .column(1)
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .ok_or_else(|| storage("catalog owner column is not Utf8"))?;
+                let required = if kind == ConstructionChunkKind::Node {
+                    2
+                } else {
+                    4
+                };
+                for row in 0..batch.num_rows() {
+                    let owner_name = owner.value(row);
+                    match kind {
+                        ConstructionChunkKind::Node => {
+                            catalog.intern_label_at(owner_name, now_micros);
+                        }
+                        ConstructionChunkKind::Edge => {
+                            catalog.intern_relation_type_at(owner_name, now_micros);
+                        }
+                    }
+                    for field in &batch.schema().fields()[required..] {
+                        catalog.intern_property_at(field.name(), Some(owner_name), now_micros);
+                    }
+                }
+            }
+        }
+    }
+    let output = "shaped-runtime-catalog.parquet";
+    write_parquet(root, output, &catalog.to_record_batch())?;
+    Ok(output.to_owned())
+}
+
 fn read_fixed<const N: usize>(reader: &mut impl Read) -> Result<Option<[u8; N]>, GfError> {
     let mut record = [0_u8; N];
     let mut filled = 0;
@@ -1975,6 +2505,22 @@ fn validate_unified_and_details(
     {
         return Err(storage("identity and canonical detail domains disagree"));
     }
+    validate_detail_domain::<NODE_DETAIL_WIDTH>(
+        root,
+        identities_name,
+        node_details_name,
+        0,
+        cancelled,
+        evidence,
+    )?;
+    validate_detail_domain::<EDGE_DETAIL_WIDTH>(
+        root,
+        identities_name,
+        edge_details_name,
+        1,
+        cancelled,
+        evidence,
+    )?;
     validate_endpoints(
         root,
         identities_name,
@@ -1990,6 +2536,67 @@ fn validate_unified_and_details(
         .checked_add(new_edges)
         .ok_or_else(|| storage("edge surrogate overflow"))?;
     Ok((node_count, edge_count, max_node, max_edge))
+}
+
+fn validate_detail_domain<const N: usize>(
+    root: &StableDirectory,
+    identities_name: &str,
+    details_name: Option<&str>,
+    kind: u8,
+    cancelled: &mut impl FnMut() -> bool,
+    evidence: &mut GraphConstructionEvidence,
+) -> Result<(), GfError> {
+    let Some(details_name) = details_name else {
+        return Ok(());
+    };
+    let mut identities = BufReader::with_capacity(
+        BLOCK_BYTES,
+        root.open_child_file(OsStr::new(identities_name))
+            .map_err(storage)?,
+    );
+    let mut details = BufReader::with_capacity(
+        BLOCK_BYTES,
+        root.open_child_file(OsStr::new(details_name))
+            .map_err(storage)?,
+    );
+    let mut identity = read_fixed::<BASE_IDENTITY_WIDTH>(&mut identities)?;
+    let mut count = 0_u64;
+    while let Some(detail) = read_fixed::<N>(&mut details)? {
+        while identity
+            .as_ref()
+            .is_some_and(|item| item[17] == 1 || item[16] != kind || item[..16] < detail[..16])
+        {
+            identity = read_fixed::<BASE_IDENTITY_WIDTH>(&mut identities)?;
+            account_merge_read::<BASE_IDENTITY_WIDTH>(evidence);
+        }
+        if identity
+            .as_ref()
+            .is_none_or(|item| item[17] != 0 || item[16] != kind || item[..16] != detail[..16])
+        {
+            return Err(storage(
+                "canonical detail UUID differs from identity domain",
+            ));
+        }
+        account_merge_read::<N>(evidence);
+        identity = read_fixed::<BASE_IDENTITY_WIDTH>(&mut identities)?;
+        account_merge_read::<BASE_IDENTITY_WIDTH>(evidence);
+        count += 1;
+        if count.is_multiple_of(4096) {
+            reject_cancelled(cancelled)?;
+        }
+    }
+    while identity
+        .as_ref()
+        .is_some_and(|item| item[17] == 1 || item[16] != kind)
+    {
+        identity = read_fixed::<BASE_IDENTITY_WIDTH>(&mut identities)?;
+    }
+    if identity.is_some() {
+        return Err(storage(
+            "identity domain contains a row without canonical detail",
+        ));
+    }
+    Ok(())
 }
 
 fn validate_endpoints(
@@ -2108,6 +2715,90 @@ fn assign_surrogates(
         .map_err(storage)?;
     root.sync().map_err(storage)?;
     Ok(output.to_owned())
+}
+
+fn resolve_endpoint_surrogates(
+    root: &StableDirectory,
+    identities_name: &str,
+    endpoints_name: Option<&str>,
+    window_rows: usize,
+    fan_in: usize,
+    cancelled: &mut impl FnMut() -> bool,
+    evidence: &mut GraphConstructionEvidence,
+) -> Result<Option<String>, GfError> {
+    let Some(endpoints_name) = endpoints_name else {
+        return Ok(None);
+    };
+    let mut identities = BufReader::with_capacity(
+        BLOCK_BYTES,
+        root.open_child_file(OsStr::new(identities_name))
+            .map_err(storage)?,
+    );
+    let mut endpoints = BufReader::with_capacity(
+        BLOCK_BYTES,
+        root.open_child_file(OsStr::new(endpoints_name))
+            .map_err(storage)?,
+    );
+    let mut identity = read_fixed::<BASE_IDENTITY_WIDTH>(&mut identities)?;
+    let mut window = Vec::<[u8; RESOLVED_ENDPOINT_WIDTH]>::with_capacity(window_rows);
+    let mut runs = Vec::new();
+    let mut sequence = 0_u64;
+    while let Some(endpoint) = read_fixed::<ENDPOINT_WIDTH>(&mut endpoints)? {
+        while identity
+            .as_ref()
+            .is_some_and(|record| record[..16] < endpoint[..16])
+        {
+            identity = read_fixed::<BASE_IDENTITY_WIDTH>(&mut identities)?;
+            account_merge_read::<BASE_IDENTITY_WIDTH>(evidence);
+        }
+        let node = identity
+            .as_ref()
+            .filter(|record| record[..16] == endpoint[..16] && record[16] == 0)
+            .ok_or_else(|| storage("endpoint UUID lacks node surrogate"))?;
+        if node[24..32].iter().all(|byte| *byte == 0) {
+            return Err(storage("endpoint node surrogate is zero"));
+        }
+        let mut resolved = [0_u8; RESOLVED_ENDPOINT_WIDTH];
+        resolved[..16].copy_from_slice(&endpoint[16..32]);
+        resolved[16] = endpoint[32];
+        resolved[24..32].copy_from_slice(&node[24..32]);
+        window.push(resolved);
+        account_merge_read::<ENDPOINT_WIDTH>(evidence);
+        if window.len() == window_rows {
+            window.sort_unstable();
+            let name = format!("merge-resolved-source-{sequence:020}.run");
+            let receipt = write_fixed_run(root, &name, &window)?;
+            evidence.merge_written_bytes =
+                evidence.merge_written_bytes.saturating_add(receipt.bytes);
+            evidence.merge_written_records = evidence
+                .merge_written_records
+                .saturating_add(window.len() as u64);
+            runs.push(name);
+            window.clear();
+            sequence = sequence.saturating_add(1);
+            reject_cancelled(cancelled)?;
+        }
+    }
+    if !window.is_empty() {
+        window.sort_unstable();
+        let name = format!("merge-resolved-source-{sequence:020}.run");
+        let receipt = write_fixed_run(root, &name, &window)?;
+        evidence.merge_written_bytes = evidence.merge_written_bytes.saturating_add(receipt.bytes);
+        evidence.merge_written_records = evidence
+            .merge_written_records
+            .saturating_add(window.len() as u64);
+        runs.push(name);
+    }
+    merge_fixed_all::<RESOLVED_ENDPOINT_WIDTH>(
+        root,
+        runs,
+        "merge-resolved",
+        fan_in,
+        false,
+        cancelled,
+        evidence,
+    )
+    .map(Some)
 }
 
 fn create_base_snapshot(
@@ -2282,6 +2973,12 @@ fn authenticate_artifact(
                         return Err(storage("edge detail run record is malformed"));
                     }
                 }
+                if width == NODE_DETAIL_WIDTH {
+                    let label_len = record[16] as usize;
+                    if label_len == 0 || record[17 + label_len..].iter().any(|byte| *byte != 0) {
+                        return Err(storage("node detail run record is malformed"));
+                    }
+                }
                 if width == BASE_IDENTITY_WIDTH
                     && (!matches!(record[16], 0 | 1)
                         || record[17] != 1
@@ -2367,6 +3064,7 @@ fn receipt_from_intent(intent: &ChunkIntent) -> Result<ConstructionChunkReceipt,
         rows: intent.rows,
         input_bytes: intent.input_bytes,
         input_sha256: intent.input_sha256.clone(),
+        schema_sha256: intent.schema_sha256.clone(),
         run_records: intent.run_records,
         parquet: intent
             .parquet
@@ -2397,6 +3095,11 @@ fn validate_receipt_semantics(
         || receipt.input_bytes > budgets.max_batch_bytes as u64
         || receipt.run_records > budgets.max_run_records as u64
         || receipt.input_sha256.len() != 64
+        || receipt.schema_sha256.len() != 64
+        || !receipt
+            .schema_sha256
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit())
         || !receipt
             .input_sha256
             .bytes()
@@ -2479,14 +3182,35 @@ fn validate_parquet_shape(
         return Err(storage("Parquet identity changed during schema reopen"));
     }
     let builder = ParquetRecordBatchReaderBuilder::try_new(file).map_err(storage)?;
-    let expected = match receipt.kind {
+    let expected_prefix = match receipt.kind {
         ConstructionChunkKind::Node => &*CONSTRUCTION_NODE_SCHEMA,
         ConstructionChunkKind::Edge => &*CONSTRUCTION_EDGE_SCHEMA,
     };
-    if builder.schema().as_ref() != expected.as_ref()
+    let schema = builder.schema();
+    if schema.fields().len() < expected_prefix.fields().len()
+        || schema.fields()[..expected_prefix.fields().len()] != expected_prefix.fields()[..]
+        || normalized_schema_digest(schema.as_ref())? != receipt.schema_sha256
         || builder.metadata().file_metadata().num_rows() != receipt.rows as i64
     {
         return Err(storage("Parquet schema or row count differs from receipt"));
+    }
+    let mut reader = builder.with_batch_size(4096).build().map_err(storage)?;
+    let identity_name = if receipt.kind == ConstructionChunkKind::Node {
+        "node_uuid"
+    } else {
+        "edge_uuid"
+    };
+    let mut previous: Option<[u8; 16]> = None;
+    for batch in &mut reader {
+        let batch = batch.map_err(storage)?;
+        let identities = uuid_column(&batch, identity_name)?;
+        for row in 0..batch.num_rows() {
+            let value = uuid_value(identities, row)?;
+            if previous.is_some_and(|prior| prior >= value) {
+                return Err(storage("row artifact is not strictly UUID sorted"));
+            }
+            previous = Some(value);
+        }
     }
     Ok(())
 }
@@ -2517,6 +3241,11 @@ fn validate_intent(intent: &ChunkIntent, checkpoint: &Checkpoint) -> Result<(), 
         || intent.run_records > checkpoint.budgets.max_run_records as u64
         || intent.run_records != expected_run_records
         || intent.input_sha256.len() != 64
+        || intent.schema_sha256.len() != 64
+        || !intent
+            .schema_sha256
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit())
         || !intent
             .input_sha256
             .bytes()
@@ -2576,6 +3305,7 @@ fn validate_checkpoint(
         || !checkpoint.project_identity.matches(project)
         || !checkpoint.session_identity.matches(session)
         || checkpoint.parent_topology_generation != generation
+        || checkpoint.session_now_micros <= 0
         || checkpoint.budgets != budgets
         || checkpoint.base_identities.is_some() != (generation != 0)
         || checkpoint.next_sequence > budgets.max_chunks
@@ -2839,7 +3569,8 @@ fn remove_unrecorded_artifact(
             ConstructionChunkKind::Node => &*CONSTRUCTION_NODE_SCHEMA,
             ConstructionChunkKind::Edge => &*CONSTRUCTION_EDGE_SCHEMA,
         };
-        if builder.schema().as_ref() != expected.as_ref()
+        if builder.schema().fields().len() < expected.fields().len()
+            || builder.schema().fields()[..expected.fields().len()] != expected.fields()[..]
             || builder.metadata().file_metadata().num_rows() != rows as i64
         {
             return Err(storage("unrecorded Parquet artifact is not session-owned"));
@@ -2893,6 +3624,11 @@ fn validate_sorted_run(file: &mut File, width: usize) -> Result<(), GfError> {
                 || (width == EDGE_DETAIL_WIDTH
                     && (record[48] == 0
                         || record[49 + record[48] as usize..]
+                            .iter()
+                            .any(|byte| *byte != 0)))
+                || (width == NODE_DETAIL_WIDTH
+                    && (record[16] == 0
+                        || record[17 + record[16] as usize..]
                             .iter()
                             .any(|byte| *byte != 0)))
                 || (width == BASE_IDENTITY_WIDTH
@@ -3009,7 +3745,7 @@ fn hex(bytes: &[u8]) -> String {
 mod tests {
     use std::sync::Arc;
 
-    use arrow::array::{FixedSizeBinaryArray, StringArray, UInt32Array};
+    use arrow::array::{FixedSizeBinaryArray, Int64Array, StringArray};
     use tempfile::TempDir;
 
     use super::*;
@@ -3026,7 +3762,7 @@ mod tests {
             CONSTRUCTION_NODE_SCHEMA.clone(),
             vec![
                 Arc::new(fixed(&uuids)),
-                Arc::new(UInt32Array::from(vec![7_u32; rows])),
+                Arc::new(StringArray::from(vec!["Person"; rows])),
             ],
         )
         .unwrap()
@@ -3046,9 +3782,9 @@ mod tests {
             CONSTRUCTION_EDGE_SCHEMA.clone(),
             vec![
                 Arc::new(fixed(&edges)),
+                Arc::new(StringArray::from(vec!["R"; rows])),
                 Arc::new(fixed(&src)),
                 Arc::new(fixed(&dst)),
-                Arc::new(StringArray::from(vec!["R"; rows])),
             ],
         )
         .unwrap()
@@ -3062,6 +3798,56 @@ mod tests {
             GraphConstructionBudgets::default(),
         )
         .unwrap()
+    }
+
+    #[test]
+    fn row_artifact_retains_dynamic_properties_and_is_uuid_sorted() {
+        let root = TempDir::new().unwrap();
+        let mut session = open(&root, 99);
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("node_uuid", DataType::FixedSizeBinary(16), false),
+            Field::new("label", DataType::Utf8, false),
+            Field::new("score", DataType::Int64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(fixed(&[3_u128.to_be_bytes(), 1_u128.to_be_bytes()])),
+                Arc::new(StringArray::from(vec!["Person", "Person"])),
+                Arc::new(Int64Array::from(vec![30, 10])),
+            ],
+        )
+        .unwrap();
+        let receipt = session
+            .append(ConstructionChunkKind::Node, "properties", &batch)
+            .unwrap();
+        let file = session
+            .root
+            .open_child_file(OsStr::new(&receipt.parquet.name))
+            .unwrap();
+        let batches = ParquetRecordBatchReaderBuilder::try_new(file)
+            .unwrap()
+            .build()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        let uuids = uuid_column(&batches[0], "node_uuid").unwrap();
+        let scores = batches[0]
+            .column_by_name("score")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(uuid_value(uuids, 0).unwrap(), 1_u128.to_be_bytes());
+        assert_eq!(scores.values(), &[10, 30]);
+        drop(session);
+
+        let resumed = open(&root, 99);
+        assert!(resumed.checkpoint.session_now_micros > 0);
+        assert_eq!(
+            resumed.read_receipt(0).unwrap().schema_sha256,
+            receipt.schema_sha256
+        );
     }
 
     #[test]
@@ -3135,6 +3921,15 @@ mod tests {
             assert_eq!(shape.edge_count, (chunks * 2) as u64);
             assert_eq!(shape.max_node_surrogate, (chunks * 4) as u64);
             assert_eq!(shape.max_edge_surrogate, (chunks * 2) as u64);
+            assert_eq!(shape.node_rows.len(), 1);
+            assert_eq!(shape.edge_rows.len(), 1);
+            assert!(shape.edge_endpoints.is_some());
+            assert!(
+                session
+                    .root
+                    .open_child_file(OsStr::new(&shape.runtime_catalog))
+                    .is_ok()
+            );
             assert!(session.evidence().peak_merge_inputs <= 2);
             assert!(session.evidence().merge_read_bytes > 0);
             assert!(session.evidence().merge_written_bytes > 0);
@@ -3228,9 +4023,9 @@ mod tests {
             CONSTRUCTION_EDGE_SCHEMA.clone(),
             vec![
                 Arc::new(fixed(&[9_000_u128.to_be_bytes()])),
-                Arc::new(fixed(&endpoint)),
-                Arc::new(fixed(&endpoint)),
                 Arc::new(StringArray::from(vec!["R"])),
+                Arc::new(fixed(&endpoint)),
+                Arc::new(fixed(&endpoint)),
             ],
         )
         .unwrap();
@@ -3240,6 +4035,26 @@ mod tests {
         session.seal().unwrap();
         let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
         assert_eq!(shape.edge_count, 1);
+        let mut resolved = BufReader::new(
+            session
+                .root
+                .open_child_file(OsStr::new(shape.edge_endpoints.as_ref().unwrap()))
+                .unwrap(),
+        );
+        let source = read_fixed::<RESOLVED_ENDPOINT_WIDTH>(&mut resolved)
+            .unwrap()
+            .unwrap();
+        let target = read_fixed::<RESOLVED_ENDPOINT_WIDTH>(&mut resolved)
+            .unwrap()
+            .unwrap();
+        assert_eq!(&source[..16], &9_000_u128.to_be_bytes());
+        assert_eq!((source[16], target[16]), (0, 1));
+        assert_eq!(&source[24..32], &target[24..32]);
+        assert!(
+            read_fixed::<RESOLVED_ENDPOINT_WIDTH>(&mut resolved)
+                .unwrap()
+                .is_none()
+        );
         drop(session);
         let mut resumed = GraphConstructionSession::open(
             root.path(),

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -7092,6 +7092,26 @@ mod tests {
         let Ok(root) = std::env::var("GF_CONSTRUCTION_CRASH_ROOT") else {
             return;
         };
+        if std::env::var_os("GF_CONSTRUCTION_PUBLICATION_CRASH").is_some() {
+            crate::open_or_initialize_project(Path::new(&root)).unwrap();
+            let mut session = GraphConstructionSession::open(
+                Path::new(&root),
+                Uuid::from_u128(9_470),
+                0,
+                GraphConstructionBudgets::default(),
+            )
+            .unwrap();
+            session
+                .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 2))
+                .unwrap();
+            session.seal().unwrap();
+            let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+            let encoding = session.encode_canonical(&shape, 1).unwrap();
+            session
+                .publish_canonical(&encoding, Uuid::from_u128(9_471), Uuid::from_u128(9_472))
+                .unwrap();
+            return;
+        }
         let mut session = GraphConstructionSession::open(
             Path::new(&root),
             Uuid::from_u128(600),
@@ -7114,6 +7134,69 @@ mod tests {
             session.seal().unwrap();
             session.shape_canonical_with_cancellation(|| false).unwrap();
         }
+    }
+
+    #[test]
+    fn publication_crash_after_current_finalizes_same_target_on_reopen() {
+        let root = TempDir::new().unwrap();
+        let status = std::process::Command::new(std::env::current_exe().unwrap())
+            .arg("--exact")
+            .arg("graph_construction::tests::crash_subprocess_helper")
+            .arg("--nocapture")
+            .env("GF_CONSTRUCTION_CRASH_ROOT", root.path())
+            .env("GF_CONSTRUCTION_PUBLICATION_CRASH", "1")
+            .env(
+                "GF_CONSTRUCTION_FAILPOINT_COOKIE",
+                "graphforge-construction-test-v1",
+            )
+            .env(
+                "GF_CONSTRUCTION_FAILPOINT",
+                "publication.after_current_before_receipt",
+            )
+            .status()
+            .unwrap();
+        assert_eq!(status.code(), Some(86));
+
+        let target = Uuid::from_u128(9_471);
+        assert_eq!(
+            crate::resolve_project_generation(root.path())
+                .unwrap()
+                .generation_uuid(),
+            target
+        );
+        let operation = Uuid::from_u128(9_470);
+        let operation_root = root
+            .path()
+            .join(PRIVATE_ROOT)
+            .join(operation.simple().to_string());
+        assert!(!operation_root.join(PUBLICATION_RECEIPT).exists());
+        let encoding: GraphConstructionEncoding = serde_json::from_slice(
+            &std::fs::read(operation_root.join("encoded-v1/inventory.json")).unwrap(),
+        )
+        .unwrap();
+        let mut resumed = GraphConstructionSession::open(
+            root.path(),
+            operation,
+            0,
+            GraphConstructionBudgets::default(),
+        )
+        .unwrap();
+        let receipt = resumed
+            .publish_canonical(&encoding, target, Uuid::from_u128(9_472))
+            .unwrap();
+        assert_eq!(receipt.generation_uuid, target);
+        assert!(receipt.idempotent_replay);
+        assert!(operation_root.join(PUBLICATION_RECEIPT).is_file());
+
+        let current = crate::resolve_project_generation(root.path()).unwrap();
+        assert_eq!(current.generation_uuid(), target);
+        let inventory = current.graph_files_inventory().unwrap().unwrap();
+        let materialized = TempDir::new().unwrap();
+        let graph = materialized.path().join("graph");
+        std::fs::create_dir(&graph).unwrap();
+        crate::materialize_graph_objects(root.path(), &inventory, &graph).unwrap();
+        let uuid_index = crate::UuidMembershipIndex::open(&graph).unwrap();
+        assert_eq!(uuid_index.count(crate::UuidIndexKind::Node), 2);
     }
 
     #[test]
@@ -7160,7 +7243,7 @@ mod tests {
                 .path()
                 .join(PRIVATE_ROOT)
                 .join(Uuid::from_u128(600).simple().to_string())
-                .join("encoded-v1/graph/.graphforge-cache/uuid-membership");
+                .join("encoded-v1/graph/topology/uuid-membership");
             assert!(!membership.join(".construction-intent.json").exists());
             assert!(std::fs::read_dir(membership).unwrap().all(|entry| {
                 !entry
@@ -7369,11 +7452,6 @@ mod tests {
             .join(operation.simple().to_string())
             .join(&encoding.root)
             .join("graph");
-        std::fs::write(
-            graph.join("topology/generation.json"),
-            br#"{"topology_generation":1,"search_generation":0}"#,
-        )
-        .unwrap();
         let nodes = crate::read_nodes(&graph).unwrap();
         assert_eq!(nodes.iter().map(RecordBatch::num_rows).sum::<usize>(), 3);
         let edges = crate::read_edges(
@@ -7733,7 +7811,7 @@ mod tests {
             .path()
             .join(PRIVATE_ROOT)
             .join(operation.simple().to_string())
-            .join("encoded-v1/graph/.graphforge-cache/uuid-membership");
+            .join("encoded-v1/graph/topology/uuid-membership");
         if uuid_private.exists() {
             assert_eq!(std::fs::read_dir(&uuid_private).unwrap().count(), 0);
         }
@@ -8060,11 +8138,6 @@ mod tests {
             )
             .unwrap();
         }
-        std::fs::write(
-            assembled.join("topology/generation.json"),
-            br#"{"topology_generation":3,"search_generation":0}"#,
-        )
-        .unwrap();
         let opened = crate::UuidMembershipIndex::open(&assembled).unwrap();
         assert_eq!(opened.count(crate::UuidIndexKind::Node), 4);
     }
@@ -8128,8 +8201,8 @@ mod tests {
             .join(operation.simple().to_string())
             .join(&encoded.root)
             .join("graph");
-        let parent_index = project.path().join(".graphforge-cache/uuid-membership");
-        let encoded_index = graph.join(".graphforge-cache/uuid-membership");
+        let parent_index = project.path().join("topology/uuid-membership");
+        let encoded_index = graph.join("topology/uuid-membership");
         let parent_manifest: serde_json::Value =
             serde_json::from_slice(&std::fs::read(parent_index.join("manifest.json")).unwrap())
                 .unwrap();
@@ -8143,11 +8216,6 @@ mod tests {
                 std::fs::copy(parent_index.join(name), encoded_index.join(name)).unwrap();
             }
         }
-        std::fs::write(
-            graph.join("topology/generation.json"),
-            br#"{"topology_generation":2,"search_generation":0}"#,
-        )
-        .unwrap();
         let index = crate::UuidMembershipIndex::open(&graph).unwrap();
         assert_eq!(index.count(crate::UuidIndexKind::Node), 3);
         assert_eq!(index.count(crate::UuidIndexKind::Edge), 1);
@@ -8170,7 +8238,7 @@ mod tests {
             .unwrap();
         session.seal().unwrap();
         let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
-        let membership = project.path().join(".graphforge-cache/uuid-membership");
+        let membership = project.path().join("topology/uuid-membership");
         let victim = std::fs::read_dir(&membership)
             .unwrap()
             .map(Result::unwrap)
@@ -8315,6 +8383,19 @@ mod tests {
                 .iter()
                 .any(|entry| entry.relative_path.starts_with("topology/nodes/"))
         );
+        assert!(
+            inventory
+                .files
+                .iter()
+                .any(|entry| { entry.relative_path == "topology/uuid-membership/manifest.json" })
+        );
+        let materialized = TempDir::new().unwrap();
+        let materialized_graph = materialized.path().join("graph");
+        std::fs::create_dir(&materialized_graph).unwrap();
+        crate::materialize_graph_objects(root.path(), &inventory, &materialized_graph).unwrap();
+        let uuid_index = crate::UuidMembershipIndex::open(&materialized_graph).unwrap();
+        assert_eq!(uuid_index.count(crate::UuidIndexKind::Node), 2);
+        assert_eq!(uuid_index.count(crate::UuidIndexKind::Edge), 0);
         drop(current);
         let receipt_path = root
             .path()

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -39,6 +39,7 @@ use crate::uuid_membership::{AuthenticatedUuidIndexSnapshot, UuidConstructionSna
 
 const FORMAT_VERSION: u32 = 5;
 const PRIVATE_ROOT: &str = ".graphforge-construction";
+const SESSION_LOCK: &str = "session.lock";
 const CHECKPOINT: &str = "checkpoint.json";
 const INTENT: &str = "intent.json";
 const SHAPE_INTENT: &str = "shape-intent.json";
@@ -728,6 +729,7 @@ pub struct GraphConstructionSession {
     parent_catalog: RuntimeCatalog,
     compact_parent: Option<crate::GraphFilesInventory>,
     semantic_authority: Option<ConstructionSemanticAuthority>,
+    _session_lock: File,
     _reservation: ProcessReservation,
 }
 
@@ -1395,7 +1397,16 @@ impl GraphConstructionSession {
         let root = private
             .create_child_directory(OsStr::new(&operation_name))
             .map_err(storage)?;
-        if !root.try_lock_exclusive().map_err(storage)? {
+        // Directory handles cannot be locked on Windows. Retain an authenticated
+        // regular child for the lifetime of the session and use the storage
+        // layer's cross-platform lock abstraction on that exact descriptor.
+        let session_lock = root
+            .open_or_create_child_file(OsStr::new(SESSION_LOCK))
+            .map_err(storage)?;
+        if file_link_count(&session_lock).map_err(storage)? != 1 {
+            return Err(storage("construction session lock has unexpected links"));
+        }
+        if !crate::file_lock::try_lock_exclusive(&session_lock).map_err(storage)? {
             return Err(storage(
                 "construction operation is locked by another process",
             ));
@@ -1608,6 +1619,7 @@ impl GraphConstructionSession {
             parent_catalog,
             compact_parent,
             semantic_authority,
+            _session_lock: session_lock,
             _reservation: reservation,
         };
         recover_shape_intent(&session.root, &mut session.checkpoint)?;
@@ -7510,6 +7522,21 @@ mod tests {
                 .append(ConstructionChunkKind::Node, "late-node", &node_batch(1, 1))
                 .is_err()
         );
+    }
+
+    #[test]
+    fn session_coordination_file_is_exclusively_locked() {
+        let root = TempDir::new().unwrap();
+        let stable = StableDirectory::open(root.path()).unwrap();
+        let owner = stable
+            .open_or_create_child_file(OsStr::new(SESSION_LOCK))
+            .unwrap();
+        assert!(crate::file_lock::try_lock_exclusive(&owner).unwrap());
+
+        let contender = stable.open_child_file(OsStr::new(SESSION_LOCK)).unwrap();
+        assert!(!crate::file_lock::try_lock_exclusive(&contender).unwrap());
+        crate::file_lock::unlock(&owner).unwrap();
+        assert!(crate::file_lock::try_lock_exclusive(&contender).unwrap());
     }
 
     #[cfg(unix)]

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -913,7 +913,8 @@ fn extract_runs(kind: ConstructionChunkKind, batch: &RecordBatch) -> Result<RunA
             detail[..16].copy_from_slice(&edge);
             detail[16..32].copy_from_slice(&uuid_value(src, row)?);
             detail[32..48].copy_from_slice(&uuid_value(dst, row)?);
-            detail[48] = route.len() as u8;
+            detail[48] = u8::try_from(route.len())
+                .map_err(|_| storage("canonical edge route exceeds identifier bound"))?;
             detail[49..49 + route.len()].copy_from_slice(route);
             details.push(detail);
         }
@@ -963,14 +964,11 @@ fn validate_schema(kind: ConstructionChunkKind, batch: &RecordBatch) -> Result<(
             .as_any()
             .downcast_ref::<StringArray>()
             .ok_or_else(|| storage("canonical edge route is not Utf8"))?;
-        if routes.iter().flatten().any(|route| {
-            route.is_empty()
-                || route.len() > 255
-                || route.contains('/')
-                || route.contains('\\')
-                || route == "."
-                || route == ".."
-        }) {
+        if routes
+            .iter()
+            .flatten()
+            .any(|route| !graphforge_core::identifier::is_graph_identifier(route))
+        {
             return Err(storage("invalid canonical edge route"));
         }
     }

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -623,6 +623,7 @@ pub(crate) struct ConstructionPublicationReceipt {
     project_identity: IdentityRecord,
     session_identity: IdentityRecord,
     intent_sha256: String,
+    transaction_uuid: Uuid,
     target_generation_uuid: Uuid,
     target_generation_manifest_sha256: String,
 }
@@ -765,6 +766,7 @@ impl GraphConstructionSession {
             project_identity: self.checkpoint.project_identity.clone(),
             session_identity: self.checkpoint.session_identity.clone(),
             intent_sha256: control_sha256(&intent)?,
+            transaction_uuid: intent.transaction_uuid,
             target_generation_uuid,
             target_generation_manifest_sha256: target_generation_manifest_sha256.to_owned(),
         };
@@ -2696,6 +2698,7 @@ fn read_publication_receipt(
         || receipt.operation_uuid != checkpoint.operation_uuid
         || receipt.project_identity != checkpoint.project_identity
         || receipt.session_identity != checkpoint.session_identity
+        || receipt.transaction_uuid != intent.transaction_uuid
         || receipt.target_generation_uuid != intent.target_generation_uuid
     {
         return Err(storage("publication receipt differs from durable intent"));
@@ -2721,16 +2724,15 @@ fn authenticate_published_target(
             "published target is not a child of the pinned parent generation",
         ));
     }
-    let current = crate::resolve_project_generation(project_dir).map_err(|error| {
-        storage(format!(
-            "published CURRENT cannot be authenticated: {error}"
-        ))
-    })?;
-    if current.generation_uuid() != target.generation_uuid()
-        || current.manifest_sha256() != target.manifest_sha256()
+    let journal = crate::published_project_transaction(project_dir, receipt.transaction_uuid)
+        .map_err(|error| storage(format!("project publication journal is invalid: {error}")))?
+        .ok_or_else(|| storage("project publication journal is not published"))?;
+    if journal.transaction_uuid != receipt.transaction_uuid
+        || journal.generation_uuid != receipt.target_generation_uuid
+        || journal.generation_manifest_sha256 != target.manifest_sha256()
     {
         return Err(storage(
-            "published target is not the exact committed CURRENT generation",
+            "project publication journal differs from construction publication authority",
         ));
     }
     Ok(())
@@ -8093,6 +8095,7 @@ mod tests {
         replace_control(&session.root, CHECKPOINT, &session.checkpoint).unwrap();
         drop(session);
         let published = publish_empty_generation(&root, target, transaction);
+        publish_empty_generation(&root, Uuid::from_u128(9_413), Uuid::from_u128(9_414));
         let mut reopened = GraphConstructionSession::open(
             root.path(),
             operation,
@@ -8158,7 +8161,7 @@ mod tests {
     }
 
     #[test]
-    fn publication_finish_rejects_wrong_target_parent_and_current() {
+    fn publication_finish_rejects_wrong_target_and_parent() {
         let wrong_target_root = TempDir::new().unwrap();
         let operation = Uuid::from_u128(9_430);
         let intended = Uuid::from_u128(9_431);
@@ -8197,35 +8200,34 @@ mod tests {
                 .to_string()
                 .contains("not a child of the pinned parent")
         );
+    }
 
-        let wrong_current_root = TempDir::new().unwrap();
-        let mut session = encoded_publication_session(&wrong_current_root, Uuid::from_u128(9_450));
+    #[test]
+    fn published_receipt_reopens_after_later_current_advances() {
+        let root = TempDir::new().unwrap();
+        let operation = Uuid::from_u128(9_450);
+        let mut session = encoded_publication_session(&root, operation);
         let target = Uuid::from_u128(9_451);
         let transaction = Uuid::from_u128(9_452);
         session.begin_publication(target, transaction).unwrap();
-        let target_receipt = publish_empty_generation(&wrong_current_root, target, transaction);
-        session
+        let target_receipt = publish_empty_generation(&root, target, transaction);
+        let construction_receipt = session
             .finish_publication(target, &hex(&target_receipt.generation_manifest_sha256))
             .unwrap();
         drop(session);
-        publish_empty_generation(
-            &wrong_current_root,
-            Uuid::from_u128(9_453),
-            Uuid::from_u128(9_454),
-        );
-        let error = match GraphConstructionSession::open(
-            wrong_current_root.path(),
-            Uuid::from_u128(9_450),
+        publish_empty_generation(&root, Uuid::from_u128(9_453), Uuid::from_u128(9_454));
+        let mut reopened = GraphConstructionSession::open(
+            root.path(),
+            operation,
             0,
             GraphConstructionBudgets::default(),
-        ) {
-            Ok(_) => panic!("published recovery accepted a different CURRENT"),
-            Err(error) => error,
-        };
-        assert!(
-            error
-                .to_string()
-                .contains("not the exact committed CURRENT")
+        )
+        .unwrap();
+        assert_eq!(
+            reopened
+                .finish_publication(target, &hex(&target_receipt.generation_manifest_sha256))
+                .unwrap(),
+            construction_receipt
         );
     }
 

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -845,6 +845,191 @@ impl GraphConstructionSession {
         Ok(encoded)
     }
 
+    /// Install the authenticated canonical inventory into the project CAS and
+    /// publish exactly one project generation from the session's pinned parent.
+    /// The CAS lease remains held through the sole `CURRENT` replacement.
+    pub fn publish_canonical(
+        &mut self,
+        encoding: &GraphConstructionEncoding,
+        target_generation_uuid: Uuid,
+        transaction_uuid: Uuid,
+    ) -> Result<crate::ProjectPublicationReceipt, GfError> {
+        if self.checkpoint.publication_state == Some(ConstructionPublicationState::Published) {
+            let published =
+                crate::published_project_transaction(&self.project_path, transaction_uuid)?
+                    .ok_or_else(|| storage("published construction transaction is absent"))?;
+            if published.generation_uuid != target_generation_uuid {
+                return Err(storage("published construction target changed"));
+            }
+            self.finish_publication(
+                target_generation_uuid,
+                &hex(&published.generation_manifest_sha256),
+            )?;
+            return Ok(published);
+        }
+        let expected_inventory = self
+            .checkpoint
+            .encoding_inventory_sha256
+            .as_deref()
+            .ok_or_else(|| storage("construction publication requires encoded inventory"))?;
+        if crate::graph_construction_encoding::inventory_authority_sha256(encoding)?
+            != expected_inventory
+        {
+            return Err(storage("publication encoding authority changed"));
+        }
+        if encoding.generation != self.checkpoint.parent_topology_generation.saturating_add(1) {
+            return Err(storage("publication topology generation changed"));
+        }
+        crate::graph_construction_encoding::authenticate_for_publication(&self.root, encoding)?;
+        self.begin_publication(target_generation_uuid, transaction_uuid)?;
+
+        let admission = crate::filesystem_admission::admit_project_lifecycle(
+            &self.project_path,
+            crate::filesystem_admission::ProjectLifecycleMode::Durable,
+            crate::filesystem_admission::ProjectRootRequirement::Existing,
+        )?;
+        admission.revalidate_identity()?;
+        let parent = crate::resolve_project_generation(admission.root())?;
+        if parent.generation_uuid() != self.checkpoint.parent_generation_uuid
+            || hex(&parent.manifest_sha256()) != self.checkpoint.parent_generation_manifest_sha256
+        {
+            return Err(storage("construction parent is no longer CURRENT"));
+        }
+
+        let lease = crate::begin_graph_object_publication(admission.root())?;
+        let mut manifest_state = match parent.declared_graph_files_participant()? {
+            Some(crate::GraphFilesParticipant::V2(root)) => {
+                crate::graph_object_store::GraphManifestState::open(
+                    &lease,
+                    root,
+                    crate::GraphManifestLimits::default(),
+                )?
+                .0
+            }
+            Some(crate::GraphFilesParticipant::V1(inventory)) if inventory.file_count == 0 => {
+                crate::graph_object_store::GraphManifestState::empty()
+            }
+            Some(crate::GraphFilesParticipant::V1(_)) => {
+                return Err(storage(
+                    "nonempty construction parent requires compact graph root",
+                ));
+            }
+            None => crate::graph_object_store::GraphManifestState::empty(),
+        };
+        for retained in &encoding.retained_artifacts {
+            let entry = manifest_state
+                .entries()
+                .find(|entry| entry.relative_path == retained.target_path)
+                .ok_or_else(|| storage("retained construction object is absent from parent"))?;
+            if entry.byte_length != retained.bytes || entry.content_sha256 != retained.sha256 {
+                return Err(storage("retained construction object authority changed"));
+            }
+        }
+
+        let workspace = self
+            .project_path
+            .join(PRIVATE_ROOT)
+            .join(self.checkpoint.operation_uuid.simple().to_string())
+            .join(&encoding.root)
+            .join("graph");
+        let workspace_identity =
+            graphforge_filesystem::path_identity(&workspace).map_err(storage)?;
+        let encoded_directory = self
+            .root
+            .open_child_directory(OsStr::new(&encoding.root))
+            .map_err(storage)?
+            .open_child_directory(OsStr::new("graph"))
+            .map_err(storage)?;
+        if workspace_identity != encoded_directory.identity() {
+            return Err(storage("encoded workspace path identity changed"));
+        }
+        let sealed_paths = encoding
+            .artifacts
+            .iter()
+            .map(|artifact| PathBuf::from(&artifact.path))
+            .collect::<Vec<_>>();
+        let (graph_root, _) = crate::graph_object_store::append_graph_files_v2(
+            &lease,
+            &workspace,
+            &mut manifest_state,
+            &sealed_paths,
+            &[],
+        )?;
+        if graphforge_filesystem::path_identity(&workspace).map_err(storage)?
+            != encoded_directory.identity()
+        {
+            return Err(storage(
+                "encoded workspace identity changed during CAS install",
+            ));
+        }
+        for artifact in &encoding.artifacts {
+            let entry = manifest_state
+                .entries()
+                .find(|entry| entry.relative_path == artifact.path)
+                .ok_or_else(|| storage("installed construction artifact is absent"))?;
+            if entry.byte_length != artifact.bytes || entry.content_sha256 != artifact.sha256 {
+                return Err(storage("installed construction artifact authority changed"));
+            }
+        }
+
+        let graph_participant = crate::graph_files::graph_files_root_participant(&graph_root)?;
+        let capabilities = parent
+            .capabilities()
+            .into_iter()
+            .map(|capability| crate::ProjectCapability {
+                capability_id: capability.capability_id,
+                capability_version: capability.capability_version,
+            })
+            .collect();
+        let mut participants = parent
+            .participant_snapshots()?
+            .into_iter()
+            .filter(|snapshot| {
+                snapshot.capability_id != crate::GRAPH_CAPABILITY_ID
+                    || snapshot.record_family_id != crate::GRAPH_FILES_FAMILY
+            })
+            .map(|snapshot| {
+                let encoding = match snapshot.encoding.as_str() {
+                    "parquet" => crate::ProjectParticipantEncoding::Parquet,
+                    "arrow" => crate::ProjectParticipantEncoding::Arrow,
+                    "json" => crate::ProjectParticipantEncoding::Json,
+                    _ => return Err(storage("parent participant encoding is unsupported")),
+                };
+                Ok(crate::ProjectParticipant {
+                    capability_id: snapshot.capability_id,
+                    capability_version: snapshot.capability_version,
+                    record_family_id: snapshot.record_family_id,
+                    record_version: snapshot.record_version,
+                    encoding,
+                    schema_fingerprint: snapshot.schema_fingerprint,
+                    row_count: snapshot.row_count,
+                    bytes: snapshot.bytes,
+                })
+            })
+            .collect::<Result<Vec<_>, GfError>>()?;
+        participants.push(graph_participant);
+        let request = crate::ProjectGenerationRequest {
+            transaction_uuid,
+            generation_uuid: target_generation_uuid,
+            capabilities,
+            participants,
+        };
+        let publication =
+            match crate::project_publication::stage_project_generation_from_admitted_parent(
+                admission, parent, &request, None,
+            )? {
+                crate::ProjectStageOutcome::Staged(staged) => staged
+                    .validate(|_| Ok(()), |_, _| Ok(()))?
+                    .publish_with_graph_objects(&lease)?,
+                crate::ProjectStageOutcome::AlreadyPublished(receipt) => receipt,
+            };
+        self.finish_publication(
+            target_generation_uuid,
+            &hex(&publication.generation_manifest_sha256),
+        )?;
+        Ok(publication)
+    }
+
     /// Create or resume an operation pinned to one parent topology generation.
     pub fn open_with_mode(
         project_dir: &Path,
@@ -8070,6 +8255,117 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("result changed")
+        );
+    }
+
+    #[test]
+    fn canonical_publication_installs_compact_graph_and_advances_current_once() {
+        let root = TempDir::new().unwrap();
+        crate::open_or_initialize_project(root.path()).unwrap();
+        let operation = Uuid::from_u128(9_450);
+        let target = Uuid::from_u128(9_451);
+        let transaction = Uuid::from_u128(9_452);
+        let mut session = GraphConstructionSession::open(
+            root.path(),
+            operation,
+            0,
+            GraphConstructionBudgets::default(),
+        )
+        .unwrap();
+        session
+            .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 2))
+            .unwrap();
+        session.seal().unwrap();
+        let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+        let encoding = session.encode_canonical(&shape, 1).unwrap();
+
+        let receipt = session
+            .publish_canonical(&encoding, target, transaction)
+            .unwrap();
+        assert_eq!(receipt.generation_uuid, target);
+        assert!(!receipt.idempotent_replay);
+        let current = crate::resolve_project_generation(root.path()).unwrap();
+        assert_eq!(current.generation_uuid(), target);
+        let inventory = current.graph_files_inventory().unwrap().unwrap();
+        assert!(
+            inventory
+                .files
+                .iter()
+                .any(|entry| entry.relative_path == "topology/generation.json")
+        );
+        assert!(
+            inventory
+                .files
+                .iter()
+                .any(|entry| entry.relative_path.starts_with("topology/nodes/"))
+        );
+        drop(current);
+        drop(session);
+
+        let mut resumed = GraphConstructionSession::open(
+            root.path(),
+            operation,
+            0,
+            GraphConstructionBudgets::default(),
+        )
+        .unwrap();
+        let replay = resumed
+            .publish_canonical(&encoding, target, transaction)
+            .unwrap();
+        assert_eq!(replay.generation_uuid, target);
+        assert_eq!(
+            crate::resolve_project_generation(root.path())
+                .unwrap()
+                .generation_uuid(),
+            target
+        );
+    }
+
+    #[test]
+    fn canonical_publication_rejects_tampered_artifact_before_current() {
+        let root = TempDir::new().unwrap();
+        let parent = crate::open_or_initialize_project(root.path()).unwrap();
+        let prior = parent.generation_uuid();
+        drop(parent);
+        let operation = Uuid::from_u128(9_460);
+        let mut session = GraphConstructionSession::open(
+            root.path(),
+            operation,
+            0,
+            GraphConstructionBudgets::default(),
+        )
+        .unwrap();
+        session
+            .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 1))
+            .unwrap();
+        session.seal().unwrap();
+        let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+        let encoding = session.encode_canonical(&shape, 1).unwrap();
+        let victim = root
+            .path()
+            .join(PRIVATE_ROOT)
+            .join(operation.simple().to_string())
+            .join(&encoding.root)
+            .join("graph")
+            .join(&encoding.artifacts[0].path);
+        std::fs::write(victim, b"tampered").unwrap();
+
+        assert!(
+            session
+                .publish_canonical(&encoding, Uuid::from_u128(9_461), Uuid::from_u128(9_462),)
+                .unwrap_err()
+                .to_string()
+                .contains("artifact differs")
+        );
+        assert_eq!(
+            crate::resolve_project_generation(root.path())
+                .unwrap()
+                .generation_uuid(),
+            prior
+        );
+        assert_eq!(
+            session.checkpoint.publication_state,
+            Some(ConstructionPublicationState::Sealed)
         );
     }
 

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -12,6 +12,7 @@ use std::ffi::{OsStr, OsString};
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Seek, Write};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{LazyLock, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -24,7 +25,8 @@ use arrow::compute::take;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use graphforge_core::GfError;
 use graphforge_filesystem::{FileIdentity, StableDirectory, file_identity, file_link_count};
-use graphforge_ir::RuntimeCatalog;
+use graphforge_ir::{CompositionBindingContext, CompositionBindingLimits, RuntimeCatalog};
+use graphforge_ontology::ActivationMode;
 use parquet::arrow::ArrowWriter;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::file::reader::{ChunkReader, Length};
@@ -104,9 +106,9 @@ pub struct GraphConstructionBudgets {
     pub max_run_records: usize,
     /// Maximum inputs opened by one external merge group.
     pub merge_fan_in: usize,
-    /// Maximum exact Arrow schema groups accepted by one session. Construction
-    /// deliberately requires one stable schema per entity kind, so this may be
-    /// one (single-kind sessions) or two (nodes plus edges).
+    /// Maximum exact Arrow schema groups accepted by one session. Schemas are
+    /// retained as a bounded external registry and merged at encode time; they
+    /// are not required to be identical across chunks.
     pub max_schema_groups: usize,
     /// Maximum trailing property columns in either stable entity schema.
     pub max_property_columns: usize,
@@ -126,7 +128,7 @@ impl Default for GraphConstructionBudgets {
             max_chunks: 1_000_000,
             max_run_records: 4 * 65_536,
             merge_fan_in: 32,
-            max_schema_groups: 2,
+            max_schema_groups: 256,
             max_property_columns: 4_096,
             max_catalog_entries: 1_000_000,
             max_catalog_decoded_bytes: 256 << 20,
@@ -142,7 +144,7 @@ impl GraphConstructionBudgets {
             || self.max_chunks == 0
             || self.max_run_records < 4 * self.max_batch_rows
             || self.merge_fan_in < 2
-            || !(1..=2).contains(&self.max_schema_groups)
+            || !(1..=4_096).contains(&self.max_schema_groups)
             || self.max_property_columns == 0
             || self.max_catalog_entries == 0
             || self.max_catalog_decoded_bytes == 0
@@ -274,6 +276,8 @@ pub struct GraphConstructionEvidence {
 pub struct ConstructionShape {
     /// Ontology mode authenticated at session open and used for physical routing.
     pub ontology_mode: graphforge_core::OntologyMode,
+    /// Digest of the exact compiled composition and physical semantic bindings.
+    pub semantic_authority_sha256: Option<String>,
     /// Parent generation retained by the publisher; zero denotes an empty base.
     pub parent_topology_generation: u64,
     /// Authenticated parent UUID-manifest authority. The shaped identities file
@@ -307,8 +311,57 @@ pub struct ConstructionShape {
     pub max_edge_surrogate: u64,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+/// Exact generation-pinned semantic authority for construction.
+pub struct ConstructionSemanticAuthority {
+    /// Generation-pinned ontology composition and declared construction mode.
+    pub composition: crate::WorkspaceOntologyComposition,
+    /// Compiled opaque physical routes and stable storage identifiers.
+    pub bindings: crate::SemanticStorageBindings,
+}
+
+impl ConstructionSemanticAuthority {
+    /// Validate the compiled composition and its stable physical bindings.
+    pub fn validate(&self) -> Result<(), GfError> {
+        let compiled = self.composition.compile()?;
+        self.bindings.validate_against(&compiled)
+    }
+
+    fn mode(&self) -> graphforge_core::OntologyMode {
+        match self.composition.profile_default {
+            ActivationMode::Exploratory => graphforge_core::OntologyMode::Exploratory,
+            ActivationMode::Advisory => graphforge_core::OntologyMode::Advisory,
+            ActivationMode::Strict => graphforge_core::OntologyMode::Strict,
+        }
+    }
+
+    pub(crate) fn digest(&self) -> Result<String, GfError> {
+        let mut digest = Sha256::new();
+        digest.update(b"graphforge-construction-semantic-authority/v1\0");
+        digest.update(self.composition.to_canonical_json()?);
+        digest.update(self.bindings.to_canonical_json()?);
+        Ok(hex(&digest.finalize()))
+    }
+
+    pub(crate) fn context(&self) -> Result<CompositionBindingContext, GfError> {
+        let compiled = self.composition.compile()?;
+        self.bindings.validate_against(&compiled)?;
+        Ok(CompositionBindingContext::new(
+            Arc::new(compiled),
+            self.composition.bridges.clone(),
+            CompositionBindingLimits::default(),
+        )
+        .with_generation_storage_ids(
+            self.bindings
+                .bindings
+                .iter()
+                .map(|binding| (binding.symbol.clone(), binding.storage_id)),
+        ))
+    }
+}
+
 pub use crate::graph_construction_encoding::{
-    GraphConstructionEncoding, GraphConstructionEncodingEvidence,
+    ConstructionRetainedArtifact, GraphConstructionEncoding, GraphConstructionEncodingEvidence,
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -350,6 +403,7 @@ pub struct ConstructionChunkReceipt {
     session_identity: IdentityRecord,
     parent_topology_generation: u64,
     ontology_mode: graphforge_core::OntologyMode,
+    semantic_authority_sha256: Option<String>,
     prior_receipt_sha256: Option<String>,
     /// Caller-stable idempotency key.
     pub chunk_id: String,
@@ -382,6 +436,7 @@ struct Checkpoint {
     session_identity: IdentityRecord,
     parent_topology_generation: u64,
     ontology_mode: graphforge_core::OntologyMode,
+    semantic_authority_sha256: Option<String>,
     /// One authority-bound timestamp used by every catalog/topology row produced
     /// by this operation. Reopen never consults the wall clock again.
     session_now_micros: i64,
@@ -392,8 +447,8 @@ struct Checkpoint {
     last_receipt_sha256: Option<String>,
     has_base_snapshot: bool,
     parent_catalog_sha256: Option<String>,
-    node_schema_sha256: Option<String>,
-    edge_schema_sha256: Option<String>,
+    node_schema_sha256: BTreeSet<String>,
+    edge_schema_sha256: BTreeSet<String>,
     base_work: UuidConstructionSnapshotWork,
     evidence: GraphConstructionEvidence,
 }
@@ -414,6 +469,7 @@ struct ChunkIntent {
     schema_sha256: String,
     parent_topology_generation: u64,
     ontology_mode: graphforge_core::OntologyMode,
+    semantic_authority_sha256: Option<String>,
     prior_receipt_sha256: Option<String>,
     run_records: u64,
     accounted_live_bytes: u64,
@@ -431,6 +487,7 @@ struct ShapeIntent {
     session_identity: IdentityRecord,
     parent_topology_generation: u64,
     ontology_mode: graphforge_core::OntologyMode,
+    semantic_authority_sha256: Option<String>,
     budgets: GraphConstructionBudgets,
     last_receipt_sha256: Option<String>,
     baseline_evidence: GraphConstructionEvidence,
@@ -475,6 +532,7 @@ pub struct GraphConstructionSession {
     checkpoint: Checkpoint,
     base_snapshot: Option<AuthenticatedUuidIndexSnapshot>,
     parent_catalog: RuntimeCatalog,
+    semantic_authority: Option<ConstructionSemanticAuthority>,
     _reservation: ProcessReservation,
 }
 
@@ -515,13 +573,13 @@ impl GraphConstructionSession {
             generation,
             self.checkpoint.ontology_mode,
             self.base_snapshot.as_ref(),
+            self.semantic_authority.as_ref(),
             self.checkpoint.budgets,
             &mut cancelled,
         )
     }
 
     /// Create or resume an operation pinned to one parent topology generation.
-    #[allow(clippy::too_many_lines)]
     pub fn open_with_mode(
         project_dir: &Path,
         operation_uuid: Uuid,
@@ -529,7 +587,54 @@ impl GraphConstructionSession {
         ontology_mode: graphforge_core::OntologyMode,
         budgets: GraphConstructionBudgets,
     ) -> Result<Self, GfError> {
+        if ontology_mode != graphforge_core::OntologyMode::Exploratory {
+            return Err(storage(
+                "strict or advisory construction requires pinned semantic authority",
+            ));
+        }
+        Self::open_internal(
+            project_dir,
+            operation_uuid,
+            parent_topology_generation,
+            ontology_mode,
+            None,
+            budgets,
+        )
+    }
+
+    /// Open with exact composition and physical semantic routing authority.
+    pub fn open_with_semantic_authority(
+        project_dir: &Path,
+        operation_uuid: Uuid,
+        parent_topology_generation: u64,
+        authority: ConstructionSemanticAuthority,
+        budgets: GraphConstructionBudgets,
+    ) -> Result<Self, GfError> {
+        authority.validate()?;
+        Self::open_internal(
+            project_dir,
+            operation_uuid,
+            parent_topology_generation,
+            authority.mode(),
+            Some(authority),
+            budgets,
+        )
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn open_internal(
+        project_dir: &Path,
+        operation_uuid: Uuid,
+        parent_topology_generation: u64,
+        ontology_mode: graphforge_core::OntologyMode,
+        semantic_authority: Option<ConstructionSemanticAuthority>,
+        budgets: GraphConstructionBudgets,
+    ) -> Result<Self, GfError> {
         let budgets = budgets.validate()?;
+        let semantic_authority_sha256 = semantic_authority
+            .as_ref()
+            .map(ConstructionSemanticAuthority::digest)
+            .transpose()?;
         let project = StableDirectory::open(project_dir).map_err(storage)?;
         if crate::read_topology_generation(project_dir)? != parent_topology_generation {
             return Err(storage(
@@ -606,6 +711,7 @@ impl GraphConstructionSession {
                     session_identity: session_identity.into(),
                     parent_topology_generation,
                     ontology_mode,
+                    semantic_authority_sha256: semantic_authority_sha256.clone(),
                     session_now_micros: SystemTime::now()
                         .duration_since(UNIX_EPOCH)
                         .map_err(storage)?
@@ -619,8 +725,8 @@ impl GraphConstructionSession {
                     last_receipt_sha256: None,
                     has_base_snapshot: parent_topology_generation != 0,
                     parent_catalog_sha256: parent_catalog_sha256.clone(),
-                    node_schema_sha256: None,
-                    edge_schema_sha256: None,
+                    node_schema_sha256: BTreeSet::new(),
+                    edge_schema_sha256: BTreeSet::new(),
                     base_work,
                     evidence,
                 };
@@ -636,6 +742,7 @@ impl GraphConstructionSession {
             session_identity,
             parent_topology_generation,
             ontology_mode,
+            semantic_authority_sha256.as_deref(),
             budgets,
             parent_catalog_sha256.as_deref(),
         )?;
@@ -646,6 +753,7 @@ impl GraphConstructionSession {
             checkpoint,
             base_snapshot,
             parent_catalog,
+            semantic_authority,
             _reservation: reservation,
         };
         recover_shape_intent(&session.root, &mut session.checkpoint)?;
@@ -788,23 +896,21 @@ impl GraphConstructionSession {
             }
             return Err(storage("conflicting construction chunk replay"));
         }
-        let (known_schema, other_schema) = match kind {
+        let (known_schemas, other_schemas) = match kind {
             ConstructionChunkKind::Node => (
-                self.checkpoint.node_schema_sha256.as_ref(),
-                self.checkpoint.edge_schema_sha256.as_ref(),
+                &self.checkpoint.node_schema_sha256,
+                &self.checkpoint.edge_schema_sha256,
             ),
             ConstructionChunkKind::Edge => (
-                self.checkpoint.edge_schema_sha256.as_ref(),
-                self.checkpoint.node_schema_sha256.as_ref(),
+                &self.checkpoint.edge_schema_sha256,
+                &self.checkpoint.node_schema_sha256,
             ),
         };
-        if known_schema.is_some_and(|known| known != &schema_sha256) {
-            return Err(storage(
-                "construction requires one stable Arrow schema per entity kind",
-            ));
-        }
-        if known_schema.is_none()
-            && usize::from(other_schema.is_some()).saturating_add(1)
+        if !known_schemas.contains(&schema_sha256)
+            && known_schemas
+                .len()
+                .saturating_add(other_schemas.len())
+                .saturating_add(1)
                 > self.checkpoint.budgets.max_schema_groups
         {
             return Err(storage("construction schema-group budget exhausted"));
@@ -834,6 +940,7 @@ impl GraphConstructionSession {
             schema_sha256,
             parent_topology_generation: self.checkpoint.parent_topology_generation,
             ontology_mode: self.checkpoint.ontology_mode,
+            semantic_authority_sha256: self.checkpoint.semantic_authority_sha256.clone(),
             prior_receipt_sha256: self.checkpoint.last_receipt_sha256.clone(),
             run_records: run_records as u64,
             accounted_live_bytes: 0,
@@ -992,6 +1099,7 @@ impl GraphConstructionSession {
             session_identity: self.checkpoint.session_identity.clone(),
             parent_topology_generation: self.checkpoint.parent_topology_generation,
             ontology_mode: self.checkpoint.ontology_mode,
+            semantic_authority_sha256: self.checkpoint.semantic_authority_sha256.clone(),
             budgets: self.checkpoint.budgets,
             last_receipt_sha256: self.checkpoint.last_receipt_sha256.clone(),
             baseline_evidence: self.checkpoint.evidence.clone(),
@@ -1229,6 +1337,7 @@ impl GraphConstructionSession {
             .max(measured_shape_bytes(&self.root)?);
         let shape = ConstructionShape {
             ontology_mode: self.checkpoint.ontology_mode,
+            semantic_authority_sha256: self.checkpoint.semantic_authority_sha256.clone(),
             parent_topology_generation: self.checkpoint.parent_topology_generation,
             parent_uuid_manifest_sha256: self
                 .base_snapshot
@@ -1287,6 +1396,7 @@ impl GraphConstructionSession {
                 session_identity: self.checkpoint.session_identity.clone(),
                 parent_topology_generation: self.checkpoint.parent_topology_generation,
                 ontology_mode: self.checkpoint.ontology_mode,
+                semantic_authority_sha256: self.checkpoint.semantic_authority_sha256.clone(),
                 budgets: self.checkpoint.budgets,
                 last_receipt_sha256: self.checkpoint.last_receipt_sha256.clone(),
                 baseline_evidence: shape_intent.baseline_evidence,
@@ -1437,6 +1547,7 @@ impl GraphConstructionSession {
             || receipt.session_identity != self.checkpoint.session_identity
             || receipt.parent_topology_generation != self.checkpoint.parent_topology_generation
             || receipt.ontology_mode != self.checkpoint.ontology_mode
+            || receipt.semantic_authority_sha256 != self.checkpoint.semantic_authority_sha256
         {
             return Err(storage("receipt authority differs from session checkpoint"));
         }
@@ -1481,10 +1592,14 @@ impl GraphConstructionSession {
         self.checkpoint.saw_edge |= receipt.kind == ConstructionChunkKind::Edge;
         match receipt.kind {
             ConstructionChunkKind::Node => {
-                self.checkpoint.node_schema_sha256 = Some(receipt.schema_sha256.clone());
+                self.checkpoint
+                    .node_schema_sha256
+                    .insert(receipt.schema_sha256.clone());
             }
             ConstructionChunkKind::Edge => {
-                self.checkpoint.edge_schema_sha256 = Some(receipt.schema_sha256.clone());
+                self.checkpoint
+                    .edge_schema_sha256
+                    .insert(receipt.schema_sha256.clone());
             }
         }
         self.checkpoint.last_receipt_sha256 = Some(sha256(receipt_bytes));
@@ -1834,13 +1949,13 @@ struct HashingWriter<W> {
 }
 
 #[derive(Clone, Default)]
-struct IoCounter {
+pub(crate) struct IoCounter {
     bytes: std::sync::Arc<AtomicU64>,
     operations: std::sync::Arc<AtomicU64>,
 }
 
 impl IoCounter {
-    fn account(&self, bytes: usize) {
+    pub(crate) fn account(&self, bytes: usize) {
         if bytes != 0 {
             self.bytes.fetch_add(bytes as u64, Ordering::Relaxed);
             self.operations.fetch_add(1, Ordering::Relaxed);
@@ -1855,9 +1970,16 @@ impl IoCounter {
             .parquet_read_operations
             .saturating_add(self.operations.load(Ordering::Relaxed));
     }
+
+    pub(crate) fn values(&self) -> (u64, u64) {
+        (
+            self.bytes.load(Ordering::Relaxed),
+            self.operations.load(Ordering::Relaxed),
+        )
+    }
 }
 
-struct CountingRead<R> {
+pub(crate) struct CountingRead<R> {
     inner: R,
     counter: IoCounter,
 }
@@ -1870,9 +1992,9 @@ impl<R: Read> Read for CountingRead<R> {
     }
 }
 
-struct CountingChunkReader {
-    file: File,
-    counter: IoCounter,
+pub(crate) struct CountingChunkReader {
+    pub(crate) file: File,
+    pub(crate) counter: IoCounter,
 }
 
 impl Length for CountingChunkReader {
@@ -2033,6 +2155,7 @@ fn recover_shape_intent(
             .as_ref()
             .ok_or_else(|| storage("complete shape manifest lacks output"))?;
         if shape.ontology_mode != checkpoint.ontology_mode
+            || shape.semantic_authority_sha256 != checkpoint.semantic_authority_sha256
             || shape.runtime_catalog_now_micros != checkpoint.session_now_micros
             || shape.runtime_catalog_inputs_sha256.len() != 64
             || !shape
@@ -2098,6 +2221,7 @@ fn validate_shape_binding(intent: &ShapeIntent, checkpoint: &Checkpoint) -> Resu
         || intent.session_identity != checkpoint.session_identity
         || intent.parent_topology_generation != checkpoint.parent_topology_generation
         || intent.ontology_mode != checkpoint.ontology_mode
+        || intent.semantic_authority_sha256 != checkpoint.semantic_authority_sha256
         || intent.budgets != checkpoint.budgets
         || intent.last_receipt_sha256 != checkpoint.last_receipt_sha256
     {
@@ -3934,6 +4058,7 @@ fn receipt_from_intent(intent: &ChunkIntent) -> Result<ConstructionChunkReceipt,
         session_identity: intent.session_identity.clone(),
         parent_topology_generation: intent.parent_topology_generation,
         ontology_mode: intent.ontology_mode,
+        semantic_authority_sha256: intent.semantic_authority_sha256.clone(),
         prior_receipt_sha256: intent.prior_receipt_sha256.clone(),
         chunk_id: intent.chunk_id.clone(),
         sequence: intent.sequence,
@@ -4126,6 +4251,7 @@ fn validate_intent(intent: &ChunkIntent, checkpoint: &Checkpoint) -> Result<(), 
             || intent.sequence.saturating_add(1) == checkpoint.next_sequence)
         || intent.parent_topology_generation != checkpoint.parent_topology_generation
         || intent.ontology_mode != checkpoint.ontology_mode
+        || intent.semantic_authority_sha256 != checkpoint.semantic_authority_sha256
         || (intent.sequence == checkpoint.next_sequence
             && intent.prior_receipt_sha256 != checkpoint.last_receipt_sha256)
         || intent.chunk_key != chunk_key_name(&intent.chunk_id)
@@ -4187,6 +4313,7 @@ fn validate_intent(intent: &ChunkIntent, checkpoint: &Checkpoint) -> Result<(), 
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn validate_checkpoint(
     checkpoint: &Checkpoint,
     operation: Uuid,
@@ -4194,6 +4321,7 @@ fn validate_checkpoint(
     session: FileIdentity,
     generation: u64,
     ontology_mode: graphforge_core::OntologyMode,
+    semantic_authority_sha256: Option<&str>,
     budgets: GraphConstructionBudgets,
     parent_catalog_sha256: Option<&str>,
 ) -> Result<(), GfError> {
@@ -4203,6 +4331,13 @@ fn validate_checkpoint(
         || !checkpoint.session_identity.matches(session)
         || checkpoint.parent_topology_generation != generation
         || checkpoint.ontology_mode != ontology_mode
+        || checkpoint.semantic_authority_sha256.as_deref() != semantic_authority_sha256
+        || checkpoint
+            .semantic_authority_sha256
+            .as_ref()
+            .is_some_and(|digest| {
+                digest.len() != 64 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit())
+            })
         || checkpoint.session_now_micros <= 0
         || checkpoint.budgets != budgets
         || checkpoint.has_base_snapshot != (generation != 0)
@@ -4230,18 +4365,16 @@ fn validate_checkpoint(
         || checkpoint.evidence.current_transitions != 0
         || checkpoint
             .node_schema_sha256
-            .as_ref()
-            .is_some_and(|digest| {
-                digest.len() != 64 || !digest.bytes().all(|b| b.is_ascii_hexdigit())
-            })
+            .iter()
+            .any(|digest| digest.len() != 64 || !digest.bytes().all(|b| b.is_ascii_hexdigit()))
         || checkpoint
             .edge_schema_sha256
-            .as_ref()
-            .is_some_and(|digest| {
-                digest.len() != 64 || !digest.bytes().all(|b| b.is_ascii_hexdigit())
-            })
-        || usize::from(checkpoint.node_schema_sha256.is_some())
-            .saturating_add(usize::from(checkpoint.edge_schema_sha256.is_some()))
+            .iter()
+            .any(|digest| digest.len() != 64 || !digest.bytes().all(|b| b.is_ascii_hexdigit()))
+        || checkpoint
+            .node_schema_sha256
+            .len()
+            .saturating_add(checkpoint.edge_schema_sha256.len())
             > budgets.max_schema_groups
     {
         return Err(storage("checkpoint authority or resume parameters changed"));
@@ -4624,7 +4757,7 @@ fn write_control_body(
 }
 
 #[cfg(test)]
-fn construction_failpoint(name: &str) {
+pub(crate) fn construction_failpoint(name: &str) {
     if std::env::var("GF_CONSTRUCTION_FAILPOINT_COOKIE").as_deref()
         == Ok("graphforge-construction-test-v1")
         && std::env::var("GF_CONSTRUCTION_FAILPOINT").as_deref() == Ok(name)
@@ -4634,7 +4767,7 @@ fn construction_failpoint(name: &str) {
 }
 
 #[cfg(not(test))]
-fn construction_failpoint(_name: &str) {}
+pub(crate) fn construction_failpoint(_name: &str) {}
 
 fn sha256(bytes: &[u8]) -> String {
     hex(&Sha256::digest(bytes))
@@ -4765,6 +4898,68 @@ mod tests {
             ],
         )
         .unwrap()
+    }
+
+    fn semantic_authority(mode: graphforge_core::OntologyMode) -> ConstructionSemanticAuthority {
+        let document = graphforge_ontology::OntologyDoc {
+            ontology_id: "https://graphforge.dev/ontology/construction-test".into(),
+            version: "1.0.0".into(),
+            entity_types: vec![graphforge_ontology::EntityTypeDef {
+                name: "Person".into(),
+                r#abstract: false,
+                parent: None,
+            }],
+            relation_types: vec![graphforge_ontology::RelationTypeDef {
+                name: "R".into(),
+                src: "Person".into(),
+                dst: "Person".into(),
+                inverse: None,
+                semantic: graphforge_ontology::SemanticFlags::default(),
+            }],
+            properties: vec![
+                graphforge_ontology::PropertyDef {
+                    owner: "Person".into(),
+                    name: "score".into(),
+                    value_type: graphforge_ontology::PropertyValueType::Int64,
+                    nullable: true,
+                    multivalued: false,
+                    default_json: None,
+                },
+                graphforge_ontology::PropertyDef {
+                    owner: "R".into(),
+                    name: "weight".into(),
+                    value_type: graphforge_ontology::PropertyValueType::Int64,
+                    nullable: true,
+                    multivalued: false,
+                    default_json: None,
+                },
+            ],
+            constraints: vec![],
+            migrations: vec![],
+        };
+        let value = serde_json::to_value(&document).unwrap();
+        let legacy = crate::WorkspaceOntology {
+            contract_version: 1,
+            mode: match mode {
+                graphforge_core::OntologyMode::Strict => crate::WorkspaceOntologyMode::Strict,
+                graphforge_core::OntologyMode::Advisory => crate::WorkspaceOntologyMode::Advisory,
+                graphforge_core::OntologyMode::Exploratory => {
+                    crate::WorkspaceOntologyMode::Advisory
+                }
+            },
+            source_format: Some(crate::WorkspaceOntologySourceFormat::Json),
+            canonical_ontology_sha256: Some(sha256(&serde_json::to_vec(&value).unwrap())),
+            canonical_ontology: Some(value),
+        };
+        let composition = crate::WorkspaceOntologyComposition::virtual_legacy(&legacy)
+            .unwrap()
+            .unwrap();
+        let bindings =
+            crate::SemanticStorageBindings::project(&composition.compile().unwrap(), None).unwrap();
+        ConstructionSemanticAuthority {
+            composition,
+            bindings,
+        }
     }
 
     fn open(root: &TempDir, operation: u128) -> GraphConstructionSession {
@@ -5146,7 +5341,7 @@ mod tests {
         let slots = online_merge_name_slot_bound(1_000_000, 32);
         assert!(slots <= 31 * 4, "retained slots: {slots}");
         assert!(slots < 1_000_000 / 1_000);
-        assert_eq!(GraphConstructionBudgets::default().max_schema_groups, 2);
+        assert_eq!(GraphConstructionBudgets::default().max_schema_groups, 256);
     }
 
     #[test]
@@ -5286,8 +5481,8 @@ mod tests {
             .append(ConstructionChunkKind::Edge, "edges", &edge_batch(100, 1))
             .unwrap_err();
         assert!(error.to_string().contains("schema-group budget"));
-        assert!(session.checkpoint.node_schema_sha256.is_some());
-        assert!(session.checkpoint.edge_schema_sha256.is_none());
+        assert_eq!(session.checkpoint.node_schema_sha256.len(), 1);
+        assert!(session.checkpoint.edge_schema_sha256.is_empty());
     }
 
     #[test]
@@ -5869,12 +6064,67 @@ mod tests {
         session
             .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 8))
             .unwrap();
+        if std::env::var_os("GF_CONSTRUCTION_UUID_ENCODE_CRASH").is_some() {
+            session.seal().unwrap();
+            let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+            session.encode_canonical(&shape, 1).unwrap();
+        }
         if std::env::var_os("GF_CONSTRUCTION_SHAPE_CRASH").is_some() {
             session
                 .append(ConstructionChunkKind::Node, "nodes-2", &node_batch(9, 8))
                 .unwrap();
             session.seal().unwrap();
             session.shape_canonical_with_cancellation(|| false).unwrap();
+        }
+    }
+
+    #[test]
+    fn uuid_encoding_crashes_recover_every_durable_boundary() {
+        for failpoint in [
+            "uuid_encode.after_intent",
+            "uuid_encode.after_temps",
+            "uuid_encode.after_delta_runs",
+            "uuid_encode.after_manifest",
+            "uuid_encode.after_intent_removal",
+        ] {
+            let root = TempDir::new().unwrap();
+            let status = std::process::Command::new(std::env::current_exe().unwrap())
+                .arg("--exact")
+                .arg("graph_construction::tests::crash_subprocess_helper")
+                .arg("--nocapture")
+                .env("GF_CONSTRUCTION_CRASH_ROOT", root.path())
+                .env("GF_CONSTRUCTION_UUID_ENCODE_CRASH", "1")
+                .env(
+                    "GF_CONSTRUCTION_FAILPOINT_COOKIE",
+                    "graphforge-construction-test-v1",
+                )
+                .env("GF_CONSTRUCTION_FAILPOINT", failpoint)
+                .status()
+                .unwrap();
+            assert_eq!(status.code(), Some(86), "{failpoint}");
+            let mut resumed = GraphConstructionSession::open(
+                root.path(),
+                Uuid::from_u128(600),
+                0,
+                GraphConstructionBudgets::default(),
+            )
+            .unwrap();
+            let shape = resumed.shape_canonical_with_cancellation(|| false).unwrap();
+            let encoded = resumed.encode_canonical(&shape, 1).unwrap();
+            assert_eq!(encoded.evidence.membership_records, 8, "{failpoint}");
+            let membership = root
+                .path()
+                .join(PRIVATE_ROOT)
+                .join(Uuid::from_u128(600).simple().to_string())
+                .join("encoded-v1/graph/.graphforge-cache/uuid-membership");
+            assert!(!membership.join(".construction-intent.json").exists());
+            assert!(std::fs::read_dir(membership).unwrap().all(|entry| {
+                !entry
+                    .unwrap()
+                    .file_name()
+                    .to_string_lossy()
+                    .ends_with(".tmp")
+            }));
         }
     }
 
@@ -6011,11 +6261,25 @@ mod tests {
     fn canonical_encoder_outputs_feed_ordinary_readers_index_and_adjacency() {
         let root = TempDir::new().unwrap();
         let operation = Uuid::from_u128(9_320);
-        let mut session = GraphConstructionSession::open_with_mode(
+        let authority = semantic_authority(graphforge_core::OntologyMode::Strict);
+        let route = |kind, local: &str| {
+            authority
+                .bindings
+                .bindings
+                .iter()
+                .find(|binding| binding.route_kind == kind && binding.symbol.local_id == local)
+                .unwrap()
+                .route
+                .clone()
+        };
+        let relation_route = route(crate::SemanticRouteKind::Relation, "R");
+        let node_property_route = route(crate::SemanticRouteKind::NodeProperty, "Person:score");
+        let edge_property_route = route(crate::SemanticRouteKind::EdgeProperty, "R:weight");
+        let mut session = GraphConstructionSession::open_with_semantic_authority(
             root.path(),
             operation,
             0,
-            graphforge_core::OntologyMode::Strict,
+            authority,
             GraphConstructionBudgets::default(),
         )
         .unwrap();
@@ -6061,9 +6325,14 @@ mod tests {
         .unwrap();
         let nodes = crate::read_nodes(&graph).unwrap();
         assert_eq!(nodes.iter().map(RecordBatch::num_rows).sum::<usize>(), 3);
-        let edges = crate::read_edges(&graph, "R", graphforge_core::OntologyMode::Strict).unwrap();
+        let edges = crate::read_edges(
+            &graph,
+            &relation_route,
+            graphforge_core::OntologyMode::Strict,
+        )
+        .unwrap();
         assert_eq!(edges.iter().map(RecordBatch::num_rows).sum::<usize>(), 2);
-        let node_properties = crate::read_properties(&graph, "Person").unwrap();
+        let node_properties = crate::read_properties(&graph, &node_property_route).unwrap();
         assert_eq!(
             node_properties
                 .iter()
@@ -6071,7 +6340,7 @@ mod tests {
                 .sum::<usize>(),
             3
         );
-        let edge_properties = crate::read_edge_properties(&graph, "R").unwrap();
+        let edge_properties = crate::read_edge_properties(&graph, &edge_property_route).unwrap();
         assert_eq!(
             edge_properties
                 .iter()
@@ -6092,14 +6361,79 @@ mod tests {
     }
 
     #[test]
-    fn canonical_encoder_cancellation_recovers_and_corruption_fails_closed() {
+    fn canonical_encoder_merges_bounded_heterogeneous_node_schemas() {
         let root = TempDir::new().unwrap();
-        let operation = Uuid::from_u128(9_322);
-        let mut session = GraphConstructionSession::open_with_mode(
+        let operation = Uuid::from_u128(9_323);
+        let authority = semantic_authority(graphforge_core::OntologyMode::Strict);
+        let property_route = authority
+            .bindings
+            .bindings
+            .iter()
+            .find(|binding| {
+                binding.route_kind == crate::SemanticRouteKind::NodeProperty
+                    && binding.symbol.local_id == "Person:score"
+            })
+            .unwrap()
+            .route
+            .clone();
+        let mut session = GraphConstructionSession::open_with_semantic_authority(
             root.path(),
             operation,
             0,
-            graphforge_core::OntologyMode::Strict,
+            authority,
+            GraphConstructionBudgets::default(),
+        )
+        .unwrap();
+        session
+            .append(ConstructionChunkKind::Node, "plain", &node_batch(1, 1))
+            .unwrap();
+        session
+            .append(
+                ConstructionChunkKind::Node,
+                "property",
+                &node_property_batch(2, 1),
+            )
+            .unwrap();
+        session.seal().unwrap();
+        let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+        assert_eq!(shape.node_rows.len(), 2);
+        let encoded = session.encode_canonical(&shape, 1).unwrap();
+        let graph = root
+            .path()
+            .join(PRIVATE_ROOT)
+            .join(operation.simple().to_string())
+            .join(&encoded.root)
+            .join("graph");
+        assert_eq!(
+            crate::read_nodes(&graph)
+                .unwrap()
+                .iter()
+                .map(RecordBatch::num_rows)
+                .sum::<usize>(),
+            2
+        );
+        assert_eq!(
+            crate::read_properties(&graph, &property_route)
+                .unwrap()
+                .iter()
+                .map(RecordBatch::num_rows)
+                .sum::<usize>(),
+            1
+        );
+        assert!(encoded.evidence.peak_batch_rows <= 65_536);
+        assert!(encoded.evidence.input_read_operations > 0);
+        assert!(encoded.evidence.output_write_operations > 0);
+    }
+
+    #[test]
+    fn canonical_encoder_cancellation_recovers_and_corruption_fails_closed() {
+        let root = TempDir::new().unwrap();
+        let operation = Uuid::from_u128(9_322);
+        let mut session = GraphConstructionSession::open_with_semantic_authority(
+            root.path(),
+            operation,
+            0,
+            semantic_authority(graphforge_core::OntologyMode::Strict),
             GraphConstructionBudgets {
                 max_batch_rows: 2,
                 ..GraphConstructionBudgets::default()
@@ -6130,6 +6464,14 @@ mod tests {
             })
             .unwrap_err();
         assert!(error.to_string().contains("cancelled"));
+        let uuid_private = root
+            .path()
+            .join(PRIVATE_ROOT)
+            .join(operation.simple().to_string())
+            .join("encoded-v1/graph/.graphforge-cache/uuid-membership");
+        if uuid_private.exists() {
+            assert_eq!(std::fs::read_dir(&uuid_private).unwrap().count(), 0);
+        }
 
         let encoded = session.encode_canonical(&shape, 1).unwrap();
         let operation_root = root
@@ -6156,20 +6498,20 @@ mod tests {
         let root = TempDir::new().unwrap();
         let operation = Uuid::from_u128(9_321);
         drop(
-            GraphConstructionSession::open_with_mode(
+            GraphConstructionSession::open_with_semantic_authority(
                 root.path(),
                 operation,
                 0,
-                graphforge_core::OntologyMode::Advisory,
+                semantic_authority(graphforge_core::OntologyMode::Advisory),
                 GraphConstructionBudgets::default(),
             )
             .unwrap(),
         );
-        let error = match GraphConstructionSession::open_with_mode(
+        let error = match GraphConstructionSession::open_with_semantic_authority(
             root.path(),
             operation,
             0,
-            graphforge_core::OntologyMode::Strict,
+            semantic_authority(graphforge_core::OntologyMode::Strict),
             GraphConstructionBudgets::default(),
         ) {
             Ok(_) => panic!("ontology mode mismatch was accepted"),
@@ -6187,14 +6529,27 @@ mod tests {
         ] {
             let root = TempDir::new().unwrap();
             let operation = Uuid::from_u128(9_330 + offset);
-            let mut session = GraphConstructionSession::open_with_mode(
-                root.path(),
-                operation,
-                0,
-                mode,
-                GraphConstructionBudgets::default(),
-            )
-            .unwrap();
+            let authority = (mode != graphforge_core::OntologyMode::Exploratory)
+                .then(|| semantic_authority(mode));
+            let mut session = if mode == graphforge_core::OntologyMode::Exploratory {
+                GraphConstructionSession::open_with_mode(
+                    root.path(),
+                    operation,
+                    0,
+                    mode,
+                    GraphConstructionBudgets::default(),
+                )
+                .unwrap()
+            } else {
+                GraphConstructionSession::open_with_semantic_authority(
+                    root.path(),
+                    operation,
+                    0,
+                    authority.clone().unwrap(),
+                    GraphConstructionBudgets::default(),
+                )
+                .unwrap()
+            };
             session
                 .append(
                     ConstructionChunkKind::Node,
@@ -6219,8 +6574,19 @@ mod tests {
                 .join(operation.simple().to_string())
                 .join(&encoding.root)
                 .join("graph");
+            let route = |kind, local: &str, fallback: &str| {
+                authority
+                    .as_ref()
+                    .and_then(|authority| {
+                        authority.bindings.bindings.iter().find(|binding| {
+                            binding.route_kind == kind && binding.symbol.local_id == local
+                        })
+                    })
+                    .map_or_else(|| fallback.to_owned(), |binding| binding.route.clone())
+            };
+            let relation_route = route(crate::SemanticRouteKind::Relation, "R", "R");
             assert_eq!(
-                crate::read_edges(&graph, "R", mode)
+                crate::read_edges(&graph, &relation_route, mode)
                     .unwrap()
                     .iter()
                     .map(RecordBatch::num_rows)
@@ -6229,13 +6595,17 @@ mod tests {
             );
             let property_stem = if mode == graphforge_core::OntologyMode::Exploratory {
                 assert!(graph.join("topology/edges/_exploratory").is_dir());
-                "_untyped"
+                "_untyped".to_owned()
             } else {
-                assert!(graph.join("topology/edges/R").is_dir());
-                "Person"
+                assert!(!graph.join("topology/edges/R").exists());
+                route(
+                    crate::SemanticRouteKind::NodeProperty,
+                    "Person:score",
+                    "Person",
+                )
             };
             assert_eq!(
-                crate::read_properties(&graph, property_stem)
+                crate::read_properties(&graph, &property_stem)
                     .unwrap()
                     .iter()
                     .map(RecordBatch::num_rows)
@@ -6243,11 +6613,18 @@ mod tests {
                 2
             );
             assert_eq!(
-                crate::read_edge_properties(&graph, "R")
-                    .unwrap()
-                    .iter()
-                    .map(RecordBatch::num_rows)
-                    .sum::<usize>(),
+                crate::read_edge_properties(
+                    &graph,
+                    &route(
+                        crate::SemanticRouteKind::EdgeProperty,
+                        "R:weight",
+                        "_exploratory",
+                    ),
+                )
+                .unwrap()
+                .iter()
+                .map(RecordBatch::num_rows)
+                .sum::<usize>(),
                 1
             );
         }
@@ -6274,7 +6651,7 @@ mod tests {
         assert_eq!(encoded.evidence.retained_index_payload_bytes, 0);
         assert_eq!(encoded.evidence.retained_topology_bytes_copied, 0);
         assert_eq!(encoded.evidence.prior_topology_rows_decoded, 0);
-        assert_eq!(encoded.evidence.retained_index_runs, 3);
+        assert_eq!(encoded.evidence.retained_index_runs, 2);
         let index_outputs = encoded
             .artifacts
             .iter()
@@ -6283,6 +6660,29 @@ mod tests {
         // New identity + reverse runs and the new manifest. The retained base
         // and level-one descriptors remain structural references.
         assert_eq!(index_outputs, 3);
+        assert!(!encoded.retained_artifacts.is_empty());
+        let assembled = project
+            .path()
+            .join(PRIVATE_ROOT)
+            .join(operation.simple().to_string())
+            .join(&encoded.root)
+            .join("graph");
+        for retained in &encoded.retained_artifacts {
+            let target = assembled.join(&retained.target_path);
+            std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+            std::fs::hard_link(
+                std::path::Path::new(&retained.source_root).join(&retained.source_path),
+                target,
+            )
+            .unwrap();
+        }
+        std::fs::write(
+            assembled.join("topology/generation.json"),
+            br#"{"topology_generation":3,"search_generation":0}"#,
+        )
+        .unwrap();
+        let opened = crate::UuidMembershipIndex::open(&assembled).unwrap();
+        assert_eq!(opened.count(crate::UuidIndexKind::Node), 4);
     }
 
     #[test]
@@ -6334,5 +6734,39 @@ mod tests {
         let index = crate::UuidMembershipIndex::open(&graph).unwrap();
         assert_eq!(index.count(crate::UuidIndexKind::Node), 3);
         assert_eq!(index.count(crate::UuidIndexKind::Edge), 1);
+    }
+
+    #[test]
+    fn parent_uuid_path_substitution_is_rejected_before_encoding() {
+        let project = nonempty_project_with_nodes(2);
+        let operation = Uuid::from_u128(9_342);
+        let mut session = GraphConstructionSession::open_with_mode(
+            project.path(),
+            operation,
+            1,
+            graphforge_core::OntologyMode::Exploratory,
+            GraphConstructionBudgets::default(),
+        )
+        .unwrap();
+        session
+            .append(ConstructionChunkKind::Node, "delta", &node_batch(3, 1))
+            .unwrap();
+        session.seal().unwrap();
+        let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+        let membership = project.path().join(".graphforge-cache/uuid-membership");
+        let victim = std::fs::read_dir(&membership)
+            .unwrap()
+            .map(Result::unwrap)
+            .map(|entry| entry.path())
+            .find(|path| {
+                path.extension()
+                    .is_some_and(|extension| extension == "uuidx")
+            })
+            .unwrap();
+        let saved = victim.with_extension("uuidx.saved");
+        std::fs::rename(&victim, &saved).unwrap();
+        std::fs::copy(&saved, &victim).unwrap();
+        let error = session.encode_canonical(&shape, 2).unwrap_err();
+        assert!(error.to_string().contains("identity changed"));
     }
 }

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -272,6 +272,8 @@ pub struct GraphConstructionEvidence {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 /// Publisher input produced from a sealed construction session.
 pub struct ConstructionShape {
+    /// Ontology mode authenticated at session open and used for physical routing.
+    pub ontology_mode: graphforge_core::OntologyMode,
     /// Parent generation retained by the publisher; zero denotes an empty base.
     pub parent_topology_generation: u64,
     /// Authenticated parent UUID-manifest authority. The shaped identities file
@@ -304,6 +306,10 @@ pub struct ConstructionShape {
     /// Assigned edge surrogate tail.
     pub max_edge_surrogate: u64,
 }
+
+pub use crate::graph_construction_encoding::{
+    GraphConstructionEncoding, GraphConstructionEncodingEvidence,
+};
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 struct IdentityRecord {
@@ -343,6 +349,7 @@ pub struct ConstructionChunkReceipt {
     project_identity: IdentityRecord,
     session_identity: IdentityRecord,
     parent_topology_generation: u64,
+    ontology_mode: graphforge_core::OntologyMode,
     prior_receipt_sha256: Option<String>,
     /// Caller-stable idempotency key.
     pub chunk_id: String,
@@ -374,6 +381,7 @@ struct Checkpoint {
     project_identity: IdentityRecord,
     session_identity: IdentityRecord,
     parent_topology_generation: u64,
+    ontology_mode: graphforge_core::OntologyMode,
     /// One authority-bound timestamp used by every catalog/topology row produced
     /// by this operation. Reopen never consults the wall clock again.
     session_now_micros: i64,
@@ -405,6 +413,7 @@ struct ChunkIntent {
     input_sha256: String,
     schema_sha256: String,
     parent_topology_generation: u64,
+    ontology_mode: graphforge_core::OntologyMode,
     prior_receipt_sha256: Option<String>,
     run_records: u64,
     accounted_live_bytes: u64,
@@ -421,6 +430,7 @@ struct ShapeIntent {
     project_identity: IdentityRecord,
     session_identity: IdentityRecord,
     parent_topology_generation: u64,
+    ontology_mode: graphforge_core::OntologyMode,
     budgets: GraphConstructionBudgets,
     last_receipt_sha256: Option<String>,
     baseline_evidence: GraphConstructionEvidence,
@@ -469,12 +479,54 @@ pub struct GraphConstructionSession {
 }
 
 impl GraphConstructionSession {
+    /// Encode a completed canonical shape into private, ordinary GraphForge
+    /// graph/index artifacts. This does not publish either topology generation
+    /// or project `CURRENT`; the generation-last publisher consumes the sealed
+    /// inventory later.
+    pub fn encode_canonical(
+        &mut self,
+        shape: &ConstructionShape,
+        generation: u64,
+    ) -> Result<GraphConstructionEncoding, GfError> {
+        self.encode_canonical_with_cancellation(shape, generation, || false)
+    }
+
+    /// Cancellation-aware form of [`Self::encode_canonical`]. Installed files
+    /// remain private and are deterministically regenerated on resume; only the
+    /// final inventory is authoritative.
+    pub fn encode_canonical_with_cancellation(
+        &mut self,
+        shape: &ConstructionShape,
+        generation: u64,
+        mut cancelled: impl FnMut() -> bool,
+    ) -> Result<GraphConstructionEncoding, GfError> {
+        self.revalidate_authority()?;
+        if self.checkpoint.state != GraphConstructionState::Sealed {
+            return Err(storage("only a sealed session can be encoded"));
+        }
+        let completed = read_completed_shape(&self.root, &self.checkpoint)?
+            .ok_or_else(|| storage("canonical shape is not complete"))?;
+        if &completed != shape {
+            return Err(storage("encoder input differs from completed shape"));
+        }
+        crate::graph_construction_encoding::encode(
+            &self.root,
+            shape,
+            generation,
+            self.checkpoint.ontology_mode,
+            self.base_snapshot.as_ref(),
+            self.checkpoint.budgets,
+            &mut cancelled,
+        )
+    }
+
     /// Create or resume an operation pinned to one parent topology generation.
     #[allow(clippy::too_many_lines)]
-    pub fn open(
+    pub fn open_with_mode(
         project_dir: &Path,
         operation_uuid: Uuid,
         parent_topology_generation: u64,
+        ontology_mode: graphforge_core::OntologyMode,
         budgets: GraphConstructionBudgets,
     ) -> Result<Self, GfError> {
         let budgets = budgets.validate()?;
@@ -553,6 +605,7 @@ impl GraphConstructionSession {
                     project_identity: project_identity.into(),
                     session_identity: session_identity.into(),
                     parent_topology_generation,
+                    ontology_mode,
                     session_now_micros: SystemTime::now()
                         .duration_since(UNIX_EPOCH)
                         .map_err(storage)?
@@ -582,6 +635,7 @@ impl GraphConstructionSession {
             project_identity,
             session_identity,
             parent_topology_generation,
+            ontology_mode,
             budgets,
             parent_catalog_sha256.as_deref(),
         )?;
@@ -598,6 +652,22 @@ impl GraphConstructionSession {
         session.recover_intent()?;
         session.revalidate_authority()?;
         Ok(session)
+    }
+
+    #[cfg(test)]
+    fn open(
+        project_dir: &Path,
+        operation_uuid: Uuid,
+        parent_topology_generation: u64,
+        budgets: GraphConstructionBudgets,
+    ) -> Result<Self, GfError> {
+        Self::open_with_mode(
+            project_dir,
+            operation_uuid,
+            parent_topology_generation,
+            graphforge_core::OntologyMode::Exploratory,
+            budgets,
+        )
     }
 
     /// Current private state.
@@ -763,6 +833,7 @@ impl GraphConstructionSession {
             input_sha256,
             schema_sha256,
             parent_topology_generation: self.checkpoint.parent_topology_generation,
+            ontology_mode: self.checkpoint.ontology_mode,
             prior_receipt_sha256: self.checkpoint.last_receipt_sha256.clone(),
             run_records: run_records as u64,
             accounted_live_bytes: 0,
@@ -920,6 +991,7 @@ impl GraphConstructionSession {
             project_identity: self.checkpoint.project_identity.clone(),
             session_identity: self.checkpoint.session_identity.clone(),
             parent_topology_generation: self.checkpoint.parent_topology_generation,
+            ontology_mode: self.checkpoint.ontology_mode,
             budgets: self.checkpoint.budgets,
             last_receipt_sha256: self.checkpoint.last_receipt_sha256.clone(),
             baseline_evidence: self.checkpoint.evidence.clone(),
@@ -1156,6 +1228,7 @@ impl GraphConstructionSession {
             .peak_merge_temporary_bytes
             .max(measured_shape_bytes(&self.root)?);
         let shape = ConstructionShape {
+            ontology_mode: self.checkpoint.ontology_mode,
             parent_topology_generation: self.checkpoint.parent_topology_generation,
             parent_uuid_manifest_sha256: self
                 .base_snapshot
@@ -1213,6 +1286,7 @@ impl GraphConstructionSession {
                 project_identity: self.checkpoint.project_identity.clone(),
                 session_identity: self.checkpoint.session_identity.clone(),
                 parent_topology_generation: self.checkpoint.parent_topology_generation,
+                ontology_mode: self.checkpoint.ontology_mode,
                 budgets: self.checkpoint.budgets,
                 last_receipt_sha256: self.checkpoint.last_receipt_sha256.clone(),
                 baseline_evidence: shape_intent.baseline_evidence,
@@ -1362,6 +1436,7 @@ impl GraphConstructionSession {
             || receipt.project_identity != self.checkpoint.project_identity
             || receipt.session_identity != self.checkpoint.session_identity
             || receipt.parent_topology_generation != self.checkpoint.parent_topology_generation
+            || receipt.ontology_mode != self.checkpoint.ontology_mode
         {
             return Err(storage("receipt authority differs from session checkpoint"));
         }
@@ -1957,7 +2032,8 @@ fn recover_shape_intent(
             .shape
             .as_ref()
             .ok_or_else(|| storage("complete shape manifest lacks output"))?;
-        if shape.runtime_catalog_now_micros != checkpoint.session_now_micros
+        if shape.ontology_mode != checkpoint.ontology_mode
+            || shape.runtime_catalog_now_micros != checkpoint.session_now_micros
             || shape.runtime_catalog_inputs_sha256.len() != 64
             || !shape
                 .runtime_catalog_inputs_sha256
@@ -2021,6 +2097,7 @@ fn validate_shape_binding(intent: &ShapeIntent, checkpoint: &Checkpoint) -> Resu
         || intent.project_identity != checkpoint.project_identity
         || intent.session_identity != checkpoint.session_identity
         || intent.parent_topology_generation != checkpoint.parent_topology_generation
+        || intent.ontology_mode != checkpoint.ontology_mode
         || intent.budgets != checkpoint.budgets
         || intent.last_receipt_sha256 != checkpoint.last_receipt_sha256
     {
@@ -3856,6 +3933,7 @@ fn receipt_from_intent(intent: &ChunkIntent) -> Result<ConstructionChunkReceipt,
         project_identity: intent.project_identity.clone(),
         session_identity: intent.session_identity.clone(),
         parent_topology_generation: intent.parent_topology_generation,
+        ontology_mode: intent.ontology_mode,
         prior_receipt_sha256: intent.prior_receipt_sha256.clone(),
         chunk_id: intent.chunk_id.clone(),
         sequence: intent.sequence,
@@ -4047,6 +4125,7 @@ fn validate_intent(intent: &ChunkIntent, checkpoint: &Checkpoint) -> Result<(), 
         || !(intent.sequence == checkpoint.next_sequence
             || intent.sequence.saturating_add(1) == checkpoint.next_sequence)
         || intent.parent_topology_generation != checkpoint.parent_topology_generation
+        || intent.ontology_mode != checkpoint.ontology_mode
         || (intent.sequence == checkpoint.next_sequence
             && intent.prior_receipt_sha256 != checkpoint.last_receipt_sha256)
         || intent.chunk_key != chunk_key_name(&intent.chunk_id)
@@ -4114,6 +4193,7 @@ fn validate_checkpoint(
     project: FileIdentity,
     session: FileIdentity,
     generation: u64,
+    ontology_mode: graphforge_core::OntologyMode,
     budgets: GraphConstructionBudgets,
     parent_catalog_sha256: Option<&str>,
 ) -> Result<(), GfError> {
@@ -4122,6 +4202,7 @@ fn validate_checkpoint(
         || !checkpoint.project_identity.matches(project)
         || !checkpoint.session_identity.matches(session)
         || checkpoint.parent_topology_generation != generation
+        || checkpoint.ontology_mode != ontology_mode
         || checkpoint.session_now_micros <= 0
         || checkpoint.budgets != budgets
         || checkpoint.has_base_snapshot != (generation != 0)
@@ -4632,6 +4713,60 @@ mod tests {
         .unwrap()
     }
 
+    fn node_property_batch(first: u128, rows: usize) -> RecordBatch {
+        let uuids = (first..first + rows as u128)
+            .map(u128::to_be_bytes)
+            .collect::<Vec<_>>();
+        let mut fields = CONSTRUCTION_NODE_SCHEMA
+            .fields()
+            .iter()
+            .map(|field| field.as_ref().clone())
+            .collect::<Vec<_>>();
+        fields.push(Field::new("score", DataType::Int64, true));
+        RecordBatch::try_new(
+            Arc::new(Schema::new(fields)),
+            vec![
+                Arc::new(fixed(&uuids)),
+                Arc::new(StringArray::from(vec!["Person"; rows])),
+                Arc::new(Int64Array::from_iter_values(
+                    (0..rows).map(|row| row as i64 + 10),
+                )),
+            ],
+        )
+        .unwrap()
+    }
+
+    fn edge_property_batch(first: u128, rows: usize) -> RecordBatch {
+        let edges = (first..first + rows as u128)
+            .map(u128::to_be_bytes)
+            .collect::<Vec<_>>();
+        let src = (1..=rows as u128)
+            .map(u128::to_be_bytes)
+            .collect::<Vec<_>>();
+        let dst = (2..=rows as u128 + 1)
+            .map(u128::to_be_bytes)
+            .collect::<Vec<_>>();
+        let mut fields = CONSTRUCTION_EDGE_SCHEMA
+            .fields()
+            .iter()
+            .map(|field| field.as_ref().clone())
+            .collect::<Vec<_>>();
+        fields.push(Field::new("weight", DataType::Int64, true));
+        RecordBatch::try_new(
+            Arc::new(Schema::new(fields)),
+            vec![
+                Arc::new(fixed(&edges)),
+                Arc::new(StringArray::from(vec!["R"; rows])),
+                Arc::new(fixed(&src)),
+                Arc::new(fixed(&dst)),
+                Arc::new(Int64Array::from_iter_values(
+                    (0..rows).map(|row| row as i64 + 20),
+                )),
+            ],
+        )
+        .unwrap()
+    }
+
     fn open(root: &TempDir, operation: u128) -> GraphConstructionSession {
         GraphConstructionSession::open(
             root.path(),
@@ -4683,6 +4818,43 @@ mod tests {
             &[Uuid::from_u128(100)],
         )
         .unwrap();
+        project
+    }
+
+    fn nonempty_project_generation_two() -> TempDir {
+        let project = nonempty_project_with_nodes(2);
+        std::fs::write(
+            project.path().join("topology/generation.json"),
+            br#"{"topology_generation":2,"search_generation":2}"#,
+        )
+        .unwrap();
+        crate::uuid_membership::append_uuid_membership_delta(
+            project.path(),
+            2,
+            &[(Uuid::from_u128(3), 3)],
+            &[Uuid::from_u128(101)],
+        )
+        .unwrap();
+        let tails_schema = Arc::new(Schema::new(vec![
+            Field::new("max_node_id", DataType::UInt64, false),
+            Field::new("max_edge_id", DataType::UInt64, false),
+        ]));
+        let tails = RecordBatch::try_new(
+            tails_schema.clone(),
+            vec![
+                Arc::new(arrow::array::UInt64Array::from(vec![3])),
+                Arc::new(arrow::array::UInt64Array::from(vec![2])),
+            ],
+        )
+        .unwrap();
+        let mut writer = ArrowWriter::try_new(
+            File::create(project.path().join("topology/surrogate_tails.parquet")).unwrap(),
+            tails_schema,
+            None,
+        )
+        .unwrap();
+        writer.write(&tails).unwrap();
+        writer.close().unwrap();
         project
     }
 
@@ -5833,5 +6005,334 @@ mod tests {
             resumed.shape_canonical_with_cancellation(|| false).unwrap();
             assert_eq!(resumed.evidence(), &expected, "{failpoint}");
         }
+    }
+
+    #[test]
+    fn canonical_encoder_outputs_feed_ordinary_readers_index_and_adjacency() {
+        let root = TempDir::new().unwrap();
+        let operation = Uuid::from_u128(9_320);
+        let mut session = GraphConstructionSession::open_with_mode(
+            root.path(),
+            operation,
+            0,
+            graphforge_core::OntologyMode::Strict,
+            GraphConstructionBudgets::default(),
+        )
+        .unwrap();
+        session
+            .append(
+                ConstructionChunkKind::Node,
+                "nodes-a",
+                &node_property_batch(1, 2),
+            )
+            .unwrap();
+        session
+            .append(
+                ConstructionChunkKind::Node,
+                "nodes-b",
+                &node_property_batch(3, 1),
+            )
+            .unwrap();
+        session
+            .append(
+                ConstructionChunkKind::Edge,
+                "edges",
+                &edge_property_batch(100, 2),
+            )
+            .unwrap();
+        session.seal().unwrap();
+        let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+        assert_eq!(shape.ontology_mode, graphforge_core::OntologyMode::Strict);
+        let encoding = session.encode_canonical(&shape, 1).unwrap();
+        assert_eq!(encoding.evidence.prior_topology_rows_decoded, 0);
+        assert_eq!(encoding.evidence.retained_topology_bytes_copied, 0);
+        assert_eq!(encoding.evidence.membership_records, 5);
+
+        let graph = root
+            .path()
+            .join(PRIVATE_ROOT)
+            .join(operation.simple().to_string())
+            .join(&encoding.root)
+            .join("graph");
+        std::fs::write(
+            graph.join("topology/generation.json"),
+            br#"{"topology_generation":1,"search_generation":0}"#,
+        )
+        .unwrap();
+        let nodes = crate::read_nodes(&graph).unwrap();
+        assert_eq!(nodes.iter().map(RecordBatch::num_rows).sum::<usize>(), 3);
+        let edges = crate::read_edges(&graph, "R", graphforge_core::OntologyMode::Strict).unwrap();
+        assert_eq!(edges.iter().map(RecordBatch::num_rows).sum::<usize>(), 2);
+        let node_properties = crate::read_properties(&graph, "Person").unwrap();
+        assert_eq!(
+            node_properties
+                .iter()
+                .map(RecordBatch::num_rows)
+                .sum::<usize>(),
+            3
+        );
+        let edge_properties = crate::read_edge_properties(&graph, "R").unwrap();
+        assert_eq!(
+            edge_properties
+                .iter()
+                .map(RecordBatch::num_rows)
+                .sum::<usize>(),
+            2
+        );
+        let index = crate::UuidMembershipIndex::open(&graph).unwrap();
+        assert_eq!(index.count(crate::UuidIndexKind::Node), 3);
+        assert_eq!(index.count(crate::UuidIndexKind::Edge), 2);
+        let adjacency =
+            crate::adjacency::build_adjacency_index(&graph, shape.runtime_catalog_now_micros)
+                .unwrap();
+        assert!(!adjacency.is_empty());
+
+        let resumed = session.encode_canonical(&shape, 1).unwrap();
+        assert_eq!(resumed, encoding);
+    }
+
+    #[test]
+    fn canonical_encoder_cancellation_recovers_and_corruption_fails_closed() {
+        let root = TempDir::new().unwrap();
+        let operation = Uuid::from_u128(9_322);
+        let mut session = GraphConstructionSession::open_with_mode(
+            root.path(),
+            operation,
+            0,
+            graphforge_core::OntologyMode::Strict,
+            GraphConstructionBudgets {
+                max_batch_rows: 2,
+                ..GraphConstructionBudgets::default()
+            },
+        )
+        .unwrap();
+        session
+            .append(
+                ConstructionChunkKind::Node,
+                "nodes",
+                &node_property_batch(1, 2),
+            )
+            .unwrap();
+        session
+            .append(
+                ConstructionChunkKind::Node,
+                "nodes-2",
+                &node_property_batch(3, 1),
+            )
+            .unwrap();
+        session.seal().unwrap();
+        let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+        let mut polls = 0;
+        let error = session
+            .encode_canonical_with_cancellation(&shape, 1, || {
+                polls += 1;
+                polls == 3
+            })
+            .unwrap_err();
+        assert!(error.to_string().contains("cancelled"));
+
+        let encoded = session.encode_canonical(&shape, 1).unwrap();
+        let operation_root = root
+            .path()
+            .join(PRIVATE_ROOT)
+            .join(operation.simple().to_string())
+            .join(&encoded.root);
+        let victim = encoded
+            .artifacts
+            .iter()
+            .find(|artifact| artifact.path.starts_with("topology/nodes/"))
+            .unwrap();
+        std::fs::write(operation_root.join("graph").join(&victim.path), b"corrupt").unwrap();
+        let error = session.encode_canonical(&shape, 1).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("canonical artifact differs from inventory")
+        );
+    }
+
+    #[test]
+    fn construction_checkpoint_rejects_ontology_mode_change_on_resume() {
+        let root = TempDir::new().unwrap();
+        let operation = Uuid::from_u128(9_321);
+        drop(
+            GraphConstructionSession::open_with_mode(
+                root.path(),
+                operation,
+                0,
+                graphforge_core::OntologyMode::Advisory,
+                GraphConstructionBudgets::default(),
+            )
+            .unwrap(),
+        );
+        let error = match GraphConstructionSession::open_with_mode(
+            root.path(),
+            operation,
+            0,
+            graphforge_core::OntologyMode::Strict,
+            GraphConstructionBudgets::default(),
+        ) {
+            Ok(_) => panic!("ontology mode mismatch was accepted"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("resume parameters changed"));
+    }
+
+    #[test]
+    fn canonical_routing_is_checkpoint_bound_in_all_ontology_modes() {
+        for (offset, mode) in [
+            (0_u128, graphforge_core::OntologyMode::Exploratory),
+            (1, graphforge_core::OntologyMode::Advisory),
+            (2, graphforge_core::OntologyMode::Strict),
+        ] {
+            let root = TempDir::new().unwrap();
+            let operation = Uuid::from_u128(9_330 + offset);
+            let mut session = GraphConstructionSession::open_with_mode(
+                root.path(),
+                operation,
+                0,
+                mode,
+                GraphConstructionBudgets::default(),
+            )
+            .unwrap();
+            session
+                .append(
+                    ConstructionChunkKind::Node,
+                    "nodes",
+                    &node_property_batch(1, 2),
+                )
+                .unwrap();
+            session
+                .append(
+                    ConstructionChunkKind::Edge,
+                    "edges",
+                    &edge_property_batch(100, 1),
+                )
+                .unwrap();
+            session.seal().unwrap();
+            let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+            assert_eq!(shape.ontology_mode, mode);
+            let encoding = session.encode_canonical(&shape, 1).unwrap();
+            let graph = root
+                .path()
+                .join(PRIVATE_ROOT)
+                .join(operation.simple().to_string())
+                .join(&encoding.root)
+                .join("graph");
+            assert_eq!(
+                crate::read_edges(&graph, "R", mode)
+                    .unwrap()
+                    .iter()
+                    .map(RecordBatch::num_rows)
+                    .sum::<usize>(),
+                1
+            );
+            let property_stem = if mode == graphforge_core::OntologyMode::Exploratory {
+                assert!(graph.join("topology/edges/_exploratory").is_dir());
+                "_untyped"
+            } else {
+                assert!(graph.join("topology/edges/R").is_dir());
+                "Person"
+            };
+            assert_eq!(
+                crate::read_properties(&graph, property_stem)
+                    .unwrap()
+                    .iter()
+                    .map(RecordBatch::num_rows)
+                    .sum::<usize>(),
+                2
+            );
+            assert_eq!(
+                crate::read_edge_properties(&graph, "R")
+                    .unwrap()
+                    .iter()
+                    .map(RecordBatch::num_rows)
+                    .sum::<usize>(),
+                1
+            );
+        }
+    }
+
+    #[test]
+    fn generation_two_parent_index_is_structurally_referenced_without_payload_copy() {
+        let project = nonempty_project_generation_two();
+        let operation = Uuid::from_u128(9_340);
+        let mut session = GraphConstructionSession::open_with_mode(
+            project.path(),
+            operation,
+            2,
+            graphforge_core::OntologyMode::Exploratory,
+            GraphConstructionBudgets::default(),
+        )
+        .unwrap();
+        session
+            .append(ConstructionChunkKind::Node, "delta", &node_batch(4, 1))
+            .unwrap();
+        session.seal().unwrap();
+        let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+        let encoded = session.encode_canonical(&shape, 3).unwrap();
+        assert_eq!(encoded.evidence.retained_index_payload_bytes, 0);
+        assert_eq!(encoded.evidence.retained_topology_bytes_copied, 0);
+        assert_eq!(encoded.evidence.prior_topology_rows_decoded, 0);
+        assert_eq!(encoded.evidence.retained_index_runs, 3);
+        let index_outputs = encoded
+            .artifacts
+            .iter()
+            .filter(|artifact| artifact.path.contains("uuid-membership"))
+            .count();
+        // New identity + reverse runs and the new manifest. The retained base
+        // and level-one descriptors remain structural references.
+        assert_eq!(index_outputs, 3);
+    }
+
+    #[test]
+    fn generation_one_parent_uses_streamed_binary_carry_and_authenticates_result() {
+        let project = nonempty_project_with_nodes(2);
+        let operation = Uuid::from_u128(9_341);
+        let mut session = GraphConstructionSession::open_with_mode(
+            project.path(),
+            operation,
+            1,
+            graphforge_core::OntologyMode::Exploratory,
+            GraphConstructionBudgets::default(),
+        )
+        .unwrap();
+        session
+            .append(ConstructionChunkKind::Node, "delta", &node_batch(3, 1))
+            .unwrap();
+        session.seal().unwrap();
+        let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+        let encoded = session.encode_canonical(&shape, 2).unwrap();
+        assert!(encoded.evidence.retained_index_payload_bytes > 0);
+
+        let graph = project
+            .path()
+            .join(PRIVATE_ROOT)
+            .join(operation.simple().to_string())
+            .join(&encoded.root)
+            .join("graph");
+        let parent_index = project.path().join(".graphforge-cache/uuid-membership");
+        let encoded_index = graph.join(".graphforge-cache/uuid-membership");
+        let parent_manifest: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(parent_index.join("manifest.json")).unwrap())
+                .unwrap();
+        for run in parent_manifest["runs"].as_array().unwrap() {
+            if !run["base"].as_bool().unwrap() {
+                continue;
+            }
+            for field in ["identities", "node_surrogates"] {
+                let name = run[field]["name"].as_str().unwrap();
+                assert_eq!(std::fs::metadata(parent_index.join(name)).unwrap().len(), 0);
+                std::fs::copy(parent_index.join(name), encoded_index.join(name)).unwrap();
+            }
+        }
+        std::fs::write(
+            graph.join("topology/generation.json"),
+            br#"{"topology_generation":2,"search_generation":0}"#,
+        )
+        .unwrap();
+        let index = crate::UuidMembershipIndex::open(&graph).unwrap();
+        assert_eq!(index.count(crate::UuidIndexKind::Node), 3);
+        assert_eq!(index.count(crate::UuidIndexKind::Edge), 1);
     }
 }

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -10,7 +10,7 @@ use std::cmp::Reverse;
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap};
 use std::ffi::{OsStr, OsString};
 use std::fs::File;
-use std::io::{BufReader, BufWriter, Read, Write};
+use std::io::{BufReader, BufWriter, Read, Seek, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{LazyLock, Mutex};
@@ -108,6 +108,12 @@ pub struct GraphConstructionBudgets {
     /// deliberately requires one stable schema per entity kind, so this may be
     /// one (single-kind sessions) or two (nodes plus edges).
     pub max_schema_groups: usize,
+    /// Maximum trailing property columns in either stable entity schema.
+    pub max_property_columns: usize,
+    /// Maximum persisted runtime-catalog entries admitted from the parent.
+    pub max_catalog_entries: usize,
+    /// Maximum decoded Arrow bytes admitted while streaming the parent catalog.
+    pub max_catalog_decoded_bytes: usize,
 }
 
 impl Default for GraphConstructionBudgets {
@@ -119,6 +125,9 @@ impl Default for GraphConstructionBudgets {
             max_run_records: 4 * 65_536,
             merge_fan_in: 32,
             max_schema_groups: 2,
+            max_property_columns: 4_096,
+            max_catalog_entries: 1_000_000,
+            max_catalog_decoded_bytes: 256 << 20,
         }
     }
 }
@@ -131,6 +140,9 @@ impl GraphConstructionBudgets {
             || self.max_run_records < 4 * self.max_batch_rows
             || self.merge_fan_in < 2
             || !(1..=2).contains(&self.max_schema_groups)
+            || self.max_property_columns == 0
+            || self.max_catalog_entries == 0
+            || self.max_catalog_decoded_bytes == 0
         {
             return Err(storage("invalid construction budgets"));
         }
@@ -170,6 +182,18 @@ pub struct GraphConstructionEvidence {
     pub authentication_read_bytes: u64,
     /// Actual bounded authentication reads.
     pub authentication_read_operations: u64,
+    /// Parent runtime-catalog bytes read through its retained descriptor.
+    pub parent_catalog_read_bytes: u64,
+    /// Parent runtime-catalog read operations observed by the bounded reader.
+    pub parent_catalog_read_operations: u64,
+    /// Retained UUID-index bytes loaded by bounded construction probes.
+    pub retained_probe_read_bytes: u64,
+    /// One-MiB retained UUID-index cache fills performed by construction probes.
+    pub retained_probe_block_loads: u64,
+    /// Shaped-output bytes read while constructing its authenticated inventory.
+    pub shaped_output_authentication_bytes: u64,
+    /// Bounded reads used to construct the shaped-output inventory.
+    pub shaped_output_authentication_operations: u64,
     /// Fixed-width run records.
     pub run_records: u64,
     /// Largest retained Arrow row window.
@@ -213,6 +237,8 @@ pub struct GraphConstructionEvidence {
     pub peak_accounted_live_bytes: u64,
     /// Largest number of merge-source names retained by the online scheduler.
     pub peak_merge_name_slots: u64,
+    /// Largest number of endpoint-window names retained by its online merge.
+    pub peak_resolved_endpoint_name_slots: u64,
     /// File and directory durability barriers completed during shaping.
     pub merge_fsync_operations: u64,
     /// Bytes returned by instrumented Parquet range/sequential reads in shaping.
@@ -488,14 +514,16 @@ impl GraphConstructionSession {
             };
             (Some(snapshot), work)
         };
-        let (parent_catalog, parent_catalog_sha256) =
-            load_parent_runtime_catalog(project_dir, parent_topology_generation)?;
+        let (parent_catalog, parent_catalog_sha256, parent_catalog_work) =
+            load_parent_runtime_catalog(&project, parent_topology_generation, budgets)?;
         let checkpoint = match root.open_child_file(OsStr::new(CHECKPOINT)) {
             Ok(mut file) => decode_bounded(&mut file)?,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                 let evidence = GraphConstructionEvidence {
                     authentication_read_bytes: base_work.authentication_bytes,
                     authentication_read_operations: base_work.authentication_blocks,
+                    parent_catalog_read_bytes: parent_catalog_work.bytes,
+                    parent_catalog_read_operations: parent_catalog_work.operations,
                     ..GraphConstructionEvidence::default()
                 };
                 let initial = Checkpoint {
@@ -615,6 +643,16 @@ impl GraphConstructionSession {
             return Err(storage("empty construction chunk"));
         }
         let input_bytes = batch.get_array_memory_size();
+        let required_columns = if kind == ConstructionChunkKind::Node {
+            2
+        } else {
+            4
+        };
+        if batch.num_columns().saturating_sub(required_columns)
+            > self.checkpoint.budgets.max_property_columns
+        {
+            return Err(storage("construction property-column budget exhausted"));
+        }
         if batch.num_rows() > self.checkpoint.budgets.max_batch_rows
             || input_bytes > self.checkpoint.budgets.max_batch_bytes
             || self.checkpoint.next_sequence >= self.checkpoint.budgets.max_chunks
@@ -1008,6 +1046,7 @@ impl GraphConstructionSession {
                 base,
                 self.checkpoint.budgets.max_batch_rows,
                 &mut cancelled,
+                &mut self.checkpoint.evidence,
             )?;
         }
         let identities = assign_surrogates(
@@ -1098,7 +1137,9 @@ impl GraphConstructionSession {
             max_node_surrogate,
             max_edge_surrogate,
         };
-        let mut outputs = vec![receipt_for_existing(&self.root, &shape.identities)?];
+        let (identity_output, mut inventory_work) =
+            receipt_for_existing_with_work(&self.root, &shape.identities)?;
+        let mut outputs = vec![identity_output];
         for name in shape
             .node_details
             .iter()
@@ -1108,8 +1149,23 @@ impl GraphConstructionSession {
             .chain(shape.edge_endpoints.iter())
             .chain(std::iter::once(&shape.runtime_catalog))
         {
-            outputs.push(receipt_for_existing(&self.root, name)?);
+            let (output, work) = receipt_for_existing_with_work(&self.root, name)?;
+            inventory_work.bytes = inventory_work.bytes.saturating_add(work.bytes);
+            inventory_work.operations = inventory_work.operations.saturating_add(work.operations);
+            outputs.push(output);
         }
+        self.checkpoint.evidence.shaped_output_authentication_bytes = self
+            .checkpoint
+            .evidence
+            .shaped_output_authentication_bytes
+            .saturating_add(inventory_work.bytes);
+        self.checkpoint
+            .evidence
+            .shaped_output_authentication_operations = self
+            .checkpoint
+            .evidence
+            .shaped_output_authentication_operations
+            .saturating_add(inventory_work.operations);
         replace_control(
             &self.root,
             SHAPE_INTENT,
@@ -1959,6 +2015,13 @@ fn read_completed_shape(
 }
 
 fn receipt_for_existing(root: &StableDirectory, name: &str) -> Result<ArtifactReceipt, GfError> {
+    receipt_for_existing_with_work(root, name).map(|(receipt, _)| receipt)
+}
+
+fn receipt_for_existing_with_work(
+    root: &StableDirectory,
+    name: &str,
+) -> Result<(ArtifactReceipt, ReadWork), GfError> {
     let mut file = root.open_child_file(OsStr::new(name)).map_err(storage)?;
     if file_link_count(&file).map_err(storage)? != 1 {
         return Err(storage("shaped output has extra links"));
@@ -1977,14 +2040,17 @@ fn receipt_for_existing(root: &StableDirectory, name: &str) -> Result<ArtifactRe
         bytes = bytes.saturating_add(count as u64);
         operations = operations.saturating_add(1);
     }
-    Ok(ArtifactReceipt {
-        name: name.to_owned(),
-        bytes,
-        sha256: hex(&digest.finalize()),
-        identity: identity.into(),
-        write_operations: operations,
-        fsync_operations: 0,
-    })
+    Ok((
+        ArtifactReceipt {
+            name: name.to_owned(),
+            bytes,
+            sha256: hex(&digest.finalize()),
+            identity: identity.into(),
+            write_operations: 0,
+            fsync_operations: 0,
+        },
+        ReadWork { bytes, operations },
+    ))
 }
 
 fn authenticate_shaped_output(
@@ -2357,39 +2423,6 @@ impl FixedMergeAccumulator {
             level += 1;
         }
     }
-}
-
-fn merge_fixed_all<const N: usize>(
-    root: &StableDirectory,
-    mut inputs: Vec<String>,
-    prefix: &str,
-    fan_in: usize,
-    reject_duplicates: bool,
-    cancelled: &mut impl FnMut() -> bool,
-    evidence: &mut GraphConstructionEvidence,
-) -> Result<String, GfError> {
-    if inputs.is_empty() {
-        return Err(storage("external merge has no input"));
-    }
-    let mut level = 0_usize;
-    while inputs.len() > 1 {
-        evidence.merge_passes = evidence.merge_passes.saturating_add(1);
-        let mut outputs = Vec::with_capacity(inputs.len().div_ceil(fan_in));
-        for (group, names) in inputs.chunks(fan_in).enumerate() {
-            reject_cancelled(cancelled)?;
-            let output = format!("{prefix}-l{level:03}-g{group:08}.run");
-            merge_fixed_group::<N>(root, names, &output, reject_duplicates, cancelled, evidence)?;
-            outputs.push(output);
-        }
-        for old in &inputs {
-            if old.starts_with("merge-") && !outputs.contains(old) {
-                unlink_named(root, old)?;
-            }
-        }
-        inputs = outputs;
-        level += 1;
-    }
-    Ok(inputs.pop().expect("one merge output"))
 }
 
 fn merge_fixed_group<const N: usize>(
@@ -2888,50 +2921,91 @@ fn build_runtime_catalog(
 }
 
 fn load_parent_runtime_catalog(
-    project_path: &Path,
+    project: &StableDirectory,
     parent_generation: u64,
-) -> Result<(RuntimeCatalog, Option<String>), GfError> {
+    budgets: GraphConstructionBudgets,
+) -> Result<(RuntimeCatalog, Option<String>, ReadWork), GfError> {
     if parent_generation == 0 {
-        return Ok((RuntimeCatalog::new(), None));
+        return Ok((RuntimeCatalog::new(), None, ReadWork::default()));
     }
-    let path = project_path.join("topology/runtime_catalog.parquet");
-    let digest = match std::fs::read(&path) {
-        Ok(bytes) => Some(sha256(&bytes)),
+    let topology = match project.open_child_directory(OsStr::new("topology")) {
+        Ok(topology) => topology,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            return Ok((RuntimeCatalog::new(), None));
+            return Ok((RuntimeCatalog::new(), None, ReadWork::default()));
         }
-        Err(error) => {
-            return Err(storage(format!(
-                "cannot hash pinned parent catalog: {error}"
-            )));
-        }
+        Err(error) => return Err(storage(error)),
     };
-    let file = match File::open(&path) {
+    let mut file = match topology.open_child_file(OsStr::new("runtime_catalog.parquet")) {
         Ok(file) => file,
-        Err(error) => {
-            return Err(storage(format!(
-                "cannot open pinned parent catalog: {error}"
-            )));
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok((RuntimeCatalog::new(), None, ReadWork::default()));
         }
+        Err(error) => return Err(storage(error)),
     };
-    let reader = ParquetRecordBatchReaderBuilder::try_new(file)
-        .map_err(storage)?
-        .with_batch_size(4096)
-        .build()
-        .map_err(storage)?;
-    let mut batches = Vec::new();
+    if file_link_count(&file).map_err(storage)? != 1 {
+        return Err(storage("parent runtime catalog has extra links"));
+    }
+    let identity = file_identity(&file).map_err(storage)?;
+    let mut digest = Sha256::new();
+    let mut work = ReadWork::default();
+    let mut block = vec![0_u8; BLOCK_BYTES];
+    loop {
+        let count = file.read(&mut block).map_err(storage)?;
+        if count == 0 {
+            break;
+        }
+        digest.update(&block[..count]);
+        work.bytes = work.bytes.saturating_add(count as u64);
+        work.operations = work.operations.saturating_add(1);
+    }
+    file.rewind().map_err(storage)?;
+    if file_identity(&file).map_err(storage)? != identity {
+        return Err(storage("parent runtime catalog identity changed"));
+    }
+    let counter = IoCounter::default();
+    let reader = ParquetRecordBatchReaderBuilder::try_new(CountingChunkReader {
+        file,
+        counter: counter.clone(),
+    })
+    .map_err(storage)?
+    .with_batch_size(4_096.min(budgets.max_catalog_entries))
+    .build()
+    .map_err(storage)?;
+    let mut catalog = RuntimeCatalog::new();
+    let mut entries = 0_usize;
+    let mut decoded_bytes = 0_usize;
     for batch in reader {
-        batches.push(batch.map_err(storage)?);
+        let batch = batch.map_err(storage)?;
+        entries = entries
+            .checked_add(batch.num_rows())
+            .ok_or_else(|| storage("parent runtime catalog entry count overflow"))?;
+        decoded_bytes = decoded_bytes
+            .checked_add(batch.get_array_memory_size())
+            .ok_or_else(|| storage("parent runtime catalog decoded size overflow"))?;
+        if entries > budgets.max_catalog_entries
+            || decoded_bytes > budgets.max_catalog_decoded_bytes
+        {
+            return Err(storage("parent runtime catalog admission budget exhausted"));
+        }
+        catalog.extend_from_record_batch(&batch).map_err(storage)?;
     }
-    if batches.is_empty() {
-        return Ok((RuntimeCatalog::new(), digest));
+    work.bytes = work
+        .bytes
+        .saturating_add(counter.bytes.load(Ordering::Relaxed));
+    work.operations = work
+        .operations
+        .saturating_add(counter.operations.load(Ordering::Relaxed));
+    let named = topology
+        .open_child_file(OsStr::new("runtime_catalog.parquet"))
+        .map_err(storage)?;
+    if file_identity(&named).map_err(storage)? != identity
+        || file_link_count(&named).map_err(storage)? != 1
+    {
+        return Err(storage("parent runtime catalog authority changed"));
     }
-    let schema = batches[0].schema();
-    let merged = arrow::compute::concat_batches(&schema, &batches).map_err(storage)?;
-    Ok((
-        RuntimeCatalog::from_record_batch(&merged).map_err(storage)?,
-        digest,
-    ))
+    topology.revalidate_named().map_err(storage)?;
+    project.revalidate_named().map_err(storage)?;
+    Ok((catalog, Some(hex(&digest.finalize())), work))
 }
 
 fn read_fixed<const N: usize>(reader: &mut impl Read) -> Result<Option<[u8; N]>, GfError> {
@@ -3023,6 +3097,7 @@ fn reject_staged_base_conflicts(
     base: &mut AuthenticatedUuidIndexSnapshot,
     window_rows: usize,
     cancelled: &mut impl FnMut() -> bool,
+    evidence: &mut GraphConstructionEvidence,
 ) -> Result<(), GfError> {
     let mut reader = BufReader::with_capacity(
         BLOCK_BYTES,
@@ -3042,8 +3117,10 @@ fn reject_staged_base_conflicts(
         if requested.is_empty() {
             break;
         }
-        let (nodes, _) = base.probe(UuidIndexKind::Node, &requested)?;
-        let (edges, _) = base.probe(UuidIndexKind::Edge, &requested)?;
+        let (nodes, node_work) = base.probe(UuidIndexKind::Node, &requested)?;
+        let (edges, edge_work) = base.probe(UuidIndexKind::Edge, &requested)?;
+        account_probe_work(&node_work, evidence);
+        account_probe_work(&edge_work, evidence);
         if nodes
             .into_iter()
             .zip(edges)
@@ -3396,7 +3473,7 @@ fn resolve_endpoint_surrogates(
     );
     let mut identity = read_fixed::<BASE_IDENTITY_WIDTH>(&mut identities)?;
     let mut window = Vec::<[u8; RESOLVED_ENDPOINT_WIDTH]>::with_capacity(window_rows);
-    let mut runs = Vec::new();
+    let mut resolved = FixedMergeAccumulator::new("merge-resolved", fan_in, false);
     let mut sequence = 0_u64;
     loop {
         let mut endpoint_window = Vec::with_capacity(window_rows);
@@ -3434,11 +3511,11 @@ fn resolve_endpoint_surrogates(
             }
         }
         if !base_requests.is_empty() {
-            let resolved = base
+            let (resolved, probe_work) = base
                 .as_deref_mut()
                 .ok_or_else(|| storage("endpoint UUID lacks node surrogate"))?
-                .lookup_node_surrogates(&base_requests)?
-                .0;
+                .lookup_node_surrogates(&base_requests)?;
+            account_probe_work(&probe_work, evidence);
             for (position, surrogate) in base_positions.into_iter().zip(resolved) {
                 surrogates[position] = surrogate;
             }
@@ -3467,7 +3544,10 @@ fn resolve_endpoint_surrogates(
                 .merge_fsync_operations
                 .saturating_add(receipt.fsync_operations);
             account_sequential_write(receipt.bytes, evidence);
-            runs.push(name);
+            resolved.push::<RESOLVED_ENDPOINT_WIDTH>(root, name, cancelled, evidence)?;
+            evidence.peak_resolved_endpoint_name_slots = evidence
+                .peak_resolved_endpoint_name_slots
+                .max(resolved.slot_count() as u64);
             window.clear();
             sequence = sequence.saturating_add(1);
             reject_cancelled(cancelled)?;
@@ -3485,21 +3565,27 @@ fn resolve_endpoint_surrogates(
             .merge_fsync_operations
             .saturating_add(receipt.fsync_operations);
         account_sequential_write(receipt.bytes, evidence);
-        runs.push(name);
+        resolved.push::<RESOLVED_ENDPOINT_WIDTH>(root, name, cancelled, evidence)?;
+        evidence.peak_resolved_endpoint_name_slots = evidence
+            .peak_resolved_endpoint_name_slots
+            .max(resolved.slot_count() as u64);
     }
-    merge_fixed_all::<RESOLVED_ENDPOINT_WIDTH>(
-        root,
-        runs,
-        "merge-resolved",
-        fan_in,
-        false,
-        cancelled,
-        evidence,
-    )
-    .map(Some)
+    resolved.finish_optional::<RESOLVED_ENDPOINT_WIDTH>(root, cancelled, evidence)
 }
 
-#[derive(Clone, Copy)]
+fn account_probe_work(
+    work: &crate::uuid_membership::UuidProbeMetrics,
+    evidence: &mut GraphConstructionEvidence,
+) {
+    evidence.retained_probe_read_bytes = evidence
+        .retained_probe_read_bytes
+        .saturating_add(work.read_bytes);
+    evidence.retained_probe_block_loads = evidence
+        .retained_probe_block_loads
+        .saturating_add(work.file_seeks);
+}
+
+#[derive(Clone, Copy, Debug, Default)]
 struct ReadWork {
     bytes: u64,
     operations: u64,
@@ -4643,8 +4729,10 @@ mod tests {
         .unwrap();
         write_parquet(&private, "nodes.parquet", &rows).unwrap();
         let mut evidence = GraphConstructionEvidence::default();
-        let (parent_catalog, parent_catalog_sha256) =
-            load_parent_runtime_catalog(project.path(), 1).unwrap();
+        let project_root = StableDirectory::open(project.path()).unwrap();
+        let (parent_catalog, parent_catalog_sha256, _) =
+            load_parent_runtime_catalog(&project_root, 1, GraphConstructionBudgets::default())
+                .unwrap();
         assert!(parent_catalog_sha256.is_some());
         let output = build_runtime_catalog(
             parent_catalog,
@@ -4738,6 +4826,123 @@ mod tests {
         assert!(slots <= 31 * 4, "retained slots: {slots}");
         assert!(slots < 1_000_000 / 1_000);
         assert_eq!(GraphConstructionBudgets::default().max_schema_groups, 2);
+    }
+
+    #[test]
+    fn resolved_endpoint_windows_use_logarithmic_name_state_at_1x_2x_4x() {
+        for windows in [1_u64, 2, 4] {
+            let root = TempDir::new().unwrap();
+            let budgets = GraphConstructionBudgets {
+                max_batch_rows: 2,
+                max_run_records: 8,
+                merge_fan_in: 2,
+                ..GraphConstructionBudgets::default()
+            };
+            let mut session = GraphConstructionSession::open(
+                root.path(),
+                Uuid::from_u128(7_100 + u128::from(windows)),
+                0,
+                budgets,
+            )
+            .unwrap();
+            let nodes = windows + 1;
+            for offset in (0..nodes).step_by(2) {
+                let rows = usize::try_from((nodes - offset).min(2)).unwrap();
+                session
+                    .append(
+                        ConstructionChunkKind::Node,
+                        &format!("nodes-{offset}"),
+                        &node_batch(1 + u128::from(offset), rows),
+                    )
+                    .unwrap();
+            }
+            for offset in (0..windows).step_by(2) {
+                let rows = usize::try_from((windows - offset).min(2)).unwrap();
+                session
+                    .append(
+                        ConstructionChunkKind::Edge,
+                        &format!("edges-{offset}"),
+                        &edge_batch(10_000 + u128::from(offset), rows),
+                    )
+                    .unwrap();
+            }
+            session.seal().unwrap();
+            let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+            let expected_slots = u64::from(windows.ilog2()).max(1);
+            assert!(
+                session.evidence().peak_resolved_endpoint_name_slots <= expected_slots,
+                "windows={windows} slots={}",
+                session.evidence().peak_resolved_endpoint_name_slots
+            );
+            let expected_inventory_bytes = std::iter::once(&shape.identities)
+                .chain(shape.node_details.iter())
+                .chain(shape.edge_details.iter())
+                .chain(shape.node_rows.iter())
+                .chain(shape.edge_rows.iter())
+                .chain(shape.edge_endpoints.iter())
+                .chain(std::iter::once(&shape.runtime_catalog))
+                .map(|name| {
+                    session
+                        .root
+                        .open_child_file(OsStr::new(name))
+                        .unwrap()
+                        .metadata()
+                        .unwrap()
+                        .len()
+                })
+                .sum::<u64>();
+            assert_eq!(
+                session.evidence().shaped_output_authentication_bytes,
+                expected_inventory_bytes
+            );
+            assert!(session.evidence().shaped_output_authentication_operations > 0);
+        }
+    }
+
+    #[test]
+    fn parent_catalog_streaming_enforces_entry_and_decoded_byte_budgets() {
+        let root = TempDir::new().unwrap();
+        let project = StableDirectory::open(root.path()).unwrap();
+        let topology = project
+            .create_child_directory(OsStr::new("topology"))
+            .unwrap();
+        let mut source = RuntimeCatalog::new();
+        for index in 0..5_000 {
+            source.intern_label_at(&format!("Label{index:05}"), 42);
+        }
+        write_parquet(
+            &topology,
+            "runtime_catalog.parquet",
+            &source.to_record_batch(),
+        )
+        .unwrap();
+
+        let too_few = GraphConstructionBudgets {
+            max_catalog_entries: 4_999,
+            ..GraphConstructionBudgets::default()
+        };
+        assert!(
+            load_parent_runtime_catalog(&project, 1, too_few)
+                .unwrap_err()
+                .to_string()
+                .contains("admission budget")
+        );
+        let too_small = GraphConstructionBudgets {
+            max_catalog_decoded_bytes: 1,
+            ..GraphConstructionBudgets::default()
+        };
+        assert!(
+            load_parent_runtime_catalog(&project, 1, too_small)
+                .unwrap_err()
+                .to_string()
+                .contains("admission budget")
+        );
+        let (restored, digest, work) =
+            load_parent_runtime_catalog(&project, 1, GraphConstructionBudgets::default()).unwrap();
+        assert_eq!(restored.to_record_batch().num_rows(), 5_000);
+        assert!(digest.is_some());
+        assert!(work.bytes > 0);
+        assert!(work.operations > 0);
     }
 
     #[test]
@@ -5009,6 +5214,15 @@ mod tests {
             .shape_canonical_with_cancellation(|| false)
             .unwrap();
         assert_eq!((shape.node_count, shape.edge_count), (2, 2));
+        assert!(retained_endpoints.evidence().retained_probe_read_bytes > 0);
+        assert!(retained_endpoints.evidence().retained_probe_block_loads > 0);
+        assert!(
+            retained_endpoints.evidence().retained_probe_read_bytes
+                <= retained_endpoints
+                    .evidence()
+                    .retained_probe_block_loads
+                    .saturating_mul(BLOCK_BYTES as u64)
+        );
         let mut resolved = BufReader::new(
             retained_endpoints
                 .root

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -42,6 +42,8 @@ const PRIVATE_ROOT: &str = ".graphforge-construction";
 const CHECKPOINT: &str = "checkpoint.json";
 const INTENT: &str = "intent.json";
 const SHAPE_INTENT: &str = "shape-intent.json";
+const PUBLICATION_INTENT: &str = "publication-intent.json";
+const PUBLICATION_RECEIPT: &str = "publication-receipt.json";
 const BLOCK_BYTES: usize = 1 << 20;
 const MAX_CONTROL_BYTES: u64 = 64 << 10;
 const MAX_SHAPE_CONTROL_BYTES: u64 = 32 << 20;
@@ -73,6 +75,65 @@ pub static CONSTRUCTION_EDGE_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
 
 fn storage(error: impl std::fmt::Display) -> GfError {
     GfError::Storage(format!("graph construction session: {error}"))
+}
+
+fn current_parent_generation_authority(project_dir: &Path) -> Result<(Uuid, String), GfError> {
+    match crate::resolve_project_generation(project_dir) {
+        Ok(parent) => Ok((parent.generation_uuid(), hex(&parent.manifest_sha256()))),
+        Err(error) => {
+            #[cfg(test)]
+            {
+                let _ = &error;
+                // Unit fixtures predating the project-container layer exercise
+                // construction mechanics only. Give them a stable non-nil
+                // synthetic authority; production never takes this branch.
+                let identity =
+                    file_identity(&File::open(project_dir).map_err(storage)?).map_err(storage)?;
+                let mut digest = Sha256::new();
+                digest.update(b"graphforge-construction-test-parent/v1\0");
+                digest.update(identity.volume_serial.to_be_bytes());
+                digest.update(identity.file_id);
+                let bytes: [u8; 32] = digest.finalize().into();
+                let mut uuid_bytes = [0_u8; 16];
+                uuid_bytes.copy_from_slice(&bytes[..16]);
+                uuid_bytes[0] |= 1;
+                return Ok((Uuid::from_bytes(uuid_bytes), hex(&bytes)));
+            }
+            #[cfg(not(test))]
+            return Err(storage(format!(
+                "parent project generation cannot be authenticated: {error}"
+            )));
+        }
+    }
+}
+
+fn authenticate_exact_parent_generation(
+    project_dir: &Path,
+    checkpoint: &Checkpoint,
+) -> Result<(Uuid, String), GfError> {
+    match crate::resolve_generation_by_uuid(project_dir, checkpoint.parent_generation_uuid) {
+        Ok(parent) => {
+            let authority = (parent.generation_uuid(), hex(&parent.manifest_sha256()));
+            if authority.1 != checkpoint.parent_generation_manifest_sha256 {
+                return Err(storage("parent generation manifest authority changed"));
+            }
+            Ok(authority)
+        }
+        Err(error) => {
+            #[cfg(test)]
+            {
+                let synthetic = current_parent_generation_authority(project_dir)?;
+                if synthetic.0 == checkpoint.parent_generation_uuid
+                    && synthetic.1 == checkpoint.parent_generation_manifest_sha256
+                {
+                    return Ok(synthetic);
+                }
+            }
+            Err(storage(format!(
+                "exact parent project generation cannot be authenticated: {error}"
+            )))
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -167,6 +228,14 @@ pub enum GraphConstructionState {
     Sealed,
     /// Explicitly abandoned.
     Aborted,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum ConstructionPublicationState {
+    Sealed,
+    Publishing,
+    Published,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -463,6 +532,8 @@ struct Checkpoint {
     project_identity: IdentityRecord,
     session_identity: IdentityRecord,
     parent_topology_generation: u64,
+    parent_generation_uuid: Uuid,
+    parent_generation_manifest_sha256: String,
     ontology_mode: graphforge_core::OntologyMode,
     semantic_authority_sha256: Option<String>,
     /// One authority-bound timestamp used by every catalog/topology row produced
@@ -470,6 +541,7 @@ struct Checkpoint {
     session_now_micros: i64,
     budgets: GraphConstructionBudgets,
     state: GraphConstructionState,
+    publication_state: Option<ConstructionPublicationState>,
     next_sequence: u64,
     saw_edge: bool,
     last_receipt_sha256: Option<String>,
@@ -531,6 +603,30 @@ struct ShapeIntent {
     shape_authority_sha256: Option<String>,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct ConstructionPublicationIntent {
+    format_version: u32,
+    operation_uuid: Uuid,
+    project_identity: IdentityRecord,
+    session_identity: IdentityRecord,
+    parent_generation_uuid: Uuid,
+    parent_generation_manifest_sha256: String,
+    target_generation_uuid: Uuid,
+    transaction_uuid: Uuid,
+    shape_authority_sha256: String,
+    encoding_inventory_sha256: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct ConstructionPublicationReceipt {
+    operation_uuid: Uuid,
+    project_identity: IdentityRecord,
+    session_identity: IdentityRecord,
+    intent_sha256: String,
+    target_generation_uuid: Uuid,
+    target_generation_manifest_sha256: String,
+}
+
 static ACTIVE_OPERATIONS: LazyLock<Mutex<BTreeSet<String>>> =
     LazyLock::new(|| Mutex::new(BTreeSet::new()));
 
@@ -571,6 +667,112 @@ pub struct GraphConstructionSession {
 }
 
 impl GraphConstructionSession {
+    /// Durably bind the sealed private inventory to the one target that the
+    /// existing project publisher will stage. This records replay authority;
+    /// it does not install objects, stage a generation, or mutate `CURRENT`.
+    #[allow(
+        dead_code,
+        reason = "consumed by the next #932 publisher integration slice"
+    )]
+    pub(crate) fn begin_publication(
+        &mut self,
+        target_generation_uuid: Uuid,
+        transaction_uuid: Uuid,
+    ) -> Result<ConstructionPublicationIntent, GfError> {
+        self.revalidate_authority()?;
+        recover_publication(&self.root, &mut self.checkpoint)?;
+        if self.checkpoint.publication_state == Some(ConstructionPublicationState::Publishing) {
+            let intent = read_publication_intent(&self.root, &self.checkpoint)?;
+            if intent.target_generation_uuid == target_generation_uuid
+                && intent.transaction_uuid == transaction_uuid
+            {
+                return Ok(intent);
+            }
+            return Err(storage("publication replay target changed"));
+        }
+        if self.checkpoint.state != GraphConstructionState::Sealed
+            || self.checkpoint.publication_state != Some(ConstructionPublicationState::Sealed)
+        {
+            return Err(storage("only a sealed session can begin publication"));
+        }
+        let shape_authority_sha256 = self
+            .checkpoint
+            .shape_authority_sha256
+            .clone()
+            .ok_or_else(|| storage("publication requires completed shape authority"))?;
+        let encoding_inventory_sha256 = self
+            .checkpoint
+            .encoding_inventory_sha256
+            .clone()
+            .ok_or_else(|| storage("publication requires encoded inventory authority"))?;
+        let intent = ConstructionPublicationIntent {
+            format_version: FORMAT_VERSION,
+            operation_uuid: self.checkpoint.operation_uuid,
+            project_identity: self.checkpoint.project_identity.clone(),
+            session_identity: self.checkpoint.session_identity.clone(),
+            parent_generation_uuid: self.checkpoint.parent_generation_uuid,
+            parent_generation_manifest_sha256: self
+                .checkpoint
+                .parent_generation_manifest_sha256
+                .clone(),
+            target_generation_uuid,
+            transaction_uuid,
+            shape_authority_sha256,
+            encoding_inventory_sha256,
+        };
+        validate_publication_intent(&intent, &self.checkpoint)?;
+        install_control(&self.root, PUBLICATION_INTENT, &intent)?;
+        self.checkpoint.publication_state = Some(ConstructionPublicationState::Publishing);
+        replace_control(&self.root, CHECKPOINT, &self.checkpoint)?;
+        Ok(intent)
+    }
+
+    /// Record the sole project publisher's exact durable result. Replay must
+    /// supply the same target generation and manifest digest.
+    #[allow(
+        dead_code,
+        reason = "consumed by the next #932 publisher integration slice"
+    )]
+    pub(crate) fn finish_publication(
+        &mut self,
+        target_generation_uuid: Uuid,
+        target_generation_manifest_sha256: &str,
+    ) -> Result<ConstructionPublicationReceipt, GfError> {
+        recover_publication(&self.root, &mut self.checkpoint)?;
+        if self.checkpoint.publication_state == Some(ConstructionPublicationState::Published) {
+            let receipt = read_publication_receipt(&self.root, &self.checkpoint)?;
+            if receipt.target_generation_uuid == target_generation_uuid
+                && receipt.target_generation_manifest_sha256 == target_generation_manifest_sha256
+            {
+                return Ok(receipt);
+            }
+            return Err(storage("published replay result changed"));
+        }
+        if self.checkpoint.publication_state != Some(ConstructionPublicationState::Publishing) {
+            return Err(storage("publication has no durable intent"));
+        }
+        validate_sha256(
+            target_generation_manifest_sha256,
+            "target generation manifest",
+        )?;
+        let intent = read_publication_intent(&self.root, &self.checkpoint)?;
+        if intent.target_generation_uuid != target_generation_uuid {
+            return Err(storage("published target differs from durable intent"));
+        }
+        let receipt = ConstructionPublicationReceipt {
+            operation_uuid: self.checkpoint.operation_uuid,
+            project_identity: self.checkpoint.project_identity.clone(),
+            session_identity: self.checkpoint.session_identity.clone(),
+            intent_sha256: control_sha256(&intent)?,
+            target_generation_uuid,
+            target_generation_manifest_sha256: target_generation_manifest_sha256.to_owned(),
+        };
+        install_control(&self.root, PUBLICATION_RECEIPT, &receipt)?;
+        self.checkpoint.publication_state = Some(ConstructionPublicationState::Published);
+        replace_control(&self.root, CHECKPOINT, &self.checkpoint)?;
+        Ok(receipt)
+    }
+
     /// Encode a completed canonical shape into private, ordinary GraphForge
     /// graph/index artifacts. This does not publish either topology generation
     /// or project `CURRENT`; the generation-last publisher consumes the sealed
@@ -593,7 +795,9 @@ impl GraphConstructionSession {
         mut cancelled: impl FnMut() -> bool,
     ) -> Result<GraphConstructionEncoding, GfError> {
         self.revalidate_authority()?;
-        if self.checkpoint.state != GraphConstructionState::Sealed {
+        if self.checkpoint.state != GraphConstructionState::Sealed
+            || self.checkpoint.publication_state != Some(ConstructionPublicationState::Sealed)
+        {
             return Err(storage("only a sealed session can be encoded"));
         }
         let completed = read_completed_shape(&self.root, &self.checkpoint)?
@@ -693,11 +897,6 @@ impl GraphConstructionSession {
             .map(ConstructionSemanticAuthority::digest)
             .transpose()?;
         let project = StableDirectory::open(project_dir).map_err(storage)?;
-        if crate::read_topology_generation(project_dir)? != parent_topology_generation {
-            return Err(storage(
-                "requested parent generation is not current at session open",
-            ));
-        }
         let project_identity = project.identity();
         let key = format!(
             "{}:{}:{}",
@@ -726,7 +925,81 @@ impl GraphConstructionSession {
             session_identity,
         )?;
         cleanup_owned_artifact_temps(&root)?;
-        let (base_snapshot, base_work) = if parent_topology_generation == 0 {
+        // Authenticate private recovery authority before consulting the
+        // mutable public pointer. A publishing/published replay resolves its
+        // exact immutable parent and therefore remains recoverable after
+        // `CURRENT` has advanced.
+        let mut recovered_checkpoint = match root.open_child_file(OsStr::new(CHECKPOINT)) {
+            Ok(mut file) => Some(decode_bounded::<Checkpoint>(&mut file)?),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => return Err(storage(error)),
+        };
+        if let Some(checkpoint) = recovered_checkpoint.as_mut() {
+            if checkpoint.format_version != FORMAT_VERSION
+                || checkpoint.operation_uuid != operation_uuid
+                || !checkpoint.project_identity.matches(project_identity)
+                || !checkpoint.session_identity.matches(session_identity)
+            {
+                return Err(storage("checkpoint private authority changed"));
+            }
+            recover_publication(&root, checkpoint)?;
+        }
+        let (parent_generation_uuid, parent_generation_manifest_sha256) =
+            match recovered_checkpoint.as_ref() {
+                Some(checkpoint)
+                    if matches!(
+                        checkpoint.publication_state,
+                        Some(
+                            ConstructionPublicationState::Publishing
+                                | ConstructionPublicationState::Published
+                        )
+                    ) =>
+                {
+                    authenticate_exact_parent_generation(project_dir, checkpoint)?
+                }
+                Some(checkpoint) => {
+                    let current = current_parent_generation_authority(project_dir)?;
+                    if current.0 != checkpoint.parent_generation_uuid
+                        || current.1 != checkpoint.parent_generation_manifest_sha256
+                    {
+                        return Err(storage("construction parent project generation changed"));
+                    }
+                    current
+                }
+                None => current_parent_generation_authority(project_dir)?,
+            };
+        if recovered_checkpoint.as_ref().is_none_or(|checkpoint| {
+            !matches!(
+                checkpoint.publication_state,
+                Some(
+                    ConstructionPublicationState::Publishing
+                        | ConstructionPublicationState::Published
+                )
+            )
+        }) && crate::read_topology_generation(project_dir)? != parent_topology_generation
+        {
+            return Err(storage(
+                "requested parent generation is not current at session open",
+            ));
+        }
+        let publication_replay = recovered_checkpoint.as_ref().is_some_and(|checkpoint| {
+            matches!(
+                checkpoint.publication_state,
+                Some(
+                    ConstructionPublicationState::Publishing
+                        | ConstructionPublicationState::Published
+                )
+            )
+        });
+        let (base_snapshot, base_work) = if publication_replay {
+            (
+                None,
+                recovered_checkpoint
+                    .as_ref()
+                    .expect("publication replay has a checkpoint")
+                    .base_work,
+            )
+        } else if parent_topology_generation == 0 {
             (None, UuidConstructionSnapshotWork::default())
         } else {
             let mut snapshot = AuthenticatedUuidIndexSnapshot::open_at_generation(
@@ -746,53 +1019,64 @@ impl GraphConstructionSession {
             };
             (Some(snapshot), work)
         };
-        let (parent_catalog, parent_catalog_sha256, parent_catalog_work) =
-            load_parent_runtime_catalog(&project, parent_topology_generation, budgets)?;
-        let checkpoint = match root.open_child_file(OsStr::new(CHECKPOINT)) {
-            Ok(mut file) => decode_bounded(&mut file)?,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                let evidence = GraphConstructionEvidence {
-                    authentication_read_bytes: base_work.authentication_bytes,
-                    authentication_read_operations: base_work.authentication_blocks,
-                    parent_catalog_read_bytes: parent_catalog_work.bytes,
-                    parent_catalog_read_operations: parent_catalog_work.operations,
-                    peak_catalog_entries: parent_catalog.entry_count() as u64,
-                    peak_catalog_identifier_bytes: parent_catalog.retained_identifier_bytes()
-                        as u64,
-                    ..GraphConstructionEvidence::default()
-                };
-                let initial = Checkpoint {
-                    format_version: FORMAT_VERSION,
-                    operation_uuid,
-                    project_identity: project_identity.into(),
-                    session_identity: session_identity.into(),
-                    parent_topology_generation,
-                    ontology_mode,
-                    semantic_authority_sha256: semantic_authority_sha256.clone(),
-                    session_now_micros: SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .map_err(storage)?
-                        .as_micros()
-                        .try_into()
-                        .map_err(|_| storage("session timestamp exceeds i64"))?,
-                    budgets,
-                    state: GraphConstructionState::Staging,
-                    next_sequence: 0,
-                    saw_edge: false,
-                    last_receipt_sha256: None,
-                    has_base_snapshot: parent_topology_generation != 0,
-                    parent_catalog_sha256: parent_catalog_sha256.clone(),
-                    node_schema_sha256: BTreeSet::new(),
-                    edge_schema_sha256: BTreeSet::new(),
-                    shape_authority_sha256: None,
-                    encoding_inventory_sha256: None,
-                    base_work,
-                    evidence,
-                };
-                install_control(&root, CHECKPOINT, &initial)?;
-                initial
-            }
-            Err(error) => return Err(storage(error)),
+        let (parent_catalog, parent_catalog_sha256, parent_catalog_work) = if publication_replay {
+            (
+                RuntimeCatalog::new(),
+                recovered_checkpoint
+                    .as_ref()
+                    .expect("publication replay has a checkpoint")
+                    .parent_catalog_sha256
+                    .clone(),
+                ReadWork::default(),
+            )
+        } else {
+            load_parent_runtime_catalog(&project, parent_topology_generation, budgets)?
+        };
+        let checkpoint = if let Some(checkpoint) = recovered_checkpoint {
+            checkpoint
+        } else {
+            let evidence = GraphConstructionEvidence {
+                authentication_read_bytes: base_work.authentication_bytes,
+                authentication_read_operations: base_work.authentication_blocks,
+                parent_catalog_read_bytes: parent_catalog_work.bytes,
+                parent_catalog_read_operations: parent_catalog_work.operations,
+                peak_catalog_entries: parent_catalog.entry_count() as u64,
+                peak_catalog_identifier_bytes: parent_catalog.retained_identifier_bytes() as u64,
+                ..GraphConstructionEvidence::default()
+            };
+            let initial = Checkpoint {
+                format_version: FORMAT_VERSION,
+                operation_uuid,
+                project_identity: project_identity.into(),
+                session_identity: session_identity.into(),
+                parent_topology_generation,
+                parent_generation_uuid,
+                parent_generation_manifest_sha256: parent_generation_manifest_sha256.clone(),
+                ontology_mode,
+                semantic_authority_sha256: semantic_authority_sha256.clone(),
+                session_now_micros: SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map_err(storage)?
+                    .as_micros()
+                    .try_into()
+                    .map_err(|_| storage("session timestamp exceeds i64"))?,
+                budgets,
+                state: GraphConstructionState::Staging,
+                publication_state: None,
+                next_sequence: 0,
+                saw_edge: false,
+                last_receipt_sha256: None,
+                has_base_snapshot: parent_topology_generation != 0,
+                parent_catalog_sha256: parent_catalog_sha256.clone(),
+                node_schema_sha256: BTreeSet::new(),
+                edge_schema_sha256: BTreeSet::new(),
+                shape_authority_sha256: None,
+                encoding_inventory_sha256: None,
+                base_work,
+                evidence,
+            };
+            install_control(&root, CHECKPOINT, &initial)?;
+            initial
         };
         validate_checkpoint(
             &checkpoint,
@@ -804,6 +1088,8 @@ impl GraphConstructionSession {
             semantic_authority_sha256.as_deref(),
             budgets,
             parent_catalog_sha256.as_deref(),
+            parent_generation_uuid,
+            &parent_generation_manifest_sha256,
         )?;
         let mut session = Self {
             project_path: project_dir.to_path_buf(),
@@ -1123,6 +1409,7 @@ impl GraphConstructionSession {
             .authentication_read_operations
             .saturating_add(read_operations);
         self.checkpoint.state = GraphConstructionState::Sealed;
+        self.checkpoint.publication_state = Some(ConstructionPublicationState::Sealed);
         replace_control(&self.root, CHECKPOINT, &self.checkpoint)
     }
 
@@ -1135,7 +1422,9 @@ impl GraphConstructionSession {
         mut cancelled: impl FnMut() -> bool,
     ) -> Result<ConstructionShape, GfError> {
         self.revalidate_authority()?;
-        if self.checkpoint.state != GraphConstructionState::Sealed {
+        if self.checkpoint.state != GraphConstructionState::Sealed
+            || self.checkpoint.publication_state != Some(ConstructionPublicationState::Sealed)
+        {
             return Err(storage("only a sealed session can be shaped"));
         }
         reject_cancelled(&mut cancelled)?;
@@ -1479,8 +1768,8 @@ impl GraphConstructionSession {
     pub fn abort(&mut self) -> Result<(), GfError> {
         self.revalidate_authority()?;
         self.recover_intent()?;
-        if self.checkpoint.state == GraphConstructionState::Sealed {
-            return Err(storage("sealed session belongs to the publisher"));
+        if self.checkpoint.state != GraphConstructionState::Staging {
+            return Err(storage("non-staging session belongs to the publisher"));
         }
         self.checkpoint.state = GraphConstructionState::Aborted;
         replace_control(&self.root, CHECKPOINT, &self.checkpoint)
@@ -2321,6 +2610,133 @@ fn validate_shape_binding(intent: &ShapeIntent, checkpoint: &Checkpoint) -> Resu
         return Err(storage("construction shape manifest authority changed"));
     }
     Ok(())
+}
+
+fn control_sha256(value: &impl Serialize) -> Result<String, GfError> {
+    Ok(sha256(&serde_json::to_vec(value).map_err(storage)?))
+}
+
+fn validate_sha256(value: &str, label: &str) -> Result<(), GfError> {
+    if value.len() != 64 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(storage(format!("{label} digest is invalid")));
+    }
+    Ok(())
+}
+
+fn validate_publication_intent(
+    intent: &ConstructionPublicationIntent,
+    checkpoint: &Checkpoint,
+) -> Result<(), GfError> {
+    if intent.format_version != FORMAT_VERSION
+        || intent.operation_uuid != checkpoint.operation_uuid
+        || intent.project_identity != checkpoint.project_identity
+        || intent.session_identity != checkpoint.session_identity
+        || intent.parent_generation_uuid != checkpoint.parent_generation_uuid
+        || intent.parent_generation_manifest_sha256 != checkpoint.parent_generation_manifest_sha256
+        || intent.shape_authority_sha256
+            != checkpoint
+                .shape_authority_sha256
+                .clone()
+                .unwrap_or_default()
+        || intent.encoding_inventory_sha256
+            != checkpoint
+                .encoding_inventory_sha256
+                .clone()
+                .unwrap_or_default()
+        || intent.target_generation_uuid.is_nil()
+        || intent.transaction_uuid.is_nil()
+    {
+        return Err(storage("publication intent authority changed"));
+    }
+    validate_sha256(
+        &intent.parent_generation_manifest_sha256,
+        "parent generation manifest",
+    )?;
+    validate_sha256(&intent.shape_authority_sha256, "shape authority")?;
+    validate_sha256(&intent.encoding_inventory_sha256, "encoding inventory")
+}
+
+fn read_publication_intent(
+    root: &StableDirectory,
+    checkpoint: &Checkpoint,
+) -> Result<ConstructionPublicationIntent, GfError> {
+    let mut file = root
+        .open_child_file(OsStr::new(PUBLICATION_INTENT))
+        .map_err(storage)?;
+    let intent = decode_bounded(&mut file)?;
+    validate_publication_intent(&intent, checkpoint)?;
+    Ok(intent)
+}
+
+fn read_publication_receipt(
+    root: &StableDirectory,
+    checkpoint: &Checkpoint,
+) -> Result<ConstructionPublicationReceipt, GfError> {
+    let intent = read_publication_intent(root, checkpoint)?;
+    let mut file = root
+        .open_child_file(OsStr::new(PUBLICATION_RECEIPT))
+        .map_err(storage)?;
+    let receipt: ConstructionPublicationReceipt = decode_bounded(&mut file)?;
+    validate_sha256(
+        &receipt.target_generation_manifest_sha256,
+        "target generation manifest",
+    )?;
+    if receipt.intent_sha256 != control_sha256(&intent)?
+        || receipt.operation_uuid != checkpoint.operation_uuid
+        || receipt.project_identity != checkpoint.project_identity
+        || receipt.session_identity != checkpoint.session_identity
+        || receipt.target_generation_uuid != intent.target_generation_uuid
+    {
+        return Err(storage("publication receipt differs from durable intent"));
+    }
+    Ok(receipt)
+}
+
+fn recover_publication(root: &StableDirectory, checkpoint: &mut Checkpoint) -> Result<(), GfError> {
+    let intent = match root.open_child_file(OsStr::new(PUBLICATION_INTENT)) {
+        Ok(mut file) => {
+            let intent: ConstructionPublicationIntent = decode_bounded(&mut file)?;
+            validate_publication_intent(&intent, checkpoint)?;
+            Some(intent)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => return Err(storage(error)),
+    };
+    if intent.is_some()
+        && checkpoint.publication_state == Some(ConstructionPublicationState::Sealed)
+    {
+        checkpoint.publication_state = Some(ConstructionPublicationState::Publishing);
+        replace_control(root, CHECKPOINT, checkpoint)?;
+    }
+    let receipt_exists = match root.open_child_file(OsStr::new(PUBLICATION_RECEIPT)) {
+        Ok(file) => {
+            drop(file);
+            true
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+        Err(error) => return Err(storage(error)),
+    };
+    if receipt_exists {
+        let _ = read_publication_receipt(root, checkpoint)?;
+        if checkpoint.publication_state == Some(ConstructionPublicationState::Publishing) {
+            checkpoint.publication_state = Some(ConstructionPublicationState::Published);
+            replace_control(root, CHECKPOINT, checkpoint)?;
+        }
+    }
+    match checkpoint.publication_state {
+        Some(ConstructionPublicationState::Publishing) if intent.is_none() => {
+            Err(storage("publishing checkpoint lacks durable intent"))
+        }
+        Some(ConstructionPublicationState::Published) if !receipt_exists => {
+            Err(storage("published checkpoint lacks durable receipt"))
+        }
+        None | Some(ConstructionPublicationState::Sealed) if intent.is_some() || receipt_exists => {
+            Err(storage(
+                "publication metadata is inconsistent with session state",
+            ))
+        }
+        _ => Ok(()),
+    }
 }
 
 fn read_completed_shape(
@@ -4481,12 +4897,22 @@ fn validate_checkpoint(
     semantic_authority_sha256: Option<&str>,
     budgets: GraphConstructionBudgets,
     parent_catalog_sha256: Option<&str>,
+    parent_generation_uuid: Uuid,
+    parent_generation_manifest_sha256: &str,
 ) -> Result<(), GfError> {
     if checkpoint.format_version != FORMAT_VERSION
         || checkpoint.operation_uuid != operation
         || !checkpoint.project_identity.matches(project)
         || !checkpoint.session_identity.matches(session)
         || checkpoint.parent_topology_generation != generation
+        || checkpoint.parent_generation_uuid != parent_generation_uuid
+        || checkpoint.parent_generation_manifest_sha256 != parent_generation_manifest_sha256
+        || checkpoint.parent_generation_uuid.is_nil()
+        || validate_sha256(
+            &checkpoint.parent_generation_manifest_sha256,
+            "parent generation manifest",
+        )
+        .is_err()
         || checkpoint.ontology_mode != ontology_mode
         || checkpoint.semantic_authority_sha256.as_deref() != semantic_authority_sha256
         || checkpoint
@@ -4527,6 +4953,18 @@ fn validate_checkpoint(
             })
         || checkpoint.encoding_inventory_sha256.is_some()
             && checkpoint.shape_authority_sha256.is_none()
+        || match checkpoint.state {
+            GraphConstructionState::Staging | GraphConstructionState::Aborted => {
+                checkpoint.publication_state.is_some()
+            }
+            GraphConstructionState::Sealed => checkpoint.publication_state.is_none(),
+        }
+        || matches!(
+            checkpoint.publication_state,
+            Some(
+                ConstructionPublicationState::Publishing | ConstructionPublicationState::Published
+            )
+        ) && checkpoint.encoding_inventory_sha256.is_none()
         || checkpoint.evidence.input_batches != checkpoint.next_sequence
         || checkpoint.evidence.parquet_shards != checkpoint.next_sequence
         || checkpoint.evidence.peak_batch_rows > budgets.max_batch_rows as u64
@@ -4566,28 +5004,41 @@ fn cleanup_authenticated_control_temps(
         }
         let mut file = root.open_child_file(&name).map_err(storage)?;
         let body = read_bounded_limit(&mut file, MAX_SHAPE_CONTROL_BYTES)?;
-        let authenticated =
-            serde_json::from_slice::<Checkpoint>(&body).is_ok_and(|value| {
-                value.format_version == FORMAT_VERSION
-                    && value.operation_uuid == operation
-                    && value.project_identity.matches(project)
-                    && value.session_identity.matches(session)
-            }) || serde_json::from_slice::<ChunkIntent>(&body).is_ok_and(|value| {
-                value.format_version == FORMAT_VERSION
-                    && value.operation_uuid == operation
-                    && value.project_identity.matches(project)
-                    && value.session_identity.matches(session)
-            }) || serde_json::from_slice::<ConstructionChunkReceipt>(&body).is_ok_and(|value| {
+        let authenticated = serde_json::from_slice::<Checkpoint>(&body).is_ok_and(|value| {
+            value.format_version == FORMAT_VERSION
+                && value.operation_uuid == operation
+                && value.project_identity.matches(project)
+                && value.session_identity.matches(session)
+        }) || serde_json::from_slice::<ChunkIntent>(&body).is_ok_and(|value| {
+            value.format_version == FORMAT_VERSION
+                && value.operation_uuid == operation
+                && value.project_identity.matches(project)
+                && value.session_identity.matches(session)
+        }) || serde_json::from_slice::<ConstructionChunkReceipt>(&body)
+            .is_ok_and(|value| {
                 value.operation_uuid == operation
                     && value.project_identity.matches(project)
                     && value.session_identity.matches(session)
-            }) || serde_json::from_slice::<ReceiptPointer>(&body).is_ok_and(|value| {
+            })
+            || serde_json::from_slice::<ReceiptPointer>(&body).is_ok_and(|value| {
                 value.operation_uuid == operation
                     && value.project_identity.matches(project)
                     && value.session_identity.matches(session)
-            }) || serde_json::from_slice::<ShapeIntent>(&body).is_ok_and(|value| {
+            })
+            || serde_json::from_slice::<ShapeIntent>(&body).is_ok_and(|value| {
                 value.format_version == FORMAT_VERSION
                     && value.operation_uuid == operation
+                    && value.project_identity.matches(project)
+                    && value.session_identity.matches(session)
+            })
+            || serde_json::from_slice::<ConstructionPublicationIntent>(&body).is_ok_and(|value| {
+                value.format_version == FORMAT_VERSION
+                    && value.operation_uuid == operation
+                    && value.project_identity.matches(project)
+                    && value.session_identity.matches(session)
+            })
+            || serde_json::from_slice::<ConstructionPublicationReceipt>(&body).is_ok_and(|value| {
+                value.operation_uuid == operation
                     && value.project_identity.matches(project)
                     && value.session_identity.matches(session)
             });
@@ -5495,7 +5946,7 @@ mod tests {
     }
 
     #[test]
-    fn replay_binds_property_schema_and_rejects_unsupported_staging_types() {
+    fn replay_binds_each_property_schema_and_rejects_unsupported_staging_types() {
         let root = TempDir::new().unwrap();
         let mut session = open(&root, 98);
         let batch_with = |property: &str| {
@@ -5531,16 +5982,16 @@ mod tests {
                 .to_string()
                 .contains("conflicting")
         );
-        assert!(
-            session
-                .append(
-                    ConstructionChunkKind::Node,
-                    "different-chunk-schema",
-                    &batch_with("renamed")
-                )
-                .unwrap_err()
-                .to_string()
-                .contains("stable Arrow schema")
+        let heterogeneous = session
+            .append(
+                ConstructionChunkKind::Node,
+                "different-chunk-schema",
+                &batch_with("renamed"),
+            )
+            .unwrap();
+        assert_ne!(
+            heterogeneous.schema_sha256,
+            session.read_receipt(0).unwrap().schema_sha256
         );
 
         let unsupported = RecordBatch::try_new(
@@ -7512,5 +7963,157 @@ mod tests {
         std::fs::copy(&saved, &victim).unwrap();
         let error = session.encode_canonical(&shape, 2).unwrap_err();
         assert!(error.to_string().contains("identity changed"));
+    }
+
+    fn encoded_publication_session(root: &TempDir, operation: Uuid) -> GraphConstructionSession {
+        let mut session = GraphConstructionSession::open(
+            root.path(),
+            operation,
+            0,
+            GraphConstructionBudgets::default(),
+        )
+        .unwrap();
+        session
+            .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 2))
+            .unwrap();
+        session.seal().unwrap();
+        let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+        session.encode_canonical(&shape, 1).unwrap();
+        session
+    }
+
+    #[test]
+    fn publication_state_is_idempotent_and_rejects_changed_target() {
+        let root = TempDir::new().unwrap();
+        let operation = Uuid::from_u128(9_400);
+        let target = Uuid::from_u128(9_401);
+        let transaction = Uuid::from_u128(9_402);
+        let mut session = encoded_publication_session(&root, operation);
+        let first = session.begin_publication(target, transaction).unwrap();
+        assert_eq!(
+            session.checkpoint.publication_state,
+            Some(ConstructionPublicationState::Publishing)
+        );
+        assert_eq!(
+            session.begin_publication(target, transaction).unwrap(),
+            first
+        );
+        assert!(
+            session
+                .begin_publication(Uuid::from_u128(9_403), transaction)
+                .unwrap_err()
+                .to_string()
+                .contains("target changed")
+        );
+        let digest = "ab".repeat(32);
+        let receipt = session.finish_publication(target, &digest).unwrap();
+        assert_eq!(
+            session.checkpoint.publication_state,
+            Some(ConstructionPublicationState::Published)
+        );
+        assert_eq!(
+            session.finish_publication(target, &digest).unwrap(),
+            receipt
+        );
+        assert!(
+            session
+                .finish_publication(target, &"cd".repeat(32))
+                .unwrap_err()
+                .to_string()
+                .contains("result changed")
+        );
+    }
+
+    #[test]
+    fn project_container_parent_binding_uses_exact_uuid_and_manifest() {
+        let root = TempDir::new().unwrap();
+        let parent = crate::open_or_initialize_project(root.path()).unwrap();
+        let expected = (parent.generation_uuid(), hex(&parent.manifest_sha256()));
+        drop(parent);
+        assert_eq!(
+            current_parent_generation_authority(root.path()).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn publication_reopen_recovers_each_durable_crash_boundary() {
+        let root = TempDir::new().unwrap();
+        let operation = Uuid::from_u128(9_410);
+        let target = Uuid::from_u128(9_411);
+        let transaction = Uuid::from_u128(9_412);
+        let mut session = encoded_publication_session(&root, operation);
+        session.begin_publication(target, transaction).unwrap();
+        session.checkpoint.publication_state = Some(ConstructionPublicationState::Sealed);
+        replace_control(&session.root, CHECKPOINT, &session.checkpoint).unwrap();
+        drop(session);
+        std::fs::create_dir_all(root.path().join("topology")).unwrap();
+        std::fs::write(
+            root.path().join("topology/generation.json"),
+            br#"{"topology_generation":99,"search_generation":0}"#,
+        )
+        .unwrap();
+        let mut reopened = GraphConstructionSession::open(
+            root.path(),
+            operation,
+            0,
+            GraphConstructionBudgets::default(),
+        )
+        .unwrap();
+        assert_eq!(
+            reopened.checkpoint.publication_state,
+            Some(ConstructionPublicationState::Publishing)
+        );
+        reopened
+            .finish_publication(target, &"ef".repeat(32))
+            .unwrap();
+        reopened.checkpoint.publication_state = Some(ConstructionPublicationState::Publishing);
+        replace_control(&reopened.root, CHECKPOINT, &reopened.checkpoint).unwrap();
+        drop(reopened);
+        let reopened = GraphConstructionSession::open(
+            root.path(),
+            operation,
+            0,
+            GraphConstructionBudgets::default(),
+        )
+        .unwrap();
+        assert_eq!(
+            reopened.checkpoint.publication_state,
+            Some(ConstructionPublicationState::Published)
+        );
+    }
+
+    #[test]
+    fn publication_reopen_rejects_corrupt_or_mismatched_authority() {
+        let root = TempDir::new().unwrap();
+        let operation = Uuid::from_u128(9_420);
+        let mut session = encoded_publication_session(&root, operation);
+        session
+            .begin_publication(Uuid::from_u128(9_421), Uuid::from_u128(9_422))
+            .unwrap();
+        let intent_path = root
+            .path()
+            .join(PRIVATE_ROOT)
+            .join(operation.simple().to_string())
+            .join(PUBLICATION_INTENT);
+        let mut intent: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&intent_path).unwrap()).unwrap();
+        intent["parent_generation_manifest_sha256"] = serde_json::Value::String("00".repeat(32));
+        std::fs::write(&intent_path, serde_json::to_vec(&intent).unwrap()).unwrap();
+        drop(session);
+        let error = match GraphConstructionSession::open(
+            root.path(),
+            operation,
+            0,
+            GraphConstructionBudgets::default(),
+        ) {
+            Ok(_) => panic!("corrupt publication intent was accepted"),
+            Err(error) => error,
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("publication intent authority changed")
+        );
     }
 }

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -2937,11 +2937,16 @@ pub(crate) struct CountingChunkReader<R = File> {
 
 pub(crate) trait ConstructionFileHandle: Send + Sync {
     fn descriptor(&self) -> &File;
+    fn length(&self) -> u64;
 }
 
 impl ConstructionFileHandle for File {
     fn descriptor(&self) -> &File {
         self
+    }
+
+    fn length(&self) -> u64 {
+        self.metadata().map_or(0, |metadata| metadata.len())
     }
 }
 
@@ -2949,14 +2954,15 @@ impl ConstructionFileHandle for crate::graph_object_store::AuthenticatedGraphObj
     fn descriptor(&self) -> &File {
         self.as_ref()
     }
+
+    fn length(&self) -> u64 {
+        self.authenticated_length()
+    }
 }
 
 impl<R: ConstructionFileHandle> Length for CountingChunkReader<R> {
     fn len(&self) -> u64 {
-        self.file
-            .descriptor()
-            .metadata()
-            .map_or(0, |metadata| metadata.len())
+        self.file.length()
     }
 }
 
@@ -7537,6 +7543,24 @@ mod tests {
         assert!(!crate::file_lock::try_lock_exclusive(&contender).unwrap());
         crate::file_lock::unlock(&owner).unwrap();
         assert!(crate::file_lock::try_lock_exclusive(&contender).unwrap());
+    }
+
+    #[test]
+    fn counting_reader_uses_authenticated_cas_length() {
+        let root = TempDir::new().unwrap();
+        let payload = b"authenticated parquet-sized payload";
+        let (digest, _) = crate::install_graph_object_bytes(root.path(), payload).unwrap();
+        let file = crate::graph_object_store::open_graph_object_by_digest(
+            root.path(),
+            &digest,
+            payload.len() as u64,
+        )
+        .unwrap();
+        let reader = CountingChunkReader {
+            file,
+            counter: IoCounter::default(),
+        };
+        assert_eq!(Length::len(&reader), payload.len() as u64);
     }
 
     #[cfg(unix)]

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -44,6 +44,7 @@ const INTENT: &str = "intent.json";
 const SHAPE_INTENT: &str = "shape-intent.json";
 const BLOCK_BYTES: usize = 1 << 20;
 const MAX_CONTROL_BYTES: u64 = 64 << 10;
+const MAX_SHAPE_CONTROL_BYTES: u64 = 32 << 20;
 const IDENTITY_WIDTH: usize = 16;
 const ENDPOINT_WIDTH: usize = 48;
 const RESOLVED_ENDPOINT_WIDTH: usize = 32;
@@ -386,7 +387,7 @@ impl IdentityRecord {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-struct ArtifactReceipt {
+pub(crate) struct ArtifactReceipt {
     name: String,
     bytes: u64,
     sha256: String,
@@ -567,6 +568,7 @@ impl GraphConstructionSession {
         if &completed != shape {
             return Err(storage("encoder input differs from completed shape"));
         }
+        let shape_outputs = read_completed_shape_outputs(&self.root, &self.checkpoint)?;
         crate::graph_construction_encoding::encode(
             &self.root,
             shape,
@@ -574,6 +576,7 @@ impl GraphConstructionSession {
             self.checkpoint.ontology_mode,
             self.base_snapshot.as_ref(),
             self.semantic_authority.as_ref(),
+            &shape_outputs,
             self.checkpoint.budgets,
             &mut cancelled,
         )
@@ -2147,7 +2150,7 @@ fn recover_shape_intent(
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(error) => return Err(storage(error)),
     };
-    let intent: ShapeIntent = decode_bounded(&mut file)?;
+    let intent: ShapeIntent = decode_shape_intent(&mut file)?;
     validate_shape_binding(&intent, checkpoint)?;
     if intent.complete {
         let shape = intent
@@ -2239,7 +2242,7 @@ fn read_completed_shape(
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => return Err(storage(error)),
     };
-    let manifest: ShapeIntent = decode_bounded(&mut file)?;
+    let manifest: ShapeIntent = decode_shape_intent(&mut file)?;
     validate_shape_binding(&manifest, checkpoint)?;
     if !manifest.complete {
         return Err(storage("incomplete construction shape was not recovered"));
@@ -2251,6 +2254,42 @@ fn read_completed_shape(
         .shape
         .ok_or_else(|| storage("complete shape manifest lacks output"))
         .map(Some)
+}
+
+fn read_completed_shape_outputs(
+    root: &StableDirectory,
+    checkpoint: &Checkpoint,
+) -> Result<Vec<ArtifactReceipt>, GfError> {
+    let mut file = root
+        .open_child_file(OsStr::new(SHAPE_INTENT))
+        .map_err(storage)?;
+    let manifest: ShapeIntent = decode_shape_intent(&mut file)?;
+    validate_shape_binding(&manifest, checkpoint)?;
+    if !manifest.complete || manifest.shape.is_none() {
+        return Err(storage("complete construction shape inventory is absent"));
+    }
+    Ok(manifest.outputs)
+}
+
+pub(crate) fn authenticate_shaped_outputs(
+    root: &StableDirectory,
+    outputs: &[ArtifactReceipt],
+) -> Result<(), GfError> {
+    for output in outputs {
+        authenticate_shaped_output(root, output)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn shaped_output_sha256<'a>(
+    outputs: &'a [ArtifactReceipt],
+    name: &str,
+) -> Result<&'a str, GfError> {
+    outputs
+        .iter()
+        .find(|output| output.name == name)
+        .map(|output| output.sha256.as_str())
+        .ok_or_else(|| storage("shaped output receipt is absent"))
 }
 
 fn receipt_for_existing(root: &StableDirectory, name: &str) -> Result<ArtifactReceipt, GfError> {
@@ -4394,7 +4433,7 @@ fn cleanup_authenticated_control_temps(
             continue;
         }
         let mut file = root.open_child_file(&name).map_err(storage)?;
-        let body = read_bounded(&mut file)?;
+        let body = read_bounded_limit(&mut file, MAX_SHAPE_CONTROL_BYTES)?;
         let authenticated =
             serde_json::from_slice::<Checkpoint>(&body).is_ok_and(|value| {
                 value.format_version == FORMAT_VERSION
@@ -4412,6 +4451,11 @@ fn cleanup_authenticated_control_temps(
                     && value.session_identity.matches(session)
             }) || serde_json::from_slice::<ReceiptPointer>(&body).is_ok_and(|value| {
                 value.operation_uuid == operation
+                    && value.project_identity.matches(project)
+                    && value.session_identity.matches(session)
+            }) || serde_json::from_slice::<ShapeIntent>(&body).is_ok_and(|value| {
+                value.format_version == FORMAT_VERSION
+                    && value.operation_uuid == operation
                     && value.project_identity.matches(project)
                     && value.session_identity.matches(session)
             });
@@ -4500,10 +4544,7 @@ fn install_control<T: Serialize>(
     target: &str,
     value: &T,
 ) -> Result<(), GfError> {
-    let body = serde_json::to_vec(value).map_err(storage)?;
-    if body.len() as u64 > MAX_CONTROL_BYTES {
-        return Err(storage("control record exceeds bound"));
-    }
+    let body = encode_control(value, target)?;
     let temporary = control_temp(target);
     let mut file = root
         .create_replaceable_child_file(OsStr::new(&temporary))
@@ -4525,10 +4566,7 @@ fn replace_control<T: Serialize>(
     target: &str,
     value: &T,
 ) -> Result<(), GfError> {
-    let body = serde_json::to_vec(value).map_err(storage)?;
-    if body.len() as u64 > MAX_CONTROL_BYTES {
-        return Err(storage("control record exceeds bound"));
-    }
+    let body = encode_control(value, target)?;
     let temporary = control_temp(target);
     let mut file = root
         .create_replaceable_child_file(OsStr::new(&temporary))
@@ -4545,19 +4583,64 @@ fn replace_control<T: Serialize>(
     Ok(())
 }
 
+fn control_limit(target: &str) -> u64 {
+    if target == SHAPE_INTENT {
+        MAX_SHAPE_CONTROL_BYTES
+    } else {
+        MAX_CONTROL_BYTES
+    }
+}
+
+struct BoundedControlWriter {
+    body: Vec<u8>,
+    limit: usize,
+}
+
+impl Write for BoundedControlWriter {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        if self.body.len().saturating_add(bytes.len()) > self.limit {
+            return Err(std::io::Error::other("control record exceeds bound"));
+        }
+        self.body.extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn encode_control<T: Serialize>(value: &T, target: &str) -> Result<Vec<u8>, GfError> {
+    let limit = usize::try_from(control_limit(target)).map_err(storage)?;
+    let mut writer = BoundedControlWriter {
+        body: Vec::new(),
+        limit,
+    };
+    serde_json::to_writer(&mut writer, value).map_err(storage)?;
+    Ok(writer.body)
+}
+
 fn decode_bounded<T: for<'de> Deserialize<'de>>(file: &mut File) -> Result<T, GfError> {
     serde_json::from_slice(&read_bounded(file)?).map_err(storage)
 }
 
+fn decode_shape_intent(file: &mut File) -> Result<ShapeIntent, GfError> {
+    serde_json::from_slice(&read_bounded_limit(file, MAX_SHAPE_CONTROL_BYTES)?).map_err(storage)
+}
+
 fn read_bounded(file: &mut File) -> Result<Vec<u8>, GfError> {
-    if file.metadata().map_err(storage)?.len() > MAX_CONTROL_BYTES {
+    read_bounded_limit(file, MAX_CONTROL_BYTES)
+}
+
+fn read_bounded_limit(file: &mut File, limit: u64) -> Result<Vec<u8>, GfError> {
+    if file.metadata().map_err(storage)?.len() > limit {
         return Err(storage("control record exceeds bound"));
     }
     let mut body = Vec::new();
-    file.take(MAX_CONTROL_BYTES + 1)
+    file.take(limit + 1)
         .read_to_end(&mut body)
         .map_err(storage)?;
-    if body.len() as u64 > MAX_CONTROL_BYTES {
+    if body.len() as u64 > limit {
         return Err(storage("control record exceeds bound"));
     }
     Ok(body)
@@ -4796,6 +4879,18 @@ mod tests {
         FixedSizeBinaryArray::try_from_iter(values.iter().map(|value| value.as_slice())).unwrap()
     }
 
+    fn tree_has_no_temps(path: &Path) -> bool {
+        std::fs::read_dir(path).unwrap().all(|entry| {
+            let entry = entry.unwrap();
+            let path = entry.path();
+            if path.is_dir() {
+                tree_has_no_temps(&path)
+            } else {
+                !entry.file_name().to_string_lossy().ends_with(".tmp")
+            }
+        })
+    }
+
     fn node_batch(first: u128, rows: usize) -> RecordBatch {
         let uuids = (first..first + rows as u128)
             .map(u128::to_be_bytes)
@@ -4847,6 +4942,10 @@ mod tests {
     }
 
     fn node_property_batch(first: u128, rows: usize) -> RecordBatch {
+        node_property_batch_for(first, rows, "Person")
+    }
+
+    fn node_property_batch_for(first: u128, rows: usize, label: &str) -> RecordBatch {
         let uuids = (first..first + rows as u128)
             .map(u128::to_be_bytes)
             .collect::<Vec<_>>();
@@ -4860,10 +4959,28 @@ mod tests {
             Arc::new(Schema::new(fields)),
             vec![
                 Arc::new(fixed(&uuids)),
-                Arc::new(StringArray::from(vec!["Person"; rows])),
+                Arc::new(StringArray::from(vec![label; rows])),
                 Arc::new(Int64Array::from_iter_values(
                     (0..rows).map(|row| row as i64 + 10),
                 )),
+            ],
+        )
+        .unwrap()
+    }
+
+    fn heterogeneous_property_batch(uuid: u128, property: usize) -> RecordBatch {
+        let mut fields = CONSTRUCTION_NODE_SCHEMA
+            .fields()
+            .iter()
+            .map(|field| field.as_ref().clone())
+            .collect::<Vec<_>>();
+        fields.push(Field::new(format!("p{property:03}"), DataType::Int64, true));
+        RecordBatch::try_new(
+            Arc::new(Schema::new(fields)),
+            vec![
+                Arc::new(fixed(&[uuid.to_be_bytes()])),
+                Arc::new(StringArray::from(vec!["Person"])),
+                Arc::new(Int64Array::from(vec![property as i64])),
             ],
         )
         .unwrap()
@@ -4904,11 +5021,18 @@ mod tests {
         let document = graphforge_ontology::OntologyDoc {
             ontology_id: "https://graphforge.dev/ontology/construction-test".into(),
             version: "1.0.0".into(),
-            entity_types: vec![graphforge_ontology::EntityTypeDef {
-                name: "Person".into(),
-                r#abstract: false,
-                parent: None,
-            }],
+            entity_types: vec![
+                graphforge_ontology::EntityTypeDef {
+                    name: "Person".into(),
+                    r#abstract: false,
+                    parent: None,
+                },
+                graphforge_ontology::EntityTypeDef {
+                    name: "Child".into(),
+                    r#abstract: false,
+                    parent: Some("Person".into()),
+                },
+            ],
             relation_types: vec![graphforge_ontology::RelationTypeDef {
                 name: "R".into(),
                 src: "Person".into(),
@@ -5483,6 +5607,14 @@ mod tests {
         assert!(error.to_string().contains("schema-group budget"));
         assert_eq!(session.checkpoint.node_schema_sha256.len(), 1);
         assert!(session.checkpoint.edge_schema_sha256.is_empty());
+    }
+
+    #[test]
+    fn shape_control_encoding_fails_closed_above_its_separate_cap() {
+        let oversized = "x".repeat((MAX_SHAPE_CONTROL_BYTES + 1) as usize);
+        let error = encode_control(&oversized, SHAPE_INTENT).unwrap_err();
+        assert!(error.to_string().contains("control record exceeds bound"));
+        assert_eq!(control_limit(CHECKPOINT), MAX_CONTROL_BYTES);
     }
 
     #[test]
@@ -6081,11 +6213,17 @@ mod tests {
     #[test]
     fn uuid_encoding_crashes_recover_every_durable_boundary() {
         for failpoint in [
+            "encode.parquet.after_temp_fsync.topology/nodes/00000000000000000001-00000000000000000008.parquet",
+            "encode.parquet.after_install.topology/nodes/00000000000000000001-00000000000000000008.parquet",
+            "encode.copy.after_temp_fsync.topology/runtime_catalog.parquet",
+            "encode.copy.after_install.topology/runtime_catalog.parquet",
             "uuid_encode.after_intent",
             "uuid_encode.after_temps",
             "uuid_encode.after_delta_runs",
             "uuid_encode.after_manifest",
             "uuid_encode.after_intent_removal",
+            "encode.control.after_temp_fsync.inventory.json",
+            "encode.control.after_install.inventory.json",
         ] {
             let root = TempDir::new().unwrap();
             let status = std::process::Command::new(std::env::current_exe().unwrap())
@@ -6125,6 +6263,13 @@ mod tests {
                     .to_string_lossy()
                     .ends_with(".tmp")
             }));
+            let encoded_root = root
+                .path()
+                .join(PRIVATE_ROOT)
+                .join(Uuid::from_u128(600).simple().to_string())
+                .join("encoded-v1");
+            assert!(tree_has_no_temps(&encoded_root));
+            assert!(!encoded_root.join("encoding-intent.json").exists());
         }
     }
 
@@ -6423,6 +6568,105 @@ mod tests {
         assert!(encoded.evidence.peak_batch_rows <= 65_536);
         assert!(encoded.evidence.input_read_operations > 0);
         assert!(encoded.evidence.output_write_operations > 0);
+        assert_eq!(encoded.evidence.peak_open_input_readers, 1);
+    }
+
+    #[test]
+    fn canonical_encoder_routes_inherited_property_by_declaring_owner() {
+        let root = TempDir::new().unwrap();
+        let operation = Uuid::from_u128(9_324);
+        let authority = semantic_authority(graphforge_core::OntologyMode::Strict);
+        let property_route = authority
+            .bindings
+            .bindings
+            .iter()
+            .find(|binding| {
+                binding.route_kind == crate::SemanticRouteKind::NodeProperty
+                    && binding.symbol.local_id == "Person:score"
+            })
+            .unwrap()
+            .route
+            .clone();
+        let mut session = GraphConstructionSession::open_with_semantic_authority(
+            root.path(),
+            operation,
+            0,
+            authority,
+            GraphConstructionBudgets::default(),
+        )
+        .unwrap();
+        session
+            .append(
+                ConstructionChunkKind::Node,
+                "child",
+                &node_property_batch_for(1, 2, "Child"),
+            )
+            .unwrap();
+        session.seal().unwrap();
+        let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+        let encoded = session.encode_canonical(&shape, 1).unwrap();
+        let graph = root
+            .path()
+            .join(PRIVATE_ROOT)
+            .join(operation.simple().to_string())
+            .join(&encoded.root)
+            .join("graph");
+        assert_eq!(
+            crate::read_properties(&graph, &property_route)
+                .unwrap()
+                .iter()
+                .map(RecordBatch::num_rows)
+                .sum::<usize>(),
+            2
+        );
+    }
+
+    #[test]
+    fn canonical_encoder_keeps_256_heterogeneous_schemas_to_one_live_reader() {
+        let root = TempDir::new().unwrap();
+        let operation = Uuid::from_u128(9_325);
+        let budgets = GraphConstructionBudgets {
+            max_batch_rows: 1,
+            max_run_records: 4,
+            ..GraphConstructionBudgets::default()
+        };
+        let mut session = GraphConstructionSession::open_with_mode(
+            root.path(),
+            operation,
+            0,
+            graphforge_core::OntologyMode::Exploratory,
+            budgets,
+        )
+        .unwrap();
+        for index in 0..256 {
+            session
+                .append(
+                    ConstructionChunkKind::Node,
+                    &format!("schema-{index:03}"),
+                    &heterogeneous_property_batch(index as u128 + 1, index),
+                )
+                .unwrap();
+        }
+        session.seal().unwrap();
+        let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+        assert_eq!(shape.node_rows.len(), 256);
+        let encoded = session.encode_canonical(&shape, 1).unwrap();
+        assert_eq!(encoded.evidence.peak_open_input_readers, 1);
+        assert!(encoded.evidence.peak_batch_rows <= 1);
+        let graph = root
+            .path()
+            .join(PRIVATE_ROOT)
+            .join(operation.simple().to_string())
+            .join(&encoded.root)
+            .join("graph");
+        assert_eq!(
+            crate::read_nodes(&graph)
+                .unwrap()
+                .iter()
+                .map(RecordBatch::num_rows)
+                .sum::<usize>(),
+            256
+        );
     }
 
     #[test]
@@ -6686,6 +6930,35 @@ mod tests {
     }
 
     #[test]
+    fn completed_encoding_replay_reauthenticates_retained_parent_payload() {
+        let project = nonempty_project_generation_two();
+        let operation = Uuid::from_u128(9_343);
+        let mut session = GraphConstructionSession::open_with_mode(
+            project.path(),
+            operation,
+            2,
+            graphforge_core::OntologyMode::Exploratory,
+            GraphConstructionBudgets::default(),
+        )
+        .unwrap();
+        session
+            .append(ConstructionChunkKind::Node, "delta", &node_batch(4, 1))
+            .unwrap();
+        session.seal().unwrap();
+        let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+        let encoded = session.encode_canonical(&shape, 3).unwrap();
+        let retained = encoded.retained_artifacts.first().unwrap();
+        let path = std::path::Path::new(&retained.source_root).join(&retained.source_path);
+        let mut file = std::fs::OpenOptions::new().write(true).open(path).unwrap();
+        use std::io::{Seek as _, SeekFrom};
+        file.seek(SeekFrom::Start(0)).unwrap();
+        file.write_all(&[0xff]).unwrap();
+        file.sync_all().unwrap();
+        let error = session.encode_canonical(&shape, 3).unwrap_err();
+        assert!(error.to_string().contains("retained construction"));
+    }
+
+    #[test]
     fn generation_one_parent_uses_streamed_binary_carry_and_authenticates_result() {
         let project = nonempty_project_with_nodes(2);
         let operation = Uuid::from_u128(9_341);
@@ -6704,6 +6977,10 @@ mod tests {
         let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
         let encoded = session.encode_canonical(&shape, 2).unwrap();
         assert!(encoded.evidence.retained_index_payload_bytes > 0);
+        assert!(encoded.evidence.membership_read_bytes > 0);
+        assert!(
+            encoded.evidence.membership_total_write_bytes > encoded.evidence.membership_write_bytes
+        );
 
         let graph = project
             .path()

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -1,0 +1,1035 @@
+//! Durable, bounded staging for one-generation graph construction.
+//!
+//! A construction session is deliberately not a repeated [`crate::GraphWriter`]
+//! call. Each Arrow window is encoded directly to one immutable Parquet shard,
+//! accompanied by sorted fixed-width identity/endpoint runs and an authenticated
+//! receipt. No topology generation or public authority is changed while chunks
+//! are accepted. The final generation-last publication consumes this sealed
+//! inventory as one transaction.
+
+use std::collections::BTreeSet;
+use std::fs::{self, File, OpenOptions};
+use std::io::{BufReader, BufWriter, Read, Write};
+use std::path::{Path, PathBuf};
+
+use arrow::array::{Array, FixedSizeBinaryArray, RecordBatch};
+use graphforge_core::GfError;
+use parquet::arrow::ArrowWriter;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+const SESSION_FORMAT: u32 = 1;
+const SESSION_DIR: &str = ".graphforge-construction";
+const MANIFEST_FILE: &str = "session.json";
+const BLOCK_BYTES: usize = 1 << 20;
+const UUID_BYTES: usize = 16;
+const ENDPOINT_RECORD_BYTES: usize = 48;
+const MAX_CONTROL_BYTES: u64 = 16 << 20;
+
+fn storage(error: impl std::fmt::Display) -> GfError {
+    GfError::Storage(format!("graph construction session: {error}"))
+}
+
+/// The two ordered construction phases.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConstructionChunkKind {
+    /// Canonical node input. Must precede all edge chunks.
+    Node,
+    /// Canonical edge input.
+    Edge,
+}
+
+impl ConstructionChunkKind {
+    const fn tag(self) -> &'static str {
+        match self {
+            Self::Node => "node",
+            Self::Edge => "edge",
+        }
+    }
+}
+
+/// Explicit fixed windows for a construction session.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GraphConstructionBudgets {
+    /// Maximum rows in one accepted Arrow window.
+    pub max_batch_rows: usize,
+    /// Maximum Arrow-owned bytes in one accepted window.
+    pub max_batch_bytes: usize,
+    /// Maximum immutable chunks in one session.
+    pub max_chunks: usize,
+    /// Maximum fixed-width records buffered for sorting one chunk.
+    pub max_run_records: usize,
+    /// Maximum files opened by a later external merge group.
+    pub merge_fan_in: usize,
+}
+
+impl Default for GraphConstructionBudgets {
+    fn default() -> Self {
+        Self {
+            max_batch_rows: 65_536,
+            max_batch_bytes: 64 << 20,
+            // 8,192 65K-row windows cover more than 536 million accepted rows
+            // while keeping the authenticated receipt inventory below its
+            // explicit control-file bound.
+            max_chunks: 8_192,
+            max_run_records: 65_536 * 3,
+            merge_fan_in: 32,
+        }
+    }
+}
+
+impl GraphConstructionBudgets {
+    fn validate(self) -> Result<Self, GfError> {
+        if self.max_batch_rows == 0
+            || self.max_batch_bytes == 0
+            || self.max_chunks == 0
+            || self.max_chunks > 8_192
+            || self.max_run_records < self.max_batch_rows
+            || self.merge_fan_in < 2
+        {
+            return Err(storage("invalid construction budgets"));
+        }
+        Ok(self)
+    }
+}
+
+/// Durable state of the private session. `Sealed` still does not change CURRENT.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum GraphConstructionState {
+    /// More chunks may be accepted.
+    Staging,
+    /// Inventory is complete and may be handed to one generation-last commit.
+    Sealed,
+    /// Caller abandoned the private session.
+    Aborted,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct ArtifactReceipt {
+    relative_path: String,
+    bytes: u64,
+    sha256: String,
+}
+
+/// Authenticated, idempotent acknowledgement for one immutable Arrow chunk.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ConstructionChunkReceipt {
+    /// Caller-stable idempotency key.
+    pub chunk_id: String,
+    /// Monotonic accepted-chunk sequence.
+    pub sequence: u64,
+    /// Node or edge phase.
+    pub kind: ConstructionChunkKind,
+    /// Rows encoded into the immutable Parquet shard.
+    pub rows: u64,
+    /// Arrow-owned bytes charged for the accepted window.
+    pub input_bytes: u64,
+    /// Fixed-width records sorted for the chunk.
+    pub run_records: u64,
+    /// Canonical digest over the Arrow values and schema.
+    pub input_sha256: String,
+    parquet: ArtifactReceipt,
+    identities: ArtifactReceipt,
+    endpoints: Option<ArtifactReceipt>,
+}
+
+/// Aggregate-only evidence. It contains no graph identities.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GraphConstructionEvidence {
+    /// Arrow rows accepted.
+    pub input_rows: u64,
+    /// Arrow batches accepted (idempotent replays excluded).
+    pub input_batches: u64,
+    /// Immutable Parquet shards sealed.
+    pub parquet_shards: u64,
+    /// Physical bytes written to private session artifacts and receipts.
+    pub physical_bytes_written: u64,
+    /// Physical bytes read while authenticating a resumed session.
+    pub authentication_bytes_read: u64,
+    /// Block-granular read operations.
+    pub read_blocks: u64,
+    /// Block-granular write operations.
+    pub write_blocks: u64,
+    /// Fixed-width identity/endpoint records written.
+    pub run_records: u64,
+    /// Maximum Arrow rows retained by one append call.
+    pub peak_batch_rows: u64,
+    /// Maximum Arrow-owned bytes retained by one append call.
+    pub peak_batch_bytes: u64,
+    /// Maximum fixed-width records sorted by one append call.
+    pub peak_run_records: u64,
+    /// Prior committed topology rows decoded while staging. Always zero.
+    pub prior_topology_rows_decoded: u64,
+    /// Public generation transitions while staging. Always zero.
+    pub current_transitions: u64,
+    /// Idempotent accepted replays.
+    pub replayed_chunks: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct SessionManifest {
+    format_version: u32,
+    operation_uuid: Uuid,
+    parent_topology_generation: u64,
+    state: GraphConstructionState,
+    budgets: GraphConstructionBudgets,
+    receipts: Vec<ConstructionChunkReceipt>,
+    evidence: GraphConstructionEvidence,
+}
+
+/// Storage-owned private construction session.
+///
+/// Opening an existing operation authenticates every receipt and referenced
+/// artifact before accepting more input. Session files live below a private
+/// project directory and are not graph-catalog discoverable.
+pub struct GraphConstructionSession {
+    root: PathBuf,
+    manifest: SessionManifest,
+}
+
+impl GraphConstructionSession {
+    /// Create or resume one stable operation.
+    ///
+    /// `parent_topology_generation` is pinned for the lifetime of the session;
+    /// the eventual commit must reject a changed CURRENT rather than silently
+    /// rebasing accepted chunks.
+    pub fn open(
+        project_dir: &Path,
+        operation_uuid: Uuid,
+        parent_topology_generation: u64,
+        budgets: GraphConstructionBudgets,
+    ) -> Result<Self, GfError> {
+        let budgets = budgets.validate()?;
+        let root = project_dir
+            .join(SESSION_DIR)
+            .join(operation_uuid.simple().to_string());
+        fs::create_dir_all(&root).map_err(storage)?;
+        let path = root.join(MANIFEST_FILE);
+        let mut session = if path.is_file() {
+            let bytes = read_bounded(&path, MAX_CONTROL_BYTES)?;
+            let manifest: SessionManifest = serde_json::from_slice(&bytes).map_err(storage)?;
+            if manifest.format_version != SESSION_FORMAT
+                || manifest.operation_uuid != operation_uuid
+                || manifest.parent_topology_generation != parent_topology_generation
+                || manifest.budgets != budgets
+            {
+                return Err(storage("resume parameters do not match durable session"));
+            }
+            Self { root, manifest }
+        } else {
+            let manifest = SessionManifest {
+                format_version: SESSION_FORMAT,
+                operation_uuid,
+                parent_topology_generation,
+                state: GraphConstructionState::Staging,
+                budgets,
+                receipts: Vec::new(),
+                evidence: GraphConstructionEvidence::default(),
+            };
+            let session = Self { root, manifest };
+            session.persist_manifest_create()?;
+            session
+        };
+        session.recover_durable_receipts()?;
+        session.authenticate_receipts()?;
+        Ok(session)
+    }
+
+    /// Pinned parent topology generation.
+    #[must_use]
+    pub const fn parent_topology_generation(&self) -> u64 {
+        self.manifest.parent_topology_generation
+    }
+
+    /// Current private state.
+    #[must_use]
+    pub const fn state(&self) -> GraphConstructionState {
+        self.manifest.state
+    }
+
+    /// Aggregate bounded-work evidence.
+    #[must_use]
+    pub const fn evidence(&self) -> &GraphConstructionEvidence {
+        &self.manifest.evidence
+    }
+
+    /// Durable receipts in accepted order.
+    #[must_use]
+    pub fn receipts(&self) -> &[ConstructionChunkReceipt] {
+        &self.manifest.receipts
+    }
+
+    /// Accept one bounded Arrow chunk and seal its Parquet/run artifacts.
+    ///
+    /// Replaying `chunk_id` with byte-identical Arrow input is idempotent. A
+    /// conflicting replay fails closed. Node chunks must precede edge chunks.
+    pub fn append(
+        &mut self,
+        kind: ConstructionChunkKind,
+        chunk_id: &str,
+        batch: &RecordBatch,
+    ) -> Result<ConstructionChunkReceipt, GfError> {
+        if self.manifest.state != GraphConstructionState::Staging {
+            return Err(storage("session is not accepting chunks"));
+        }
+        validate_chunk_id(chunk_id)?;
+        if batch.num_rows() == 0 {
+            return Err(storage("empty construction chunk"));
+        }
+        let bytes = batch.get_array_memory_size();
+        if batch.num_rows() > self.manifest.budgets.max_batch_rows
+            || bytes > self.manifest.budgets.max_batch_bytes
+        {
+            return Err(storage("Arrow chunk exceeds the configured window"));
+        }
+        if self.manifest.receipts.len() >= self.manifest.budgets.max_chunks {
+            return Err(storage("construction chunk count exhausted"));
+        }
+        if kind == ConstructionChunkKind::Node
+            && self
+                .manifest
+                .receipts
+                .iter()
+                .any(|receipt| receipt.kind == ConstructionChunkKind::Edge)
+        {
+            return Err(storage("node chunk cannot follow edge staging"));
+        }
+        let input_sha256 = digest_record_batch(batch);
+        if let Some(existing) = self
+            .manifest
+            .receipts
+            .iter()
+            .find(|receipt| receipt.chunk_id == chunk_id)
+            .cloned()
+        {
+            if existing.kind != kind
+                || existing.rows != batch.num_rows() as u64
+                || existing.input_sha256 != input_sha256
+            {
+                return Err(storage("conflicting construction chunk replay"));
+            }
+            self.manifest.evidence.replayed_chunks =
+                self.manifest.evidence.replayed_chunks.saturating_add(1);
+            self.persist_manifest_replace()?;
+            return Ok(existing);
+        }
+
+        let arrays = extract_required_arrays(kind, batch)?;
+        let run_records = arrays.identity.len().saturating_add(arrays.endpoints.len());
+        if run_records > self.manifest.budgets.max_run_records {
+            return Err(storage("chunk index-run window exhausted"));
+        }
+        let sequence = self.manifest.receipts.len() as u64;
+        let stem = format!("{:020}-{}", sequence, kind.tag());
+        // A crash before the receipt is durable may leave only this session's
+        // exact next-sequence artifacts. They are not accepted input and are
+        // safe to discard before retrying the same sequence.
+        self.remove_unreceipted_sequence(&stem)?;
+        let parquet = write_parquet_artifact(&self.root, &format!("{stem}.parquet"), batch)?;
+        let identities = write_fixed_artifact(
+            &self.root,
+            &format!("{stem}.identities.run"),
+            UUID_BYTES,
+            arrays.identity,
+        )?;
+        let endpoints = if arrays.endpoints.is_empty() {
+            None
+        } else {
+            Some(write_fixed_artifact(
+                &self.root,
+                &format!("{stem}.endpoints.run"),
+                ENDPOINT_RECORD_BYTES,
+                arrays.endpoints,
+            )?)
+        };
+        let receipt = ConstructionChunkReceipt {
+            chunk_id: chunk_id.to_owned(),
+            sequence,
+            kind,
+            rows: batch.num_rows() as u64,
+            input_bytes: bytes as u64,
+            run_records: run_records as u64,
+            input_sha256,
+            parquet,
+            identities,
+            endpoints,
+        };
+        let receipt_path = self.root.join(format!("{stem}.receipt.json"));
+        let receipt_bytes = serde_json::to_vec(&receipt).map_err(storage)?;
+        write_create_synced(&receipt_path, &receipt_bytes)?;
+
+        let evidence = &mut self.manifest.evidence;
+        evidence.input_rows = evidence.input_rows.saturating_add(batch.num_rows() as u64);
+        evidence.input_batches = evidence.input_batches.saturating_add(1);
+        evidence.parquet_shards = evidence.parquet_shards.saturating_add(1);
+        evidence.physical_bytes_written = evidence
+            .physical_bytes_written
+            .saturating_add(receipt.parquet.bytes)
+            .saturating_add(receipt.identities.bytes)
+            .saturating_add(receipt.endpoints.as_ref().map_or(0, |item| item.bytes))
+            .saturating_add(receipt_bytes.len() as u64);
+        evidence.write_blocks = evidence
+            .write_blocks
+            .saturating_add(receipt.parquet.bytes.div_ceil(BLOCK_BYTES as u64))
+            .saturating_add(receipt.identities.bytes.div_ceil(BLOCK_BYTES as u64))
+            .saturating_add(
+                receipt
+                    .endpoints
+                    .as_ref()
+                    .map_or(0, |item| item.bytes.div_ceil(BLOCK_BYTES as u64)),
+            )
+            .saturating_add(1);
+        evidence.run_records = evidence.run_records.saturating_add(receipt.run_records);
+        evidence.peak_batch_rows = evidence.peak_batch_rows.max(batch.num_rows() as u64);
+        evidence.peak_batch_bytes = evidence.peak_batch_bytes.max(bytes as u64);
+        evidence.peak_run_records = evidence.peak_run_records.max(run_records as u64);
+        self.manifest.receipts.push(receipt.clone());
+        self.persist_manifest_replace()?;
+        Ok(receipt)
+    }
+
+    /// Seal the authenticated private inventory. This does not modify graph
+    /// data, topology generation, or CURRENT.
+    pub fn seal(&mut self) -> Result<(), GfError> {
+        if self.manifest.state != GraphConstructionState::Staging {
+            return Err(storage("only a staging session can be sealed"));
+        }
+        self.authenticate_receipts()?;
+        self.manifest.state = GraphConstructionState::Sealed;
+        self.persist_manifest_replace()
+    }
+
+    /// Mark the private session aborted. The prior graph remains authoritative.
+    pub fn abort(&mut self) -> Result<(), GfError> {
+        if self.manifest.state == GraphConstructionState::Sealed {
+            return Err(storage(
+                "sealed construction must be resolved by the publisher",
+            ));
+        }
+        self.manifest.state = GraphConstructionState::Aborted;
+        self.persist_manifest_replace()
+    }
+
+    fn authenticate_receipts(&mut self) -> Result<(), GfError> {
+        let mut chunk_ids = BTreeSet::new();
+        let mut expected_sequence = 0_u64;
+        let mut saw_edge = false;
+        let mut bytes_read = 0_u64;
+        let mut blocks = 0_u64;
+        for receipt in &self.manifest.receipts {
+            if receipt.sequence != expected_sequence || !chunk_ids.insert(&receipt.chunk_id) {
+                return Err(storage("non-canonical receipt sequence"));
+            }
+            if receipt.kind == ConstructionChunkKind::Node && saw_edge {
+                return Err(storage("node receipt follows edge receipt"));
+            }
+            saw_edge |= receipt.kind == ConstructionChunkKind::Edge;
+            for artifact in [&receipt.parquet, &receipt.identities]
+                .into_iter()
+                .chain(receipt.endpoints.iter())
+            {
+                let (read, count) = authenticate_artifact(&self.root, artifact)?;
+                bytes_read = bytes_read.saturating_add(read);
+                blocks = blocks.saturating_add(count);
+            }
+            let stem = format!("{:020}-{}", receipt.sequence, receipt.kind.tag());
+            let body = read_bounded(
+                &self.root.join(format!("{stem}.receipt.json")),
+                MAX_CONTROL_BYTES,
+            )?;
+            let durable: ConstructionChunkReceipt =
+                serde_json::from_slice(&body).map_err(storage)?;
+            if durable != *receipt {
+                return Err(storage("receipt does not match session inventory"));
+            }
+            bytes_read = bytes_read.saturating_add(body.len() as u64);
+            blocks = blocks.saturating_add(1);
+            expected_sequence = expected_sequence.saturating_add(1);
+        }
+        self.manifest.evidence.authentication_bytes_read = self
+            .manifest
+            .evidence
+            .authentication_bytes_read
+            .saturating_add(bytes_read);
+        self.manifest.evidence.read_blocks =
+            self.manifest.evidence.read_blocks.saturating_add(blocks);
+        Ok(())
+    }
+
+    fn recover_durable_receipts(&mut self) -> Result<(), GfError> {
+        loop {
+            let sequence = self.manifest.receipts.len() as u64;
+            let prefix = format!("{sequence:020}-");
+            let mut candidates = fs::read_dir(&self.root)
+                .map_err(storage)?
+                .filter_map(Result::ok)
+                .filter_map(|entry| entry.file_name().into_string().ok())
+                .filter(|name| name.starts_with(&prefix) && name.ends_with(".receipt.json"))
+                .collect::<Vec<_>>();
+            candidates.sort();
+            if candidates.is_empty() {
+                break;
+            }
+            if candidates.len() != 1 {
+                return Err(storage("ambiguous durable receipt recovery"));
+            }
+            let body = read_bounded(&self.root.join(&candidates[0]), MAX_CONTROL_BYTES)?;
+            let receipt: ConstructionChunkReceipt =
+                serde_json::from_slice(&body).map_err(storage)?;
+            if receipt.sequence != sequence
+                || candidates[0]
+                    != format!(
+                        "{:020}-{}.receipt.json",
+                        receipt.sequence,
+                        receipt.kind.tag()
+                    )
+                || self
+                    .manifest
+                    .receipts
+                    .iter()
+                    .any(|existing| existing.chunk_id == receipt.chunk_id)
+            {
+                return Err(storage("invalid recovered construction receipt"));
+            }
+            for artifact in [&receipt.parquet, &receipt.identities]
+                .into_iter()
+                .chain(receipt.endpoints.iter())
+            {
+                authenticate_artifact(&self.root, artifact)?;
+            }
+            let evidence = &mut self.manifest.evidence;
+            evidence.input_rows = evidence.input_rows.saturating_add(receipt.rows);
+            evidence.input_batches = evidence.input_batches.saturating_add(1);
+            evidence.parquet_shards = evidence.parquet_shards.saturating_add(1);
+            evidence.physical_bytes_written = evidence
+                .physical_bytes_written
+                .saturating_add(receipt.parquet.bytes)
+                .saturating_add(receipt.identities.bytes)
+                .saturating_add(receipt.endpoints.as_ref().map_or(0, |item| item.bytes))
+                .saturating_add(body.len() as u64);
+            evidence.write_blocks = evidence
+                .write_blocks
+                .saturating_add(receipt.parquet.bytes.div_ceil(BLOCK_BYTES as u64))
+                .saturating_add(receipt.identities.bytes.div_ceil(BLOCK_BYTES as u64))
+                .saturating_add(
+                    receipt
+                        .endpoints
+                        .as_ref()
+                        .map_or(0, |item| item.bytes.div_ceil(BLOCK_BYTES as u64)),
+                )
+                .saturating_add(1);
+            evidence.run_records = evidence.run_records.saturating_add(receipt.run_records);
+            evidence.peak_batch_rows = evidence.peak_batch_rows.max(receipt.rows);
+            evidence.peak_batch_bytes = evidence.peak_batch_bytes.max(receipt.input_bytes);
+            evidence.peak_run_records = evidence.peak_run_records.max(receipt.run_records);
+            self.manifest.receipts.push(receipt);
+            self.persist_manifest_replace()?;
+        }
+        Ok(())
+    }
+
+    fn remove_unreceipted_sequence(&self, stem: &str) -> Result<(), GfError> {
+        for suffix in ["parquet", "identities.run", "endpoints.run"] {
+            let path = self.root.join(format!("{stem}.{suffix}"));
+            match fs::remove_file(&path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(storage(error)),
+            }
+        }
+        sync_directory(&self.root)
+    }
+
+    fn persist_manifest_create(&self) -> Result<(), GfError> {
+        let body = serde_json::to_vec(&self.manifest).map_err(storage)?;
+        write_create_synced(&self.root.join(MANIFEST_FILE), &body)
+    }
+
+    fn persist_manifest_replace(&self) -> Result<(), GfError> {
+        let body = serde_json::to_vec(&self.manifest).map_err(storage)?;
+        let temporary = self
+            .root
+            .join(format!(".{MANIFEST_FILE}.{}.tmp", Uuid::new_v4()));
+        write_create_synced(&temporary, &body)?;
+        fs::rename(&temporary, self.root.join(MANIFEST_FILE)).map_err(storage)?;
+        sync_directory(&self.root)
+    }
+}
+
+struct ChunkArrays {
+    identity: Vec<[u8; UUID_BYTES]>,
+    endpoints: Vec<[u8; ENDPOINT_RECORD_BYTES]>,
+}
+
+fn extract_required_arrays(
+    kind: ConstructionChunkKind,
+    batch: &RecordBatch,
+) -> Result<ChunkArrays, GfError> {
+    let identity_name = match kind {
+        ConstructionChunkKind::Node => "node_uuid",
+        ConstructionChunkKind::Edge => "edge_uuid",
+    };
+    let identities = uuid_column(batch, identity_name)?;
+    let mut identity = (0..batch.num_rows())
+        .map(|index| uuid_value(identities, index))
+        .collect::<Result<Vec<_>, _>>()?;
+    identity.sort_unstable();
+    if identity.windows(2).any(|pair| pair[0] == pair[1]) {
+        return Err(storage("duplicate UUID inside construction chunk"));
+    }
+    let endpoints = if kind == ConstructionChunkKind::Edge {
+        let src = uuid_column(batch, "src_uuid")?;
+        let dst = uuid_column(batch, "dst_uuid")?;
+        let edge = uuid_column(batch, "edge_uuid")?;
+        let mut values = Vec::with_capacity(batch.num_rows().saturating_mul(2));
+        for index in 0..batch.num_rows() {
+            let edge_uuid = uuid_value(edge, index)?;
+            for (role, endpoint) in [uuid_value(src, index)?, uuid_value(dst, index)?]
+                .into_iter()
+                .enumerate()
+            {
+                let mut record = [0_u8; ENDPOINT_RECORD_BYTES];
+                record[..16].copy_from_slice(&endpoint);
+                record[16..32].copy_from_slice(&edge_uuid);
+                record[32] = role as u8;
+                values.push(record);
+            }
+        }
+        values.sort_unstable();
+        values
+    } else {
+        Vec::new()
+    };
+    Ok(ChunkArrays {
+        identity,
+        endpoints,
+    })
+}
+
+fn uuid_column<'a>(
+    batch: &'a RecordBatch,
+    name: &str,
+) -> Result<&'a FixedSizeBinaryArray, GfError> {
+    let index = batch
+        .schema()
+        .index_of(name)
+        .map_err(|_| storage(format!("missing required column {name}")))?;
+    let array = batch
+        .column(index)
+        .as_any()
+        .downcast_ref::<FixedSizeBinaryArray>()
+        .ok_or_else(|| storage(format!("{name} must be FixedSizeBinary(16)")))?;
+    if array.value_length() != 16 || array.null_count() != 0 {
+        return Err(storage(format!(
+            "{name} must be non-null FixedSizeBinary(16)"
+        )));
+    }
+    Ok(array)
+}
+
+fn uuid_value(array: &FixedSizeBinaryArray, index: usize) -> Result<[u8; 16], GfError> {
+    array
+        .value(index)
+        .try_into()
+        .map_err(|_| storage("UUID value has invalid width"))
+}
+
+fn digest_record_batch(batch: &RecordBatch) -> String {
+    let mut digest = Sha256::new();
+    digest.update(format!("{:?}", batch.schema()).as_bytes());
+    digest.update((batch.num_rows() as u64).to_be_bytes());
+    for column in batch.columns() {
+        digest_array_data(&column.to_data(), &mut digest);
+    }
+    hex_digest(digest.finalize().as_slice())
+}
+
+fn digest_array_data(data: &arrow::array::ArrayData, digest: &mut Sha256) {
+    digest.update((data.len() as u64).to_be_bytes());
+    digest.update((data.offset() as u64).to_be_bytes());
+    for buffer in data.buffers() {
+        digest.update((buffer.len() as u64).to_be_bytes());
+        digest.update(buffer.as_slice());
+    }
+    if let Some(nulls) = data.nulls() {
+        digest.update((nulls.offset() as u64).to_be_bytes());
+        digest.update(nulls.buffer().as_slice());
+    }
+    digest.update((data.child_data().len() as u64).to_be_bytes());
+    for child in data.child_data() {
+        digest_array_data(child, digest);
+    }
+}
+
+fn write_parquet_artifact(
+    root: &Path,
+    name: &str,
+    batch: &RecordBatch,
+) -> Result<ArtifactReceipt, GfError> {
+    let path = root.join(name);
+    let file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .map_err(storage)?;
+    let mut writer = ArrowWriter::try_new(
+        BufWriter::with_capacity(BLOCK_BYTES, file),
+        batch.schema(),
+        None,
+    )
+    .map_err(storage)?;
+    writer.write(batch).map_err(storage)?;
+    writer.finish().map_err(storage)?;
+    writer.sync().map_err(storage)?;
+    writer.inner().get_ref().sync_all().map_err(storage)?;
+    sync_directory(root)?;
+    describe_artifact(root, name)
+}
+
+fn write_fixed_artifact<const N: usize>(
+    root: &Path,
+    name: &str,
+    width: usize,
+    records: Vec<[u8; N]>,
+) -> Result<ArtifactReceipt, GfError> {
+    if N != width {
+        return Err(storage("fixed run width mismatch"));
+    }
+    let path = root.join(name);
+    let file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .map_err(storage)?;
+    let mut output = BufWriter::with_capacity(BLOCK_BYTES, file);
+    for record in records {
+        output.write_all(&record).map_err(storage)?;
+    }
+    output.flush().map_err(storage)?;
+    output.get_ref().sync_all().map_err(storage)?;
+    sync_directory(root)?;
+    describe_artifact(root, name)
+}
+
+fn describe_artifact(root: &Path, name: &str) -> Result<ArtifactReceipt, GfError> {
+    let path = root.join(name);
+    let (sha256, bytes, _) = hash_file(&path)?;
+    Ok(ArtifactReceipt {
+        relative_path: name.to_owned(),
+        bytes,
+        sha256,
+    })
+}
+
+fn authenticate_artifact(root: &Path, receipt: &ArtifactReceipt) -> Result<(u64, u64), GfError> {
+    if receipt.relative_path.contains('/')
+        || receipt.relative_path.contains('\\')
+        || receipt.relative_path.starts_with('.')
+    {
+        return Err(storage("invalid artifact path"));
+    }
+    let (digest, bytes, blocks) = hash_file(&root.join(&receipt.relative_path))?;
+    if bytes != receipt.bytes || digest != receipt.sha256 {
+        return Err(storage("construction artifact authentication failed"));
+    }
+    if receipt.relative_path.ends_with(".identities.run") && bytes % UUID_BYTES as u64 != 0 {
+        return Err(storage("truncated identity run"));
+    }
+    if receipt.relative_path.ends_with(".endpoints.run")
+        && bytes % ENDPOINT_RECORD_BYTES as u64 != 0
+    {
+        return Err(storage("truncated endpoint run"));
+    }
+    Ok((bytes, blocks))
+}
+
+fn hash_file(path: &Path) -> Result<(String, u64, u64), GfError> {
+    let file = File::open(path).map_err(storage)?;
+    let mut input = BufReader::with_capacity(BLOCK_BYTES, file);
+    let mut block = vec![0_u8; BLOCK_BYTES];
+    let mut digest = Sha256::new();
+    let mut bytes = 0_u64;
+    let mut blocks = 0_u64;
+    loop {
+        let count = input.read(&mut block).map_err(storage)?;
+        if count == 0 {
+            break;
+        }
+        digest.update(&block[..count]);
+        bytes = bytes.saturating_add(count as u64);
+        blocks = blocks.saturating_add(1);
+    }
+    Ok((hex_digest(digest.finalize().as_slice()), bytes, blocks))
+}
+
+fn read_bounded(path: &Path, maximum: u64) -> Result<Vec<u8>, GfError> {
+    let file = File::open(path).map_err(storage)?;
+    if file.metadata().map_err(storage)?.len() > maximum {
+        return Err(storage("control file exceeds bound"));
+    }
+    let mut body = Vec::new();
+    BufReader::new(file)
+        .take(maximum.saturating_add(1))
+        .read_to_end(&mut body)
+        .map_err(storage)?;
+    if body.len() as u64 > maximum {
+        return Err(storage("control file exceeds bound"));
+    }
+    Ok(body)
+}
+
+fn write_create_synced(path: &Path, bytes: &[u8]) -> Result<(), GfError> {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(storage)?;
+    file.write_all(bytes).map_err(storage)?;
+    file.sync_all().map_err(storage)?;
+    let parent = path
+        .parent()
+        .ok_or_else(|| storage("control path has no parent"))?;
+    sync_directory(parent)
+}
+
+fn sync_directory(path: &Path) -> Result<(), GfError> {
+    File::open(path)
+        .and_then(|file| file.sync_all())
+        .map_err(storage)
+}
+
+fn validate_chunk_id(value: &str) -> Result<(), GfError> {
+    if value.is_empty()
+        || value.len() > 128
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        return Err(storage("invalid construction chunk id"));
+    }
+    Ok(())
+}
+
+fn hex_digest(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut result = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        result.push(HEX[(byte >> 4) as usize] as char);
+        result.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::array::FixedSizeBinaryArray;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn uuid(seed: u128) -> [u8; 16] {
+        seed.to_be_bytes()
+    }
+
+    fn fixed(values: &[[u8; 16]]) -> FixedSizeBinaryArray {
+        FixedSizeBinaryArray::try_from_iter(values.iter().map(|value| value.as_slice())).unwrap()
+    }
+
+    fn node_batch(first: u128, rows: usize) -> RecordBatch {
+        let values = (first..first + rows as u128).map(uuid).collect::<Vec<_>>();
+        RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "node_uuid",
+                DataType::FixedSizeBinary(16),
+                false,
+            )])),
+            vec![Arc::new(fixed(&values))],
+        )
+        .unwrap()
+    }
+
+    fn edge_batch(first: u128, rows: usize) -> RecordBatch {
+        let edges = (first..first + rows as u128).map(uuid).collect::<Vec<_>>();
+        let src = (0..rows)
+            .map(|index| uuid(index as u128 + 1))
+            .collect::<Vec<_>>();
+        let dst = (0..rows)
+            .map(|index| uuid(index as u128 + 2))
+            .collect::<Vec<_>>();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("edge_uuid", DataType::FixedSizeBinary(16), false),
+            Field::new("src_uuid", DataType::FixedSizeBinary(16), false),
+            Field::new("dst_uuid", DataType::FixedSizeBinary(16), false),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(fixed(&edges)),
+                Arc::new(fixed(&src)),
+                Arc::new(fixed(&dst)),
+            ],
+        )
+        .unwrap()
+    }
+
+    fn open(root: &TempDir, operation: Uuid) -> GraphConstructionSession {
+        GraphConstructionSession::open(
+            root.path(),
+            operation,
+            7,
+            GraphConstructionBudgets::default(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn direct_chunks_resume_and_replay_without_publication() {
+        let root = TempDir::new().unwrap();
+        let operation = Uuid::from_u128(9);
+        let batch = node_batch(1, 8);
+        let mut session = open(&root, operation);
+        let first = session
+            .append(ConstructionChunkKind::Node, "nodes-0", &batch)
+            .unwrap();
+        assert_eq!(first.rows, 8);
+        assert_eq!(session.evidence().current_transitions, 0);
+        drop(session);
+
+        let mut resumed = open(&root, operation);
+        assert_eq!(resumed.receipts(), &[first.clone()]);
+        assert!(resumed.evidence().authentication_bytes_read > 0);
+        assert_eq!(
+            resumed
+                .append(ConstructionChunkKind::Node, "nodes-0", &batch)
+                .unwrap(),
+            first
+        );
+        assert_eq!(resumed.receipts().len(), 1);
+        assert_eq!(resumed.evidence().replayed_chunks, 1);
+    }
+
+    #[test]
+    fn durable_receipt_recovers_crash_before_manifest_advance() {
+        let root = TempDir::new().unwrap();
+        let operation = Uuid::from_u128(91);
+        let batch = node_batch(1, 8);
+        let mut session = open(&root, operation);
+        let receipt = session
+            .append(ConstructionChunkKind::Node, "nodes-0", &batch)
+            .unwrap();
+
+        // Model the exact crash window: shard, run, and receipt are durable,
+        // but the replace of session.json did not become authoritative.
+        session.manifest.receipts.clear();
+        session.manifest.evidence = GraphConstructionEvidence::default();
+        session.persist_manifest_replace().unwrap();
+        drop(session);
+
+        let resumed = open(&root, operation);
+        assert_eq!(resumed.receipts(), &[receipt]);
+        assert_eq!(resumed.evidence().input_rows, 8);
+        assert_eq!(resumed.evidence().input_batches, 1);
+        assert_eq!(resumed.evidence().current_transitions, 0);
+    }
+
+    #[test]
+    fn conflicting_replay_and_node_after_edge_fail_closed() {
+        let root = TempDir::new().unwrap();
+        let mut session = open(&root, Uuid::from_u128(10));
+        session
+            .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 2))
+            .unwrap();
+        assert!(
+            session
+                .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 3))
+                .is_err()
+        );
+        session
+            .append(ConstructionChunkKind::Edge, "edges", &edge_batch(100, 2))
+            .unwrap();
+        assert!(
+            session
+                .append(ConstructionChunkKind::Node, "late", &node_batch(20, 1))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn truncated_run_fails_resume_authentication() {
+        let root = TempDir::new().unwrap();
+        let operation = Uuid::from_u128(11);
+        let mut session = open(&root, operation);
+        let receipt = session
+            .append(ConstructionChunkKind::Edge, "edges", &edge_batch(100, 2))
+            .unwrap();
+        let path = session.root.join(receipt.endpoints.unwrap().relative_path);
+        drop(session);
+        let file = OpenOptions::new().write(true).open(path).unwrap();
+        file.set_len(47).unwrap();
+        assert!(
+            GraphConstructionSession::open(
+                root.path(),
+                operation,
+                7,
+                GraphConstructionBudgets::default()
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn one_two_four_times_work_is_linear_and_windows_are_fixed() {
+        let mut evidence = Vec::new();
+        for chunks in [1_u64, 2, 4] {
+            let root = TempDir::new().unwrap();
+            let mut session = open(&root, Uuid::from_u128(100 + chunks as u128));
+            for chunk in 0..chunks {
+                session
+                    .append(
+                        ConstructionChunkKind::Node,
+                        &format!("n-{chunk}"),
+                        &node_batch(1 + u128::from(chunk) * 32, 32),
+                    )
+                    .unwrap();
+            }
+            evidence.push(session.evidence().clone());
+        }
+        for (index, scale) in [1_u64, 2, 4].into_iter().enumerate() {
+            assert_eq!(evidence[index].input_rows, scale * 32);
+            assert_eq!(evidence[index].input_batches, scale);
+            assert_eq!(evidence[index].parquet_shards, scale);
+            assert_eq!(evidence[index].run_records, scale * 32);
+            assert_eq!(evidence[index].peak_batch_rows, 32);
+            assert_eq!(evidence[index].peak_run_records, 32);
+            assert_eq!(evidence[index].prior_topology_rows_decoded, 0);
+            assert_eq!(evidence[index].current_transitions, 0);
+        }
+    }
+
+    #[test]
+    fn seal_and_abort_preserve_private_state() {
+        let root = TempDir::new().unwrap();
+        let mut sealed = open(&root, Uuid::from_u128(20));
+        sealed
+            .append(ConstructionChunkKind::Node, "n", &node_batch(1, 1))
+            .unwrap();
+        sealed.seal().unwrap();
+        assert_eq!(sealed.state(), GraphConstructionState::Sealed);
+        assert!(
+            sealed
+                .append(ConstructionChunkKind::Node, "n2", &node_batch(2, 1))
+                .is_err()
+        );
+
+        let mut aborted = open(&root, Uuid::from_u128(21));
+        aborted.abort().unwrap();
+        assert_eq!(aborted.state(), GraphConstructionState::Aborted);
+        assert_eq!(aborted.evidence().current_transitions, 0);
+    }
+}

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -6,11 +6,12 @@
 //! the next sequence. `CURRENT` is never touched by this module's staging or
 //! sealing path. A generation-last publisher consumes the sealed inventory.
 
-use std::collections::BTreeSet;
+use std::cmp::Reverse;
+use std::collections::{BTreeSet, BinaryHeap};
 use std::ffi::{OsStr, OsString};
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{LazyLock, Mutex};
 
 use arrow::array::{Array, FixedSizeBinaryArray, RecordBatch, StringArray, UInt32Array};
@@ -32,6 +33,7 @@ const FORMAT_VERSION: u32 = 2;
 const PRIVATE_ROOT: &str = ".graphforge-construction";
 const CHECKPOINT: &str = "checkpoint.json";
 const INTENT: &str = "intent.json";
+const SHAPE_INTENT: &str = "shape-intent.json";
 const BLOCK_BYTES: usize = 1 << 20;
 const MAX_CONTROL_BYTES: u64 = 64 << 10;
 const IDENTITY_WIDTH: usize = 16;
@@ -167,6 +169,45 @@ pub struct GraphConstructionEvidence {
     pub current_transitions: u64,
     /// Exact idempotent replays.
     pub replayed_chunks: u64,
+    /// Temporary and final fixed-width records read by canonical shaping.
+    pub merge_read_records: u64,
+    /// Temporary and final fixed-width records written by canonical shaping.
+    pub merge_written_records: u64,
+    /// External merge groups completed (including intermediate levels).
+    pub merge_groups: u64,
+    /// Highest number of simultaneously open merge inputs.
+    pub peak_merge_inputs: u64,
+    /// Exact fixed-width payload bytes read during shaping.
+    pub merge_read_bytes: u64,
+    /// Exact fixed-width payload bytes written during shaping.
+    pub merge_written_bytes: u64,
+    /// Bounded reader refills implied by the fixed one-MiB I/O window.
+    pub merge_read_blocks: u64,
+    /// Bounded writer flushes implied by the fixed one-MiB I/O window.
+    pub merge_write_blocks: u64,
+    /// Number of completed merge levels across shaped domains.
+    pub merge_passes: u64,
+    /// Largest measured temporary merge footprint.
+    pub peak_merge_temporary_bytes: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+/// Publisher input produced from a sealed construction session.
+pub struct ConstructionShape {
+    /// UUID-sorted node/edge identity records with assigned surrogates.
+    pub identities: String,
+    /// UUID-sorted node type records, when nodes were staged.
+    pub node_details: Option<String>,
+    /// UUID-sorted edge endpoint and relation records, when edges were staged.
+    pub edge_details: Option<String>,
+    /// Live retained plus staged nodes.
+    pub node_count: u64,
+    /// Live retained plus staged edges.
+    pub edge_count: u64,
+    /// Assigned node surrogate tail.
+    pub max_node_surrogate: u64,
+    /// Assigned edge surrogate tail.
+    pub max_edge_surrogate: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -266,6 +307,20 @@ struct ChunkIntent {
     details: Option<ArtifactReceipt>,
 }
 
+#[derive(Serialize, Deserialize)]
+struct ShapeIntent {
+    format_version: u32,
+    operation_uuid: Uuid,
+    project_identity: IdentityRecord,
+    session_identity: IdentityRecord,
+    parent_topology_generation: u64,
+    budgets: GraphConstructionBudgets,
+    last_receipt_sha256: Option<String>,
+    complete: bool,
+    shape: Option<ConstructionShape>,
+    outputs: Vec<ArtifactReceipt>,
+}
+
 static ACTIVE_OPERATIONS: LazyLock<Mutex<BTreeSet<String>>> =
     LazyLock::new(|| Mutex::new(BTreeSet::new()));
 
@@ -295,6 +350,7 @@ impl Drop for ProcessReservation {
 
 /// Descriptor-relative, exclusively owned private construction session.
 pub struct GraphConstructionSession {
+    project_path: PathBuf,
     project: StableDirectory,
     root: StableDirectory,
     checkpoint: Checkpoint,
@@ -418,12 +474,14 @@ impl GraphConstructionSession {
             budgets,
         )?;
         let mut session = Self {
+            project_path: project_dir.to_path_buf(),
             project,
             root,
             checkpoint,
             base_snapshot,
             _reservation: reservation,
         };
+        recover_shape_intent(&session.root, &session.checkpoint)?;
         session.recover_intent()?;
         session.revalidate_authority()?;
         Ok(session)
@@ -652,6 +710,214 @@ impl GraphConstructionSession {
             .saturating_add(read_operations);
         self.checkpoint.state = GraphConstructionState::Sealed;
         replace_control(&self.root, CHECKPOINT, &self.checkpoint)
+    }
+
+    /// Validate the sealed identity domains and produce deterministic,
+    /// UUID-sorted canonical construction runs.  This is deliberately still
+    /// private staging: the generation-last publisher owns Parquet and CURRENT.
+    #[allow(clippy::too_many_lines)] // One authenticated external-shape lifecycle; ordering is the invariant.
+    pub fn shape_canonical_with_cancellation(
+        &mut self,
+        mut cancelled: impl FnMut() -> bool,
+    ) -> Result<ConstructionShape, GfError> {
+        self.revalidate_authority()?;
+        if self.checkpoint.state != GraphConstructionState::Sealed {
+            return Err(storage("only a sealed session can be shaped"));
+        }
+        reject_cancelled(&mut cancelled)?;
+        if let Some(shape) = read_completed_shape(&self.root, &self.checkpoint)? {
+            return Ok(shape);
+        }
+        reject_existing_merge_artifacts(&self.root)?;
+
+        let mut unified = Vec::new();
+        if self.checkpoint.base_identities.is_some() {
+            unified.push(BASE_IDENTITIES.to_owned());
+        }
+        let mut node_details = Vec::new();
+        let mut edge_details = Vec::new();
+        let mut endpoints = Vec::new();
+        let mut receipts = Vec::new();
+        for sequence in 0..self.checkpoint.next_sequence {
+            reject_cancelled(&mut cancelled)?;
+            let receipt = self.read_receipt(sequence)?;
+            validate_receipt_artifacts(&self.root, &receipt)?;
+            match receipt.kind {
+                ConstructionChunkKind::Node => node_details.push(String::new()),
+                ConstructionChunkKind::Edge => {
+                    edge_details.push(String::new());
+                    endpoints.push(String::new());
+                }
+            }
+            receipts.push(receipt);
+        }
+        let shape_intent = ShapeIntent {
+            format_version: FORMAT_VERSION,
+            operation_uuid: self.checkpoint.operation_uuid,
+            project_identity: self.checkpoint.project_identity.clone(),
+            session_identity: self.checkpoint.session_identity.clone(),
+            parent_topology_generation: self.checkpoint.parent_topology_generation,
+            budgets: self.checkpoint.budgets,
+            last_receipt_sha256: self.checkpoint.last_receipt_sha256.clone(),
+            complete: false,
+            shape: None,
+            outputs: Vec::new(),
+        };
+        install_control(&self.root, SHAPE_INTENT, &shape_intent)?;
+        node_details.clear();
+        edge_details.clear();
+        endpoints.clear();
+        for (sequence, receipt) in receipts.iter().enumerate() {
+            let name = format!("merge-unified-{sequence:020}.run");
+            convert_identity_run(&self.root, receipt, &name, &mut self.checkpoint.evidence)?;
+            unified.push(name);
+            match receipt.kind {
+                ConstructionChunkKind::Node => {
+                    let name = format!("merge-node-source-{sequence:020}.run");
+                    copy_authenticated_run::<NODE_DETAIL_WIDTH>(
+                        &self.root,
+                        &receipt.details,
+                        &name,
+                        &mut self.checkpoint.evidence,
+                    )?;
+                    node_details.push(name);
+                }
+                ConstructionChunkKind::Edge => {
+                    let detail = format!("merge-edge-source-{sequence:020}.run");
+                    copy_authenticated_run::<EDGE_DETAIL_WIDTH>(
+                        &self.root,
+                        &receipt.details,
+                        &detail,
+                        &mut self.checkpoint.evidence,
+                    )?;
+                    edge_details.push(detail);
+                    let endpoint = format!("merge-endpoint-source-{sequence:020}.run");
+                    copy_authenticated_run::<ENDPOINT_WIDTH>(
+                        &self.root,
+                        receipt
+                            .endpoints
+                            .as_ref()
+                            .ok_or_else(|| storage("edge receipt lacks endpoint run"))?,
+                        &endpoint,
+                        &mut self.checkpoint.evidence,
+                    )?;
+                    endpoints.push(endpoint);
+                }
+            }
+        }
+        let identities = merge_fixed_all::<BASE_IDENTITY_WIDTH>(
+            &self.root,
+            unified,
+            "merge-identities",
+            self.checkpoint.budgets.merge_fan_in,
+            true,
+            &mut cancelled,
+            &mut self.checkpoint.evidence,
+        )?;
+        let node_details = merge_optional::<NODE_DETAIL_WIDTH>(
+            &self.root,
+            node_details,
+            "merge-node-details",
+            self.checkpoint.budgets.merge_fan_in,
+            true,
+            &mut cancelled,
+            &mut self.checkpoint.evidence,
+        )?;
+        let edge_details = merge_optional::<EDGE_DETAIL_WIDTH>(
+            &self.root,
+            edge_details,
+            "merge-edge-details",
+            self.checkpoint.budgets.merge_fan_in,
+            true,
+            &mut cancelled,
+            &mut self.checkpoint.evidence,
+        )?;
+        let endpoints = merge_optional::<ENDPOINT_WIDTH>(
+            &self.root,
+            endpoints,
+            "merge-endpoints",
+            self.checkpoint.budgets.merge_fan_in,
+            false,
+            &mut cancelled,
+            &mut self.checkpoint.evidence,
+        )?;
+        let (base_max_node, base_max_edge) = match self.checkpoint.parent_topology_generation {
+            0 => (0, 0),
+            _ => crate::writer::read_surrogate_tails(
+                // The retained project directory is revalidated immediately above.
+                &self.project_path,
+            )?
+            .ok_or_else(|| storage("nonempty parent lacks surrogate tails"))?,
+        };
+        if base_max_node != self.checkpoint.base_work.max_node_surrogate {
+            return Err(storage("UUID snapshot and surrogate tails disagree"));
+        }
+        let (node_count, edge_count, max_node_surrogate, max_edge_surrogate) =
+            validate_unified_and_details(
+                &self.root,
+                &identities,
+                node_details.as_deref(),
+                edge_details.as_deref(),
+                endpoints.as_deref(),
+                base_max_node,
+                base_max_edge,
+                &mut cancelled,
+                &mut self.checkpoint.evidence,
+            )?;
+        let identities = assign_surrogates(
+            &self.root,
+            &identities,
+            base_max_node,
+            base_max_edge,
+            &mut cancelled,
+            &mut self.checkpoint.evidence,
+        )?;
+        self.checkpoint.evidence.merge_read_blocks = self
+            .checkpoint
+            .evidence
+            .merge_read_bytes
+            .div_ceil(BLOCK_BYTES as u64);
+        self.checkpoint.evidence.merge_write_blocks = self
+            .checkpoint
+            .evidence
+            .merge_written_bytes
+            .div_ceil(BLOCK_BYTES as u64);
+        self.checkpoint.evidence.peak_merge_temporary_bytes = self
+            .checkpoint
+            .evidence
+            .peak_merge_temporary_bytes
+            .max(measured_shape_bytes(&self.root)?);
+        let shape = ConstructionShape {
+            identities,
+            node_details,
+            edge_details,
+            node_count,
+            edge_count,
+            max_node_surrogate,
+            max_edge_surrogate,
+        };
+        let mut outputs = vec![receipt_for_existing(&self.root, &shape.identities)?];
+        for name in shape.node_details.iter().chain(shape.edge_details.iter()) {
+            outputs.push(receipt_for_existing(&self.root, name)?);
+        }
+        replace_control(&self.root, CHECKPOINT, &self.checkpoint)?;
+        replace_control(
+            &self.root,
+            SHAPE_INTENT,
+            &ShapeIntent {
+                format_version: FORMAT_VERSION,
+                operation_uuid: self.checkpoint.operation_uuid,
+                project_identity: self.checkpoint.project_identity.clone(),
+                session_identity: self.checkpoint.session_identity.clone(),
+                parent_topology_generation: self.checkpoint.parent_topology_generation,
+                budgets: self.checkpoint.budgets,
+                last_receipt_sha256: self.checkpoint.last_receipt_sha256.clone(),
+                complete: true,
+                shape: Some(shape.clone()),
+                outputs,
+            },
+        )?;
+        Ok(shape)
     }
 
     /// Abort before seal. CURRENT remains unchanged.
@@ -1155,8 +1421,693 @@ fn encode_base_identity(identity: ConstructionUuidIdentity) -> [u8; BASE_IDENTIT
         crate::uuid_membership::UuidIndexKind::Node => 0,
         crate::uuid_membership::UuidIndexKind::Edge => 1,
     };
+    // Retained parent member; session-converted records keep this byte zero.
+    record[17] = 1;
     record[24..].copy_from_slice(&identity.surrogate.to_be_bytes());
     record
+}
+
+fn reject_existing_merge_artifacts(root: &StableDirectory) -> Result<(), GfError> {
+    for name in root.child_names().map_err(storage)? {
+        let Some(name) = name.to_str() else { continue };
+        if name.starts_with("merge-") || name.starts_with("shaped-") {
+            return Err(storage("unowned construction shaping artifact exists"));
+        }
+    }
+    Ok(())
+}
+
+fn planned_shape_names(
+    chunks: usize,
+    identity_inputs: usize,
+    node_runs: usize,
+    edge_runs: usize,
+    endpoint_runs: usize,
+    fan_in: usize,
+) -> Vec<String> {
+    let mut names = (0..chunks)
+        .map(|sequence| format!("merge-unified-{sequence:020}.run"))
+        .collect::<Vec<_>>();
+    plan_merge_names(identity_inputs, "merge-identities", fan_in, &mut names);
+    plan_merge_names(node_runs, "merge-node-details", fan_in, &mut names);
+    plan_merge_names(edge_runs, "merge-edge-details", fan_in, &mut names);
+    plan_merge_names(endpoint_runs, "merge-endpoints", fan_in, &mut names);
+    names.push("shaped-identities.run".to_owned());
+    names
+}
+
+fn plan_merge_names(mut count: usize, prefix: &str, fan_in: usize, names: &mut Vec<String>) {
+    let mut level = 0;
+    while count > 1 {
+        let groups = count.div_ceil(fan_in);
+        names.extend((0..groups).map(|group| format!("{prefix}-l{level:03}-g{group:08}.run")));
+        count = groups;
+        level += 1;
+    }
+}
+
+fn recover_shape_intent(root: &StableDirectory, checkpoint: &Checkpoint) -> Result<(), GfError> {
+    let mut file = match root.open_child_file(OsStr::new(SHAPE_INTENT)) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(storage(error)),
+    };
+    let intent: ShapeIntent = decode_bounded(&mut file)?;
+    validate_shape_binding(&intent, checkpoint)?;
+    if intent.complete {
+        let shape = intent
+            .shape
+            .as_ref()
+            .ok_or_else(|| storage("complete shape manifest lacks output"))?;
+        if intent.outputs.is_empty()
+            || !intent
+                .outputs
+                .iter()
+                .any(|item| item.name == shape.identities)
+        {
+            return Err(storage("complete shape manifest inventory is incomplete"));
+        }
+        for output in &intent.outputs {
+            authenticate_shaped_output(root, output)?;
+        }
+        return Ok(());
+    }
+    if intent.shape.is_some() || !intent.outputs.is_empty() {
+        return Err(storage("incomplete shape intent claims completed output"));
+    }
+    let mut node_runs = 0;
+    let mut edge_runs = 0;
+    let mut source_names = Vec::new();
+    for sequence in 0..checkpoint.next_sequence {
+        let mut file = root
+            .open_child_file(OsStr::new(&receipt_name(sequence)))
+            .map_err(storage)?;
+        let receipt: ConstructionChunkReceipt = decode_bounded(&mut file)?;
+        match receipt.kind {
+            ConstructionChunkKind::Node => {
+                node_runs += 1;
+                source_names.push(format!("merge-node-source-{sequence:020}.run"));
+            }
+            ConstructionChunkKind::Edge => {
+                edge_runs += 1;
+                source_names.push(format!("merge-edge-source-{sequence:020}.run"));
+                source_names.push(format!("merge-endpoint-source-{sequence:020}.run"));
+            }
+        }
+    }
+    let chunks = usize::try_from(checkpoint.next_sequence)
+        .map_err(|_| storage("construction shape chunk count exceeds this platform"))?;
+    let mut names = planned_shape_names(
+        chunks,
+        chunks + usize::from(checkpoint.base_identities.is_some()),
+        node_runs,
+        edge_runs,
+        edge_runs,
+        checkpoint.budgets.merge_fan_in,
+    );
+    names.extend(source_names);
+    for name in names {
+        match root.open_child_file(OsStr::new(&name)) {
+            Ok(file) => {
+                if file_link_count(&file).map_err(storage)? != 1 {
+                    return Err(storage("construction shape artifact has extra links"));
+                }
+                drop(file);
+                unlink_named(root, &name)?;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(storage(error)),
+        }
+    }
+    unlink_named(root, SHAPE_INTENT)
+}
+
+fn validate_shape_binding(intent: &ShapeIntent, checkpoint: &Checkpoint) -> Result<(), GfError> {
+    if intent.format_version != FORMAT_VERSION
+        || intent.operation_uuid != checkpoint.operation_uuid
+        || intent.project_identity != checkpoint.project_identity
+        || intent.session_identity != checkpoint.session_identity
+        || intent.parent_topology_generation != checkpoint.parent_topology_generation
+        || intent.budgets != checkpoint.budgets
+        || intent.last_receipt_sha256 != checkpoint.last_receipt_sha256
+    {
+        return Err(storage("construction shape manifest authority changed"));
+    }
+    Ok(())
+}
+
+fn read_completed_shape(
+    root: &StableDirectory,
+    checkpoint: &Checkpoint,
+) -> Result<Option<ConstructionShape>, GfError> {
+    let mut file = match root.open_child_file(OsStr::new(SHAPE_INTENT)) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(storage(error)),
+    };
+    let manifest: ShapeIntent = decode_bounded(&mut file)?;
+    validate_shape_binding(&manifest, checkpoint)?;
+    if !manifest.complete {
+        return Err(storage("incomplete construction shape was not recovered"));
+    }
+    for output in &manifest.outputs {
+        authenticate_shaped_output(root, output)?;
+    }
+    manifest
+        .shape
+        .ok_or_else(|| storage("complete shape manifest lacks output"))
+        .map(Some)
+}
+
+fn receipt_for_existing(root: &StableDirectory, name: &str) -> Result<ArtifactReceipt, GfError> {
+    let mut file = root.open_child_file(OsStr::new(name)).map_err(storage)?;
+    if file_link_count(&file).map_err(storage)? != 1 {
+        return Err(storage("shaped output has extra links"));
+    }
+    let identity = file_identity(&file).map_err(storage)?;
+    let mut digest = Sha256::new();
+    let mut bytes = 0_u64;
+    let mut operations = 0_u64;
+    let mut block = vec![0_u8; BLOCK_BYTES];
+    loop {
+        let count = file.read(&mut block).map_err(storage)?;
+        if count == 0 {
+            break;
+        }
+        digest.update(&block[..count]);
+        bytes = bytes.saturating_add(count as u64);
+        operations = operations.saturating_add(1);
+    }
+    Ok(ArtifactReceipt {
+        name: name.to_owned(),
+        bytes,
+        sha256: hex(&digest.finalize()),
+        identity: identity.into(),
+        write_operations: operations,
+    })
+}
+
+fn authenticate_shaped_output(
+    root: &StableDirectory,
+    expected: &ArtifactReceipt,
+) -> Result<(), GfError> {
+    if !is_shape_artifact_name(&expected.name) && !canonical_artifact_target(&expected.name) {
+        return Err(storage("shape manifest output name is not canonical"));
+    }
+    let actual = receipt_for_existing(root, &expected.name)?;
+    if actual.bytes != expected.bytes
+        || actual.sha256 != expected.sha256
+        || actual.identity != expected.identity
+    {
+        return Err(storage("shape manifest output authentication changed"));
+    }
+    Ok(())
+}
+
+fn is_shape_artifact_name(name: &str) -> bool {
+    if name == "shaped-identities.run" {
+        return true;
+    }
+    if let Some(sequence) = name
+        .strip_prefix("merge-unified-")
+        .and_then(|body| body.strip_suffix(".run"))
+    {
+        return sequence.len() == 20 && sequence.bytes().all(|byte| byte.is_ascii_digit());
+    }
+    for prefix in [
+        "merge-node-source-",
+        "merge-edge-source-",
+        "merge-endpoint-source-",
+    ] {
+        if let Some(sequence) = name
+            .strip_prefix(prefix)
+            .and_then(|body| body.strip_suffix(".run"))
+        {
+            return sequence.len() == 20 && sequence.bytes().all(|byte| byte.is_ascii_digit());
+        }
+    }
+    [
+        "merge-identities-l",
+        "merge-node-details-l",
+        "merge-edge-details-l",
+        "merge-endpoints-l",
+    ]
+    .iter()
+    .any(|prefix| {
+        name.strip_prefix(prefix).is_some_and(|tail| {
+            tail.len() == 17
+                && tail.get(3..5) == Some("-g")
+                && tail.get(13..) == Some(".run")
+                && tail[..3].bytes().all(|byte| byte.is_ascii_digit())
+                && tail[5..13].bytes().all(|byte| byte.is_ascii_digit())
+        })
+    })
+}
+
+fn measured_shape_bytes(root: &StableDirectory) -> Result<u64, GfError> {
+    let mut bytes = 0_u64;
+    for name in root.child_names().map_err(storage)? {
+        let Some(name) = name.to_str() else { continue };
+        if is_shape_artifact_name(name) {
+            bytes = bytes.saturating_add(
+                root.open_child_file(OsStr::new(name))
+                    .map_err(storage)?
+                    .metadata()
+                    .map_err(storage)?
+                    .len(),
+            );
+        }
+    }
+    Ok(bytes)
+}
+
+fn account_merge_read<const N: usize>(evidence: &mut GraphConstructionEvidence) {
+    evidence.merge_read_records = evidence.merge_read_records.saturating_add(1);
+    evidence.merge_read_bytes = evidence.merge_read_bytes.saturating_add(N as u64);
+}
+
+fn account_merge_write<const N: usize>(evidence: &mut GraphConstructionEvidence) {
+    evidence.merge_written_records = evidence.merge_written_records.saturating_add(1);
+    evidence.merge_written_bytes = evidence.merge_written_bytes.saturating_add(N as u64);
+}
+
+fn convert_identity_run(
+    root: &StableDirectory,
+    receipt: &ConstructionChunkReceipt,
+    output: &str,
+    evidence: &mut GraphConstructionEvidence,
+) -> Result<(), GfError> {
+    let input = root
+        .open_child_file(OsStr::new(&receipt.identities.name))
+        .map_err(storage)?;
+    if !receipt
+        .identities
+        .identity
+        .matches(file_identity(&input).map_err(storage)?)
+        || file_link_count(&input).map_err(storage)? != 1
+    {
+        return Err(storage("identity source authority changed before merge"));
+    }
+    let temporary = artifact_temp(output);
+    let file = root
+        .create_replaceable_child_file(OsStr::new(&temporary))
+        .map_err(storage)?;
+    let identity = file_identity(&file).map_err(storage)?;
+    let mut reader = BufReader::with_capacity(BLOCK_BYTES, input);
+    let mut writer = BufWriter::with_capacity(BLOCK_BYTES, file);
+    let mut digest = Sha256::new();
+    let mut bytes = 0_u64;
+    while let Some(uuid) = read_fixed::<IDENTITY_WIDTH>(&mut reader)? {
+        digest.update(uuid);
+        bytes = bytes.saturating_add(IDENTITY_WIDTH as u64);
+        let mut record = [0_u8; BASE_IDENTITY_WIDTH];
+        record[..16].copy_from_slice(&uuid);
+        record[16] = u8::from(receipt.kind == ConstructionChunkKind::Edge);
+        writer.write_all(&record).map_err(storage)?;
+        account_merge_read::<IDENTITY_WIDTH>(evidence);
+        account_merge_write::<BASE_IDENTITY_WIDTH>(evidence);
+    }
+    if bytes != receipt.identities.bytes || hex(&digest.finalize()) != receipt.identities.sha256 {
+        return Err(storage("identity source content changed before merge"));
+    }
+    writer.flush().map_err(storage)?;
+    writer.get_ref().sync_all().map_err(storage)?;
+    drop(writer);
+    root.install_child(OsStr::new(&temporary), identity, OsStr::new(output))
+        .map_err(storage)?;
+    root.sync().map_err(storage)
+}
+
+fn copy_authenticated_run<const N: usize>(
+    root: &StableDirectory,
+    receipt: &ArtifactReceipt,
+    output: &str,
+    evidence: &mut GraphConstructionEvidence,
+) -> Result<(), GfError> {
+    let input = root
+        .open_child_file(OsStr::new(&receipt.name))
+        .map_err(storage)?;
+    if !receipt
+        .identity
+        .matches(file_identity(&input).map_err(storage)?)
+        || file_link_count(&input).map_err(storage)? != 1
+    {
+        return Err(storage("construction merge source authority changed"));
+    }
+    let temporary = artifact_temp(output);
+    let file = root
+        .create_replaceable_child_file(OsStr::new(&temporary))
+        .map_err(storage)?;
+    let identity = file_identity(&file).map_err(storage)?;
+    let mut reader = BufReader::with_capacity(BLOCK_BYTES, input);
+    let mut writer = BufWriter::with_capacity(BLOCK_BYTES, file);
+    let mut digest = Sha256::new();
+    let mut bytes = 0_u64;
+    while let Some(record) = read_fixed::<N>(&mut reader)? {
+        digest.update(record);
+        bytes = bytes.saturating_add(N as u64);
+        writer.write_all(&record).map_err(storage)?;
+        account_merge_read::<N>(evidence);
+        account_merge_write::<N>(evidence);
+    }
+    if bytes != receipt.bytes || hex(&digest.finalize()) != receipt.sha256 {
+        return Err(storage("construction merge source content changed"));
+    }
+    writer.flush().map_err(storage)?;
+    writer.get_ref().sync_all().map_err(storage)?;
+    drop(writer);
+    root.install_child(OsStr::new(&temporary), identity, OsStr::new(output))
+        .map_err(storage)?;
+    root.sync().map_err(storage)
+}
+
+fn merge_optional<const N: usize>(
+    root: &StableDirectory,
+    inputs: Vec<String>,
+    prefix: &str,
+    fan_in: usize,
+    reject_duplicates: bool,
+    cancelled: &mut impl FnMut() -> bool,
+    evidence: &mut GraphConstructionEvidence,
+) -> Result<Option<String>, GfError> {
+    if inputs.is_empty() {
+        Ok(None)
+    } else {
+        merge_fixed_all::<N>(
+            root,
+            inputs,
+            prefix,
+            fan_in,
+            reject_duplicates,
+            cancelled,
+            evidence,
+        )
+        .map(Some)
+    }
+}
+
+fn merge_fixed_all<const N: usize>(
+    root: &StableDirectory,
+    mut inputs: Vec<String>,
+    prefix: &str,
+    fan_in: usize,
+    reject_duplicates: bool,
+    cancelled: &mut impl FnMut() -> bool,
+    evidence: &mut GraphConstructionEvidence,
+) -> Result<String, GfError> {
+    if inputs.is_empty() {
+        return Err(storage("external merge has no input"));
+    }
+    let mut level = 0_usize;
+    while inputs.len() > 1 {
+        evidence.merge_passes = evidence.merge_passes.saturating_add(1);
+        let mut outputs = Vec::with_capacity(inputs.len().div_ceil(fan_in));
+        for (group, names) in inputs.chunks(fan_in).enumerate() {
+            reject_cancelled(cancelled)?;
+            let output = format!("{prefix}-l{level:03}-g{group:08}.run");
+            merge_fixed_group::<N>(root, names, &output, reject_duplicates, cancelled, evidence)?;
+            outputs.push(output);
+        }
+        for old in &inputs {
+            if old.starts_with("merge-") && !outputs.contains(old) {
+                unlink_named(root, old)?;
+            }
+        }
+        inputs = outputs;
+        level += 1;
+    }
+    Ok(inputs.pop().expect("one merge output"))
+}
+
+fn merge_fixed_group<const N: usize>(
+    root: &StableDirectory,
+    inputs: &[String],
+    output: &str,
+    reject_duplicates: bool,
+    cancelled: &mut impl FnMut() -> bool,
+    evidence: &mut GraphConstructionEvidence,
+) -> Result<(), GfError> {
+    let mut readers = inputs
+        .iter()
+        .map(|name| {
+            root.open_child_file(OsStr::new(name))
+                .map(|file| BufReader::with_capacity(BLOCK_BYTES, file))
+                .map_err(storage)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    evidence.peak_merge_inputs = evidence.peak_merge_inputs.max(readers.len() as u64);
+    let temporary = artifact_temp(output);
+    let file = root
+        .create_replaceable_child_file(OsStr::new(&temporary))
+        .map_err(storage)?;
+    let identity = file_identity(&file).map_err(storage)?;
+    let mut writer = BufWriter::with_capacity(BLOCK_BYTES, file);
+    let mut heap = BinaryHeap::new();
+    for (index, reader) in readers.iter_mut().enumerate() {
+        if let Some(record) = read_fixed::<N>(reader)? {
+            heap.push(Reverse((record, index)));
+            account_merge_read::<N>(evidence);
+        }
+    }
+    let mut previous = None;
+    while let Some(Reverse((record, index))) = heap.pop() {
+        if reject_duplicates
+            && previous
+                .as_ref()
+                .is_some_and(|prior: &[u8; N]| prior[..16] == record[..16])
+        {
+            return Err(storage("duplicate identity across construction runs"));
+        }
+        writer.write_all(&record).map_err(storage)?;
+        account_merge_write::<N>(evidence);
+        previous = Some(record);
+        if evidence.merge_written_records.is_multiple_of(4096) {
+            reject_cancelled(cancelled)?;
+        }
+        if let Some(next) = read_fixed::<N>(&mut readers[index])? {
+            heap.push(Reverse((next, index)));
+            account_merge_read::<N>(evidence);
+        }
+    }
+    writer.flush().map_err(storage)?;
+    writer.get_ref().sync_all().map_err(storage)?;
+    drop(writer);
+    root.install_child(OsStr::new(&temporary), identity, OsStr::new(output))
+        .map_err(storage)?;
+    root.sync().map_err(storage)?;
+    evidence.merge_groups = evidence.merge_groups.saturating_add(1);
+    evidence.peak_merge_temporary_bytes = evidence
+        .peak_merge_temporary_bytes
+        .max(measured_shape_bytes(root)?);
+    Ok(())
+}
+
+fn read_fixed<const N: usize>(reader: &mut impl Read) -> Result<Option<[u8; N]>, GfError> {
+    let mut record = [0_u8; N];
+    let mut filled = 0;
+    while filled < N {
+        match reader.read(&mut record[filled..]).map_err(storage)? {
+            0 if filled == 0 => return Ok(None),
+            0 => return Err(storage("truncated fixed-width construction run")),
+            count => filled += count,
+        }
+    }
+    Ok(Some(record))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn validate_unified_and_details(
+    root: &StableDirectory,
+    identities_name: &str,
+    node_details_name: Option<&str>,
+    edge_details_name: Option<&str>,
+    endpoints_name: Option<&str>,
+    base_max_node: u64,
+    base_max_edge: u64,
+    cancelled: &mut impl FnMut() -> bool,
+    evidence: &mut GraphConstructionEvidence,
+) -> Result<(u64, u64, u64, u64), GfError> {
+    let mut identities = BufReader::with_capacity(
+        BLOCK_BYTES,
+        root.open_child_file(OsStr::new(identities_name))
+            .map_err(storage)?,
+    );
+    let mut node_count = 0_u64;
+    let mut edge_count = 0_u64;
+    let mut new_nodes = 0_u64;
+    let mut new_edges = 0_u64;
+    while let Some(record) = read_fixed::<BASE_IDENTITY_WIDTH>(&mut identities)? {
+        match record[16] {
+            0 => {
+                node_count += 1;
+                if record[17] == 0 {
+                    new_nodes += 1;
+                }
+            }
+            1 => {
+                edge_count += 1;
+                if record[17] == 0 {
+                    new_edges += 1;
+                }
+            }
+            _ => return Err(storage("invalid identity kind in unified merge")),
+        }
+        account_merge_read::<BASE_IDENTITY_WIDTH>(evidence);
+        if (node_count + edge_count).is_multiple_of(4096) {
+            reject_cancelled(cancelled)?;
+        }
+    }
+    let detail_count = |name: Option<&str>, width: u64| -> Result<u64, GfError> {
+        let Some(name) = name else { return Ok(0) };
+        let bytes = root
+            .open_child_file(OsStr::new(name))
+            .map_err(storage)?
+            .metadata()
+            .map_err(storage)?
+            .len();
+        if bytes % width != 0 {
+            return Err(storage("truncated canonical detail run"));
+        }
+        Ok(bytes / width)
+    };
+    if detail_count(node_details_name, NODE_DETAIL_WIDTH as u64)? != new_nodes
+        || detail_count(edge_details_name, EDGE_DETAIL_WIDTH as u64)? != new_edges
+    {
+        return Err(storage("identity and canonical detail domains disagree"));
+    }
+    validate_endpoints(
+        root,
+        identities_name,
+        endpoints_name,
+        new_edges,
+        cancelled,
+        evidence,
+    )?;
+    let max_node = base_max_node
+        .checked_add(new_nodes)
+        .ok_or_else(|| storage("node surrogate overflow"))?;
+    let max_edge = base_max_edge
+        .checked_add(new_edges)
+        .ok_or_else(|| storage("edge surrogate overflow"))?;
+    Ok((node_count, edge_count, max_node, max_edge))
+}
+
+fn validate_endpoints(
+    root: &StableDirectory,
+    identities_name: &str,
+    endpoints_name: Option<&str>,
+    new_edges: u64,
+    cancelled: &mut impl FnMut() -> bool,
+    evidence: &mut GraphConstructionEvidence,
+) -> Result<(), GfError> {
+    if new_edges == 0 {
+        return if endpoints_name.is_none() {
+            Ok(())
+        } else {
+            Err(storage("endpoint run exists without new edges"))
+        };
+    }
+    let endpoints_name = endpoints_name.ok_or_else(|| storage("new edges lack endpoints"))?;
+    let mut identities = BufReader::with_capacity(
+        BLOCK_BYTES,
+        root.open_child_file(OsStr::new(identities_name))
+            .map_err(storage)?,
+    );
+    let mut endpoints = BufReader::with_capacity(
+        BLOCK_BYTES,
+        root.open_child_file(OsStr::new(endpoints_name))
+            .map_err(storage)?,
+    );
+    let mut identity = read_fixed::<BASE_IDENTITY_WIDTH>(&mut identities)?;
+    let mut endpoint_count = 0_u64;
+    while let Some(endpoint) = read_fixed::<ENDPOINT_WIDTH>(&mut endpoints)? {
+        while identity
+            .as_ref()
+            .is_some_and(|item| item[..16] < endpoint[..16])
+        {
+            identity = read_fixed::<BASE_IDENTITY_WIDTH>(&mut identities)?;
+            account_merge_read::<BASE_IDENTITY_WIDTH>(evidence);
+        }
+        let Some(node) = identity.as_ref() else {
+            return Err(storage("edge endpoint UUID does not exist"));
+        };
+        if node[..16] != endpoint[..16] || node[16] != 0 {
+            return Err(storage("edge endpoint is not a node UUID"));
+        }
+        if endpoint[32] > 1 || endpoint[33..].iter().any(|byte| *byte != 0) {
+            return Err(storage("endpoint run record is not canonical"));
+        }
+        endpoint_count += 1;
+        account_merge_read::<ENDPOINT_WIDTH>(evidence);
+        if endpoint_count.is_multiple_of(4096) {
+            reject_cancelled(cancelled)?;
+        }
+    }
+    if endpoint_count != new_edges.saturating_mul(2) {
+        return Err(storage(
+            "edge endpoint cardinality differs from edge domain",
+        ));
+    }
+    Ok(())
+}
+
+fn assign_surrogates(
+    root: &StableDirectory,
+    input_name: &str,
+    mut node_tail: u64,
+    mut edge_tail: u64,
+    cancelled: &mut impl FnMut() -> bool,
+    evidence: &mut GraphConstructionEvidence,
+) -> Result<String, GfError> {
+    let output = "shaped-identities.run";
+    let temporary = artifact_temp(output);
+    let file = root
+        .create_replaceable_child_file(OsStr::new(&temporary))
+        .map_err(storage)?;
+    let identity = file_identity(&file).map_err(storage)?;
+    let mut reader = BufReader::with_capacity(
+        BLOCK_BYTES,
+        root.open_child_file(OsStr::new(input_name))
+            .map_err(storage)?,
+    );
+    let mut writer = BufWriter::with_capacity(BLOCK_BYTES, file);
+    let mut count = 0_u64;
+    while let Some(mut record) = read_fixed::<BASE_IDENTITY_WIDTH>(&mut reader)? {
+        if record[17] == 0 {
+            let surrogate = match record[16] {
+                0 => {
+                    node_tail = node_tail
+                        .checked_add(1)
+                        .ok_or_else(|| storage("node surrogate overflow"))?;
+                    node_tail
+                }
+                1 => {
+                    edge_tail = edge_tail
+                        .checked_add(1)
+                        .ok_or_else(|| storage("edge surrogate overflow"))?;
+                    edge_tail
+                }
+                _ => return Err(storage("invalid identity kind during shaping")),
+            };
+            record[24..32].copy_from_slice(&surrogate.to_be_bytes());
+        } else if record[17] != 1 {
+            return Err(storage("invalid retained identity marker during shaping"));
+        }
+        writer.write_all(&record).map_err(storage)?;
+        account_merge_read::<BASE_IDENTITY_WIDTH>(evidence);
+        account_merge_write::<BASE_IDENTITY_WIDTH>(evidence);
+        count += 1;
+        if count.is_multiple_of(4096) {
+            reject_cancelled(cancelled)?;
+        }
+    }
+    writer.flush().map_err(storage)?;
+    writer.get_ref().sync_all().map_err(storage)?;
+    drop(writer);
+    root.install_child(OsStr::new(&temporary), identity, OsStr::new(output))
+        .map_err(storage)?;
+    root.sync().map_err(storage)?;
+    Ok(output.to_owned())
 }
 
 fn create_base_snapshot(
@@ -1333,7 +2284,8 @@ fn authenticate_artifact(
                 }
                 if width == BASE_IDENTITY_WIDTH
                     && (!matches!(record[16], 0 | 1)
-                        || record[17..24].iter().any(|byte| *byte != 0)
+                        || record[17] != 1
+                        || record[18..24].iter().any(|byte| *byte != 0)
                         || (record[16] == 0 && record[24..].iter().all(|byte| *byte == 0))
                         || (record[16] == 1 && record[24..].iter().any(|byte| *byte != 0)))
                 {
@@ -1749,7 +2701,7 @@ fn is_owned_artifact_temp(name: &str) -> bool {
 }
 
 fn canonical_artifact_target(name: &str) -> bool {
-    if name == BASE_IDENTITIES {
+    if name == BASE_IDENTITIES || is_shape_artifact_name(name) {
         return true;
     }
     let Some(body) = name.strip_prefix("chunk-") else {
@@ -1945,7 +2897,8 @@ fn validate_sorted_run(file: &mut File, width: usize) -> Result<(), GfError> {
                             .any(|byte| *byte != 0)))
                 || (width == BASE_IDENTITY_WIDTH
                     && (!matches!(record[16], 0 | 1)
-                        || record[17..24].iter().any(|byte| *byte != 0)
+                        || record[17] != 1
+                        || record[18..24].iter().any(|byte| *byte != 0)
                         || (record[16] == 0 && record[24..].iter().all(|byte| *byte == 0))
                         || (record[16] == 1 && record[24..].iter().any(|byte| *byte != 0))))
             {
@@ -2144,6 +3097,161 @@ mod tests {
             assert_eq!(session.state(), GraphConstructionState::Sealed);
             assert!(session.evidence().authentication_read_bytes > 0);
         }
+    }
+
+    #[test]
+    fn shaping_is_bounded_deterministic_and_multipass_at_1x_2x_4x() {
+        for chunks in [1_usize, 2, 4] {
+            let root = TempDir::new().unwrap();
+            let mut session = GraphConstructionSession::open(
+                root.path(),
+                Uuid::from_u128(7_000 + chunks as u128),
+                0,
+                GraphConstructionBudgets {
+                    merge_fan_in: 2,
+                    ..GraphConstructionBudgets::default()
+                },
+            )
+            .unwrap();
+            for chunk in 0..chunks {
+                session
+                    .append(
+                        ConstructionChunkKind::Node,
+                        &format!("nodes-{chunk}"),
+                        &node_batch(1 + chunk as u128 * 4, 4),
+                    )
+                    .unwrap();
+            }
+            session
+                .append(
+                    ConstructionChunkKind::Edge,
+                    "edges",
+                    &edge_batch(10_000, chunks * 2),
+                )
+                .unwrap();
+            session.seal().unwrap();
+            let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+            assert_eq!(shape.node_count, (chunks * 4) as u64);
+            assert_eq!(shape.edge_count, (chunks * 2) as u64);
+            assert_eq!(shape.max_node_surrogate, (chunks * 4) as u64);
+            assert_eq!(shape.max_edge_surrogate, (chunks * 2) as u64);
+            assert!(session.evidence().peak_merge_inputs <= 2);
+            assert!(session.evidence().merge_read_bytes > 0);
+            assert!(session.evidence().merge_written_bytes > 0);
+            if chunks == 4 {
+                assert!(session.evidence().merge_passes >= 2);
+            }
+        }
+    }
+
+    #[test]
+    fn shaping_rejects_cross_kind_duplicates_and_missing_endpoints() {
+        let root = TempDir::new().unwrap();
+        let mut duplicate = open(&root, 8_001);
+        duplicate
+            .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 2))
+            .unwrap();
+        duplicate
+            .append(ConstructionChunkKind::Edge, "edges", &edge_batch(1, 1))
+            .unwrap();
+        duplicate.seal().unwrap();
+        assert!(
+            duplicate
+                .shape_canonical_with_cancellation(|| false)
+                .unwrap_err()
+                .to_string()
+                .contains("duplicate identity")
+        );
+
+        let root = TempDir::new().unwrap();
+        let mut missing = open(&root, 8_002);
+        missing
+            .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 2))
+            .unwrap();
+        missing
+            .append(ConstructionChunkKind::Edge, "edges", &edge_batch(20_000, 2))
+            .unwrap();
+        missing.seal().unwrap();
+        assert!(
+            missing
+                .shape_canonical_with_cancellation(|| false)
+                .unwrap_err()
+                .to_string()
+                .contains("endpoint")
+        );
+    }
+
+    #[test]
+    fn shaping_cancellation_is_recovered_on_reopen() {
+        let root = TempDir::new().unwrap();
+        let mut session = open(&root, 8_003);
+        for chunk in 0..4 {
+            session
+                .append(
+                    ConstructionChunkKind::Node,
+                    &format!("nodes-{chunk}"),
+                    &node_batch(1 + chunk * 8, 8),
+                )
+                .unwrap();
+        }
+        session.seal().unwrap();
+        let mut polls = 0;
+        assert!(
+            session
+                .shape_canonical_with_cancellation(|| {
+                    polls += 1;
+                    polls > 6
+                })
+                .is_err()
+        );
+        drop(session);
+        let mut resumed = GraphConstructionSession::open(
+            root.path(),
+            Uuid::from_u128(8_003),
+            0,
+            GraphConstructionBudgets::default(),
+        )
+        .unwrap();
+        resumed.shape_canonical_with_cancellation(|| false).unwrap();
+    }
+
+    #[test]
+    fn fixed_merge_reader_rejects_truncation_and_self_loop_is_valid() {
+        assert!(read_fixed::<16>(&mut std::io::Cursor::new(vec![0_u8; 15])).is_err());
+        let root = TempDir::new().unwrap();
+        let mut session = open(&root, 8_004);
+        session
+            .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 1))
+            .unwrap();
+        let endpoint = [1_u128.to_be_bytes()];
+        let edge = RecordBatch::try_new(
+            CONSTRUCTION_EDGE_SCHEMA.clone(),
+            vec![
+                Arc::new(fixed(&[9_000_u128.to_be_bytes()])),
+                Arc::new(fixed(&endpoint)),
+                Arc::new(fixed(&endpoint)),
+                Arc::new(StringArray::from(vec!["R"])),
+            ],
+        )
+        .unwrap();
+        session
+            .append(ConstructionChunkKind::Edge, "self-loop", &edge)
+            .unwrap();
+        session.seal().unwrap();
+        let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+        assert_eq!(shape.edge_count, 1);
+        drop(session);
+        let mut resumed = GraphConstructionSession::open(
+            root.path(),
+            Uuid::from_u128(8_004),
+            0,
+            GraphConstructionBudgets::default(),
+        )
+        .unwrap();
+        assert_eq!(
+            resumed.shape_canonical_with_cancellation(|| false).unwrap(),
+            shape
+        );
     }
 
     #[test]

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -1673,6 +1673,12 @@ impl GraphConstructionSession {
         self.checkpoint.state
     }
 
+    /// Whether this session crossed its sole project publication commit point.
+    #[must_use]
+    pub fn publication_committed(&self) -> bool {
+        self.checkpoint.publication_state == Some(ConstructionPublicationState::Published)
+    }
+
     /// Pinned parent topology generation.
     #[must_use]
     pub const fn parent_topology_generation(&self) -> u64 {

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -10,7 +10,7 @@ use std::collections::BTreeSet;
 use std::ffi::{OsStr, OsString};
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Write};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::{LazyLock, Mutex};
 
 use arrow::array::{Array, FixedSizeBinaryArray, RecordBatch, StringArray, UInt32Array};
@@ -23,6 +23,11 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
+use crate::uuid_membership::{
+    ConstructionUuidIdentity, UuidConstructionSnapshot, UuidConstructionSnapshotWork,
+    open_uuid_construction_snapshot,
+};
+
 const FORMAT_VERSION: u32 = 2;
 const PRIVATE_ROOT: &str = ".graphforge-construction";
 const CHECKPOINT: &str = "checkpoint.json";
@@ -31,6 +36,10 @@ const BLOCK_BYTES: usize = 1 << 20;
 const MAX_CONTROL_BYTES: u64 = 64 << 10;
 const IDENTITY_WIDTH: usize = 16;
 const ENDPOINT_WIDTH: usize = 48;
+const NODE_DETAIL_WIDTH: usize = 20;
+const EDGE_DETAIL_WIDTH: usize = 304;
+const BASE_IDENTITY_WIDTH: usize = 32;
+const BASE_IDENTITIES: &str = "base-identities.run";
 
 /// Canonical node construction input: UUID and primary type id.
 pub static CONSTRUCTION_NODE_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
@@ -94,7 +103,7 @@ impl Default for GraphConstructionBudgets {
             max_batch_rows: 65_536,
             max_batch_bytes: 64 << 20,
             max_chunks: 1_000_000,
-            max_run_records: 3 * 65_536,
+            max_run_records: 4 * 65_536,
             merge_fan_in: 32,
         }
     }
@@ -105,7 +114,7 @@ impl GraphConstructionBudgets {
         if self.max_batch_rows == 0
             || self.max_batch_bytes == 0
             || self.max_chunks == 0
-            || self.max_run_records < 3 * self.max_batch_rows
+            || self.max_run_records < 4 * self.max_batch_rows
             || self.merge_fan_in < 2
         {
             return Err(storage("invalid construction budgets"));
@@ -215,6 +224,7 @@ pub struct ConstructionChunkReceipt {
     parquet: ArtifactReceipt,
     identities: ArtifactReceipt,
     endpoints: Option<ArtifactReceipt>,
+    details: ArtifactReceipt,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -229,6 +239,8 @@ struct Checkpoint {
     next_sequence: u64,
     saw_edge: bool,
     last_receipt_sha256: Option<String>,
+    base_identities: Option<ArtifactReceipt>,
+    base_work: UuidConstructionSnapshotWork,
     evidence: GraphConstructionEvidence,
 }
 
@@ -251,6 +263,7 @@ struct ChunkIntent {
     parquet: Option<ArtifactReceipt>,
     identities: Option<ArtifactReceipt>,
     endpoints: Option<ArtifactReceipt>,
+    details: Option<ArtifactReceipt>,
 }
 
 static ACTIVE_OPERATIONS: LazyLock<Mutex<BTreeSet<String>>> =
@@ -285,6 +298,7 @@ pub struct GraphConstructionSession {
     project: StableDirectory,
     root: StableDirectory,
     checkpoint: Checkpoint,
+    base_snapshot: Option<UuidConstructionSnapshot>,
     _reservation: ProcessReservation,
 }
 
@@ -331,9 +345,50 @@ impl GraphConstructionSession {
             session_identity,
         )?;
         cleanup_owned_artifact_temps(&root)?;
+        let checkpoint_exists = match root.open_child_file(OsStr::new(CHECKPOINT)) {
+            Ok(file) => {
+                drop(file);
+                true
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+            Err(error) => return Err(storage(error)),
+        };
+        if !checkpoint_exists && parent_topology_generation != 0 {
+            remove_unrecorded_base(&root)?;
+        }
+        let (base_snapshot, base_identities, base_work) = if parent_topology_generation == 0 {
+            (None, None, UuidConstructionSnapshotWork::default())
+        } else if checkpoint_exists {
+            let mut checkpoint_file = root
+                .open_child_file(OsStr::new(CHECKPOINT))
+                .map_err(storage)?;
+            let recorded: Checkpoint = decode_bounded(&mut checkpoint_file)?;
+            let receipt = recorded
+                .base_identities
+                .as_ref()
+                .ok_or_else(|| storage("nonempty parent lacks retained identity run"))?;
+            let (snapshot, work) = authenticate_base_snapshot(
+                project_dir,
+                parent_topology_generation,
+                &root,
+                receipt,
+            )?;
+            (Some(snapshot), Some(receipt.clone()), work)
+        } else {
+            let (snapshot, receipt, work) =
+                create_base_snapshot(project_dir, parent_topology_generation, &root)?;
+            (Some(snapshot), Some(receipt), work)
+        };
         let checkpoint = match root.open_child_file(OsStr::new(CHECKPOINT)) {
             Ok(mut file) => decode_bounded(&mut file)?,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                let mut evidence = GraphConstructionEvidence::default();
+                evidence.authentication_read_bytes = base_work.authentication_bytes;
+                evidence.authentication_read_operations = base_work.authentication_blocks;
+                if let Some(base) = &base_identities {
+                    evidence.write_bytes = base.bytes;
+                    evidence.write_operations = base.write_operations;
+                }
                 let initial = Checkpoint {
                     format_version: FORMAT_VERSION,
                     operation_uuid,
@@ -345,7 +400,9 @@ impl GraphConstructionSession {
                     next_sequence: 0,
                     saw_edge: false,
                     last_receipt_sha256: None,
-                    evidence: GraphConstructionEvidence::default(),
+                    base_identities,
+                    base_work,
+                    evidence,
                 };
                 install_control(&root, CHECKPOINT, &initial)?;
                 initial
@@ -364,6 +421,7 @@ impl GraphConstructionSession {
             project,
             root,
             checkpoint,
+            base_snapshot,
             _reservation: reservation,
         };
         session.recover_intent()?;
@@ -463,7 +521,8 @@ impl GraphConstructionSession {
         let run_records = arrays
             .identities
             .len()
-            .saturating_add(arrays.endpoints.len());
+            .saturating_add(arrays.endpoints.len())
+            .saturating_add(batch.num_rows());
         if run_records > self.checkpoint.budgets.max_run_records {
             return Err(storage("construction run window exhausted"));
         }
@@ -486,6 +545,7 @@ impl GraphConstructionSession {
             parquet: None,
             identities: None,
             endpoints: None,
+            details: None,
         };
         install_control(&self.root, INTENT, &intent)?;
         reject_cancelled(&mut cancelled)?;
@@ -513,6 +573,16 @@ impl GraphConstructionSession {
             replace_control(&self.root, INTENT, &intent)?;
             reject_cancelled(&mut cancelled)?;
         }
+        intent.details = Some(match &arrays.details {
+            DetailRuns::Node(records) => {
+                write_fixed_run(&self.root, &format!("{stem}.node-details.run"), records)?
+            }
+            DetailRuns::Edge(records) => {
+                write_fixed_run(&self.root, &format!("{stem}.edge-details.run"), records)?
+            }
+        });
+        replace_control(&self.root, INTENT, &intent)?;
+        reject_cancelled(&mut cancelled)?;
         let receipt = receipt_from_intent(&intent)?;
         let receipt_name = receipt_name(sequence);
         install_control(&self.root, &receipt_name, &receipt)?;
@@ -552,7 +622,7 @@ impl GraphConstructionSession {
             if receipt.prior_receipt_sha256 != prior_digest {
                 return Err(storage("receipt journal chain is discontinuous"));
             }
-            for artifact in [&receipt.parquet, &receipt.identities]
+            for artifact in [&receipt.parquet, &receipt.identities, &receipt.details]
                 .into_iter()
                 .chain(receipt.endpoints.iter())
             {
@@ -652,6 +722,7 @@ impl GraphConstructionSession {
                     intent.parquet.clone(),
                     intent.identities.clone(),
                     intent.endpoints.clone(),
+                    intent.details.clone(),
                 ]
                 .into_iter()
                 .flatten()
@@ -680,6 +751,21 @@ impl GraphConstructionSession {
                     remove_unrecorded_artifact(
                         &self.root,
                         &format!("{stem}.endpoints.run"),
+                        intent.kind,
+                        intent.rows,
+                    )?;
+                }
+                if intent.details.is_none() {
+                    remove_unrecorded_artifact(
+                        &self.root,
+                        &format!(
+                            "{stem}.{}-details.run",
+                            if intent.kind == ConstructionChunkKind::Node {
+                                "node"
+                            } else {
+                                "edge"
+                            }
+                        ),
                         intent.kind,
                         intent.rows,
                     )?;
@@ -726,7 +812,7 @@ impl GraphConstructionSession {
         evidence.peak_batch_rows = evidence.peak_batch_rows.max(receipt.rows);
         evidence.peak_batch_bytes = evidence.peak_batch_bytes.max(receipt.input_bytes);
         evidence.peak_run_records = evidence.peak_run_records.max(receipt.run_records);
-        for artifact in [&receipt.parquet, &receipt.identities]
+        for artifact in [&receipt.parquet, &receipt.identities, &receipt.details]
             .into_iter()
             .chain(receipt.endpoints.iter())
         {
@@ -755,6 +841,9 @@ impl GraphConstructionSession {
         {
             return Err(storage("retained construction authority identity changed"));
         }
+        if let Some(snapshot) = &self.base_snapshot {
+            snapshot.revalidate()?;
+        }
         Ok(())
     }
 }
@@ -771,6 +860,12 @@ struct ReceiptPointer {
 struct RunArrays {
     identities: Vec<[u8; IDENTITY_WIDTH]>,
     endpoints: Vec<[u8; ENDPOINT_WIDTH]>,
+    details: DetailRuns,
+}
+
+enum DetailRuns {
+    Node(Vec<[u8; NODE_DETAIL_WIDTH]>),
+    Edge(Vec<[u8; EDGE_DETAIL_WIDTH]>),
 }
 
 fn extract_runs(kind: ConstructionChunkKind, batch: &RecordBatch) -> Result<RunArrays, GfError> {
@@ -790,11 +885,17 @@ fn extract_runs(kind: ConstructionChunkKind, batch: &RecordBatch) -> Result<RunA
         return Err(storage("duplicate identity inside chunk"));
     }
     let mut endpoints = Vec::new();
-    if kind == ConstructionChunkKind::Edge {
+    let details = if kind == ConstructionChunkKind::Edge {
         let edges = uuid_column(batch, "edge_uuid")?;
         let src = uuid_column(batch, "src_uuid")?;
         let dst = uuid_column(batch, "dst_uuid")?;
+        let routes = batch
+            .column(3)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| storage("canonical edge route is not Utf8"))?;
         endpoints.reserve(batch.num_rows().saturating_mul(2));
+        let mut details = Vec::with_capacity(batch.num_rows());
         for row in 0..batch.num_rows() {
             let edge = uuid_value(edges, row)?;
             for (role, endpoint) in [uuid_value(src, row)?, uuid_value(dst, row)?]
@@ -807,12 +908,39 @@ fn extract_runs(kind: ConstructionChunkKind, batch: &RecordBatch) -> Result<RunA
                 record[32] = role as u8;
                 endpoints.push(record);
             }
+            let route = routes.value(row).as_bytes();
+            let mut detail = [0_u8; EDGE_DETAIL_WIDTH];
+            detail[..16].copy_from_slice(&edge);
+            detail[16..32].copy_from_slice(&uuid_value(src, row)?);
+            detail[32..48].copy_from_slice(&uuid_value(dst, row)?);
+            detail[48] = route.len() as u8;
+            detail[49..49 + route.len()].copy_from_slice(route);
+            details.push(detail);
         }
         endpoints.sort_unstable();
-    }
+        details.sort_unstable();
+        DetailRuns::Edge(details)
+    } else {
+        let nodes = uuid_column(batch, "node_uuid")?;
+        let types = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .ok_or_else(|| storage("canonical node type is not UInt32"))?;
+        let mut details = Vec::with_capacity(batch.num_rows());
+        for row in 0..batch.num_rows() {
+            let mut detail = [0_u8; NODE_DETAIL_WIDTH];
+            detail[..16].copy_from_slice(&uuid_value(nodes, row)?);
+            detail[16..20].copy_from_slice(&types.value(row).to_be_bytes());
+            details.push(detail);
+        }
+        details.sort_unstable();
+        DetailRuns::Node(details)
+    };
     Ok(RunArrays {
         identities,
         endpoints,
+        details,
     })
 }
 
@@ -1022,6 +1150,117 @@ fn write_fixed_run<const N: usize>(
     Ok(receipt)
 }
 
+fn encode_base_identity(identity: ConstructionUuidIdentity) -> [u8; BASE_IDENTITY_WIDTH] {
+    let mut record = [0_u8; BASE_IDENTITY_WIDTH];
+    record[..16].copy_from_slice(identity.uuid.as_bytes());
+    record[16] = match identity.kind {
+        crate::uuid_membership::UuidIndexKind::Node => 0,
+        crate::uuid_membership::UuidIndexKind::Edge => 1,
+    };
+    record[24..].copy_from_slice(&identity.surrogate.to_be_bytes());
+    record
+}
+
+fn create_base_snapshot(
+    project_dir: &Path,
+    generation: u64,
+    root: &StableDirectory,
+) -> Result<
+    (
+        UuidConstructionSnapshot,
+        ArtifactReceipt,
+        UuidConstructionSnapshotWork,
+    ),
+    GfError,
+> {
+    let temporary = artifact_temp(BASE_IDENTITIES);
+    let file = root
+        .create_replaceable_child_file(OsStr::new(&temporary))
+        .map_err(storage)?;
+    let identity = file_identity(&file).map_err(storage)?;
+    let mut writer = HashingWriter::new(file);
+    let records_per_block = (BLOCK_BYTES / BASE_IDENTITY_WIDTH).max(1);
+    let block_bytes = records_per_block * BASE_IDENTITY_WIDTH;
+    let mut block = Vec::with_capacity(block_bytes);
+    let (snapshot, work) = open_uuid_construction_snapshot(project_dir, generation, |value| {
+        block.extend_from_slice(&encode_base_identity(value));
+        if block.len() == block_bytes {
+            writer.write_all(&block).map_err(storage)?;
+            block.clear();
+        }
+        Ok(())
+    })?;
+    if !block.is_empty() {
+        writer.write_all(&block).map_err(storage)?;
+    }
+    writer.flush().map_err(storage)?;
+    writer.inner.sync_all().map_err(storage)?;
+    let receipt = ArtifactReceipt {
+        name: BASE_IDENTITIES.to_owned(),
+        bytes: writer.bytes,
+        sha256: hex(&writer.digest.finalize()),
+        identity: identity.into(),
+        write_operations: writer.operations,
+    };
+    root.sync().map_err(storage)?;
+    root.install_child(
+        OsStr::new(&temporary),
+        identity,
+        OsStr::new(BASE_IDENTITIES),
+    )
+    .map_err(storage)?;
+    root.sync().map_err(storage)?;
+    Ok((snapshot, receipt, work))
+}
+
+fn authenticate_base_snapshot(
+    project_dir: &Path,
+    generation: u64,
+    root: &StableDirectory,
+    receipt: &ArtifactReceipt,
+) -> Result<(UuidConstructionSnapshot, UuidConstructionSnapshotWork), GfError> {
+    let mut retained = BufReader::with_capacity(
+        BLOCK_BYTES,
+        root.open_child_file(OsStr::new(BASE_IDENTITIES))
+            .map_err(storage)?,
+    );
+    let (snapshot, work) = open_uuid_construction_snapshot(project_dir, generation, |value| {
+        let mut record = [0_u8; BASE_IDENTITY_WIDTH];
+        retained.read_exact(&mut record).map_err(storage)?;
+        if record != encode_base_identity(value) {
+            return Err(storage(
+                "retained base identities differ from parent UUID authority",
+            ));
+        }
+        Ok(())
+    })?;
+    let mut trailing = [0_u8; 1];
+    if retained.read(&mut trailing).map_err(storage)? != 0 {
+        return Err(storage("retained base identities have trailing records"));
+    }
+    authenticate_artifact(root, receipt)?;
+    Ok((snapshot, work))
+}
+
+fn remove_unrecorded_base(root: &StableDirectory) -> Result<(), GfError> {
+    let mut file = match root.open_child_file(OsStr::new(BASE_IDENTITIES)) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(storage(error)),
+    };
+    let identity = file_identity(&file).map_err(storage)?;
+    if file_link_count(&file).map_err(storage)? != 1
+        || file.metadata().map_err(storage)?.len() % BASE_IDENTITY_WIDTH as u64 != 0
+    {
+        return Err(storage("unrecorded base identity run is not session-owned"));
+    }
+    validate_sorted_run(&mut file, BASE_IDENTITY_WIDTH)?;
+    drop(file);
+    root.unlink_child_if_identity(OsStr::new(BASE_IDENTITIES), identity)
+        .map_err(storage)?;
+    root.sync().map_err(storage)
+}
+
 #[derive(Clone, Copy)]
 struct ReadWork {
     bytes: u64,
@@ -1049,9 +1288,17 @@ fn authenticate_artifact(
     let mut bytes = 0_u64;
     let mut operations = 0_u64;
     let width = if receipt.name.ends_with(".identities.run") {
-        Some(IDENTITY_WIDTH)
+        Some(if receipt.name == BASE_IDENTITIES {
+            BASE_IDENTITY_WIDTH
+        } else {
+            IDENTITY_WIDTH
+        })
     } else if receipt.name.ends_with(".endpoints.run") {
         Some(ENDPOINT_WIDTH)
+    } else if receipt.name.ends_with(".node-details.run") {
+        Some(NODE_DETAIL_WIDTH)
+    } else if receipt.name.ends_with(".edge-details.run") {
+        Some(EDGE_DETAIL_WIDTH)
     } else {
         None
     };
@@ -1080,6 +1327,20 @@ fn authenticate_artifact(
                 {
                     return Err(storage("endpoint run record is malformed"));
                 }
+                if width == EDGE_DETAIL_WIDTH {
+                    let route_len = record[48] as usize;
+                    if route_len == 0 || record[49 + route_len..].iter().any(|byte| *byte != 0) {
+                        return Err(storage("edge detail run record is malformed"));
+                    }
+                }
+                if width == BASE_IDENTITY_WIDTH
+                    && (!matches!(record[16], 0 | 1)
+                        || record[17..24].iter().any(|byte| *byte != 0)
+                        || (record[16] == 0 && record[24..].iter().all(|byte| *byte == 0))
+                        || (record[16] == 1 && record[24..].iter().any(|byte| *byte != 0)))
+                {
+                    return Err(storage("base identity run record is malformed"));
+                }
                 previous = Some(record.to_vec());
             }
             pending.drain(..complete);
@@ -1097,7 +1358,10 @@ fn authenticate_artifact(
 fn validate_artifact_name(receipt: &ArtifactReceipt) -> Result<(), GfError> {
     let valid_suffix = receipt.name.ends_with(".parquet")
         || receipt.name.ends_with(".identities.run")
-        || receipt.name.ends_with(".endpoints.run");
+        || receipt.name.ends_with(".endpoints.run")
+        || receipt.name.ends_with(".node-details.run")
+        || receipt.name.ends_with(".edge-details.run")
+        || receipt.name == BASE_IDENTITIES;
     if !valid_suffix
         || receipt.name.starts_with('.')
         || receipt.name.contains('/')
@@ -1110,16 +1374,32 @@ fn validate_artifact_name(receipt: &ArtifactReceipt) -> Result<(), GfError> {
             .file_id
             .bytes()
             .all(|byte| byte.is_ascii_hexdigit())
-        || receipt.bytes == 0
-        || receipt.write_operations == 0
+        || ((receipt.bytes == 0 || receipt.write_operations == 0)
+            && receipt.name != BASE_IDENTITIES)
     {
         return Err(storage("invalid construction artifact receipt"));
     }
-    if receipt.name.ends_with(".identities.run") && receipt.bytes % IDENTITY_WIDTH as u64 != 0 {
+    if receipt.name.ends_with(".identities.run")
+        && receipt.bytes
+            % if receipt.name == BASE_IDENTITIES {
+                BASE_IDENTITY_WIDTH as u64
+            } else {
+                IDENTITY_WIDTH as u64
+            }
+            != 0
+    {
         return Err(storage("truncated identity run"));
     }
     if receipt.name.ends_with(".endpoints.run") && receipt.bytes % ENDPOINT_WIDTH as u64 != 0 {
         return Err(storage("truncated endpoint run"));
+    }
+    if receipt.name.ends_with(".node-details.run") && receipt.bytes % NODE_DETAIL_WIDTH as u64 != 0
+    {
+        return Err(storage("truncated node detail run"));
+    }
+    if receipt.name.ends_with(".edge-details.run") && receipt.bytes % EDGE_DETAIL_WIDTH as u64 != 0
+    {
+        return Err(storage("truncated edge detail run"));
     }
     Ok(())
 }
@@ -1147,6 +1427,10 @@ fn receipt_from_intent(intent: &ChunkIntent) -> Result<ConstructionChunkReceipt,
             .clone()
             .ok_or_else(|| storage("intent lacks identity run"))?,
         endpoints: intent.endpoints.clone(),
+        details: intent
+            .details
+            .clone()
+            .ok_or_else(|| storage("intent lacks detail run"))?,
     })
 }
 
@@ -1170,15 +1454,25 @@ fn validate_receipt_semantics(
         || receipt.parquet.name != format!("{}.parquet", artifact_stem(sequence, receipt.kind))
         || receipt.identities.name
             != format!("{}.identities.run", artifact_stem(sequence, receipt.kind))
+        || receipt.details.name
+            != format!(
+                "{}.{}-details.run",
+                artifact_stem(sequence, receipt.kind),
+                if receipt.kind == ConstructionChunkKind::Node {
+                    "node"
+                } else {
+                    "edge"
+                }
+            )
         || (receipt.kind == ConstructionChunkKind::Node && receipt.endpoints.is_some())
         || (receipt.kind == ConstructionChunkKind::Edge && receipt.endpoints.is_none())
         || receipt.identities.bytes / IDENTITY_WIDTH as u64 != receipt.rows
         || receipt.run_records
             != receipt.rows
                 * if receipt.kind == ConstructionChunkKind::Edge {
-                    3
+                    4
                 } else {
-                    1
+                    2
                 }
     {
         return Err(storage("receipt semantics are inconsistent"));
@@ -1189,8 +1483,17 @@ fn validate_receipt_semantics(
     {
         return Err(storage("endpoint receipt semantics are inconsistent"));
     }
+    let detail_width = if receipt.kind == ConstructionChunkKind::Node {
+        NODE_DETAIL_WIDTH
+    } else {
+        EDGE_DETAIL_WIDTH
+    };
+    if receipt.details.bytes / detail_width as u64 != receipt.rows {
+        return Err(storage("detail receipt semantics are inconsistent"));
+    }
     validate_artifact_name(&receipt.parquet)?;
     validate_artifact_name(&receipt.identities)?;
+    validate_artifact_name(&receipt.details)?;
     if let Some(endpoints) = &receipt.endpoints {
         validate_artifact_name(endpoints)?;
     }
@@ -1201,7 +1504,7 @@ fn validate_receipt_artifacts(
     root: &StableDirectory,
     receipt: &ConstructionChunkReceipt,
 ) -> Result<(), GfError> {
-    for artifact in [&receipt.parquet, &receipt.identities]
+    for artifact in [&receipt.parquet, &receipt.identities, &receipt.details]
         .into_iter()
         .chain(receipt.endpoints.iter())
     {
@@ -1244,9 +1547,9 @@ fn validate_intent(intent: &ChunkIntent, checkpoint: &Checkpoint) -> Result<(), 
         intent
             .rows
             .saturating_mul(if intent.kind == ConstructionChunkKind::Edge {
-                3
+                4
             } else {
-                1
+                2
             });
     if intent.format_version != FORMAT_VERSION
         || intent.operation_uuid != checkpoint.operation_uuid
@@ -1285,6 +1588,25 @@ fn validate_intent(intent: &ChunkIntent, checkpoint: &Checkpoint) -> Result<(), 
                         .saturating_mul(2)
                         .saturating_mul(ENDPOINT_WIDTH as u64)
         })
+        || intent.details.as_ref().is_some_and(|artifact| {
+            artifact.name
+                != format!(
+                    "{stem}.{}-details.run",
+                    if intent.kind == ConstructionChunkKind::Node {
+                        "node"
+                    } else {
+                        "edge"
+                    }
+                )
+                || artifact.bytes
+                    != intent
+                        .rows
+                        .saturating_mul(if intent.kind == ConstructionChunkKind::Node {
+                            NODE_DETAIL_WIDTH
+                        } else {
+                            EDGE_DETAIL_WIDTH
+                        } as u64)
+        })
     {
         return Err(storage("durable intent is inconsistent with checkpoint"));
     }
@@ -1305,6 +1627,7 @@ fn validate_checkpoint(
         || !checkpoint.session_identity.matches(session)
         || checkpoint.parent_topology_generation != generation
         || checkpoint.budgets != budgets
+        || checkpoint.base_identities.is_some() != (generation != 0)
         || checkpoint.next_sequence > budgets.max_chunks
         || checkpoint.last_receipt_sha256.is_some() != (checkpoint.next_sequence != 0)
         || checkpoint
@@ -1322,6 +1645,18 @@ fn validate_checkpoint(
         || checkpoint.evidence.current_transitions != 0
     {
         return Err(storage("checkpoint authority or resume parameters changed"));
+    }
+    if let Some(base) = &checkpoint.base_identities {
+        validate_artifact_name(base)?;
+        if base.name != BASE_IDENTITIES
+            || base.bytes / BASE_IDENTITY_WIDTH as u64
+                != checkpoint
+                    .base_work
+                    .live_nodes
+                    .saturating_add(checkpoint.base_work.live_edges)
+        {
+            return Err(storage("checkpoint base identity receipt is inconsistent"));
+        }
     }
     Ok(())
 }
@@ -1416,6 +1751,9 @@ fn is_owned_artifact_temp(name: &str) -> bool {
 }
 
 fn canonical_artifact_target(name: &str) -> bool {
+    if name == BASE_IDENTITIES {
+        return true;
+    }
     let Some(body) = name.strip_prefix("chunk-") else {
         return false;
     };
@@ -1431,6 +1769,8 @@ fn canonical_artifact_target(name: &str) -> bool {
                 | "edge.parquet"
                 | "edge.identities.run"
                 | "edge.endpoints.run"
+                | "node.node-details.run"
+                | "edge.edge-details.run"
         )
 }
 
@@ -1559,6 +1899,10 @@ fn remove_unrecorded_artifact(
             IDENTITY_WIDTH
         } else if name.ends_with(".endpoints.run") {
             ENDPOINT_WIDTH
+        } else if name.ends_with(".node-details.run") {
+            NODE_DETAIL_WIDTH
+        } else if name.ends_with(".edge-details.run") {
+            EDGE_DETAIL_WIDTH
         } else {
             return Err(storage("unrecorded artifact name is not canonical"));
         };
@@ -1596,6 +1940,16 @@ fn validate_sorted_run(file: &mut File, width: usize) -> Result<(), GfError> {
                 .is_some_and(|prior| prior.as_slice() >= record)
                 || (width == ENDPOINT_WIDTH
                     && (!matches!(record[32], 0 | 1) || record[33..].iter().any(|byte| *byte != 0)))
+                || (width == EDGE_DETAIL_WIDTH
+                    && (record[48] == 0
+                        || record[49 + record[48] as usize..]
+                            .iter()
+                            .any(|byte| *byte != 0)))
+                || (width == BASE_IDENTITY_WIDTH
+                    && (!matches!(record[16], 0 | 1)
+                        || record[17..24].iter().any(|byte| *byte != 0)
+                        || (record[16] == 0 && record[24..].iter().all(|byte| *byte == 0))
+                        || (record[16] == 1 && record[24..].iter().any(|byte| *byte != 0))))
             {
                 return Err(storage("unrecorded fixed run is malformed"));
             }
@@ -1777,7 +2131,7 @@ mod tests {
             assert_eq!(session.accepted_chunks(), chunks);
             assert_eq!(session.evidence().input_rows, chunks * 32);
             assert_eq!(session.evidence().peak_batch_rows, 32);
-            assert_eq!(session.evidence().peak_run_records, 32);
+            assert_eq!(session.evidence().peak_run_records, 64);
             assert_eq!(session.evidence().prior_topology_rows_decoded, 0);
             assert_eq!(session.evidence().current_transitions, 0);
             let checkpoint_bytes = session

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -919,6 +919,24 @@ impl GraphConstructionSession {
         target_generation_uuid: Uuid,
         transaction_uuid: Uuid,
     ) -> Result<crate::ProjectPublicationReceipt, GfError> {
+        self.publish_canonical_with_cancellation(
+            encoding,
+            target_generation_uuid,
+            transaction_uuid,
+            || false,
+        )
+    }
+
+    /// Publish while polling cancellation through the final pre-`CURRENT` boundary.
+    #[allow(clippy::too_many_lines)]
+    pub fn publish_canonical_with_cancellation(
+        &mut self,
+        encoding: &GraphConstructionEncoding,
+        target_generation_uuid: Uuid,
+        transaction_uuid: Uuid,
+        mut cancelled: impl FnMut() -> bool,
+    ) -> Result<crate::ProjectPublicationReceipt, GfError> {
+        reject_cancelled(&mut cancelled)?;
         if self.checkpoint.publication_state == Some(ConstructionPublicationState::Published) {
             let published =
                 crate::published_project_transaction(&self.project_path, transaction_uuid)?
@@ -1100,7 +1118,7 @@ impl GraphConstructionSession {
             )? {
                 crate::ProjectStageOutcome::Staged(staged) => staged
                     .validate(|_| Ok(()), |_, _| Ok(()))?
-                    .publish_with_graph_objects(&lease)?,
+                    .publish_with_graph_objects_cancellable(&lease, &mut cancelled)?,
                 crate::ProjectStageOutcome::AlreadyPublished(receipt) => receipt,
             };
         construction_failpoint("publication.after_current_before_receipt");

--- a/crates/graphforge-storage/src/graph_construction_encoding.rs
+++ b/crates/graphforge-storage/src/graph_construction_encoding.rs
@@ -4,7 +4,8 @@
 //! It converts the shaper's authenticated, UUID-ordered streams into the exact
 //! ordinary storage schemas and prepares a streamed UUID-membership manifest.
 
-use std::collections::BTreeMap;
+use std::cmp::Reverse;
+use std::collections::{BTreeMap, BinaryHeap};
 use std::ffi::OsStr;
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Seek, Write};
@@ -22,15 +23,25 @@ use graphforge_core::GfError;
 use graphforge_core::OntologyMode;
 use graphforge_filesystem::{StableDirectory, file_identity};
 use graphforge_ir::runtime_entity_type_id;
+use graphforge_ir::{CompositionBindingContext, SymbolBinding};
+use graphforge_ontology::{QualifiedSymbol, SymbolKind};
 use parquet::arrow::ArrowWriter;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
-use crate::graph_construction::{ConstructionShape, GraphConstructionBudgets};
-use crate::schemas::{TOPOLOGY_NODES_SCHEMA, TYPED_EDGE_SCHEMA, uuid_field};
-use crate::uuid_membership::{AuthenticatedUuidIndexSnapshot, ConstructionIndexOutput};
+use crate::graph_construction::{
+    ConstructionSemanticAuthority, ConstructionShape, CountingChunkReader,
+    GraphConstructionBudgets, IoCounter,
+};
+use crate::schemas::{
+    TOPOLOGY_NODES_SCHEMA, TYPED_EDGE_SCHEMA, uuid_field, with_semantic_route_metadata,
+};
+use crate::uuid_membership::{
+    AuthenticatedUuidIndexSnapshot, ConstructionIndexOutput, ConstructionIndexReference,
+};
+use crate::{SemanticRouteKind, SemanticStorageBindings};
 
 const ENCODED_ROOT: &str = "encoded-v1";
 const INVENTORY: &str = "inventory.json";
@@ -40,6 +51,179 @@ const NODE_DETAIL_WIDTH: usize = 272;
 const EDGE_DETAIL_WIDTH: usize = 304;
 const RESOLVED_ENDPOINT_WIDTH: usize = 32;
 const COPY_BUFFER_BYTES: usize = 1 << 20;
+
+struct CountingWriter {
+    inner: File,
+    counter: IoCounter,
+}
+
+struct CountingInput<R> {
+    inner: R,
+    counter: IoCounter,
+}
+
+impl<R: Read> Read for CountingInput<R> {
+    fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        let read = self.inner.read(buffer)?;
+        self.counter.account(read);
+        Ok(read)
+    }
+}
+
+impl Write for CountingWriter {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        let written = self.inner.write(buffer)?;
+        self.counter.account(written);
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+struct EncodingRowCursor {
+    reader: Box<dyn Iterator<Item = Result<RecordBatch, arrow::error::ArrowError>>>,
+    batch: Option<RecordBatch>,
+    row: usize,
+    batch_sequence: u64,
+    counter: IoCounter,
+    counter_accounted: bool,
+}
+
+impl EncodingRowCursor {
+    fn current_uuid(
+        &mut self,
+        uuid_name: &str,
+        evidence: &mut GraphConstructionEncodingEvidence,
+    ) -> Result<Option<[u8; 16]>, GfError> {
+        loop {
+            if let Some(batch) = &self.batch
+                && self.row < batch.num_rows()
+            {
+                let values = required_uuid(batch, uuid_name)?;
+                return Ok(Some(values.value(self.row).try_into().expect("fixed UUID")));
+            }
+            self.batch = self.reader.next().transpose().map_err(storage)?;
+            self.row = 0;
+            self.batch_sequence = self.batch_sequence.saturating_add(1);
+            if self.batch.is_none() {
+                if !self.counter_accounted {
+                    let (bytes, operations) = self.counter.values();
+                    evidence.input_read_bytes = evidence.input_read_bytes.saturating_add(bytes);
+                    evidence.input_read_operations =
+                        evidence.input_read_operations.saturating_add(operations);
+                    self.counter_accounted = true;
+                }
+                return Ok(None);
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+struct MergedEncodingRow {
+    source: usize,
+    batch_sequence: u64,
+    batch: RecordBatch,
+    row: usize,
+}
+
+type EncodingRowHeap = BinaryHeap<(Reverse<[u8; 16]>, Reverse<usize>)>;
+
+fn open_merged_rows(
+    source: &StableDirectory,
+    names: &[String],
+    uuid_name: &str,
+    budgets: GraphConstructionBudgets,
+    evidence: &mut GraphConstructionEncodingEvidence,
+) -> Result<(Vec<EncodingRowCursor>, EncodingRowHeap), GfError> {
+    if names.len() > budgets.max_schema_groups {
+        return Err(storage(
+            "encoded schema registry exceeds its cardinality cap",
+        ));
+    }
+    let mut cursors = Vec::with_capacity(names.len());
+    for name in names {
+        let file = source.open_child_file(OsStr::new(name)).map_err(storage)?;
+        let counter = IoCounter::default();
+        let reader = ParquetRecordBatchReaderBuilder::try_new(CountingChunkReader {
+            file,
+            counter: counter.clone(),
+        })
+        .map_err(storage)?
+        .with_batch_size(budgets.max_batch_rows)
+        .build()
+        .map_err(storage)?;
+        cursors.push(EncodingRowCursor {
+            reader: Box::new(reader),
+            batch: None,
+            row: 0,
+            batch_sequence: 0,
+            counter,
+            counter_accounted: false,
+        });
+    }
+    let mut heap = BinaryHeap::new();
+    for (index, cursor) in cursors.iter_mut().enumerate() {
+        if let Some(uuid) = cursor.current_uuid(uuid_name, evidence)? {
+            heap.push((Reverse(uuid), Reverse(index)));
+        }
+    }
+    Ok((cursors, heap))
+}
+
+fn next_merged_window(
+    cursors: &mut [EncodingRowCursor],
+    heap: &mut BinaryHeap<(Reverse<[u8; 16]>, Reverse<usize>)>,
+    uuid_name: &str,
+    budgets: GraphConstructionBudgets,
+    cancelled: &mut impl FnMut() -> bool,
+    evidence: &mut GraphConstructionEncodingEvidence,
+) -> Result<Vec<MergedEncodingRow>, GfError> {
+    let mut rows = Vec::with_capacity(budgets.max_batch_rows);
+    let mut retained_bytes = 0_usize;
+    let mut previous = None;
+    while rows.len() < budgets.max_batch_rows {
+        let Some((Reverse(uuid), Reverse(source))) = heap.pop() else {
+            break;
+        };
+        if previous.is_some_and(|prior| prior >= uuid) {
+            return Err(storage(
+                "heterogeneous row streams are not globally unique and sorted",
+            ));
+        }
+        previous = Some(uuid);
+        let cursor = &mut cursors[source];
+        let batch = cursor.batch.as_ref().expect("heap row has batch");
+        if rows.iter().all(|row: &MergedEncodingRow| {
+            row.source != source || row.batch_sequence != cursor.batch_sequence
+        }) {
+            account_batch(batch, budgets, evidence)?;
+            retained_bytes = retained_bytes.saturating_add(batch.get_array_memory_size());
+            if !rows.is_empty() && retained_bytes > budgets.max_batch_bytes {
+                heap.push((Reverse(uuid), Reverse(source)));
+                break;
+            }
+        }
+        rows.push(MergedEncodingRow {
+            source,
+            batch_sequence: cursor.batch_sequence,
+            batch: batch.clone(),
+            row: cursor.row,
+        });
+        cursor.row += 1;
+        if let Some(next) = cursor.current_uuid(uuid_name, evidence)? {
+            heap.push((Reverse(next), Reverse(source)));
+        }
+        if rows.len().is_multiple_of(4096) && cancelled() {
+            return Err(storage("construction encoding cancelled"));
+        }
+    }
+    evidence.peak_batch_rows = evidence.peak_batch_rows.max(rows.len() as u64);
+    evidence.peak_batch_bytes = evidence.peak_batch_bytes.max(retained_bytes as u64);
+    Ok(rows)
+}
 
 fn storage(error: impl std::fmt::Display) -> GfError {
     GfError::Storage(format!("graph construction encoding: {error}"))
@@ -54,6 +238,31 @@ pub struct ConstructionEncodedArtifact {
     pub bytes: u64,
     /// Lowercase SHA-256 of the file.
     pub sha256: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+/// Exact authenticated parent object that a publisher must structurally retain.
+pub struct ConstructionRetainedArtifact {
+    /// Stable authenticated parent directory supplied to the publisher.
+    pub source_root: String,
+    /// Device identity of the authenticated parent directory.
+    pub source_root_volume: u64,
+    /// File identity of the authenticated parent directory.
+    pub source_root_file_id: String,
+    /// Parent-root-relative immutable object name.
+    pub source_path: String,
+    /// Device identity of the retained immutable object.
+    pub source_volume: u64,
+    /// File identity of the retained immutable object.
+    pub source_file_id: String,
+    /// Generation-root-relative target name for structural installation.
+    pub target_path: String,
+    /// Exact retained object length.
+    pub bytes: u64,
+    /// Exact retained object digest.
+    pub sha256: String,
+    /// Authenticated parent index manifest that authorized this reference.
+    pub parent_manifest_sha256: String,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -87,6 +296,20 @@ pub struct GraphConstructionEncodingEvidence {
     pub retained_index_runs: u64,
     /// Retained v3 payload bytes read only for required binary-carry compaction.
     pub retained_index_payload_bytes: u64,
+    /// Actual block reads performed by v3 construction encoding and carry.
+    pub membership_read_operations: u64,
+    /// Actual block writes, including outputs superseded by carry.
+    pub membership_write_operations: u64,
+    /// All v3 bytes written, including superseded carry inputs.
+    pub membership_total_write_bytes: u64,
+    /// v3 durability barriers.
+    pub membership_fsync_operations: u64,
+    /// Newly created immutable v3 runs, including superseded carry inputs.
+    pub membership_created_runs: u64,
+    /// Peak live v3 transform/merge buffer bytes.
+    pub membership_peak_buffer_bytes: u64,
+    /// Peak bytes in owned temporary v3 outputs.
+    pub membership_peak_temporary_bytes: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -98,20 +321,26 @@ pub struct GraphConstructionEncoding {
     pub generation: u64,
     /// Physical routing authority pinned by the construction checkpoint.
     pub ontology_mode: OntologyMode,
+    /// Exact compiled composition/physical binding authority, when present.
+    pub semantic_authority_sha256: Option<String>,
     /// Shaper authority digest for normalized catalog inputs.
     pub shape_inputs_sha256: String,
     /// Sorted, unique canonical artifact records.
     pub artifacts: Vec<ConstructionEncodedArtifact>,
+    /// Authenticated retained-parent objects required to assemble this graph.
+    pub retained_artifacts: Vec<ConstructionRetainedArtifact>,
     /// Measured bounded work.
     pub evidence: GraphConstructionEncodingEvidence,
 }
 
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 pub(crate) fn encode(
     source: &StableDirectory,
     shape: &ConstructionShape,
     generation: u64,
     ontology_mode: OntologyMode,
     parent_index: Option<&AuthenticatedUuidIndexSnapshot>,
+    semantic_authority: Option<&ConstructionSemanticAuthority>,
     budgets: GraphConstructionBudgets,
     cancelled: &mut impl FnMut() -> bool,
 ) -> Result<GraphConstructionEncoding, GfError> {
@@ -119,6 +348,12 @@ pub(crate) fn encode(
         return Err(storage(
             "shape ontology mode differs from session authority",
         ));
+    }
+    let semantic_digest = semantic_authority
+        .map(ConstructionSemanticAuthority::digest)
+        .transpose()?;
+    if shape.semantic_authority_sha256 != semantic_digest {
+        return Err(storage("shape semantic authority differs from session"));
     }
     if generation == 0 || generation <= shape.parent_topology_generation {
         return Err(storage("encoded generation is not newer than its parent"));
@@ -133,6 +368,7 @@ pub(crate) fn encode(
         authenticate_inventory(&output, &existing)?;
         if existing.generation != generation
             || existing.ontology_mode != shape.ontology_mode
+            || existing.semantic_authority_sha256 != shape.semantic_authority_sha256
             || existing.shape_inputs_sha256 != shape.runtime_catalog_inputs_sha256
         {
             return Err(storage("completed encoding belongs to another generation"));
@@ -140,12 +376,15 @@ pub(crate) fn encode(
         return Ok(existing);
     }
 
-    let label_ids = read_runtime_label_ids(source, &shape.runtime_catalog, budgets)?;
-    let mut artifacts = Vec::new();
     let mut evidence = GraphConstructionEncodingEvidence {
         peak_open_writers: 1,
         ..Default::default()
     };
+    let label_ids = read_runtime_label_ids(source, &shape.runtime_catalog, budgets, &mut evidence)?;
+    let semantic_context = semantic_authority
+        .map(ConstructionSemanticAuthority::context)
+        .transpose()?;
+    let mut artifacts = Vec::new();
 
     encode_nodes(
         source,
@@ -153,6 +392,8 @@ pub(crate) fn encode(
         shape,
         &label_ids,
         ontology_mode,
+        semantic_context.as_ref(),
+        semantic_authority.map(|authority| &authority.bindings),
         budgets,
         cancelled,
         &mut artifacts,
@@ -163,6 +404,8 @@ pub(crate) fn encode(
         &output,
         shape,
         ontology_mode,
+        semantic_context.as_ref(),
+        semantic_authority.map(|authority| &authority.bindings),
         budgets,
         cancelled,
         &mut artifacts,
@@ -197,8 +440,20 @@ pub(crate) fn encode(
     )?;
     evidence.membership_records = index.input_records;
     evidence.membership_write_bytes = index.write_bytes;
+    evidence.membership_total_write_bytes = index.write_bytes;
+    evidence.membership_read_operations = index.read_operations;
+    evidence.membership_write_operations = index.write_operations;
+    evidence.membership_fsync_operations = index.fsync_operations;
+    evidence.membership_created_runs = index.created_runs;
+    evidence.membership_peak_buffer_bytes = index.peak_buffer_bytes;
+    evidence.membership_peak_temporary_bytes = index.peak_temporary_bytes;
     evidence.retained_index_runs = index.retained_runs;
     evidence.retained_index_payload_bytes = index.retained_payload_bytes;
+    let retained_artifacts = index
+        .retained_references
+        .into_iter()
+        .map(retained_artifact)
+        .collect();
     artifacts.extend(index.artifacts.into_iter().map(index_artifact));
 
     artifacts.sort_unstable_by(|left, right| left.path.cmp(&right.path));
@@ -212,13 +467,30 @@ pub(crate) fn encode(
         root: ENCODED_ROOT.to_owned(),
         generation,
         ontology_mode: shape.ontology_mode,
+        semantic_authority_sha256: shape.semantic_authority_sha256.clone(),
         shape_inputs_sha256: shape.runtime_catalog_inputs_sha256.clone(),
         artifacts,
+        retained_artifacts,
         evidence,
     };
     install_json(&output, INVENTORY, &completed)?;
     authenticate_inventory(&output, &completed)?;
     Ok(completed)
+}
+
+fn retained_artifact(value: ConstructionIndexReference) -> ConstructionRetainedArtifact {
+    ConstructionRetainedArtifact {
+        source_root: value.source_root,
+        source_root_volume: value.source_root_volume,
+        source_root_file_id: value.source_root_file_id,
+        source_path: value.source_path,
+        source_volume: value.source_volume,
+        source_file_id: value.source_file_id,
+        target_path: value.target_path,
+        bytes: value.bytes,
+        sha256: value.sha256,
+        parent_manifest_sha256: value.parent_manifest_sha256,
+    }
 }
 
 fn index_artifact(value: ConstructionIndexOutput) -> ConstructionEncodedArtifact {
@@ -229,6 +501,113 @@ fn index_artifact(value: ConstructionIndexOutput) -> ConstructionEncodedArtifact
     }
 }
 
+#[derive(Clone)]
+struct ResolvedOwner {
+    input: String,
+    symbol: Option<QualifiedSymbol>,
+    topology_route: String,
+    storage_id: Option<u32>,
+}
+
+fn resolve_owner(
+    context: Option<&CompositionBindingContext>,
+    bindings: Option<&SemanticStorageBindings>,
+    symbol_kind: SymbolKind,
+    route_kind: SemanticRouteKind,
+    input: &str,
+    runtime_route: &str,
+) -> Result<ResolvedOwner, GfError> {
+    let (Some(context), Some(bindings)) = (context, bindings) else {
+        return Ok(ResolvedOwner {
+            input: input.to_owned(),
+            symbol: None,
+            topology_route: runtime_route.to_owned(),
+            storage_id: None,
+        });
+    };
+    let (binding, _) = context
+        .resolve(symbol_kind, input)
+        .map_err(|error| storage(format!("semantic owner resolution failed: {error:?}")))?;
+    match binding {
+        SymbolBinding::Runtime { .. } => Ok(ResolvedOwner {
+            input: input.to_owned(),
+            symbol: None,
+            topology_route: runtime_route.to_owned(),
+            storage_id: None,
+        }),
+        SymbolBinding::Qualified(symbol) => {
+            let physical = bindings
+                .bindings
+                .iter()
+                .find(|candidate| candidate.route_kind == route_kind && candidate.symbol == symbol)
+                .ok_or_else(|| storage("qualified owner lacks physical semantic binding"))?;
+            Ok(ResolvedOwner {
+                input: input.to_owned(),
+                symbol: Some(symbol),
+                topology_route: physical.route.clone(),
+                storage_id: Some(physical.storage_id),
+            })
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn property_projection(
+    input: &RecordBatch,
+    required: usize,
+    indexes: &[u32],
+    owner: &ResolvedOwner,
+    owner_kind: SymbolKind,
+    route_kind: SemanticRouteKind,
+    context: Option<&CompositionBindingContext>,
+    bindings: Option<&SemanticStorageBindings>,
+) -> Result<(String, Vec<usize>), GfError> {
+    let mut fields = Vec::new();
+    let mut route = None;
+    for column_index in required..input.num_columns() {
+        let column = input.column(column_index);
+        if !indexes.iter().any(|index| !column.is_null(*index as usize)) {
+            continue;
+        }
+        if let (Some(context), Some(bindings), Some(owner_symbol)) =
+            (context, bindings, owner.symbol.as_ref())
+        {
+            let schema = input.schema();
+            let field = schema.field(column_index);
+            let (binding, _) = context
+                .resolve_owned_property(owner_kind, &owner.input, field.name())
+                .map_err(|error| {
+                    storage(format!("semantic property resolution failed: {error:?}"))
+                })?;
+            let SymbolBinding::Qualified(symbol) = binding else {
+                return Err(storage(
+                    "qualified owner property resolved to runtime authority",
+                ));
+            };
+            let physical = bindings
+                .bindings
+                .iter()
+                .find(|candidate| {
+                    candidate.route_kind == route_kind
+                        && candidate.symbol == symbol
+                        && candidate.owner.as_ref() == Some(owner_symbol)
+                })
+                .ok_or_else(|| storage("qualified property lacks owner-bound physical route"))?;
+            if route.as_ref().is_some_and(|known| known != &physical.route) {
+                return Err(storage(
+                    "one semantic owner maps to multiple property routes",
+                ));
+            }
+            route = Some(physical.route.clone());
+        }
+        fields.push(column_index);
+    }
+    Ok((
+        route.unwrap_or_else(|| owner.topology_route.clone()),
+        fields,
+    ))
+}
+
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 fn encode_nodes(
     source: &StableDirectory,
@@ -236,47 +615,50 @@ fn encode_nodes(
     shape: &ConstructionShape,
     label_ids: &BTreeMap<String, u32>,
     ontology_mode: OntologyMode,
+    semantic_context: Option<&CompositionBindingContext>,
+    semantic_bindings: Option<&SemanticStorageBindings>,
     budgets: GraphConstructionBudgets,
     cancelled: &mut impl FnMut() -> bool,
     artifacts: &mut Vec<ConstructionEncodedArtifact>,
     evidence: &mut GraphConstructionEncodingEvidence,
 ) -> Result<(), GfError> {
-    if shape.node_rows.len() > 1 {
-        return Err(storage(
-            "canonical node encoding requires one stable schema",
-        ));
-    }
-    let Some(rows_name) = shape.node_rows.first() else {
+    if shape.node_rows.is_empty() {
         return Ok(());
-    };
+    }
     let details_name = shape
         .node_details
         .as_deref()
         .ok_or_else(|| storage("node rows lack canonical details"))?;
     let mut identities = FixedReader::<IDENTITY_WIDTH>::open(source, &shape.identities, evidence)?;
     let mut details = FixedReader::<NODE_DETAIL_WIDTH>::open(source, details_name, evidence)?;
-    let row_file = source
-        .open_child_file(OsStr::new(rows_name))
-        .map_err(storage)?;
-    let mut rows = ParquetRecordBatchReaderBuilder::try_new(row_file)
-        .map_err(storage)?
-        .with_batch_size(budgets.max_batch_rows)
-        .build()
-        .map_err(storage)?;
+    let (mut row_cursors, mut row_heap) =
+        open_merged_rows(source, &shape.node_rows, "node_uuid", budgets, evidence)?;
     let mut ordinal = 0_u64;
-    for input in &mut rows {
+    loop {
         if cancelled() {
             return Err(storage("construction encoding cancelled"));
         }
-        let input = input.map_err(storage)?;
-        account_batch(&input, budgets, evidence)?;
-        let uuids = required_uuid(&input, "node_uuid")?;
-        let labels = required_string(&input, "label")?;
-        let mut out_uuid = Vec::with_capacity(input.num_rows());
-        let mut out_id = Vec::with_capacity(input.num_rows());
-        let mut out_type = Vec::with_capacity(input.num_rows());
-        let mut groups = BTreeMap::<String, Vec<u32>>::new();
-        for row in 0..input.num_rows() {
+        let merged = next_merged_window(
+            &mut row_cursors,
+            &mut row_heap,
+            "node_uuid",
+            budgets,
+            cancelled,
+            evidence,
+        )?;
+        if merged.is_empty() {
+            break;
+        }
+        let mut out_uuid = Vec::with_capacity(merged.len());
+        let mut out_id = Vec::with_capacity(merged.len());
+        let mut out_type = Vec::with_capacity(merged.len());
+        let mut owners = BTreeMap::<String, ResolvedOwner>::new();
+        let mut groups = BTreeMap::<(usize, u64, String), (RecordBatch, Vec<u32>)>::new();
+        for merged_row in &merged {
+            let input = &merged_row.batch;
+            let row = merged_row.row;
+            let uuids = required_uuid(input, "node_uuid")?;
+            let labels = required_string(input, "label")?;
             let uuid: [u8; 16] = uuids.value(row).try_into().expect("fixed UUID");
             let identity = next_kind(&mut identities, 0)?
                 .ok_or_else(|| storage("node identity stream ended early"))?;
@@ -291,20 +673,45 @@ fn encode_nodes(
             if label != labels.value(row) {
                 return Err(storage("node detail label differs from normalized row"));
             }
-            let type_id = *label_ids
-                .get(label)
-                .ok_or_else(|| storage("node label is absent from runtime catalog"))?;
+            let runtime_route = if ontology_mode == OntologyMode::Exploratory {
+                "_untyped"
+            } else {
+                label
+            };
+            let owner = if let Some(owner) = owners.get(label) {
+                owner.clone()
+            } else {
+                let owner = resolve_owner(
+                    semantic_context,
+                    semantic_bindings,
+                    SymbolKind::Entity,
+                    SemanticRouteKind::Entity,
+                    label,
+                    runtime_route,
+                )?;
+                owners.insert(label.to_owned(), owner.clone());
+                owner
+            };
+            let type_id = match owner.storage_id {
+                Some(storage_id) => storage_id,
+                None => *label_ids
+                    .get(label)
+                    .ok_or_else(|| storage("node label is absent from runtime catalog"))?,
+            };
             out_uuid.push(uuid);
             out_id.push(u64::from_be_bytes(
                 identity[24..32].try_into().expect("fixed"),
             ));
             out_type.push(type_id);
-            let route = if ontology_mode == OntologyMode::Exploratory {
-                "_untyped"
-            } else {
-                label
-            };
-            groups.entry(route.to_owned()).or_default().push(row as u32);
+            groups
+                .entry((
+                    merged_row.source,
+                    merged_row.batch_sequence,
+                    label.to_owned(),
+                ))
+                .or_insert_with(|| (input.clone(), Vec::new()))
+                .1
+                .push(u32::try_from(row).map_err(storage)?);
         }
         if out_id.is_empty() {
             continue;
@@ -319,20 +726,47 @@ fn encode_nodes(
         let last = *out_id.last().expect("nonempty");
         let path = format!("topology/nodes/{first:020}-{last:020}.parquet");
         artifacts.push(write_parquet(output, &path, &canonical, evidence)?);
-        for (label, indexes) in groups {
+        for ((_source, _batch_sequence, label), (input, indexes)) in groups {
             if input.num_columns() == 2 {
+                continue;
+            }
+            let owner = owners
+                .get(&label)
+                .ok_or_else(|| storage("node owner resolution was lost"))?;
+            let (route, fields) = property_projection(
+                &input,
+                2,
+                &indexes,
+                owner,
+                SymbolKind::Entity,
+                SemanticRouteKind::NodeProperty,
+                semantic_context,
+                semantic_bindings,
+            )?;
+            if fields.is_empty() {
                 continue;
             }
             let property = property_batch(
                 &input,
-                2,
                 "node_uuid",
                 "graphforge.entity_type",
-                &label,
+                &route,
                 &indexes,
+                &fields,
             )?;
+            let property = if owner.symbol.is_some() {
+                with_route_metadata_batch(
+                    &property,
+                    &route,
+                    semantic_context
+                        .expect("qualified owner has context")
+                        .fingerprint(),
+                )?
+            } else {
+                property
+            };
             let path = format!(
-                "properties/{label}/{:020}-{ordinal:020}.parquet",
+                "properties/{route}/{:020}-{ordinal:020}.parquet",
                 shape.parent_topology_generation + 1
             );
             artifacts.push(write_parquet(output, &path, &property, evidence)?);
@@ -342,6 +776,8 @@ fn encode_nodes(
     if details.next()?.is_some() || next_kind(&mut identities, 0)?.is_some() {
         return Err(storage("node streams contain unconsumed rows"));
     }
+    identities.account(evidence);
+    details.account(evidence);
     Ok(())
 }
 
@@ -351,19 +787,16 @@ fn encode_edges(
     output: &StableDirectory,
     shape: &ConstructionShape,
     ontology_mode: OntologyMode,
+    semantic_context: Option<&CompositionBindingContext>,
+    semantic_bindings: Option<&SemanticStorageBindings>,
     budgets: GraphConstructionBudgets,
     cancelled: &mut impl FnMut() -> bool,
     artifacts: &mut Vec<ConstructionEncodedArtifact>,
     evidence: &mut GraphConstructionEncodingEvidence,
 ) -> Result<(), GfError> {
-    if shape.edge_rows.len() > 1 {
-        return Err(storage(
-            "canonical edge encoding requires one stable schema",
-        ));
-    }
-    let Some(rows_name) = shape.edge_rows.first() else {
+    if shape.edge_rows.is_empty() {
         return Ok(());
-    };
+    }
     let details_name = shape
         .edge_details
         .as_deref()
@@ -376,33 +809,40 @@ fn encode_edges(
     let mut details = FixedReader::<EDGE_DETAIL_WIDTH>::open(source, details_name, evidence)?;
     let mut endpoints =
         FixedReader::<RESOLVED_ENDPOINT_WIDTH>::open(source, endpoints_name, evidence)?;
-    let row_file = source
-        .open_child_file(OsStr::new(rows_name))
-        .map_err(storage)?;
-    let mut rows = ParquetRecordBatchReaderBuilder::try_new(row_file)
-        .map_err(storage)?
-        .with_batch_size(budgets.max_batch_rows)
-        .build()
-        .map_err(storage)?;
+    let (mut row_cursors, mut row_heap) =
+        open_merged_rows(source, &shape.edge_rows, "edge_uuid", budgets, evidence)?;
     let mut ordinal = 0_u64;
-    for input in &mut rows {
+    loop {
         if cancelled() {
             return Err(storage("construction encoding cancelled"));
         }
-        let input = input.map_err(storage)?;
-        account_batch(&input, budgets, evidence)?;
-        let uuids = required_uuid(&input, "edge_uuid")?;
-        let srcs = required_uuid(&input, "source_uuid")?;
-        let dsts = required_uuid(&input, "target_uuid")?;
-        let routes = required_string(&input, "rel_type")?;
-        let mut out_uuid = Vec::with_capacity(input.num_rows());
-        let mut out_src = Vec::with_capacity(input.num_rows());
-        let mut out_dst = Vec::with_capacity(input.num_rows());
-        let mut out_id = Vec::with_capacity(input.num_rows());
-        let mut out_src_id = Vec::with_capacity(input.num_rows());
-        let mut out_dst_id = Vec::with_capacity(input.num_rows());
-        let mut groups = BTreeMap::<String, Vec<u32>>::new();
-        for row in 0..input.num_rows() {
+        let merged = next_merged_window(
+            &mut row_cursors,
+            &mut row_heap,
+            "edge_uuid",
+            budgets,
+            cancelled,
+            evidence,
+        )?;
+        if merged.is_empty() {
+            break;
+        }
+        let mut out_uuid = Vec::with_capacity(merged.len());
+        let mut out_src = Vec::with_capacity(merged.len());
+        let mut out_dst = Vec::with_capacity(merged.len());
+        let mut out_id = Vec::with_capacity(merged.len());
+        let mut out_src_id = Vec::with_capacity(merged.len());
+        let mut out_dst_id = Vec::with_capacity(merged.len());
+        let mut owners = BTreeMap::<String, ResolvedOwner>::new();
+        let mut groups =
+            BTreeMap::<(usize, u64, String), (RecordBatch, Vec<u32>, Vec<usize>)>::new();
+        for (output_row, merged_row) in merged.iter().enumerate() {
+            let input = &merged_row.batch;
+            let row = merged_row.row;
+            let uuids = required_uuid(input, "edge_uuid")?;
+            let srcs = required_uuid(input, "source_uuid")?;
+            let dsts = required_uuid(input, "target_uuid")?;
+            let routes = required_string(input, "rel_type")?;
             let uuid: [u8; 16] = uuids.value(row).try_into().expect("fixed UUID");
             let identity = next_kind(&mut identities, 1)?
                 .ok_or_else(|| storage("edge identity stream ended early"))?;
@@ -445,7 +885,33 @@ fn encode_edges(
             out_dst_id.push(u64::from_be_bytes(
                 target_endpoint[24..32].try_into().expect("fixed"),
             ));
-            groups.entry(route.to_owned()).or_default().push(row as u32);
+            if !owners.contains_key(route) {
+                let runtime_route = if ontology_mode == OntologyMode::Exploratory {
+                    "_exploratory"
+                } else {
+                    route
+                };
+                owners.insert(
+                    route.to_owned(),
+                    resolve_owner(
+                        semantic_context,
+                        semantic_bindings,
+                        SymbolKind::Relation,
+                        SemanticRouteKind::Relation,
+                        route,
+                        runtime_route,
+                    )?,
+                );
+            }
+            let group = groups
+                .entry((
+                    merged_row.source,
+                    merged_row.batch_sequence,
+                    route.to_owned(),
+                ))
+                .or_insert_with(|| (input.clone(), Vec::new(), Vec::new()));
+            group.1.push(u32::try_from(row).map_err(storage)?);
+            group.2.push(output_row);
         }
         if out_id.is_empty() {
             continue;
@@ -459,9 +925,18 @@ fn encode_edges(
             &out_dst_id,
             shape.runtime_catalog_now_micros,
         )?;
-        for (route, indexes) in groups {
-            let mut selected = select_rows(&canonical, &indexes)?;
-            let topology_route = if ontology_mode == OntologyMode::Exploratory {
+        for ((_source, _batch_sequence, route), (input, indexes, output_indexes)) in groups {
+            let output_indexes = output_indexes
+                .into_iter()
+                .map(|value| u32::try_from(value).map_err(storage))
+                .collect::<Result<Vec<_>, _>>()?;
+            let mut selected = select_rows(&canonical, &output_indexes)?;
+            let owner = owners
+                .get(&route)
+                .ok_or_else(|| storage("edge owner resolution was lost"))?;
+            let topology_route = if owner.symbol.is_none()
+                && ontology_mode == OntologyMode::Exploratory
+            {
                 let routes = StringArray::from(vec![route.as_str(); selected.num_rows()]);
                 let mut fields = selected
                     .schema()
@@ -477,8 +952,17 @@ fn encode_edges(
                         .map_err(storage)?;
                 "_exploratory"
             } else {
-                route.as_str()
+                owner.topology_route.as_str()
             };
+            if owner.symbol.is_some() {
+                selected = with_route_metadata_batch(
+                    &selected,
+                    topology_route,
+                    semantic_context
+                        .expect("qualified owner has context")
+                        .fingerprint(),
+                )?;
+            }
             let ids = selected
                 .column_by_name("edge_id")
                 .and_then(|array| array.as_any().downcast_ref::<UInt64Array>())
@@ -488,16 +972,40 @@ fn encode_edges(
             let path = format!("topology/edges/{topology_route}/{first:020}-{last:020}.parquet");
             artifacts.push(write_parquet(output, &path, &selected, evidence)?);
             if input.num_columns() > 4 {
-                let property = property_batch(
+                let (property_route, fields) = property_projection(
                     &input,
                     4,
+                    &indexes,
+                    owner,
+                    SymbolKind::Relation,
+                    SemanticRouteKind::EdgeProperty,
+                    semantic_context,
+                    semantic_bindings,
+                )?;
+                if fields.is_empty() {
+                    continue;
+                }
+                let property = property_batch(
+                    &input,
                     "edge_uuid",
                     "graphforge.rel_type",
-                    &route,
+                    &property_route,
                     &indexes,
+                    &fields,
                 )?;
+                let property = if owner.symbol.is_some() {
+                    with_route_metadata_batch(
+                        &property,
+                        &property_route,
+                        semantic_context
+                            .expect("qualified owner has context")
+                            .fingerprint(),
+                    )?
+                } else {
+                    property
+                };
                 let path = format!(
-                    "edge_properties/{route}/{:020}-{ordinal:020}.parquet",
+                    "edge_properties/{property_route}/{:020}-{ordinal:020}.parquet",
                     shape.parent_topology_generation + 1
                 );
                 artifacts.push(write_parquet(output, &path, &property, evidence)?);
@@ -511,6 +1019,9 @@ fn encode_edges(
     {
         return Err(storage("edge streams contain unconsumed rows"));
     }
+    identities.account(evidence);
+    details.account(evidence);
+    endpoints.account(evidence);
     Ok(())
 }
 
@@ -584,18 +1095,18 @@ fn edge_batch(
 
 fn property_batch(
     input: &RecordBatch,
-    required: usize,
     uuid_name: &str,
     metadata_key: &str,
     owner: &str,
     indexes: &[u32],
+    field_indexes: &[usize],
 ) -> Result<RecordBatch, GfError> {
     let indexes = UInt32Array::from(indexes.to_vec());
     let mut fields = vec![uuid_field(uuid_name)];
     fields.extend(
-        input.schema().fields()[required..]
+        field_indexes
             .iter()
-            .map(|field| field.as_ref().clone()),
+            .map(|index| input.schema().field(*index).clone()),
     );
     let schema = Schema::new(fields).with_metadata(
         [(metadata_key.to_owned(), owner.to_owned())]
@@ -603,10 +1114,19 @@ fn property_batch(
             .collect(),
     );
     let columns = std::iter::once(input.column(0))
-        .chain(input.columns()[required..].iter())
+        .chain(field_indexes.iter().map(|index| input.column(*index)))
         .map(|array| take(array.as_ref(), &indexes, None).map_err(storage))
         .collect::<Result<Vec<ArrayRef>, _>>()?;
     RecordBatch::try_new(Arc::new(schema), columns).map_err(storage)
+}
+
+fn with_route_metadata_batch(
+    batch: &RecordBatch,
+    route: &str,
+    fingerprint: &str,
+) -> Result<RecordBatch, GfError> {
+    let schema = with_semantic_route_metadata(batch.schema().as_ref(), route, fingerprint);
+    RecordBatch::try_new(Arc::new(schema), batch.columns().to_vec()).map_err(storage)
 }
 
 fn select_rows(batch: &RecordBatch, indexes: &[u32]) -> Result<RecordBatch, GfError> {
@@ -654,16 +1174,22 @@ fn read_runtime_label_ids(
     source: &StableDirectory,
     name: &str,
     budgets: GraphConstructionBudgets,
+    evidence: &mut GraphConstructionEncodingEvidence,
 ) -> Result<BTreeMap<String, u32>, GfError> {
     let file = source.open_child_file(OsStr::new(name)).map_err(storage)?;
-    let mut reader = ParquetRecordBatchReaderBuilder::try_new(file)
-        .map_err(storage)?
-        .with_batch_size(budgets.max_batch_rows)
-        .build()
-        .map_err(storage)?;
+    let counter = IoCounter::default();
+    let mut reader = ParquetRecordBatchReaderBuilder::try_new(CountingChunkReader {
+        file,
+        counter: counter.clone(),
+    })
+    .map_err(storage)?
+    .with_batch_size(budgets.max_batch_rows)
+    .build()
+    .map_err(storage)?;
     let mut labels = BTreeMap::new();
     for batch in &mut reader {
         let batch = batch.map_err(storage)?;
+        account_batch(&batch, budgets, evidence)?;
         let kinds = required_string(&batch, "entry_kind")?;
         let names = required_string(&batch, "name")?;
         let ids = batch
@@ -679,6 +1205,9 @@ fn read_runtime_label_ids(
             }
         }
     }
+    let (bytes, operations) = counter.values();
+    evidence.input_read_bytes = evidence.input_read_bytes.saturating_add(bytes);
+    evidence.input_read_operations = evidence.input_read_operations.saturating_add(operations);
     Ok(labels)
 }
 
@@ -722,7 +1251,16 @@ fn write_parquet(
         .create_replaceable_child_file(OsStr::new(&temporary))
         .map_err(storage)?;
     let identity = file_identity(&file).map_err(storage)?;
-    let mut writer = ArrowWriter::try_new(file, batch.schema(), None).map_err(storage)?;
+    let counter = IoCounter::default();
+    let mut writer = ArrowWriter::try_new(
+        CountingWriter {
+            inner: file,
+            counter: counter.clone(),
+        },
+        batch.schema(),
+        None,
+    )
+    .map_err(storage)?;
     writer.write(batch).map_err(storage)?;
     writer.close().map_err(storage)?;
     let mut file = directory
@@ -734,8 +1272,9 @@ fn write_parquet(
         .replace_child(OsStr::new(&temporary), identity, OsStr::new(&name))
         .map_err(storage)?;
     directory.sync().map_err(storage)?;
-    evidence.output_write_bytes = evidence.output_write_bytes.saturating_add(artifact.bytes);
-    evidence.output_write_operations = evidence.output_write_operations.saturating_add(1);
+    let (written, operations) = counter.values();
+    evidence.output_write_bytes = evidence.output_write_bytes.saturating_add(written);
+    evidence.output_write_operations = evidence.output_write_operations.saturating_add(operations);
     evidence.fsync_operations = evidence.fsync_operations.saturating_add(2);
     Ok(artifact)
 }
@@ -857,6 +1396,12 @@ fn authenticate_inventory(
 ) -> Result<(), GfError> {
     if inventory.root != ENCODED_ROOT
         || inventory.shape_inputs_sha256.len() != 64
+        || inventory
+            .semantic_authority_sha256
+            .as_ref()
+            .is_some_and(|digest| {
+                digest.len() != 64 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit())
+            })
         || !inventory
             .shape_inputs_sha256
             .bytes()
@@ -903,26 +1448,30 @@ fn install_json<T: Serialize>(
 }
 
 struct FixedReader<const N: usize> {
-    reader: BufReader<File>,
+    reader: BufReader<CountingInput<File>>,
+    counter: IoCounter,
 }
 
 impl<const N: usize> FixedReader<N> {
     fn open(
         root: &StableDirectory,
         name: &str,
-        evidence: &mut GraphConstructionEncodingEvidence,
+        _evidence: &mut GraphConstructionEncodingEvidence,
     ) -> Result<Self, GfError> {
         let file = root.open_child_file(OsStr::new(name)).map_err(storage)?;
         if file.metadata().map_err(storage)?.len() % N as u64 != 0 {
             return Err(storage("fixed-width construction stream is truncated"));
         }
-        let bytes = file.metadata().map_err(storage)?.len();
-        evidence.input_read_bytes = evidence.input_read_bytes.saturating_add(bytes);
-        evidence.input_read_operations = evidence
-            .input_read_operations
-            .saturating_add(bytes.div_ceil(COPY_BUFFER_BYTES as u64));
+        let counter = IoCounter::default();
         Ok(Self {
-            reader: BufReader::with_capacity(COPY_BUFFER_BYTES, file),
+            reader: BufReader::with_capacity(
+                COPY_BUFFER_BYTES,
+                CountingInput {
+                    inner: file,
+                    counter: counter.clone(),
+                },
+            ),
+            counter,
         })
     }
 
@@ -940,6 +1489,12 @@ impl<const N: usize> FixedReader<N> {
             read += amount;
         }
         Ok(Some(record))
+    }
+
+    fn account(&self, evidence: &mut GraphConstructionEncodingEvidence) {
+        let (bytes, operations) = self.counter.values();
+        evidence.input_read_bytes = evidence.input_read_bytes.saturating_add(bytes);
+        evidence.input_read_operations = evidence.input_read_operations.saturating_add(operations);
     }
 }
 

--- a/crates/graphforge-storage/src/graph_construction_encoding.rs
+++ b/crates/graphforge-storage/src/graph_construction_encoding.rs
@@ -15,8 +15,8 @@ use std::sync::Arc;
 use std::cell::RefCell;
 
 use arrow::array::{
-    Array, ArrayRef, FixedSizeBinaryArray, ListArray, StringArray, TimestampMicrosecondArray,
-    UInt32Array, UInt64Array,
+    Array, ArrayRef, BooleanArray, FixedSizeBinaryArray, ListArray, StringArray,
+    TimestampMicrosecondArray, UInt32Array, UInt64Array,
 };
 use arrow::compute::take;
 use arrow::datatypes::{DataType, Field, Schema};
@@ -36,6 +36,10 @@ use uuid::Uuid;
 use crate::graph_construction::{
     ArtifactReceipt, ConstructionSemanticAuthority, ConstructionShape, CountingChunkReader,
     GraphConstructionBudgets, IoCounter, open_authenticated_shape_source, shaped_output_sha256,
+};
+use crate::property_overlay::{
+    PROPERTY_GENERATION_KEY, PROPERTY_KIND_KEY, PROPERTY_ORDINAL_KEY, PROPERTY_OVERLAY_FORMAT,
+    PROPERTY_OVERLAY_FORMAT_KEY, PROPERTY_ROUTE_KEY, PROPERTY_TOMBSTONE_FIELD, PropertyRouteKind,
 };
 use crate::schemas::{
     TOPOLOGY_NODES_SCHEMA, TYPED_EDGE_SCHEMA, uuid_field, with_semantic_route_metadata,
@@ -577,7 +581,7 @@ fn retained_artifact(value: ConstructionIndexReference) -> ConstructionRetainedA
 
 fn index_artifact(value: ConstructionIndexOutput) -> ConstructionEncodedArtifact {
     ConstructionEncodedArtifact {
-        path: format!(".graphforge-cache/uuid-membership/{}", value.name),
+        path: format!("topology/uuid-membership/{}", value.name),
         bytes: value.bytes,
         sha256: value.sha256,
     }
@@ -813,7 +817,7 @@ fn encode_node_properties(
     artifacts: &mut Vec<ConstructionEncodedArtifact>,
     evidence: &mut GraphConstructionEncodingEvidence,
 ) -> Result<(), GfError> {
-    let mut ordinal = 0_u64;
+    let mut ordinals = BTreeMap::<String, u64>::new();
     for name in &shape.node_rows {
         if cancelled() {
             return Err(storage("construction encoding cancelled"));
@@ -869,6 +873,7 @@ fn encode_node_properties(
                     semantic_bindings,
                 )?;
                 for (route, fields) in projections {
+                    let ordinal = ordinals.entry(route.clone()).or_default();
                     let property = property_batch(
                         &input,
                         "node_uuid",
@@ -876,6 +881,10 @@ fn encode_node_properties(
                         &owner.topology_route,
                         &indexes,
                         &fields,
+                        PropertyRouteKind::Node,
+                        &route,
+                        shape.parent_topology_generation + 1,
+                        *ordinal,
                     )?;
                     let property = if owner.symbol.is_some() {
                         with_route_metadata_batch(
@@ -893,7 +902,7 @@ fn encode_node_properties(
                         shape.parent_topology_generation + 1
                     );
                     artifacts.push(write_parquet(output, &path, &property, evidence)?);
-                    ordinal = ordinal.saturating_add(1);
+                    *ordinal = ordinal.saturating_add(1);
                 }
             }
         }
@@ -1101,7 +1110,7 @@ fn encode_edge_properties(
     artifacts: &mut Vec<ConstructionEncodedArtifact>,
     evidence: &mut GraphConstructionEncodingEvidence,
 ) -> Result<(), GfError> {
-    let mut ordinal = 0_u64;
+    let mut ordinals = BTreeMap::<String, u64>::new();
     for name in &shape.edge_rows {
         if cancelled() {
             return Err(storage("construction encoding cancelled"));
@@ -1157,6 +1166,7 @@ fn encode_edge_properties(
                     semantic_bindings,
                 )?;
                 for (property_route, fields) in projections {
+                    let ordinal = ordinals.entry(property_route.clone()).or_default();
                     let property = property_batch(
                         &input,
                         "edge_uuid",
@@ -1164,6 +1174,10 @@ fn encode_edge_properties(
                         &owner.topology_route,
                         &indexes,
                         &fields,
+                        PropertyRouteKind::Edge,
+                        &property_route,
+                        shape.parent_topology_generation + 1,
+                        *ordinal,
                     )?;
                     let property = if owner.symbol.is_some() {
                         with_route_metadata_batch(
@@ -1181,7 +1195,7 @@ fn encode_edge_properties(
                         shape.parent_topology_generation + 1
                     );
                     artifacts.push(write_parquet(output, &path, &property, evidence)?);
-                    ordinal = ordinal.saturating_add(1);
+                    *ordinal = ordinal.saturating_add(1);
                 }
             }
         }
@@ -1271,23 +1285,47 @@ fn property_batch(
     owner: &str,
     indexes: &[u32],
     field_indexes: &[usize],
+    kind: PropertyRouteKind,
+    route: &str,
+    generation: u64,
+    ordinal: u64,
 ) -> Result<RecordBatch, GfError> {
     let indexes = UInt32Array::from(indexes.to_vec());
-    let mut fields = vec![uuid_field(uuid_name)];
+    let mut fields = vec![
+        uuid_field(uuid_name),
+        Field::new(PROPERTY_TOMBSTONE_FIELD, DataType::Boolean, false),
+    ];
     fields.extend(
         field_indexes
             .iter()
             .map(|index| input.schema().field(*index).clone()),
     );
     let schema = Schema::new(fields).with_metadata(
-        [(metadata_key.to_owned(), owner.to_owned())]
-            .into_iter()
-            .collect(),
+        [
+            (metadata_key.to_owned(), owner.to_owned()),
+            (
+                PROPERTY_OVERLAY_FORMAT_KEY.to_owned(),
+                PROPERTY_OVERLAY_FORMAT.to_owned(),
+            ),
+            (PROPERTY_ROUTE_KEY.to_owned(), route.to_owned()),
+            (
+                PROPERTY_KIND_KEY.to_owned(),
+                kind.metadata_value().to_owned(),
+            ),
+            (PROPERTY_GENERATION_KEY.to_owned(), generation.to_string()),
+            (PROPERTY_ORDINAL_KEY.to_owned(), ordinal.to_string()),
+        ]
+        .into_iter()
+        .collect(),
     );
-    let columns = std::iter::once(input.column(0))
+    let mut columns = std::iter::once(input.column(0))
         .chain(field_indexes.iter().map(|index| input.column(*index)))
         .map(|array| take(array.as_ref(), &indexes, None).map_err(storage))
         .collect::<Result<Vec<ArrayRef>, _>>()?;
+    columns.insert(
+        1,
+        Arc::new(BooleanArray::from(vec![false; indexes.len()])) as ArrayRef,
+    );
     RecordBatch::try_new(Arc::new(schema), columns).map_err(storage)
 }
 

--- a/crates/graphforge-storage/src/graph_construction_encoding.rs
+++ b/crates/graphforge-storage/src/graph_construction_encoding.rs
@@ -1788,26 +1788,30 @@ fn authenticate_inventory(
         let parent = parent_index
             .ok_or_else(|| storage("retained artifacts lack authenticated parent snapshot"))?;
         let mut previous = None;
+        let mut references = Vec::with_capacity(inventory.retained_artifacts.len());
         for retained in &inventory.retained_artifacts {
             if previous.is_some_and(|value: &str| value >= retained.target_path.as_str()) {
                 return Err(storage(
                     "retained artifact targets are not unique and sorted",
                 ));
             }
-            parent.authenticate_construction_reference(
-                &retained.source_root,
-                retained.source_root_volume,
-                &retained.source_root_file_id,
-                &retained.source_path,
-                retained.source_volume,
-                &retained.source_file_id,
-                &retained.target_path,
-                retained.bytes,
-                &retained.sha256,
-                &retained.parent_manifest_sha256,
-            )?;
+            references.push(
+                crate::uuid_membership::ConstructionReferenceAuthentication {
+                    source_root: &retained.source_root,
+                    source_root_volume: retained.source_root_volume,
+                    source_root_file_id: &retained.source_root_file_id,
+                    source_path: &retained.source_path,
+                    source_volume: retained.source_volume,
+                    source_file_id: &retained.source_file_id,
+                    target_path: &retained.target_path,
+                    bytes: retained.bytes,
+                    sha256: &retained.sha256,
+                    parent_manifest_sha256: &retained.parent_manifest_sha256,
+                },
+            );
             previous = Some(retained.target_path.as_str());
         }
+        parent.authenticate_construction_references(&references)?;
     }
     Ok(())
 }

--- a/crates/graphforge-storage/src/graph_construction_encoding.rs
+++ b/crates/graphforge-storage/src/graph_construction_encoding.rs
@@ -1037,13 +1037,6 @@ fn encode_edges(
                 && ontology_mode == OntologyMode::Exploratory
             {
                 let routes = StringArray::from(vec![route.as_str(); selected.num_rows()]);
-                let mut fields = selected
-                    .schema()
-                    .fields()
-                    .iter()
-                    .map(|field| field.as_ref().clone())
-                    .collect::<Vec<_>>();
-                fields.push(Field::new("rel_type_name", DataType::Utf8, false));
                 let mut columns = selected.columns().to_vec();
                 columns.push(Arc::new(routes));
                 selected =
@@ -1630,7 +1623,7 @@ fn authenticate_file(path: &str, file: &mut File) -> Result<ConstructionEncodedA
 pub(crate) fn read_inventory(
     root: &StableDirectory,
 ) -> Result<Option<GraphConstructionEncoding>, GfError> {
-    let mut file = match root.open_child_file(OsStr::new(INVENTORY)) {
+    let file = match root.open_child_file(OsStr::new(INVENTORY)) {
         Ok(file) => file,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => return Err(storage(error)),
@@ -1638,13 +1631,13 @@ pub(crate) fn read_inventory(
     if file.metadata().map_err(storage)?.len() > MAX_INVENTORY_BYTES {
         return Err(storage("canonical inventory exceeds bound"));
     }
-    serde_json::from_reader(&mut file)
+    serde_json::from_reader(BufReader::with_capacity(COPY_BUFFER_BYTES, file))
         .map(Some)
         .map_err(storage)
 }
 
 fn read_encoding_intent(root: &StableDirectory) -> Result<Option<EncodingIntent>, GfError> {
-    let mut file = match root.open_child_file(OsStr::new(ENCODING_INTENT)) {
+    let file = match root.open_child_file(OsStr::new(ENCODING_INTENT)) {
         Ok(file) => file,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => return Err(storage(error)),
@@ -1652,7 +1645,7 @@ fn read_encoding_intent(root: &StableDirectory) -> Result<Option<EncodingIntent>
     if file.metadata().map_err(storage)?.len() > MAX_INVENTORY_BYTES {
         return Err(storage("encoding intent exceeds bound"));
     }
-    serde_json::from_reader(&mut file)
+    serde_json::from_reader(BufReader::with_capacity(COPY_BUFFER_BYTES, file))
         .map(Some)
         .map_err(storage)
 }
@@ -1858,8 +1851,10 @@ fn install_json<T: Serialize>(
         identity,
         armed: true,
     };
-    serde_json::to_writer(&mut file, value).map_err(storage)?;
-    file.flush().map_err(storage)?;
+    let mut writer = BufWriter::with_capacity(COPY_BUFFER_BYTES, &mut file);
+    serde_json::to_writer(&mut writer, value).map_err(storage)?;
+    writer.flush().map_err(storage)?;
+    drop(writer);
     file.sync_all().map_err(storage)?;
     crate::graph_construction::construction_failpoint(&format!(
         "encode.control.after_temp_fsync.{name}"

--- a/crates/graphforge-storage/src/graph_construction_encoding.rs
+++ b/crates/graphforge-storage/src/graph_construction_encoding.rs
@@ -1278,6 +1278,7 @@ fn edge_batch(
     .map_err(storage)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn property_batch(
     input: &RecordBatch,
     uuid_name: &str,
@@ -1626,7 +1627,9 @@ fn authenticate_file(path: &str, file: &mut File) -> Result<ConstructionEncodedA
     })
 }
 
-fn read_inventory(root: &StableDirectory) -> Result<Option<GraphConstructionEncoding>, GfError> {
+pub(crate) fn read_inventory(
+    root: &StableDirectory,
+) -> Result<Option<GraphConstructionEncoding>, GfError> {
     let mut file = match root.open_child_file(OsStr::new(INVENTORY)) {
         Ok(file) => file,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),

--- a/crates/graphforge-storage/src/graph_construction_encoding.rs
+++ b/crates/graphforge-storage/src/graph_construction_encoding.rs
@@ -1,0 +1,954 @@
+//! Publication-independent canonical encoding for sealed construction shapes.
+//!
+//! This layer deliberately stops before graph-object installation or `CURRENT`.
+//! It converts the shaper's authenticated, UUID-ordered streams into the exact
+//! ordinary storage schemas and prepares a streamed UUID-membership manifest.
+
+use std::collections::BTreeMap;
+use std::ffi::OsStr;
+use std::fs::File;
+use std::io::{BufReader, BufWriter, Read, Seek, Write};
+use std::path::{Component, Path};
+use std::sync::Arc;
+
+use arrow::array::{
+    Array, ArrayRef, FixedSizeBinaryArray, ListArray, StringArray, TimestampMicrosecondArray,
+    UInt32Array, UInt64Array,
+};
+use arrow::compute::take;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use graphforge_core::GfError;
+use graphforge_core::OntologyMode;
+use graphforge_filesystem::{StableDirectory, file_identity};
+use graphforge_ir::runtime_entity_type_id;
+use parquet::arrow::ArrowWriter;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::graph_construction::{ConstructionShape, GraphConstructionBudgets};
+use crate::schemas::{TOPOLOGY_NODES_SCHEMA, TYPED_EDGE_SCHEMA, uuid_field};
+use crate::uuid_membership::{AuthenticatedUuidIndexSnapshot, ConstructionIndexOutput};
+
+const ENCODED_ROOT: &str = "encoded-v1";
+const INVENTORY: &str = "inventory.json";
+const MAX_INVENTORY_BYTES: u64 = 16 << 20;
+const IDENTITY_WIDTH: usize = 32;
+const NODE_DETAIL_WIDTH: usize = 272;
+const EDGE_DETAIL_WIDTH: usize = 304;
+const RESOLVED_ENDPOINT_WIDTH: usize = 32;
+const COPY_BUFFER_BYTES: usize = 1 << 20;
+
+fn storage(error: impl std::fmt::Display) -> GfError {
+    GfError::Storage(format!("graph construction encoding: {error}"))
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+/// One private canonical artifact authenticated by the completed inventory.
+pub struct ConstructionEncodedArtifact {
+    /// Normalized graph-root-relative path.
+    pub path: String,
+    /// Exact physical bytes.
+    pub bytes: u64,
+    /// Lowercase SHA-256 of the file.
+    pub sha256: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+/// Measured bounded work for canonical encoding.
+pub struct GraphConstructionEncodingEvidence {
+    /// Shaped input bytes read sequentially.
+    pub input_read_bytes: u64,
+    /// Bounded input read operations.
+    pub input_read_operations: u64,
+    /// Canonical output bytes written.
+    pub output_write_bytes: u64,
+    /// Canonical output write operations.
+    pub output_write_operations: u64,
+    /// Completed file and directory durability barriers.
+    pub fsync_operations: u64,
+    /// Topology rows decoded from the retained parent. Always zero.
+    pub prior_topology_rows_decoded: u64,
+    /// Retained topology bytes copied. Always zero.
+    pub retained_topology_bytes_copied: u64,
+    /// Largest decoded Arrow window.
+    pub peak_batch_rows: u64,
+    /// Largest decoded Arrow window in bytes.
+    pub peak_batch_bytes: u64,
+    /// Largest number of simultaneously live shard writers. Always one.
+    pub peak_open_writers: u64,
+    /// New identity records streamed into the v3 index.
+    pub membership_records: u64,
+    /// New v3 membership bytes written.
+    pub membership_write_bytes: u64,
+    /// Retained v3 run descriptors structurally reused.
+    pub retained_index_runs: u64,
+    /// Retained v3 payload bytes read only for required binary-carry compaction.
+    pub retained_index_payload_bytes: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+/// Completed private canonical artifact inventory.
+pub struct GraphConstructionEncoding {
+    /// Directory below the private operation root containing this inventory.
+    pub root: String,
+    /// Generation the eventual publisher must bind.
+    pub generation: u64,
+    /// Physical routing authority pinned by the construction checkpoint.
+    pub ontology_mode: OntologyMode,
+    /// Shaper authority digest for normalized catalog inputs.
+    pub shape_inputs_sha256: String,
+    /// Sorted, unique canonical artifact records.
+    pub artifacts: Vec<ConstructionEncodedArtifact>,
+    /// Measured bounded work.
+    pub evidence: GraphConstructionEncodingEvidence,
+}
+
+pub(crate) fn encode(
+    source: &StableDirectory,
+    shape: &ConstructionShape,
+    generation: u64,
+    ontology_mode: OntologyMode,
+    parent_index: Option<&AuthenticatedUuidIndexSnapshot>,
+    budgets: GraphConstructionBudgets,
+    cancelled: &mut impl FnMut() -> bool,
+) -> Result<GraphConstructionEncoding, GfError> {
+    if shape.ontology_mode != ontology_mode {
+        return Err(storage(
+            "shape ontology mode differs from session authority",
+        ));
+    }
+    if generation == 0 || generation <= shape.parent_topology_generation {
+        return Err(storage("encoded generation is not newer than its parent"));
+    }
+    if cancelled() {
+        return Err(storage("construction encoding cancelled"));
+    }
+    let output = source
+        .create_child_directory(OsStr::new(ENCODED_ROOT))
+        .map_err(storage)?;
+    if let Some(existing) = read_inventory(&output)? {
+        authenticate_inventory(&output, &existing)?;
+        if existing.generation != generation
+            || existing.ontology_mode != shape.ontology_mode
+            || existing.shape_inputs_sha256 != shape.runtime_catalog_inputs_sha256
+        {
+            return Err(storage("completed encoding belongs to another generation"));
+        }
+        return Ok(existing);
+    }
+
+    let label_ids = read_runtime_label_ids(source, &shape.runtime_catalog, budgets)?;
+    let mut artifacts = Vec::new();
+    let mut evidence = GraphConstructionEncodingEvidence {
+        peak_open_writers: 1,
+        ..Default::default()
+    };
+
+    encode_nodes(
+        source,
+        &output,
+        shape,
+        &label_ids,
+        ontology_mode,
+        budgets,
+        cancelled,
+        &mut artifacts,
+        &mut evidence,
+    )?;
+    encode_edges(
+        source,
+        &output,
+        shape,
+        ontology_mode,
+        budgets,
+        cancelled,
+        &mut artifacts,
+        &mut evidence,
+    )?;
+    copy_artifact(
+        source,
+        &shape.runtime_catalog,
+        &output,
+        "topology/runtime_catalog.parquet",
+        &mut artifacts,
+        &mut evidence,
+    )?;
+    write_surrogate_tails(
+        &output,
+        shape.max_node_surrogate,
+        shape.max_edge_surrogate,
+        &mut artifacts,
+        &mut evidence,
+    )?;
+
+    let index = crate::uuid_membership::encode_construction_index(
+        source,
+        &shape.identities,
+        &output,
+        generation,
+        shape.parent_topology_generation,
+        parent_index,
+        shape.node_count,
+        shape.edge_count,
+        cancelled,
+    )?;
+    evidence.membership_records = index.input_records;
+    evidence.membership_write_bytes = index.write_bytes;
+    evidence.retained_index_runs = index.retained_runs;
+    evidence.retained_index_payload_bytes = index.retained_payload_bytes;
+    artifacts.extend(index.artifacts.into_iter().map(index_artifact));
+
+    artifacts.sort_unstable_by(|left, right| left.path.cmp(&right.path));
+    if artifacts
+        .windows(2)
+        .any(|pair| pair[0].path == pair[1].path)
+    {
+        return Err(storage("canonical encoding contains duplicate paths"));
+    }
+    let completed = GraphConstructionEncoding {
+        root: ENCODED_ROOT.to_owned(),
+        generation,
+        ontology_mode: shape.ontology_mode,
+        shape_inputs_sha256: shape.runtime_catalog_inputs_sha256.clone(),
+        artifacts,
+        evidence,
+    };
+    install_json(&output, INVENTORY, &completed)?;
+    authenticate_inventory(&output, &completed)?;
+    Ok(completed)
+}
+
+fn index_artifact(value: ConstructionIndexOutput) -> ConstructionEncodedArtifact {
+    ConstructionEncodedArtifact {
+        path: format!(".graphforge-cache/uuid-membership/{}", value.name),
+        bytes: value.bytes,
+        sha256: value.sha256,
+    }
+}
+
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+fn encode_nodes(
+    source: &StableDirectory,
+    output: &StableDirectory,
+    shape: &ConstructionShape,
+    label_ids: &BTreeMap<String, u32>,
+    ontology_mode: OntologyMode,
+    budgets: GraphConstructionBudgets,
+    cancelled: &mut impl FnMut() -> bool,
+    artifacts: &mut Vec<ConstructionEncodedArtifact>,
+    evidence: &mut GraphConstructionEncodingEvidence,
+) -> Result<(), GfError> {
+    if shape.node_rows.len() > 1 {
+        return Err(storage(
+            "canonical node encoding requires one stable schema",
+        ));
+    }
+    let Some(rows_name) = shape.node_rows.first() else {
+        return Ok(());
+    };
+    let details_name = shape
+        .node_details
+        .as_deref()
+        .ok_or_else(|| storage("node rows lack canonical details"))?;
+    let mut identities = FixedReader::<IDENTITY_WIDTH>::open(source, &shape.identities, evidence)?;
+    let mut details = FixedReader::<NODE_DETAIL_WIDTH>::open(source, details_name, evidence)?;
+    let row_file = source
+        .open_child_file(OsStr::new(rows_name))
+        .map_err(storage)?;
+    let mut rows = ParquetRecordBatchReaderBuilder::try_new(row_file)
+        .map_err(storage)?
+        .with_batch_size(budgets.max_batch_rows)
+        .build()
+        .map_err(storage)?;
+    let mut ordinal = 0_u64;
+    for input in &mut rows {
+        if cancelled() {
+            return Err(storage("construction encoding cancelled"));
+        }
+        let input = input.map_err(storage)?;
+        account_batch(&input, budgets, evidence)?;
+        let uuids = required_uuid(&input, "node_uuid")?;
+        let labels = required_string(&input, "label")?;
+        let mut out_uuid = Vec::with_capacity(input.num_rows());
+        let mut out_id = Vec::with_capacity(input.num_rows());
+        let mut out_type = Vec::with_capacity(input.num_rows());
+        let mut groups = BTreeMap::<String, Vec<u32>>::new();
+        for row in 0..input.num_rows() {
+            let uuid: [u8; 16] = uuids.value(row).try_into().expect("fixed UUID");
+            let identity = next_kind(&mut identities, 0)?
+                .ok_or_else(|| storage("node identity stream ended early"))?;
+            let detail = details
+                .next()?
+                .ok_or_else(|| storage("node detail stream ended early"))?;
+            if identity[..16] != uuid || detail[..16] != uuid || identity[17] != 0 {
+                return Err(storage("node row/detail/identity streams differ"));
+            }
+            let label_len = usize::from(detail[16]);
+            let label = std::str::from_utf8(&detail[17..17 + label_len]).map_err(storage)?;
+            if label != labels.value(row) {
+                return Err(storage("node detail label differs from normalized row"));
+            }
+            let type_id = *label_ids
+                .get(label)
+                .ok_or_else(|| storage("node label is absent from runtime catalog"))?;
+            out_uuid.push(uuid);
+            out_id.push(u64::from_be_bytes(
+                identity[24..32].try_into().expect("fixed"),
+            ));
+            out_type.push(type_id);
+            let route = if ontology_mode == OntologyMode::Exploratory {
+                "_untyped"
+            } else {
+                label
+            };
+            groups.entry(route.to_owned()).or_default().push(row as u32);
+        }
+        if out_id.is_empty() {
+            continue;
+        }
+        let canonical = node_batch(
+            &out_uuid,
+            &out_id,
+            &out_type,
+            shape.runtime_catalog_now_micros,
+        )?;
+        let first = *out_id.first().expect("nonempty");
+        let last = *out_id.last().expect("nonempty");
+        let path = format!("topology/nodes/{first:020}-{last:020}.parquet");
+        artifacts.push(write_parquet(output, &path, &canonical, evidence)?);
+        for (label, indexes) in groups {
+            if input.num_columns() == 2 {
+                continue;
+            }
+            let property = property_batch(
+                &input,
+                2,
+                "node_uuid",
+                "graphforge.entity_type",
+                &label,
+                &indexes,
+            )?;
+            let path = format!(
+                "properties/{label}/{:020}-{ordinal:020}.parquet",
+                shape.parent_topology_generation + 1
+            );
+            artifacts.push(write_parquet(output, &path, &property, evidence)?);
+            ordinal = ordinal.saturating_add(1);
+        }
+    }
+    if details.next()?.is_some() || next_kind(&mut identities, 0)?.is_some() {
+        return Err(storage("node streams contain unconsumed rows"));
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+fn encode_edges(
+    source: &StableDirectory,
+    output: &StableDirectory,
+    shape: &ConstructionShape,
+    ontology_mode: OntologyMode,
+    budgets: GraphConstructionBudgets,
+    cancelled: &mut impl FnMut() -> bool,
+    artifacts: &mut Vec<ConstructionEncodedArtifact>,
+    evidence: &mut GraphConstructionEncodingEvidence,
+) -> Result<(), GfError> {
+    if shape.edge_rows.len() > 1 {
+        return Err(storage(
+            "canonical edge encoding requires one stable schema",
+        ));
+    }
+    let Some(rows_name) = shape.edge_rows.first() else {
+        return Ok(());
+    };
+    let details_name = shape
+        .edge_details
+        .as_deref()
+        .ok_or_else(|| storage("edge rows lack canonical details"))?;
+    let endpoints_name = shape
+        .edge_endpoints
+        .as_deref()
+        .ok_or_else(|| storage("edge rows lack resolved endpoints"))?;
+    let mut identities = FixedReader::<IDENTITY_WIDTH>::open(source, &shape.identities, evidence)?;
+    let mut details = FixedReader::<EDGE_DETAIL_WIDTH>::open(source, details_name, evidence)?;
+    let mut endpoints =
+        FixedReader::<RESOLVED_ENDPOINT_WIDTH>::open(source, endpoints_name, evidence)?;
+    let row_file = source
+        .open_child_file(OsStr::new(rows_name))
+        .map_err(storage)?;
+    let mut rows = ParquetRecordBatchReaderBuilder::try_new(row_file)
+        .map_err(storage)?
+        .with_batch_size(budgets.max_batch_rows)
+        .build()
+        .map_err(storage)?;
+    let mut ordinal = 0_u64;
+    for input in &mut rows {
+        if cancelled() {
+            return Err(storage("construction encoding cancelled"));
+        }
+        let input = input.map_err(storage)?;
+        account_batch(&input, budgets, evidence)?;
+        let uuids = required_uuid(&input, "edge_uuid")?;
+        let srcs = required_uuid(&input, "source_uuid")?;
+        let dsts = required_uuid(&input, "target_uuid")?;
+        let routes = required_string(&input, "rel_type")?;
+        let mut out_uuid = Vec::with_capacity(input.num_rows());
+        let mut out_src = Vec::with_capacity(input.num_rows());
+        let mut out_dst = Vec::with_capacity(input.num_rows());
+        let mut out_id = Vec::with_capacity(input.num_rows());
+        let mut out_src_id = Vec::with_capacity(input.num_rows());
+        let mut out_dst_id = Vec::with_capacity(input.num_rows());
+        let mut groups = BTreeMap::<String, Vec<u32>>::new();
+        for row in 0..input.num_rows() {
+            let uuid: [u8; 16] = uuids.value(row).try_into().expect("fixed UUID");
+            let identity = next_kind(&mut identities, 1)?
+                .ok_or_else(|| storage("edge identity stream ended early"))?;
+            let detail = details
+                .next()?
+                .ok_or_else(|| storage("edge detail stream ended early"))?;
+            let source_endpoint = endpoints
+                .next()?
+                .ok_or_else(|| storage("edge endpoint stream ended early"))?;
+            let target_endpoint = endpoints
+                .next()?
+                .ok_or_else(|| storage("edge endpoint stream ended early"))?;
+            if identity[..16] != uuid
+                || detail[..16] != uuid
+                || identity[17] != 0
+                || source_endpoint[..16] != uuid
+                || target_endpoint[..16] != uuid
+                || source_endpoint[16] != 0
+                || target_endpoint[16] != 1
+            {
+                return Err(storage("edge row/detail/identity/endpoint streams differ"));
+            }
+            let route_len = usize::from(detail[48]);
+            let route = std::str::from_utf8(&detail[49..49 + route_len]).map_err(storage)?;
+            if route != routes.value(row)
+                || detail[16..32] != srcs.value(row)[..]
+                || detail[32..48] != dsts.value(row)[..]
+            {
+                return Err(storage("edge canonical detail differs from normalized row"));
+            }
+            out_uuid.push(uuid);
+            out_src.push(srcs.value(row).try_into().expect("fixed UUID"));
+            out_dst.push(dsts.value(row).try_into().expect("fixed UUID"));
+            out_id.push(u64::from_be_bytes(
+                identity[24..32].try_into().expect("fixed"),
+            ));
+            out_src_id.push(u64::from_be_bytes(
+                source_endpoint[24..32].try_into().expect("fixed"),
+            ));
+            out_dst_id.push(u64::from_be_bytes(
+                target_endpoint[24..32].try_into().expect("fixed"),
+            ));
+            groups.entry(route.to_owned()).or_default().push(row as u32);
+        }
+        if out_id.is_empty() {
+            continue;
+        }
+        let canonical = edge_batch(
+            &out_uuid,
+            &out_src,
+            &out_dst,
+            &out_id,
+            &out_src_id,
+            &out_dst_id,
+            shape.runtime_catalog_now_micros,
+        )?;
+        for (route, indexes) in groups {
+            let mut selected = select_rows(&canonical, &indexes)?;
+            let topology_route = if ontology_mode == OntologyMode::Exploratory {
+                let routes = StringArray::from(vec![route.as_str(); selected.num_rows()]);
+                let mut fields = selected
+                    .schema()
+                    .fields()
+                    .iter()
+                    .map(|field| field.as_ref().clone())
+                    .collect::<Vec<_>>();
+                fields.push(Field::new("rel_type_name", DataType::Utf8, false));
+                let mut columns = selected.columns().to_vec();
+                columns.push(Arc::new(routes));
+                selected =
+                    RecordBatch::try_new(crate::schemas::EXPLORATORY_EDGE_SCHEMA.clone(), columns)
+                        .map_err(storage)?;
+                "_exploratory"
+            } else {
+                route.as_str()
+            };
+            let ids = selected
+                .column_by_name("edge_id")
+                .and_then(|array| array.as_any().downcast_ref::<UInt64Array>())
+                .ok_or_else(|| storage("canonical edge ids are incompatible"))?;
+            let first = ids.value(0);
+            let last = ids.value(ids.len() - 1);
+            let path = format!("topology/edges/{topology_route}/{first:020}-{last:020}.parquet");
+            artifacts.push(write_parquet(output, &path, &selected, evidence)?);
+            if input.num_columns() > 4 {
+                let property = property_batch(
+                    &input,
+                    4,
+                    "edge_uuid",
+                    "graphforge.rel_type",
+                    &route,
+                    &indexes,
+                )?;
+                let path = format!(
+                    "edge_properties/{route}/{:020}-{ordinal:020}.parquet",
+                    shape.parent_topology_generation + 1
+                );
+                artifacts.push(write_parquet(output, &path, &property, evidence)?);
+                ordinal = ordinal.saturating_add(1);
+            }
+        }
+    }
+    if details.next()?.is_some()
+        || endpoints.next()?.is_some()
+        || next_kind(&mut identities, 1)?.is_some()
+    {
+        return Err(storage("edge streams contain unconsumed rows"));
+    }
+    Ok(())
+}
+
+fn next_kind(
+    identities: &mut FixedReader<IDENTITY_WIDTH>,
+    kind: u8,
+) -> Result<Option<[u8; IDENTITY_WIDTH]>, GfError> {
+    while let Some(record) = identities.next()? {
+        if record[16] == kind {
+            return Ok(Some(record));
+        }
+        if !matches!(record[16], 0 | 1) {
+            return Err(storage("identity stream contains invalid kind"));
+        }
+    }
+    Ok(None)
+}
+
+fn node_batch(
+    uuids: &[[u8; 16]],
+    ids: &[u64],
+    types: &[u32],
+    now: i64,
+) -> Result<RecordBatch, GfError> {
+    let nullable = ListArray::from_iter_primitive::<arrow::datatypes::UInt32Type, _, _>(
+        types.iter().map(|value| Some([Some(*value)])),
+    );
+    let labels = ListArray::new(
+        Arc::new(Field::new("item", DataType::UInt32, false)),
+        nullable.offsets().clone(),
+        nullable.values().clone(),
+        None,
+    );
+    RecordBatch::try_new(
+        TOPOLOGY_NODES_SCHEMA.clone(),
+        vec![
+            Arc::new(FixedSizeBinaryArray::try_from_iter(uuids.iter().copied()).map_err(storage)?),
+            Arc::new(UInt64Array::from(ids.to_vec())),
+            Arc::new(UInt32Array::from(types.to_vec())),
+            Arc::new(labels),
+            Arc::new(TimestampMicrosecondArray::from(vec![now; ids.len()]).with_timezone("UTC")),
+            Arc::new(TimestampMicrosecondArray::from(vec![now; ids.len()]).with_timezone("UTC")),
+        ],
+    )
+    .map_err(storage)
+}
+
+fn edge_batch(
+    uuids: &[[u8; 16]],
+    srcs: &[[u8; 16]],
+    dsts: &[[u8; 16]],
+    ids: &[u64],
+    src_ids: &[u64],
+    dst_ids: &[u64],
+    now: i64,
+) -> Result<RecordBatch, GfError> {
+    RecordBatch::try_new(
+        TYPED_EDGE_SCHEMA.clone(),
+        vec![
+            Arc::new(FixedSizeBinaryArray::try_from_iter(uuids.iter().copied()).map_err(storage)?),
+            Arc::new(FixedSizeBinaryArray::try_from_iter(srcs.iter().copied()).map_err(storage)?),
+            Arc::new(FixedSizeBinaryArray::try_from_iter(dsts.iter().copied()).map_err(storage)?),
+            Arc::new(UInt64Array::from(ids.to_vec())),
+            Arc::new(UInt64Array::from(src_ids.to_vec())),
+            Arc::new(UInt64Array::from(dst_ids.to_vec())),
+            Arc::new(TimestampMicrosecondArray::from(vec![now; ids.len()]).with_timezone("UTC")),
+        ],
+    )
+    .map_err(storage)
+}
+
+fn property_batch(
+    input: &RecordBatch,
+    required: usize,
+    uuid_name: &str,
+    metadata_key: &str,
+    owner: &str,
+    indexes: &[u32],
+) -> Result<RecordBatch, GfError> {
+    let indexes = UInt32Array::from(indexes.to_vec());
+    let mut fields = vec![uuid_field(uuid_name)];
+    fields.extend(
+        input.schema().fields()[required..]
+            .iter()
+            .map(|field| field.as_ref().clone()),
+    );
+    let schema = Schema::new(fields).with_metadata(
+        [(metadata_key.to_owned(), owner.to_owned())]
+            .into_iter()
+            .collect(),
+    );
+    let columns = std::iter::once(input.column(0))
+        .chain(input.columns()[required..].iter())
+        .map(|array| take(array.as_ref(), &indexes, None).map_err(storage))
+        .collect::<Result<Vec<ArrayRef>, _>>()?;
+    RecordBatch::try_new(Arc::new(schema), columns).map_err(storage)
+}
+
+fn select_rows(batch: &RecordBatch, indexes: &[u32]) -> Result<RecordBatch, GfError> {
+    let indexes = UInt32Array::from(indexes.to_vec());
+    let columns = batch
+        .columns()
+        .iter()
+        .map(|array| take(array.as_ref(), &indexes, None).map_err(storage))
+        .collect::<Result<Vec<_>, _>>()?;
+    RecordBatch::try_new(batch.schema(), columns).map_err(storage)
+}
+
+fn required_uuid<'a>(
+    batch: &'a RecordBatch,
+    name: &str,
+) -> Result<&'a FixedSizeBinaryArray, GfError> {
+    batch
+        .column_by_name(name)
+        .and_then(|column| column.as_any().downcast_ref::<FixedSizeBinaryArray>())
+        .ok_or_else(|| storage(format!("{name} is not FixedSizeBinary(16)")))
+}
+
+fn required_string<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a StringArray, GfError> {
+    batch
+        .column_by_name(name)
+        .and_then(|column| column.as_any().downcast_ref::<StringArray>())
+        .ok_or_else(|| storage(format!("{name} is not Utf8")))
+}
+
+fn account_batch(
+    batch: &RecordBatch,
+    budgets: GraphConstructionBudgets,
+    evidence: &mut GraphConstructionEncodingEvidence,
+) -> Result<(), GfError> {
+    let bytes = batch.get_array_memory_size();
+    if batch.num_rows() > budgets.max_batch_rows || bytes > budgets.max_batch_bytes {
+        return Err(storage("decoded canonical batch exceeds encoding budget"));
+    }
+    evidence.peak_batch_rows = evidence.peak_batch_rows.max(batch.num_rows() as u64);
+    evidence.peak_batch_bytes = evidence.peak_batch_bytes.max(bytes as u64);
+    Ok(())
+}
+
+fn read_runtime_label_ids(
+    source: &StableDirectory,
+    name: &str,
+    budgets: GraphConstructionBudgets,
+) -> Result<BTreeMap<String, u32>, GfError> {
+    let file = source.open_child_file(OsStr::new(name)).map_err(storage)?;
+    let mut reader = ParquetRecordBatchReaderBuilder::try_new(file)
+        .map_err(storage)?
+        .with_batch_size(budgets.max_batch_rows)
+        .build()
+        .map_err(storage)?;
+    let mut labels = BTreeMap::new();
+    for batch in &mut reader {
+        let batch = batch.map_err(storage)?;
+        let kinds = required_string(&batch, "entry_kind")?;
+        let names = required_string(&batch, "name")?;
+        let ids = batch
+            .column_by_name("runtime_id")
+            .and_then(|column| column.as_any().downcast_ref::<UInt32Array>())
+            .ok_or_else(|| storage("runtime catalog id is not UInt32"))?;
+        for row in 0..batch.num_rows() {
+            if kinds.value(row) == "entity_type" {
+                let tagged = runtime_entity_type_id(graphforge_ir::RuntimeTypeId(ids.value(row))).0;
+                if labels.insert(names.value(row).to_owned(), tagged).is_some() {
+                    return Err(storage("runtime catalog repeats an entity type"));
+                }
+            }
+        }
+    }
+    Ok(labels)
+}
+
+fn write_surrogate_tails(
+    output: &StableDirectory,
+    max_node_id: u64,
+    max_edge_id: u64,
+    artifacts: &mut Vec<ConstructionEncodedArtifact>,
+    evidence: &mut GraphConstructionEncodingEvidence,
+) -> Result<(), GfError> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("max_node_id", DataType::UInt64, false),
+        Field::new("max_edge_id", DataType::UInt64, false),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(UInt64Array::from(vec![max_node_id])),
+            Arc::new(UInt64Array::from(vec![max_edge_id])),
+        ],
+    )
+    .map_err(storage)?;
+    artifacts.push(write_parquet(
+        output,
+        "topology/surrogate_tails.parquet",
+        &batch,
+        evidence,
+    )?);
+    Ok(())
+}
+
+fn write_parquet(
+    root: &StableDirectory,
+    relative: &str,
+    batch: &RecordBatch,
+    evidence: &mut GraphConstructionEncodingEvidence,
+) -> Result<ConstructionEncodedArtifact, GfError> {
+    let (directory, name) = directory_for(root, relative)?;
+    let temporary = format!(".{}-{}.tmp", name, Uuid::new_v4().simple());
+    let file = directory
+        .create_replaceable_child_file(OsStr::new(&temporary))
+        .map_err(storage)?;
+    let identity = file_identity(&file).map_err(storage)?;
+    let mut writer = ArrowWriter::try_new(file, batch.schema(), None).map_err(storage)?;
+    writer.write(batch).map_err(storage)?;
+    writer.close().map_err(storage)?;
+    let mut file = directory
+        .open_child_file(OsStr::new(&temporary))
+        .map_err(storage)?;
+    file.sync_all().map_err(storage)?;
+    let artifact = authenticate_file(relative, &mut file)?;
+    directory
+        .replace_child(OsStr::new(&temporary), identity, OsStr::new(&name))
+        .map_err(storage)?;
+    directory.sync().map_err(storage)?;
+    evidence.output_write_bytes = evidence.output_write_bytes.saturating_add(artifact.bytes);
+    evidence.output_write_operations = evidence.output_write_operations.saturating_add(1);
+    evidence.fsync_operations = evidence.fsync_operations.saturating_add(2);
+    Ok(artifact)
+}
+
+fn copy_artifact(
+    source: &StableDirectory,
+    source_name: &str,
+    output: &StableDirectory,
+    relative: &str,
+    artifacts: &mut Vec<ConstructionEncodedArtifact>,
+    evidence: &mut GraphConstructionEncodingEvidence,
+) -> Result<(), GfError> {
+    let mut input = BufReader::with_capacity(
+        COPY_BUFFER_BYTES,
+        source
+            .open_child_file(OsStr::new(source_name))
+            .map_err(storage)?,
+    );
+    let (directory, name) = directory_for(output, relative)?;
+    let temporary = format!(".{}-{}.tmp", name, Uuid::new_v4().simple());
+    let file = directory
+        .create_replaceable_child_file(OsStr::new(&temporary))
+        .map_err(storage)?;
+    let identity = file_identity(&file).map_err(storage)?;
+    let mut writer = BufWriter::with_capacity(COPY_BUFFER_BYTES, file);
+    let bytes = std::io::copy(&mut input, &mut writer).map_err(storage)?;
+    writer.flush().map_err(storage)?;
+    writer.get_ref().sync_all().map_err(storage)?;
+    drop(writer);
+    let mut file = directory
+        .open_child_file(OsStr::new(&temporary))
+        .map_err(storage)?;
+    let artifact = authenticate_file(relative, &mut file)?;
+    if artifact.bytes != bytes {
+        return Err(storage("copied canonical artifact length changed"));
+    }
+    directory
+        .replace_child(OsStr::new(&temporary), identity, OsStr::new(&name))
+        .map_err(storage)?;
+    directory.sync().map_err(storage)?;
+    evidence.input_read_bytes = evidence.input_read_bytes.saturating_add(bytes);
+    evidence.input_read_operations = evidence
+        .input_read_operations
+        .saturating_add(bytes.div_ceil(COPY_BUFFER_BYTES as u64));
+    evidence.output_write_bytes = evidence.output_write_bytes.saturating_add(bytes);
+    evidence.output_write_operations = evidence
+        .output_write_operations
+        .saturating_add(bytes.div_ceil(COPY_BUFFER_BYTES as u64));
+    evidence.fsync_operations = evidence.fsync_operations.saturating_add(2);
+    artifacts.push(artifact);
+    Ok(())
+}
+
+fn directory_for(
+    root: &StableDirectory,
+    relative: &str,
+) -> Result<(StableDirectory, String), GfError> {
+    let path = Path::new(relative);
+    if path.is_absolute() {
+        return Err(storage("canonical artifact path is absolute"));
+    }
+    let mut components = path.components().collect::<Vec<_>>();
+    let name = match components.pop() {
+        Some(Component::Normal(name)) => name
+            .to_str()
+            .ok_or_else(|| storage("canonical artifact name is not UTF-8"))?
+            .to_owned(),
+        _ => return Err(storage("canonical artifact path has no file name")),
+    };
+    let mut directory = root
+        .create_child_directory(OsStr::new("graph"))
+        .map_err(storage)?;
+    for component in components {
+        let Component::Normal(name) = component else {
+            return Err(storage("canonical artifact path is not normalized"));
+        };
+        directory = directory.create_child_directory(name).map_err(storage)?;
+    }
+    Ok((directory, name))
+}
+
+fn authenticate_file(path: &str, file: &mut File) -> Result<ConstructionEncodedArtifact, GfError> {
+    let mut digest = Sha256::new();
+    let mut bytes = 0_u64;
+    let mut buffer = vec![0_u8; COPY_BUFFER_BYTES];
+    file.rewind().map_err(storage)?;
+    loop {
+        let read = file.read(&mut buffer).map_err(storage)?;
+        if read == 0 {
+            break;
+        }
+        digest.update(&buffer[..read]);
+        bytes = bytes.saturating_add(read as u64);
+    }
+    Ok(ConstructionEncodedArtifact {
+        path: path.to_owned(),
+        bytes,
+        sha256: hex(&digest.finalize()),
+    })
+}
+
+fn read_inventory(root: &StableDirectory) -> Result<Option<GraphConstructionEncoding>, GfError> {
+    let mut file = match root.open_child_file(OsStr::new(INVENTORY)) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(storage(error)),
+    };
+    if file.metadata().map_err(storage)?.len() > MAX_INVENTORY_BYTES {
+        return Err(storage("canonical inventory exceeds bound"));
+    }
+    serde_json::from_reader(&mut file)
+        .map(Some)
+        .map_err(storage)
+}
+
+fn authenticate_inventory(
+    root: &StableDirectory,
+    inventory: &GraphConstructionEncoding,
+) -> Result<(), GfError> {
+    if inventory.root != ENCODED_ROOT
+        || inventory.shape_inputs_sha256.len() != 64
+        || !inventory
+            .shape_inputs_sha256
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit())
+        || inventory
+            .artifacts
+            .windows(2)
+            .any(|pair| pair[0].path >= pair[1].path)
+        || inventory.evidence.prior_topology_rows_decoded != 0
+        || inventory.evidence.retained_topology_bytes_copied != 0
+    {
+        return Err(storage("canonical inventory invariants are invalid"));
+    }
+    for expected in &inventory.artifacts {
+        let (directory, name) = directory_for(root, &expected.path)?;
+        let mut file = directory
+            .open_child_file(OsStr::new(&name))
+            .map_err(storage)?;
+        let actual = authenticate_file(&expected.path, &mut file)?;
+        if &actual != expected {
+            return Err(storage("canonical artifact differs from inventory"));
+        }
+    }
+    Ok(())
+}
+
+fn install_json<T: Serialize>(
+    root: &StableDirectory,
+    name: &str,
+    value: &T,
+) -> Result<(), GfError> {
+    let temporary = format!(".{name}-{}.tmp", Uuid::new_v4().simple());
+    let mut file = root
+        .create_replaceable_child_file(OsStr::new(&temporary))
+        .map_err(storage)?;
+    let identity = file_identity(&file).map_err(storage)?;
+    serde_json::to_writer(&mut file, value).map_err(storage)?;
+    file.flush().map_err(storage)?;
+    file.sync_all().map_err(storage)?;
+    drop(file);
+    root.replace_child(OsStr::new(&temporary), identity, OsStr::new(name))
+        .map_err(storage)?;
+    root.sync().map_err(storage)
+}
+
+struct FixedReader<const N: usize> {
+    reader: BufReader<File>,
+}
+
+impl<const N: usize> FixedReader<N> {
+    fn open(
+        root: &StableDirectory,
+        name: &str,
+        evidence: &mut GraphConstructionEncodingEvidence,
+    ) -> Result<Self, GfError> {
+        let file = root.open_child_file(OsStr::new(name)).map_err(storage)?;
+        if file.metadata().map_err(storage)?.len() % N as u64 != 0 {
+            return Err(storage("fixed-width construction stream is truncated"));
+        }
+        let bytes = file.metadata().map_err(storage)?.len();
+        evidence.input_read_bytes = evidence.input_read_bytes.saturating_add(bytes);
+        evidence.input_read_operations = evidence
+            .input_read_operations
+            .saturating_add(bytes.div_ceil(COPY_BUFFER_BYTES as u64));
+        Ok(Self {
+            reader: BufReader::with_capacity(COPY_BUFFER_BYTES, file),
+        })
+    }
+
+    fn next(&mut self) -> Result<Option<[u8; N]>, GfError> {
+        let mut record = [0_u8; N];
+        let mut read = 0;
+        while read < N {
+            let amount = self.reader.read(&mut record[read..]).map_err(storage)?;
+            if amount == 0 {
+                if read == 0 {
+                    return Ok(None);
+                }
+                return Err(storage("fixed-width construction stream is truncated"));
+            }
+            read += amount;
+        }
+        Ok(Some(record))
+    }
+}
+
+fn hex(bytes: &[u8]) -> String {
+    const DIGITS: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(DIGITS[(byte >> 4) as usize] as char);
+        out.push(DIGITS[(byte & 0x0f) as usize] as char);
+    }
+    out
+}

--- a/crates/graphforge-storage/src/graph_construction_encoding.rs
+++ b/crates/graphforge-storage/src/graph_construction_encoding.rs
@@ -4,8 +4,7 @@
 //! It converts the shaper's authenticated, UUID-ordered streams into the exact
 //! ordinary storage schemas and prepares a streamed UUID-membership manifest.
 
-use std::cmp::Reverse;
-use std::collections::{BTreeMap, BinaryHeap};
+use std::collections::BTreeMap;
 use std::ffi::OsStr;
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Seek, Write};
@@ -21,7 +20,7 @@ use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use graphforge_core::GfError;
 use graphforge_core::OntologyMode;
-use graphforge_filesystem::{StableDirectory, file_identity};
+use graphforge_filesystem::{StableDirectory, file_identity, file_link_count};
 use graphforge_ir::runtime_entity_type_id;
 use graphforge_ir::{CompositionBindingContext, SymbolBinding};
 use graphforge_ontology::{QualifiedSymbol, SymbolKind};
@@ -32,8 +31,8 @@ use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::graph_construction::{
-    ConstructionSemanticAuthority, ConstructionShape, CountingChunkReader,
-    GraphConstructionBudgets, IoCounter,
+    ArtifactReceipt, ConstructionSemanticAuthority, ConstructionShape, CountingChunkReader,
+    GraphConstructionBudgets, IoCounter, authenticate_shaped_outputs, shaped_output_sha256,
 };
 use crate::schemas::{
     TOPOLOGY_NODES_SCHEMA, TYPED_EDGE_SCHEMA, uuid_field, with_semantic_route_metadata,
@@ -45,6 +44,7 @@ use crate::{SemanticRouteKind, SemanticStorageBindings};
 
 const ENCODED_ROOT: &str = "encoded-v1";
 const INVENTORY: &str = "inventory.json";
+const ENCODING_INTENT: &str = "encoding-intent.json";
 const MAX_INVENTORY_BYTES: u64 = 16 << 20;
 const IDENTITY_WIDTH: usize = 32;
 const NODE_DETAIL_WIDTH: usize = 272;
@@ -60,6 +60,37 @@ struct CountingWriter {
 struct CountingInput<R> {
     inner: R,
     counter: IoCounter,
+}
+
+struct EncodingTempGuard<'a> {
+    directory: &'a StableDirectory,
+    name: String,
+    identity: graphforge_filesystem::FileIdentity,
+    armed: bool,
+}
+
+impl EncodingTempGuard<'_> {
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for EncodingTempGuard<'_> {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        if let Ok(file) = self.directory.open_child_file(OsStr::new(&self.name))
+            && file_identity(&file).ok() == Some(self.identity)
+            && file_link_count(&file).ok() == Some(1)
+        {
+            drop(file);
+            let _ = self
+                .directory
+                .unlink_child_if_identity(OsStr::new(&self.name), self.identity);
+            let _ = self.directory.sync();
+        }
+    }
 }
 
 impl<R: Read> Read for CountingInput<R> {
@@ -80,149 +111,6 @@ impl Write for CountingWriter {
     fn flush(&mut self) -> std::io::Result<()> {
         self.inner.flush()
     }
-}
-
-struct EncodingRowCursor {
-    reader: Box<dyn Iterator<Item = Result<RecordBatch, arrow::error::ArrowError>>>,
-    batch: Option<RecordBatch>,
-    row: usize,
-    batch_sequence: u64,
-    counter: IoCounter,
-    counter_accounted: bool,
-}
-
-impl EncodingRowCursor {
-    fn current_uuid(
-        &mut self,
-        uuid_name: &str,
-        evidence: &mut GraphConstructionEncodingEvidence,
-    ) -> Result<Option<[u8; 16]>, GfError> {
-        loop {
-            if let Some(batch) = &self.batch
-                && self.row < batch.num_rows()
-            {
-                let values = required_uuid(batch, uuid_name)?;
-                return Ok(Some(values.value(self.row).try_into().expect("fixed UUID")));
-            }
-            self.batch = self.reader.next().transpose().map_err(storage)?;
-            self.row = 0;
-            self.batch_sequence = self.batch_sequence.saturating_add(1);
-            if self.batch.is_none() {
-                if !self.counter_accounted {
-                    let (bytes, operations) = self.counter.values();
-                    evidence.input_read_bytes = evidence.input_read_bytes.saturating_add(bytes);
-                    evidence.input_read_operations =
-                        evidence.input_read_operations.saturating_add(operations);
-                    self.counter_accounted = true;
-                }
-                return Ok(None);
-            }
-        }
-    }
-}
-
-#[derive(Clone)]
-struct MergedEncodingRow {
-    source: usize,
-    batch_sequence: u64,
-    batch: RecordBatch,
-    row: usize,
-}
-
-type EncodingRowHeap = BinaryHeap<(Reverse<[u8; 16]>, Reverse<usize>)>;
-
-fn open_merged_rows(
-    source: &StableDirectory,
-    names: &[String],
-    uuid_name: &str,
-    budgets: GraphConstructionBudgets,
-    evidence: &mut GraphConstructionEncodingEvidence,
-) -> Result<(Vec<EncodingRowCursor>, EncodingRowHeap), GfError> {
-    if names.len() > budgets.max_schema_groups {
-        return Err(storage(
-            "encoded schema registry exceeds its cardinality cap",
-        ));
-    }
-    let mut cursors = Vec::with_capacity(names.len());
-    for name in names {
-        let file = source.open_child_file(OsStr::new(name)).map_err(storage)?;
-        let counter = IoCounter::default();
-        let reader = ParquetRecordBatchReaderBuilder::try_new(CountingChunkReader {
-            file,
-            counter: counter.clone(),
-        })
-        .map_err(storage)?
-        .with_batch_size(budgets.max_batch_rows)
-        .build()
-        .map_err(storage)?;
-        cursors.push(EncodingRowCursor {
-            reader: Box::new(reader),
-            batch: None,
-            row: 0,
-            batch_sequence: 0,
-            counter,
-            counter_accounted: false,
-        });
-    }
-    let mut heap = BinaryHeap::new();
-    for (index, cursor) in cursors.iter_mut().enumerate() {
-        if let Some(uuid) = cursor.current_uuid(uuid_name, evidence)? {
-            heap.push((Reverse(uuid), Reverse(index)));
-        }
-    }
-    Ok((cursors, heap))
-}
-
-fn next_merged_window(
-    cursors: &mut [EncodingRowCursor],
-    heap: &mut BinaryHeap<(Reverse<[u8; 16]>, Reverse<usize>)>,
-    uuid_name: &str,
-    budgets: GraphConstructionBudgets,
-    cancelled: &mut impl FnMut() -> bool,
-    evidence: &mut GraphConstructionEncodingEvidence,
-) -> Result<Vec<MergedEncodingRow>, GfError> {
-    let mut rows = Vec::with_capacity(budgets.max_batch_rows);
-    let mut retained_bytes = 0_usize;
-    let mut previous = None;
-    while rows.len() < budgets.max_batch_rows {
-        let Some((Reverse(uuid), Reverse(source))) = heap.pop() else {
-            break;
-        };
-        if previous.is_some_and(|prior| prior >= uuid) {
-            return Err(storage(
-                "heterogeneous row streams are not globally unique and sorted",
-            ));
-        }
-        previous = Some(uuid);
-        let cursor = &mut cursors[source];
-        let batch = cursor.batch.as_ref().expect("heap row has batch");
-        if rows.iter().all(|row: &MergedEncodingRow| {
-            row.source != source || row.batch_sequence != cursor.batch_sequence
-        }) {
-            account_batch(batch, budgets, evidence)?;
-            retained_bytes = retained_bytes.saturating_add(batch.get_array_memory_size());
-            if !rows.is_empty() && retained_bytes > budgets.max_batch_bytes {
-                heap.push((Reverse(uuid), Reverse(source)));
-                break;
-            }
-        }
-        rows.push(MergedEncodingRow {
-            source,
-            batch_sequence: cursor.batch_sequence,
-            batch: batch.clone(),
-            row: cursor.row,
-        });
-        cursor.row += 1;
-        if let Some(next) = cursor.current_uuid(uuid_name, evidence)? {
-            heap.push((Reverse(next), Reverse(source)));
-        }
-        if rows.len().is_multiple_of(4096) && cancelled() {
-            return Err(storage("construction encoding cancelled"));
-        }
-    }
-    evidence.peak_batch_rows = evidence.peak_batch_rows.max(rows.len() as u64);
-    evidence.peak_batch_bytes = evidence.peak_batch_bytes.max(retained_bytes as u64);
-    Ok(rows)
 }
 
 fn storage(error: impl std::fmt::Display) -> GfError {
@@ -297,11 +185,15 @@ pub struct GraphConstructionEncodingEvidence {
     /// Retained v3 payload bytes read only for required binary-carry compaction.
     pub retained_index_payload_bytes: u64,
     /// Actual block reads performed by v3 construction encoding and carry.
+    pub membership_read_bytes: u64,
+    /// Actual block reads performed by v3 construction encoding and carry.
     pub membership_read_operations: u64,
     /// Actual block writes, including outputs superseded by carry.
     pub membership_write_operations: u64,
     /// All v3 bytes written, including superseded carry inputs.
     pub membership_total_write_bytes: u64,
+    /// Largest number of decoded shaped-row readers simultaneously live.
+    pub peak_open_input_readers: u64,
     /// v3 durability barriers.
     pub membership_fsync_operations: u64,
     /// Newly created immutable v3 runs, including superseded carry inputs.
@@ -333,6 +225,15 @@ pub struct GraphConstructionEncoding {
     pub evidence: GraphConstructionEncodingEvidence,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct EncodingIntent {
+    generation: u64,
+    parent_generation: u64,
+    ontology_mode: OntologyMode,
+    semantic_authority_sha256: Option<String>,
+    shape_inputs_sha256: String,
+}
+
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 pub(crate) fn encode(
     source: &StableDirectory,
@@ -341,6 +242,7 @@ pub(crate) fn encode(
     ontology_mode: OntologyMode,
     parent_index: Option<&AuthenticatedUuidIndexSnapshot>,
     semantic_authority: Option<&ConstructionSemanticAuthority>,
+    shape_outputs: &[ArtifactReceipt],
     budgets: GraphConstructionBudgets,
     cancelled: &mut impl FnMut() -> bool,
 ) -> Result<GraphConstructionEncoding, GfError> {
@@ -355,8 +257,10 @@ pub(crate) fn encode(
     if shape.semantic_authority_sha256 != semantic_digest {
         return Err(storage("shape semantic authority differs from session"));
     }
-    if generation == 0 || generation <= shape.parent_topology_generation {
-        return Err(storage("encoded generation is not newer than its parent"));
+    if generation != shape.parent_topology_generation.saturating_add(1) {
+        return Err(storage(
+            "encoded generation is not consecutive to its parent",
+        ));
     }
     if cancelled() {
         return Err(storage("construction encoding cancelled"));
@@ -364,8 +268,9 @@ pub(crate) fn encode(
     let output = source
         .create_child_directory(OsStr::new(ENCODED_ROOT))
         .map_err(storage)?;
+    cleanup_encoding_temps(&output, budgets)?;
     if let Some(existing) = read_inventory(&output)? {
-        authenticate_inventory(&output, &existing)?;
+        authenticate_inventory(&output, &existing, parent_index)?;
         if existing.generation != generation
             || existing.ontology_mode != shape.ontology_mode
             || existing.semantic_authority_sha256 != shape.semantic_authority_sha256
@@ -373,7 +278,25 @@ pub(crate) fn encode(
         {
             return Err(storage("completed encoding belongs to another generation"));
         }
+        remove_encoding_intent(&output)?;
         return Ok(existing);
+    }
+
+    let intent = EncodingIntent {
+        generation,
+        parent_generation: shape.parent_topology_generation,
+        ontology_mode,
+        semantic_authority_sha256: shape.semantic_authority_sha256.clone(),
+        shape_inputs_sha256: shape.runtime_catalog_inputs_sha256.clone(),
+    };
+    match read_encoding_intent(&output)? {
+        Some(existing) if existing != intent => {
+            return Err(storage(
+                "incomplete encoding intent belongs to another authority",
+            ));
+        }
+        Some(_) => {}
+        None => install_json(&output, ENCODING_INTENT, &intent)?,
     }
 
     let mut evidence = GraphConstructionEncodingEvidence {
@@ -427,9 +350,12 @@ pub(crate) fn encode(
         &mut evidence,
     )?;
 
+    authenticate_shaped_outputs(source, shape_outputs)?;
+
     let index = crate::uuid_membership::encode_construction_index(
         source,
         &shape.identities,
+        shaped_output_sha256(shape_outputs, &shape.identities)?,
         &output,
         generation,
         shape.parent_topology_generation,
@@ -439,7 +365,8 @@ pub(crate) fn encode(
         cancelled,
     )?;
     evidence.membership_records = index.input_records;
-    evidence.membership_write_bytes = index.write_bytes;
+    evidence.membership_read_bytes = index.read_bytes;
+    evidence.membership_write_bytes = index.final_write_bytes;
     evidence.membership_total_write_bytes = index.write_bytes;
     evidence.membership_read_operations = index.read_operations;
     evidence.membership_write_operations = index.write_operations;
@@ -473,8 +400,10 @@ pub(crate) fn encode(
         retained_artifacts,
         evidence,
     };
+    authenticate_shaped_outputs(source, shape_outputs)?;
     install_json(&output, INVENTORY, &completed)?;
-    authenticate_inventory(&output, &completed)?;
+    authenticate_inventory(&output, &completed, parent_index)?;
+    remove_encoding_intent(&output)?;
     Ok(completed)
 }
 
@@ -569,7 +498,7 @@ fn property_projection(
         if !indexes.iter().any(|index| !column.is_null(*index as usize)) {
             continue;
         }
-        if let (Some(context), Some(bindings), Some(owner_symbol)) =
+        if let (Some(context), Some(bindings), Some(_owner_symbol)) =
             (context, bindings, owner.symbol.as_ref())
         {
             let schema = input.schema();
@@ -587,12 +516,11 @@ fn property_projection(
             let physical = bindings
                 .bindings
                 .iter()
-                .find(|candidate| {
-                    candidate.route_kind == route_kind
-                        && candidate.symbol == symbol
-                        && candidate.owner.as_ref() == Some(owner_symbol)
-                })
+                .find(|candidate| candidate.route_kind == route_kind && candidate.symbol == symbol)
                 .ok_or_else(|| storage("qualified property lacks owner-bound physical route"))?;
+            if physical.owner.is_none() {
+                return Err(storage("qualified property binding lacks declaring owner"));
+            }
             if route.as_ref().is_some_and(|known| known != &physical.route) {
                 return Err(storage(
                     "one semantic owner maps to multiple property routes",
@@ -631,48 +559,29 @@ fn encode_nodes(
         .ok_or_else(|| storage("node rows lack canonical details"))?;
     let mut identities = FixedReader::<IDENTITY_WIDTH>::open(source, &shape.identities, evidence)?;
     let mut details = FixedReader::<NODE_DETAIL_WIDTH>::open(source, details_name, evidence)?;
-    let (mut row_cursors, mut row_heap) =
-        open_merged_rows(source, &shape.node_rows, "node_uuid", budgets, evidence)?;
-    let mut ordinal = 0_u64;
+    let rows_per_window = budgets
+        .max_batch_rows
+        .min((budgets.max_batch_bytes / 128).max(1));
     loop {
         if cancelled() {
             return Err(storage("construction encoding cancelled"));
         }
-        let merged = next_merged_window(
-            &mut row_cursors,
-            &mut row_heap,
-            "node_uuid",
-            budgets,
-            cancelled,
-            evidence,
-        )?;
-        if merged.is_empty() {
-            break;
-        }
-        let mut out_uuid = Vec::with_capacity(merged.len());
-        let mut out_id = Vec::with_capacity(merged.len());
-        let mut out_type = Vec::with_capacity(merged.len());
+        let mut out_uuid = Vec::with_capacity(rows_per_window);
+        let mut out_id = Vec::with_capacity(rows_per_window);
+        let mut out_type = Vec::with_capacity(rows_per_window);
         let mut owners = BTreeMap::<String, ResolvedOwner>::new();
-        let mut groups = BTreeMap::<(usize, u64, String), (RecordBatch, Vec<u32>)>::new();
-        for merged_row in &merged {
-            let input = &merged_row.batch;
-            let row = merged_row.row;
-            let uuids = required_uuid(input, "node_uuid")?;
-            let labels = required_string(input, "label")?;
-            let uuid: [u8; 16] = uuids.value(row).try_into().expect("fixed UUID");
-            let identity = next_kind(&mut identities, 0)?
-                .ok_or_else(|| storage("node identity stream ended early"))?;
-            let detail = details
-                .next()?
-                .ok_or_else(|| storage("node detail stream ended early"))?;
-            if identity[..16] != uuid || detail[..16] != uuid || identity[17] != 0 {
-                return Err(storage("node row/detail/identity streams differ"));
+        while out_uuid.len() < rows_per_window {
+            let (identity, detail) = match (next_kind(&mut identities, 0)?, details.next()?) {
+                (Some(identity), Some(detail)) => (identity, detail),
+                (None, None) => break,
+                _ => return Err(storage("node detail and identity stream lengths differ")),
+            };
+            if identity[..16] != detail[..16] || identity[17] != 0 {
+                return Err(storage("node detail and identity streams differ"));
             }
+            let uuid: [u8; 16] = detail[..16].try_into().expect("fixed UUID");
             let label_len = usize::from(detail[16]);
             let label = std::str::from_utf8(&detail[17..17 + label_len]).map_err(storage)?;
-            if label != labels.value(row) {
-                return Err(storage("node detail label differs from normalized row"));
-            }
             let runtime_route = if ontology_mode == OntologyMode::Exploratory {
                 "_untyped"
             } else {
@@ -703,18 +612,12 @@ fn encode_nodes(
                 identity[24..32].try_into().expect("fixed"),
             ));
             out_type.push(type_id);
-            groups
-                .entry((
-                    merged_row.source,
-                    merged_row.batch_sequence,
-                    label.to_owned(),
-                ))
-                .or_insert_with(|| (input.clone(), Vec::new()))
-                .1
-                .push(u32::try_from(row).map_err(storage)?);
+            if out_uuid.len().is_multiple_of(4096) && cancelled() {
+                return Err(storage("construction encoding cancelled"));
+            }
         }
         if out_id.is_empty() {
-            continue;
+            break;
         }
         let canonical = node_batch(
             &out_uuid,
@@ -722,62 +625,132 @@ fn encode_nodes(
             &out_type,
             shape.runtime_catalog_now_micros,
         )?;
+        account_batch(&canonical, budgets, evidence)?;
         let first = *out_id.first().expect("nonempty");
         let last = *out_id.last().expect("nonempty");
         let path = format!("topology/nodes/{first:020}-{last:020}.parquet");
         artifacts.push(write_parquet(output, &path, &canonical, evidence)?);
-        for ((_source, _batch_sequence, label), (input, indexes)) in groups {
-            if input.num_columns() == 2 {
-                continue;
-            }
-            let owner = owners
-                .get(&label)
-                .ok_or_else(|| storage("node owner resolution was lost"))?;
-            let (route, fields) = property_projection(
-                &input,
-                2,
-                &indexes,
-                owner,
-                SymbolKind::Entity,
-                SemanticRouteKind::NodeProperty,
-                semantic_context,
-                semantic_bindings,
-            )?;
-            if fields.is_empty() {
-                continue;
-            }
-            let property = property_batch(
-                &input,
-                "node_uuid",
-                "graphforge.entity_type",
-                &route,
-                &indexes,
-                &fields,
-            )?;
-            let property = if owner.symbol.is_some() {
-                with_route_metadata_batch(
-                    &property,
-                    &route,
-                    semantic_context
-                        .expect("qualified owner has context")
-                        .fingerprint(),
-                )?
-            } else {
-                property
-            };
-            let path = format!(
-                "properties/{route}/{:020}-{ordinal:020}.parquet",
-                shape.parent_topology_generation + 1
-            );
-            artifacts.push(write_parquet(output, &path, &property, evidence)?);
-            ordinal = ordinal.saturating_add(1);
-        }
     }
     if details.next()?.is_some() || next_kind(&mut identities, 0)?.is_some() {
         return Err(storage("node streams contain unconsumed rows"));
     }
     identities.account(evidence);
     details.account(evidence);
+    encode_node_properties(
+        source,
+        output,
+        shape,
+        ontology_mode,
+        semantic_context,
+        semantic_bindings,
+        budgets,
+        cancelled,
+        artifacts,
+        evidence,
+    )
+}
+
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+fn encode_node_properties(
+    source: &StableDirectory,
+    output: &StableDirectory,
+    shape: &ConstructionShape,
+    ontology_mode: OntologyMode,
+    semantic_context: Option<&CompositionBindingContext>,
+    semantic_bindings: Option<&SemanticStorageBindings>,
+    budgets: GraphConstructionBudgets,
+    cancelled: &mut impl FnMut() -> bool,
+    artifacts: &mut Vec<ConstructionEncodedArtifact>,
+    evidence: &mut GraphConstructionEncodingEvidence,
+) -> Result<(), GfError> {
+    let mut ordinal = 0_u64;
+    for name in &shape.node_rows {
+        if cancelled() {
+            return Err(storage("construction encoding cancelled"));
+        }
+        let file = source.open_child_file(OsStr::new(name)).map_err(storage)?;
+        let counter = IoCounter::default();
+        let mut reader = ParquetRecordBatchReaderBuilder::try_new(CountingChunkReader {
+            file,
+            counter: counter.clone(),
+        })
+        .map_err(storage)?
+        .with_batch_size(budgets.max_batch_rows)
+        .build()
+        .map_err(storage)?;
+        evidence.peak_open_input_readers = evidence.peak_open_input_readers.max(1);
+        for input in &mut reader {
+            let input = input.map_err(storage)?;
+            account_batch(&input, budgets, evidence)?;
+            if input.num_columns() == 2 {
+                continue;
+            }
+            let labels = required_string(&input, "label")?;
+            let mut groups = BTreeMap::<String, Vec<u32>>::new();
+            for row in 0..input.num_rows() {
+                groups
+                    .entry(labels.value(row).to_owned())
+                    .or_default()
+                    .push(u32::try_from(row).map_err(storage)?);
+            }
+            for (label, indexes) in groups {
+                let runtime_route = if ontology_mode == OntologyMode::Exploratory {
+                    "_untyped"
+                } else {
+                    label.as_str()
+                };
+                let owner = resolve_owner(
+                    semantic_context,
+                    semantic_bindings,
+                    SymbolKind::Entity,
+                    SemanticRouteKind::Entity,
+                    &label,
+                    runtime_route,
+                )?;
+                let (route, fields) = property_projection(
+                    &input,
+                    2,
+                    &indexes,
+                    &owner,
+                    SymbolKind::Entity,
+                    SemanticRouteKind::NodeProperty,
+                    semantic_context,
+                    semantic_bindings,
+                )?;
+                if fields.is_empty() {
+                    continue;
+                }
+                let property = property_batch(
+                    &input,
+                    "node_uuid",
+                    "graphforge.entity_type",
+                    &route,
+                    &indexes,
+                    &fields,
+                )?;
+                let property = if owner.symbol.is_some() {
+                    with_route_metadata_batch(
+                        &property,
+                        &route,
+                        semantic_context
+                            .expect("qualified owner has context")
+                            .fingerprint(),
+                    )?
+                } else {
+                    property
+                };
+                let path = format!(
+                    "properties/{route}/{:020}-{ordinal:020}.parquet",
+                    shape.parent_topology_generation + 1
+                );
+                artifacts.push(write_parquet(output, &path, &property, evidence)?);
+                ordinal = ordinal.saturating_add(1);
+            }
+        }
+        let (bytes, operations) = counter.values();
+        evidence.input_read_bytes = evidence.input_read_bytes.saturating_add(bytes);
+        evidence.input_read_operations = evidence.input_read_operations.saturating_add(operations);
+    }
     Ok(())
 }
 
@@ -809,52 +782,32 @@ fn encode_edges(
     let mut details = FixedReader::<EDGE_DETAIL_WIDTH>::open(source, details_name, evidence)?;
     let mut endpoints =
         FixedReader::<RESOLVED_ENDPOINT_WIDTH>::open(source, endpoints_name, evidence)?;
-    let (mut row_cursors, mut row_heap) =
-        open_merged_rows(source, &shape.edge_rows, "edge_uuid", budgets, evidence)?;
-    let mut ordinal = 0_u64;
+    let rows_per_window = budgets
+        .max_batch_rows
+        .min((budgets.max_batch_bytes / 192).max(1));
     loop {
         if cancelled() {
             return Err(storage("construction encoding cancelled"));
         }
-        let merged = next_merged_window(
-            &mut row_cursors,
-            &mut row_heap,
-            "edge_uuid",
-            budgets,
-            cancelled,
-            evidence,
-        )?;
-        if merged.is_empty() {
-            break;
-        }
-        let mut out_uuid = Vec::with_capacity(merged.len());
-        let mut out_src = Vec::with_capacity(merged.len());
-        let mut out_dst = Vec::with_capacity(merged.len());
-        let mut out_id = Vec::with_capacity(merged.len());
-        let mut out_src_id = Vec::with_capacity(merged.len());
-        let mut out_dst_id = Vec::with_capacity(merged.len());
-        let mut owners = BTreeMap::<String, ResolvedOwner>::new();
-        let mut groups =
-            BTreeMap::<(usize, u64, String), (RecordBatch, Vec<u32>, Vec<usize>)>::new();
-        for (output_row, merged_row) in merged.iter().enumerate() {
-            let input = &merged_row.batch;
-            let row = merged_row.row;
-            let uuids = required_uuid(input, "edge_uuid")?;
-            let srcs = required_uuid(input, "source_uuid")?;
-            let dsts = required_uuid(input, "target_uuid")?;
-            let routes = required_string(input, "rel_type")?;
-            let uuid: [u8; 16] = uuids.value(row).try_into().expect("fixed UUID");
-            let identity = next_kind(&mut identities, 1)?
-                .ok_or_else(|| storage("edge identity stream ended early"))?;
-            let detail = details
-                .next()?
-                .ok_or_else(|| storage("edge detail stream ended early"))?;
-            let source_endpoint = endpoints
-                .next()?
-                .ok_or_else(|| storage("edge endpoint stream ended early"))?;
-            let target_endpoint = endpoints
-                .next()?
-                .ok_or_else(|| storage("edge endpoint stream ended early"))?;
+        let mut out_uuid = Vec::with_capacity(rows_per_window);
+        let mut out_src = Vec::with_capacity(rows_per_window);
+        let mut out_dst = Vec::with_capacity(rows_per_window);
+        let mut out_id = Vec::with_capacity(rows_per_window);
+        let mut out_src_id = Vec::with_capacity(rows_per_window);
+        let mut out_dst_id = Vec::with_capacity(rows_per_window);
+        let mut groups = BTreeMap::<String, Vec<u32>>::new();
+        while out_uuid.len() < rows_per_window {
+            let (identity, detail) = match (next_kind(&mut identities, 1)?, details.next()?) {
+                (Some(identity), Some(detail)) => (identity, detail),
+                (None, None) => break,
+                _ => return Err(storage("edge detail and identity stream lengths differ")),
+            };
+            let (Some(source_endpoint), Some(target_endpoint)) =
+                (endpoints.next()?, endpoints.next()?)
+            else {
+                return Err(storage("edge endpoint stream ended early"));
+            };
+            let uuid: [u8; 16] = detail[..16].try_into().expect("fixed UUID");
             if identity[..16] != uuid
                 || detail[..16] != uuid
                 || identity[17] != 0
@@ -867,15 +820,9 @@ fn encode_edges(
             }
             let route_len = usize::from(detail[48]);
             let route = std::str::from_utf8(&detail[49..49 + route_len]).map_err(storage)?;
-            if route != routes.value(row)
-                || detail[16..32] != srcs.value(row)[..]
-                || detail[32..48] != dsts.value(row)[..]
-            {
-                return Err(storage("edge canonical detail differs from normalized row"));
-            }
             out_uuid.push(uuid);
-            out_src.push(srcs.value(row).try_into().expect("fixed UUID"));
-            out_dst.push(dsts.value(row).try_into().expect("fixed UUID"));
+            out_src.push(detail[16..32].try_into().expect("fixed UUID"));
+            out_dst.push(detail[32..48].try_into().expect("fixed UUID"));
             out_id.push(u64::from_be_bytes(
                 identity[24..32].try_into().expect("fixed"),
             ));
@@ -885,36 +832,16 @@ fn encode_edges(
             out_dst_id.push(u64::from_be_bytes(
                 target_endpoint[24..32].try_into().expect("fixed"),
             ));
-            if !owners.contains_key(route) {
-                let runtime_route = if ontology_mode == OntologyMode::Exploratory {
-                    "_exploratory"
-                } else {
-                    route
-                };
-                owners.insert(
-                    route.to_owned(),
-                    resolve_owner(
-                        semantic_context,
-                        semantic_bindings,
-                        SymbolKind::Relation,
-                        SemanticRouteKind::Relation,
-                        route,
-                        runtime_route,
-                    )?,
-                );
+            groups
+                .entry(route.to_owned())
+                .or_default()
+                .push(u32::try_from(out_uuid.len() - 1).map_err(storage)?);
+            if out_uuid.len().is_multiple_of(4096) && cancelled() {
+                return Err(storage("construction encoding cancelled"));
             }
-            let group = groups
-                .entry((
-                    merged_row.source,
-                    merged_row.batch_sequence,
-                    route.to_owned(),
-                ))
-                .or_insert_with(|| (input.clone(), Vec::new(), Vec::new()));
-            group.1.push(u32::try_from(row).map_err(storage)?);
-            group.2.push(output_row);
         }
         if out_id.is_empty() {
-            continue;
+            break;
         }
         let canonical = edge_batch(
             &out_uuid,
@@ -925,15 +852,22 @@ fn encode_edges(
             &out_dst_id,
             shape.runtime_catalog_now_micros,
         )?;
-        for ((_source, _batch_sequence, route), (input, indexes, output_indexes)) in groups {
-            let output_indexes = output_indexes
-                .into_iter()
-                .map(|value| u32::try_from(value).map_err(storage))
-                .collect::<Result<Vec<_>, _>>()?;
+        account_batch(&canonical, budgets, evidence)?;
+        for (route, output_indexes) in groups {
             let mut selected = select_rows(&canonical, &output_indexes)?;
-            let owner = owners
-                .get(&route)
-                .ok_or_else(|| storage("edge owner resolution was lost"))?;
+            let runtime_route = if ontology_mode == OntologyMode::Exploratory {
+                "_exploratory"
+            } else {
+                route.as_str()
+            };
+            let owner = resolve_owner(
+                semantic_context,
+                semantic_bindings,
+                SymbolKind::Relation,
+                SemanticRouteKind::Relation,
+                &route,
+                runtime_route,
+            )?;
             let topology_route = if owner.symbol.is_none()
                 && ontology_mode == OntologyMode::Exploratory
             {
@@ -971,12 +905,93 @@ fn encode_edges(
             let last = ids.value(ids.len() - 1);
             let path = format!("topology/edges/{topology_route}/{first:020}-{last:020}.parquet");
             artifacts.push(write_parquet(output, &path, &selected, evidence)?);
-            if input.num_columns() > 4 {
+        }
+    }
+    if details.next()?.is_some()
+        || endpoints.next()?.is_some()
+        || next_kind(&mut identities, 1)?.is_some()
+    {
+        return Err(storage("edge streams contain unconsumed rows"));
+    }
+    identities.account(evidence);
+    details.account(evidence);
+    endpoints.account(evidence);
+    encode_edge_properties(
+        source,
+        output,
+        shape,
+        ontology_mode,
+        semantic_context,
+        semantic_bindings,
+        budgets,
+        cancelled,
+        artifacts,
+        evidence,
+    )
+}
+
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+fn encode_edge_properties(
+    source: &StableDirectory,
+    output: &StableDirectory,
+    shape: &ConstructionShape,
+    ontology_mode: OntologyMode,
+    semantic_context: Option<&CompositionBindingContext>,
+    semantic_bindings: Option<&SemanticStorageBindings>,
+    budgets: GraphConstructionBudgets,
+    cancelled: &mut impl FnMut() -> bool,
+    artifacts: &mut Vec<ConstructionEncodedArtifact>,
+    evidence: &mut GraphConstructionEncodingEvidence,
+) -> Result<(), GfError> {
+    let mut ordinal = 0_u64;
+    for name in &shape.edge_rows {
+        if cancelled() {
+            return Err(storage("construction encoding cancelled"));
+        }
+        let file = source.open_child_file(OsStr::new(name)).map_err(storage)?;
+        let counter = IoCounter::default();
+        let mut reader = ParquetRecordBatchReaderBuilder::try_new(CountingChunkReader {
+            file,
+            counter: counter.clone(),
+        })
+        .map_err(storage)?
+        .with_batch_size(budgets.max_batch_rows)
+        .build()
+        .map_err(storage)?;
+        evidence.peak_open_input_readers = evidence.peak_open_input_readers.max(1);
+        for input in &mut reader {
+            let input = input.map_err(storage)?;
+            account_batch(&input, budgets, evidence)?;
+            if input.num_columns() == 4 {
+                continue;
+            }
+            let routes = required_string(&input, "rel_type")?;
+            let mut groups = BTreeMap::<String, Vec<u32>>::new();
+            for row in 0..input.num_rows() {
+                groups
+                    .entry(routes.value(row).to_owned())
+                    .or_default()
+                    .push(u32::try_from(row).map_err(storage)?);
+            }
+            for (route, indexes) in groups {
+                let runtime_route = if ontology_mode == OntologyMode::Exploratory {
+                    "_exploratory"
+                } else {
+                    route.as_str()
+                };
+                let owner = resolve_owner(
+                    semantic_context,
+                    semantic_bindings,
+                    SymbolKind::Relation,
+                    SemanticRouteKind::Relation,
+                    &route,
+                    runtime_route,
+                )?;
                 let (property_route, fields) = property_projection(
                     &input,
                     4,
                     &indexes,
-                    owner,
+                    &owner,
                     SymbolKind::Relation,
                     SemanticRouteKind::EdgeProperty,
                     semantic_context,
@@ -1012,16 +1027,10 @@ fn encode_edges(
                 ordinal = ordinal.saturating_add(1);
             }
         }
+        let (bytes, operations) = counter.values();
+        evidence.input_read_bytes = evidence.input_read_bytes.saturating_add(bytes);
+        evidence.input_read_operations = evidence.input_read_operations.saturating_add(operations);
     }
-    if details.next()?.is_some()
-        || endpoints.next()?.is_some()
-        || next_kind(&mut identities, 1)?.is_some()
-    {
-        return Err(storage("edge streams contain unconsumed rows"));
-    }
-    identities.account(evidence);
-    details.account(evidence);
-    endpoints.account(evidence);
     Ok(())
 }
 
@@ -1139,16 +1148,6 @@ fn select_rows(batch: &RecordBatch, indexes: &[u32]) -> Result<RecordBatch, GfEr
     RecordBatch::try_new(batch.schema(), columns).map_err(storage)
 }
 
-fn required_uuid<'a>(
-    batch: &'a RecordBatch,
-    name: &str,
-) -> Result<&'a FixedSizeBinaryArray, GfError> {
-    batch
-        .column_by_name(name)
-        .and_then(|column| column.as_any().downcast_ref::<FixedSizeBinaryArray>())
-        .ok_or_else(|| storage(format!("{name} is not FixedSizeBinary(16)")))
-}
-
 fn required_string<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a StringArray, GfError> {
     batch
         .column_by_name(name)
@@ -1251,6 +1250,12 @@ fn write_parquet(
         .create_replaceable_child_file(OsStr::new(&temporary))
         .map_err(storage)?;
     let identity = file_identity(&file).map_err(storage)?;
+    let mut temporary_guard = EncodingTempGuard {
+        directory: &directory,
+        name: temporary.clone(),
+        identity,
+        armed: true,
+    };
     let counter = IoCounter::default();
     let mut writer = ArrowWriter::try_new(
         CountingWriter {
@@ -1267,11 +1272,18 @@ fn write_parquet(
         .open_child_file(OsStr::new(&temporary))
         .map_err(storage)?;
     file.sync_all().map_err(storage)?;
+    crate::graph_construction::construction_failpoint(&format!(
+        "encode.parquet.after_temp_fsync.{relative}"
+    ));
     let artifact = authenticate_file(relative, &mut file)?;
     directory
         .replace_child(OsStr::new(&temporary), identity, OsStr::new(&name))
         .map_err(storage)?;
+    temporary_guard.disarm();
     directory.sync().map_err(storage)?;
+    crate::graph_construction::construction_failpoint(&format!(
+        "encode.parquet.after_install.{relative}"
+    ));
     let (written, operations) = counter.values();
     evidence.output_write_bytes = evidence.output_write_bytes.saturating_add(written);
     evidence.output_write_operations = evidence.output_write_operations.saturating_add(operations);
@@ -1287,11 +1299,15 @@ fn copy_artifact(
     artifacts: &mut Vec<ConstructionEncodedArtifact>,
     evidence: &mut GraphConstructionEncodingEvidence,
 ) -> Result<(), GfError> {
+    let read_counter = IoCounter::default();
     let mut input = BufReader::with_capacity(
         COPY_BUFFER_BYTES,
-        source
-            .open_child_file(OsStr::new(source_name))
-            .map_err(storage)?,
+        CountingInput {
+            inner: source
+                .open_child_file(OsStr::new(source_name))
+                .map_err(storage)?,
+            counter: read_counter.clone(),
+        },
     );
     let (directory, name) = directory_for(output, relative)?;
     let temporary = format!(".{}-{}.tmp", name, Uuid::new_v4().simple());
@@ -1299,10 +1315,26 @@ fn copy_artifact(
         .create_replaceable_child_file(OsStr::new(&temporary))
         .map_err(storage)?;
     let identity = file_identity(&file).map_err(storage)?;
-    let mut writer = BufWriter::with_capacity(COPY_BUFFER_BYTES, file);
+    let mut temporary_guard = EncodingTempGuard {
+        directory: &directory,
+        name: temporary.clone(),
+        identity,
+        armed: true,
+    };
+    let write_counter = IoCounter::default();
+    let mut writer = BufWriter::with_capacity(
+        COPY_BUFFER_BYTES,
+        CountingWriter {
+            inner: file,
+            counter: write_counter.clone(),
+        },
+    );
     let bytes = std::io::copy(&mut input, &mut writer).map_err(storage)?;
     writer.flush().map_err(storage)?;
-    writer.get_ref().sync_all().map_err(storage)?;
+    writer.get_ref().inner.sync_all().map_err(storage)?;
+    crate::graph_construction::construction_failpoint(&format!(
+        "encode.copy.after_temp_fsync.{relative}"
+    ));
     drop(writer);
     let mut file = directory
         .open_child_file(OsStr::new(&temporary))
@@ -1314,15 +1346,29 @@ fn copy_artifact(
     directory
         .replace_child(OsStr::new(&temporary), identity, OsStr::new(&name))
         .map_err(storage)?;
+    temporary_guard.disarm();
     directory.sync().map_err(storage)?;
+    crate::graph_construction::construction_failpoint(&format!(
+        "encode.copy.after_install.{relative}"
+    ));
     evidence.input_read_bytes = evidence.input_read_bytes.saturating_add(bytes);
+    let (read_bytes, read_operations) = read_counter.values();
+    if read_bytes != bytes {
+        return Err(storage("copied canonical artifact read accounting differs"));
+    }
     evidence.input_read_operations = evidence
         .input_read_operations
-        .saturating_add(bytes.div_ceil(COPY_BUFFER_BYTES as u64));
+        .saturating_add(read_operations);
     evidence.output_write_bytes = evidence.output_write_bytes.saturating_add(bytes);
+    let (write_bytes, write_operations) = write_counter.values();
+    if write_bytes != bytes {
+        return Err(storage(
+            "copied canonical artifact write accounting differs",
+        ));
+    }
     evidence.output_write_operations = evidence
         .output_write_operations
-        .saturating_add(bytes.div_ceil(COPY_BUFFER_BYTES as u64));
+        .saturating_add(write_operations);
     evidence.fsync_operations = evidence.fsync_operations.saturating_add(2);
     artifacts.push(artifact);
     Ok(())
@@ -1390,9 +1436,102 @@ fn read_inventory(root: &StableDirectory) -> Result<Option<GraphConstructionEnco
         .map_err(storage)
 }
 
+fn read_encoding_intent(root: &StableDirectory) -> Result<Option<EncodingIntent>, GfError> {
+    let mut file = match root.open_child_file(OsStr::new(ENCODING_INTENT)) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(storage(error)),
+    };
+    if file.metadata().map_err(storage)?.len() > MAX_INVENTORY_BYTES {
+        return Err(storage("encoding intent exceeds bound"));
+    }
+    serde_json::from_reader(&mut file)
+        .map(Some)
+        .map_err(storage)
+}
+
+fn remove_encoding_intent(root: &StableDirectory) -> Result<(), GfError> {
+    let file = match root.open_child_file(OsStr::new(ENCODING_INTENT)) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(storage(error)),
+    };
+    if file_link_count(&file).map_err(storage)? != 1 {
+        return Err(storage("encoding intent has unexpected links"));
+    }
+    let identity = file_identity(&file).map_err(storage)?;
+    drop(file);
+    root.unlink_child_if_identity(OsStr::new(ENCODING_INTENT), identity)
+        .map_err(storage)?;
+    root.sync().map_err(storage)
+}
+
+fn cleanup_encoding_temps(
+    root: &StableDirectory,
+    budgets: GraphConstructionBudgets,
+) -> Result<(), GfError> {
+    let limit = usize::try_from(budgets.max_chunks)
+        .unwrap_or(usize::MAX)
+        .saturating_mul(12)
+        .saturating_add(budgets.max_schema_groups.saturating_mul(8))
+        .max(1024);
+    let mut visited = 0_usize;
+    cleanup_encoding_directory(root, limit, &mut visited)
+}
+
+fn cleanup_encoding_directory(
+    directory: &StableDirectory,
+    limit: usize,
+    visited: &mut usize,
+) -> Result<(), GfError> {
+    let mut changed = false;
+    for name in directory.child_names().map_err(storage)? {
+        *visited = visited.saturating_add(1);
+        if *visited > limit {
+            return Err(storage("private encoding cleanup inventory exceeds bound"));
+        }
+        if let Ok(file) = directory.open_child_file(&name) {
+            let text = name
+                .to_str()
+                .ok_or_else(|| storage("private encoding file name is not UTF-8"))?;
+            if is_encoding_temp(text) {
+                if file_link_count(&file).map_err(storage)? != 1 {
+                    return Err(storage("private encoding temp has unexpected links"));
+                }
+                let identity = file_identity(&file).map_err(storage)?;
+                drop(file);
+                directory
+                    .unlink_child_if_identity(&name, identity)
+                    .map_err(storage)?;
+                changed = true;
+            }
+            continue;
+        }
+        let child = directory.open_child_directory(&name).map_err(storage)?;
+        cleanup_encoding_directory(&child, limit, visited)?;
+    }
+    if changed {
+        directory.sync().map_err(storage)?;
+    }
+    Ok(())
+}
+
+fn is_encoding_temp(name: &str) -> bool {
+    let Some(body) = name
+        .strip_prefix('.')
+        .and_then(|value| value.strip_suffix(".tmp"))
+    else {
+        return false;
+    };
+    body.rsplit_once('-').is_some_and(|(_, nonce)| {
+        nonce.len() == 32 && nonce.bytes().all(|byte| byte.is_ascii_hexdigit())
+    })
+}
+
 fn authenticate_inventory(
     root: &StableDirectory,
     inventory: &GraphConstructionEncoding,
+    parent_index: Option<&AuthenticatedUuidIndexSnapshot>,
 ) -> Result<(), GfError> {
     if inventory.root != ENCODED_ROOT
         || inventory.shape_inputs_sha256.len() != 64
@@ -1425,6 +1564,35 @@ fn authenticate_inventory(
             return Err(storage("canonical artifact differs from inventory"));
         }
     }
+    if inventory.retained_artifacts.is_empty() {
+        if inventory.evidence.retained_index_runs != 0 {
+            return Err(storage("retained-index evidence lacks references"));
+        }
+    } else {
+        let parent = parent_index
+            .ok_or_else(|| storage("retained artifacts lack authenticated parent snapshot"))?;
+        let mut previous = None;
+        for retained in &inventory.retained_artifacts {
+            if previous.is_some_and(|value: &str| value >= retained.target_path.as_str()) {
+                return Err(storage(
+                    "retained artifact targets are not unique and sorted",
+                ));
+            }
+            parent.authenticate_construction_reference(
+                &retained.source_root,
+                retained.source_root_volume,
+                &retained.source_root_file_id,
+                &retained.source_path,
+                retained.source_volume,
+                &retained.source_file_id,
+                &retained.target_path,
+                retained.bytes,
+                &retained.sha256,
+                &retained.parent_manifest_sha256,
+            )?;
+            previous = Some(retained.target_path.as_str());
+        }
+    }
     Ok(())
 }
 
@@ -1438,13 +1606,27 @@ fn install_json<T: Serialize>(
         .create_replaceable_child_file(OsStr::new(&temporary))
         .map_err(storage)?;
     let identity = file_identity(&file).map_err(storage)?;
+    let mut temporary_guard = EncodingTempGuard {
+        directory: root,
+        name: temporary.clone(),
+        identity,
+        armed: true,
+    };
     serde_json::to_writer(&mut file, value).map_err(storage)?;
     file.flush().map_err(storage)?;
     file.sync_all().map_err(storage)?;
+    crate::graph_construction::construction_failpoint(&format!(
+        "encode.control.after_temp_fsync.{name}"
+    ));
     drop(file);
     root.replace_child(OsStr::new(&temporary), identity, OsStr::new(name))
         .map_err(storage)?;
-    root.sync().map_err(storage)
+    temporary_guard.disarm();
+    root.sync().map_err(storage)?;
+    crate::graph_construction::construction_failpoint(&format!(
+        "encode.control.after_install.{name}"
+    ));
+    Ok(())
 }
 
 struct FixedReader<const N: usize> {

--- a/crates/graphforge-storage/src/graph_construction_encoding.rs
+++ b/crates/graphforge-storage/src/graph_construction_encoding.rs
@@ -11,6 +11,9 @@ use std::io::{BufReader, BufWriter, Read, Seek, Write};
 use std::path::{Component, Path};
 use std::sync::Arc;
 
+#[cfg(test)]
+use std::cell::RefCell;
+
 use arrow::array::{
     Array, ArrayRef, FixedSizeBinaryArray, ListArray, StringArray, TimestampMicrosecondArray,
     UInt32Array, UInt64Array,
@@ -32,7 +35,7 @@ use uuid::Uuid;
 
 use crate::graph_construction::{
     ArtifactReceipt, ConstructionSemanticAuthority, ConstructionShape, CountingChunkReader,
-    GraphConstructionBudgets, IoCounter, authenticate_shaped_outputs, shaped_output_sha256,
+    GraphConstructionBudgets, IoCounter, open_authenticated_shape_source, shaped_output_sha256,
 };
 use crate::schemas::{
     TOPOLOGY_NODES_SCHEMA, TYPED_EDGE_SCHEMA, uuid_field, with_semantic_route_metadata,
@@ -51,6 +54,30 @@ const NODE_DETAIL_WIDTH: usize = 272;
 const EDGE_DETAIL_WIDTH: usize = 304;
 const RESOLVED_ENDPOINT_WIDTH: usize = 32;
 const COPY_BUFFER_BYTES: usize = 1 << 20;
+
+#[cfg(test)]
+type SourceSpoolHook = Box<dyn FnMut(&str)>;
+#[cfg(test)]
+thread_local! {
+    static SOURCE_SPOOL_HOOK: RefCell<Option<SourceSpoolHook>> = RefCell::new(None);
+}
+
+#[cfg(test)]
+pub(crate) fn set_source_spool_hook(hook: Option<SourceSpoolHook>) {
+    SOURCE_SPOOL_HOOK.with(|slot| *slot.borrow_mut() = hook);
+}
+
+#[cfg(test)]
+fn run_source_spool_hook(phase: &str) {
+    SOURCE_SPOOL_HOOK.with(|slot| {
+        if let Some(hook) = slot.borrow_mut().as_mut() {
+            hook(phase);
+        }
+    });
+}
+
+#[cfg(not(test))]
+fn run_source_spool_hook(_phase: &str) {}
 
 struct CountingWriter {
     inner: File,
@@ -91,6 +118,65 @@ impl Drop for EncodingTempGuard<'_> {
             let _ = self.directory.sync();
         }
     }
+}
+
+fn authenticated_source_spool<'a>(
+    source: &StableDirectory,
+    outputs: &[ArtifactReceipt],
+    name: &str,
+    output: &'a StableDirectory,
+    evidence: &mut GraphConstructionEncodingEvidence,
+) -> Result<(File, EncodingTempGuard<'a>), GfError> {
+    let mut authenticated = open_authenticated_shape_source(source, outputs, name)?;
+    let temporary = format!(".authenticated-source-{}.tmp", Uuid::new_v4().simple());
+    let mut spool = output
+        .create_replaceable_child_file(OsStr::new(&temporary))
+        .map_err(storage)?;
+    let spool_identity = file_identity(&spool).map_err(storage)?;
+    let guard = EncodingTempGuard {
+        directory: output,
+        name: temporary,
+        identity: spool_identity,
+        armed: true,
+    };
+    let mut digest = Sha256::new();
+    let mut bytes = 0_u64;
+    let mut buffer = vec![0_u8; COPY_BUFFER_BYTES];
+    loop {
+        run_source_spool_hook("before_read");
+        let read = authenticated.file.read(&mut buffer).map_err(storage)?;
+        run_source_spool_hook("after_read");
+        if read == 0 {
+            break;
+        }
+        digest.update(&buffer[..read]);
+        spool.write_all(&buffer[..read]).map_err(storage)?;
+        bytes = bytes.saturating_add(read as u64);
+        evidence.input_read_bytes = evidence.input_read_bytes.saturating_add(read as u64);
+        evidence.input_read_operations = evidence.input_read_operations.saturating_add(1);
+        evidence.source_spool_write_bytes = evidence
+            .source_spool_write_bytes
+            .saturating_add(read as u64);
+        evidence.source_spool_write_operations =
+            evidence.source_spool_write_operations.saturating_add(1);
+    }
+    if file_identity(&authenticated.file).map_err(storage)? != authenticated.identity
+        || file_link_count(&authenticated.file).map_err(storage)? != 1
+        || bytes != authenticated.bytes
+        || hex(&digest.finalize()) != authenticated.sha256
+    {
+        return Err(storage(
+            "shaped source changed during authenticated spooling",
+        ));
+    }
+    spool.flush().map_err(storage)?;
+    spool.sync_all().map_err(storage)?;
+    evidence.source_spool_fsync_operations =
+        evidence.source_spool_fsync_operations.saturating_add(1);
+    evidence.source_spool_peak_temporary_bytes =
+        evidence.source_spool_peak_temporary_bytes.max(bytes);
+    spool.rewind().map_err(storage)?;
+    Ok((spool, guard))
 }
 
 impl<R: Read> Read for CountingInput<R> {
@@ -194,6 +280,18 @@ pub struct GraphConstructionEncodingEvidence {
     pub membership_total_write_bytes: u64,
     /// Largest number of decoded shaped-row readers simultaneously live.
     pub peak_open_input_readers: u64,
+    /// Authenticated source bytes written to one private random-access spool.
+    pub source_spool_write_bytes: u64,
+    /// Physical writes used by authenticated source spools.
+    pub source_spool_write_operations: u64,
+    /// Reads served from authenticated source spools to Parquet consumers.
+    pub source_spool_read_bytes: u64,
+    /// Physical reads served from authenticated source spools.
+    pub source_spool_read_operations: u64,
+    /// Durability barriers completed for authenticated source spools.
+    pub source_spool_fsync_operations: u64,
+    /// Peak owned authenticated source spool bytes (one source at a time).
+    pub source_spool_peak_temporary_bytes: u64,
     /// v3 durability barriers.
     pub membership_fsync_operations: u64,
     /// Newly created immutable v3 runs, including superseded carry inputs.
@@ -217,6 +315,8 @@ pub struct GraphConstructionEncoding {
     pub semantic_authority_sha256: Option<String>,
     /// Shaper authority digest for normalized catalog inputs.
     pub shape_inputs_sha256: String,
+    /// Canonical authority over the sealed shape and every authenticated source receipt.
+    pub shape_authority_sha256: String,
     /// Sorted, unique canonical artifact records.
     pub artifacts: Vec<ConstructionEncodedArtifact>,
     /// Authenticated retained-parent objects required to assemble this graph.
@@ -232,6 +332,16 @@ struct EncodingIntent {
     ontology_mode: OntologyMode,
     semantic_authority_sha256: Option<String>,
     shape_inputs_sha256: String,
+    shape_authority_sha256: String,
+}
+
+pub(crate) fn inventory_authority_sha256(
+    inventory: &GraphConstructionEncoding,
+) -> Result<String, GfError> {
+    let mut digest = Sha256::new();
+    digest.update(b"graphforge-construction-encoding-inventory/v1\0");
+    digest.update(serde_json::to_vec(inventory).map_err(storage)?);
+    Ok(hex(&digest.finalize()))
 }
 
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
@@ -243,6 +353,8 @@ pub(crate) fn encode(
     parent_index: Option<&AuthenticatedUuidIndexSnapshot>,
     semantic_authority: Option<&ConstructionSemanticAuthority>,
     shape_outputs: &[ArtifactReceipt],
+    shape_authority_sha256: &str,
+    expected_inventory_sha256: Option<&str>,
     budgets: GraphConstructionBudgets,
     cancelled: &mut impl FnMut() -> bool,
 ) -> Result<GraphConstructionEncoding, GfError> {
@@ -275,11 +387,28 @@ pub(crate) fn encode(
             || existing.ontology_mode != shape.ontology_mode
             || existing.semantic_authority_sha256 != shape.semantic_authority_sha256
             || existing.shape_inputs_sha256 != shape.runtime_catalog_inputs_sha256
+            || existing.shape_authority_sha256 != shape_authority_sha256
         {
             return Err(storage("completed encoding belongs to another generation"));
         }
-        remove_encoding_intent(&output)?;
-        return Ok(existing);
+        let actual_authority = inventory_authority_sha256(&existing)?;
+        match expected_inventory_sha256 {
+            Some(expected) if expected == actual_authority => {
+                remove_encoding_intent(&output)?;
+                return Ok(existing);
+            }
+            Some(_) => {
+                return Err(storage(
+                    "completed encoding differs from checkpoint inventory authority",
+                ));
+            }
+            None => {
+                // An inventory installed before its checkpoint receipt is not
+                // authoritative. Regenerate it from the sealed shape instead
+                // of adopting self-described output after a crash.
+                remove_encoding_control(&output, INVENTORY)?;
+            }
+        }
     }
 
     let intent = EncodingIntent {
@@ -288,6 +417,7 @@ pub(crate) fn encode(
         ontology_mode,
         semantic_authority_sha256: shape.semantic_authority_sha256.clone(),
         shape_inputs_sha256: shape.runtime_catalog_inputs_sha256.clone(),
+        shape_authority_sha256: shape_authority_sha256.to_owned(),
     };
     match read_encoding_intent(&output)? {
         Some(existing) if existing != intent => {
@@ -303,16 +433,38 @@ pub(crate) fn encode(
         peak_open_writers: 1,
         ..Default::default()
     };
-    let label_ids = read_runtime_label_ids(source, &shape.runtime_catalog, budgets, &mut evidence)?;
+    let mut artifacts = Vec::new();
+    let label_ids = {
+        let (catalog_spool, _catalog_guard) = authenticated_source_spool(
+            source,
+            shape_outputs,
+            &shape.runtime_catalog,
+            &output,
+            &mut evidence,
+        )?;
+        let label_ids = read_runtime_label_ids(
+            catalog_spool.try_clone().map_err(storage)?,
+            budgets,
+            &mut evidence,
+        )?;
+        copy_artifact(
+            catalog_spool.try_clone().map_err(storage)?,
+            &output,
+            "topology/runtime_catalog.parquet",
+            &mut artifacts,
+            &mut evidence,
+        )?;
+        label_ids
+    };
     let semantic_context = semantic_authority
         .map(ConstructionSemanticAuthority::context)
         .transpose()?;
-    let mut artifacts = Vec::new();
 
     encode_nodes(
         source,
         &output,
         shape,
+        shape_outputs,
         &label_ids,
         ontology_mode,
         semantic_context.as_ref(),
@@ -326,19 +478,12 @@ pub(crate) fn encode(
         source,
         &output,
         shape,
+        shape_outputs,
         ontology_mode,
         semantic_context.as_ref(),
         semantic_authority.map(|authority| &authority.bindings),
         budgets,
         cancelled,
-        &mut artifacts,
-        &mut evidence,
-    )?;
-    copy_artifact(
-        source,
-        &shape.runtime_catalog,
-        &output,
-        "topology/runtime_catalog.parquet",
         &mut artifacts,
         &mut evidence,
     )?;
@@ -349,8 +494,6 @@ pub(crate) fn encode(
         &mut artifacts,
         &mut evidence,
     )?;
-
-    authenticate_shaped_outputs(source, shape_outputs)?;
 
     let index = crate::uuid_membership::encode_construction_index(
         source,
@@ -396,11 +539,11 @@ pub(crate) fn encode(
         ontology_mode: shape.ontology_mode,
         semantic_authority_sha256: shape.semantic_authority_sha256.clone(),
         shape_inputs_sha256: shape.runtime_catalog_inputs_sha256.clone(),
+        shape_authority_sha256: shape_authority_sha256.to_owned(),
         artifacts,
         retained_artifacts,
         evidence,
     };
-    authenticate_shaped_outputs(source, shape_outputs)?;
     install_json(&output, INVENTORY, &completed)?;
     authenticate_inventory(&output, &completed, parent_index)?;
     remove_encoding_intent(&output)?;
@@ -481,7 +624,7 @@ fn resolve_owner(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn property_projection(
+fn property_projections(
     input: &RecordBatch,
     required: usize,
     indexes: &[u32],
@@ -490,15 +633,14 @@ fn property_projection(
     route_kind: SemanticRouteKind,
     context: Option<&CompositionBindingContext>,
     bindings: Option<&SemanticStorageBindings>,
-) -> Result<(String, Vec<usize>), GfError> {
-    let mut fields = Vec::new();
-    let mut route = None;
+) -> Result<Vec<(String, Vec<usize>)>, GfError> {
+    let mut projections = BTreeMap::<String, Vec<usize>>::new();
     for column_index in required..input.num_columns() {
         let column = input.column(column_index);
         if !indexes.iter().any(|index| !column.is_null(*index as usize)) {
             continue;
         }
-        if let (Some(context), Some(bindings), Some(_owner_symbol)) =
+        let route = if let (Some(context), Some(bindings), Some(_owner_symbol)) =
             (context, bindings, owner.symbol.as_ref())
         {
             let schema = input.schema();
@@ -521,19 +663,13 @@ fn property_projection(
             if physical.owner.is_none() {
                 return Err(storage("qualified property binding lacks declaring owner"));
             }
-            if route.as_ref().is_some_and(|known| known != &physical.route) {
-                return Err(storage(
-                    "one semantic owner maps to multiple property routes",
-                ));
-            }
-            route = Some(physical.route.clone());
-        }
-        fields.push(column_index);
+            physical.route.clone()
+        } else {
+            owner.topology_route.clone()
+        };
+        projections.entry(route).or_default().push(column_index);
     }
-    Ok((
-        route.unwrap_or_else(|| owner.topology_route.clone()),
-        fields,
-    ))
+    Ok(projections.into_iter().collect())
 }
 
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
@@ -541,6 +677,7 @@ fn encode_nodes(
     source: &StableDirectory,
     output: &StableDirectory,
     shape: &ConstructionShape,
+    shape_outputs: &[ArtifactReceipt],
     label_ids: &BTreeMap<String, u32>,
     ontology_mode: OntologyMode,
     semantic_context: Option<&CompositionBindingContext>,
@@ -557,8 +694,9 @@ fn encode_nodes(
         .node_details
         .as_deref()
         .ok_or_else(|| storage("node rows lack canonical details"))?;
-    let mut identities = FixedReader::<IDENTITY_WIDTH>::open(source, &shape.identities, evidence)?;
-    let mut details = FixedReader::<NODE_DETAIL_WIDTH>::open(source, details_name, evidence)?;
+    let mut identities =
+        FixedReader::<IDENTITY_WIDTH>::open(source, shape_outputs, &shape.identities)?;
+    let mut details = FixedReader::<NODE_DETAIL_WIDTH>::open(source, shape_outputs, details_name)?;
     let rows_per_window = budgets
         .max_batch_rows
         .min((budgets.max_batch_bytes / 128).max(1));
@@ -634,12 +772,13 @@ fn encode_nodes(
     if details.next()?.is_some() || next_kind(&mut identities, 0)?.is_some() {
         return Err(storage("node streams contain unconsumed rows"));
     }
-    identities.account(evidence);
-    details.account(evidence);
+    identities.authenticate_and_account(evidence)?;
+    details.authenticate_and_account(evidence)?;
     encode_node_properties(
         source,
         output,
         shape,
+        shape_outputs,
         ontology_mode,
         semantic_context,
         semantic_bindings,
@@ -655,6 +794,7 @@ fn encode_node_properties(
     source: &StableDirectory,
     output: &StableDirectory,
     shape: &ConstructionShape,
+    shape_outputs: &[ArtifactReceipt],
     ontology_mode: OntologyMode,
     semantic_context: Option<&CompositionBindingContext>,
     semantic_bindings: Option<&SemanticStorageBindings>,
@@ -668,7 +808,8 @@ fn encode_node_properties(
         if cancelled() {
             return Err(storage("construction encoding cancelled"));
         }
-        let file = source.open_child_file(OsStr::new(name)).map_err(storage)?;
+        let (file, _spool_guard) =
+            authenticated_source_spool(source, shape_outputs, name, output, evidence)?;
         let counter = IoCounter::default();
         let mut reader = ParquetRecordBatchReaderBuilder::try_new(CountingChunkReader {
             file,
@@ -707,7 +848,7 @@ fn encode_node_properties(
                     &label,
                     runtime_route,
                 )?;
-                let (route, fields) = property_projection(
+                let projections = property_projections(
                     &input,
                     2,
                     &indexes,
@@ -717,39 +858,42 @@ fn encode_node_properties(
                     semantic_context,
                     semantic_bindings,
                 )?;
-                if fields.is_empty() {
-                    continue;
+                for (route, fields) in projections {
+                    let property = property_batch(
+                        &input,
+                        "node_uuid",
+                        "graphforge.entity_type",
+                        &owner.topology_route,
+                        &indexes,
+                        &fields,
+                    )?;
+                    let property = if owner.symbol.is_some() {
+                        with_route_metadata_batch(
+                            &property,
+                            &route,
+                            semantic_context
+                                .expect("qualified owner has context")
+                                .fingerprint(),
+                        )?
+                    } else {
+                        property
+                    };
+                    let path = format!(
+                        "properties/{route}/{:020}-{ordinal:020}.parquet",
+                        shape.parent_topology_generation + 1
+                    );
+                    artifacts.push(write_parquet(output, &path, &property, evidence)?);
+                    ordinal = ordinal.saturating_add(1);
                 }
-                let property = property_batch(
-                    &input,
-                    "node_uuid",
-                    "graphforge.entity_type",
-                    &route,
-                    &indexes,
-                    &fields,
-                )?;
-                let property = if owner.symbol.is_some() {
-                    with_route_metadata_batch(
-                        &property,
-                        &route,
-                        semantic_context
-                            .expect("qualified owner has context")
-                            .fingerprint(),
-                    )?
-                } else {
-                    property
-                };
-                let path = format!(
-                    "properties/{route}/{:020}-{ordinal:020}.parquet",
-                    shape.parent_topology_generation + 1
-                );
-                artifacts.push(write_parquet(output, &path, &property, evidence)?);
-                ordinal = ordinal.saturating_add(1);
             }
         }
         let (bytes, operations) = counter.values();
         evidence.input_read_bytes = evidence.input_read_bytes.saturating_add(bytes);
         evidence.input_read_operations = evidence.input_read_operations.saturating_add(operations);
+        evidence.source_spool_read_bytes = evidence.source_spool_read_bytes.saturating_add(bytes);
+        evidence.source_spool_read_operations = evidence
+            .source_spool_read_operations
+            .saturating_add(operations);
     }
     Ok(())
 }
@@ -759,6 +903,7 @@ fn encode_edges(
     source: &StableDirectory,
     output: &StableDirectory,
     shape: &ConstructionShape,
+    shape_outputs: &[ArtifactReceipt],
     ontology_mode: OntologyMode,
     semantic_context: Option<&CompositionBindingContext>,
     semantic_bindings: Option<&SemanticStorageBindings>,
@@ -778,10 +923,11 @@ fn encode_edges(
         .edge_endpoints
         .as_deref()
         .ok_or_else(|| storage("edge rows lack resolved endpoints"))?;
-    let mut identities = FixedReader::<IDENTITY_WIDTH>::open(source, &shape.identities, evidence)?;
-    let mut details = FixedReader::<EDGE_DETAIL_WIDTH>::open(source, details_name, evidence)?;
+    let mut identities =
+        FixedReader::<IDENTITY_WIDTH>::open(source, shape_outputs, &shape.identities)?;
+    let mut details = FixedReader::<EDGE_DETAIL_WIDTH>::open(source, shape_outputs, details_name)?;
     let mut endpoints =
-        FixedReader::<RESOLVED_ENDPOINT_WIDTH>::open(source, endpoints_name, evidence)?;
+        FixedReader::<RESOLVED_ENDPOINT_WIDTH>::open(source, shape_outputs, endpoints_name)?;
     let rows_per_window = budgets
         .max_batch_rows
         .min((budgets.max_batch_bytes / 192).max(1));
@@ -913,13 +1059,14 @@ fn encode_edges(
     {
         return Err(storage("edge streams contain unconsumed rows"));
     }
-    identities.account(evidence);
-    details.account(evidence);
-    endpoints.account(evidence);
+    identities.authenticate_and_account(evidence)?;
+    details.authenticate_and_account(evidence)?;
+    endpoints.authenticate_and_account(evidence)?;
     encode_edge_properties(
         source,
         output,
         shape,
+        shape_outputs,
         ontology_mode,
         semantic_context,
         semantic_bindings,
@@ -935,6 +1082,7 @@ fn encode_edge_properties(
     source: &StableDirectory,
     output: &StableDirectory,
     shape: &ConstructionShape,
+    shape_outputs: &[ArtifactReceipt],
     ontology_mode: OntologyMode,
     semantic_context: Option<&CompositionBindingContext>,
     semantic_bindings: Option<&SemanticStorageBindings>,
@@ -948,7 +1096,8 @@ fn encode_edge_properties(
         if cancelled() {
             return Err(storage("construction encoding cancelled"));
         }
-        let file = source.open_child_file(OsStr::new(name)).map_err(storage)?;
+        let (file, _spool_guard) =
+            authenticated_source_spool(source, shape_outputs, name, output, evidence)?;
         let counter = IoCounter::default();
         let mut reader = ParquetRecordBatchReaderBuilder::try_new(CountingChunkReader {
             file,
@@ -987,7 +1136,7 @@ fn encode_edge_properties(
                     &route,
                     runtime_route,
                 )?;
-                let (property_route, fields) = property_projection(
+                let projections = property_projections(
                     &input,
                     4,
                     &indexes,
@@ -997,39 +1146,42 @@ fn encode_edge_properties(
                     semantic_context,
                     semantic_bindings,
                 )?;
-                if fields.is_empty() {
-                    continue;
+                for (property_route, fields) in projections {
+                    let property = property_batch(
+                        &input,
+                        "edge_uuid",
+                        "graphforge.rel_type",
+                        &owner.topology_route,
+                        &indexes,
+                        &fields,
+                    )?;
+                    let property = if owner.symbol.is_some() {
+                        with_route_metadata_batch(
+                            &property,
+                            &property_route,
+                            semantic_context
+                                .expect("qualified owner has context")
+                                .fingerprint(),
+                        )?
+                    } else {
+                        property
+                    };
+                    let path = format!(
+                        "edge_properties/{property_route}/{:020}-{ordinal:020}.parquet",
+                        shape.parent_topology_generation + 1
+                    );
+                    artifacts.push(write_parquet(output, &path, &property, evidence)?);
+                    ordinal = ordinal.saturating_add(1);
                 }
-                let property = property_batch(
-                    &input,
-                    "edge_uuid",
-                    "graphforge.rel_type",
-                    &property_route,
-                    &indexes,
-                    &fields,
-                )?;
-                let property = if owner.symbol.is_some() {
-                    with_route_metadata_batch(
-                        &property,
-                        &property_route,
-                        semantic_context
-                            .expect("qualified owner has context")
-                            .fingerprint(),
-                    )?
-                } else {
-                    property
-                };
-                let path = format!(
-                    "edge_properties/{property_route}/{:020}-{ordinal:020}.parquet",
-                    shape.parent_topology_generation + 1
-                );
-                artifacts.push(write_parquet(output, &path, &property, evidence)?);
-                ordinal = ordinal.saturating_add(1);
             }
         }
         let (bytes, operations) = counter.values();
         evidence.input_read_bytes = evidence.input_read_bytes.saturating_add(bytes);
         evidence.input_read_operations = evidence.input_read_operations.saturating_add(operations);
+        evidence.source_spool_read_bytes = evidence.source_spool_read_bytes.saturating_add(bytes);
+        evidence.source_spool_read_operations = evidence
+            .source_spool_read_operations
+            .saturating_add(operations);
     }
     Ok(())
 }
@@ -1170,12 +1322,10 @@ fn account_batch(
 }
 
 fn read_runtime_label_ids(
-    source: &StableDirectory,
-    name: &str,
+    file: File,
     budgets: GraphConstructionBudgets,
     evidence: &mut GraphConstructionEncodingEvidence,
 ) -> Result<BTreeMap<String, u32>, GfError> {
-    let file = source.open_child_file(OsStr::new(name)).map_err(storage)?;
     let counter = IoCounter::default();
     let mut reader = ParquetRecordBatchReaderBuilder::try_new(CountingChunkReader {
         file,
@@ -1207,6 +1357,10 @@ fn read_runtime_label_ids(
     let (bytes, operations) = counter.values();
     evidence.input_read_bytes = evidence.input_read_bytes.saturating_add(bytes);
     evidence.input_read_operations = evidence.input_read_operations.saturating_add(operations);
+    evidence.source_spool_read_bytes = evidence.source_spool_read_bytes.saturating_add(bytes);
+    evidence.source_spool_read_operations = evidence
+        .source_spool_read_operations
+        .saturating_add(operations);
     Ok(labels)
 }
 
@@ -1292,20 +1446,18 @@ fn write_parquet(
 }
 
 fn copy_artifact(
-    source: &StableDirectory,
-    source_name: &str,
+    mut source_file: File,
     output: &StableDirectory,
     relative: &str,
     artifacts: &mut Vec<ConstructionEncodedArtifact>,
     evidence: &mut GraphConstructionEncodingEvidence,
 ) -> Result<(), GfError> {
     let read_counter = IoCounter::default();
+    source_file.rewind().map_err(storage)?;
     let mut input = BufReader::with_capacity(
         COPY_BUFFER_BYTES,
         CountingInput {
-            inner: source
-                .open_child_file(OsStr::new(source_name))
-                .map_err(storage)?,
+            inner: source_file,
             counter: read_counter.clone(),
         },
     );
@@ -1358,6 +1510,10 @@ fn copy_artifact(
     }
     evidence.input_read_operations = evidence
         .input_read_operations
+        .saturating_add(read_operations);
+    evidence.source_spool_read_bytes = evidence.source_spool_read_bytes.saturating_add(read_bytes);
+    evidence.source_spool_read_operations = evidence
+        .source_spool_read_operations
         .saturating_add(read_operations);
     evidence.output_write_bytes = evidence.output_write_bytes.saturating_add(bytes);
     let (write_bytes, write_operations) = write_counter.values();
@@ -1451,17 +1607,21 @@ fn read_encoding_intent(root: &StableDirectory) -> Result<Option<EncodingIntent>
 }
 
 fn remove_encoding_intent(root: &StableDirectory) -> Result<(), GfError> {
-    let file = match root.open_child_file(OsStr::new(ENCODING_INTENT)) {
+    remove_encoding_control(root, ENCODING_INTENT)
+}
+
+fn remove_encoding_control(root: &StableDirectory, name: &str) -> Result<(), GfError> {
+    let file = match root.open_child_file(OsStr::new(name)) {
         Ok(file) => file,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(error) => return Err(storage(error)),
     };
     if file_link_count(&file).map_err(storage)? != 1 {
-        return Err(storage("encoding intent has unexpected links"));
+        return Err(storage("encoding control has unexpected links"));
     }
     let identity = file_identity(&file).map_err(storage)?;
     drop(file);
-    root.unlink_child_if_identity(OsStr::new(ENCODING_INTENT), identity)
+    root.unlink_child_if_identity(OsStr::new(name), identity)
         .map_err(storage)?;
     root.sync().map_err(storage)
 }
@@ -1535,6 +1695,7 @@ fn authenticate_inventory(
 ) -> Result<(), GfError> {
     if inventory.root != ENCODED_ROOT
         || inventory.shape_inputs_sha256.len() != 64
+        || inventory.shape_authority_sha256.len() != 64
         || inventory
             .semantic_authority_sha256
             .as_ref()
@@ -1543,6 +1704,10 @@ fn authenticate_inventory(
             })
         || !inventory
             .shape_inputs_sha256
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit())
+        || !inventory
+            .shape_authority_sha256
             .bytes()
             .all(|byte| byte.is_ascii_hexdigit())
         || inventory
@@ -1632,15 +1797,21 @@ fn install_json<T: Serialize>(
 struct FixedReader<const N: usize> {
     reader: BufReader<CountingInput<File>>,
     counter: IoCounter,
+    identity: graphforge_filesystem::FileIdentity,
+    expected_bytes: u64,
+    expected_sha256: String,
+    digest: Sha256,
+    consumed_bytes: u64,
 }
 
 impl<const N: usize> FixedReader<N> {
     fn open(
         root: &StableDirectory,
+        outputs: &[ArtifactReceipt],
         name: &str,
-        _evidence: &mut GraphConstructionEncodingEvidence,
     ) -> Result<Self, GfError> {
-        let file = root.open_child_file(OsStr::new(name)).map_err(storage)?;
+        let authenticated = open_authenticated_shape_source(root, outputs, name)?;
+        let file = authenticated.file;
         if file.metadata().map_err(storage)?.len() % N as u64 != 0 {
             return Err(storage("fixed-width construction stream is truncated"));
         }
@@ -1654,6 +1825,11 @@ impl<const N: usize> FixedReader<N> {
                 },
             ),
             counter,
+            identity: authenticated.identity,
+            expected_bytes: authenticated.bytes,
+            expected_sha256: authenticated.sha256,
+            digest: Sha256::new(),
+            consumed_bytes: 0,
         })
     }
 
@@ -1670,13 +1846,28 @@ impl<const N: usize> FixedReader<N> {
             }
             read += amount;
         }
+        self.digest.update(record);
+        self.consumed_bytes = self.consumed_bytes.saturating_add(N as u64);
         Ok(Some(record))
     }
 
-    fn account(&self, evidence: &mut GraphConstructionEncodingEvidence) {
+    fn authenticate_and_account(
+        &self,
+        evidence: &mut GraphConstructionEncodingEvidence,
+    ) -> Result<(), GfError> {
+        if file_identity(&self.reader.get_ref().inner).map_err(storage)? != self.identity
+            || file_link_count(&self.reader.get_ref().inner).map_err(storage)? != 1
+            || self.consumed_bytes != self.expected_bytes
+            || hex(&self.digest.clone().finalize()) != self.expected_sha256
+        {
+            return Err(storage(
+                "fixed-width shaped source changed during consumption",
+            ));
+        }
         let (bytes, operations) = self.counter.values();
         evidence.input_read_bytes = evidence.input_read_bytes.saturating_add(bytes);
         evidence.input_read_operations = evidence.input_read_operations.saturating_add(operations);
+        Ok(())
     }
 }
 

--- a/crates/graphforge-storage/src/graph_construction_encoding.rs
+++ b/crates/graphforge-storage/src/graph_construction_encoding.rs
@@ -494,6 +494,16 @@ pub(crate) fn encode(
         &mut artifacts,
         &mut evidence,
     )?;
+    let generation_bytes = format!(
+        "{{\"topology_generation\":{generation},\"search_generation\":{generation},\"property_generation\":{generation}}}\n"
+    );
+    copy_artifact(
+        std::io::Cursor::new(generation_bytes.into_bytes()),
+        &output,
+        "topology/generation.json",
+        &mut artifacts,
+        &mut evidence,
+    )?;
 
     let index = crate::uuid_membership::encode_construction_index(
         source,
@@ -1445,8 +1455,8 @@ fn write_parquet(
     Ok(artifact)
 }
 
-fn copy_artifact(
-    mut source_file: File,
+fn copy_artifact<R: Read + Seek>(
+    mut source_file: R,
     output: &StableDirectory,
     relative: &str,
     artifacts: &mut Vec<ConstructionEncodedArtifact>,
@@ -1756,6 +1766,32 @@ fn authenticate_inventory(
                 &retained.parent_manifest_sha256,
             )?;
             previous = Some(retained.target_path.as_str());
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn authenticate_for_publication(
+    source: &StableDirectory,
+    inventory: &GraphConstructionEncoding,
+) -> Result<(), GfError> {
+    let encoded = source
+        .open_child_directory(OsStr::new(ENCODED_ROOT))
+        .map_err(storage)?;
+    let recorded = read_inventory(&encoded)?
+        .ok_or_else(|| storage("canonical encoding inventory is absent"))?;
+    if &recorded != inventory {
+        return Err(storage(
+            "publication inventory differs from durable encoding",
+        ));
+    }
+    for expected in &inventory.artifacts {
+        let (directory, name) = directory_for(&encoded, &expected.path)?;
+        let mut file = directory
+            .open_child_file(OsStr::new(&name))
+            .map_err(storage)?;
+        if authenticate_file(&expected.path, &mut file)? != *expected {
+            return Err(storage("canonical artifact differs from durable inventory"));
         }
     }
     Ok(())

--- a/crates/graphforge-storage/src/graph_files.rs
+++ b/crates/graphforge-storage/src/graph_files.rs
@@ -476,13 +476,6 @@ pub fn infer_role(relative: &Path) -> GraphFileRole {
                 "topology" => GraphFileRole::Topology,
                 "properties" | "edge_properties" => GraphFileRole::Properties,
                 "indexes" | "index" => GraphFileRole::Index,
-                ".graphforge-cache"
-                    if components.next().is_some_and(|component| {
-                        component.as_os_str() == std::ffi::OsStr::new("uuid-membership")
-                    }) =>
-                {
-                    GraphFileRole::Index
-                }
                 "deltas" => GraphFileRole::Delta,
                 "runtime_catalog.parquet" => GraphFileRole::Catalog,
                 _ if first.starts_with("runtime_catalog") => GraphFileRole::Catalog,

--- a/crates/graphforge-storage/src/graph_files.rs
+++ b/crates/graphforge-storage/src/graph_files.rs
@@ -444,6 +444,7 @@ pub fn materialize_graph_tree(
                 .map_err(|error| storage("create private graph directory", parent, error))?;
         }
         copy_regular_file(&source, &destination)?;
+        make_private_copy_owner_writable(&destination)?;
         evidence.files_copied = evidence.files_copied.saturating_add(1);
         evidence.bytes_copied = evidence.bytes_copied.saturating_add(entry.byte_length);
     }
@@ -785,6 +786,30 @@ fn copy_regular_file(source: &Path, destination: &Path) -> Result<[u8; 32], GfEr
     Ok(digest)
 }
 
+#[cfg(unix)]
+fn make_private_copy_owner_writable(path: &Path) -> Result<(), GfError> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let metadata = fs::metadata(path)
+        .map_err(|error| storage("inspect private graph file permissions", path, error))?;
+    let mut permissions = metadata.permissions();
+    permissions.set_mode(permissions.mode() | 0o200);
+    fs::set_permissions(path, permissions)
+        .map_err(|error| storage("make private graph file owner-writable", path, error))?;
+    sync_file(path)
+}
+
+#[cfg(not(unix))]
+fn make_private_copy_owner_writable(path: &Path) -> Result<(), GfError> {
+    let mut permissions = fs::metadata(path)
+        .map_err(|error| storage("inspect private graph file permissions", path, error))?
+        .permissions();
+    permissions.set_readonly(false);
+    fs::set_permissions(path, permissions)
+        .map_err(|error| storage("make private graph file owner-writable", path, error))?;
+    sync_file(path)
+}
+
 fn hash_file(path: &Path) -> Result<[u8; 32], GfError> {
     hash_file_counted(path).map(|(digest, _)| digest)
 }
@@ -1057,6 +1082,11 @@ mod tests {
         assert_eq!(evidence.files_copied, 2);
         assert_eq!(evidence.bytes_copied, inventory.total_byte_length);
 
+        let sealed_source = graph_tree_root(generation.path()).join("properties/Person.parquet");
+        let mut sealed_permissions = fs::metadata(&sealed_source).unwrap().permissions();
+        sealed_permissions.set_readonly(true);
+        fs::set_permissions(&sealed_source, sealed_permissions).unwrap();
+
         let private = tempfile::tempdir().unwrap();
         let opened = materialize_graph_tree(
             &graph_tree_root(generation.path()),
@@ -1066,10 +1096,35 @@ mod tests {
         .unwrap();
         assert_eq!(opened.strategy, GraphFilesOpenStrategy::PrivateMaterialize);
         assert_eq!(opened.files_copied, 2);
-        assert_eq!(
-            fs::read(private.path().join("properties/Person.parquet")).unwrap(),
-            b"person"
+        let private_copy = private.path().join("properties/Person.parquet");
+        assert!(
+            fs::metadata(&sealed_source)
+                .unwrap()
+                .permissions()
+                .readonly()
         );
+        assert!(
+            !fs::metadata(&private_copy)
+                .unwrap()
+                .permissions()
+                .readonly()
+        );
+        assert_eq!(fs::read(&private_copy).unwrap(), b"person");
+        assert_eq!(
+            hash_file(&private_copy).unwrap(),
+            hash_file(&sealed_source).unwrap()
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt as _;
+
+            assert_ne!(
+                fs::metadata(&private_copy).unwrap().ino(),
+                fs::metadata(&sealed_source).unwrap().ino()
+            );
+        }
+        fs::write(&private_copy, b"private rewrite").unwrap();
+        assert_eq!(fs::read(&sealed_source).unwrap(), b"person");
         assert_eq!(pinned_open_evidence(&inventory).files_opened_in_place, 2);
     }
 

--- a/crates/graphforge-storage/src/graph_files.rs
+++ b/crates/graphforge-storage/src/graph_files.rs
@@ -37,7 +37,6 @@ const MAX_GRAPH_FILES: usize = 100_000;
 const HASH_BUFFER_BYTES: usize = 64 * 1024;
 const GRAPH_FILES_SCHEMA_CANONICAL_BYTES: &[u8] =
     b"graphforge-graph-files/1|relative_path|byte_length|content_sha256|role";
-#[cfg(test)]
 const GRAPH_FILES_V2_SCHEMA_CANONICAL_BYTES: &[u8] =
     b"graphforge-graph-files-root/2|root_node_sha256|logical_file_count|logical_byte_length";
 
@@ -177,7 +176,6 @@ pub fn inventory_participant(
 }
 
 /// Encode a compact v2 root as the registered `graph`/`files` participant.
-#[cfg(test)]
 pub(crate) fn graph_files_root_participant(
     root: &crate::GraphFilesRootV2,
 ) -> Result<ProjectParticipant, GfError> {
@@ -194,7 +192,7 @@ pub(crate) fn graph_files_root_participant(
         )
         .map_err(|error| GfError::Validation(error.to_string()))?,
         row_count: root.logical_file_count,
-        bytes: crate::encode_graph_files_root_v2(root)?,
+        bytes: crate::graph_manifest::encode_root(root)?,
     })
 }
 
@@ -478,6 +476,13 @@ pub fn infer_role(relative: &Path) -> GraphFileRole {
                 "topology" => GraphFileRole::Topology,
                 "properties" | "edge_properties" => GraphFileRole::Properties,
                 "indexes" | "index" => GraphFileRole::Index,
+                ".graphforge-cache"
+                    if components.next().is_some_and(|component| {
+                        component.as_os_str() == std::ffi::OsStr::new("uuid-membership")
+                    }) =>
+                {
+                    GraphFileRole::Index
+                }
                 "deltas" => GraphFileRole::Delta,
                 "runtime_catalog.parquet" => GraphFileRole::Catalog,
                 _ if first.starts_with("runtime_catalog") => GraphFileRole::Catalog,

--- a/crates/graphforge-storage/src/graph_manifest.rs
+++ b/crates/graphforge-storage/src/graph_manifest.rs
@@ -394,17 +394,12 @@ fn validate_path(value: &str) -> Result<(), GfError> {
     {
         return Err(validation("invalid graph manifest relative path"));
     }
-    let components = path.components().collect::<Vec<_>>();
-    if components
-        .first()
+    if path
+        .components()
+        .next()
         .is_some_and(|component| component.as_os_str() == std::ffi::OsStr::new(".graphforge-cache"))
-        && !components.get(1).is_some_and(|component| {
-            component.as_os_str() == std::ffi::OsStr::new("uuid-membership")
-        })
     {
-        return Err(validation(
-            "unauthoritative derived cache path cannot be authoritative",
-        ));
+        return Err(validation("derived cache path cannot be authoritative"));
     }
     Ok(())
 }

--- a/crates/graphforge-storage/src/graph_manifest.rs
+++ b/crates/graphforge-storage/src/graph_manifest.rs
@@ -394,12 +394,17 @@ fn validate_path(value: &str) -> Result<(), GfError> {
     {
         return Err(validation("invalid graph manifest relative path"));
     }
-    if path
-        .components()
-        .next()
+    let components = path.components().collect::<Vec<_>>();
+    if components
+        .first()
         .is_some_and(|component| component.as_os_str() == std::ffi::OsStr::new(".graphforge-cache"))
+        && !components.get(1).is_some_and(|component| {
+            component.as_os_str() == std::ffi::OsStr::new("uuid-membership")
+        })
     {
-        return Err(validation("derived cache path cannot be authoritative"));
+        return Err(validation(
+            "unauthoritative derived cache path cannot be authoritative",
+        ));
     }
     Ok(())
 }

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -1940,7 +1940,36 @@ pub fn read_graph_object_by_digest(
 /// Open and stream-authenticate one immutable CAS object without allocating its payload.
 pub(crate) struct AuthenticatedGraphObject {
     file: File,
-    _cas: ReadOnlyCasRoot,
+    _cas: std::sync::Arc<ReadOnlyCasRoot>,
+}
+
+#[derive(Clone)]
+pub(crate) struct GraphObjectReadLease {
+    cas: std::sync::Arc<ReadOnlyCasRoot>,
+}
+
+impl std::fmt::Debug for GraphObjectReadLease {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("GraphObjectReadLease")
+            .finish_non_exhaustive()
+    }
+}
+
+pub(crate) fn begin_graph_object_read(root: &Path) -> Result<GraphObjectReadLease, GfError> {
+    Ok(GraphObjectReadLease {
+        cas: std::sync::Arc::new(ReadOnlyCasRoot::open(root)?),
+    })
+}
+
+impl GraphObjectReadLease {
+    pub(crate) fn open(
+        &self,
+        digest: &str,
+        expected_length: u64,
+    ) -> Result<AuthenticatedGraphObject, GfError> {
+        open_graph_object_with_read_lease(self, digest, expected_length)
+    }
 }
 
 impl std::fmt::Debug for AuthenticatedGraphObject {
@@ -2004,11 +2033,22 @@ pub(crate) fn open_graph_object_by_digest(
     digest: &str,
     expected_length: u64,
 ) -> Result<AuthenticatedGraphObject, GfError> {
-    let cas = ReadOnlyCasRoot::open(root)?;
-    let mut file = cas.open_digest(digest)?;
-    let metadata = file
-        .metadata()
-        .map_err(|error| storage("inspect stable graph object", root, error))?;
+    begin_graph_object_read(root)?.open(digest, expected_length)
+}
+
+fn open_graph_object_with_read_lease(
+    lease: &GraphObjectReadLease,
+    digest: &str,
+    expected_length: u64,
+) -> Result<AuthenticatedGraphObject, GfError> {
+    let mut file = lease.cas.open_digest(digest)?;
+    let metadata = file.metadata().map_err(|error| {
+        storage(
+            "inspect stable graph object",
+            &lease.cas.diagnostic_root,
+            error,
+        )
+    })?;
     // CAS payloads are deliberately hard-linked into private materializations,
     // so their link count is not an authority signal. The stable no-follow CAS
     // traversal, exact digest address, exact length, and streamed digest bind
@@ -2022,9 +2062,13 @@ pub(crate) fn open_graph_object_by_digest(
     let mut hasher = Sha256::new();
     let mut block = vec![0_u8; 1 << 20];
     loop {
-        let count = file
-            .read(&mut block)
-            .map_err(|error| storage("authenticate graph object", root, error))?;
+        let count = file.read(&mut block).map_err(|error| {
+            storage(
+                "authenticate graph object",
+                &lease.cas.diagnostic_root,
+                error,
+            )
+        })?;
         if count == 0 {
             break;
         }
@@ -2034,8 +2078,11 @@ pub(crate) fn open_graph_object_by_digest(
         return Err(validation("graph object digest does not match its address"));
     }
     file.rewind()
-        .map_err(|error| storage("rewind graph object", root, error))?;
-    Ok(AuthenticatedGraphObject { file, _cas: cas })
+        .map_err(|error| storage("rewind graph object", &lease.cas.diagnostic_root, error))?;
+    Ok(AuthenticatedGraphObject {
+        file,
+        _cas: std::sync::Arc::clone(&lease.cas),
+    })
 }
 
 fn read_graph_object_by_digest_from_read_only_cas(

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -18,6 +18,7 @@ use crate::{
     GraphFilesOpenStrategy, GraphFilesRootV2, GraphManifestNode, GraphManifestNodeKind,
 };
 use graphforge_filesystem::StableDirectory;
+use parquet::file::reader::{ChunkReader, Length};
 
 /// Project-relative root of immutable graph objects.
 pub const GRAPH_OBJECTS_DIR: &str = "graph-objects";
@@ -1937,11 +1938,72 @@ pub fn read_graph_object_by_digest(
 }
 
 /// Open and stream-authenticate one immutable CAS object without allocating its payload.
+pub(crate) struct AuthenticatedGraphObject {
+    file: File,
+    _cas: ReadOnlyCasRoot,
+}
+
+impl std::fmt::Debug for AuthenticatedGraphObject {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("AuthenticatedGraphObject")
+            .finish_non_exhaustive()
+    }
+}
+
+impl AuthenticatedGraphObject {
+    pub(crate) fn try_clone_file(&self) -> std::io::Result<File> {
+        self.file.try_clone()
+    }
+}
+
+impl AsRef<File> for AuthenticatedGraphObject {
+    fn as_ref(&self) -> &File {
+        &self.file
+    }
+}
+
+impl Read for AuthenticatedGraphObject {
+    fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        self.file.read(buffer)
+    }
+}
+
+impl Seek for AuthenticatedGraphObject {
+    fn seek(&mut self, position: std::io::SeekFrom) -> std::io::Result<u64> {
+        self.file.seek(position)
+    }
+}
+
+impl Length for AuthenticatedGraphObject {
+    fn len(&self) -> u64 {
+        self.file.metadata().map_or(0, |metadata| metadata.len())
+    }
+}
+
+impl ChunkReader for AuthenticatedGraphObject {
+    type T = std::io::BufReader<File>;
+
+    fn get_read(&self, start: u64) -> parquet::errors::Result<Self::T> {
+        let mut file = self.file.try_clone()?;
+        file.seek(std::io::SeekFrom::Start(start))?;
+        Ok(std::io::BufReader::new(file))
+    }
+
+    fn get_bytes(&self, start: u64, length: usize) -> parquet::errors::Result<bytes::Bytes> {
+        let mut file = self.file.try_clone()?;
+        file.seek(std::io::SeekFrom::Start(start))?;
+        let mut value = vec![0; length];
+        file.read_exact(&mut value)?;
+        Ok(value.into())
+    }
+}
+
 pub(crate) fn open_graph_object_by_digest(
     root: &Path,
     digest: &str,
     expected_length: u64,
-) -> Result<File, GfError> {
+) -> Result<AuthenticatedGraphObject, GfError> {
     let cas = ReadOnlyCasRoot::open(root)?;
     let mut file = cas.open_digest(digest)?;
     let metadata = file
@@ -1951,7 +2013,10 @@ pub(crate) fn open_graph_object_by_digest(
     // so their link count is not an authority signal. The stable no-follow CAS
     // traversal, exact digest address, exact length, and streamed digest bind
     // this descriptor without relaxing path-native child-file admission.
-    if !metadata.is_file() || metadata.len() != expected_length {
+    if !metadata.is_file()
+        || metadata.len() != expected_length
+        || !metadata.permissions().readonly()
+    {
         return Err(validation("graph object authority changed"));
     }
     let mut hasher = Sha256::new();
@@ -1970,7 +2035,7 @@ pub(crate) fn open_graph_object_by_digest(
     }
     file.rewind()
         .map_err(|error| storage("rewind graph object", root, error))?;
-    Ok(file)
+    Ok(AuthenticatedGraphObject { file, _cas: cas })
 }
 
 fn read_graph_object_by_digest_from_read_only_cas(
@@ -2045,6 +2110,14 @@ where
     let destination_name = std::ffi::OsStr::new(&digest[2..]);
     if let Ok(file) = bucket.open_child_file(destination_name) {
         verify_file(file, digest, expected_length, &cas.diagnostic_root)?;
+        let file = bucket.open_child_file(destination_name).map_err(|error| {
+            storage(
+                "reopen graph object for sealing",
+                &cas.diagnostic_root,
+                error,
+            )
+        })?;
+        seal_graph_object(&file, &cas.diagnostic_root)?;
         return Ok(GraphObjectInstallEvidence {
             reused_existing: true,
             ..GraphObjectInstallEvidence::default()
@@ -2080,6 +2153,7 @@ where
         expected_length,
         &cas.diagnostic_root,
     )?;
+    seal_graph_object(&temporary, &cas.diagnostic_root)?;
     let installed = if let Ok((_installed, _identity)) = cas.tmp.link_child_into(
         &temporary_name,
         &temporary,
@@ -2151,6 +2225,16 @@ fn verify_file(
         return Err(validation("graph object digest does not match its address"));
     }
     Ok(())
+}
+
+fn seal_graph_object(file: &File, diagnostic: &Path) -> Result<(), GfError> {
+    let mut permissions = file
+        .metadata()
+        .map_err(|error| storage("inspect graph object permissions", diagnostic, error))?
+        .permissions();
+    permissions.set_readonly(true);
+    file.set_permissions(permissions)
+        .map_err(|error| storage("seal graph object permissions", diagnostic, error))
 }
 
 fn hash_regular_file(path: &Path) -> Result<[u8; 32], GfError> {
@@ -2671,6 +2755,26 @@ mod tests {
         let publication = publish_rx.recv_timeout(Duration::from_secs(2)).unwrap();
         publish_thread.join().unwrap();
         drop(publication);
+    }
+
+    #[test]
+    fn authenticated_reader_keeps_cas_sealed_through_descriptor_consumption() {
+        let root = tempfile::tempdir().unwrap();
+        let payload = b"authenticated payload";
+        let (digest, _) = install_graph_object_bytes(root.path(), payload).unwrap();
+        let mut reader =
+            open_graph_object_by_digest(root.path(), &digest, payload.len() as u64).unwrap();
+        let path = graph_object_path(root.path(), &digest).unwrap();
+
+        let mutation = fs::OpenOptions::new().write(true).open(&path);
+        assert!(
+            mutation.is_err(),
+            "sealed CAS object accepted in-place mutation"
+        );
+
+        let mut decoded = Vec::new();
+        reader.read_to_end(&mut decoded).unwrap();
+        assert_eq!(decoded, payload);
     }
 
     #[cfg(unix)]

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -1960,6 +1960,7 @@ pub fn read_graph_object_by_digest(
 /// Open and stream-authenticate one immutable CAS object without allocating its payload.
 pub(crate) struct AuthenticatedGraphObject {
     file: File,
+    authenticated_length: u64,
     _cas: std::sync::Arc<ReadOnlyCasRoot>,
 }
 
@@ -2004,6 +2005,10 @@ impl AuthenticatedGraphObject {
     pub(crate) fn try_clone_file(&self) -> std::io::Result<File> {
         self.file.try_clone()
     }
+
+    pub(crate) fn authenticated_length(&self) -> u64 {
+        self.authenticated_length
+    }
 }
 
 impl AsRef<File> for AuthenticatedGraphObject {
@@ -2026,7 +2031,7 @@ impl Seek for AuthenticatedGraphObject {
 
 impl Length for AuthenticatedGraphObject {
     fn len(&self) -> u64 {
-        self.file.metadata().map_or(0, |metadata| metadata.len())
+        self.authenticated_length
     }
 }
 
@@ -2101,6 +2106,7 @@ fn open_graph_object_with_read_lease(
         .map_err(|error| storage("rewind graph object", &lease.cas.diagnostic_root, error))?;
     Ok(AuthenticatedGraphObject {
         file,
+        authenticated_length: expected_length,
         _cas: std::sync::Arc::clone(&lease.cas),
     })
 }
@@ -2853,6 +2859,7 @@ mod tests {
         let (digest, _) = install_graph_object_bytes(root.path(), payload).unwrap();
         let mut reader =
             open_graph_object_by_digest(root.path(), &digest, payload.len() as u64).unwrap();
+        assert_eq!(reader.len(), payload.len() as u64);
         let path = graph_object_path(root.path(), &digest).unwrap();
 
         let mutation = fs::OpenOptions::new().write(true).open(&path);

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -2142,12 +2142,17 @@ fn validate_logical_path(path: &Path) -> Result<(), GfError> {
     {
         return Err(validation("invalid graph object logical path"));
     }
-    if path
-        .components()
-        .next()
+    let components = path.components().collect::<Vec<_>>();
+    if components
+        .first()
         .is_some_and(|component| component.as_os_str() == std::ffi::OsStr::new(".graphforge-cache"))
+        && !components.get(1).is_some_and(|component| {
+            component.as_os_str() == std::ffi::OsStr::new("uuid-membership")
+        })
     {
-        return Err(validation("derived cache path cannot be sealed"));
+        return Err(validation(
+            "unauthoritative derived cache path cannot be sealed",
+        ));
     }
     Ok(())
 }

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -2109,15 +2109,7 @@ where
     let bucket = cas.digest_bucket(digest, true)?;
     let destination_name = std::ffi::OsStr::new(&digest[2..]);
     if let Ok(file) = bucket.open_child_file(destination_name) {
-        verify_file(file, digest, expected_length, &cas.diagnostic_root)?;
-        let file = bucket.open_child_file(destination_name).map_err(|error| {
-            storage(
-                "reopen graph object for sealing",
-                &cas.diagnostic_root,
-                error,
-            )
-        })?;
-        seal_graph_object(&file, &cas.diagnostic_root)?;
+        verify_and_seal_graph_object(&file, digest, expected_length, &cas.diagnostic_root)?;
         return Ok(GraphObjectInstallEvidence {
             reused_existing: true,
             ..GraphObjectInstallEvidence::default()
@@ -2225,6 +2217,22 @@ fn verify_file(
         return Err(validation("graph object digest does not match its address"));
     }
     Ok(())
+}
+
+fn verify_and_seal_graph_object(
+    file: &File,
+    digest: &str,
+    expected_length: u64,
+    diagnostic: &Path,
+) -> Result<(), GfError> {
+    verify_file(
+        file.try_clone()
+            .map_err(|error| storage("clone graph object for authentication", diagnostic, error))?,
+        digest,
+        expected_length,
+        diagnostic,
+    )?;
+    seal_graph_object(file, diagnostic)
 }
 
 fn seal_graph_object(file: &File, diagnostic: &Path) -> Result<(), GfError> {
@@ -2775,6 +2783,29 @@ mod tests {
         let mut decoded = Vec::new();
         reader.read_to_end(&mut decoded).unwrap();
         assert_eq!(decoded, payload);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reuse_seals_the_authenticated_descriptor_not_a_replaced_path() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let payload = b"descriptor-bound payload";
+        let (digest, _) = install_graph_object_bytes(root.path(), payload).unwrap();
+        let path = graph_object_path(root.path(), &digest).unwrap();
+        let displaced = path.with_extension("displaced");
+        let descriptor = File::open(&path).unwrap();
+
+        fs::rename(&path, &displaced).unwrap();
+        fs::set_permissions(&displaced, fs::Permissions::from_mode(0o600)).unwrap();
+        fs::write(&path, b"hostile replacement").unwrap();
+        verify_and_seal_graph_object(&descriptor, &digest, payload.len() as u64, root.path())
+            .unwrap();
+
+        assert!(fs::metadata(&displaced).unwrap().permissions().readonly());
+        assert!(!fs::metadata(&path).unwrap().permissions().readonly());
+        assert!(open_graph_object_by_digest(root.path(), &digest, payload.len() as u64).is_err());
     }
 
     #[cfg(unix)]

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -2142,17 +2142,12 @@ fn validate_logical_path(path: &Path) -> Result<(), GfError> {
     {
         return Err(validation("invalid graph object logical path"));
     }
-    let components = path.components().collect::<Vec<_>>();
-    if components
-        .first()
+    if path
+        .components()
+        .next()
         .is_some_and(|component| component.as_os_str() == std::ffi::OsStr::new(".graphforge-cache"))
-        && !components.get(1).is_some_and(|component| {
-            component.as_os_str() == std::ffi::OsStr::new("uuid-membership")
-        })
     {
-        return Err(validation(
-            "unauthoritative derived cache path cannot be sealed",
-        ));
+        return Err(validation("derived cache path cannot be sealed"));
     }
     Ok(())
 }

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -2162,7 +2162,7 @@ where
                 error,
             )
         })?;
-        verify_file(existing, digest, expected_length, &cas.diagnostic_root)?;
+        verify_and_seal_graph_object(&existing, digest, expected_length, &cas.diagnostic_root)?;
         false
     };
     cas.tmp
@@ -2225,6 +2225,10 @@ fn verify_and_seal_graph_object(
     expected_length: u64,
     diagnostic: &Path,
 ) -> Result<(), GfError> {
+    // Reuse is safe only after the exact opened inode is no longer writable.
+    // Hashing first would leave a window in which the already-authenticated
+    // bytes could be changed before the subsequent chmod.
+    seal_graph_object(file, diagnostic)?;
     verify_file(
         file.try_clone()
             .map_err(|error| storage("clone graph object for authentication", diagnostic, error))?,
@@ -2232,7 +2236,17 @@ fn verify_and_seal_graph_object(
         expected_length,
         diagnostic,
     )?;
-    seal_graph_object(file, diagnostic)
+    if !file
+        .metadata()
+        .map_err(|error| storage("reinspect sealed graph object", diagnostic, error))?
+        .permissions()
+        .readonly()
+    {
+        return Err(validation(
+            "graph object became writable during authentication",
+        ));
+    }
+    Ok(())
 }
 
 fn seal_graph_object(file: &File, diagnostic: &Path) -> Result<(), GfError> {
@@ -2806,6 +2820,28 @@ mod tests {
         assert!(fs::metadata(&displaced).unwrap().permissions().readonly());
         assert!(!fs::metadata(&path).unwrap().permissions().readonly());
         assert!(open_graph_object_by_digest(root.path(), &digest, payload.len() as u64).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reuse_seals_same_inode_before_digest_authentication() {
+        let root = tempfile::tempdir().unwrap();
+        let payload = b"seal-before-authentication";
+        let digest = hex_digest(Sha256::digest(payload).into());
+        let path = root.path().join("candidate");
+        fs::write(&path, payload).unwrap();
+        let descriptor = File::open(&path).unwrap();
+
+        seal_graph_object(&descriptor, root.path()).unwrap();
+        assert!(fs::OpenOptions::new().write(true).open(&path).is_err());
+        verify_file(
+            descriptor.try_clone().unwrap(),
+            &digest,
+            payload.len() as u64,
+            root.path(),
+        )
+        .unwrap();
+        assert!(descriptor.metadata().unwrap().permissions().readonly());
     }
 
     #[cfg(unix)]

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -2238,6 +2238,11 @@ where
         verify_and_seal_graph_object(&existing, digest, expected_length, &cas.diagnostic_root)?;
         false
     };
+    // Windows cannot open a deletion handle while the original temporary
+    // handle remains open without delete sharing. Publication and concurrent
+    // winner authentication are complete, so release it before exact-identity
+    // cleanup; the installed hard link remains sealed.
+    drop(temporary);
     cas.tmp
         .unlink_child_if_identity(&temporary_name, temporary_identity)
         .map_err(|error| {

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -1936,6 +1936,43 @@ pub fn read_graph_object_by_digest(
     read_graph_object_by_digest_from_read_only_cas(&cas, digest, max_length)
 }
 
+/// Open and stream-authenticate one immutable CAS object without allocating its payload.
+pub(crate) fn open_graph_object_by_digest(
+    root: &Path,
+    digest: &str,
+    expected_length: u64,
+) -> Result<File, GfError> {
+    let cas = ReadOnlyCasRoot::open(root)?;
+    let mut file = cas.open_digest(digest)?;
+    let metadata = file
+        .metadata()
+        .map_err(|error| storage("inspect stable graph object", root, error))?;
+    // CAS payloads are deliberately hard-linked into private materializations,
+    // so their link count is not an authority signal. The stable no-follow CAS
+    // traversal, exact digest address, exact length, and streamed digest bind
+    // this descriptor without relaxing path-native child-file admission.
+    if !metadata.is_file() || metadata.len() != expected_length {
+        return Err(validation("graph object authority changed"));
+    }
+    let mut hasher = Sha256::new();
+    let mut block = vec![0_u8; 1 << 20];
+    loop {
+        let count = file
+            .read(&mut block)
+            .map_err(|error| storage("authenticate graph object", root, error))?;
+        if count == 0 {
+            break;
+        }
+        hasher.update(&block[..count]);
+    }
+    if hex_digest(hasher.finalize().into()) != digest {
+        return Err(validation("graph object digest does not match its address"));
+    }
+    file.rewind()
+        .map_err(|error| storage("rewind graph object", root, error))?;
+    Ok(file)
+}
+
 fn read_graph_object_by_digest_from_read_only_cas(
     cas: &ReadOnlyCasRoot,
     digest: &str,

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -1311,6 +1311,26 @@ pub fn graph_object_path(root: &Path, digest: &str) -> Result<PathBuf, GfError> 
         .join(&digest[2..]))
 }
 
+#[cfg(test)]
+pub(crate) fn corrupt_sealed_graph_object_for_test(path: &Path, bytes: &[u8]) {
+    let metadata = fs::metadata(path).expect("inspect sealed graph object fixture");
+    assert!(
+        metadata.permissions().readonly(),
+        "graph object fixture must be sealed before hostile corruption"
+    );
+    let mut permissions = metadata.permissions();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        permissions.set_mode(permissions.mode() | 0o200);
+    }
+    #[cfg(not(unix))]
+    permissions.set_readonly(false);
+    fs::set_permissions(path, permissions)
+        .expect("make exact graph object fixture owner-writable for hostile corruption");
+    fs::write(path, bytes).expect("corrupt exact sealed graph object fixture");
+}
+
 /// Install exact in-memory bytes under their SHA-256 identity.
 pub fn install_graph_object_bytes(
     root: &Path,
@@ -2998,7 +3018,10 @@ mod tests {
             b"payload"
         );
 
-        fs::write(graph_object_path(root.path(), &digest).unwrap(), b"corrupt").unwrap();
+        corrupt_sealed_graph_object_for_test(
+            &graph_object_path(root.path(), &digest).unwrap(),
+            b"corrupt",
+        );
         assert!(install_graph_object_bytes(root.path(), b"payload").is_err());
     }
 
@@ -3377,11 +3400,10 @@ mod tests {
         );
 
         let (another_orphan, _) = install_graph_object_bytes(container.path(), b"another").unwrap();
-        fs::write(
-            graph_object_path(container.path(), &root.root_node_sha256).unwrap(),
+        corrupt_sealed_graph_object_for_test(
+            &graph_object_path(container.path(), &root.root_node_sha256).unwrap(),
             b"tampered",
-        )
-        .unwrap();
+        );
         assert!(
             gc_graph_objects(
                 container.path(),

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -31,6 +31,12 @@ pub use graph_projection::{
     materialize_graph_projection, materialize_portable_graph_tree_projection,
 };
 
+pub mod graph_construction;
+pub use graph_construction::{
+    ConstructionChunkKind, ConstructionChunkReceipt, GraphConstructionBudgets,
+    GraphConstructionEvidence, GraphConstructionSession, GraphConstructionState,
+};
+
 pub mod graph_files;
 #[cfg(test)]
 pub(crate) use graph_files::graph_files_root_participant;

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -32,10 +32,12 @@ pub use graph_projection::{
 };
 
 pub mod graph_construction;
+mod graph_construction_encoding;
 pub use graph_construction::{
     CONSTRUCTION_EDGE_SCHEMA, CONSTRUCTION_NODE_SCHEMA, ConstructionChunkKind,
     ConstructionChunkReceipt, ConstructionShape, GraphConstructionBudgets,
-    GraphConstructionEvidence, GraphConstructionSession, GraphConstructionState,
+    GraphConstructionEncoding, GraphConstructionEncodingEvidence, GraphConstructionEvidence,
+    GraphConstructionSession, GraphConstructionState,
 };
 
 pub mod graph_files;

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -35,9 +35,10 @@ pub mod graph_construction;
 mod graph_construction_encoding;
 pub use graph_construction::{
     CONSTRUCTION_EDGE_SCHEMA, CONSTRUCTION_NODE_SCHEMA, ConstructionChunkKind,
-    ConstructionChunkReceipt, ConstructionShape, GraphConstructionBudgets,
-    GraphConstructionEncoding, GraphConstructionEncodingEvidence, GraphConstructionEvidence,
-    GraphConstructionSession, GraphConstructionState,
+    ConstructionChunkReceipt, ConstructionRetainedArtifact, ConstructionSemanticAuthority,
+    ConstructionShape, GraphConstructionBudgets, GraphConstructionEncoding,
+    GraphConstructionEncodingEvidence, GraphConstructionEvidence, GraphConstructionSession,
+    GraphConstructionState,
 };
 
 pub mod graph_files;

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -34,8 +34,8 @@ pub use graph_projection::{
 pub mod graph_construction;
 pub use graph_construction::{
     CONSTRUCTION_EDGE_SCHEMA, CONSTRUCTION_NODE_SCHEMA, ConstructionChunkKind,
-    ConstructionChunkReceipt, GraphConstructionBudgets, GraphConstructionEvidence,
-    GraphConstructionSession, GraphConstructionState,
+    ConstructionChunkReceipt, ConstructionShape, GraphConstructionBudgets,
+    GraphConstructionEvidence, GraphConstructionSession, GraphConstructionState,
 };
 
 pub mod graph_files;

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -33,8 +33,9 @@ pub use graph_projection::{
 
 pub mod graph_construction;
 pub use graph_construction::{
-    ConstructionChunkKind, ConstructionChunkReceipt, GraphConstructionBudgets,
-    GraphConstructionEvidence, GraphConstructionSession, GraphConstructionState,
+    CONSTRUCTION_EDGE_SCHEMA, CONSTRUCTION_NODE_SCHEMA, ConstructionChunkKind,
+    ConstructionChunkReceipt, GraphConstructionBudgets, GraphConstructionEvidence,
+    GraphConstructionSession, GraphConstructionState,
 };
 
 pub mod graph_files;

--- a/crates/graphforge-storage/src/project_portable_v2_export.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_export.rs
@@ -1675,7 +1675,9 @@ fn open_planned_source(planned: &PlannedFile) -> Result<(File, Option<Identity>)
             digest,
             length,
         } => {
-            let source = lease.open(digest, *length)?;
+            let source = lease
+                .open(digest, *length)
+                .map_err(|_| err("GF_SOURCE_CHANGED", "pinned CAS source changed"))?;
             let mut file = source.try_clone_file().map_err(storage)?;
             file.seek(SeekFrom::Start(0)).map_err(storage)?;
             Ok((file, None))
@@ -2162,6 +2164,42 @@ fn storage(e: impl std::fmt::Display) -> ExportError {
 mod tests {
     use super::*;
     use crate::open_or_initialize_project;
+
+    fn compact_graph_generation() -> (tempfile::TempDir, ResolvedProjectGeneration) {
+        let project = tempfile::tempdir().unwrap();
+        open_or_initialize_project(project.path()).unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let relative = PathBuf::from("topology/nodes/part-00000.parquet");
+        fs::create_dir_all(workspace.path().join(relative.parent().unwrap())).unwrap();
+        fs::write(workspace.path().join(&relative), b"compact graph payload").unwrap();
+        let lease = crate::begin_graph_object_publication(project.path()).unwrap();
+        let mut state = crate::GraphManifestState::empty();
+        let (root, _) =
+            crate::append_graph_files_v2(&lease, workspace.path(), &mut state, &[relative], &[])
+                .unwrap();
+        let request = crate::ProjectGenerationRequest {
+            transaction_uuid: Uuid::new_v4(),
+            generation_uuid: Uuid::new_v4(),
+            capabilities: vec![crate::ProjectCapability {
+                capability_id: crate::GRAPH_CAPABILITY_ID.into(),
+                capability_version: 1,
+            }],
+            participants: vec![crate::graph_files_root_participant(&root).unwrap()],
+        };
+        let crate::ProjectStageOutcome::Staged(staged) =
+            crate::stage_project_generation(project.path(), &request).unwrap()
+        else {
+            panic!("fresh compact generation replayed");
+        };
+        staged
+            .validate(|_| Ok(()), |_, _| Ok(()))
+            .unwrap()
+            .publish_with_graph_objects(&lease)
+            .unwrap();
+        drop(lease);
+        let generation = crate::resolve_project_generation(project.path()).unwrap();
+        (project, generation)
+    }
 
     fn graph_generation() -> (tempfile::TempDir, ResolvedProjectGeneration) {
         graph_generation_with_composition(false)
@@ -3747,6 +3785,92 @@ mod tests {
         };
         let error = plan_complete_portable_v2(&generation, limited).unwrap_err();
         assert_eq!(error.code, PortableV2ErrorCode::LimitExceeded);
+    }
+
+    #[test]
+    fn compact_plan_is_reusable_across_representations_cancelled_retry_and_cas_tamper() {
+        let (project, generation) = compact_graph_generation();
+        let limits = PortableV2ExportLimits::default();
+        let plan = plan_complete_portable_v2(&generation, limits).unwrap();
+        assert!(
+            plan.files
+                .iter()
+                .any(|file| matches!(file.source, PlannedSource::Cas { .. }))
+        );
+        let out = tempfile::tempdir().unwrap();
+        let expanded = out.path().join("compact.gfproject");
+        let bundle = out.path().join("compact.gfpb");
+        let cancelled_bundle = out.path().join("cancelled.gfpb");
+        let active = AtomicBool::new(false);
+        let expanded_receipt = export_complete_portable_v2(
+            &plan,
+            &expanded,
+            PortableV2Output::Expanded,
+            limits,
+            &active,
+            |_| {},
+        )
+        .unwrap();
+        let cancelled = AtomicBool::new(true);
+        assert_eq!(
+            export_complete_portable_v2(
+                &plan,
+                &cancelled_bundle,
+                PortableV2Output::Bundle,
+                limits,
+                &cancelled,
+                |_| {},
+            )
+            .unwrap_err()
+            .code,
+            PortableV2ErrorCode::Cancelled
+        );
+        assert!(!cancelled_bundle.exists());
+        let bundle_receipt = export_complete_portable_v2(
+            &plan,
+            &bundle,
+            PortableV2Output::Bundle,
+            limits,
+            &active,
+            |_| {},
+        )
+        .unwrap();
+        assert_eq!(
+            expanded_receipt.package_digest,
+            bundle_receipt.package_digest
+        );
+        verify_portable_v2(&expanded, PortableV2Mode::Full, limits, Some(&active)).unwrap();
+        verify_portable_v2(&bundle, PortableV2Mode::Full, limits, Some(&active)).unwrap();
+
+        let payload_digest = hex(Sha256::digest(b"compact graph payload").into());
+        let (digest, length) = plan
+            .files
+            .iter()
+            .find_map(|file| match &file.source {
+                PlannedSource::Cas { digest, length, .. } if digest == &payload_digest => {
+                    Some((digest.clone(), *length))
+                }
+                PlannedSource::File { .. } | PlannedSource::Control(_) => None,
+                PlannedSource::Cas { .. } => None,
+            })
+            .unwrap();
+        let object = crate::graph_object_store::graph_object_path(project.path(), &digest).unwrap();
+        let mut permissions = fs::metadata(&object).unwrap().permissions();
+        permissions.set_readonly(false);
+        fs::set_permissions(&object, permissions).unwrap();
+        fs::write(&object, vec![b'x'; usize::try_from(length).unwrap()]).unwrap();
+        let tampered = out.path().join("tampered.gfpb");
+        let error = export_complete_portable_v2(
+            &plan,
+            &tampered,
+            PortableV2Output::Bundle,
+            limits,
+            &active,
+            |_| {},
+        )
+        .unwrap_err();
+        assert_eq!(error.code, PortableV2ErrorCode::ConcurrentMutation);
+        assert!(!tampered.exists());
     }
 
     #[test]

--- a/crates/graphforge-storage/src/project_portable_v2_export.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_export.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeSet;
 use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Write};
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -52,17 +52,24 @@ pub struct PortableV2ExportProgress {
     /// Planned source payload bytes.
     pub bytes_total: u64,
 }
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct PlannedFile {
     source: PlannedSource,
     path: String,
     length: u64,
     digest: [u8; 32],
 }
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum PlannedSource {
-    File { path: PathBuf, identity: Identity },
-    Cas(crate::graph_object_store::AuthenticatedGraphObject),
+    File {
+        path: PathBuf,
+        identity: Identity,
+    },
+    Cas {
+        lease: crate::graph_object_store::GraphObjectReadLease,
+        digest: String,
+        length: u64,
+    },
     Control(Vec<u8>),
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -74,6 +81,7 @@ struct Identity {
     len: u64,
     modified: Option<std::time::SystemTime>,
 }
+#[derive(Clone)]
 /// Immutable pinned-generation metadata plan; contains no payload buffers.
 pub struct PortableV2ExportPlan {
     generation_uuid: Uuid,
@@ -850,11 +858,19 @@ pub fn plan_selected_portable_v2(
     if selection.include_graph_tree
         && let Some(inv) = g.graph_files_inventory()?
     {
+        let graph_authority = g.declared_graph_files_participant()?;
+        let graph_cas = if matches!(graph_authority, Some(crate::GraphFilesParticipant::V2(_))) {
+            Some(crate::graph_object_store::begin_graph_object_read(
+                g.container_root(),
+            )?)
+        } else {
+            None
+        };
         let id = "graph-tree".to_owned();
         let mut owned = Vec::new();
         for e in inv.files {
             let path = format!("data/components/graph-data/{id}/{}", e.relative_path);
-            let f = match g.declared_graph_files_participant()? {
+            let f = match &graph_authority {
                 Some(crate::GraphFilesParticipant::V1(_)) => inspect(
                     &g.graph_tree_root().join(&e.relative_path),
                     &path,
@@ -862,7 +878,7 @@ pub fn plan_selected_portable_v2(
                     &mut total,
                 )?,
                 Some(crate::GraphFilesParticipant::V2(_)) => inspect_cas(
-                    g.container_root(),
+                    graph_cas.as_ref().expect("compact authority has CAS lease"),
                     &e.content_sha256,
                     e.byte_length,
                     &path,
@@ -1496,7 +1512,7 @@ fn inspect(
     })
 }
 fn inspect_cas(
-    root: &Path,
+    lease: &crate::graph_object_store::GraphObjectReadLease,
     digest: &str,
     expected_length: u64,
     path: &str,
@@ -1513,14 +1529,17 @@ fn inspect_cas(
     if *total > limits.max_total_bytes {
         return Err(limit("total too large"));
     }
-    let source =
-        crate::graph_object_store::open_graph_object_by_digest(root, digest, expected_length)?;
-    let digest = parse_sha256(digest)?;
+    let _authenticated = lease.open(digest, expected_length)?;
+    let digest_bytes = parse_sha256(digest)?;
     Ok(PlannedFile {
-        source: PlannedSource::Cas(source),
+        source: PlannedSource::Cas {
+            lease: lease.clone(),
+            digest: digest.to_owned(),
+            length: expected_length,
+        },
         path: path.into(),
         length: expected_length,
-        digest,
+        digest: digest_bytes,
     })
 }
 fn inline_control(
@@ -1651,7 +1670,16 @@ fn open_planned_source(planned: &PlannedFile) -> Result<(File, Option<Identity>)
             }
             Ok((input, Some(*expected)))
         }
-        PlannedSource::Cas(source) => Ok((source.try_clone_file().map_err(storage)?, None)),
+        PlannedSource::Cas {
+            lease,
+            digest,
+            length,
+        } => {
+            let source = lease.open(digest, *length)?;
+            let mut file = source.try_clone_file().map_err(storage)?;
+            file.seek(SeekFrom::Start(0)).map_err(storage)?;
+            Ok((file, None))
+        }
         PlannedSource::Control(_) => unreachable!("control source returned above"),
     }
 }
@@ -2757,7 +2785,9 @@ mod tests {
             .source
         {
             PlannedSource::Control(bytes) => bytes.clone(),
-            PlannedSource::File { .. } => panic!("projected module must be an inline control"),
+            PlannedSource::File { .. } | PlannedSource::Cas { .. } => {
+                panic!("projected module must be an inline control")
+            }
         };
         let mut module: serde_json::Value = serde_json::from_slice(&module_bytes).unwrap();
         module["ontology_id"] = "https://graphforge.dev/ontology/tampered".into();
@@ -2787,7 +2817,9 @@ mod tests {
             .source
         {
             PlannedSource::Control(bytes) => bytes.clone(),
-            PlannedSource::File { .. } => panic!("composition must be an inline control"),
+            PlannedSource::File { .. } | PlannedSource::Cas { .. } => {
+                panic!("composition must be an inline control")
+            }
         };
         let mut control: serde_json::Value = serde_json::from_slice(&control_bytes).unwrap();
         control["required_features"]
@@ -2837,7 +2869,9 @@ mod tests {
             .source
         {
             PlannedSource::Control(bytes) => bytes.clone(),
-            PlannedSource::File { .. } => panic!("projected bridge must be an inline control"),
+            PlannedSource::File { .. } | PlannedSource::Cas { .. } => {
+                panic!("projected bridge must be an inline control")
+            }
         };
         let mut bridge: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         bridge["authored_version"] = "tampered-v2".into();
@@ -3751,7 +3785,7 @@ mod tests {
             .iter()
             .find_map(|file| match &file.source {
                 PlannedSource::File { path, .. } => Some(path),
-                PlannedSource::Control(_) => None,
+                PlannedSource::Control(_) | PlannedSource::Cas { .. } => None,
             })
             .unwrap();
         let original = fs::read(source).unwrap();

--- a/crates/graphforge-storage/src/project_portable_v2_export.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_export.rs
@@ -52,16 +52,17 @@ pub struct PortableV2ExportProgress {
     /// Planned source payload bytes.
     pub bytes_total: u64,
 }
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct PlannedFile {
     source: PlannedSource,
     path: String,
     length: u64,
     digest: [u8; 32],
 }
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 enum PlannedSource {
     File { path: PathBuf, identity: Identity },
+    Cas(crate::graph_object_store::AuthenticatedGraphObject),
     Control(Vec<u8>),
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -73,7 +74,6 @@ struct Identity {
     len: u64,
     modified: Option<std::time::SystemTime>,
 }
-#[derive(Clone)]
 /// Immutable pinned-generation metadata plan; contains no payload buffers.
 pub struct PortableV2ExportPlan {
     generation_uuid: Uuid,
@@ -853,9 +853,24 @@ pub fn plan_selected_portable_v2(
         let id = "graph-tree".to_owned();
         let mut owned = Vec::new();
         for e in inv.files {
-            let source = g.graph_tree_root().join(&e.relative_path);
             let path = format!("data/components/graph-data/{id}/{}", e.relative_path);
-            let f = inspect(&source, &path, limits, &mut total)?;
+            let f = match g.declared_graph_files_participant()? {
+                Some(crate::GraphFilesParticipant::V1(_)) => inspect(
+                    &g.graph_tree_root().join(&e.relative_path),
+                    &path,
+                    limits,
+                    &mut total,
+                )?,
+                Some(crate::GraphFilesParticipant::V2(_)) => inspect_cas(
+                    g.container_root(),
+                    &e.content_sha256,
+                    e.byte_length,
+                    &path,
+                    limits,
+                    &mut total,
+                )?,
+                None => return Err(err("GF_SOURCE_CHANGED", "graph authority disappeared")),
+            };
             if f.length != e.byte_length || hex(f.digest) != e.content_sha256 {
                 return Err(err(
                     "GF_SOURCE_CHANGED",
@@ -1480,6 +1495,34 @@ fn inspect(
         digest: digest.finalize().into(),
     })
 }
+fn inspect_cas(
+    root: &Path,
+    digest: &str,
+    expected_length: u64,
+    path: &str,
+    limits: PortableV2ExportLimits,
+    total: &mut u64,
+) -> Result<PlannedFile, ExportError> {
+    if path.len() > limits.max_path_bytes || expected_length > limits.max_entry_bytes {
+        return Err(limit("CAS entry exceeds configured limit"));
+    }
+    valid_path(path)?;
+    *total = total
+        .checked_add(expected_length)
+        .ok_or_else(|| limit("size overflow"))?;
+    if *total > limits.max_total_bytes {
+        return Err(limit("total too large"));
+    }
+    let source =
+        crate::graph_object_store::open_graph_object_by_digest(root, digest, expected_length)?;
+    let digest = parse_sha256(digest)?;
+    Ok(PlannedFile {
+        source: PlannedSource::Cas(source),
+        path: path.into(),
+        length: expected_length,
+        digest,
+    })
+}
 fn inline_control(
     path: &str,
     bytes: Vec<u8>,
@@ -1523,17 +1566,7 @@ fn copy(
         tick(bytes.len() as u64);
         return Ok(());
     }
-    let PlannedSource::File {
-        path,
-        identity: planned_identity,
-    } = &planned.source
-    else {
-        unreachable!("control source returned above")
-    };
-    let mut input = open_source_no_follow(path)?;
-    if identity(&input.metadata().map_err(storage)?)? != *planned_identity {
-        return Err(err("GF_SOURCE_CHANGED", "source changed"));
-    }
+    let (mut input, planned_identity) = open_planned_source(planned)?;
     let mut buffer = vec![0; size];
     let mut digest = Sha256::new();
     let mut bytes_read = 0;
@@ -1551,9 +1584,11 @@ fn copy(
         tick(count as u64);
     }
     output.sync_all().map_err(storage)?;
-    if bytes_read != planned.length
-        || <[u8; 32]>::from(digest.finalize()) != planned.digest
-        || identity(&input.metadata().map_err(storage)?)? != *planned_identity
+    if bytes_read != planned.length || <[u8; 32]>::from(digest.finalize()) != planned.digest {
+        return Err(err("GF_SOURCE_CHANGED", "source changed during export"));
+    }
+    if let Some(expected) = planned_identity
+        && identity(&input.metadata().map_err(storage)?)? != expected
     {
         return Err(err("GF_SOURCE_CHANGED", "source changed during export"));
     }
@@ -1576,17 +1611,7 @@ fn stream(
         tick(bytes.len() as u64);
         return Ok(());
     }
-    let PlannedSource::File {
-        path,
-        identity: planned_identity,
-    } = &planned.source
-    else {
-        unreachable!("control source returned above")
-    };
-    let mut input = open_source_no_follow(path)?;
-    if identity(&input.metadata().map_err(storage)?)? != *planned_identity {
-        return Err(err("GF_SOURCE_CHANGED", "source changed"));
-    }
+    let (mut input, planned_identity) = open_planned_source(planned)?;
     let mut buffer = vec![0; size];
     let mut digest = Sha256::new();
     let mut bytes_read = 0;
@@ -1604,13 +1629,43 @@ fn stream(
         bytes_read += count as u64;
         tick(count as u64);
     }
-    if bytes_read != planned.length
-        || <[u8; 32]>::from(digest.finalize()) != planned.digest
-        || identity(&input.metadata().map_err(storage)?)? != *planned_identity
+    if bytes_read != planned.length || <[u8; 32]>::from(digest.finalize()) != planned.digest {
+        return Err(err("GF_SOURCE_CHANGED", "source changed during export"));
+    }
+    if let Some(expected) = planned_identity
+        && identity(&input.metadata().map_err(storage)?)? != expected
     {
         return Err(err("GF_SOURCE_CHANGED", "source changed during export"));
     }
     Ok(())
+}
+fn open_planned_source(planned: &PlannedFile) -> Result<(File, Option<Identity>), ExportError> {
+    match &planned.source {
+        PlannedSource::File {
+            path,
+            identity: expected,
+        } => {
+            let input = open_source_no_follow(path)?;
+            if identity(&input.metadata().map_err(storage)?)? != *expected {
+                return Err(err("GF_SOURCE_CHANGED", "source changed"));
+            }
+            Ok((input, Some(*expected)))
+        }
+        PlannedSource::Cas(source) => Ok((source.try_clone_file().map_err(storage)?, None)),
+        PlannedSource::Control(_) => unreachable!("control source returned above"),
+    }
+}
+
+fn parse_sha256(value: &str) -> Result<[u8; 32], ExportError> {
+    if value.len() != 64 {
+        return Err(err("GF_INTEGRITY_FAILED", "invalid CAS digest length"));
+    }
+    let mut bytes = [0_u8; 32];
+    for (index, byte) in bytes.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&value[index * 2..index * 2 + 2], 16)
+            .map_err(|_| err("GF_INTEGRITY_FAILED", "invalid CAS digest"))?;
+    }
+    Ok(bytes)
 }
 fn header(out: &mut File, h: &mut Sha256, path: &str, size: u64) -> Result<(), ExportError> {
     if let Ok((name, prefix)) = split(path) {

--- a/crates/graphforge-storage/src/project_publication.rs
+++ b/crates/graphforge-storage/src/project_publication.rs
@@ -1738,12 +1738,6 @@ fn replace_current(
                 "CURRENT",
                 false,
             )?;
-            if cancellation.as_mut().is_some_and(|cancelled| cancelled()) {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Interrupted,
-                    "publication cancelled before CURRENT commit point",
-                ));
-            }
             if let Some(admission) = lifecycle_admission {
                 admission
                     .revalidate_identity()
@@ -1758,6 +1752,15 @@ fn replace_current(
                 lease
                     .revalidate_for_root(staged.parent.container_root())
                     .map_err(std::io::Error::other)?;
+            }
+            // This is deliberately the final fallible predicate before the
+            // single native replacement commit point. After replacement,
+            // reconciliation owns the result and cancellation cannot undo it.
+            if cancellation.as_mut().is_some_and(|cancelled| cancelled()) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Interrupted,
+                    "publication cancelled at project.before_current_replace",
+                ));
             }
             Ok(())
         },

--- a/crates/graphforge-storage/src/project_publication.rs
+++ b/crates/graphforge-storage/src/project_publication.rs
@@ -1354,7 +1354,7 @@ impl ValidatedProjectGeneration {
     /// Returns a stable publication error whose diagnostic states whether the
     /// commit point was crossed.
     pub fn publish(mut self) -> Result<ProjectPublicationReceipt, GfError> {
-        self.publish_with_optional_graph_objects(None)
+        self.publish_with_optional_graph_objects(None, None)
     }
 
     /// Publish a compact graph generation while holding its CAS lease through
@@ -1363,12 +1363,23 @@ impl ValidatedProjectGeneration {
         mut self,
         lease: &crate::GraphObjectPublicationLease,
     ) -> Result<ProjectPublicationReceipt, GfError> {
-        self.publish_with_optional_graph_objects(Some(lease))
+        self.publish_with_optional_graph_objects(Some(lease), None)
+    }
+
+    /// Publish a compact graph while polling cancellation until the atomic
+    /// `CURRENT` replacement commit point.
+    pub(crate) fn publish_with_graph_objects_cancellable(
+        mut self,
+        lease: &crate::GraphObjectPublicationLease,
+        cancelled: &mut dyn FnMut() -> bool,
+    ) -> Result<ProjectPublicationReceipt, GfError> {
+        self.publish_with_optional_graph_objects(Some(lease), Some(cancelled))
     }
 
     fn publish_with_optional_graph_objects(
         &mut self,
         graph_object_lease: Option<&crate::GraphObjectPublicationLease>,
+        cancellation: Option<&mut dyn FnMut() -> bool>,
     ) -> Result<ProjectPublicationReceipt, GfError> {
         self.0.admission.revalidate_identity()?;
         let lifecycle_admission = self.0.admission.readmit_for_publish()?;
@@ -1379,7 +1390,11 @@ impl ValidatedProjectGeneration {
             self.0.admission.revalidate_identity()?;
         }
         let result = self
-            .publish_inner(graph_object_lease, lifecycle_admission.as_ref())
+            .publish_inner(
+                graph_object_lease,
+                lifecycle_admission.as_ref(),
+                cancellation,
+            )
             .map_err(|error| {
                 if matches!(error, GfError::Project { .. }) {
                     error
@@ -1434,6 +1449,7 @@ impl ValidatedProjectGeneration {
         &self,
         graph_object_lease: Option<&crate::GraphObjectPublicationLease>,
         lifecycle_admission: Option<&crate::filesystem_admission::ProjectLifecycleAdmission>,
+        cancellation: Option<&mut dyn FnMut() -> bool>,
     ) -> Result<ProjectPublicationReceipt, GfError> {
         let staged = &self.0;
         let compact_graph = has_compact_graph_participant(staged)?;
@@ -1460,6 +1476,7 @@ impl ValidatedProjectGeneration {
             manifest_sha256,
             graph_object_lease,
             lifecycle_admission,
+            cancellation,
         )?;
         finish_published_generation(staged, manifest_sha256)?;
         Ok(ProjectPublicationReceipt {
@@ -1678,6 +1695,7 @@ fn replace_current(
     manifest_sha256: [u8; 32],
     graph_object_lease: Option<&crate::GraphObjectPublicationLease>,
     lifecycle_admission: Option<&crate::filesystem_admission::ProjectLifecycleAdmission>,
+    mut cancellation: Option<&mut dyn FnMut() -> bool>,
 ) -> Result<(), GfError> {
     let current = CurrentRecord {
         format: "graphforge-project".into(),
@@ -1720,6 +1738,12 @@ fn replace_current(
                 "CURRENT",
                 false,
             )?;
+            if cancellation.as_mut().is_some_and(|cancelled| cancelled()) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Interrupted,
+                    "publication cancelled before CURRENT commit point",
+                ));
+            }
             if let Some(admission) = lifecycle_admission {
                 admission
                     .revalidate_identity()

--- a/crates/graphforge-storage/src/project_publication.rs
+++ b/crates/graphforge-storage/src/project_publication.rs
@@ -3016,11 +3016,10 @@ mod tests {
             panic!("new request unexpectedly replayed");
         };
 
-        fs::write(
-            crate::graph_object_path(root.path(), &payload_digest).unwrap(),
+        crate::graph_object_store::corrupt_sealed_graph_object_for_test(
+            &crate::graph_object_path(root.path(), &payload_digest).unwrap(),
             b"corrupt",
-        )
-        .unwrap();
+        );
         let validated = staged
             .validate(|_| Ok(()), |_, _| Ok(()))
             .expect("intermediate validation must not rehash compact payloads");

--- a/crates/graphforge-storage/src/project_publication.rs
+++ b/crates/graphforge-storage/src/project_publication.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
-use graphforge_core::{GfError, ProjectErrorCode};
+use graphforge_core::{ApiErrorCode, GfError, ProjectErrorCode};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
@@ -1396,7 +1396,7 @@ impl ValidatedProjectGeneration {
                 cancellation,
             )
             .map_err(|error| {
-                if matches!(error, GfError::Project { .. }) {
+                if matches!(error, GfError::Project { .. } | GfError::Api { .. }) {
                     error
                 } else {
                     publication_error_from_parts(
@@ -1790,6 +1790,20 @@ fn reconcile_current_replacement_error(
     manifest_sha256: [u8; 32],
     error: &AtomicPublishError,
 ) -> Result<(), GfError> {
+    // `Interrupted` is emitted only by the final predicate inside
+    // `before_replace`; the native namespace operation has not started, so
+    // committed=false is proven without consulting recovery-visible journals.
+    if matches!(error, AtomicPublishError::Io(error) if error.kind() == std::io::ErrorKind::Interrupted)
+    {
+        return Err(GfError::Api {
+            code: ApiErrorCode::Cancelled,
+            message: format!(
+                "transaction_uuid={} generation_uuid={} boundary=project.before_current_replace committed=false",
+                transaction_uuid.hyphenated(),
+                generation_uuid.hyphenated()
+            ),
+        });
+    }
     // The native primitive distinguishes a proved no-op from an outcome whose
     // namespace state requires reconciliation. Re-read CURRENT under the
     // still-held writer lock for every error so callers never receive

--- a/crates/graphforge-storage/src/project_publication.rs
+++ b/crates/graphforge-storage/src/project_publication.rs
@@ -1787,7 +1787,7 @@ fn reconcile_current_replacement_error(
     manifest_sha256: [u8; 32],
     error: &AtomicPublishError,
 ) -> Result<(), GfError> {
-    // `Interrupted` is emitted only by the final predicate inside
+    // `CancelledBeforeReplace` is emitted only by the final predicate inside
     // `before_replace`; the native namespace operation has not started, so
     // committed=false is proven without consulting recovery-visible journals.
     if matches!(error, AtomicPublishError::CancelledBeforeReplace) {

--- a/crates/graphforge-storage/src/project_publication.rs
+++ b/crates/graphforge-storage/src/project_publication.rs
@@ -1757,10 +1757,7 @@ fn replace_current(
             // single native replacement commit point. After replacement,
             // reconciliation owns the result and cancellation cannot undo it.
             if cancellation.as_mut().is_some_and(|cancelled| cancelled()) {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Interrupted,
-                    "publication cancelled at project.before_current_replace",
-                ));
+                return Err(std::io::Error::other(CancelledBeforeReplace));
             }
             Ok(())
         },
@@ -1793,8 +1790,7 @@ fn reconcile_current_replacement_error(
     // `Interrupted` is emitted only by the final predicate inside
     // `before_replace`; the native namespace operation has not started, so
     // committed=false is proven without consulting recovery-visible journals.
-    if matches!(error, AtomicPublishError::Io(error) if error.kind() == std::io::ErrorKind::Interrupted)
-    {
+    if matches!(error, AtomicPublishError::CancelledBeforeReplace) {
         return Err(GfError::Api {
             code: ApiErrorCode::Cancelled,
             message: format!(
@@ -2419,6 +2415,7 @@ pub(crate) fn write_journal(path: &Path, journal: &JournalRecord) -> Result<(), 
 pub(crate) enum AtomicPublishError {
     Io(std::io::Error),
     Replacement(graphforge_filesystem::ReplaceFileError),
+    CancelledBeforeReplace,
 }
 
 impl std::fmt::Display for AtomicPublishError {
@@ -2426,6 +2423,7 @@ impl std::fmt::Display for AtomicPublishError {
         match self {
             Self::Io(error) => error.fmt(formatter),
             Self::Replacement(error) => error.fmt(formatter),
+            Self::CancelledBeforeReplace => formatter.write_str("cancelled before replacement"),
         }
     }
 }
@@ -2434,9 +2432,26 @@ impl std::error::Error for AtomicPublishError {}
 
 impl From<std::io::Error> for AtomicPublishError {
     fn from(error: std::io::Error) -> Self {
-        Self::Io(error)
+        if let Some(source) = error.get_ref()
+            && source.is::<CancelledBeforeReplace>()
+        {
+            Self::CancelledBeforeReplace
+        } else {
+            Self::Io(error)
+        }
     }
 }
+
+#[derive(Debug)]
+struct CancelledBeforeReplace;
+
+impl std::fmt::Display for CancelledBeforeReplace {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("publication cancelled at project.before_current_replace")
+    }
+}
+
+impl std::error::Error for CancelledBeforeReplace {}
 
 pub(crate) fn publish_atomic_bytes(
     path: &Path,
@@ -4129,6 +4144,32 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(error.code(), "GF_PROJECT_CORRUPT");
+    }
+
+    #[test]
+    fn generic_eintr_is_reconciled_and_never_masquerades_as_cancellation() {
+        let root = project();
+        let interrupted = AtomicPublishError::from(std::io::Error::new(
+            std::io::ErrorKind::Interrupted,
+            "injected unrelated EINTR",
+        ));
+        assert!(matches!(interrupted, AtomicPublishError::Io(_)));
+        let error = reconcile_current_replacement_error(
+            root.path(),
+            Uuid::now_v7(),
+            Uuid::now_v7(),
+            [0x42; 32],
+            &interrupted,
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), "GF_PUBLICATION_FAILED");
+        assert!(error.to_string().contains("committed=false"));
+
+        let cancellation = AtomicPublishError::from(std::io::Error::other(CancelledBeforeReplace));
+        assert!(matches!(
+            cancellation,
+            AtomicPublishError::CancelledBeforeReplace
+        ));
     }
 
     #[test]

--- a/crates/graphforge-storage/src/schemas.rs
+++ b/crates/graphforge-storage/src/schemas.rs
@@ -105,6 +105,41 @@ pub fn duration_struct_fields() -> Fields {
     ])
 }
 
+/// Whether an Arrow value can be normalized into GraphForge's ordinary
+/// persisted property representation.
+#[must_use]
+pub fn property_data_type_supported(data_type: &DataType) -> bool {
+    match data_type {
+        DataType::List(field) | DataType::LargeList(field) => {
+            property_data_type_supported(field.data_type())
+        }
+        DataType::Boolean
+        | DataType::Int8
+        | DataType::Int16
+        | DataType::Int32
+        | DataType::Int64
+        | DataType::UInt8
+        | DataType::UInt16
+        | DataType::UInt32
+        | DataType::Float32
+        | DataType::Float64
+        | DataType::Utf8
+        | DataType::LargeUtf8
+        | DataType::Time64(arrow::datatypes::TimeUnit::Nanosecond) => true,
+        DataType::Timestamp(arrow::datatypes::TimeUnit::Microsecond, zone) => {
+            zone.as_deref() == Some("UTC")
+        }
+        DataType::Struct(fields) => {
+            fields == &duration_struct_fields()
+                || fields == &date_struct_fields()
+                || fields == &localdatetime_struct_fields()
+                || fields == &time_struct_fields()
+                || fields == &datetime_struct_fields()
+        }
+        _ => false,
+    }
+}
+
 /// `Struct{epoch_day: Int64}` — a Cypher `date` typed value (ADR 0012): i64 days
 /// since the Unix epoch, spanning the full openCypher year range
 /// −999,999,999..+999,999,999. A self-describing one-field struct (a bare Int64

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -584,6 +584,308 @@ pub struct AuthenticatedUuidIndexSnapshot {
     authenticated_blocks: u64,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ConstructionUuidIdentity {
+    pub uuid: Uuid,
+    pub kind: UuidIndexKind,
+    pub surrogate: u64,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct UuidConstructionSnapshotWork {
+    pub authentication_bytes: u64,
+    pub authentication_blocks: u64,
+    pub live_nodes: u64,
+    pub live_edges: u64,
+    pub max_node_surrogate: u64,
+}
+
+/// Retained authority for a UUID snapshot authenticated exactly once while its
+/// live identities were emitted as one bounded sorted stream.
+pub(crate) struct UuidConstructionSnapshot {
+    root: graphforge_filesystem::StableDirectory,
+    root_identity: graphforge_filesystem::FileIdentity,
+    manifest_file: File,
+    manifest_identity: graphforge_filesystem::FileIdentity,
+    manifest_sha256: String,
+    manifest: Manifest,
+    named_files: Vec<(String, graphforge_filesystem::FileIdentity)>,
+}
+
+impl UuidConstructionSnapshot {
+    pub(crate) fn revalidate(&self) -> Result<(), GfError> {
+        self.root.revalidate_named().map_err(storage_err)?;
+        if self.root.identity() != self.root_identity
+            || graphforge_filesystem::file_identity(&self.manifest_file).map_err(storage_err)?
+                != self.manifest_identity
+            || graphforge_filesystem::file_link_count(&self.manifest_file).map_err(storage_err)?
+                != 1
+        {
+            return Err(storage_err("construction UUID snapshot authority changed"));
+        }
+        let mut manifest = self
+            .root
+            .open_child_file(std::ffi::OsStr::new(MANIFEST))
+            .map_err(storage_err)?;
+        let body = read_bounded(&mut manifest, MAX_MANIFEST_BYTES)?;
+        if graphforge_filesystem::file_identity(&manifest).map_err(storage_err)?
+            != self.manifest_identity
+            || hex_sha256(&body) != self.manifest_sha256
+            || serde_json::from_slice::<Manifest>(&body).map_err(storage_err)? != self.manifest
+        {
+            return Err(storage_err("construction UUID manifest changed"));
+        }
+        for (name, identity) in &self.named_files {
+            let file = self
+                .root
+                .open_child_file(std::ffi::OsStr::new(name))
+                .map_err(storage_err)?;
+            if graphforge_filesystem::file_identity(&file).map_err(storage_err)? != *identity
+                || graphforge_filesystem::file_link_count(&file).map_err(storage_err)? != 1
+            {
+                return Err(storage_err("construction UUID run identity changed"));
+            }
+        }
+        Ok(())
+    }
+}
+
+struct ConstructionRunCursor {
+    file: File,
+    descriptor: FileRecord,
+    width: usize,
+    block_index: usize,
+    block: Vec<u8>,
+    within: usize,
+    records: u64,
+    bytes: u64,
+    blocks: u64,
+    digest: Sha256,
+    finished: bool,
+}
+
+impl ConstructionRunCursor {
+    fn new(file: File, descriptor: FileRecord, width: usize) -> Self {
+        Self {
+            file,
+            descriptor,
+            width,
+            block_index: 0,
+            block: Vec::new(),
+            within: 0,
+            records: 0,
+            bytes: 0,
+            blocks: 0,
+            digest: Sha256::new(),
+            finished: false,
+        }
+    }
+
+    fn next_record(&mut self) -> Result<Option<Vec<u8>>, GfError> {
+        if self.finished {
+            return Ok(None);
+        }
+        if self.within == self.block.len() {
+            if self.block_index == self.descriptor.blocks.len() {
+                self.finished = true;
+                if self.records != self.descriptor.count
+                    || self.bytes != self.descriptor.count.saturating_mul(self.width as u64)
+                    || hex_bytes(&self.digest.clone().finalize()) != self.descriptor.sha256
+                {
+                    return Err(storage_err("construction UUID run authentication failed"));
+                }
+                return Ok(None);
+            }
+            let descriptor = &self.descriptor.blocks[self.block_index];
+            if descriptor.offset != self.bytes
+                || descriptor.len as usize % self.width != 0
+                || descriptor.len == 0
+            {
+                return Err(storage_err("construction UUID block framing changed"));
+            }
+            self.block.resize(descriptor.len as usize, 0);
+            self.file.read_exact(&mut self.block).map_err(storage_err)?;
+            let key_width = if self.width == IDENTITY_RECORD_WIDTH {
+                16
+            } else {
+                8
+            };
+            if hex_sha256(&self.block) != descriptor.sha256
+                || hex_sha256_key(&self.block[..key_width]) != descriptor.first_key
+                || hex_sha256_key(
+                    &self.block
+                        [self.block.len() - self.width..self.block.len() - self.width + key_width],
+                ) != descriptor.last_key
+            {
+                return Err(storage_err("construction UUID block digest changed"));
+            }
+            self.digest.update(&self.block);
+            self.bytes = self.bytes.saturating_add(self.block.len() as u64);
+            self.blocks = self.blocks.saturating_add(1);
+            self.block_index += 1;
+            self.within = 0;
+        }
+        let end = self.within + self.width;
+        let record = self.block[self.within..end].to_vec();
+        self.within = end;
+        self.records = self.records.saturating_add(1);
+        Ok(Some(record))
+    }
+}
+
+/// Authenticate each retained UUID byte once and emit the live identity set in
+/// UUID order. The returned token revalidates inode/name authority without
+/// rereading retained payload bytes.
+pub(crate) fn open_uuid_construction_snapshot(
+    project_dir: &Path,
+    generation: u64,
+    mut emit: impl FnMut(ConstructionUuidIdentity) -> Result<(), GfError>,
+) -> Result<(UuidConstructionSnapshot, UuidConstructionSnapshotWork), GfError> {
+    let root = graphforge_filesystem::StableDirectory::open(&project_dir.join(INDEX_DIR))
+        .map_err(storage_err)?;
+    let root_identity = root.identity();
+    let mut manifest_file = root
+        .open_child_file(std::ffi::OsStr::new(MANIFEST))
+        .map_err(storage_err)?;
+    let manifest_identity =
+        graphforge_filesystem::file_identity(&manifest_file).map_err(storage_err)?;
+    let body = read_bounded(&mut manifest_file, MAX_MANIFEST_BYTES)?;
+    let manifest_sha256 = hex_sha256(&body);
+    let manifest: Manifest = serde_json::from_slice(&body).map_err(storage_err)?;
+    if manifest.format_version != FORMAT_VERSION || manifest.current_generation != generation {
+        return Err(storage_err(
+            "construction UUID snapshot generation is stale",
+        ));
+    }
+    validate_run_descriptors(&manifest)?;
+    let mut named_files = Vec::with_capacity(manifest.runs.len().saturating_mul(2));
+    let mut identity_cursors = Vec::with_capacity(manifest.runs.len());
+    let mut work = UuidConstructionSnapshotWork {
+        authentication_bytes: body.len() as u64,
+        authentication_blocks: 1,
+        ..Default::default()
+    };
+    for run in &manifest.runs {
+        let identities = root
+            .open_child_file(std::ffi::OsStr::new(&run.identities.name))
+            .map_err(storage_err)?;
+        let identity = graphforge_filesystem::file_identity(&identities).map_err(storage_err)?;
+        if graphforge_filesystem::file_link_count(&identities).map_err(storage_err)? != 1 {
+            return Err(storage_err(
+                "construction UUID identity run has extra links",
+            ));
+        }
+        named_files.push((run.identities.name.clone(), identity));
+        identity_cursors.push(ConstructionRunCursor::new(
+            identities,
+            run.identities.clone(),
+            IDENTITY_RECORD_WIDTH,
+        ));
+
+        let surrogates = root
+            .open_child_file(std::ffi::OsStr::new(&run.node_surrogates.name))
+            .map_err(storage_err)?;
+        let surrogate_identity =
+            graphforge_filesystem::file_identity(&surrogates).map_err(storage_err)?;
+        if graphforge_filesystem::file_link_count(&surrogates).map_err(storage_err)? != 1 {
+            return Err(storage_err(
+                "construction UUID surrogate run has extra links",
+            ));
+        }
+        named_files.push((run.node_surrogates.name.clone(), surrogate_identity));
+        let mut cursor = ConstructionRunCursor::new(
+            surrogates,
+            run.node_surrogates.clone(),
+            NODE_LOOKUP_RECORD_WIDTH,
+        );
+        while cursor.next_record()?.is_some() {}
+        work.authentication_bytes = work.authentication_bytes.saturating_add(cursor.bytes);
+        work.authentication_blocks = work.authentication_blocks.saturating_add(cursor.blocks);
+    }
+
+    let mut heads = identity_cursors
+        .iter_mut()
+        .map(ConstructionRunCursor::next_record)
+        .collect::<Result<Vec<_>, _>>()?;
+    loop {
+        let Some(next_uuid) = heads
+            .iter()
+            .flatten()
+            .map(|record| &record[..16])
+            .min()
+            .map(<[u8]>::to_vec)
+        else {
+            break;
+        };
+        let indexes = heads
+            .iter()
+            .enumerate()
+            .filter_map(|(index, record)| {
+                record
+                    .as_ref()
+                    .is_some_and(|record| record[..16] == next_uuid)
+                    .then_some(index)
+            })
+            .collect::<Vec<_>>();
+        let selected = *indexes
+            .iter()
+            .max_by_key(|index| manifest.runs[**index].last_generation)
+            .expect("one UUID head was selected");
+        let record = heads[selected].as_ref().expect("selected head exists");
+        let kind = record[16];
+        if !matches!(kind, 0..=3) || record[17..24].iter().any(|byte| *byte != 0) {
+            return Err(storage_err(
+                "construction UUID identity record is malformed",
+            ));
+        }
+        if matches!(kind, 0 | 1) {
+            let identity = ConstructionUuidIdentity {
+                uuid: Uuid::from_bytes(record[..16].try_into().expect("fixed UUID width")),
+                kind: if kind == 0 {
+                    UuidIndexKind::Node
+                } else {
+                    UuidIndexKind::Edge
+                },
+                surrogate: u64::from_be_bytes(record[24..32].try_into().expect("fixed")),
+            };
+            if identity.kind == UuidIndexKind::Node {
+                if identity.surrogate == 0 {
+                    return Err(storage_err("live node has zero surrogate"));
+                }
+                work.live_nodes = work.live_nodes.saturating_add(1);
+                work.max_node_surrogate = work.max_node_surrogate.max(identity.surrogate);
+            } else {
+                work.live_edges = work.live_edges.saturating_add(1);
+            }
+            emit(identity)?;
+        }
+        for index in indexes {
+            heads[index] = identity_cursors[index].next_record()?;
+        }
+    }
+    for cursor in &identity_cursors {
+        work.authentication_bytes = work.authentication_bytes.saturating_add(cursor.bytes);
+        work.authentication_blocks = work.authentication_blocks.saturating_add(cursor.blocks);
+    }
+    if work.live_nodes != manifest.live_node_count || work.live_edges != manifest.live_edge_count {
+        return Err(storage_err(
+            "construction UUID live counts differ from manifest",
+        ));
+    }
+    root.revalidate_named().map_err(storage_err)?;
+    let token = UuidConstructionSnapshot {
+        root,
+        root_identity,
+        manifest_file,
+        manifest_identity,
+        manifest_sha256,
+        manifest,
+        named_files,
+    };
+    token.revalidate()?;
+    Ok((token, work))
+}
+
 impl AuthenticatedUuidIndexSnapshot {
     pub(crate) fn open_at_generation(project_dir: &Path, generation: u64) -> Result<Self, GfError> {
         let root_path = project_dir.join(INDEX_DIR);

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -1074,6 +1074,26 @@ pub(crate) fn pin_uuid_construction_snapshot(
     Ok(token)
 }
 
+#[allow(clippy::struct_field_names)]
+pub(crate) struct ConstructionReferenceAuthentication<'a> {
+    pub(crate) source_root: &'a str,
+    pub(crate) source_root_volume: u64,
+    pub(crate) source_root_file_id: &'a str,
+    pub(crate) source_path: &'a str,
+    pub(crate) source_volume: u64,
+    pub(crate) source_file_id: &'a str,
+    pub(crate) target_path: &'a str,
+    pub(crate) bytes: u64,
+    pub(crate) sha256: &'a str,
+    pub(crate) parent_manifest_sha256: &'a str,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct ConstructionReferenceAuthenticationWork {
+    pub(crate) global_revalidation_bytes: u64,
+    pub(crate) referenced_payload_bytes: u64,
+}
+
 impl AuthenticatedUuidIndexSnapshot {
     fn open_retained_file(&self, record: &FileRecord) -> Result<File, GfError> {
         let (held, expected) = self
@@ -1135,40 +1155,75 @@ impl AuthenticatedUuidIndexSnapshot {
         })
     }
 
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn authenticate_construction_reference(
+    pub(crate) fn authenticate_construction_references(
         &self,
-        source_root: &str,
-        source_root_volume: u64,
-        source_root_file_id: &str,
-        source_path: &str,
-        source_volume: u64,
-        source_file_id: &str,
-        target_path: &str,
-        bytes: u64,
-        sha256: &str,
-        parent_manifest_sha256: &str,
-    ) -> Result<(), GfError> {
+        references: &[ConstructionReferenceAuthentication<'_>],
+    ) -> Result<ConstructionReferenceAuthenticationWork, GfError> {
+        self.authenticate_construction_references_with(references, || {})
+    }
+
+    fn authenticate_construction_references_with(
+        &self,
+        references: &[ConstructionReferenceAuthentication<'_>],
+        before_final_revalidation: impl FnOnce(),
+    ) -> Result<ConstructionReferenceAuthenticationWork, GfError> {
         self.revalidate()?;
-        if source_root != self.graph_root_path.to_string_lossy()
-            || source_root_volume != self.graph_root_identity.volume_serial
-            || source_root_file_id != hex_bytes(&self.graph_root_identity.file_id)
-            || parent_manifest_sha256 != self.manifest_sha256
-            || !target_path.starts_with(&format!("{INDEX_DIR}/"))
+        let mut referenced_payload_bytes = 0_u64;
+        for reference in references {
+            referenced_payload_bytes = referenced_payload_bytes
+                .saturating_add(self.authenticate_construction_reference_once(reference)?);
+        }
+        before_final_revalidation();
+        self.revalidate()?;
+        Ok(ConstructionReferenceAuthenticationWork {
+            global_revalidation_bytes: self.snapshot_authentication_bytes().saturating_mul(2),
+            referenced_payload_bytes,
+        })
+    }
+
+    fn snapshot_authentication_bytes(&self) -> u64 {
+        let manifest_bytes = self
+            .manifest_file
+            .metadata()
+            .map_or(0, |metadata| metadata.len());
+        self.manifest
+            .runs
+            .iter()
+            .fold(manifest_bytes, |total, run| {
+                total
+                    .saturating_add(run.identities.count.saturating_mul(IDENTITY_RECORD_BYTES))
+                    .saturating_add(
+                        run.node_surrogates
+                            .count
+                            .saturating_mul(NODE_LOOKUP_RECORD_BYTES),
+                    )
+            })
+    }
+
+    fn authenticate_construction_reference_once(
+        &self,
+        reference: &ConstructionReferenceAuthentication<'_>,
+    ) -> Result<u64, GfError> {
+        if reference.source_root != self.graph_root_path.to_string_lossy()
+            || reference.source_root_volume != self.graph_root_identity.volume_serial
+            || reference.source_root_file_id != hex_bytes(&self.graph_root_identity.file_id)
+            || reference.parent_manifest_sha256 != self.manifest_sha256
+            || !reference.target_path.starts_with(&format!("{INDEX_DIR}/"))
         {
             return Err(storage_err(
                 "retained construction reference authority changed",
             ));
         }
-        let name = target_path
+        let name = reference
+            .target_path
             .strip_prefix(&format!("{INDEX_DIR}/"))
             .ok_or_else(|| storage_err("retained construction target path is invalid"))?;
         let expected_source = self
             .cas_source_paths
             .as_ref()
             .and_then(|paths| paths.get(name))
-            .map_or(target_path, |(path, _, _)| path.as_str());
-        if source_path != expected_source {
+            .map_or(reference.target_path, |(path, _, _)| path.as_str());
+        if reference.source_path != expected_source {
             return Err(storage_err("retained construction source path changed"));
         }
         let record = self
@@ -1200,26 +1255,26 @@ impl AuthenticatedUuidIndexSnapshot {
             digest.update(&block[..count]);
             actual_bytes = actual_bytes.saturating_add(count as u64);
         }
-        if identity.volume_serial != source_volume
-            || hex_bytes(&identity.file_id) != source_file_id
-            || bytes != expected_bytes
+        if identity.volume_serial != reference.source_volume
+            || hex_bytes(&identity.file_id) != reference.source_file_id
+            || reference.bytes != expected_bytes
             || actual_bytes != expected_bytes
-            || sha256 != record.sha256
+            || reference.sha256 != record.sha256
             || hex_bytes(&digest.finalize()) != record.sha256
         {
             return Err(storage_err(format!(
                 "retained construction reference changed: volume={} expected_volume={} file_id={} expected_file_id={} bytes={} expected_bytes={} reference_sha={} manifest_sha={}",
                 identity.volume_serial,
-                source_volume,
+                reference.source_volume,
                 hex_bytes(&identity.file_id),
-                source_file_id,
+                reference.source_file_id,
                 actual_bytes,
                 expected_bytes,
-                sha256,
+                reference.sha256,
                 record.sha256
             )));
         }
-        self.revalidate()
+        Ok(actual_bytes)
     }
 
     pub(crate) fn open_at_generation(project_dir: &Path, generation: u64) -> Result<Self, GfError> {
@@ -6080,6 +6135,128 @@ mod tests {
         .unwrap_err();
         assert!(
             error.to_string().contains("block authentication"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn compact_retained_reference_authentication_is_batched_and_linear() {
+        let source = tempfile::tempdir().unwrap();
+        crate::generation::force_bump_topology_generation_for_test(source.path()).unwrap();
+        append_uuid_membership_delta(
+            source.path(),
+            1,
+            &[(Uuid::from_u128(1), 1), (Uuid::from_u128(2), 2)],
+            &[Uuid::from_u128(100)],
+        )
+        .unwrap();
+        crate::generation::force_bump_topology_generation_for_test(source.path()).unwrap();
+        append_uuid_membership_delta(
+            source.path(),
+            2,
+            &[(Uuid::from_u128(3), 3)],
+            &[Uuid::from_u128(101)],
+        )
+        .unwrap();
+        let (inventory, _) = crate::capture_graph_files(source.path()).unwrap();
+
+        let container = tempfile::tempdir().unwrap();
+        crate::open_or_initialize_project(container.path()).unwrap();
+        let lease = crate::begin_graph_object_publication(container.path()).unwrap();
+        let paths = inventory
+            .files
+            .iter()
+            .map(|entry| PathBuf::from(&entry.relative_path))
+            .collect::<Vec<_>>();
+        crate::append_graph_files_v2(
+            &lease,
+            source.path(),
+            &mut crate::GraphManifestState::empty(),
+            &paths,
+            &[],
+        )
+        .unwrap();
+        drop(lease);
+
+        let snapshot = AuthenticatedUuidIndexSnapshot::open_from_compact_inventory(
+            container.path(),
+            &inventory,
+            2,
+        )
+        .unwrap();
+        let retained = snapshot
+            .manifest
+            .runs
+            .iter()
+            .flat_map(|run| [&run.identities, &run.node_surrogates])
+            .map(|record| snapshot.retained_reference(record).unwrap())
+            .collect::<Vec<_>>();
+        assert!(retained.len() > 2);
+        let references = retained
+            .iter()
+            .map(|reference| ConstructionReferenceAuthentication {
+                source_root: &reference.source_root,
+                source_root_volume: reference.source_root_volume,
+                source_root_file_id: &reference.source_root_file_id,
+                source_path: &reference.source_path,
+                source_volume: reference.source_volume,
+                source_file_id: &reference.source_file_id,
+                target_path: &reference.target_path,
+                bytes: reference.bytes,
+                sha256: &reference.sha256,
+                parent_manifest_sha256: &reference.parent_manifest_sha256,
+            })
+            .collect::<Vec<_>>();
+        let work = snapshot
+            .authenticate_construction_references(&references)
+            .unwrap();
+        assert_eq!(
+            work.global_revalidation_bytes,
+            snapshot.snapshot_authentication_bytes() * 2
+        );
+        assert_eq!(
+            work.referenced_payload_bytes,
+            retained
+                .iter()
+                .map(|reference| reference.bytes)
+                .sum::<u64>()
+        );
+
+        let victim_reference = retained
+            .iter()
+            .find(|reference| reference.bytes > 0)
+            .expect("one retained UUID payload is non-empty");
+        let victim = Path::new(&victim_reference.source_root).join(&victim_reference.source_path);
+        let original = fs::read(&victim).unwrap();
+        let mut permissions = fs::metadata(&victim).unwrap().permissions();
+        permissions.set_readonly(false);
+        fs::set_permissions(&victim, permissions).unwrap();
+        fs::write(&victim, vec![0_u8; original.len()]).unwrap();
+        assert!(
+            snapshot
+                .authenticate_construction_references(&references)
+                .is_err()
+        );
+        fs::write(&victim, &original).unwrap();
+        let mut permissions = fs::metadata(&victim).unwrap().permissions();
+        permissions.set_readonly(true);
+        fs::set_permissions(&victim, permissions).unwrap();
+
+        let error = snapshot
+            .authenticate_construction_references_with(&references, || {
+                let mut permissions = fs::metadata(&victim).unwrap().permissions();
+                permissions.set_readonly(false);
+                fs::set_permissions(&victim, permissions).unwrap();
+                fs::write(&victim, vec![0_u8; original.len()]).unwrap();
+                let mut permissions = fs::metadata(&victim).unwrap().permissions();
+                permissions.set_readonly(true);
+                fs::set_permissions(&victim, permissions).unwrap();
+            })
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("digest does not match its address"),
             "{error}"
         );
     }

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -11,7 +11,7 @@ use std::cmp::Reverse;
 use std::collections::{BTreeSet, BinaryHeap, HashMap};
 use std::fmt::Write as _;
 use std::fs::{self, File};
-use std::io::{BufReader, Read, Seek, SeekFrom, Write};
+use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
 use arrow::array::{Array, FixedSizeBinaryArray, UInt64Array};
@@ -582,6 +582,22 @@ pub struct AuthenticatedUuidIndexSnapshot {
     runs: Vec<AuthenticatedRun>,
     authenticated_bytes: u64,
     authenticated_blocks: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ConstructionIndexOutput {
+    pub name: String,
+    pub bytes: u64,
+    pub sha256: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct ConstructionIndexEncoding {
+    pub artifacts: Vec<ConstructionIndexOutput>,
+    pub input_records: u64,
+    pub write_bytes: u64,
+    pub retained_runs: u64,
+    pub retained_payload_bytes: u64,
 }
 
 #[cfg(test)]
@@ -1197,6 +1213,594 @@ impl AuthenticatedUuidIndexSnapshot {
             metrics,
         ))
     }
+}
+
+/// Encode the shaper's UUID-ordered 32-byte delta directly as a v3 membership
+/// participant. Retained descriptors are cloned, not rebuilt from topology;
+/// retained payloads are read only when binary-carry compaction is required.
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+pub(crate) fn encode_construction_index(
+    source: &graphforge_filesystem::StableDirectory,
+    identities_name: &str,
+    encoded: &graphforge_filesystem::StableDirectory,
+    generation: u64,
+    parent_generation: u64,
+    parent: Option<&AuthenticatedUuidIndexSnapshot>,
+    live_nodes: u64,
+    live_edges: u64,
+    cancelled: &mut impl FnMut() -> bool,
+) -> Result<ConstructionIndexEncoding, GfError> {
+    let graph = encoded
+        .create_child_directory(std::ffi::OsStr::new("graph"))
+        .map_err(storage_err)?;
+    let cache = graph
+        .create_child_directory(std::ffi::OsStr::new(".graphforge-cache"))
+        .map_err(storage_err)?;
+    let index = cache
+        .create_child_directory(std::ffi::OsStr::new("uuid-membership"))
+        .map_err(storage_err)?;
+    let mut manifest = if parent_generation == 0 {
+        if parent.is_some() {
+            return Err(storage_err("empty construction parent has UUID snapshot"));
+        }
+        Manifest {
+            format_version: FORMAT_VERSION,
+            base_generation: 0,
+            current_generation: 0,
+            live_node_count: 0,
+            live_edge_count: 0,
+            runs: Vec::new(),
+        }
+    } else {
+        let parent = parent.ok_or_else(|| {
+            storage_err("nonempty construction parent lacks authenticated UUID snapshot")
+        })?;
+        parent.revalidate()?;
+        if parent.manifest.current_generation != parent_generation {
+            return Err(storage_err("construction UUID parent generation changed"));
+        }
+        parent.manifest.clone()
+    };
+    if generation != parent_generation.saturating_add(1) {
+        return Err(storage_err(
+            "construction UUID generation is not consecutive",
+        ));
+    }
+
+    let identity_temp = format!(".construction-identities-{}.tmp", Uuid::new_v4().simple());
+    let surrogate_temp = format!(".construction-surrogates-{}.tmp", Uuid::new_v4().simple());
+    let mut input = BufReader::with_capacity(
+        BULK_IO_BYTES,
+        source
+            .open_child_file(std::ffi::OsStr::new(identities_name))
+            .map_err(storage_err)?,
+    );
+    let identity_file = index
+        .create_replaceable_child_file(std::ffi::OsStr::new(&identity_temp))
+        .map_err(storage_err)?;
+    let surrogate_file = index
+        .create_replaceable_child_file(std::ffi::OsStr::new(&surrogate_temp))
+        .map_err(storage_err)?;
+    let identity_identity =
+        graphforge_filesystem::file_identity(&identity_file).map_err(storage_err)?;
+    let surrogate_identity =
+        graphforge_filesystem::file_identity(&surrogate_file).map_err(storage_err)?;
+    let mut identity_writer = BufWriter::with_capacity(BULK_IO_BYTES, identity_file);
+    let mut surrogate_writer = BufWriter::with_capacity(BULK_IO_BYTES, surrogate_file);
+    let mut previous_uuid = None;
+    let mut previous_surrogate = 0_u64;
+    let mut node_count = 0_u64;
+    let mut edge_count = 0_u64;
+    loop {
+        if cancelled() {
+            return Err(storage_err("construction index encoding cancelled"));
+        }
+        let mut record = [0_u8; IDENTITY_RECORD_WIDTH];
+        let mut filled = 0;
+        while filled < record.len() {
+            let read = input.read(&mut record[filled..]).map_err(storage_err)?;
+            if read == 0 {
+                if filled == 0 {
+                    break;
+                }
+                return Err(storage_err("construction identity stream is truncated"));
+            }
+            filled += read;
+        }
+        if filled == 0 {
+            break;
+        }
+        let uuid: [u8; 16] = record[..16].try_into().expect("fixed UUID");
+        if previous_uuid.is_some_and(|prior| prior >= uuid)
+            || record[17..24].iter().any(|byte| *byte != 0)
+        {
+            return Err(storage_err("construction identity stream is not canonical"));
+        }
+        previous_uuid = Some(uuid);
+        match record[16] {
+            0 => {
+                let surrogate = u64::from_be_bytes(record[24..32].try_into().expect("fixed"));
+                if surrogate == 0 || surrogate <= previous_surrogate {
+                    return Err(storage_err(
+                        "construction node surrogate stream is not increasing",
+                    ));
+                }
+                previous_surrogate = surrogate;
+                surrogate_writer
+                    .write_all(&surrogate.to_be_bytes())
+                    .and_then(|()| surrogate_writer.write_all(&uuid))
+                    .map_err(storage_err)?;
+                node_count = node_count.saturating_add(1);
+            }
+            1 if record[24..32].iter().any(|byte| *byte != 0) => {
+                // Construction assigns edge surrogates for canonical topology,
+                // while v3 edge membership deliberately stores zero.
+                record[24..32].fill(0);
+                edge_count = edge_count.saturating_add(1);
+            }
+            1 => edge_count = edge_count.saturating_add(1),
+            _ => return Err(storage_err("construction identity kind is invalid")),
+        }
+        identity_writer.write_all(&record).map_err(storage_err)?;
+    }
+    if manifest.live_node_count.saturating_add(node_count) != live_nodes
+        || manifest.live_edge_count.saturating_add(edge_count) != live_edges
+    {
+        return Err(storage_err(
+            "construction UUID delta counts differ from shaped counts",
+        ));
+    }
+    identity_writer.flush().map_err(storage_err)?;
+    surrogate_writer.flush().map_err(storage_err)?;
+    identity_writer.get_ref().sync_all().map_err(storage_err)?;
+    surrogate_writer.get_ref().sync_all().map_err(storage_err)?;
+    drop(identity_writer);
+    drop(surrogate_writer);
+
+    let mut artifacts = Vec::new();
+    let identity_record = describe_and_install_construction_run(
+        &index,
+        &identity_temp,
+        identity_identity,
+        "identities-v3",
+        generation,
+        IDENTITY_RECORD_WIDTH,
+        &mut artifacts,
+    )?;
+    let surrogate_record = describe_and_install_construction_run(
+        &index,
+        &surrogate_temp,
+        surrogate_identity,
+        "node-surrogates-v3",
+        generation,
+        NODE_LOOKUP_RECORD_WIDTH,
+        &mut artifacts,
+    )?;
+    let mut output_names = artifacts
+        .iter()
+        .map(|artifact| artifact.name.clone())
+        .collect::<BTreeSet<_>>();
+
+    if parent_generation == 0 {
+        let base_identity = install_empty_construction_run(
+            &index,
+            "identities-v3-base",
+            0,
+            IDENTITY_RECORD_WIDTH,
+            &mut artifacts,
+        )?;
+        let base_surrogate = install_empty_construction_run(
+            &index,
+            "node-surrogates-v3-base",
+            0,
+            NODE_LOOKUP_RECORD_WIDTH,
+            &mut artifacts,
+        )?;
+        output_names.insert(base_identity.name.clone());
+        output_names.insert(base_surrogate.name.clone());
+        manifest.runs.push(RunRecord {
+            base: true,
+            level: 0,
+            first_generation: 0,
+            last_generation: 0,
+            identities: base_identity,
+            node_surrogates: base_surrogate,
+            node_count: 0,
+            edge_count: 0,
+            deleted_node_count: 0,
+            deleted_edge_count: 0,
+        });
+    }
+    manifest.runs.push(RunRecord {
+        base: false,
+        level: 0,
+        first_generation: generation,
+        last_generation: generation,
+        identities: identity_record,
+        node_surrogates: surrogate_record,
+        node_count,
+        edge_count,
+        deleted_node_count: 0,
+        deleted_edge_count: 0,
+    });
+
+    let mut retained_payload_bytes = 0_u64;
+    compact_construction_levels(
+        &index,
+        parent,
+        generation,
+        &mut manifest,
+        &mut artifacts,
+        &mut output_names,
+        &mut retained_payload_bytes,
+        cancelled,
+    )?;
+    manifest.current_generation = generation;
+    manifest.live_node_count = live_nodes;
+    manifest.live_edge_count = live_edges;
+    manifest
+        .runs
+        .sort_unstable_by_key(|run| run.first_generation);
+    validate_run_descriptors(&manifest)?;
+
+    let body = serde_json::to_vec(&manifest).map_err(storage_err)?;
+    let manifest_output = install_construction_bytes(&index, MANIFEST, &body)?;
+    artifacts.push(manifest_output);
+    let retained_names = manifest_file_names(&manifest);
+    for artifact in artifacts
+        .iter()
+        .filter(|artifact| artifact.name != MANIFEST && !retained_names.contains(&artifact.name))
+    {
+        let file = index
+            .open_child_file(std::ffi::OsStr::new(&artifact.name))
+            .map_err(storage_err)?;
+        let identity = graphforge_filesystem::file_identity(&file).map_err(storage_err)?;
+        index
+            .unlink_child_if_identity(std::ffi::OsStr::new(&artifact.name), identity)
+            .map_err(storage_err)?;
+    }
+    artifacts
+        .retain(|artifact| artifact.name == MANIFEST || retained_names.contains(&artifact.name));
+    artifacts.sort_unstable_by(|left, right| left.name.cmp(&right.name));
+    let write_bytes = artifacts.iter().map(|artifact| artifact.bytes).sum();
+    index.sync().map_err(storage_err)?;
+    cache.sync().map_err(storage_err)?;
+    graph.sync().map_err(storage_err)?;
+    encoded.sync().map_err(storage_err)?;
+    Ok(ConstructionIndexEncoding {
+        artifacts,
+        input_records: node_count.saturating_add(edge_count),
+        write_bytes,
+        retained_runs: manifest.runs.len() as u64,
+        retained_payload_bytes,
+    })
+}
+
+fn compact_construction_levels(
+    output: &graphforge_filesystem::StableDirectory,
+    parent: Option<&AuthenticatedUuidIndexSnapshot>,
+    generation: u64,
+    manifest: &mut Manifest,
+    artifacts: &mut Vec<ConstructionIndexOutput>,
+    output_names: &mut BTreeSet<String>,
+    retained_payload_bytes: &mut u64,
+    cancelled: &mut impl FnMut() -> bool,
+) -> Result<(), GfError> {
+    for level in 0_u8..=63 {
+        loop {
+            if cancelled() {
+                return Err(storage_err("construction index encoding cancelled"));
+            }
+            let mut indexes = manifest
+                .runs
+                .iter()
+                .enumerate()
+                .filter_map(|(index, run)| (!run.base && run.level == level).then_some(index))
+                .collect::<Vec<_>>();
+            if indexes.len() < 2 {
+                break;
+            }
+            if indexes.len() != 2 {
+                return Err(storage_err("construction manifest level overflow"));
+            }
+            indexes.sort_unstable_by_key(|index| manifest.runs[*index].first_generation);
+            let right = manifest.runs.remove(indexes[1]);
+            let left = manifest.runs.remove(indexes[0]);
+            if left.last_generation.saturating_add(1) != right.first_generation {
+                return Err(storage_err(
+                    "construction index intervals are discontinuous",
+                ));
+            }
+            let identities = merge_construction_records(
+                output,
+                parent,
+                &left.identities,
+                &right.identities,
+                output_names,
+                &format!("identities-v3-l{}", level + 1),
+                generation,
+                IDENTITY_RECORD_WIDTH,
+                artifacts,
+                retained_payload_bytes,
+                cancelled,
+            )?;
+            let surrogates = merge_construction_records(
+                output,
+                parent,
+                &left.node_surrogates,
+                &right.node_surrogates,
+                output_names,
+                &format!("node-surrogates-v3-l{}", level + 1),
+                generation,
+                NODE_LOOKUP_RECORD_WIDTH,
+                artifacts,
+                retained_payload_bytes,
+                cancelled,
+            )?;
+            output_names.insert(identities.name.clone());
+            output_names.insert(surrogates.name.clone());
+            manifest.runs.push(RunRecord {
+                base: false,
+                level: level + 1,
+                first_generation: left.first_generation,
+                last_generation: right.last_generation,
+                identities,
+                node_surrogates: surrogates,
+                node_count: left.node_count.saturating_add(right.node_count),
+                edge_count: left.edge_count.saturating_add(right.edge_count),
+                deleted_node_count: left
+                    .deleted_node_count
+                    .saturating_add(right.deleted_node_count),
+                deleted_edge_count: left
+                    .deleted_edge_count
+                    .saturating_add(right.deleted_edge_count),
+            });
+        }
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn merge_construction_records(
+    output: &graphforge_filesystem::StableDirectory,
+    parent: Option<&AuthenticatedUuidIndexSnapshot>,
+    left: &FileRecord,
+    right: &FileRecord,
+    output_names: &BTreeSet<String>,
+    prefix: &str,
+    generation: u64,
+    width: usize,
+    artifacts: &mut Vec<ConstructionIndexOutput>,
+    retained_payload_bytes: &mut u64,
+    cancelled: &mut impl FnMut() -> bool,
+) -> Result<FileRecord, GfError> {
+    let mut left_reader = BufReader::with_capacity(
+        BULK_IO_BYTES,
+        open_construction_source(output, parent, left, output_names, retained_payload_bytes)?,
+    );
+    let mut right_reader = BufReader::with_capacity(
+        BULK_IO_BYTES,
+        open_construction_source(output, parent, right, output_names, retained_payload_bytes)?,
+    );
+    let temporary = format!(".construction-merge-{}.tmp", Uuid::new_v4().simple());
+    let file = output
+        .create_replaceable_child_file(std::ffi::OsStr::new(&temporary))
+        .map_err(storage_err)?;
+    let identity = graphforge_filesystem::file_identity(&file).map_err(storage_err)?;
+    let mut writer = BufWriter::with_capacity(BULK_IO_BYTES, file);
+    let key_width = if width == IDENTITY_RECORD_WIDTH {
+        16
+    } else {
+        8
+    };
+    let mut left_record = read_construction_record(&mut left_reader, width)?;
+    let mut right_record = read_construction_record(&mut right_reader, width)?;
+    while left_record.is_some() || right_record.is_some() {
+        if cancelled() {
+            return Err(storage_err("construction index encoding cancelled"));
+        }
+        let take_left = match (&left_record, &right_record) {
+            (Some(left), Some(right)) => {
+                if left[..key_width] == right[..key_width] {
+                    return Err(storage_err("construction index merge found duplicate key"));
+                }
+                left[..key_width] < right[..key_width]
+            }
+            (Some(_), None) => true,
+            (None, Some(_)) => false,
+            (None, None) => break,
+        };
+        if take_left {
+            writer
+                .write_all(left_record.as_ref().expect("left exists"))
+                .map_err(storage_err)?;
+            left_record = read_construction_record(&mut left_reader, width)?;
+        } else {
+            writer
+                .write_all(right_record.as_ref().expect("right exists"))
+                .map_err(storage_err)?;
+            right_record = read_construction_record(&mut right_reader, width)?;
+        }
+    }
+    writer.flush().map_err(storage_err)?;
+    writer.get_ref().sync_all().map_err(storage_err)?;
+    drop(writer);
+    describe_and_install_construction_run(
+        output, &temporary, identity, prefix, generation, width, artifacts,
+    )
+}
+
+fn open_construction_source(
+    output: &graphforge_filesystem::StableDirectory,
+    parent: Option<&AuthenticatedUuidIndexSnapshot>,
+    record: &FileRecord,
+    output_names: &BTreeSet<String>,
+    retained_payload_bytes: &mut u64,
+) -> Result<File, GfError> {
+    if output_names.contains(&record.name) {
+        output
+            .open_child_file(std::ffi::OsStr::new(&record.name))
+            .map_err(storage_err)
+    } else {
+        let parent =
+            parent.ok_or_else(|| storage_err("construction merge lacks retained source"))?;
+        *retained_payload_bytes =
+            retained_payload_bytes.saturating_add(record.count.saturating_mul(
+                if record.name.starts_with("identities-") {
+                    IDENTITY_RECORD_BYTES
+                } else {
+                    NODE_LOOKUP_RECORD_BYTES
+                },
+            ));
+        parent
+            .root
+            .open_child_file(std::ffi::OsStr::new(&record.name))
+            .map_err(storage_err)
+    }
+}
+
+fn read_construction_record(
+    reader: &mut impl Read,
+    width: usize,
+) -> Result<Option<Vec<u8>>, GfError> {
+    let mut record = vec![0_u8; width];
+    let mut filled = 0;
+    while filled < width {
+        let read = reader.read(&mut record[filled..]).map_err(storage_err)?;
+        if read == 0 {
+            if filled == 0 {
+                return Ok(None);
+            }
+            return Err(storage_err("construction index merge source is truncated"));
+        }
+        filled += read;
+    }
+    Ok(Some(record))
+}
+
+fn install_empty_construction_run(
+    output: &graphforge_filesystem::StableDirectory,
+    prefix: &str,
+    generation: u64,
+    width: usize,
+    artifacts: &mut Vec<ConstructionIndexOutput>,
+) -> Result<FileRecord, GfError> {
+    let temporary = format!(".construction-empty-{}.tmp", Uuid::new_v4().simple());
+    let file = output
+        .create_replaceable_child_file(std::ffi::OsStr::new(&temporary))
+        .map_err(storage_err)?;
+    let identity = graphforge_filesystem::file_identity(&file).map_err(storage_err)?;
+    file.sync_all().map_err(storage_err)?;
+    drop(file);
+    describe_and_install_construction_run(
+        output, &temporary, identity, prefix, generation, width, artifacts,
+    )
+}
+
+fn describe_and_install_construction_run(
+    output: &graphforge_filesystem::StableDirectory,
+    temporary: &str,
+    identity: graphforge_filesystem::FileIdentity,
+    prefix: &str,
+    generation: u64,
+    width: usize,
+    artifacts: &mut Vec<ConstructionIndexOutput>,
+) -> Result<FileRecord, GfError> {
+    let mut file = output
+        .open_child_file(std::ffi::OsStr::new(temporary))
+        .map_err(storage_err)?;
+    let bytes = file.metadata().map_err(storage_err)?.len();
+    if bytes % width as u64 != 0 {
+        return Err(storage_err("construction index run is truncated"));
+    }
+    let block_bytes = (BULK_IO_BYTES / width) * width;
+    let key_width = if width == IDENTITY_RECORD_WIDTH {
+        16
+    } else {
+        8
+    };
+    let mut digest = Sha256::new();
+    let mut blocks = Vec::new();
+    let mut offset = 0_u64;
+    let mut buffer = vec![0_u8; block_bytes];
+    loop {
+        let mut filled = 0;
+        while filled < buffer.len() {
+            let read = file.read(&mut buffer[filled..]).map_err(storage_err)?;
+            if read == 0 {
+                break;
+            }
+            filled += read;
+        }
+        if filled == 0 {
+            break;
+        }
+        if filled % width != 0 {
+            return Err(storage_err("construction index block framing changed"));
+        }
+        let block = &buffer[..filled];
+        digest.update(block);
+        blocks.push(BlockRecord {
+            offset,
+            len: u32::try_from(filled).map_err(storage_err)?,
+            first_key: hex_bytes(&block[..key_width]),
+            last_key: hex_bytes(&block[filled - width..filled - width + key_width]),
+            sha256: hex_sha256(block),
+        });
+        offset = offset.saturating_add(filled as u64);
+        if filled < buffer.len() {
+            break;
+        }
+    }
+    let sha256 = hex_bytes(&digest.finalize());
+    let name = format!("{prefix}-{generation}-{}.uuidx", &sha256[..16]);
+    output
+        .replace_child(
+            std::ffi::OsStr::new(temporary),
+            identity,
+            std::ffi::OsStr::new(&name),
+        )
+        .map_err(storage_err)?;
+    output.sync().map_err(storage_err)?;
+    artifacts.push(ConstructionIndexOutput {
+        name: name.clone(),
+        bytes,
+        sha256: sha256.clone(),
+    });
+    Ok(FileRecord {
+        name,
+        count: bytes / width as u64,
+        sha256,
+        blocks,
+    })
+}
+
+fn install_construction_bytes(
+    output: &graphforge_filesystem::StableDirectory,
+    name: &str,
+    bytes: &[u8],
+) -> Result<ConstructionIndexOutput, GfError> {
+    let temporary = format!(".{name}-{}.tmp", Uuid::new_v4().simple());
+    let mut file = output
+        .create_replaceable_child_file(std::ffi::OsStr::new(&temporary))
+        .map_err(storage_err)?;
+    let identity = graphforge_filesystem::file_identity(&file).map_err(storage_err)?;
+    file.write_all(bytes).map_err(storage_err)?;
+    file.sync_all().map_err(storage_err)?;
+    drop(file);
+    output
+        .replace_child(
+            std::ffi::OsStr::new(&temporary),
+            identity,
+            std::ffi::OsStr::new(name),
+        )
+        .map_err(storage_err)?;
+    output.sync().map_err(storage_err)?;
+    Ok(ConstructionIndexOutput {
+        name: name.to_owned(),
+        bytes: bytes.len() as u64,
+        sha256: hex_sha256(bytes),
+    })
 }
 
 impl UuidMembershipIndex {

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -4276,6 +4276,42 @@ mod tests {
     }
 
     #[test]
+    fn construction_snapshot_streams_live_uuid_authority_in_order() {
+        let (dir, nodes, edges) = fixture();
+        rebuild_uuid_membership_indexes(dir.path(), UuidIndexBuildLimits::default()).unwrap();
+        let mut streamed = Vec::new();
+        let (snapshot, work) = open_uuid_construction_snapshot(dir.path(), 0, |identity| {
+            streamed.push(identity);
+            Ok(())
+        })
+        .unwrap();
+
+        let mut expected = nodes
+            .iter()
+            .copied()
+            .zip(1_u64..)
+            .map(|(uuid, surrogate)| ConstructionUuidIdentity {
+                uuid,
+                kind: UuidIndexKind::Node,
+                surrogate,
+            })
+            .chain(edges.iter().copied().map(|uuid| ConstructionUuidIdentity {
+                uuid,
+                kind: UuidIndexKind::Edge,
+                surrogate: 0,
+            }))
+            .collect::<Vec<_>>();
+        expected.sort_by_key(|identity| identity.uuid);
+        assert_eq!(streamed, expected);
+        assert_eq!(work.live_nodes, nodes.len() as u64);
+        assert_eq!(work.live_edges, edges.len() as u64);
+        assert_eq!(work.max_node_surrogate, nodes.len() as u64);
+        assert!(work.authentication_bytes > 0);
+        assert!(work.authentication_blocks > 0);
+        snapshot.revalidate().unwrap();
+    }
+
+    #[test]
     fn forced_rebuild_receipt_binds_newly_staged_manifest() {
         let (dir, _, _) = fixture();
         rebuild_uuid_membership_indexes(dir.path(), UuidIndexBuildLimits::default()).unwrap();

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -11,7 +11,7 @@ use std::cmp::Reverse;
 use std::collections::{BTreeSet, BinaryHeap, HashMap};
 use std::fmt::Write as _;
 use std::fs::{self, File};
-use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
+use std::io::{BufReader, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
 use arrow::array::{Array, FixedSizeBinaryArray, UInt64Array};
@@ -33,6 +33,7 @@ const BULK_IO_BYTES: usize = 1 << 20;
 // that can be discarded and reconstructed without violating that contract.
 const INDEX_DIR: &str = "topology/uuid-membership";
 const MANIFEST: &str = "manifest.json";
+const CONSTRUCTION_INTENT: &str = ".construction-intent.json";
 
 fn storage_err(error: impl std::fmt::Display) -> GfError {
     GfError::Storage(format!("UUID membership index: {error}"))
@@ -573,6 +574,9 @@ pub struct UuidMembershipIndex {
 /// Long-lived authenticated UUID-index snapshot retained by construction writers.
 #[derive(Debug)]
 pub struct AuthenticatedUuidIndexSnapshot {
+    graph_root: graphforge_filesystem::StableDirectory,
+    graph_root_path: PathBuf,
+    graph_root_identity: graphforge_filesystem::FileIdentity,
     root: graphforge_filesystem::StableDirectory,
     root_identity: graphforge_filesystem::FileIdentity,
     manifest_file: File,
@@ -591,13 +595,122 @@ pub(crate) struct ConstructionIndexOutput {
     pub sha256: String,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct ConstructionIndexReference {
+    pub source_root: String,
+    pub source_root_volume: u64,
+    pub source_root_file_id: String,
+    pub source_path: String,
+    pub source_volume: u64,
+    pub source_file_id: String,
+    pub target_path: String,
+    pub bytes: u64,
+    pub sha256: String,
+    pub parent_manifest_sha256: String,
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(crate) struct ConstructionIndexEncoding {
     pub artifacts: Vec<ConstructionIndexOutput>,
+    pub retained_references: Vec<ConstructionIndexReference>,
     pub input_records: u64,
+    pub read_bytes: u64,
+    pub read_operations: u64,
     pub write_bytes: u64,
+    pub write_operations: u64,
+    pub fsync_operations: u64,
+    pub created_runs: u64,
     pub retained_runs: u64,
     pub retained_payload_bytes: u64,
+    pub peak_buffer_bytes: u64,
+    pub peak_temporary_bytes: u64,
+}
+
+#[derive(Default)]
+struct ConstructionIndexWork {
+    read_bytes: u64,
+    read_operations: u64,
+    write_bytes: u64,
+    write_operations: u64,
+    fsync_operations: u64,
+    created_runs: u64,
+    retained_runs: u64,
+    retained_payload_bytes: u64,
+    peak_buffer_bytes: u64,
+    peak_temporary_bytes: u64,
+}
+
+#[derive(Serialize, Deserialize)]
+struct ConstructionRecoveryIntent {
+    format_version: u32,
+    generation: u64,
+    parent_generation: u64,
+    identities_name: String,
+    source_volume: u64,
+    source_file_id: String,
+    source_bytes: u64,
+    authority_sha256: String,
+}
+
+struct ConstructionIndexCleanupGuard<'a> {
+    encoded: &'a graphforge_filesystem::StableDirectory,
+    armed: bool,
+}
+
+impl ConstructionIndexCleanupGuard<'_> {
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for ConstructionIndexCleanupGuard<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = cleanup_private_construction_index(self.encoded);
+        }
+    }
+}
+
+impl ConstructionRecoveryIntent {
+    fn authenticate(&self) -> Result<(), GfError> {
+        let expected = construction_intent_digest(
+            self.format_version,
+            self.generation,
+            self.parent_generation,
+            &self.identities_name,
+            self.source_volume,
+            &self.source_file_id,
+            self.source_bytes,
+        );
+        if self.format_version != FORMAT_VERSION || self.authority_sha256 != expected {
+            return Err(storage_err(
+                "construction recovery intent authentication failed",
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn construction_intent_digest(
+    format_version: u32,
+    generation: u64,
+    parent_generation: u64,
+    identities_name: &str,
+    source_volume: u64,
+    source_file_id: &str,
+    source_bytes: u64,
+) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"graphforge.uuid-membership.construction-intent.v1\0");
+    digest.update(format_version.to_be_bytes());
+    digest.update(generation.to_be_bytes());
+    digest.update(parent_generation.to_be_bytes());
+    digest.update((identities_name.len() as u64).to_be_bytes());
+    digest.update(identities_name.as_bytes());
+    digest.update(source_volume.to_be_bytes());
+    digest.update(source_file_id.as_bytes());
+    digest.update(source_bytes.to_be_bytes());
+    hex_bytes(&digest.finalize())
 }
 
 #[cfg(test)]
@@ -954,7 +1067,59 @@ pub(crate) fn pin_uuid_construction_snapshot(
 }
 
 impl AuthenticatedUuidIndexSnapshot {
+    fn open_retained_file(&self, record: &FileRecord) -> Result<File, GfError> {
+        let (held, expected) = self
+            .runs
+            .iter()
+            .find_map(|run| {
+                if run.descriptor.identities == *record {
+                    Some((&run.identities, run.identities_identity))
+                } else if run.descriptor.node_surrogates == *record {
+                    Some((&run.node_surrogates, run.node_surrogates_identity))
+                } else {
+                    None
+                }
+            })
+            .ok_or_else(|| storage_err("retained UUID descriptor is not authenticated"))?;
+        let file = held.try_clone().map_err(storage_err)?;
+        if graphforge_filesystem::file_identity(&file).map_err(storage_err)? != expected
+            || graphforge_filesystem::file_link_count(&file).map_err(storage_err)? != 1
+        {
+            return Err(storage_err("retained UUID run identity changed"));
+        }
+        Ok(file)
+    }
+
+    fn retained_reference(
+        &self,
+        record: &FileRecord,
+    ) -> Result<ConstructionIndexReference, GfError> {
+        let file = self.open_retained_file(record)?;
+        let identity = graphforge_filesystem::file_identity(&file).map_err(storage_err)?;
+        Ok(ConstructionIndexReference {
+            source_root: self.graph_root_path.to_string_lossy().into_owned(),
+            source_root_volume: self.graph_root_identity.volume_serial,
+            source_root_file_id: hex_bytes(&self.graph_root_identity.file_id),
+            source_path: format!("{INDEX_DIR}/{}", record.name),
+            source_volume: identity.volume_serial,
+            source_file_id: hex_bytes(&identity.file_id),
+            target_path: format!("{INDEX_DIR}/{}", record.name),
+            bytes: record
+                .count
+                .saturating_mul(if record.name.starts_with("identities-") {
+                    IDENTITY_RECORD_BYTES
+                } else {
+                    NODE_LOOKUP_RECORD_BYTES
+                }),
+            sha256: record.sha256.clone(),
+            parent_manifest_sha256: self.manifest_sha256.clone(),
+        })
+    }
+
     pub(crate) fn open_at_generation(project_dir: &Path, generation: u64) -> Result<Self, GfError> {
+        let graph_root =
+            graphforge_filesystem::StableDirectory::open(project_dir).map_err(storage_err)?;
+        let graph_root_identity = graph_root.identity();
         let root_path = project_dir.join(INDEX_DIR);
         let root = graphforge_filesystem::StableDirectory::open(&root_path).map_err(storage_err)?;
         let root_identity = root.identity();
@@ -993,6 +1158,9 @@ impl AuthenticatedUuidIndexSnapshot {
             });
         }
         Ok(Self {
+            graph_root,
+            graph_root_path: project_dir.to_path_buf(),
+            graph_root_identity,
             root,
             root_identity,
             manifest_file,
@@ -1027,6 +1195,10 @@ impl AuthenticatedUuidIndexSnapshot {
     }
 
     pub(crate) fn revalidate(&self) -> Result<(), GfError> {
+        self.graph_root.revalidate_named().map_err(storage_err)?;
+        if self.graph_root.identity() != self.graph_root_identity {
+            return Err(storage_err("UUID graph root identity changed"));
+        }
         self.root.revalidate_named().map_err(storage_err)?;
         if self.root.identity() != self.root_identity {
             return Err(storage_err("UUID index root identity changed"));
@@ -1230,6 +1402,48 @@ pub(crate) fn encode_construction_index(
     live_edges: u64,
     cancelled: &mut impl FnMut() -> bool,
 ) -> Result<ConstructionIndexEncoding, GfError> {
+    cleanup_private_construction_index(encoded)?;
+    let mut cleanup_guard = ConstructionIndexCleanupGuard {
+        encoded,
+        armed: true,
+    };
+    let result = encode_construction_index_inner(
+        source,
+        identities_name,
+        encoded,
+        generation,
+        parent_generation,
+        parent,
+        live_nodes,
+        live_edges,
+        cancelled,
+    );
+    match result {
+        Ok(value) => {
+            cleanup_guard.disarm();
+            Ok(value)
+        }
+        Err(original) => {
+            cleanup_private_construction_index(encoded).map_err(|cleanup| {
+                storage_err(format!("{original}; exact cleanup also failed: {cleanup}"))
+            })?;
+            Err(original)
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+fn encode_construction_index_inner(
+    source: &graphforge_filesystem::StableDirectory,
+    identities_name: &str,
+    encoded: &graphforge_filesystem::StableDirectory,
+    generation: u64,
+    parent_generation: u64,
+    parent: Option<&AuthenticatedUuidIndexSnapshot>,
+    live_nodes: u64,
+    live_edges: u64,
+    cancelled: &mut impl FnMut() -> bool,
+) -> Result<ConstructionIndexEncoding, GfError> {
     let graph = encoded
         .create_child_directory(std::ffi::OsStr::new("graph"))
         .map_err(storage_err)?;
@@ -1267,81 +1481,127 @@ pub(crate) fn encode_construction_index(
         ));
     }
 
+    let mut work = ConstructionIndexWork::default();
     let identity_temp = format!(".construction-identities-{}.tmp", Uuid::new_v4().simple());
     let surrogate_temp = format!(".construction-surrogates-{}.tmp", Uuid::new_v4().simple());
-    let mut input = BufReader::with_capacity(
-        BULK_IO_BYTES,
-        source
-            .open_child_file(std::ffi::OsStr::new(identities_name))
-            .map_err(storage_err)?,
+    let mut input = source
+        .open_child_file(std::ffi::OsStr::new(identities_name))
+        .map_err(storage_err)?;
+    let input_len = input.metadata().map_err(storage_err)?.len();
+    if input_len % IDENTITY_RECORD_BYTES != 0 {
+        return Err(storage_err("construction identity stream is truncated"));
+    }
+    let source_identity = graphforge_filesystem::file_identity(&input).map_err(storage_err)?;
+    let source_file_id = hex_bytes(&source_identity.file_id);
+    let mut intent = ConstructionRecoveryIntent {
+        format_version: FORMAT_VERSION,
+        generation,
+        parent_generation,
+        identities_name: identities_name.to_owned(),
+        source_volume: source_identity.volume_serial,
+        source_file_id: source_file_id.clone(),
+        source_bytes: input_len,
+        authority_sha256: String::new(),
+    };
+    intent.authority_sha256 = construction_intent_digest(
+        intent.format_version,
+        intent.generation,
+        intent.parent_generation,
+        &intent.identities_name,
+        intent.source_volume,
+        &intent.source_file_id,
+        intent.source_bytes,
     );
-    let identity_file = index
+    write_construction_intent(&index, &intent, &mut work)?;
+    crate::graph_construction::construction_failpoint("uuid_encode.after_intent");
+    let mut identity_writer = index
         .create_replaceable_child_file(std::ffi::OsStr::new(&identity_temp))
         .map_err(storage_err)?;
-    let surrogate_file = index
+    let mut surrogate_writer = index
         .create_replaceable_child_file(std::ffi::OsStr::new(&surrogate_temp))
         .map_err(storage_err)?;
     let identity_identity =
-        graphforge_filesystem::file_identity(&identity_file).map_err(storage_err)?;
+        graphforge_filesystem::file_identity(&identity_writer).map_err(storage_err)?;
     let surrogate_identity =
-        graphforge_filesystem::file_identity(&surrogate_file).map_err(storage_err)?;
-    let mut identity_writer = BufWriter::with_capacity(BULK_IO_BYTES, identity_file);
-    let mut surrogate_writer = BufWriter::with_capacity(BULK_IO_BYTES, surrogate_file);
+        graphforge_filesystem::file_identity(&surrogate_writer).map_err(storage_err)?;
+    crate::graph_construction::construction_failpoint("uuid_encode.after_temps");
+    let aligned_input_bytes = (BULK_IO_BYTES / IDENTITY_RECORD_WIDTH) * IDENTITY_RECORD_WIDTH;
+    let aligned_surrogate_bytes =
+        (BULK_IO_BYTES / NODE_LOOKUP_RECORD_WIDTH) * NODE_LOOKUP_RECORD_WIDTH;
+    let mut input_block = vec![0_u8; aligned_input_bytes];
+    let mut surrogate_block = Vec::with_capacity(aligned_surrogate_bytes);
+    work.peak_buffer_bytes = (input_block.len() + surrogate_block.capacity()) as u64;
     let mut previous_uuid = None;
     let mut previous_surrogate = 0_u64;
     let mut node_count = 0_u64;
     let mut edge_count = 0_u64;
-    loop {
+    let mut remaining = input_len;
+    while remaining != 0 {
         if cancelled() {
             return Err(storage_err("construction index encoding cancelled"));
         }
-        let mut record = [0_u8; IDENTITY_RECORD_WIDTH];
-        let mut filled = 0;
-        while filled < record.len() {
-            let read = input.read(&mut record[filled..]).map_err(storage_err)?;
-            if read == 0 {
-                if filled == 0 {
-                    break;
+        let count =
+            usize::try_from(remaining.min(input_block.len() as u64)).map_err(storage_err)?;
+        input
+            .read_exact(&mut input_block[..count])
+            .map_err(storage_err)?;
+        work.read_bytes = work.read_bytes.saturating_add(count as u64);
+        work.read_operations = work.read_operations.saturating_add(1);
+        for record in input_block[..count].chunks_exact_mut(IDENTITY_RECORD_WIDTH) {
+            let uuid: [u8; 16] = record[..16].try_into().expect("fixed UUID");
+            if previous_uuid.is_some_and(|prior| prior >= uuid)
+                || record[17..24].iter().any(|byte| *byte != 0)
+            {
+                return Err(storage_err("construction identity stream is not canonical"));
+            }
+            previous_uuid = Some(uuid);
+            match record[16] {
+                0 => {
+                    let surrogate = u64::from_be_bytes(record[24..32].try_into().expect("fixed"));
+                    if surrogate == 0 || surrogate <= previous_surrogate {
+                        return Err(storage_err(
+                            "construction node surrogate stream is not increasing",
+                        ));
+                    }
+                    previous_surrogate = surrogate;
+                    if surrogate_block.len() + NODE_LOOKUP_RECORD_WIDTH > aligned_surrogate_bytes {
+                        surrogate_writer
+                            .write_all(&surrogate_block)
+                            .map_err(storage_err)?;
+                        work.write_bytes = work
+                            .write_bytes
+                            .saturating_add(surrogate_block.len() as u64);
+                        work.write_operations = work.write_operations.saturating_add(1);
+                        surrogate_block.clear();
+                    }
+                    surrogate_block.extend_from_slice(&surrogate.to_be_bytes());
+                    surrogate_block.extend_from_slice(&uuid);
+                    node_count = node_count.saturating_add(1);
                 }
-                return Err(storage_err("construction identity stream is truncated"));
-            }
-            filled += read;
-        }
-        if filled == 0 {
-            break;
-        }
-        let uuid: [u8; 16] = record[..16].try_into().expect("fixed UUID");
-        if previous_uuid.is_some_and(|prior| prior >= uuid)
-            || record[17..24].iter().any(|byte| *byte != 0)
-        {
-            return Err(storage_err("construction identity stream is not canonical"));
-        }
-        previous_uuid = Some(uuid);
-        match record[16] {
-            0 => {
-                let surrogate = u64::from_be_bytes(record[24..32].try_into().expect("fixed"));
-                if surrogate == 0 || surrogate <= previous_surrogate {
-                    return Err(storage_err(
-                        "construction node surrogate stream is not increasing",
-                    ));
+                1 => {
+                    // Construction assigns edge surrogates for topology; v3
+                    // edge membership deliberately stores zero.
+                    record[24..32].fill(0);
+                    edge_count = edge_count.saturating_add(1);
                 }
-                previous_surrogate = surrogate;
-                surrogate_writer
-                    .write_all(&surrogate.to_be_bytes())
-                    .and_then(|()| surrogate_writer.write_all(&uuid))
-                    .map_err(storage_err)?;
-                node_count = node_count.saturating_add(1);
+                _ => return Err(storage_err("construction identity kind is invalid")),
             }
-            1 if record[24..32].iter().any(|byte| *byte != 0) => {
-                // Construction assigns edge surrogates for canonical topology,
-                // while v3 edge membership deliberately stores zero.
-                record[24..32].fill(0);
-                edge_count = edge_count.saturating_add(1);
-            }
-            1 => edge_count = edge_count.saturating_add(1),
-            _ => return Err(storage_err("construction identity kind is invalid")),
         }
-        identity_writer.write_all(&record).map_err(storage_err)?;
+        identity_writer
+            .write_all(&input_block[..count])
+            .map_err(storage_err)?;
+        work.write_bytes = work.write_bytes.saturating_add(count as u64);
+        work.write_operations = work.write_operations.saturating_add(1);
+        remaining -= count as u64;
+    }
+    if !surrogate_block.is_empty() {
+        surrogate_writer
+            .write_all(&surrogate_block)
+            .map_err(storage_err)?;
+        work.write_bytes = work
+            .write_bytes
+            .saturating_add(surrogate_block.len() as u64);
+        work.write_operations = work.write_operations.saturating_add(1);
     }
     if manifest.live_node_count.saturating_add(node_count) != live_nodes
         || manifest.live_edge_count.saturating_add(edge_count) != live_edges
@@ -1352,8 +1612,9 @@ pub(crate) fn encode_construction_index(
     }
     identity_writer.flush().map_err(storage_err)?;
     surrogate_writer.flush().map_err(storage_err)?;
-    identity_writer.get_ref().sync_all().map_err(storage_err)?;
-    surrogate_writer.get_ref().sync_all().map_err(storage_err)?;
+    identity_writer.sync_all().map_err(storage_err)?;
+    surrogate_writer.sync_all().map_err(storage_err)?;
+    work.fsync_operations = work.fsync_operations.saturating_add(2);
     drop(identity_writer);
     drop(surrogate_writer);
 
@@ -1366,6 +1627,7 @@ pub(crate) fn encode_construction_index(
         generation,
         IDENTITY_RECORD_WIDTH,
         &mut artifacts,
+        &mut work,
     )?;
     let surrogate_record = describe_and_install_construction_run(
         &index,
@@ -1375,11 +1637,13 @@ pub(crate) fn encode_construction_index(
         generation,
         NODE_LOOKUP_RECORD_WIDTH,
         &mut artifacts,
+        &mut work,
     )?;
     let mut output_names = artifacts
         .iter()
         .map(|artifact| artifact.name.clone())
         .collect::<BTreeSet<_>>();
+    crate::graph_construction::construction_failpoint("uuid_encode.after_delta_runs");
 
     if parent_generation == 0 {
         let base_identity = install_empty_construction_run(
@@ -1388,6 +1652,7 @@ pub(crate) fn encode_construction_index(
             0,
             IDENTITY_RECORD_WIDTH,
             &mut artifacts,
+            &mut work,
         )?;
         let base_surrogate = install_empty_construction_run(
             &index,
@@ -1395,6 +1660,7 @@ pub(crate) fn encode_construction_index(
             0,
             NODE_LOOKUP_RECORD_WIDTH,
             &mut artifacts,
+            &mut work,
         )?;
         output_names.insert(base_identity.name.clone());
         output_names.insert(base_surrogate.name.clone());
@@ -1433,8 +1699,10 @@ pub(crate) fn encode_construction_index(
         &mut artifacts,
         &mut output_names,
         &mut retained_payload_bytes,
+        &mut work,
         cancelled,
     )?;
+    work.retained_payload_bytes = retained_payload_bytes;
     manifest.current_generation = generation;
     manifest.live_node_count = live_nodes;
     manifest.live_edge_count = live_edges;
@@ -1444,9 +1712,24 @@ pub(crate) fn encode_construction_index(
     validate_run_descriptors(&manifest)?;
 
     let body = serde_json::to_vec(&manifest).map_err(storage_err)?;
-    let manifest_output = install_construction_bytes(&index, MANIFEST, &body)?;
+    let manifest_output = install_construction_bytes(&index, MANIFEST, &body, &mut work)?;
+    crate::graph_construction::construction_failpoint("uuid_encode.after_manifest");
     artifacts.push(manifest_output);
     let retained_names = manifest_file_names(&manifest);
+    let created_payload_bytes = artifacts
+        .iter()
+        .filter(|artifact| artifact.name != MANIFEST)
+        .map(|artifact| artifact.bytes)
+        .sum::<u64>();
+    work.created_runs = artifacts
+        .iter()
+        .filter(|artifact| artifact.name != MANIFEST)
+        .count() as u64;
+    // All byte and operation counters above are updated at the actual read,
+    // write, flush, and durability sites. Never reconstruct I/O from file
+    // lengths here: short reads and discarded carry outputs are observable.
+    work.peak_buffer_bytes = work.peak_buffer_bytes.max((3 * BULK_IO_BYTES) as u64);
+    work.peak_temporary_bytes = created_payload_bytes.saturating_add(body.len() as u64);
     for artifact in artifacts
         .iter()
         .filter(|artifact| artifact.name != MANIFEST && !retained_names.contains(&artifact.name))
@@ -1462,20 +1745,161 @@ pub(crate) fn encode_construction_index(
     artifacts
         .retain(|artifact| artifact.name == MANIFEST || retained_names.contains(&artifact.name));
     artifacts.sort_unstable_by(|left, right| left.name.cmp(&right.name));
-    let write_bytes = artifacts.iter().map(|artifact| artifact.bytes).sum();
+    let mut retained_references = Vec::new();
+    let locally_owned = artifacts
+        .iter()
+        .map(|artifact| artifact.name.as_str())
+        .collect::<BTreeSet<_>>();
+    if let Some(parent) = parent {
+        let mut referenced = BTreeSet::new();
+        for record in manifest
+            .runs
+            .iter()
+            .flat_map(|run| [&run.identities, &run.node_surrogates])
+        {
+            if !locally_owned.contains(record.name.as_str())
+                && referenced.insert(record.name.clone())
+            {
+                retained_references.push(parent.retained_reference(record)?);
+            }
+        }
+        work.retained_runs = manifest
+            .runs
+            .iter()
+            .filter(|run| {
+                !locally_owned.contains(run.identities.name.as_str())
+                    && !locally_owned.contains(run.node_surrogates.name.as_str())
+            })
+            .count() as u64;
+        parent.revalidate()?;
+    }
+    retained_references.sort_unstable_by(|left, right| left.target_path.cmp(&right.target_path));
+    let intent_file = index
+        .open_child_file(std::ffi::OsStr::new(CONSTRUCTION_INTENT))
+        .map_err(storage_err)?;
+    let intent_identity =
+        graphforge_filesystem::file_identity(&intent_file).map_err(storage_err)?;
+    index
+        .unlink_child_if_identity(std::ffi::OsStr::new(CONSTRUCTION_INTENT), intent_identity)
+        .map_err(storage_err)?;
+    crate::graph_construction::construction_failpoint("uuid_encode.after_intent_removal");
     index.sync().map_err(storage_err)?;
     cache.sync().map_err(storage_err)?;
     graph.sync().map_err(storage_err)?;
     encoded.sync().map_err(storage_err)?;
+    work.fsync_operations = work.fsync_operations.saturating_add(4);
     Ok(ConstructionIndexEncoding {
         artifacts,
+        retained_references,
         input_records: node_count.saturating_add(edge_count),
-        write_bytes,
-        retained_runs: manifest.runs.len() as u64,
-        retained_payload_bytes,
+        read_bytes: work.read_bytes,
+        read_operations: work.read_operations,
+        write_bytes: work.write_bytes,
+        write_operations: work.write_operations,
+        fsync_operations: work.fsync_operations,
+        created_runs: work.created_runs,
+        retained_runs: work.retained_runs,
+        retained_payload_bytes: work.retained_payload_bytes,
+        peak_buffer_bytes: work.peak_buffer_bytes,
+        peak_temporary_bytes: work.peak_temporary_bytes,
     })
 }
 
+fn cleanup_private_construction_index(
+    encoded: &graphforge_filesystem::StableDirectory,
+) -> Result<(), GfError> {
+    let graph = match encoded.open_child_directory(std::ffi::OsStr::new("graph")) {
+        Ok(value) => value,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(storage_err(error)),
+    };
+    let cache = match graph.open_child_directory(std::ffi::OsStr::new(".graphforge-cache")) {
+        Ok(value) => value,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(storage_err(error)),
+    };
+    let index = match cache.open_child_directory(std::ffi::OsStr::new("uuid-membership")) {
+        Ok(value) => value,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(storage_err(error)),
+    };
+    match index.open_child_file(std::ffi::OsStr::new(CONSTRUCTION_INTENT)) {
+        Ok(mut file) => {
+            if file.metadata().map_err(storage_err)?.len() > 16 * 1024 {
+                return Err(storage_err("construction recovery intent is oversized"));
+            }
+            let mut body = Vec::new();
+            file.read_to_end(&mut body).map_err(storage_err)?;
+            let intent: ConstructionRecoveryIntent =
+                serde_json::from_slice(&body).map_err(storage_err)?;
+            intent.authenticate()?;
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(storage_err(error)),
+    }
+    for name in index.child_names().map_err(storage_err)? {
+        let name_text = name
+            .to_str()
+            .ok_or_else(|| storage_err("construction recovery inventory name is not UTF-8"))?;
+        if name_text != CONSTRUCTION_INTENT
+            && name_text != MANIFEST
+            && !name_text.starts_with(".construction-")
+            && !name_text.starts_with(".manifest.json-")
+            && !name_text.starts_with("identities-v3")
+            && !name_text.starts_with("node-surrogates-v3")
+        {
+            return Err(storage_err(
+                "construction recovery inventory contains an unauthorised object",
+            ));
+        }
+        let file = index.open_child_file(&name).map_err(storage_err)?;
+        if graphforge_filesystem::file_link_count(&file).map_err(storage_err)? != 1 {
+            return Err(storage_err(
+                "private construction index artifact has extra links",
+            ));
+        }
+        let identity = graphforge_filesystem::file_identity(&file).map_err(storage_err)?;
+        index
+            .unlink_child_if_identity(&name, identity)
+            .map_err(storage_err)?;
+    }
+    index.sync().map_err(storage_err)?;
+    cache.sync().map_err(storage_err)?;
+    graph.sync().map_err(storage_err)?;
+    encoded.sync().map_err(storage_err)
+}
+
+fn write_construction_intent(
+    index: &graphforge_filesystem::StableDirectory,
+    intent: &ConstructionRecoveryIntent,
+    work: &mut ConstructionIndexWork,
+) -> Result<(), GfError> {
+    intent.authenticate()?;
+    let body = serde_json::to_vec(intent).map_err(storage_err)?;
+    let temporary = format!(".construction-intent-{}.tmp", Uuid::new_v4().simple());
+    let mut file = index
+        .create_replaceable_child_file(std::ffi::OsStr::new(&temporary))
+        .map_err(storage_err)?;
+    let identity = graphforge_filesystem::file_identity(&file).map_err(storage_err)?;
+    file.write_all(&body).map_err(storage_err)?;
+    work.write_bytes = work.write_bytes.saturating_add(body.len() as u64);
+    work.write_operations = work.write_operations.saturating_add(1);
+    file.sync_all().map_err(storage_err)?;
+    work.fsync_operations = work.fsync_operations.saturating_add(1);
+    drop(file);
+    index
+        .replace_child(
+            std::ffi::OsStr::new(&temporary),
+            identity,
+            std::ffi::OsStr::new(CONSTRUCTION_INTENT),
+        )
+        .map_err(storage_err)?;
+    index.sync().map_err(storage_err)?;
+    work.fsync_operations = work.fsync_operations.saturating_add(1);
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
 fn compact_construction_levels(
     output: &graphforge_filesystem::StableDirectory,
     parent: Option<&AuthenticatedUuidIndexSnapshot>,
@@ -1484,6 +1908,7 @@ fn compact_construction_levels(
     artifacts: &mut Vec<ConstructionIndexOutput>,
     output_names: &mut BTreeSet<String>,
     retained_payload_bytes: &mut u64,
+    work: &mut ConstructionIndexWork,
     cancelled: &mut impl FnMut() -> bool,
 ) -> Result<(), GfError> {
     for level in 0_u8..=63 {
@@ -1522,6 +1947,7 @@ fn compact_construction_levels(
                 IDENTITY_RECORD_WIDTH,
                 artifacts,
                 retained_payload_bytes,
+                work,
                 cancelled,
             )?;
             let surrogates = merge_construction_records(
@@ -1535,6 +1961,7 @@ fn compact_construction_levels(
                 NODE_LOOKUP_RECORD_WIDTH,
                 artifacts,
                 retained_payload_bytes,
+                work,
                 cancelled,
             )?;
             output_names.insert(identities.name.clone());
@@ -1572,34 +1999,34 @@ fn merge_construction_records(
     width: usize,
     artifacts: &mut Vec<ConstructionIndexOutput>,
     retained_payload_bytes: &mut u64,
+    work: &mut ConstructionIndexWork,
     cancelled: &mut impl FnMut() -> bool,
 ) -> Result<FileRecord, GfError> {
-    let mut left_reader = BufReader::with_capacity(
-        BULK_IO_BYTES,
+    let mut left_reader = ConstructionBlockCursor::new(
         open_construction_source(output, parent, left, output_names, retained_payload_bytes)?,
-    );
-    let mut right_reader = BufReader::with_capacity(
-        BULK_IO_BYTES,
+        left.clone(),
+        width,
+    )?;
+    let mut right_reader = ConstructionBlockCursor::new(
         open_construction_source(output, parent, right, output_names, retained_payload_bytes)?,
-    );
+        right.clone(),
+        width,
+    )?;
     let temporary = format!(".construction-merge-{}.tmp", Uuid::new_v4().simple());
     let file = output
         .create_replaceable_child_file(std::ffi::OsStr::new(&temporary))
         .map_err(storage_err)?;
     let identity = graphforge_filesystem::file_identity(&file).map_err(storage_err)?;
-    let mut writer = BufWriter::with_capacity(BULK_IO_BYTES, file);
+    let mut writer = file;
     let key_width = if width == IDENTITY_RECORD_WIDTH {
         16
     } else {
         8
     };
-    let mut left_record = read_construction_record(&mut left_reader, width)?;
-    let mut right_record = read_construction_record(&mut right_reader, width)?;
-    while left_record.is_some() || right_record.is_some() {
-        if cancelled() {
-            return Err(storage_err("construction index encoding cancelled"));
-        }
-        let take_left = match (&left_record, &right_record) {
+    let output_bytes = (BULK_IO_BYTES / width) * width;
+    let mut output_block = Vec::with_capacity(output_bytes);
+    while left_reader.current().is_some() || right_reader.current().is_some() {
+        let take_left = match (left_reader.current(), right_reader.current()) {
             (Some(left), Some(right)) => {
                 if left[..key_width] == right[..key_width] {
                     return Err(storage_err("construction index merge found duplicate key"));
@@ -1610,24 +2037,140 @@ fn merge_construction_records(
             (None, Some(_)) => false,
             (None, None) => break,
         };
-        if take_left {
-            writer
-                .write_all(left_record.as_ref().expect("left exists"))
-                .map_err(storage_err)?;
-            left_record = read_construction_record(&mut left_reader, width)?;
+        let selected = if take_left {
+            left_reader.current().expect("left exists")
         } else {
-            writer
-                .write_all(right_record.as_ref().expect("right exists"))
-                .map_err(storage_err)?;
-            right_record = read_construction_record(&mut right_reader, width)?;
+            right_reader.current().expect("right exists")
+        };
+        output_block.extend_from_slice(selected);
+        if take_left {
+            left_reader.advance()?;
+        } else {
+            right_reader.advance()?;
+        }
+        if output_block.len() + width > output_bytes {
+            if cancelled() {
+                return Err(storage_err("construction index encoding cancelled"));
+            }
+            writer.write_all(&output_block).map_err(storage_err)?;
+            work.write_bytes = work.write_bytes.saturating_add(output_block.len() as u64);
+            work.write_operations = work.write_operations.saturating_add(1);
+            output_block.clear();
         }
     }
+    if !output_block.is_empty() {
+        writer.write_all(&output_block).map_err(storage_err)?;
+        work.write_bytes = work.write_bytes.saturating_add(output_block.len() as u64);
+        work.write_operations = work.write_operations.saturating_add(1);
+    }
     writer.flush().map_err(storage_err)?;
-    writer.get_ref().sync_all().map_err(storage_err)?;
+    writer.sync_all().map_err(storage_err)?;
+    work.fsync_operations = work.fsync_operations.saturating_add(1);
+    work.read_bytes = work
+        .read_bytes
+        .saturating_add(left_reader.read_bytes)
+        .saturating_add(right_reader.read_bytes);
+    work.read_operations = work
+        .read_operations
+        .saturating_add(left_reader.read_operations)
+        .saturating_add(right_reader.read_operations);
     drop(writer);
     describe_and_install_construction_run(
-        output, &temporary, identity, prefix, generation, width, artifacts,
+        output, &temporary, identity, prefix, generation, width, artifacts, work,
     )
+}
+
+struct ConstructionBlockCursor {
+    file: File,
+    descriptor: FileRecord,
+    width: usize,
+    block: Vec<u8>,
+    block_index: usize,
+    within: usize,
+    records: u64,
+    digest: Sha256,
+    finished: bool,
+    read_bytes: u64,
+    read_operations: u64,
+}
+
+impl ConstructionBlockCursor {
+    fn new(file: File, descriptor: FileRecord, width: usize) -> Result<Self, GfError> {
+        let mut cursor = Self {
+            file,
+            descriptor,
+            width,
+            block: Vec::new(),
+            block_index: 0,
+            within: 0,
+            records: 0,
+            digest: Sha256::new(),
+            finished: false,
+            read_bytes: 0,
+            read_operations: 0,
+        };
+        cursor.fill()?;
+        Ok(cursor)
+    }
+
+    fn current(&self) -> Option<&[u8]> {
+        (!self.finished).then(|| &self.block[self.within..self.within + self.width])
+    }
+
+    fn advance(&mut self) -> Result<(), GfError> {
+        if self.finished {
+            return Ok(());
+        }
+        self.within += self.width;
+        self.records = self.records.saturating_add(1);
+        if self.within == self.block.len() {
+            self.fill()?;
+        }
+        Ok(())
+    }
+
+    fn fill(&mut self) -> Result<(), GfError> {
+        if self.block_index == self.descriptor.blocks.len() {
+            self.finished = true;
+            if self.records != self.descriptor.count
+                || hex_bytes(&self.digest.clone().finalize()) != self.descriptor.sha256
+            {
+                return Err(storage_err(
+                    "construction merge source authentication failed",
+                ));
+            }
+            return Ok(());
+        }
+        let expected = &self.descriptor.blocks[self.block_index];
+        if expected.offset != self.records.saturating_mul(self.width as u64)
+            || expected.len == 0
+            || !(expected.len as usize).is_multiple_of(self.width)
+        {
+            return Err(storage_err("construction merge block framing changed"));
+        }
+        self.block.resize(expected.len as usize, 0);
+        self.file.read_exact(&mut self.block).map_err(storage_err)?;
+        self.read_bytes = self.read_bytes.saturating_add(self.block.len() as u64);
+        self.read_operations = self.read_operations.saturating_add(1);
+        let key_width = if self.width == IDENTITY_RECORD_WIDTH {
+            16
+        } else {
+            8
+        };
+        if hex_sha256(&self.block) != expected.sha256
+            || hex_sha256_key(&self.block[..key_width]) != expected.first_key
+            || hex_sha256_key(
+                &self.block
+                    [self.block.len() - self.width..self.block.len() - self.width + key_width],
+            ) != expected.last_key
+        {
+            return Err(storage_err("construction merge source block changed"));
+        }
+        self.digest.update(&self.block);
+        self.block_index += 1;
+        self.within = 0;
+        Ok(())
+    }
 }
 
 fn open_construction_source(
@@ -1652,30 +2195,8 @@ fn open_construction_source(
                     NODE_LOOKUP_RECORD_BYTES
                 },
             ));
-        parent
-            .root
-            .open_child_file(std::ffi::OsStr::new(&record.name))
-            .map_err(storage_err)
+        parent.open_retained_file(record)
     }
-}
-
-fn read_construction_record(
-    reader: &mut impl Read,
-    width: usize,
-) -> Result<Option<Vec<u8>>, GfError> {
-    let mut record = vec![0_u8; width];
-    let mut filled = 0;
-    while filled < width {
-        let read = reader.read(&mut record[filled..]).map_err(storage_err)?;
-        if read == 0 {
-            if filled == 0 {
-                return Ok(None);
-            }
-            return Err(storage_err("construction index merge source is truncated"));
-        }
-        filled += read;
-    }
-    Ok(Some(record))
 }
 
 fn install_empty_construction_run(
@@ -1684,6 +2205,7 @@ fn install_empty_construction_run(
     generation: u64,
     width: usize,
     artifacts: &mut Vec<ConstructionIndexOutput>,
+    work: &mut ConstructionIndexWork,
 ) -> Result<FileRecord, GfError> {
     let temporary = format!(".construction-empty-{}.tmp", Uuid::new_v4().simple());
     let file = output
@@ -1691,12 +2213,14 @@ fn install_empty_construction_run(
         .map_err(storage_err)?;
     let identity = graphforge_filesystem::file_identity(&file).map_err(storage_err)?;
     file.sync_all().map_err(storage_err)?;
+    work.fsync_operations = work.fsync_operations.saturating_add(1);
     drop(file);
     describe_and_install_construction_run(
-        output, &temporary, identity, prefix, generation, width, artifacts,
+        output, &temporary, identity, prefix, generation, width, artifacts, work,
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn describe_and_install_construction_run(
     output: &graphforge_filesystem::StableDirectory,
     temporary: &str,
@@ -1705,6 +2229,7 @@ fn describe_and_install_construction_run(
     generation: u64,
     width: usize,
     artifacts: &mut Vec<ConstructionIndexOutput>,
+    work: &mut ConstructionIndexWork,
 ) -> Result<FileRecord, GfError> {
     let mut file = output
         .open_child_file(std::ffi::OsStr::new(temporary))
@@ -1731,6 +2256,8 @@ fn describe_and_install_construction_run(
                 break;
             }
             filled += read;
+            work.read_bytes = work.read_bytes.saturating_add(read as u64);
+            work.read_operations = work.read_operations.saturating_add(1);
         }
         if filled == 0 {
             break;
@@ -1762,6 +2289,7 @@ fn describe_and_install_construction_run(
         )
         .map_err(storage_err)?;
     output.sync().map_err(storage_err)?;
+    work.fsync_operations = work.fsync_operations.saturating_add(1);
     artifacts.push(ConstructionIndexOutput {
         name: name.clone(),
         bytes,
@@ -1779,6 +2307,7 @@ fn install_construction_bytes(
     output: &graphforge_filesystem::StableDirectory,
     name: &str,
     bytes: &[u8],
+    work: &mut ConstructionIndexWork,
 ) -> Result<ConstructionIndexOutput, GfError> {
     let temporary = format!(".{name}-{}.tmp", Uuid::new_v4().simple());
     let mut file = output
@@ -1786,7 +2315,10 @@ fn install_construction_bytes(
         .map_err(storage_err)?;
     let identity = graphforge_filesystem::file_identity(&file).map_err(storage_err)?;
     file.write_all(bytes).map_err(storage_err)?;
+    work.write_bytes = work.write_bytes.saturating_add(bytes.len() as u64);
+    work.write_operations = work.write_operations.saturating_add(1);
     file.sync_all().map_err(storage_err)?;
+    work.fsync_operations = work.fsync_operations.saturating_add(1);
     drop(file);
     output
         .replace_child(
@@ -1796,6 +2328,7 @@ fn install_construction_bytes(
         )
         .map_err(storage_err)?;
     output.sync().map_err(storage_err)?;
+    work.fsync_operations = work.fsync_operations.saturating_add(1);
     Ok(ConstructionIndexOutput {
         name: name.to_owned(),
         bytes: bytes.len() as u64,
@@ -4830,6 +5363,7 @@ fn sha256_reader(reader: &mut impl Read) -> Result<String, GfError> {
 
 #[cfg(test)]
 mod tests {
+    use std::io::BufWriter;
     use std::sync::{Arc, Barrier};
 
     use arrow::array::{FixedSizeBinaryArray, UInt64Array};
@@ -4838,6 +5372,54 @@ mod tests {
     use parquet::arrow::ArrowWriter;
 
     use super::*;
+
+    #[test]
+    fn construction_encoder_io_geometry_is_block_bounded() {
+        for records in [32_768_u64, 65_536, 131_072] {
+            let source_dir = tempfile::tempdir().unwrap();
+            let encoded_dir = tempfile::tempdir().unwrap();
+            let mut input = BufWriter::with_capacity(
+                BULK_IO_BYTES,
+                File::create(source_dir.path().join("identities.run")).unwrap(),
+            );
+            for value in 1..=records {
+                input.write_all(&u128::from(value).to_be_bytes()).unwrap();
+                input.write_all(&[0]).unwrap();
+                input.write_all(&[0; 7]).unwrap();
+                input.write_all(&value.to_be_bytes()).unwrap();
+            }
+            input.flush().unwrap();
+            drop(input);
+            let source = graphforge_filesystem::StableDirectory::open(source_dir.path()).unwrap();
+            let encoded = graphforge_filesystem::StableDirectory::open(encoded_dir.path()).unwrap();
+            let result = encode_construction_index(
+                &source,
+                "identities.run",
+                &encoded,
+                1,
+                0,
+                None,
+                records,
+                0,
+                &mut || false,
+            )
+            .unwrap();
+            let identity_blocks = (records * IDENTITY_RECORD_BYTES).div_ceil(BULK_IO_BYTES as u64);
+            let surrogate_blocks =
+                (records * NODE_LOOKUP_RECORD_BYTES).div_ceil(BULK_IO_BYTES as u64);
+            assert!(
+                result.read_operations <= 2 * identity_blocks + surrogate_blocks + 4,
+                "{records}: {} reads",
+                result.read_operations
+            );
+            assert!(
+                result.write_operations <= identity_blocks + surrogate_blocks + 4,
+                "{records}: {} writes",
+                result.write_operations
+            );
+            assert!(result.peak_buffer_bytes <= 3 * BULK_IO_BYTES as u64);
+        }
+    }
 
     #[test]
     fn fixed_width_codecs_distinguish_clean_eof_from_partial_tail() {

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -584,6 +584,7 @@ pub struct AuthenticatedUuidIndexSnapshot {
     authenticated_blocks: u64,
 }
 
+#[cfg(test)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct ConstructionUuidIdentity {
     pub uuid: Uuid,
@@ -602,6 +603,7 @@ pub(crate) struct UuidConstructionSnapshotWork {
 
 /// Retained authority for a UUID snapshot authenticated exactly once while its
 /// live identities were emitted as one bounded sorted stream.
+#[cfg(test)]
 pub(crate) struct UuidConstructionSnapshot {
     root: graphforge_filesystem::StableDirectory,
     root_identity: graphforge_filesystem::FileIdentity,
@@ -614,16 +616,8 @@ pub(crate) struct UuidConstructionSnapshot {
     payload_consumed: bool,
 }
 
+#[cfg(test)]
 impl UuidConstructionSnapshot {
-    pub(crate) fn declared_work(&self, max_node_surrogate: u64) -> UuidConstructionSnapshotWork {
-        UuidConstructionSnapshotWork {
-            live_nodes: self.manifest.live_node_count,
-            live_edges: self.manifest.live_edge_count,
-            max_node_surrogate,
-            ..Default::default()
-        }
-    }
-
     pub(crate) fn revalidate(&self) -> Result<(), GfError> {
         self.root.revalidate_named().map_err(storage_err)?;
         if self.root.identity() != self.root_identity
@@ -778,6 +772,7 @@ impl UuidConstructionSnapshot {
     }
 }
 
+#[cfg(test)]
 struct ConstructionRunCursor {
     file: File,
     descriptor: FileRecord,
@@ -792,6 +787,7 @@ struct ConstructionRunCursor {
     finished: bool,
 }
 
+#[cfg(test)]
 impl ConstructionRunCursor {
     fn new(file: File, descriptor: FileRecord, width: usize) -> Self {
         Self {
@@ -878,6 +874,7 @@ pub(crate) fn open_uuid_construction_snapshot(
 /// Pin the generation's manifest and every run inode without reading retained
 /// payload bytes.  The caller later consumes those bytes exactly once through
 /// [`UuidConstructionSnapshot::stream_authenticated`].
+#[cfg(test)]
 pub(crate) fn pin_uuid_construction_snapshot(
     project_dir: &Path,
     generation: u64,
@@ -995,14 +992,25 @@ impl AuthenticatedUuidIndexSnapshot {
     pub(crate) fn topology_generation(&self) -> u64 {
         self.manifest.current_generation
     }
-    fn take_authentication_work(&mut self) -> (u64, u64) {
+
+    pub(crate) fn count(&self, kind: UuidIndexKind) -> u64 {
+        match kind {
+            UuidIndexKind::Node => self.manifest.live_node_count,
+            UuidIndexKind::Edge => self.manifest.live_edge_count,
+        }
+    }
+
+    pub(crate) fn manifest_sha256(&self) -> &str {
+        &self.manifest_sha256
+    }
+    pub(crate) fn take_authentication_work(&mut self) -> (u64, u64) {
         (
             std::mem::take(&mut self.authenticated_bytes),
             std::mem::take(&mut self.authenticated_blocks),
         )
     }
 
-    fn revalidate(&self) -> Result<(), GfError> {
+    pub(crate) fn revalidate(&self) -> Result<(), GfError> {
         self.root.revalidate_named().map_err(storage_err)?;
         if self.root.identity() != self.root_identity {
             return Err(storage_err("UUID index root identity changed"));

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -8,7 +8,7 @@
 //! counts, and SHA-256 before serving bounded binary-search probes.
 
 use std::cmp::Reverse;
-use std::collections::{BTreeSet, BinaryHeap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap};
 use std::fmt::Write as _;
 use std::fs::{self, File};
 use std::io::{BufReader, Read, Seek, SeekFrom, Write};
@@ -586,6 +586,7 @@ pub struct AuthenticatedUuidIndexSnapshot {
     runs: Vec<AuthenticatedRun>,
     authenticated_bytes: u64,
     authenticated_blocks: u64,
+    cas_source_paths: Option<BTreeMap<String, (String, String, u64)>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1088,9 +1089,11 @@ impl AuthenticatedUuidIndexSnapshot {
             })
             .ok_or_else(|| storage_err("retained UUID descriptor is not authenticated"))?;
         let mut file = held.try_clone().map_err(storage_err)?;
-        if graphforge_filesystem::file_identity(&file).map_err(storage_err)? != expected
-            || graphforge_filesystem::file_link_count(&file).map_err(storage_err)? != 1
-        {
+        let identity_changed =
+            graphforge_filesystem::file_identity(&file).map_err(storage_err)? != expected;
+        let path_native_link_changed = self.cas_source_paths.is_none()
+            && graphforge_filesystem::file_link_count(&file).map_err(storage_err)? != 1;
+        if identity_changed || path_native_link_changed {
             return Err(storage_err("retained UUID run identity changed"));
         }
         file.seek(SeekFrom::Start(0)).map_err(storage_err)?;
@@ -1103,11 +1106,19 @@ impl AuthenticatedUuidIndexSnapshot {
     ) -> Result<ConstructionIndexReference, GfError> {
         let file = self.open_retained_file(record)?;
         let identity = graphforge_filesystem::file_identity(&file).map_err(storage_err)?;
+        let source_path = self
+            .cas_source_paths
+            .as_ref()
+            .and_then(|paths| paths.get(&record.name))
+            .map_or_else(
+                || format!("{INDEX_DIR}/{}", record.name),
+                |(path, _, _)| path.clone(),
+            );
         Ok(ConstructionIndexReference {
             source_root: self.graph_root_path.to_string_lossy().into_owned(),
             source_root_volume: self.graph_root_identity.volume_serial,
             source_root_file_id: hex_bytes(&self.graph_root_identity.file_id),
-            source_path: format!("{INDEX_DIR}/{}", record.name),
+            source_path,
             source_volume: identity.volume_serial,
             source_file_id: hex_bytes(&identity.file_id),
             target_path: format!("{INDEX_DIR}/{}", record.name),
@@ -1142,16 +1153,23 @@ impl AuthenticatedUuidIndexSnapshot {
             || source_root_volume != self.graph_root_identity.volume_serial
             || source_root_file_id != hex_bytes(&self.graph_root_identity.file_id)
             || parent_manifest_sha256 != self.manifest_sha256
-            || source_path != target_path
-            || !source_path.starts_with(&format!("{INDEX_DIR}/"))
+            || !target_path.starts_with(&format!("{INDEX_DIR}/"))
         {
             return Err(storage_err(
                 "retained construction reference authority changed",
             ));
         }
-        let name = source_path
+        let name = target_path
             .strip_prefix(&format!("{INDEX_DIR}/"))
-            .ok_or_else(|| storage_err("retained construction source path is invalid"))?;
+            .ok_or_else(|| storage_err("retained construction target path is invalid"))?;
+        let expected_source = self
+            .cas_source_paths
+            .as_ref()
+            .and_then(|paths| paths.get(name))
+            .map_or(target_path, |(path, _, _)| path.as_str());
+        if source_path != expected_source {
+            return Err(storage_err("retained construction source path changed"));
+        }
         let record = self
             .manifest
             .runs
@@ -1257,6 +1275,140 @@ impl AuthenticatedUuidIndexSnapshot {
             runs,
             authenticated_bytes,
             authenticated_blocks,
+            cas_source_paths: None,
+        })
+    }
+
+    #[allow(
+        clippy::too_many_lines,
+        reason = "one descriptor-lifetime authentication pass keeps every CAS file and manifest binding in scope"
+    )]
+    pub(crate) fn open_from_compact_inventory(
+        container_root: &Path,
+        inventory: &crate::GraphFilesInventory,
+        generation: u64,
+    ) -> Result<Self, GfError> {
+        let graph_root =
+            graphforge_filesystem::StableDirectory::open(container_root).map_err(storage_err)?;
+        let graph_root_identity = graph_root.identity();
+        let root =
+            graphforge_filesystem::StableDirectory::open(container_root).map_err(storage_err)?;
+        let root_identity = root.identity();
+        let manifest_path = format!("{INDEX_DIR}/{MANIFEST}");
+        let manifest_entry = inventory
+            .files
+            .iter()
+            .find(|entry| entry.relative_path == manifest_path)
+            .ok_or_else(|| storage_err("compact UUID manifest is absent"))?;
+        let mut manifest_file = crate::graph_object_store::open_graph_object_by_digest(
+            container_root,
+            &manifest_entry.content_sha256,
+            manifest_entry.byte_length,
+        )?;
+        let manifest_identity =
+            graphforge_filesystem::file_identity(&manifest_file).map_err(storage_err)?;
+        let body = read_bounded(&mut manifest_file, MAX_MANIFEST_BYTES)?;
+        let manifest_sha256 = hex_sha256(&body);
+        let manifest: Manifest = serde_json::from_slice(&body).map_err(storage_err)?;
+        if manifest.format_version != FORMAT_VERSION || manifest.current_generation != generation {
+            return Err(storage_err(
+                "authenticated compact snapshot generation is stale",
+            ));
+        }
+        validate_run_descriptors(&manifest)?;
+        let mut runs = Vec::with_capacity(manifest.runs.len());
+        let mut paths = BTreeMap::new();
+        let manifest_physical =
+            crate::graph_object_path(container_root, &manifest_entry.content_sha256)?;
+        paths.insert(
+            MANIFEST.to_owned(),
+            (
+                manifest_physical
+                    .strip_prefix(container_root)
+                    .map_err(storage_err)?
+                    .to_string_lossy()
+                    .into_owned(),
+                manifest_entry.content_sha256.clone(),
+                manifest_entry.byte_length,
+            ),
+        );
+        let mut authenticated_bytes = body.len() as u64;
+        let mut authenticated_blocks = 1_u64;
+        for descriptor in &manifest.runs {
+            let mut open_record = |record: &FileRecord, width: u64| -> Result<File, GfError> {
+                let logical = format!("{INDEX_DIR}/{}", record.name);
+                let entry = inventory
+                    .files
+                    .iter()
+                    .find(|entry| entry.relative_path == logical)
+                    .ok_or_else(|| storage_err("compact UUID run is absent"))?;
+                if entry.content_sha256 != record.sha256
+                    || entry.byte_length != record.count.saturating_mul(width)
+                {
+                    return Err(storage_err("compact UUID run authority changed"));
+                }
+                let file = crate::graph_object_store::open_graph_object_by_digest(
+                    container_root,
+                    &entry.content_sha256,
+                    entry.byte_length,
+                )?;
+                let physical = crate::graph_object_path(container_root, &entry.content_sha256)?;
+                let relative = physical
+                    .strip_prefix(container_root)
+                    .map_err(storage_err)?
+                    .to_string_lossy()
+                    .into_owned();
+                paths.insert(
+                    record.name.clone(),
+                    (relative, entry.content_sha256.clone(), entry.byte_length),
+                );
+                Ok(file)
+            };
+            let identities = open_record(&descriptor.identities, IDENTITY_RECORD_BYTES)?;
+            let node_surrogates =
+                open_record(&descriptor.node_surrogates, NODE_LOOKUP_RECORD_BYTES)?;
+            authenticate_file_blocks(
+                &mut identities.try_clone().map_err(storage_err)?,
+                &descriptor.identities,
+                IDENTITY_RECORD_BYTES,
+                None,
+            )?;
+            authenticate_file_blocks(
+                &mut node_surrogates.try_clone().map_err(storage_err)?,
+                &descriptor.node_surrogates,
+                NODE_LOOKUP_RECORD_BYTES,
+                None,
+            )?;
+            authenticated_bytes = authenticated_bytes
+                .saturating_add(descriptor.identities.count * IDENTITY_RECORD_BYTES)
+                .saturating_add(descriptor.node_surrogates.count * NODE_LOOKUP_RECORD_BYTES);
+            authenticated_blocks = authenticated_blocks
+                .saturating_add(descriptor.identities.blocks.len() as u64)
+                .saturating_add(descriptor.node_surrogates.blocks.len() as u64);
+            runs.push(AuthenticatedRun {
+                identities_identity: graphforge_filesystem::file_identity(&identities)
+                    .map_err(storage_err)?,
+                node_surrogates_identity: graphforge_filesystem::file_identity(&node_surrogates)
+                    .map_err(storage_err)?,
+                identities,
+                node_surrogates,
+                descriptor: descriptor.clone(),
+            });
+        }
+        Ok(Self {
+            graph_root,
+            graph_root_path: container_root.to_path_buf(),
+            graph_root_identity,
+            root,
+            root_identity,
+            manifest_file,
+            manifest_identity,
+            manifest_sha256,
+            manifest,
+            runs,
+            authenticated_bytes,
+            authenticated_blocks,
+            cas_source_paths: Some(paths),
         })
     }
 
@@ -1285,6 +1437,50 @@ impl AuthenticatedUuidIndexSnapshot {
         self.graph_root.revalidate_named().map_err(storage_err)?;
         if self.graph_root.identity() != self.graph_root_identity {
             return Err(storage_err("UUID graph root identity changed"));
+        }
+        if let Some(objects) = &self.cas_source_paths {
+            let (_, manifest_digest, manifest_length) = objects
+                .get(MANIFEST)
+                .ok_or_else(|| storage_err("compact UUID manifest authority is absent"))?;
+            let mut manifest = crate::graph_object_store::open_graph_object_by_digest(
+                &self.graph_root_path,
+                manifest_digest,
+                *manifest_length,
+            )?;
+            if graphforge_filesystem::file_identity(&manifest).map_err(storage_err)?
+                != self.manifest_identity
+            {
+                return Err(storage_err("compact UUID manifest identity changed"));
+            }
+            let body = read_bounded(&mut manifest, MAX_MANIFEST_BYTES)?;
+            if hex_sha256(&body) != self.manifest_sha256
+                || serde_json::from_slice::<Manifest>(&body).map_err(storage_err)? != self.manifest
+            {
+                return Err(storage_err("compact UUID manifest authentication changed"));
+            }
+            for run in &self.runs {
+                for (record, identity) in [
+                    (&run.descriptor.identities, run.identities_identity),
+                    (
+                        &run.descriptor.node_surrogates,
+                        run.node_surrogates_identity,
+                    ),
+                ] {
+                    let (_, digest, length) = objects
+                        .get(&record.name)
+                        .ok_or_else(|| storage_err("compact UUID run authority is absent"))?;
+                    let file = crate::graph_object_store::open_graph_object_by_digest(
+                        &self.graph_root_path,
+                        digest,
+                        *length,
+                    )?;
+                    if graphforge_filesystem::file_identity(&file).map_err(storage_err)? != identity
+                    {
+                        return Err(storage_err("compact UUID run identity changed"));
+                    }
+                }
+            }
+            return Ok(());
         }
         self.root.revalidate_named().map_err(storage_err)?;
         if self.root.identity() != self.root_identity {

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -616,6 +616,7 @@ pub(crate) struct ConstructionIndexEncoding {
     pub input_records: u64,
     pub read_bytes: u64,
     pub read_operations: u64,
+    pub final_write_bytes: u64,
     pub write_bytes: u64,
     pub write_operations: u64,
     pub fsync_operations: u64,
@@ -649,6 +650,7 @@ struct ConstructionRecoveryIntent {
     source_volume: u64,
     source_file_id: String,
     source_bytes: u64,
+    source_sha256: String,
     authority_sha256: String,
 }
 
@@ -681,6 +683,7 @@ impl ConstructionRecoveryIntent {
             self.source_volume,
             &self.source_file_id,
             self.source_bytes,
+            &self.source_sha256,
         );
         if self.format_version != FORMAT_VERSION || self.authority_sha256 != expected {
             return Err(storage_err(
@@ -691,6 +694,7 @@ impl ConstructionRecoveryIntent {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn construction_intent_digest(
     format_version: u32,
     generation: u64,
@@ -699,9 +703,10 @@ fn construction_intent_digest(
     source_volume: u64,
     source_file_id: &str,
     source_bytes: u64,
+    source_sha256: &str,
 ) -> String {
     let mut digest = Sha256::new();
-    digest.update(b"graphforge.uuid-membership.construction-intent.v1\0");
+    digest.update(b"graphforge.uuid-membership.construction-intent.v2\0");
     digest.update(format_version.to_be_bytes());
     digest.update(generation.to_be_bytes());
     digest.update(parent_generation.to_be_bytes());
@@ -710,6 +715,7 @@ fn construction_intent_digest(
     digest.update(source_volume.to_be_bytes());
     digest.update(source_file_id.as_bytes());
     digest.update(source_bytes.to_be_bytes());
+    digest.update(source_sha256.as_bytes());
     hex_bytes(&digest.finalize())
 }
 
@@ -1081,12 +1087,13 @@ impl AuthenticatedUuidIndexSnapshot {
                 }
             })
             .ok_or_else(|| storage_err("retained UUID descriptor is not authenticated"))?;
-        let file = held.try_clone().map_err(storage_err)?;
+        let mut file = held.try_clone().map_err(storage_err)?;
         if graphforge_filesystem::file_identity(&file).map_err(storage_err)? != expected
             || graphforge_filesystem::file_link_count(&file).map_err(storage_err)? != 1
         {
             return Err(storage_err("retained UUID run identity changed"));
         }
+        file.seek(SeekFrom::Start(0)).map_err(storage_err)?;
         Ok(file)
     }
 
@@ -1114,6 +1121,86 @@ impl AuthenticatedUuidIndexSnapshot {
             sha256: record.sha256.clone(),
             parent_manifest_sha256: self.manifest_sha256.clone(),
         })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn authenticate_construction_reference(
+        &self,
+        source_root: &str,
+        source_root_volume: u64,
+        source_root_file_id: &str,
+        source_path: &str,
+        source_volume: u64,
+        source_file_id: &str,
+        target_path: &str,
+        bytes: u64,
+        sha256: &str,
+        parent_manifest_sha256: &str,
+    ) -> Result<(), GfError> {
+        self.revalidate()?;
+        if source_root != self.graph_root_path.to_string_lossy()
+            || source_root_volume != self.graph_root_identity.volume_serial
+            || source_root_file_id != hex_bytes(&self.graph_root_identity.file_id)
+            || parent_manifest_sha256 != self.manifest_sha256
+            || source_path != target_path
+            || !source_path.starts_with(&format!("{INDEX_DIR}/"))
+        {
+            return Err(storage_err(
+                "retained construction reference authority changed",
+            ));
+        }
+        let name = source_path
+            .strip_prefix(&format!("{INDEX_DIR}/"))
+            .ok_or_else(|| storage_err("retained construction source path is invalid"))?;
+        let record = self
+            .manifest
+            .runs
+            .iter()
+            .flat_map(|run| [&run.identities, &run.node_surrogates])
+            .find(|record| record.name == name)
+            .ok_or_else(|| storage_err("retained construction run is absent"))?;
+        let mut file = self.open_retained_file(record)?;
+        let identity = graphforge_filesystem::file_identity(&file).map_err(storage_err)?;
+        let expected_bytes =
+            record
+                .count
+                .saturating_mul(if record.name.starts_with("identities-") {
+                    IDENTITY_RECORD_BYTES
+                } else {
+                    NODE_LOOKUP_RECORD_BYTES
+                });
+        file.seek(SeekFrom::Start(0)).map_err(storage_err)?;
+        let mut digest = Sha256::new();
+        let mut actual_bytes = 0_u64;
+        let mut block = vec![0_u8; BULK_IO_BYTES];
+        loop {
+            let count = file.read(&mut block).map_err(storage_err)?;
+            if count == 0 {
+                break;
+            }
+            digest.update(&block[..count]);
+            actual_bytes = actual_bytes.saturating_add(count as u64);
+        }
+        if identity.volume_serial != source_volume
+            || hex_bytes(&identity.file_id) != source_file_id
+            || bytes != expected_bytes
+            || actual_bytes != expected_bytes
+            || sha256 != record.sha256
+            || hex_bytes(&digest.finalize()) != record.sha256
+        {
+            return Err(storage_err(format!(
+                "retained construction reference changed: volume={} expected_volume={} file_id={} expected_file_id={} bytes={} expected_bytes={} reference_sha={} manifest_sha={}",
+                identity.volume_serial,
+                source_volume,
+                hex_bytes(&identity.file_id),
+                source_file_id,
+                actual_bytes,
+                expected_bytes,
+                sha256,
+                record.sha256
+            )));
+        }
+        self.revalidate()
     }
 
     pub(crate) fn open_at_generation(project_dir: &Path, generation: u64) -> Result<Self, GfError> {
@@ -1394,6 +1481,7 @@ impl AuthenticatedUuidIndexSnapshot {
 pub(crate) fn encode_construction_index(
     source: &graphforge_filesystem::StableDirectory,
     identities_name: &str,
+    identities_sha256: &str,
     encoded: &graphforge_filesystem::StableDirectory,
     generation: u64,
     parent_generation: u64,
@@ -1410,6 +1498,7 @@ pub(crate) fn encode_construction_index(
     let result = encode_construction_index_inner(
         source,
         identities_name,
+        identities_sha256,
         encoded,
         generation,
         parent_generation,
@@ -1436,6 +1525,7 @@ pub(crate) fn encode_construction_index(
 fn encode_construction_index_inner(
     source: &graphforge_filesystem::StableDirectory,
     identities_name: &str,
+    identities_sha256: &str,
     encoded: &graphforge_filesystem::StableDirectory,
     generation: u64,
     parent_generation: u64,
@@ -1501,6 +1591,7 @@ fn encode_construction_index_inner(
         source_volume: source_identity.volume_serial,
         source_file_id: source_file_id.clone(),
         source_bytes: input_len,
+        source_sha256: identities_sha256.to_owned(),
         authority_sha256: String::new(),
     };
     intent.authority_sha256 = construction_intent_digest(
@@ -1511,6 +1602,7 @@ fn encode_construction_index_inner(
         intent.source_volume,
         &intent.source_file_id,
         intent.source_bytes,
+        &intent.source_sha256,
     );
     write_construction_intent(&index, &intent, &mut work)?;
     crate::graph_construction::construction_failpoint("uuid_encode.after_intent");
@@ -1535,6 +1627,7 @@ fn encode_construction_index_inner(
     let mut previous_surrogate = 0_u64;
     let mut node_count = 0_u64;
     let mut edge_count = 0_u64;
+    let mut source_digest = Sha256::new();
     let mut remaining = input_len;
     while remaining != 0 {
         if cancelled() {
@@ -1545,6 +1638,7 @@ fn encode_construction_index_inner(
         input
             .read_exact(&mut input_block[..count])
             .map_err(storage_err)?;
+        source_digest.update(&input_block[..count]);
         work.read_bytes = work.read_bytes.saturating_add(count as u64);
         work.read_operations = work.read_operations.saturating_add(1);
         for record in input_block[..count].chunks_exact_mut(IDENTITY_RECORD_WIDTH) {
@@ -1593,6 +1687,9 @@ fn encode_construction_index_inner(
         work.write_bytes = work.write_bytes.saturating_add(count as u64);
         work.write_operations = work.write_operations.saturating_add(1);
         remaining -= count as u64;
+    }
+    if hex_bytes(&source_digest.finalize()) != identities_sha256 {
+        return Err(storage_err("construction identity source digest changed"));
     }
     if !surrogate_block.is_empty() {
         surrogate_writer
@@ -1745,6 +1842,7 @@ fn encode_construction_index_inner(
     artifacts
         .retain(|artifact| artifact.name == MANIFEST || retained_names.contains(&artifact.name));
     artifacts.sort_unstable_by(|left, right| left.name.cmp(&right.name));
+    let final_write_bytes = artifacts.iter().map(|artifact| artifact.bytes).sum();
     let mut retained_references = Vec::new();
     let locally_owned = artifacts
         .iter()
@@ -1794,6 +1892,7 @@ fn encode_construction_index_inner(
         input_records: node_count.saturating_add(edge_count),
         read_bytes: work.read_bytes,
         read_operations: work.read_operations,
+        final_write_bytes,
         write_bytes: work.write_bytes,
         write_operations: work.write_operations,
         fsync_operations: work.fsync_operations,
@@ -5392,9 +5491,12 @@ mod tests {
             drop(input);
             let source = graphforge_filesystem::StableDirectory::open(source_dir.path()).unwrap();
             let encoded = graphforge_filesystem::StableDirectory::open(encoded_dir.path()).unwrap();
+            let source_sha256 =
+                hex_sha256(&fs::read(source_dir.path().join("identities.run")).unwrap());
             let result = encode_construction_index(
                 &source,
                 "identities.run",
+                &source_sha256,
                 &encoded,
                 1,
                 0,

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -1537,10 +1537,10 @@ fn encode_construction_index_inner(
     let graph = encoded
         .create_child_directory(std::ffi::OsStr::new("graph"))
         .map_err(storage_err)?;
-    let cache = graph
-        .create_child_directory(std::ffi::OsStr::new(".graphforge-cache"))
+    let topology = graph
+        .create_child_directory(std::ffi::OsStr::new("topology"))
         .map_err(storage_err)?;
-    let index = cache
+    let index = topology
         .create_child_directory(std::ffi::OsStr::new("uuid-membership"))
         .map_err(storage_err)?;
     let mut manifest = if parent_generation == 0 {
@@ -1882,7 +1882,7 @@ fn encode_construction_index_inner(
         .map_err(storage_err)?;
     crate::graph_construction::construction_failpoint("uuid_encode.after_intent_removal");
     index.sync().map_err(storage_err)?;
-    cache.sync().map_err(storage_err)?;
+    topology.sync().map_err(storage_err)?;
     graph.sync().map_err(storage_err)?;
     encoded.sync().map_err(storage_err)?;
     work.fsync_operations = work.fsync_operations.saturating_add(4);
@@ -1912,12 +1912,12 @@ fn cleanup_private_construction_index(
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(error) => return Err(storage_err(error)),
     };
-    let cache = match graph.open_child_directory(std::ffi::OsStr::new(".graphforge-cache")) {
+    let topology = match graph.open_child_directory(std::ffi::OsStr::new("topology")) {
         Ok(value) => value,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(error) => return Err(storage_err(error)),
     };
-    let index = match cache.open_child_directory(std::ffi::OsStr::new("uuid-membership")) {
+    let index = match topology.open_child_directory(std::ffi::OsStr::new("uuid-membership")) {
         Ok(value) => value,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(error) => return Err(storage_err(error)),
@@ -1963,7 +1963,7 @@ fn cleanup_private_construction_index(
             .map_err(storage_err)?;
     }
     index.sync().map_err(storage_err)?;
-    cache.sync().map_err(storage_err)?;
+    topology.sync().map_err(storage_err)?;
     graph.sync().map_err(storage_err)?;
     encoded.sync().map_err(storage_err)
 }

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -587,6 +587,7 @@ pub struct AuthenticatedUuidIndexSnapshot {
     authenticated_bytes: u64,
     authenticated_blocks: u64,
     cas_source_paths: Option<BTreeMap<String, (String, String, u64)>>,
+    _cas_leases: Vec<crate::graph_object_store::AuthenticatedGraphObject>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1276,6 +1277,7 @@ impl AuthenticatedUuidIndexSnapshot {
             authenticated_bytes,
             authenticated_blocks,
             cas_source_paths: None,
+            _cas_leases: Vec::new(),
         })
     }
 
@@ -1300,14 +1302,15 @@ impl AuthenticatedUuidIndexSnapshot {
             .iter()
             .find(|entry| entry.relative_path == manifest_path)
             .ok_or_else(|| storage_err("compact UUID manifest is absent"))?;
-        let mut manifest_file = crate::graph_object_store::open_graph_object_by_digest(
+        let mut manifest_lease = crate::graph_object_store::open_graph_object_by_digest(
             container_root,
             &manifest_entry.content_sha256,
             manifest_entry.byte_length,
         )?;
         let manifest_identity =
-            graphforge_filesystem::file_identity(&manifest_file).map_err(storage_err)?;
-        let body = read_bounded(&mut manifest_file, MAX_MANIFEST_BYTES)?;
+            graphforge_filesystem::file_identity(manifest_lease.as_ref()).map_err(storage_err)?;
+        let body = read_bounded(&mut manifest_lease, MAX_MANIFEST_BYTES)?;
+        let manifest_file = manifest_lease.try_clone_file().map_err(storage_err)?;
         let manifest_sha256 = hex_sha256(&body);
         let manifest: Manifest = serde_json::from_slice(&body).map_err(storage_err)?;
         if manifest.format_version != FORMAT_VERSION || manifest.current_generation != generation {
@@ -1332,6 +1335,7 @@ impl AuthenticatedUuidIndexSnapshot {
                 manifest_entry.byte_length,
             ),
         );
+        let mut cas_leases = vec![manifest_lease];
         let mut authenticated_bytes = body.len() as u64;
         let mut authenticated_blocks = 1_u64;
         for descriptor in &manifest.runs {
@@ -1347,7 +1351,7 @@ impl AuthenticatedUuidIndexSnapshot {
                 {
                     return Err(storage_err("compact UUID run authority changed"));
                 }
-                let file = crate::graph_object_store::open_graph_object_by_digest(
+                let lease = crate::graph_object_store::open_graph_object_by_digest(
                     container_root,
                     &entry.content_sha256,
                     entry.byte_length,
@@ -1362,6 +1366,8 @@ impl AuthenticatedUuidIndexSnapshot {
                     record.name.clone(),
                     (relative, entry.content_sha256.clone(), entry.byte_length),
                 );
+                let file = lease.try_clone_file().map_err(storage_err)?;
+                cas_leases.push(lease);
                 Ok(file)
             };
             let identities = open_record(&descriptor.identities, IDENTITY_RECORD_BYTES)?;
@@ -1409,6 +1415,7 @@ impl AuthenticatedUuidIndexSnapshot {
             authenticated_bytes,
             authenticated_blocks,
             cas_source_paths: Some(paths),
+            _cas_leases: cas_leases,
         })
     }
 
@@ -1442,17 +1449,17 @@ impl AuthenticatedUuidIndexSnapshot {
             let (_, manifest_digest, manifest_length) = objects
                 .get(MANIFEST)
                 .ok_or_else(|| storage_err("compact UUID manifest authority is absent"))?;
-            let mut manifest = crate::graph_object_store::open_graph_object_by_digest(
+            let mut manifest_lease = crate::graph_object_store::open_graph_object_by_digest(
                 &self.graph_root_path,
                 manifest_digest,
                 *manifest_length,
             )?;
-            if graphforge_filesystem::file_identity(&manifest).map_err(storage_err)?
+            if graphforge_filesystem::file_identity(manifest_lease.as_ref()).map_err(storage_err)?
                 != self.manifest_identity
             {
                 return Err(storage_err("compact UUID manifest identity changed"));
             }
-            let body = read_bounded(&mut manifest, MAX_MANIFEST_BYTES)?;
+            let body = read_bounded(&mut manifest_lease, MAX_MANIFEST_BYTES)?;
             if hex_sha256(&body) != self.manifest_sha256
                 || serde_json::from_slice::<Manifest>(&body).map_err(storage_err)? != self.manifest
             {
@@ -1474,7 +1481,8 @@ impl AuthenticatedUuidIndexSnapshot {
                         digest,
                         *length,
                     )?;
-                    if graphforge_filesystem::file_identity(&file).map_err(storage_err)? != identity
+                    if graphforge_filesystem::file_identity(file.as_ref()).map_err(storage_err)?
+                        != identity
                     {
                         return Err(storage_err("compact UUID run identity changed"));
                     }
@@ -4000,8 +4008,9 @@ fn topology_delta_sha256(
     encoded
 }
 
-fn read_bounded(file: &mut File, maximum: u64) -> Result<Vec<u8>, GfError> {
-    let length = file.metadata().map_err(storage_err)?.len();
+fn read_bounded(file: &mut (impl Read + Seek), maximum: u64) -> Result<Vec<u8>, GfError> {
+    let length = file.seek(SeekFrom::End(0)).map_err(storage_err)?;
+    file.seek(SeekFrom::Start(0)).map_err(storage_err)?;
     if length > maximum {
         return Err(storage_err("recovery control record exceeds size limit"));
     }

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -608,11 +608,22 @@ pub(crate) struct UuidConstructionSnapshot {
     manifest_file: File,
     manifest_identity: graphforge_filesystem::FileIdentity,
     manifest_sha256: String,
+    manifest_bytes: u64,
     manifest: Manifest,
     named_files: Vec<(String, graphforge_filesystem::FileIdentity)>,
+    payload_consumed: bool,
 }
 
 impl UuidConstructionSnapshot {
+    pub(crate) fn declared_work(&self, max_node_surrogate: u64) -> UuidConstructionSnapshotWork {
+        UuidConstructionSnapshotWork {
+            live_nodes: self.manifest.live_node_count,
+            live_edges: self.manifest.live_edge_count,
+            max_node_surrogate,
+            ..Default::default()
+        }
+    }
+
     pub(crate) fn revalidate(&self) -> Result<(), GfError> {
         self.root.revalidate_named().map_err(storage_err)?;
         if self.root.identity() != self.root_identity
@@ -647,6 +658,123 @@ impl UuidConstructionSnapshot {
             }
         }
         Ok(())
+    }
+
+    /// Authenticate each retained payload block exactly once and emit the live
+    /// identity domain as a bounded UUID-ordered stream.
+    pub(crate) fn stream_authenticated(
+        &mut self,
+        mut emit: impl FnMut(ConstructionUuidIdentity) -> Result<(), GfError>,
+    ) -> Result<UuidConstructionSnapshotWork, GfError> {
+        if self.payload_consumed {
+            return Err(storage_err(
+                "construction UUID payload was already consumed",
+            ));
+        }
+        self.revalidate()?;
+        let mut identity_cursors = Vec::with_capacity(self.manifest.runs.len());
+        let mut work = UuidConstructionSnapshotWork {
+            authentication_bytes: self.manifest_bytes,
+            authentication_blocks: 1,
+            ..Default::default()
+        };
+        for run in &self.manifest.runs {
+            let identities = self
+                .root
+                .open_child_file(std::ffi::OsStr::new(&run.identities.name))
+                .map_err(storage_err)?;
+            identity_cursors.push(ConstructionRunCursor::new(
+                identities,
+                run.identities.clone(),
+                IDENTITY_RECORD_WIDTH,
+            ));
+            let surrogates = self
+                .root
+                .open_child_file(std::ffi::OsStr::new(&run.node_surrogates.name))
+                .map_err(storage_err)?;
+            let mut cursor = ConstructionRunCursor::new(
+                surrogates,
+                run.node_surrogates.clone(),
+                NODE_LOOKUP_RECORD_WIDTH,
+            );
+            while cursor.next_record()?.is_some() {}
+            work.authentication_bytes = work.authentication_bytes.saturating_add(cursor.bytes);
+            work.authentication_blocks = work.authentication_blocks.saturating_add(cursor.blocks);
+        }
+        let mut heads = identity_cursors
+            .iter_mut()
+            .map(ConstructionRunCursor::next_record)
+            .collect::<Result<Vec<_>, _>>()?;
+        loop {
+            let Some(next_uuid) = heads
+                .iter()
+                .flatten()
+                .map(|record| &record[..16])
+                .min()
+                .map(<[u8]>::to_vec)
+            else {
+                break;
+            };
+            let indexes = heads
+                .iter()
+                .enumerate()
+                .filter_map(|(index, record)| {
+                    record
+                        .as_ref()
+                        .is_some_and(|record| record[..16] == next_uuid)
+                        .then_some(index)
+                })
+                .collect::<Vec<_>>();
+            let selected = *indexes
+                .iter()
+                .max_by_key(|index| self.manifest.runs[**index].last_generation)
+                .expect("one UUID head was selected");
+            let record = heads[selected].as_ref().expect("selected head exists");
+            let kind = record[16];
+            if !matches!(kind, 0..=3) || record[17..24].iter().any(|byte| *byte != 0) {
+                return Err(storage_err(
+                    "construction UUID identity record is malformed",
+                ));
+            }
+            if matches!(kind, 0 | 1) {
+                let identity = ConstructionUuidIdentity {
+                    uuid: Uuid::from_bytes(record[..16].try_into().expect("fixed UUID width")),
+                    kind: if kind == 0 {
+                        UuidIndexKind::Node
+                    } else {
+                        UuidIndexKind::Edge
+                    },
+                    surrogate: u64::from_be_bytes(record[24..32].try_into().expect("fixed")),
+                };
+                if identity.kind == UuidIndexKind::Node {
+                    if identity.surrogate == 0 {
+                        return Err(storage_err("live node has zero surrogate"));
+                    }
+                    work.live_nodes = work.live_nodes.saturating_add(1);
+                    work.max_node_surrogate = work.max_node_surrogate.max(identity.surrogate);
+                } else {
+                    work.live_edges = work.live_edges.saturating_add(1);
+                }
+                emit(identity)?;
+            }
+            for index in indexes {
+                heads[index] = identity_cursors[index].next_record()?;
+            }
+        }
+        for cursor in &identity_cursors {
+            work.authentication_bytes = work.authentication_bytes.saturating_add(cursor.bytes);
+            work.authentication_blocks = work.authentication_blocks.saturating_add(cursor.blocks);
+        }
+        if work.live_nodes != self.manifest.live_node_count
+            || work.live_edges != self.manifest.live_edge_count
+        {
+            return Err(storage_err(
+                "construction UUID live counts differ from manifest",
+            ));
+        }
+        self.payload_consumed = true;
+        self.revalidate()?;
+        Ok(work)
     }
 }
 
@@ -736,11 +864,24 @@ impl ConstructionRunCursor {
 /// Authenticate each retained UUID byte once and emit the live identity set in
 /// UUID order. The returned token revalidates inode/name authority without
 /// rereading retained payload bytes.
+#[cfg(test)]
 pub(crate) fn open_uuid_construction_snapshot(
     project_dir: &Path,
     generation: u64,
-    mut emit: impl FnMut(ConstructionUuidIdentity) -> Result<(), GfError>,
+    emit: impl FnMut(ConstructionUuidIdentity) -> Result<(), GfError>,
 ) -> Result<(UuidConstructionSnapshot, UuidConstructionSnapshotWork), GfError> {
+    let mut token = pin_uuid_construction_snapshot(project_dir, generation)?;
+    let work = token.stream_authenticated(emit)?;
+    Ok((token, work))
+}
+
+/// Pin the generation's manifest and every run inode without reading retained
+/// payload bytes.  The caller later consumes those bytes exactly once through
+/// [`UuidConstructionSnapshot::stream_authenticated`].
+pub(crate) fn pin_uuid_construction_snapshot(
+    project_dir: &Path,
+    generation: u64,
+) -> Result<UuidConstructionSnapshot, GfError> {
     let root = graphforge_filesystem::StableDirectory::open(&project_dir.join(INDEX_DIR))
         .map_err(storage_err)?;
     let root_identity = root.identity();
@@ -759,12 +900,6 @@ pub(crate) fn open_uuid_construction_snapshot(
     }
     validate_run_descriptors(&manifest)?;
     let mut named_files = Vec::with_capacity(manifest.runs.len().saturating_mul(2));
-    let mut identity_cursors = Vec::with_capacity(manifest.runs.len());
-    let mut work = UuidConstructionSnapshotWork {
-        authentication_bytes: body.len() as u64,
-        authentication_blocks: 1,
-        ..Default::default()
-    };
     for run in &manifest.runs {
         let identities = root
             .open_child_file(std::ffi::OsStr::new(&run.identities.name))
@@ -776,11 +911,6 @@ pub(crate) fn open_uuid_construction_snapshot(
             ));
         }
         named_files.push((run.identities.name.clone(), identity));
-        identity_cursors.push(ConstructionRunCursor::new(
-            identities,
-            run.identities.clone(),
-            IDENTITY_RECORD_WIDTH,
-        ));
 
         let surrogates = root
             .open_child_file(std::ffi::OsStr::new(&run.node_surrogates.name))
@@ -793,84 +923,6 @@ pub(crate) fn open_uuid_construction_snapshot(
             ));
         }
         named_files.push((run.node_surrogates.name.clone(), surrogate_identity));
-        let mut cursor = ConstructionRunCursor::new(
-            surrogates,
-            run.node_surrogates.clone(),
-            NODE_LOOKUP_RECORD_WIDTH,
-        );
-        while cursor.next_record()?.is_some() {}
-        work.authentication_bytes = work.authentication_bytes.saturating_add(cursor.bytes);
-        work.authentication_blocks = work.authentication_blocks.saturating_add(cursor.blocks);
-    }
-
-    let mut heads = identity_cursors
-        .iter_mut()
-        .map(ConstructionRunCursor::next_record)
-        .collect::<Result<Vec<_>, _>>()?;
-    loop {
-        let Some(next_uuid) = heads
-            .iter()
-            .flatten()
-            .map(|record| &record[..16])
-            .min()
-            .map(<[u8]>::to_vec)
-        else {
-            break;
-        };
-        let indexes = heads
-            .iter()
-            .enumerate()
-            .filter_map(|(index, record)| {
-                record
-                    .as_ref()
-                    .is_some_and(|record| record[..16] == next_uuid)
-                    .then_some(index)
-            })
-            .collect::<Vec<_>>();
-        let selected = *indexes
-            .iter()
-            .max_by_key(|index| manifest.runs[**index].last_generation)
-            .expect("one UUID head was selected");
-        let record = heads[selected].as_ref().expect("selected head exists");
-        let kind = record[16];
-        if !matches!(kind, 0..=3) || record[17..24].iter().any(|byte| *byte != 0) {
-            return Err(storage_err(
-                "construction UUID identity record is malformed",
-            ));
-        }
-        if matches!(kind, 0 | 1) {
-            let identity = ConstructionUuidIdentity {
-                uuid: Uuid::from_bytes(record[..16].try_into().expect("fixed UUID width")),
-                kind: if kind == 0 {
-                    UuidIndexKind::Node
-                } else {
-                    UuidIndexKind::Edge
-                },
-                surrogate: u64::from_be_bytes(record[24..32].try_into().expect("fixed")),
-            };
-            if identity.kind == UuidIndexKind::Node {
-                if identity.surrogate == 0 {
-                    return Err(storage_err("live node has zero surrogate"));
-                }
-                work.live_nodes = work.live_nodes.saturating_add(1);
-                work.max_node_surrogate = work.max_node_surrogate.max(identity.surrogate);
-            } else {
-                work.live_edges = work.live_edges.saturating_add(1);
-            }
-            emit(identity)?;
-        }
-        for index in indexes {
-            heads[index] = identity_cursors[index].next_record()?;
-        }
-    }
-    for cursor in &identity_cursors {
-        work.authentication_bytes = work.authentication_bytes.saturating_add(cursor.bytes);
-        work.authentication_blocks = work.authentication_blocks.saturating_add(cursor.blocks);
-    }
-    if work.live_nodes != manifest.live_node_count || work.live_edges != manifest.live_edge_count {
-        return Err(storage_err(
-            "construction UUID live counts differ from manifest",
-        ));
     }
     root.revalidate_named().map_err(storage_err)?;
     let token = UuidConstructionSnapshot {
@@ -879,11 +931,13 @@ pub(crate) fn open_uuid_construction_snapshot(
         manifest_file,
         manifest_identity,
         manifest_sha256,
+        manifest_bytes: body.len() as u64,
         manifest,
         named_files,
+        payload_consumed: false,
     };
     token.revalidate()?;
-    Ok((token, work))
+    Ok(token)
 }
 
 impl AuthenticatedUuidIndexSnapshot {

--- a/crates/graphforge-storage/src/writer.rs
+++ b/crates/graphforge-storage/src/writer.rs
@@ -92,7 +92,7 @@ fn surrogate_tails_schema() -> SchemaRef {
     ]))
 }
 
-fn read_surrogate_tails(dir: &Path) -> Result<Option<(u64, u64)>, GfError> {
+pub(crate) fn read_surrogate_tails(dir: &Path) -> Result<Option<(u64, u64)>, GfError> {
     use arrow::array::Array;
 
     let path = dir.join(SURROGATE_TAILS_FILE);

--- a/crates/graphforge-storage/src/writer.rs
+++ b/crates/graphforge-storage/src/writer.rs
@@ -102,7 +102,10 @@ pub(crate) fn read_surrogate_tails(dir: &Path) -> Result<Option<(u64, u64)>, GfE
     read_surrogate_tails_file(input).map(Some)
 }
 
-pub(crate) fn read_surrogate_tails_file(input: fs::File) -> Result<(u64, u64), GfError> {
+pub(crate) fn read_surrogate_tails_file<R>(input: R) -> Result<(u64, u64), GfError>
+where
+    R: parquet::file::reader::ChunkReader + 'static,
+{
     use arrow::array::Array;
 
     let mut reader = ParquetRecordBatchReaderBuilder::try_new(input)

--- a/crates/graphforge-storage/src/writer.rs
+++ b/crates/graphforge-storage/src/writer.rs
@@ -93,14 +93,18 @@ fn surrogate_tails_schema() -> SchemaRef {
 }
 
 pub(crate) fn read_surrogate_tails(dir: &Path) -> Result<Option<(u64, u64)>, GfError> {
-    use arrow::array::Array;
-
     let path = dir.join(SURROGATE_TAILS_FILE);
     let input = match fs::File::open(&path) {
         Ok(input) => input,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => return Err(io_err(&error)),
     };
+    read_surrogate_tails_file(input).map(Some)
+}
+
+pub(crate) fn read_surrogate_tails_file(input: fs::File) -> Result<(u64, u64), GfError> {
+    use arrow::array::Array;
+
     let mut reader = ParquetRecordBatchReaderBuilder::try_new(input)
         .map_err(pq_err)?
         .with_batch_size(2)
@@ -125,7 +129,7 @@ pub(crate) fn read_surrogate_tails(dir: &Path) -> Result<Option<(u64, u64)>, GfE
         }
         Ok(column.value(0))
     };
-    Ok(Some((value("max_node_id")?, value("max_edge_id")?)))
+    Ok((value("max_node_id")?, value("max_edge_id")?))
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/adr/0020-ntfs-write-through-namespace-durability.md
+++ b/docs/adr/0020-ntfs-write-through-namespace-durability.md
@@ -42,7 +42,11 @@ replacement, and deterministic reconciliation without weakening
 GraphForge supports Windows durability only on fixed, writable local **NTFS**
 volumes whose storage stack honestly honors write-through completion. ReFS is
 stable unsupported/unproven and returns `GF_UNSUPPORTED_FILESYSTEM` before the
-project root is mutated.
+project root is mutated. The supported OS floor is Windows 10 version 1709 or
+Windows Server version 1709 because readonly-safe retained-handle deletion uses
+`FileDispositionInfoEx` with `FILE_DISPOSITION_FLAG_IGNORE_READONLY_ATTRIBUTE`.
+Older implementations fail with an actionable unsupported-platform error;
+GraphForge never clears a readonly attribute shared by a published hard link.
 
 For each probed file publication, GraphForge:
 

--- a/docs/development/g500-certification.md
+++ b/docs/development/g500-certification.md
@@ -93,6 +93,14 @@ finalization recovers only the last acknowledged durable generation. No partial
 candidate may be addressable, and the last complete atomic journal entry remains
 valid.
 
+Bounded ingest uses one public `GraphConstructionSession`: its opaque session
+UUID is durably recorded before the first node chunk, recovery resumes that
+exact session, nodes precede edges, and `seal_and_publish` is invoked once after
+all chunks. Phase evidence records RSS, elapsed time, disk bytes, immutable
+shards, accepted rows/batches, writes, and authentication reads. Adjacent
+1x/2x/4x observations must show bounded resident windows and topology work that
+scales with rows; continued material RSS growth with edge count is a failure.
+
 Fingerprint reconciliation is explicit: source and imported durable generation
 IDs are distinct; semantic package and transport digests are distinct;
 ontology/capability authority fingerprints match; canonical source/imported

--- a/docs/development/perf-g500-ladder.md
+++ b/docs/development/perf-g500-ladder.md
@@ -18,7 +18,7 @@ edges.
 | Pinned `github.com/graph500/graph500` generator | No — bounded bench-local Kronecker in the test file |
 | Graph500 BFS kernel / harmonic-mean TEPS | Non-goal (`teps` is `null`) |
 | One-billion-live-edge product certification | No — that is #745 |
-| Engineering green (generate → ingest → reopen → GSI → `LIMIT 1000`) | Yes, on `GraphForge::publish_bulk_*` + `execute` |
+| Engineering green (generate → ingest → reopen → GSI → `LIMIT 1000`) | Yes, through one resumable `GraphConstructionSession` + `execute` |
 
 ## What is new versus the #710 SCALE-20 client
 
@@ -34,8 +34,10 @@ This ladder replaces that with **external sort + spill + k-way merge**:
 3. K-way merge the sorted runs, emitting each unique undirected pair once.
 
 Peak resident edges never exceed `buffer_edges`, **independent of total edge
-count**. Live edges stream straight into `publish_bulk_edges` during the merge,
-so ingest is bounded too.
+count**. Nodes and merged live edges are appended as bounded Arrow chunks to
+one disk-owned construction session. Its opaque UUID is fsynced before append,
+so an interrupted rung resumes the same session; publication performs exactly
+one `CURRENT` transition after all chunks are sealed.
 
 ## Counts always reconcile
 
@@ -107,17 +109,16 @@ stops — no larger rung is attempted and no SCALE-26 pass is claimed.
 > (`vmhwm` | `ps_sampled`) so a `ps_sampled` value is read as a floor. Run
 > provisioned certification rungs on **Linux**.
 
-> Ingest-phase attribution: `publish_bulk_nodes` / `publish_bulk_edges` retain
-> request-sized normalization, identity, endpoint, writer, delta, and receipt
-> state. Existing fixed-schema Parquet is copied through bounded 64K-row batches,
-> and writer reopen reads only final row-group surrogate tails; neither operation
-> materializes accumulated topology. While ingest runs, the atomic journal is
+> Ingest-phase attribution: construction writes bounded node and edge Arrow
+> windows into immutable Parquet shards and retains only bounded merge/probe
+> state; accumulated topology remains disk-owned. While ingest runs, the atomic journal is
 > refreshed every two seconds with the current subphase, edge-chunk index,
 > anonymous/file RSS, disk usage, and aggregate topology rewrite counters. An
 > `oom` with `first_failing_phase: "ingest"` therefore remains an upstream
-> publication failure, not a generator-memory regression. Append-only linear-I/O
-> construction is tracked separately by #901 and remains required before the
-> billion-edge close gate.
+> construction failure, not a generator-memory regression. Each completed
+> ingest phase records elapsed time, RSS, disk bytes, shard count, input rows,
+> batches, writes, and authentication reads so 1x/2x/4x observations can test
+> bounded memory and linear topology work directly.
 
 ## Commands
 

--- a/docs/development/perf-g500-ladder.md
+++ b/docs/development/perf-g500-ladder.md
@@ -109,6 +109,12 @@ stops — no larger rung is attempted and no SCALE-26 pass is claimed.
 > (`vmhwm` | `ps_sampled`) so a `ps_sampled` value is read as a floor. Run
 > provisioned certification rungs on **Linux**.
 
+Provisioned runs must set `GF_G500_LADDER_WORKSPACE` to a stable run directory.
+If omitted, the runner derives `workspace/<rung>` beside
+`GF_G500_LADDER_JOURNAL_OUT`; it refuses a provisioned rung when neither path is
+available. The fsynced opaque construction-session UUID and spill/project state
+therefore survive process replacement and are reused on re-entry.
+
 > Ingest-phase attribution: construction writes bounded node and edge Arrow
 > windows into immutable Parquet shards and retains only bounded merge/probe
 > state; accumulated topology remains disk-owned. While ingest runs, the atomic journal is

--- a/scripts/ci/test-non-cypher-surface-gate.py
+++ b/scripts/ci/test-non-cypher-surface-gate.py
@@ -29,7 +29,7 @@ class SurfaceGateTests(unittest.TestCase):
 
     def test_checked_in_inventory_is_complete(self) -> None:
         self.assertEqual(GATE.validate(), [])
-        self.assertEqual(len(GATE.public_methods()), 362)
+        self.assertEqual(len(GATE.public_methods()), 369)
         self.assertEqual(len(GATE.algorithm_registry()), 94)
 
     def test_new_or_removed_public_method_fails_frozen_digest(self) -> None:

--- a/scripts/ci/test-non-cypher-surface-gate.py
+++ b/scripts/ci/test-non-cypher-surface-gate.py
@@ -29,7 +29,7 @@ class SurfaceGateTests(unittest.TestCase):
 
     def test_checked_in_inventory_is_complete(self) -> None:
         self.assertEqual(GATE.validate(), [])
-        self.assertEqual(len(GATE.public_methods()), 369)
+        self.assertEqual(len(GATE.public_methods()), 372)
         self.assertEqual(len(GATE.algorithm_registry()), 94)
 
     def test_new_or_removed_public_method_fails_frozen_digest(self) -> None:

--- a/tests/contracts/non-cypher-rust-surface.json
+++ b/tests/contracts/non-cypher-rust-surface.json
@@ -1,7 +1,7 @@
 {
   "contract_version": 1,
   "scope": "Rust non-Cypher public release surface",
-  "public_method_digest": "f95b7cb7b6612d357fa4a9e9df165ff684910e93f3a48df46e997bae6a60ba64",
+  "public_method_digest": "71c92e47b6e43da553be7288724d522e303da5d4677e60f51e7ea8d9f8a41b99",
   "method_policy": {
     "receiver_defaults": {
       "GraphForge": "release-tested",
@@ -294,13 +294,20 @@
       "ids": [
         "GraphConstructionSession.abort",
         "GraphConstructionSession.append_edges",
+        "GraphConstructionSession.append_edges_with_cancellation",
         "GraphConstructionSession.append_nodes",
+        "GraphConstructionSession.append_nodes_with_cancellation",
         "GraphConstructionSession.progress",
         "GraphConstructionSession.seal_and_publish",
+        "GraphConstructionSession.seal_and_publish_with_cancellation",
         "GraphForge.begin_graph_construction",
         "GraphForge.resume_graph_construction"
       ],
       "test_refs": [
+        {
+          "path": "crates/graphforge-api/src/resumable_construction.rs",
+          "symbol": "cancelled_public_construction_preserves_current"
+        },
         {
           "path": "crates/graphforge-api/src/resumable_construction.rs",
           "symbol": "graphforge_multi_chunk_construction_publishes_once_and_reopens"

--- a/tests/contracts/non-cypher-rust-surface.json
+++ b/tests/contracts/non-cypher-rust-surface.json
@@ -304,6 +304,14 @@
         {
           "path": "crates/graphforge-api/src/resumable_construction.rs",
           "symbol": "graphforge_multi_chunk_construction_publishes_once_and_reopens"
+        },
+        {
+          "path": "crates/graphforge-api/src/resumable_construction.rs",
+          "symbol": "refresh_boundaries_preserve_the_prior_workspace_on_failure"
+        },
+        {
+          "path": "crates/graphforge-api/tests/resumable_construction_surface.rs",
+          "symbol": "construction_contract_is_nameable_from_graphforge_api_alone"
         }
       ]
     },

--- a/tests/contracts/non-cypher-rust-surface.json
+++ b/tests/contracts/non-cypher-rust-surface.json
@@ -1,11 +1,12 @@
 {
   "contract_version": 1,
   "scope": "Rust non-Cypher public release surface",
-  "public_method_digest": "2d86746c592716a79fe12cb5471f1c9b90ce8e91bfca772b19110cdfafa468d1",
+  "public_method_digest": "f95b7cb7b6612d357fa4a9e9df165ff684910e93f3a48df46e997bae6a60ba64",
   "method_policy": {
     "receiver_defaults": {
       "GraphForge": "release-tested",
       "GraphImportSession": "release-tested",
+      "GraphConstructionSession": "release-tested",
       "GraphTransaction": "introspection",
       "RepositoryContext": "designed-only",
       "crate": "release-tested",
@@ -286,6 +287,23 @@
         {
           "path": "crates/graphforge-api/src/checkpoint_graph_diff.rs",
           "symbol": "extracts_uuid_ordered_logical_nodes_and_edges_from_pinned_generation"
+        }
+      ]
+    },
+    "resumable-construction": {
+      "ids": [
+        "GraphConstructionSession.abort",
+        "GraphConstructionSession.append_edges",
+        "GraphConstructionSession.append_nodes",
+        "GraphConstructionSession.progress",
+        "GraphConstructionSession.seal_and_publish",
+        "GraphForge.begin_graph_construction",
+        "GraphForge.resume_graph_construction"
+      ],
+      "test_refs": [
+        {
+          "path": "crates/graphforge-api/src/resumable_construction.rs",
+          "symbol": "graphforge_multi_chunk_construction_publishes_once_and_reopens"
         }
       ]
     },

--- a/tools/bazel/parity/migration_target_map.json
+++ b/tools/bazel/parity/migration_target_map.json
@@ -1,7 +1,7 @@
 {
   "schema": "graphforge.bazel-migration-target-map.v1",
   "issue": 6,
-  "cargo_target_count": 120,
+  "cargo_target_count": 121,
   "targets": [
     {
       "package": "graphforge-api",
@@ -252,6 +252,16 @@
       "bazel_label": "//crates/graphforge-api:search_public_surface",
       "exception_id": null,
       "notes": "#8"
+    },
+    {
+      "package": "graphforge-api",
+      "target": "resumable_construction_surface",
+      "class": "integration-test",
+      "source": "crates/graphforge-api/tests/resumable_construction_surface.rs",
+      "status": "mapped",
+      "bazel_label": "//crates/graphforge-api:resumable_construction_surface",
+      "exception_id": null,
+      "notes": "#932 resumable graph construction public surface"
     },
     {
       "package": "graphforge-api",


### PR DESCRIPTION
Closes #932

## Summary

- add the ordinary public Rust `GraphConstructionSession` lifecycle for bounded, durable node/edge Arrow chunks, deterministic resume/replay, cancellation, and one compact generation publication
- route the Graph500 ladder through that public session with no bulk-publication escape hatch, stable cross-process recovery, and post-publication RSS/disk/I/O/work evidence
- make compact CAS generations interoperable with portable-v2 expanded and bundle export, verification, clean import, reopen, retry, and tamper detection
- preserve one authoritative `CURRENT`, exact catalog/UUID/counter identity, typed cancellation, and recovery at both pre- and post-publication interruption boundaries

## Verification

- `cargo test -p graphforge-api --test scale_g500_ladder` — 17 passed, 2 approved-host-only ignored
- storage/API focused construction, cancellation, CAS export, replay, and process re-entry regressions — passed
- `cargo clippy -p graphforge-storage -p graphforge-api -- -D warnings` — passed
- `python3 scripts/ci/test-non-cypher-surface-gate.py` — 12 passed
- `make pre-push-fast` — passed

The real provisioned S20/S22 certification artifacts remain the post-merge execution evidence required before closing the scale tracker; this PR supplies and verifies the public construction/lifecycle path that produces them.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790386422&installation_model_id=20486&pr_number=950&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F950&signature=9fa87cca9bf18bc13169b2f87739527e155ffacd9ce5804ae3f3d414119dded8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resumable graph construction with durable sessions, progress tracking, chunked node and edge uploads, cancellation, recovery, and safe abort.
  * Added idempotent generation sealing and publication with rollback protection.
  * Added authenticated graph-construction artifacts, UUID indexes, and support for CAS-backed portable exports.
* **Bug Fixes**
  * Standardized identifier validation, including Unicode names and the 255-byte limit.
  * Improved corruption detection, schema validation, and protection against unintended object modification.
* **Tests**
  * Expanded coverage for cancellation, recovery, replay, rollback, scaling, and cross-process session re-entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->