### PR TITLE
fix(storage): separate ordinal identity authority

### DIFF
--- a/crates/graphforge-filesystem/src/lib.rs
+++ b/crates/graphforge-filesystem/src/lib.rs
@@ -17,6 +17,89 @@ pub struct FileIdentity {
     pub file_id: [u8; 16],
 }
 
+/// Exclusive Windows capability used while constructing one CAS object.
+#[cfg(windows)]
+#[derive(Debug)]
+pub struct WindowsCasWriter {
+    file: File,
+    identity: FileIdentity,
+}
+
+#[cfg(windows)]
+impl io::Write for WindowsCasWriter {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        io::Write::write(&mut self.file, buffer)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        io::Write::flush(&mut self.file)
+    }
+}
+
+#[cfg(windows)]
+impl io::Read for WindowsCasWriter {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        io::Read::read(&mut self.file, buffer)
+    }
+}
+
+#[cfg(windows)]
+impl io::Seek for WindowsCasWriter {
+    fn seek(&mut self, position: io::SeekFrom) -> io::Result<u64> {
+        io::Seek::seek(&mut self.file, position)
+    }
+}
+
+#[cfg(windows)]
+impl WindowsCasWriter {
+    /// Flush the exact retained writer.
+    pub fn sync_all(&self) -> io::Result<()> {
+        self.file.sync_all()
+    }
+
+    /// Return the immutable identity captured at exclusive creation.
+    #[must_use]
+    pub fn identity(&self) -> FileIdentity {
+        self.identity
+    }
+}
+
+/// Read-only Windows capability for a canonically sealed CAS object.
+#[cfg(windows)]
+#[derive(Debug)]
+pub struct WindowsSealedCasFile(File);
+
+#[cfg(windows)]
+impl WindowsSealedCasFile {
+    /// Consume the sealed capability as a standard read-only file handle.
+    #[must_use]
+    pub fn into_file(self) -> File {
+        self.0
+    }
+}
+
+/// Exclusive retained handle for authenticating a released legacy Windows CAS object.
+#[cfg(windows)]
+#[derive(Debug)]
+pub struct WindowsLegacyCasAdopter {
+    file: File,
+    identity: FileIdentity,
+}
+
+#[cfg(windows)]
+impl io::Read for WindowsLegacyCasAdopter {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        io::Read::read(&mut self.file, buffer)
+    }
+}
+
+#[cfg(windows)]
+impl io::Seek for WindowsLegacyCasAdopter {
+    fn seek(&mut self, position: io::SeekFrom) -> io::Result<u64> {
+        io::Seek::seek(&mut self.file, position)
+    }
+}
+
 /// Retained directory capability whose children are opened without following
 /// links or reparse points.
 #[derive(Debug)]
@@ -145,6 +228,132 @@ impl StableDirectory {
         validate_stable_child_file(&file, &path)?;
         self.revalidate_named()?;
         Ok(file)
+    }
+
+    /// Create a Windows CAS child with exclusive data-write authority.
+    ///
+    /// Readers may coexist, but no second writer can be admitted. The handle
+    /// retains the native authority needed for the irreversible seal.
+    #[cfg(windows)]
+    pub fn create_cas_child_file(&self, name: &OsStr) -> io::Result<WindowsCasWriter> {
+        validate_child_name(name)?;
+        self.revalidate_named()?;
+        let path = self.path.join(name);
+        let file = windows::create_cas_writer(&path)?;
+        validate_stable_child_file(&file, &path)?;
+        self.revalidate_named()?;
+        Ok(WindowsCasWriter {
+            identity: file_identity(&file)?,
+            file,
+        })
+    }
+
+    /// Convert an exact Windows CAS writer into an identity-matched sealed reader.
+    #[cfg(windows)]
+    pub fn seal_cas_child_file(
+        &self,
+        name: &OsStr,
+        writer: WindowsCasWriter,
+    ) -> io::Result<WindowsSealedCasFile> {
+        validate_child_name(name)?;
+        self.revalidate_named()?;
+        let path = self.path.join(name);
+        let expected = writer.identity;
+        if file_identity(&writer.file)? != expected || path_identity(&path)? != expected {
+            return Err(io::Error::other(
+                "CAS writer identity changed before sealing",
+            ));
+        }
+        windows::seal_cas_writer(&writer.file)?;
+        if file_identity(&writer.file)? != expected || path_identity(&path)? != expected {
+            return Err(io::Error::other(
+                "CAS writer identity changed while sealing",
+            ));
+        }
+        let bridge = windows::open_cas_bridge(&path)?;
+        if file_identity(&bridge)? != expected {
+            return Err(io::Error::other(
+                "CAS bridge identity changed while sealing",
+            ));
+        }
+        drop(writer.file);
+        let reader = windows::open_sealed_cas_reader(&path)?;
+        validate_stable_child_file(&reader, &path)?;
+        if file_identity(&reader)? != expected || path_identity(&path)? != expected {
+            return Err(io::Error::other(
+                "CAS identity changed while reopening sealed reader",
+            ));
+        }
+        drop(bridge);
+        self.revalidate_named()?;
+        Ok(WindowsSealedCasFile(reader))
+    }
+
+    /// Open a canonically sealed Windows CAS child while excluding writers.
+    #[cfg(windows)]
+    pub fn open_cas_child_file(&self, name: &OsStr) -> io::Result<WindowsSealedCasFile> {
+        validate_child_name(name)?;
+        self.revalidate_named()?;
+        let path = self.path.join(name);
+        let reader = windows::open_sealed_cas_reader(&path)?;
+        validate_stable_child_file(&reader, &path)?;
+        if !reader.metadata()?.permissions().readonly()
+            || !windows::has_canonical_cas_dacl(&reader)?
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "CAS child is not canonically sealed",
+            ));
+        }
+        self.revalidate_named()?;
+        Ok(WindowsSealedCasFile(reader))
+    }
+
+    /// Retain an exclusive metadata handle for authenticating a legacy sealed CAS child.
+    #[cfg(windows)]
+    pub fn open_legacy_cas_child_for_adoption(
+        &self,
+        name: &OsStr,
+    ) -> io::Result<WindowsLegacyCasAdopter> {
+        validate_child_name(name)?;
+        self.revalidate_named()?;
+        let path = self.path.join(name);
+        let file = windows::open_legacy_cas_adopter(&path)?;
+        validate_stable_child_file(&file, &path)?;
+        let identity = file_identity(&file)?;
+        if path_identity(&path)? != identity {
+            return Err(io::Error::other("legacy CAS identity changed during open"));
+        }
+        self.revalidate_named()?;
+        Ok(WindowsLegacyCasAdopter { file, identity })
+    }
+
+    /// Canonically seal a retained legacy CAS child after caller authentication.
+    #[cfg(windows)]
+    pub fn adopt_legacy_cas_child(
+        &self,
+        name: &OsStr,
+        adopter: WindowsLegacyCasAdopter,
+    ) -> io::Result<WindowsSealedCasFile> {
+        validate_child_name(name)?;
+        self.revalidate_named()?;
+        let path = self.path.join(name);
+        windows::set_canonical_cas_dacl(&adopter.file)?;
+        let bridge = windows::open_cas_bridge(&path)?;
+        if file_identity(&bridge)? != adopter.identity {
+            return Err(io::Error::other("legacy CAS bridge identity changed"));
+        }
+        drop(adopter.file);
+        let reader = windows::open_sealed_cas_reader(&path)?;
+        if file_identity(&reader)? != adopter.identity || path_identity(&path)? != adopter.identity
+        {
+            return Err(io::Error::other(
+                "legacy CAS identity changed during adoption",
+            ));
+        }
+        drop(bridge);
+        self.revalidate_named()?;
+        Ok(WindowsSealedCasFile(reader))
     }
 
     /// Create a new regular child whose retained handle permits an atomic
@@ -1204,14 +1413,20 @@ mod windows {
         ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
     };
     #[cfg(test)]
