### PR TITLE
feat(storage): complete ordinal reverse identity authority

### DIFF
--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -354,17 +354,20 @@ pub mod uuid_membership;
 pub use uuid_membership::{
     AuthenticatedUuidIndexSnapshot, UuidIndexAppendMetrics, UuidIndexBuildLimits,
     UuidIndexBuildMetrics, UuidIndexKind, UuidIndexOrphanGcWork, UuidMembershipIndex,
-    UuidProbeMetrics, maintain_uuid_membership_orphans, rebuild_uuid_membership_indexes,
-    rebuild_v4_ordinal_identity, uuid_membership_index_is_fresh, uuid_membership_index_present,
+    UuidProbeMetrics, V4OrdinalRebuildDisposition, V4OrdinalRebuildEvidence,
+    maintain_uuid_membership_orphans, rebuild_uuid_membership_indexes, rebuild_v4_ordinal_identity,
+    rebuild_v4_ordinal_identity_with_evidence, uuid_membership_index_is_fresh,
+    uuid_membership_index_present,
 };
 
 pub mod ordinal_identity_v4;
 pub use ordinal_identity_v4::{
     AuthenticatedV4OrdinalIdentityAuthority, ORDINAL_IDENTITY_MANIFEST, ORDINAL_IDENTITY_V4,
     V4OrdinalAdmissionMetrics, V4OrdinalArtifact, V4OrdinalArtifactKind, V4OrdinalBlock,
-    V4OrdinalIdentityDiscovery, V4OrdinalIdentityError, V4OrdinalIdentityLimits,
-    V4OrdinalIdentityManifest, V4OrdinalIdentityOpen, V4OrdinalLookup, V4OrdinalLookupMetrics,
-    V4OrdinalRange, V4OrdinalTombstoneBlock, V4OrdinalTombstones,
+    V4OrdinalFailureEvidence, V4OrdinalFailureKind, V4OrdinalIdentityDiscovery,
+    V4OrdinalIdentityError, V4OrdinalIdentityLimits, V4OrdinalIdentityManifest,
+    V4OrdinalIdentityOpen, V4OrdinalLookup, V4OrdinalLookupMetrics, V4OrdinalRange,
+    V4OrdinalTombstoneBlock, V4OrdinalTombstones,
 };
 
 pub mod property_overlay;

--- a/crates/graphforge-storage/src/ordinal_identity_v4.rs
+++ b/crates/graphforge-storage/src/ordinal_identity_v4.rs
@@ -352,6 +352,52 @@ pub enum V4OrdinalIdentityError {
     },
 }
 
+/// Sanitized failure classification for admission and lookup evidence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum V4OrdinalFailureKind {
+    /// Filesystem or decoding failure.
+    Io,
+    /// Noncanonical or internally inconsistent descriptor state.
+    InvalidDescriptor,
+    /// The selected and encoded topology generations differ.
+    GenerationMismatch,
+    /// Authenticated bytes, identities, or retained capabilities disagree.
+    Authentication,
+    /// The caller batch exceeded its configured bound.
+    RequestLimit,
+}
+
+/// Aggregate-only evidence for a failed admission or lookup.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct V4OrdinalFailureEvidence {
+    /// Typed first failure without identities, paths, or record contents.
+    pub kind: V4OrdinalFailureKind,
+    /// One when authentication failed, otherwise zero.
+    pub authentication_failures: u64,
+}
+
+impl V4OrdinalIdentityError {
+    /// Return sanitized aggregate evidence for this first failure.
+    #[must_use]
+    pub const fn evidence(&self) -> V4OrdinalFailureEvidence {
+        let kind = match self {
+            Self::Io => V4OrdinalFailureKind::Io,
+            Self::InvalidDescriptor(_) => V4OrdinalFailureKind::InvalidDescriptor,
+            Self::GenerationMismatch { .. } => V4OrdinalFailureKind::GenerationMismatch,
+            Self::Authentication => V4OrdinalFailureKind::Authentication,
+            Self::RequestLimit { .. } => V4OrdinalFailureKind::RequestLimit,
+        };
+        V4OrdinalFailureEvidence {
+            kind,
+            authentication_failures: if matches!(self, Self::Authentication) {
+                1
+            } else {
+                0
+            },
+        }
+    }
+}
+
 /// Aggregate-only admission work.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct V4OrdinalAdmissionMetrics {
@@ -2312,6 +2358,22 @@ mod tests {
                 ))
             ));
         }
