### PR TITLE
fix(storage): remove redundant authenticated construction passes

### DIFF
--- a/crates/graphforge-api/src/resumable_construction.rs
+++ b/crates/graphforge-api/src/resumable_construction.rs
@@ -235,15 +235,19 @@ impl GraphConstructionSession<'_> {
             token.checkpoint()?;
         }
         let _visibility = self.graph.graph_visibility.lock()?;
-        if self.inner.state() == GraphConstructionState::Staging {
-            self.inner.seal()?;
-        }
         let topology_generation = self.inner.parent_topology_generation().saturating_add(1);
-        let encoding = self
-            .inner
-            .prepare_canonical_encoding_with_cancellation(topology_generation, || {
-                cancellation.is_some_and(crate::CancellationToken::is_cancelled)
-            })?;
+        let encoding = if self.inner.state() == GraphConstructionState::Staging {
+            self.inner
+                .seal_and_prepare_canonical_encoding_with_cancellation(
+                    topology_generation,
+                    || cancellation.is_some_and(crate::CancellationToken::is_cancelled),
+                )?
+        } else {
+            self.inner
+                .prepare_canonical_encoding_with_cancellation(topology_generation, || {
+                    cancellation.is_some_and(crate::CancellationToken::is_cancelled)
+                })?
+        };
         if let Some(token) = cancellation {
             token.checkpoint()?;
         }
@@ -264,8 +268,13 @@ impl GraphConstructionSession<'_> {
                     "construction publication did not resolve its exact generation".into(),
                 ));
             }
-            let (prepared_dir, prepared_guard, _) =
+            let (prepared_dir, prepared_guard, hydration_evidence) =
                 super::hydrate_graph_workspace(&resolved, false)?;
