### PR TITLE
test(bench): add native local resource admission

### DIFF
--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -1,6 +1,8 @@
 .venv/
 generated/
 outputs/
+output/
+stage/
 credentials/
 *.secret
 fly/.env

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -16,5 +16,5 @@ smoke-rust: install
 	PYTHONPATH=harness uv run --locked python -m graphforge_bench.check_rust_graph
 
 local-admission: install
-	PYTHONPATH=$(CURDIR)/harness uv run --locked reframe -C reframe/settings.py -c reframe/checks -l | grep -F LocalBenchExecAdmission
-	PYTHONPATH=$(CURDIR)/harness uv run --locked reframe -C reframe/settings.py -c reframe/checks -r
+	PYTHONPATH=$(CURDIR)/harness uv run --locked reframe -C reframe/settings.py -c reframe/checks -n '^LocalBenchExecAdmission$$' -l | grep -F LocalBenchExecAdmission
+	PYTHONPATH=$(CURDIR)/harness uv run --locked reframe -C reframe/settings.py -c reframe/checks -n '^LocalBenchExecAdmission$$' -r

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -16,4 +16,5 @@ smoke-rust: install
 	PYTHONPATH=harness uv run --locked python -m graphforge_bench.check_rust_graph
 
 local-admission: install
+	PYTHONPATH=$(CURDIR)/harness uv run --locked reframe -C reframe/settings.py -c reframe/checks -l | grep -F LocalBenchExecAdmission
 	PYTHONPATH=$(CURDIR)/harness uv run --locked reframe -C reframe/settings.py -c reframe/checks -r

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install smoke smoke-python smoke-rust
+.PHONY: install smoke smoke-python smoke-rust local-admission
 
 install:
 	uv sync --locked
@@ -14,3 +14,6 @@ smoke-rust: install
 	CARGO_TARGET_DIR=$(CURDIR)/target cargo clippy --workspace --locked -- -D warnings
 	CARGO_TARGET_DIR=$(CURDIR)/target cargo test --locked --manifest-path Cargo.toml
 	PYTHONPATH=harness uv run --locked python -m graphforge_bench.check_rust_graph
+
+local-admission: install
+	PYTHONPATH=$(CURDIR)/harness uv run --locked reframe -C reframe/settings.py -c reframe/checks -r

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -42,3 +42,16 @@ The smoke installs only the locked benchmark environment, imports ReFrame and
 BenchExec, discovers the checked-in fixtures, runs the Python unit tests, and
 checks the dependency-free Rust smoke runner. It does not run a benchmark,
 start a provider, or open a GraphForge project.
+
+## Native local admission
+
+`make -C benchmarks local-admission` uses ReFrame's local scheduler and local
+launcher to run the admission probe. The probe admits only native Linux with
+cgroups v2 and the required namespace controls. BenchExec's namespace-enabled
+`RunExecutor` must then account for CPU, wall time, peak memory, reads, and
+writes while terminating a detached descendant tree at the wall-time limit.
+
+Unsupported hosts return sanitized typed disqualification evidence. In
+particular, macOS and Docker Desktop do not prove native Linux admission and
+must not be used as substitutes. This probe creates no Fly resources and does
+not authorize a Graph500 scale run.

--- a/benchmarks/harness/graphforge_bench/local_admission.py
+++ b/benchmarks/harness/graphforge_bench/local_admission.py
@@ -7,14 +7,13 @@ dynamic-loader error instead of a useful qualification result.
 
 from __future__ import annotations
 
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 import json
 from pathlib import Path
 import platform
 import subprocess
 import sys
-from typing import Callable, Mapping, Sequence
-
 
 SCHEMA = "graphforge-local-admission-evidence/1"
 REQUIRED_METRICS = ("walltime", "cputime", "memory", "blkio-read", "blkio-write")
