### PR TITLE
fix(scale): use construction-budget Arrow batches

### DIFF
--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -875,8 +875,8 @@ fn run_rung(
             &spill_dir.join("construction-session.uuid"),
             GraphConstructionBudgets::default(),
         );
-        let append_started = Instant::now();
-        if construction.progress().publication_committed {
+        let (append_s, reconciliation_s) = if construction.progress().publication_committed {
+            let reconciliation_started = Instant::now();
             let mut fingerprint = Sha256::new();
             let merge = merge_runs(&spill.runs, None, |src, dst| {
                 fingerprint.update(src.to_le_bytes());
@@ -886,7 +886,9 @@ fn run_rung(
             live_unique_edges = merge.live_unique_edges;
             duplicates_rejected = merge.duplicates_rejected;
             input_fingerprint = format!("sha256:{}", hex_encode(fingerprint.finalize()));
+            (None, Some(reconciliation_started.elapsed().as_secs_f64()))
         } else {
+            let append_started = Instant::now();
             publish_nodes(&mut construction, 1u64 << rung.scale, None);
             INGEST_SUBPHASE.store(2, Ordering::Relaxed);
             let mut sink = EdgeSink::new(&mut construction, None);
@@ -896,8 +898,8 @@ fn run_rung(
             live_unique_edges = merge.live_unique_edges;
             duplicates_rejected = merge.duplicates_rejected;
             input_fingerprint = format!("sha256:{}", hex_encode(sink.finish()));
-        }
-        let append_s = append_started.elapsed().as_secs_f64();
+            (Some(append_started.elapsed().as_secs_f64()), None)
+        };
         let seal_started = Instant::now();
         construction
             .seal_and_publish()
@@ -929,11 +931,12 @@ fn run_rung(
                     "configured_rows_per_chunk": CONSTRUCTION_BATCH_ROWS,
                     "submitted_chunks": construction_evidence.input_batches,
                     "append_wall_time_s": append_s,
+                    "reconciliation_wall_time_s": reconciliation_s,
                     "seal_publication_wall_time_s": seal_publication_s,
                     "input_rows": construction_evidence.input_rows,
                     "input_batches": construction_evidence.input_batches,
                     "parquet_shards": construction_evidence.parquet_shards,
-                    "immutable_artifacts": immutable_artifact_count(1_u64 << rung.scale, &construction_evidence),
+                    "immutable_artifacts": construction_evidence.immutable_artifacts,
                     "write_bytes": construction_evidence.write_bytes,
                     "write_operations": construction_evidence.write_operations,
                     "fsync_operations": construction_evidence.fsync_operations,
@@ -2750,33 +2753,46 @@ fn graph500_driver_has_no_bulk_publication_escape_hatch() {
 }
 
 #[test]
-fn graph500_driver_uses_the_authoritative_construction_batch_budget() {
+fn million_edge_sink_uses_sixteen_durable_chunks_and_replays_stably() {
+    let project = TempDir::new().expect("million-edge construction project");
+    let graph = GraphForge::new(project.path().to_str()).expect("open million-edge project");
+    let budgets = GraphConstructionBudgets::default();
+    assert_eq!(CONSTRUCTION_BATCH_ROWS, budgets.max_batch_rows);
+    let mut session = graph
+        .begin_graph_construction(budgets)
+        .expect("begin million-edge construction");
+    publish_nodes(&mut session, 2, None);
+    let session_uuid = session.session_uuid();
+    let mut sink = EdgeSink::new(&mut session, None);
+    for _ in 0..1_048_576 {
+        sink.push(0, 1);
+    }
+    sink.flush();
+    let first_digest = sink.finish();
+    let first = session.progress();
     assert_eq!(
-        CONSTRUCTION_BATCH_ROWS,
-        GraphConstructionBudgets::default().max_batch_rows
+        first.accepted_chunks, 17,
+        "one node plus sixteen edge chunks"
     );
-    assert_eq!(1_048_576_usize.div_ceil(CONSTRUCTION_BATCH_ROWS), 16);
-    let source = include_str!("scale_g500_ladder.rs");
-    assert!(
-        !source.contains(&["8", "192"].join("_")),
-        "hidden 8,192-row durable transaction boundary reintroduced"
-    );
-}
+    assert_eq!(first.evidence.input_batches, 17);
+    assert_eq!(first.evidence.parquet_shards, 17);
+    assert_eq!(first.evidence.immutable_artifacts, 67);
+    drop(session);
 
-fn immutable_artifact_count(
-    node_rows: u64,
-    evidence: &graphforge_storage::GraphConstructionEvidence,
-) -> u64 {
-    let node_chunks = node_rows.div_ceil(CONSTRUCTION_BATCH_ROWS as u64);
-    let edge_chunks = evidence
-        .input_batches
-        .checked_sub(node_chunks)
-        .expect("accepted chunks must include every node chunk");
-    // Node chunks own Parquet, identity, and detail artifacts. Edge chunks add
-    // the endpoint run. Both are fixed by the construction receipt contract.
-    node_chunks
-        .saturating_mul(3)
-        .saturating_add(edge_chunks.saturating_mul(4))
+    let mut replay = graph
+        .resume_graph_construction(session_uuid, budgets)
+        .expect("resume million-edge construction");
+    let mut sink = EdgeSink::new(&mut replay, None);
+    for _ in 0..1_048_576 {
+        sink.push(0, 1);
+    }
+    sink.flush();
+    assert_eq!(sink.finish(), first_digest);
+    let replayed = replay.progress();
+    assert_eq!(replayed.accepted_chunks, 17);
+    assert_eq!(replayed.evidence.input_batches, 17);
+    assert_eq!(replayed.evidence.immutable_artifacts, 67);
+    assert_eq!(replayed.evidence.replayed_chunks, 16);
 }
 
 #[test]
@@ -2830,10 +2846,7 @@ fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
             progress.evidence.parquet_shards,
             progress.evidence.input_batches
         );
-        assert_eq!(
-            immutable_artifact_count(base_nodes * factor, &progress.evidence),
-            7 * factor + 4
-        );
+        assert_eq!(progress.evidence.immutable_artifacts, 7 * factor + 4);
         assert_eq!(progress.evidence.fsync_operations, 23 * factor + 13);
         assert!(progress.evidence.peak_batch_rows <= CONSTRUCTION_BATCH_ROWS as u64);
         assert!(progress.evidence.peak_accounted_live_bytes <= 64 * 1024 * 1024);
@@ -2868,8 +2881,25 @@ fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
                 .enumerate()
             {
                 if index == 4 {
+                    // One bounded edge merge window may overlap its immutable
+                    // identity, endpoint, and detail inputs with the unified
+                    // identity output. These are the construction format's
+                    // fixed record widths, so this is a derived byte bound,
+                    // not general-purpose disk slack.
+                    const IDENTITY_RECORD_BYTES: u64 = 16;
+                    const ENDPOINT_RECORD_BYTES: u64 = 48;
+                    const EDGE_DETAIL_RECORD_BYTES: u64 = 304;
+                    const UNIFIED_IDENTITY_RECORD_BYTES: u64 = 32;
+                    let fixed_edge_merge_window_bytes = CONSTRUCTION_BATCH_ROWS as u64
+                        * (IDENTITY_RECORD_BYTES
+                            + ENDPOINT_RECORD_BYTES
+                            + EDGE_DETAIL_RECORD_BYTES
+                            + UNIFIED_IDENTITY_RECORD_BYTES);
                     assert!(
-                        *observed <= base.saturating_mul(factor).saturating_add(64 * 1024 * 1024),
+                        *observed
+                            <= base
+                                .saturating_mul(factor)
+                                .saturating_add(fixed_edge_merge_window_bytes),
                         "disk-backed merge footprint exceeded linear work: baseline={base} observed={observed} factor={factor}"
                     );
                     continue;

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -929,7 +929,7 @@ fn run_rung(
                 "input_fingerprint": input_fingerprint,
                 "construction": {
                     "configured_rows_per_chunk": CONSTRUCTION_BATCH_ROWS,
-                    "submitted_chunks": construction_evidence.input_batches,
+                    "submitted_chunks": submitted_chunk_count(&construction_evidence),
                     "append_wall_time_s": append_s,
                     "reconciliation_wall_time_s": reconciliation_s,
                     "seal_publication_wall_time_s": seal_publication_s,
@@ -2793,6 +2793,13 @@ fn million_edge_sink_uses_sixteen_durable_chunks_and_replays_stably() {
     assert_eq!(replayed.evidence.input_batches, 17);
     assert_eq!(replayed.evidence.immutable_artifacts, 67);
     assert_eq!(replayed.evidence.replayed_chunks, 16);
+    assert_eq!(submitted_chunk_count(&replayed.evidence), 33);
+}
+
+fn submitted_chunk_count(evidence: &graphforge_storage::GraphConstructionEvidence) -> u64 {
+    evidence
+        .input_batches
+        .saturating_add(evidence.replayed_chunks)
 }
 
 #[test]

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -49,8 +49,9 @@ const GENERATOR_SOURCE: &str = "crates/graphforge-api/tests/scale_g500_ladder.rs
 
 const NODE_LABEL: &str = "Node";
 const REL_TYPE: &str = "LINK";
-const BATCH_ROWS: usize = 8_192;
-const EDGE_PUBLISH_ROWS: usize = 1_048_576;
+/// One authoritative Arrow and durable-append row window for the scale client.
+/// This intentionally matches `GraphConstructionBudgets::default()`.
+const CONSTRUCTION_BATCH_ROWS: usize = 65_536;
 
 const ONE_HOP: &str = "MATCH (a)-[r]->(b) RETURN b.node_uuid AS id ORDER BY id LIMIT 1000";
 const TWO_HOP: &str =
@@ -874,6 +875,7 @@ fn run_rung(
             &spill_dir.join("construction-session.uuid"),
             GraphConstructionBudgets::default(),
         );
+        let append_started = Instant::now();
         if construction.progress().publication_committed {
             let mut fingerprint = Sha256::new();
             let merge = merge_runs(&spill.runs, None, |src, dst| {
@@ -895,9 +897,12 @@ fn run_rung(
             duplicates_rejected = merge.duplicates_rejected;
             input_fingerprint = format!("sha256:{}", hex_encode(sink.finish()));
         }
+        let append_s = append_started.elapsed().as_secs_f64();
+        let seal_started = Instant::now();
         construction
             .seal_and_publish()
             .expect("publish rung construction");
+        let seal_publication_s = seal_started.elapsed().as_secs_f64();
         let construction_evidence = construction.progress().evidence;
         INGEST_SUBPHASE.store(0, Ordering::Relaxed);
         heartbeat.stop();
@@ -921,11 +926,17 @@ fn run_rung(
                 "duplicates_rejected": duplicates_rejected,
                 "input_fingerprint": input_fingerprint,
                 "construction": {
+                    "configured_rows_per_chunk": CONSTRUCTION_BATCH_ROWS,
+                    "submitted_chunks": construction_evidence.input_batches,
+                    "append_wall_time_s": append_s,
+                    "seal_publication_wall_time_s": seal_publication_s,
                     "input_rows": construction_evidence.input_rows,
                     "input_batches": construction_evidence.input_batches,
                     "parquet_shards": construction_evidence.parquet_shards,
+                    "immutable_artifacts": immutable_artifact_count(1_u64 << rung.scale, &construction_evidence),
                     "write_bytes": construction_evidence.write_bytes,
                     "write_operations": construction_evidence.write_operations,
+                    "fsync_operations": construction_evidence.fsync_operations,
                     "authentication_read_bytes": construction_evidence.authentication_read_bytes,
                     "authentication_read_operations": construction_evidence.authentication_read_operations,
                     "peak_batch_rows": construction_evidence.peak_batch_rows,
@@ -1187,7 +1198,7 @@ fn provisioned_rungs_through(profile: &ScaleProfile, max_scale: u32) -> Result<V
 }
 
 // ---------------------------------------------------------------------------
-// Streaming edge publisher (bounded by EDGE_PUBLISH_ROWS).
+// Streaming edge publisher (bounded by CONSTRUCTION_BATCH_ROWS).
 // ---------------------------------------------------------------------------
 
 struct EdgeSink<'a, 'graph> {
@@ -1206,7 +1217,7 @@ impl<'a, 'graph> EdgeSink<'a, 'graph> {
         EdgeSink {
             session,
             cancellation,
-            buf: Vec::with_capacity(EDGE_PUBLISH_ROWS),
+            buf: Vec::with_capacity(CONSTRUCTION_BATCH_ROWS),
             chunk_index: 0,
             hasher: Sha256::new(),
         }
@@ -1217,7 +1228,7 @@ impl<'a, 'graph> EdgeSink<'a, 'graph> {
         self.hasher.update(src.to_le_bytes());
         self.hasher.update(dst.to_le_bytes());
         self.buf.push((src, dst));
-        if self.buf.len() >= EDGE_PUBLISH_ROWS {
+        if self.buf.len() >= CONSTRUCTION_BATCH_ROWS {
             self.flush();
         }
     }
@@ -1227,50 +1238,40 @@ impl<'a, 'graph> EdgeSink<'a, 'graph> {
         if self.buf.is_empty() {
             return;
         }
-        let mut offset = 0usize;
-        while offset < self.buf.len() {
-            self.check_cancellation();
-            let end = (offset + BATCH_ROWS).min(self.buf.len());
-            let slice = &self.buf[offset..end];
-            let mut edge_ids = Vec::with_capacity(slice.len());
-            let mut sources = Vec::with_capacity(slice.len());
-            let mut targets = Vec::with_capacity(slice.len());
-            for (local, &(src, dst)) in slice.iter().enumerate() {
-                let ordinal = self
-                    .chunk_index
-                    .saturating_mul(EDGE_PUBLISH_ROWS as u128)
-                    .saturating_add(u128::try_from(offset + local).expect("edge ordinal"));
-                edge_ids.push(uuidv7(0xE000_0000_0000u128 + ordinal + 1));
-                sources.push(uuidv7(u128::from(src) + 1));
-                targets.push(uuidv7(u128::from(dst) + 1));
-            }
-            let batch = RecordBatch::try_new(
-                CONSTRUCTION_EDGE_SCHEMA.clone(),
-                vec![
-                    Arc::new(
-                        FixedSizeBinaryArray::try_from_iter(edge_ids.iter().map(Uuid::as_bytes))
-                            .expect("edge_uuid column"),
-                    ),
-                    Arc::new(StringArray::from(vec![REL_TYPE; slice.len()])),
-                    Arc::new(
-                        FixedSizeBinaryArray::try_from_iter(sources.iter().map(Uuid::as_bytes))
-                            .expect("source_uuid column"),
-                    ),
-                    Arc::new(
-                        FixedSizeBinaryArray::try_from_iter(targets.iter().map(Uuid::as_bytes))
-                            .expect("target_uuid column"),
-                    ),
-                ],
-            )
-            .expect("edge batch");
-            self.session
-                .append_edges(
-                    &format!("edges-{:016x}-{:08x}", self.chunk_index, offset),
-                    &batch,
-                )
-                .expect("append construction edge chunk");
-            offset = end;
+        let mut edge_ids = Vec::with_capacity(self.buf.len());
+        let mut sources = Vec::with_capacity(self.buf.len());
+        let mut targets = Vec::with_capacity(self.buf.len());
+        for (local, &(src, dst)) in self.buf.iter().enumerate() {
+            let ordinal = self
+                .chunk_index
+                .saturating_mul(CONSTRUCTION_BATCH_ROWS as u128)
+                .saturating_add(u128::try_from(local).expect("edge ordinal"));
+            edge_ids.push(uuidv7(0xE000_0000_0000u128 + ordinal + 1));
+            sources.push(uuidv7(u128::from(src) + 1));
+            targets.push(uuidv7(u128::from(dst) + 1));
         }
+        let batch = RecordBatch::try_new(
+            CONSTRUCTION_EDGE_SCHEMA.clone(),
+            vec![
+                Arc::new(
+                    FixedSizeBinaryArray::try_from_iter(edge_ids.iter().map(Uuid::as_bytes))
+                        .expect("edge_uuid column"),
+                ),
+                Arc::new(StringArray::from(vec![REL_TYPE; self.buf.len()])),
+                Arc::new(
+                    FixedSizeBinaryArray::try_from_iter(sources.iter().map(Uuid::as_bytes))
+                        .expect("source_uuid column"),
+                ),
+                Arc::new(
+                    FixedSizeBinaryArray::try_from_iter(targets.iter().map(Uuid::as_bytes))
+                        .expect("target_uuid column"),
+                ),
+            ],
+        )
+        .expect("edge batch");
+        self.session
+            .append_edges(&format!("edges-{:016x}", self.chunk_index), &batch)
+            .expect("append construction edge chunk");
         INGEST_CHUNK_INDEX.store(
             u64::try_from(self.chunk_index).unwrap_or(u64::MAX),
             Ordering::Relaxed,
@@ -1309,35 +1310,26 @@ fn publish_nodes(
             !cancellation.is_some_and(|flag| flag.load(Ordering::SeqCst)),
             "node publication cancelled"
         );
-        let chunk_end = (offset + EDGE_PUBLISH_ROWS).min(total);
-        let mut inner = offset;
-        while inner < chunk_end {
-            assert!(
-                !cancellation.is_some_and(|flag| flag.load(Ordering::SeqCst)),
-                "node publication cancelled"
-            );
-            let end = (inner + BATCH_ROWS).min(chunk_end);
-            let count = end - inner;
-            let ids = (inner..end)
-                .map(|index| uuidv7(u128::try_from(index + 1).expect("node seed")))
-                .collect::<Vec<_>>();
-            let batch = RecordBatch::try_new(
-                CONSTRUCTION_NODE_SCHEMA.clone(),
-                vec![
-                    Arc::new(
-                        FixedSizeBinaryArray::try_from_iter(ids.iter().map(Uuid::as_bytes))
-                            .expect("node_uuid column"),
-                    ),
-                    Arc::new(StringArray::from(vec![NODE_LABEL; count])),
-                ],
-            )
-            .expect("node batch");
-            session
-                .append_nodes(&format!("nodes-{inner:016x}"), &batch)
-                .expect("append construction node chunk");
-            inner = end;
-        }
-        offset = chunk_end;
+        let end = (offset + CONSTRUCTION_BATCH_ROWS).min(total);
+        let count = end - offset;
+        let ids = (offset..end)
+            .map(|index| uuidv7(u128::try_from(index + 1).expect("node seed")))
+            .collect::<Vec<_>>();
+        let batch = RecordBatch::try_new(
+            CONSTRUCTION_NODE_SCHEMA.clone(),
+            vec![
+                Arc::new(
+                    FixedSizeBinaryArray::try_from_iter(ids.iter().map(Uuid::as_bytes))
+                        .expect("node_uuid column"),
+                ),
+                Arc::new(StringArray::from(vec![NODE_LABEL; count])),
+            ],
+        )
+        .expect("node batch");
+        session
+            .append_nodes(&format!("nodes-{offset:016x}"), &batch)
+            .expect("append construction node chunk");
+        offset = end;
     }
 }
 
@@ -2758,14 +2750,44 @@ fn graph500_driver_has_no_bulk_publication_escape_hatch() {
 }
 
 #[test]
+fn graph500_driver_uses_the_authoritative_construction_batch_budget() {
+    assert_eq!(
+        CONSTRUCTION_BATCH_ROWS,
+        GraphConstructionBudgets::default().max_batch_rows
+    );
+    assert_eq!(1_048_576_usize.div_ceil(CONSTRUCTION_BATCH_ROWS), 16);
+    let source = include_str!("scale_g500_ladder.rs");
+    assert!(
+        !source.contains(&["8", "192"].join("_")),
+        "hidden 8,192-row durable transaction boundary reintroduced"
+    );
+}
+
+fn immutable_artifact_count(
+    node_rows: u64,
+    evidence: &graphforge_storage::GraphConstructionEvidence,
+) -> u64 {
+    let node_chunks = node_rows.div_ceil(CONSTRUCTION_BATCH_ROWS as u64);
+    let edge_chunks = evidence
+        .input_batches
+        .checked_sub(node_chunks)
+        .expect("accepted chunks must include every node chunk");
+    // Node chunks own Parquet, identity, and detail artifacts. Edge chunks add
+    // the endpoint run. Both are fixed by the construction receipt contract.
+    node_chunks
+        .saturating_mul(3)
+        .saturating_add(edge_chunks.saturating_mul(4))
+}
+
+#[test]
 fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
     let budgets = GraphConstructionBudgets {
-        max_batch_rows: BATCH_ROWS,
-        max_run_records: 4 * BATCH_ROWS,
+        max_batch_rows: CONSTRUCTION_BATCH_ROWS,
+        max_run_records: 4 * CONSTRUCTION_BATCH_ROWS,
         merge_fan_in: 2,
         ..GraphConstructionBudgets::default()
     };
-    let base_nodes = BATCH_ROWS as u64;
+    let base_nodes = CONSTRUCTION_BATCH_ROWS as u64;
     let mut baseline_peaks: Option<[u64; 11]> = None;
     for factor in [1_u64, 2, 4] {
         let project = TempDir::new().expect("tiny construction project");
@@ -2803,9 +2825,17 @@ fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
             .expect("publish tiny construction");
         let progress = resumed.progress();
         assert_eq!(progress.evidence.input_rows, 2 * base_nodes * factor - 1);
-        assert!(progress.evidence.input_batches <= 2 * factor + 1);
-        assert!(progress.evidence.parquet_shards <= progress.evidence.input_batches);
-        assert!(progress.evidence.peak_batch_rows <= BATCH_ROWS as u64);
+        assert_eq!(progress.evidence.input_batches, 2 * factor + 1);
+        assert_eq!(
+            progress.evidence.parquet_shards,
+            progress.evidence.input_batches
+        );
+        assert_eq!(
+            immutable_artifact_count(base_nodes * factor, &progress.evidence),
+            7 * factor + 4
+        );
+        assert_eq!(progress.evidence.fsync_operations, 23 * factor + 13);
+        assert!(progress.evidence.peak_batch_rows <= CONSTRUCTION_BATCH_ROWS as u64);
         assert!(progress.evidence.peak_accounted_live_bytes <= 64 * 1024 * 1024);
         assert!(progress.evidence.peak_run_records <= budgets.max_run_records as u64);
         assert!(progress.evidence.peak_merge_inputs <= 64);
@@ -2839,7 +2869,7 @@ fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
             {
                 if index == 4 {
                     assert!(
-                        *observed <= base.saturating_mul(factor).saturating_add(4 * 1024 * 1024),
+                        *observed <= base.saturating_mul(factor).saturating_add(64 * 1024 * 1024),
                         "disk-backed merge footprint exceeded linear work: baseline={base} observed={observed} factor={factor}"
                     );
                     continue;

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -1647,7 +1647,7 @@ impl GraphConstructionSession {
             let graph_source = StableDirectory::open(graph_source_dir).map_err(storage)?;
             load_parent_runtime_catalog(&graph_source, parent_topology_generation, budgets)?
         };
-        let mut checkpoint = if let Some(checkpoint) = recovered_checkpoint {
+        let checkpoint = if let Some(checkpoint) = recovered_checkpoint {
             checkpoint
         } else {
             let evidence = GraphConstructionEvidence {
@@ -1708,11 +1708,6 @@ impl GraphConstructionSession {
             parent_generation_uuid,
             &parent_generation_manifest_sha256,
         )?;
-        if checkpoint.next_sequence != 0 && checkpoint.evidence.immutable_artifacts == 0 {
-            checkpoint.evidence.immutable_artifacts =
-                authenticated_receipt_artifact_count(&root, &checkpoint)?;
-            replace_control(&root, CHECKPOINT, &checkpoint)?;
-        }
         let compact_parent = compact_inventory;
         let mut session = Self {
             project_path: project_dir.to_path_buf(),
@@ -1729,6 +1724,13 @@ impl GraphConstructionSession {
         recover_shape_intent(&session.root, &mut session.checkpoint)?;
         session.recover_intent()?;
         session.revalidate_authority()?;
+        if session.checkpoint.next_sequence != 0
+            && session.checkpoint.evidence.immutable_artifacts == 0
+        {
+            session.checkpoint.evidence.immutable_artifacts =
+                authenticated_receipt_artifact_count(&session.root, &session.checkpoint)?;
+            replace_control(&session.root, CHECKPOINT, &session.checkpoint)?;
+        }
         Ok(session)
     }
 
@@ -7262,6 +7264,39 @@ mod tests {
         .expect("incompatible checkpoint must fail admission");
         assert!(error.to_string().contains("checkpoint authority"));
         assert_eq!(std::fs::read(checkpoint_path).unwrap(), before);
+    }
+
+    #[test]
+    fn complete_legacy_shape_intent_recovers_before_artifact_backfill() {
+        let root = TempDir::new().unwrap();
+        let operation = Uuid::from_u128(9_805);
+        let mut session = open(&root, operation.as_u128());
+        session
+            .append(ConstructionChunkKind::Node, "node", &node_batch(1, 2))
+            .unwrap();
+        session.seal().unwrap();
+        let expected_shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+
+        let mut intent_file = session
+            .root
+            .open_child_file(OsStr::new(SHAPE_INTENT))
+            .unwrap();
+        let mut intent = decode_shape_intent(&mut intent_file).unwrap();
+        intent.baseline_evidence.immutable_artifacts = 0;
+        intent.final_evidence.as_mut().unwrap().immutable_artifacts = 0;
+        session.checkpoint.evidence = intent.baseline_evidence.clone();
+        session.checkpoint.shape_authority_sha256 = None;
+        replace_control(&session.root, SHAPE_INTENT, &intent).unwrap();
+        replace_control(&session.root, CHECKPOINT, &session.checkpoint).unwrap();
+        drop(session);
+
+        let mut resumed = open(&root, operation.as_u128());
+        assert_eq!(resumed.evidence().immutable_artifacts, 3);
+        assert!(resumed.checkpoint.shape_authority_sha256.is_some());
+        assert_eq!(
+            resumed.shape_canonical_with_cancellation(|| false).unwrap(),
+            expected_shape
+        );
     }
 
     #[test]

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -334,6 +334,9 @@ pub struct GraphConstructionEvidence {
     pub input_batches: u64,
     /// Immutable Parquet shards.
     pub parquet_shards: u64,
+    /// Immutable payload artifacts accepted from authenticated chunk receipts.
+    #[serde(default)]
+    pub immutable_artifacts: u64,
     /// Bytes submitted through measured immutable-artifact writers.
     /// Control-record traffic is deliberately reported by the outer I/O probe.
     pub write_bytes: u64,
@@ -1533,6 +1536,11 @@ impl GraphConstructionSession {
                 return Err(storage("checkpoint private authority changed"));
             }
             recover_publication(project_dir, &root, checkpoint)?;
+            if checkpoint.next_sequence != 0 && checkpoint.evidence.immutable_artifacts == 0 {
+                checkpoint.evidence.immutable_artifacts =
+                    authenticated_receipt_artifact_count(&root, checkpoint)?;
+                replace_control(&root, CHECKPOINT, checkpoint)?;
+            }
         }
         let (parent_generation_uuid, parent_generation_manifest_sha256) =
             match recovered_checkpoint.as_ref() {
@@ -2659,6 +2667,7 @@ impl GraphConstructionSession {
             .into_iter()
             .chain(receipt.endpoints.iter())
         {
+            evidence.immutable_artifacts = evidence.immutable_artifacts.saturating_add(1);
             evidence.write_bytes = evidence.write_bytes.saturating_add(artifact.bytes);
             evidence.write_operations = evidence
                 .write_operations
@@ -6015,6 +6024,11 @@ fn validate_checkpoint(
         ) && checkpoint.encoding_inventory_sha256.is_none()
         || checkpoint.evidence.input_batches != checkpoint.next_sequence
         || checkpoint.evidence.parquet_shards != checkpoint.next_sequence
+        || checkpoint.evidence.immutable_artifacts != 0
+            && (checkpoint.evidence.immutable_artifacts
+                < checkpoint.next_sequence.saturating_mul(3)
+                || checkpoint.evidence.immutable_artifacts
+                    > checkpoint.next_sequence.saturating_mul(4))
         || checkpoint.evidence.peak_batch_rows > budgets.max_batch_rows as u64
         || checkpoint.evidence.peak_batch_bytes > budgets.max_batch_bytes as u64
         || checkpoint.evidence.peak_run_records > budgets.max_run_records as u64
@@ -6414,6 +6428,40 @@ fn artifact_stem(sequence: u64, kind: ConstructionChunkKind) -> String {
 
 fn receipt_name(sequence: u64) -> String {
     format!("receipt-{sequence:020}.json")
+}
+
+fn authenticated_receipt_artifact_count(
+    root: &StableDirectory,
+    checkpoint: &Checkpoint,
+) -> Result<u64, GfError> {
+    let mut count = 0_u64;
+    let mut prior_digest = None;
+    for sequence in 0..checkpoint.next_sequence {
+        let mut file = root
+            .open_child_file(OsStr::new(&receipt_name(sequence)))
+            .map_err(storage)?;
+        let receipt: ConstructionChunkReceipt = decode_bounded(&mut file)?;
+        validate_receipt_semantics(&receipt, sequence, checkpoint.budgets)?;
+        if receipt.operation_uuid != checkpoint.operation_uuid
+            || receipt.project_identity != checkpoint.project_identity
+            || receipt.session_identity != checkpoint.session_identity
+            || receipt.parent_topology_generation != checkpoint.parent_topology_generation
+            || receipt.ontology_mode != checkpoint.ontology_mode
+            || receipt.semantic_authority_sha256 != checkpoint.semantic_authority_sha256
+            || receipt.prior_receipt_sha256 != prior_digest
+        {
+            return Err(storage("legacy receipt authority or chain changed"));
+        }
+        count = count.saturating_add(3 + u64::from(receipt.endpoints.is_some()));
+        let body = serde_json::to_vec(&receipt).map_err(storage)?;
+        prior_digest = Some(sha256(&body));
+    }
+    if prior_digest != checkpoint.last_receipt_sha256 {
+        return Err(storage(
+            "legacy receipt journal tail differs from checkpoint",
+        ));
+    }
+    Ok(count)
 }
 
 fn chunk_key_name(chunk_id: &str) -> String {
@@ -7082,6 +7130,32 @@ mod tests {
                 .to_string()
                 .contains("unsupported")
         );
+    }
+
+    #[test]
+    fn legacy_artifact_evidence_is_authenticated_and_backfilled_before_append() {
+        let root = TempDir::new().unwrap();
+        let operation = 9_801_u128;
+        let mut session = open(&root, operation);
+        session
+            .append(
+                ConstructionChunkKind::Node,
+                "legacy-node",
+                &node_batch(1, 2),
+            )
+            .unwrap();
+        assert_eq!(session.evidence().immutable_artifacts, 3);
+        session.checkpoint.evidence.immutable_artifacts = 0;
+        replace_control(&session.root, CHECKPOINT, &session.checkpoint).unwrap();
+        drop(session);
+
+        let mut resumed = open(&root, operation);
+        assert_eq!(resumed.evidence().immutable_artifacts, 3);
+        resumed
+            .append(ConstructionChunkKind::Node, "new-node", &node_batch(3, 1))
+            .unwrap();
+        assert_eq!(resumed.accepted_chunks(), 2);
+        assert_eq!(resumed.evidence().immutable_artifacts, 6);
     }
 
     #[test]

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -1536,11 +1536,6 @@ impl GraphConstructionSession {
                 return Err(storage("checkpoint private authority changed"));
             }
             recover_publication(project_dir, &root, checkpoint)?;
-            if checkpoint.next_sequence != 0 && checkpoint.evidence.immutable_artifacts == 0 {
-                checkpoint.evidence.immutable_artifacts =
-                    authenticated_receipt_artifact_count(&root, checkpoint)?;
-                replace_control(&root, CHECKPOINT, checkpoint)?;
-            }
         }
         let (parent_generation_uuid, parent_generation_manifest_sha256) =
             match recovered_checkpoint.as_ref() {
@@ -1652,7 +1647,7 @@ impl GraphConstructionSession {
             let graph_source = StableDirectory::open(graph_source_dir).map_err(storage)?;
             load_parent_runtime_catalog(&graph_source, parent_topology_generation, budgets)?
         };
-        let checkpoint = if let Some(checkpoint) = recovered_checkpoint {
+        let mut checkpoint = if let Some(checkpoint) = recovered_checkpoint {
             checkpoint
         } else {
             let evidence = GraphConstructionEvidence {
@@ -1713,6 +1708,11 @@ impl GraphConstructionSession {
             parent_generation_uuid,
             &parent_generation_manifest_sha256,
         )?;
+        if checkpoint.next_sequence != 0 && checkpoint.evidence.immutable_artifacts == 0 {
+            checkpoint.evidence.immutable_artifacts =
+                authenticated_receipt_artifact_count(&root, &checkpoint)?;
+            replace_control(&root, CHECKPOINT, &checkpoint)?;
+        }
         let compact_parent = compact_inventory;
         let mut session = Self {
             project_path: project_dir.to_path_buf(),
@@ -6436,12 +6436,17 @@ fn authenticated_receipt_artifact_count(
 ) -> Result<u64, GfError> {
     let mut count = 0_u64;
     let mut prior_digest = None;
+    let mut saw_edge = false;
     for sequence in 0..checkpoint.next_sequence {
         let mut file = root
             .open_child_file(OsStr::new(&receipt_name(sequence)))
             .map_err(storage)?;
         let receipt: ConstructionChunkReceipt = decode_bounded(&mut file)?;
         validate_receipt_semantics(&receipt, sequence, checkpoint.budgets)?;
+        if receipt.kind == ConstructionChunkKind::Node && saw_edge {
+            return Err(storage("node receipt follows edge receipt"));
+        }
+        saw_edge |= receipt.kind == ConstructionChunkKind::Edge;
         if receipt.operation_uuid != checkpoint.operation_uuid
             || receipt.project_identity != checkpoint.project_identity
             || receipt.session_identity != checkpoint.session_identity
@@ -6460,6 +6465,9 @@ fn authenticated_receipt_artifact_count(
         return Err(storage(
             "legacy receipt journal tail differs from checkpoint",
         ));
+    }
+    if saw_edge != checkpoint.saw_edge {
+        return Err(storage("checkpoint phase differs from receipt journal"));
     }
     Ok(count)
 }
@@ -7156,6 +7164,104 @@ mod tests {
             .unwrap();
         assert_eq!(resumed.accepted_chunks(), 2);
         assert_eq!(resumed.evidence().immutable_artifacts, 6);
+    }
+
+    #[test]
+    fn legacy_artifact_backfill_rejects_corrupt_chain_without_rewriting_checkpoint() {
+        let root = TempDir::new().unwrap();
+        let operation = Uuid::from_u128(9_802);
+        let mut session = open(&root, operation.as_u128());
+        session
+            .append(ConstructionChunkKind::Node, "first", &node_batch(1, 1))
+            .unwrap();
+        session
+            .append(ConstructionChunkKind::Node, "second", &node_batch(2, 1))
+            .unwrap();
+        let mut second = session.read_receipt(1).unwrap();
+        second.prior_receipt_sha256 = Some(sha256(b"corrupt receipt chain"));
+        replace_control(&session.root, &receipt_name(1), &second).unwrap();
+        session.checkpoint.evidence.immutable_artifacts = 0;
+        replace_control(&session.root, CHECKPOINT, &session.checkpoint).unwrap();
+        let checkpoint_path = root
+            .path()
+            .join(PRIVATE_ROOT)
+            .join(operation.simple().to_string())
+            .join(CHECKPOINT);
+        let before = std::fs::read(&checkpoint_path).unwrap();
+        drop(session);
+
+        let error = GraphConstructionSession::open(
+            root.path(),
+            operation,
+            0,
+            GraphConstructionBudgets::default(),
+        )
+        .err()
+        .expect("corrupt receipt chain must fail closed");
+        assert!(error.to_string().contains("receipt authority or chain"));
+        assert_eq!(std::fs::read(checkpoint_path).unwrap(), before);
+    }
+
+    #[test]
+    fn legacy_artifact_backfill_reconciles_phase_without_rewriting_checkpoint() {
+        let root = TempDir::new().unwrap();
+        let operation = Uuid::from_u128(9_803);
+        let mut session = open(&root, operation.as_u128());
+        session
+            .append(ConstructionChunkKind::Edge, "edge", &edge_batch(1, 1))
+            .unwrap();
+        session.checkpoint.evidence.immutable_artifacts = 0;
+        session.checkpoint.saw_edge = false;
+        replace_control(&session.root, CHECKPOINT, &session.checkpoint).unwrap();
+        let checkpoint_path = root
+            .path()
+            .join(PRIVATE_ROOT)
+            .join(operation.simple().to_string())
+            .join(CHECKPOINT);
+        let before = std::fs::read(&checkpoint_path).unwrap();
+        drop(session);
+
+        let error = GraphConstructionSession::open(
+            root.path(),
+            operation,
+            0,
+            GraphConstructionBudgets::default(),
+        )
+        .err()
+        .expect("receipt phase mismatch must fail closed");
+        assert!(error.to_string().contains("checkpoint phase"));
+        assert_eq!(std::fs::read(checkpoint_path).unwrap(), before);
+    }
+
+    #[test]
+    fn incompatible_checkpoint_fails_before_legacy_artifact_backfill_rewrite() {
+        let root = TempDir::new().unwrap();
+        let operation = Uuid::from_u128(9_804);
+        let mut session = open(&root, operation.as_u128());
+        session
+            .append(ConstructionChunkKind::Node, "node", &node_batch(1, 1))
+            .unwrap();
+        session.checkpoint.evidence.immutable_artifacts = 0;
+        session.checkpoint.budgets.max_chunks -= 1;
+        replace_control(&session.root, CHECKPOINT, &session.checkpoint).unwrap();
+        let checkpoint_path = root
+            .path()
+            .join(PRIVATE_ROOT)
+            .join(operation.simple().to_string())
+            .join(CHECKPOINT);
+        let before = std::fs::read(&checkpoint_path).unwrap();
+        drop(session);
+
+        let error = GraphConstructionSession::open(
+            root.path(),
+            operation,
+            0,
+            GraphConstructionBudgets::default(),
+        )
+        .err()
+        .expect("incompatible checkpoint must fail admission");
+        assert!(error.to_string().contains("checkpoint authority"));
+        assert_eq!(std::fs::read(checkpoint_path).unwrap(), before);
     }
 
     #[test]

--- a/docs/development/perf-g500-ladder.md
+++ b/docs/development/perf-g500-ladder.md
@@ -135,9 +135,13 @@ updates, and file/directory durability barriers; choosing a smaller Arrow
 window multiplies that fixed durability work without improving the session's
 bounded-memory guarantee. Ingest evidence records the configured rows per
 chunk, submitted chunks, artifact and synchronization counts, append elapsed
-time, and combined seal/publication elapsed time. Deterministic 1x/2x/4x tests
-require exact chunk counts and bounded peak windows while aggregate merge work
-remains linear in accepted rows.
+time, reconciliation elapsed time, and combined seal/publication elapsed time.
+Fresh staging reports append time and a null reconciliation time; published
+re-entry reports reconciliation time and a null append time. The immutable
+artifact count is storage-owned evidence reconstructed, for legacy
+checkpoints, from the authenticated receipt chain. Deterministic 1x/2x/4x
+tests require exact chunk counts and bounded peak windows while aggregate
+merge work remains linear in accepted rows.
 
 ## Commands
 

--- a/docs/development/perf-g500-ladder.md
+++ b/docs/development/perf-g500-ladder.md
@@ -126,6 +126,19 @@ therefore survive process replacement and are reused on re-entry.
 > batches, writes, and authentication reads so 1x/2x/4x observations can test
 > bounded memory and linear topology work directly.
 
+The scale client has one authoritative construction boundary: 65,536 rows,
+matching `GraphConstructionBudgets::default().max_batch_rows`. Each full Arrow
+batch is submitted as one durable construction chunk. There is no smaller
+8,192-row subdivision and no larger outer edge buffer. This matters because a
+chunk intentionally owns authenticated artifacts, intent/receipt/checkpoint
+updates, and file/directory durability barriers; choosing a smaller Arrow
+window multiplies that fixed durability work without improving the session's
+bounded-memory guarantee. Ingest evidence records the configured rows per
+chunk, submitted chunks, artifact and synchronization counts, append elapsed
+time, and combined seal/publication elapsed time. Deterministic 1x/2x/4x tests
+require exact chunk counts and bounded peak windows while aggregate merge work
+remains linear in accepted rows.
+
 ## Commands
 
 Always-on CI (SCALE-10 smoke + all reconciliation / determinism / bounded /


### PR DESCRIPTION
Closes #979.

## Outcome

- replaces the hidden 8,192-row subdivision and one-million-row outer buffer with one authoritative 65,536-row Arrow/durable construction boundary;
- preserves deterministic UUIDs, chunk IDs, bounded memory, resumable idempotent replay, and node-before-edge ordering;
- records storage-owned accepted artifact and synchronization evidence plus distinct append, reconciliation, and seal/publication timing;
- safely backfills legacy artifact evidence only after complete checkpoint admission and authenticated receipt-chain validation;
- documents why undersized chunks multiply durability overhead.

## Evidence

- real 1,048,576-edge session: exactly 16 edge appends plus one node append, 67 accepted immutable artifacts, stable digest, and 16 idempotent replay chunks;
- deterministic 1x/2x/4x durable lifecycle with exact chunks/artifacts/fsyncs, bounded 65,536-row memory window, and derived fixed-width merge overlap;
- legacy happy path and corrupt-chain, phase-order, incompatible-checkpoint no-rewrite coverage;
- full `graphforge-storage` suite: 902 passed, 2 ignored, all integration and doc tests passed;
- full `scale_g500_ladder` target: 18 passed, 2 ignored;
- formatting, diff checks, and non-Cypher public-surface gate 12/12 passed.

## Boundaries

This PR fixes harness transaction amplification and its evidence. #951 remains the storage-attribution gate; #901 remains the integrated constant-factor I/O close gate. No Fly resources were created.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790505086&installation_model_id=20486&pr_number=980&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F980&signature=9030f7647ed80faac74bcdb222fa7771dc4083eb3fdd934163a1ab5ab2234344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved large-scale graph construction by processing data in consistent construction windows.
  * Reduced redundant work when resuming publications with previously committed input.
  * Added more predictable scaling for batches, storage artifacts, synchronization, and memory usage.

* **Reliability**
  * Improved checkpoint validation and recovery, including support for legacy checkpoints.
  * Added stronger verification of committed artifacts and receipt chains.

* **Observability**
  * Expanded construction evidence with artifact, synchronization, chunk, and timing metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->