### PR TITLE
fix(exec): preserve bounded query work evidence

### DIFF
--- a/crates/graphforge-api/src/graph_inspection.rs
+++ b/crates/graphforge-api/src/graph_inspection.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, Mutex};
 use arrow::array::{Array, ArrayRef, ListArray, StringArray, UInt64Array};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
+use futures::StreamExt;
 use graphforge_core::{ApiErrorCode, GfError};
 
 use crate::GraphForge;
@@ -112,69 +113,98 @@ impl GraphForge {
             .clone();
         view.runtime_catalog = Arc::new(Mutex::new(catalog));
 
-        let nodes = view.execute_read_only(NODE_LABELS_QUERY)?;
-        let relationships = view.execute_read_only(RELATIONSHIP_TYPES_QUERY)?;
-        inspection_from_results(&nodes.batches, &relationships.batches)
+        let node_stream = view.execute_stream(NODE_LABELS_QUERY)?;
+        let inspection = view.block_on(inspection_from_node_stream(node_stream))?;
+        let relationship_stream = view.execute_stream(RELATIONSHIP_TYPES_QUERY)?;
+        view.block_on(inspection_from_relationship_stream(
+            relationship_stream,
+            inspection,
+        ))
     }
 }
 
-fn inspection_from_results(
-    node_batches: &[RecordBatch],
-    relationship_batches: &[RecordBatch],
+async fn inspection_from_node_stream(
+    mut stream: graphforge_exec::SendableRecordBatchStream,
 ) -> Result<GraphInspection, GfError> {
     let mut inspection = GraphInspection::default();
-    for batch in node_batches {
-        inspection.total_nodes = inspection
-            .total_nodes
-            .checked_add(
-                u64::try_from(batch.num_rows())
-                    .map_err(|_| resource_limit("graph inspection node batch exceeds UInt64"))?,
-            )
-            .ok_or_else(|| resource_limit("graph inspection node count exceeds UInt64"))?;
-        let labels = batch
-            .column_by_name("labels")
-            .and_then(|column| column.as_any().downcast_ref::<ListArray>())
-            .ok_or_else(|| schema_error("graph inspection labels column is not List<Utf8>"))?;
-        for row in 0..batch.num_rows() {
-            if labels.is_null(row) {
-                return Err(schema_error("graph inspection labels row is null"));
-            }
-            let values = labels.value(row);
-            let values = values
-                .as_any()
-                .downcast_ref::<StringArray>()
-                .ok_or_else(|| schema_error("graph inspection label item is not Utf8"))?;
-            let mut unique = BTreeSet::new();
-            for index in 0..values.len() {
-                if values.is_null(index) {
-                    return Err(schema_error("graph inspection label item is null"));
-                }
-                unique.insert(values.value(index));
-            }
-            for label in unique {
-                increment(&mut inspection.label_counts, label)?;
-            }
-        }
-    }
-
-    for batch in relationship_batches {
-        let relationship_types = batch
-            .column_by_name("relationship_type")
-            .and_then(|column| column.as_any().downcast_ref::<StringArray>())
-            .ok_or_else(|| schema_error("graph inspection relationship_type column is not Utf8"))?;
-        for row in 0..batch.num_rows() {
-            if relationship_types.is_null(row) {
-                return Err(schema_error(
-                    "graph inspection relationship_type row is null",
-                ));
-            }
-            increment(
-                &mut inspection.relationship_type_counts,
-                relationship_types.value(row),
-            )?;
-        }
+    while let Some(batch) = stream.next().await {
+        accumulate_node_batch(&mut inspection, &batch.map_err(execution_error)?)?;
     }
     Ok(inspection)
+}
+
+async fn inspection_from_relationship_stream(
+    mut stream: graphforge_exec::SendableRecordBatchStream,
+    mut inspection: GraphInspection,
+) -> Result<GraphInspection, GfError> {
+    while let Some(batch) = stream.next().await {
+        accumulate_relationship_batch(&mut inspection, &batch.map_err(execution_error)?)?;
+    }
+    Ok(inspection)
+}
+
+fn accumulate_node_batch(
+    inspection: &mut GraphInspection,
+    batch: &RecordBatch,
+) -> Result<(), GfError> {
+    inspection.total_nodes = inspection
+        .total_nodes
+        .checked_add(
+            u64::try_from(batch.num_rows())
+                .map_err(|_| resource_limit("graph inspection node batch exceeds UInt64"))?,
+        )
+        .ok_or_else(|| resource_limit("graph inspection node count exceeds UInt64"))?;
+    let labels = batch
+        .column_by_name("labels")
+        .and_then(|column| column.as_any().downcast_ref::<ListArray>())
+        .ok_or_else(|| schema_error("graph inspection labels column is not List<Utf8>"))?;
+    for row in 0..batch.num_rows() {
+        if labels.is_null(row) {
+            return Err(schema_error("graph inspection labels row is null"));
+        }
+        let values = labels.value(row);
+        let values = values
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| schema_error("graph inspection label item is not Utf8"))?;
+        let mut unique = BTreeSet::new();
+        for index in 0..values.len() {
+            if values.is_null(index) {
+                return Err(schema_error("graph inspection label item is null"));
+            }
+            unique.insert(values.value(index));
+        }
+        for label in unique {
+            increment(&mut inspection.label_counts, label)?;
+        }
+    }
+    Ok(())
+}
+
+fn accumulate_relationship_batch(
+    inspection: &mut GraphInspection,
+    batch: &RecordBatch,
+) -> Result<(), GfError> {
+    let relationship_types = batch
+        .column_by_name("relationship_type")
+        .and_then(|column| column.as_any().downcast_ref::<StringArray>())
+        .ok_or_else(|| schema_error("graph inspection relationship_type column is not Utf8"))?;
+    for row in 0..batch.num_rows() {
+        if relationship_types.is_null(row) {
+            return Err(schema_error(
+                "graph inspection relationship_type row is null",
+            ));
+        }
+        increment(
+            &mut inspection.relationship_type_counts,
+            relationship_types.value(row),
+        )?;
+    }
+    Ok(())
+}
+
+fn execution_error(error: datafusion::error::DataFusionError) -> GfError {
+    GfError::Execution(error.to_string())
 }
 
 fn increment(counts: &mut BTreeMap<String, u64>, name: &str) -> Result<(), GfError> {

--- a/crates/graphforge-api/src/graph_inspection.rs
+++ b/crates/graphforge-api/src/graph_inspection.rs
@@ -128,7 +128,10 @@ async fn inspection_from_node_stream(
 ) -> Result<GraphInspection, GfError> {
     let mut inspection = GraphInspection::default();
     while let Some(batch) = stream.next().await {
-        accumulate_node_batch(&mut inspection, &batch.map_err(execution_error)?)?;
+        accumulate_node_batch(
+            &mut inspection,
+            &batch.map_err(|error| GfError::Execution(error.to_string()))?,
+        )?;
     }
     Ok(inspection)
 }
@@ -138,7 +141,10 @@ async fn inspection_from_relationship_stream(
     mut inspection: GraphInspection,
 ) -> Result<GraphInspection, GfError> {
     while let Some(batch) = stream.next().await {
-        accumulate_relationship_batch(&mut inspection, &batch.map_err(execution_error)?)?;
+        accumulate_relationship_batch(
+            &mut inspection,
+            &batch.map_err(|error| GfError::Execution(error.to_string()))?,
+        )?;
     }
     Ok(inspection)
 }
@@ -201,10 +207,6 @@ fn accumulate_relationship_batch(
         )?;
     }
     Ok(())
-}
-
-fn execution_error(error: datafusion::error::DataFusionError) -> GfError {
-    GfError::Execution(error.to_string())
 }
 
 fn increment(counts: &mut BTreeMap<String, u64>, name: &str) -> Result<(), GfError> {

--- a/crates/graphforge-api/tests/fixed_hop_limit.rs
+++ b/crates/graphforge-api/tests/fixed_hop_limit.rs
@@ -52,13 +52,11 @@ const ORDERED_TWO_HOP: &str =
 
 fn measured_identity_query(forge: &GraphForge, query: &str) -> (Vec<Vec<u8>>, DemandSnapshot) {
     io_stats::reset();
-    demand::reset();
-    let result = forge.execute(query).unwrap();
-    demand::disable();
+    let (result, snapshot) = demand::capture(|| forge.execute(query));
+    let result = result.unwrap();
     let io = io_stats::snapshot();
     assert_eq!(io.edge_full_reads + io.edge_filtered_reads, 0, "{io:#?}");
     assert_eq!(io.node_full_reads + io.node_filtered_reads, 0, "{io:#?}");
-    let snapshot = demand::snapshot();
     assert_eq!(snapshot.sorts.len(), 1, "{snapshot:#?}");
     let sort = &snapshot.sorts[0];
     assert_eq!(sort.fetch, Some(LIMIT), "{snapshot:#?}");
@@ -67,7 +65,12 @@ fn measured_identity_query(forge: &GraphForge, query: &str) -> (Vec<Vec<u8>>, De
         "{snapshot:#?}"
     );
     assert_eq!(sort.retained_bytes, 0, "{snapshot:#?}");
-    assert_eq!(snapshot.operator_rss.len(), 2, "{snapshot:#?}");
+    let expected_hops = usize::from(query.contains("-[r2]->")) + 1;
+    assert_eq!(
+        snapshot.operator_rss.len(),
+        expected_hops + 1,
+        "{snapshot:#?}"
+    );
     assert!(
         snapshot.operator_rss.iter().all(|operator| {
             operator.peak_bytes >= operator.before_bytes

--- a/crates/graphforge-api/tests/fixed_hop_limit.rs
+++ b/crates/graphforge-api/tests/fixed_hop_limit.rs
@@ -37,7 +37,6 @@ const TS: i64 = 1_700_000_000_000_000;
 const NODE_TYPE: TypeId = TypeId(0);
 const FAN_OUT: usize = 8;
 const LIMIT: usize = 1_000;
-const MAX_BATCH_ROWS: u64 = 8_192;
 const WRITE_WINDOW: usize = 32 * 1024;
 
 /// Serializes the process-global storage counters used by the assertions.
@@ -60,8 +59,9 @@ fn measured_identity_query(forge: &GraphForge, query: &str) -> (Vec<Vec<u8>>, De
     assert_eq!(snapshot.sorts.len(), 1, "{snapshot:#?}");
     let sort = &snapshot.sorts[0];
     assert_eq!(sort.fetch, Some(LIMIT), "{snapshot:#?}");
+    assert!(snapshot.execution_batch_rows > 0, "{snapshot:#?}");
     assert!(
-        sort.output_rows <= (LIMIT + MAX_BATCH_ROWS as usize) as u64,
+        sort.output_rows <= (LIMIT as u64).saturating_add(snapshot.execution_batch_rows),
         "{snapshot:#?}"
     );
     assert_eq!(sort.retained_bytes, 0, "{snapshot:#?}");
@@ -551,7 +551,7 @@ fn assert_bounded_demand(snapshot: &DemandSnapshot, expected_hops: usize, requir
         assert!(hop.edge_full_reads <= 1, "{snapshot:#?}");
         assert_eq!(hop.node_full_reads, 0, "{snapshot:#?}");
         assert!(
-            hop.candidates_generated <= required + MAX_BATCH_ROWS,
+            hop.candidates_generated <= required + snapshot.execution_batch_rows,
             "required={required}, snapshot={snapshot:#?}"
         );
     }

--- a/crates/graphforge-api/tests/fixed_hop_limit.rs
+++ b/crates/graphforge-api/tests/fixed_hop_limit.rs
@@ -59,6 +59,30 @@ fn measured_identity_query(forge: &GraphForge, query: &str) -> (Vec<Vec<u8>>, De
     assert_eq!(io.edge_full_reads + io.edge_filtered_reads, 0, "{io:#?}");
     assert_eq!(io.node_full_reads + io.node_filtered_reads, 0, "{io:#?}");
     let snapshot = demand::snapshot();
+    assert_eq!(snapshot.sorts.len(), 1, "{snapshot:#?}");
+    let sort = &snapshot.sorts[0];
+    assert_eq!(sort.fetch, Some(LIMIT), "{snapshot:#?}");
+    assert!(
+        sort.output_rows <= (LIMIT + MAX_BATCH_ROWS as usize) as u64,
+        "{snapshot:#?}"
+    );
+    assert_eq!(sort.retained_bytes, 0, "{snapshot:#?}");
+    assert_eq!(snapshot.operator_rss.len(), 2, "{snapshot:#?}");
+    assert!(
+        snapshot.operator_rss.iter().all(|operator| {
+            operator.peak_bytes >= operator.before_bytes
+                && operator.peak_bytes >= operator.after_bytes
+                && (operator.after_bytes > 0 || !cfg!(target_os = "linux"))
+        }),
+        "{snapshot:#?}"
+    );
+    assert!(
+        snapshot.memory_reserved_after
+            <= snapshot
+                .memory_reserved_before
+                .saturating_add(snapshot.returned_batch_bytes),
+        "{snapshot:#?}"
+    );
     assert_eq!(
         snapshot
             .hops
@@ -742,16 +766,22 @@ fn ordered_destination_uuid_projection_is_exact_and_linear_at_1x_2x_4x() {
             hop.identity_bytes_read,
             hop.identity_read_calls,
             hop.identity_revalidation_calls,
+            snapshot.sorts[0].fetch,
+            snapshot.sorts[0].retained_bytes,
         ));
     }
     for pair in work.windows(2) {
-        let (prior_rows, prior_bytes, prior_calls, prior_revalidation) = pair[0];
-        let (next_rows, next_bytes, next_calls, next_revalidation) = pair[1];
+        let (prior_rows, prior_bytes, prior_calls, prior_revalidation, prior_fetch, prior_retained) =
+            pair[0];
+        let (next_rows, next_bytes, next_calls, next_revalidation, next_fetch, next_retained) =
+            pair[1];
         assert_eq!(next_rows, prior_rows * 2, "{work:?}");
         // Fixed block/range boundaries may add one coalesced read, but neither
         // bytes nor calls may acquire a chunk-times-graph multiplier.
         assert!(next_bytes <= prior_bytes * 2 + 2 * 1024 * 1024, "{work:?}");
         assert!(next_calls <= prior_calls * 2 + 2, "{work:?}");
+        assert_eq!((prior_fetch, next_fetch), (Some(LIMIT), Some(LIMIT)));
+        assert_eq!((prior_retained, next_retained), (0, 0));
         assert!(
             next_revalidation <= prior_revalidation * 2 + 2,
             "session authentication must be linear in retained artifacts: {work:?}"

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -53,7 +53,6 @@ const REL_TYPE: &str = "LINK";
 /// One authoritative Arrow and durable-append row window for the scale client.
 /// This intentionally matches `GraphConstructionBudgets::default()`.
 const CONSTRUCTION_BATCH_ROWS: usize = 65_536;
-const EXECUTION_BATCH_ROWS: u64 = 8_192;
 
 const ONE_HOP: &str = "MATCH (a)-[r]->(b) RETURN b.node_uuid AS id ORDER BY id LIMIT 1000";
 const TWO_HOP: &str =
@@ -570,6 +569,7 @@ fn query_work_evidence(snapshot: &DemandSnapshot) -> Value {
         "memory_reserved_before": snapshot.memory_reserved_before,
         "memory_reserved_after": snapshot.memory_reserved_after,
         "returned_batch_bytes": snapshot.returned_batch_bytes,
+        "execution_batch_rows": snapshot.execution_batch_rows,
         "cancellations": snapshot.cancellations,
         "max_in_flight_reads": snapshot.max_in_flight_reads,
     })
@@ -579,10 +579,12 @@ fn bounded_ordered_limit(snapshot: &DemandSnapshot, expected_hops: usize, limit:
     snapshot.hops.len() == expected_hops
         && snapshot.sorts.len() == 1
         && snapshot.sorts[0].fetch == Some(limit)
+        && snapshot.execution_batch_rows > 0
         // DataFusion's baseline output counter is charged before its final
         // fetch wrapper slices the terminal batch, so it may include at most
         // one physical batch beyond the returned TopK rows.
-        && snapshot.sorts[0].output_rows <= (limit as u64).saturating_add(EXECUTION_BATCH_ROWS)
+        && snapshot.sorts[0].output_rows
+            <= (limit as u64).saturating_add(snapshot.execution_batch_rows)
         && snapshot.sorts[0].retained_bytes == 0
         && snapshot.operator_rss.len() == expected_hops.saturating_add(1)
         && snapshot.operator_rss.iter().all(|operator| {

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -16,8 +16,10 @@
 //! certify one billion live edges — that is #745. Small rungs run in normal CI;
 //! large rungs are opt-in via `make bench-g500-ladder`.
 
+#![recursion_limit = "256"]
+
 use std::cmp::Reverse;
-use std::collections::BinaryHeap;
+use std::collections::{BTreeMap, BinaryHeap};
 use std::fs::{self, File};
 use std::io::{BufReader, BufWriter, ErrorKind, Read, Write};
 use std::path::{Path, PathBuf};
@@ -29,6 +31,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use arrow::array::{Array, FixedSizeBinaryArray, Int64Array, StringArray, UInt64Array};
 use arrow::record_batch::RecordBatch;
+
 use graphforge_api::{
     CONSTRUCTION_EDGE_SCHEMA, CONSTRUCTION_NODE_SCHEMA, CancellationToken,
     GraphConstructionBudgets, GraphConstructionSession, GraphForge, OperationId, PortableSelection,
@@ -498,6 +501,179 @@ struct RungOutcome {
     evidence: Value,
 }
 
+fn exact_descriptor_allocation(paths: &[PathBuf]) -> Value {
+    let mut logical_bytes = 0_u64;
+    let mut allocated = 0_u64;
+    for path in paths {
+        logical_bytes = logical_bytes.saturating_add(
+            fs::metadata(path)
+                .expect("generator descriptor metadata")
+                .len(),
+        );
+        let file = File::open(path).expect("open exact allocation descriptor");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt as _;
+            allocated = allocated.saturating_add(
+                file.metadata()
+                    .expect("exact descriptor metadata")
+                    .blocks()
+                    .saturating_mul(512),
+            );
+        }
+        #[cfg(not(unix))]
+        panic!("certification descriptor allocation requires Unix stat blocks");
+    }
+    json!({
+        "category": "generator_spill",
+        "logical_bytes": logical_bytes,
+        "allocated_bytes": allocated,
+        "logical_references": paths.len(),
+        "physical_objects": paths.len(),
+        "source": "generator_exact_descriptors",
+    })
+}
+
+fn exact_descriptor_identities(paths: &[PathBuf]) -> BTreeMap<String, u64> {
+    paths
+        .iter()
+        .map(|path| {
+            let file = File::open(path).expect("open exact allocation descriptor");
+            let identity = graphforge_filesystem::file_identity(&file)
+                .expect("exact descriptor native identity");
+            let allocation = graphforge_filesystem::file_space_usage(&file)
+                .expect("exact descriptor allocation")
+                .allocated_bytes;
+            let mut file_id = String::with_capacity(32);
+            for byte in identity.file_id {
+                use std::fmt::Write as _;
+                write!(&mut file_id, "{byte:02x}").expect("write identity string");
+            }
+            (
+                format!("{:016x}:{file_id}", identity.volume_serial),
+                allocation,
+            )
+        })
+        .collect()
+}
+
+fn portable_export_allocation(receipt: &graphforge_api::PortableV2ExportFacadeResult) -> Value {
+    json!({
+        "category": "portable_package",
+        "logical_bytes": receipt.allocation_logical_bytes,
+        "allocated_bytes": receipt.allocation_identity_allocated_bytes.values().copied().sum::<u64>(),
+        "logical_references": receipt.allocation_physical_objects,
+        "physical_objects": receipt.allocation_physical_objects,
+        "source": "portable_writer_receipt",
+    })
+}
+
+fn storage_attribution_value(project: &Path) -> Value {
+    let mut value =
+        serde_json::to_value(storage_attribution(project)).expect("serialize storage attribution");
+    value
+        .as_object_mut()
+        .expect("storage attribution object")
+        .remove("generation_uuid");
+    value
+        .as_object_mut()
+        .expect("storage attribution object")
+        .remove("physical_identity_allocated_bytes");
+    value
+}
+
+fn reject_unsanitized_evidence(value: &Value) -> Result<(), String> {
+    fn visit(value: &Value, trail: &str) -> Result<(), String> {
+        match value {
+            Value::Object(fields) => {
+                for (key, child) in fields {
+                    let normalized = key.to_ascii_lowercase();
+                    if [
+                        "secret",
+                        "credential",
+                        "password",
+                        "token",
+                        "machine_id",
+                        "volume_id",
+                        "provider_resource_id",
+                        "absolute_path",
+                        "host_path",
+                    ]
+                    .iter()
+                    .any(|needle| normalized.contains(needle))
+                    {
+                        return Err(format!("sensitive evidence key at {trail}.{key}"));
+                    }
+                    visit(child, &format!("{trail}.{key}"))?;
+                }
+            }
+            Value::Array(items) => {
+                for (index, child) in items.iter().enumerate() {
+                    visit(child, &format!("{trail}[{index}]"))?;
+                }
+            }
+            Value::String(text) => {
+                if Uuid::parse_str(text).is_ok() {
+                    return Err(format!("raw UUID at {trail}"));
+                }
+                if text.starts_with('/')
+                    || text.starts_with("\\\\")
+                    || (text.len() >= 3
+                        && text.as_bytes()[1] == b':'
+                        && matches!(text.as_bytes()[2], b'/' | b'\\'))
+                    || text.split_whitespace().any(|part| part.starts_with('/'))
+                {
+                    return Err(format!("absolute host path at {trail}"));
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+    visit(value, "$")
+}
+
+fn sanitized_construction_evidence(
+    evidence: &graphforge_storage::GraphConstructionEvidence,
+) -> Value {
+    let mut value = serde_json::to_value(evidence).expect("serialize construction evidence");
+    value
+        .as_object_mut()
+        .expect("construction evidence object")
+        .remove("storage_active_identity_allocated_bytes");
+    value
+        .as_object_mut()
+        .expect("construction evidence object")
+        .remove("storage_allocation_transitions");
+    value
+}
+
+fn storage_attribution(project: &Path) -> graphforge_storage::StorageAttributionSnapshot {
+    let graph = GraphForge::new(project.to_str()).expect("open attribution facade");
+    let snapshot = graph
+        .storage_attribution()
+        .expect("capture authenticated storage attribution through public facade");
+    snapshot
+        .validate_reconciliation()
+        .expect("storage attribution reconciliation");
+    assert!(
+        snapshot.is_fully_classified(),
+        "qualification refuses unclassified retained artifacts"
+    );
+    snapshot
+}
+
+#[test]
+fn public_storage_attribution_is_generation_bound_and_fully_classified() {
+    let project = TempDir::new().expect("storage attribution project");
+    let graph = GraphForge::new(project.path().to_str()).expect("open attribution facade");
+    let snapshot = graph
+        .storage_attribution()
+        .expect("public facade storage attribution");
+    snapshot.validate_for_qualification().unwrap();
+    assert!(snapshot.is_fully_classified());
+}
+
 /// Check the envelope after a phase. Returns `Some(error_class)` on the first
 /// violation so the caller can stop the ladder. `ladder_started` is the
 /// ladder-level clock so the 4 h wall-clock fail-safe bounds the whole run, not each
@@ -505,14 +681,12 @@ struct RungOutcome {
 fn envelope_violation(
     env: &RunEnvelope,
     ladder_started: Instant,
-    project: &Path,
-    spill: &Path,
+    disk_used_bytes: u64,
 ) -> Option<&'static str> {
     if peak_rss().is_some_and(|(rss, _)| rss > env.rss_bytes) {
         return Some("oom");
     }
-    let disk = directory_bytes(project).unwrap_or(0) + directory_bytes(spill).unwrap_or(0);
-    if disk > env.disk_bytes {
+    if disk_used_bytes > env.disk_bytes {
         return Some("disk_exhaustion");
     }
     if ladder_started.elapsed().as_secs() > env.timeout_s {
@@ -758,8 +932,6 @@ impl IngestHeartbeat {
         rung: &Rung,
         completed_rungs: &[Value],
         steps: &[Value],
-        project: &Path,
-        spill: &Path,
     ) -> Self {
         let Ok(path) = std::env::var("GF_G500_LADDER_JOURNAL_OUT") else {
             return Self {
@@ -775,8 +947,6 @@ impl IngestHeartbeat {
         let scale = rung.scale;
         let completed_rungs = completed_rungs.to_vec();
         let steps = steps.to_vec();
-        let project = project.to_path_buf();
-        let spill = spill.to_path_buf();
         let handle = thread::spawn(move || {
             loop {
                 let value = json!({
@@ -791,8 +961,6 @@ impl IngestHeartbeat {
                     "active_chunk_index": INGEST_CHUNK_INDEX.load(Ordering::Relaxed),
                     "process_memory": linux_process_memory(),
                     "storage_io": storage_io_value(),
-                    "disk_used_bytes": directory_bytes(&project).unwrap_or(0)
-                        .saturating_add(directory_bytes(&spill).unwrap_or(0)),
                     "completed_rungs": completed_rungs,
                     "active_steps": steps,
                     "first_failing_phase": null,
@@ -892,7 +1060,11 @@ fn run_rung(
         None,
     );
     let generate_s = gen_started.elapsed().as_secs_f64();
-    let gen_violation = envelope_violation(&env, ladder_started, &project, &spill_dir);
+    let generator_allocation = exact_descriptor_allocation(&spill.runs);
+    let generator_allocated_bytes = generator_allocation["allocated_bytes"]
+        .as_u64()
+        .expect("generator allocated bytes");
+    let gen_violation = envelope_violation(&env, ladder_started, generator_allocated_bytes);
     if let Some(class) = gen_violation {
         first_failing_phase = Some("generate");
         error_class = Some(class);
@@ -908,6 +1080,7 @@ fn run_rung(
             "peak_buffer_len": spill.peak_buffer_len,
             "buffer_edges": rung.buffer_edges,
             "run_count": spill.runs.len(),
+            "storage": generator_allocation,
         }
     }));
     persist_phase_journal(
@@ -945,8 +1118,7 @@ fn run_rung(
         graphforge_storage::io_stats::reset();
         INGEST_CHUNK_INDEX.store(0, Ordering::Relaxed);
         INGEST_SUBPHASE.store(1, Ordering::Relaxed);
-        let heartbeat =
-            IngestHeartbeat::start(profile, rung, completed_rungs, &steps, &project, &spill_dir);
+        let heartbeat = IngestHeartbeat::start(profile, rung, completed_rungs, &steps);
         let mut construction = open_persisted_construction(
             &graph,
             &spill_dir.join("construction-session.uuid"),
@@ -986,9 +1158,21 @@ fn run_rung(
         INGEST_SUBPHASE.store(0, Ordering::Relaxed);
         heartbeat.stop();
         drop(graph);
+        let committed_snapshot = storage_attribution(&project);
+        let ingest_disk_used_bytes =
+            generator_allocated_bytes.saturating_add(committed_snapshot.allocated_bytes);
+        let committed_storage =
+            serde_json::to_value(committed_snapshot).expect("serialize committed storage");
+        let construction_phases =
+            graphforge_storage::ConstructionPhaseAttribution::from_construction(
+                &construction_evidence,
+            );
+        construction_phases
+            .validate_reconciliation()
+            .expect("construction phase attribution reconciliation");
         ingest_ran = true;
         let ingest_s = ingest_started.elapsed().as_secs_f64();
-        let ingest_violation = envelope_violation(&env, ladder_started, &project, &spill_dir);
+        let ingest_violation = envelope_violation(&env, ladder_started, ingest_disk_used_bytes);
         if let Some(class) = ingest_violation {
             first_failing_phase = Some("ingest");
             error_class = Some(class);
@@ -998,8 +1182,7 @@ fn run_rung(
             "pass": ingest_violation.is_none(),
             "wall_time_s": ingest_s,
             "rss_peak_bytes": rss_value(),
-            "disk_used_bytes": directory_bytes(&project).unwrap_or(0)
-                .saturating_add(directory_bytes(&spill_dir).unwrap_or(0)),
+            "disk_used_bytes": ingest_disk_used_bytes,
             "detail": {
                 "live_unique_edges": live_unique_edges,
                 "duplicates_rejected": duplicates_rejected,
@@ -1036,7 +1219,10 @@ fn run_rung(
                     "parquet_write_operations": construction_evidence.parquet_write_operations,
                     "retained_probe_read_bytes": construction_evidence.retained_probe_read_bytes,
                     "retained_probe_block_loads": construction_evidence.retained_probe_block_loads,
+                    "storage_transient_peak_allocated_bytes": construction_evidence.storage_transient_peak_allocated_bytes,
                 },
+                "committed_storage": committed_storage,
+                "application_io_phases": construction_phases,
             }
         }));
         persist_phase_journal(
@@ -1072,7 +1258,9 @@ fn run_rung(
         let graph = GraphForge::new(Some(project.to_str().expect("utf8 project")))
             .expect("reopen GraphForge");
         let reopen_s = reopen_started.elapsed().as_secs_f64();
-        let reopen_violation = envelope_violation(&env, ladder_started, &project, &spill_dir);
+        let reopen_disk_used_bytes =
+            generator_allocated_bytes.saturating_add(storage_attribution(&project).allocated_bytes);
+        let reopen_violation = envelope_violation(&env, ladder_started, reopen_disk_used_bytes);
         if let Some(class) = reopen_violation {
             first_failing_phase = Some("reopen");
             error_class = Some(class);
@@ -1114,7 +1302,9 @@ fn run_rung(
             let failure = result.as_ref().err().map(ToString::to_string);
             node_count = result.unwrap_or(0);
             let expected = 1u64 << rung.scale;
-            let mut violation = envelope_violation(&env, ladder_started, &project, &spill_dir);
+            let count_disk_used_bytes = generator_allocated_bytes
+                .saturating_add(storage_attribution(&project).allocated_bytes);
+            let mut violation = envelope_violation(&env, ladder_started, count_disk_used_bytes);
             if failure.is_some() {
                 violation = Some("execution_failure");
             } else if node_count != expected {
@@ -1160,7 +1350,9 @@ fn run_rung(
             let failure = result.as_ref().err().map(ToString::to_string);
             edge_count = result.as_ref().map_or(0, scalar_count);
             gsi = gsi_undirected(node_count, edge_count);
-            let mut violation = envelope_violation(&env, ladder_started, &project, &spill_dir);
+            let count_disk_used_bytes = generator_allocated_bytes
+                .saturating_add(storage_attribution(&project).allocated_bytes);
+            let mut violation = envelope_violation(&env, ladder_started, count_disk_used_bytes);
             if failure.is_some() {
                 violation = Some("execution_failure");
             } else if edge_count != live_unique_edges {
@@ -1219,7 +1411,9 @@ fn run_rung(
                 let (result, work) = execute_with_bounded_evidence(&graph, query);
                 let failure = result.as_ref().err().map(ToString::to_string);
                 let rows = result.as_ref().map_or(0, row_count);
-                let mut violation = envelope_violation(&env, ladder_started, &project, &spill_dir);
+                let query_disk_used_bytes = generator_allocated_bytes
+                    .saturating_add(storage_attribution(&project).allocated_bytes);
+                let mut violation = envelope_violation(&env, ladder_started, query_disk_used_bytes);
                 if failure.is_some() {
                     violation = Some("execution_failure");
                 } else if rows > 1_000 {
@@ -1256,8 +1450,11 @@ fn run_rung(
         drop(graph);
     }
 
-    let disk_used_bytes =
-        directory_bytes(&project).unwrap_or(0) + directory_bytes(&spill_dir).unwrap_or(0);
+    let disk_used_bytes = generator_allocated_bytes.saturating_add(
+        ingest_ran
+            .then(|| storage_attribution(&project).allocated_bytes)
+            .unwrap_or(0),
+    );
     // Tri-state: reconciliation is only *evaluated* once ingest has run. A rung
     // stopped in the generate phase is reported as null (not evaluated), never
     // as a forced `true`.
@@ -1601,26 +1798,6 @@ fn git_sha() -> Value {
         .filter(|output| output.status.success())
         .and_then(|output| String::from_utf8(output.stdout).ok())
         .map_or(Value::Null, |sha| Value::String(sha.trim().to_owned()))
-}
-
-fn directory_bytes(path: &Path) -> std::io::Result<u64> {
-    if !path.exists() {
-        return Ok(0);
-    }
-    if path.is_file() {
-        return Ok(path.metadata()?.len());
-    }
-    let mut total = 0u64;
-    for entry in fs::read_dir(path)? {
-        let entry = entry?;
-        let metadata = entry.metadata()?;
-        total += if metadata.is_dir() {
-            directory_bytes(&entry.path())?
-        } else {
-            metadata.len()
-        };
-    }
-    Ok(total)
 }
 
 /// Returns `(bytes, source)`. `"vmhwm"` (Linux `/proc/self/status`) is a true
@@ -2078,14 +2255,16 @@ struct PhaseJournal {
     path: PathBuf,
     phases: Vec<Value>,
     monitor: ResourceMonitor,
+    allocation: graphforge_storage::StorageAllocationLifecycle,
 }
 
 impl PhaseJournal {
-    fn new(path: PathBuf, workspace: &Path, envelope: Envelope) -> Self {
+    fn new(path: PathBuf, _workspace: &Path, envelope: Envelope) -> Self {
         Self {
             path,
             phases: Vec::new(),
-            monitor: ResourceMonitor::start(workspace.to_path_buf(), envelope),
+            monitor: ResourceMonitor::start(envelope),
+            allocation: graphforge_storage::StorageAllocationLifecycle::default(),
         }
     }
 
@@ -2101,7 +2280,10 @@ impl PhaseJournal {
         detail: Value,
     ) {
         let fingerprint = fingerprint.map_or(Value::Null, Value::String);
-        self.monitor.sample_disk();
+        // Every phase owns the live allocation union for its full duration,
+        // even when it does not install or remove an allocation identity.
+        self.monitor
+            .observe_allocated_union(self.allocation.current_allocated_bytes());
         if let Some(code) = self.monitor.failure_code() {
             self.phases.push(json!({
                 "id": id, "status": "fail",
@@ -2147,6 +2329,50 @@ impl PhaseJournal {
         self.monitor.cancellation.clone()
     }
 
+    fn replace_allocation_owner(&mut self, owner: &str, identities: &BTreeMap<String, u64>) {
+        self.allocation
+            .replace_owner(owner, identities)
+            .expect("replace exact allocation owner");
+        self.monitor
+            .observe_allocated_union(self.allocation.current_allocated_bytes());
+    }
+
+    fn replace_project_owner(
+        &mut self,
+        owner: &str,
+        generation: &graphforge_storage::ResolvedProjectGeneration,
+    ) {
+        let project = graphforge_storage::capture_project_storage_identity_union(generation)
+            .expect("capture retained project identity union");
+        self.replace_allocation_owner(owner, &project.physical_identity_allocated_bytes);
+    }
+
+    fn replay_allocation_transitions(
+        &mut self,
+        owner: &str,
+        transitions: &[graphforge_storage::StorageAllocationTransition],
+    ) {
+        for transition in transitions {
+            self.allocation
+                .apply_owner_transition(owner, transition)
+                .expect("apply writer-owned allocation transition");
+            self.monitor
+                .observe_allocated_union(self.allocation.current_allocated_bytes());
+        }
+    }
+
+    fn remove_allocation_owner(&mut self, owner: &str) {
+        self.allocation
+            .remove_owner(owner)
+            .expect("remove exact allocation owner");
+        self.monitor
+            .observe_allocated_union(self.allocation.current_allocated_bytes());
+    }
+
+    fn current_allocated_union(&self) -> u64 {
+        self.allocation.current_allocated_bytes()
+    }
+
     fn flush(&self) {
         let staged = self.path.with_extension("json.tmp");
         fs::write(
@@ -2172,7 +2398,6 @@ impl Drop for PhaseJournal {
             .failure_code()
             .or_else(|| std::thread::panicking().then_some("operation_failed"));
         if let Some(code) = failure_code {
-            self.monitor.sample_disk();
             self.phases.push(json!({
                 "id": CERTIFICATION_PHASES[self.phases.len()], "status": "fail",
                 "elapsed_ms": 0,
@@ -2208,7 +2433,6 @@ fn certification_query(
 }
 
 struct ResourceMonitor {
-    workspace: PathBuf,
     cancellation: CancellationToken,
     stop: Arc<AtomicBool>,
     peak_rss: Arc<AtomicU64>,
@@ -2219,29 +2443,24 @@ struct ResourceMonitor {
 }
 
 impl ResourceMonitor {
-    fn start(workspace: PathBuf, envelope: Envelope) -> Self {
+    fn start(envelope: Envelope) -> Self {
         let initial_rss = current_rss_bytes().expect("certification host must expose process RSS");
-        let initial_disk = allocated_bytes(&workspace)
-            .expect("certification host must expose allocated disk bytes");
         let cancellation = CancellationToken::new();
         let stop = Arc::new(AtomicBool::new(false));
         let peak_rss = Arc::new(AtomicU64::new(initial_rss));
-        let peak_disk = Arc::new(AtomicU64::new(initial_disk));
+        let peak_disk = Arc::new(AtomicU64::new(0));
         let failure = Arc::new(AtomicU64::new(0));
         let worker_cancellation = cancellation.clone();
         let worker_stop = Arc::clone(&stop);
         let worker_peak_rss = Arc::clone(&peak_rss);
-        let worker_peak_disk = Arc::clone(&peak_disk);
         let worker_failure = Arc::clone(&failure);
-        let worker_workspace = workspace.clone();
         let started = Instant::now();
         let elapsed_before_process = certification_elapsed_before_process();
         let worker = thread::spawn(move || {
-            let mut samples = 0_u8;
             while !worker_stop.load(Ordering::Relaxed) {
                 let rss = current_rss_bytes().expect("certification RSS probe failed");
                 worker_peak_rss.fetch_max(rss, Ordering::Relaxed);
-                let mut code = if rss > envelope.rss_bytes {
+                let code = if rss > envelope.rss_bytes {
                     1
                 } else if elapsed_before_process
                     .saturating_add(started.elapsed())
@@ -2252,14 +2471,6 @@ impl ResourceMonitor {
                 } else {
                     0
                 };
-                if samples == 0 {
-                    let disk = allocated_bytes(&worker_workspace)
-                        .expect("certification disk probe failed");
-                    worker_peak_disk.fetch_max(disk, Ordering::Relaxed);
-                    if disk > envelope.disk_bytes {
-                        code = 2;
-                    }
-                }
                 if code != 0 {
                     worker_failure
                         .compare_exchange(0, code, Ordering::SeqCst, Ordering::Relaxed)
@@ -2267,12 +2478,10 @@ impl ResourceMonitor {
                     worker_cancellation.cancel();
                     break;
                 }
-                samples = (samples + 1) % 20;
                 thread::sleep(Duration::from_millis(250));
             }
         });
         Self {
-            workspace,
             cancellation,
             stop,
             peak_rss,
@@ -2283,10 +2492,9 @@ impl ResourceMonitor {
         }
     }
 
-    fn sample_disk(&self) {
-        let disk = allocated_bytes(&self.workspace).expect("certification disk probe failed");
-        self.peak_disk.fetch_max(disk, Ordering::Relaxed);
-        if disk > self.envelope.disk_bytes {
+    fn observe_allocated_union(&self, bytes: u64) {
+        self.peak_disk.fetch_max(bytes, Ordering::Relaxed);
+        if bytes > self.envelope.disk_bytes {
             self.failure
                 .compare_exchange(0, 2, Ordering::SeqCst, Ordering::Relaxed)
                 .ok();
@@ -2341,23 +2549,6 @@ impl Drop for ResourceMonitor {
             worker.join().expect("resource watchdog thread");
         }
     }
-}
-
-fn allocated_bytes(path: &Path) -> Result<u64, &'static str> {
-    let output = Command::new("du").arg("-sk").arg(path).output();
-    output
-        .ok()
-        .filter(|out| out.status.success())
-        .and_then(|out| {
-            String::from_utf8(out.stdout)
-                .ok()?
-                .split_whitespace()
-                .next()?
-                .parse::<u64>()
-                .ok()
-        })
-        .map(|kibibytes| kibibytes.saturating_mul(1024))
-        .ok_or("allocated disk usage is unavailable")
 }
 
 fn result_fingerprint(result: &graphforge_api::ExecutionResult) -> String {
@@ -2436,7 +2627,17 @@ fn current_generation_uuid(graph: &GraphForge) -> Uuid {
     Uuid::from_bytes(bytes)
 }
 
-fn create_bounded_drill_package(root: &Path, limits: PortableV2Limits) -> (PathBuf, String) {
+struct DrillAllocationEvidence {
+    project: BTreeMap<String, u64>,
+    construction: BTreeMap<String, u64>,
+    expanded: BTreeMap<String, u64>,
+    cancelled_export: BTreeMap<String, u64>,
+}
+
+fn create_bounded_drill_package(
+    root: &Path,
+    limits: PortableV2Limits,
+) -> (PathBuf, String, DrillAllocationEvidence) {
     let project = root.join("drill-source");
     let package = root.join("drill.gfpb");
     fs::create_dir_all(&project).expect("bounded drill project");
@@ -2454,11 +2655,21 @@ fn create_bounded_drill_package(root: &Path, limits: PortableV2Limits) -> (PathB
     construction
         .seal_and_publish()
         .expect("publish bounded drill construction");
+    let construction_identities = construction
+        .progress()
+        .evidence
+        .storage_active_identity_allocated_bytes;
     drop(construction);
     drop(graph);
     let graph = GraphForge::new(project.to_str()).expect("reopen bounded drill project");
+    let project_generation = graphforge_storage::resolve_project_generation(&project)
+        .expect("resolve bounded drill project");
+    let project_identities =
+        graphforge_storage::capture_project_storage_identity_union(&project_generation)
+            .expect("bounded drill retained project attribution")
+            .physical_identity_allocated_bytes;
     let expanded = root.join("drill-expanded");
-    graph
+    let expanded_receipt = graph
         .export_portable_v2(
             &PortableV2ExportRequest {
                 selection: PortableSelection::Current,
@@ -2474,31 +2685,31 @@ fn create_bounded_drill_package(root: &Path, limits: PortableV2Limits) -> (PathB
         .expect("export compact drill expanded package");
     verify_portable_v2(
         &PortableVerifyRequest {
-            input: expanded,
+            input: expanded.clone(),
             mode: PortableV2Mode::Full,
             limits,
         },
         None,
     )
     .expect("verify compact drill expanded package");
+    let expanded_identities = expanded_receipt.allocation_identity_allocated_bytes;
+    fs::remove_dir_all(&expanded).expect("remove bounded expanded drill package");
     let cancelled = AtomicBool::new(true);
     let cancelled_path = root.join("drill-cancelled.gfpb");
-    assert!(
-        graph
-            .export_portable_v2(
-                &PortableV2ExportRequest {
-                    selection: PortableSelection::Current,
-                    output_path: cancelled_path.clone(),
-                    representation: PortableV2Output::Bundle,
-                    profile: PortableV2SelectionProfile::Complete,
-                    subset: None,
-                    limits,
-                },
-                Some(&cancelled),
-                |_| {},
-            )
-            .is_err()
-    );
+    let cancelled_error = graph
+        .export_portable_v2(
+            &PortableV2ExportRequest {
+                selection: PortableSelection::Current,
+                output_path: cancelled_path.clone(),
+                representation: PortableV2Output::Bundle,
+                profile: PortableV2SelectionProfile::Complete,
+                subset: None,
+                limits,
+            },
+            Some(&cancelled),
+            |_| {},
+        )
+        .expect_err("cancelled drill export must fail");
     assert!(!cancelled_path.exists());
     let receipt = graph
         .export_portable_v2(
@@ -2514,11 +2725,29 @@ fn create_bounded_drill_package(root: &Path, limits: PortableV2Limits) -> (PathB
             |_| {},
         )
         .expect("export bounded drill package");
-    (package, receipt.package_digest)
+    (
+        package,
+        receipt.package_digest,
+        DrillAllocationEvidence {
+            project: project_identities,
+            construction: construction_identities,
+            expanded: expanded_identities,
+            cancelled_export: cancelled_error.allocation_identity_allocated_bytes,
+        },
+    )
 }
 
 #[allow(clippy::too_many_lines)]
 fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value {
+    run_integrated_certification_with_edge_factor(root, target_live, None)
+}
+
+#[allow(clippy::too_many_lines)]
+fn run_integrated_certification_with_edge_factor(
+    root: &Path,
+    target_live: Option<u64>,
+    preflight_edge_factor: Option<u32>,
+) -> Value {
     let source = root.join("source");
     let imported = root.join("imported");
     let package = root.join("project.gfpb");
@@ -2550,7 +2779,7 @@ fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value 
     let edge_factor = if target_live.is_some() {
         certification_profile.edgefactor
     } else {
-        4
+        preflight_edge_factor.unwrap_or(4)
     };
     let initiator = if target_live.is_some() {
         certification_profile.initiator
@@ -2593,10 +2822,19 @@ fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value 
         || target_live_fingerprint.expect("target-live payload fingerprint"),
         |value| value.input_fingerprint.clone(),
     );
+    if let Some(spills) = &spills {
+        journal.replace_allocation_owner(
+            "generator_spill",
+            &exact_descriptor_identities(&spills.runs),
+        );
+    }
     journal.pass("generate", phase, Some(generation_fingerprint.clone()));
 
     let phase = Instant::now();
     let graph = GraphForge::new(source.to_str()).expect("open certification source");
+    let initial_generation = graphforge_storage::resolve_project_generation(&source)
+        .expect("resolve initial source generation");
+    journal.replace_project_owner("source_project", &initial_generation);
     let mut construction = graph
         .begin_graph_construction(Default::default())
         .expect("begin certification construction");
@@ -2624,12 +2862,36 @@ fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value 
     construction
         .seal_and_publish()
         .expect("publish certification construction");
+    let construction_evidence = construction.progress().evidence;
+    let mut construction_phases =
+        graphforge_storage::ConstructionPhaseAttribution::from_construction(&construction_evidence);
+    construction_phases
+        .validate_for_qualification()
+        .expect("certification construction phase attribution");
+    let pre_construction_union = journal.current_allocated_union();
+    journal.replay_allocation_transitions(
+        "construction",
+        &construction_evidence.storage_allocation_transitions,
+    );
+    // Construction artifacts are private to this session and cannot alias the
+    // already-open source project. The storage-owned numeric high-water mark
+    // therefore restores peaks compacted out of durable checkpoint history.
+    journal.monitor.observe_allocated_union(
+        pre_construction_union
+            .saturating_add(construction_evidence.storage_transient_peak_total_allocated_bytes),
+    );
+    let committed_generation = graphforge_storage::resolve_project_generation(&source)
+        .expect("resolve committed ingest generation");
+    journal.replace_project_owner("source_project", &committed_generation);
     journal.pass("ingest", phase, Some(input_fingerprint));
 
     let phase = Instant::now();
     let csr = graph
         .rebuild_adjacency(Some(journal.cancellation_token()))
         .expect("build certification CSR");
+    let csr_generation = graphforge_storage::resolve_project_generation(&source)
+        .expect("resolve committed CSR generation");
+    journal.replace_project_owner("source_project", &csr_generation);
     journal.pass(
         "csr",
         phase,
@@ -2721,6 +2983,10 @@ fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value 
         )
         .expect("portable-v2 export");
     assert_eq!(source_generation, exported.generation_uuid);
+    journal.replace_allocation_owner(
+        "portable_package",
+        &exported.allocation_identity_allocated_bytes,
+    );
     journal.pass("export", phase, Some(exported.package_digest.clone()));
     let phase = Instant::now();
     let verified = verify_portable_v2(
@@ -2747,6 +3013,23 @@ fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value 
         Some(journal.cancellation()),
     )
     .expect("atomic portable-v2 import");
+    // Replay the storage-owned operation transitions in their actual order:
+    // private materialization coexisted with the published generation until
+    // deterministic staging cleanup completed.
+    journal.replace_allocation_owner(
+        "import_materialized",
+        &imported_receipt.materialized_identity_allocated_bytes,
+    );
+    journal.replace_allocation_owner(
+        "clean_import",
+        &imported_receipt.published_identity_allocated_bytes,
+    );
+    assert!(imported_receipt.materialized_cleanup_parent_sync_confirmed);
+    assert_eq!(
+        imported_receipt.materialized_cleanup_removed_identity_allocated_bytes,
+        imported_receipt.materialized_identity_allocated_bytes
+    );
+    journal.remove_allocation_owner("import_materialized");
     assert_ne!(exported.generation_uuid, imported_receipt.generation_uuid);
     journal.pass(
         "import",
@@ -2757,6 +3040,9 @@ fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value 
     let imported_graph = GraphForge::new(imported.to_str()).expect("reopen import");
     journal.pass("imported_reopen", phase, None);
     let phase = Instant::now();
+    let imported_generation = graphforge_storage::resolve_project_generation(&imported)
+        .expect("resolve clean import generation");
+    journal.replace_project_owner("clean_import_project", &imported_generation);
     let imported_nodes = imported_graph
         .node_count(NODE_LABEL)
         .expect("imported nodes");
@@ -2831,11 +3117,31 @@ fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value 
         Some(imported_2hop.clone()),
         query_work_evidence(&imported_2hop_work),
     );
-
+    let source_storage = storage_attribution_value(&source);
+    let source_project_current_allocated_bytes =
+        graphforge_storage::capture_project_storage_identity_union(
+            &graphforge_storage::resolve_project_generation(&source)
+                .expect("resolve authoritative source project"),
+        )
+        .expect("capture authoritative source project identity union")
+        .allocated_bytes;
+    let imported_storage = storage_attribution_value(&imported);
+    let package_storage = portable_export_allocation(&exported);
     // Representative drills use the same verifier/import boundaries but never
     // repeat the billion-edge payload.
     let phase = Instant::now();
-    let (drill_package, drill_digest) = create_bounded_drill_package(root, limits);
+    let (drill_package, drill_digest, drill_allocation) =
+        create_bounded_drill_package(root, limits);
+    journal.replace_allocation_owner("drill_project", &drill_allocation.project);
+    journal.replace_allocation_owner("drill_construction", &drill_allocation.construction);
+    journal.replace_allocation_owner("drill_expanded", &drill_allocation.expanded);
+    journal.remove_allocation_owner("drill_expanded");
+    journal.replace_allocation_owner("drill_cancelled_export", &drill_allocation.cancelled_export);
+    journal.remove_allocation_owner("drill_cancelled_export");
+    journal.replace_allocation_owner(
+        "drill_package",
+        &exact_descriptor_identities(std::slice::from_ref(&drill_package)),
+    );
     let drill_verified = verify_portable_v2(
         &PortableVerifyRequest {
             input: drill_package.clone(),
@@ -2856,6 +3162,10 @@ fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value 
         file.write_all(b"corruption").expect("append corruption");
         file.flush().expect("flush corruption");
     }
+    journal.replace_allocation_owner(
+        "corrupt_drill_package",
+        &exact_descriptor_identities(std::slice::from_ref(&corrupt)),
+    );
     assert!(
         verify_portable_v2(
             &PortableVerifyRequest {
@@ -2901,18 +3211,55 @@ fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value 
     journal.pass("drill_resource_limit", phase, None);
     let phase = Instant::now();
     let interrupted = root.join("interrupted-target");
-    assert!(
-        GraphForge::import_portable_v2(
-            &interrupted,
-            &PortableV2ImportRequest {
-                input: drill_package,
-                operation_id: OperationId(uuidv7(0x746)),
-                limits,
-            },
-            Some(&AtomicBool::new(true))
-        )
-        .is_err()
+    let interrupted_operation = uuidv7(0x746);
+    let interrupted_generation = Uuid::new_v5(
+        &interrupted_operation,
+        b"graphforge-portable-v2-import-generation/1",
     );
+    let interrupted_cancelled = AtomicBool::new(false);
+    let supported_capabilities = [
+        "epistemic",
+        "graph",
+        "knowledge",
+        "provenance",
+        "valid_time",
+        "workspace",
+    ]
+    .into_iter()
+    .map(|capability_id| graphforge_storage::ProjectCapability {
+        capability_id: capability_id.into(),
+        capability_version: 1,
+    })
+    .collect::<Vec<_>>();
+    let interrupted_error = graphforge_storage::import_complete_portable_v2_with_progress(
+        &drill_package,
+        &interrupted,
+        interrupted_operation,
+        interrupted_generation,
+        &supported_capabilities,
+        limits,
+        Some(&interrupted_cancelled),
+        |progress| {
+            if progress.phase == graphforge_storage::PortableV2ImportPhase::Materialized {
+                interrupted_cancelled.store(true, Ordering::SeqCst);
+            }
+        },
+    )
+    .expect_err("cancelled finalization must fail");
+    assert!(interrupted_error.recovery_reauthentication_read_bytes > 0);
+    assert!(interrupted_error.recovery_reauthentication_read_calls > 0);
+    construction_phases.add_recovery_reauthentication(
+        interrupted_error.recovery_reauthentication_read_bytes,
+        interrupted_error.recovery_reauthentication_read_calls,
+    );
+    construction_phases
+        .validate_for_qualification()
+        .expect("interrupted recovery phase attribution");
+    journal.replace_allocation_owner(
+        "interrupted_import",
+        &interrupted_error.allocation_identity_allocated_bytes,
+    );
+    journal.remove_allocation_owner("interrupted_import");
     assert!(!interrupted.join("CURRENT").exists());
     journal.pass("drill_interrupted_finalization", phase, None);
 
@@ -2925,10 +3272,12 @@ fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value 
         digest.update(two_hop.as_bytes());
         format!("sha256:{}", hex_encode(digest.finalize()))
     };
-    json!({
-        "source_generation": exported.generation_uuid.to_string(),
+    let workspace_current_allocated_bytes = journal.current_allocated_union();
+    let evidence = json!({
+        "source_export_generation_authenticated": source_generation == exported.generation_uuid,
+        "import_receipt_reopen_authenticated": current_generation_uuid(&imported_graph) == imported_receipt.generation_uuid,
+        "source_import_generations_distinct": exported.generation_uuid != imported_receipt.generation_uuid,
         "package": exported.package_digest, "transport": exported.transport_digest,
-        "imported_generation": imported_receipt.generation_uuid.to_string(),
         "raw_attempts": spills.as_ref().map_or_else(|| summary.as_ref().unwrap().raw_attempts, |value| value.raw_attempts),
         "self_loops_rejected": spills.as_ref().map_or_else(|| summary.as_ref().unwrap().self_loops_rejected, |value| value.self_loops_rejected),
         "duplicates_rejected": generated_counts.as_ref().map_or_else(|| summary.as_ref().unwrap().duplicates_rejected, |value| value.duplicates_rejected),
@@ -2943,8 +3292,19 @@ fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value 
         "compatibility": serde_json::to_value(verified.compatibility).expect("compatibility JSON"),
         "source_authority_fingerprint": source_authority_fingerprint,
         "imported_authority_fingerprint": imported_authority_fingerprint,
+        "storage": {
+            "source": source_storage,
+            "source_project_current_allocated_bytes": source_project_current_allocated_bytes,
+            "portable_package": package_storage,
+            "clean_import": imported_storage,
+            "construction": sanitized_construction_evidence(&construction_evidence),
+            "application_io_phases": construction_phases,
+            "workspace_current_allocated_bytes": workspace_current_allocated_bytes,
+        },
         "phases": journal.phases,
-    })
+    });
+    reject_unsanitized_evidence(&evidence).expect("certification lifecycle evidence is sanitized");
+    evidence
 }
 
 #[test]
@@ -2952,16 +3312,128 @@ fn certification_lifecycle_journals_equivalent_round_trip_and_drills() {
     let root = TempDir::new().expect("certification smoke root");
     let evidence = run_integrated_certification(root.path(), None);
     assert_eq!(evidence["source_edges"], evidence["imported_edges"]);
-    assert_ne!(
-        evidence["source_generation"],
-        evidence["imported_generation"]
-    );
+    assert_eq!(evidence["source_export_generation_authenticated"], true);
+    assert_eq!(evidence["import_receipt_reopen_authenticated"], true);
+    assert_eq!(evidence["source_import_generations_distinct"], true);
+    reject_unsanitized_evidence(&evidence).expect("lifecycle evidence remains sanitized");
+}
+
+#[test]
+fn certification_evidence_sanitizer_rejects_identity_paths_and_sensitive_keys() {
+    for (value, expected) in [
+        (
+            json!({"proof": "018f6e45-7f12-7c00-8000-000000000001"}),
+            "raw UUID",
+        ),
+        (
+            json!({"proof": "/var/lib/graphforge/project"}),
+            "absolute host path",
+        ),
+        (
+            json!({"nested": {"api_token": "redacted"}}),
+            "sensitive evidence key",
+        ),
+    ] {
+        let error = reject_unsanitized_evidence(&value).expect_err("unsafe evidence must fail");
+        assert!(
+            error.contains(expected),
+            "unexpected sanitizer failure: {error}"
+        );
+    }
+    reject_unsanitized_evidence(&json!({
+        "generation_authenticated": true,
+        "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }))
+    .expect("closed proof is safe");
+}
+
+#[test]
+fn equivalent_full_lifecycle_1x_2x_4x_has_bounded_phase_slopes() {
+    const FIELDS: [&str; 7] = [
+        "read_bytes",
+        "write_bytes",
+        "read_calls",
+        "write_calls",
+        "object_count",
+        "block_count",
+        "fsync_calls",
+    ];
+    let mut baseline: Option<BTreeMap<String, [u64; 7]>> = None;
+    for factor in [1_u32, 2, 4] {
+        let root = TempDir::new().expect("full lifecycle ladder root");
+        let evidence =
+            run_integrated_certification_with_edge_factor(root.path(), None, Some(factor));
+        assert_eq!(evidence["source_edges"], evidence["imported_edges"]);
+        let phases = evidence["storage"]["application_io_phases"]["phases"]
+            .as_object()
+            .expect("phase evidence object");
+        let attribution: graphforge_storage::ConstructionPhaseAttribution =
+            serde_json::from_value(evidence["storage"]["application_io_phases"].clone())
+                .expect("decode phase evidence");
+        attribution
+            .validate_for_qualification()
+            .expect("full lifecycle phase qualification");
+        let recovery = &phases["recovery_reauthentication"];
+        assert!(
+            recovery["read_bytes"].as_u64().unwrap_or(0) > 0,
+            "{factor}x interrupted-finalization recovery must report authenticated bytes"
+        );
+        assert!(
+            recovery["read_calls"].as_u64().unwrap_or(0) > 0,
+            "{factor}x interrupted-finalization recovery must report authenticated calls"
+        );
+        let observations = phases
+            .iter()
+            .map(|(name, values)| {
+                let counters = std::array::from_fn(|index| {
+                    values[FIELDS[index]]
+                        .as_u64()
+                        .expect("phase counter is an integer")
+                });
+                (name.clone(), counters)
+            })
+            .collect::<BTreeMap<_, _>>();
+        if let Some(base) = &baseline {
+            assert_eq!(
+                base.keys().collect::<Vec<_>>(),
+                observations.keys().collect::<Vec<_>>()
+            );
+            for (phase, current) in &observations {
+                for (index, value) in current.iter().enumerate() {
+                    let first = base[phase][index];
+                    if first == 0 {
+                        assert_eq!(
+                            *value, 0,
+                            "{phase}.{} appeared only at a larger rung",
+                            FIELDS[index]
+                        );
+                    } else {
+                        assert!(
+                            *value <= first.saturating_mul(u64::from(factor)).saturating_mul(2),
+                            "{phase}.{} exceeded the documented 2x constant-factor ceiling",
+                            FIELDS[index]
+                        );
+                    }
+                }
+            }
+        } else {
+            baseline = Some(observations);
+        }
+        let interrupted = evidence["phases"]
+            .as_array()
+            .expect("lifecycle phases")
+            .iter()
+            .find(|phase| phase["id"] == "drill_interrupted_finalization")
+            .expect("interrupted-finalization recovery drill");
+        assert_eq!(interrupted["status"], "pass");
+    }
 }
 
 #[test]
 fn certification_watchdog_persists_typed_first_failure() {
     let root = TempDir::new().expect("watchdog root");
-    fs::write(root.path().join("allocated.bin"), [0_u8; 4096]).expect("allocated fixture");
+    let allocated = root.path().join("allocated.bin");
+    fs::write(&allocated, [0_u8; 4096]).expect("allocated fixture");
     let journal_path = root.path().join("journal.json");
     let mut journal = PhaseJournal::new(
         journal_path.clone(),
@@ -2971,6 +3443,10 @@ fn certification_watchdog_persists_typed_first_failure() {
             disk_bytes: 0,
             timeout_s: u64::MAX,
         },
+    );
+    journal.replace_allocation_owner(
+        "watchdog_fixture",
+        &exact_descriptor_identities(&[allocated]),
     );
     let failure = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         journal.pass("resource_probe", Instant::now(), None);
@@ -3127,6 +3603,32 @@ fn submitted_chunk_count(evidence: &graphforge_storage::GraphConstructionEvidenc
 }
 
 #[test]
+fn active_ingest_heartbeat_does_not_recursively_scan_storage() {
+    let source = include_str!("scale_g500_ladder.rs");
+    let heartbeat = source
+        .split("struct IngestHeartbeat")
+        .nth(1)
+        .and_then(|tail| tail.split("fn run_rung").next())
+        .expect("heartbeat source boundary");
+    let recursive_probe = ["directory", "bytes"].join("_");
+    assert!(
+        !heartbeat.contains(&recursive_probe),
+        "active heartbeat must consume counters, not enumerate project paths"
+    );
+    let monitor = source
+        .split("struct ResourceMonitor")
+        .nth(1)
+        .and_then(|tail| tail.split("fn certification_elapsed_before_process").next())
+        .expect("resource monitor source boundary");
+    for forbidden in ["read_dir", "walkdir", "du\""] {
+        assert!(
+            !monitor.contains(forbidden),
+            "resource monitor must use storage-owned observations, not {forbidden}"
+        );
+    }
+}
+
+#[test]
 fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
     let budgets = GraphConstructionBudgets {
         max_batch_rows: CONSTRUCTION_BATCH_ROWS,
@@ -3136,6 +3638,8 @@ fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
     };
     let base_nodes = CONSTRUCTION_BATCH_ROWS as u64;
     let mut baseline_peaks: Option<[u64; 11]> = None;
+    let mut baseline_storage: Option<(u64, u64)> = None;
+    let mut baseline_phase_io: Option<(u64, u64, u64, u64)> = None;
     for factor in [1_u64, 2, 4] {
         let project = TempDir::new().expect("tiny construction project");
         let graph = GraphForge::new(project.path().to_str()).expect("open tiny project");
@@ -3255,6 +3759,79 @@ fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
         assert!(progress.evidence.parquet_write_operations > 0);
         assert_ne!(receipt.generation_uuid, before);
         assert_eq!(current_generation_uuid(&graph), receipt.generation_uuid);
+        let phases =
+            graphforge_storage::ConstructionPhaseAttribution::from_construction(&progress.evidence);
+        phases.validate_reconciliation().unwrap();
+        let shape =
+            &phases.phases[&graphforge_storage::StorageIoPhase::ShapeConsumeReauthentication];
+        assert!(progress.evidence.merge_read_operations > 0);
+        assert!(progress.evidence.merge_write_operations > 0);
+        assert_eq!(
+            shape.write_bytes,
+            progress
+                .evidence
+                .merge_written_bytes
+                .saturating_add(progress.evidence.parquet_write_bytes)
+        );
+        assert_eq!(
+            shape.write_calls,
+            progress
+                .evidence
+                .merge_write_operations
+                .saturating_add(progress.evidence.parquet_write_operations)
+        );
+        assert_eq!(
+            shape.read_calls,
+            progress
+                .evidence
+                .shape_input_validation_read_operations
+                .saturating_add(progress.evidence.merge_read_operations)
+                .saturating_add(progress.evidence.parquet_read_operations)
+                .saturating_add(progress.evidence.shaped_output_authentication_operations)
+                .saturating_add(progress.evidence.parent_catalog_read_operations)
+                .saturating_add(progress.evidence.retained_probe_block_loads)
+        );
+        let phase_observation = (
+            phases.totals.read_bytes,
+            phases.totals.write_bytes,
+            phases.totals.read_calls,
+            phases.totals.write_calls,
+        );
+        if let Some(baseline) = baseline_phase_io {
+            // Each lifecycle has fixed authenticated control work. Preserve a
+            // documented 2x constant-factor ceiling around ideal linear growth
+            // instead of pretending the intercept is zero at the 1x fixture.
+            let ceiling = |base: u64| base.saturating_mul(factor).saturating_mul(2);
+            assert!(phase_observation.0 <= ceiling(baseline.0));
+            assert!(phase_observation.1 <= ceiling(baseline.1));
+            assert!(phase_observation.2 <= ceiling(baseline.2));
+            assert!(phase_observation.3 <= ceiling(baseline.3));
+        } else {
+            baseline_phase_io = Some(phase_observation);
+        }
+        let generation = graphforge_storage::resolve_project_generation(project.path())
+            .expect("resolve tiny generation");
+        let storage = graphforge_storage::capture_storage_attribution(&generation)
+            .expect("capture tiny storage attribution");
+        storage
+            .validate_reconciliation()
+            .expect("reconcile tiny storage attribution");
+        assert!(
+            storage.is_fully_classified(),
+            "unclassified tiny construction storage: {storage:#?}"
+        );
+        if let Some((base_logical, base_allocated)) = baseline_storage {
+            assert!(
+                storage.logical_bytes <= base_logical.saturating_mul(factor),
+                "authenticated logical bytes exceeded linear growth"
+            );
+            assert!(
+                storage.allocated_bytes <= base_allocated.saturating_mul(factor),
+                "deduplicated allocated bytes exceeded linear growth"
+            );
+        } else {
+            baseline_storage = Some((storage.logical_bytes, storage.allocated_bytes));
+        }
         drop(resumed);
         let replay = graph
             .resume_graph_construction(session_uuid, budgets)
@@ -3380,7 +3957,12 @@ fn certification_target_live_full_lifecycle_evidence() {
             "source_nodes": lifecycle["source_nodes"], "source_edges": source_edges,
             "imported_nodes": lifecycle["imported_nodes"], "imported_edges": lifecycle["imported_edges"],
         },
-        "identities": { "source_generation": lifecycle["source_generation"], "package": lifecycle["package"], "transport": lifecycle["transport"], "imported_generation": lifecycle["imported_generation"] },
+        "identities": {
+            "source_export_generation_authenticated": lifecycle["source_export_generation_authenticated"],
+            "import_receipt_reopen_authenticated": lifecycle["import_receipt_reopen_authenticated"],
+            "source_import_generations_distinct": lifecycle["source_import_generations_distinct"],
+            "package": lifecycle["package"], "transport": lifecycle["transport"]
+        },
         "package": {
             "contract": lifecycle["portable_contract"], "format": "portable-project-v2-bundle",
             "class": lifecycle["package_class"], "integrity": lifecycle["integrity"],
@@ -3389,10 +3971,12 @@ fn certification_target_live_full_lifecycle_evidence() {
         },
         "equivalence": { "source_project_fingerprint": lifecycle["source_project_fingerprint"], "imported_project_fingerprint": lifecycle["imported_project_fingerprint"] },
         "authority": { "source_fingerprint": lifecycle["source_authority_fingerprint"], "imported_fingerprint": lifecycle["imported_authority_fingerprint"] },
+        "storage_attribution": lifecycle["storage"],
         "phases": phases,
-        "envelope": { "peak_rss_bytes": peak_rss, "peak_disk_bytes": peak_disk, "wall_time_s": elapsed_before_process.saturating_add(started.elapsed()).as_secs_f64() },
+        "envelope": { "peak_rss_bytes": peak_rss, "peak_disk_bytes": peak_disk, "peak_disk_source": "storage_owned_active_identity_union", "wall_time_s": elapsed_before_process.saturating_add(started.elapsed()).as_secs_f64() },
         "result": "pass", "first_failure": null,
     });
+    reject_unsanitized_evidence(&evidence).expect("provider certification evidence is sanitized");
     let out = PathBuf::from(std::env::var("GF_G500_CERT_EVIDENCE_OUT").expect("evidence output"));
     fs::write(out, serde_json::to_vec_pretty(&evidence).unwrap())
         .expect("write certification evidence");

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -2310,7 +2310,8 @@ impl PhaseJournal {
     }
 
     fn fail_with_detail(&mut self, id: &str, started: Instant, code: &str, detail: Value) {
-        self.monitor.sample_disk();
+        self.monitor
+            .observe_allocated_union(self.allocation.current_allocated_bytes());
         self.phases.push(json!({
             "id": id, "status": "fail",
             "elapsed_ms": u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -16,10 +16,8 @@
 //! certify one billion live edges — that is #745. Small rungs run in normal CI;
 //! large rungs are opt-in via `make bench-g500-ladder`.
 
-#![recursion_limit = "256"]
-
 use std::cmp::Reverse;
-use std::collections::{BTreeMap, BinaryHeap};
+use std::collections::BinaryHeap;
 use std::fs::{self, File};
 use std::io::{BufReader, BufWriter, ErrorKind, Read, Write};
 use std::path::{Path, PathBuf};
@@ -31,14 +29,14 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use arrow::array::{Array, FixedSizeBinaryArray, Int64Array, StringArray, UInt64Array};
 use arrow::record_batch::RecordBatch;
-
 use graphforge_api::{
     CONSTRUCTION_EDGE_SCHEMA, CONSTRUCTION_NODE_SCHEMA, CancellationToken,
     GraphConstructionBudgets, GraphConstructionSession, GraphForge, OperationId, PortableSelection,
     PortableV2ExportRequest, PortableV2ImportRequest, PortableV2Limits, PortableV2Mode,
     PortableV2Output, PortableV2SelectionProfile, PortableVerifyRequest, verify_portable_v2,
 };
-use graphforge_core::uuid::Uuid;
+use graphforge_core::{GfError, uuid::Uuid};
+use graphforge_exec::demand::{self, DemandSnapshot};
 use serde::Deserialize;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
@@ -55,6 +53,7 @@ const REL_TYPE: &str = "LINK";
 /// One authoritative Arrow and durable-append row window for the scale client.
 /// This intentionally matches `GraphConstructionBudgets::default()`.
 const CONSTRUCTION_BATCH_ROWS: usize = 65_536;
+const EXECUTION_BATCH_ROWS: u64 = 8_192;
 
 const ONE_HOP: &str = "MATCH (a)-[r]->(b) RETURN b.node_uuid AS id ORDER BY id LIMIT 1000";
 const TWO_HOP: &str =
@@ -500,179 +499,6 @@ struct RungOutcome {
     evidence: Value,
 }
 
-fn exact_descriptor_allocation(paths: &[PathBuf]) -> Value {
-    let mut logical_bytes = 0_u64;
-    let mut allocated = 0_u64;
-    for path in paths {
-        logical_bytes = logical_bytes.saturating_add(
-            fs::metadata(path)
-                .expect("generator descriptor metadata")
-                .len(),
-        );
-        let file = File::open(path).expect("open exact allocation descriptor");
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::MetadataExt as _;
-            allocated = allocated.saturating_add(
-                file.metadata()
-                    .expect("exact descriptor metadata")
-                    .blocks()
-                    .saturating_mul(512),
-            );
-        }
-        #[cfg(not(unix))]
-        panic!("certification descriptor allocation requires Unix stat blocks");
-    }
-    json!({
-        "category": "generator_spill",
-        "logical_bytes": logical_bytes,
-        "allocated_bytes": allocated,
-        "logical_references": paths.len(),
-        "physical_objects": paths.len(),
-        "source": "generator_exact_descriptors",
-    })
-}
-
-fn exact_descriptor_identities(paths: &[PathBuf]) -> BTreeMap<String, u64> {
-    paths
-        .iter()
-        .map(|path| {
-            let file = File::open(path).expect("open exact allocation descriptor");
-            let identity = graphforge_filesystem::file_identity(&file)
-                .expect("exact descriptor native identity");
-            let allocation = graphforge_filesystem::file_space_usage(&file)
-                .expect("exact descriptor allocation")
-                .allocated_bytes;
-            let mut file_id = String::with_capacity(32);
-            for byte in identity.file_id {
-                use std::fmt::Write as _;
-                write!(&mut file_id, "{byte:02x}").expect("write identity string");
-            }
-            (
-                format!("{:016x}:{file_id}", identity.volume_serial),
-                allocation,
-            )
-        })
-        .collect()
-}
-
-fn portable_export_allocation(receipt: &graphforge_api::PortableV2ExportFacadeResult) -> Value {
-    json!({
-        "category": "portable_package",
-        "logical_bytes": receipt.allocation_logical_bytes,
-        "allocated_bytes": receipt.allocation_identity_allocated_bytes.values().copied().sum::<u64>(),
-        "logical_references": receipt.allocation_physical_objects,
-        "physical_objects": receipt.allocation_physical_objects,
-        "source": "portable_writer_receipt",
-    })
-}
-
-fn storage_attribution_value(project: &Path) -> Value {
-    let mut value =
-        serde_json::to_value(storage_attribution(project)).expect("serialize storage attribution");
-    value
-        .as_object_mut()
-        .expect("storage attribution object")
-        .remove("generation_uuid");
-    value
-        .as_object_mut()
-        .expect("storage attribution object")
-        .remove("physical_identity_allocated_bytes");
-    value
-}
-
-fn reject_unsanitized_evidence(value: &Value) -> Result<(), String> {
-    fn visit(value: &Value, trail: &str) -> Result<(), String> {
-        match value {
-            Value::Object(fields) => {
-                for (key, child) in fields {
-                    let normalized = key.to_ascii_lowercase();
-                    if [
-                        "secret",
-                        "credential",
-                        "password",
-                        "token",
-                        "machine_id",
-                        "volume_id",
-                        "provider_resource_id",
-                        "absolute_path",
-                        "host_path",
-                    ]
-                    .iter()
-                    .any(|needle| normalized.contains(needle))
-                    {
-                        return Err(format!("sensitive evidence key at {trail}.{key}"));
-                    }
-                    visit(child, &format!("{trail}.{key}"))?;
-                }
-            }
-            Value::Array(items) => {
-                for (index, child) in items.iter().enumerate() {
-                    visit(child, &format!("{trail}[{index}]"))?;
-                }
-            }
-            Value::String(text) => {
-                if Uuid::parse_str(text).is_ok() {
-                    return Err(format!("raw UUID at {trail}"));
-                }
-                if text.starts_with('/')
-                    || text.starts_with("\\\\")
-                    || (text.len() >= 3
-                        && text.as_bytes()[1] == b':'
-                        && matches!(text.as_bytes()[2], b'/' | b'\\'))
-                    || text.split_whitespace().any(|part| part.starts_with('/'))
-                {
-                    return Err(format!("absolute host path at {trail}"));
-                }
-            }
-            _ => {}
-        }
-        Ok(())
-    }
-    visit(value, "$")
-}
-
-fn sanitized_construction_evidence(
-    evidence: &graphforge_storage::GraphConstructionEvidence,
-) -> Value {
-    let mut value = serde_json::to_value(evidence).expect("serialize construction evidence");
-    value
-        .as_object_mut()
-        .expect("construction evidence object")
-        .remove("storage_active_identity_allocated_bytes");
-    value
-        .as_object_mut()
-        .expect("construction evidence object")
-        .remove("storage_allocation_transitions");
-    value
-}
-
-fn storage_attribution(project: &Path) -> graphforge_storage::StorageAttributionSnapshot {
-    let graph = GraphForge::new(project.to_str()).expect("open attribution facade");
-    let snapshot = graph
-        .storage_attribution()
-        .expect("capture authenticated storage attribution through public facade");
-    snapshot
-        .validate_reconciliation()
-        .expect("storage attribution reconciliation");
-    assert!(
-        snapshot.is_fully_classified(),
-        "qualification refuses unclassified retained artifacts"
-    );
-    snapshot
-}
-
-#[test]
-fn public_storage_attribution_is_generation_bound_and_fully_classified() {
-    let project = TempDir::new().expect("storage attribution project");
-    let graph = GraphForge::new(project.path().to_str()).expect("open attribution facade");
-    let snapshot = graph
-        .storage_attribution()
-        .expect("public facade storage attribution");
-    snapshot.validate_for_qualification().unwrap();
-    assert!(snapshot.is_fully_classified());
-}
-
 /// Check the envelope after a phase. Returns `Some(error_class)` on the first
 /// violation so the caller can stop the ladder. `ladder_started` is the
 /// ladder-level clock so the 4 h wall-clock fail-safe bounds the whole run, not each
@@ -680,12 +506,14 @@ fn public_storage_attribution_is_generation_bound_and_fully_classified() {
 fn envelope_violation(
     env: &RunEnvelope,
     ladder_started: Instant,
-    disk_used_bytes: u64,
+    project: &Path,
+    spill: &Path,
 ) -> Option<&'static str> {
     if peak_rss().is_some_and(|(rss, _)| rss > env.rss_bytes) {
         return Some("oom");
     }
-    if disk_used_bytes > env.disk_bytes {
+    let disk = directory_bytes(project).unwrap_or(0) + directory_bytes(spill).unwrap_or(0);
+    if disk > env.disk_bytes {
         return Some("disk_exhaustion");
     }
     if ladder_started.elapsed().as_secs() > env.timeout_s {
@@ -697,6 +525,82 @@ fn envelope_violation(
 /// Current peak RSS as a JSON value (bytes or null).
 fn rss_value() -> Value {
     peak_rss().map_or(Value::Null, |(bytes, _)| json!(bytes))
+}
+
+fn execute_with_bounded_evidence(
+    graph: &GraphForge,
+    query: &str,
+) -> (
+    Result<graphforge_api::ExecutionResult, GfError>,
+    DemandSnapshot,
+) {
+    demand::reset();
+    let result = graph.execute(query);
+    demand::disable();
+    (result, demand::snapshot())
+}
+
+fn query_work_evidence(snapshot: &DemandSnapshot) -> Value {
+    json!({
+        "hops": snapshot.hops.iter().map(|(edge_var, hop)| json!({
+            "edge_var": edge_var,
+            "input_batches": hop.input_batches,
+            "input_rows": hop.input_rows,
+            "candidates_generated": hop.candidates_generated,
+            "rows_emitted": hop.rows_emitted,
+            "edge_rows_scanned": hop.edge_rows_scanned,
+            "node_rows_scanned": hop.node_rows_scanned,
+            "identity_read_calls": hop.identity_read_calls,
+            "identity_bytes_read": hop.identity_bytes_read,
+            "identity_peak_buffer_bytes": hop.identity_peak_buffer_bytes,
+        })).collect::<Vec<_>>(),
+        "sorts": snapshot.sorts.iter().map(|sort| json!({
+            "ordinal": sort.ordinal,
+            "fetch": sort.fetch,
+            "output_rows": sort.output_rows,
+            "spill_count": sort.spill_count,
+            "spilled_rows": sort.spilled_rows,
+            "spilled_bytes": sort.spilled_bytes,
+            "retained_bytes": sort.retained_bytes,
+        })).collect::<Vec<_>>(),
+        "operator_rss": snapshot.operator_rss.iter().map(|operator| json!({
+            "ordinal": operator.ordinal,
+            "operator": operator.operator,
+            "before_bytes": operator.before_bytes,
+            "peak_bytes": operator.peak_bytes,
+            "after_bytes": operator.after_bytes,
+        })).collect::<Vec<_>>(),
+        "memory_reserved_before": snapshot.memory_reserved_before,
+        "memory_reserved_after": snapshot.memory_reserved_after,
+        "returned_batch_bytes": snapshot.returned_batch_bytes,
+        "cancellations": snapshot.cancellations,
+        "max_in_flight_reads": snapshot.max_in_flight_reads,
+    })
+}
+
+fn bounded_ordered_limit(snapshot: &DemandSnapshot, expected_hops: usize, limit: usize) -> bool {
+    snapshot.hops.len() == expected_hops
+        && snapshot.sorts.len() == 1
+        && snapshot.sorts[0].fetch == Some(limit)
+        // DataFusion's baseline output counter is charged before its final
+        // fetch wrapper slices the terminal batch, so it may include at most
+        // one physical batch beyond the returned TopK rows.
+        && snapshot.sorts[0].output_rows <= (limit as u64).saturating_add(EXECUTION_BATCH_ROWS)
+        && snapshot.sorts[0].retained_bytes == 0
+        && snapshot.operator_rss.len() == expected_hops.saturating_add(1)
+        && snapshot.operator_rss.iter().all(|operator| {
+            operator.peak_bytes >= operator.before_bytes
+                && operator.peak_bytes >= operator.after_bytes
+                && (operator.after_bytes > 0 || !cfg!(target_os = "linux"))
+        })
+        && snapshot.memory_reserved_after
+            <= snapshot
+                .memory_reserved_before
+                .saturating_add(snapshot.returned_batch_bytes)
+        && snapshot
+            .hops
+            .values()
+            .all(|hop| hop.reads_after_cancel == 0)
 }
 
 fn linux_process_memory() -> Value {
@@ -855,6 +759,8 @@ impl IngestHeartbeat {
         rung: &Rung,
         completed_rungs: &[Value],
         steps: &[Value],
+        project: &Path,
+        spill: &Path,
     ) -> Self {
         let Ok(path) = std::env::var("GF_G500_LADDER_JOURNAL_OUT") else {
             return Self {
@@ -870,6 +776,8 @@ impl IngestHeartbeat {
         let scale = rung.scale;
         let completed_rungs = completed_rungs.to_vec();
         let steps = steps.to_vec();
+        let project = project.to_path_buf();
+        let spill = spill.to_path_buf();
         let handle = thread::spawn(move || {
             loop {
                 let value = json!({
@@ -884,6 +792,8 @@ impl IngestHeartbeat {
                     "active_chunk_index": INGEST_CHUNK_INDEX.load(Ordering::Relaxed),
                     "process_memory": linux_process_memory(),
                     "storage_io": storage_io_value(),
+                    "disk_used_bytes": directory_bytes(&project).unwrap_or(0)
+                        .saturating_add(directory_bytes(&spill).unwrap_or(0)),
                     "completed_rungs": completed_rungs,
                     "active_steps": steps,
                     "first_failing_phase": null,
@@ -983,11 +893,7 @@ fn run_rung(
         None,
     );
     let generate_s = gen_started.elapsed().as_secs_f64();
-    let generator_allocation = exact_descriptor_allocation(&spill.runs);
-    let generator_allocated_bytes = generator_allocation["allocated_bytes"]
-        .as_u64()
-        .expect("generator allocated bytes");
-    let gen_violation = envelope_violation(&env, ladder_started, generator_allocated_bytes);
+    let gen_violation = envelope_violation(&env, ladder_started, &project, &spill_dir);
     if let Some(class) = gen_violation {
         first_failing_phase = Some("generate");
         error_class = Some(class);
@@ -1003,7 +909,6 @@ fn run_rung(
             "peak_buffer_len": spill.peak_buffer_len,
             "buffer_edges": rung.buffer_edges,
             "run_count": spill.runs.len(),
-            "storage": generator_allocation,
         }
     }));
     persist_phase_journal(
@@ -1041,7 +946,8 @@ fn run_rung(
         graphforge_storage::io_stats::reset();
         INGEST_CHUNK_INDEX.store(0, Ordering::Relaxed);
         INGEST_SUBPHASE.store(1, Ordering::Relaxed);
-        let heartbeat = IngestHeartbeat::start(profile, rung, completed_rungs, &steps);
+        let heartbeat =
+            IngestHeartbeat::start(profile, rung, completed_rungs, &steps, &project, &spill_dir);
         let mut construction = open_persisted_construction(
             &graph,
             &spill_dir.join("construction-session.uuid"),
@@ -1081,21 +987,9 @@ fn run_rung(
         INGEST_SUBPHASE.store(0, Ordering::Relaxed);
         heartbeat.stop();
         drop(graph);
-        let committed_snapshot = storage_attribution(&project);
-        let ingest_disk_used_bytes =
-            generator_allocated_bytes.saturating_add(committed_snapshot.allocated_bytes);
-        let committed_storage =
-            serde_json::to_value(committed_snapshot).expect("serialize committed storage");
-        let construction_phases =
-            graphforge_storage::ConstructionPhaseAttribution::from_construction(
-                &construction_evidence,
-            );
-        construction_phases
-            .validate_reconciliation()
-            .expect("construction phase attribution reconciliation");
         ingest_ran = true;
         let ingest_s = ingest_started.elapsed().as_secs_f64();
-        let ingest_violation = envelope_violation(&env, ladder_started, ingest_disk_used_bytes);
+        let ingest_violation = envelope_violation(&env, ladder_started, &project, &spill_dir);
         if let Some(class) = ingest_violation {
             first_failing_phase = Some("ingest");
             error_class = Some(class);
@@ -1105,7 +999,8 @@ fn run_rung(
             "pass": ingest_violation.is_none(),
             "wall_time_s": ingest_s,
             "rss_peak_bytes": rss_value(),
-            "disk_used_bytes": ingest_disk_used_bytes,
+            "disk_used_bytes": directory_bytes(&project).unwrap_or(0)
+                .saturating_add(directory_bytes(&spill_dir).unwrap_or(0)),
             "detail": {
                 "live_unique_edges": live_unique_edges,
                 "duplicates_rejected": duplicates_rejected,
@@ -1142,10 +1037,7 @@ fn run_rung(
                     "parquet_write_operations": construction_evidence.parquet_write_operations,
                     "retained_probe_read_bytes": construction_evidence.retained_probe_read_bytes,
                     "retained_probe_block_loads": construction_evidence.retained_probe_block_loads,
-                    "storage_transient_peak_allocated_bytes": construction_evidence.storage_transient_peak_allocated_bytes,
                 },
-                "committed_storage": committed_storage,
-                "application_io_phases": construction_phases,
             }
         }));
         persist_phase_journal(
@@ -1163,7 +1055,7 @@ fn run_rung(
         );
     }
 
-    // ---- reopen + recount ----
+    // ---- reopen + independently durable recount/query boundaries ----
     let mut node_count = 0u64;
     let mut edge_count = 0u64;
     let mut gsi = String::new();
@@ -1180,13 +1072,8 @@ fn run_rung(
         let reopen_started = Instant::now();
         let graph = GraphForge::new(Some(project.to_str().expect("utf8 project")))
             .expect("reopen GraphForge");
-        node_count = graph.node_count(NODE_LABEL).expect("node_count");
-        edge_count = scalar_count(&graph.execute(COUNT_EDGES).expect("edge count"));
         let reopen_s = reopen_started.elapsed().as_secs_f64();
-        gsi = gsi_undirected(node_count, edge_count);
-        let reopen_disk_used_bytes =
-            generator_allocated_bytes.saturating_add(storage_attribution(&project).allocated_bytes);
-        let reopen_violation = envelope_violation(&env, ladder_started, reopen_disk_used_bytes);
+        let reopen_violation = envelope_violation(&env, ladder_started, &project, &spill_dir);
         if let Some(class) = reopen_violation {
             first_failing_phase = Some("reopen");
             error_class = Some(class);
@@ -1196,7 +1083,8 @@ fn run_rung(
             "pass": reopen_violation.is_none(),
             "wall_time_s": reopen_s,
             "rss_peak_bytes": rss_value(),
-            "detail": { "node_count": node_count, "edge_count": edge_count, "gsi": gsi }
+            "process_memory": linux_process_memory(),
+            "detail": { "opened": true }
         }));
         persist_phase_journal(
             profile,
@@ -1212,49 +1100,43 @@ fn run_rung(
             first_failing_phase.zip(error_class),
         );
 
-        // ---- deterministic LIMIT queries ----
         if first_failing_phase.is_none() {
-            let hop1_started = Instant::now();
             persist_phase_journal(
                 profile,
                 rung,
                 completed_rungs,
-                "query",
+                "node_count",
                 "running",
                 &steps,
                 None,
             );
-            let hop1 = graph.execute(ONE_HOP).expect("one-hop LIMIT");
-            let hop1_rows = row_count(&hop1);
-            steps.push(json!({
-                "id": "cypher_limit_1hop",
-                "pass": hop1_rows <= 1_000,
-                "wall_time_s": hop1_started.elapsed().as_secs_f64(),
-                "detail": { "rows": hop1_rows }
-            }));
-
-            let hop2_started = Instant::now();
-            let hop2 = graph.execute(TWO_HOP).expect("two-hop LIMIT");
-            let hop2_rows = row_count(&hop2);
-            steps.push(json!({
-                "id": "cypher_limit_2hop",
-                "pass": hop2_rows <= 1_000,
-                "wall_time_s": hop2_started.elapsed().as_secs_f64(),
-                "detail": { "rows": hop2_rows }
-            }));
-            let query_disk_used_bytes = generator_allocated_bytes
-                .saturating_add(storage_attribution(&project).allocated_bytes);
-            let query_violation = envelope_violation(&env, ladder_started, query_disk_used_bytes);
-            if let Some(class) = query_violation {
-                first_failing_phase = Some("query");
+            let count_started = Instant::now();
+            let result = graph.node_count(NODE_LABEL);
+            let failure = result.as_ref().err().map(ToString::to_string);
+            node_count = result.unwrap_or(0);
+            let expected = 1u64 << rung.scale;
+            let mut violation = envelope_violation(&env, ladder_started, &project, &spill_dir);
+            if failure.is_some() {
+                violation = Some("execution_failure");
+            } else if node_count != expected {
+                violation = Some("result_mismatch");
+            }
+            if let Some(class) = violation {
+                first_failing_phase = Some("node_count");
                 error_class = Some(class);
             }
+            steps.push(json!({
+                "id": "node_count", "pass": violation.is_none(),
+                "wall_time_s": count_started.elapsed().as_secs_f64(),
+                "rss_peak_bytes": rss_value(), "process_memory": linux_process_memory(),
+                "detail": { "count": node_count, "expected": expected, "failure": failure }
+            }));
             persist_phase_journal(
                 profile,
                 rung,
                 completed_rungs,
-                "query",
-                if query_violation.is_some() {
+                "node_count",
+                if violation.is_some() {
                     "phase_failed"
                 } else {
                     "phase_completed"
@@ -1263,14 +1145,120 @@ fn run_rung(
                 first_failing_phase.zip(error_class),
             );
         }
+
+        if first_failing_phase.is_none() {
+            persist_phase_journal(
+                profile,
+                rung,
+                completed_rungs,
+                "edge_count",
+                "running",
+                &steps,
+                None,
+            );
+            let count_started = Instant::now();
+            let (result, work) = execute_with_bounded_evidence(&graph, COUNT_EDGES);
+            let failure = result.as_ref().err().map(ToString::to_string);
+            edge_count = result.as_ref().map_or(0, scalar_count);
+            gsi = gsi_undirected(node_count, edge_count);
+            let mut violation = envelope_violation(&env, ladder_started, &project, &spill_dir);
+            if failure.is_some() {
+                violation = Some("execution_failure");
+            } else if edge_count != live_unique_edges {
+                violation = Some("result_mismatch");
+            } else if work.memory_reserved_after
+                > work
+                    .memory_reserved_before
+                    .saturating_add(work.returned_batch_bytes)
+            {
+                violation = Some("memory_retained");
+            }
+            if let Some(class) = violation {
+                first_failing_phase = Some("edge_count");
+                error_class = Some(class);
+            }
+            steps.push(json!({
+                "id": "edge_count", "pass": violation.is_none(),
+                "wall_time_s": count_started.elapsed().as_secs_f64(),
+                "rss_peak_bytes": rss_value(), "process_memory": linux_process_memory(),
+                "detail": { "count": edge_count, "expected": live_unique_edges, "gsi": gsi,
+                    "failure": failure, "work": query_work_evidence(&work) }
+            }));
+            persist_phase_journal(
+                profile,
+                rung,
+                completed_rungs,
+                "edge_count",
+                if violation.is_some() {
+                    "phase_failed"
+                } else {
+                    "phase_completed"
+                },
+                &steps,
+                first_failing_phase.zip(error_class),
+            );
+        }
+
+        // ---- deterministic LIMIT queries, each with its own atomic journal ----
+        if first_failing_phase.is_none() {
+            for (phase, query, expected_hops) in
+                [("one_hop", ONE_HOP, 1usize), ("two_hop", TWO_HOP, 2usize)]
+            {
+                if first_failing_phase.is_some() {
+                    break;
+                }
+                persist_phase_journal(
+                    profile,
+                    rung,
+                    completed_rungs,
+                    phase,
+                    "running",
+                    &steps,
+                    None,
+                );
+                let query_started = Instant::now();
+                let (result, work) = execute_with_bounded_evidence(&graph, query);
+                let failure = result.as_ref().err().map(ToString::to_string);
+                let rows = result.as_ref().map_or(0, row_count);
+                let mut violation = envelope_violation(&env, ladder_started, &project, &spill_dir);
+                if failure.is_some() {
+                    violation = Some("execution_failure");
+                } else if rows > 1_000 {
+                    violation = Some("result_mismatch");
+                } else if !bounded_ordered_limit(&work, expected_hops, 1_000) {
+                    violation = Some("operator_budget_violation");
+                }
+                if let Some(class) = violation {
+                    first_failing_phase = Some(phase);
+                    error_class = Some(class);
+                }
+                steps.push(json!({
+                    "id": phase, "pass": violation.is_none(),
+                    "wall_time_s": query_started.elapsed().as_secs_f64(),
+                    "rss_peak_bytes": rss_value(), "process_memory": linux_process_memory(),
+                    "detail": { "rows": rows, "failure": failure,
+                        "work": query_work_evidence(&work) }
+                }));
+                persist_phase_journal(
+                    profile,
+                    rung,
+                    completed_rungs,
+                    phase,
+                    if violation.is_some() {
+                        "phase_failed"
+                    } else {
+                        "phase_completed"
+                    },
+                    &steps,
+                    first_failing_phase.zip(error_class),
+                );
+            }
+        }
         drop(graph);
     }
 
-    let disk_used_bytes = generator_allocated_bytes.saturating_add(
-        ingest_ran
-            .then(|| storage_attribution(&project).allocated_bytes)
-            .unwrap_or(0),
-    );
+    let disk_used_bytes =
+        directory_bytes(&project).unwrap_or(0) + directory_bytes(&spill_dir).unwrap_or(0);
     // Tri-state: reconciliation is only *evaluated* once ingest has run. A rung
     // stopped in the generate phase is reported as null (not evaluated), never
     // as a forced `true`.
@@ -1614,6 +1602,26 @@ fn git_sha() -> Value {
         .filter(|output| output.status.success())
         .and_then(|output| String::from_utf8(output.stdout).ok())
         .map_or(Value::Null, |sha| Value::String(sha.trim().to_owned()))
+}
+
+fn directory_bytes(path: &Path) -> std::io::Result<u64> {
+    if !path.exists() {
+        return Ok(0);
+    }
+    if path.is_file() {
+        return Ok(path.metadata()?.len());
+    }
+    let mut total = 0u64;
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        let metadata = entry.metadata()?;
+        total += if metadata.is_dir() {
+            directory_bytes(&entry.path())?
+        } else {
+            metadata.len()
+        };
+    }
+    Ok(total)
 }
 
 /// Returns `(bytes, source)`. `"vmhwm"` (Linux `/proc/self/status`) is a true
@@ -2043,18 +2051,22 @@ fn phase_journal_atomically_preserves_completed_rungs_and_active_state() {
 // entry point below uses the same phases after target-live generation.
 // ---------------------------------------------------------------------------
 
-const CERTIFICATION_PHASES: [&str; 17] = [
+const CERTIFICATION_PHASES: [&str; 21] = [
     "preflight",
     "generate",
     "ingest",
     "csr",
     "source_reopen",
+    "source_node_count",
+    "source_edge_count",
     "source_query_1hop",
     "source_query_2hop",
     "export",
     "verify",
     "import",
     "imported_reopen",
+    "imported_node_count",
+    "imported_edge_count",
     "imported_query_1hop",
     "imported_query_2hop",
     "drill_corruption",
@@ -2067,32 +2079,37 @@ struct PhaseJournal {
     path: PathBuf,
     phases: Vec<Value>,
     monitor: ResourceMonitor,
-    allocation: graphforge_storage::StorageAllocationLifecycle,
 }
 
 impl PhaseJournal {
-    fn new(path: PathBuf, _workspace: &Path, envelope: Envelope) -> Self {
+    fn new(path: PathBuf, workspace: &Path, envelope: Envelope) -> Self {
         Self {
             path,
             phases: Vec::new(),
-            monitor: ResourceMonitor::start(envelope),
-            allocation: graphforge_storage::StorageAllocationLifecycle::default(),
+            monitor: ResourceMonitor::start(workspace.to_path_buf(), envelope),
         }
     }
 
     fn pass(&mut self, id: &str, started: Instant, fingerprint: Option<String>) {
+        self.pass_with_detail(id, started, fingerprint, Value::Null);
+    }
+
+    fn pass_with_detail(
+        &mut self,
+        id: &str,
+        started: Instant,
+        fingerprint: Option<String>,
+        detail: Value,
+    ) {
         let fingerprint = fingerprint.map_or(Value::Null, Value::String);
-        // Every phase owns the live allocation union for its full duration,
-        // even when it does not install or remove an allocation identity.
-        self.monitor
-            .observe_allocated_union(self.allocation.current_allocated_bytes());
+        self.monitor.sample_disk();
         if let Some(code) = self.monitor.failure_code() {
             self.phases.push(json!({
                 "id": id, "status": "fail",
                 "elapsed_ms": u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
                 "rss_peak_bytes": self.monitor.peak_rss.load(Ordering::Relaxed),
                 "disk_peak_bytes": self.monitor.peak_disk.load(Ordering::Relaxed),
-                "fingerprint": fingerprint, "failure_code": code,
+                "fingerprint": fingerprint, "detail": detail, "failure_code": code,
             }));
             self.flush();
             panic!("certification resource watchdog stopped phase {id}: {code}");
@@ -2105,7 +2122,20 @@ impl PhaseJournal {
             "rss_peak_bytes": rss_peak_bytes,
             "disk_peak_bytes": disk_peak_bytes,
             "fingerprint": fingerprint,
+            "detail": detail,
             "failure_code": null,
+        }));
+        self.flush();
+    }
+
+    fn fail_with_detail(&mut self, id: &str, started: Instant, code: &str, detail: Value) {
+        self.monitor.sample_disk();
+        self.phases.push(json!({
+            "id": id, "status": "fail",
+            "elapsed_ms": u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+            "rss_peak_bytes": self.monitor.peak_rss.load(Ordering::Relaxed),
+            "disk_peak_bytes": self.monitor.peak_disk.load(Ordering::Relaxed),
+            "fingerprint": null, "detail": detail, "failure_code": code,
         }));
         self.flush();
     }
@@ -2116,50 +2146,6 @@ impl PhaseJournal {
 
     fn cancellation_token(&self) -> CancellationToken {
         self.monitor.cancellation.clone()
-    }
-
-    fn replace_allocation_owner(&mut self, owner: &str, identities: &BTreeMap<String, u64>) {
-        self.allocation
-            .replace_owner(owner, identities)
-            .expect("replace exact allocation owner");
-        self.monitor
-            .observe_allocated_union(self.allocation.current_allocated_bytes());
-    }
-
-    fn replace_project_owner(
-        &mut self,
-        owner: &str,
-        generation: &graphforge_storage::ResolvedProjectGeneration,
-    ) {
-        let project = graphforge_storage::capture_project_storage_identity_union(generation)
-            .expect("capture retained project identity union");
-        self.replace_allocation_owner(owner, &project.physical_identity_allocated_bytes);
-    }
-
-    fn replay_allocation_transitions(
-        &mut self,
-        owner: &str,
-        transitions: &[graphforge_storage::StorageAllocationTransition],
-    ) {
-        for transition in transitions {
-            self.allocation
-                .apply_owner_transition(owner, transition)
-                .expect("apply writer-owned allocation transition");
-            self.monitor
-                .observe_allocated_union(self.allocation.current_allocated_bytes());
-        }
-    }
-
-    fn remove_allocation_owner(&mut self, owner: &str) {
-        self.allocation
-            .remove_owner(owner)
-            .expect("remove exact allocation owner");
-        self.monitor
-            .observe_allocated_union(self.allocation.current_allocated_bytes());
-    }
-
-    fn current_allocated_union(&self) -> u64 {
-        self.allocation.current_allocated_bytes()
     }
 
     fn flush(&self) {
@@ -2187,19 +2173,43 @@ impl Drop for PhaseJournal {
             .failure_code()
             .or_else(|| std::thread::panicking().then_some("operation_failed"));
         if let Some(code) = failure_code {
+            self.monitor.sample_disk();
             self.phases.push(json!({
                 "id": CERTIFICATION_PHASES[self.phases.len()], "status": "fail",
                 "elapsed_ms": 0,
                 "rss_peak_bytes": self.monitor.peak_rss.load(Ordering::Relaxed),
                 "disk_peak_bytes": self.monitor.peak_disk.load(Ordering::Relaxed),
-                "fingerprint": null, "failure_code": code,
+                "fingerprint": null, "detail": null, "failure_code": code,
             }));
             self.flush();
         }
     }
 }
 
+fn certification_query(
+    graph: &GraphForge,
+    query: &str,
+    phase_id: &str,
+    started: Instant,
+    journal: &mut PhaseJournal,
+) -> (graphforge_api::ExecutionResult, DemandSnapshot) {
+    let (result, work) = execute_with_bounded_evidence(graph, query);
+    match result {
+        Ok(result) => (result, work),
+        Err(error) => {
+            journal.fail_with_detail(
+                phase_id,
+                started,
+                "execution_failure",
+                json!({ "error": error.to_string(), "work": query_work_evidence(&work) }),
+            );
+            panic!("{phase_id} failed: {error}");
+        }
+    }
+}
+
 struct ResourceMonitor {
+    workspace: PathBuf,
     cancellation: CancellationToken,
     stop: Arc<AtomicBool>,
     peak_rss: Arc<AtomicU64>,
@@ -2210,24 +2220,29 @@ struct ResourceMonitor {
 }
 
 impl ResourceMonitor {
-    fn start(envelope: Envelope) -> Self {
+    fn start(workspace: PathBuf, envelope: Envelope) -> Self {
         let initial_rss = current_rss_bytes().expect("certification host must expose process RSS");
+        let initial_disk = allocated_bytes(&workspace)
+            .expect("certification host must expose allocated disk bytes");
         let cancellation = CancellationToken::new();
         let stop = Arc::new(AtomicBool::new(false));
         let peak_rss = Arc::new(AtomicU64::new(initial_rss));
-        let peak_disk = Arc::new(AtomicU64::new(0));
+        let peak_disk = Arc::new(AtomicU64::new(initial_disk));
         let failure = Arc::new(AtomicU64::new(0));
         let worker_cancellation = cancellation.clone();
         let worker_stop = Arc::clone(&stop);
         let worker_peak_rss = Arc::clone(&peak_rss);
+        let worker_peak_disk = Arc::clone(&peak_disk);
         let worker_failure = Arc::clone(&failure);
+        let worker_workspace = workspace.clone();
         let started = Instant::now();
         let elapsed_before_process = certification_elapsed_before_process();
         let worker = thread::spawn(move || {
+            let mut samples = 0_u8;
             while !worker_stop.load(Ordering::Relaxed) {
                 let rss = current_rss_bytes().expect("certification RSS probe failed");
                 worker_peak_rss.fetch_max(rss, Ordering::Relaxed);
-                let code = if rss > envelope.rss_bytes {
+                let mut code = if rss > envelope.rss_bytes {
                     1
                 } else if elapsed_before_process
                     .saturating_add(started.elapsed())
@@ -2238,6 +2253,14 @@ impl ResourceMonitor {
                 } else {
                     0
                 };
+                if samples == 0 {
+                    let disk = allocated_bytes(&worker_workspace)
+                        .expect("certification disk probe failed");
+                    worker_peak_disk.fetch_max(disk, Ordering::Relaxed);
+                    if disk > envelope.disk_bytes {
+                        code = 2;
+                    }
+                }
                 if code != 0 {
                     worker_failure
                         .compare_exchange(0, code, Ordering::SeqCst, Ordering::Relaxed)
@@ -2245,10 +2268,12 @@ impl ResourceMonitor {
                     worker_cancellation.cancel();
                     break;
                 }
+                samples = (samples + 1) % 20;
                 thread::sleep(Duration::from_millis(250));
             }
         });
         Self {
+            workspace,
             cancellation,
             stop,
             peak_rss,
@@ -2259,9 +2284,10 @@ impl ResourceMonitor {
         }
     }
 
-    fn observe_allocated_union(&self, bytes: u64) {
-        self.peak_disk.fetch_max(bytes, Ordering::Relaxed);
-        if bytes > self.envelope.disk_bytes {
+    fn sample_disk(&self) {
+        let disk = allocated_bytes(&self.workspace).expect("certification disk probe failed");
+        self.peak_disk.fetch_max(disk, Ordering::Relaxed);
+        if disk > self.envelope.disk_bytes {
             self.failure
                 .compare_exchange(0, 2, Ordering::SeqCst, Ordering::Relaxed)
                 .ok();
@@ -2316,6 +2342,23 @@ impl Drop for ResourceMonitor {
             worker.join().expect("resource watchdog thread");
         }
     }
+}
+
+fn allocated_bytes(path: &Path) -> Result<u64, &'static str> {
+    let output = Command::new("du").arg("-sk").arg(path).output();
+    output
+        .ok()
+        .filter(|out| out.status.success())
+        .and_then(|out| {
+            String::from_utf8(out.stdout)
+                .ok()?
+                .split_whitespace()
+                .next()?
+                .parse::<u64>()
+                .ok()
+        })
+        .map(|kibibytes| kibibytes.saturating_mul(1024))
+        .ok_or("allocated disk usage is unavailable")
 }
 
 fn result_fingerprint(result: &graphforge_api::ExecutionResult) -> String {
@@ -2394,17 +2437,7 @@ fn current_generation_uuid(graph: &GraphForge) -> Uuid {
     Uuid::from_bytes(bytes)
 }
 
-struct DrillAllocationEvidence {
-    project: BTreeMap<String, u64>,
-    construction: BTreeMap<String, u64>,
-    expanded: BTreeMap<String, u64>,
-    cancelled_export: BTreeMap<String, u64>,
-}
-
-fn create_bounded_drill_package(
-    root: &Path,
-    limits: PortableV2Limits,
-) -> (PathBuf, String, DrillAllocationEvidence) {
+fn create_bounded_drill_package(root: &Path, limits: PortableV2Limits) -> (PathBuf, String) {
     let project = root.join("drill-source");
     let package = root.join("drill.gfpb");
     fs::create_dir_all(&project).expect("bounded drill project");
@@ -2422,21 +2455,11 @@ fn create_bounded_drill_package(
     construction
         .seal_and_publish()
         .expect("publish bounded drill construction");
-    let construction_identities = construction
-        .progress()
-        .evidence
-        .storage_active_identity_allocated_bytes;
     drop(construction);
     drop(graph);
     let graph = GraphForge::new(project.to_str()).expect("reopen bounded drill project");
-    let project_generation = graphforge_storage::resolve_project_generation(&project)
-        .expect("resolve bounded drill project");
-    let project_identities =
-        graphforge_storage::capture_project_storage_identity_union(&project_generation)
-            .expect("bounded drill retained project attribution")
-            .physical_identity_allocated_bytes;
     let expanded = root.join("drill-expanded");
-    let expanded_receipt = graph
+    graph
         .export_portable_v2(
             &PortableV2ExportRequest {
                 selection: PortableSelection::Current,
@@ -2452,31 +2475,31 @@ fn create_bounded_drill_package(
         .expect("export compact drill expanded package");
     verify_portable_v2(
         &PortableVerifyRequest {
-            input: expanded.clone(),
+            input: expanded,
             mode: PortableV2Mode::Full,
             limits,
         },
         None,
     )
     .expect("verify compact drill expanded package");
-    let expanded_identities = expanded_receipt.allocation_identity_allocated_bytes;
-    fs::remove_dir_all(&expanded).expect("remove bounded expanded drill package");
     let cancelled = AtomicBool::new(true);
     let cancelled_path = root.join("drill-cancelled.gfpb");
-    let cancelled_error = graph
-        .export_portable_v2(
-            &PortableV2ExportRequest {
-                selection: PortableSelection::Current,
-                output_path: cancelled_path.clone(),
-                representation: PortableV2Output::Bundle,
-                profile: PortableV2SelectionProfile::Complete,
-                subset: None,
-                limits,
-            },
-            Some(&cancelled),
-            |_| {},
-        )
-        .expect_err("cancelled drill export must fail");
+    assert!(
+        graph
+            .export_portable_v2(
+                &PortableV2ExportRequest {
+                    selection: PortableSelection::Current,
+                    output_path: cancelled_path.clone(),
+                    representation: PortableV2Output::Bundle,
+                    profile: PortableV2SelectionProfile::Complete,
+                    subset: None,
+                    limits,
+                },
+                Some(&cancelled),
+                |_| {},
+            )
+            .is_err()
+    );
     assert!(!cancelled_path.exists());
     let receipt = graph
         .export_portable_v2(
@@ -2492,29 +2515,11 @@ fn create_bounded_drill_package(
             |_| {},
         )
         .expect("export bounded drill package");
-    (
-        package,
-        receipt.package_digest,
-        DrillAllocationEvidence {
-            project: project_identities,
-            construction: construction_identities,
-            expanded: expanded_identities,
-            cancelled_export: cancelled_error.allocation_identity_allocated_bytes,
-        },
-    )
+    (package, receipt.package_digest)
 }
 
 #[allow(clippy::too_many_lines)]
 fn run_integrated_certification(root: &Path, target_live: Option<u64>) -> Value {
-    run_integrated_certification_with_edge_factor(root, target_live, None)
-}
-
-#[allow(clippy::too_many_lines)]
-fn run_integrated_certification_with_edge_factor(
-    root: &Path,
-    target_live: Option<u64>,
-    preflight_edge_factor: Option<u32>,
-) -> Value {
     let source = root.join("source");
     let imported = root.join("imported");
     let package = root.join("project.gfpb");
@@ -2546,7 +2551,7 @@ fn run_integrated_certification_with_edge_factor(
     let edge_factor = if target_live.is_some() {
         certification_profile.edgefactor
     } else {
-        preflight_edge_factor.unwrap_or(4)
+        4
     };
     let initiator = if target_live.is_some() {
         certification_profile.initiator
@@ -2589,19 +2594,10 @@ fn run_integrated_certification_with_edge_factor(
         || target_live_fingerprint.expect("target-live payload fingerprint"),
         |value| value.input_fingerprint.clone(),
     );
-    if let Some(spills) = &spills {
-        journal.replace_allocation_owner(
-            "generator_spill",
-            &exact_descriptor_identities(&spills.runs),
-        );
-    }
     journal.pass("generate", phase, Some(generation_fingerprint.clone()));
 
     let phase = Instant::now();
     let graph = GraphForge::new(source.to_str()).expect("open certification source");
-    let initial_generation = graphforge_storage::resolve_project_generation(&source)
-        .expect("resolve initial source generation");
-    journal.replace_project_owner("source_project", &initial_generation);
     let mut construction = graph
         .begin_graph_construction(Default::default())
         .expect("begin certification construction");
@@ -2629,36 +2625,12 @@ fn run_integrated_certification_with_edge_factor(
     construction
         .seal_and_publish()
         .expect("publish certification construction");
-    let construction_evidence = construction.progress().evidence;
-    let mut construction_phases =
-        graphforge_storage::ConstructionPhaseAttribution::from_construction(&construction_evidence);
-    construction_phases
-        .validate_for_qualification()
-        .expect("certification construction phase attribution");
-    let pre_construction_union = journal.current_allocated_union();
-    journal.replay_allocation_transitions(
-        "construction",
-        &construction_evidence.storage_allocation_transitions,
-    );
-    // Construction artifacts are private to this session and cannot alias the
-    // already-open source project. The storage-owned numeric high-water mark
-    // therefore restores peaks compacted out of durable checkpoint history.
-    journal.monitor.observe_allocated_union(
-        pre_construction_union
-            .saturating_add(construction_evidence.storage_transient_peak_total_allocated_bytes),
-    );
-    let committed_generation = graphforge_storage::resolve_project_generation(&source)
-        .expect("resolve committed ingest generation");
-    journal.replace_project_owner("source_project", &committed_generation);
     journal.pass("ingest", phase, Some(input_fingerprint));
 
     let phase = Instant::now();
     let csr = graph
         .rebuild_adjacency(Some(journal.cancellation_token()))
         .expect("build certification CSR");
-    let csr_generation = graphforge_storage::resolve_project_generation(&source)
-        .expect("resolve committed CSR generation");
-    journal.replace_project_owner("source_project", &csr_generation);
     journal.pass(
         "csr",
         phase,
@@ -2669,8 +2641,24 @@ fn run_integrated_certification_with_edge_factor(
 
     let phase = Instant::now();
     let graph = GraphForge::new(source.to_str()).expect("reopen source");
+    journal.pass("source_reopen", phase, None);
+    let phase = Instant::now();
     let source_nodes = graph.node_count(NODE_LABEL).expect("source nodes");
-    let source_edges = scalar_count(&graph.execute(COUNT_EDGES).expect("source edges"));
+    journal.pass_with_detail(
+        "source_node_count",
+        phase,
+        None,
+        json!({ "count": source_nodes }),
+    );
+    let phase = Instant::now();
+    let (source_edge_result, source_edge_work) = certification_query(
+        &graph,
+        COUNT_EDGES,
+        "source_edge_count",
+        phase,
+        &mut journal,
+    );
+    let source_edges = scalar_count(&source_edge_result);
     let expected_live_edges = generated_counts.as_ref().map_or_else(
         || {
             summary
@@ -2681,15 +2669,42 @@ fn run_integrated_certification_with_edge_factor(
         |counts| counts.live_unique_edges,
     );
     assert_eq!(source_edges, expected_live_edges);
-    journal.pass("source_reopen", phase, None);
+    journal.pass_with_detail(
+        "source_edge_count",
+        phase,
+        None,
+        json!({ "count": source_edges, "work": query_work_evidence(&source_edge_work) }),
+    );
     let phase = Instant::now();
-    let source_1hop = result_fingerprint(&graph.execute(ONE_HOP).expect("source 1hop"));
-    journal.pass("source_query_1hop", phase, Some(source_1hop.clone()));
+    let (source_1hop_result, source_1hop_work) =
+        certification_query(&graph, ONE_HOP, "source_query_1hop", phase, &mut journal);
+    assert!(
+        bounded_ordered_limit(&source_1hop_work, 1, 1_000),
+        "{source_1hop_work:#?}"
+    );
+    let source_1hop = result_fingerprint(&source_1hop_result);
+    journal.pass_with_detail(
+        "source_query_1hop",
+        phase,
+        Some(source_1hop.clone()),
+        query_work_evidence(&source_1hop_work),
+    );
     let phase = Instant::now();
-    let source_2hop = result_fingerprint(&graph.execute(TWO_HOP).expect("source 2hop"));
+    let (source_2hop_result, source_2hop_work) =
+        certification_query(&graph, TWO_HOP, "source_query_2hop", phase, &mut journal);
+    assert!(
+        bounded_ordered_limit(&source_2hop_work, 2, 1_000),
+        "{source_2hop_work:#?}"
+    );
+    let source_2hop = result_fingerprint(&source_2hop_result);
     let source_authority_fingerprint = authority_fingerprint(&graph);
     let source_generation = current_generation_uuid(&graph);
-    journal.pass("source_query_2hop", phase, Some(source_2hop.clone()));
+    journal.pass_with_detail(
+        "source_query_2hop",
+        phase,
+        Some(source_2hop.clone()),
+        query_work_evidence(&source_2hop_work),
+    );
 
     let phase = Instant::now();
     let exported = graph
@@ -2707,10 +2722,6 @@ fn run_integrated_certification_with_edge_factor(
         )
         .expect("portable-v2 export");
     assert_eq!(source_generation, exported.generation_uuid);
-    journal.replace_allocation_owner(
-        "portable_package",
-        &exported.allocation_identity_allocated_bytes,
-    );
     journal.pass("export", phase, Some(exported.package_digest.clone()));
     let phase = Instant::now();
     let verified = verify_portable_v2(
@@ -2737,23 +2748,6 @@ fn run_integrated_certification_with_edge_factor(
         Some(journal.cancellation()),
     )
     .expect("atomic portable-v2 import");
-    // Replay the storage-owned operation transitions in their actual order:
-    // private materialization coexisted with the published generation until
-    // deterministic staging cleanup completed.
-    journal.replace_allocation_owner(
-        "import_materialized",
-        &imported_receipt.materialized_identity_allocated_bytes,
-    );
-    journal.replace_allocation_owner(
-        "clean_import",
-        &imported_receipt.published_identity_allocated_bytes,
-    );
-    assert!(imported_receipt.materialized_cleanup_parent_sync_confirmed);
-    assert_eq!(
-        imported_receipt.materialized_cleanup_removed_identity_allocated_bytes,
-        imported_receipt.materialized_identity_allocated_bytes
-    );
-    journal.remove_allocation_owner("import_materialized");
     assert_ne!(exported.generation_uuid, imported_receipt.generation_uuid);
     journal.pass(
         "import",
@@ -2762,25 +2756,69 @@ fn run_integrated_certification_with_edge_factor(
     );
     let phase = Instant::now();
     let imported_graph = GraphForge::new(imported.to_str()).expect("reopen import");
-    let imported_generation = graphforge_storage::resolve_project_generation(&imported)
-        .expect("resolve clean import generation");
-    journal.replace_project_owner("clean_import_project", &imported_generation);
+    journal.pass("imported_reopen", phase, None);
+    let phase = Instant::now();
     let imported_nodes = imported_graph
         .node_count(NODE_LABEL)
         .expect("imported nodes");
-    let imported_edges =
-        scalar_count(&imported_graph.execute(COUNT_EDGES).expect("imported edges"));
+    journal.pass_with_detail(
+        "imported_node_count",
+        phase,
+        None,
+        json!({ "count": imported_nodes }),
+    );
+    let phase = Instant::now();
+    let (imported_edge_result, imported_edge_work) = certification_query(
+        &imported_graph,
+        COUNT_EDGES,
+        "imported_edge_count",
+        phase,
+        &mut journal,
+    );
+    let imported_edges = scalar_count(&imported_edge_result);
     assert_eq!(
         (source_nodes, source_edges),
         (imported_nodes, imported_edges)
     );
-    journal.pass("imported_reopen", phase, None);
+    journal.pass_with_detail(
+        "imported_edge_count",
+        phase,
+        None,
+        json!({ "count": imported_edges, "work": query_work_evidence(&imported_edge_work) }),
+    );
     let phase = Instant::now();
-    let imported_1hop = result_fingerprint(&imported_graph.execute(ONE_HOP).expect("import 1hop"));
+    let (imported_1hop_result, imported_1hop_work) = certification_query(
+        &imported_graph,
+        ONE_HOP,
+        "imported_query_1hop",
+        phase,
+        &mut journal,
+    );
+    assert!(
+        bounded_ordered_limit(&imported_1hop_work, 1, 1_000),
+        "{imported_1hop_work:#?}"
+    );
+    let imported_1hop = result_fingerprint(&imported_1hop_result);
     assert_eq!(source_1hop, imported_1hop);
-    journal.pass("imported_query_1hop", phase, Some(imported_1hop.clone()));
+    journal.pass_with_detail(
+        "imported_query_1hop",
+        phase,
+        Some(imported_1hop.clone()),
+        query_work_evidence(&imported_1hop_work),
+    );
     let phase = Instant::now();
-    let imported_2hop = result_fingerprint(&imported_graph.execute(TWO_HOP).expect("import 2hop"));
+    let (imported_2hop_result, imported_2hop_work) = certification_query(
+        &imported_graph,
+        TWO_HOP,
+        "imported_query_2hop",
+        phase,
+        &mut journal,
+    );
+    assert!(
+        bounded_ordered_limit(&imported_2hop_work, 2, 1_000),
+        "{imported_2hop_work:#?}"
+    );
+    let imported_2hop = result_fingerprint(&imported_2hop_result);
     let imported_authority_fingerprint = authority_fingerprint(&imported_graph);
     assert_eq!(
         current_generation_uuid(&imported_graph),
@@ -2788,32 +2826,17 @@ fn run_integrated_certification_with_edge_factor(
     );
     assert_eq!(source_2hop, imported_2hop);
     assert_eq!(source_authority_fingerprint, imported_authority_fingerprint);
-    journal.pass("imported_query_2hop", phase, Some(imported_2hop.clone()));
-    let source_storage = storage_attribution_value(&source);
-    let source_project_current_allocated_bytes =
-        graphforge_storage::capture_project_storage_identity_union(
-            &graphforge_storage::resolve_project_generation(&source)
-                .expect("resolve authoritative source project"),
-        )
-        .expect("capture authoritative source project identity union")
-        .allocated_bytes;
-    let imported_storage = storage_attribution_value(&imported);
-    let package_storage = portable_export_allocation(&exported);
+    journal.pass_with_detail(
+        "imported_query_2hop",
+        phase,
+        Some(imported_2hop.clone()),
+        query_work_evidence(&imported_2hop_work),
+    );
+
     // Representative drills use the same verifier/import boundaries but never
     // repeat the billion-edge payload.
     let phase = Instant::now();
-    let (drill_package, drill_digest, drill_allocation) =
-        create_bounded_drill_package(root, limits);
-    journal.replace_allocation_owner("drill_project", &drill_allocation.project);
-    journal.replace_allocation_owner("drill_construction", &drill_allocation.construction);
-    journal.replace_allocation_owner("drill_expanded", &drill_allocation.expanded);
-    journal.remove_allocation_owner("drill_expanded");
-    journal.replace_allocation_owner("drill_cancelled_export", &drill_allocation.cancelled_export);
-    journal.remove_allocation_owner("drill_cancelled_export");
-    journal.replace_allocation_owner(
-        "drill_package",
-        &exact_descriptor_identities(std::slice::from_ref(&drill_package)),
-    );
+    let (drill_package, drill_digest) = create_bounded_drill_package(root, limits);
     let drill_verified = verify_portable_v2(
         &PortableVerifyRequest {
             input: drill_package.clone(),
@@ -2834,10 +2857,6 @@ fn run_integrated_certification_with_edge_factor(
         file.write_all(b"corruption").expect("append corruption");
         file.flush().expect("flush corruption");
     }
-    journal.replace_allocation_owner(
-        "corrupt_drill_package",
-        &exact_descriptor_identities(std::slice::from_ref(&corrupt)),
-    );
     assert!(
         verify_portable_v2(
             &PortableVerifyRequest {
@@ -2883,55 +2902,18 @@ fn run_integrated_certification_with_edge_factor(
     journal.pass("drill_resource_limit", phase, None);
     let phase = Instant::now();
     let interrupted = root.join("interrupted-target");
-    let interrupted_operation = uuidv7(0x746);
-    let interrupted_generation = Uuid::new_v5(
-        &interrupted_operation,
-        b"graphforge-portable-v2-import-generation/1",
+    assert!(
+        GraphForge::import_portable_v2(
+            &interrupted,
+            &PortableV2ImportRequest {
+                input: drill_package,
+                operation_id: OperationId(uuidv7(0x746)),
+                limits,
+            },
+            Some(&AtomicBool::new(true))
+        )
+        .is_err()
     );
-    let interrupted_cancelled = AtomicBool::new(false);
-    let supported_capabilities = [
-        "epistemic",
-        "graph",
-        "knowledge",
-        "provenance",
-        "valid_time",
-        "workspace",
-    ]
-    .into_iter()
-    .map(|capability_id| graphforge_storage::ProjectCapability {
-        capability_id: capability_id.into(),
-        capability_version: 1,
-    })
-    .collect::<Vec<_>>();
-    let interrupted_error = graphforge_storage::import_complete_portable_v2_with_progress(
-        &drill_package,
-        &interrupted,
-        interrupted_operation,
-        interrupted_generation,
-        &supported_capabilities,
-        limits,
-        Some(&interrupted_cancelled),
-        |progress| {
-            if progress.phase == graphforge_storage::PortableV2ImportPhase::Materialized {
-                interrupted_cancelled.store(true, Ordering::SeqCst);
-            }
-        },
-    )
-    .expect_err("cancelled finalization must fail");
-    assert!(interrupted_error.recovery_reauthentication_read_bytes > 0);
-    assert!(interrupted_error.recovery_reauthentication_read_calls > 0);
-    construction_phases.add_recovery_reauthentication(
-        interrupted_error.recovery_reauthentication_read_bytes,
-        interrupted_error.recovery_reauthentication_read_calls,
-    );
-    construction_phases
-        .validate_for_qualification()
-        .expect("interrupted recovery phase attribution");
-    journal.replace_allocation_owner(
-        "interrupted_import",
-        &interrupted_error.allocation_identity_allocated_bytes,
-    );
-    journal.remove_allocation_owner("interrupted_import");
     assert!(!interrupted.join("CURRENT").exists());
     journal.pass("drill_interrupted_finalization", phase, None);
 
@@ -2944,12 +2926,10 @@ fn run_integrated_certification_with_edge_factor(
         digest.update(two_hop.as_bytes());
         format!("sha256:{}", hex_encode(digest.finalize()))
     };
-    let workspace_current_allocated_bytes = journal.current_allocated_union();
-    let evidence = json!({
-        "source_export_generation_authenticated": source_generation == exported.generation_uuid,
-        "import_receipt_reopen_authenticated": current_generation_uuid(&imported_graph) == imported_receipt.generation_uuid,
-        "source_import_generations_distinct": exported.generation_uuid != imported_receipt.generation_uuid,
+    json!({
+        "source_generation": exported.generation_uuid.to_string(),
         "package": exported.package_digest, "transport": exported.transport_digest,
+        "imported_generation": imported_receipt.generation_uuid.to_string(),
         "raw_attempts": spills.as_ref().map_or_else(|| summary.as_ref().unwrap().raw_attempts, |value| value.raw_attempts),
         "self_loops_rejected": spills.as_ref().map_or_else(|| summary.as_ref().unwrap().self_loops_rejected, |value| value.self_loops_rejected),
         "duplicates_rejected": generated_counts.as_ref().map_or_else(|| summary.as_ref().unwrap().duplicates_rejected, |value| value.duplicates_rejected),
@@ -2964,19 +2944,8 @@ fn run_integrated_certification_with_edge_factor(
         "compatibility": serde_json::to_value(verified.compatibility).expect("compatibility JSON"),
         "source_authority_fingerprint": source_authority_fingerprint,
         "imported_authority_fingerprint": imported_authority_fingerprint,
-        "storage": {
-            "source": source_storage,
-            "source_project_current_allocated_bytes": source_project_current_allocated_bytes,
-            "portable_package": package_storage,
-            "clean_import": imported_storage,
-            "construction": sanitized_construction_evidence(&construction_evidence),
-            "application_io_phases": construction_phases,
-            "workspace_current_allocated_bytes": workspace_current_allocated_bytes,
-        },
         "phases": journal.phases,
-    });
-    reject_unsanitized_evidence(&evidence).expect("certification lifecycle evidence is sanitized");
-    evidence
+    })
 }
 
 #[test]
@@ -2984,128 +2953,16 @@ fn certification_lifecycle_journals_equivalent_round_trip_and_drills() {
     let root = TempDir::new().expect("certification smoke root");
     let evidence = run_integrated_certification(root.path(), None);
     assert_eq!(evidence["source_edges"], evidence["imported_edges"]);
-    assert_eq!(evidence["source_export_generation_authenticated"], true);
-    assert_eq!(evidence["import_receipt_reopen_authenticated"], true);
-    assert_eq!(evidence["source_import_generations_distinct"], true);
-    reject_unsanitized_evidence(&evidence).expect("lifecycle evidence remains sanitized");
-}
-
-#[test]
-fn certification_evidence_sanitizer_rejects_identity_paths_and_sensitive_keys() {
-    for (value, expected) in [
-        (
-            json!({"proof": "018f6e45-7f12-7c00-8000-000000000001"}),
-            "raw UUID",
-        ),
-        (
-            json!({"proof": "/var/lib/graphforge/project"}),
-            "absolute host path",
-        ),
-        (
-            json!({"nested": {"api_token": "redacted"}}),
-            "sensitive evidence key",
-        ),
-    ] {
-        let error = reject_unsanitized_evidence(&value).expect_err("unsafe evidence must fail");
-        assert!(
-            error.contains(expected),
-            "unexpected sanitizer failure: {error}"
-        );
-    }
-    reject_unsanitized_evidence(&json!({
-        "generation_authenticated": true,
-        "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-    }))
-    .expect("closed proof is safe");
-}
-
-#[test]
-fn equivalent_full_lifecycle_1x_2x_4x_has_bounded_phase_slopes() {
-    const FIELDS: [&str; 7] = [
-        "read_bytes",
-        "write_bytes",
-        "read_calls",
-        "write_calls",
-        "object_count",
-        "block_count",
-        "fsync_calls",
-    ];
-    let mut baseline: Option<BTreeMap<String, [u64; 7]>> = None;
-    for factor in [1_u32, 2, 4] {
-        let root = TempDir::new().expect("full lifecycle ladder root");
-        let evidence =
-            run_integrated_certification_with_edge_factor(root.path(), None, Some(factor));
-        assert_eq!(evidence["source_edges"], evidence["imported_edges"]);
-        let phases = evidence["storage"]["application_io_phases"]["phases"]
-            .as_object()
-            .expect("phase evidence object");
-        let attribution: graphforge_storage::ConstructionPhaseAttribution =
-            serde_json::from_value(evidence["storage"]["application_io_phases"].clone())
-                .expect("decode phase evidence");
-        attribution
-            .validate_for_qualification()
-            .expect("full lifecycle phase qualification");
-        let recovery = &phases["recovery_reauthentication"];
-        assert!(
-            recovery["read_bytes"].as_u64().unwrap_or(0) > 0,
-            "{factor}x interrupted-finalization recovery must report authenticated bytes"
-        );
-        assert!(
-            recovery["read_calls"].as_u64().unwrap_or(0) > 0,
-            "{factor}x interrupted-finalization recovery must report authenticated calls"
-        );
-        let observations = phases
-            .iter()
-            .map(|(name, values)| {
-                let counters = std::array::from_fn(|index| {
-                    values[FIELDS[index]]
-                        .as_u64()
-                        .expect("phase counter is an integer")
-                });
-                (name.clone(), counters)
-            })
-            .collect::<BTreeMap<_, _>>();
-        if let Some(base) = &baseline {
-            assert_eq!(
-                base.keys().collect::<Vec<_>>(),
-                observations.keys().collect::<Vec<_>>()
-            );
-            for (phase, current) in &observations {
-                for (index, value) in current.iter().enumerate() {
-                    let first = base[phase][index];
-                    if first == 0 {
-                        assert_eq!(
-                            *value, 0,
-                            "{phase}.{} appeared only at a larger rung",
-                            FIELDS[index]
-                        );
-                    } else {
-                        assert!(
-                            *value <= first.saturating_mul(u64::from(factor)).saturating_mul(2),
-                            "{phase}.{} exceeded the documented 2x constant-factor ceiling",
-                            FIELDS[index]
-                        );
-                    }
-                }
-            }
-        } else {
-            baseline = Some(observations);
-        }
-        let interrupted = evidence["phases"]
-            .as_array()
-            .expect("lifecycle phases")
-            .iter()
-            .find(|phase| phase["id"] == "drill_interrupted_finalization")
-            .expect("interrupted-finalization recovery drill");
-        assert_eq!(interrupted["status"], "pass");
-    }
+    assert_ne!(
+        evidence["source_generation"],
+        evidence["imported_generation"]
+    );
 }
 
 #[test]
 fn certification_watchdog_persists_typed_first_failure() {
     let root = TempDir::new().expect("watchdog root");
-    let allocated = root.path().join("allocated.bin");
-    fs::write(&allocated, [0_u8; 4096]).expect("allocated fixture");
+    fs::write(root.path().join("allocated.bin"), [0_u8; 4096]).expect("allocated fixture");
     let journal_path = root.path().join("journal.json");
     let mut journal = PhaseJournal::new(
         journal_path.clone(),
@@ -3115,10 +2972,6 @@ fn certification_watchdog_persists_typed_first_failure() {
             disk_bytes: 0,
             timeout_s: u64::MAX,
         },
-    );
-    journal.replace_allocation_owner(
-        "watchdog_fixture",
-        &exact_descriptor_identities(&[allocated]),
     );
     let failure = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         journal.pass("resource_probe", Instant::now(), None);
@@ -3275,32 +3128,6 @@ fn submitted_chunk_count(evidence: &graphforge_storage::GraphConstructionEvidenc
 }
 
 #[test]
-fn active_ingest_heartbeat_does_not_recursively_scan_storage() {
-    let source = include_str!("scale_g500_ladder.rs");
-    let heartbeat = source
-        .split("struct IngestHeartbeat")
-        .nth(1)
-        .and_then(|tail| tail.split("fn run_rung").next())
-        .expect("heartbeat source boundary");
-    let recursive_probe = ["directory", "bytes"].join("_");
-    assert!(
-        !heartbeat.contains(&recursive_probe),
-        "active heartbeat must consume counters, not enumerate project paths"
-    );
-    let monitor = source
-        .split("struct ResourceMonitor")
-        .nth(1)
-        .and_then(|tail| tail.split("fn certification_elapsed_before_process").next())
-        .expect("resource monitor source boundary");
-    for forbidden in ["read_dir", "walkdir", "du\""] {
-        assert!(
-            !monitor.contains(forbidden),
-            "resource monitor must use storage-owned observations, not {forbidden}"
-        );
-    }
-}
-
-#[test]
 fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
     let budgets = GraphConstructionBudgets {
         max_batch_rows: CONSTRUCTION_BATCH_ROWS,
@@ -3310,8 +3137,6 @@ fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
     };
     let base_nodes = CONSTRUCTION_BATCH_ROWS as u64;
     let mut baseline_peaks: Option<[u64; 11]> = None;
-    let mut baseline_storage: Option<(u64, u64)> = None;
-    let mut baseline_phase_io: Option<(u64, u64, u64, u64)> = None;
     for factor in [1_u64, 2, 4] {
         let project = TempDir::new().expect("tiny construction project");
         let graph = GraphForge::new(project.path().to_str()).expect("open tiny project");
@@ -3431,79 +3256,6 @@ fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
         assert!(progress.evidence.parquet_write_operations > 0);
         assert_ne!(receipt.generation_uuid, before);
         assert_eq!(current_generation_uuid(&graph), receipt.generation_uuid);
-        let phases =
-            graphforge_storage::ConstructionPhaseAttribution::from_construction(&progress.evidence);
-        phases.validate_reconciliation().unwrap();
-        let shape =
-            &phases.phases[&graphforge_storage::StorageIoPhase::ShapeConsumeReauthentication];
-        assert!(progress.evidence.merge_read_operations > 0);
-        assert!(progress.evidence.merge_write_operations > 0);
-        assert_eq!(
-            shape.write_bytes,
-            progress
-                .evidence
-                .merge_written_bytes
-                .saturating_add(progress.evidence.parquet_write_bytes)
-        );
-        assert_eq!(
-            shape.write_calls,
-            progress
-                .evidence
-                .merge_write_operations
-                .saturating_add(progress.evidence.parquet_write_operations)
-        );
-        assert_eq!(
-            shape.read_calls,
-            progress
-                .evidence
-                .shape_input_validation_read_operations
-                .saturating_add(progress.evidence.merge_read_operations)
-                .saturating_add(progress.evidence.parquet_read_operations)
-                .saturating_add(progress.evidence.shaped_output_authentication_operations)
-                .saturating_add(progress.evidence.parent_catalog_read_operations)
-                .saturating_add(progress.evidence.retained_probe_block_loads)
-        );
-        let phase_observation = (
-            phases.totals.read_bytes,
-            phases.totals.write_bytes,
-            phases.totals.read_calls,
-            phases.totals.write_calls,
-        );
-        if let Some(baseline) = baseline_phase_io {
-            // Each lifecycle has fixed authenticated control work. Preserve a
-            // documented 2x constant-factor ceiling around ideal linear growth
-            // instead of pretending the intercept is zero at the 1x fixture.
-            let ceiling = |base: u64| base.saturating_mul(factor).saturating_mul(2);
-            assert!(phase_observation.0 <= ceiling(baseline.0));
-            assert!(phase_observation.1 <= ceiling(baseline.1));
-            assert!(phase_observation.2 <= ceiling(baseline.2));
-            assert!(phase_observation.3 <= ceiling(baseline.3));
-        } else {
-            baseline_phase_io = Some(phase_observation);
-        }
-        let generation = graphforge_storage::resolve_project_generation(project.path())
-            .expect("resolve tiny generation");
-        let storage = graphforge_storage::capture_storage_attribution(&generation)
-            .expect("capture tiny storage attribution");
-        storage
-            .validate_reconciliation()
-            .expect("reconcile tiny storage attribution");
-        assert!(
-            storage.is_fully_classified(),
-            "unclassified tiny construction storage: {storage:#?}"
-        );
-        if let Some((base_logical, base_allocated)) = baseline_storage {
-            assert!(
-                storage.logical_bytes <= base_logical.saturating_mul(factor),
-                "authenticated logical bytes exceeded linear growth"
-            );
-            assert!(
-                storage.allocated_bytes <= base_allocated.saturating_mul(factor),
-                "deduplicated allocated bytes exceeded linear growth"
-            );
-        } else {
-            baseline_storage = Some((storage.logical_bytes, storage.allocated_bytes));
-        }
         drop(resumed);
         let replay = graph
             .resume_graph_construction(session_uuid, budgets)
@@ -3629,12 +3381,7 @@ fn certification_target_live_full_lifecycle_evidence() {
             "source_nodes": lifecycle["source_nodes"], "source_edges": source_edges,
             "imported_nodes": lifecycle["imported_nodes"], "imported_edges": lifecycle["imported_edges"],
         },
-        "identities": {
-            "source_export_generation_authenticated": lifecycle["source_export_generation_authenticated"],
-            "import_receipt_reopen_authenticated": lifecycle["import_receipt_reopen_authenticated"],
-            "source_import_generations_distinct": lifecycle["source_import_generations_distinct"],
-            "package": lifecycle["package"], "transport": lifecycle["transport"]
-        },
+        "identities": { "source_generation": lifecycle["source_generation"], "package": lifecycle["package"], "transport": lifecycle["transport"], "imported_generation": lifecycle["imported_generation"] },
         "package": {
             "contract": lifecycle["portable_contract"], "format": "portable-project-v2-bundle",
             "class": lifecycle["package_class"], "integrity": lifecycle["integrity"],
@@ -3643,12 +3390,10 @@ fn certification_target_live_full_lifecycle_evidence() {
         },
         "equivalence": { "source_project_fingerprint": lifecycle["source_project_fingerprint"], "imported_project_fingerprint": lifecycle["imported_project_fingerprint"] },
         "authority": { "source_fingerprint": lifecycle["source_authority_fingerprint"], "imported_fingerprint": lifecycle["imported_authority_fingerprint"] },
-        "storage_attribution": lifecycle["storage"],
         "phases": phases,
-        "envelope": { "peak_rss_bytes": peak_rss, "peak_disk_bytes": peak_disk, "peak_disk_source": "storage_owned_active_identity_union", "wall_time_s": elapsed_before_process.saturating_add(started.elapsed()).as_secs_f64() },
+        "envelope": { "peak_rss_bytes": peak_rss, "peak_disk_bytes": peak_disk, "wall_time_s": elapsed_before_process.saturating_add(started.elapsed()).as_secs_f64() },
         "result": "pass", "first_failure": null,
     });
-    reject_unsanitized_evidence(&evidence).expect("provider certification evidence is sanitized");
     let out = PathBuf::from(std::env::var("GF_G500_CERT_EVIDENCE_OUT").expect("evidence output"));
     fs::write(out, serde_json::to_vec_pretty(&evidence).unwrap())
         .expect("write certification evidence");

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -534,10 +534,7 @@ fn execute_with_bounded_evidence(
     Result<graphforge_api::ExecutionResult, GfError>,
     DemandSnapshot,
 ) {
-    demand::reset();
-    let result = graph.execute(query);
-    demand::disable();
-    (result, demand::snapshot())
+    demand::capture(|| graph.execute(query))
 }
 
 fn query_work_evidence(snapshot: &DemandSnapshot) -> Value {

--- a/crates/graphforge-exec/src/demand.rs
+++ b/crates/graphforge-exec/src/demand.rs
@@ -193,8 +193,35 @@ pub struct DemandSnapshot {
 }
 
 static CAPTURE_ENABLED: AtomicBool = AtomicBool::new(false);
+static CAPTURE_GUARD: Mutex<()> = Mutex::new(());
 static CAPTURE: LazyLock<Mutex<DemandSnapshot>> =
     LazyLock::new(|| Mutex::new(DemandSnapshot::default()));
+
+struct CaptureDisable;
+
+impl Drop for CaptureDisable {
+    fn drop(&mut self) {
+        disable();
+    }
+}
+
+/// Run one ordinary operation with exclusive aggregate diagnostic capture.
+///
+/// Capture is process-global because physical execution may cross worker
+/// threads. Serializing the complete operation prevents concurrent tests or
+/// certification phases from mixing counters while leaving execution itself
+/// unchanged.
+#[doc(hidden)]
+pub fn capture<T>(operation: impl FnOnce() -> T) -> (T, DemandSnapshot) {
+    let _exclusive = CAPTURE_GUARD
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    reset();
+    let disable_on_exit = CaptureDisable;
+    let result = operation();
+    drop(disable_on_exit);
+    (result, snapshot())
+}
 
 /// Reset and enable fixed-hop demand capture.
 #[doc(hidden)]
@@ -229,10 +256,6 @@ pub(crate) fn record_plan_completion(
     memory_reserved_after: usize,
     returned_batch_bytes: usize,
 ) {
-    if !capture_enabled() {
-        return;
-    }
-
     fn metric(metrics: &datafusion::physical_plan::metrics::MetricsSet, name: &str) -> u64 {
         metrics
             .sum_by_name(name)
@@ -255,6 +278,10 @@ pub(crate) fn record_plan_completion(
         for child in plan.children() {
             visit(child, sorts);
         }
+    }
+
+    if !capture_enabled() {
+        return;
     }
 
     let mut sorts = Vec::new();

--- a/crates/graphforge-exec/src/demand.rs
+++ b/crates/graphforge-exec/src/demand.rs
@@ -129,17 +129,67 @@ pub struct FilterSnapshot {
     pub output_rows: u64,
 }
 
+/// Aggregate-only evidence from one fetch-aware physical sort.
+#[doc(hidden)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SortSnapshot {
+    /// Stable pre-order ordinal in the executed physical plan.
+    pub ordinal: usize,
+    /// Physical TopK bound. `None` denotes an unbounded full sort.
+    pub fetch: Option<usize>,
+    /// Rows observed by the physical sort's baseline metric. DataFusion
+    /// charges a batch before its fetch wrapper slices the terminal batch, so
+    /// this may exceed `fetch` by at most one configured execution batch.
+    pub output_rows: u64,
+    /// Spill operations performed by the sort.
+    pub spill_count: u64,
+    /// Rows written to spill files.
+    pub spilled_rows: u64,
+    /// Bytes written to spill files.
+    pub spilled_bytes: u64,
+    /// Memory still reserved by the sort after its stream was released.
+    pub retained_bytes: u64,
+}
+
+/// Observational process-RSS samples while one physical operator stream lived.
+/// These are diagnostics, not allocator ownership claims.
+#[doc(hidden)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct OperatorRssSnapshot {
+    /// Stable physical-plan traversal ordinal among instrumented operators.
+    pub ordinal: usize,
+    /// Sanitized physical operator class.
+    pub operator: &'static str,
+    /// Process RSS immediately before the operator stream was created.
+    pub before_bytes: u64,
+    /// Highest process RSS sampled while the operator stream was polled.
+    pub peak_bytes: u64,
+    /// Process RSS when the operator stream was released.
+    pub after_bytes: u64,
+}
+
 /// Aggregate-only diagnostic snapshot for the most recently reset capture.
+#[doc(hidden)]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct DemandSnapshot {
     /// Per-hop counters keyed by the edge variable id.
     pub hops: BTreeMap<u32, HopSnapshot>,
     /// Selective filter counters.
     pub filters: BTreeMap<usize, FilterSnapshot>,
+    /// Fetch-aware sort work collected from the executed ordinary plan.
+    pub sorts: Vec<SortSnapshot>,
+    /// Per-operator observational RSS lifetimes.
+    pub operator_rss: Vec<OperatorRssSnapshot>,
     /// Number of query cancellation signals.
     pub cancellations: u64,
     /// Maximum simultaneous filtered-read calls.
     pub max_in_flight_reads: u64,
+    /// Query memory-pool reservation before physical execution.
+    pub memory_reserved_before: u64,
+    /// Query memory-pool reservation after every operator stream was dropped.
+    pub memory_reserved_after: u64,
+    /// Arrow bytes retained by the returned result batches.
+    pub returned_batch_bytes: u64,
 }
 
 static CAPTURE_ENABLED: AtomicBool = AtomicBool::new(false);
@@ -168,6 +218,52 @@ pub fn snapshot() -> DemandSnapshot {
 
 pub(crate) fn capture_enabled() -> bool {
     CAPTURE_ENABLED.load(Ordering::Relaxed)
+}
+
+/// Preserve physical-plan and memory evidence after execution, including when
+/// collection failed. This runs on the ordinary execution path; capture merely
+/// decides whether the aggregate counters are retained for a caller/test.
+pub(crate) fn record_plan_completion(
+    plan: &Arc<dyn ExecutionPlan>,
+    memory_reserved_before: usize,
+    memory_reserved_after: usize,
+    returned_batch_bytes: usize,
+) {
+    if !capture_enabled() {
+        return;
+    }
+
+    fn metric(metrics: &datafusion::physical_plan::metrics::MetricsSet, name: &str) -> u64 {
+        metrics
+            .sum_by_name(name)
+            .map_or(0, |value| value.as_usize() as u64)
+    }
+
+    fn visit(plan: &Arc<dyn ExecutionPlan>, sorts: &mut Vec<SortSnapshot>) {
+        if plan.downcast_ref::<SortExec>().is_some() {
+            let metrics = plan.metrics().unwrap_or_default();
+            sorts.push(SortSnapshot {
+                ordinal: sorts.len(),
+                fetch: plan.fetch(),
+                output_rows: metrics.output_rows().map_or(0, |value| value as u64),
+                spill_count: metrics.spill_count().map_or(0, |value| value as u64),
+                spilled_rows: metrics.spilled_rows().map_or(0, |value| value as u64),
+                spilled_bytes: metrics.spilled_bytes().map_or(0, |value| value as u64),
+                retained_bytes: metric(&metrics, "mem_used"),
+            });
+        }
+        for child in plan.children() {
+            visit(child, sorts);
+        }
+    }
+
+    let mut sorts = Vec::new();
+    visit(plan, &mut sorts);
+    let mut capture = CAPTURE.lock().expect("demand stats lock");
+    capture.sorts = sorts;
+    capture.memory_reserved_before = memory_reserved_before as u64;
+    capture.memory_reserved_after = memory_reserved_after as u64;
+    capture.returned_batch_bytes = returned_batch_bytes as u64;
 }
 
 fn with_hop(edge_var: u32, update: impl FnOnce(&mut HopSnapshot)) {
@@ -450,9 +546,17 @@ impl PhysicalOptimizerRule for FixedHopDemandRule {
             plan
         };
         let Some(terminal) = find_terminal_demand(&plan) else {
+            if capture_enabled() {
+                let mut rss_ordinal = 0;
+                return instrument_operator_rss(plan, &mut rss_ordinal);
+            }
             return Ok(plan);
         };
         if !contains_demand_expand(&plan) {
+            if capture_enabled() {
+                let mut rss_ordinal = 0;
+                return instrument_operator_rss(plan, &mut rss_ordinal);
+            }
             return Ok(plan);
         }
         let demand = Arc::new(QueryDemand::new());
@@ -467,11 +571,13 @@ impl PhysicalOptimizerRule for FixedHopDemandRule {
             Arc::clone(&demand),
             &mut filter_ordinal,
         )?;
-        Ok(Arc::new(DemandGuardExec::new(
+        let guarded: Arc<dyn ExecutionPlan> = Arc::new(DemandGuardExec::new(
             rewritten,
             demand,
             terminal.cancel_after,
-        )))
+        ));
+        let mut rss_ordinal = 0;
+        instrument_operator_rss(guarded, &mut rss_ordinal)
     }
 
     fn name(&self) -> &str {
@@ -481,6 +587,197 @@ impl PhysicalOptimizerRule for FixedHopDemandRule {
     fn schema_check(&self) -> bool {
         true
     }
+}
+
+fn instrument_operator_rss(
+    plan: Arc<dyn ExecutionPlan>,
+    ordinal: &mut usize,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let children = plan.children();
+    let rewritten = children
+        .into_iter()
+        .map(|child| instrument_operator_rss(Arc::clone(child), ordinal))
+        .collect::<Result<Vec<_>>>()?;
+    let rebuilt = if rewritten.is_empty() {
+        plan
+    } else {
+        plan.with_new_children(rewritten)?
+    };
+    let operator = if rebuilt.downcast_ref::<ExpandExec>().is_some() {
+        Some("expand")
+    } else if rebuilt.downcast_ref::<SortExec>().is_some() {
+        Some("sort")
+    } else {
+        None
+    };
+    let Some(operator) = operator else {
+        return Ok(rebuilt);
+    };
+    let current = *ordinal;
+    *ordinal += 1;
+    Ok(Arc::new(RssProbeExec::new(rebuilt, current, operator)))
+}
+
+struct RssProbeExec {
+    input: Arc<dyn ExecutionPlan>,
+    ordinal: usize,
+    operator: &'static str,
+    props: Arc<PlanProperties>,
+}
+
+impl RssProbeExec {
+    fn new(input: Arc<dyn ExecutionPlan>, ordinal: usize, operator: &'static str) -> Self {
+        Self {
+            props: Arc::clone(input.properties()),
+            input,
+            ordinal,
+            operator,
+        }
+    }
+}
+
+impl fmt::Debug for RssProbeExec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OperatorRssProbeExec")
+            .field("ordinal", &self.ordinal)
+            .field("operator", &self.operator)
+            .finish_non_exhaustive()
+    }
+}
+
+impl DisplayAs for RssProbeExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "OperatorRssProbeExec: ordinal={}, operator={}",
+            self.ordinal, self.operator
+        )
+    }
+}
+
+impl ExecutionPlan for RssProbeExec {
+    fn name(&self) -> &str {
+        "OperatorRssProbeExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.props
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        mut children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let input = children
+            .pop()
+            .ok_or_else(|| DataFusionError::Internal("RSS probe needs one child".into()))?;
+        Ok(Arc::new(Self::new(input, self.ordinal, self.operator)))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let stream = self.input.execute(partition, context)?;
+        let before = current_rss_bytes();
+        if capture_enabled() {
+            let mut capture = CAPTURE.lock().expect("demand stats lock");
+            if let Some(operator) = capture
+                .operator_rss
+                .iter_mut()
+                .find(|operator| operator.ordinal == self.ordinal)
+            {
+                operator.before_bytes = match (operator.before_bytes, before) {
+                    (0, value) | (value, 0) => value,
+                    (left, right) => left.min(right),
+                };
+                operator.peak_bytes = operator.peak_bytes.max(before);
+            } else {
+                capture.operator_rss.push(OperatorRssSnapshot {
+                    ordinal: self.ordinal,
+                    operator: self.operator,
+                    before_bytes: before,
+                    peak_bytes: before,
+                    after_bytes: 0,
+                });
+            }
+        }
+        Ok(Box::pin(RssProbeStream {
+            schema: stream.schema(),
+            inner: stream,
+            ordinal: self.ordinal,
+        }))
+    }
+}
+
+struct RssProbeStream {
+    schema: SchemaRef,
+    inner: SendableRecordBatchStream,
+    ordinal: usize,
+}
+
+impl Stream for RssProbeStream {
+    type Item = Result<arrow::array::RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let result = Pin::new(&mut self.inner).poll_next(cx);
+        record_operator_rss(self.ordinal, false);
+        result
+    }
+}
+
+impl Drop for RssProbeStream {
+    fn drop(&mut self) {
+        record_operator_rss(self.ordinal, true);
+    }
+}
+
+impl RecordBatchStream for RssProbeStream {
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+}
+
+fn record_operator_rss(ordinal: usize, released: bool) {
+    if !capture_enabled() {
+        return;
+    }
+    let rss = current_rss_bytes();
+    let mut capture = CAPTURE.lock().expect("demand stats lock");
+    if let Some(operator) = capture
+        .operator_rss
+        .iter_mut()
+        .find(|operator| operator.ordinal == ordinal)
+    {
+        operator.peak_bytes = operator.peak_bytes.max(rss);
+        if released {
+            operator.after_bytes = rss;
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn current_rss_bytes() -> u64 {
+    std::fs::read_to_string("/proc/self/status")
+        .ok()
+        .and_then(|status| {
+            status.lines().find_map(|line| {
+                line.strip_prefix("VmRSS:")
+                    .and_then(|value| value.trim().trim_end_matches(" kB").trim().parse().ok())
+                    .map(|kb: u64| kb.saturating_mul(1024))
+            })
+        })
+        .unwrap_or(0)
+}
+
+#[cfg(not(target_os = "linux"))]
+const fn current_rss_bytes() -> u64 {
+    0
 }
 
 fn collect_expr_columns(expr: &Arc<dyn PhysicalExpr>, required: &mut BTreeSet<usize>) {

--- a/crates/graphforge-exec/src/demand.rs
+++ b/crates/graphforge-exec/src/demand.rs
@@ -289,7 +289,17 @@ pub(crate) fn record_plan_completion(
 
     let mut sorts = Vec::new();
     visit(plan, &mut sorts);
+    let completion_rss = current_rss_bytes();
     let mut capture = CAPTURE.lock().expect("demand stats lock");
+    // The physical plan can retain an RSS-probe stream after collection has
+    // completed. Treat this ordinary collect-completion boundary as the
+    // authoritative release observation for wrappers that have not dropped.
+    for operator in &mut capture.operator_rss {
+        if operator.after_bytes == 0 {
+            operator.after_bytes = completion_rss;
+            operator.peak_bytes = operator.peak_bytes.max(completion_rss);
+        }
+    }
     capture.sorts = sorts;
     capture.memory_reserved_before = memory_reserved_before as u64;
     capture.memory_reserved_after = memory_reserved_after as u64;

--- a/crates/graphforge-exec/src/demand.rs
+++ b/crates/graphforge-exec/src/demand.rs
@@ -190,6 +190,8 @@ pub struct DemandSnapshot {
     pub memory_reserved_after: u64,
     /// Arrow bytes retained by the returned result batches.
     pub returned_batch_bytes: u64,
+    /// DataFusion batch-row budget configured for the executed session.
+    pub execution_batch_rows: u64,
 }
 
 static CAPTURE_ENABLED: AtomicBool = AtomicBool::new(false);
@@ -255,6 +257,7 @@ pub(crate) fn record_plan_completion(
     memory_reserved_before: usize,
     memory_reserved_after: usize,
     returned_batch_bytes: usize,
+    execution_batch_rows: usize,
 ) {
     fn metric(metrics: &datafusion::physical_plan::metrics::MetricsSet, name: &str) -> u64 {
         metrics
@@ -291,6 +294,7 @@ pub(crate) fn record_plan_completion(
     capture.memory_reserved_before = memory_reserved_before as u64;
     capture.memory_reserved_after = memory_reserved_after as u64;
     capture.returned_batch_bytes = returned_batch_bytes as u64;
+    capture.execution_batch_rows = execution_batch_rows as u64;
 }
 
 fn with_hop(edge_var: u32, update: impl FnOnce(&mut HopSnapshot)) {

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -5611,6 +5611,7 @@ impl ExecutionSession {
             memory_reserved_before,
             memory_reserved_after,
             returned_batch_bytes,
+            task_ctx.session_config().batch_size(),
         );
         let mut batches = collected.map_err(|e| GfError::Execution(e.to_string()))?;
 

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -5596,9 +5596,23 @@ impl ExecutionSession {
         let resolved_plan = self.resolve_row_count_expressions(plan, params).await?;
         let (physical, fallback_schema) = self.plan_physical(&resolved_plan, params).await?;
 
-        let mut batches = collect(Arc::clone(&physical), self.ctx.task_ctx())
-            .await
-            .map_err(|e| GfError::Execution(e.to_string()))?;
+        let task_ctx = self.ctx.task_ctx();
+        let memory_reserved_before = task_ctx.memory_pool().reserved();
+        let collected = collect(Arc::clone(&physical), Arc::clone(&task_ctx)).await;
+        let memory_reserved_after = task_ctx.memory_pool().reserved();
+        let returned_batch_bytes = collected.as_ref().map_or(0, |batches| {
+            batches
+                .iter()
+                .map(arrow::record_batch::RecordBatch::get_array_memory_size)
+                .sum()
+        });
+        demand::record_plan_completion(
+            &physical,
+            memory_reserved_before,
+            memory_reserved_after,
+            returned_batch_bytes,
+        );
+        let mut batches = collected.map_err(|e| GfError::Execution(e.to_string()))?;
 
         // DataFusion's collect may return zero batches for an empty stream.
         // Public callers (and DF54-era optimistic publish tests) index


### PR DESCRIPTION
Implements #904

## Summary
- stream ordinary graph inspection counting instead of collecting graph-cardinality Arrow results
- preserve fetch-aware SortExec, spill, memory-pool, result-byte, and observational per-operator RSS evidence on the ordinary execution path, including failed collection
- journal reopen, node count, edge count, one-hop, and two-hop independently for source and clean import, with query evidence persisted at the first failure
- enforce lower-rung fixed-cardinality TopK, release, and imported-evidence invariants without a ladder-only executor or larger-memory assumption

## Root-cause boundary
Issue #904 remains open; real S20 acceptance on the 4 GiB class remains required. No Fly run was performed for this PR. The existing DataFusion fetch-aware `SortExec` remained spill-free under deterministic lower-rung evidence, so this change instruments its actual budget and release state rather than adding an unproven alternate spill path.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `python3 scripts/ci/test-non-cypher-surface-gate.py` (12 passed)
- `cargo test -p graphforge-exec demand::tests --lib` (focused demand tests passed before final rebase)
- `cargo test -p graphforge-api --test fixed_hop_limit ordered_destination_uuid_projection_is_exact_and_linear_at_1x_2x_4x` (passed before final rebase)
- `cargo test -p graphforge-api --test scale_g500_ladder certification_lifecycle_journals_equivalent_round_trip_and_drills` (passed before final rebase)
- `cargo test -p graphforge-api graph_inspection` (4 passed before final rebase)
- `cargo check -p graphforge-exec -p graphforge-api --tests` (passed before final rebase)

The final rebase only incorporated merged public certification runner PR #985, which does not overlap these files. A redundant local cold rebuild was not run after rebase because the host disk reached its safety floor; exact-head CI is authoritative.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790574510&installation_model_id=20486&pr_number=987&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F987&signature=9e04641c732fb8dacba660d0a56697a823d71bf957883fcfc1fb69c41b9a731d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Graph inspection now processes large query results incrementally, improving efficiency and reducing memory pressure.
  * Query execution better tracks memory usage, returned data, sorting, and operator resource consumption.

* **Monitoring & Reliability**
  * Added detailed demand and resource evidence for bounded queries, cancellations, limits, and multi-phase operations.
  * Improved validation of memory limits, result sizes, and fixed-hop query behavior across different graph scales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->