+            self.inner.record_hydration_application_read_bytes(
+                hydration_evidence
+                    .bytes_validated
+                    .saturating_add(hydration_evidence.bytes_copied),
+            )?;
             let runtime_catalog = super::load_runtime_catalog(&prepared_dir)?;
             let property_inventory = std::sync::Arc::new(
                 graphforge_storage::AuthenticatedPropertyInventory::from_resolved_generation(
@@ -706,5 +715,85 @@ mod tests {
                 .generation_uuid(),
             child_receipt.generation_uuid
         );
+    }
+
+    #[test]
+    fn construction_application_reads_reconcile_and_scale_at_one_two_four() {
+        let mut observations = Vec::new();
+        for scale in [1_024_usize, 2_048, 4_096] {
+            let graph = GraphForge::new(None).unwrap();
+            let mut session = graph.begin_graph_construction(Default::default()).unwrap();
+            let ids = (0..scale).map(|_| Uuid::now_v7()).collect::<Vec<_>>();
+            session.append_nodes("nodes", &nodes(&ids)).unwrap();
+            session.seal_and_publish().unwrap();
+            let evidence = &session.progress().evidence;
+            assert_eq!(evidence.seal_application_read_bytes, 0);
+            assert!(evidence.shape_application_read_bytes > 0);
+            assert!(evidence.encode_application_read_bytes > 0);
+            assert!(evidence.publication_application_read_bytes > 0);
+            assert!(evidence.cas_application_read_bytes > 0);
+            assert!(evidence.hydration_application_read_bytes > 0);
+            let reconciled = evidence
+                .seal_application_read_bytes
+                .saturating_add(evidence.shape_application_read_bytes)
+                .saturating_add(evidence.encode_application_read_bytes)
+                .saturating_add(evidence.publication_application_read_bytes)
+                .saturating_add(evidence.cas_application_read_bytes)
+                .saturating_add(evidence.hydration_application_read_bytes);
+            assert_eq!(evidence.total_application_read_bytes(), reconciled);
+            let payload = evidence.write_bytes;
+            assert!(
+                payload > 100_000,
+                "fixture must dominate fixed control overhead"
+            );
+            for (phase, ceiling) in [
+                (evidence.shape_application_read_bytes, 24_u64),
+                (evidence.encode_application_read_bytes, 24),
+                (evidence.publication_application_read_bytes, 2),
+                (evidence.cas_application_read_bytes, 24),
+                (evidence.hydration_application_read_bytes, 24),
+                (reconciled, 80),
+            ] {
+                assert!(
+                    phase <= payload.saturating_mul(ceiling),
+                    "phase exceeded its fixed application bytes-per-staged-payload ceiling"
+                );
+            }
+            assert_eq!(
+                evidence.cas_application_read_bytes,
+                evidence.canonical_output_bytes
+            );
+            assert!(evidence.staged_and_retained_disk_bytes >= payload);
+            observations.push((
+                payload,
+                [
+                    evidence.shape_application_read_bytes,
+                    evidence.encode_application_read_bytes,
+                    evidence.cas_application_read_bytes,
+                    evidence.hydration_application_read_bytes,
+                    reconciled,
+                ],
+            ));
+        }
+        for adjacent in observations.windows(2) {
+            let (prior_payload, prior_phases) = adjacent[0];
+            let (next_payload, next_phases) = adjacent[1];
+            assert!(next_payload * 10 >= prior_payload * 17);
+            assert!(next_payload * 10 <= prior_payload * 23);
+            for (prior, next) in prior_phases.into_iter().zip(next_phases) {
+                assert!(
+                    next * 10 >= prior * 15,
+                    "payload-owned phase grew below 1.5x"
+                );
+                assert!(
+                    next * 10 <= prior * 25,
+                    "payload-owned phase grew above 2.5x"
+                );
+                let prior_normalized = prior.saturating_mul(1_000_000) / prior_payload;
+                let next_normalized = next.saturating_mul(1_000_000) / next_payload;
+                assert!(next_normalized * 2 >= prior_normalized);
+                assert!(next_normalized <= prior_normalized.saturating_mul(2));
+            }
+        }
     }
 }

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -303,6 +303,31 @@ enum ConstructionPublicationState {
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 /// Measured application I/O and bounded retained-window evidence.
 pub struct GraphConstructionEvidence {
+    /// All application-observed payload bytes read by the seal phase.
+    #[serde(default)]
+    pub seal_application_read_bytes: u64,
+    /// All application-observed payload bytes read by canonical shaping, including
+    /// authentication and merge consumption.
+    #[serde(default)]
+    pub shape_application_read_bytes: u64,
+    /// All application-observed shaped payload bytes read by canonical encoding.
+    #[serde(default)]
+    pub encode_application_read_bytes: u64,
+    /// Application-observed durable control bytes read immediately before publication.
+    #[serde(default)]
+    pub publication_application_read_bytes: u64,
+    /// Application-observed source or reused-object payload bytes read by CAS adoption.
+    #[serde(default)]
+    pub cas_application_read_bytes: u64,
+    /// Application-observed published payload bytes read while hydrating the workspace.
+    #[serde(default)]
+    pub hydration_application_read_bytes: u64,
+    /// New canonical graph payload bytes emitted by encoding.
+    #[serde(default)]
+    pub canonical_output_bytes: u64,
+    /// Staged artifact bytes plus structurally retained parent payload bytes.
+    #[serde(default)]
+    pub staged_and_retained_disk_bytes: u64,
     /// Rows accepted.
     pub input_rows: u64,
     /// Non-replay chunks accepted.
@@ -401,6 +426,19 @@ pub struct GraphConstructionEvidence {
     pub parquet_write_bytes: u64,
     /// Instrumented Parquet writer submissions in shaping.
     pub parquet_write_operations: u64,
+}
+
+impl GraphConstructionEvidence {
+    /// Reconciled application-observed payload/control bytes read across construction.
+    #[must_use]
+    pub const fn total_application_read_bytes(&self) -> u64 {
+        self.seal_application_read_bytes
+            .saturating_add(self.shape_application_read_bytes)
+            .saturating_add(self.encode_application_read_bytes)
+            .saturating_add(self.publication_application_read_bytes)
+            .saturating_add(self.cas_application_read_bytes)
+            .saturating_add(self.hydration_application_read_bytes)
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -871,7 +909,7 @@ impl GraphConstructionSession {
         {
             return Err(storage("only a sealed session can be encoded"));
         }
-        let completed = read_completed_shape(&self.root, &self.checkpoint)?
+        let completed = read_completed_shape(&self.root, &self.checkpoint, false)?
             .ok_or_else(|| storage("canonical shape is not complete"))?;
         if &completed != shape {
             return Err(storage("encoder input differs from completed shape"));
@@ -894,6 +932,25 @@ impl GraphConstructionSession {
             self.checkpoint.budgets,
             &mut cancelled,
         )?;
+        self.checkpoint.evidence.encode_application_read_bytes = self
+            .checkpoint
+            .evidence
+            .encode_application_read_bytes
+            .saturating_add(encoded.evidence.input_read_bytes)
+            .saturating_add(encoded.evidence.membership_read_bytes);
+        self.checkpoint.evidence.canonical_output_bytes = encoded
+            .artifacts
+            .iter()
+            .map(|artifact| artifact.bytes)
+            .sum();
+        self.checkpoint.evidence.staged_and_retained_disk_bytes =
+            self.checkpoint.evidence.write_bytes.saturating_add(
+                encoded
+                    .retained_artifacts
+                    .iter()
+                    .map(|artifact| artifact.bytes)
+                    .sum(),
+            );
         let inventory_authority =
             crate::graph_construction_encoding::inventory_authority_sha256(&encoded)?;
         match self.checkpoint.encoding_inventory_sha256.as_deref() {
@@ -980,9 +1037,15 @@ impl GraphConstructionSession {
         if encoding.generation != self.checkpoint.parent_topology_generation.saturating_add(1) {
             return Err(storage("publication topology generation changed"));
         }
-        crate::graph_construction_encoding::authenticate_for_publication(&self.root, encoding)?;
-        self.begin_publication(target_generation_uuid, transaction_uuid)?;
-
+        let inventory_control_bytes =
+            crate::graph_construction_encoding::authenticate_inventory_control_for_publication(
+                &self.root, encoding,
+            )?;
+        self.checkpoint.evidence.publication_application_read_bytes = self
+            .checkpoint
+            .evidence
+            .publication_application_read_bytes
+            .saturating_add(inventory_control_bytes);
         let admission = crate::filesystem_admission::admit_project_lifecycle(
             &self.project_path,
             self.checkpoint.lifecycle_mode,
@@ -997,25 +1060,31 @@ impl GraphConstructionSession {
         }
 
         let lease = crate::begin_graph_object_publication(admission.root())?;
-        let mut manifest_state = match parent.declared_graph_files_participant()? {
-            Some(crate::GraphFilesParticipant::V2(root)) => {
-                crate::graph_object_store::GraphManifestState::open(
-                    &lease,
-                    root,
-                    crate::GraphManifestLimits::default(),
-                )?
-                .0
-            }
-            Some(crate::GraphFilesParticipant::V1(inventory)) if inventory.file_count == 0 => {
-                crate::graph_object_store::GraphManifestState::empty()
-            }
-            Some(crate::GraphFilesParticipant::V1(_)) => {
-                return Err(storage(
-                    "nonempty construction parent requires compact graph root",
-                ));
-            }
-            None => crate::graph_object_store::GraphManifestState::empty(),
-        };
+        let (mut manifest_state, manifest_read_bytes) =
+            match parent.declared_graph_files_participant()? {
+                Some(crate::GraphFilesParticipant::V2(root)) => {
+                    let (state, evidence) = crate::graph_object_store::GraphManifestState::open(
+                        &lease,
+                        root,
+                        crate::GraphManifestLimits::default(),
+                    )?;
+                    (state, evidence.decoded_bytes)
+                }
+                Some(crate::GraphFilesParticipant::V1(inventory)) if inventory.file_count == 0 => {
+                    (crate::graph_object_store::GraphManifestState::empty(), 0)
+                }
+                Some(crate::GraphFilesParticipant::V1(_)) => {
+                    return Err(storage(
+                        "nonempty construction parent requires compact graph root",
+                    ));
+                }
+                None => (crate::graph_object_store::GraphManifestState::empty(), 0),
+            };
+        self.checkpoint.evidence.publication_application_read_bytes = self
+            .checkpoint
+            .evidence
+            .publication_application_read_bytes
+            .saturating_add(manifest_read_bytes);
         for retained in &encoding.retained_artifacts {
             let entry = manifest_state
                 .entries()
@@ -1043,18 +1112,30 @@ impl GraphConstructionSession {
         if workspace_identity != encoded_directory.identity() {
             return Err(storage("encoded workspace path identity changed"));
         }
-        let sealed_paths = encoding
+        let sealed_files = encoding
             .artifacts
             .iter()
-            .map(|artifact| PathBuf::from(&artifact.path))
+            .map(
+                |artifact| crate::graph_object_store::AuthenticatedGraphFile {
+                    relative_path: PathBuf::from(&artifact.path),
+                    byte_length: artifact.bytes,
+                    content_sha256: artifact.sha256.clone(),
+                },
+            )
             .collect::<Vec<_>>();
-        let (graph_root, _) = crate::graph_object_store::append_graph_files_v2(
-            &lease,
-            &workspace,
-            &mut manifest_state,
-            &sealed_paths,
-            &[],
-        )?;
+        let (graph_root, cas_evidence) =
+            crate::graph_object_store::append_authenticated_graph_files_v2(
+                &lease,
+                &workspace,
+                &mut manifest_state,
+                &sealed_files,
+                &[],
+            )?;
+        self.checkpoint.evidence.cas_application_read_bytes = self
+            .checkpoint
+            .evidence
+            .cas_application_read_bytes
+            .saturating_add(cas_evidence.payload_bytes_hashed);
         if graphforge_filesystem::path_identity(&workspace).map_err(storage)?
             != encoded_directory.identity()
         {
@@ -1071,6 +1152,11 @@ impl GraphConstructionSession {
                 return Err(storage("installed construction artifact authority changed"));
             }
         }
+
+        // CAS installation is private and unreachable until the publication
+        // intent and generation are committed. Authenticate all source bytes
+        // first so corruption leaves the session sealed and retryable.
+        self.begin_publication(target_generation_uuid, transaction_uuid)?;
 
         let graph_participant = crate::graph_files::graph_files_root_participant(&graph_root)?;
         let capabilities = parent
@@ -1659,7 +1745,21 @@ impl GraphConstructionSession {
             }
             return Ok(inventory);
         }
-        let shape = self.shape_canonical_with_cancellation(&mut cancelled)?;
+        let shape = self.shape_canonical_inner(&mut cancelled, false)?;
+        self.encode_canonical_with_cancellation(&shape, generation, cancelled)
+    }
+
+    /// Seal receipt authority and immediately prepare canonical encoding with
+    /// one input-authentication pass. If the process stops after the sealed
+    /// checkpoint, resume performs that authentication before consuming data.
+    #[doc(hidden)]
+    pub fn seal_and_prepare_canonical_encoding_with_cancellation(
+        &mut self,
+        generation: u64,
+        mut cancelled: impl FnMut() -> bool,
+    ) -> Result<GraphConstructionEncoding, GfError> {
+        self.seal_inner(false)?;
+        let shape = self.shape_canonical_inner(&mut cancelled, false)?;
         self.encode_canonical_with_cancellation(&shape, generation, cancelled)
     }
 
@@ -1708,6 +1808,18 @@ impl GraphConstructionSession {
     #[must_use]
     pub const fn evidence(&self) -> &GraphConstructionEvidence {
         &self.checkpoint.evidence
+    }
+
+    /// Record application-observed reads performed by the facade's post-publication
+    /// hydration before the refreshed workspace becomes visible.
+    #[doc(hidden)]
+    pub fn record_hydration_application_read_bytes(&mut self, bytes: u64) -> Result<(), GfError> {
+        self.checkpoint.evidence.hydration_application_read_bytes = self
+            .checkpoint
+            .evidence
+            .hydration_application_read_bytes
+            .saturating_add(bytes);
+        replace_control(&self.root, CHECKPOINT, &self.checkpoint)
     }
 
     /// Number of durably accepted chunks.
@@ -1929,6 +2041,10 @@ impl GraphConstructionSession {
     /// Independently reopen and authenticate every sealed artifact once, then
     /// freeze the private inventory. No generation authority changes here.
     pub fn seal(&mut self) -> Result<(), GfError> {
+        self.seal_inner(true)
+    }
+
+    fn seal_inner(&mut self, authenticate_artifacts: bool) -> Result<(), GfError> {
         self.revalidate_authority()?;
         self.recover_intent()?;
         if self.checkpoint.state != GraphConstructionState::Staging {
@@ -1948,9 +2064,11 @@ impl GraphConstructionSession {
             if receipt.prior_receipt_sha256 != prior_digest {
                 return Err(storage("receipt journal chain is discontinuous"));
             }
-            let work = validate_receipt_artifacts(&self.root, &receipt)?;
-            read_bytes = read_bytes.saturating_add(work.bytes);
-            read_operations = read_operations.saturating_add(work.operations);
+            if authenticate_artifacts {
+                let work = validate_receipt_artifacts(&self.root, &receipt)?;
+                read_bytes = read_bytes.saturating_add(work.bytes);
+                read_operations = read_operations.saturating_add(work.operations);
+            }
             let body = serde_json::to_vec(&receipt).map_err(storage)?;
             prior_digest = Some(sha256(&body));
         }
@@ -1970,6 +2088,11 @@ impl GraphConstructionSession {
             .evidence
             .authentication_read_operations
             .saturating_add(read_operations);
+        self.checkpoint.evidence.seal_application_read_bytes = self
+            .checkpoint
+            .evidence
+            .seal_application_read_bytes
+            .saturating_add(read_bytes);
         self.checkpoint.state = GraphConstructionState::Sealed;
         self.checkpoint.publication_state = Some(ConstructionPublicationState::Sealed);
         replace_control(&self.root, CHECKPOINT, &self.checkpoint)
@@ -1981,7 +2104,16 @@ impl GraphConstructionSession {
     #[allow(clippy::too_many_lines)] // One authenticated external-shape lifecycle; ordering is the invariant.
     pub fn shape_canonical_with_cancellation(
         &mut self,
+        cancelled: impl FnMut() -> bool,
+    ) -> Result<ConstructionShape, GfError> {
+        self.shape_canonical_inner(cancelled, true)
+    }
+
+    #[allow(clippy::too_many_lines)] // One authenticated external-shape lifecycle; ordering is the invariant.
+    fn shape_canonical_inner(
+        &mut self,
         mut cancelled: impl FnMut() -> bool,
+        authenticate_completed_outputs: bool,
     ) -> Result<ConstructionShape, GfError> {
         self.revalidate_authority()?;
         if self.checkpoint.state != GraphConstructionState::Sealed
@@ -1990,7 +2122,9 @@ impl GraphConstructionSession {
             return Err(storage("only a sealed session can be shaped"));
         }
         reject_cancelled(&mut cancelled)?;
-        if let Some(shape) = read_completed_shape(&self.root, &self.checkpoint)? {
+        if let Some(shape) =
+            read_completed_shape(&self.root, &self.checkpoint, authenticate_completed_outputs)?
+        {
             return Ok(shape);
         }
         reject_existing_merge_artifacts(&self.root)?;
@@ -2023,7 +2157,14 @@ impl GraphConstructionSession {
         for sequence in 0..self.checkpoint.next_sequence {
             reject_cancelled(&mut cancelled)?;
             let receipt = self.read_receipt(sequence)?;
-            let work = validate_receipt_artifacts(&self.root, &receipt)?;
+            // Fixed-width inputs authenticate their exact inode, length and
+            // digest in the merge consumers below. Parquet's range-oriented
+            // decoder cannot establish a whole-file digest, so retain exactly
+            // one explicit whole-file authentication pass for that artifact.
+            let mut work = authenticate_artifact(&self.root, &receipt.parquet)?;
+            let metadata_work = validate_parquet_metadata(&self.root, &receipt)?;
+            work.bytes = work.bytes.saturating_add(metadata_work.bytes);
+            work.operations = work.operations.saturating_add(metadata_work.operations);
             self.checkpoint.evidence.shape_input_validation_read_bytes = self
                 .checkpoint
                 .evidence
@@ -2302,6 +2443,15 @@ impl GraphConstructionSession {
             .evidence
             .shaped_output_authentication_operations
             .saturating_add(inventory_work.operations);
+        self.checkpoint.evidence.shape_application_read_bytes = self
+            .checkpoint
+            .evidence
+            .shape_input_validation_read_bytes
+            .saturating_add(self.checkpoint.evidence.merge_read_bytes)
+            .saturating_add(self.checkpoint.evidence.parquet_read_bytes)
+            .saturating_add(self.checkpoint.evidence.shaped_output_authentication_bytes)
+            .saturating_add(self.checkpoint.evidence.parent_catalog_read_bytes)
+            .saturating_add(self.checkpoint.evidence.retained_probe_read_bytes);
         let shape_authority_sha256 = shape_authority_sha256(&shape, &outputs)?;
         self.checkpoint.shape_authority_sha256 = Some(shape_authority_sha256.clone());
         replace_control(
@@ -3049,6 +3199,7 @@ fn write_parquet(
         .map_err(storage)?;
     root.sync().map_err(storage)?;
     construction_failpoint(&format!("artifact.after_install.{name}"));
+    persist_shape_receipt(root, &receipt)?;
     Ok(receipt)
 }
 
@@ -3088,6 +3239,7 @@ fn write_fixed_run<const N: usize>(
         .map_err(storage)?;
     root.sync().map_err(storage)?;
     construction_failpoint(&format!("artifact.after_install.{name}"));
+    persist_shape_receipt(root, &receipt)?;
     Ok(receipt)
 }
 
@@ -3151,9 +3303,24 @@ fn recover_shape_intent(
             checkpoint.evidence = final_evidence.clone();
             checkpoint.shape_authority_sha256 = Some(expected_shape_authority);
             replace_control(root, CHECKPOINT, checkpoint)?;
-        } else if checkpoint.evidence != *final_evidence
-            || checkpoint.shape_authority_sha256.as_deref() != Some(&expected_shape_authority)
-        {
+        } else {
+            let mut shape_owned_evidence = checkpoint.evidence.clone();
+            shape_owned_evidence.encode_application_read_bytes =
+                final_evidence.encode_application_read_bytes;
+            shape_owned_evidence.publication_application_read_bytes =
+                final_evidence.publication_application_read_bytes;
+            shape_owned_evidence.cas_application_read_bytes =
+                final_evidence.cas_application_read_bytes;
+            shape_owned_evidence.hydration_application_read_bytes =
+                final_evidence.hydration_application_read_bytes;
+            shape_owned_evidence.canonical_output_bytes = final_evidence.canonical_output_bytes;
+            shape_owned_evidence.staged_and_retained_disk_bytes =
+                final_evidence.staged_and_retained_disk_bytes;
+            if shape_owned_evidence == *final_evidence
+                && checkpoint.shape_authority_sha256.as_deref() == Some(&expected_shape_authority)
+            {
+                return Ok(());
+            }
             return Err(storage("shape evidence authority differs from inventory"));
         }
         return Ok(());
@@ -3380,6 +3547,7 @@ fn recover_publication(
 fn read_completed_shape(
     root: &StableDirectory,
     checkpoint: &Checkpoint,
+    authenticate_outputs: bool,
 ) -> Result<Option<ConstructionShape>, GfError> {
     let mut file = match root.open_child_file(OsStr::new(SHAPE_INTENT)) {
         Ok(file) => file,
@@ -3391,8 +3559,10 @@ fn read_completed_shape(
     if !manifest.complete {
         return Err(storage("incomplete construction shape was not recovered"));
     }
-    for output in &manifest.outputs {
-        authenticate_shaped_output(root, output)?;
+    if authenticate_outputs {
+        for output in &manifest.outputs {
+            authenticate_shaped_output(root, output)?;
+        }
     }
     let shape = manifest
         .shape
@@ -3472,6 +3642,30 @@ fn receipt_for_existing_with_work(
     root: &StableDirectory,
     name: &str,
 ) -> Result<(ArtifactReceipt, ReadWork), GfError> {
+    let capability_name = shape_receipt_name(name);
+    if let Ok(mut capability_file) = root.open_child_file(OsStr::new(&capability_name)) {
+        let control_bytes = capability_file.metadata().map_err(storage)?.len();
+        let receipt: ArtifactReceipt = decode_bounded(&mut capability_file)?;
+        if receipt.name != name {
+            return Err(storage("shaped writer capability names another artifact"));
+        }
+        let file = root.open_child_file(OsStr::new(name)).map_err(storage)?;
+        if file_link_count(&file).map_err(storage)? != 1
+            || !receipt
+                .identity
+                .matches(file_identity(&file).map_err(storage)?)
+            || file.metadata().map_err(storage)?.len() != receipt.bytes
+        {
+            return Err(storage("shaped writer capability identity changed"));
+        }
+        return Ok((
+            receipt,
+            ReadWork {
+                bytes: control_bytes,
+                operations: 1,
+            },
+        ));
+    }
     let mut file = root.open_child_file(OsStr::new(name)).map_err(storage)?;
     if file_link_count(&file).map_err(storage)? != 1 {
         return Err(storage("shaped output has extra links"));
@@ -3501,6 +3695,17 @@ fn receipt_for_existing_with_work(
         },
         ReadWork { bytes, operations },
     ))
+}
+
+fn shape_receipt_name(name: &str) -> String {
+    format!("shape-receipt-{}.json", &sha256(name.as_bytes())[..32])
+}
+
+fn persist_shape_receipt(root: &StableDirectory, receipt: &ArtifactReceipt) -> Result<(), GfError> {
+    if is_shape_artifact_name(&receipt.name) || canonical_artifact_target(&receipt.name) {
+        install_control(root, &shape_receipt_name(&receipt.name), receipt)?;
+    }
+    Ok(())
 }
 
 fn authenticate_shaped_output(
@@ -3655,7 +3860,8 @@ fn convert_identity_run(
         .map_err(storage)?;
     let identity = file_identity(&file).map_err(storage)?;
     let mut reader = BufReader::with_capacity(BLOCK_BYTES, input);
-    let mut writer = BufWriter::with_capacity(BLOCK_BYTES, file);
+    let hashing = HashingWriter::new(file);
+    let mut writer = BufWriter::with_capacity(BLOCK_BYTES, hashing);
     let mut digest = Sha256::new();
     let mut bytes = 0_u64;
     while let Some(uuid) = read_fixed::<IDENTITY_WIDTH>(&mut reader)? {
@@ -3672,7 +3878,7 @@ fn convert_identity_run(
         return Err(storage("identity source content changed before merge"));
     }
     writer.flush().map_err(storage)?;
-    writer.get_ref().sync_all().map_err(storage)?;
+    writer.get_ref().inner.sync_all().map_err(storage)?;
     account_sequential_write(bytes.saturating_mul(2), evidence);
     drop(writer);
     root.install_child(OsStr::new(&temporary), identity, OsStr::new(output))
@@ -3706,7 +3912,8 @@ fn copy_authenticated_run<const N: usize>(
         .map_err(storage)?;
     let identity = file_identity(&file).map_err(storage)?;
     let mut reader = BufReader::with_capacity(BLOCK_BYTES, input);
-    let mut writer = BufWriter::with_capacity(BLOCK_BYTES, file);
+    let hashing = HashingWriter::new(file);
+    let mut writer = BufWriter::with_capacity(BLOCK_BYTES, hashing);
     let mut digest = Sha256::new();
     let mut bytes = 0_u64;
     while let Some(record) = read_fixed::<N>(&mut reader)? {
@@ -3720,12 +3927,21 @@ fn copy_authenticated_run<const N: usize>(
         return Err(storage("construction merge source content changed"));
     }
     writer.flush().map_err(storage)?;
-    writer.get_ref().sync_all().map_err(storage)?;
+    writer.get_ref().inner.sync_all().map_err(storage)?;
     account_sequential_write(bytes, evidence);
     drop(writer);
     root.install_child(OsStr::new(&temporary), identity, OsStr::new(output))
         .map_err(storage)?;
     root.sync().map_err(storage)?;
+    let output_receipt = ArtifactReceipt {
+        name: output.to_owned(),
+        bytes,
+        sha256: receipt.sha256.clone(),
+        identity: identity.into(),
+        write_operations: bytes.div_ceil(BLOCK_BYTES as u64),
+        fsync_operations: 2,
+    };
+    install_control(root, &shape_receipt_name(output), &output_receipt)?;
     evidence.merge_fsync_operations = evidence.merge_fsync_operations.saturating_add(2);
     Ok(())
 }
@@ -3882,7 +4098,7 @@ fn merge_fixed_group<const N: usize>(
     reject_duplicates: bool,
     cancelled: &mut impl FnMut() -> bool,
     evidence: &mut GraphConstructionEvidence,
-) -> Result<(), GfError> {
+) -> Result<ArtifactReceipt, GfError> {
     let mut readers = inputs
         .iter()
         .map(|name| {
@@ -3902,7 +4118,8 @@ fn merge_fixed_group<const N: usize>(
         .create_replaceable_child_file(OsStr::new(&temporary))
         .map_err(storage)?;
     let identity = file_identity(&file).map_err(storage)?;
-    let mut writer = BufWriter::with_capacity(BLOCK_BYTES, file);
+    let hashing = HashingWriter::new(file);
+    let mut writer = BufWriter::with_capacity(BLOCK_BYTES, hashing);
     let mut heap = BinaryHeap::new();
     for (index, reader) in readers.iter_mut().enumerate() {
         if let Some(record) = read_fixed::<N>(reader)? {
@@ -3931,22 +4148,28 @@ fn merge_fixed_group<const N: usize>(
         }
     }
     writer.flush().map_err(storage)?;
-    writer.get_ref().sync_all().map_err(storage)?;
-    account_sequential_write(
-        writer.get_ref().metadata().map_err(storage)?.len(),
-        evidence,
-    );
+    writer.get_ref().inner.sync_all().map_err(storage)?;
+    account_sequential_write(writer.get_ref().bytes, evidence);
+    let receipt = ArtifactReceipt {
+        name: output.to_owned(),
+        bytes: writer.get_ref().bytes,
+        sha256: hex(&writer.get_ref().digest.clone().finalize()),
+        identity: identity.into(),
+        write_operations: writer.get_ref().operations,
+        fsync_operations: 2,
+    };
     drop(writer);
     root.install_child(OsStr::new(&temporary), identity, OsStr::new(output))
         .map_err(storage)?;
     root.sync().map_err(storage)?;
     construction_failpoint("shape.fixed_merge.after_install");
+    persist_shape_receipt(root, &receipt)?;
     evidence.merge_fsync_operations = evidence.merge_fsync_operations.saturating_add(2);
     evidence.merge_groups = evidence.merge_groups.saturating_add(1);
     evidence.peak_merge_temporary_bytes = evidence
         .peak_merge_temporary_bytes
         .max(measured_shape_bytes(root)?);
-    Ok(())
+    Ok(receipt)
 }
 
 struct RowCursor {
@@ -4135,6 +4358,7 @@ fn merge_row_group(
         .map_err(storage)?;
     root.sync().map_err(storage)?;
     construction_failpoint("shape.row_merge.after_install");
+    persist_shape_receipt(root, &receipt)?;
     evidence.merge_fsync_operations = evidence.merge_fsync_operations.saturating_add(4);
     evidence.merge_groups = evidence.merge_groups.saturating_add(1);
     evidence.merge_written_bytes = evidence.merge_written_bytes.saturating_add(receipt.bytes);
@@ -5003,7 +5227,8 @@ fn assign_surrogates(
         reader.get_ref().metadata().map_err(storage)?.len(),
         evidence,
     );
-    let mut writer = BufWriter::with_capacity(BLOCK_BYTES, file);
+    let hashing = HashingWriter::new(file);
+    let mut writer = BufWriter::with_capacity(BLOCK_BYTES, hashing);
     let mut count = 0_u64;
     while let Some(mut record) = read_fixed::<BASE_IDENTITY_WIDTH>(&mut reader)? {
         if record[17] == 0 {
@@ -5035,15 +5260,21 @@ fn assign_surrogates(
         }
     }
     writer.flush().map_err(storage)?;
-    writer.get_ref().sync_all().map_err(storage)?;
-    account_sequential_write(
-        writer.get_ref().metadata().map_err(storage)?.len(),
-        evidence,
-    );
+    writer.get_ref().inner.sync_all().map_err(storage)?;
+    account_sequential_write(writer.get_ref().bytes, evidence);
+    let output_receipt = ArtifactReceipt {
+        name: output.to_owned(),
+        bytes: writer.get_ref().bytes,
+        sha256: hex(&writer.get_ref().digest.clone().finalize()),
+        identity: identity.into(),
+        write_operations: writer.get_ref().operations,
+        fsync_operations: 2,
+    };
     drop(writer);
     root.install_child(OsStr::new(&temporary), identity, OsStr::new(output))
         .map_err(storage)?;
     root.sync().map_err(storage)?;
+    persist_shape_receipt(root, &output_receipt)?;
     evidence.merge_fsync_operations = evidence.merge_fsync_operations.saturating_add(2);
     Ok(output.to_owned())
 }
@@ -5501,6 +5732,45 @@ fn validate_parquet_shape(
             }
             previous = Some(value);
         }
+    }
+    Ok(ReadWork {
+        bytes: counter.bytes.load(Ordering::Relaxed),
+        operations: counter.operations.load(Ordering::Relaxed),
+    })
+}
+
+fn validate_parquet_metadata(
+    root: &StableDirectory,
+    receipt: &ConstructionChunkReceipt,
+) -> Result<ReadWork, GfError> {
+    let file = root
+        .open_child_file(OsStr::new(&receipt.parquet.name))
+        .map_err(storage)?;
+    if !receipt
+        .parquet
+        .identity
+        .matches(file_identity(&file).map_err(storage)?)
+    {
+        return Err(storage("Parquet identity changed during metadata reopen"));
+    }
+    let counter = IoCounter::default();
+    let builder = ParquetRecordBatchReaderBuilder::try_new(CountingChunkReader {
+        file,
+        counter: counter.clone(),
+    })
+    .map_err(storage)?;
+    let expected_prefix = match receipt.kind {
+        ConstructionChunkKind::Node => &*CONSTRUCTION_NODE_SCHEMA,
+        ConstructionChunkKind::Edge => &*CONSTRUCTION_EDGE_SCHEMA,
+    };
+    let schema = builder.schema();
+    if schema.fields().len() < expected_prefix.fields().len()
+        || schema.fields()[..expected_prefix.fields().len()] != expected_prefix.fields()[..]
+        || normalized_schema_digest(schema.as_ref()) != receipt.schema_sha256
+        || builder.metadata().file_metadata().num_rows()
+            != i64::try_from(receipt.rows).map_err(|_| storage("receipt row count exceeds i64"))?
+    {
+        return Err(storage("Parquet schema or row count differs from receipt"));
     }
     Ok(ReadWork {
         bytes: counter.bytes.load(Ordering::Relaxed),
@@ -7078,6 +7348,90 @@ mod tests {
         assert_eq!(one_rows.sha256, two_rows.sha256);
         assert_eq!((one_shape.node_count, one_shape.edge_count), (8, 0));
         assert_eq!((two_shape.node_count, two_shape.edge_count), (8, 0));
+    }
+
+    #[test]
+    fn immediate_seal_prepare_authenticates_staged_bytes_once_with_constant_factor() {
+        let mut observations = Vec::new();
+        for rows in [64_usize, 128, 256] {
+            let root = TempDir::new().unwrap();
+            crate::open_or_initialize_project(root.path()).unwrap();
+            let mut session = GraphConstructionSession::open(
+                root.path(),
+                Uuid::now_v7(),
+                0,
+                GraphConstructionBudgets::default(),
+            )
+            .unwrap();
+            session
+                .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, rows))
+                .unwrap();
+            session
+                .seal_and_prepare_canonical_encoding_with_cancellation(1, || false)
+                .unwrap();
+            let evidence = session.evidence();
+            assert_eq!(evidence.authentication_read_bytes, 0);
+            assert!(evidence.shape_input_validation_read_bytes > 0);
+            assert!(
+                evidence.shaped_output_authentication_bytes < evidence.canonical_output_bytes / 4,
+                "writer-completed shaped outputs were reopened: auth={} canonical={}",
+                evidence.shaped_output_authentication_bytes,
+                evidence.canonical_output_bytes
+            );
+            assert!(
+                evidence.shape_input_validation_read_bytes
+                    <= evidence.write_bytes.saturating_mul(3),
+                "shape authentication exceeded three staged-byte passes"
+            );
+            observations.push((rows, evidence.shape_input_validation_read_bytes));
+        }
+        for pair in observations.windows(2) {
+            let (smaller_rows, smaller_bytes) = pair[0];
+            let (larger_rows, larger_bytes) = pair[1];
+            assert_eq!(larger_rows, smaller_rows * 2);
+            assert!(larger_bytes >= smaller_bytes);
+            assert!(
+                larger_bytes <= smaller_bytes.saturating_mul(3),
+                "doubling rows exceeded the bounded linear byte envelope"
+            );
+        }
+    }
+
+    #[test]
+    fn interrupted_immediate_seal_reauthenticates_before_resume_consumption() {
+        let root = TempDir::new().unwrap();
+        crate::open_or_initialize_project(root.path()).unwrap();
+        let operation = Uuid::now_v7();
+        let mut session = GraphConstructionSession::open(
+            root.path(),
+            operation,
+            0,
+            GraphConstructionBudgets::default(),
+        )
+        .unwrap();
+        session
+            .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 64))
+            .unwrap();
+        assert!(
+            session
+                .seal_and_prepare_canonical_encoding_with_cancellation(1, || true)
+                .is_err()
+        );
+        assert_eq!(session.state(), GraphConstructionState::Sealed);
+        assert_eq!(session.evidence().authentication_read_bytes, 0);
+        drop(session);
+
+        let mut resumed = GraphConstructionSession::open(
+            root.path(),
+            operation,
+            0,
+            GraphConstructionBudgets::default(),
+        )
+        .unwrap();
+        resumed
+            .prepare_canonical_encoding_with_cancellation(1, || false)
+            .unwrap();
+        assert!(resumed.evidence().shape_input_validation_read_bytes > 0);
     }
 
     #[test]
@@ -8961,13 +9315,61 @@ mod tests {
             .join(&encoding.artifacts[0].path);
         std::fs::write(victim, b"tampered").unwrap();
 
+        let error = session
+            .publish_canonical(&encoding, Uuid::from_u128(9_461), Uuid::from_u128(9_462))
+            .unwrap_err()
+            .to_string();
         assert!(
-            session
-                .publish_canonical(&encoding, Uuid::from_u128(9_461), Uuid::from_u128(9_462),)
-                .unwrap_err()
-                .to_string()
-                .contains("artifact differs")
+            error.contains("authenticated graph file metadata changed")
+                || error.contains("digest or length changed"),
+            "unexpected corruption error: {error}"
         );
+        assert_eq!(
+            crate::resolve_project_generation(root.path())
+                .unwrap()
+                .generation_uuid(),
+            prior
+        );
+        assert_eq!(
+            session.checkpoint.publication_state,
+            Some(ConstructionPublicationState::Sealed)
+        );
+    }
+
+    #[test]
+    fn canonical_publication_rejects_replaced_durable_inventory_without_payload_reads() {
+        let root = TempDir::new().unwrap();
+        let parent = crate::open_or_initialize_project(root.path()).unwrap();
+        let prior = parent.generation_uuid();
+        drop(parent);
+        let operation = Uuid::from_u128(9_468);
+        let mut session = GraphConstructionSession::open(
+            root.path(),
+            operation,
+            0,
+            GraphConstructionBudgets::default(),
+        )
+        .unwrap();
+        session
+            .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 1))
+            .unwrap();
+        session.seal().unwrap();
+        let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+        let encoding = session.encode_canonical(&shape, 1).unwrap();
+        let inventory_path = root
+            .path()
+            .join(PRIVATE_ROOT)
+            .join(operation.simple().to_string())
+            .join("encoded-v1/inventory.json");
+        let mut replaced: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&inventory_path).unwrap()).unwrap();
+        replaced["generation"] = serde_json::json!(2);
+        std::fs::write(&inventory_path, serde_json::to_vec(&replaced).unwrap()).unwrap();
+
+        let error = session
+            .publish_canonical(&encoding, Uuid::from_u128(9_469), Uuid::from_u128(9_470))
+            .unwrap_err();
+        assert!(error.to_string().contains("durable encoding"));
         assert_eq!(
             crate::resolve_project_generation(root.path())
                 .unwrap()

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -3331,6 +3331,7 @@ fn recover_shape_intent(
     if intent.final_evidence.is_some() || checkpoint.evidence != intent.baseline_evidence {
         return Err(storage("incomplete shape changed committed evidence"));
     }
+    cleanup_incomplete_shape_capabilities(root)?;
     for child in root.child_names().map_err(storage)? {
         let Some(name) = child.to_str() else { continue };
         if !name.starts_with("merge-") && !name.starts_with("shaped-") {
@@ -3349,6 +3350,43 @@ fn recover_shape_intent(
         }
     }
     unlink_named(root, SHAPE_INTENT)
+}
+
+fn cleanup_incomplete_shape_capabilities(root: &StableDirectory) -> Result<(), GfError> {
+    for child in root.child_names().map_err(storage)? {
+        let Some(name) = child.to_str() else { continue };
+        if !name.starts_with("shape-receipt-") {
+            continue;
+        }
+        let mut file = root.open_child_file(OsStr::new(name)).map_err(storage)?;
+        if file_link_count(&file).map_err(storage)? != 1 {
+            return Err(storage("shaped writer capability has extra links"));
+        }
+        let identity = file_identity(&file).map_err(storage)?;
+        let receipt: ArtifactReceipt = decode_bounded(&mut file)?;
+        if shape_receipt_name(&receipt.name) != name {
+            return Err(storage("shaped writer capability name changed"));
+        }
+        if !is_shape_artifact_name(&receipt.name) {
+            continue;
+        }
+        if !is_canonical_sha256(&receipt.sha256) {
+            return Err(storage("shaped writer capability digest changed"));
+        }
+        match root.open_child_file(OsStr::new(&receipt.name)) {
+            Ok(artifact) => {
+                drop(artifact);
+                authenticate_shaped_output(root, &receipt)?;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(storage(error)),
+        }
+        drop(file);
+        root.unlink_child_if_identity(OsStr::new(name), identity)
+            .map_err(storage)?;
+        root.sync().map_err(storage)?;
+    }
+    Ok(())
 }
 
 fn validate_shape_binding(intent: &ShapeIntent, checkpoint: &Checkpoint) -> Result<(), GfError> {
@@ -3703,9 +3741,53 @@ fn shape_receipt_name(name: &str) -> String {
 
 fn persist_shape_receipt(root: &StableDirectory, receipt: &ArtifactReceipt) -> Result<(), GfError> {
     if is_shape_artifact_name(&receipt.name) || canonical_artifact_target(&receipt.name) {
-        install_control(root, &shape_receipt_name(&receipt.name), receipt)?;
+        let capability_name = shape_receipt_name(&receipt.name);
+        match root.open_child_file(OsStr::new(&capability_name)) {
+            Ok(mut file) => {
+                if file_link_count(&file).map_err(storage)? != 1 {
+                    return Err(storage("shaped writer capability has extra links"));
+                }
+                let existing: ArtifactReceipt = decode_bounded(&mut file)?;
+                if existing != *receipt {
+                    return Err(storage("shaped writer capability changed"));
+                }
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                install_control(root, &capability_name, receipt)?;
+            }
+            Err(error) => return Err(storage(error)),
+        }
     }
     Ok(())
+}
+
+fn unlink_writer_capability(
+    root: &StableDirectory,
+    name: &str,
+    expected: Option<&ArtifactReceipt>,
+) -> Result<(), GfError> {
+    let capability_name = shape_receipt_name(name);
+    let mut file = match root.open_child_file(OsStr::new(&capability_name)) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(storage(error)),
+    };
+    if file_link_count(&file).map_err(storage)? != 1 {
+        return Err(storage("writer capability has extra links"));
+    }
+    let identity = file_identity(&file).map_err(storage)?;
+    let receipt: ArtifactReceipt = decode_bounded(&mut file)?;
+    if receipt.name != name
+        || shape_receipt_name(&receipt.name) != capability_name
+        || expected.is_some_and(|expected| expected != &receipt)
+    {
+        return Err(storage("writer capability differs from artifact authority"));
+    }
+    authenticate_shaped_output(root, &receipt)?;
+    drop(file);
+    root.unlink_child_if_identity(OsStr::new(&capability_name), identity)
+        .map_err(storage)?;
+    root.sync().map_err(storage)
 }
 
 fn authenticate_shaped_output(
@@ -3941,7 +4023,7 @@ fn copy_authenticated_run<const N: usize>(
         write_operations: bytes.div_ceil(BLOCK_BYTES as u64),
         fsync_operations: 2,
     };
-    install_control(root, &shape_receipt_name(output), &output_receipt)?;
+    persist_shape_receipt(root, &output_receipt)?;
     evidence.merge_fsync_operations = evidence.merge_fsync_operations.saturating_add(2);
     Ok(())
 }
@@ -6205,6 +6287,7 @@ fn unlink_artifact(root: &StableDirectory, receipt: &ArtifactReceipt) -> Result<
     if !receipt.identity.matches(identity) || file_link_count(&file).map_err(storage)? != 1 {
         return Err(storage("orphan artifact identity changed"));
     }
+    unlink_writer_capability(root, &receipt.name, Some(receipt))?;
     drop(file);
     root.unlink_child_if_identity(OsStr::new(&receipt.name), identity)
         .map_err(storage)?;
@@ -6262,6 +6345,7 @@ fn remove_unrecorded_artifact(
         }
         validate_sorted_run(&mut file, width)?;
     }
+    unlink_writer_capability(root, name, None)?;
     root.unlink_child_if_identity(OsStr::new(name), identity)
         .map_err(storage)?;
     root.sync().map_err(storage)
@@ -6428,6 +6512,24 @@ mod tests {
                 !entry.file_name().to_string_lossy().ends_with(".tmp")
             }
         })
+    }
+
+    #[test]
+    fn shaped_writer_capability_resume_adopts_only_the_exact_receipt() {
+        let temporary = TempDir::new().unwrap();
+        let root = StableDirectory::open(temporary.path()).unwrap();
+        std::fs::write(temporary.path().join("shaped-identities.run"), b"identity").unwrap();
+        let (receipt, _) = receipt_for_existing_with_work(&root, "shaped-identities.run").unwrap();
+
+        persist_shape_receipt(&root, &receipt).unwrap();
+        persist_shape_receipt(&root, &receipt).unwrap();
+
+        let mut mismatched = receipt;
+        mismatched.sha256 = "0".repeat(64);
+        let error = persist_shape_receipt(&root, &mismatched)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("shaped writer capability changed"));
     }
 
     fn node_batch(first: u128, rows: usize) -> RecordBatch {
@@ -7154,13 +7256,15 @@ mod tests {
                 "windows={windows} slots={}",
                 session.evidence().peak_resolved_endpoint_name_slots
             );
-            let expected_inventory_bytes = std::iter::once(&shape.identities)
+            let shaped_outputs = std::iter::once(&shape.identities)
                 .chain(shape.node_details.iter())
                 .chain(shape.edge_details.iter())
                 .chain(shape.node_rows.iter())
                 .chain(shape.edge_rows.iter())
                 .chain(shape.edge_endpoints.iter())
-                .chain(std::iter::once(&shape.runtime_catalog))
+                .chain(std::iter::once(&shape.runtime_catalog));
+            let expected_payload_bytes = shaped_outputs
+                .clone()
                 .map(|name| {
                     session
                         .root
@@ -7171,10 +7275,22 @@ mod tests {
                         .len()
                 })
                 .sum::<u64>();
+            let expected_capability_bytes = shaped_outputs
+                .map(|name| {
+                    session
+                        .root
+                        .open_child_file(OsStr::new(&shape_receipt_name(name)))
+                        .unwrap()
+                        .metadata()
+                        .unwrap()
+                        .len()
+                })
+                .sum::<u64>();
             assert_eq!(
                 session.evidence().shaped_output_authentication_bytes,
-                expected_inventory_bytes
+                expected_capability_bytes
             );
+            assert!(expected_capability_bytes < expected_payload_bytes);
             assert!(session.evidence().shaped_output_authentication_operations > 0);
         }
     }
@@ -9321,7 +9437,8 @@ mod tests {
             .to_string();
         assert!(
             error.contains("authenticated graph file metadata changed")
-                || error.contains("digest or length changed"),
+                || error.contains("digest or length changed")
+                || error.contains("graph object source is not the declared regular file"),
             "unexpected corruption error: {error}"
         );
         assert_eq!(

--- a/crates/graphforge-storage/src/graph_construction_encoding.rs
+++ b/crates/graphforge-storage/src/graph_construction_encoding.rs
@@ -86,6 +86,7 @@ fn run_source_spool_hook(_phase: &str) {}
 struct CountingWriter {
     inner: File,
     counter: IoCounter,
+    digest: Sha256,
 }
 
 struct CountingInput<R> {
@@ -195,6 +196,7 @@ impl Write for CountingWriter {
     fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
         let written = self.inner.write(buffer)?;
         self.counter.account(written);
+        self.digest.update(&buffer[..written]);
         Ok(written)
     }
 
@@ -1457,21 +1459,24 @@ fn write_parquet(
         CountingWriter {
             inner: file,
             counter: counter.clone(),
+            digest: Sha256::new(),
         },
         batch.schema(),
         None,
     )
     .map_err(storage)?;
     writer.write(batch).map_err(storage)?;
-    writer.close().map_err(storage)?;
-    let mut file = directory
-        .open_child_file(OsStr::new(&temporary))
-        .map_err(storage)?;
-    file.sync_all().map_err(storage)?;
+    let writer = writer.into_inner().map_err(storage)?;
+    writer.inner.sync_all().map_err(storage)?;
     crate::graph_construction::construction_failpoint(&format!(
         "encode.parquet.after_temp_fsync.{relative}"
     ));
-    let artifact = authenticate_file(relative, &mut file)?;
+    let (written, operations) = counter.values();
+    let artifact = ConstructionEncodedArtifact {
+        path: relative.to_owned(),
+        bytes: written,
+        sha256: hex(&writer.digest.finalize()),
+    };
     directory
         .replace_child(OsStr::new(&temporary), identity, OsStr::new(&name))
         .map_err(storage)?;
@@ -1480,7 +1485,6 @@ fn write_parquet(
     crate::graph_construction::construction_failpoint(&format!(
         "encode.parquet.after_install.{relative}"
     ));
-    let (written, operations) = counter.values();
     evidence.output_write_bytes = evidence.output_write_bytes.saturating_add(written);
     evidence.output_write_operations = evidence.output_write_operations.saturating_add(operations);
     evidence.fsync_operations = evidence.fsync_operations.saturating_add(2);
@@ -1521,6 +1525,7 @@ fn copy_artifact<R: Read + Seek>(
         CountingWriter {
             inner: file,
             counter: write_counter.clone(),
+            digest: Sha256::new(),
         },
     );
     let bytes = std::io::copy(&mut input, &mut writer).map_err(storage)?;
@@ -1529,11 +1534,13 @@ fn copy_artifact<R: Read + Seek>(
     crate::graph_construction::construction_failpoint(&format!(
         "encode.copy.after_temp_fsync.{relative}"
     ));
-    drop(writer);
-    let mut file = directory
-        .open_child_file(OsStr::new(&temporary))
-        .map_err(storage)?;
-    let artifact = authenticate_file(relative, &mut file)?;
+    let writer = writer.into_inner().map_err(storage)?;
+    let (write_bytes, write_operations) = write_counter.values();
+    let artifact = ConstructionEncodedArtifact {
+        path: relative.to_owned(),
+        bytes: write_bytes,
+        sha256: hex(&writer.digest.finalize()),
+    };
     if artifact.bytes != bytes {
         return Err(storage("copied canonical artifact length changed"));
     }
@@ -1558,7 +1565,6 @@ fn copy_artifact<R: Read + Seek>(
         .source_spool_read_operations
         .saturating_add(read_operations);
     evidence.output_write_bytes = evidence.output_write_bytes.saturating_add(bytes);
-    let (write_bytes, write_operations) = write_counter.values();
     if write_bytes != bytes {
         return Err(storage(
             "copied canonical artifact write accounting differs",
@@ -1809,10 +1815,12 @@ fn authenticate_inventory(
     Ok(())
 }
 
-pub(crate) fn authenticate_for_publication(
+/// Bind publication to the durable encoding control record without rereading
+/// payload bytes. Payloads are authenticated by the subsequent CAS install.
+pub(crate) fn authenticate_inventory_control_for_publication(
     source: &StableDirectory,
     inventory: &GraphConstructionEncoding,
-) -> Result<(), GfError> {
+) -> Result<u64, GfError> {
     let encoded = source
         .open_child_directory(OsStr::new(ENCODED_ROOT))
         .map_err(storage)?;
@@ -1823,16 +1831,12 @@ pub(crate) fn authenticate_for_publication(
             "publication inventory differs from durable encoding",
         ));
     }
-    for expected in &inventory.artifacts {
-        let (directory, name) = directory_for(&encoded, &expected.path)?;
-        let mut file = directory
-            .open_child_file(OsStr::new(&name))
-            .map_err(storage)?;
-        if authenticate_file(&expected.path, &mut file)? != *expected {
-            return Err(storage("canonical artifact differs from durable inventory"));
-        }
-    }
-    Ok(())
+    encoded
+        .open_child_file(OsStr::new(INVENTORY))
+        .map_err(storage)?
+        .metadata()
+        .map(|metadata| metadata.len())
+        .map_err(storage)
 }
 
 fn install_json<T: Serialize>(

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -130,6 +130,12 @@ struct CasRoot {
     lifecycle_identity: graphforge_filesystem::FileIdentity,
 }
 
+struct TemporaryObject {
+    name: std::ffi::OsString,
+    file: File,
+    identity: graphforge_filesystem::FileIdentity,
+}
+
 struct ReadOnlyCasRoot {
     diagnostic_root: PathBuf,
     project: StableDirectory,
@@ -534,12 +540,12 @@ pub fn graph_object_publication_is_live(root: &Path) -> Result<bool, GfError> {
     Ok(live)
 }
 
-/// Exact physical work for one object installation.
+/// Exact application-observed work for one object installation.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct GraphObjectInstallEvidence {
     /// Source payload bytes read and hashed.
     pub bytes_hashed: u64,
-    /// New physical bytes installed into the object store.
+    /// Logical payload bytes newly installed into the object store.
     pub bytes_installed: u64,
     /// Whether an already installed exact object satisfied the request.
     pub reused_existing: bool,
@@ -552,7 +558,7 @@ pub struct GraphFilesMigrationEvidence {
     pub payload_objects: u64,
     /// Source payload bytes hashed.
     pub payload_bytes_hashed: u64,
-    /// New physical payload and segment bytes installed.
+    /// Logical payload and segment bytes newly installed.
     pub bytes_installed: u64,
 }
 
@@ -565,8 +571,18 @@ pub struct GraphFilesAppendEvidence {
     pub prior_entries_examined: u64,
     /// New/replaced payload bytes hashed, including verification passes.
     pub payload_bytes_hashed: u64,
-    /// New physical object bytes installed.
+    /// Logical object bytes newly installed.
     pub bytes_installed: u64,
+}
+
+/// A graph file whose content identity was established by an upstream durable
+/// writer. Publication still authenticates these bytes while installing them;
+/// this capability only removes a redundant standalone pre-hash pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AuthenticatedGraphFile {
+    pub(crate) relative_path: PathBuf,
+    pub(crate) byte_length: u64,
+    pub(crate) content_sha256: String,
 }
 
 /// Storage-owned, root-bound state for a sequence of path-copy publications.
@@ -869,6 +885,41 @@ pub fn append_graph_files_v2(
     sealed_paths: &[PathBuf],
     tombstones: &[String],
 ) -> Result<(GraphFilesRootV2, GraphFilesAppendEvidence), GfError> {
+    append_graph_files_v2_inner(lease, workspace, state, sealed_paths, None, tombstones)
+}
+
+/// Publish writer-authenticated files with one copy-and-hash authentication
+/// pass. The expected digest is never trusted without that install-time pass.
+pub(crate) fn append_authenticated_graph_files_v2(
+    lease: &GraphObjectPublicationLease,
+    workspace: &Path,
+    state: &mut GraphManifestState,
+    sealed_files: &[AuthenticatedGraphFile],
+    tombstones: &[String],
+) -> Result<(GraphFilesRootV2, GraphFilesAppendEvidence), GfError> {
+    let paths = sealed_files
+        .iter()
+        .map(|file| file.relative_path.clone())
+        .collect::<Vec<_>>();
+    append_graph_files_v2_inner(
+        lease,
+        workspace,
+        state,
+        &paths,
+        Some(sealed_files),
+        tombstones,
+    )
+}
+
+#[allow(clippy::too_many_lines)]
+fn append_graph_files_v2_inner(
+    lease: &GraphObjectPublicationLease,
+    workspace: &Path,
+    state: &mut GraphManifestState,
+    sealed_paths: &[PathBuf],
+    authenticated: Option<&[AuthenticatedGraphFile]>,
+    tombstones: &[String],
+) -> Result<(GraphFilesRootV2, GraphFilesAppendEvidence), GfError> {
     validate_publication_identity(lease)?;
     if state
         .project_identity
@@ -904,20 +955,34 @@ pub fn append_graph_files_v2(
         .root
         .as_ref()
         .map_or(0, |root| root.logical_byte_length);
-    for relative in sealed_paths {
+    for (index, relative) in sealed_paths.iter().enumerate() {
         let source = workspace.join(relative);
-        let metadata = fs::symlink_metadata(&source)
-            .map_err(|error| storage("inspect sealed graph file", &source, error))?;
-        if !metadata.is_file() || metadata.file_type().is_symlink() {
-            return Err(validation("sealed graph path is not a regular file"));
-        }
-        let digest = hash_regular_file(&source)?;
-        let digest = hex_digest(digest);
+        let (digest, expected_length, prehashed_bytes) = if let Some(files) = authenticated {
+            let expected = files
+                .get(index)
+                .ok_or_else(|| validation("authenticated graph inventory is incomplete"))?;
+            if expected.relative_path != *relative {
+                return Err(validation("authenticated graph file metadata changed"));
+            }
+            validate_digest(&expected.content_sha256)?;
+            (expected.content_sha256.clone(), expected.byte_length, 0)
+        } else {
+            let metadata = fs::symlink_metadata(&source)
+                .map_err(|error| storage("inspect sealed graph file", &source, error))?;
+            if !metadata.is_file() || metadata.file_type().is_symlink() {
+                return Err(validation("sealed graph path is not a regular file"));
+            }
+            (
+                hex_digest(hash_regular_file(&source)?),
+                metadata.len(),
+                metadata.len(),
+            )
+        };
         let installed =
-            install_graph_object_file_with_lease(lease, &source, &digest, metadata.len())?;
+            install_graph_object_file_with_lease(lease, &source, &digest, expected_length)?;
         evidence.payload_bytes_hashed = evidence
             .payload_bytes_hashed
-            .saturating_add(metadata.len())
+            .saturating_add(prehashed_bytes)
             .saturating_add(installed.bytes_hashed);
         evidence.bytes_installed = evidence
             .bytes_installed
@@ -928,7 +993,7 @@ pub fn append_graph_files_v2(
             .to_owned();
         let entry = crate::GraphFileEntry {
             relative_path: relative_path.clone(),
-            byte_length: metadata.len(),
+            byte_length: expected_length,
             content_sha256: digest,
             role: crate::graph_files::infer_role(relative),
         };
@@ -948,6 +1013,10 @@ pub fn append_graph_files_v2(
             logical_byte_length = logical_byte_length.saturating_sub(previous.byte_length);
         }
     }
+    // All payload objects are authenticated before any manifest node can
+    // reference them. A returned error here therefore leaves only unreferenced,
+    // retry-safe CAS state.
+    returned_error_boundary("append:before-manifest-reference")?;
     evidence.changed_entries_examined =
         u64::try_from(additions.len().saturating_add(tombstones.len())).unwrap_or(u64::MAX);
     let mut root_digest = match state.root.as_ref() {
@@ -1346,7 +1415,7 @@ fn install_graph_object_bytes_with_lease(
 ) -> Result<(String, GraphObjectInstallEvidence), GfError> {
     let digest = hex_digest(Sha256::digest(bytes).into());
     let expected_length = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
-    install_object(&lease.cas, &digest, expected_length, |file| {
+    install_object(&lease.cas, &digest, expected_length, false, |file| {
         file.write_all(bytes).map_err(|error| {
             storage(
                 "write temporary graph object",
@@ -1361,7 +1430,9 @@ fn install_graph_object_bytes_with_lease(
                 error,
             )
         })?;
-        Ok(expected_length)
+        // The source is already resident memory; only the mandatory temporary
+        // file verification below is an application-observed payload read.
+        Ok(0)
     })
     .map(|evidence| (digest, evidence))
 }
@@ -1392,43 +1463,49 @@ fn install_graph_object_file_with_lease(
             "graph object source is not the declared regular file",
         ));
     }
-    install_object(&lease.cas, expected_digest, expected_length, |output| {
-        let mut input = File::open(source)
-            .map_err(|error| storage("open graph object source", source, error))?;
-        let mut hasher = Sha256::new();
-        let mut total = 0_u64;
-        let mut buffer = vec![0_u8; BUFFER_BYTES];
-        loop {
-            let read = input
-                .read(&mut buffer)
-                .map_err(|error| storage("read graph object source", source, error))?;
-            if read == 0 {
-                break;
+    install_object(
+        &lease.cas,
+        expected_digest,
+        expected_length,
+        true,
+        |output| {
+            let mut input = File::open(source)
+                .map_err(|error| storage("open graph object source", source, error))?;
+            let mut hasher = Sha256::new();
+            let mut total = 0_u64;
+            let mut buffer = vec![0_u8; BUFFER_BYTES];
+            loop {
+                let read = input
+                    .read(&mut buffer)
+                    .map_err(|error| storage("read graph object source", source, error))?;
+                if read == 0 {
+                    break;
+                }
+                output.write_all(&buffer[..read]).map_err(|error| {
+                    storage(
+                        "write temporary graph object",
+                        &lease.cas.diagnostic_root,
+                        error,
+                    )
+                })?;
+                hasher.update(&buffer[..read]);
+                total = total.saturating_add(u64::try_from(read).unwrap_or(u64::MAX));
             }
-            output.write_all(&buffer[..read]).map_err(|error| {
+            if total != expected_length || hex_digest(hasher.finalize().into()) != expected_digest {
+                return Err(validation(
+                    "graph object source digest or length changed during install",
+                ));
+            }
+            output.sync_all().map_err(|error| {
                 storage(
-                    "write temporary graph object",
+                    "fsync temporary graph object",
                     &lease.cas.diagnostic_root,
                     error,
                 )
             })?;
-            hasher.update(&buffer[..read]);
-            total = total.saturating_add(u64::try_from(read).unwrap_or(u64::MAX));
-        }
-        if total != expected_length || hex_digest(hasher.finalize().into()) != expected_digest {
-            return Err(validation(
-                "graph object source digest or length changed during install",
-            ));
-        }
-        output.sync_all().map_err(|error| {
-            storage(
-                "fsync temporary graph object",
-                &lease.cas.diagnostic_root,
-                error,
-            )
-        })?;
-        Ok(total)
-    })
+            Ok(total)
+        },
+    )
 }
 
 /// Read and cryptographically verify an immutable object.
@@ -1503,14 +1580,6 @@ fn materialize_from_cas(
     let source = bucket
         .open_child_file(source_name)
         .map_err(|error| storage("open materialization source", &cas.diagnostic_root, error))?;
-    verify_file(
-        source.try_clone().map_err(|error| {
-            storage("clone materialization source", &cas.diagnostic_root, error)
-        })?,
-        &entry.content_sha256,
-        entry.byte_length,
-        &cas.diagnostic_root,
-    )?;
     let source_identity = graphforge_filesystem::file_identity(&source).map_err(|error| {
         storage(
             "identify materialization source",
@@ -2173,6 +2242,7 @@ fn install_object<F>(
     cas: &CasRoot,
     digest: &str,
     expected_length: u64,
+    writer_authenticated: bool,
     write_temporary: F,
 ) -> Result<GraphObjectInstallEvidence, GfError>
 where
@@ -2184,6 +2254,7 @@ where
     if let Ok(file) = bucket.open_child_file(destination_name) {
         verify_and_seal_graph_object(&file, digest, expected_length, &cas.diagnostic_root)?;
         return Ok(GraphObjectInstallEvidence {
+            bytes_hashed: expected_length,
             reused_existing: true,
             ..GraphObjectInstallEvidence::default()
         });
@@ -2207,23 +2278,71 @@ where
         )
     })?;
     let bytes_hashed = write_temporary(&mut temporary)?;
-    temporary
-        .rewind()
-        .map_err(|error| storage("rewind temporary graph object", &cas.diagnostic_root, error))?;
-    verify_file(
-        temporary.try_clone().map_err(|error| {
-            storage("clone temporary graph object", &cas.diagnostic_root, error)
-        })?,
+    if !writer_authenticated {
+        temporary.rewind().map_err(|error| {
+            storage("rewind temporary graph object", &cas.diagnostic_root, error)
+        })?;
+        verify_file(
+            temporary.try_clone().map_err(|error| {
+                storage("clone temporary graph object", &cas.diagnostic_root, error)
+            })?,
+            digest,
+            expected_length,
+            &cas.diagnostic_root,
+        )?;
+    }
+    let installed = finalize_temporary_object(
+        cas,
+        &bucket,
+        TemporaryObject {
+            name: temporary_name,
+            file: temporary,
+            identity: temporary_identity,
+        },
         digest,
         expected_length,
-        &cas.diagnostic_root,
     )?;
-    seal_graph_object(&temporary, &cas.diagnostic_root)?;
+    Ok(GraphObjectInstallEvidence {
+        bytes_hashed: bytes_hashed
+            .saturating_add(if writer_authenticated {
+                0
+            } else {
+                expected_length
+            })
+            .saturating_add(if installed { 0 } else { expected_length }),
+        bytes_installed: if installed { expected_length } else { 0 },
+        reused_existing: !installed,
+    })
+}
+
+fn finalize_temporary_object(
+    cas: &CasRoot,
+    bucket: &StableDirectory,
+    temporary: TemporaryObject,
+    digest: &str,
+    expected_length: u64,
+) -> Result<bool, GfError> {
+    let destination_name = std::ffi::OsStr::new(&digest[2..]);
+    seal_graph_object(&temporary.file, &cas.diagnostic_root)?;
+    let sealed_metadata = temporary
+        .file
+        .metadata()
+        .map_err(|error| storage("reinspect fresh graph object", &cas.diagnostic_root, error))?;
+    if graphforge_filesystem::file_identity(&temporary.file)
+        .map_err(|error| storage("reidentify fresh graph object", &cas.diagnostic_root, error))?
+        != temporary.identity
+        || !sealed_metadata.is_file()
+        || sealed_metadata.len() != expected_length
+        || !sealed_metadata.permissions().readonly()
+    {
+        return Err(validation("fresh graph object post-hash authority changed"));
+    }
+    returned_error_boundary("install:temp-sealed")?;
     let installed = if let Ok((_installed, _identity)) = cas.tmp.link_child_into(
-        &temporary_name,
-        &temporary,
-        temporary_identity,
-        &bucket,
+        &temporary.name,
+        &temporary.file,
+        temporary.identity,
+        bucket,
         destination_name,
     ) {
         true
@@ -2238,20 +2357,10 @@ where
         verify_and_seal_graph_object(&existing, digest, expected_length, &cas.diagnostic_root)?;
         false
     };
-    // Windows cannot open a deletion handle while the original temporary
-    // handle remains open without delete sharing. Publication and concurrent
-    // winner authentication are complete, so release it before exact-identity
-    // cleanup; the installed hard link remains sealed.
-    drop(temporary);
-    cas.tmp
-        .unlink_child_if_identity(&temporary_name, temporary_identity)
-        .map_err(|error| {
-            storage(
-                "remove stable temporary graph object",
-                &cas.diagnostic_root,
-                error,
-            )
-        })?;
+    returned_error_boundary("install:final-linked")?;
+    // The destination namespace must be durable before its temporary alias is
+    // removed; after a crash, retry can therefore authenticate the final CAS
+    // name without depending on the temporary namespace.
     bucket.sync().map_err(|error| {
         storage(
             "sync stable graph object bucket",
@@ -2259,11 +2368,30 @@ where
             error,
         )
     })?;
-    Ok(GraphObjectInstallEvidence {
-        bytes_hashed,
-        bytes_installed: if installed { expected_length } else { 0 },
-        reused_existing: !installed,
-    })
+    returned_error_boundary("install:bucket-synced")?;
+    // Windows cannot open a deletion handle while the original temporary
+    // handle remains open without delete sharing. Publication and concurrent
+    // winner authentication are complete, so release it before exact-identity
+    // cleanup; the fresh CAS-owned inode remains sealed at its final name.
+    drop(temporary.file);
+    cas.tmp
+        .unlink_child_if_identity(&temporary.name, temporary.identity)
+        .map_err(|error| {
+            storage(
+                "remove stable temporary graph object",
+                &cas.diagnostic_root,
+                error,
+            )
+        })?;
+    returned_error_boundary("install:temp-unlinked")?;
+    cas.tmp.sync().map_err(|error| {
+        storage(
+            "sync stable graph object temporary directory",
+            &cas.diagnostic_root,
+            error,
+        )
+    })?;
+    Ok(installed)
 }
 
 fn verify_file(
@@ -2422,6 +2550,79 @@ mod tests {
             ),
             other => panic!("unexpected injected error: {other}"),
         }
+    }
+
+    #[test]
+    fn install_crash_boundaries_leave_only_valid_or_recoverable_unreferenced_state() {
+        let boundaries = [
+            "install:temp-sealed",
+            "install:final-linked",
+            "install:bucket-synced",
+            "install:temp-unlinked",
+            "append:before-manifest-reference",
+        ];
+        for boundary in boundaries {
+            let container = tempfile::tempdir().unwrap();
+            let workspace = tempfile::tempdir().unwrap();
+            let relative_path = PathBuf::from("boundary.parquet");
+            let payload = vec![0x5a_u8; 4096];
+            fs::write(workspace.path().join(&relative_path), &payload).unwrap();
+            let digest = hex_digest(Sha256::digest(&payload).into());
+            let sealed = [AuthenticatedGraphFile {
+                relative_path,
+                byte_length: payload.len() as u64,
+                content_sha256: digest.clone(),
+            }];
+            let lease = begin_graph_object_publication(container.path()).unwrap();
+            let mut failed_state = GraphManifestState::empty();
+
+            inject_returned_error(Some(boundary));
+            let error = append_authenticated_graph_files_v2(
+                &lease,
+                workspace.path(),
+                &mut failed_state,
+                &sealed,
+                &[],
+            )
+            .unwrap_err();
+            inject_returned_error(None);
+            assert_injected_error(error, boundary);
+            assert!(
+                failed_state.root().is_none(),
+                "{boundary} exposed a manifest reference"
+            );
+
+            let object = graph_object_path(container.path(), &digest).unwrap();
+            let recoverable_temporary_exists = container
+                .path()
+                .join(GRAPH_OBJECTS_DIR)
+                .join(TEMP_DIR)
+                .read_dir()
+                .unwrap()
+                .next()
+                .is_some();
+            if object.exists() {
+                verify_graph_object(container.path(), &digest, payload.len() as u64).unwrap();
+            } else {
+                assert!(
+                    recoverable_temporary_exists,
+                    "{boundary} lost both the valid object and recoverable temporary"
+                );
+            }
+
+            let mut retry_state = GraphManifestState::empty();
+            append_authenticated_graph_files_v2(
+                &lease,
+                workspace.path(),
+                &mut retry_state,
+                &sealed,
+                &[],
+            )
+            .unwrap();
+            assert!(retry_state.root().is_some());
+            verify_graph_object(container.path(), &digest, payload.len() as u64).unwrap();
+        }
+        inject_returned_error(None);
     }
 
     #[test]
@@ -3348,6 +3549,120 @@ mod tests {
         assert_eq!(resolved.len(), FILES);
         assert!(evidence.segments_examined <= (2 * FILES - 1) as u64);
         assert!(evidence.work_units <= (4 * FILES - 2) as u64);
+    }
+
+    #[test]
+    fn authenticated_publication_hashes_each_payload_once_with_constant_factor() {
+        for files in [1_usize, 2, 4] {
+            let container = tempfile::tempdir().unwrap();
+            let workspace = tempfile::tempdir().unwrap();
+            let sealed = (0..files)
+                .map(|ordinal| {
+                    let payload = vec![u8::try_from(ordinal + 1).unwrap(); 4096];
+                    let relative_path = PathBuf::from(format!("shards/{ordinal}.parquet"));
+                    let source = workspace.path().join(&relative_path);
+                    fs::create_dir_all(source.parent().unwrap()).unwrap();
+                    fs::write(source, &payload).unwrap();
+                    AuthenticatedGraphFile {
+                        relative_path,
+                        byte_length: payload.len() as u64,
+                        content_sha256: hex_digest(Sha256::digest(&payload).into()),
+                    }
+                })
+                .collect::<Vec<_>>();
+            let lease = begin_graph_object_publication(container.path()).unwrap();
+            let mut state = GraphManifestState::empty();
+            let (_, evidence) = append_authenticated_graph_files_v2(
+                &lease,
+                workspace.path(),
+                &mut state,
+                &sealed,
+                &[],
+            )
+            .unwrap();
+            assert_eq!(
+                evidence.payload_bytes_hashed,
+                u64::try_from(files * 4096).unwrap()
+            );
+            let mut replay_state = GraphManifestState::empty();
+            let (_, replay_evidence) = append_authenticated_graph_files_v2(
+                &lease,
+                workspace.path(),
+                &mut replay_state,
+                &sealed,
+                &[],
+            )
+            .unwrap();
+            assert_eq!(
+                replay_evidence.payload_bytes_hashed,
+                u64::try_from(files * 4096).unwrap(),
+                "CAS reuse must report its one mandatory physical authentication read"
+            );
+            drop(lease);
+            let reclaimed =
+                gc_graph_objects(container.path(), &[], crate::GraphManifestLimits::default())
+                    .unwrap();
+            assert!(reclaimed.objects_removed >= files as u64);
+        }
+    }
+
+    #[test]
+    fn authenticated_publication_still_rejects_corrupt_writer_output() {
+        let container = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let relative_path = PathBuf::from("corrupt.parquet");
+        fs::write(workspace.path().join(&relative_path), b"mutated!").unwrap();
+        let sealed = [AuthenticatedGraphFile {
+            relative_path,
+            byte_length: 8,
+            content_sha256: hex_digest(Sha256::digest(b"original").into()),
+        }];
+        let lease = begin_graph_object_publication(container.path()).unwrap();
+        let mut state = GraphManifestState::empty();
+        assert!(
+            append_authenticated_graph_files_v2(
+                &lease,
+                workspace.path(),
+                &mut state,
+                &sealed,
+                &[],
+            )
+            .is_err()
+        );
+        assert!(state.root().is_none());
+    }
+
+    #[test]
+    fn cas_copy_isolated_from_preexisting_writable_source_descriptor() {
+        let container = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let relative_path = PathBuf::from("owned.parquet");
+        let payload = vec![9_u8; 4096];
+        let workspace_path = workspace.path().join(&relative_path);
+        fs::write(&workspace_path, &payload).unwrap();
+        let mut hostile = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&workspace_path)
+            .unwrap();
+        let sealed = [AuthenticatedGraphFile {
+            relative_path,
+            byte_length: payload.len() as u64,
+            content_sha256: hex_digest(Sha256::digest(&payload).into()),
+        }];
+        let lease = begin_graph_object_publication(container.path()).unwrap();
+        let mut state = GraphManifestState::empty();
+        append_authenticated_graph_files_v2(&lease, workspace.path(), &mut state, &sealed, &[])
+            .unwrap();
+        assert!(workspace_path.exists());
+        hostile.rewind().unwrap();
+        hostile.write_all(&vec![0x44; payload.len()]).unwrap();
+        hostile.sync_all().unwrap();
+        verify_graph_object(
+            container.path(),
+            &sealed[0].content_sha256,
+            payload.len() as u64,
+        )
+        .unwrap();
     }
 
     #[test]

--- a/docs/reference/scale-limits.md
+++ b/docs/reference/scale-limits.md
@@ -197,6 +197,46 @@ heap vectors for every graph edge.
 | Bounded delta overlay without full base copy | Covered by storage overlay parity tests |
 | Selected-subgraph projection bounded by selection | Covered by export path iterating selected node ids |
 | Peak RSS / cold-warm first-use on #334 fixtures | Hardware-specific observation only; recorded in [`m4-exit-evidence.json`](../development/m4-exit-evidence.json). Never a CI pass/fail gate. |
+## Construction integrity I/O
+
+The facade's immediate seal-and-publish path commits the receipt journal, then
+authenticates fixed-width staged artifacts while canonical shaping consumes
+them. Parquet keeps one whole-file digest pass because its bounded range
+decoder does not necessarily visit every file byte in digest order; metadata
+and row decoding are separately counted rather than mislabeled as
+authentication. Final shaped writers durably record their exact digest, length,
+and inode identity; inventory construction reads those small capabilities
+instead of reopening payloads. Incomplete/crash-resumed writers do not receive
+that authority and must regenerate or reauthenticate. A
+crash after that checkpoint does not trust unfinished work: resume performs the
+same full authentication before consumption. Ordinary standalone `seal` keeps
+its independent authentication contract.
+
+Encoding computes output digests over the bytes accepted by its writers and
+retains file and directory durability barriers. Construction publication binds
+the in-memory encoding to the durable inventory control record, then carries
+that authenticated inventory into the graph object store. The object store does
+not trust the recorded digest as a substitute for reading bytes. It creates a
+fresh CAS-owned inode and copies and hashes the source into that inode in one
+pass. It then fsyncs and seals the inode, checks its identity, length, and
+readonly state, links its final digest name, and durably syncs that destination
+directory before removing and syncing the temporary name. A pre-existing
+writable source descriptor therefore has no authority over the CAS inode.
+Reopening a compact workspace links the stable named CAS descriptor and
+performs one full verification on the installed hard link.
+These constant-factor bounds preserve corruption detection while keeping
+seal/publication I/O proportional to canonical output.
+
+`GraphConstructionEvidence` reconciles application-observed bytes read by
+owner: seal, shape, encode, publication control, CAS install/reuse, and
+hydration. The reported total is exactly the saturating sum of those six
+fields. These counters are logical application I/O, not filesystem-device
+physical reads or allocated/peak disk measurements. CAS evidence includes
+source-copy reads and mandatory authentication of reused or concurrently
+installed objects; it never reports a cache hit as zero application work.
+Actual allocated/peak disk and S20/S22 evidence remain harness-owned work in
+#951; #901 remains open until those measurements confirm the repaired path.
+
 ---
 
 ## Why Edge Count, Not Node Count


### PR DESCRIPTION
## Summary

- fuse staged fixed-run authentication into shape consumption and persist completed-writer digest/length/identity capabilities
- hash each new CAS payload once while copying it into a fresh private CAS inode, with fail-closed durability and recovery boundaries
- remove redundant shaped-output, publication, and hydration payload passes while preserving corruption and reopen semantics
- report application-observed read bytes honestly and document that #951 owns device-level/allocated/peak-disk evidence

## Why

Fly S20 attempt 5 showed bounded RSS but extreme constant-factor authenticated I/O during seal/publication. This change removes redundant whole-payload passes without weakening integrity or crash recovery.

## Validation

- `cargo test -p graphforge-storage graph_object_store::tests --lib` — 30 passed
- `cargo test -p graphforge-api resumable_construction --lib` — 5 passed
- `cargo clippy -p graphforge-storage -p graphforge-api --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 scripts/ci/test-non-cypher-surface-gate.py` — 12 passed
- `python3 scripts/ci/cargo-bazel-drift-check.py`
- `git diff --check`
- independent exact-head review: no actionable findings

## Scope

Fixes #971.

#901 remains open and blocked by #951 for actual S20/S22 RSS, elapsed-time, allocated/peak-disk, and provider evidence.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790457588&installation_model_id=20486&pr_number=972&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F972&signature=728e4e05b9cbd5c9fae19acd682845d6b7ad6afa451bc0faa97fbab57ff94dc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Reliability**
  - Improved recovery and resume behavior for interrupted graph construction and publication.
  - Added stronger validation to detect corrupted or tampered artifacts and inventories.
  - Enhanced cleanup and retry safety during graph file installation.

- **Performance**
  - Reduced redundant data reads during sealing, shaping, encoding, and publication.
  - Improved tracking of application read volumes, retained storage, and output sizes.
  - Added scale coverage for inputs ranging from 1,024 to 4,096 nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->