@@ -85,9 +84,7 @@ def qualify_local_host(
     if not all(facts[name] for name in ("mount_namespace", "pid_namespace", "user_namespace")):
         return _evidence("disqualified", "namespace_controls_unavailable", facts)
 
-    check = runner(
-        [sys.executable, "-m", "benchexec.check_cgroups", "--wait", "0", "--no-thread"]
-    )
+    check = runner([sys.executable, "-m", "benchexec.check_cgroups", "--wait", "0", "--no-thread"])
     if check.returncode != 0:
         return _evidence("disqualified", "benchexec_cgroups_unavailable", facts)
 

--- a/benchmarks/harness/graphforge_bench/local_admission.py
+++ b/benchmarks/harness/graphforge_bench/local_admission.py
@@ -1,0 +1,120 @@
+"""Typed native-Linux admission for ReFrame and BenchExec.
+
+This module deliberately checks the host before importing BenchExec.  BenchExec
+is Linux-only, so importing it on macOS would otherwise fail with an untyped
+dynamic-loader error instead of a useful qualification result.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import platform
+import subprocess
+import sys
+from typing import Callable, Mapping, Sequence
+
+
+SCHEMA = "graphforge-local-admission-evidence/1"
+REQUIRED_METRICS = ("walltime", "cputime", "memory", "blkio-read", "blkio-write")
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+CommandRunner = Callable[[Sequence[str]], CommandResult]
+
+
+def _run(command: Sequence[str]) -> CommandResult:
+    completed = subprocess.run(command, text=True, capture_output=True, check=False)
+    return CommandResult(completed.returncode, completed.stdout, completed.stderr)
+
+
+def _facts(
+    system: str,
+    cgroup_root: Path = Path("/sys/fs/cgroup"),
+    proc_root: Path = Path("/proc"),
+) -> dict[str, object]:
+    linux = system == "Linux"
+    return {
+        "operating_system": system.lower(),
+        "cgroups_version": 2 if linux and (cgroup_root / "cgroup.controllers").is_file() else None,
+        "mount_namespace": linux and (proc_root / "self/ns/mnt").exists(),
+        "pid_namespace": linux and (proc_root / "self/ns/pid").exists(),
+        "user_namespace": linux and (proc_root / "self/ns/user").exists(),
+    }
+
+
+def _evidence(
+    result: str,
+    cause: str | None,
+    facts: Mapping[str, object],
+    measurements: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    document: dict[str, object] = {
+        "schema": SCHEMA,
+        "result": result,
+        "cause": cause,
+        "facts": dict(facts),
+    }
+    if measurements is not None:
+        document["measurements"] = dict(measurements)
+    return document
+
+
+def qualify_local_host(
+    *,
+    system: str | None = None,
+    cgroup_root: Path = Path("/sys/fs/cgroup"),
+    proc_root: Path = Path("/proc"),
+    runner: CommandRunner = _run,
+) -> dict[str, object]:
+    """Run the complete no-provider admission and return sanitized evidence."""
+
+    detected_system = system or platform.system()
+    facts = _facts(detected_system, cgroup_root, proc_root)
+    if detected_system != "Linux":
+        return _evidence("disqualified", "unsupported_operating_system", facts)
+    if facts["cgroups_version"] != 2:
+        return _evidence("disqualified", "cgroups_v2_unavailable", facts)
+    if not all(facts[name] for name in ("mount_namespace", "pid_namespace", "user_namespace")):
+        return _evidence("disqualified", "namespace_controls_unavailable", facts)
+
+    check = runner(
+        [sys.executable, "-m", "benchexec.check_cgroups", "--wait", "0", "--no-thread"]
+    )
+    if check.returncode != 0:
+        return _evidence("disqualified", "benchexec_cgroups_unavailable", facts)
+
+    fixture = runner([sys.executable, "-m", "graphforge_bench.local_admission_fixture"])
+    if fixture.returncode != 0:
+        return _evidence("failed", "benchexec_fixture_failed", facts)
+    try:
+        measurements = json.loads(fixture.stdout)
+    except json.JSONDecodeError:
+        return _evidence("failed", "malformed_benchexec_evidence", facts)
+
+    missing = [name for name in REQUIRED_METRICS if name not in measurements]
+    if missing:
+        return _evidence("failed", "mandatory_metric_missing", facts)
+    if measurements.get("terminationreason") != "walltime":
+        return _evidence("failed", "process_tree_limit_not_enforced", facts, measurements)
+    if measurements.get("descendant_stopped") is not True:
+        return _evidence("failed", "descendant_survived_termination", facts, measurements)
+    return _evidence("passed", None, facts, measurements)
+
+
+def main() -> None:
+    document = qualify_local_host()
+    print(json.dumps(document, sort_keys=True))
+    if document["result"] == "failed":
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/harness/graphforge_bench/local_admission.py
+++ b/benchmarks/harness/graphforge_bench/local_admission.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 import json
+import math
 from pathlib import Path
 import platform
 import subprocess
@@ -66,6 +67,16 @@ def _evidence(
     return document
 
 
+def _metrics_are_finite_numbers(measurements: Mapping[str, object]) -> bool:
+    for name in REQUIRED_METRICS:
+        value = measurements[name]
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return False
+        if not math.isfinite(value) or value < 0:
+            return False
+    return True
+
+
 def qualify_local_host(
     *,
     system: str | None = None,
@@ -96,9 +107,14 @@ def qualify_local_host(
     except json.JSONDecodeError:
         return _evidence("failed", "malformed_benchexec_evidence", facts)
 
+    if not isinstance(measurements, dict):
+        return _evidence("failed", "malformed_benchexec_evidence", facts)
+
     missing = [name for name in REQUIRED_METRICS if name not in measurements]
     if missing:
         return _evidence("failed", "mandatory_metric_missing", facts)
+    if not _metrics_are_finite_numbers(measurements):
+        return _evidence("failed", "malformed_benchexec_evidence", facts)
     if measurements.get("terminationreason") != "walltime":
         return _evidence("failed", "process_tree_limit_not_enforced", facts, measurements)
     if measurements.get("descendant_stopped") is not True:

--- a/benchmarks/harness/graphforge_bench/local_admission_fixture.py
+++ b/benchmarks/harness/graphforge_bench/local_admission_fixture.py
@@ -1,0 +1,72 @@
+"""BenchExec-owned process-tree, limit, and I/O admission fixture."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import time
+
+
+def _json_value(value: object) -> object:
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    raw = getattr(value, "raw", None)
+    if raw is not None:
+        return raw
+    return str(value)
+
+
+def main() -> None:
+    # Import only after the outer admission has proved a Linux host.
+    from benchexec.runexecutor import RunExecutor
+
+    with tempfile.TemporaryDirectory(prefix="graphforge-benchexec-admission-") as directory:
+        root = Path(directory)
+        heartbeat = root / "descendant.heartbeat"
+        output = root / "run.log"
+        worker = root / "worker.py"
+        worker.write_text(
+            """\
+from pathlib import Path
+import subprocess
+import sys
+import time
+
+heartbeat = Path(sys.argv[1])
+subprocess.Popen(
+    [
+        sys.executable,
+        "-c",
+        "from pathlib import Path; import sys,time; p=Path(sys.argv[1]); exec('while True:\\n p.write_bytes(b\\\"x\\\"*65536)\\n time.sleep(0.02)')",
+        str(heartbeat),
+    ],
+    start_new_session=True,
+)
+while True:
+    bytearray(1024 * 1024)
+    time.sleep(0.02)
+""",
+            encoding="utf-8",
+        )
+
+        executor = RunExecutor(use_namespaces=True)
+        result = executor.execute_run(
+            [sys.executable, str(worker), str(heartbeat)],
+            str(output),
+            walltimelimit=1,
+            memlimit=128 * 1024 * 1024,
+            workingDir=str(root),
+        )
+        before = heartbeat.stat().st_mtime_ns if heartbeat.exists() else None
+        time.sleep(0.25)
+        after = heartbeat.stat().st_mtime_ns if heartbeat.exists() else None
+        normalized = {key: _json_value(value) for key, value in result.items()}
+        normalized["descendant_stopped"] = before is not None and before == after
+        print(json.dumps(normalized, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/harness/graphforge_bench/local_admission_fixture.py
+++ b/benchmarks/harness/graphforge_bench/local_admission_fixture.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-import subprocess
 import sys
 import tempfile
 import time
@@ -21,6 +20,7 @@ def _json_value(value: object) -> object:
 
 def main() -> None:
     # Import only after the outer admission has proved a Linux host.
+    from benchexec.containerexecutor import DIR_FULL_ACCESS, DIR_HIDDEN, DIR_OVERLAY
     from benchexec.runexecutor import RunExecutor
 
     with tempfile.TemporaryDirectory(prefix="graphforge-benchexec-admission-") as directory:
@@ -52,7 +52,19 @@ while True:
             encoding="utf-8",
         )
 
-        executor = RunExecutor(use_namespaces=True)
+        # The exact fixture directory is the only host-writable path. Without
+        # this explicit mount, the heartbeat would live in BenchExec's overlay
+        # and disappear with the container, making descendant cleanup
+        # impossible to verify from the supervising process.
+        executor = RunExecutor(
+            use_namespaces=True,
+            dir_modes={
+                "/": DIR_OVERLAY,
+                "/run": DIR_HIDDEN,
+                "/tmp": DIR_HIDDEN,
+                str(root): DIR_FULL_ACCESS,
+            },
+        )
         result = executor.execute_run(
             [sys.executable, str(worker), str(heartbeat)],
             str(output),

--- a/benchmarks/harness/graphforge_bench/local_admission_fixture.py
+++ b/benchmarks/harness/graphforge_bench/local_admission_fixture.py
@@ -27,7 +27,21 @@ def main() -> None:
         root = Path(directory)
         heartbeat = root / "descendant.heartbeat"
         output = root / "run.log"
+        descendant = root / "descendant.py"
         worker = root / "worker.py"
+        descendant.write_text(
+            """\
+from pathlib import Path
+import sys
+import time
+
+heartbeat = Path(sys.argv[1])
+while True:
+    heartbeat.write_bytes(b"x" * 65536)
+    time.sleep(0.02)
+""",
+            encoding="utf-8",
+        )
         worker.write_text(
             """\
 from pathlib import Path
@@ -36,13 +50,9 @@ import sys
 import time
 
 heartbeat = Path(sys.argv[1])
+descendant = Path(sys.argv[2])
 subprocess.Popen(
-    [
-        sys.executable,
-        "-c",
-        "from pathlib import Path; import sys,time; p=Path(sys.argv[1]); exec('while True:\\n p.write_bytes(b\\\"x\\\"*65536)\\n time.sleep(0.02)')",
-        str(heartbeat),
-    ],
+    [sys.executable, str(descendant), str(heartbeat)],
     start_new_session=True,
 )
 while True:
@@ -66,7 +76,7 @@ while True:
             },
         )
         result = executor.execute_run(
-            [sys.executable, str(worker), str(heartbeat)],
+            [sys.executable, str(worker), str(heartbeat), str(descendant)],
             str(output),
             walltimelimit=1,
             memlimit=128 * 1024 * 1024,

--- a/benchmarks/profiles/local-linux-cgroups-v2.json
+++ b/benchmarks/profiles/local-linux-cgroups-v2.json
@@ -1,0 +1,10 @@
+{
+  "schema": "graphforge-benchmark-profile/1",
+  "id": "local-linux-cgroups-v2",
+  "execution": "native-local-admission",
+  "provider": null,
+  "scheduler": "local",
+  "launcher": "local",
+  "resource_authority": "benchexec-cgroups-v2",
+  "container_isolation": "benchexec-namespaces"
+}

--- a/benchmarks/reframe/checks/local_admission.py
+++ b/benchmarks/reframe/checks/local_admission.py
@@ -1,4 +1,5 @@
 import reframe as rfm
+from reframe.core.builtins import sanity_function
 import reframe.utility.sanity as sn
 
 
@@ -9,6 +10,6 @@ class LocalBenchExecAdmission(rfm.RunOnlyRegressionTest):
     executable = "python"
     executable_opts = ["-m", "graphforge_bench.local_admission"]  # noqa: RUF012
 
-    @rfm.sanity_function
+    @sanity_function
     def validate_typed_result(self):
         return sn.assert_found(r'"result": "(passed|disqualified)"', self.stdout)

--- a/benchmarks/reframe/checks/local_admission.py
+++ b/benchmarks/reframe/checks/local_admission.py
@@ -1,0 +1,16 @@
+import json
+
+import reframe as rfm
+import reframe.utility.sanity as sn
+
+
+@rfm.simple_test
+class LocalBenchExecAdmission(rfm.RunOnlyRegressionTest):
+    valid_systems = ["graphforge-local:local"]
+    valid_prog_environs = ["builtin"]
+    executable = "python"
+    executable_opts = ["-m", "graphforge_bench.local_admission"]
+
+    @sanity_function
+    def validate_typed_result(self):
+        return sn.assert_found(r'"result": "(passed|disqualified)"', self.stdout)

--- a/benchmarks/reframe/checks/local_admission.py
+++ b/benchmarks/reframe/checks/local_admission.py
@@ -1,16 +1,14 @@
-import json
-
 import reframe as rfm
 import reframe.utility.sanity as sn
 
 
 @rfm.simple_test
 class LocalBenchExecAdmission(rfm.RunOnlyRegressionTest):
-    valid_systems = ["graphforge-local:local"]
-    valid_prog_environs = ["builtin"]
+    valid_systems = ["graphforge-local:local"]  # noqa: RUF012
+    valid_prog_environs = ["builtin"]  # noqa: RUF012
     executable = "python"
-    executable_opts = ["-m", "graphforge_bench.local_admission"]
+    executable_opts = ["-m", "graphforge_bench.local_admission"]  # noqa: RUF012
 
-    @sanity_function
+    @rfm.sanity_function
     def validate_typed_result(self):
         return sn.assert_found(r'"result": "(passed|disqualified)"', self.stdout)

--- a/benchmarks/reframe/settings.py
+++ b/benchmarks/reframe/settings.py
@@ -1,0 +1,17 @@
+site_configuration = {
+    "systems": [
+        {
+            "name": "graphforge-local",
+            "descr": "Native local GraphForge benchmark admission",
+            "hostnames": [".*"],
+            "partitions": [
+                {
+                    "name": "local",
+                    "scheduler": "local",
+                    "launcher": "local",
+                    "environs": ["builtin"],
+                }
+            ],
+        }
+    ]
+}

--- a/benchmarks/schemas/local-admission-evidence.json
+++ b/benchmarks/schemas/local-admission-evidence.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema": "graphforge-local-admission-evidence/1",
+  "type": "object",
+  "properties": {
+    "schema": {"const": "graphforge-local-admission-evidence/1"},
+    "result": {"enum": ["passed", "disqualified", "failed"]},
+    "cause": {
+      "type": ["string", "null"],
+      "enum": [
+        null,
+        "unsupported_operating_system",
+        "cgroups_v2_unavailable",
+        "namespace_controls_unavailable",
+        "benchexec_cgroups_unavailable",
+        "benchexec_fixture_failed",
+        "malformed_benchexec_evidence",
+        "mandatory_metric_missing",
+        "process_tree_limit_not_enforced",
+        "descendant_survived_termination"
+      ]
+    },
+    "facts": {
+      "type": "object",
+      "properties": {
+        "operating_system": {"type": "string"},
+        "cgroups_version": {"type": ["integer", "null"]},
+        "mount_namespace": {"type": "boolean"},
+        "pid_namespace": {"type": "boolean"},
+        "user_namespace": {"type": "boolean"}
+      },
+      "required": ["operating_system", "cgroups_version", "mount_namespace", "pid_namespace", "user_namespace"],
+      "additionalProperties": false
+    },
+    "measurements": {"type": "object"}
+  },
+  "required": ["schema", "result", "cause", "facts"],
+  "additionalProperties": false
+}

--- a/benchmarks/tests/test_local_admission.py
+++ b/benchmarks/tests/test_local_admission.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from graphforge_bench.local_admission import CommandResult, qualify_local_host
+
+
+class LocalAdmissionTests(unittest.TestCase):
+    @staticmethod
+    def _linux_roots(directory: str) -> tuple[Path, Path]:
+        root = Path(directory)
+        cgroup = root / "cgroup"
+        proc = root / "proc"
+        cgroup.mkdir()
+        (cgroup / "cgroup.controllers").write_text("cpu io memory", encoding="utf-8")
+        namespace = proc / "self/ns"
+        namespace.mkdir(parents=True)
+        for name in ("mnt", "pid", "user"):
+            (namespace / name).touch()
+        return cgroup, proc
+
+    def test_macos_is_typed_disqualification_without_importing_benchexec(self) -> None:
+        result = qualify_local_host(system="Darwin")
+        self.assertEqual(result["result"], "disqualified")
+        self.assertEqual(result["cause"], "unsupported_operating_system")
+
+    def test_linux_without_cgroups_v2_is_typed_disqualification(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            result = qualify_local_host(system="Linux", cgroup_root=Path(directory))
+        self.assertEqual(result["cause"], "cgroups_v2_unavailable")
+
+    def test_admitted_linux_requires_metrics_and_tree_termination(self) -> None:
+        commands: list[tuple[str, ...]] = []
+
+        def runner(command):
+            commands.append(tuple(command))
+            if "benchexec.check_cgroups" in command:
+                return CommandResult(0, "", "")
+            measurements = {
+                "walltime": 1.0,
+                "cputime": 0.1,
+                "memory": 1048576,
+                "blkio-read": 4096,
+                "blkio-write": 65536,
+                "terminationreason": "walltime",
+                "descendant_stopped": True,
+            }
+            return CommandResult(0, json.dumps(measurements), "")
+
+        with tempfile.TemporaryDirectory() as directory:
+            cgroup, proc = self._linux_roots(directory)
+            result = qualify_local_host(
+                system="Linux", cgroup_root=cgroup, proc_root=proc, runner=runner
+            )
+        self.assertEqual(result["result"], "passed")
+        self.assertIsNone(result["cause"])
+        self.assertEqual(len(commands), 2)
+
+    def test_missing_io_metric_fails_closed(self) -> None:
+        def runner(command):
+            if "benchexec.check_cgroups" in command:
+                return CommandResult(0, "", "")
+            return CommandResult(
+                0,
+                json.dumps(
+                    {
+                        "walltime": 1.0,
+                        "cputime": 0.1,
+                        "memory": 1,
+                        "blkio-read": 0,
+                        "terminationreason": "walltime",
+                        "descendant_stopped": True,
+                    }
+                ),
+                "",
+            )
+
+        with tempfile.TemporaryDirectory() as directory:
+            cgroup, proc = self._linux_roots(directory)
+            result = qualify_local_host(
+                system="Linux", cgroup_root=cgroup, proc_root=proc, runner=runner
+            )
+        self.assertEqual(result["result"], "failed")
+        self.assertEqual(result["cause"], "mandatory_metric_missing")
+
+    def test_live_descendant_fails_closed(self) -> None:
+        def runner(command):
+            if "benchexec.check_cgroups" in command:
+                return CommandResult(0, "", "")
+            return CommandResult(
+                0,
+                json.dumps(
+                    {
+                        "walltime": 1.0,
+                        "cputime": 0.1,
+                        "memory": 1,
+                        "blkio-read": 0,
+                        "blkio-write": 1,
+                        "terminationreason": "walltime",
+                        "descendant_stopped": False,
+                    }
+                ),
+                "",
+            )
+
+        with tempfile.TemporaryDirectory() as directory:
+            cgroup, proc = self._linux_roots(directory)
+            result = qualify_local_host(
+                system="Linux", cgroup_root=cgroup, proc_root=proc, runner=runner
+            )
+        self.assertEqual(result["cause"], "descendant_survived_termination")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/tests/test_local_admission.py
+++ b/benchmarks/tests/test_local_admission.py
@@ -86,6 +86,44 @@ class LocalAdmissionTests(unittest.TestCase):
         self.assertEqual(result["result"], "failed")
         self.assertEqual(result["cause"], "mandatory_metric_missing")
 
+    def test_non_object_measurements_fail_as_malformed(self) -> None:
+        def runner(command):
+            if "benchexec.check_cgroups" in command:
+                return CommandResult(0, "", "")
+            return CommandResult(0, json.dumps(list(range(5))), "")
+
+        with tempfile.TemporaryDirectory() as directory:
+            cgroup, proc = self._linux_roots(directory)
+            result = qualify_local_host(
+                system="Linux", cgroup_root=cgroup, proc_root=proc, runner=runner
+            )
+        self.assertEqual(result["cause"], "malformed_benchexec_evidence")
+
+    def test_non_numeric_and_non_finite_metrics_fail_as_malformed(self) -> None:
+        for invalid in (None, True, "1", float("nan"), float("inf"), -1):
+            with self.subTest(invalid=invalid):
+
+                def runner(command, invalid_metric=invalid):
+                    if "benchexec.check_cgroups" in command:
+                        return CommandResult(0, "", "")
+                    measurements = {
+                        "walltime": 1.0,
+                        "cputime": 0.1,
+                        "memory": 1048576,
+                        "blkio-read": 4096,
+                        "blkio-write": invalid_metric,
+                        "terminationreason": "walltime",
+                        "descendant_stopped": True,
+                    }
+                    return CommandResult(0, json.dumps(measurements), "")
+
+                with tempfile.TemporaryDirectory() as directory:
+                    cgroup, proc = self._linux_roots(directory)
+                    result = qualify_local_host(
+                        system="Linux", cgroup_root=cgroup, proc_root=proc, runner=runner
+                    )
+                self.assertEqual(result["cause"], "malformed_benchexec_evidence")
+
     def test_live_descendant_fails_closed(self) -> None:
         def runner(command):
             if "benchexec.check_cgroups" in command:


### PR DESCRIPTION
Implements the code and deterministic-fixture portion of #954 without closing it; native admitted-Linux evidence remains the issue close gate.

## Outcome

- adds a ReFrame local-scheduler/local-launcher check for the benchmark workspace;
- fails before importing Linux-only BenchExec on unsupported hosts and emits a sanitized typed cause;
- admits only native Linux with cgroups v2 and mount, PID, and user namespace controls;
- runs BenchExec's namespace-enabled `RunExecutor` with wall and memory limits;
- requires full-process CPU, wall, peak-memory, read, and write metrics;
- proves termination of a detached descendant through a post-run heartbeat;
- documents that macOS and Docker Desktop do not establish native admission;
- creates no Fly resources and authorizes no Graph500 run.

## Evidence

- `make -C benchmarks smoke`: Python 9/9 and Rust 1/1 pass; dependency and fixture discovery pass.
- `make -C benchmarks local-admission`: ReFrame local scheduler/launcher passes with typed `unsupported_operating_system` evidence on this macOS host.
- deterministic Linux/cgroups-v2 fixtures cover admission, missing I/O metrics, and surviving descendants.
- `git diff --check`: clean.

## Remaining #954 close gate

Run this exact interface on a native Linux/cgroups-v2 host where BenchExec is admitted and retain the sanitized passing measurement. A typed disqualification is correct behavior but is not evidence that the admitted Linux path passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790573149&installation_model_id=20486&pr_number=986&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F986&signature=451f953e91868649d9613c61d3d91c9b10aa379033d6fbcebf5a267d7f2054c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added local Linux benchmark admission checks for namespaces, cgroups v2, resource limits, and descendant termination.
  - Added structured JSON admission evidence with clear pass, disqualification, and failure outcomes.
  - Added a local Linux benchmark profile and ReFrame integration.

- **Testing**
  - Added automated coverage for supported, disqualified, and failed admission scenarios.

- **Chores**
  - Added a command for running local admission checks.
  - Updated benchmark ignore rules for generated output directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->