### PR TITLE
feat(storage): append and compact v4 ordinal identity runs

### DIFF
--- a/crates/graphforge-filesystem/src/lib.rs
+++ b/crates/graphforge-filesystem/src/lib.rs
@@ -429,6 +429,20 @@ impl StableDirectory {
         self.revalidate_named()
     }
 
+    /// Remove one empty child directory only while its retained and named
+    /// identities still match. Callers must first authenticate and empty the
+    /// directory through the returned child capability.
+    pub fn remove_child_directory_if_identity(
+        &self,
+        name: &OsStr,
+        expected: FileIdentity,
+    ) -> io::Result<()> {
+        validate_child_name(name)?;
+        self.revalidate_named()?;
+        stable_remove_child_directory_if_identity(&self.file, &self.path, name, expected)?;
+        self.revalidate_named()
+    }
+
     /// Atomically publish a retained temporary child as `target` within this
     /// retained directory. Cooperative publishers must serialize the target.
     pub fn replace_child(
@@ -713,6 +727,43 @@ fn stable_unlink_child_if_identity(
     rustix::fs::unlinkat(parent, name, AtFlags::empty()).map_err(io::Error::from)
 }
 
+#[cfg(unix)]
+fn stable_remove_child_directory_if_identity(
+    parent: &File,
+    _path: &Path,
+    name: &OsStr,
+    expected: FileIdentity,
+) -> io::Result<()> {
+    use rustix::fs::{AtFlags, Mode, OFlags};
+    let opened = rustix::fs::openat(
+        parent,
+        name,
+        OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::DIRECTORY | OFlags::CLOEXEC,
+        Mode::empty(),
+    )
+    .map(File::from)
+    .map_err(io::Error::from)?;
+    if file_identity(&opened)? != expected {
+        return Err(io::Error::other(
+            "child directory identity changed before removal",
+        ));
+    }
+    let named =
+        rustix::fs::statat(parent, name, AtFlags::SYMLINK_NOFOLLOW).map_err(io::Error::from)?;
+    #[allow(clippy::cast_sign_loss, clippy::unnecessary_cast)]
+    let volume_serial = named.st_dev as u64;
+    let named_identity = FileIdentity {
+        volume_serial,
+        file_id: u128::from(named.st_ino).to_le_bytes(),
+    };
+    if named_identity != expected {
+        return Err(io::Error::other(
+            "child directory identity changed before removal",
+        ));
+    }
+    rustix::fs::unlinkat(parent, name, AtFlags::REMOVEDIR).map_err(io::Error::from)
+}
+
 #[cfg(windows)]
 fn stable_open_directory(path: &Path) -> io::Result<File> {
     use std::os::windows::fs::OpenOptionsExt as _;
@@ -849,6 +900,23 @@ fn stable_unlink_child_if_identity(
     windows::delete_file_by_handle(&child, expected)
 }
 
+#[cfg(windows)]
+fn stable_remove_child_directory_if_identity(
+    _parent: &File,
+    path: &Path,
+    name: &OsStr,
+    expected: FileIdentity,
+) -> io::Result<()> {
+    let child = path.join(name);
+    let retained = stable_open_directory(&child)?;
+    if file_identity(&retained)? != expected || path_identity(&child)? != expected {
+        return Err(io::Error::other(
+            "child directory identity changed before removal",
+        ));
+    }
+    std::fs::remove_dir(child)
+}
+
 #[cfg(all(not(unix), not(windows)))]
 fn stable_open_directory(_path: &Path) -> io::Result<File> {
     Err(io::Error::new(
@@ -905,6 +973,19 @@ fn stable_link_child(
 
 #[cfg(all(not(unix), not(windows)))]
 fn stable_unlink_child_if_identity(
+    _parent: &File,
+    _path: &Path,
+    _name: &OsStr,
+    _expected: FileIdentity,
+) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "stable directories unsupported",
+    ))
+}
+
+#[cfg(all(not(unix), not(windows)))]
+fn stable_remove_child_directory_if_identity(
     _parent: &File,
     _path: &Path,
     _name: &OsStr,

--- a/crates/graphforge-filesystem/src/lib.rs
+++ b/crates/graphforge-filesystem/src/lib.rs
@@ -956,6 +956,7 @@ fn stable_remove_child_directory_if_identity(
             "child directory identity changed before removal",
         ));
     }
+    drop(retained);
     std::fs::remove_dir(child)
 }
 

--- a/crates/graphforge-filesystem/src/lib.rs
+++ b/crates/graphforge-filesystem/src/lib.rs
@@ -385,6 +385,14 @@ impl StableDirectory {
         stable_child_names(&self.file, &self.path)
     }
 
+    /// Enumerate no more than `limit` child names from this retained directory.
+    /// Returns `InvalidData` instead of materializing an attacker-sized sibling
+    /// inventory when the bound is exceeded.
+    pub fn child_names_bounded(&self, limit: usize) -> io::Result<Vec<std::ffi::OsString>> {
+        self.revalidate_named()?;
+        stable_child_names_bounded(&self.file, &self.path, limit)
+    }
+
     /// Create a hard link between retained source and destination directories.
     pub fn link_child_into(
         &self,
@@ -654,10 +662,19 @@ fn stable_open_or_create_child_file(parent: &File, path: &Path, name: &OsStr) ->
 }
 
 #[cfg(unix)]
-fn stable_child_names(parent: &File, _path: &Path) -> io::Result<Vec<std::ffi::OsString>> {
+fn stable_child_names(parent: &File, path: &Path) -> io::Result<Vec<std::ffi::OsString>> {
+    stable_child_names_bounded(parent, path, usize::MAX)
+}
+
+#[cfg(unix)]
+fn stable_child_names_bounded(
+    parent: &File,
+    _path: &Path,
+    limit: usize,
+) -> io::Result<Vec<std::ffi::OsString>> {
     use std::os::unix::ffi::OsStrExt as _;
     let directory = rustix::fs::Dir::read_from(parent).map_err(io::Error::from)?;
-    directory
+    let names = directory
         .map(|entry| {
             let entry = entry.map_err(io::Error::from)?;
             let name = OsStr::from_bytes(entry.file_name().to_bytes());
@@ -666,7 +683,15 @@ fn stable_child_names(parent: &File, _path: &Path) -> io::Result<Vec<std::ffi::O
         .filter(|entry| {
             !matches!(entry, Ok(name) if name == OsStr::new(".") || name == OsStr::new(".."))
         })
-        .collect()
+        .take(limit.saturating_add(1))
+        .collect::<io::Result<Vec<_>>>()?;
+    if names.len() > limit {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "stable directory child count exceeds bound",
+        ));
+    }
+    Ok(names)
 }
 
 #[cfg(unix)]
@@ -868,10 +893,27 @@ fn stable_open_or_create_child_file(parent: &File, path: &Path, name: &OsStr) ->
 }
 
 #[cfg(windows)]
-fn stable_child_names(_parent: &File, path: &Path) -> io::Result<Vec<std::ffi::OsString>> {
-    std::fs::read_dir(path)?
+fn stable_child_names(parent: &File, path: &Path) -> io::Result<Vec<std::ffi::OsString>> {
+    stable_child_names_bounded(parent, path, usize::MAX)
+}
+
+#[cfg(windows)]
+fn stable_child_names_bounded(
+    _parent: &File,
+    path: &Path,
+    limit: usize,
+) -> io::Result<Vec<std::ffi::OsString>> {
+    let names = std::fs::read_dir(path)?
         .map(|entry| entry.map(|entry| entry.file_name()))
-        .collect()
+        .take(limit.saturating_add(1))
+        .collect::<io::Result<Vec<_>>>()?;
+    if names.len() > limit {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "stable directory child count exceeds bound",
+        ));
+    }
+    Ok(names)
 }
 
 #[cfg(windows)]
@@ -954,6 +996,15 @@ fn stable_child_names(_parent: &File, _path: &Path) -> io::Result<Vec<std::ffi::
         io::ErrorKind::Unsupported,
         "stable directories unsupported",
     ))
+}
+
+#[cfg(all(not(unix), not(windows)))]
+fn stable_child_names_bounded(
+    parent: &File,
+    path: &Path,
+    _limit: usize,
+) -> io::Result<Vec<std::ffi::OsString>> {
+    stable_child_names(parent, path)
 }
 
 #[cfg(all(not(unix), not(windows)))]

--- a/crates/graphforge-storage/src/ordinal_identity_v4.rs
+++ b/crates/graphforge-storage/src/ordinal_identity_v4.rs
@@ -968,6 +968,11 @@ fn validate_manifest(
             "forward identity authority is absent",
         ));
     }
+    if manifest.forward_identities.len() > STREAM_BYTES / FORWARD_RECORD_WIDTH_USIZE {
+        return Err(V4OrdinalIdentityError::InvalidDescriptor(
+            "forward run count exceeds bounded admission cursors",
+        ));
+    }
     let mut prior_forward_generation = 0;
     for run in &manifest.forward_identities {
         require_kind(run, V4OrdinalArtifactKind::ForwardIdentities, manifest)?;
@@ -1206,7 +1211,14 @@ fn validate_unique_forward_runs(
                 .max(FORWARD_RECORD_WIDTH_USIZE)
         })
         .collect::<Vec<_>>();