-    use windows_sys::Win32::Security::{DACL_SECURITY_INFORMATION, OWNER_SECURITY_INFORMATION};
-    use windows_sys::Win32::Security::{PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES};
+    use windows_sys::Win32::Security::OWNER_SECURITY_INFORMATION;
+    use windows_sys::Win32::Security::{
+        ACL, ACL_SIZE_INFORMATION, AclSizeInformation, DACL_SECURITY_INFORMATION,
+        GetAclInformation, GetSecurityDescriptorControl, GetSecurityDescriptorDacl,
+        PROTECTED_DACL_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR, SE_DACL_PROTECTED,
+        SECURITY_ATTRIBUTES,
+    };
     use windows_sys::Win32::Storage::FileSystem::{
-        BY_HANDLE_FILE_INFORMATION, CreateDirectoryW, DELETE, FILE_DISPOSITION_FLAG_DELETE,
+        BY_HANDLE_FILE_INFORMATION, CreateDirectoryW, DELETE, FILE_ATTRIBUTE_READONLY,
+        FILE_BASIC_INFO, FILE_DISPOSITION_FLAG_DELETE,
         FILE_DISPOSITION_FLAG_IGNORE_READONLY_ATTRIBUTE, FILE_DISPOSITION_INFO_EX,
         FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_FLAG_WRITE_THROUGH,
         FILE_ID_INFO, FILE_NAME_NORMALIZED, FILE_READ_ATTRIBUTES, FILE_RENAME_INFO,
-        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FILE_WRITE_ATTRIBUTES,
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FILE_WRITE_ATTRIBUTES, FileBasicInfo,
         FileDispositionInfoEx, FileIdInfo, FileRenameInfo, FileRenameInfoEx, GetDriveTypeW,
         GetFileInformationByHandle, GetFileInformationByHandleEx, GetFinalPathNameByHandleW,
         GetVolumeInformationW, GetVolumePathNameW, SetFileInformationByHandle, VOLUME_NAME_DOS,
@@ -1230,6 +1445,278 @@ mod windows {
     const FILESYSTEM_NAME_CAPACITY: usize = 256;
     const FILE_RENAME_REPLACE_IF_EXISTS_FLAG: u32 = 0x0000_0001;
     const FILE_RENAME_POSIX_SEMANTICS_FLAG: u32 = 0x0000_0002;
+
+    pub(super) fn create_cas_writer(path: &Path) -> io::Result<File> {
+        use windows_sys::Win32::Foundation::{GENERIC_READ, GENERIC_WRITE};
+        use windows_sys::Win32::Storage::FileSystem::WRITE_DAC;
+        std::fs::OpenOptions::new()
+            // `access_mode` supplies the exact native rights below, but the
+            // standard library still requires a write intent when a create
+            // disposition is requested.
+            .write(true)
+            .create_new(true)
+            .access_mode(GENERIC_READ | GENERIC_WRITE | WRITE_DAC)
+            .share_mode(FILE_SHARE_READ)
+            .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_WRITE_THROUGH)
+            .open(path)
+    }
+
+    pub(super) fn seal_cas_writer(writer: &File) -> io::Result<()> {
+        writer.sync_all()?;
+        let current_attributes = information(writer)?.dwFileAttributes;
+        let mut basic = FILE_BASIC_INFO {
+            CreationTime: 0,
+            LastAccessTime: 0,
+            LastWriteTime: 0,
+            ChangeTime: 0,
+            FileAttributes: current_attributes | FILE_ATTRIBUTE_READONLY,
+        };
+        // SAFETY: `writer` is live and the fixed-size input is valid.
+        if unsafe {
+            SetFileInformationByHandle(
+                writer.as_raw_handle(),
+                FileBasicInfo,
+                (&raw mut basic).cast(),
+                u32::try_from(std::mem::size_of::<FILE_BASIC_INFO>())
+                    .expect("FILE_BASIC_INFO size fits u32"),
+            )
+        } == 0
+        {
+            return Err(io::Error::last_os_error());
+        }
+
+        set_canonical_cas_dacl(writer)?;
+        writer.sync_all()
+    }
+
+    fn canonical_cas_descriptor() -> io::Result<PSECURITY_DESCRIPTOR> {
+        // The owner is the ordinary (non-administrator) GraphForge process.
+        // Keep the sealed payload non-writable while retaining exactly the
+        // metadata right required by FileDispositionInfoEx's
+        // IGNORE_READONLY_ATTRIBUTE deletion path: FILE_GENERIC_READ | DELETE
+        // | FILE_WRITE_ATTRIBUTES. Use the file-specific mapped mask so the
+        // stored ACE has no generic bits. In particular, this grants neither
+        // data write/append nor WRITE_DAC.
+        cas_descriptor("D:P(A;;0x00130189;;;OW)(A;;FA;;;SY)(A;;FA;;;BA)")
+    }
+
+    fn cas_descriptor(sddl: &str) -> io::Result<PSECURITY_DESCRIPTOR> {
+        let descriptor_text = wide(OsStr::new(sddl))?;
+        let mut descriptor: PSECURITY_DESCRIPTOR = std::ptr::null_mut();
+        // SAFETY: the SDDL input and descriptor output are valid.
+        if unsafe {
+            ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                descriptor_text.as_ptr(),
+                SDDL_REVISION_1,
+                &mut descriptor,
+                std::ptr::null_mut(),
+            )
+        } == 0
+        {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(descriptor)
+        }
+    }
+
+    pub(super) fn set_canonical_cas_dacl(writer: &File) -> io::Result<()> {
+        let descriptor = canonical_cas_descriptor()?;
+        set_cas_dacl(writer, descriptor)
+    }
+
+    fn set_cas_dacl(writer: &File, descriptor: PSECURITY_DESCRIPTOR) -> io::Result<()> {
+        let mut present = 0;
+        let mut defaulted = 0;
+        let mut dacl = std::ptr::null_mut();
+        // SAFETY: the converted descriptor is live and outputs are valid.
+        let got_dacl = unsafe {
+            GetSecurityDescriptorDacl(descriptor, &mut present, &mut dacl, &mut defaulted)
+        };
+        let operation = if got_dacl == 0 || present == 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            // SAFETY: the writer owns WRITE_DAC and the DACL remains live.
+            let status = unsafe {
+                windows_sys::Win32::Security::Authorization::SetSecurityInfo(
+                    writer.as_raw_handle(),
+                    windows_sys::Win32::Security::Authorization::SE_FILE_OBJECT,
+                    DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                    dacl,
+                    std::ptr::null_mut(),
+                )
+            };
+            if status == 0 {
+                Ok(())
+            } else {
+                Err(io::Error::from_raw_os_error(
+                    i32::try_from(status).unwrap_or(i32::MAX),
+                ))
+            }
+        };
+        // SAFETY: conversion allocated this descriptor with LocalAlloc.
+        unsafe { LocalFree(descriptor.cast()) };
+        operation
+    }
+
+    #[cfg(test)]
+    pub(super) fn replace_with_owner_only_cas_dacl(path: &Path) -> io::Result<()> {
+        use windows_sys::Win32::Foundation::GENERIC_READ;
+        use windows_sys::Win32::Storage::FileSystem::WRITE_DAC;
+        let file = std::fs::OpenOptions::new()
+            .access_mode(GENERIC_READ | WRITE_DAC)
+            .share_mode(FILE_SHARE_READ)
+            .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+            .open(path)?;
+        let descriptor = cas_descriptor("D:P(A;;0x00130189;;;OW)")?;
+        set_cas_dacl(&file, descriptor)
+    }
+
+    pub(super) fn open_sealed_cas_reader(path: &Path) -> io::Result<File> {
+        std::fs::OpenOptions::new()
+            .read(true)
+            .share_mode(FILE_SHARE_READ)
+            .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+            .open(path)
+    }
+
+    pub(super) fn open_cas_bridge(path: &Path) -> io::Result<File> {
+        std::fs::OpenOptions::new()
+            .read(true)
+            .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+            .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+            .open(path)
+    }
+
+    pub(super) fn open_legacy_cas_adopter(path: &Path) -> io::Result<File> {
+        use windows_sys::Win32::Foundation::GENERIC_READ;
+        use windows_sys::Win32::Storage::FileSystem::WRITE_DAC;
+        // Released Windows objects carry the read-only attribute but inherited
+        // DACLs. This exclusive metadata handle safely upgrades only those
+        // objects. Writable planted files and files with a pre-opened writer
+        // are rejected rather than blessed as CAS authority.
+        let writer = std::fs::OpenOptions::new()
+            .access_mode(GENERIC_READ | WRITE_DAC | FILE_WRITE_ATTRIBUTES)
+            .share_mode(FILE_SHARE_READ)
+            .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_WRITE_THROUGH)
+            .open(path)?;
+        if information(&writer)?.dwFileAttributes & FILE_ATTRIBUTE_READONLY == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "unsealed CAS child cannot be adopted",
+            ));
+        }
+        Ok(writer)
+    }
+
+    pub(super) fn has_canonical_cas_dacl(file: &File) -> io::Result<bool> {
+        use windows_sys::Win32::Security::Authorization::{GetSecurityInfo, SE_FILE_OBJECT};
+
+        let expected_descriptor = canonical_cas_descriptor()?;
+        let mut actual: PSECURITY_DESCRIPTOR = std::ptr::null_mut();
+        // SAFETY: all optional component outputs are null and the descriptor
+        // output is released below.
+        let status = unsafe {
+            GetSecurityInfo(
+                file.as_raw_handle(),
+                SE_FILE_OBJECT,
+                DACL_SECURITY_INFORMATION,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                &raw mut actual,
+            )
+        };
+        if status != 0 {
+            // SAFETY: canonical descriptor was allocated with LocalAlloc.
+            unsafe { LocalFree(expected_descriptor.cast()) };
+            return Err(io::Error::from_raw_os_error(
+                i32::try_from(status).unwrap_or(i32::MAX),
+            ));
+        }
+        let result = descriptors_have_same_protected_dacl(actual, expected_descriptor);
+        // SAFETY: actual was allocated by GetSecurityInfo.
+        unsafe { LocalFree(actual.cast()) };
+        // SAFETY: canonical descriptor was allocated with LocalAlloc.
+        unsafe { LocalFree(expected_descriptor.cast()) };
+        result
+    }
+
+    fn descriptors_have_same_protected_dacl(
+        actual: PSECURITY_DESCRIPTOR,
+        expected: PSECURITY_DESCRIPTOR,
+    ) -> io::Result<bool> {
+        let mut control = 0;
+        let mut revision = 0;
+        // The protection bit is the security property we require. Other
+        // descriptor-control bits (notably SE_DACL_AUTO_INHERITED) describe
+        // provenance and may legitimately differ after SetSecurityInfo.
+        if unsafe { GetSecurityDescriptorControl(actual, &raw mut control, &raw mut revision) } == 0
+        {
+            return Err(io::Error::last_os_error());
+        }
+        if control & SE_DACL_PROTECTED == 0 {
+            return Ok(false);
+        }
+
+        let actual_dacl = descriptor_dacl(actual)?;
+        let expected_dacl = descriptor_dacl(expected)?;
+        let actual_bytes = acl_bytes_in_use(actual_dacl)?;
+        let expected_bytes = acl_bytes_in_use(expected_dacl)?;
+        if actual_bytes != expected_bytes {
+            return Ok(false);
+        }
+        // SAFETY: both ACL pointers remain owned by their live descriptors and
+        // GetAclInformation proved the byte ranges occupied by their ACEs.
+        Ok(unsafe {
+            std::slice::from_raw_parts(actual_dacl.cast::<u8>(), actual_bytes)
+                == std::slice::from_raw_parts(expected_dacl.cast::<u8>(), expected_bytes)
+        })
+    }
+
+    fn descriptor_dacl(descriptor: PSECURITY_DESCRIPTOR) -> io::Result<*mut ACL> {
+        let mut present = 0;
+        let mut defaulted = 0;
+        let mut dacl = std::ptr::null_mut();
+        if unsafe {
+            GetSecurityDescriptorDacl(
+                descriptor,
+                &raw mut present,
+                &raw mut dacl,
+                &raw mut defaulted,
+            )
+        } == 0
+        {
+            return Err(io::Error::last_os_error());
+        }
+        if present == 0 || dacl.is_null() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "security descriptor has no explicit DACL",
+            ));
+        }
+        Ok(dacl)
+    }
+
+    fn acl_bytes_in_use(dacl: *const ACL) -> io::Result<usize> {
+        let mut information = ACL_SIZE_INFORMATION::default();
+        if unsafe {
+            GetAclInformation(
+                dacl,
+                (&raw mut information).cast(),
+                u32::try_from(std::mem::size_of::<ACL_SIZE_INFORMATION>())
+                    .expect("ACL_SIZE_INFORMATION size fits u32"),
+                AclSizeInformation,
+            )
+        } == 0
+        {
+            return Err(io::Error::last_os_error());
+        }
+        usize::try_from(information.AclBytesInUse)
+            .map_err(|_| io::Error::other("ACL byte length does not fit usize"))
+    }
 
     pub(super) fn replace_file(
         directory: &File,
@@ -2537,22 +3024,77 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn stable_directory_unlinks_exact_readonly_child_without_unsealing_hard_link() {
+    fn stable_directory_adopts_readonly_legacy_cas_without_data_write_authority() {
+        use std::io::Read as _;
+        use std::os::windows::fs::OpenOptionsExt as _;
+
+        const FILE_SHARE_READ: u32 = 0x0000_0001;
+        const FILE_SHARE_WRITE: u32 = 0x0000_0002;
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("legacy");
+        let payload = b"authenticated legacy payload";
+        std::fs::write(&path, payload).unwrap();
+        let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+        permissions.set_readonly(true);
+        std::fs::set_permissions(&path, permissions).unwrap();
+        let stable = StableDirectory::open(root.path()).unwrap();
+        let expected = path_identity(&path).unwrap();
+
+        let mut adopter = stable
+            .open_legacy_cas_child_for_adoption(OsStr::new("legacy"))
+            .unwrap();
+        let mut authenticated = Vec::new();
+        adopter.read_to_end(&mut authenticated).unwrap();
+        assert_eq!(authenticated, payload);
+        assert!(
+            std::fs::OpenOptions::new()
+                .write(true)
+                .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+                .open(&path)
+                .is_err()
+        );
+
+        let adopted = stable
+            .adopt_legacy_cas_child(OsStr::new("legacy"), adopter)
+            .unwrap();
+        assert_eq!(file_identity(&adopted.0).unwrap(), expected);
+        assert_eq!(std::fs::read(&path).unwrap(), payload);
+        drop(adopted);
+        assert!(stable.open_cas_child_file(OsStr::new("legacy")).is_ok());
+        assert!(
+            std::fs::OpenOptions::new()
+                .write(true)
+                .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+                .open(&path)
+                .is_err()
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn stable_directory_unlinks_canonical_cas_child_without_unsealing_hard_link() {
         use std::io::Write as _;
 
         let root = tempfile::tempdir().unwrap();
         let stable = StableDirectory::open(root.path()).unwrap();
         let temporary_path = root.path().join("temporary");
         let installed_path = root.path().join("installed");
-        let mut temporary = stable.create_child_file(OsStr::new("temporary")).unwrap();
+        let mut temporary = stable
+            .create_cas_child_file(OsStr::new("temporary"))
+            .unwrap();
         temporary.write_all(b"sealed").unwrap();
         temporary.sync_all().unwrap();
-        let identity = file_identity(&temporary).unwrap();
+        let identity = temporary.identity();
+        let temporary = stable
+            .seal_cas_child_file(OsStr::new("temporary"), temporary)
+            .unwrap()
+            .into_file();
+        assert!(
+            stable.open_cas_child_file(OsStr::new("temporary")).is_ok(),
+            "a freshly sealed CAS child must pass canonical reopen"
+        );
         std::fs::hard_link(&temporary_path, &installed_path).unwrap();
         assert_eq!(path_identity(&installed_path).unwrap(), identity);
-        let mut permissions = temporary.metadata().unwrap().permissions();
-        permissions.set_readonly(true);
-        temporary.set_permissions(permissions).unwrap();
         assert!(temporary.metadata().unwrap().permissions().readonly());
         assert!(
             std::fs::metadata(&installed_path)
@@ -2561,6 +3103,8 @@ mod tests {
                 .readonly()
         );
         drop(temporary);
+        windows::replace_with_owner_only_cas_dacl(&temporary_path).unwrap();
+        assert_eq!(path_identity(&temporary_path).unwrap(), identity);
 
         stable
             .unlink_child_if_identity(OsStr::new("temporary"), identity)

--- a/crates/graphforge-storage/src/durable_rewrite.rs
+++ b/crates/graphforge-storage/src/durable_rewrite.rs
@@ -154,25 +154,13 @@ pub(crate) fn reconcile_auxiliary(
         },
     )?;
     let current = crate::generation::read_generation_state_raw(root)?;
-    let relative = Path::new(&receipt.path);
     canonical_journal_path(&receipt.path)?;
-    let mut directory = graphforge_filesystem::StableDirectory::open(root).map_err(storage)?;
-    let mut components = relative.components().peekable();
-    let mut file = None;
-    while let Some(component) = components.next() {
-        let Component::Normal(name) = component else {
-            return Err(storage("auxiliary receipt path is not canonical"));
-        };
-        if components.peek().is_some() {
-            directory = directory.open_child_directory(name).map_err(storage)?;
-        } else {
-            file = match directory.open_child_file(name) {
-                Ok(file) => Some(file),
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
-                Err(error) => return Err(storage(error)),
-            };
-        }
-    }
+    let (directory, name) = retained_parent_at(root, &guard.directory, &receipt.path)?;
+    let file = match directory.open_child_file(&name) {
+        Ok(file) => Some(file),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => return Err(storage(error)),
+    };
     let exact = if let Some(file) = file {
         let (bytes, digest) = hash_reader(file.try_clone().map_err(storage)?)?;
         directory.revalidate_named().map_err(storage)?;
@@ -222,10 +210,60 @@ fn canonical_relative(root: &Path, path: &Path) -> Result<String, GfError> {
             "rewrite destination is not a canonical relative path",
         ));
     }
-    relative
-        .to_str()
-        .map(str::to_owned)
-        .ok_or_else(|| storage("rewrite destination is not UTF-8"))
+    let mut wire = String::new();
+    for component in relative.components() {
+        let Component::Normal(component) = component else {
+            return Err(storage(
+                "rewrite destination is not a canonical relative path",
+            ));
+        };
+        let component = component
+            .to_str()
+            .ok_or_else(|| storage("rewrite destination is not UTF-8"))?;
+        // Journal paths are a platform-neutral wire format, not native path
+        // strings. A backslash is a separator on Windows and a filename byte
+        // on Unix, so admitting it would make the same authenticated journal
+        // name different objects on different hosts.
+        if component.contains('\\') {
+            return Err(storage("rewrite destination cannot be encoded canonically"));
+        }
+        if !wire.is_empty() {
+            wire.push('/');
+        }
+        wire.push_str(component);
+    }
+    Ok(wire)
+}
+
+/// Decode an authenticated journal path to its canonical, slash-separated
+/// wire spelling. Version-1 journals written by older Windows builds used
+/// native backslashes. They remain recoverable on Windows only when the whole
+/// spelling is unambiguously legacy; mixed separators fail closed.
+fn normalize_journal_path(value: &str, allow_legacy_windows: bool) -> Result<String, GfError> {
+    let has_forward = value.contains('/');
+    let has_back = value.contains('\\');
+    if has_back && (!allow_legacy_windows || has_forward) {
+        return Err(storage("rewrite journal contains non-canonical path"));
+    }
+    let normalized = if has_back {
+        value.replace('\\', "/")
+    } else {
+        value.to_owned()
+    };
+    if normalized.is_empty()
+        || normalized.starts_with('/')
+        || normalized.ends_with('/')
+        || normalized
+            .split('/')
+            .any(|component| component.is_empty() || component == "." || component == "..")
+    {
+        return Err(storage("rewrite journal contains non-canonical path"));
+    }
+    Ok(normalized)
+}
+
+fn decoded_journal_path(value: &str) -> Result<String, GfError> {
+    normalize_journal_path(value, cfg!(windows))
 }
 
 fn hash_reader(mut file: File) -> Result<(u64, String), GfError> {
@@ -482,20 +520,19 @@ fn retained_parent_at(
     root: &StableDirectory,
     relative: &str,
 ) -> Result<(StableDirectory, std::ffi::OsString), GfError> {
-    let path = Path::new(relative);
-    let mut components = path.components().peekable();
+    let wire = decoded_journal_path(relative)?;
+    let mut components = wire.split('/').peekable();
     let mut directory = StableDirectory::open(root_path).map_err(storage)?;
     if directory.identity() != root.identity() {
         return Err(storage("rewrite root identity changed"));
     }
-    while let Some(component) = components.next() {
-        let Component::Normal(name) = component else {
-            return Err(storage("non-canonical journal path"));
-        };
+    while let Some(name) = components.next() {
         if components.peek().is_none() {
-            return Ok((directory, name.to_os_string()));
+            return Ok((directory, std::ffi::OsString::from(name)));
         }
-        directory = directory.open_child_directory(name).map_err(storage)?;
+        directory = directory
+            .open_child_directory(std::ffi::OsStr::new(name))
+            .map_err(storage)?;
     }
     Err(storage("empty journal path"))
 }
@@ -563,6 +600,15 @@ fn recover_locked(
         }
         return remove_journal(root);
     }
+    // The durable intent is the single replay authority for both the live
+    // commit and crash recovery.  Acquire the ordinal lifecycle lock here,
+    // after authenticating the intent, so every v4 replay owns the same
+    // exclusion across all artifact installs and the generation-last switch.
+    let _ordinal_writer = if intent.auxiliary.as_ref().is_some_and(is_v4_ordinal_receipt) {
+        Some(acquire_ordinal_writer_lock(root)?)
+    } else {
+        None
+    };
     let authority_count = intent
         .entries
         .iter()
@@ -613,6 +659,46 @@ fn recover_locked(
         false,
     )?;
     remove_journal(root)
+}
+
+struct OrdinalWriterGuard {
+    _directory: StableDirectory,
+    file: File,
+    _identity: FileIdentity,
+}
+
+impl Drop for OrdinalWriterGuard {
+    fn drop(&mut self) {
+        let _ = crate::file_lock::unlock(&self.file);
+    }
+}
+
+fn acquire_ordinal_writer_lock(root: &StableDirectory) -> Result<OrdinalWriterGuard, GfError> {
+    let directory = root
+        .open_child_directory(std::ffi::OsStr::new("topology"))
+        .and_then(|topology| topology.open_child_directory(std::ffi::OsStr::new("uuid-membership")))
+        .map_err(storage)?;
+    let file = directory
+        .open_child_file(std::ffi::OsStr::new("ordinal-v4.lock"))
+        .map_err(storage)?;
+    if graphforge_filesystem::file_link_count(&file).map_err(storage)? != 1 {
+        return Err(storage("ordinal writer lock has invalid link count"));
+    }
+    crate::file_lock::lock_exclusive(&file).map_err(storage)?;
+    let identity = graphforge_filesystem::file_identity(&file).map_err(storage)?;
+    let named = directory
+        .open_child_file(std::ffi::OsStr::new("ordinal-v4.lock"))
+        .map_err(storage)?;
+    if graphforge_filesystem::file_identity(&named).map_err(storage)? != identity
+        || graphforge_filesystem::file_link_count(&named).map_err(storage)? != 1
+    {
+        return Err(storage("ordinal writer lock identity changed"));
+    }
+    Ok(OrdinalWriterGuard {
+        _directory: directory,
+        file,
+        _identity: identity,
+    })
 }
 
 fn cleanup_preparing_input(
@@ -683,18 +769,25 @@ fn verify_generation_authority(
 }
 
 fn validate_intent(intent: &Intent) -> Result<(), GfError> {
+    validate_intent_for_platform(intent, cfg!(windows))
+}
+
+fn validate_intent_for_platform(
+    intent: &Intent,
+    allow_legacy_windows: bool,
+) -> Result<(), GfError> {
     let mut destinations = std::collections::HashSet::new();
     let mut temporaries = std::collections::HashSet::new();
     for entry in &intent.entries {
-        if !destinations.insert(&entry.destination) || !temporaries.insert(&entry.temporary) {
+        let destination = normalize_journal_path(&entry.destination, allow_legacy_windows)?;
+        let temporary = normalize_journal_path(&entry.temporary, allow_legacy_windows)?;
+        if !destinations.insert(destination.clone()) || !temporaries.insert(temporary.clone()) {
             return Err(storage("rewrite journal contains duplicate paths"));
         }
-        canonical_journal_path(&entry.destination)?;
-        canonical_journal_path(&entry.temporary)?;
-        if entry.destination == JOURNAL
-            || entry.destination == LOCK
-            || entry.temporary == JOURNAL
-            || entry.temporary == LOCK
+        if destination == JOURNAL
+            || destination == LOCK
+            || temporary == JOURNAL
+            || temporary == LOCK
         {
             return Err(storage("rewrite journal targets a reserved control"));
         }
@@ -704,7 +797,10 @@ fn validate_intent(intent: &Intent) -> Result<(), GfError> {
         .iter()
         .filter(|entry| entry.class == EntryClass::GenerationAuthority)
         .collect::<Vec<_>>();
-    if authority.len() != 1 || authority[0].destination != "topology/generation.json" {
+    if authority.len() != 1
+        || normalize_journal_path(&authority[0].destination, allow_legacy_windows)?
+            != "topology/generation.json"
+    {
         return Err(storage("rewrite journal has invalid generation authority"));
     }
     if intent.next.topology < intent.prior.topology
@@ -715,10 +811,14 @@ fn validate_intent(intent: &Intent) -> Result<(), GfError> {
         return Err(storage("rewrite generation transition is not monotonic"));
     }
     if let Some(receipt) = &intent.auxiliary {
+        canonical_journal_path(&receipt.path)?;
         let entry = intent
             .entries
             .iter()
-            .find(|entry| entry.destination == receipt.path)
+            .find(|entry| {
+                normalize_journal_path(&entry.destination, allow_legacy_windows)
+                    .is_ok_and(|destination| destination == receipt.path)
+            })
             .ok_or_else(|| storage("auxiliary receipt path is not staged"))?;
         if entry.class != EntryClass::Data
             || entry.sha256 != receipt.digest
@@ -735,13 +835,7 @@ fn validate_intent(intent: &Intent) -> Result<(), GfError> {
 }
 
 fn canonical_journal_path(value: &str) -> Result<(), GfError> {
-    let path = Path::new(value);
-    if path.as_os_str().is_empty()
-        || path.is_absolute()
-        || path
-            .components()
-            .any(|component| !matches!(component, Component::Normal(_)))
-    {
+    if normalize_journal_path(value, false).is_err() {
         return Err(storage("rewrite journal contains non-canonical path"));
     }
     Ok(())
@@ -910,6 +1004,12 @@ pub(crate) fn commit_with_participant(
     }
     let auxiliary = participant_auxiliary.or(auxiliary);
     let reserved = root.join("topology/uuid-membership");
+    let ordinal_lock_path = reserved.join("ordinal-v4.lock");
+    if stages_ordinal_lock(&batch, &ordinal_lock_path) {
+        return Err(storage(
+            "ordinal writer lock is stable lifecycle state and cannot be staged",
+        ));
+    }
     if has_participant
         && batch
             .staged_paths()
@@ -929,11 +1029,9 @@ pub(crate) fn commit_with_participant(
         ));
     }
     if stages_reserved
-        && auxiliary.as_ref().is_none_or(|receipt| {
-            receipt.kind != "uuid-membership/v3"
-                || receipt.schema_version != 3
-                || receipt.path != "topology/uuid-membership/topology-receipt.json"
-        })
+        && auxiliary
+            .as_ref()
+            .is_none_or(|receipt| !valid_uuid_receipt(receipt))
     {
         return Err(storage(
             "UUID rewrite participant must stage its namespace and exact typed receipt",
@@ -1063,6 +1161,46 @@ pub(crate) fn commit_with_participant(
     guard.revalidate()?;
     crate::io_stats::record_rewrite_commit();
     Ok(next)
+}
+
+fn stages_ordinal_lock(batch: &RewriteBatch, ordinal_lock_path: &Path) -> bool {
+    batch
+        .staged_paths()
+        .any(|destination| destination == ordinal_lock_path)
+}
+
+fn valid_uuid_receipt(receipt: &AuxiliaryReceipt) -> bool {
+    matches!(
+        (
+            receipt.kind.as_str(),
+            receipt.schema_version,
+            receipt.path.as_str()
+        ),
+        (
+            "uuid-membership/v3",
+            3,
+            "topology/uuid-membership/topology-receipt.json"
+        ) | (
+            "uuid-membership/v4",
+            4,
+            "topology/uuid-membership/ordinal-v4-receipt.json"
+        )
+    )
+}
+
+fn is_v4_ordinal_receipt(receipt: &AuxiliaryReceipt) -> bool {
+    matches!(
+        (
+            receipt.kind.as_str(),
+            receipt.schema_version,
+            receipt.path.as_str()
+        ),
+        (
+            "uuid-membership/v4",
+            4,
+            "topology/uuid-membership/ordinal-v4-receipt.json"
+        )
+    )
 }
 
 #[cfg(test)]
@@ -1211,6 +1349,65 @@ mod tests {
         assert!(validate_intent(&valid).is_ok());
         valid.auxiliary.as_mut().unwrap().digest = "00".repeat(32);
         assert!(validate_intent(&valid).is_err());
+
+        let mut cross_paired = valid.auxiliary.unwrap();
+        cross_paired.digest = valid.entries[0].sha256.clone();
+        cross_paired.path = "topology/uuid-membership/ordinal-v4-receipt.json".to_owned();
+        assert!(!valid_uuid_receipt(&cross_paired));
+        cross_paired.kind = "uuid-membership/v4".to_owned();
+        cross_paired.schema_version = 4;
+        assert!(valid_uuid_receipt(&cross_paired));
+    }
+
+    #[test]
+    fn journal_wire_paths_are_slash_canonical_and_bind_legacy_windows_entries() {
+        let root = Path::new("project-root");
+        let native = root
+            .join("topology")
+            .join("uuid-membership")
+            .join("receipt.json");
+        assert_eq!(
+            canonical_relative(root, &native).unwrap(),
+            "topology/uuid-membership/receipt.json"
+        );
+
+        let mut legacy = intent();
+        legacy.auxiliary = Some(AuxiliaryReceipt {
+            kind: "uuid-membership/v3".to_owned(),
+            schema_version: 3,
+            path: legacy.entries[0].destination.clone(),
+            digest: legacy.entries[0].sha256.clone(),
+            bytes: legacy.entries[0].bytes,
+        });
+        for entry in &mut legacy.entries {
+            entry.destination = entry.destination.replace('/', "\\");
+            entry.temporary = entry.temporary.replace('/', "\\");
+        }
+        // The receipt was already platform-neutral while old Windows journal
+        // entries were native-spelled. Their authenticated names still bind.
+        assert!(validate_intent_for_platform(&legacy, true).is_ok());
+        assert!(validate_intent_for_platform(&legacy, false).is_err());
+
+        legacy.entries[0].destination = "topology\\uuid-membership/receipt.json".to_owned();
+        assert!(validate_intent_for_platform(&legacy, true).is_err());
+    }
+
+    #[test]
+    fn legacy_windows_normalization_rejects_cross_spelling_aliases() {
+        let mut aliased = intent();
+        aliased.entries[0].destination = "same/path".to_owned();
+        aliased.entries[1].destination = "same\\path".to_owned();
+        assert!(validate_intent_for_platform(&aliased, true).is_err());
+    }
+
+    #[test]
+    fn ordinal_lifecycle_lock_can_never_be_a_staged_destination() {
+        let root = TempDir::new().unwrap();
+        let path = root.path().join("topology/uuid-membership/ordinal-v4.lock");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let mut batch = RewriteBatch::new();
+        batch.stage_bytes(&path, b"replacement").unwrap();
+        assert!(stages_ordinal_lock(&batch, &path));
     }
 
     #[test]
@@ -1364,6 +1561,92 @@ mod tests {
 
         let next = single_value_rewrite(armed_root.path(), 13);
         commit(next, armed_root.path(), true, true, false, None).unwrap();
+    }
+
+    #[test]
+    fn subprocess_v4_recovery_waits_for_active_ordinal_reader() {
+        const CHILD_ROOT: &str = "GRAPHFORGE_V4_RECOVERY_CHILD_ROOT";
+        if let Ok(root) = std::env::var(CHILD_ROOT) {
+            std::fs::write(Path::new(&root).join("recovery-started"), []).unwrap();
+            recover(Path::new(&root)).unwrap();
+            std::fs::write(Path::new(&root).join("recovery-finished"), []).unwrap();
+            return;
+        }
+
+        let root = TempDir::new().unwrap();
+        let index = root.path().join("topology/uuid-membership");
+        std::fs::create_dir_all(&index).unwrap();
+        std::fs::write(index.join("ordinal-v4.lock"), []).unwrap();
+        let receipt = br#"{"schema_version":4}"#;
+        let receipt_digest = hex(&Sha256::digest(receipt));
+        let participant: RewriteParticipantPreparer<'_> = Box::new(move |context, batch| {
+            batch.stage_bytes(
+                &context
+                    .project_root
+                    .join("topology/uuid-membership/ordinal-v4-manifest.json"),
+                br#"{"schema_version":4}"#,
+            )?;
+            batch.stage_bytes(
+                &context
+                    .project_root
+                    .join("topology/uuid-membership/ordinal-v4-receipt.json"),
+                receipt,
+            )?;
+            Ok(Some(AuxiliaryReceipt {
+                kind: "uuid-membership/v4".to_owned(),
+                schema_version: 4,
+                path: "topology/uuid-membership/ordinal-v4-receipt.json".to_owned(),
+                digest: receipt_digest,
+                bytes: receipt.len() as u64,
+            }))
+        });
+        FAIL_AFTER_DURABLE_INTENT.set(true);
+        assert!(
+            commit_with_participant(
+                RewriteBatch::new(),
+                root.path(),
+                true,
+                false,
+                false,
+                None,
+                Some(participant),
+            )
+            .is_err()
+        );
+
+        let stable_index = StableDirectory::open(&index).unwrap();
+        let reader_lock = stable_index
+            .open_child_file(std::ffi::OsStr::new("ordinal-v4.lock"))
+            .unwrap();
+        <File as fs4::FileExt>::lock_shared(&reader_lock).unwrap();
+        let mut child = std::process::Command::new(std::env::current_exe().unwrap())
+            .arg("--exact")
+            .arg("durable_rewrite::tests::subprocess_v4_recovery_waits_for_active_ordinal_reader")
+            .arg("--nocapture")
+            .env(CHILD_ROOT, root.path())
+            .spawn()
+            .unwrap();
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !root.path().join("recovery-started").exists() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "recovery child did not start"
+            );
+            std::thread::yield_now();
+        }
+        assert_eq!(child.try_wait().unwrap(), None);
+        assert!(!root.path().join("recovery-finished").exists());
+        <File as fs4::FileExt>::unlock(&reader_lock).unwrap();
+        assert!(child.wait().unwrap().success());
+        assert!(root.path().join("recovery-finished").is_file());
+        assert!(!root.path().join(JOURNAL).exists());
+        assert_eq!(
+            crate::generation::read_generation_state_raw(root.path())
+                .unwrap()
+                .topology,
+            1
+        );
     }
 
     #[test]

--- a/crates/graphforge-storage/src/durable_rewrite.rs
+++ b/crates/graphforge-storage/src/durable_rewrite.rs
@@ -701,6 +701,31 @@ fn acquire_ordinal_writer_lock(root: &StableDirectory) -> Result<OrdinalWriterGu
     })
 }
 
+fn initialize_ordinal_writer_lock(root: &StableDirectory) -> Result<(), GfError> {
+    let directory = root
+        .open_child_directory(std::ffi::OsStr::new("topology"))
+        .and_then(|topology| topology.open_child_directory(std::ffi::OsStr::new("uuid-membership")))
+        .map_err(storage)?;
+    let file = directory
+        .open_or_create_child_file(std::ffi::OsStr::new("ordinal-v4.lock"))
+        .map_err(storage)?;
+    if graphforge_filesystem::file_link_count(&file).map_err(storage)? != 1 {
+        return Err(storage("ordinal writer lock has invalid link count"));
+    }
+    let identity = graphforge_filesystem::file_identity(&file).map_err(storage)?;
+    file.sync_all().map_err(storage)?;
+    directory.sync().map_err(storage)?;
+    let named = directory
+        .open_child_file(std::ffi::OsStr::new("ordinal-v4.lock"))
+        .map_err(storage)?;
+    if graphforge_filesystem::file_identity(&named).map_err(storage)? != identity
+        || graphforge_filesystem::file_link_count(&named).map_err(storage)? != 1
+    {
+        return Err(storage("ordinal writer lock identity changed"));
+    }
+    Ok(())
+}
+
 fn cleanup_preparing_input(
     root_path: &Path,
     root: &StableDirectory,
@@ -1115,6 +1140,12 @@ pub(crate) fn commit_with_participant(
     };
     validate_intent(&intent)?;
     intent.checksum = checksum(&intent)?;
+    if intent.auxiliary.as_ref().is_some_and(is_v4_ordinal_receipt) {
+        // Recovery requires this stable lifecycle lock before it can install
+        // any v4 artifact. Make the lock durable before publishing even a
+        // preparing intent so every durable receipt is recoverable.
+        initialize_ordinal_writer_lock(&guard.directory)?;
+    }
     crate::project_failpoint::hit(
         "rewrite.before_intent",
         None,
@@ -1576,7 +1607,7 @@ mod tests {
         let root = TempDir::new().unwrap();
         let index = root.path().join("topology/uuid-membership");
         std::fs::create_dir_all(&index).unwrap();
-        std::fs::write(index.join("ordinal-v4.lock"), []).unwrap();
+        assert!(!index.join("ordinal-v4.lock").exists());
         let receipt = br#"{"schema_version":4}"#;
         let receipt_digest = hex(&Sha256::digest(receipt));
         let participant: RewriteParticipantPreparer<'_> = Box::new(move |context, batch| {
@@ -1613,6 +1644,7 @@ mod tests {
             )
             .is_err()
         );
+        assert!(index.join("ordinal-v4.lock").is_file());
 
         let stable_index = StableDirectory::open(&index).unwrap();
         let reader_lock = stable_index

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -767,8 +767,18 @@ pub struct GraphConstructionSession {
     parent_catalog: RuntimeCatalog,
     compact_parent: Option<crate::GraphFilesInventory>,
     semantic_authority: Option<ConstructionSemanticAuthority>,
-    _session_lock: File,
+    session_lock: File,
     _reservation: ProcessReservation,
+}
+
+impl Drop for GraphConstructionSession {
+    fn drop(&mut self) {
+        // A concurrently forked child can retain a duplicate of this open-file
+        // description until exec closes its CLOEXEC descriptors. Unlock before
+        // closing our handle so session ownership ends at this Rust lifetime,
+        // even while such a duplicate is still alive.
+        let _ = crate::file_lock::unlock(&self.session_lock);
+    }
 }
 
 impl GraphConstructionSession {
@@ -1705,7 +1715,7 @@ impl GraphConstructionSession {
             parent_catalog,
             compact_parent,
             semantic_authority,
-            _session_lock: session_lock,
+            session_lock,
             _reservation: reservation,
         };
         recover_shape_intent(&session.root, &mut session.checkpoint)?;
@@ -7975,6 +7985,28 @@ mod tests {
         .unwrap();
         assert_eq!(resumed.accepted_chunks(), 0);
         assert!(resumed.root.open_child_file(OsStr::new(INTENT)).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn session_drop_unlocks_before_a_duplicated_descriptor_closes() {
+        let root = TempDir::new().unwrap();
+        let operation = Uuid::from_u128(301);
+        let session = open(&root, 301);
+        let inherited_descriptor = session.session_lock.try_clone().unwrap();
+
+        drop(session);
+
+        let resumed = GraphConstructionSession::open(
+            root.path(),
+            operation,
+            0,
+            GraphConstructionBudgets::default(),
+        )
+        .unwrap();
+        assert_eq!(resumed.accepted_chunks(), 0);
+        drop(resumed);
+        drop(inherited_descriptor);
     }
 
     #[test]

--- a/crates/graphforge-storage/src/graph_delta_journal.rs
+++ b/crates/graphforge-storage/src/graph_delta_journal.rs
@@ -1343,21 +1343,12 @@ pub fn prepare_graph_delta(
     let (inventory, files_participant) = capture_graph_files(workspace.path())?;
     let unchanged_base_files = count_preserved_base_files(&parent_inventory, &inventory)?;
     let parent_base_count = count_base_files(&parent_inventory)?;
-    let preserved_base_parquet_digests = unchanged_base_files == parent_base_count
-        && parent_inventory
-            .files
-            .iter()
-            .filter(|entry| {
-                Path::new(&entry.relative_path)
-                    .extension()
-                    .is_some_and(|ext| ext.eq_ignore_ascii_case("parquet"))
-            })
-            .all(|parent_entry| {
-                inventory.files.iter().any(|child| {
-                    child.relative_path == parent_entry.relative_path
-                        && child.content_sha256 == parent_entry.content_sha256
-                })
-            });
+    let preserved_base_parquet_digests = base_parquet_digests_preserved(
+        &parent_inventory,
+        &inventory,
+        unchanged_base_files,
+        parent_base_count,
+    )?;
     let state_fingerprint =
         bounded_materialized_fingerprint(workspace.path(), &inventory, request.limits)?;
     Ok(PreparedGraphDelta {
@@ -1792,6 +1783,42 @@ fn count_preserved_base_files(
     })
 }
 
+fn base_parquet_digests_preserved(
+    parent: &GraphFilesInventory,
+    child: &GraphFilesInventory,
+    unchanged_base_files: u64,
+    parent_base_count: u64,
+) -> Result<bool, GfError> {
+    if unchanged_base_files != parent_base_count {
+        return Ok(false);
+    }
+    for parent_entry in &parent.files {
+        let parent_path =
+            crate::graph_files::canonical_inventory_relative_text(&parent_entry.relative_path)?;
+        if !Path::new(&parent_path)
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("parquet"))
+        {
+            continue;
+        }
+        let mut preserved = false;
+        for child_entry in &child.files {
+            let child_path =
+                crate::graph_files::canonical_inventory_relative_text(&child_entry.relative_path)?;
+            if child_path == parent_path
+                && child_entry.content_sha256 == parent_entry.content_sha256
+            {
+                preserved = true;
+                break;
+            }
+        }
+        if !preserved {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
 fn parse_run_sequence(relative: &str) -> Result<u64, GfError> {
     let prefix = "deltas/run_";
     let suffix = format!(".{GRAPH_DELTA_RUN_EXTENSION}");
@@ -1890,6 +1917,30 @@ mod crash_oracle_tests {
         AuthorityClass, PublicationIds, PublicationPhase, default_durable_ids, expected_authority,
         publication_ops, simulate_crash,
     };
+
+    #[test]
+    fn legacy_parent_path_spelling_preserves_exact_parquet_digest_evidence() {
+        let inventory = |relative_path: &str, digest: &str| GraphFilesInventory {
+            format: "graphforge-graph-files".to_owned(),
+            format_version: 1,
+            files: vec![GraphFileEntry {
+                relative_path: relative_path.to_owned(),
+                byte_length: 7,
+                content_sha256: digest.to_owned(),
+                role: GraphFileRole::Topology,
+            }],
+            file_count: 1,
+            total_byte_length: 7,
+        };
+        let parent = inventory("topology\\nodes.parquet", &"11".repeat(32));
+        let child = inventory("topology/nodes.parquet", &"11".repeat(32));
+        let unchanged = count_preserved_base_files(&parent, &child).unwrap();
+        let base_count = count_base_files(&parent).unwrap();
+        assert!(base_parquet_digests_preserved(&parent, &child, unchanged, base_count).unwrap());
+
+        let substituted = inventory("topology/nodes.parquet", &"22".repeat(32));
+        assert!(!base_parquet_digests_preserved(&parent, &substituted, 1, 1).unwrap());
+    }
 
     #[test]
     fn parquet_footer_limit_fails_before_decoder_allocation() {

--- a/crates/graphforge-storage/src/graph_delta_journal.rs
+++ b/crates/graphforge-storage/src/graph_delta_journal.rs
@@ -873,13 +873,14 @@ pub fn list_delta_runs(
 ) -> Result<Vec<&GraphFileEntry>, GfError> {
     let mut runs = Vec::new();
     for entry in &inventory.files {
-        if !entry.relative_path.starts_with("deltas/") {
+        let relative = crate::graph_files::canonical_inventory_relative_text(&entry.relative_path)?;
+        if !relative.starts_with("deltas/") {
             continue;
         }
         if entry.role != GraphFileRole::Delta {
             return Err(corrupt("delta path has non-delta inventory role"));
         }
-        let sequence = parse_run_sequence(&entry.relative_path)?;
+        let sequence = parse_run_sequence(&relative)?;
         runs.push((sequence, entry));
     }
     runs.sort_by_key(|(sequence, _)| *sequence);
@@ -914,7 +915,7 @@ pub fn load_verified_delta_runs(
         if usize::try_from(entry.byte_length).unwrap_or(usize::MAX) > limits.max_run_bytes {
             return Err(resource_limit("graph delta run bytes"));
         }
-        let path = graph_root.join(&entry.relative_path);
+        let path = crate::graph_files::resolve_v1_inventory_entry(graph_root, entry)?;
         let bytes = fs::read(&path).map_err(|error| storage("read delta run", &path, error))?;
         if bytes.len() as u64 != entry.byte_length {
             return Err(corrupt("graph delta run length mismatch"));
@@ -1159,7 +1160,7 @@ fn preflight_canonical_parquet(
         .iter()
         .filter(|entry| entry.relative_path.ends_with(".parquet"))
     {
-        let path = graph_root.join(&entry.relative_path);
+        let path = crate::graph_files::resolve_v1_inventory_entry(graph_root, entry)?;
         let mut file =
             File::open(&path).map_err(|error| storage("open Parquet preflight", &path, error))?;
         let file_len = file
@@ -1316,8 +1317,9 @@ pub fn prepare_graph_delta(
         GfError::Storage(format!("create graph delta staging directory: {error}"))
     })?;
     for entry in &parent_inventory.files {
-        let source = parent_tree.join(&entry.relative_path);
-        let destination = workspace.path().join(&entry.relative_path);
+        let source = crate::graph_files::resolve_v1_inventory_entry(&parent_tree, entry)?;
+        let relative = crate::graph_files::canonical_inventory_relative_path(&entry.relative_path)?;
+        let destination = workspace.path().join(relative);
         if let Some(parent_dir) = destination.parent() {
             fs::create_dir_all(parent_dir)
                 .map_err(|error| storage("create delta staging parent", parent_dir, error))?;
@@ -1339,13 +1341,8 @@ pub fn prepare_graph_delta(
     file.sync_all()
         .map_err(|error| storage("flush delta run", &new_path, error))?;
     let (inventory, files_participant) = capture_graph_files(workspace.path())?;
-    let unchanged_base_files = count_preserved_base_files(&parent_inventory, &inventory);
-    let parent_base_count = parent_inventory
-        .files
-        .iter()
-        .filter(|entry| !entry.relative_path.starts_with("deltas/"))
-        .filter(|entry| !is_gfdr_path(&entry.relative_path))
-        .count() as u64;
+    let unchanged_base_files = count_preserved_base_files(&parent_inventory, &inventory)?;
+    let parent_base_count = count_base_files(&parent_inventory)?;
     let preserved_base_parquet_digests = unchanged_base_files == parent_base_count
         && parent_inventory
             .files
@@ -1769,19 +1766,30 @@ fn is_gfdr_path(relative: &str) -> bool {
         .is_some_and(|ext| ext.eq_ignore_ascii_case(GRAPH_DELTA_RUN_EXTENSION))
 }
 
-fn count_preserved_base_files(parent: &GraphFilesInventory, child: &GraphFilesInventory) -> u64 {
-    parent
-        .files
-        .iter()
-        .filter(|entry| !is_gfdr_path(&entry.relative_path))
-        .filter(|parent_entry| {
-            child.files.iter().any(|child_entry| {
-                child_entry.relative_path == parent_entry.relative_path
-                    && child_entry.content_sha256 == parent_entry.content_sha256
-                    && child_entry.byte_length == parent_entry.byte_length
-            })
-        })
-        .count() as u64
+fn count_base_files(inventory: &GraphFilesInventory) -> Result<u64, GfError> {
+    inventory.files.iter().try_fold(0_u64, |count, entry| {
+        let relative = crate::graph_files::canonical_inventory_relative_text(&entry.relative_path)?;
+        Ok(count + u64::from(!relative.starts_with("deltas/") && !is_gfdr_path(&relative)))
+    })
+}
+
+fn count_preserved_base_files(
+    parent: &GraphFilesInventory,
+    child: &GraphFilesInventory,
+) -> Result<u64, GfError> {
+    parent.files.iter().try_fold(0_u64, |count, parent_entry| {
+        let parent_path =
+            crate::graph_files::canonical_inventory_relative_text(&parent_entry.relative_path)?;
+        if is_gfdr_path(&parent_path) {
+            return Ok(count);
+        }
+        let preserved = child.files.iter().any(|child_entry| {
+            child_entry.relative_path == parent_path
+                && child_entry.content_sha256 == parent_entry.content_sha256
+                && child_entry.byte_length == parent_entry.byte_length
+        });
+        Ok(count + u64::from(preserved))
+    })
 }
 
 fn parse_run_sequence(relative: &str) -> Result<u64, GfError> {

--- a/crates/graphforge-storage/src/graph_files.rs
+++ b/crates/graphforge-storage/src/graph_files.rs
@@ -384,23 +384,11 @@ pub fn verify_graph_tree(
     collect_regular_file_paths(graph_root, graph_root, &mut observed)?;
     let mut resolved = BTreeSet::new();
     for entry in &inventory.files {
-        let path = resolve_v1_inventory_entry(graph_root, entry)?;
-        resolved.insert(
-            path.strip_prefix(graph_root)
-                .map_err(|_| corrupt("generation graph path escaped tree"))?
-                .to_path_buf(),
-        );
-    }
-    if observed != resolved {
-        return Err(corrupt(
-            "generation graph tree inventory does not match on-disk files",
-        ));
-    }
-    for entry in &inventory.files {
-        let path = resolve_v1_inventory_entry(graph_root, entry)?;
-        reject_link(&path)?;
-        let metadata = fs::symlink_metadata(&path)
-            .map_err(|error| storage("inspect generation graph file", &path, error))?;
+        let retained = resolve_v1_inventory_entry_retained(graph_root, entry)?;
+        let metadata = retained
+            .file
+            .metadata()
+            .map_err(|error| storage("inspect generation graph file", &retained.path, error))?;
         if !metadata.is_file() {
             return Err(corrupt("generation graph entry is not a regular file"));
         }
@@ -409,12 +397,23 @@ pub fn verify_graph_tree(
                 "generation graph file length does not match inventory",
             ));
         }
-        let digest = hash_file(&path)?;
-        if hex_digest(digest) != entry.content_sha256 {
-            return Err(corrupt(
-                "generation graph file digest does not match inventory",
-            ));
+        if graphforge_filesystem::file_identity(&retained.file).ok() != Some(retained.identity)
+            || graphforge_filesystem::path_identity(&retained.path).ok() != Some(retained.identity)
+        {
+            return Err(corrupt("generation graph file identity changed"));
         }
+        resolved.insert(
+            retained
+                .path
+                .strip_prefix(graph_root)
+                .map_err(|_| corrupt("generation graph path escaped tree"))?
+                .to_path_buf(),
+        );
+    }
+    if observed != resolved {
+        return Err(corrupt(
+            "generation graph tree inventory does not match on-disk files",
+        ));
     }
     Ok(())
 }
@@ -831,6 +830,10 @@ fn hash_file(path: &Path) -> Result<[u8; 32], GfError> {
 
 fn hash_file_counted(path: &Path) -> Result<([u8; 32], u64), GfError> {
     let mut file = File::open(path).map_err(|error| storage("open graph file", path, error))?;
+    hash_reader(&mut file, path)
+}
+
+fn hash_reader(file: &mut File, path: &Path) -> Result<([u8; 32], u64), GfError> {
     let mut hasher = Sha256::new();
     let mut read_calls = 0_u64;
     let mut buffer = vec![0_u8; HASH_BUFFER_BYTES];
@@ -984,24 +987,54 @@ pub(crate) fn resolve_v1_inventory_entry(
     graph_root: &Path,
     entry: &GraphFileEntry,
 ) -> Result<PathBuf, GfError> {
+    resolve_v1_inventory_entry_retained(graph_root, entry).map(|resolved| resolved.path)
+}
+
+struct RetainedV1InventoryEntry {
+    path: PathBuf,
+    file: File,
+    identity: graphforge_filesystem::FileIdentity,
+}
+
+fn resolve_v1_inventory_entry_retained(
+    graph_root: &Path,
+    entry: &GraphFileEntry,
+) -> Result<RetainedV1InventoryEntry, GfError> {
     let mut authenticated = Vec::new();
     for relative in inventory_relative_path_candidates(&entry.relative_path)? {
         let path = graph_root.join(&relative);
-        let Ok(metadata) = fs::symlink_metadata(&path) else {
+        let Ok(mut file) = open_retained_relative_file(graph_root, &relative) else {
             continue;
         };
-        if metadata.file_type().is_symlink()
-            || !metadata.is_file()
-            || metadata.len() != entry.byte_length
-        {
+        let metadata = file
+            .metadata()
+            .map_err(|error| storage("inspect retained graph file", &path, error))?;
+        if !metadata.is_file() || metadata.len() != entry.byte_length {
             continue;
         }
-        if hex_digest(hash_file(&path)?) == entry.content_sha256 {
-            authenticated.push(path);
+        let identity = graphforge_filesystem::file_identity(&file)
+            .map_err(|error| storage("identify retained graph file", &path, error))?;
+        if graphforge_filesystem::path_identity(&path).ok() != Some(identity) {
+            continue;
+        }
+        if hex_digest(hash_reader(&mut file, &path)?.0) == entry.content_sha256
+            && graphforge_filesystem::path_identity(&path).ok() == Some(identity)
+        {
+            authenticated.push(RetainedV1InventoryEntry {
+                path,
+                file,
+                identity,
+            });
         }
     }
     match authenticated.as_slice() {
-        [path] => Ok(path.clone()),
+        [resolved] => Ok(RetainedV1InventoryEntry {
+            path: resolved.path.clone(),
+            file: resolved.file.try_clone().map_err(|error| {
+                storage("retain authenticated graph file", &resolved.path, error)
+            })?,
+            identity: resolved.identity,
+        }),
         [] => Err(corrupt(
             "generation graph file has no authenticated legacy path resolution",
         )),
@@ -1009,6 +1042,22 @@ pub(crate) fn resolve_v1_inventory_entry(
             "generation graph file has ambiguous authenticated legacy path resolutions",
         )),
     }
+}
+
+fn open_retained_relative_file(graph_root: &Path, relative: &Path) -> std::io::Result<File> {
+    let mut directory = graphforge_filesystem::StableDirectory::open(graph_root)?;
+    let mut components = relative.components().peekable();
+    while let Some(component) = components.next() {
+        let Component::Normal(name) = component else {
+            return Err(std::io::Error::other("graph file path is not canonical"));
+        };
+        if components.peek().is_some() {
+            directory = directory.open_child_directory(name)?;
+        } else {
+            return directory.open_child_file(name);
+        }
+    }
+    Err(std::io::Error::other("graph file path is empty"))
 }
 
 fn validate_wire_component(component: &str) -> Result<(), GfError> {

--- a/crates/graphforge-storage/src/graph_files.rs
+++ b/crates/graphforge-storage/src/graph_files.rs
@@ -5,7 +5,7 @@
 //! lengths, digests, roles). Open paths validate inventory against that tree and
 //! never assemble the complete graph into one in-memory Arrow/binary payload.
 
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeSet, HashSet};
 use std::fs::{self, File};
 use std::io::Read;
 use std::path::{Component, Path, PathBuf};
@@ -14,6 +14,7 @@ use graphforge_core::canonical::{CANONICAL_CONTRACT_VERSION, CanonicalDomain, fi
 use graphforge_core::{GfError, ProjectErrorCode};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use unicode_normalization::UnicodeNormalization;
 
 use crate::project_failpoint;
 use crate::project_publication::{ProjectParticipant, ProjectParticipantEncoding};
@@ -297,6 +298,7 @@ pub fn stage_graph_tree(
     generation_root: &Path,
     inventory: &GraphFilesInventory,
 ) -> Result<GraphFilesOpenEvidence, GfError> {
+    validate_inventory_contract(inventory)?;
     let destination_root = graph_tree_root(generation_root);
     if destination_root.exists() {
         return Err(publication_failed(
@@ -311,10 +313,9 @@ pub fn stage_graph_tree(
         ..GraphFilesOpenEvidence::default()
     };
     for entry in &inventory.files {
-        let relative = Path::new(&entry.relative_path);
-        validate_relative_path(relative)?;
-        let source = source_root.join(relative);
-        let destination = destination_root.join(relative);
+        let source = resolve_v1_inventory_entry(source_root, entry)?;
+        let relative = canonical_inventory_relative_path(&entry.relative_path)?;
+        let destination = destination_root.join(&relative);
         reject_link(&source)?;
         let metadata = fs::symlink_metadata(&source)
             .map_err(|error| storage("inspect graph source file", &source, error))?;
@@ -379,21 +380,24 @@ pub fn verify_graph_tree(
         return Err(corrupt("generation graph tree is not a directory"));
     }
 
-    let mut observed = BTreeMap::new();
-    collect_regular_files(graph_root, graph_root, &mut observed)?;
-    let expected: BTreeSet<_> = inventory
-        .files
-        .iter()
-        .map(|entry| entry.relative_path.clone())
-        .collect();
-    let observed_keys: BTreeSet<_> = observed.keys().cloned().collect();
-    if observed_keys != expected {
+    let mut observed = BTreeSet::new();
+    collect_regular_file_paths(graph_root, graph_root, &mut observed)?;
+    let mut resolved = BTreeSet::new();
+    for entry in &inventory.files {
+        let path = resolve_v1_inventory_entry(graph_root, entry)?;
+        resolved.insert(
+            path.strip_prefix(graph_root)
+                .map_err(|_| corrupt("generation graph path escaped tree"))?
+                .to_path_buf(),
+        );
+    }
+    if observed != resolved {
         return Err(corrupt(
             "generation graph tree inventory does not match on-disk files",
         ));
     }
     for entry in &inventory.files {
-        let path = graph_root.join(&entry.relative_path);
+        let path = resolve_v1_inventory_entry(graph_root, entry)?;
         reject_link(&path)?;
         let metadata = fs::symlink_metadata(&path)
             .map_err(|error| storage("inspect generation graph file", &path, error))?;
@@ -436,9 +440,9 @@ pub fn materialize_graph_tree(
         ..GraphFilesOpenEvidence::default()
     };
     for entry in &inventory.files {
-        let relative = Path::new(&entry.relative_path);
-        let source = graph_root.join(relative);
-        let destination = target.join(relative);
+        let source = resolve_v1_inventory_entry(graph_root, entry)?;
+        let relative = canonical_inventory_relative_path(&entry.relative_path)?;
+        let destination = target.join(&relative);
         if let Some(parent) = destination.parent() {
             fs::create_dir_all(parent)
                 .map_err(|error| storage("create private graph directory", parent, error))?;
@@ -584,6 +588,7 @@ fn validate_inventory_contract(inventory: &GraphFilesInventory) -> Result<(), Gf
     let mut total = 0_u64;
     let mut previous: Option<&str> = None;
     let mut seen = HashSet::new();
+    let mut canonical_destinations = HashSet::new();
     for entry in &inventory.files {
         if previous.is_some_and(|value| value >= entry.relative_path.as_str()) {
             return Err(validation(
@@ -593,7 +598,13 @@ fn validate_inventory_contract(inventory: &GraphFilesInventory) -> Result<(), Gf
         if !seen.insert(entry.relative_path.as_str()) {
             return Err(validation("graph files inventory contains duplicate paths"));
         }
-        validate_relative_path(Path::new(&entry.relative_path))?;
+        let _ = inventory_relative_path_candidates(&entry.relative_path)?;
+        let canonical_destination = canonical_inventory_relative_path(&entry.relative_path)?;
+        if !canonical_destinations.insert(portable_case_collision_key(&canonical_destination)?) {
+            return Err(validation(
+                "graph files inventory paths have an ambiguous canonical destination",
+            ));
+        }
         if entry.content_sha256.len() != 64
             || !entry
                 .content_sha256
@@ -615,6 +626,15 @@ fn validate_inventory_contract(inventory: &GraphFilesInventory) -> Result<(), Gf
         ));
     }
     Ok(())
+}
+
+/// Conservative portable key for filesystems with case-insensitive lookup.
+///
+/// NFC before and after Unicode uppercase expansion makes the comparison
+/// deterministic across hosts without rewriting the authenticated wire path.
+fn portable_case_collision_key(path: &Path) -> Result<String, GfError> {
+    let text = path_text(path)?;
+    Ok(text.nfc().flat_map(char::to_uppercase).nfc().collect())
 }
 
 fn collect_source_files(directory: &Path, paths: &mut Vec<PathBuf>) -> Result<(), GfError> {
@@ -712,10 +732,10 @@ fn collect_source_files_from(
     Ok(())
 }
 
-fn collect_regular_files(
+fn collect_regular_file_paths(
     root: &Path,
     directory: &Path,
-    observed: &mut BTreeMap<String, PathBuf>,
+    observed: &mut BTreeSet<PathBuf>,
 ) -> Result<(), GfError> {
     let mut entries = directory
         .read_dir()
@@ -732,21 +752,16 @@ fn collect_regular_files(
             return Err(corrupt("generation graph tree contains a symbolic link"));
         }
         if file_type.is_dir() {
-            collect_regular_files(root, &path, observed)?;
+            collect_regular_file_paths(root, &path, observed)?;
         } else if file_type.is_file() {
             let relative = path
                 .strip_prefix(root)
                 .map_err(|_| corrupt("generation graph path escaped tree"))?;
-            if is_graph_operational_file(relative) {
-                continue;
-            }
-            validate_relative_path(relative)?;
-            let key = path_text(relative)?;
-            if observed.insert(key, path).is_some() {
-                return Err(corrupt("generation graph tree has duplicate paths"));
-            }
-            if observed.len() > MAX_GRAPH_FILES {
-                return Err(resource_limit("graph files count exceeds limit"));
+            if !is_graph_operational_file(relative) {
+                observed.insert(relative.to_path_buf());
+                if observed.len() > MAX_GRAPH_FILES {
+                    return Err(resource_limit("graph files count exceeds limit"));
+                }
             }
         } else {
             return Err(corrupt("generation graph tree contains a special file"));
@@ -888,9 +903,154 @@ fn validate_relative_path(path: &Path) -> Result<(), GfError> {
 }
 
 fn path_text(path: &Path) -> Result<String, GfError> {
-    path.to_str()
-        .map(str::to_owned)
-        .ok_or_else(|| validation("graph file path is not UTF-8"))
+    let mut encoded = String::new();
+    for component in path.components() {
+        let Component::Normal(component) = component else {
+            return Err(validation("invalid graph file relative path"));
+        };
+        let component = component
+            .to_str()
+            .ok_or_else(|| validation("graph file path is not UTF-8"))?;
+        validate_wire_component(component)?;
+        if !encoded.is_empty() {
+            encoded.push('/');
+        }
+        encoded.push_str(component);
+    }
+    if encoded.is_empty() {
+        return Err(validation("invalid graph file relative path"));
+    }
+    Ok(encoded)
+}
+
+/// Decode the platform-independent inventory spelling without asking the host
+/// path parser to interpret wire separators or aliases.
+fn wire_relative_path(text: &str) -> Result<PathBuf, GfError> {
+    if text.is_empty() || text.starts_with('/') || text.ends_with('/') {
+        return Err(validation("invalid graph file wire path"));
+    }
+    let mut path = PathBuf::new();
+    for component in text.split('/') {
+        validate_wire_component(component)?;
+        path.push(component);
+    }
+    if path_text(&path)? != text {
+        return Err(validation("graph file wire path is not canonical"));
+    }
+    Ok(path)
+}
+
+pub(crate) fn canonical_inventory_relative_path(text: &str) -> Result<PathBuf, GfError> {
+    if text.contains('\\') {
+        wire_relative_path(&text.replace('\\', "/"))
+    } else {
+        wire_relative_path(text)
+    }
+}
+
+pub(crate) fn canonical_inventory_relative_text(text: &str) -> Result<String, GfError> {
+    Ok(canonical_inventory_relative_path(text)?
+        .to_string_lossy()
+        .replace('\\', "/"))
+}
+
+fn inventory_relative_path_candidates(text: &str) -> Result<Vec<PathBuf>, GfError> {
+    if !text.contains('\\') {
+        return wire_relative_path(text).map(|path| vec![path]);
+    }
+    if text.is_empty()
+        || text.starts_with(['/', '\\'])
+        || text.ends_with(['/', '\\'])
+        || text
+            .split(['/', '\\'])
+            .any(|component| component.is_empty() || matches!(component, "." | ".."))
+    {
+        return Err(validation("invalid legacy graph file path"));
+    }
+
+    let exact = text.split('/').fold(PathBuf::new(), |mut path, component| {
+        path.push(component);
+        path
+    });
+    let normalized = canonical_inventory_relative_path(text)?;
+    if exact == normalized {
+        Ok(vec![exact])
+    } else {
+        Ok(vec![exact, normalized])
+    }
+}
+
+pub(crate) fn resolve_v1_inventory_entry(
+    graph_root: &Path,
+    entry: &GraphFileEntry,
+) -> Result<PathBuf, GfError> {
+    let mut authenticated = Vec::new();
+    for relative in inventory_relative_path_candidates(&entry.relative_path)? {
+        let path = graph_root.join(&relative);
+        let Ok(metadata) = fs::symlink_metadata(&path) else {
+            continue;
+        };
+        if metadata.file_type().is_symlink()
+            || !metadata.is_file()
+            || metadata.len() != entry.byte_length
+        {
+            continue;
+        }
+        if hex_digest(hash_file(&path)?) == entry.content_sha256 {
+            authenticated.push(path);
+        }
+    }
+    match authenticated.as_slice() {
+        [path] => Ok(path.clone()),
+        [] => Err(corrupt(
+            "generation graph file has no authenticated legacy path resolution",
+        )),
+        _ => Err(corrupt(
+            "generation graph file has ambiguous authenticated legacy path resolutions",
+        )),
+    }
+}
+
+fn validate_wire_component(component: &str) -> Result<(), GfError> {
+    if component.is_empty()
+        || matches!(component, "." | "..")
+        || component.ends_with([' ', '.'])
+        || component.chars().any(|character| {
+            character.is_control()
+                || matches!(character, '<' | '>' | ':' | '"' | '\\' | '|' | '?' | '*')
+        })
+    {
+        return Err(validation("graph file path has a non-portable component"));
+    }
+    let stem = component.split('.').next().unwrap_or(component);
+    if matches!(
+        stem.to_ascii_uppercase().as_str(),
+        "CON"
+            | "PRN"
+            | "AUX"
+            | "NUL"
+            | "COM1"
+            | "COM2"
+            | "COM3"
+            | "COM4"
+            | "COM5"
+            | "COM6"
+            | "COM7"
+            | "COM8"
+            | "COM9"
+            | "LPT1"
+            | "LPT2"
+            | "LPT3"
+            | "LPT4"
+            | "LPT5"
+            | "LPT6"
+            | "LPT7"
+            | "LPT8"
+            | "LPT9"
+    ) {
+        return Err(validation("graph file path has a reserved component"));
+    }
+    Ok(())
 }
 
 fn reject_link(path: &Path) -> Result<(), GfError> {
@@ -975,6 +1135,229 @@ mod tests {
         assert_eq!(inventory.files[1].role, GraphFileRole::Topology);
         assert_eq!(participant.record_family_id, GRAPH_FILES_FAMILY);
         assert_eq!(decode_inventory(&participant.bytes).unwrap(), inventory);
+    }
+
+    #[test]
+    fn wire_paths_are_forward_slash_canonical_and_resolve_v4_controls() {
+        for name in [
+            "topology/uuid-membership/ordinal-v4-manifest.json",
+            "topology/uuid-membership/ordinal-v4-receipt.json",
+            "topology/uuid-membership/ordinal-v4.lock",
+        ] {
+            let decoded = wire_relative_path(name).unwrap();
+            assert_eq!(
+                decoded.components().count(),
+                3,
+                "wire separators must decode as components on every host"
+            );
+            assert_eq!(path_text(&decoded).unwrap(), name);
+        }
+
+        for ambiguous in [
+            "topology\\uuid-membership\\ordinal-v4-manifest.json",
+            "topology//ordinal-v4-manifest.json",
+            "topology/../ordinal-v4-manifest.json",
+            "topology/NUL.json",
+            "topology/trailing.",
+        ] {
+            assert!(wire_relative_path(ambiguous).is_err(), "{ambiguous}");
+        }
+    }
+
+    #[test]
+    fn canonical_inventory_bytes_and_order_do_not_depend_on_host_separators() {
+        let source = tempfile::tempdir().unwrap();
+        fs::create_dir_all(source.path().join("topology/uuid-membership")).unwrap();
+        fs::write(
+            source
+                .path()
+                .join("topology/uuid-membership/ordinal-v4-receipt.json"),
+            b"receipt",
+        )
+        .unwrap();
+        fs::write(
+            source
+                .path()
+                .join("topology/uuid-membership/ordinal-v4-manifest.json"),
+            b"manifest",
+        )
+        .unwrap();
+
+        let (inventory, participant) = capture_graph_files(source.path()).unwrap();
+        assert_eq!(
+            inventory
+                .files
+                .iter()
+                .map(|entry| entry.relative_path.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "topology/uuid-membership/ordinal-v4-manifest.json",
+                "topology/uuid-membership/ordinal-v4-receipt.json",
+            ]
+        );
+        let expected = concat!(
+            "{\"format\":\"graphforge-graph-files\",\"format_version\":1,\"files\":[",
+            "{\"relative_path\":\"topology/uuid-membership/ordinal-v4-manifest.json\",",
+            "\"byte_length\":8,\"content_sha256\":",
+            "\"05b3abf2579a5eb66403cd78be557fd860633a1fe2103c7642030defe32c657f\",",
+            "\"role\":\"topology\"},",
+            "{\"relative_path\":\"topology/uuid-membership/ordinal-v4-receipt.json\",",
+            "\"byte_length\":7,\"content_sha256\":",
+            "\"6f32860910ca0fb2a20c7fda143666b09dbf8db5238195c90a586fb542ff0cad\",",
+            "\"role\":\"topology\"}],\"file_count\":2,\"total_byte_length\":15}\n"
+        );
+        assert_eq!(participant.bytes, expected.as_bytes());
+        assert_eq!(participant.bytes, encode_inventory(&inventory).unwrap());
+        assert_eq!(decode_inventory(&participant.bytes).unwrap(), inventory);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn legacy_windows_v1_path_reopens_after_move_and_republishes_canonically() {
+        let graph_root = tempfile::tempdir().unwrap();
+        let canonical = graph_root.path().join("topology/nodes.parquet");
+        fs::create_dir_all(canonical.parent().unwrap()).unwrap();
+        fs::write(&canonical, b"nodes").unwrap();
+        let digest = hex_digest(hash_file(&canonical).unwrap());
+        let inventory = GraphFilesInventory {
+            format: GRAPH_FILES_FORMAT.into(),
+            format_version: GRAPH_FILES_FORMAT_VERSION,
+            files: vec![GraphFileEntry {
+                relative_path: "topology\\nodes.parquet".into(),
+                byte_length: 5,
+                content_sha256: digest,
+                role: GraphFileRole::Topology,
+            }],
+            file_count: 1,
+            total_byte_length: 5,
+        };
+
+        verify_graph_tree(graph_root.path(), &inventory).unwrap();
+        let private = tempfile::tempdir().unwrap();
+        materialize_graph_tree(graph_root.path(), &inventory, private.path()).unwrap();
+        let (republished, participant) = capture_graph_files(private.path()).unwrap();
+        assert_eq!(republished.files[0].relative_path, "topology/nodes.parquet");
+        assert!(!participant.bytes.contains(&b'\\'));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn legacy_windows_v1_path_rejects_authenticated_literal_ambiguity() {
+        let graph_root = tempfile::tempdir().unwrap();
+        let canonical = graph_root.path().join("topology/nodes.parquet");
+        fs::create_dir_all(canonical.parent().unwrap()).unwrap();
+        fs::write(&canonical, b"nodes").unwrap();
+        fs::write(graph_root.path().join("topology\\nodes.parquet"), b"nodes").unwrap();
+        let inventory = GraphFilesInventory {
+            format: GRAPH_FILES_FORMAT.into(),
+            format_version: GRAPH_FILES_FORMAT_VERSION,
+            files: vec![GraphFileEntry {
+                relative_path: "topology\\nodes.parquet".into(),
+                byte_length: 5,
+                content_sha256: hex_digest(hash_file(&canonical).unwrap()),
+                role: GraphFileRole::Topology,
+            }],
+            file_count: 1,
+            total_byte_length: 5,
+        };
+
+        assert!(verify_graph_tree(graph_root.path(), &inventory).is_err());
+    }
+
+    #[test]
+    fn legacy_windows_v1_path_rejects_duplicate_canonical_destinations() {
+        let digest = hex_digest(Sha256::digest(b"nodes").into());
+        let inventory = GraphFilesInventory {
+            format: GRAPH_FILES_FORMAT.into(),
+            format_version: GRAPH_FILES_FORMAT_VERSION,
+            files: vec![
+                GraphFileEntry {
+                    relative_path: "topology/nodes.parquet".into(),
+                    byte_length: 5,
+                    content_sha256: digest.clone(),
+                    role: GraphFileRole::Topology,
+                },
+                GraphFileEntry {
+                    relative_path: "topology\\nodes.parquet".into(),
+                    byte_length: 5,
+                    content_sha256: digest,
+                    role: GraphFileRole::Topology,
+                },
+            ],
+            file_count: 2,
+            total_byte_length: 10,
+        };
+
+        assert!(validate_inventory_contract(&inventory).is_err());
+    }
+
+    #[test]
+    fn v1_paths_reject_portable_unicode_case_collisions_before_staging() {
+        let digest = hex_digest(Sha256::digest(b"nodes").into());
+        let inventory = GraphFilesInventory {
+            format: GRAPH_FILES_FORMAT.into(),
+            format_version: GRAPH_FILES_FORMAT_VERSION,
+            files: vec![
+                GraphFileEntry {
+                    relative_path: "topology/Å.parquet".into(),
+                    byte_length: 5,
+                    content_sha256: digest.clone(),
+                    role: GraphFileRole::Topology,
+                },
+                GraphFileEntry {
+                    relative_path: "topology/å.parquet".into(),
+                    byte_length: 5,
+                    content_sha256: digest,
+                    role: GraphFileRole::Topology,
+                },
+            ],
+            file_count: 2,
+            total_byte_length: 10,
+        };
+        let source = tempfile::tempdir().unwrap();
+        let target = tempfile::tempdir().unwrap();
+
+        assert!(stage_graph_tree(source.path(), target.path(), &inventory).is_err());
+        assert!(materialize_graph_tree(source.path(), &inventory, target.path()).is_err());
+        assert!(target.path().read_dir().unwrap().next().is_none());
+    }
+
+    #[test]
+    fn portable_case_key_collides_greek_sigma_and_final_sigma() {
+        assert_eq!(
+            portable_case_collision_key(Path::new("topology/σ.parquet")).unwrap(),
+            portable_case_collision_key(Path::new("topology/ς.parquet")).unwrap()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn legacy_windows_v1_literal_unix_name_migrates_to_canonical_path() {
+        let source = tempfile::tempdir().unwrap();
+        let literal = source.path().join("topology\\nodes.parquet");
+        fs::write(&literal, b"nodes").unwrap();
+        let inventory = GraphFilesInventory {
+            format: GRAPH_FILES_FORMAT.into(),
+            format_version: GRAPH_FILES_FORMAT_VERSION,
+            files: vec![GraphFileEntry {
+                relative_path: "topology\\nodes.parquet".into(),
+                byte_length: 5,
+                content_sha256: hex_digest(hash_file(&literal).unwrap()),
+                role: GraphFileRole::Topology,
+            }],
+            file_count: 1,
+            total_byte_length: 5,
+        };
+
+        verify_graph_tree(source.path(), &inventory).unwrap();
+        let generation = tempfile::tempdir().unwrap();
+        stage_graph_tree(source.path(), generation.path(), &inventory).unwrap();
+        let staged = graph_tree_root(generation.path());
+        assert_eq!(
+            fs::read(staged.join("topology/nodes.parquet")).unwrap(),
+            b"nodes"
+        );
+        assert!(!staged.join("topology\\nodes.parquet").exists());
     }
 
     #[test]

--- a/crates/graphforge-storage/src/graph_manifest.rs
+++ b/crates/graphforge-storage/src/graph_manifest.rs
@@ -105,6 +105,17 @@ pub struct GraphManifestResolveEvidence {
     pub work_units: u64,
 }
 
+/// Shared admission state for a bounded set of exact-path lookups against one
+/// authenticated root. Cached nodes are decoded and charged only once, while
+/// traversal work and examined leaf entries remain aggregate across lookups.
+#[derive(Debug, Default)]
+pub(crate) struct GraphManifestTargetedState {
+    nodes: BTreeMap<String, GraphManifestNode>,
+    decoded_bytes: u64,
+    work_units: u64,
+    entries_examined: usize,
+}
+
 /// Encode one validated node as canonical JSON-line bytes.
 pub fn encode_node(node: &GraphManifestNode) -> Result<Vec<u8>, GfError> {
     validate_node(node)?;
@@ -284,6 +295,142 @@ where
         ));
     }
     Ok((files, evidence))
+}
+
+/// Resolve and authenticate one exact logical path without opening unrelated
+/// graph payload objects or walking unrelated radix branches.
+pub(crate) fn resolve_manifest_entry<F>(
+    root: &GraphFilesRootV2,
+    relative_path: &str,
+    limits: GraphManifestLimits,
+    load: F,
+) -> Result<Option<GraphFileEntry>, GfError>
+where
+    F: FnMut(&str) -> Result<Vec<u8>, GfError>,
+{
+    let mut state = GraphManifestTargetedState::default();
+    resolve_manifest_entry_with_state(root, relative_path, limits, &mut state, load)
+}
+
+/// Resolve one exact path while sharing cache and aggregate admission counters
+/// with sibling lookups against the same authenticated root.
+#[allow(clippy::too_many_lines)]
+pub(crate) fn resolve_manifest_entry_with_state<F>(
+    root: &GraphFilesRootV2,
+    relative_path: &str,
+    limits: GraphManifestLimits,
+    state: &mut GraphManifestTargetedState,
+    mut load: F,
+) -> Result<Option<GraphFileEntry>, GfError>
+where
+    F: FnMut(&str) -> Result<Vec<u8>, GfError>,
+{
+    validate_root(root)?;
+    let route = hex_digest(logical_path_digest(relative_path));
+    let mut digest = root.root_node_sha256.clone();
+    let mut depth = 0_u8;
+    let mut visited = BTreeSet::new();
+    for _ in 0..=GRAPH_RADIX_DEPTH {
+        if !visited.insert(digest.clone()) {
+            return Err(validation("graph manifest targeted path contains a cycle"));
+        }
+        let node = if let Some(node) = state.nodes.get(&digest) {
+            node.clone()
+        } else {
+            if state.nodes.len() >= limits.max_segments {
+                return Err(validation("graph manifest targeted segment limit exceeded"));
+            }
+            let bytes = load(&digest)?;
+            state.decoded_bytes = state
+                .decoded_bytes
+                .checked_add(u64::try_from(bytes.len()).unwrap_or(u64::MAX))
+                .ok_or_else(|| validation("graph manifest targeted decode total overflow"))?;
+            if state.decoded_bytes > limits.max_decoded_bytes {
+                return Err(validation("graph manifest targeted decode limit exceeded"));
+            }
+            if object_digest(&bytes) != digest {
+                return Err(validation("graph manifest node digest mismatch"));
+            }
+            let node = decode_node(&bytes)?;
+            state.nodes.insert(digest.clone(), node.clone());
+            node
+        };
+        state.work_units = state
+            .work_units
+            .checked_add(1)
+            .ok_or_else(|| validation("graph manifest targeted work overflow"))?;
+        if state.work_units > limits.max_work_units {
+            return Err(validation("graph manifest targeted work limit exceeded"));
+        }
+        if node.depth != depth {
+            return Err(validation("graph manifest radix depth mismatch"));
+        }
+        let prefix_end = usize::from(depth)
+            .checked_add(node.prefix.len())
+            .ok_or_else(|| validation("graph manifest prefix overflow"))?;
+        if prefix_end > usize::from(GRAPH_RADIX_DEPTH)
+            || route.get(usize::from(depth)..prefix_end) != Some(node.prefix.as_str())
+        {
+            return Ok(None);
+        }
+        depth = u8::try_from(prefix_end)
+            .map_err(|_| validation("graph manifest prefix depth overflow"))?;
+        match node.kind {
+            GraphManifestNodeKind::Branch { children } => {
+                state.work_units = state
+                    .work_units
+                    .checked_add(u64::try_from(children.len()).unwrap_or(u64::MAX))
+                    .ok_or_else(|| validation("graph manifest targeted work overflow"))?;
+                if state.work_units > limits.max_work_units {
+                    return Err(validation("graph manifest targeted work limit exceeded"));
+                }
+                if depth >= GRAPH_RADIX_DEPTH {
+                    return Err(validation("graph manifest branch exceeds radix depth"));
+                }
+                let nibble = route
+                    .get(usize::from(depth)..=usize::from(depth))
+                    .ok_or_else(|| validation("graph manifest route is incomplete"))?;
+                validate_nibble(nibble)?;
+                let Some(child) = children.get(nibble) else {
+                    return Ok(None);
+                };
+                digest.clone_from(child);
+                depth = depth.saturating_add(1);
+            }
+            GraphManifestNodeKind::Leaf {
+                path_sha256,
+                entries,
+            } => {
+                state.entries_examined = state
+                    .entries_examined
+                    .checked_add(entries.len())
+                    .ok_or_else(|| validation("graph manifest targeted entry total overflow"))?;
+                if state.entries_examined > limits.max_entries {
+                    return Err(validation("graph manifest targeted entry limit exceeded"));
+                }
+                state.work_units = state
+                    .work_units
+                    .checked_add(u64::try_from(entries.len()).unwrap_or(u64::MAX))
+                    .ok_or_else(|| validation("graph manifest targeted work overflow"))?;
+                if state.work_units > limits.max_work_units {
+                    return Err(validation("graph manifest targeted work limit exceeded"));
+                }
+                if depth != GRAPH_RADIX_DEPTH || path_sha256 != route {
+                    return Err(validation("graph manifest leaf is not terminal"));
+                }
+                for entry in entries {
+                    if hex_digest(logical_path_digest(&entry.relative_path)) != path_sha256 {
+                        return Err(validation("graph manifest leaf path digest mismatch"));
+                    }
+                    if entry.relative_path == relative_path {
+                        return Ok(Some(entry));
+                    }
+                }
+                return Ok(None);
+            }
+        }
+    }
+    Err(validation("graph manifest path exceeds radix depth"))
 }
 
 fn admit_work(
@@ -666,5 +813,114 @@ mod tests {
         let (entries, _) =
             resolve_manifest(&root, GraphManifestLimits::default(), |_| Ok(bytes.clone())).unwrap();
         assert_eq!(entries.len(), 1);
+        assert_eq!(
+            resolve_manifest_entry(&root, path, GraphManifestLimits::default(), |_| Ok(
+                bytes.clone()
+            ))
+            .unwrap()
+            .unwrap()
+            .relative_path,
+            path
+        );
+        assert!(
+            resolve_manifest_entry(
+                &root,
+                "topology/other.parquet",
+                GraphManifestLimits::default(),
+                |_| Ok(bytes.clone())
+            )
+            .unwrap()
+            .is_none()
+        );
+        let tight = GraphManifestLimits {
+            max_decoded_bytes: bytes.len() as u64 - 1,
+            ..GraphManifestLimits::default()
+        };
+        assert!(resolve_manifest_entry(&root, path, tight, |_| Ok(bytes.clone())).is_err());
+        let no_work = GraphManifestLimits {
+            max_work_units: 0,
+            ..GraphManifestLimits::default()
+        };
+        assert!(resolve_manifest_entry(&root, path, no_work, |_| Ok(bytes.clone())).is_err());
+    }
+
+    #[test]
+    fn sibling_targeted_lookups_share_one_union_segment_budget() {
+        let mut selected = BTreeMap::<String, String>::new();
+        for candidate in 0..10_000 {
+            let path = format!("topology/authority-{candidate}.json");
+            let route = hex_digest(logical_path_digest(&path));
+            selected.entry(route[..1].into()).or_insert(path);
+            if selected.len() == 3 {
+                break;
+            }
+        }
+        assert_eq!(selected.len(), 3);
+
+        let mut objects = BTreeMap::new();
+        let mut children = BTreeMap::new();
+        for (nibble, path) in &selected {
+            let route = hex_digest(logical_path_digest(path));
+            let leaf = GraphManifestNode {
+                format: GRAPH_MANIFEST_NODE_FORMAT.into(),
+                format_version: GRAPH_MANIFEST_NODE_VERSION,
+                depth: 1,
+                prefix: route[1..].into(),
+                kind: GraphManifestNodeKind::Leaf {
+                    path_sha256: route,
+                    entries: vec![GraphFileEntry {
+                        relative_path: path.clone(),
+                        byte_length: 1,
+                        content_sha256: "a".repeat(64),
+                        role: GraphFileRole::Topology,
+                    }],
+                },
+            };
+            let bytes = encode_node(&leaf).unwrap();
+            let digest = object_digest(&bytes);
+            objects.insert(digest.clone(), bytes);
+            children.insert(nibble.clone(), digest);
+        }
+        let root_node = GraphManifestNode {
+            format: GRAPH_MANIFEST_NODE_FORMAT.into(),
+            format_version: GRAPH_MANIFEST_NODE_VERSION,
+            depth: 0,
+            prefix: String::new(),
+            kind: GraphManifestNodeKind::Branch { children },
+        };
+        let root_bytes = encode_node(&root_node).unwrap();
+        let root_digest = object_digest(&root_bytes);
+        objects.insert(root_digest.clone(), root_bytes);
+        let root = GraphFilesRootV2 {
+            format: GRAPH_FILES_V2_FORMAT.into(),
+            format_version: GRAPH_FILES_V2_VERSION,
+            root_node_sha256: root_digest,
+            logical_file_count: 3,
+            logical_byte_length: 3,
+        };
+        let limits = GraphManifestLimits {
+            max_segments: 3,
+            max_entries: 3,
+            max_decoded_bytes: 64 * 1024,
+            max_work_units: 64,
+        };
+        for path in selected.values() {
+            assert!(
+                resolve_manifest_entry(&root, path, limits, |digest| Ok(objects[digest].clone()))
+                    .unwrap()
+                    .is_some()
+            );
+        }
+
+        let mut state = GraphManifestTargetedState::default();
+        let mut results = selected.values().map(|path| {
+            resolve_manifest_entry_with_state(&root, path, limits, &mut state, |digest| {
+                Ok(objects[digest].clone())
+            })
+        });
+        assert!(results.next().unwrap().unwrap().is_some());
+        assert!(results.next().unwrap().unwrap().is_some());
+        let error = results.next().unwrap().unwrap_err();
+        assert!(error.to_string().contains("segment limit"), "{error}");
     }
 }

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -2298,7 +2298,9 @@ where
     #[cfg(windows)]
     let temporary_identity = temporary.identity();
     let bytes_hashed = write_temporary(&mut temporary)?;
-    if !writer_authenticated {
+    let preseal_bytes_hashed = if writer_authenticated || cfg!(windows) {
+        0
+    } else {
         temporary.rewind().map_err(|error| {
             storage("rewind temporary graph object", &cas.diagnostic_root, error)
         })?;
@@ -2308,7 +2310,11 @@ where
             expected_length,
             &cas.diagnostic_root,
         )?;
-    }
+        expected_length
+    };
+    // Windows must close the writable handle and reopen an exact-identity,
+    // protected read handle before publication. That transition authenticates
+    // the complete payload below, so a second pre-seal read would be redundant.
     let (installed, sealed_bytes_hashed) = finalize_temporary_object(
         cas,
         &bucket,
@@ -2322,11 +2328,7 @@ where
     )?;
     Ok(GraphObjectInstallEvidence {
         bytes_hashed: bytes_hashed
-            .saturating_add(if writer_authenticated {
-                0
-            } else {
-                expected_length
-            })
+            .saturating_add(preseal_bytes_hashed)
             .saturating_add(sealed_bytes_hashed)
             .saturating_add(if installed { 0 } else { expected_length }),
         bytes_installed: if installed { expected_length } else { 0 },

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -132,9 +132,23 @@ struct CasRoot {
 
 struct TemporaryObject {
     name: std::ffi::OsString,
+    #[cfg(unix)]
+    file: File,
+    #[cfg(windows)]
+    file: graphforge_filesystem::WindowsCasWriter,
+    identity: graphforge_filesystem::FileIdentity,
+}
+
+struct SealedTemporaryObject {
+    name: std::ffi::OsString,
     file: File,
     identity: graphforge_filesystem::FileIdentity,
 }
+
+#[cfg(unix)]
+type CasTemporaryWriter = File;
+#[cfg(windows)]
+type CasTemporaryWriter = graphforge_filesystem::WindowsCasWriter;
 
 struct ReadOnlyCasRoot {
     diagnostic_root: PathBuf,
@@ -1096,9 +1110,10 @@ pub fn migrate_graph_files_v1_to_v2(
     validate_publication_identity(lease)?;
     let mut evidence = GraphFilesMigrationEvidence::default();
     for entry in &inventory.files {
+        let source = crate::graph_files::resolve_v1_inventory_entry(graph_root, entry)?;
         let installed = install_graph_object_file_with_lease(
             lease,
-            &graph_root.join(&entry.relative_path),
+            &source,
             &entry.content_sha256,
             entry.byte_length,
         )?;
@@ -1113,12 +1128,16 @@ pub fn migrate_graph_files_v1_to_v2(
     let mut root_digest =
         install_manifest_node(lease, &empty_branch(0), &mut evidence.bytes_installed)?;
     for entry in &inventory.files {
+        let mut canonical_entry = entry.clone();
+        canonical_entry.relative_path =
+            crate::graph_files::canonical_inventory_relative_text(&entry.relative_path)?;
+        let canonical_path = canonical_entry.relative_path.clone();
         root_digest = update_manifest_path(
             lease,
             Some(&root_digest),
             0,
-            &entry.relative_path,
-            Some(entry.clone()),
+            &canonical_path,
+            Some(canonical_entry),
             &mut evidence.bytes_installed,
         )?
         .ok_or_else(|| validation("radix migration unexpectedly removed the root"))?;
@@ -2246,30 +2265,29 @@ fn install_object<F>(
     write_temporary: F,
 ) -> Result<GraphObjectInstallEvidence, GfError>
 where
-    F: FnOnce(&mut File) -> Result<u64, GfError>,
+    F: FnOnce(&mut CasTemporaryWriter) -> Result<u64, GfError>,
 {
     validate_digest(digest)?;
     let bucket = cas.digest_bucket(digest, true)?;
     let destination_name = std::ffi::OsStr::new(&digest[2..]);
-    if let Ok(file) = bucket.open_child_file(destination_name) {
-        verify_and_seal_graph_object(&file, digest, expected_length, &cas.diagnostic_root)?;
-        return Ok(GraphObjectInstallEvidence {
-            bytes_hashed: expected_length,
-            reused_existing: true,
-            ..GraphObjectInstallEvidence::default()
-        });
+    if let Some(evidence) =
+        try_reuse_existing_object(cas, &bucket, destination_name, digest, expected_length)?
+    {
+        return Ok(evidence);
     }
     let temporary_name = std::ffi::OsString::from(Uuid::new_v4().hyphenated().to_string());
-    let mut temporary = cas
-        .tmp
-        .create_child_file(&temporary_name)
-        .map_err(|error| {
-            storage(
-                "create stable temporary graph object",
-                &cas.diagnostic_root,
-                error,
-            )
-        })?;
+    #[cfg(unix)]
+    let temporary = cas.tmp.create_child_file(&temporary_name);
+    #[cfg(windows)]
+    let temporary = cas.tmp.create_cas_child_file(&temporary_name);
+    let mut temporary = temporary.map_err(|error| {
+        storage(
+            "create stable temporary graph object",
+            &cas.diagnostic_root,
+            error,
+        )
+    })?;
+    #[cfg(unix)]
     let temporary_identity = graphforge_filesystem::file_identity(&temporary).map_err(|error| {
         storage(
             "inspect temporary graph object",
@@ -2277,21 +2295,21 @@ where
             error,
         )
     })?;
+    #[cfg(windows)]
+    let temporary_identity = temporary.identity();
     let bytes_hashed = write_temporary(&mut temporary)?;
     if !writer_authenticated {
         temporary.rewind().map_err(|error| {
             storage("rewind temporary graph object", &cas.diagnostic_root, error)
         })?;
-        verify_file(
-            temporary.try_clone().map_err(|error| {
-                storage("clone temporary graph object", &cas.diagnostic_root, error)
-            })?,
+        verify_stream(
+            &mut temporary,
             digest,
             expected_length,
             &cas.diagnostic_root,
         )?;
     }
-    let installed = finalize_temporary_object(
+    let (installed, sealed_bytes_hashed) = finalize_temporary_object(
         cas,
         &bucket,
         TemporaryObject {
@@ -2309,10 +2327,96 @@ where
             } else {
                 expected_length
             })
+            .saturating_add(sealed_bytes_hashed)
             .saturating_add(if installed { 0 } else { expected_length }),
         bytes_installed: if installed { expected_length } else { 0 },
         reused_existing: !installed,
     })
+}
+
+fn reused_object_evidence(expected_length: u64) -> GraphObjectInstallEvidence {
+    GraphObjectInstallEvidence {
+        bytes_hashed: expected_length,
+        reused_existing: true,
+        ..GraphObjectInstallEvidence::default()
+    }
+}
+
+#[cfg(unix)]
+fn try_reuse_existing_object(
+    cas: &CasRoot,
+    bucket: &StableDirectory,
+    destination_name: &std::ffi::OsStr,
+    digest: &str,
+    expected_length: u64,
+) -> Result<Option<GraphObjectInstallEvidence>, GfError> {
+    let file = match bucket.open_child_file(destination_name) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(storage(
+                "open existing graph object",
+                &cas.diagnostic_root,
+                error,
+            ));
+        }
+    };
+    verify_and_seal_graph_object(
+        &file,
+        digest,
+        expected_length,
+        &graph_object_path(&cas.diagnostic_root, digest)?,
+        &cas.diagnostic_root,
+    )?;
+    Ok(Some(reused_object_evidence(expected_length)))
+}
+
+#[cfg(windows)]
+fn try_reuse_existing_object(
+    cas: &CasRoot,
+    bucket: &StableDirectory,
+    destination_name: &std::ffi::OsStr,
+    digest: &str,
+    expected_length: u64,
+) -> Result<Option<GraphObjectInstallEvidence>, GfError> {
+    let file = match bucket.open_cas_child_file(destination_name) {
+        Ok(file) => file.into_file(),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(canonical_error) => {
+            let mut legacy = bucket
+                .open_legacy_cas_child_for_adoption(destination_name)
+                .map_err(|legacy_error| {
+                    storage(
+                        "reject unsealed or busy graph object",
+                        &cas.diagnostic_root,
+                        if legacy_error.kind() == std::io::ErrorKind::NotFound {
+                            canonical_error
+                        } else {
+                            legacy_error
+                        },
+                    )
+                })?;
+            verify_stream(&mut legacy, digest, expected_length, &cas.diagnostic_root)?;
+            bucket
+                .adopt_legacy_cas_child(destination_name, legacy)
+                .map(graphforge_filesystem::WindowsSealedCasFile::into_file)
+                .map_err(|error| {
+                    storage(
+                        "adopt authenticated legacy graph object",
+                        &cas.diagnostic_root,
+                        error,
+                    )
+                })?
+        }
+    };
+    verify_and_seal_graph_object(
+        &file,
+        digest,
+        expected_length,
+        &graph_object_path(&cas.diagnostic_root, digest)?,
+        &cas.diagnostic_root,
+    )?;
+    Ok(Some(reused_object_evidence(expected_length)))
 }
 
 fn finalize_temporary_object(
@@ -2321,9 +2425,34 @@ fn finalize_temporary_object(
     temporary: TemporaryObject,
     digest: &str,
     expected_length: u64,
-) -> Result<bool, GfError> {
+) -> Result<(bool, u64), GfError> {
     let destination_name = std::ffi::OsStr::new(&digest[2..]);
-    seal_graph_object(&temporary.file, &cas.diagnostic_root)?;
+    let temporary_path = cas
+        .diagnostic_root
+        .join(GRAPH_OBJECTS_DIR)
+        .join(TEMP_DIR)
+        .join(&temporary.name);
+    #[cfg(unix)]
+    let temporary = {
+        seal_graph_object(&temporary.file, &temporary_path, &cas.diagnostic_root)?;
+        SealedTemporaryObject {
+            name: temporary.name,
+            file: temporary.file,
+            identity: temporary.identity,
+        }
+    };
+    #[cfg(windows)]
+    let temporary = transition_temporary_to_sealed_reader(
+        &cas.tmp,
+        temporary,
+        digest,
+        expected_length,
+        &cas.diagnostic_root,
+    )?;
+    #[cfg(unix)]
+    let sealed_bytes_hashed = 0;
+    #[cfg(windows)]
+    let sealed_bytes_hashed = expected_length;
     let sealed_metadata = temporary
         .file
         .metadata()
@@ -2347,14 +2476,26 @@ fn finalize_temporary_object(
     ) {
         true
     } else {
-        let existing = bucket.open_child_file(destination_name).map_err(|error| {
+        #[cfg(unix)]
+        let existing = bucket.open_child_file(destination_name);
+        #[cfg(windows)]
+        let existing = bucket
+            .open_cas_child_file(destination_name)
+            .map(graphforge_filesystem::WindowsSealedCasFile::into_file);
+        let existing = existing.map_err(|error| {
             storage(
                 "open concurrently installed graph object",
                 &cas.diagnostic_root,
                 error,
             )
         })?;
-        verify_and_seal_graph_object(&existing, digest, expected_length, &cas.diagnostic_root)?;
+        verify_and_seal_graph_object(
+            &existing,
+            digest,
+            expected_length,
+            &graph_object_path(&cas.diagnostic_root, digest)?,
+            &cas.diagnostic_root,
+        )?;
         false
     };
     returned_error_boundary("install:final-linked")?;
@@ -2391,7 +2532,59 @@ fn finalize_temporary_object(
             error,
         )
     })?;
-    Ok(installed)
+    Ok((installed, sealed_bytes_hashed))
+}
+
+#[cfg(windows)]
+fn transition_temporary_to_sealed_reader(
+    temporary_directory: &StableDirectory,
+    temporary: TemporaryObject,
+    digest: &str,
+    expected_length: u64,
+    diagnostic: &Path,
+) -> Result<SealedTemporaryObject, GfError> {
+    temporary.file.sync_all().map_err(|error| {
+        storage(
+            "sync temporary graph object before sealing",
+            diagnostic,
+            error,
+        )
+    })?;
+    let identity = temporary.identity;
+    let name = temporary.name;
+    let file = temporary_directory
+        .seal_cas_child_file(&name, temporary.file)
+        .map(graphforge_filesystem::WindowsSealedCasFile::into_file)
+        .map_err(|error| storage("reopen sealed temporary graph object", diagnostic, error))?;
+    if graphforge_filesystem::file_identity(&file).map_err(|error| {
+        storage(
+            "reidentify sealed temporary graph object",
+            diagnostic,
+            error,
+        )
+    })? != identity
+    {
+        return Err(validation(
+            "temporary graph object identity changed while sealing",
+        ));
+    }
+    verify_file(
+        file.try_clone().map_err(|error| {
+            storage(
+                "clone sealed temporary graph object for authentication",
+                diagnostic,
+                error,
+            )
+        })?,
+        digest,
+        expected_length,
+        diagnostic,
+    )?;
+    Ok(SealedTemporaryObject {
+        name,
+        file,
+        identity,
+    })
 }
 
 fn verify_file(
@@ -2425,16 +2618,55 @@ fn verify_file(
     Ok(())
 }
 
+fn verify_stream(
+    file: &mut impl Read,
+    digest: &str,
+    expected_length: u64,
+    diagnostic: &Path,
+) -> Result<(), GfError> {
+    let mut hasher = Sha256::new();
+    let mut total = 0_u64;
+    let mut buffer = vec![0_u8; BUFFER_BYTES];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .map_err(|error| storage("read graph object handle", diagnostic, error))?;
+        if read == 0 {
+            break;
+        }
+        total = total.saturating_add(u64::try_from(read).unwrap_or(u64::MAX));
+        hasher.update(&buffer[..read]);
+    }
+    if total != expected_length || hex_digest(hasher.finalize().into()) != digest {
+        return Err(validation("graph object digest does not match its address"));
+    }
+    Ok(())
+}
+
 fn verify_and_seal_graph_object(
     file: &File,
     digest: &str,
     expected_length: u64,
+    object_path: &Path,
     diagnostic: &Path,
 ) -> Result<(), GfError> {
     // Reuse is safe only after the exact opened inode is no longer writable.
     // Hashing first would leave a window in which the already-authenticated
     // bytes could be changed before the subsequent chmod.
-    seal_graph_object(file, diagnostic)?;
+    #[cfg(unix)]
+    seal_graph_object(file, object_path, diagnostic)?;
+    #[cfg(windows)]
+    {
+        let _ = object_path;
+        if !file
+            .metadata()
+            .map_err(|error| storage("inspect sealed graph object", diagnostic, error))?
+            .permissions()
+            .readonly()
+        {
+            return Err(validation("graph object is not canonically sealed"));
+        }
+    }
     verify_file(
         file.try_clone()
             .map_err(|error| storage("clone graph object for authentication", diagnostic, error))?,
@@ -2455,14 +2687,17 @@ fn verify_and_seal_graph_object(
     Ok(())
 }
 
-fn seal_graph_object(file: &File, diagnostic: &Path) -> Result<(), GfError> {
+#[cfg(unix)]
+fn seal_graph_object(file: &File, object_path: &Path, diagnostic: &Path) -> Result<(), GfError> {
+    let _ = object_path;
     let mut permissions = file
         .metadata()
         .map_err(|error| storage("inspect graph object permissions", diagnostic, error))?
         .permissions();
     permissions.set_readonly(true);
     file.set_permissions(permissions)
-        .map_err(|error| storage("seal graph object permissions", diagnostic, error))
+        .map_err(|error| storage("seal graph object permissions", diagnostic, error))?;
+    Ok(())
 }
 
 fn hash_regular_file(path: &Path) -> Result<[u8; 32], GfError> {
@@ -3094,8 +3329,14 @@ mod tests {
         fs::rename(&path, &displaced).unwrap();
         fs::set_permissions(&displaced, fs::Permissions::from_mode(0o600)).unwrap();
         fs::write(&path, b"hostile replacement").unwrap();
-        verify_and_seal_graph_object(&descriptor, &digest, payload.len() as u64, root.path())
-            .unwrap();
+        verify_and_seal_graph_object(
+            &descriptor,
+            &digest,
+            payload.len() as u64,
+            &displaced,
+            root.path(),
+        )
+        .unwrap();
 
         assert!(fs::metadata(&displaced).unwrap().permissions().readonly());
         assert!(!fs::metadata(&path).unwrap().permissions().readonly());
@@ -3112,7 +3353,7 @@ mod tests {
         fs::write(&path, payload).unwrap();
         let descriptor = File::open(&path).unwrap();
 
-        seal_graph_object(&descriptor, root.path()).unwrap();
+        seal_graph_object(&descriptor, &path, root.path()).unwrap();
         assert!(fs::OpenOptions::new().write(true).open(&path).is_err());
         verify_file(
             descriptor.try_clone().unwrap(),
@@ -3122,6 +3363,150 @@ mod tests {
         )
         .unwrap();
         assert!(descriptor.metadata().unwrap().permissions().readonly());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fresh_write_descriptor_can_be_sealed_without_losing_named_identity() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("fresh-object");
+        let mut descriptor = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .unwrap();
+        descriptor.write_all(b"fresh payload").unwrap();
+        descriptor.sync_all().unwrap();
+        let identity = graphforge_filesystem::file_identity(&descriptor).unwrap();
+
+        seal_graph_object(&descriptor, &path, root.path()).unwrap();
+
+        assert_eq!(
+            graphforge_filesystem::path_identity(&path).unwrap(),
+            identity
+        );
+        assert!(descriptor.metadata().unwrap().permissions().readonly());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn fresh_cas_transition_excludes_writers_before_and_after_seal() {
+        use std::os::windows::fs::OpenOptionsExt as _;
+        use std::process::Command;
+
+        const HELPER: &str = "GRAPHFORGE_CAS_WRITER_EXCLUSION_HELPER";
+        const FILE_SHARE_READ: u32 = 0x0000_0001;
+        const FILE_SHARE_WRITE: u32 = 0x0000_0002;
+        if let Some(path) = std::env::var_os(HELPER) {
+            let writer = OpenOptions::new()
+                .write(true)
+                .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+                .open(path);
+            assert!(writer.is_err(), "child unexpectedly acquired CAS writer");
+            return;
+        }
+
+        let root = tempfile::tempdir().unwrap();
+        let directory = StableDirectory::open(root.path()).unwrap();
+        let name = std::ffi::OsStr::new("temporary");
+        let path = root.path().join(name);
+        let payload = b"sealed only after exclusive read admission";
+        let mut writer = directory.create_cas_child_file(name).unwrap();
+        writer.write_all(payload).unwrap();
+
+        let assert_child_writer_denied = || {
+            let status = Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "graph_object_store::tests::fresh_cas_transition_excludes_writers_before_and_after_seal",
+                    "--nocapture",
+                ])
+                .env(HELPER, &path)
+                .status()
+                .unwrap();
+            assert!(status.success());
+        };
+        assert_child_writer_denied();
+        let sealed = directory.seal_cas_child_file(name, writer).unwrap();
+        assert_child_writer_denied();
+        assert_eq!(
+            graphforge_filesystem::file_identity(&sealed.into_file()).unwrap(),
+            graphforge_filesystem::path_identity(&path).unwrap()
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn ordinary_owner_can_cleanup_fresh_cas_temp_and_gc_sealed_object() {
+        let root = tempfile::tempdir().unwrap();
+        let payload = b"owner-only Windows CAS cleanup";
+
+        let (digest, evidence) = install_graph_object_bytes(root.path(), payload).unwrap();
+        assert!(!evidence.reused_existing);
+        let object = graph_object_path(root.path(), &digest).unwrap();
+        assert!(object.exists());
+
+        // Installation must remove the sealed temporary hard link using the
+        // same owner capability available to a restricted, non-admin process.
+        let lease = begin_graph_object_publication(root.path()).unwrap();
+        assert!(lease.cas.tmp.child_names().unwrap().is_empty());
+        drop(lease);
+
+        // GC uses that same narrow capability on the canonical sealed name.
+        let reclaimed =
+            gc_graph_objects(root.path(), &[], crate::GraphManifestLimits::default()).unwrap();
+        assert_eq!(reclaimed.objects_removed, 1);
+        assert_eq!(reclaimed.bytes_removed, payload.len() as u64);
+        assert!(!object.exists());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn reuse_rejects_planted_unsealed_object_without_mutating_it() {
+        let root = tempfile::tempdir().unwrap();
+        let payload = b"planted writable object";
+        let digest = hex_digest(Sha256::digest(payload).into());
+        let lease = begin_graph_object_publication(root.path()).unwrap();
+        let bucket = lease.cas.digest_bucket(&digest, true).unwrap();
+        let name = std::ffi::OsStr::new(&digest[2..]);
+        let path = graph_object_path(root.path(), &digest).unwrap();
+        fs::write(&path, payload).unwrap();
+        assert!(!fs::metadata(&path).unwrap().permissions().readonly());
+        assert!(bucket.open_cas_child_file(name).is_err());
+        drop(lease);
+
+        assert!(install_graph_object_bytes(root.path(), payload).is_err());
+        assert_eq!(fs::read(&path).unwrap(), payload);
+        assert!(!fs::metadata(&path).unwrap().permissions().readonly());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn authenticated_released_readonly_object_is_adopted_canonically() {
+        use std::os::windows::fs::OpenOptionsExt as _;
+
+        const FILE_SHARE_READ: u32 = 0x0000_0001;
+        const FILE_SHARE_WRITE: u32 = 0x0000_0002;
+        let root = tempfile::tempdir().unwrap();
+        let payload = b"released readonly inherited-dacl object";
+        let digest = hex_digest(Sha256::digest(payload).into());
+        let lease = begin_graph_object_publication(root.path()).unwrap();
+        let _bucket = lease.cas.digest_bucket(&digest, true).unwrap();
+        let path = graph_object_path(root.path(), &digest).unwrap();
+        fs::write(&path, payload).unwrap();
+        let mut permissions = fs::metadata(&path).unwrap().permissions();
+        permissions.set_readonly(true);
+        fs::set_permissions(&path, permissions).unwrap();
+        drop(lease);
+
+        let (_, evidence) = install_graph_object_bytes(root.path(), payload).unwrap();
+        assert!(evidence.reused_existing);
+        let writer = OpenOptions::new()
+            .write(true)
+            .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+            .open(&path);
+        assert!(writer.is_err(), "canonical adoption retained write access");
     }
 
     #[cfg(unix)]
@@ -3224,6 +3609,16 @@ mod tests {
         assert_eq!(first.bytes_hashed, 7);
         assert_eq!(first.bytes_installed, 7);
         assert!(!first.reused_existing);
+        assert!(
+            root.path()
+                .join(GRAPH_OBJECTS_DIR)
+                .join(TEMP_DIR)
+                .read_dir()
+                .unwrap()
+                .next()
+                .is_none(),
+            "fresh installation retained its sealed temporary alias"
+        );
         let (_, second) = install_graph_object_bytes(root.path(), b"payload").unwrap();
         assert!(second.reused_existing);
         assert_eq!(
@@ -3236,6 +3631,23 @@ mod tests {
             b"corrupt",
         );
         assert!(install_graph_object_bytes(root.path(), b"payload").is_err());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_fresh_sealed_install_removes_its_temporary_alias() {
+        let root = tempfile::tempdir().unwrap();
+        install_graph_object_bytes(root.path(), b"windows sealed payload").unwrap();
+
+        assert!(
+            root.path()
+                .join(GRAPH_OBJECTS_DIR)
+                .join(TEMP_DIR)
+                .read_dir()
+                .unwrap()
+                .next()
+                .is_none()
+        );
     }
 
     #[test]
@@ -3302,6 +3714,36 @@ mod tests {
             })
             .unwrap();
         assert_eq!(files, inventory.files);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn migrates_windows_authored_v1_path_into_canonical_v2_manifest() {
+        let container = tempfile::tempdir().unwrap();
+        let graph = tempfile::tempdir().unwrap();
+        let source = graph.path().join("topology/nodes.parquet");
+        fs::create_dir_all(source.parent().unwrap()).unwrap();
+        fs::write(&source, b"nodes").unwrap();
+        let inventory = crate::GraphFilesInventory {
+            format: "graphforge-graph-files".into(),
+            format_version: 1,
+            files: vec![crate::GraphFileEntry {
+                relative_path: "topology\\nodes.parquet".into(),
+                byte_length: 5,
+                content_sha256: hex_digest(Sha256::digest(b"nodes").into()),
+                role: crate::GraphFileRole::Topology,
+            }],
+            file_count: 1,
+            total_byte_length: 5,
+        };
+        let lease = begin_graph_object_publication(container.path()).unwrap();
+        let (root, _) = migrate_graph_files_v1_to_v2(&lease, graph.path(), &inventory).unwrap();
+        let (files, _) =
+            crate::resolve_graph_manifest(&root, crate::GraphManifestLimits::default(), |digest| {
+                read_graph_object_by_digest(container.path(), digest, 1024 * 1024)
+            })
+            .unwrap();
+        assert_eq!(files[0].relative_path, "topology/nodes.parquet");
     }
 
     #[test]

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -360,11 +360,11 @@ pub use uuid_membership::{
 
 pub mod ordinal_identity_v4;
 pub use ordinal_identity_v4::{
-    ORDINAL_IDENTITY_MANIFEST, ORDINAL_IDENTITY_V4, V4OrdinalAdmissionMetrics, V4OrdinalArtifact,
-    V4OrdinalArtifactKind, V4OrdinalBlock, V4OrdinalIdentityAuthority, V4OrdinalIdentityError,
-    V4OrdinalIdentityHandle, V4OrdinalIdentityLimits, V4OrdinalIdentityManifest,
-    V4OrdinalIdentityOpen, V4OrdinalLookup, V4OrdinalLookupMetrics, V4OrdinalRange,
-    V4OrdinalTombstoneBlock, V4OrdinalTombstones,
+    AuthenticatedV4OrdinalIdentityAuthority, ORDINAL_IDENTITY_MANIFEST, ORDINAL_IDENTITY_V4,
+    V4OrdinalAdmissionMetrics, V4OrdinalArtifact, V4OrdinalArtifactKind, V4OrdinalBlock,
+    V4OrdinalIdentityDiscovery, V4OrdinalIdentityError, V4OrdinalIdentityLimits,
+    V4OrdinalIdentityManifest, V4OrdinalIdentityOpen, V4OrdinalLookup, V4OrdinalLookupMetrics,
+    V4OrdinalRange, V4OrdinalTombstoneBlock, V4OrdinalTombstones,
 };
 
 pub mod property_overlay;

--- a/crates/graphforge-storage/src/ordinal_identity_v4.rs
+++ b/crates/graphforge-storage/src/ordinal_identity_v4.rs
@@ -18,10 +18,13 @@ use uuid::Uuid;
 /// Immutable v4 manifest version.
 pub const ORDINAL_IDENTITY_V4: u32 = 4;
 /// Canonical location below a graph project.
-pub const ORDINAL_IDENTITY_MANIFEST: &str = "topology/uuid-membership/manifest.json";
+pub const ORDINAL_IDENTITY_MANIFEST: &str = "topology/uuid-membership/ordinal-v4-manifest.json";
 const INDEX_DIR: &str = "topology/uuid-membership";
-const MANIFEST_NAME: &str = "manifest.json";
+const MANIFEST_NAME: &str = "ordinal-v4-manifest.json";
 const LOCK_NAME: &str = "ordinal-v4.lock";
+const RECEIPT_FILE_NAME: &str = "ordinal-v4-receipt.json";
+const RECEIPT_NAME: &str = "topology/uuid-membership/ordinal-v4-receipt.json";
+const GENERATION_NAME: &str = "topology/generation.json";
 const UUID_WIDTH: u64 = 16;
 const FORWARD_RECORD_WIDTH: u64 = UUID_WIDTH + 8;
 const FORWARD_RECORD_WIDTH_USIZE: usize = UUID_WIDTH_USIZE + 8;
@@ -161,7 +164,7 @@ pub struct V4OrdinalIdentityManifest {
     /// Must equal [`ORDINAL_IDENTITY_V4`].
     pub format_version: u32,
     /// Exact topology generation served by this snapshot.
-    pub topology_generation: u64,
+    pub(crate) topology_generation: u64,
     /// UUID-sorted forward artifacts, included to reject mixed authority.
     pub forward_identities: Vec<V4OrdinalArtifact>,
     /// Nonoverlapping packed ordinal ranges.
@@ -176,7 +179,121 @@ pub struct V4OrdinalIdentityAuthority {
     /// Exact topology generation authorized by the project root.
     pub topology_generation: u64,
     /// Lowercase SHA-256 of the authorized membership manifest bytes.
-    pub manifest_sha256: String,
+    pub(crate) manifest_sha256: String,
+}
+
+/// Opaque ordinal authority authenticated through one pinned project generation.
+#[derive(Clone, Debug)]
+pub struct AuthenticatedV4OrdinalIdentityAuthority {
+    pub(crate) authority: V4OrdinalIdentityAuthority,
+}
+
+impl AuthenticatedV4OrdinalIdentityAuthority {
+    #[cfg(test)]
+    pub(crate) fn authority(&self) -> &V4OrdinalIdentityAuthority {
+        &self.authority
+    }
+
+    /// Open the selected ordinal facet at an admitted graph root.
+    pub fn open(
+        &self,
+        graph_root: &Path,
+        limits: V4OrdinalIdentityLimits,
+    ) -> Result<V4OrdinalIdentityOpen, V4OrdinalIdentityError> {
+        V4OrdinalIdentityHandle::open(graph_root, &self.authority, limits)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SelectedOrdinalReceipt {
+    nonce: String,
+    expected_generation: u64,
+    topology_delta_sha256: String,
+    manifest_sha256: String,
+}
+
+impl crate::ResolvedProjectGeneration {
+    /// Resolve the ordinal receipt through the pinned generation's authenticated
+    /// graph/files participant. Absence is a clean rebuild requirement; any
+    /// partial or malformed residue fails closed.
+    pub fn authenticated_v4_ordinal_authority(
+        &self,
+    ) -> Result<Option<AuthenticatedV4OrdinalIdentityAuthority>, graphforge_core::GfError> {
+        let mut targeted_state = crate::graph_manifest::GraphManifestTargetedState::default();
+        let receipt = self.authenticated_graph_file_bytes_with_state(
+            RECEIPT_NAME,
+            MAX_MANIFEST_BYTES,
+            Some(&mut targeted_state),
+        )?;
+        let manifest = self.authenticated_graph_file_bytes_with_state(
+            ORDINAL_IDENTITY_MANIFEST,
+            MAX_MANIFEST_BYTES,
+            Some(&mut targeted_state),
+        )?;
+        match (receipt, manifest) {
+            (None, None) => Ok(None),
+            (None, Some(_)) | (Some(_), None) => Err(graphforge_core::GfError::Validation(
+                "selected ordinal facet has incomplete authority residue".into(),
+            )),
+            (Some((_, receipt_bytes)), Some((manifest_entry, manifest_bytes))) => {
+                let receipt: SelectedOrdinalReceipt = serde_json::from_slice(&receipt_bytes)
+                    .map_err(|_| {
+                        graphforge_core::GfError::Validation(
+                            "selected ordinal receipt is malformed".into(),
+                        )
+                    })?;
+                let generation = self
+                    .authenticated_graph_file_bytes_with_state(
+                        GENERATION_NAME,
+                        MAX_MANIFEST_BYTES,
+                        Some(&mut targeted_state),
+                    )?
+                    .ok_or_else(|| {
+                        graphforge_core::GfError::Validation(
+                            "selected topology generation authority is absent".into(),
+                        )
+                    })?;
+                let generation: serde_json::Value =
+                    serde_json::from_slice(&generation.1).map_err(|_| {
+                        graphforge_core::GfError::Validation(
+                            "selected topology generation authority is malformed".into(),
+                        )
+                    })?;
+                let selected_generation = generation
+                    .get("topology_generation")
+                    .and_then(serde_json::Value::as_u64)
+                    .ok_or_else(|| {
+                        graphforge_core::GfError::Validation(
+                            "selected topology generation is missing".into(),
+                        )
+                    })?;
+                let manifest_digest = hex(&Sha256::digest(&manifest_bytes));
+                let canonical_hex = |value: &str, length: usize| {
+                    value.len() == length
+                        && value
+                            .bytes()
+                            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+                };
+                if !canonical_hex(&receipt.nonce, 32)
+                    || !canonical_hex(&receipt.topology_delta_sha256, 64)
+                    || receipt.expected_generation != selected_generation
+                    || receipt.manifest_sha256 != manifest_entry.content_sha256
+                    || receipt.manifest_sha256 != manifest_digest
+                {
+                    return Err(graphforge_core::GfError::Validation(
+                        "selected ordinal receipt does not authenticate its manifest".into(),
+                    ));
+                }
+                Ok(Some(AuthenticatedV4OrdinalIdentityAuthority {
+                    authority: V4OrdinalIdentityAuthority {
+                        topology_generation: selected_generation,
+                        manifest_sha256: manifest_digest,
+                    },
+                }))
+            }
+        }
+    }
 }
 
 /// Typed open disposition. V3 is never parsed as v4.
@@ -187,6 +304,18 @@ pub enum V4OrdinalIdentityOpen {
     /// A valid version marker that requires an explicit rebuild.
     RebuildRequired {
         /// Version found in the manifest.
+        found_version: u32,
+    },
+}
+
+/// Discovery result for the additive ordinal facet.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum V4OrdinalIdentityDiscovery {
+    /// The v4 path exists and must be authenticated by [`V4OrdinalIdentityHandle::open`].
+    Present,
+    /// Current canonical v3 node/edge authority is valid but ordinal v4 is absent.
+    RebuildRequired {
+        /// Canonical legacy facet version that requires ordinal construction.
         found_version: u32,
     },
 }
@@ -348,14 +477,67 @@ pub struct V4OrdinalIdentityHandle {
 }
 
 impl V4OrdinalIdentityHandle {
+    /// Return the exact v4 facet names admitted through this retained,
+    /// generation-authenticated handle.
+    pub(crate) fn referenced_file_names(&self) -> BTreeSet<String> {
+        std::iter::once(MANIFEST_NAME.to_owned())
+            .chain(std::iter::once(RECEIPT_FILE_NAME.to_owned()))
+            .chain(std::iter::once(LOCK_NAME.to_owned()))
+            .chain(
+                self.forward
+                    .iter()
+                    .map(|artifact| artifact.descriptor.name.clone()),
+            )
+            .chain(
+                self.ranges
+                    .iter()
+                    .map(|range| range.artifact.descriptor.name.clone()),
+            )
+            .chain(
+                self.tombstones
+                    .iter()
+                    .map(|run| run.artifact.descriptor.name.clone()),
+            )
+            .collect()
+    }
+
+    /// Classify the additive ordinal facet without treating a present file as
+    /// trusted. A present malformed v4 remains `Present` and subsequently
+    /// fails authenticated open; discovery never falls back around it.
+    pub fn discover(
+        project_dir: &Path,
+        topology_generation: u64,
+    ) -> Result<V4OrdinalIdentityDiscovery, V4OrdinalIdentityError> {
+        let root = StableDirectory::open(&project_dir.join(INDEX_DIR)).map_err(io_error)?;
+        match root.open_child_file(MANIFEST_NAME.as_ref()) {
+            Ok(_) => return Ok(V4OrdinalIdentityDiscovery::Present),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(io_error(error)),
+        }
+        if crate::UuidMembershipIndex::open_at_generation(project_dir, topology_generation).is_err()
+        {
+            return Err(V4OrdinalIdentityError::InvalidDescriptor(
+                "current v3 authority failed authentication",
+            ));
+        }
+        Ok(V4OrdinalIdentityDiscovery::RebuildRequired { found_version: 3 })
+    }
+
     /// Open and authenticate one immutable v4 generation.
-    pub fn open(
+    #[allow(clippy::too_many_lines)] // One admission lifecycle; ordering is the authority invariant.
+    pub(crate) fn open(
         project_dir: &Path,
         authority: &V4OrdinalIdentityAuthority,
         limits: V4OrdinalIdentityLimits,
     ) -> Result<V4OrdinalIdentityOpen, V4OrdinalIdentityError> {
         validate_limits(limits)?;
         let root = StableDirectory::open(&project_dir.join(INDEX_DIR)).map_err(io_error)?;
+        let coordination_file = root.open_child_file(LOCK_NAME.as_ref()).map_err(io_error)?;
+        if file_link_count(&coordination_file).map_err(io_error)? != 1 {
+            return Err(V4OrdinalIdentityError::Authentication);
+        }
+        <File as fs4::FileExt>::lock_shared(&coordination_file).map_err(io_error)?;
+        let coordination_identity = file_identity(&coordination_file).map_err(io_error)?;
         let mut manifest_file = root
             .open_child_file(MANIFEST_NAME.as_ref())
             .map_err(io_error)?;
@@ -365,15 +547,9 @@ impl V4OrdinalIdentityHandle {
         }
         let body = read_bounded(&mut manifest_file, MAX_MANIFEST_BYTES)?;
         authenticate_manifest_authority(&body, authority)?;
-        let Some(manifest) = parse_manifest(&body, authority.topology_generation)? else {
-            return Ok(V4OrdinalIdentityOpen::RebuildRequired { found_version: 3 });
-        };
-        let coordination_file = root.open_child_file(LOCK_NAME.as_ref()).map_err(io_error)?;
-        if file_link_count(&coordination_file).map_err(io_error)? != 1 {
-            return Err(V4OrdinalIdentityError::Authentication);
-        }
-        <File as fs4::FileExt>::lock_shared(&coordination_file).map_err(io_error)?;
-        let coordination_identity = file_identity(&coordination_file).map_err(io_error)?;
+        let manifest = parse_manifest(&body, authority.topology_generation)?.ok_or(
+            V4OrdinalIdentityError::InvalidDescriptor("v3 occupies the v4 manifest path"),
+        )?;
         validate_manifest(&manifest, authority.topology_generation)?;
 
         let mut admission =
@@ -439,6 +615,11 @@ impl V4OrdinalIdentityHandle {
                 blocks: run.blocks.clone(),
             });
         }
+        // The coordination lock protects admission from a concurrent writer,
+        // not the lifetime of an immutable snapshot. Releasing it here keeps
+        // retained handles from starving publication. Revalidation below
+        // still pins the manifest, lock inode, and every immutable artifact.
+        <File as fs4::FileExt>::unlock(&coordination_file).map_err(io_error)?;
         admission.ranges = ranges.len() as u64;
         admission.tombstone_runs = tombstones.len() as u64;
         Ok(V4OrdinalIdentityOpen::Ready(Box::new(Self {
@@ -1426,6 +1607,23 @@ mod tests {
         }
     }
 
+    #[test]
+    fn retained_authenticated_handle_never_reenumerates_replaced_manifest_names() {
+        let fixture = Fixture::new(&[2], &[1]);
+        let handle = fixture.open(V4OrdinalIdentityLimits::default());
+        let mut replacement = fixture.manifest.clone();
+        replacement.forward_identities[0].name = "planted-forward.uuidx".into();
+        fs::write(
+            fixture.root.path().join(INDEX_DIR).join(MANIFEST_NAME),
+            serde_json::to_vec(&replacement).unwrap(),
+        )
+        .unwrap();
+
+        let referenced = handle.referenced_file_names();
+        assert!(referenced.contains("forward.uuidx"));
+        assert!(!referenced.contains("planted-forward.uuidx"));
+    }
+
     fn artifact(
         name: String,
         kind: V4OrdinalArtifactKind,
@@ -1469,22 +1667,6 @@ mod tests {
                 sha256: hex(&Sha256::digest(block)),
             })
             .collect()
-    }
-
-    fn v3_file_json(name: &str, width: u32) -> serde_json::Value {
-        let key_hex_len = if width == 32 { 32 } else { 16 };
-        serde_json::json!({
-            "name": name,
-            "count": 1,
-            "sha256": "0".repeat(64),
-            "blocks": [{
-                "offset": 0,
-                "len": width,
-                "first_key": "1".repeat(key_hex_len),
-                "last_key": "1".repeat(key_hex_len),
-                "sha256": "2".repeat(64)
-            }]
-        })
     }
 
     #[test]
@@ -1537,83 +1719,81 @@ mod tests {
     }
 
     #[test]
-    fn v3_is_explicitly_rebuild_required_and_mixed_kind_fails() {
+    fn absent_v4_classifies_valid_v3_and_present_malformed_v4_never_falls_back() {
+        let (root, _, _) = crate::uuid_membership::tests::fixture();
+        fs::write(
+            root.path().join("topology/generation.json"),
+            b"{\"topology_generation\":7,\"search_generation\":0,\"property_generation\":0}\n",
+        )
+        .unwrap();
+        crate::rebuild_uuid_membership_indexes(root.path(), crate::UuidIndexBuildLimits::default())
+            .unwrap();
+        let index = root.path().join(INDEX_DIR);
+        fs::write(index.join(LOCK_NAME), []).unwrap();
+        let v4_path = index.join(MANIFEST_NAME);
+        let v3_path = index.join("manifest.json");
+        let v3 = fs::read(&v3_path).unwrap();
+        assert!(matches!(
+            V4OrdinalIdentityHandle::discover(root.path(), 7).unwrap(),
+            V4OrdinalIdentityDiscovery::RebuildRequired { found_version: 3 }
+        ));
+        assert!(matches!(
+            V4OrdinalIdentityHandle::open(
+                root.path(),
+                &V4OrdinalIdentityAuthority {
+                    topology_generation: 7,
+                    manifest_sha256: "00".repeat(32),
+                },
+                V4OrdinalIdentityLimits::default()
+            ),
+            Err(V4OrdinalIdentityError::Io)
+        ));
+        fs::remove_file(&v3_path).unwrap();
+        assert!(matches!(
+            V4OrdinalIdentityHandle::discover(root.path(), 7),
+            Err(V4OrdinalIdentityError::InvalidDescriptor(_))
+        ));
+        fs::write(&v3_path, &v3).unwrap();
+        let v3_manifest: serde_json::Value = serde_json::from_slice(&v3).unwrap();
+        let run_name = v3_manifest["runs"][0]["identities"]["name"]
+            .as_str()
+            .unwrap();
+        let run_path = index.join(run_name);
+        let mut run = fs::read(&run_path).unwrap();
+        run[0] ^= 1;
+        fs::write(&run_path, run).unwrap();
+        assert!(matches!(
+            V4OrdinalIdentityHandle::discover(root.path(), 7),
+            Err(V4OrdinalIdentityError::InvalidDescriptor(_))
+        ));
+
+        fs::write(&v4_path, b"{\"format_version\":4}").unwrap();
+        assert_eq!(
+            V4OrdinalIdentityHandle::discover(root.path(), 7).unwrap(),
+            V4OrdinalIdentityDiscovery::Present
+        );
+        let malformed_digest = hex(&Sha256::digest(b"{\"format_version\":4}"));
+        assert!(matches!(
+            V4OrdinalIdentityHandle::open(
+                root.path(),
+                &V4OrdinalIdentityAuthority {
+                    topology_generation: 7,
+                    manifest_sha256: malformed_digest,
+                },
+                V4OrdinalIdentityLimits::default()
+            ),
+            Err(V4OrdinalIdentityError::InvalidDescriptor(_)) | Err(V4OrdinalIdentityError::Io)
+        ));
+
         let fixture = Fixture::new(&[2], &[]);
-        let manifest_path = fixture.root.path().join(INDEX_DIR).join(MANIFEST_NAME);
-        let v3 = serde_json::json!({
-            "format_version": 3,
-            "base_generation": 7,
-            "current_generation": 7,
-            "live_node_count": 1,
-            "live_edge_count": 0,
-            "runs": [{
-                "base": true,
-                "level": 0,
-                "first_generation": 0,
-                "last_generation": 7,
-                "identities": v3_file_json("identities.bin", 32),
-                "node_surrogates": v3_file_json("node-surrogates.bin", 24),
-                "node_count": 1,
-                "edge_count": 0,
-                "deleted_node_count": 0,
-                "deleted_edge_count": 0
-            }]
-        });
-        fs::write(&manifest_path, serde_json::to_vec(&v3).unwrap()).unwrap();
-        fs::remove_file(fixture.root.path().join(INDEX_DIR).join(LOCK_NAME)).unwrap();
-        assert!(matches!(
-            V4OrdinalIdentityHandle::open(
-                fixture.root.path(),
-                &fixture.authority(7),
-                V4OrdinalIdentityLimits::default()
-            )
-            .unwrap(),
-            V4OrdinalIdentityOpen::RebuildRequired { found_version: 3 }
-        ));
-        fs::write(fixture.root.path().join(INDEX_DIR).join(LOCK_NAME), []).unwrap();
-
-        let mut mixed_v3 = v3.clone();
-        mixed_v3["ordinal_ranges"] = serde_json::json!([]);
-        fs::write(&manifest_path, serde_json::to_vec(&mixed_v3).unwrap()).unwrap();
-        assert!(matches!(
-            V4OrdinalIdentityHandle::open(
-                fixture.root.path(),
-                &fixture.authority(7),
-                V4OrdinalIdentityLimits::default()
-            ),
-            Err(V4OrdinalIdentityError::InvalidDescriptor(_))
-        ));
-        let mut run_mixed = v3.clone();
-        run_mixed["runs"][0]["v4_generation"] = serde_json::json!(7);
-        let mut file_mixed = v3.clone();
-        file_mixed["runs"][0]["identities"]["v4_digest"] = serde_json::json!("mixed");
-        let mut block_mixed = v3.clone();
-        block_mixed["runs"][0]["identities"]["blocks"][0]["v4_offset"] = serde_json::json!(0);
-        for nested_mixed in [run_mixed, file_mixed, block_mixed] {
-            fs::write(&manifest_path, serde_json::to_vec(&nested_mixed).unwrap()).unwrap();
-            assert!(matches!(
-                V4OrdinalIdentityHandle::open(
-                    fixture.root.path(),
-                    &fixture.authority(7),
-                    V4OrdinalIdentityLimits::default()
-                ),
-                Err(V4OrdinalIdentityError::InvalidDescriptor(_))
-            ));
-        }
-        fs::write(&manifest_path, br#"{"format_version":5}"#).unwrap();
-        assert!(matches!(
-            V4OrdinalIdentityHandle::open(
-                fixture.root.path(),
-                &fixture.authority(7),
-                V4OrdinalIdentityLimits::default()
-            ),
-            Err(V4OrdinalIdentityError::InvalidDescriptor(_))
-        ));
-
         fixture.publish();
         let mut mixed = fixture.manifest.clone();
         mixed.ordinal_ranges[0].artifact.kind = V4OrdinalArtifactKind::ForwardIdentities;
-        fs::write(&manifest_path, serde_json::to_vec(&mixed).unwrap()).unwrap();
+        fs::write(
+            fixture.root.path().join(INDEX_DIR).join(MANIFEST_NAME),
+            serde_json::to_vec(&mixed).unwrap(),
+        )
+        .unwrap();
         assert!(matches!(
             V4OrdinalIdentityHandle::open(
                 fixture.root.path(),

--- a/crates/graphforge-storage/src/project_generation.rs
+++ b/crates/graphforge-storage/src/project_generation.rs
@@ -112,6 +112,89 @@ impl Drop for GenerationLease {
 }
 
 impl ResolvedProjectGeneration {
+    pub(crate) fn authenticated_graph_file_bytes_with_state(
+        &self,
+        relative_path: &str,
+        maximum: u64,
+        targeted_state: Option<&mut crate::graph_manifest::GraphManifestTargetedState>,
+    ) -> Result<Option<(crate::GraphFileEntry, Vec<u8>)>, GfError> {
+        let Some(participant) = self.declared_graph_files_participant()? else {
+            return Ok(None);
+        };
+        let entry = match &participant {
+            crate::GraphFilesParticipant::V1(inventory) => {
+                let legacy_path = relative_path.replace('/', "\\");
+                let exact = inventory
+                    .files
+                    .binary_search_by(|entry| entry.relative_path.as_str().cmp(relative_path))
+                    .ok();
+                let legacy = inventory
+                    .files
+                    .binary_search_by(|entry| entry.relative_path.as_str().cmp(&legacy_path))
+                    .ok();
+                match (exact, legacy) {
+                    (Some(index), None) | (None, Some(index)) => {
+                        Some(inventory.files[index].clone())
+                    }
+                    (None, None) => None,
+                    (Some(_), Some(_)) => {
+                        return Err(corrupt(
+                            "selected graph control has ambiguous legacy inventory paths",
+                        ));
+                    }
+                }
+            }
+            crate::GraphFilesParticipant::V2(root) => {
+                let limits = crate::GraphManifestLimits {
+                    max_segments: 65,
+                    max_entries: 1024,
+                    max_decoded_bytes: 16 * 1024 * 1024,
+                    max_work_units: 4096,
+                };
+                let mut local_state = crate::graph_manifest::GraphManifestTargetedState::default();
+                let state = targeted_state.unwrap_or(&mut local_state);
+                crate::graph_manifest::resolve_manifest_entry_with_state(
+                    root,
+                    relative_path,
+                    limits,
+                    state,
+                    |digest| {
+                        crate::read_graph_object_by_digest(
+                            self.container_root(),
+                            digest,
+                            4 * 1024 * 1024,
+                        )
+                    },
+                )?
+            }
+        };
+        let Some(entry) = entry else { return Ok(None) };
+        if entry.byte_length > maximum {
+            return Err(corrupt("selected graph control exceeds its read bound"));
+        }
+        let bytes = match participant {
+            crate::GraphFilesParticipant::V1(_) => {
+                let graph_root = self.graph_tree_root();
+                let path = crate::graph_files::resolve_v1_inventory_entry(&graph_root, &entry)?;
+                let relative = path
+                    .strip_prefix(&graph_root)
+                    .map_err(|_| corrupt("selected graph control escaped graph root"))?;
+                read_stable_graph_control(&graph_root, relative, entry.byte_length, maximum)?
+            }
+            crate::GraphFilesParticipant::V2(_) => crate::read_graph_object_by_digest(
+                self.container_root(),
+                &entry.content_sha256,
+                maximum,
+            )?,
+        };
+        crate::graph_manifest::verify_object_bytes(
+            &entry.content_sha256,
+            entry.byte_length,
+            &bytes,
+        )?;
+        Ok(Some((entry, bytes)))
+    }
+
     /// Canonical project container root used for this resolution.
     #[must_use]
     pub fn container_root(&self) -> &Path {
@@ -1497,6 +1580,56 @@ fn read_bounded_regular_file(path: &Path, maximum: u64) -> Result<Vec<u8>, std::
     Ok(bytes)
 }
 
+fn read_stable_graph_control(
+    graph_root: &Path,
+    relative: &Path,
+    expected_length: u64,
+    maximum: u64,
+) -> Result<Vec<u8>, GfError> {
+    let mut directory = graphforge_filesystem::StableDirectory::open(graph_root)
+        .map_err(|_| corrupt("selected graph root cannot be retained"))?;
+    let mut components = relative.components().peekable();
+    let mut file = None;
+    while let Some(component) = components.next() {
+        let Component::Normal(name) = component else {
+            return Err(corrupt("selected graph control path is not canonical"));
+        };
+        if components.peek().is_some() {
+            directory = directory
+                .open_child_directory(name)
+                .map_err(|_| corrupt("selected graph control parent cannot be retained"))?;
+        } else {
+            file = Some(
+                directory
+                    .open_child_file(name)
+                    .map_err(|_| corrupt("selected graph control is not a regular child"))?,
+            );
+        }
+    }
+    let file = file.ok_or_else(|| corrupt("selected graph control path is empty"))?;
+    let metadata = file
+        .metadata()
+        .map_err(|_| corrupt("selected graph control metadata is unreadable"))?;
+    if metadata.len() != expected_length || expected_length > maximum {
+        return Err(corrupt(
+            "selected graph control length differs from inventory",
+        ));
+    }
+    let capacity = usize::try_from(expected_length)
+        .map_err(|_| corrupt("selected graph control length exceeds address space"))?;
+    let mut bytes = Vec::with_capacity(capacity);
+    file.take(expected_length.saturating_add(1))
+        .read_to_end(&mut bytes)
+        .map_err(|_| corrupt("selected graph control cannot be read"))?;
+    if bytes.len() as u64 != expected_length {
+        return Err(corrupt("selected graph control changed while reading"));
+    }
+    directory
+        .revalidate_named()
+        .map_err(|_| corrupt("selected graph control parent identity changed"))?;
+    Ok(bytes)
+}
+
 fn read_exact_participant(path: &Path, expected_length: u64) -> Result<Vec<u8>, GfError> {
     let file = open_regular_file(path)
         .map_err(|_| corrupt("participant is missing, linked, or unreadable"))?;
@@ -1605,6 +1738,99 @@ mod tests {
         fs::write(root.join(CURRENT_FILE), canonical_line(&current)).unwrap();
     }
 
+    fn install_graph_generation(
+        root: &Path,
+        generation_uuid: Uuid,
+        generation: u64,
+        compact: bool,
+        omit_receipt: bool,
+        wrong_receipt_generation: bool,
+        include_v4: bool,
+    ) -> [u8; 32] {
+        let generation_root = root
+            .join("generations")
+            .join(generation_uuid.hyphenated().to_string());
+        let graph = crate::graph_tree_root(&generation_root);
+        let index = graph.join("topology/uuid-membership");
+        fs::create_dir_all(&index).unwrap();
+        fs::write(generation_root.join(LEASE_FILE), []).unwrap();
+        let manifest_bytes = format!("{{\"format_version\":4,\"topology_generation\":{generation},\"forward_identities\":[],\"ordinal_ranges\":[],\"tombstones\":[]}}").into_bytes();
+        let manifest_digest = sha256_hex(Sha256::digest(&manifest_bytes).into());
+        if include_v4 {
+            fs::write(index.join("ordinal-v4-manifest.json"), &manifest_bytes).unwrap();
+            fs::write(index.join("ordinal-v4.lock"), []).unwrap();
+        }
+        let receipt = serde_json::json!({
+            "nonce": Uuid::now_v7().simple().to_string(),
+            "expected_generation": if wrong_receipt_generation { generation + 1 } else { generation },
+            "topology_delta_sha256": "1".repeat(64),
+            "manifest_sha256": manifest_digest,
+        });
+        if include_v4 {
+            fs::write(
+                index.join("ordinal-v4-receipt.json"),
+                serde_json::to_vec(&receipt).unwrap(),
+            )
+            .unwrap();
+        }
+        fs::write(
+            graph.join("topology/generation.json"),
+            format!("{{\"topology_generation\":{generation}}}"),
+        )
+        .unwrap();
+        if include_v4 && omit_receipt {
+            fs::remove_file(index.join("ordinal-v4-receipt.json")).unwrap();
+        }
+        crate::rebuild_uuid_membership_indexes(&graph, crate::UuidIndexBuildLimits::default())
+            .unwrap();
+        let (inventory, expanded) = crate::capture_graph_files(&graph).unwrap();
+        let participant = if compact {
+            let lease = crate::begin_graph_object_publication(root).unwrap();
+            let (compact_root, _) =
+                crate::graph_object_store::migrate_graph_files_v1_to_v2(&lease, &graph, &inventory)
+                    .unwrap();
+            crate::graph_files_root_participant(&compact_root).unwrap()
+        } else {
+            expanded
+        };
+        let relative = "graph/files.json";
+        let participant_path = generation_root.join(PARTICIPANTS_DIR).join(relative);
+        fs::create_dir_all(participant_path.parent().unwrap()).unwrap();
+        fs::write(&participant_path, &participant.bytes).unwrap();
+        let descriptor = ParticipantDescriptor {
+            capability_id: participant.capability_id.clone(),
+            capability_version: participant.capability_version,
+            record_family_id: participant.record_family_id.clone(),
+            record_version: participant.record_version,
+            relative_path: relative.into(),
+            encoding: match participant.encoding {
+                crate::ProjectParticipantEncoding::Parquet => "parquet",
+                crate::ProjectParticipantEncoding::Arrow => "arrow",
+                crate::ProjectParticipantEncoding::Json => "json",
+            }
+            .into(),
+            byte_length: participant.bytes.len() as u64,
+            row_count: participant.row_count,
+            schema_fingerprint: sha256_hex(participant.schema_fingerprint),
+            content_sha256: sha256_hex(Sha256::digest(&participant.bytes).into()),
+        };
+        let manifest = GenerationManifest {
+            format: "graphforge-generation".into(),
+            format_version: 1,
+            generation_uuid: generation_uuid.hyphenated().to_string(),
+            parent_generation_uuid: None,
+            transaction_uuid: Uuid::now_v7().hyphenated().to_string(),
+            capabilities: vec![CapabilityDescriptor {
+                capability_id: "graph".into(),
+                capability_version: 1,
+            }],
+            participants: vec![descriptor],
+        };
+        let bytes = canonical_line(&manifest);
+        fs::write(generation_root.join(MANIFEST_FILE), &bytes).unwrap();
+        Sha256::digest(&bytes).into()
+    }
+
     fn project() -> (tempfile::TempDir, Uuid) {
         let root = tempfile::tempdir().unwrap();
         fs::write(root.path().join(FORMAT_FILE), PROJECT_FORMAT_BYTES).unwrap();
@@ -1613,6 +1839,169 @@ mod tests {
         let digest = install_generation(root.path(), generation_uuid);
         write_current(root.path(), generation_uuid, digest);
         (root, generation_uuid)
+    }
+
+    #[test]
+    fn pinned_v1_graph_inventory_authenticates_ordinal_receipt_and_generation() {
+        let root = tempfile::tempdir().unwrap();
+        fs::write(root.path().join(FORMAT_FILE), PROJECT_FORMAT_BYTES).unwrap();
+        fs::create_dir(root.path().join("generations")).unwrap();
+        let first = Uuid::now_v7();
+        let first_digest =
+            install_graph_generation(root.path(), first, 7, false, false, false, true);
+        write_current(root.path(), first, first_digest);
+        let pinned = resolve_project_generation(root.path()).unwrap();
+        let authority = pinned
+            .authenticated_v4_ordinal_authority()
+            .unwrap()
+            .unwrap();
+        assert_eq!(authority.authority().topology_generation, 7);
+
+        let second = Uuid::now_v7();
+        let second_digest =
+            install_graph_generation(root.path(), second, 8, false, false, false, true);
+        write_current(root.path(), second, second_digest);
+        assert_eq!(
+            pinned
+                .authenticated_v4_ordinal_authority()
+                .unwrap()
+                .unwrap()
+                .authority()
+                .topology_generation,
+            7
+        );
+        assert_eq!(
+            resolve_project_generation(root.path())
+                .unwrap()
+                .authenticated_v4_ordinal_authority()
+                .unwrap()
+                .unwrap()
+                .authority()
+                .topology_generation,
+            8
+        );
+    }
+
+    #[test]
+    fn compact_v2_graph_inventory_authenticates_selected_ordinal_controls() {
+        let root = tempfile::tempdir().unwrap();
+        fs::write(root.path().join(FORMAT_FILE), PROJECT_FORMAT_BYTES).unwrap();
+        fs::create_dir(root.path().join("generations")).unwrap();
+        let generation = Uuid::now_v7();
+        let digest = install_graph_generation(root.path(), generation, 9, true, false, false, true);
+        write_current(root.path(), generation, digest);
+        let authority = resolve_project_generation(root.path())
+            .unwrap()
+            .authenticated_v4_ordinal_authority()
+            .unwrap()
+            .unwrap();
+        assert_eq!(authority.authority().topology_generation, 9);
+    }
+
+    #[test]
+    fn ordinal_selection_distinguishes_clean_absence_from_partial_residue() {
+        let clean = tempfile::tempdir().unwrap();
+        let selected = open_or_initialize_project(clean.path()).unwrap();
+        assert!(
+            selected
+                .authenticated_v4_ordinal_authority()
+                .unwrap()
+                .is_none()
+        );
+
+        let residue = tempfile::tempdir().unwrap();
+        fs::write(residue.path().join(FORMAT_FILE), PROJECT_FORMAT_BYTES).unwrap();
+        fs::create_dir(residue.path().join("generations")).unwrap();
+        let generation = Uuid::now_v7();
+        let digest =
+            install_graph_generation(residue.path(), generation, 7, false, true, false, true);
+        write_current(residue.path(), generation, digest);
+        assert!(
+            resolve_project_generation(residue.path())
+                .unwrap()
+                .authenticated_v4_ordinal_authority()
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn ordinal_selection_rejects_a_receipt_from_another_topology_generation() {
+        let root = tempfile::tempdir().unwrap();
+        fs::write(root.path().join(FORMAT_FILE), PROJECT_FORMAT_BYTES).unwrap();
+        fs::create_dir(root.path().join("generations")).unwrap();
+        let generation = Uuid::now_v7();
+        let digest = install_graph_generation(root.path(), generation, 7, false, false, true, true);
+        write_current(root.path(), generation, digest);
+        assert!(
+            resolve_project_generation(root.path())
+                .unwrap()
+                .authenticated_v4_ordinal_authority()
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn ordinal_selection_rejects_manifest_mutation_under_authentic_receipt() {
+        let root = tempfile::tempdir().unwrap();
+        fs::write(root.path().join(FORMAT_FILE), PROJECT_FORMAT_BYTES).unwrap();
+        fs::create_dir(root.path().join("generations")).unwrap();
+        let generation = Uuid::now_v7();
+        let digest =
+            install_graph_generation(root.path(), generation, 7, false, false, false, true);
+        write_current(root.path(), generation, digest);
+        let selected = resolve_project_generation(root.path()).unwrap();
+        fs::write(
+            selected
+                .graph_tree_root()
+                .join("topology/uuid-membership/ordinal-v4-manifest.json"),
+            b"substituted",
+        )
+        .unwrap();
+        assert!(selected.authenticated_v4_ordinal_authority().is_err());
+    }
+
+    #[test]
+    fn public_orphan_maintenance_rejects_selected_v3_manifest_substitution() {
+        let root = tempfile::tempdir().unwrap();
+        fs::write(root.path().join(FORMAT_FILE), PROJECT_FORMAT_BYTES).unwrap();
+        fs::create_dir(root.path().join("generations")).unwrap();
+        let generation = Uuid::now_v7();
+        let digest =
+            install_graph_generation(root.path(), generation, 7, false, false, false, false);
+        write_current(root.path(), generation, digest);
+        let selected = resolve_project_generation(root.path()).unwrap();
+        crate::maintain_uuid_membership_orphans(&selected.graph_tree_root(), 16).unwrap();
+
+        let manifest = selected
+            .graph_tree_root()
+            .join("topology/uuid-membership/manifest.json");
+        fs::write(&manifest, b"substituted").unwrap();
+        assert!(crate::maintain_uuid_membership_orphans(&selected.graph_tree_root(), 16).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn selected_v1_ordinal_control_rejects_a_peerless_fifo_without_blocking() {
+        let root = tempfile::tempdir().unwrap();
+        fs::write(root.path().join(FORMAT_FILE), PROJECT_FORMAT_BYTES).unwrap();
+        fs::create_dir(root.path().join("generations")).unwrap();
+        let generation = Uuid::now_v7();
+        let digest =
+            install_graph_generation(root.path(), generation, 7, false, false, false, true);
+        write_current(root.path(), generation, digest);
+        let selected = resolve_project_generation(root.path()).unwrap();
+        let receipt = selected
+            .graph_tree_root()
+            .join("topology/uuid-membership/ordinal-v4-receipt.json");
+        fs::remove_file(&receipt).unwrap();
+        assert!(
+            std::process::Command::new("mkfifo")
+                .arg(&receipt)
+                .status()
+                .unwrap()
+                .success()
+        );
+        assert!(selected.authenticated_v4_ordinal_authority().is_err());
     }
 
     fn open_generation_lease(root: &Path, generation: Uuid) -> File {

--- a/crates/graphforge-storage/src/project_portable_v2_export.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_export.rs
@@ -152,11 +152,10 @@ impl PortableV2ExportPlan {
             ) {
                 continue;
             }
-            let source = staging.path().join(&entry.relative_path);
-            let path = format!(
-                "data/components/graph-data/graph-tree/{}",
-                entry.relative_path
-            );
+            let source = crate::graph_files::resolve_v1_inventory_entry(staging.path(), entry)?;
+            let relative =
+                crate::graph_files::canonical_inventory_relative_text(&entry.relative_path)?;
+            let path = format!("data/components/graph-data/graph-tree/{relative}");
             let planned = inspect(&source, &path, limits, &mut total)?;
             if planned.length != entry.byte_length || hex(planned.digest) != entry.content_sha256 {
                 return Err(err(
@@ -869,10 +868,12 @@ pub fn plan_selected_portable_v2(
         let id = "graph-tree".to_owned();
         let mut owned = Vec::new();
         for e in inv.files {
-            let path = format!("data/components/graph-data/{id}/{}", e.relative_path);
+            let canonical =
+                crate::graph_files::canonical_inventory_relative_text(&e.relative_path)?;
+            let path = format!("data/components/graph-data/{id}/{canonical}");
             let f = match &graph_authority {
                 Some(crate::GraphFilesParticipant::V1(_)) => inspect(
-                    &g.graph_tree_root().join(&e.relative_path),
+                    &crate::graph_files::resolve_v1_inventory_entry(&g.graph_tree_root(), &e)?,
                     &path,
                     limits,
                     &mut total,

--- a/crates/graphforge-storage/src/project_retention.rs
+++ b/crates/graphforge-storage/src/project_retention.rs
@@ -1528,4 +1528,24 @@ mod tests {
                 .exists()
         );
     }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_gc_unlinks_an_unreachable_canonically_sealed_object() {
+        let root = tempfile::tempdir().unwrap();
+        open_or_initialize_project(root.path()).unwrap();
+        let (digest, _) =
+            crate::install_graph_object_bytes(root.path(), b"windows unreachable").unwrap();
+
+        let report =
+            execute_project_cleanup(root.path(), policy(2), ProjectRetentionLimits::default())
+                .unwrap();
+
+        assert_eq!(report.graph_object_sweep.objects_removed, 1);
+        assert!(
+            !crate::graph_object_path(root.path(), &digest)
+                .unwrap()
+                .exists()
+        );
+    }
 }

--- a/crates/graphforge-storage/src/property_overlay.rs
+++ b/crates/graphforge-storage/src/property_overlay.rs
@@ -594,11 +594,19 @@ impl AuthenticatedPropertyInventory {
                 let entries = inventory
                     .files
                     .into_iter()
-                    .map(|entry| {
-                        let relative = PathBuf::from(&entry.relative_path);
-                        (entry, relative)
+                    .map(|mut entry| {
+                        let path = crate::graph_files::resolve_v1_inventory_entry(&root, &entry)?;
+                        let relative = path
+                            .strip_prefix(&root)
+                            .map_err(|_| corrupt("legacy graph file escaped its root"))?
+                            .to_path_buf();
+                        entry.relative_path =
+                            crate::graph_files::canonical_inventory_relative_text(
+                                &entry.relative_path,
+                            )?;
+                        Ok((entry, relative))
                     })
-                    .collect();
+                    .collect::<Result<Vec<_>, GfError>>()?;
                 Self::admit_entries(&root, entries, requested_route)
             }
             crate::graph_files::GraphFilesParticipant::V2(_) => {

--- a/crates/graphforge-storage/src/property_overlay.rs
+++ b/crates/graphforge-storage/src/property_overlay.rs
@@ -591,22 +591,8 @@ impl AuthenticatedPropertyInventory {
         let mut admitted = match participant {
             crate::graph_files::GraphFilesParticipant::V1(_) => {
                 let root = generation.graph_tree_root();
-                let entries = inventory
-                    .files
-                    .into_iter()
-                    .map(|mut entry| {
-                        let path = crate::graph_files::resolve_v1_inventory_entry(&root, &entry)?;
-                        let relative = path
-                            .strip_prefix(&root)
-                            .map_err(|_| corrupt("legacy graph file escaped its root"))?
-                            .to_path_buf();
-                        entry.relative_path =
-                            crate::graph_files::canonical_inventory_relative_text(
-                                &entry.relative_path,
-                            )?;
-                        Ok((entry, relative))
-                    })
-                    .collect::<Result<Vec<_>, GfError>>()?;
+                let entries =
+                    resolve_v1_property_entries_for_route(&root, inventory.files, requested_route)?;
                 Self::admit_entries(&root, entries, requested_route)
             }
             crate::graph_files::GraphFilesParticipant::V2(_) => {
@@ -1183,6 +1169,52 @@ fn parse_inventory_property_path(
         ))),
         _ => Err(corrupt("property inventory path is not canonical")),
     }
+}
+
+fn inventory_entry_reaches_route(
+    role: crate::GraphFileRole,
+    canonical_relative: &str,
+    requested_route: Option<(PropertyRouteKind, &str)>,
+) -> Result<bool, GfError> {
+    let parsed = parse_inventory_property_path(canonical_relative)?;
+    if role != crate::GraphFileRole::Properties {
+        if parsed.is_some() {
+            return Err(corrupt("property inventory entry has the wrong role"));
+        }
+        // Preserve full-inventory admission: only the explicitly targeted
+        // route path may avoid resolving unrelated graph payloads.
+        return Ok(requested_route.is_none());
+    }
+    let Some((kind, route, _, _)) = parsed else {
+        return Err(corrupt("properties role names a non-property path"));
+    };
+    Ok(requested_route.is_none_or(|requested| (kind, route.as_str()) == requested))
+}
+
+fn resolve_v1_property_entries_for_route(
+    root: &Path,
+    entries: Vec<crate::GraphFileEntry>,
+    requested_route: Option<(PropertyRouteKind, &str)>,
+) -> Result<Vec<(crate::GraphFileEntry, PathBuf)>, GfError> {
+    let mut selected = Vec::new();
+    for mut entry in entries {
+        let canonical =
+            crate::graph_files::canonical_inventory_relative_text(&entry.relative_path)?;
+        if !inventory_entry_reaches_route(entry.role, &canonical, requested_route)? {
+            continue;
+        }
+        // Resolve with the original spelling so a legacy backslash-authored
+        // inventory can still authenticate its one unambiguous physical path.
+        // Logical classification above uses the portable canonical spelling.
+        let path = crate::graph_files::resolve_v1_inventory_entry(root, &entry)?;
+        let relative = path
+            .strip_prefix(root)
+            .map_err(|_| corrupt("legacy graph file escaped its root"))?
+            .to_path_buf();
+        entry.relative_path = canonical;
+        selected.push((entry, relative));
+    }
+    Ok(selected)
 }
 
 fn open_retained_under(
@@ -3430,6 +3462,29 @@ mod tests {
             content_sha256: digest_hex(&Sha256::digest(&bytes)),
             role: crate::GraphFileRole::Properties,
         };
+        let missing_unrelated = crate::GraphFileEntry {
+            relative_path: format!("properties/Unrelated/{}", id.file_name()),
+            byte_length: u64::MAX,
+            content_sha256: "00".repeat(32),
+            role: crate::GraphFileRole::Properties,
+        };
+        let resolved = resolve_v1_property_entries_for_route(
+            dir.path(),
+            vec![entry.clone(), missing_unrelated.clone()],
+            Some((PropertyRouteKind::Node, "Person")),
+        )
+        .unwrap();
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].0.relative_path, entry.relative_path);
+        assert!(
+            resolve_v1_property_entries_for_route(
+                dir.path(),
+                vec![entry.clone(), missing_unrelated],
+                None,
+            )
+            .is_err(),
+            "full V1 admission must continue authenticating unrelated graph payloads"
+        );
         let inventory = Arc::new(
             AuthenticatedPropertyInventory::from_entries_at_root(dir.path(), vec![entry.clone()])
                 .unwrap(),

--- a/crates/graphforge-storage/src/runtime_entity_labels.rs
+++ b/crates/graphforge-storage/src/runtime_entity_labels.rs
@@ -590,6 +590,19 @@ migrations: []
 
     #[test]
     fn exploratory_legacy_ids_migrate_to_tagged_form() {
+        const CHILD: &str = "GRAPHFORGE_RUNTIME_LABEL_MIGRATION_IO_CHILD";
+        if std::env::var_os(CHILD).is_none() {
+            let status = std::process::Command::new(std::env::current_exe().unwrap())
+                .arg("--exact")
+                .arg("runtime_entity_labels::tests::exploratory_legacy_ids_migrate_to_tagged_form")
+                .arg("--nocapture")
+                .env(CHILD, "1")
+                .status()
+                .unwrap();
+            assert!(status.success(), "isolated runtime-label I/O proof failed");
+            return;
+        }
+
         let dir = TempDir::new().unwrap();
         let endpoints = [uuid::Uuid::from_u128(1), uuid::Uuid::from_u128(2)];
         let mut seed =

--- a/crates/graphforge-storage/src/semantic_bindings.rs
+++ b/crates/graphforge-storage/src/semantic_bindings.rs
@@ -1720,8 +1720,9 @@ pub fn materialize_semantic_migration(
         let mut max_batch_rows = 0_usize;
         for entry in &inventory.files {
             checkpoint()?;
-            let source = source_graph_root.join(&entry.relative_path);
-            let relative = PathBuf::from(&entry.relative_path);
+            let source = crate::graph_files::resolve_v1_inventory_entry(source_graph_root, entry)?;
+            let relative =
+                crate::graph_files::canonical_inventory_relative_path(&entry.relative_path)?;
             let old_route = semantic_route_from_relative(&relative);
             let target_relative = migrated_semantic_relative(&relative, &route_moves);
             let target = staging_graph_root.join(target_relative);

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -33,6 +33,9 @@ const BULK_IO_BYTES: usize = 1 << 20;
 // that can be discarded and reconstructed without violating that contract.
 const INDEX_DIR: &str = "topology/uuid-membership";
 const MANIFEST: &str = "manifest.json";
+const V4_ORDINAL_MANIFEST: &str = "ordinal-v4-manifest.json";
+#[cfg(test)]
+const V4_ORDINAL_RECEIPT: &str = "ordinal-v4-receipt.json";
 const CONSTRUCTION_INTENT: &str = ".construction-intent.json";
 
 fn storage_err(error: impl std::fmt::Display) -> GfError {
@@ -2883,14 +2886,173 @@ pub fn maintain_uuid_membership_orphans(
     project_dir: &Path,
     maximum: usize,
 ) -> Result<UuidIndexOrphanGcWork, GfError> {
+    let selected = selected_generation_for_graph_root(project_dir)?;
+    let ordinal_authority = selected
+        .as_ref()
+        .map(crate::ResolvedProjectGeneration::authenticated_v4_ordinal_authority)
+        .transpose()?
+        .flatten();
+    let membership_authority = selected
+        .as_ref()
+        .map(authenticated_v3_membership_authority)
+        .transpose()?
+        .flatten();
+    maintain_uuid_membership_orphans_with_authorities(
+        project_dir,
+        maximum,
+        membership_authority.as_ref(),
+        ordinal_authority.as_ref(),
+    )
+}
+
+#[derive(Clone, Debug)]
+struct AuthenticatedV3MembershipAuthority {
+    topology_generation: u64,
+    manifest_sha256: String,
+}
+
+fn authenticated_v3_membership_authority(
+    selected: &crate::ResolvedProjectGeneration,
+) -> Result<Option<AuthenticatedV3MembershipAuthority>, GfError> {
+    let mut state = crate::graph_manifest::GraphManifestTargetedState::default();
+    let receipt = selected.authenticated_graph_file_bytes_with_state(
+        &format!("{INDEX_DIR}/{TOPOLOGY_RECEIPT}"),
+        MAX_MANIFEST_BYTES,
+        Some(&mut state),
+    )?;
+    let manifest = selected.authenticated_graph_file_bytes_with_state(
+        &format!("{INDEX_DIR}/{MANIFEST}"),
+        MAX_MANIFEST_BYTES,
+        Some(&mut state),
+    )?;
+    match (receipt, manifest) {
+        (None, None) => Ok(None),
+        (None, Some(_)) | (Some(_), None) => Err(storage_err(
+            "selected UUID membership facet has incomplete authority residue",
+        )),
+        (Some((_, receipt_bytes)), Some((manifest_entry, manifest_bytes))) => {
+            let receipt: TopologyIndexReceipt =
+                serde_json::from_slice(&receipt_bytes).map_err(storage_err)?;
+            let generation = selected
+                .authenticated_graph_file_bytes_with_state(
+                    "topology/generation.json",
+                    MAX_MANIFEST_BYTES,
+                    Some(&mut state),
+                )?
+                .ok_or_else(|| storage_err("selected topology generation authority is absent"))?;
+            let generation: serde_json::Value =
+                serde_json::from_slice(&generation.1).map_err(storage_err)?;
+            let topology_generation = generation
+                .get("topology_generation")
+                .and_then(serde_json::Value::as_u64)
+                .ok_or_else(|| storage_err("selected topology generation is missing"))?;
+            let manifest_sha256 = hex_sha256(&manifest_bytes);
+            let canonical_hex = |value: &str, length: usize| {
+                value.len() == length
+                    && value
+                        .bytes()
+                        .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+            };
+            if !canonical_hex(&receipt.nonce, 32)
+                || !canonical_hex(&receipt.topology_delta_sha256, 64)
+                || !canonical_hex(&receipt.manifest_sha256, 64)
+                || receipt.expected_generation != topology_generation
+                || receipt.manifest_sha256 != manifest_entry.content_sha256
+                || receipt.manifest_sha256 != manifest_sha256
+            {
+                return Err(storage_err(
+                    "selected UUID membership receipt does not authenticate its manifest",
+                ));
+            }
+            Ok(Some(AuthenticatedV3MembershipAuthority {
+                topology_generation,
+                manifest_sha256,
+            }))
+        }
+    }
+}
+
+/// Retain the selected project generation whenever `graph_root` is its
+/// generation-owned graph tree. Standalone graph roots deliberately have no
+/// project-generation provenance and therefore cannot authorize a present v4
+/// facet.
+fn selected_generation_for_graph_root(
+    graph_root: &Path,
+) -> Result<Option<crate::ResolvedProjectGeneration>, GfError> {
+    let Some(generation_root) = graph_root
+        .file_name()
+        .filter(|name| *name == std::ffi::OsStr::new("graph"))
+        .and_then(|_| graph_root.parent())
+    else {
+        return Ok(None);
+    };
+    let Some(project_generations_dir) = generation_root.parent() else {
+        return Ok(None);
+    };
+    if project_generations_dir.file_name() != Some(std::ffi::OsStr::new("generations")) {
+        return Ok(None);
+    }
+    let Some(container_root) = project_generations_dir.parent() else {
+        return Ok(None);
+    };
+    let selected = crate::resolve_project_generation(container_root)?;
+    let supplied = graph_root.canonicalize().map_err(storage_err)?;
+    let authenticated = selected
+        .graph_tree_root()
+        .canonicalize()
+        .map_err(storage_err)?;
+    if supplied != authenticated {
+        return Err(storage_err(
+            "graph root is not the currently selected project generation",
+        ));
+    }
+    Ok(Some(selected))
+}
+
+#[cfg(test)]
+pub(crate) fn maintain_uuid_membership_orphans_with_ordinal_authority(
+    project_dir: &Path,
+    maximum: usize,
+    ordinal_authority: Option<&crate::AuthenticatedV4OrdinalIdentityAuthority>,
+) -> Result<UuidIndexOrphanGcWork, GfError> {
+    let manifest_bytes =
+        fs::read(project_dir.join(INDEX_DIR).join(MANIFEST)).map_err(storage_err)?;
+    let manifest: Manifest = serde_json::from_slice(&manifest_bytes).map_err(storage_err)?;
+    let membership_authority = AuthenticatedV3MembershipAuthority {
+        topology_generation: manifest.current_generation,
+        manifest_sha256: hex_sha256(&manifest_bytes),
+    };
+    maintain_uuid_membership_orphans_with_authorities(
+        project_dir,
+        maximum,
+        Some(&membership_authority),
+        ordinal_authority,
+    )
+}
+
+fn maintain_uuid_membership_orphans_with_authorities(
+    project_dir: &Path,
+    maximum: usize,
+    membership_authority: Option<&AuthenticatedV3MembershipAuthority>,
+    ordinal_authority: Option<&crate::AuthenticatedV4OrdinalIdentityAuthority>,
+) -> Result<UuidIndexOrphanGcWork, GfError> {
     crate::durable_rewrite::with_rewrite_lock(project_dir, |project| {
-        collect_uuid_orphans_locked(project, maximum)
+        collect_uuid_orphans_locked(
+            project,
+            project_dir,
+            maximum,
+            membership_authority,
+            ordinal_authority,
+        )
     })
 }
 
 fn collect_uuid_orphans_locked(
     project: &graphforge_filesystem::StableDirectory,
+    project_root: &Path,
     maximum: usize,
+    membership_authority: Option<&AuthenticatedV3MembershipAuthority>,
+    ordinal_authority: Option<&crate::AuthenticatedV4OrdinalIdentityAuthority>,
 ) -> Result<UuidIndexOrphanGcWork, GfError> {
     let topology = match project.open_child_directory(std::ffi::OsStr::new("topology")) {
         Ok(value) => value,
@@ -2909,11 +3071,27 @@ fn collect_uuid_orphans_locked(
     let mut manifest_file = index
         .open_child_file(std::ffi::OsStr::new(MANIFEST))
         .map_err(storage_err)?;
-    let manifest: Manifest =
-        serde_json::from_slice(&read_bounded(&mut manifest_file, MAX_MANIFEST_BYTES)?)
-            .map_err(storage_err)?;
+    let manifest_bytes = read_bounded(&mut manifest_file, MAX_MANIFEST_BYTES)?;
+    let membership_authority = membership_authority.ok_or_else(|| {
+        storage_err("UUID membership orphan maintenance requires selected generation authority")
+    })?;
+    if hex_sha256(&manifest_bytes) != membership_authority.manifest_sha256 {
+        return Err(storage_err(
+            "UUID membership manifest differs from selected generation authority",
+        ));
+    }
+    let manifest: Manifest = serde_json::from_slice(&manifest_bytes).map_err(storage_err)?;
+    if manifest.current_generation != membership_authority.topology_generation {
+        return Err(storage_err(
+            "UUID membership generation differs from selected generation authority",
+        ));
+    }
     validate_run_descriptors(&manifest)?;
-    let referenced = manifest_file_names(&manifest);
+    let mut referenced = manifest_file_names(&manifest);
+    referenced.extend(authenticated_v4_references(
+        project_root,
+        ordinal_authority,
+    )?);
     let mut names = index.child_names().map_err(storage_err)?;
     names.sort();
     let mut work = UuidIndexOrphanGcWork::default();
@@ -2951,6 +3129,32 @@ fn collect_uuid_orphans_locked(
     Ok(work)
 }
 
+fn authenticated_v4_references(
+    project_root: &Path,
+    authority: Option<&crate::AuthenticatedV4OrdinalIdentityAuthority>,
+) -> Result<BTreeSet<String>, GfError> {
+    let Some(authority) = authority else {
+        let index = graphforge_filesystem::StableDirectory::open(&project_root.join(INDEX_DIR))
+            .map_err(storage_err)?;
+        return match index.open_child_file(std::ffi::OsStr::new(V4_ORDINAL_MANIFEST)) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(BTreeSet::new()),
+            Ok(_) => Err(storage_err(
+                "v4 ordinal authority requires an authenticated selected generation",
+            )),
+            Err(error) => Err(storage_err(error)),
+        };
+    };
+    match authority
+        .open(project_root, crate::V4OrdinalIdentityLimits::default())
+        .map_err(storage_err)?
+    {
+        crate::V4OrdinalIdentityOpen::Ready(handle) => Ok(handle.referenced_file_names()),
+        crate::V4OrdinalIdentityOpen::RebuildRequired { .. } => {
+            Err(storage_err("v4 ordinal authority requires rebuild"))
+        }
+    }
+}
+
 fn is_canonical_run_name(name: &str) -> bool {
     let Some(stem) = name.strip_suffix(".uuidx") else {
         return false;
@@ -2958,9 +3162,24 @@ fn is_canonical_run_name(name: &str) -> bool {
     let Some((prefix, digest)) = stem.rsplit_once('-') else {
         return false;
     };
-    (prefix.starts_with("identities-v3") || prefix.starts_with("node-surrogates-v3"))
+    let is_v4 = is_canonical_v4_artifact_prefix(prefix);
+    ((prefix.starts_with("identities-v3") || prefix.starts_with("node-surrogates-v3")) || is_v4)
         && digest.len() == 16
-        && digest.bytes().all(|byte| byte.is_ascii_hexdigit())
+        && if is_v4 {
+            digest
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+        } else {
+            digest.bytes().all(|byte| byte.is_ascii_hexdigit())
+        }
+}
+
+fn is_canonical_v4_artifact_prefix(prefix: &str) -> bool {
+    let Some((kind, generation)) = prefix.rsplit_once('-') else {
+        return false;
+    };
+    matches!(kind, "forward-v4" | "ordinal-v4" | "tombstones-v4")
+        && generation.parse::<u64>().is_ok_and(|value| value != 0)
 }
 
 /// Whether the manifest version and topology generation match the workspace.
@@ -3031,6 +3250,17 @@ pub(crate) fn commit_uuid_topology_rewrite(
         return Ok(CommittedUuidTopologyRewrite::NoTopologyChange);
     }
     ensure_uuid_membership_migrated(project_dir)?;
+    let selected = selected_generation_for_graph_root(project_dir)?;
+    let ordinal_authority = selected
+        .as_ref()
+        .map(crate::ResolvedProjectGeneration::authenticated_v4_ordinal_authority)
+        .transpose()?
+        .flatten();
+    let membership_authority = selected
+        .as_ref()
+        .map(authenticated_v3_membership_authority)
+        .transpose()?
+        .flatten();
     let prepared = std::rc::Rc::new(std::cell::RefCell::new(None));
     let prepared_from_callback = std::rc::Rc::clone(&prepared);
     let generations = std::rc::Rc::new(std::cell::Cell::new(None));
@@ -3052,7 +3282,23 @@ pub(crate) fn commit_uuid_topology_rewrite(
                 }
                 return Ok(None);
             }
-            let orphan_gc = collect_uuid_orphans_locked(context.project, DEFAULT_ORPHAN_GC_LIMIT)?;
+            // Standalone graph roots have no selected project-generation
+            // inventory capable of authenticating reachability. Topology
+            // publication remains valid there, but orphan deletion must be
+            // conservatively deferred rather than self-authorizing the live
+            // manifest. Project-generation roots retain the authenticated GC
+            // path, including the v3/v4 union.
+            let orphan_gc = if membership_authority.is_some() {
+                collect_uuid_orphans_locked(
+                    context.project,
+                    context.project_root,
+                    DEFAULT_ORPHAN_GC_LIMIT,
+                    membership_authority.as_ref(),
+                    ordinal_authority.as_ref(),
+                )?
+            } else {
+                UuidIndexOrphanGcWork::default()
+            };
             if !uuid_membership_index_present(context.project_root) {
                 return Err(storage_err(
                     "UUID membership index migration is required before topology mutation",
@@ -5763,7 +6009,7 @@ fn sha256_reader(reader: &mut impl Read) -> Result<String, GfError> {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use std::io::BufWriter;
     use std::sync::{Arc, Barrier};
 
@@ -5894,7 +6140,7 @@ mod tests {
         writer.close().unwrap();
     }
 
-    fn fixture() -> (tempfile::TempDir, Vec<Uuid>, Vec<Uuid>) {
+    pub(crate) fn fixture() -> (tempfile::TempDir, Vec<Uuid>, Vec<Uuid>) {
         let dir = tempfile::tempdir().unwrap();
         let nodes = vec![Uuid::from_u128(3), Uuid::from_u128(1), Uuid::from_u128(2)];
         let edges = vec![Uuid::from_u128(12), Uuid::from_u128(11)];
@@ -5905,6 +6151,218 @@ mod tests {
             &edges,
         );
         (dir, nodes, edges)
+    }
+
+    fn install_test_v4_facet(
+        project: &Path,
+        generation: u64,
+        nodes: &[Uuid],
+    ) -> (Vec<String>, crate::AuthenticatedV4OrdinalIdentityAuthority) {
+        let root = project.join(INDEX_DIR);
+        fs::write(root.join("ordinal-v4.lock"), []).unwrap();
+        let mappings = nodes.iter().copied().zip(1_u64..).collect::<Vec<_>>();
+        let mut forward_mappings = mappings.clone();
+        forward_mappings.sort_unstable_by_key(|(uuid, _)| *uuid);
+        let forward_bytes = forward_mappings
+            .iter()
+            .flat_map(|(uuid, id)| uuid.as_bytes().iter().copied().chain(id.to_be_bytes()))
+            .collect::<Vec<_>>();
+        let ordinal_bytes = mappings
+            .iter()
+            .flat_map(|(uuid, _)| uuid.as_bytes().iter().copied())
+            .collect::<Vec<_>>();
+        let forward_digest = hex_sha256(&forward_bytes);
+        let ordinal_digest = hex_sha256(&ordinal_bytes);
+        let tombstone_bytes = (nodes.len() as u64).to_be_bytes();
+        let tombstone_digest = hex_sha256(&tombstone_bytes);
+        let forward_name = format!("forward-v4-{generation}-{}.uuidx", &forward_digest[..16]);
+        let ordinal_name = format!("ordinal-v4-{generation}-{}.uuidx", &ordinal_digest[..16]);
+        let tombstone_name = format!(
+            "tombstones-v4-{generation}-{}.uuidx",
+            &tombstone_digest[..16]
+        );
+        fs::write(root.join(&forward_name), &forward_bytes).unwrap();
+        fs::write(root.join(&ordinal_name), &ordinal_bytes).unwrap();
+        fs::write(root.join(&tombstone_name), tombstone_bytes).unwrap();
+        let manifest = crate::V4OrdinalIdentityManifest {
+            format_version: crate::ORDINAL_IDENTITY_V4,
+            topology_generation: generation,
+            forward_identities: vec![crate::V4OrdinalArtifact {
+                name: forward_name.clone(),
+                kind: crate::V4OrdinalArtifactKind::ForwardIdentities,
+                generation,
+                bytes: forward_bytes.len() as u64,
+                sha256: forward_digest,
+            }],
+            ordinal_ranges: vec![crate::V4OrdinalRange {
+                first_node_id: 1,
+                count: nodes.len() as u64,
+                artifact: crate::V4OrdinalArtifact {
+                    name: ordinal_name.clone(),
+                    kind: crate::V4OrdinalArtifactKind::OrdinalUuids,
+                    generation,
+                    bytes: ordinal_bytes.len() as u64,
+                    sha256: ordinal_digest,
+                },
+                blocks: vec![crate::V4OrdinalBlock {
+                    offset: 0,
+                    count: nodes.len() as u64,
+                    sha256: hex_sha256(&ordinal_bytes),
+                }],
+            }],
+            tombstones: vec![crate::V4OrdinalTombstones {
+                generation,
+                artifact: crate::V4OrdinalArtifact {
+                    name: tombstone_name.clone(),
+                    kind: crate::V4OrdinalArtifactKind::NodeTombstones,
+                    generation,
+                    bytes: 8,
+                    sha256: tombstone_digest.clone(),
+                },
+                blocks: vec![crate::V4OrdinalTombstoneBlock {
+                    offset: 0,
+                    count: 1,
+                    first: nodes.len() as u64,
+                    last: nodes.len() as u64,
+                    sha256: tombstone_digest,
+                }],
+            }],
+        };
+        let body = serde_json::to_vec(&manifest).unwrap();
+        fs::write(root.join(V4_ORDINAL_MANIFEST), &body).unwrap();
+        let receipt = TopologyIndexReceipt {
+            nonce: Uuid::new_v4().simple().to_string(),
+            expected_generation: generation,
+            topology_delta_sha256: hex_sha256(b"test-v4-facet"),
+            manifest_sha256: hex_sha256(&body),
+        };
+        fs::write(
+            root.join(V4_ORDINAL_RECEIPT),
+            serde_json::to_vec(&receipt).unwrap(),
+        )
+        .unwrap();
+        let authority = crate::AuthenticatedV4OrdinalIdentityAuthority {
+            authority: crate::ordinal_identity_v4::V4OrdinalIdentityAuthority {
+                topology_generation: generation,
+                manifest_sha256: hex_sha256(&body),
+            },
+        };
+        (vec![forward_name, ordinal_name, tombstone_name], authority)
+    }
+
+    #[test]
+    fn orphan_collection_authenticates_and_preserves_union_of_v3_and_v4_facets() {
+        let (dir, nodes, edges) = fixture();
+        fs::write(
+            dir.path().join("topology/generation.json"),
+            b"{\"topology_generation\":7,\"search_generation\":0,\"property_generation\":0}\n",
+        )
+        .unwrap();
+        rebuild_uuid_membership_indexes(dir.path(), UuidIndexBuildLimits::default()).unwrap();
+        let (selected, authority) = install_test_v4_facet(dir.path(), 7, &nodes);
+        let orphan = dir
+            .path()
+            .join(INDEX_DIR)
+            .join("ordinal-v4-7-0000000000000000.uuidx");
+        fs::write(&orphan, b"orphan").unwrap();
+
+        let work = maintain_uuid_membership_orphans_with_ordinal_authority(
+            dir.path(),
+            16,
+            Some(&authority),
+        )
+        .unwrap();
+        assert_eq!(work.removed, 1);
+        assert!(!orphan.exists());
+        for name in selected {
+            assert!(dir.path().join(INDEX_DIR).join(name).exists());
+        }
+        let mut v3 = UuidMembershipIndex::open(dir.path()).unwrap();
+        assert_eq!(v3.count(UuidIndexKind::Node), nodes.len() as u64);
+        assert_eq!(v3.count(UuidIndexKind::Edge), edges.len() as u64);
+        assert_eq!(
+            v3.probe(UuidIndexKind::Edge, &[edges[0]]).unwrap().0,
+            vec![true]
+        );
+
+        let receipt_path = dir.path().join(INDEX_DIR).join(V4_ORDINAL_RECEIPT);
+        let manifest_path = dir.path().join(INDEX_DIR).join(V4_ORDINAL_MANIFEST);
+        let mut manifest: crate::V4OrdinalIdentityManifest =
+            serde_json::from_slice(&fs::read(&manifest_path).unwrap()).unwrap();
+        manifest.topology_generation = 8;
+        let replacement = serde_json::to_vec(&manifest).unwrap();
+        fs::write(&manifest_path, &replacement).unwrap();
+        let mut receipt: TopologyIndexReceipt =
+            serde_json::from_slice(&fs::read(&receipt_path).unwrap()).unwrap();
+        receipt.expected_generation = 8;
+        receipt.manifest_sha256 = hex_sha256(&replacement);
+        fs::write(&receipt_path, serde_json::to_vec(&receipt).unwrap()).unwrap();
+        assert!(
+            maintain_uuid_membership_orphans_with_ordinal_authority(
+                dir.path(),
+                16,
+                Some(&authority)
+            )
+            .is_err()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ordinal_orphan_admission_rejects_link_fifo_and_oversized_manifest() {
+        use std::os::unix::fs::symlink;
+
+        let (dir, nodes, _) = fixture();
+        fs::write(
+            dir.path().join("topology/generation.json"),
+            b"{\"topology_generation\":7,\"search_generation\":0,\"property_generation\":0}\n",
+        )
+        .unwrap();
+        rebuild_uuid_membership_indexes(dir.path(), UuidIndexBuildLimits::default()).unwrap();
+        let (_, authority) = install_test_v4_facet(dir.path(), 7, &nodes);
+        let manifest = dir.path().join(INDEX_DIR).join(V4_ORDINAL_MANIFEST);
+        let original = fs::read(&manifest).unwrap();
+        let replacement = dir.path().join(INDEX_DIR).join("replacement.json");
+        fs::write(&replacement, &original).unwrap();
+
+        fs::remove_file(&manifest).unwrap();
+        symlink(&replacement, &manifest).unwrap();
+        assert!(
+            maintain_uuid_membership_orphans_with_ordinal_authority(
+                dir.path(),
+                16,
+                Some(&authority)
+            )
+            .is_err()
+        );
+        fs::remove_file(&manifest).unwrap();
+
+        assert!(
+            std::process::Command::new("mkfifo")
+                .arg(&manifest)
+                .status()
+                .unwrap()
+                .success()
+        );
+        assert!(
+            maintain_uuid_membership_orphans_with_ordinal_authority(
+                dir.path(),
+                16,
+                Some(&authority)
+            )
+            .is_err()
+        );
+        fs::remove_file(&manifest).unwrap();
+
+        fs::write(&manifest, vec![b'x'; MAX_MANIFEST_BYTES as usize + 1]).unwrap();
+        assert!(
+            maintain_uuid_membership_orphans_with_ordinal_authority(
+                dir.path(),
+                16,
+                Some(&authority)
+            )
+            .is_err()
+        );
     }
 
     fn receipt_manifest_digest(project: &Path) -> String {
@@ -6519,12 +6977,16 @@ mod tests {
         fs::copy(&live, &orphan_one).unwrap();
         fs::copy(&live, &orphan_two).unwrap();
 
-        let first = maintain_uuid_membership_orphans(dir.path(), 1).unwrap();
+        assert!(maintain_uuid_membership_orphans(dir.path(), 1).is_err());
+
+        let first =
+            maintain_uuid_membership_orphans_with_ordinal_authority(dir.path(), 1, None).unwrap();
         assert_eq!(first.candidates, 2);
         assert_eq!(first.removed, 1);
         assert_eq!(first.deferred_limit, 1);
         assert!(live.is_file());
-        let second = maintain_uuid_membership_orphans(dir.path(), 64).unwrap();
+        let second =
+            maintain_uuid_membership_orphans_with_ordinal_authority(dir.path(), 64, None).unwrap();
         assert_eq!(second.removed, 1);
         assert!(live.is_file());
         assert!(!orphan_one.exists());

--- a/crates/graphforge-storage/src/writer.rs
+++ b/crates/graphforge-storage/src/writer.rs
@@ -6392,6 +6392,24 @@ mod tests {
 
     #[test]
     fn authenticated_endpoint_registration_decodes_zero_topology_rows() {
+        const CHILD: &str = "GRAPHFORGE_ENDPOINT_REGISTRATION_IO_CHILD";
+        if std::env::var_os(CHILD).is_none() {
+            let status = std::process::Command::new(std::env::current_exe().unwrap())
+                .arg("--exact")
+                .arg(
+                    "writer::tests::authenticated_endpoint_registration_decodes_zero_topology_rows",
+                )
+                .arg("--nocapture")
+                .env(CHILD, "1")
+                .status()
+                .unwrap();
+            assert!(
+                status.success(),
+                "isolated endpoint-registration I/O proof failed"
+            );
+            return;
+        }
+
         let dir = TempDir::new().unwrap();
         let left = new_v7();
         let right = new_v7();

--- a/docs/book/architecture/storage.md
+++ b/docs/book/architecture/storage.md
@@ -87,9 +87,10 @@ domain-separated mapping commitment and count. Strict forward UUID ordering and
 that bounded reconciliation reject duplicate, missing, or cross-generation
 identity mappings without constructing a graph-sized in-memory map.
 
-The retained reader owns a shared capability on `ordinal-v4.lock`; every v4
-publisher must hold that same file exclusively across artifact installation and
-manifest replacement. Each admitted file's stable identity, length, and
+The reader holds `ordinal-v4.lock` shared only during admission, then releases
+it after pinning the immutable files; every v4 publisher holds that same stable
+file exclusively across artifact installation and manifest replacement. Each
+admitted file's stable identity, length, and
 high-resolution modification time are retained as a fast change detector.
 That cooperative ownership is not the cryptographic boundary: every selected
 ordinal or tombstone block is verified against its manifest digest before its
@@ -629,7 +630,7 @@ legacy projects without it use the bounded tail migration path once.
 
 Bulk endpoint resolution uses the persistent authenticated
 `topology/uuid-membership/` snapshot published with each immutable graph
-generation. Its manifest authenticates the
+generation. The existing `manifest.json` facet authenticates the
 topology generation, record counts, lengths, and SHA-256 digests. Nodes have a
 sorted fixed-width `UUID -> node_id` file; edges have a sorted UUID membership
 file. Builds use bounded external sort runs and bounded-fan-in merges. Probes
@@ -642,6 +643,14 @@ and exactly zero per-record filesystem seeks while decoding zero topology rows.
 Duplicate node or edge UUIDs, reuse of one UUID across the node and edge
 domains, stale manifests, and missing, truncated, checksum-mismatched, or
 identity/reverse-inconsistent index files fail closed.
+
+Node ordinal resolution is a distinct, additive authority facet in the same
+directory. Its `ordinal-v4-manifest.json`, `ordinal-v4-receipt.json`, and
+`ordinal-v4.lock` never replace or reinterpret the v3 node-and-edge manifest.
+Both facets name the same topology generation but have independent receipt-bound
+manifest digests. If the ordinal facet is absent while current v3 is canonical,
+discovery returns a typed rebuild requirement. A present ordinal path must pass
+authenticated open and never falls back to v3 when malformed or substituted.
 
 New publications use a compact version-2 `graph/files` root. Payloads and
 fixed-depth radix nodes live once in the project content-addressed object

--- a/docs/book/architecture/uuid-membership-index.md
+++ b/docs/book/architecture/uuid-membership-index.md
@@ -1,34 +1,50 @@
-# UUID membership index
+# UUID identity authority facets
 
-GraphForge persists authoritative node and edge identities in Parquet. Bulk
-ingest uses a derived UUID membership index so validation does not materialize
-the complete graph in memory.
+GraphForge keeps two generation-coupled authorities under
+`topology/uuid-membership/`. They share a topology generation, not a manifest
+schema or digest.
 
-## Format version 1
+## UUID membership facet
 
-`indexes/uuid-membership/manifest.json` records the format version, canonical
-`topology_generation`, and the filename, record count, and SHA-256 digest for
-the node and edge indexes. Each immutable `.uuidx` file is an ascending,
-duplicate-free sequence of raw 16-byte UUID values. The file length must equal
-`count * 16`.
+`manifest.json` is the existing v3 authority for both node and edge UUID
+membership and node `UUID -> node_id` resolution. Existing endpoint-resolution,
+construction, and mutation consumers continue to authenticate this facet
+unchanged. Its immutable runs and `topology-receipt.json` remain reachable
+until the v3 manifest no longer selects them.
 
-Readers fail closed if the manifest is missing, has an unsupported version,
-names a non-local file, disagrees with the topology generation, or if an index
-length or checksum differs. They never fall back to a graph-wide in-memory set.
-Lookups use binary search and preserve the caller's request order; metrics
-contain only counts and file-seek totals, never UUIDs.
+## Node ordinal facet
 
-## Publication and recovery
+`ordinal-v4-manifest.json` is the additive node-only authority for bounded
+`node_id -> UUID` reads. `ordinal-v4-receipt.json` binds its exact manifest
+digest and topology generation. The receipt is authoritative only when its
+exact bytes are selected by the pinned project generation's authenticated
+`graph/files` participant; a coherent sibling receipt/manifest replacement is
+not provenance. `ordinal-v4.lock` coordinates admission with
+the durable writer. Forward and ordinal artifacts authenticate the same node
+mapping independently. Ordinal payloads are packed by contiguous node-ID range
+and carry fixed-size authenticated block fences.
 
-Rebuild scans canonical Parquet in configured record batches, sorts bounded
-runs, and merges them with a configured fan-in. Immutable data files are
-synced before a sibling temporary manifest is atomically renamed and the index
-directory is synced. A crash before that final rename leaves the prior manifest
-and its immutable files authoritative. Readers that opened the prior snapshot
-continue to use it while a rebuild is in progress.
+Discovery and authenticated open are separate operations. When the ordinal
+manifest is absent, discovery validates that current v3 authority is canonical
+before returning `RebuildRequired`. When the ordinal path exists, discovery
+reports it as present without trusting its contents. Authenticated open then
+requires the ordinal digest selected by the project receipt. A malformed,
+substituted, or generation-mismatched ordinal facet fails closed and never
+falls back to v3.
 
-Graph mutation publication rebuilds the workspace index before the graph tree
-is captured, so the Parquet topology and its membership manifest enter the same
-immutable project generation. Existing projects migrate through the explicit
-bounded rebuild API. Corrupt or stale indexes are integrity errors and are not
-silently rebuilt during reads.
+The reader takes the shared ordinal lock before reading the manifest and
+releases it after pinning the manifest and immutable artifacts. The durable
+writer takes the project rewrite lock first and the exclusive ordinal lock
+second, retaining it through data installation and the manifest switch. A
+long-lived immutable read handle therefore cannot starve a writer; it advances
+only by opening a newly receipt-authorized generation.
+
+Orphan collection starts from the current authenticated v3 manifest and, when
+the ordinal facet exists, requires the opaque authority resolved from a pinned
+project generation before authenticating the v4 manifest and artifacts. It
+retains the union. Hashing an untrusted manifest or receipt is never treated as
+provenance for deciding reachability.
+
+Both facets are persistent graph authority, not `.graphforge-cache/` content.
+Construction and canonical v3-to-v4 publication are specified separately by
+#969; append, deletion, and compaction are specified by #968.


### PR DESCRIPTION
## Summary
- separate the existing node+edge UUID-membership v3 facet from the node ordinal-identity v4 facet
- derive ordinal authority only from the selected project's authenticated graph/files participant
- use bounded, retained, no-follow control-file reads and stable writer-lock ownership
- preserve the authenticated union of v3 and v4 artifacts during orphan maintenance
- document the two generation-coupled authority facets

## Root cause
The merged v4 reader reused the live v3 manifest path even though v3 serves both node and edge membership while v4 is node-only. It also lacked a durable independent provenance chain for cleanup.

## Validation
- `cargo test -p graphforge-storage --lib` — 861 passed, 2 ignored
- strict `graphforge-storage` clippy — passed
- formatting and diff checks — passed
- non-Cypher public surface gate — 12/12
- Cargo/Bazel drift check — passed
- independent exact-head review — no remaining concrete blocker

Closes #974

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/975"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790469922&installation_model_id=20486&pr_number=975&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F975&signature=05346c749384de258b1b3f71d83e6a21c43e9a3eca1126b1b47bb1077c0327f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bounded, authenticated lookup for graph manifest entries.
  * Improved support for compact graph manifests and legacy inventory migration.
  * Added secure Windows object creation, sealing, reuse, and legacy adoption.
  * Added authenticated v4 ordinal identity discovery and access.
* **Bug Fixes**
  * Strengthened path validation, canonicalization, traversal protection, and recovery handling.
  * Improved cleanup safety by preventing unauthorized orphan deletion and ensuring sealed objects can be removed.
* **Tests**
  * Expanded coverage for tampering, migration, locking, recovery, path handling, and Windows-specific storage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->