+    }
+
+    #[test]
+    fn failure_evidence_is_typed_sanitized_and_counts_authentication() {
+        let authentication = V4OrdinalIdentityError::Authentication.evidence();
+        assert_eq!(authentication.kind, V4OrdinalFailureKind::Authentication);
+        assert_eq!(authentication.authentication_failures, 1);
+
+        let bounded = V4OrdinalIdentityError::RequestLimit {
+            requested: 2,
+            maximum: 1,
+        }
+        .evidence();
+        assert_eq!(bounded.kind, V4OrdinalFailureKind::RequestLimit);
+        assert_eq!(bounded.authentication_failures, 0);
+        assert!(!format!("{bounded:?}").contains('/'));
     }
 
     #[test]

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -146,7 +146,8 @@ pub struct V4OrdinalRebuildEvidence {
     pub write_blocks: u64,
     /// Largest bounded construction buffer.
     pub peak_buffer_bytes: u64,
-    /// Maximum coexisting construction artifact bytes.
+    /// Maximum total coexisting scratch bytes across sort runs, merge outputs,
+    /// surrogate runs, and final immutable artifacts.
     pub peak_temporary_bytes: u64,
     /// Durable artifact flushes completed.
     pub fsync_operations: u64,
@@ -170,6 +171,56 @@ pub(crate) struct V4OrdinalBuildMetrics {
     pub(crate) peak_temporary_bytes: u64,
     pub(crate) fsync_operations: u64,
     pub(crate) cancellation_polls: u64,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct V4RebuildScratchAccounting {
+    peak_bytes: u64,
+    sorted_projection_bytes: u64,
+}
+
+impl V4RebuildScratchAccounting {
+    fn register_sorted_projection(&mut self, path: &Path) -> Result<(), GfError> {
+        self.sorted_projection_bytes = path.metadata().map_err(storage_err)?.len();
+        // A complete merge output coexists with the complete input round until
+        // that round is retired. The sorter owns both sets, so account for the
+        // overlap directly instead of inspecting the active scratch tree.
+        self.observe(self.sorted_projection_bytes.checked_mul(2))
+    }
+
+    fn register_surrogate_projection(&mut self, path: &Path) -> Result<(), GfError> {
+        let surrogate_bytes = path.metadata().map_err(storage_err)?.len();
+        if surrogate_bytes != self.sorted_projection_bytes {
+            return Err(storage_err(
+                "v4 rebuild projections have inconsistent scratch sizes",
+            ));
+        }
+        // UUID-sorted input remains live while a complete surrogate merge
+        // output coexists with its complete input round.
+        self.observe(
+            self.sorted_projection_bytes.checked_add(
+                surrogate_bytes
+                    .checked_mul(2)
+                    .ok_or_else(|| storage_err("v4 rebuild scratch byte count overflow"))?,
+            ),
+        )
+    }
+
+    fn register_artifacts(&mut self, artifact_peak: u64) -> Result<(), GfError> {
+        // Both final sort projections remain open while the immutable forward
+        // and ordinal artifacts are streamed.
+        self.observe(
+            self.sorted_projection_bytes
+                .checked_mul(2)
+                .and_then(|bytes| bytes.checked_add(artifact_peak)),
+        )
+    }
+
+    fn observe(&mut self, bytes: Option<u64>) -> Result<(), GfError> {
+        let bytes = bytes.ok_or_else(|| storage_err("v4 rebuild scratch byte count overflow"))?;
+        self.peak_bytes = self.peak_bytes.max(bytes);
+        Ok(())
+    }
 }
 
 /// Aggregate-only work evidence for one incremental v4 publication.
@@ -7304,6 +7355,7 @@ fn stage_v4_ordinal_rebuild_locked(
     let artifact_directory =
         graphforge_filesystem::StableDirectory::open(&artifact_root).map_err(storage_err)?;
     let mut metrics = UuidIndexBuildMetrics::default();
+    let mut scratch_accounting = V4RebuildScratchAccounting::default();
 
     // Both bounded projections originate from this single canonical topology
     // scan. For an immutable project generation, authenticate its declared
@@ -7344,7 +7396,9 @@ fn stage_v4_ordinal_rebuild_locked(
     // No v3 index file is opened or used as migration authority.
     let uuid_sorted =
         merge_node_surrogate_runs(uuid_runs, scratch.path(), limits.merge_fan_in, &mut metrics)?;
+    scratch_accounting.register_sorted_projection(&uuid_sorted)?;
     let ordinal_sorted = build_surrogate_run(&uuid_sorted, scratch.path(), limits, &mut metrics)?;
+    scratch_accounting.register_surrogate_projection(&ordinal_sorted)?;
 
     let mut writer = V4OrdinalConstructionWriter::start(generation, &artifact_directory)?;
     let mut cancelled = || false;
@@ -7363,6 +7417,7 @@ fn stage_v4_ordinal_rebuild_locked(
         writer.push_ordinal(node_id, Uuid::from_bytes(uuid), &mut cancelled)?;
     }
     let (manifest, v4_metrics) = writer.finish()?;
+    scratch_accounting.register_artifacts(v4_metrics.peak_temporary_bytes)?;
     metrics.node_count = v4_metrics.input_records;
     for artifact in manifest
         .forward_identities
@@ -7380,17 +7435,26 @@ fn stage_v4_ordinal_rebuild_locked(
         return Err(storage_err("v4 ordinal manifest exceeds bound"));
     }
     batch.stage_bytes(&destination.join(V4_ORDINAL_MANIFEST), &manifest_bytes)?;
+    v4_rebuild_evidence(generation, metrics, &v4_metrics, scratch_accounting)
+}
+
+fn v4_rebuild_evidence(
+    generation: u64,
+    build: UuidIndexBuildMetrics,
+    artifacts: &V4OrdinalBuildMetrics,
+    scratch: V4RebuildScratchAccounting,
+) -> Result<V4OrdinalRebuildEvidence, GfError> {
     Ok(V4OrdinalRebuildEvidence {
         disposition: V4OrdinalRebuildDisposition::CanonicalTopology,
         topology_generation: generation,
-        input_identities: v4_metrics.input_records,
-        ordinal_ranges: u64::try_from(v4_metrics.ranges).map_err(storage_err)?,
-        artifact_bytes: v4_metrics.artifact_bytes,
-        write_blocks: v4_metrics.write_blocks,
-        peak_buffer_bytes: u64::try_from(v4_metrics.peak_buffer_bytes).map_err(storage_err)?,
-        peak_temporary_bytes: v4_metrics.peak_temporary_bytes,
-        fsync_operations: v4_metrics.fsync_operations,
-        build: metrics,
+        input_identities: artifacts.input_records,
+        ordinal_ranges: u64::try_from(artifacts.ranges).map_err(storage_err)?,
+        artifact_bytes: artifacts.artifact_bytes,
+        write_blocks: artifacts.write_blocks,
+        peak_buffer_bytes: u64::try_from(artifacts.peak_buffer_bytes).map_err(storage_err)?,
+        peak_temporary_bytes: scratch.peak_bytes,
+        fsync_operations: artifacts.fsync_operations,
+        build,
     })
 }
 
@@ -10473,10 +10537,43 @@ pub(crate) mod tests {
             return;
         }
 
-        for failpoint in [
-            "rewrite.before_intent",
-            "rewrite.after_preparing_disarm",
-            "rewrite.after_durable_intent",
+        #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+        enum PreRecoveryDisposition {
+            PriorV3Only,
+            IncompleteV4,
+            CompleteV4,
+        }
+
+        for (failpoint, expected) in [
+            ("rewrite.before_intent", PreRecoveryDisposition::PriorV3Only),
+            (
+                "rewrite.after_preparing_disarm",
+                PreRecoveryDisposition::PriorV3Only,
+            ),
+            (
+                "rewrite.after_durable_intent",
+                PreRecoveryDisposition::CompleteV4,
+            ),
+            (
+                "rewrite.after_first_data_install",
+                PreRecoveryDisposition::CompleteV4,
+            ),
+            (
+                "rewrite.after_middle_data_install",
+                PreRecoveryDisposition::CompleteV4,
+            ),
+            (
+                "rewrite.after_last_data_install",
+                PreRecoveryDisposition::CompleteV4,
+            ),
+            (
+                "rewrite.before_generation_authority",
+                PreRecoveryDisposition::CompleteV4,
+            ),
+            (
+                "rewrite.after_generation_authority",
+                PreRecoveryDisposition::CompleteV4,
+            ),
         ] {
             let (dir, _, _) = fixture();
             fs::write(
@@ -10512,12 +10609,42 @@ pub(crate) mod tests {
                 Some(crate::project_failpoint::exit_code()),
                 "{failpoint}"
             );
+            // Inspect the crashed tree before recovery. The prior v3 authority
+            // must remain valid at every boundary; v4 is either absent,
+            // incomplete and therefore inadmissible, or already complete.
+            UuidMembershipIndex::open(dir.path()).unwrap();
+            let index = dir.path().join(INDEX_DIR);
+            let manifest = fs::read(index.join(V4_ORDINAL_MANIFEST)).ok();
+            let receipt = fs::read(index.join(V4_ORDINAL_RECEIPT)).ok();
+            let observed = match (manifest.as_deref(), receipt.as_deref()) {
+                (None, None) => PreRecoveryDisposition::PriorV3Only,
+                (Some(manifest), Some(receipt)) => {
+                    let receipt: TopologyIndexReceipt = serde_json::from_slice(receipt).unwrap();
+                    assert_eq!(receipt.expected_generation, 7, "{failpoint}");
+                    assert_eq!(receipt.manifest_sha256, hex_sha256(manifest), "{failpoint}");
+                    let authority = crate::ordinal_identity_v4::V4OrdinalIdentityAuthority {
+                        topology_generation: 7,
+                        manifest_sha256: receipt.manifest_sha256,
+                    };
+                    assert!(matches!(
+                        crate::ordinal_identity_v4::V4OrdinalIdentityHandle::open(
+                            dir.path(),
+                            &authority,
+                            crate::V4OrdinalIdentityLimits::default()
+                        ),
+                        Ok(crate::V4OrdinalIdentityOpen::Ready(_))
+                    ));
+                    PreRecoveryDisposition::CompleteV4
+                }
+                _ => PreRecoveryDisposition::IncompleteV4,
+            };
+            assert_eq!(observed, expected, "{failpoint}");
+
             assert!(child(true).success(), "{failpoint}");
             assert!(!dir.path().join(".graphforge-rewrite-v1.json").exists());
             assert_eq!(manifest_generation(dir.path()).unwrap(), Some(7));
             UuidMembershipIndex::open(dir.path()).unwrap();
 
-            let index = dir.path().join(INDEX_DIR);
             let manifest_bytes = fs::read(index.join(V4_ORDINAL_MANIFEST)).unwrap();
             let receipt: TopologyIndexReceipt =
                 serde_json::from_slice(&fs::read(index.join(V4_ORDINAL_RECEIPT)).unwrap()).unwrap();
@@ -10536,6 +10663,32 @@ pub(crate) mod tests {
                 Ok(crate::V4OrdinalIdentityOpen::Ready(_))
             ));
         }
+    }
+
+    #[test]
+    fn v4_rebuild_scratch_accounting_is_exact_linear_and_overflow_bounded() {
+        for identities in [1_u64, 2, 4] {
+            let dir = tempfile::tempdir().unwrap();
+            let uuid = dir.path().join("uuid.run");
+            let ordinal = dir.path().join("ordinal.run");
+            fs::write(&uuid, vec![0_u8; usize::try_from(identities * 24).unwrap()]).unwrap();
+            fs::write(
+                &ordinal,
+                vec![0_u8; usize::try_from(identities * 24).unwrap()],
+            )
+            .unwrap();
+            let mut accounting = V4RebuildScratchAccounting::default();
+            accounting.register_sorted_projection(&uuid).unwrap();
+            accounting.register_surrogate_projection(&ordinal).unwrap();
+            accounting.register_artifacts(identities * 40).unwrap();
+            assert_eq!(accounting.peak_bytes, identities * 88);
+        }
+
+        let mut accounting = V4RebuildScratchAccounting {
+            peak_bytes: 0,
+            sorted_projection_bytes: u64::MAX,
+        };
+        assert!(accounting.register_artifacts(1).is_err());
     }
 
     #[test]

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -122,6 +122,38 @@ pub struct UuidIndexBuildMetrics {
     pub temporary_runs: u64,
 }
 
+/// Explicit source disposition for a v4 ordinal rebuild.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum V4OrdinalRebuildDisposition {
+    /// Rebuilt from canonical topology; v3 reverse runs were not interpreted.
+    CanonicalTopology,
+}
+
+/// Aggregate-only evidence for one explicit v4 rebuild/migration.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct V4OrdinalRebuildEvidence {
+    /// Rebuild source and migration disposition.
+    pub disposition: V4OrdinalRebuildDisposition,
+    /// Exact topology generation published.
+    pub topology_generation: u64,
+    /// Canonical node identities accepted.
+    pub input_identities: u64,
+    /// Maximal contiguous ordinal ranges emitted.
+    pub ordinal_ranges: u64,
+    /// Immutable v4 artifact payload bytes written before publication staging.
+    pub artifact_bytes: u64,
+    /// Fixed-size artifact blocks submitted.
+    pub write_blocks: u64,
+    /// Largest bounded construction buffer.
+    pub peak_buffer_bytes: u64,
+    /// Maximum coexisting construction artifact bytes.
+    pub peak_temporary_bytes: u64,
+    /// Durable artifact flushes completed.
+    pub fsync_operations: u64,
+    /// Existing bounded external-sort evidence.
+    pub build: UuidIndexBuildMetrics,
+}
+
 const V4_ORDINAL_BLOCK_BYTES: usize = 64 * 1024;
 // Durable rewrite admits 16,384 graph-file entries. Reserve generation.json
 // plus forward, tombstone, receipt, and manifest participants.