-    let cursor_bytes = buffer_lengths.iter().sum::<usize>();
+    let cursor_bytes =
+        buffer_lengths
+            .iter()
+            .sum::<usize>()
+            .saturating_add(runs.len().saturating_mul(
+                std::mem::size_of::<ForwardRunCursor>()
+                    + std::mem::size_of::<Reverse<([u8; UUID_WIDTH_USIZE], usize)>>(),
+            ));
     metrics.peak_buffer_bytes = metrics.peak_buffer_bytes.max(
         metrics
             .retained_descriptor_bytes

--- a/crates/graphforge-storage/src/ordinal_identity_v4.rs
+++ b/crates/graphforge-storage/src/ordinal_identity_v4.rs
@@ -3,7 +3,8 @@
 //! This module deliberately exposes no publication API. Version-three state is
 //! reported as rebuild-required and is never interpreted through this format.
 
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::cmp::Reverse;
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap, VecDeque};
 use std::fmt::Write as _;
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
@@ -165,7 +166,8 @@ pub struct V4OrdinalIdentityManifest {
     pub format_version: u32,
     /// Exact topology generation served by this snapshot.
     pub(crate) topology_generation: u64,
-    /// UUID-sorted forward artifacts, included to reject mixed authority.
+    /// Individually UUID-sorted immutable forward runs in strictly increasing
+    /// publication-generation order, included to reject mixed authority.
     pub forward_identities: Vec<V4OrdinalArtifact>,
     /// Nonoverlapping packed ordinal ranges.
     pub ordinal_ranges: Vec<V4OrdinalRange>,
@@ -355,7 +357,7 @@ pub enum V4OrdinalIdentityError {
 pub struct V4OrdinalAdmissionMetrics {
     /// Immutable files authenticated.
     pub artifacts: u64,
-    /// Bytes authenticated exactly once.
+    /// Bytes read for authentication and bounded cross-run validation.
     pub authenticated_bytes: u64,
     /// Successful sequential artifact reads during admission.
     pub sequential_read_calls: u64,
@@ -433,6 +435,22 @@ struct OpenTombstones {
     blocks: Vec<TombstoneBlock>,
 }
 
+/// One immutable artifact retained by an authenticated v4 handle for a
+/// generation-advancing writer. The cloned file pins the exact admitted inode;
+/// callers must not reopen `descriptor.name` to obtain update input.
+#[derive(Debug)]
+pub(crate) struct PinnedV4OrdinalArtifact {
+    pub(crate) descriptor: V4OrdinalArtifact,
+    pub(crate) file: File,
+}
+
+/// Authenticated, inode-pinned inputs for planning the next v4 generation.
+#[derive(Debug)]
+pub(crate) struct V4OrdinalPinnedUpdateInputs {
+    pub(crate) manifest: V4OrdinalIdentityManifest,
+    pub(crate) artifacts: Vec<PinnedV4OrdinalArtifact>,
+}
+
 #[derive(Debug)]
 struct TombstoneBlockCache {
     entries: BTreeMap<(usize, u64), Vec<u64>>,
@@ -477,6 +495,54 @@ pub struct V4OrdinalIdentityHandle {
 }
 
 impl V4OrdinalIdentityHandle {
+    /// Revalidate this retained generation and clone its already-authenticated
+    /// artifact handles for a bounded append/compaction planner.
+    pub(crate) fn pinned_update_inputs(
+        &self,
+    ) -> Result<V4OrdinalPinnedUpdateInputs, V4OrdinalIdentityError> {
+        self.revalidate()?;
+        let manifest = V4OrdinalIdentityManifest {
+            format_version: ORDINAL_IDENTITY_V4,
+            topology_generation: self.topology_generation,
+            forward_identities: self
+                .forward
+                .iter()
+                .map(|artifact| artifact.descriptor.clone())
+                .collect(),
+            ordinal_ranges: self
+                .ranges
+                .iter()
+                .map(|range| range.descriptor.clone())
+                .collect(),
+            tombstones: self
+                .tombstones
+                .iter()
+                .map(|run| V4OrdinalTombstones {
+                    generation: run.artifact.descriptor.generation,
+                    artifact: run.artifact.descriptor.clone(),
+                    blocks: run.blocks.clone(),
+                })
+                .collect(),
+        };
+        let artifacts = self
+            .forward
+            .iter()
+            .map(|artifact| artifact)
+            .chain(self.ranges.iter().map(|range| &range.artifact))
+            .chain(self.tombstones.iter().map(|run| &run.artifact))
+            .map(|artifact| {
+                Ok(PinnedV4OrdinalArtifact {
+                    descriptor: artifact.descriptor.clone(),
+                    file: artifact.file.try_clone().map_err(io_error)?,
+                })
+            })
+            .collect::<Result<Vec<_>, V4OrdinalIdentityError>>()?;
+        Ok(V4OrdinalPinnedUpdateInputs {
+            manifest,
+            artifacts,
+        })
+    }
+
     /// Return the exact v4 facet names admitted through this retained,
     /// generation-authenticated handle.
     pub(crate) fn referenced_file_names(&self) -> BTreeSet<String> {
@@ -557,7 +623,6 @@ impl V4OrdinalIdentityHandle {
         let mut names = BTreeSet::new();
         let mut forward_commitment = MappingCommitment::default();
         let mut ordinal_commitment = MappingCommitment::default();
-        let mut prior_forward_uuid = None;
         let mut forward = Vec::with_capacity(manifest.forward_identities.len());
         for artifact in &manifest.forward_identities {
             require_kind(
@@ -574,11 +639,11 @@ impl V4OrdinalIdentityHandle {
                 &root,
                 artifact,
                 &manifest.ordinal_ranges,
-                &mut prior_forward_uuid,
                 &mut forward_commitment,
                 &mut admission,
             )?);
         }
+        validate_unique_forward_runs(&mut forward, &mut admission)?;
         let mut ranges = Vec::with_capacity(manifest.ordinal_ranges.len());
         for range in &manifest.ordinal_ranges {
             if !names.insert(range.artifact.name.clone()) {
@@ -903,6 +968,16 @@ fn validate_manifest(
             "forward identity authority is absent",
         ));
     }
+    let mut prior_forward_generation = 0;
+    for run in &manifest.forward_identities {
+        require_kind(run, V4OrdinalArtifactKind::ForwardIdentities, manifest)?;
+        if run.generation <= prior_forward_generation {
+            return Err(V4OrdinalIdentityError::InvalidDescriptor(
+                "forward runs are not in canonical generation order",
+            ));
+        }
+        prior_forward_generation = run.generation;
+    }
     let mut prior_end = 0_u64;
     for range in &manifest.ordinal_ranges {
         require_kind(
@@ -1066,7 +1141,6 @@ fn admit_forward_artifact(
     root: &StableDirectory,
     descriptor: &V4OrdinalArtifact,
     ranges: &[V4OrdinalRange],
-    prior_uuid: &mut Option<[u8; UUID_WIDTH_USIZE]>,
     commitment: &mut MappingCommitment,
     metrics: &mut V4OrdinalAdmissionMetrics,
 ) -> Result<OpenArtifact, V4OrdinalIdentityError> {
@@ -1079,6 +1153,7 @@ fn admit_forward_artifact(
     let mut buffer = vec![0_u8; stream_bytes];
     let mut whole = Sha256::new();
     let mut remaining = descriptor.bytes;
+    let mut prior_uuid = None;
     while remaining != 0 {
         let read = usize::try_from(remaining.min(stream_bytes as u64))
             .map_err(|_| V4OrdinalIdentityError::Authentication)?;
@@ -1104,13 +1179,104 @@ fn admit_forward_artifact(
                     "forward identity records are noncanonical",
                 ));
             }
-            *prior_uuid = Some(uuid);
+            prior_uuid = Some(uuid);
             commitment.add(&uuid, node_id);
         }
         remaining -= read as u64;
     }
     finish_admission(&mut artifact, whole, metrics)?;
     Ok(artifact)
+}
+
+/// Prove UUID uniqueness across independently sorted forward generations with
+/// one cursor per retained run. This is bounded by descriptor/run count rather
+/// than graph cardinality and performs only sequential reads.
+fn validate_unique_forward_runs(
+    runs: &mut [OpenArtifact],
+    metrics: &mut V4OrdinalAdmissionMetrics,
+) -> Result<(), V4OrdinalIdentityError> {
+    let per_run_buffer = (STREAM_BYTES / runs.len().max(1) / FORWARD_RECORD_WIDTH_USIZE).max(1)
+        * FORWARD_RECORD_WIDTH_USIZE;
+    let buffer_lengths = runs
+        .iter()
+        .map(|run| {
+            usize::try_from(run.descriptor.bytes)
+                .unwrap_or(usize::MAX)
+                .min(per_run_buffer)
+                .max(FORWARD_RECORD_WIDTH_USIZE)
+        })
+        .collect::<Vec<_>>();
+    let cursor_bytes = buffer_lengths.iter().sum::<usize>();
+    metrics.peak_buffer_bytes = metrics.peak_buffer_bytes.max(
+        metrics
+            .retained_descriptor_bytes
+            .saturating_add(metrics.manifest_bytes)
+            .saturating_add(cursor_bytes as u64),
+    );
+    let mut cursors = runs
+        .iter()
+        .zip(buffer_lengths)
+        .map(|(run, buffer_len)| ForwardRunCursor {
+            buffer: vec![0; buffer_len],
+            cursor: 0,
+            valid: 0,
+            remaining: run.descriptor.bytes,
+        })
+        .collect::<Vec<_>>();
+    let mut heap = BinaryHeap::with_capacity(runs.len());
+    for (index, run) in runs.iter_mut().enumerate() {
+        run.file.rewind().map_err(io_error)?;
+        if let Some(uuid) = cursors[index].next_uuid(run, metrics)? {
+            heap.push(Reverse((uuid, index)));
+        }
+    }
+    let mut prior = None;
+    while let Some(Reverse((uuid, index))) = heap.pop() {
+        if prior == Some(uuid) {
+            return Err(V4OrdinalIdentityError::InvalidDescriptor(
+                "forward identity UUID is repeated across generations",
+            ));
+        }
+        prior = Some(uuid);
+        if let Some(next) = cursors[index].next_uuid(&mut runs[index], metrics)? {
+            heap.push(Reverse((next, index)));
+        }
+    }
+    Ok(())
+}
+
+struct ForwardRunCursor {
+    buffer: Vec<u8>,
+    cursor: usize,
+    valid: usize,
+    remaining: u64,
+}
+
+impl ForwardRunCursor {
+    fn next_uuid(
+        &mut self,
+        run: &mut OpenArtifact,
+        metrics: &mut V4OrdinalAdmissionMetrics,
+    ) -> Result<Option<[u8; UUID_WIDTH_USIZE]>, V4OrdinalIdentityError> {
+        if self.cursor == self.valid {
+            if self.remaining == 0 {
+                return Ok(None);
+            }
+            self.valid = usize::try_from(self.remaining.min(self.buffer.len() as u64))
+                .map_err(|_| V4OrdinalIdentityError::Authentication)?;
+            run.file
+                .read_exact(&mut self.buffer[..self.valid])
+                .map_err(io_error)?;
+            record_admission_read(metrics, self.valid, self.buffer.len());
+            self.remaining -= self.valid as u64;
+            self.cursor = 0;
+        }
+        let record = &self.buffer[self.cursor..self.cursor + FORWARD_RECORD_WIDTH_USIZE];
+        self.cursor += FORWARD_RECORD_WIDTH_USIZE;
+        Ok(Some(
+            record[..UUID_WIDTH_USIZE].try_into().expect("fixed UUID"),
+        ))
+    }
 }
 fn admit_tombstone_artifact(
     root: &StableDirectory,
@@ -2009,6 +2175,103 @@ mod tests {
     }
 
     #[test]
+    fn generation_ordered_forward_runs_may_have_interleaved_uuid_keys() {
+        let mut fixture = Fixture::new(&[4], &[]);
+        let index = fixture.root.path().join(INDEX_DIR);
+        let encode = |records: &[(u128, u64)]| {
+            records
+                .iter()
+                .flat_map(|(uuid, id)| {
+                    Uuid::from_u128(*uuid)
+                        .into_bytes()
+                        .into_iter()
+                        .chain(id.to_be_bytes())
+                })
+                .collect::<Vec<_>>()
+        };
+        let older = encode(&[(1, 1), (3, 3)]);
+        let newer = encode(&[(2, 2), (4, 4)]);
+        fs::write(index.join("forward-6.uuidx"), &older).unwrap();
+        fs::write(index.join("forward-7.uuidx"), &newer).unwrap();
+        fixture.manifest.forward_identities = vec![
+            artifact(
+                "forward-6.uuidx".into(),
+                V4OrdinalArtifactKind::ForwardIdentities,
+                6,
+                &older,
+            ),
+            artifact(
+                "forward-7.uuidx".into(),
+                V4OrdinalArtifactKind::ForwardIdentities,
+                7,
+                &newer,
+            ),
+        ];
+        fixture.publish();
+
+        let _handle = fixture.open(V4OrdinalIdentityLimits::default());
+    }
+
+    #[test]
+    fn forward_runs_reject_cross_generation_duplicates_and_noncanonical_order() {
+        let mut fixture = Fixture::new(&[4], &[]);
+        let index = fixture.root.path().join(INDEX_DIR);
+        let encode = |records: &[(u128, u64)]| {
+            records
+                .iter()
+                .flat_map(|(uuid, id)| {
+                    Uuid::from_u128(*uuid)
+                        .into_bytes()
+                        .into_iter()
+                        .chain(id.to_be_bytes())
+                })
+                .collect::<Vec<_>>()
+        };
+        let older = encode(&[(1, 1), (3, 3)]);
+        let duplicate = encode(&[(1, 1), (2, 2), (4, 4)]);
+        fs::write(index.join("forward-6.uuidx"), &older).unwrap();
+        fs::write(index.join("forward-7.uuidx"), &duplicate).unwrap();
+        fixture.manifest.forward_identities = vec![
+            artifact(
+                "forward-6.uuidx".into(),
+                V4OrdinalArtifactKind::ForwardIdentities,
+                6,
+                &older,
+            ),
+            artifact(
+                "forward-7.uuidx".into(),
+                V4OrdinalArtifactKind::ForwardIdentities,
+                7,
+                &duplicate,
+            ),
+        ];
+        fixture.publish();
+        assert!(matches!(
+            V4OrdinalIdentityHandle::open(
+                fixture.root.path(),
+                &fixture.authority(7),
+                V4OrdinalIdentityLimits::default()
+            ),
+            Err(V4OrdinalIdentityError::InvalidDescriptor(
+                "forward identity UUID is repeated across generations"
+            ))
+        ));
+
+        fixture.manifest.forward_identities.swap(0, 1);
+        fixture.publish();
+        assert!(matches!(
+            V4OrdinalIdentityHandle::open(
+                fixture.root.path(),
+                &fixture.authority(7),
+                V4OrdinalIdentityLimits::default()
+            ),
+            Err(V4OrdinalIdentityError::InvalidDescriptor(
+                "forward runs are not in canonical generation order"
+            ))
+        ));
+    }
+
+    #[test]
     fn request_limit_fails_before_request_allocation() {
         let fixture = Fixture::new(&[3], &[]);
         let mut handle = fixture.open(V4OrdinalIdentityLimits {
@@ -2194,18 +2457,18 @@ mod tests {
     }
 
     #[test]
-    fn admission_streams_each_artifact_once_with_truthful_linear_counters() {
+    fn admission_streams_artifacts_with_bounded_cross_run_validation_counters() {
         let mut prior_bytes = 0;
         let mut prior_calls = 0;
         let mut prior_metadata = 0;
-        for (count, expected_calls) in [(4_096_u64, 2_u64), (8_192, 3), (16_384, 5)] {
+        for (count, expected_calls) in [(4_096_u64, 3_u64), (8_192, 4), (16_384, 6)] {
             let fixture = Fixture::new(&[count], &[]);
             let handle = fixture.open(V4OrdinalIdentityLimits::default());
             let metrics = handle.admission_metrics();
             assert_eq!(metrics.artifacts, 3);
             assert_eq!(
                 metrics.authenticated_bytes,
-                count * (FORWARD_RECORD_WIDTH + UUID_WIDTH)
+                count * (FORWARD_RECORD_WIDTH * 2 + UUID_WIDTH)
             );
             assert_eq!(metrics.sequential_read_calls, expected_calls);
             assert!(metrics.peak_buffer_bytes <= STREAM_BYTES as u64);

--- a/crates/graphforge-storage/src/ordinal_identity_v4.rs
+++ b/crates/graphforge-storage/src/ordinal_identity_v4.rs
@@ -527,7 +527,6 @@ impl V4OrdinalIdentityHandle {
         let artifacts = self
             .forward
             .iter()
-            .map(|artifact| artifact)
             .chain(self.ranges.iter().map(|range| &range.artifact))
             .chain(self.tombstones.iter().map(|run| &run.artifact))
             .map(|artifact| {

--- a/crates/graphforge-storage/src/staging.rs
+++ b/crates/graphforge-storage/src/staging.rs
@@ -37,6 +37,8 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use tempfile::NamedTempFile;
 
+pub(crate) const STAGE_FILE_BLOCK_BYTES: usize = 1024 * 1024;
+
 use graphforge_core::GfError;
 
 const STAGED_TEMP_DIRS: [&str; 3] = ["topology", "properties", "edge_properties"];
@@ -177,7 +179,7 @@ impl RewriteBatch {
             crate::io_stats::record_uuid_file_open();
             crate::io_stats::record_uuid_file_open();
         }
-        let mut block = vec![0_u8; 1024 * 1024];
+        let mut block = vec![0_u8; STAGE_FILE_BLOCK_BYTES];
         loop {
             let count =
                 std::io::Read::read(&mut input, &mut block).map_err(|error| io_err(&error))?;

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -8747,6 +8747,18 @@ pub(crate) mod tests {
     }
 
     fn assert_exact_v4_reopen(project: &Path, generation: u64) {
+        assert_exact_v4_reopen_values(
+            project,
+            generation,
+            vec![
+                Some(Uuid::from_u128(3)),
+                Some(Uuid::from_u128(1)),
+                Some(Uuid::from_u128(2)),
+            ],
+        );
+    }
+
+    fn assert_exact_v4_reopen_values(project: &Path, generation: u64, expected: Vec<Option<Uuid>>) {
         let index = project.join(INDEX_DIR);
         let manifest_bytes = fs::read(index.join(V4_ORDINAL_MANIFEST)).unwrap();
         let receipt: TopologyIndexReceipt =
@@ -8779,11 +8791,7 @@ pub(crate) mod tests {
         );
         assert_eq!(
             handle.lookup_node_uuids(&[1, 2, 3]).unwrap().values,
-            vec![
-                Some(Uuid::from_u128(3)),
-                Some(Uuid::from_u128(1)),
-                Some(Uuid::from_u128(2)),
-            ]
+            expected
         );
     }
 
@@ -9271,6 +9279,89 @@ pub(crate) mod tests {
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn v4_orphan_cleanup_subprocess_crash_retry_preserves_authenticated_union() {
+        const CHILD_ROOT: &str = "GRAPHFORGE_V4_ORPHAN_CHILD_ROOT";
+        const RETRY: &str = "GRAPHFORGE_V4_ORPHAN_RETRY";
+        if let Ok(root) = std::env::var(CHILD_ROOT) {
+            let root = Path::new(&root);
+            let manifest_bytes = fs::read(root.join(INDEX_DIR).join(V4_ORDINAL_MANIFEST)).unwrap();
+            let receipt: TopologyIndexReceipt = serde_json::from_slice(
+                &fs::read(root.join(INDEX_DIR).join(V4_ORDINAL_RECEIPT)).unwrap(),
+            )
+            .unwrap();
+            assert_eq!(receipt.manifest_sha256, hex_sha256(&manifest_bytes));
+            let authority = crate::AuthenticatedV4OrdinalIdentityAuthority {
+                authority: crate::ordinal_identity_v4::V4OrdinalIdentityAuthority {
+                    topology_generation: receipt.expected_generation,
+                    manifest_sha256: receipt.manifest_sha256,
+                },
+            };
+            maintain_uuid_membership_orphans_with_ordinal_authority(root, 16, Some(&authority))
+                .unwrap();
+            if std::env::var(RETRY).is_err() {
+                panic!("configured v4 orphan cleanup failpoint did not terminate the process");
+            }
+            return;
+        }
+
+        for failpoint in ["v4_cleanup.before_unlink", "v4_cleanup.after_unlink"] {
+            let (dir, nodes, _) = fixture();
+            fs::write(
+                dir.path().join("topology/generation.json"),
+                b"{\"topology_generation\":7,\"search_generation\":0,\"property_generation\":0}\n",
+            )
+            .unwrap();
+            rebuild_uuid_membership_indexes(dir.path(), UuidIndexBuildLimits::default()).unwrap();
+            let (referenced, _) = install_test_v4_facet(dir.path(), 7, &nodes);
+            let orphan = dir
+                .path()
+                .join(INDEX_DIR)
+                .join("forward-v4-7-0000000000000000.uuidx");
+            fs::write(&orphan, b"authenticated-orphan-candidate").unwrap();
+
+            let child = |retry: bool| {
+                let mut command = std::process::Command::new(std::env::current_exe().unwrap());
+                command
+                    .arg("--exact")
+                    .arg(
+                        "uuid_membership::tests::v4_orphan_cleanup_subprocess_crash_retry_preserves_authenticated_union",
+                    )
+                    .arg("--nocapture")
+                    .env(CHILD_ROOT, dir.path());
+                if retry {
+                    command.env(RETRY, "1");
+                } else {
+                    command
+                        .env(
+                            "GRAPHFORGE_PROJECT_FAILPOINTS",
+                            "graphforge-internal-subprocess-v1",
+                        )
+                        .env("GRAPHFORGE_PROJECT_FAILPOINT", failpoint);
+                }
+                command.status().unwrap()
+            };
+            assert_eq!(
+                child(false).code(),
+                Some(crate::project_failpoint::exit_code()),
+                "{failpoint}"
+            );
+            assert!(child(true).success(), "{failpoint}");
+            assert!(!orphan.exists(), "{failpoint}");
+            for name in &referenced {
+                assert!(
+                    dir.path().join(INDEX_DIR).join(name).is_file(),
+                    "{failpoint}"
+                );
+            }
+            assert_exact_v4_reopen_values(
+                dir.path(),
+                7,
+                vec![Some(Uuid::from_u128(3)), Some(Uuid::from_u128(1)), None],
+            );
+        }
     }
 
     #[cfg(unix)]

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -185,14 +185,19 @@ fn clone_pinned_v4_file(
     pinned: &crate::ordinal_identity_v4::V4OrdinalPinnedUpdateInputs,
     name: &str,
 ) -> Result<File, GfError> {
-    pinned
+    let mut file = pinned
         .artifacts
         .iter()
         .find(|artifact| artifact.descriptor.name == name)
         .ok_or_else(|| storage_err("authenticated v4 update input is absent"))?
         .file
         .try_clone()
-        .map_err(storage_err)
+        .map_err(storage_err)?;
+    // Update inputs are writer-exclusive retained handles. `try_clone` may
+    // share an OS file offset with the retained handle, so every sequential
+    // consumer must establish its own logical start before reading.
+    file.seek(SeekFrom::Start(0)).map_err(storage_err)?;
+    Ok(file)
 }
 
 /// Encode the already-canonical construction node stream without rescanning
@@ -6367,6 +6372,17 @@ pub(crate) fn prepare_v4_ordinal_delta(
     )?;
 
     let prior_names = v4_manifest_artifact_names(&pinned.manifest);
+    let staged_artifact_bytes = outputs.iter().try_fold(0_u64, |sum, (_, path)| {
+        sum.checked_add(path.metadata().map_err(storage_err)?.len())
+            .ok_or_else(|| storage_err("v4 staged artifact byte count overflow"))
+    })?;
+    let control_bytes =
+        u64::try_from(receipt_bytes.len() + manifest_bytes.len()).map_err(storage_err)?;
+    let staged_write_blocks = outputs.iter().try_fold(0_u64, |sum, (_, path)| {
+        let bytes = path.metadata().map_err(storage_err)?.len();
+        sum.checked_add(bytes.div_ceil(crate::staging::STAGE_FILE_BLOCK_BYTES as u64))
+            .ok_or_else(|| storage_err("v4 staged write block count overflow"))
+    })?;
     let sorting_temporary_upper = u64::try_from(nodes.len())
         .map_err(storage_err)?
         .checked_mul(24 * 4)
@@ -6385,9 +6401,8 @@ pub(crate) fn prepare_v4_ordinal_delta(
             .artifact_bytes
             .saturating_add(tombstone_bytes)
             .saturating_add(compaction.write_bytes)
-            .checked_add(
-                u64::try_from(receipt_bytes.len() + manifest_bytes.len()).map_err(storage_err)?,
-            )
+            .saturating_add(staged_artifact_bytes)
+            .checked_add(control_bytes)
             .ok_or_else(|| storage_err("v4 publication byte count overflow"))?,
         compactions: compaction.compactions,
         sequential_read_bytes: compaction.read_bytes,
@@ -6395,20 +6410,27 @@ pub(crate) fn prepare_v4_ordinal_delta(
         write_blocks: build
             .write_blocks
             .saturating_add(tombstone_blocks)
-            .saturating_add(compaction.write_blocks),
+            .saturating_add(compaction.write_blocks)
+            .saturating_add(staged_write_blocks)
+            .saturating_add(2),
         peak_buffer_bytes: build
             .peak_buffer_bytes
             .max(V4_ORDINAL_BLOCK_BYTES * 3)
+            .max(crate::staging::STAGE_FILE_BLOCK_BYTES)
             .max(external_peak_buffer),
         peak_temporary_bytes: build
             .peak_temporary_bytes
             .saturating_add(tombstone_bytes)
             .saturating_add(compaction.write_bytes)
+            .saturating_add(staged_artifact_bytes)
+            .saturating_add(control_bytes)
             .saturating_add(sorting_temporary_upper),
         fsync_operations: build
             .fsync_operations
-            .saturating_add(tombstone_blocks)
-            .saturating_add(compaction.fsync_operations),
+            .saturating_add(1)
+            .saturating_add(compaction.fsync_operations)
+            .saturating_add(u64::try_from(outputs.len()).map_err(storage_err)?)
+            .saturating_add(2),
         ..Default::default()
     };
     Ok(PreparedV4OrdinalDelta {
@@ -8481,7 +8503,10 @@ pub(crate) mod tests {
         assert_eq!(planned_third.manifest.forward_identities.len(), 2);
         assert_eq!(planned_third.manifest.ordinal_ranges.len(), 2);
         assert_eq!(planned_third.manifest.tombstones.len(), 2);
-        assert!(planned_third.metrics.peak_buffer_bytes <= V4_ORDINAL_BLOCK_BYTES * 3);
+        assert_eq!(
+            planned_third.metrics.peak_buffer_bytes,
+            crate::staging::STAGE_FILE_BLOCK_BYTES
+        );
         install_v4_plan(&third);
 
         let manifest_bytes = serde_json::to_vec(&planned_third.manifest).unwrap();
@@ -8576,11 +8601,15 @@ pub(crate) mod tests {
             .collect::<Vec<_>>();
         let (mut manifest, _) = stage_v4_ordinal_artifacts(base, 1, &index, || false).unwrap();
         let mut observed = Vec::new();
+        let mut next_node_id = ROWS_PER_GENERATION + 1;
         for generation in 2..=5_u64 {
             let pinned = pinned_v4_update(root.path(), manifest);
             let mut batch = crate::staging::RewriteBatch::new();
-            let first = (generation - 1) * ROWS_PER_GENERATION + 1;
-            let last = generation * ROWS_PER_GENERATION;
+            let multiplier = 1_u64 << (generation - 2);
+            let input_rows = ROWS_PER_GENERATION * multiplier;
+            let first = next_node_id;
+            let last = first + input_rows - 1;
+            next_node_id = last + 1;
             let nodes = (first..=last)
                 .map(|id| (Uuid::from_u128(u128::from(id)), id))
                 .collect::<Vec<_>>();
@@ -8595,10 +8624,13 @@ pub(crate) mod tests {
                 &"44".repeat(32),
             )
             .unwrap();
-            assert_eq!(planned.metrics.input_identities, ROWS_PER_GENERATION);
+            assert_eq!(planned.metrics.input_identities, input_rows);
             assert_eq!(planned.metrics.prior_topology_rows_decoded, 0);
             assert_eq!(planned.metrics.per_record_seeks, 0);
-            assert!(planned.metrics.peak_buffer_bytes <= V4_ORDINAL_BLOCK_BYTES * 3);
+            assert_eq!(
+                planned.metrics.peak_buffer_bytes,
+                crate::staging::STAGE_FILE_BLOCK_BYTES
+            );
             assert!(planned.metrics.peak_temporary_bytes != 0);
             assert!(planned.metrics.fsync_operations >= 3);
             assert!(planned.metrics.created_artifacts >= 3);
@@ -8610,9 +8642,17 @@ pub(crate) mod tests {
                 assert!(planned.metrics.sequential_read_bytes != 0);
                 assert!(planned.metrics.sequential_read_calls != 0);
             }
-            let live_rows = generation * ROWS_PER_GENERATION;
-            let bounded_amplification = live_rows * 40 * 4 + MAX_MANIFEST_BYTES;
-            assert!(planned.metrics.physical_bytes_written < bounded_amplification);
+            let control_bytes = planned.auxiliary.bytes
+                + u64::try_from(serde_json::to_vec(&planned.manifest).unwrap().len()).unwrap();
+            let data_bytes = planned.metrics.physical_bytes_written - control_bytes;
+            let new_payload_bytes = input_rows * 40;
+            assert!(data_bytes >= new_payload_bytes * 2);
+            assert!(
+                data_bytes
+                    <= (new_payload_bytes + planned.metrics.sequential_read_bytes)
+                        .saturating_mul(2)
+            );
+            assert!(planned.metrics.write_blocks <= data_bytes.div_ceil(16) + 2);
             observed.push((
                 planned.metrics.compactions,
                 planned.metrics.physical_bytes_written,
@@ -8627,6 +8667,7 @@ pub(crate) mod tests {
         );
         assert_eq!(manifest.forward_identities.len(), 2);
         assert_eq!(manifest.ordinal_ranges.len(), 2);
+        assert_eq!(next_node_id - 1, ROWS_PER_GENERATION * 16);
         assert!(observed.iter().all(|row| row.1 != 0));
     }
 

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -159,8 +159,12 @@ pub(crate) struct V4OrdinalAppendMetrics {
     pub(crate) sequential_read_bytes: u64,
     /// Bounded sequential input calls made by compaction.
     pub(crate) sequential_read_calls: u64,
+    /// Fixed-size input blocks covered by compaction reads.
+    pub(crate) sequential_read_blocks: u64,
     /// Exact artifact and control bytes written.
     pub(crate) physical_bytes_written: u64,
+    /// Artifact and control bytes submitted through output writers.
+    pub(crate) write_bytes: u64,
     /// Bounded output blocks submitted.
     pub(crate) write_blocks: u64,
     /// Largest anonymous writer buffer.
@@ -6378,6 +6382,13 @@ pub(crate) fn prepare_v4_ordinal_delta(
     })?;
     let control_bytes =
         u64::try_from(receipt_bytes.len() + manifest_bytes.len()).map_err(storage_err)?;
+    let submitted_write_bytes = build
+        .artifact_bytes
+        .saturating_add(tombstone_bytes)
+        .saturating_add(compaction.write_bytes)
+        .saturating_add(staged_artifact_bytes)
+        .checked_add(control_bytes)
+        .ok_or_else(|| storage_err("v4 submitted write byte count overflow"))?;
     let staged_write_blocks = outputs.iter().try_fold(0_u64, |sum, (_, path)| {
         let bytes = path.metadata().map_err(storage_err)?.len();
         sum.checked_add(bytes.div_ceil(crate::staging::STAGE_FILE_BLOCK_BYTES as u64))
@@ -6397,16 +6408,12 @@ pub(crate) fn prepare_v4_ordinal_delta(
         created_artifacts: delta_created_artifacts.saturating_add(compaction.created_artifacts),
         retained_artifacts: u64::try_from(retained_names.intersection(&prior_names).count())
             .map_err(storage_err)?,
-        physical_bytes_written: build
-            .artifact_bytes
-            .saturating_add(tombstone_bytes)
-            .saturating_add(compaction.write_bytes)
-            .saturating_add(staged_artifact_bytes)
-            .checked_add(control_bytes)
-            .ok_or_else(|| storage_err("v4 publication byte count overflow"))?,
+        physical_bytes_written: submitted_write_bytes,
         compactions: compaction.compactions,
         sequential_read_bytes: compaction.read_bytes,
         sequential_read_calls: compaction.read_calls,
+        sequential_read_blocks: compaction.read_blocks,
+        write_bytes: submitted_write_bytes,
         write_blocks: build
             .write_blocks
             .saturating_add(tombstone_blocks)
@@ -6504,8 +6511,10 @@ fn cleanup_abandoned_v4_plan_directories(
             "V4_PLAN_CLEANUP_BEFORE_UNLINK",
             false,
         )?;
+        let directory_identity = directory.identity();
+        drop(directory);
         plan_root
-            .remove_child_directory_if_identity(&name, directory.identity())
+            .remove_child_directory_if_identity(&name, directory_identity)
             .map_err(storage_err)?;
         crate::project_failpoint::hit(
             "v4_plan_cleanup.after_unlink",
@@ -6531,8 +6540,10 @@ fn cleanup_v4_plan_directory(
         if name == std::ffi::OsStr::new("artifacts") {
             let artifacts = directory.open_child_directory(&name).map_err(storage_err)?;
             cleanup_v4_plan_files(&artifacts, &mut bytes)?;
+            let artifacts_identity = artifacts.identity();
+            drop(artifacts);
             directory
-                .remove_child_directory_if_identity(&name, artifacts.identity())
+                .remove_child_directory_if_identity(&name, artifacts_identity)
                 .map_err(storage_err)?;
         } else {
             cleanup_v4_plan_file(directory, &name, &mut bytes)?;
@@ -6776,6 +6787,7 @@ struct V4CompactionWork {
     created_artifacts: u64,
     read_bytes: u64,
     read_calls: u64,
+    read_blocks: u64,
     write_bytes: u64,
     write_blocks: u64,
     fsync_operations: u64,
@@ -6946,6 +6958,9 @@ fn merge_v4_forward_artifacts(
     work.read_calls = work
         .read_calls
         .saturating_add(input_bytes.div_ceil(V4_ORDINAL_BLOCK_BYTES as u64));
+    work.read_blocks = work
+        .read_blocks
+        .saturating_add(input_bytes.div_ceil(V4_ORDINAL_BLOCK_BYTES as u64));
     let bytes = writer.bytes;
     let mut metrics = V4OrdinalBuildMetrics::default();
     let artifact = finish_streamed_v4_artifact(
@@ -7031,6 +7046,12 @@ fn compact_v4_ordinal_interval(
                 }
                 work.read_bytes = work.read_bytes.saturating_add(source.artifact.bytes);
                 work.read_calls = work.read_calls.saturating_add(
+                    source
+                        .artifact
+                        .bytes
+                        .div_ceil(V4_ORDINAL_BLOCK_BYTES as u64),
+                );
+                work.read_blocks = work.read_blocks.saturating_add(
                     source
                         .artifact
                         .bytes
@@ -7125,6 +7146,12 @@ fn compact_v4_tombstone_interval(
         .read_bytes
         .saturating_add(selected.iter().map(|run| run.artifact.bytes).sum::<u64>());
     work.read_calls = work.read_calls.saturating_add(
+        selected
+            .iter()
+            .map(|run| run.artifact.bytes.div_ceil(V4_ORDINAL_BLOCK_BYTES as u64))
+            .sum::<u64>(),
+    );
+    work.read_blocks = work.read_blocks.saturating_add(
         selected
             .iter()
             .map(|run| run.artifact.bytes.div_ceil(V4_ORDINAL_BLOCK_BYTES as u64))
@@ -8635,12 +8662,18 @@ pub(crate) mod tests {
             assert!(planned.metrics.fsync_operations >= 3);
             assert!(planned.metrics.created_artifacts >= 3);
             assert!(planned.metrics.write_blocks != 0);
+            assert_eq!(
+                planned.metrics.write_bytes,
+                planned.metrics.physical_bytes_written
+            );
             if planned.metrics.compactions == 0 {
                 assert_eq!(planned.metrics.sequential_read_bytes, 0);
                 assert_eq!(planned.metrics.sequential_read_calls, 0);
+                assert_eq!(planned.metrics.sequential_read_blocks, 0);
             } else {
                 assert!(planned.metrics.sequential_read_bytes != 0);
                 assert!(planned.metrics.sequential_read_calls != 0);
+                assert!(planned.metrics.sequential_read_blocks != 0);
             }
             let control_bytes = planned.auxiliary.bytes
                 + u64::try_from(serde_json::to_vec(&planned.manifest).unwrap().len()).unwrap();

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -140,6 +140,61 @@ pub(crate) struct V4OrdinalBuildMetrics {
     pub(crate) cancellation_polls: u64,
 }
 
+/// Aggregate-only work evidence for one incremental v4 publication.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct V4OrdinalAppendMetrics {
+    /// New UUID-to-surrogate mappings accepted by this publication.
+    pub input_identities: u64,
+    /// Sorted unique deletion overrides accepted by this publication.
+    pub input_tombstones: u64,
+    /// Canonical topology rows decoded from the prior generation. Always zero.
+    pub prior_topology_rows_decoded: u64,
+    /// Immutable artifacts created, including deterministic compaction outputs.
+    pub created_artifacts: u64,
+    /// Prior immutable artifacts retained without rewriting.
+    pub retained_artifacts: u64,
+    /// Binary-carry compactions completed.
+    pub compactions: u64,
+    /// Exact authenticated input bytes read by compaction.
+    pub sequential_read_bytes: u64,
+    /// Bounded sequential input calls made by compaction.
+    pub sequential_read_calls: u64,
+    /// Exact artifact and control bytes written.
+    pub physical_bytes_written: u64,
+    /// Bounded output blocks submitted.
+    pub write_blocks: u64,
+    /// Largest anonymous writer buffer.
+    pub peak_buffer_bytes: usize,
+    /// Maximum coexisting scratch output bytes.
+    pub peak_temporary_bytes: u64,
+    /// Durable file flushes completed while constructing outputs.
+    pub fsync_operations: u64,
+    /// Per-record filesystem seeks are forbidden.
+    pub per_record_seeks: u64,
+    /// Unreferenced v4 candidates examined after publication.
+    pub orphan_gc_candidates: u64,
+    /// Unreferenced v4 artifacts removed by retained identity.
+    pub orphan_gc_removed: u64,
+    /// Candidates conservatively deferred.
+    pub orphan_gc_deferred: u64,
+    /// Physical orphan bytes reclaimed.
+    pub orphan_gc_bytes: u64,
+}
+
+fn clone_pinned_v4_file(
+    pinned: &crate::ordinal_identity_v4::V4OrdinalPinnedUpdateInputs,
+    name: &str,
+) -> Result<File, GfError> {
+    pinned
+        .artifacts
+        .iter()
+        .find(|artifact| artifact.descriptor.name == name)
+        .ok_or_else(|| storage_err("authenticated v4 update input is absent"))?
+        .file
+        .try_clone()
+        .map_err(storage_err)
+}
+
 /// Encode the already-canonical construction node stream without rescanning
 /// topology or consulting v3 reverse authority. The caller owns the durable
 /// rewrite transaction and publishes the returned manifest later.
@@ -3870,6 +3925,71 @@ fn selected_generation_for_graph_root(
     Ok(Some(selected))
 }
 
+/// Pin a standalone v4 facet through the admitted local receipt while the
+/// caller is about to enter the one project rewrite critical section. Project
+/// generation roots instead require their externally selected graph/files
+/// authority and never use this local path.
+fn standalone_v4_pinned_update(
+    project_root: &Path,
+    generation: u64,
+) -> Result<Option<crate::ordinal_identity_v4::V4OrdinalPinnedUpdateInputs>, GfError> {
+    let index_path = project_root.join(INDEX_DIR);
+    let index = match graphforge_filesystem::StableDirectory::open(&index_path) {
+        Ok(index) => index,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(storage_err(error)),
+    };
+    let mut manifest_file = match index.open_child_file(std::ffi::OsStr::new(V4_ORDINAL_MANIFEST)) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(storage_err(error)),
+    };
+    let mut receipt_file = index
+        .open_child_file(std::ffi::OsStr::new(V4_ORDINAL_RECEIPT))
+        .map_err(storage_err)?;
+    let manifest = read_bounded(
+        &mut manifest_file,
+        crate::ordinal_identity_v4::MAX_MANIFEST_BYTES,
+    )?;
+    let receipt = read_bounded(
+        &mut receipt_file,
+        crate::ordinal_identity_v4::MAX_MANIFEST_BYTES,
+    )?;
+    let receipt: TopologyIndexReceipt = serde_json::from_slice(&receipt).map_err(storage_err)?;
+    let manifest_sha256 = hex_sha256(&manifest);
+    if receipt.expected_generation != generation
+        || receipt.manifest_sha256 != manifest_sha256
+        || receipt.nonce.len() != 32
+        || !receipt
+            .nonce
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return Err(storage_err(
+            "standalone v4 receipt does not authenticate current authority",
+        ));
+    }
+    index.revalidate_named().map_err(storage_err)?;
+    let authority = crate::ordinal_identity_v4::V4OrdinalIdentityAuthority {
+        topology_generation: generation,
+        manifest_sha256,
+    };
+    match crate::ordinal_identity_v4::V4OrdinalIdentityHandle::open(
+        project_root,
+        &authority,
+        crate::V4OrdinalIdentityLimits::default(),
+    )
+    .map_err(storage_err)?
+    {
+        crate::V4OrdinalIdentityOpen::Ready(handle) => {
+            handle.pinned_update_inputs().map(Some).map_err(storage_err)
+        }
+        crate::V4OrdinalIdentityOpen::RebuildRequired { .. } => Err(storage_err(
+            "standalone v4 ordinal identity requires rebuild before mutation",
+        )),
+    }
+}
+
 #[cfg(test)]
 pub(crate) fn maintain_uuid_membership_orphans_with_ordinal_authority(
     project_dir: &Path,
@@ -3975,9 +4095,34 @@ fn collect_uuid_orphans_locked(
         }
         let bytes = file.metadata().map_err(storage_err)?.len();
         let identity = graphforge_filesystem::file_identity(&file).map_err(storage_err)?;
+        if is_canonical_v4_artifact_prefix(
+            text.strip_suffix(".uuidx")
+                .and_then(|stem| stem.rsplit_once('-').map(|(prefix, _)| prefix))
+                .unwrap_or_default(),
+        ) {
+            crate::project_failpoint::hit(
+                "v4_cleanup.before_unlink",
+                None,
+                None,
+                "V4_CLEANUP_BEFORE_UNLINK",
+                false,
+            )?;
+        }
         index
             .unlink_child_if_identity(&name, identity)
             .map_err(storage_err)?;
+        if text.starts_with("forward-v4-")
+            || text.starts_with("ordinal-v4-")
+            || text.starts_with("tombstones-v4-")
+        {
+            crate::project_failpoint::hit(
+                "v4_cleanup.after_unlink",
+                None,
+                None,
+                "V4_CLEANUP_AFTER_UNLINK",
+                false,
+            )?;
+        }
         work.removed = work.removed.saturating_add(1);
         work.bytes = work.bytes.saturating_add(bytes);
     }
@@ -4075,6 +4220,32 @@ pub(crate) struct PreparedUuidIndexDelta {
     manifest: Manifest,
 }
 
+pub(crate) struct PreparedV4OrdinalDelta {
+    expected_generation: u64,
+    auxiliary: crate::AuxiliaryReceipt,
+    metrics: V4OrdinalAppendMetrics,
+    manifest: crate::V4OrdinalIdentityManifest,
+}
+
+impl PreparedV4OrdinalDelta {
+    pub(crate) fn auxiliary_receipt(&self) -> crate::AuxiliaryReceipt {
+        self.auxiliary.clone()
+    }
+
+    pub(crate) fn verify_generation(&self, committed_generation: u64) -> Result<(), GfError> {
+        if committed_generation != self.expected_generation {
+            return Err(storage_err(
+                "topology commit returned an unexpected v4 ordinal generation",
+            ));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn metrics(&self) -> &V4OrdinalAppendMetrics {
+        &self.metrics
+    }
+}
+
 pub(crate) struct UuidTopologyDelta {
     pub nodes: Vec<(Uuid, u64)>,
     pub edges: Vec<Uuid>,
@@ -4087,10 +4258,12 @@ pub(crate) enum CommittedUuidTopologyRewrite {
     Committed {
         generation: u64,
         metrics: UuidIndexAppendMetrics,
+        v4_metrics: Option<V4OrdinalAppendMetrics>,
     },
     CommittedNeedsRefresh {
         generation: u64,
         metrics: UuidIndexAppendMetrics,
+        v4_metrics: Option<V4OrdinalAppendMetrics>,
         error: GfError,
     },
 }
@@ -4117,6 +4290,30 @@ pub(crate) fn commit_uuid_topology_rewrite(
         .map(crate::ResolvedProjectGeneration::authenticated_v4_ordinal_authority)
         .transpose()?
         .flatten();
+    let ordinal_inputs = ordinal_authority
+        .as_ref()
+        .map(|authority| {
+            match authority
+                .open(project_dir, crate::V4OrdinalIdentityLimits::default())
+                .map_err(storage_err)?
+            {
+                crate::V4OrdinalIdentityOpen::Ready(handle) => {
+                    handle.pinned_update_inputs().map(Some).map_err(storage_err)
+                }
+                crate::V4OrdinalIdentityOpen::RebuildRequired { .. } => Err(storage_err(
+                    "v4 ordinal identity requires rebuild before mutation",
+                )),
+            }
+        })
+        .transpose()?
+        .flatten();
+    let ordinal_inputs = if ordinal_inputs.is_some() {
+        ordinal_inputs
+    } else if selected.is_none() {
+        standalone_v4_pinned_update(project_dir, crate::read_topology_generation(project_dir)?)?
+    } else {
+        None
+    };
     let membership_authority = selected
         .as_ref()
         .map(authenticated_v3_membership_authority)
@@ -4124,6 +4321,8 @@ pub(crate) fn commit_uuid_topology_rewrite(
         .flatten();
     let prepared = std::rc::Rc::new(std::cell::RefCell::new(None));
     let prepared_from_callback = std::rc::Rc::clone(&prepared);
+    let prepared_v4 = std::rc::Rc::new(std::cell::RefCell::new(None));
+    let prepared_v4_from_callback = std::rc::Rc::clone(&prepared_v4);
     let generations = std::rc::Rc::new(std::cell::Cell::new(None));
     let generations_from_callback = std::rc::Rc::clone(&generations);
     let root = project_dir.to_path_buf();
@@ -4217,19 +4416,61 @@ pub(crate) fn commit_uuid_topology_rewrite(
             let receipt = token
                 .as_ref()
                 .map(PreparedUuidIndexDelta::auxiliary_receipt);
+            let prepared_ordinal = ordinal_inputs
+                .as_ref()
+                .map(|pinned| {
+                    let deleted_node_ids = deleted_nodes
+                        .iter()
+                        .map(|(_, node_id)| *node_id)
+                        .collect::<Vec<_>>();
+                    prepare_v4_ordinal_delta(
+                        context.project_root,
+                        context.prior.topology,
+                        context.next.topology,
+                        pinned,
+                        batch,
+                        &delta.nodes,
+                        &deleted_node_ids,
+                        &topology_delta_sha256(
+                            &delta.nodes,
+                            &delta.edges,
+                            &deleted_nodes,
+                            &deleted_edges,
+                        ),
+                    )
+                })
+                .transpose()?;
+            let receipt = prepared_ordinal
+                .as_ref()
+                .map(PreparedV4OrdinalDelta::auxiliary_receipt)
+                .or(receipt);
             *prepared_from_callback.borrow_mut() = token;
+            *prepared_v4_from_callback.borrow_mut() = prepared_ordinal;
             Ok(receipt)
         });
     let commit =
         crate::generation::commit_topology_aware_with_participant(staged, &root, participant);
     let token = prepared.borrow_mut().take();
+    let v4_token = prepared_v4.borrow_mut().take();
     let committed = match commit {
         Ok(value) => value,
         Err(error) => {
             let (Some(token), Some((prior, next))) = (token.as_ref(), generations.get()) else {
                 return Err(error);
             };
-            match reconcile_uuid_auxiliary(&root, prior, next, token)? {
+            let membership_outcome = reconcile_uuid_auxiliary(&root, prior, next, token)?;
+            let outcome = if let Some(v4) = v4_token.as_ref() {
+                let ordinal_outcome = reconcile_v4_ordinal_auxiliary(&root, prior, next, v4)?;
+                if membership_outcome != ordinal_outcome {
+                    return Err(storage_err(
+                        "v3 and v4 auxiliary reconciliation outcomes disagree",
+                    ));
+                }
+                ordinal_outcome
+            } else {
+                membership_outcome
+            };
+            match outcome {
                 crate::durable_rewrite::AuxiliaryReconcileOutcome::Committed => Some(next.topology),
                 crate::durable_rewrite::AuxiliaryReconcileOutcome::NotCommitted => {
                     return Err(error);
@@ -4238,8 +4479,12 @@ pub(crate) fn commit_uuid_topology_rewrite(
         }
     };
     let mut committed_metrics = UuidIndexAppendMetrics::default();
+    let committed_v4_metrics = v4_token.as_ref().map(|token| token.metrics().clone());
     if let (Some(generation), Some(token)) = (committed, token.as_ref()) {
         token.verify_generation(generation)?;
+        if let Some(v4) = v4_token.as_ref() {
+            v4.verify_generation(generation)?;
+        }
         committed_metrics = token.metrics().clone();
         let refresh = injected_snapshot_refresh_failure().map_or_else(
             || {
@@ -4257,6 +4502,7 @@ pub(crate) fn commit_uuid_topology_rewrite(
             return Ok(CommittedUuidTopologyRewrite::CommittedNeedsRefresh {
                 generation,
                 metrics: committed_metrics,
+                v4_metrics: committed_v4_metrics,
                 error,
             });
         }
@@ -4266,6 +4512,7 @@ pub(crate) fn commit_uuid_topology_rewrite(
         |generation| CommittedUuidTopologyRewrite::Committed {
             generation,
             metrics: committed_metrics,
+            v4_metrics: committed_v4_metrics,
         },
     ))
 }
@@ -4415,6 +4662,52 @@ fn reconcile_uuid_auxiliary(
     {
         return Err(storage_err(
             "committed UUID receipt does not authenticate the expected manifest",
+        ));
+    }
+    Ok(outcome)
+}
+
+fn reconcile_v4_ordinal_auxiliary(
+    project_dir: &Path,
+    prior: crate::durable_rewrite::GenerationPair,
+    next: crate::durable_rewrite::GenerationPair,
+    prepared: &PreparedV4OrdinalDelta,
+) -> Result<crate::durable_rewrite::AuxiliaryReconcileOutcome, GfError> {
+    let outcome = crate::durable_rewrite::reconcile_auxiliary(
+        project_dir,
+        prior,
+        next,
+        &prepared.auxiliary_receipt(),
+    )?;
+    if outcome == crate::durable_rewrite::AuxiliaryReconcileOutcome::NotCommitted {
+        return Ok(outcome);
+    }
+    let index = graphforge_filesystem::StableDirectory::open(&project_dir.join(INDEX_DIR))
+        .map_err(storage_err)?;
+    let mut receipt_file = index
+        .open_child_file(std::ffi::OsStr::new(V4_ORDINAL_RECEIPT))
+        .map_err(storage_err)?;
+    let receipt_body = read_bounded(
+        &mut receipt_file,
+        crate::ordinal_identity_v4::MAX_MANIFEST_BYTES,
+    )?;
+    let receipt: TopologyIndexReceipt =
+        serde_json::from_slice(&receipt_body).map_err(storage_err)?;
+    let mut manifest_file = index
+        .open_child_file(std::ffi::OsStr::new(V4_ORDINAL_MANIFEST))
+        .map_err(storage_err)?;
+    let manifest_body = read_bounded(
+        &mut manifest_file,
+        crate::ordinal_identity_v4::MAX_MANIFEST_BYTES,
+    )?;
+    index.revalidate_named().map_err(storage_err)?;
+    let expected = serde_json::to_vec(&prepared.manifest).map_err(storage_err)?;
+    if receipt.expected_generation != next.topology
+        || receipt.manifest_sha256 != hex_sha256(&manifest_body)
+        || manifest_body != expected
+    {
+        return Err(storage_err(
+            "committed v4 ordinal receipt does not authenticate the expected manifest",
         ));
     }
     Ok(outcome)
@@ -5864,6 +6157,782 @@ fn open_verified(root: &Path, record: &FileRecord, record_bytes: u64) -> Result<
     Ok(file)
 }
 
+/// Stage one incremental v4 node-ordinal delta beside the canonical topology
+/// mutation. The caller supplies a receipt-authenticated, lifetime-pinned prior
+/// snapshot and owns the enclosing generation-last rewrite transaction.
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+// One manifest-last planner lifecycle; the ordering between pinned admission,
+// delta artifacts, compaction, receipt, manifest, and evidence is the invariant.
+pub(crate) fn prepare_v4_ordinal_delta(
+    project_dir: &Path,
+    current: u64,
+    generation: u64,
+    pinned: &crate::ordinal_identity_v4::V4OrdinalPinnedUpdateInputs,
+    batch: &mut crate::staging::RewriteBatch,
+    nodes: &[(Uuid, u64)],
+    deleted_node_ids: &[u64],
+    topology_delta_sha256: &str,
+) -> Result<PreparedV4OrdinalDelta, GfError> {
+    if generation
+        != current
+            .checked_add(1)
+            .ok_or_else(|| storage_err("v4 generation overflow"))?
+        || pinned.manifest.topology_generation != current
+    {
+        return Err(storage_err(
+            "prepared v4 ordinal delta is not the next authenticated generation",
+        ));
+    }
+    if topology_delta_sha256.len() != 64
+        || !topology_delta_sha256
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return Err(storage_err("v4 topology delta digest is noncanonical"));
+    }
+
+    let parent = project_dir
+        .parent()
+        .ok_or_else(|| storage_err("project directory has no staging parent"))?;
+    let scratch = tempfile::Builder::new()
+        .prefix("uuid-membership-v4-plan-")
+        .tempdir_in(parent)
+        .map_err(storage_err)?;
+    let artifacts_path = scratch.path().join("artifacts");
+    fs::create_dir(&artifacts_path).map_err(storage_err)?;
+    let artifacts =
+        graphforge_filesystem::StableDirectory::open(&artifacts_path).map_err(storage_err)?;
+
+    let mut build_metrics = UuidIndexBuildMetrics::default();
+    let uuid_sorted = external_sort_v4_nodes(nodes, scratch.path(), &mut build_metrics)?;
+    let ordinal_sorted = build_surrogate_run(
+        &uuid_sorted,
+        scratch.path(),
+        UuidIndexBuildLimits::default(),
+        &mut build_metrics,
+    )?;
+    let mut deleted = deleted_node_ids.to_vec();
+    deleted.sort_unstable();
+    if deleted.contains(&0) || deleted.windows(2).any(|pair| pair[0] == pair[1]) {
+        return Err(storage_err(
+            "v4 tombstone delta is not sorted unique nonzero",
+        ));
+    }
+
+    let prior_max = pinned
+        .manifest
+        .ordinal_ranges
+        .last()
+        .map(|range| {
+            range
+                .first_node_id
+                .checked_add(range.count.saturating_sub(1))
+                .ok_or_else(|| storage_err("retained v4 ordinal range overflows"))
+        })
+        .transpose()?
+        .unwrap_or(0);
+    let mut ordinal_probe = BufReader::new(File::open(&ordinal_sorted).map_err(storage_err)?);
+    let first_new = read_surrogate_record(&mut ordinal_probe)?;
+    if first_new.is_some_and(|(id, _)| id <= prior_max) {
+        return Err(storage_err(
+            "v4 node surrogate is not monotonic or is reused",
+        ));
+    }
+    if deleted.iter().any(|id| {
+        !pinned.manifest.ordinal_ranges.iter().any(|range| {
+            range
+                .first_node_id
+                .checked_add(range.count.saturating_sub(1))
+                .is_some_and(|last| (range.first_node_id..=last).contains(id))
+        })
+    }) {
+        return Err(storage_err(
+            "v4 tombstone does not name retained ordinal authority",
+        ));
+    }
+
+    let mut writer = V4OrdinalConstructionWriter::start(generation, &artifacts)?;
+    let mut cancelled = || false;
+    let mut forward = BufReader::with_capacity(
+        BULK_IO_BYTES,
+        File::open(&uuid_sorted).map_err(storage_err)?,
+    );
+    while let Some((uuid, node_id)) = read_node_surrogate_record(&mut forward)? {
+        writer.push_forward(Uuid::from_bytes(uuid), node_id, &mut cancelled)?;
+    }
+    let mut ordinal = BufReader::with_capacity(
+        BULK_IO_BYTES,
+        File::open(&ordinal_sorted).map_err(storage_err)?,
+    );
+    while let Some((node_id, uuid)) = read_surrogate_record(&mut ordinal)? {
+        writer.push_ordinal(node_id, Uuid::from_bytes(uuid), &mut cancelled)?;
+    }
+    let (delta_manifest, build) = writer.finish()?;
+    let (tombstones, tombstone_bytes, tombstone_blocks) =
+        write_v4_tombstone_artifact(&artifacts, generation, &deleted)?;
+    crate::project_failpoint::hit(
+        "v4_append.after_delta_artifacts",
+        None,
+        None,
+        "V4_APPEND_ARTIFACTS",
+        false,
+    )?;
+
+    let mut manifest = pinned.manifest.clone();
+    manifest.topology_generation = generation;
+    manifest
+        .forward_identities
+        .extend(delta_manifest.forward_identities);
+    manifest
+        .ordinal_ranges
+        .extend(delta_manifest.ordinal_ranges);
+    manifest.tombstones.push(tombstones);
+    manifest
+        .ordinal_ranges
+        .sort_unstable_by_key(|range| range.first_node_id);
+
+    let mut created = manifest
+        .forward_identities
+        .iter()
+        .chain(manifest.ordinal_ranges.iter().map(|range| &range.artifact))
+        .chain(manifest.tombstones.iter().map(|run| &run.artifact))
+        .filter(|artifact| artifact.generation == generation)
+        .map(|artifact| (artifact.name.clone(), artifacts_path.join(&artifact.name)))
+        .collect::<HashMap<_, _>>();
+    let compaction = compact_v4_binary_carry(
+        pinned,
+        &artifacts,
+        &artifacts_path,
+        &mut manifest,
+        &mut created,
+    )?;
+    if compaction.compactions != 0 {
+        crate::project_failpoint::hit(
+            "v4_compaction.after_outputs",
+            None,
+            None,
+            "V4_COMPACTION_OUTPUTS",
+            false,
+        )?;
+    }
+    admit_v4_construction_manifest(&manifest)?;
+
+    let destination = project_dir.join(INDEX_DIR);
+    let retained_names = v4_manifest_artifact_names(&manifest);
+    let mut outputs = created
+        .into_iter()
+        .filter(|(name, _)| retained_names.contains(name))
+        .collect::<Vec<_>>();
+    outputs.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+    for (name, path) in &outputs {
+        batch.stage_file(&destination.join(name), path)?;
+    }
+    let manifest_bytes = serde_json::to_vec(&manifest).map_err(storage_err)?;
+    let receipt = TopologyIndexReceipt {
+        nonce: Uuid::new_v4().simple().to_string(),
+        expected_generation: generation,
+        topology_delta_sha256: topology_delta_sha256.to_owned(),
+        manifest_sha256: hex_sha256(&manifest_bytes),
+    };
+    let receipt_bytes = serde_json::to_vec(&receipt).map_err(storage_err)?;
+    let receipt_path = destination.join(V4_ORDINAL_RECEIPT);
+    let manifest_path = destination.join(V4_ORDINAL_MANIFEST);
+    batch.stage_bytes(&receipt_path, &receipt_bytes)?;
+    crate::project_failpoint::hit(
+        "v4_append.after_receipt_stage",
+        None,
+        None,
+        "V4_APPEND_RECEIPT",
+        false,
+    )?;
+    batch.stage_bytes(&manifest_path, &manifest_bytes)?;
+    batch.move_staged_destination_to_end(&manifest_path);
+    crate::project_failpoint::hit(
+        "v4_append.after_manifest_stage",
+        None,
+        None,
+        "V4_APPEND_MANIFEST",
+        false,
+    )?;
+
+    let prior_names = v4_manifest_artifact_names(&pinned.manifest);
+    let output_bytes = outputs.iter().try_fold(0_u64, |sum, (_, path)| {
+        sum.checked_add(path.metadata().map_err(storage_err)?.len())
+            .ok_or_else(|| storage_err("v4 output byte count overflow"))
+    })?;
+    let sorting_temporary_upper = u64::try_from(nodes.len())
+        .map_err(storage_err)?
+        .checked_mul(24 * 4)
+        .ok_or_else(|| storage_err("v4 sorting temporary byte count overflow"))?;
+    let external_peak_buffer = build_metrics
+        .peak_buffered_records
+        .checked_mul(24)
+        .ok_or_else(|| storage_err("v4 external-sort buffer charge overflow"))?;
+    let metrics = V4OrdinalAppendMetrics {
+        input_identities: u64::try_from(nodes.len()).map_err(storage_err)?,
+        input_tombstones: u64::try_from(deleted.len()).map_err(storage_err)?,
+        created_artifacts: u64::try_from(outputs.len()).map_err(storage_err)?,
+        retained_artifacts: u64::try_from(retained_names.intersection(&prior_names).count())
+            .map_err(storage_err)?,
+        physical_bytes_written: output_bytes
+            .checked_add(
+                u64::try_from(receipt_bytes.len() + manifest_bytes.len()).map_err(storage_err)?,
+            )
+            .ok_or_else(|| storage_err("v4 publication byte count overflow"))?,
+        compactions: compaction.compactions,
+        sequential_read_bytes: compaction.read_bytes,
+        sequential_read_calls: compaction.read_calls,
+        write_blocks: output_bytes.div_ceil(V4_ORDINAL_BLOCK_BYTES as u64),
+        peak_buffer_bytes: build
+            .peak_buffer_bytes
+            .max(V4_ORDINAL_BLOCK_BYTES * 3)
+            .max(external_peak_buffer),
+        peak_temporary_bytes: build
+            .peak_temporary_bytes
+            .saturating_add(tombstone_bytes)
+            .saturating_add(compaction.write_bytes)
+            .saturating_add(sorting_temporary_upper),
+        fsync_operations: build
+            .fsync_operations
+            .saturating_add(tombstone_blocks)
+            .saturating_add(compaction.fsync_operations),
+        ..Default::default()
+    };
+    Ok(PreparedV4OrdinalDelta {
+        expected_generation: generation,
+        auxiliary: crate::AuxiliaryReceipt {
+            kind: "uuid-membership/v4".to_owned(),
+            schema_version: crate::ORDINAL_IDENTITY_V4,
+            path: format!("{INDEX_DIR}/{V4_ORDINAL_RECEIPT}"),
+            digest: hex_sha256(&receipt_bytes),
+            bytes: u64::try_from(receipt_bytes.len()).map_err(storage_err)?,
+        },
+        metrics,
+        manifest,
+    })
+}
+
+fn external_sort_v4_nodes(
+    nodes: &[(Uuid, u64)],
+    scratch: &Path,
+    metrics: &mut UuidIndexBuildMetrics,
+) -> Result<PathBuf, GfError> {
+    let limits = UuidIndexBuildLimits::default();
+    let mut runs = Vec::new();
+    let mut buffer = Vec::with_capacity(limits.run_records);
+    for &(uuid, node_id) in nodes {
+        if uuid.is_nil() || node_id == 0 {
+            return Err(storage_err("v4 node delta contains a zero identity"));
+        }
+        buffer.push((*uuid.as_bytes(), node_id));
+        metrics.peak_buffered_records = metrics.peak_buffered_records.max(buffer.len());
+        if buffer.len() == limits.run_records {
+            flush_entity_surrogate_run(&mut buffer, scratch, "v4-delta", &mut runs, metrics)?;
+        }
+    }
+    if !buffer.is_empty() {
+        flush_entity_surrogate_run(&mut buffer, scratch, "v4-delta", &mut runs, metrics)?;
+    }
+    if runs.is_empty() {
+        let path = scratch.join("v4-delta-empty.run");
+        File::create(&path)
+            .and_then(|file| file.sync_all())
+            .map_err(storage_err)?;
+        runs.push(path);
+    }
+    merge_node_surrogate_runs(runs, scratch, limits.merge_fan_in, metrics)
+}
+
+fn write_v4_tombstone_artifact(
+    index: &graphforge_filesystem::StableDirectory,
+    generation: u64,
+    ids: &[u64],
+) -> Result<(crate::V4OrdinalTombstones, u64, u64), GfError> {
+    let mut writer = V4TombstoneStreamWriter::new(index, generation)?;
+    for &id in ids {
+        writer.push(id)?;
+    }
+    writer.finish()
+}
+
+struct V4TombstoneStreamWriter<'a> {
+    index: &'a graphforge_filesystem::StableDirectory,
+    generation: u64,
+    artifact: StreamingV4Artifact,
+    blocks: Vec<crate::V4OrdinalTombstoneBlock>,
+    block: Vec<u8>,
+    offset: u64,
+    previous: Option<u64>,
+}
+
+impl<'a> V4TombstoneStreamWriter<'a> {
+    fn new(
+        index: &'a graphforge_filesystem::StableDirectory,
+        generation: u64,
+    ) -> Result<Self, GfError> {
+        Ok(Self {
+            index,
+            generation,
+            artifact: StreamingV4Artifact::create(index, "tombstones-delta")?,
+            blocks: Vec::new(),
+            block: Vec::with_capacity(V4_ORDINAL_BLOCK_BYTES),
+            offset: 0,
+            previous: None,
+        })
+    }
+
+    fn push(&mut self, id: u64) -> Result<(), GfError> {
+        if id == 0 || self.previous.is_some_and(|previous| previous >= id) {
+            return Err(storage_err(
+                "v4 tombstone stream is not strictly increasing",
+            ));
+        }
+        self.block.extend_from_slice(&id.to_be_bytes());
+        self.previous = Some(id);
+        if self.block.len() == V4_ORDINAL_BLOCK_BYTES {
+            finish_v4_tombstone_block(
+                &mut self.artifact,
+                &mut self.blocks,
+                &mut self.block,
+                &mut self.offset,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn finish(mut self) -> Result<(crate::V4OrdinalTombstones, u64, u64), GfError> {
+        finish_v4_tombstone_block(
+            &mut self.artifact,
+            &mut self.blocks,
+            &mut self.block,
+            &mut self.offset,
+        )?;
+        let byte_count = self.artifact.bytes;
+        let mut metrics = V4OrdinalBuildMetrics::default();
+        let artifact = finish_streamed_v4_artifact(
+            self.artifact,
+            self.index,
+            "tombstones-v4",
+            self.generation,
+            crate::V4OrdinalArtifactKind::NodeTombstones,
+            &mut metrics,
+        )?;
+        Ok((
+            crate::V4OrdinalTombstones {
+                generation: self.generation,
+                artifact,
+                blocks: self.blocks,
+            },
+            byte_count,
+            metrics.fsync_operations,
+        ))
+    }
+}
+
+fn finish_v4_tombstone_block(
+    writer: &mut StreamingV4Artifact,
+    blocks: &mut Vec<crate::V4OrdinalTombstoneBlock>,
+    bytes: &mut Vec<u8>,
+    offset: &mut u64,
+) -> Result<(), GfError> {
+    if bytes.is_empty() {
+        return Ok(());
+    }
+    let first = u64::from_be_bytes(bytes[..8].try_into().expect("fixed tombstone"));
+    let last = u64::from_be_bytes(
+        bytes[bytes.len() - 8..]
+            .try_into()
+            .expect("fixed tombstone"),
+    );
+    blocks.push(crate::V4OrdinalTombstoneBlock {
+        offset: *offset,
+        count: u64::try_from(bytes.len() / 8).map_err(storage_err)?,
+        first,
+        last,
+        sha256: hex_sha256(bytes),
+    });
+    writer.push(bytes)?;
+    *offset = offset
+        .checked_add(u64::try_from(bytes.len()).map_err(storage_err)?)
+        .ok_or_else(|| storage_err("v4 tombstone offset overflow"))?;
+    bytes.clear();
+    Ok(())
+}
+
+fn v4_manifest_artifact_names(manifest: &crate::V4OrdinalIdentityManifest) -> BTreeSet<String> {
+    manifest
+        .forward_identities
+        .iter()
+        .chain(manifest.ordinal_ranges.iter().map(|range| &range.artifact))
+        .chain(manifest.tombstones.iter().map(|run| &run.artifact))
+        .map(|artifact| artifact.name.clone())
+        .collect()
+}
+
+#[derive(Default)]
+struct V4CompactionWork {
+    compactions: u64,
+    read_bytes: u64,
+    read_calls: u64,
+    write_bytes: u64,
+    write_blocks: u64,
+    fsync_operations: u64,
+}
+
+fn compact_v4_binary_carry(
+    pinned: &crate::ordinal_identity_v4::V4OrdinalPinnedUpdateInputs,
+    artifacts: &graphforge_filesystem::StableDirectory,
+    artifacts_path: &Path,
+    manifest: &mut crate::V4OrdinalIdentityManifest,
+    created: &mut HashMap<String, PathBuf>,
+) -> Result<V4CompactionWork, GfError> {
+    let mut work = V4CompactionWork::default();
+    loop {
+        let intervals = v4_forward_intervals(&manifest.forward_identities)?;
+        if intervals.len() < 3 {
+            break;
+        }
+        let left = intervals[intervals.len() - 2];
+        let right = intervals[intervals.len() - 1];
+        if left.1 - left.0 != right.1 - right.0 {
+            break;
+        }
+        let left_descriptor = manifest.forward_identities[left.2].clone();
+        let right_descriptor = manifest.forward_identities[right.2].clone();
+        let merged_forward = merge_v4_forward_artifacts(
+            v4_planned_file(pinned, created, &left_descriptor.name)?,
+            v4_planned_file(pinned, created, &right_descriptor.name)?,
+            artifacts,
+            right.1,
+            &mut work,
+        )?;
+        created.insert(
+            merged_forward.name.clone(),
+            artifacts_path.join(&merged_forward.name),
+        );
+        manifest
+            .forward_identities
+            .splice(left.2..=right.2, std::iter::once(merged_forward));
+
+        compact_v4_ordinal_interval(
+            pinned,
+            artifacts,
+            artifacts_path,
+            manifest,
+            created,
+            left.0,
+            right.1,
+            &mut work,
+        )?;
+        compact_v4_tombstone_interval(
+            pinned,
+            artifacts,
+            artifacts_path,
+            manifest,
+            created,
+            left.0,
+            right.1,
+            &mut work,
+        )?;
+        work.compactions = work.compactions.saturating_add(1);
+    }
+    Ok(work)
+}
+
+/// Return `(first_generation, last_generation, descriptor_index)`. The first
+/// artifact is the immutable construction base. Every later retained forward
+/// run closes one contiguous delta interval, so binary-carry level is encoded
+/// without expanding the public manifest schema.
+fn v4_forward_intervals(
+    forwards: &[crate::V4OrdinalArtifact],
+) -> Result<Vec<(u64, u64, usize)>, GfError> {
+    let Some(base_generation) = forwards.first().map(|artifact| artifact.generation) else {
+        return Err(storage_err("v4 forward base generation is invalid"));
+    };
+    let mut intervals = vec![(1, base_generation, 0)];
+    let mut prior = base_generation;
+    for (index, artifact) in forwards.iter().enumerate().skip(1) {
+        let first = prior
+            .checked_add(1)
+            .ok_or_else(|| storage_err("v4 forward interval overflows"))?;
+        if artifact.generation < first {
+            return Err(storage_err("v4 forward generations do not increase"));
+        }
+        intervals.push((first, artifact.generation, index));
+        prior = artifact.generation;
+    }
+    Ok(intervals)
+}
+
+fn v4_planned_file(
+    pinned: &crate::ordinal_identity_v4::V4OrdinalPinnedUpdateInputs,
+    created: &HashMap<String, PathBuf>,
+    name: &str,
+) -> Result<File, GfError> {
+    created.get(name).map_or_else(
+        || clone_pinned_v4_file(pinned, name),
+        |path| File::open(path).map_err(storage_err),
+    )
+}
+
+fn read_v4_forward_record(reader: &mut impl Read) -> Result<Option<([u8; 16], u64)>, GfError> {
+    let Some(record) = read_exact_record::<24>(reader)? else {
+        return Ok(None);
+    };
+    Ok(Some((
+        record[..16].try_into().expect("fixed UUID"),
+        u64::from_be_bytes(record[16..].try_into().expect("fixed surrogate")),
+    )))
+}
+
+fn merge_v4_forward_artifacts(
+    left: File,
+    right: File,
+    index: &graphforge_filesystem::StableDirectory,
+    generation: u64,
+    work: &mut V4CompactionWork,
+) -> Result<crate::V4OrdinalArtifact, GfError> {
+    let mut readers = [
+        BufReader::with_capacity(V4_ORDINAL_BLOCK_BYTES, left),
+        BufReader::with_capacity(V4_ORDINAL_BLOCK_BYTES, right),
+    ];
+    let mut heads = [
+        read_v4_forward_record(&mut readers[0])?,
+        read_v4_forward_record(&mut readers[1])?,
+    ];
+    let mut writer = StreamingV4Artifact::create(index, "forward-compact")?;
+    let mut previous = None;
+    loop {
+        let source = match (heads[0], heads[1]) {
+            (None, None) => break,
+            (Some(_), None) => 0,
+            (None, Some(_)) => 1,
+            (Some(left), Some(right)) => usize::from(left.0 >= right.0),
+        };
+        let record = heads[source].expect("selected head");
+        if heads[0].is_some_and(|candidate| candidate.0 == record.0)
+            && heads[1].is_some_and(|candidate| candidate.0 == record.0)
+        {
+            let newer = heads[1].expect("right duplicate");
+            heads[0] = read_v4_forward_record(&mut readers[0])?;
+            heads[1] = read_v4_forward_record(&mut readers[1])?;
+            if record.1 != newer.1 {
+                return Err(storage_err("v4 compaction observed UUID reuse"));
+            }
+            write_v4_forward_record(&mut writer, newer)?;
+            previous = Some(newer.0);
+            continue;
+        }
+        if previous.is_some_and(|uuid| uuid >= record.0) {
+            return Err(storage_err("v4 compaction input is not sorted unique"));
+        }
+        write_v4_forward_record(&mut writer, record)?;
+        previous = Some(record.0);
+        heads[source] = read_v4_forward_record(&mut readers[source])?;
+    }
+    let input_bytes = readers
+        .iter()
+        .map(|reader| {
+            reader
+                .get_ref()
+                .metadata()
+                .map_or(0, |metadata| metadata.len())
+        })
+        .sum::<u64>();
+    work.read_bytes = work.read_bytes.saturating_add(input_bytes);
+    work.read_calls = work
+        .read_calls
+        .saturating_add(input_bytes.div_ceil(V4_ORDINAL_BLOCK_BYTES as u64));
+    let bytes = writer.bytes;
+    let mut metrics = V4OrdinalBuildMetrics::default();
+    let artifact = finish_streamed_v4_artifact(
+        writer,
+        index,
+        "forward-v4",
+        generation,
+        crate::V4OrdinalArtifactKind::ForwardIdentities,
+        &mut metrics,
+    )?;
+    work.write_bytes = work.write_bytes.saturating_add(bytes);
+    work.write_blocks = work
+        .write_blocks
+        .saturating_add(bytes.div_ceil(V4_ORDINAL_BLOCK_BYTES as u64));
+    work.fsync_operations = work
+        .fsync_operations
+        .saturating_add(metrics.fsync_operations);
+    Ok(artifact)
+}
+
+fn write_v4_forward_record(
+    writer: &mut StreamingV4Artifact,
+    (uuid, node_id): ([u8; 16], u64),
+) -> Result<(), GfError> {
+    writer.push(&uuid)?;
+    writer.push(&node_id.to_be_bytes())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn compact_v4_ordinal_interval(
+    pinned: &crate::ordinal_identity_v4::V4OrdinalPinnedUpdateInputs,
+    index: &graphforge_filesystem::StableDirectory,
+    artifacts_path: &Path,
+    manifest: &mut crate::V4OrdinalIdentityManifest,
+    created: &mut HashMap<String, PathBuf>,
+    first_generation: u64,
+    last_generation: u64,
+    work: &mut V4CompactionWork,
+) -> Result<(), GfError> {
+    let mut replacement = Vec::new();
+    let mut cursor = 0;
+    while cursor < manifest.ordinal_ranges.len() {
+        let range = &manifest.ordinal_ranges[cursor];
+        if !(first_generation..=last_generation).contains(&range.artifact.generation) {
+            replacement.push(range.clone());
+            cursor += 1;
+            continue;
+        }
+        let start = cursor;
+        let mut end = cursor + 1;
+        let mut prior_end = range
+            .first_node_id
+            .checked_add(range.count - 1)
+            .ok_or_else(|| storage_err("v4 ordinal range overflows"))?;
+        while end < manifest.ordinal_ranges.len() {
+            let next = &manifest.ordinal_ranges[end];
+            if !(first_generation..=last_generation).contains(&next.artifact.generation)
+                || prior_end.checked_add(1) != Some(next.first_node_id)
+            {
+                break;
+            }
+            prior_end = next
+                .first_node_id
+                .checked_add(next.count - 1)
+                .ok_or_else(|| storage_err("v4 ordinal range overflows"))?;
+            end += 1;
+        }
+        if end - start == 1 {
+            replacement.push(manifest.ordinal_ranges[start].clone());
+        } else {
+            let mut writer = V4OrdinalRangeWriter::new(
+                index,
+                replacement.len(),
+                manifest.ordinal_ranges[start].first_node_id,
+            )?;
+            for source in &manifest.ordinal_ranges[start..end] {
+                let mut file = BufReader::with_capacity(
+                    V4_ORDINAL_BLOCK_BYTES,
+                    v4_planned_file(pinned, created, &source.artifact.name)?,
+                );
+                while let Some(uuid) = read_exact_record::<16>(&mut file)? {
+                    writer.push(uuid)?;
+                }
+                work.read_bytes = work.read_bytes.saturating_add(source.artifact.bytes);
+                work.read_calls = work.read_calls.saturating_add(
+                    source
+                        .artifact
+                        .bytes
+                        .div_ceil(V4_ORDINAL_BLOCK_BYTES as u64),
+                );
+            }
+            let mut ranges = Vec::new();
+            let mut metrics = V4OrdinalBuildMetrics::default();
+            finish_streamed_v4_range(index, last_generation, writer, &mut ranges, &mut metrics)?;
+            let merged = ranges.pop().expect("one merged range");
+            created.insert(
+                merged.artifact.name.clone(),
+                artifacts_path.join(&merged.artifact.name),
+            );
+            work.write_bytes = work.write_bytes.saturating_add(merged.artifact.bytes);
+            work.write_blocks = work.write_blocks.saturating_add(
+                merged
+                    .artifact
+                    .bytes
+                    .div_ceil(V4_ORDINAL_BLOCK_BYTES as u64),
+            );
+            work.fsync_operations = work
+                .fsync_operations
+                .saturating_add(metrics.fsync_operations);
+            replacement.push(merged);
+        }
+        cursor = end;
+    }
+    manifest.ordinal_ranges = replacement;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn compact_v4_tombstone_interval(
+    pinned: &crate::ordinal_identity_v4::V4OrdinalPinnedUpdateInputs,
+    index: &graphforge_filesystem::StableDirectory,
+    artifacts_path: &Path,
+    manifest: &mut crate::V4OrdinalIdentityManifest,
+    created: &mut HashMap<String, PathBuf>,
+    first_generation: u64,
+    last_generation: u64,
+    work: &mut V4CompactionWork,
+) -> Result<(), GfError> {
+    let selected = manifest
+        .tombstones
+        .iter()
+        .filter(|run| (first_generation..=last_generation).contains(&run.generation))
+        .cloned()
+        .collect::<Vec<_>>();
+    if selected.len() < 2 {
+        return Ok(());
+    }
+    let mut readers = selected
+        .iter()
+        .map(|run| {
+            v4_planned_file(pinned, created, &run.artifact.name)
+                .map(|file| BufReader::with_capacity(V4_ORDINAL_BLOCK_BYTES, file))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut heap = BinaryHeap::<Reverse<(u64, usize)>>::new();
+    for (source, reader) in readers.iter_mut().enumerate() {
+        if let Some(bytes) = read_exact_record::<8>(reader)? {
+            heap.push(Reverse((u64::from_be_bytes(bytes), source)));
+        }
+    }
+    let mut merged = V4TombstoneStreamWriter::new(index, last_generation)?;
+    let mut previous = None;
+    while let Some(Reverse((id, source))) = heap.pop() {
+        if previous != Some(id) {
+            merged.push(id)?;
+            previous = Some(id);
+        }
+        if let Some(bytes) = read_exact_record::<8>(&mut readers[source])? {
+            heap.push(Reverse((u64::from_be_bytes(bytes), source)));
+        }
+    }
+    let (run, bytes, fsyncs) = merged.finish()?;
+    created.insert(
+        run.artifact.name.clone(),
+        artifacts_path.join(&run.artifact.name),
+    );
+    manifest
+        .tombstones
+        .retain(|candidate| !(first_generation..=last_generation).contains(&candidate.generation));
+    manifest.tombstones.push(run);
+    manifest
+        .tombstones
+        .sort_unstable_by_key(|run| run.generation);
+    work.read_bytes = work
+        .read_bytes
+        .saturating_add(selected.iter().map(|run| run.artifact.bytes).sum::<u64>());
+    work.read_calls = work.read_calls.saturating_add(
+        selected
+            .iter()
+            .map(|run| run.artifact.bytes.div_ceil(V4_ORDINAL_BLOCK_BYTES as u64))
+            .sum::<u64>(),
+    );
+    work.write_bytes = work.write_bytes.saturating_add(bytes);
+    work.write_blocks = work
+        .write_blocks
+        .saturating_add(bytes.div_ceil(V4_ORDINAL_BLOCK_BYTES as u64));
+    work.fsync_operations = work.fsync_operations.saturating_add(fsyncs);
+    Ok(())
+}
+
 /// Explicit bounded rebuild/migration path. Immutable data files are completed
 /// and synced first; `manifest.json` is atomically replaced last.
 pub fn rebuild_uuid_membership_indexes(
@@ -7137,6 +8206,251 @@ pub(crate) mod tests {
     use parquet::arrow::ArrowWriter;
 
     use super::*;
+
+    fn pinned_v4_update(
+        root: &Path,
+        manifest: crate::V4OrdinalIdentityManifest,
+    ) -> crate::ordinal_identity_v4::V4OrdinalPinnedUpdateInputs {
+        let index = root.join(INDEX_DIR);
+        let artifacts = manifest
+            .forward_identities
+            .iter()
+            .chain(manifest.ordinal_ranges.iter().map(|range| &range.artifact))
+            .chain(manifest.tombstones.iter().map(|run| &run.artifact))
+            .map(
+                |descriptor| crate::ordinal_identity_v4::PinnedV4OrdinalArtifact {
+                    descriptor: descriptor.clone(),
+                    file: File::open(index.join(&descriptor.name)).unwrap(),
+                },
+            )
+            .collect();
+        crate::ordinal_identity_v4::V4OrdinalPinnedUpdateInputs {
+            manifest,
+            artifacts,
+        }
+    }
+
+    fn install_v4_plan(batch: &crate::staging::RewriteBatch) {
+        let destinations = batch
+            .staged_paths()
+            .map(Path::to_path_buf)
+            .collect::<Vec<_>>();
+        for destination in destinations {
+            let temporary = batch.staged_temp(&destination).unwrap();
+            fs::copy(temporary, &destination).unwrap();
+        }
+    }
+
+    #[test]
+    fn v4_delta_append_delete_binary_carry_reopens_without_resurrection() {
+        let root = tempfile::tempdir().unwrap();
+        let index_path = root.path().join(INDEX_DIR);
+        fs::create_dir_all(&index_path).unwrap();
+        let index = graphforge_filesystem::StableDirectory::open(&index_path).unwrap();
+        let (base, _) = stage_v4_ordinal_artifacts(
+            [(Uuid::from_u128(1), 1_u64), (Uuid::from_u128(2), 2_u64)],
+            1,
+            &index,
+            || false,
+        )
+        .unwrap();
+        fs::write(
+            index_path.join(V4_ORDINAL_MANIFEST),
+            serde_json::to_vec(&base).unwrap(),
+        )
+        .unwrap();
+        fs::write(index_path.join("ordinal-v4.lock"), []).unwrap();
+
+        let pinned = pinned_v4_update(root.path(), base);
+        let mut second = crate::staging::RewriteBatch::new();
+        let planned_second = prepare_v4_ordinal_delta(
+            root.path(),
+            1,
+            2,
+            &pinned,
+            &mut second,
+            &[(Uuid::from_u128(3), 3_u64), (Uuid::from_u128(4), 4_u64)],
+            &[1],
+            &"11".repeat(32),
+        )
+        .unwrap();
+        assert_eq!(planned_second.metrics.input_identities, 2);
+        assert_eq!(planned_second.metrics.input_tombstones, 1);
+        assert_eq!(planned_second.metrics.prior_topology_rows_decoded, 0);
+        assert_eq!(planned_second.metrics.per_record_seeks, 0);
+        assert_eq!(planned_second.metrics.compactions, 0);
+        install_v4_plan(&second);
+
+        let pinned = pinned_v4_update(root.path(), planned_second.manifest);
+        let mut third = crate::staging::RewriteBatch::new();
+        let planned_third = prepare_v4_ordinal_delta(
+            root.path(),
+            2,
+            3,
+            &pinned,
+            &mut third,
+            &[(Uuid::from_u128(5), 5_u64)],
+            &[2],
+            &"22".repeat(32),
+        )
+        .unwrap();
+        assert_eq!(planned_third.metrics.compactions, 1);
+        assert_eq!(planned_third.manifest.forward_identities.len(), 2);
+        assert_eq!(planned_third.manifest.ordinal_ranges.len(), 2);
+        assert_eq!(planned_third.manifest.tombstones.len(), 2);
+        assert!(planned_third.metrics.peak_buffer_bytes <= V4_ORDINAL_BLOCK_BYTES * 3);
+        install_v4_plan(&third);
+
+        let manifest_bytes = serde_json::to_vec(&planned_third.manifest).unwrap();
+        fs::write(index_path.join(V4_ORDINAL_MANIFEST), &manifest_bytes).unwrap();
+        let authority = crate::ordinal_identity_v4::V4OrdinalIdentityAuthority {
+            topology_generation: 3,
+            manifest_sha256: hex_sha256(&manifest_bytes),
+        };
+        let mut handle = match crate::ordinal_identity_v4::V4OrdinalIdentityHandle::open(
+            root.path(),
+            &authority,
+            crate::V4OrdinalIdentityLimits::default(),
+        )
+        .unwrap()
+        {
+            crate::V4OrdinalIdentityOpen::Ready(handle) => handle,
+            crate::V4OrdinalIdentityOpen::RebuildRequired { .. } => panic!("v4 expected"),
+        };
+        let lookup = handle.lookup_node_uuids(&[1, 2, 3, 4, 5]).unwrap();
+        assert_eq!(
+            lookup.values,
+            vec![
+                None,
+                None,
+                Some(Uuid::from_u128(3)),
+                Some(Uuid::from_u128(4)),
+                Some(Uuid::from_u128(5)),
+            ]
+        );
+    }
+
+    #[test]
+    fn v4_delta_rejects_reuse_and_invalid_tombstones_before_staging() {
+        let root = tempfile::tempdir().unwrap();
+        let index_path = root.path().join(INDEX_DIR);
+        fs::create_dir_all(&index_path).unwrap();
+        let index = graphforge_filesystem::StableDirectory::open(&index_path).unwrap();
+        let (base, _) =
+            stage_v4_ordinal_artifacts([(Uuid::from_u128(1), 7_u64)], 1, &index, || false).unwrap();
+        let pinned = pinned_v4_update(root.path(), base);
+
+        for (nodes, tombstones) in [
+            (vec![(Uuid::from_u128(2), 7_u64)], vec![]),
+            (vec![(Uuid::from_u128(2), 8_u64)], vec![0]),
+            (vec![(Uuid::from_u128(2), 8_u64)], vec![99]),
+            (
+                vec![(Uuid::from_u128(2), 8_u64), (Uuid::from_u128(2), 9_u64)],
+                vec![],
+            ),
+        ] {
+            let mut batch = crate::staging::RewriteBatch::new();
+            assert!(
+                prepare_v4_ordinal_delta(
+                    root.path(),
+                    1,
+                    2,
+                    &pinned,
+                    &mut batch,
+                    &nodes,
+                    &tombstones,
+                    &"33".repeat(32),
+                )
+                .is_err()
+            );
+            assert!(batch.is_empty());
+        }
+    }
+
+    #[test]
+    fn v4_delta_one_two_four_history_is_bounded_and_binary_carried() {
+        let root = tempfile::tempdir().unwrap();
+        let index_path = root.path().join(INDEX_DIR);
+        fs::create_dir_all(&index_path).unwrap();
+        let index = graphforge_filesystem::StableDirectory::open(&index_path).unwrap();
+        let (mut manifest, _) =
+            stage_v4_ordinal_artifacts([(Uuid::from_u128(1), 1_u64)], 1, &index, || false).unwrap();
+        let mut observed = Vec::new();
+        for generation in 2..=5_u64 {
+            let pinned = pinned_v4_update(root.path(), manifest);
+            let mut batch = crate::staging::RewriteBatch::new();
+            let planned = prepare_v4_ordinal_delta(
+                root.path(),
+                generation - 1,
+                generation,
+                &pinned,
+                &mut batch,
+                &[(Uuid::from_u128(u128::from(generation)), generation)],
+                &[],
+                &"44".repeat(32),
+            )
+            .unwrap();
+            assert_eq!(planned.metrics.prior_topology_rows_decoded, 0);
+            assert_eq!(planned.metrics.per_record_seeks, 0);
+            assert!(planned.metrics.peak_buffer_bytes <= V4_ORDINAL_BLOCK_BYTES * 3);
+            observed.push((
+                planned.metrics.compactions,
+                planned.metrics.physical_bytes_written,
+                planned.manifest.forward_identities.len(),
+            ));
+            install_v4_plan(&batch);
+            manifest = planned.manifest;
+        }
+        assert_eq!(
+            observed.iter().map(|row| row.0).collect::<Vec<_>>(),
+            [0, 1, 0, 2]
+        );
+        assert_eq!(manifest.forward_identities.len(), 2);
+        assert_eq!(manifest.ordinal_ranges.len(), 2);
+        assert!(observed.iter().all(|row| row.1 != 0));
+    }
+
+    #[test]
+    fn standalone_existing_v4_advances_with_topology_transaction() {
+        let (dir, _, _) = fixture();
+        fs::write(
+            dir.path().join("topology/generation.json"),
+            b"{\"topology_generation\":7,\"search_generation\":0,\"property_generation\":0}\n",
+        )
+        .unwrap();
+        rebuild_uuid_membership_indexes(dir.path(), UuidIndexBuildLimits::default()).unwrap();
+        rebuild_v4_ordinal_identity(dir.path(), UuidIndexBuildLimits::default()).unwrap();
+        let topology = dir.path().join("topology/nodes.parquet");
+        let mut staged = crate::staging::RewriteBatch::new();
+        staged.stage_file(&topology, &topology).unwrap();
+        let mut snapshot = None;
+        let committed = commit_uuid_topology_rewrite(
+            dir.path(),
+            staged,
+            &UuidTopologyDelta {
+                nodes: Vec::new(),
+                edges: Vec::new(),
+                deleted_nodes: Vec::new(),
+                deleted_edges: Vec::new(),
+            },
+            &mut snapshot,
+        )
+        .unwrap();
+        assert!(matches!(
+            committed,
+            CommittedUuidTopologyRewrite::Committed { generation: 8, .. }
+        ));
+        let manifest: crate::V4OrdinalIdentityManifest = serde_json::from_slice(
+            &fs::read(dir.path().join(INDEX_DIR).join(V4_ORDINAL_MANIFEST)).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(manifest.topology_generation, 8);
+        assert!(
+            standalone_v4_pinned_update(dir.path(), 8)
+                .unwrap()
+                .is_some()
+        );
+    }
 
     #[test]
     fn shared_v4_builder_rejects_sparse_manifest_above_reader_bound() {

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -142,43 +142,43 @@ pub(crate) struct V4OrdinalBuildMetrics {
 
 /// Aggregate-only work evidence for one incremental v4 publication.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct V4OrdinalAppendMetrics {
+pub(crate) struct V4OrdinalAppendMetrics {
     /// New UUID-to-surrogate mappings accepted by this publication.
-    pub input_identities: u64,
+    pub(crate) input_identities: u64,
     /// Sorted unique deletion overrides accepted by this publication.
-    pub input_tombstones: u64,
+    pub(crate) input_tombstones: u64,
     /// Canonical topology rows decoded from the prior generation. Always zero.
-    pub prior_topology_rows_decoded: u64,
+    pub(crate) prior_topology_rows_decoded: u64,
     /// Immutable artifacts created, including deterministic compaction outputs.
-    pub created_artifacts: u64,
+    pub(crate) created_artifacts: u64,
     /// Prior immutable artifacts retained without rewriting.
-    pub retained_artifacts: u64,
+    pub(crate) retained_artifacts: u64,
     /// Binary-carry compactions completed.
-    pub compactions: u64,
+    pub(crate) compactions: u64,
     /// Exact authenticated input bytes read by compaction.
-    pub sequential_read_bytes: u64,
+    pub(crate) sequential_read_bytes: u64,
     /// Bounded sequential input calls made by compaction.
-    pub sequential_read_calls: u64,
+    pub(crate) sequential_read_calls: u64,
     /// Exact artifact and control bytes written.
-    pub physical_bytes_written: u64,
+    pub(crate) physical_bytes_written: u64,
     /// Bounded output blocks submitted.
-    pub write_blocks: u64,
+    pub(crate) write_blocks: u64,
     /// Largest anonymous writer buffer.
-    pub peak_buffer_bytes: usize,
+    pub(crate) peak_buffer_bytes: usize,
     /// Maximum coexisting scratch output bytes.
-    pub peak_temporary_bytes: u64,
+    pub(crate) peak_temporary_bytes: u64,
     /// Durable file flushes completed while constructing outputs.
-    pub fsync_operations: u64,
+    pub(crate) fsync_operations: u64,
     /// Per-record filesystem seeks are forbidden.
-    pub per_record_seeks: u64,
+    pub(crate) per_record_seeks: u64,
     /// Unreferenced v4 candidates examined after publication.
-    pub orphan_gc_candidates: u64,
+    pub(crate) orphan_gc_candidates: u64,
     /// Unreferenced v4 artifacts removed by retained identity.
-    pub orphan_gc_removed: u64,
+    pub(crate) orphan_gc_removed: u64,
     /// Candidates conservatively deferred.
-    pub orphan_gc_deferred: u64,
+    pub(crate) orphan_gc_deferred: u64,
     /// Physical orphan bytes reclaimed.
-    pub orphan_gc_bytes: u64,
+    pub(crate) orphan_gc_bytes: u64,
 }
 
 fn clone_pinned_v4_file(

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -4416,7 +4416,7 @@ pub(crate) fn commit_uuid_topology_rewrite(
             let receipt = token
                 .as_ref()
                 .map(PreparedUuidIndexDelta::auxiliary_receipt);
-            let prepared_ordinal = ordinal_inputs
+            let mut prepared_ordinal = ordinal_inputs
                 .as_ref()
                 .map(|pinned| {
                     let deleted_node_ids = deleted_nodes
@@ -4440,6 +4440,12 @@ pub(crate) fn commit_uuid_topology_rewrite(
                     )
                 })
                 .transpose()?;
+            if let Some(token) = prepared_ordinal.as_mut() {
+                token.metrics.orphan_gc_candidates = orphan_gc.candidates;
+                token.metrics.orphan_gc_removed = orphan_gc.removed;
+                token.metrics.orphan_gc_deferred = orphan_gc.deferred;
+                token.metrics.orphan_gc_bytes = orphan_gc.bytes;
+            }
             let receipt = prepared_ordinal
                 .as_ref()
                 .map(PreparedV4OrdinalDelta::auxiliary_receipt)
@@ -6194,10 +6200,12 @@ pub(crate) fn prepare_v4_ordinal_delta(
     let parent = project_dir
         .parent()
         .ok_or_else(|| storage_err("project directory has no staging parent"))?;
+    cleanup_abandoned_v4_plan_directories(project_dir, parent)?;
     let scratch = tempfile::Builder::new()
         .prefix("uuid-membership-v4-plan-")
         .tempdir_in(parent)
         .map_err(storage_err)?;
+    initialize_v4_plan_directory(project_dir, scratch.path())?;
     let artifacts_path = scratch.path().join("artifacts");
     fs::create_dir(&artifacts_path).map_err(storage_err)?;
     let artifacts =
@@ -6205,6 +6213,7 @@ pub(crate) fn prepare_v4_ordinal_delta(
 
     let mut build_metrics = UuidIndexBuildMetrics::default();
     let uuid_sorted = external_sort_v4_nodes(nodes, scratch.path(), &mut build_metrics)?;
+    reject_prior_v4_uuid_reuse(pinned, &uuid_sorted)?;
     let ordinal_sorted = build_surrogate_run(
         &uuid_sorted,
         scratch.path(),
@@ -6299,6 +6308,7 @@ pub(crate) fn prepare_v4_ordinal_delta(
         .filter(|artifact| artifact.generation == generation)
         .map(|artifact| (artifact.name.clone(), artifacts_path.join(&artifact.name)))
         .collect::<HashMap<_, _>>();
+    let delta_created_artifacts = u64::try_from(created.len()).map_err(storage_err)?;
     let compaction = compact_v4_binary_carry(
         pinned,
         &artifacts,
@@ -6356,10 +6366,6 @@ pub(crate) fn prepare_v4_ordinal_delta(
     )?;
 
     let prior_names = v4_manifest_artifact_names(&pinned.manifest);
-    let output_bytes = outputs.iter().try_fold(0_u64, |sum, (_, path)| {
-        sum.checked_add(path.metadata().map_err(storage_err)?.len())
-            .ok_or_else(|| storage_err("v4 output byte count overflow"))
-    })?;
     let sorting_temporary_upper = u64::try_from(nodes.len())
         .map_err(storage_err)?
         .checked_mul(24 * 4)
@@ -6371,10 +6377,13 @@ pub(crate) fn prepare_v4_ordinal_delta(
     let metrics = V4OrdinalAppendMetrics {
         input_identities: u64::try_from(nodes.len()).map_err(storage_err)?,
         input_tombstones: u64::try_from(deleted.len()).map_err(storage_err)?,
-        created_artifacts: u64::try_from(outputs.len()).map_err(storage_err)?,
+        created_artifacts: delta_created_artifacts.saturating_add(compaction.created_artifacts),
         retained_artifacts: u64::try_from(retained_names.intersection(&prior_names).count())
             .map_err(storage_err)?,
-        physical_bytes_written: output_bytes
+        physical_bytes_written: build
+            .artifact_bytes
+            .saturating_add(tombstone_bytes)
+            .saturating_add(compaction.write_bytes)
             .checked_add(
                 u64::try_from(receipt_bytes.len() + manifest_bytes.len()).map_err(storage_err)?,
             )
@@ -6382,7 +6391,10 @@ pub(crate) fn prepare_v4_ordinal_delta(
         compactions: compaction.compactions,
         sequential_read_bytes: compaction.read_bytes,
         sequential_read_calls: compaction.read_calls,
-        write_blocks: output_bytes.div_ceil(V4_ORDINAL_BLOCK_BYTES as u64),
+        write_blocks: build
+            .write_blocks
+            .saturating_add(tombstone_blocks)
+            .saturating_add(compaction.write_blocks),
         peak_buffer_bytes: build
             .peak_buffer_bytes
             .max(V4_ORDINAL_BLOCK_BYTES * 3)
@@ -6410,6 +6422,187 @@ pub(crate) fn prepare_v4_ordinal_delta(
         metrics,
         manifest,
     })
+}
+
+const V4_PLAN_PREFIX: &str = "uuid-membership-v4-plan-";
+const V4_PLAN_MARKER: &str = ".graphforge-v4-plan-v1";
+const V4_PLAN_CLEANUP_CANDIDATES: usize = 16;
+const V4_PLAN_PARENT_ENTRIES: usize = 65_536;
+const V4_PLAN_CLEANUP_ENTRIES: usize = 4096;
+const V4_PLAN_CLEANUP_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+
+fn v4_plan_marker(project_dir: &Path) -> Result<Vec<u8>, GfError> {
+    let identity = graphforge_filesystem::path_identity(project_dir).map_err(storage_err)?;
+    Ok(format!(
+        "graphforge-v4-plan-v1\nproject-volume={:016x}\nproject-file={}\n",
+        identity.volume_serial,
+        hex_bytes(&identity.file_id)
+    )
+    .into_bytes())
+}
+
+fn initialize_v4_plan_directory(project_dir: &Path, scratch: &Path) -> Result<(), GfError> {
+    let directory = graphforge_filesystem::StableDirectory::open(scratch).map_err(storage_err)?;
+    let marker = directory
+        .create_child_file(std::ffi::OsStr::new(V4_PLAN_MARKER))
+        .map_err(storage_err)?;
+    (&marker)
+        .write_all(&v4_plan_marker(project_dir)?)
+        .and_then(|()| marker.sync_all())
+        .map_err(storage_err)?;
+    directory.sync().map_err(storage_err)
+}
+
+/// Reclaim only exact, self-authenticating planner siblings left by process
+/// death. Inventory, entry count, and physical bytes are capped; linked,
+/// special, substituted, or structurally unexpected children fail closed.
+fn cleanup_abandoned_v4_plan_directories(
+    project_dir: &Path,
+    parent_path: &Path,
+) -> Result<(), GfError> {
+    let parent = graphforge_filesystem::StableDirectory::open(parent_path).map_err(storage_err)?;
+    let expected_marker = v4_plan_marker(project_dir)?;
+    let candidates = parent
+        .child_names_bounded(V4_PLAN_PARENT_ENTRIES)
+        .map_err(|error| {
+            storage_err(format!(
+                "v4 planner parent inventory at {}: {error}",
+                parent_path.display()
+            ))
+        })?
+        .into_iter()
+        .filter(|name| {
+            name.to_str().is_some_and(|text| {
+                text.strip_prefix(V4_PLAN_PREFIX).is_some_and(|nonce| {
+                    !nonce.is_empty() && nonce.bytes().all(|byte| byte.is_ascii_alphanumeric())
+                })
+            })
+        })
+        .take(V4_PLAN_CLEANUP_CANDIDATES + 1)
+        .collect::<Vec<_>>();
+    if candidates.len() > V4_PLAN_CLEANUP_CANDIDATES {
+        return Err(storage_err("v4 planner cleanup candidate bound exceeded"));
+    }
+    for name in candidates {
+        let directory = parent.open_child_directory(&name).map_err(storage_err)?;
+        let mut marker = directory
+            .open_child_file(std::ffi::OsStr::new(V4_PLAN_MARKER))
+            .map_err(storage_err)?;
+        if graphforge_filesystem::file_link_count(&marker).map_err(storage_err)? != 1
+            || marker.metadata().map_err(storage_err)?.len()
+                != u64::try_from(expected_marker.len()).map_err(storage_err)?
+        {
+            return Err(storage_err("v4 planner cleanup marker is not canonical"));
+        }
+        let mut observed_marker = Vec::with_capacity(expected_marker.len());
+        marker
+            .read_to_end(&mut observed_marker)
+            .map_err(storage_err)?;
+        if observed_marker != expected_marker {
+            return Err(storage_err(
+                "v4 planner cleanup marker authentication failed",
+            ));
+        }
+        cleanup_v4_plan_directory(&directory)?;
+        parent
+            .remove_child_directory_if_identity(&name, directory.identity())
+            .map_err(storage_err)?;
+        parent.sync().map_err(storage_err)?;
+    }
+    Ok(())
+}
+
+fn cleanup_v4_plan_directory(
+    directory: &graphforge_filesystem::StableDirectory,
+) -> Result<(), GfError> {
+    let names = directory
+        .child_names_bounded(V4_PLAN_CLEANUP_ENTRIES)
+        .map_err(|error| storage_err(format!("v4 planner directory inventory: {error}")))?;
+    let mut bytes = 0_u64;
+    for name in names {
+        if name == std::ffi::OsStr::new("artifacts") {
+            let artifacts = directory.open_child_directory(&name).map_err(storage_err)?;
+            cleanup_v4_plan_files(&artifacts, &mut bytes)?;
+            directory
+                .remove_child_directory_if_identity(&name, artifacts.identity())
+                .map_err(storage_err)?;
+        } else {
+            cleanup_v4_plan_file(directory, &name, &mut bytes)?;
+        }
+    }
+    directory.sync().map_err(storage_err)
+}
+
+fn cleanup_v4_plan_files(
+    directory: &graphforge_filesystem::StableDirectory,
+    bytes: &mut u64,
+) -> Result<(), GfError> {
+    let names = directory
+        .child_names_bounded(V4_PLAN_CLEANUP_ENTRIES)
+        .map_err(|error| storage_err(format!("v4 planner artifact inventory: {error}")))?;
+    for name in names {
+        cleanup_v4_plan_file(directory, &name, bytes)?;
+    }
+    directory.sync().map_err(storage_err)
+}
+
+fn cleanup_v4_plan_file(
+    directory: &graphforge_filesystem::StableDirectory,
+    name: &std::ffi::OsStr,
+    bytes: &mut u64,
+) -> Result<(), GfError> {
+    let file = directory.open_child_file(name).map_err(storage_err)?;
+    if graphforge_filesystem::file_link_count(&file).map_err(storage_err)? != 1 {
+        return Err(storage_err("v4 planner cleanup file has unexpected links"));
+    }
+    *bytes = bytes
+        .checked_add(file.metadata().map_err(storage_err)?.len())
+        .ok_or_else(|| storage_err("v4 planner cleanup byte count overflow"))?;
+    if *bytes > V4_PLAN_CLEANUP_BYTES {
+        return Err(storage_err("v4 planner cleanup byte bound exceeded"));
+    }
+    let identity = graphforge_filesystem::file_identity(&file).map_err(storage_err)?;
+    drop(file);
+    directory
+        .unlink_child_if_identity(name, identity)
+        .map_err(storage_err)
+}
+
+/// Prove that an appended UUID has never appeared in retained forward
+/// authority. Tombstones do not release identity: ordinals are monotonic and
+/// UUIDs are never reusable. Both sides are sorted, so each retained run is
+/// checked by one bounded sequential merge before anything enters the caller's
+/// rewrite batch.
+fn reject_prior_v4_uuid_reuse(
+    pinned: &crate::ordinal_identity_v4::V4OrdinalPinnedUpdateInputs,
+    uuid_sorted: &Path,
+) -> Result<(), GfError> {
+    for artifact in &pinned.manifest.forward_identities {
+        let mut prior = BufReader::with_capacity(
+            V4_ORDINAL_BLOCK_BYTES,
+            clone_pinned_v4_file(pinned, &artifact.name)?,
+        );
+        let mut appended = BufReader::with_capacity(
+            V4_ORDINAL_BLOCK_BYTES,
+            File::open(uuid_sorted).map_err(storage_err)?,
+        );
+        let mut prior_head = read_v4_forward_record(&mut prior)?;
+        let mut appended_head = read_node_surrogate_record(&mut appended)?;
+        while let (Some((prior_uuid, _)), Some((appended_uuid, _))) = (prior_head, appended_head) {
+            match prior_uuid.cmp(&appended_uuid) {
+                std::cmp::Ordering::Less => prior_head = read_v4_forward_record(&mut prior)?,
+                std::cmp::Ordering::Greater => {
+                    appended_head = read_node_surrogate_record(&mut appended)?;
+                }
+                std::cmp::Ordering::Equal => {
+                    return Err(storage_err(
+                        "v4 node UUID already exists in retained forward authority",
+                    ));
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 fn external_sort_v4_nodes(
@@ -6572,6 +6765,7 @@ fn v4_manifest_artifact_names(manifest: &crate::V4OrdinalIdentityManifest) -> BT
 #[derive(Default)]
 struct V4CompactionWork {
     compactions: u64,
+    created_artifacts: u64,
     read_bytes: u64,
     read_calls: u64,
     write_bytes: u64,
@@ -6610,6 +6804,7 @@ fn compact_v4_binary_carry(
             merged_forward.name.clone(),
             artifacts_path.join(&merged_forward.name),
         );
+        work.created_artifacts = work.created_artifacts.saturating_add(1);
         manifest
             .forward_identities
             .splice(left.2..=right.2, std::iter::once(merged_forward));
@@ -6842,6 +7037,7 @@ fn compact_v4_ordinal_interval(
                 merged.artifact.name.clone(),
                 artifacts_path.join(&merged.artifact.name),
             );
+            work.created_artifacts = work.created_artifacts.saturating_add(1);
             work.write_bytes = work.write_bytes.saturating_add(merged.artifact.bytes);
             work.write_blocks = work.write_blocks.saturating_add(
                 merged
@@ -6909,6 +7105,7 @@ fn compact_v4_tombstone_interval(
         run.artifact.name.clone(),
         artifacts_path.join(&run.artifact.name),
     );
+    work.created_artifacts = work.created_artifacts.saturating_add(1);
     manifest
         .tombstones
         .retain(|candidate| !(first_generation..=last_generation).contains(&candidate.generation));
@@ -8340,6 +8537,20 @@ pub(crate) mod tests {
             stage_v4_ordinal_artifacts([(Uuid::from_u128(1), 7_u64)], 1, &index, || false).unwrap();
         let pinned = pinned_v4_update(root.path(), base);
 
+        let mut reused_uuid = crate::staging::RewriteBatch::new();
+        let reused = prepare_v4_ordinal_delta(
+            root.path(),
+            1,
+            2,
+            &pinned,
+            &mut reused_uuid,
+            &[(Uuid::from_u128(1), 8_u64)],
+            &[],
+            &"33".repeat(32),
+        );
+        assert!(reused.is_err(), "prior UUID reuse unexpectedly passed");
+        assert!(reused_uuid.is_empty());
+
         for (nodes, tombstones) in [
             (vec![(Uuid::from_u128(2), 7_u64)], vec![]),
             (vec![(Uuid::from_u128(2), 8_u64)], vec![0]),
@@ -8373,26 +8584,49 @@ pub(crate) mod tests {
         let index_path = root.path().join(INDEX_DIR);
         fs::create_dir_all(&index_path).unwrap();
         let index = graphforge_filesystem::StableDirectory::open(&index_path).unwrap();
-        let (mut manifest, _) =
-            stage_v4_ordinal_artifacts([(Uuid::from_u128(1), 1_u64)], 1, &index, || false).unwrap();
+        const ROWS_PER_GENERATION: u64 = 257;
+        let base = (1..=ROWS_PER_GENERATION)
+            .map(|id| (Uuid::from_u128(u128::from(id)), id))
+            .collect::<Vec<_>>();
+        let (mut manifest, _) = stage_v4_ordinal_artifacts(base, 1, &index, || false).unwrap();
         let mut observed = Vec::new();
         for generation in 2..=5_u64 {
             let pinned = pinned_v4_update(root.path(), manifest);
             let mut batch = crate::staging::RewriteBatch::new();
+            let first = (generation - 1) * ROWS_PER_GENERATION + 1;
+            let last = generation * ROWS_PER_GENERATION;
+            let nodes = (first..=last)
+                .map(|id| (Uuid::from_u128(u128::from(id)), id))
+                .collect::<Vec<_>>();
             let planned = prepare_v4_ordinal_delta(
                 root.path(),
                 generation - 1,
                 generation,
                 &pinned,
                 &mut batch,
-                &[(Uuid::from_u128(u128::from(generation)), generation)],
+                &nodes,
                 &[],
                 &"44".repeat(32),
             )
             .unwrap();
+            assert_eq!(planned.metrics.input_identities, ROWS_PER_GENERATION);
             assert_eq!(planned.metrics.prior_topology_rows_decoded, 0);
             assert_eq!(planned.metrics.per_record_seeks, 0);
             assert!(planned.metrics.peak_buffer_bytes <= V4_ORDINAL_BLOCK_BYTES * 3);
+            assert!(planned.metrics.peak_temporary_bytes != 0);
+            assert!(planned.metrics.fsync_operations >= 3);
+            assert!(planned.metrics.created_artifacts >= 3);
+            assert!(planned.metrics.write_blocks != 0);
+            if planned.metrics.compactions == 0 {
+                assert_eq!(planned.metrics.sequential_read_bytes, 0);
+                assert_eq!(planned.metrics.sequential_read_calls, 0);
+            } else {
+                assert!(planned.metrics.sequential_read_bytes != 0);
+                assert!(planned.metrics.sequential_read_calls != 0);
+            }
+            let live_rows = generation * ROWS_PER_GENERATION;
+            let bounded_amplification = live_rows * 40 * 4 + MAX_MANIFEST_BYTES;
+            assert!(planned.metrics.physical_bytes_written < bounded_amplification);
             observed.push((
                 planned.metrics.compactions,
                 planned.metrics.physical_bytes_written,
@@ -8450,6 +8684,128 @@ pub(crate) mod tests {
                 .unwrap()
                 .is_some()
         );
+    }
+
+    fn v4_plan_sibling_count(project: &Path) -> usize {
+        project
+            .parent()
+            .unwrap()
+            .read_dir()
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_str()
+                    .is_some_and(|name| name.starts_with(V4_PLAN_PREFIX))
+            })
+            .count()
+    }
+
+    fn run_v4_rewrite_once(project: &Path) {
+        let topology = project.join("topology/nodes.parquet");
+        let mut staged = crate::staging::RewriteBatch::new();
+        staged.stage_file(&topology, &topology).unwrap();
+        let mut snapshot = None;
+        commit_uuid_topology_rewrite(
+            project,
+            staged,
+            &UuidTopologyDelta {
+                nodes: Vec::new(),
+                edges: Vec::new(),
+                deleted_nodes: Vec::new(),
+                deleted_edges: Vec::new(),
+            },
+            &mut snapshot,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn v4_rewrite_subprocess_crash_retry_matrix_cleans_exact_scratch() {
+        const CHILD_ROOT: &str = "GRAPHFORGE_V4_REWRITE_CHILD_ROOT";
+        const RETRY: &str = "GRAPHFORGE_V4_REWRITE_RETRY";
+        const TARGET: &str = "GRAPHFORGE_V4_REWRITE_TARGET";
+        if let Ok(root) = std::env::var(CHILD_ROOT) {
+            let root = Path::new(&root);
+            crate::durable_rewrite::recover(root).unwrap();
+            let target = std::env::var(TARGET).unwrap().parse::<u64>().unwrap();
+            if crate::read_topology_generation(root).unwrap() < target {
+                run_v4_rewrite_once(root);
+            }
+            if std::env::var(RETRY).is_err() {
+                panic!("configured v4 rewrite failpoint did not terminate the process");
+            }
+            return;
+        }
+
+        for (failpoint, target) in [
+            ("v4_append.after_delta_artifacts", 8),
+            ("v4_append.after_receipt_stage", 8),
+            ("v4_append.after_manifest_stage", 8),
+            ("v4_compaction.after_outputs", 9),
+            ("rewrite.before_intent", 8),
+            ("rewrite.after_preparing_disarm", 8),
+            ("rewrite.after_durable_intent", 8),
+        ] {
+            let (dir, _, _) = fixture();
+            fs::write(
+                dir.path().join("topology/generation.json"),
+                b"{\"topology_generation\":7,\"search_generation\":0,\"property_generation\":0}\n",
+            )
+            .unwrap();
+            rebuild_uuid_membership_indexes(dir.path(), UuidIndexBuildLimits::default()).unwrap();
+            rebuild_v4_ordinal_identity(dir.path(), UuidIndexBuildLimits::default()).unwrap();
+            if target == 9 {
+                run_v4_rewrite_once(dir.path());
+            }
+
+            let crashed = std::process::Command::new(std::env::current_exe().unwrap())
+                .arg("--exact")
+                .arg(
+                    "uuid_membership::tests::v4_rewrite_subprocess_crash_retry_matrix_cleans_exact_scratch",
+                )
+                .arg("--nocapture")
+                .env(CHILD_ROOT, dir.path())
+                .env(
+                    "GRAPHFORGE_PROJECT_FAILPOINTS",
+                    "graphforge-internal-subprocess-v1",
+                )
+                .env("GRAPHFORGE_PROJECT_FAILPOINT", failpoint)
+                .env(TARGET, target.to_string())
+                .status()
+                .unwrap();
+            assert_eq!(
+                crashed.code(),
+                Some(crate::project_failpoint::exit_code()),
+                "{failpoint}"
+            );
+
+            let retry = std::process::Command::new(std::env::current_exe().unwrap())
+                .arg("--exact")
+                .arg(
+                    "uuid_membership::tests::v4_rewrite_subprocess_crash_retry_matrix_cleans_exact_scratch",
+                )
+                .arg("--nocapture")
+                .env(CHILD_ROOT, dir.path())
+                .env(RETRY, "1")
+                .env(TARGET, target.to_string())
+                .status()
+                .unwrap();
+            assert!(retry.success(), "{failpoint}");
+            assert_eq!(v4_plan_sibling_count(dir.path()), 0, "{failpoint}");
+            assert_eq!(crate::read_topology_generation(dir.path()).unwrap(), target);
+            assert!(!dir.path().join(".graphforge-rewrite-v1.json").exists());
+            let v4: crate::V4OrdinalIdentityManifest = serde_json::from_slice(
+                &fs::read(dir.path().join(INDEX_DIR).join(V4_ORDINAL_MANIFEST)).unwrap(),
+            )
+            .unwrap();
+            assert_eq!(v4.topology_generation, target, "{failpoint}");
+            assert_eq!(
+                receipt_manifest_digest(dir.path()),
+                hex_sha256(&fs::read(dir.path().join(INDEX_DIR).join(MANIFEST)).unwrap())
+            );
+        }
     }
 
     #[test]

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -6197,15 +6197,16 @@ pub(crate) fn prepare_v4_ordinal_delta(
         return Err(storage_err("v4 topology delta digest is noncanonical"));
     }
 
-    let parent = project_dir
-        .parent()
-        .ok_or_else(|| storage_err("project directory has no staging parent"))?;
-    cleanup_abandoned_v4_plan_directories(project_dir, parent)?;
+    let plan_root = open_v4_plan_root(project_dir)?;
+    cleanup_abandoned_v4_plan_directories(&plan_root)?;
+    let plan_root_path = project_dir.join(INDEX_DIR).join(V4_PLAN_ROOT);
     let scratch = tempfile::Builder::new()
-        .prefix("uuid-membership-v4-plan-")
-        .tempdir_in(parent)
+        .prefix(V4_PLAN_PREFIX)
+        .tempdir_in(&plan_root_path)
         .map_err(storage_err)?;
-    initialize_v4_plan_directory(project_dir, scratch.path())?;
+    // The retained capability proves that path lookup did not escape or replace
+    // the authenticated, project-owned planner namespace during creation.
+    plan_root.revalidate_named().map_err(storage_err)?;
     let artifacts_path = scratch.path().join("artifacts");
     fs::create_dir(&artifacts_path).map_err(storage_err)?;
     let artifacts =
@@ -6425,90 +6426,75 @@ pub(crate) fn prepare_v4_ordinal_delta(
 }
 
 const V4_PLAN_PREFIX: &str = "uuid-membership-v4-plan-";
-const V4_PLAN_MARKER: &str = ".graphforge-v4-plan-v1";
+const V4_PLAN_ROOT: &str = ".uuid-membership-v4-plans";
 const V4_PLAN_CLEANUP_CANDIDATES: usize = 16;
-const V4_PLAN_PARENT_ENTRIES: usize = 65_536;
 const V4_PLAN_CLEANUP_ENTRIES: usize = 4096;
 const V4_PLAN_CLEANUP_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 
-fn v4_plan_marker(project_dir: &Path) -> Result<Vec<u8>, GfError> {
-    let identity = graphforge_filesystem::path_identity(project_dir).map_err(storage_err)?;
-    Ok(format!(
-        "graphforge-v4-plan-v1\nproject-volume={:016x}\nproject-file={}\n",
-        identity.volume_serial,
-        hex_bytes(&identity.file_id)
-    )
-    .into_bytes())
-}
-
-fn initialize_v4_plan_directory(project_dir: &Path, scratch: &Path) -> Result<(), GfError> {
-    let directory = graphforge_filesystem::StableDirectory::open(scratch).map_err(storage_err)?;
-    let marker = directory
-        .create_child_file(std::ffi::OsStr::new(V4_PLAN_MARKER))
-        .map_err(storage_err)?;
-    (&marker)
-        .write_all(&v4_plan_marker(project_dir)?)
-        .and_then(|()| marker.sync_all())
-        .map_err(storage_err)?;
-    directory.sync().map_err(storage_err)
-}
-
-/// Reclaim only exact, self-authenticating planner siblings left by process
-/// death. Inventory, entry count, and physical bytes are capped; linked,
-/// special, substituted, or structurally unexpected children fail closed.
-fn cleanup_abandoned_v4_plan_directories(
+fn open_v4_plan_root(
     project_dir: &Path,
-    parent_path: &Path,
+) -> Result<graphforge_filesystem::StableDirectory, GfError> {
+    let index = graphforge_filesystem::StableDirectory::open(&project_dir.join(INDEX_DIR))
+        .map_err(storage_err)?;
+    let name = std::ffi::OsStr::new(V4_PLAN_ROOT);
+    let root = match index.create_child_directory(name) {
+        Ok(root) => {
+            index.sync().map_err(storage_err)?;
+            root
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            index.open_child_directory(name).map_err(storage_err)?
+        }
+        Err(error) => return Err(storage_err(error)),
+    };
+    index.revalidate_named().map_err(storage_err)?;
+    Ok(root)
+}
+
+/// Reclaim planner directories from the authenticated project-owned namespace.
+/// Atomic child creation makes every visible entry recognizable immediately;
+/// no forgeable marker or shared-parent scan participates in ownership.
+fn cleanup_abandoned_v4_plan_directories(
+    plan_root: &graphforge_filesystem::StableDirectory,
 ) -> Result<(), GfError> {
-    let parent = graphforge_filesystem::StableDirectory::open(parent_path).map_err(storage_err)?;
-    let expected_marker = v4_plan_marker(project_dir)?;
-    let candidates = parent
-        .child_names_bounded(V4_PLAN_PARENT_ENTRIES)
-        .map_err(|error| {
-            storage_err(format!(
-                "v4 planner parent inventory at {}: {error}",
-                parent_path.display()
-            ))
-        })?
-        .into_iter()
-        .filter(|name| {
-            name.to_str().is_some_and(|text| {
-                text.strip_prefix(V4_PLAN_PREFIX).is_some_and(|nonce| {
-                    !nonce.is_empty() && nonce.bytes().all(|byte| byte.is_ascii_alphanumeric())
-                })
-            })
-        })
-        .take(V4_PLAN_CLEANUP_CANDIDATES + 1)
-        .collect::<Vec<_>>();
+    let candidates = plan_root
+        .child_names_bounded(V4_PLAN_CLEANUP_CANDIDATES + 1)
+        .map_err(|error| storage_err(format!("v4 planner namespace inventory: {error}")))?;
     if candidates.len() > V4_PLAN_CLEANUP_CANDIDATES {
         return Err(storage_err("v4 planner cleanup candidate bound exceeded"));
     }
     for name in candidates {
-        let directory = parent.open_child_directory(&name).map_err(storage_err)?;
-        let mut marker = directory
-            .open_child_file(std::ffi::OsStr::new(V4_PLAN_MARKER))
-            .map_err(storage_err)?;
-        if graphforge_filesystem::file_link_count(&marker).map_err(storage_err)? != 1
-            || marker.metadata().map_err(storage_err)?.len()
-                != u64::try_from(expected_marker.len()).map_err(storage_err)?
-        {
-            return Err(storage_err("v4 planner cleanup marker is not canonical"));
-        }
-        let mut observed_marker = Vec::with_capacity(expected_marker.len());
-        marker
-            .read_to_end(&mut observed_marker)
-            .map_err(storage_err)?;
-        if observed_marker != expected_marker {
+        if !name.to_str().is_some_and(|text| {
+            text.strip_prefix(V4_PLAN_PREFIX).is_some_and(|nonce| {
+                !nonce.is_empty() && nonce.bytes().all(|byte| byte.is_ascii_alphanumeric())
+            })
+        }) {
             return Err(storage_err(
-                "v4 planner cleanup marker authentication failed",
+                "v4 planner namespace contains an unknown child",
             ));
         }
+        let directory = plan_root.open_child_directory(&name).map_err(storage_err)?;
         cleanup_v4_plan_directory(&directory)?;
-        parent
+        crate::project_failpoint::hit(
+            "v4_plan_cleanup.before_unlink",
+            None,
+            None,
+            "V4_PLAN_CLEANUP_BEFORE_UNLINK",
+            false,
+        )?;
+        plan_root
             .remove_child_directory_if_identity(&name, directory.identity())
             .map_err(storage_err)?;
-        parent.sync().map_err(storage_err)?;
+        crate::project_failpoint::hit(
+            "v4_plan_cleanup.after_unlink",
+            None,
+            None,
+            "V4_PLAN_CLEANUP_AFTER_UNLINK",
+            false,
+        )?;
+        plan_root.sync().map_err(storage_err)?;
     }
+    plan_root.revalidate_named().map_err(storage_err)?;
     Ok(())
 }
 
@@ -8687,10 +8673,8 @@ pub(crate) mod tests {
     }
 
     fn v4_plan_sibling_count(project: &Path) -> usize {
-        project
-            .parent()
-            .unwrap()
-            .read_dir()
+        let root = project.join(INDEX_DIR).join(V4_PLAN_ROOT);
+        root.read_dir()
             .unwrap()
             .filter_map(Result::ok)
             .filter(|entry| {
@@ -8719,6 +8703,47 @@ pub(crate) mod tests {
             &mut snapshot,
         )
         .unwrap();
+    }
+
+    fn assert_exact_v4_reopen(project: &Path, generation: u64) {
+        let index = project.join(INDEX_DIR);
+        let manifest_bytes = fs::read(index.join(V4_ORDINAL_MANIFEST)).unwrap();
+        let receipt: TopologyIndexReceipt =
+            serde_json::from_slice(&fs::read(index.join(V4_ORDINAL_RECEIPT)).unwrap()).unwrap();
+        assert_eq!(receipt.expected_generation, generation);
+        assert_eq!(receipt.manifest_sha256, hex_sha256(&manifest_bytes));
+        let authority = crate::ordinal_identity_v4::V4OrdinalIdentityAuthority {
+            topology_generation: generation,
+            manifest_sha256: receipt.manifest_sha256,
+        };
+        let mut handle = match crate::ordinal_identity_v4::V4OrdinalIdentityHandle::open(
+            project,
+            &authority,
+            crate::V4OrdinalIdentityLimits::default(),
+        )
+        .unwrap()
+        {
+            crate::V4OrdinalIdentityOpen::Ready(handle) => handle,
+            crate::V4OrdinalIdentityOpen::RebuildRequired { .. } => {
+                panic!("receipt-authenticated v4 authority unexpectedly requires rebuild")
+            }
+        };
+        let pinned = handle.pinned_update_inputs().unwrap();
+        assert_eq!(pinned.manifest.topology_generation, generation);
+        assert_eq!(
+            pinned.artifacts.len(),
+            pinned.manifest.forward_identities.len()
+                + pinned.manifest.ordinal_ranges.len()
+                + pinned.manifest.tombstones.len()
+        );
+        assert_eq!(
+            handle.lookup_node_uuids(&[1, 2, 3]).unwrap().values,
+            vec![
+                Some(Uuid::from_u128(3)),
+                Some(Uuid::from_u128(1)),
+                Some(Uuid::from_u128(2)),
+            ]
+        );
     }
 
     #[test]
@@ -8805,6 +8830,56 @@ pub(crate) mod tests {
                 receipt_manifest_digest(dir.path()),
                 hex_sha256(&fs::read(dir.path().join(INDEX_DIR).join(MANIFEST)).unwrap())
             );
+            assert_exact_v4_reopen(dir.path(), target);
+        }
+
+        for cleanup_failpoint in [
+            "v4_plan_cleanup.before_unlink",
+            "v4_plan_cleanup.after_unlink",
+        ] {
+            let (dir, _, _) = fixture();
+            fs::write(
+                dir.path().join("topology/generation.json"),
+                b"{\"topology_generation\":7,\"search_generation\":0,\"property_generation\":0}\n",
+            )
+            .unwrap();
+            rebuild_uuid_membership_indexes(dir.path(), UuidIndexBuildLimits::default()).unwrap();
+            rebuild_v4_ordinal_identity(dir.path(), UuidIndexBuildLimits::default()).unwrap();
+
+            let child = |failpoint: &str, retry: bool| {
+                let mut command = std::process::Command::new(std::env::current_exe().unwrap());
+                command
+                    .arg("--exact")
+                    .arg(
+                        "uuid_membership::tests::v4_rewrite_subprocess_crash_retry_matrix_cleans_exact_scratch",
+                    )
+                    .arg("--nocapture")
+                    .env(CHILD_ROOT, dir.path())
+                    .env(
+                        "GRAPHFORGE_PROJECT_FAILPOINTS",
+                        "graphforge-internal-subprocess-v1",
+                    )
+                    .env("GRAPHFORGE_PROJECT_FAILPOINT", failpoint)
+                    .env(TARGET, "8");
+                if retry {
+                    command.env(RETRY, "1");
+                }
+                command.status().unwrap()
+            };
+            assert_eq!(
+                child("v4_append.after_delta_artifacts", false).code(),
+                Some(crate::project_failpoint::exit_code())
+            );
+            assert_eq!(v4_plan_sibling_count(dir.path()), 1);
+            assert_eq!(
+                child(cleanup_failpoint, false).code(),
+                Some(crate::project_failpoint::exit_code()),
+                "{cleanup_failpoint}"
+            );
+            assert!(child("", true).success(), "{cleanup_failpoint}");
+            assert_eq!(v4_plan_sibling_count(dir.path()), 0, "{cleanup_failpoint}");
+            assert_eq!(crate::read_topology_generation(dir.path()).unwrap(), 8);
+            assert_exact_v4_reopen(dir.path(), 8);
         }
     }
 

--- a/crates/graphforge-storage/src/writer.rs
+++ b/crates/graphforge-storage/src/writer.rs
@@ -3006,15 +3006,13 @@ impl GraphWriter {
             .uuid_physical_bytes_written
             .saturating_add(metrics.physical_bytes_written);
         work.uuid_write_blocks = work.uuid_write_blocks.saturating_add(metrics.write_blocks);
-        work.uuid_write_bytes = work
-            .uuid_write_bytes
-            .saturating_add(metrics.physical_bytes_written);
+        work.uuid_write_bytes = work.uuid_write_bytes.saturating_add(metrics.write_bytes);
         work.uuid_peak_buffered_bytes = work
             .uuid_peak_buffered_bytes
             .max(u64::try_from(metrics.peak_buffer_bytes).unwrap_or(u64::MAX));
         work.uuid_validation_blocks = work
             .uuid_validation_blocks
-            .saturating_add(metrics.sequential_read_calls);
+            .saturating_add(metrics.sequential_read_blocks);
         work.uuid_validation_bytes = work
             .uuid_validation_bytes
             .saturating_add(metrics.sequential_read_bytes);

--- a/crates/graphforge-storage/src/writer.rs
+++ b/crates/graphforge-storage/src/writer.rs
@@ -2930,8 +2930,12 @@ impl GraphWriter {
             crate::uuid_membership::CommittedUuidTopologyRewrite::Committed {
                 generation,
                 metrics,
+                v4_metrics,
             } => {
                 self.record_uuid_append_work(&metrics);
+                if let Some(metrics) = v4_metrics.as_ref() {
+                    self.record_v4_ordinal_append_work(metrics);
+                }
                 self.pending_index_nodes.clear();
                 self.pending_index_edges.clear();
                 Ok(Some(generation))
@@ -2939,9 +2943,13 @@ impl GraphWriter {
             crate::uuid_membership::CommittedUuidTopologyRewrite::CommittedNeedsRefresh {
                 generation,
                 metrics,
+                v4_metrics,
                 error,
             } => {
                 self.record_uuid_append_work(&metrics);
+                if let Some(metrics) = v4_metrics.as_ref() {
+                    self.record_v4_ordinal_append_work(metrics);
+                }
                 self.pending_index_nodes.clear();
                 self.pending_index_edges.clear();
                 self.uuid_snapshot_refresh_needed = Some(generation);
@@ -2980,6 +2988,39 @@ impl GraphWriter {
         work.uuid_validation_random_seeks = work
             .uuid_validation_random_seeks
             .saturating_add(metrics.validation_random_seeks);
+    }
+
+    fn record_v4_ordinal_append_work(
+        &mut self,
+        metrics: &crate::uuid_membership::V4OrdinalAppendMetrics,
+    ) {
+        let work = &mut self.topology_work;
+        work.uuid_input_records = work
+            .uuid_input_records
+            .saturating_add(metrics.input_identities)
+            .saturating_add(metrics.input_tombstones);
+        work.uuid_prior_topology_rows_decoded = work
+            .uuid_prior_topology_rows_decoded
+            .saturating_add(metrics.prior_topology_rows_decoded);
+        work.uuid_physical_bytes_written = work
+            .uuid_physical_bytes_written
+            .saturating_add(metrics.physical_bytes_written);
+        work.uuid_write_blocks = work.uuid_write_blocks.saturating_add(metrics.write_blocks);
+        work.uuid_write_bytes = work
+            .uuid_write_bytes
+            .saturating_add(metrics.physical_bytes_written);
+        work.uuid_peak_buffered_bytes = work
+            .uuid_peak_buffered_bytes
+            .max(u64::try_from(metrics.peak_buffer_bytes).unwrap_or(u64::MAX));
+        work.uuid_validation_blocks = work
+            .uuid_validation_blocks
+            .saturating_add(metrics.sequential_read_calls);
+        work.uuid_validation_bytes = work
+            .uuid_validation_bytes
+            .saturating_add(metrics.sequential_read_bytes);
+        work.uuid_validation_random_seeks = work
+            .uuid_validation_random_seeks
+            .saturating_add(metrics.per_record_seeks);
     }
 
     /// Best-effort write of the delta segment for `generation` — only when the

--- a/docs/book/architecture/uuid-membership-index.md
+++ b/docs/book/architecture/uuid-membership-index.md
@@ -47,4 +47,49 @@ provenance for deciding reachability.
 
 Both facets are persistent graph authority, not `.graphforge-cache/` content.
 Construction and canonical v3-to-v4 publication are specified separately by
-#969; append, deletion, and compaction are specified by #968.
+#969.
+
+### Incremental ordinal publication
+
+An ordinary topology generation publishes one UUID-sorted forward delta, the
+maximal contiguous ranges from its node-ID-sorted delta, and one sorted unique
+tombstone delta. It never decodes or rewrites canonical topology and it rejects
+zero IDs, duplicate mappings, nonmonotonic surrogate allocation, reuse, range
+overlap, and tombstones that do not name retained live authority before any
+transaction entry is staged.
+
+Forward files are canonical and strictly UUID-sorted within each generation.
+Their descriptors are strictly generation-ordered; they are not required to be
+globally concatenation-sorted. The reader authenticates every run and compares
+the aggregate forward mapping commitment with the aggregate ordinal mapping
+commitment. Historical UUID and surrogate uniqueness is also proved by the
+coupled authenticated v3 participant in the same topology transaction.
+
+The construction artifact remains an immutable base. Later forward artifacts
+close implicit contiguous generation intervals. Two adjacent equal-width delta
+intervals compact like a binary carry, so retained history stays logarithmic
+without adding mutable level metadata to the descriptor. Compaction merges
+forward records with the newer interval winning an identical mapping, merges
+tombstones as a sorted union, concatenates adjacent ordinal ranges, and retains
+nonadjacent packed ranges. The base is never rewritten by ordinary append and a
+tombstone can never be removed or resurrected.
+
+Planning consumes file handles cloned from an already authenticated v4 handle;
+it never reopens descriptor names. Sorting, merge, tombstone, and ordinal I/O
+uses fixed-size runs and 64 KiB artifact blocks. Aggregate work evidence reports
+input rows, exact physical and sequential bytes, calls, compactions, retained
+and created artifacts, peak buffers and scratch space, fsyncs, and orphan work;
+it contains no graph identities.
+
+The shared durable rewrite installs only new or compacted artifacts, then the
+receipt, then the ordinal manifest as the last data participant. The topology
+generation record remains the final authority switch. Recovery rolls the exact
+typed receipt-bound transaction forward and reconciliation verifies the exact
+expected manifest, so retry never replays a graph mutation. A retained old read
+handle fails stale named-manifest revalidation after the switch; callers advance
+by opening the exact newly receipt-authorized generation.
+
+Orphan maintenance runs only from the union of selected authenticated v3 and v4
+authority. It removes an unreferenced single-link artifact by retained identity,
+defers linked or over-budget candidates, and never treats an untrusted sibling
+manifest as reachability evidence.

--- a/docs/book/architecture/uuid-membership-index.md
+++ b/docs/book/architecture/uuid-membership-index.md
@@ -32,6 +32,15 @@ requires the ordinal digest selected by the project receipt. A malformed,
 substituted, or generation-mismatched ordinal facet fails closed and never
 falls back to v3.
 
+Standalone graph roots have no project-generation `graph/files` inventory.
+Only the mutation writer has a narrow exception: immediately before entering
+the single durable-rewrite critical section it may pin the already-open sibling
+manifest and artifacts when the sibling receipt's exact manifest digest and
+generation match current topology authority. That exception advances an
+existing facet; it cannot construct authority, is never used by public readers,
+and does not authorize orphan deletion. Selected project-generation roots must
+always use their externally authenticated `graph/files` authority.
+
 The reader takes the shared ordinal lock before reading the manifest and
 releases it after pinning the manifest and immutable artifacts. The durable
 writer takes the project rewrite lock first and the exclusive ordinal lock


### PR DESCRIPTION
Closes #968

## Summary

- admit generation-ordered, independently UUID-sorted immutable forward runs with bounded cross-run duplicate validation
- publish v4 append/delete deltas atomically with v3 and topology generation authority
- compact equal-width history by bounded binary carry while preserving packed sparse ordinal ranges and monotonic tombstones
- retain authenticated file capabilities for update planning and reject UUID/surrogate reuse before staging
- recover project-owned planner scratch and v4 orphan cleanup across deterministic crash boundaries
- report exact aggregate physical I/O, fsync, buffer, temporary-space, compaction, and orphan work evidence
- document append, compaction, standalone authority, recovery, stale-handle, and cleanup semantics

## Validation

- `cargo test -p graphforge-storage --lib --no-fail-fast`: 897 passed, 2 ignored
- parallel focused v4 suite: 8 passed
- ordinal v4 suite: 22 passed
- 11-scenario subprocess recovery matrix, including both authenticated orphan-cleanup unlink boundaries
- `cargo clippy -p graphforge-storage --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 scripts/ci/test-non-cypher-surface-gate.py`: 12 passed
- `make pre-push-fast`

## Evidence

The 1x/2x/4x/8x ladder uses proportional cardinalities and separately accounts data and control bytes. Normal append writes only delta-sized runs; deterministic binary-carry generations stream only participating levels. Prior topology rows decoded remains zero, per-record seeks remain zero, buffers are bounded, and continued history does not create graph-sized resident state.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790499289&installation_model_id=20486&pr_number=978&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F978&signature=89de2d3f4277f76519f2a684709ee0bbf7743981b4cb366a40fea125e9893f81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more efficient incremental identity updates, including support for additions, deletions, compaction, and standalone advancement.
  * Added stronger validation to prevent duplicate identifiers and invalid deletions.
  * Added authenticated recovery and cleanup handling for interrupted operations.

* **Bug Fixes**
  * Improved consistency between topology and identity update results.
  * Added safeguards for preserving valid data during crash recovery and retry scenarios.

* **Performance**
  * Improved memory usage and bounded filesystem enumeration during large update operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->