@@ -7179,6 +7211,14 @@ pub fn rebuild_v4_ordinal_identity(
     project_dir: &Path,
     limits: UuidIndexBuildLimits,
 ) -> Result<UuidIndexBuildMetrics, GfError> {
+    rebuild_v4_ordinal_identity_with_evidence(project_dir, limits).map(|evidence| evidence.build)
+}
+
+/// Rebuild v4 ordinal identity and return its explicit sanitized disposition.
+pub fn rebuild_v4_ordinal_identity_with_evidence(
+    project_dir: &Path,
+    limits: UuidIndexBuildLimits,
+) -> Result<V4OrdinalRebuildEvidence, GfError> {
     let metrics = std::rc::Rc::new(std::cell::RefCell::new(None));
     let callback_metrics = std::rc::Rc::clone(&metrics);
     let root = project_dir.to_path_buf();
@@ -7232,7 +7272,10 @@ pub fn rebuild_v4_ordinal_identity(
         &root,
         participant,
     )?;
-    Ok(metrics.borrow_mut().take().unwrap_or_default())
+    metrics
+        .borrow_mut()
+        .take()
+        .ok_or_else(|| storage_err("v4 ordinal rebuild produced no evidence"))
 }
 
 fn stage_v4_ordinal_rebuild_locked(
@@ -7240,7 +7283,7 @@ fn stage_v4_ordinal_rebuild_locked(
     generation: u64,
     limits: UuidIndexBuildLimits,
     batch: &mut crate::staging::RewriteBatch,
-) -> Result<UuidIndexBuildMetrics, GfError> {
+) -> Result<V4OrdinalRebuildEvidence, GfError> {
     if generation == 0 {
         return Err(storage_err(
             "v4 ordinal identity requires a nonzero topology generation",
@@ -7337,7 +7380,18 @@ fn stage_v4_ordinal_rebuild_locked(
         return Err(storage_err("v4 ordinal manifest exceeds bound"));
     }
     batch.stage_bytes(&destination.join(V4_ORDINAL_MANIFEST), &manifest_bytes)?;
-    Ok(metrics)
+    Ok(V4OrdinalRebuildEvidence {
+        disposition: V4OrdinalRebuildDisposition::CanonicalTopology,
+        topology_generation: generation,
+        input_identities: v4_metrics.input_records,
+        ordinal_ranges: u64::try_from(v4_metrics.ranges).map_err(storage_err)?,
+        artifact_bytes: v4_metrics.artifact_bytes,
+        write_blocks: v4_metrics.write_blocks,
+        peak_buffer_bytes: u64::try_from(v4_metrics.peak_buffer_bytes).map_err(storage_err)?,
+        peak_temporary_bytes: v4_metrics.peak_temporary_bytes,
+        fsync_operations: v4_metrics.fsync_operations,
+        build: metrics,
+    })
 }
 
 /// Ensure the current topology generation has a v3 UUID index before a
@@ -10329,7 +10383,7 @@ pub(crate) mod tests {
         )
         .unwrap();
 
-        let metrics = rebuild_v4_ordinal_identity(
+        let evidence = rebuild_v4_ordinal_identity_with_evidence(
             dir.path(),
             UuidIndexBuildLimits {
                 scan_batch_rows: 1,
@@ -10338,7 +10392,17 @@ pub(crate) mod tests {
             },
         )
         .unwrap();
-        assert_eq!(metrics.node_count, 3);
+        assert_eq!(
+            evidence.disposition,
+            V4OrdinalRebuildDisposition::CanonicalTopology
+        );
+        assert_eq!(evidence.topology_generation, 7);
+        assert_eq!(evidence.input_identities, 3);
+        assert_eq!(evidence.ordinal_ranges, 2);
+        assert!(evidence.artifact_bytes >= 3 * (24 + 16));
+        assert!(evidence.write_blocks >= 3);
+        assert!(evidence.peak_buffer_bytes <= 3 * V4_ORDINAL_BLOCK_BYTES as u64);
+        assert_eq!(evidence.build.node_count, 3);
         let root = dir.path().join(INDEX_DIR);
         let manifest_bytes = fs::read(root.join(V4_ORDINAL_MANIFEST)).unwrap();
         let manifest: crate::V4OrdinalIdentityManifest =
@@ -10390,6 +10454,88 @@ pub(crate) mod tests {
         assert_eq!(metrics.node_count, 3);
         assert!(root.join(V4_ORDINAL_MANIFEST).is_file());
         assert!(root.join(V4_ORDINAL_RECEIPT).is_file());
+    }
+
+    #[test]
+    fn v4_rebuild_subprocess_crash_retry_selects_one_complete_authority() {
+        const CHILD_ROOT: &str = "GRAPHFORGE_V4_REBUILD_CHILD_ROOT";
+        const RETRY: &str = "GRAPHFORGE_V4_REBUILD_RETRY";
+        if let Ok(root) = std::env::var(CHILD_ROOT) {
+            let root = Path::new(&root);
+            crate::durable_rewrite::recover(root).unwrap();
+            if !root.join(INDEX_DIR).join(V4_ORDINAL_MANIFEST).exists() {
+                rebuild_v4_ordinal_identity_with_evidence(root, UuidIndexBuildLimits::default())
+                    .unwrap();
+            }
+            if std::env::var(RETRY).is_err() {
+                panic!("configured v4 rebuild failpoint did not terminate the process");
+            }
+            return;
+        }
+
+        for failpoint in [
+            "rewrite.before_intent",
+            "rewrite.after_preparing_disarm",
+            "rewrite.after_durable_intent",
+        ] {
+            let (dir, _, _) = fixture();
+            fs::write(
+                dir.path().join("topology/generation.json"),
+                b"{\"topology_generation\":7,\"search_generation\":0,\"property_generation\":0}\n",
+            )
+            .unwrap();
+            rebuild_uuid_membership_indexes(dir.path(), UuidIndexBuildLimits::default()).unwrap();
+
+            let child = |retry: bool| {
+                let mut command = std::process::Command::new(std::env::current_exe().unwrap());
+                command
+                    .arg("--exact")
+                    .arg(
+                        "uuid_membership::tests::v4_rebuild_subprocess_crash_retry_selects_one_complete_authority",
+                    )
+                    .arg("--nocapture")
+                    .env(CHILD_ROOT, dir.path());
+                if retry {
+                    command.env(RETRY, "1");
+                } else {
+                    command
+                        .env(
+                            "GRAPHFORGE_PROJECT_FAILPOINTS",
+                            "graphforge-internal-subprocess-v1",
+                        )
+                        .env("GRAPHFORGE_PROJECT_FAILPOINT", failpoint);
+                }
+                command.status().unwrap()
+            };
+            assert_eq!(
+                child(false).code(),
+                Some(crate::project_failpoint::exit_code()),
+                "{failpoint}"
+            );
+            assert!(child(true).success(), "{failpoint}");
+            assert!(!dir.path().join(".graphforge-rewrite-v1.json").exists());
+            assert_eq!(manifest_generation(dir.path()).unwrap(), Some(7));
+            UuidMembershipIndex::open(dir.path()).unwrap();
+
+            let index = dir.path().join(INDEX_DIR);
+            let manifest_bytes = fs::read(index.join(V4_ORDINAL_MANIFEST)).unwrap();
+            let receipt: TopologyIndexReceipt =
+                serde_json::from_slice(&fs::read(index.join(V4_ORDINAL_RECEIPT)).unwrap()).unwrap();
+            assert_eq!(receipt.expected_generation, 7);
+            assert_eq!(receipt.manifest_sha256, hex_sha256(&manifest_bytes));
+            let authority = crate::ordinal_identity_v4::V4OrdinalIdentityAuthority {
+                topology_generation: 7,
+                manifest_sha256: receipt.manifest_sha256,
+            };
+            assert!(matches!(
+                crate::ordinal_identity_v4::V4OrdinalIdentityHandle::open(
+                    dir.path(),
+                    &authority,
+                    crate::V4OrdinalIdentityLimits::default()
+                ),
+                Ok(crate::V4OrdinalIdentityOpen::Ready(_))
+            ));
+        }
     }
 
     #[test]

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -177,6 +177,10 @@ pub(crate) struct V4OrdinalBuildMetrics {
 struct V4RebuildScratchAccounting {
     peak_bytes: u64,
     sorted_projection_bytes: u64,
+    live_artifact_bytes: u64,
+    retained_staged_bytes: u64,
+    staged_control_bytes: u64,
+    scratch_live: bool,
 }
 
 impl V4RebuildScratchAccounting {
@@ -209,10 +213,44 @@ impl V4RebuildScratchAccounting {
     fn register_artifacts(&mut self, artifact_peak: u64) -> Result<(), GfError> {
         // Both final sort projections remain open while the immutable forward
         // and ordinal artifacts are streamed.
-        self.observe(
+        self.live_artifact_bytes = artifact_peak;
+        self.scratch_live = true;
+        self.observe_current()
+    }
+
+    fn register_staged_artifact(&mut self, bytes: u64) -> Result<(), GfError> {
+        self.retained_staged_bytes = self
+            .retained_staged_bytes
+            .checked_add(bytes)
+            .ok_or_else(|| storage_err("v4 rebuild staged artifact byte count overflow"))?;
+        self.observe_current()
+    }
+
+    fn register_staged_control(&mut self, bytes: u64) -> Result<(), GfError> {
+        self.staged_control_bytes = self
+            .staged_control_bytes
+            .checked_add(bytes)
+            .ok_or_else(|| storage_err("v4 rebuild staged control byte count overflow"))?;
+        self.observe_current()
+    }
+
+    fn release_scratch(&mut self) -> Result<(), GfError> {
+        self.scratch_live = false;
+        self.observe_current()
+    }
+
+    fn observe_current(&mut self) -> Result<(), GfError> {
+        let scratch = if self.scratch_live {
             self.sorted_projection_bytes
                 .checked_mul(2)
-                .and_then(|bytes| bytes.checked_add(artifact_peak)),
+                .and_then(|bytes| bytes.checked_add(self.live_artifact_bytes))
+        } else {
+            Some(0)
+        };
+        self.observe(
+            scratch
+                .and_then(|bytes| bytes.checked_add(self.retained_staged_bytes))
+                .and_then(|bytes| bytes.checked_add(self.staged_control_bytes)),
         )
     }
 
@@ -221,6 +259,13 @@ impl V4RebuildScratchAccounting {
         self.peak_bytes = self.peak_bytes.max(bytes);
         Ok(())
     }
+}
+
+struct StagedV4OrdinalRebuild {
+    generation: u64,
+    build: UuidIndexBuildMetrics,
+    artifacts: V4OrdinalBuildMetrics,
+    scratch: V4RebuildScratchAccounting,
 }
 
 /// Aggregate-only work evidence for one incremental v4 publication.
@@ -7275,13 +7320,12 @@ pub fn rebuild_v4_ordinal_identity_with_evidence(
     let root = project_dir.to_path_buf();
     let participant: crate::durable_rewrite::RewriteParticipantPreparer<'_> =
         Box::new(move |context, batch| {
-            let built = stage_v4_ordinal_rebuild_locked(
+            let mut staged = stage_v4_ordinal_rebuild_locked(
                 context.project_root,
                 context.prior.topology,
                 limits,
                 batch,
             )?;
-            *callback_metrics.borrow_mut() = Some(built);
             let manifest_path = context
                 .project_root
                 .join(INDEX_DIR)
@@ -7306,6 +7350,16 @@ pub fn rebuild_v4_ordinal_identity_with_evidence(
                     .join(V4_ORDINAL_RECEIPT),
                 &receipt_bytes,
             )?;
+            staged.scratch.register_staged_control(
+                u64::try_from(receipt_bytes.len())
+                    .map_err(|_| storage_err("v4 rebuild receipt length overflow"))?,
+            )?;
+            *callback_metrics.borrow_mut() = Some(v4_rebuild_evidence(
+                staged.generation,
+                staged.build,
+                &staged.artifacts,
+                staged.scratch,
+            )?);
             // Artifacts, then receipt, then facet manifest. The enclosing
             // generation record remains the durable transaction's last switch.
             batch.move_staged_destination_to_end(&manifest_path);
@@ -7334,7 +7388,7 @@ fn stage_v4_ordinal_rebuild_locked(
     generation: u64,
     limits: UuidIndexBuildLimits,
     batch: &mut crate::staging::RewriteBatch,
-) -> Result<V4OrdinalRebuildEvidence, GfError> {
+) -> Result<StagedV4OrdinalRebuild, GfError> {
     if generation == 0 {
         return Err(storage_err(
             "v4 ordinal identity requires a nonzero topology generation",
@@ -7419,6 +7473,38 @@ fn stage_v4_ordinal_rebuild_locked(
     let (manifest, v4_metrics) = writer.finish()?;
     scratch_accounting.register_artifacts(v4_metrics.peak_temporary_bytes)?;
     metrics.node_count = v4_metrics.input_records;
+    stage_v4_rebuild_artifacts(
+        &manifest,
+        &destination,
+        &artifact_root,
+        batch,
+        &mut scratch_accounting,
+    )?;
+    let manifest_bytes = serde_json::to_vec(&manifest).map_err(storage_err)?;
+    if manifest_bytes.len() as u64 > crate::ordinal_identity_v4::MAX_MANIFEST_BYTES {
+        return Err(storage_err("v4 ordinal manifest exceeds bound"));
+    }
+    batch.stage_bytes(&destination.join(V4_ORDINAL_MANIFEST), &manifest_bytes)?;
+    scratch_accounting.register_staged_control(
+        u64::try_from(manifest_bytes.len())
+            .map_err(|_| storage_err("v4 ordinal manifest length overflow"))?,
+    )?;
+    scratch_accounting.release_scratch()?;
+    Ok(StagedV4OrdinalRebuild {
+        generation,
+        build: metrics,
+        artifacts: v4_metrics,
+        scratch: scratch_accounting,
+    })
+}
+
+fn stage_v4_rebuild_artifacts(
+    manifest: &crate::V4OrdinalIdentityManifest,
+    destination: &Path,
+    artifact_root: &Path,
+    batch: &mut crate::staging::RewriteBatch,
+    scratch: &mut V4RebuildScratchAccounting,
+) -> Result<(), GfError> {
     for artifact in manifest
         .forward_identities
         .iter()
@@ -7429,13 +7515,9 @@ fn stage_v4_ordinal_rebuild_locked(
             &destination.join(&artifact.name),
             &artifact_root.join(&artifact.name),
         )?;
+        scratch.register_staged_artifact(artifact.bytes)?;
     }
-    let manifest_bytes = serde_json::to_vec(&manifest).map_err(storage_err)?;
-    if manifest_bytes.len() as u64 > crate::ordinal_identity_v4::MAX_MANIFEST_BYTES {
-        return Err(storage_err("v4 ordinal manifest exceeds bound"));
-    }
-    batch.stage_bytes(&destination.join(V4_ORDINAL_MANIFEST), &manifest_bytes)?;
-    v4_rebuild_evidence(generation, metrics, &v4_metrics, scratch_accounting)
+    Ok(())
 }
 
 fn v4_rebuild_evidence(
@@ -10544,35 +10626,46 @@ pub(crate) mod tests {
             CompleteV4,
         }
 
-        for (failpoint, expected) in [
-            ("rewrite.before_intent", PreRecoveryDisposition::PriorV3Only),
+        for (failpoint, expected, expected_installed) in [
+            (
+                "rewrite.before_intent",
+                PreRecoveryDisposition::PriorV3Only,
+                0,
+            ),
             (
                 "rewrite.after_preparing_disarm",
                 PreRecoveryDisposition::PriorV3Only,
+                0,
             ),
             (
                 "rewrite.after_durable_intent",
-                PreRecoveryDisposition::CompleteV4,
+                PreRecoveryDisposition::PriorV3Only,
+                0,
             ),
             (
                 "rewrite.after_first_data_install",
-                PreRecoveryDisposition::CompleteV4,
+                PreRecoveryDisposition::IncompleteV4,
+                1,
             ),
             (
                 "rewrite.after_middle_data_install",
-                PreRecoveryDisposition::CompleteV4,
+                PreRecoveryDisposition::IncompleteV4,
+                2,
             ),
             (
                 "rewrite.after_last_data_install",
-                PreRecoveryDisposition::CompleteV4,
+                PreRecoveryDisposition::IncompleteV4,
+                usize::MAX,
             ),
             (
                 "rewrite.before_generation_authority",
-                PreRecoveryDisposition::CompleteV4,
+                PreRecoveryDisposition::IncompleteV4,
+                usize::MAX,
             ),
             (
                 "rewrite.after_generation_authority",
                 PreRecoveryDisposition::CompleteV4,
+                usize::MAX,
             ),
         ] {
             let (dir, _, _) = fixture();
@@ -10612,31 +10705,103 @@ pub(crate) mod tests {
             // Inspect the crashed tree before recovery. The prior v3 authority
             // must remain valid at every boundary; v4 is either absent,
             // incomplete and therefore inadmissible, or already complete.
-            UuidMembershipIndex::open(dir.path()).unwrap();
+            UuidMembershipIndex::open_at_generation(dir.path(), 7).unwrap();
+            let journal_path = dir.path().join(".graphforge-rewrite-v1.json");
+            let journal = fs::read(&journal_path)
+                .ok()
+                .map(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).unwrap());
+            let entries = journal
+                .as_ref()
+                .and_then(|value| value.get("entries"))
+                .and_then(serde_json::Value::as_array);
+            let intended_v4 = entries
+                .into_iter()
+                .flatten()
+                .filter(|entry| {
+                    entry["class"] == "data"
+                        && entry["destination"]
+                            .as_str()
+                            .is_some_and(|path| path.starts_with(INDEX_DIR))
+                })
+                .collect::<Vec<_>>();
+            let installed_v4 = intended_v4
+                .iter()
+                .filter(|entry| {
+                    let path = dir.path().join(entry["destination"].as_str().unwrap());
+                    let expected = entry["temporary_file"].as_str().unwrap();
+                    File::open(path)
+                        .ok()
+                        .and_then(|file| graphforge_filesystem::file_identity(&file).ok())
+                        .is_some_and(|identity| {
+                            identity
+                                .file_id
+                                .iter()
+                                .map(|byte| format!("{byte:02x}"))
+                                .collect::<String>()
+                                == expected
+                        })
+                })
+                .count();
+            if expected_installed == usize::MAX {
+                assert_eq!(installed_v4, intended_v4.len(), "{failpoint}");
+            } else {
+                assert_eq!(
+                    installed_v4, expected_installed,
+                    "{failpoint}: journal={journal:?} intended={intended_v4:?}"
+                );
+            }
+            let generation_selected = entries
+                .into_iter()
+                .flatten()
+                .find(|entry| entry["class"] == "generation_authority")
+                .is_some_and(|entry| {
+                    let expected = entry["temporary_file"].as_str().unwrap();
+                    File::open(dir.path().join("topology/generation.json"))
+                        .ok()
+                        .and_then(|file| graphforge_filesystem::file_identity(&file).ok())
+                        .is_some_and(|identity| {
+                            identity
+                                .file_id
+                                .iter()
+                                .map(|byte| format!("{byte:02x}"))
+                                .collect::<String>()
+                                == expected
+                        })
+                });
             let index = dir.path().join(INDEX_DIR);
-            let manifest = fs::read(index.join(V4_ORDINAL_MANIFEST)).ok();
-            let receipt = fs::read(index.join(V4_ORDINAL_RECEIPT)).ok();
-            let observed = match (manifest.as_deref(), receipt.as_deref()) {
-                (None, None) => PreRecoveryDisposition::PriorV3Only,
+            let coherent_v4 = match (
+                fs::read(index.join(V4_ORDINAL_MANIFEST)).ok(),
+                fs::read(index.join(V4_ORDINAL_RECEIPT)).ok(),
+            ) {
                 (Some(manifest), Some(receipt)) => {
-                    let receipt: TopologyIndexReceipt = serde_json::from_slice(receipt).unwrap();
+                    let receipt: TopologyIndexReceipt = serde_json::from_slice(&receipt).unwrap();
                     assert_eq!(receipt.expected_generation, 7, "{failpoint}");
-                    assert_eq!(receipt.manifest_sha256, hex_sha256(manifest), "{failpoint}");
+                    assert_eq!(
+                        receipt.manifest_sha256,
+                        hex_sha256(&manifest),
+                        "{failpoint}"
+                    );
                     let authority = crate::ordinal_identity_v4::V4OrdinalIdentityAuthority {
                         topology_generation: 7,
                         manifest_sha256: receipt.manifest_sha256,
                     };
-                    assert!(matches!(
+                    matches!(
                         crate::ordinal_identity_v4::V4OrdinalIdentityHandle::open(
                             dir.path(),
                             &authority,
                             crate::V4OrdinalIdentityLimits::default()
                         ),
                         Ok(crate::V4OrdinalIdentityOpen::Ready(_))
-                    ));
-                    PreRecoveryDisposition::CompleteV4
+                    )
                 }
-                _ => PreRecoveryDisposition::IncompleteV4,
+                _ => false,
+            };
+            let observed = if generation_selected && coherent_v4 {
+                PreRecoveryDisposition::CompleteV4
+            } else if installed_v4 == 0 {
+                PreRecoveryDisposition::PriorV3Only
+            } else {
+                PreRecoveryDisposition::IncompleteV4
             };
             assert_eq!(observed, expected, "{failpoint}");
 
@@ -10646,10 +10811,31 @@ pub(crate) mod tests {
             UuidMembershipIndex::open(dir.path()).unwrap();
 
             let manifest_bytes = fs::read(index.join(V4_ORDINAL_MANIFEST)).unwrap();
-            let receipt: TopologyIndexReceipt =
-                serde_json::from_slice(&fs::read(index.join(V4_ORDINAL_RECEIPT)).unwrap()).unwrap();
+            let receipt_bytes = fs::read(index.join(V4_ORDINAL_RECEIPT)).unwrap();
+            let receipt: TopologyIndexReceipt = serde_json::from_slice(&receipt_bytes).unwrap();
             assert_eq!(receipt.expected_generation, 7);
             assert_eq!(receipt.manifest_sha256, hex_sha256(&manifest_bytes));
+            let generation = crate::durable_rewrite::GenerationPair {
+                topology: 7,
+                search: 0,
+                property: 0,
+            };
+            assert_eq!(
+                crate::durable_rewrite::reconcile_auxiliary(
+                    dir.path(),
+                    generation,
+                    generation,
+                    &crate::AuxiliaryReceipt {
+                        kind: "uuid-membership/v4".to_owned(),
+                        schema_version: crate::ORDINAL_IDENTITY_V4,
+                        path: format!("{INDEX_DIR}/{V4_ORDINAL_RECEIPT}"),
+                        digest: hex_sha256(&receipt_bytes),
+                        bytes: u64::try_from(receipt_bytes.len()).unwrap(),
+                    },
+                )
+                .unwrap(),
+                crate::durable_rewrite::AuxiliaryReconcileOutcome::Committed
+            );
             let authority = crate::ordinal_identity_v4::V4OrdinalIdentityAuthority {
                 topology_generation: 7,
                 manifest_sha256: receipt.manifest_sha256,
@@ -10669,26 +10855,55 @@ pub(crate) mod tests {
     fn v4_rebuild_scratch_accounting_is_exact_linear_and_overflow_bounded() {
         for identities in [1_u64, 2, 4] {
             let dir = tempfile::tempdir().unwrap();
-            let uuid = dir.path().join("uuid.run");
-            let ordinal = dir.path().join("ordinal.run");
-            fs::write(&uuid, vec![0_u8; usize::try_from(identities * 24).unwrap()]).unwrap();
+            let uuids = (1..=identities)
+                .map(|identity| Uuid::from_u128(u128::from(identity)))
+                .collect::<Vec<_>>();
+            let node_ids = (1..=identities).collect::<Vec<_>>();
+            write_node_parquet_with_ids(
+                &dir.path().join("topology/nodes.parquet"),
+                &uuids,
+                &node_ids,
+            );
             fs::write(
-                &ordinal,
-                vec![0_u8; usize::try_from(identities * 24).unwrap()],
+                dir.path().join("topology/generation.json"),
+                b"{\"topology_generation\":7,\"search_generation\":0,\"property_generation\":0}\n",
             )
             .unwrap();
-            let mut accounting = V4RebuildScratchAccounting::default();
-            accounting.register_sorted_projection(&uuid).unwrap();
-            accounting.register_surrogate_projection(&ordinal).unwrap();
-            accounting.register_artifacts(identities * 40).unwrap();
-            assert_eq!(accounting.peak_bytes, identities * 88);
+            let evidence = rebuild_v4_ordinal_identity_with_evidence(
+                dir.path(),
+                UuidIndexBuildLimits {
+                    scan_batch_rows: 1,
+                    run_records: 1,
+                    merge_fan_in: 2,
+                },
+            )
+            .unwrap();
+            let index = dir.path().join(INDEX_DIR);
+            let manifest_bytes = fs::metadata(index.join(V4_ORDINAL_MANIFEST)).unwrap().len();
+            let receipt_bytes = fs::metadata(index.join(V4_ORDINAL_RECEIPT)).unwrap().len();
+            let with_live_scratch = identities * 48 + evidence.artifact_bytes * 2 + manifest_bytes;
+            let after_scratch_release = evidence.artifact_bytes + manifest_bytes + receipt_bytes;
+            assert_eq!(
+                evidence.peak_temporary_bytes,
+                with_live_scratch.max(after_scratch_release)
+            );
         }
 
-        let mut accounting = V4RebuildScratchAccounting {
-            peak_bytes: 0,
+        let mut projection_overflow = V4RebuildScratchAccounting {
             sorted_projection_bytes: u64::MAX,
+            ..Default::default()
         };
-        assert!(accounting.register_artifacts(1).is_err());
+        assert!(projection_overflow.register_artifacts(1).is_err());
+        let mut artifact_overflow = V4RebuildScratchAccounting {
+            retained_staged_bytes: u64::MAX,
+            ..Default::default()
+        };
+        assert!(artifact_overflow.register_staged_artifact(1).is_err());
+        let mut control_overflow = V4RebuildScratchAccounting {
+            staged_control_bytes: u64::MAX,
+            ..Default::default()
+        };
+        assert!(control_overflow.register_staged_control(1).is_err());
     }
 
     #[test]

--- a/docs/book/architecture/storage.md
+++ b/docs/book/architecture/storage.md
@@ -82,6 +82,16 @@ largest sparse surrogate, and anonymous buffers do not grow with graph
 cardinality. Version-3 state is an explicit rebuild-required disposition; a v4
 reader never interprets or mixes v3 reverse records.
 
+Fixed-hop consumers such as projection-aware expansion retain one authenticated
+generation handle and submit bounded destination-ID batches to it. They do not
+reopen or reauthenticate the full authority for each chunk. The lookup restores
+caller order while exposing sanitized requested/unique/found, selected-range,
+logical-byte, coalesced-call, and peak-buffer evidence. Typed failure evidence
+counts authentication failure without containing graph identities or paths.
+The explicit migration disposition is `CanonicalTopology`: rebuild scans
+canonical topology under the durable rewrite and never treats a v3 reverse run
+as v4 authority.
+
 Admission also streams both forward and ordinal authorities through the same
 domain-separated mapping commitment and count. Strict forward UUID ordering and
 that bounded reconciliation reject duplicate, missing, or cross-generation

--- a/docs/book/architecture/storage.md
+++ b/docs/book/architecture/storage.md
@@ -92,8 +92,9 @@ The explicit migration disposition is `CanonicalTopology`: rebuild scans
 canonical topology under the durable rewrite and never treats a v3 reverse run
 as v4 authority. Its temporary-byte peak covers every coexisting external-sort
 run, merge output, surrogate projection, and final artifact through
-storage-owned lifecycle accounting; it is not an artifact-only approximation
-or a recursive observation of the active scratch tree.
+storage-owned lifecycle accounting, including retained staging copies and
+control-record temporaries. It is not an artifact-only approximation or a
+recursive observation of the active scratch tree.
 
 Admission also streams both forward and ordinal authorities through the same
 domain-separated mapping commitment and count. Strict forward UUID ordering and

--- a/docs/book/architecture/storage.md
+++ b/docs/book/architecture/storage.md
@@ -90,7 +90,10 @@ logical-byte, coalesced-call, and peak-buffer evidence. Typed failure evidence
 counts authentication failure without containing graph identities or paths.
 The explicit migration disposition is `CanonicalTopology`: rebuild scans
 canonical topology under the durable rewrite and never treats a v3 reverse run
-as v4 authority.
+as v4 authority. Its temporary-byte peak covers every coexisting external-sort
+run, merge output, surrogate projection, and final artifact through
+storage-owned lifecycle accounting; it is not an artifact-only approximation
+or a recursive observation of the active scratch tree.
 
 Admission also streams both forward and ordinal authorities through the same
 domain-separated mapping commitment and count. Strict forward UUID ordering and

--- a/docs/book/architecture/uuid-membership-index.md
+++ b/docs/book/architecture/uuid-membership-index.md
@@ -39,6 +39,13 @@ opens a v3 reverse run as migration input. Durable-rewrite recovery either
 retains the prior v3-only authority or completes the receipt-bound v4 facet;
 there is no mixed-version read state.
 
+`peak_temporary_bytes` is the total maximum coexisting rebuild scratch, not
+merely the final artifact size. Storage-owned accounting includes scan runs and
+their merge outputs, the UUID-sorted and surrogate-sorted projections, and the
+immutable forward/range artifacts while both projections remain live. It uses
+the exact registered run lengths at lifecycle transitions rather than a
+recursive scan of an active scratch directory.
+
 Standalone graph roots have no project-generation `graph/files` inventory.
 Only the mutation writer has a narrow exception: immediately before entering
 the single durable-rewrite critical section it may pin the already-open sibling

--- a/docs/book/architecture/uuid-membership-index.md
+++ b/docs/book/architecture/uuid-membership-index.md
@@ -42,8 +42,10 @@ there is no mixed-version read state.
 `peak_temporary_bytes` is the total maximum coexisting rebuild scratch, not
 merely the final artifact size. Storage-owned accounting includes scan runs and
 their merge outputs, the UUID-sorted and surrogate-sorted projections, and the
-immutable forward/range artifacts while both projections remain live. It uses
-the exact registered run lengths at lifecycle transitions rather than a
+immutable forward/range artifacts while both projections remain live. Each
+retained `stage_file` copy and staged manifest/receipt control is charged at its
+actual lifecycle transition, so a source artifact and its retained copy both
+appear in the peak. Accounting uses exact registered lengths rather than a
 recursive scan of an active scratch directory.
 
 Standalone graph roots have no project-generation `graph/files` inventory.

--- a/docs/book/architecture/uuid-membership-index.md
+++ b/docs/book/architecture/uuid-membership-index.md
@@ -32,6 +32,13 @@ requires the ordinal digest selected by the project receipt. A malformed,
 substituted, or generation-mismatched ordinal facet fails closed and never
 falls back to v3.
 
+The explicit rebuild API constructs v4 only from canonical topology and returns
+an aggregate `CanonicalTopology` disposition with generation, identity/range,
+artifact-byte, fixed-block, buffer, temporary-run, and fsync evidence. It never
+opens a v3 reverse run as migration input. Durable-rewrite recovery either
+retains the prior v3-only authority or completes the receipt-bound v4 facet;
+there is no mixed-version read state.
+
 Standalone graph roots have no project-generation `graph/files` inventory.
 Only the mutation writer has a narrow exception: immediately before entering
 the single durable-rewrite critical section it may pin the already-open sibling
@@ -47,6 +54,14 @@ writer takes the project rewrite lock first and the exclusive ordinal lock
 second, retaining it through data installation and the manifest switch. A
 long-lived immutable read handle therefore cannot starve a writer; it advances
 only by opening a newly receipt-authorized generation.
+
+Query execution should open one authenticated handle for its pinned generation
+and reuse it across bounded destination-ID chunks. Each lookup reports only
+requested/unique/found counts, selected ranges, logical bytes, coalesced calls,
+tombstones, and bounded-buffer charges. A typed failure can be reduced to
+sanitized failure evidence, including an authentication-failure count, without
+emitting UUIDs, paths, or record contents. Consumers must not reopen the index
+per chunk or substitute the v3 membership LSM.
 
 Orphan collection starts from the current authenticated v3 manifest and, when
 the ordinal facet exists, requires the opaque authority resolved from a pinned


### PR DESCRIPTION
Closes #967.

## Outcome

- completes the generation-authenticated v4 `node_id -> node_uuid/live-state` authority introduced through #977/#978;
- exposes bounded/coalesced lookup and sanitized typed failure evidence for reusable generation-pinned consumers;
- provides an explicit canonical-topology v4 rebuild disposition that never interprets v3 reverse state;
- records storage-owned build, artifact, block, buffer, fsync, and total coexisting scratch evidence;
- documents the generation-handle reuse contract required by #966.

## Recovery and scale proof

- subprocess migration matrix covers all eight durable rewrite boundaries;
- pre-recovery inspection authenticates the prior v3 authority, exact installed participant identities, durable journal, and generation-last selection without triggering recovery;
- retry proves journal cleanup, exact receipt/manifest binding, committed auxiliary reconciliation, and authenticated v4 open;
- real 1x/2x/4x rebuilds account both sorted projections, original immutable artifacts, every retained staged copy, and manifest/receipt controls with checked overflow;
- v4 reverse identity suite 23/23, broad v4 suite 20/20, explicit rebuild 2/2, focused crash and scratch regressions green;
- storage library clippy with warnings denied, formatting/diff checks, and public-surface gate 12/12 green.

## Boundaries

Projection planning and relationship/node column pruning remain #966. No Fly resources were created.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790505604&installation_model_id=20486&pr_number=981&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F981&signature=f4e05daa2576aec8186b9df6faad55091a60332ab49cdc4b1ce2c40855194527"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed reporting for v4 ordinal identity rebuilds, including completion status, record counts, write metrics, and temporary storage usage.
  * Added sanitized failure classifications and authentication-failure indicators without exposing sensitive details.
  * Added stronger crash-recovery and publication-state handling during rebuilds.
* **Bug Fixes**
  * Improved temporary storage accounting with overflow protection and bounded resource usage.
  * Improved authority selection and consistency when rebuilding identity data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->