### PR TITLE
test(bench): make BenchExec the Linux resource authority

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -76,6 +76,21 @@ The accepted legacy shape is `{profile, phases}` with each phase containing
 `name`, `ok`, `duration_secs`, optional `max_rss_kib`, and optional
 `exit_code`. Normalization is fail-closed and stops after the first failure.
 
+## Linux resource authority
+
+`definitions/graphforge-certification-v1.xml` is the versioned BenchExec entry
+point for Linux certification. Its tool-info adapter invokes only the public
+certification binary. BenchExec owns the complete process tree, limits,
+termination, wall/CPU time, peak RSS, and read/write byte evidence; the Rust
+runner's per-phase telemetry remains preserved as the product-side account.
+
+`graphforge_bench.benchexec_authority.normalize_phase` fails closed unless all
+mandatory process-tree resource fields and a correctness verdict are present.
+It reports timeout, OOM, non-zero exit, signal, harness termination, and
+correctness failure as distinct typed outcomes. Status or wall-time disagreement
+between BenchExec and GraphForge is retained explicitly instead of choosing the
+more favorable value. Provider provisioning is outside this layer.
+
 Generated datasets, credentials, execution outputs, and local environments are
 ignored. Fly execution is forbidden until the complete benchmark stack is
 merged and has passed local and hosted qualification.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -84,7 +84,7 @@ certification binary. BenchExec owns the complete process tree, limits,
 termination, wall/CPU time, peak RSS, and read/write byte evidence; the Rust
 runner's per-phase telemetry remains preserved as the product-side account.
 
-`graphforge_bench.benchexec_authority.normalize_phase` fails closed unless all
+`graphforge_bench.benchexec_authority.normalize_run` fails closed unless all
 mandatory process-tree resource fields and a correctness verdict are present.
 It reports timeout, OOM, non-zero exit, signal, harness termination, and
 correctness failure as distinct typed outcomes. Status or wall-time disagreement

--- a/benchmarks/definitions/graphforge-certification-v1.xml
+++ b/benchmarks/definitions/graphforge-certification-v1.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<benchmark tool="graphforge_bench.tools.graphforge_certify" timelimit="14400 s"
+           hardtimelimit="14430 s" memlimit="128 GB" cpuCores="1-16">
+  <rundefinition name="graphforge-public-certification-v1">
+    <tasks name="profile"><include>profile.json</include></tasks>
+  </rundefinition>
+</benchmark>

--- a/benchmarks/definitions/graphforge-certification-v1.xml
+++ b/benchmarks/definitions/graphforge-certification-v1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <benchmark tool="graphforge_bench.tools.graphforge_certify" timelimit="14400 s"
-           hardtimelimit="14430 s" memlimit="128 GB" cpuCores="1-16">
+           hardtimelimit="14430 s" memlimit="128 GB" cpuCores="16">
   <rundefinition name="graphforge-public-certification-v1">
     <tasks name="profile"><include>profile.json</include></tasks>
   </rundefinition>

--- a/benchmarks/harness/graphforge_bench/benchexec_authority.py
+++ b/benchmarks/harness/graphforge_bench/benchexec_authority.py
@@ -8,6 +8,7 @@ from enum import StrEnum
 from typing import Any
 
 SCHEMA = "graphforge-benchexec-run/1"
+LOCAL_ADMISSION_SCHEMA = "graphforge-local-admission-evidence/1"
 
 
 class EvidenceError(ValueError):
@@ -41,6 +42,20 @@ class Limits:
             or len(set(self.cores)) != len(self.cores)
         ):
             raise EvidenceError("invalid BenchExec limits")
+
+
+def require_local_admission(evidence: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Consume #986's native fixture proof before accepting run evidence."""
+    if (
+        evidence.get("schema") != LOCAL_ADMISSION_SCHEMA
+        or evidence.get("result") != "passed"
+        or evidence.get("cause") is not None
+    ):
+        raise EvidenceError("native BenchExec admission did not pass")
+    measurements = evidence.get("measurements")
+    if not isinstance(measurements, Mapping) or measurements.get("descendant_stopped") is not True:
+        raise EvidenceError("native BenchExec child-tree proof is missing")
+    return measurements
 
 
 def adapt_run_result(raw: Mapping[str, Any], *, correctness: bool) -> dict[str, Any]:

--- a/benchmarks/harness/graphforge_bench/benchexec_authority.py
+++ b/benchmarks/harness/graphforge_bench/benchexec_authority.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
 
-SCHEMA = "graphforge-benchexec-phase/1"
+SCHEMA = "graphforge-benchexec-run/1"
 
 
 class EvidenceError(ValueError):
@@ -54,6 +54,9 @@ def adapt_run_result(raw: Mapping[str, Any], *, correctness: bool) -> dict[str, 
         "peak_rss_bytes": raw.get("memory"),
         "read_bytes": raw.get("blkio-read"),
         "write_bytes": raw.get("blkio-write"),
+        "pressure_cpu_seconds": raw.get("pressure-cpu-some"),
+        "pressure_io_seconds": raw.get("pressure-io-some"),
+        "pressure_memory_seconds": raw.get("pressure-memory-some"),
         "termination_reason": raw.get("terminationreason"),
         "exit_code": value,
         "signal": signal,
@@ -100,17 +103,14 @@ def _outcome(result: Mapping[str, Any]) -> tuple[Outcome, int | None, int | None
     return Outcome.PASSED, 0, None
 
 
-def normalize_phase(
+def normalize_run(
     *,
-    phase: str,
     benchexec: Mapping[str, Any],
     graphforge: Mapping[str, Any],
     limits: Limits,
 ) -> dict[str, Any]:
     """Preserve both sources while making BenchExec authoritative for resources."""
     limits.validate()
-    if not phase or any(character not in "abcdefghijklmnopqrstuvwxyz_" for character in phase):
-        raise EvidenceError("invalid phase")
     outcome, exit_code, signal = _outcome(benchexec)
     authority = {
         "wall_seconds": _number(benchexec, "wall_seconds"),
@@ -118,24 +118,31 @@ def normalize_phase(
         "peak_rss_bytes": _integer(benchexec, "peak_rss_bytes"),
         "read_bytes": _integer(benchexec, "read_bytes"),
         "write_bytes": _integer(benchexec, "write_bytes"),
+        "pressure_cpu_seconds": _number(benchexec, "pressure_cpu_seconds"),
+        "pressure_io_seconds": _number(benchexec, "pressure_io_seconds"),
+        "pressure_memory_seconds": _number(benchexec, "pressure_memory_seconds"),
     }
-    gf_phase = graphforge.get("phase")
     gf_status = graphforge.get("status")
-    if gf_phase != phase or gf_status not in ("passed", "failed"):
-        raise EvidenceError("GraphForge phase telemetry is malformed")
+    phases = graphforge.get("phases")
+    if gf_status not in ("passed", "failed") or not isinstance(phases, list) or not phases:
+        raise EvidenceError("GraphForge run telemetry is malformed")
+    duration_ms = 0
+    for phase in phases:
+        if not isinstance(phase, dict) or not isinstance(phase.get("phase"), str):
+            raise EvidenceError("GraphForge phase telemetry is malformed")
+        value = phase.get("duration_ms")
+        if not isinstance(value, int) or value < 0:
+            raise EvidenceError("GraphForge phase duration_ms is malformed")
+        duration_ms += value
     disagreements: list[str] = []
     if (gf_status == "passed") != (outcome == Outcome.PASSED):
         disagreements.append("status")
-    gf_duration_ms = graphforge.get("duration_ms")
-    if not isinstance(gf_duration_ms, int) or gf_duration_ms < 0:
-        raise EvidenceError("GraphForge duration_ms is malformed")
-    if abs(gf_duration_ms / 1000 - authority["wall_seconds"]) > max(
+    if abs(duration_ms / 1000 - authority["wall_seconds"]) > max(
         1.0, authority["wall_seconds"] * 0.1
     ):
         disagreements.append("wall_time")
     return {
         "schema": SCHEMA,
-        "phase": phase,
         "outcome": outcome,
         "exit_code": exit_code,
         "signal": signal,

--- a/benchmarks/harness/graphforge_bench/benchexec_authority.py
+++ b/benchmarks/harness/graphforge_bench/benchexec_authority.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import StrEnum
+import math
 from typing import Any
+
+from graphforge_bench.local_admission import REQUIRED_METRICS
 
 SCHEMA = "graphforge-benchexec-run/1"
 LOCAL_ADMISSION_SCHEMA = "graphforge-local-admission-evidence/1"
@@ -13,6 +16,15 @@ LOCAL_ADMISSION_SCHEMA = "graphforge-local-admission-evidence/1"
 
 class EvidenceError(ValueError):
     """BenchExec or phase evidence is absent, malformed, or contradictory."""
+
+
+def _finite_number(value: object) -> bool:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    try:
+        return math.isfinite(value)
+    except OverflowError:
+        return False
 
 
 class Outcome(StrEnum):
@@ -34,7 +46,9 @@ class Limits:
 
     def validate(self) -> None:
         if (
-            self.wall_seconds <= 0
+            not _finite_number(self.wall_seconds)
+            or self.wall_seconds <= 0
+            or not _finite_number(self.cpu_seconds)
             or self.cpu_seconds <= 0
             or self.memory_bytes <= 0
             or not self.cores
@@ -53,7 +67,15 @@ def require_local_admission(evidence: Mapping[str, Any]) -> Mapping[str, Any]:
     ):
         raise EvidenceError("native BenchExec admission did not pass")
     measurements = evidence.get("measurements")
-    if not isinstance(measurements, Mapping) or measurements.get("descendant_stopped") is not True:
+    if not isinstance(measurements, Mapping):
+        raise EvidenceError("native BenchExec child-tree proof is missing")
+    for key in REQUIRED_METRICS:
+        value = measurements.get(key)
+        if not _finite_number(value) or value < 0:
+            raise EvidenceError(f"native BenchExec admission metric is invalid: {key}")
+    if measurements.get("terminationreason") != "walltime":
+        raise EvidenceError("native BenchExec termination proof is missing")
+    if measurements.get("descendant_stopped") is not True:
         raise EvidenceError("native BenchExec child-tree proof is missing")
     return measurements
 
@@ -81,7 +103,7 @@ def adapt_run_result(raw: Mapping[str, Any], *, correctness: bool) -> dict[str, 
 
 def _number(values: Mapping[str, Any], key: str) -> float:
     value = values.get(key)
-    if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
+    if not _finite_number(value) or value < 0:
         raise EvidenceError(f"missing or invalid BenchExec field: {key}")
     return float(value)
 

--- a/benchmarks/harness/graphforge_bench/benchexec_authority.py
+++ b/benchmarks/harness/graphforge_bench/benchexec_authority.py
@@ -1,0 +1,151 @@
+"""Fail-closed normalization of BenchExec's Linux process-tree evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Mapping
+
+
+SCHEMA = "graphforge-benchexec-phase/1"
+
+
+class EvidenceError(ValueError):
+    """BenchExec or phase evidence is absent, malformed, or contradictory."""
+
+
+class Outcome(StrEnum):
+    PASSED = "passed"
+    TIMEOUT = "timeout"
+    OOM = "oom"
+    EXIT = "exit"
+    SIGNAL = "signal"
+    HARNESS = "harness"
+    CORRECTNESS = "correctness"
+
+
+@dataclass(frozen=True)
+class Limits:
+    wall_seconds: float
+    cpu_seconds: float
+    memory_bytes: int
+    cores: tuple[int, ...]
+
+    def validate(self) -> None:
+        if (
+            self.wall_seconds <= 0
+            or self.cpu_seconds <= 0
+            or self.memory_bytes <= 0
+            or not self.cores
+            or any(core < 0 for core in self.cores)
+            or len(set(self.cores)) != len(self.cores)
+        ):
+            raise EvidenceError("invalid BenchExec limits")
+
+
+def adapt_run_result(raw: Mapping[str, Any], *, correctness: bool) -> dict[str, Any]:
+    """Translate BenchExec RunExecutor keys without weakening mandatory evidence."""
+    exitcode = raw.get("exitcode")
+    value = getattr(exitcode, "value", None)
+    signal = getattr(exitcode, "signal", None)
+    return {
+        "wall_seconds": raw.get("walltime"),
+        "cpu_seconds": raw.get("cputime"),
+        "peak_rss_bytes": raw.get("memory"),
+        "read_bytes": raw.get("blkio-read"),
+        "write_bytes": raw.get("blkio-write"),
+        "termination_reason": raw.get("terminationreason"),
+        "exit_code": value,
+        "signal": signal,
+        "correctness": correctness,
+    }
+
+
+def _number(values: Mapping[str, Any], key: str) -> float:
+    value = values.get(key)
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
+        raise EvidenceError(f"missing or invalid BenchExec field: {key}")
+    return float(value)
+
+
+def _integer(values: Mapping[str, Any], key: str) -> int:
+    value = values.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise EvidenceError(f"missing or invalid BenchExec field: {key}")
+    return value
+
+
+def _outcome(result: Mapping[str, Any]) -> tuple[Outcome, int | None, int | None]:
+    termination = result.get("termination_reason")
+    if termination == "cputime" or termination == "walltime":
+        return Outcome.TIMEOUT, None, None
+    if termination == "memory":
+        return Outcome.OOM, None, None
+    if termination not in (None, ""):
+        return Outcome.HARNESS, None, None
+    signal = result.get("signal")
+    if signal is not None:
+        if not isinstance(signal, int) or signal <= 0:
+            raise EvidenceError("invalid BenchExec signal")
+        return Outcome.SIGNAL, None, signal
+    exit_code = result.get("exit_code")
+    if not isinstance(exit_code, int):
+        raise EvidenceError("missing BenchExec exit_code")
+    if exit_code != 0:
+        return Outcome.EXIT, exit_code, None
+    if result.get("correctness") is False:
+        return Outcome.CORRECTNESS, 0, None
+    if result.get("correctness") is not True:
+        raise EvidenceError("missing correctness verdict")
+    return Outcome.PASSED, 0, None
+
+
+def normalize_phase(
+    *,
+    phase: str,
+    benchexec: Mapping[str, Any],
+    graphforge: Mapping[str, Any],
+    limits: Limits,
+) -> dict[str, Any]:
+    """Preserve both sources while making BenchExec authoritative for resources."""
+    limits.validate()
+    if not phase or any(character not in "abcdefghijklmnopqrstuvwxyz_" for character in phase):
+        raise EvidenceError("invalid phase")
+    outcome, exit_code, signal = _outcome(benchexec)
+    authority = {
+        "wall_seconds": _number(benchexec, "wall_seconds"),
+        "cpu_seconds": _number(benchexec, "cpu_seconds"),
+        "peak_rss_bytes": _integer(benchexec, "peak_rss_bytes"),
+        "read_bytes": _integer(benchexec, "read_bytes"),
+        "write_bytes": _integer(benchexec, "write_bytes"),
+    }
+    gf_phase = graphforge.get("phase")
+    gf_status = graphforge.get("status")
+    if gf_phase != phase or gf_status not in ("passed", "failed"):
+        raise EvidenceError("GraphForge phase telemetry is malformed")
+    disagreements: list[str] = []
+    if (gf_status == "passed") != (outcome == Outcome.PASSED):
+        disagreements.append("status")
+    gf_duration_ms = graphforge.get("duration_ms")
+    if not isinstance(gf_duration_ms, int) or gf_duration_ms < 0:
+        raise EvidenceError("GraphForge duration_ms is malformed")
+    if abs(gf_duration_ms / 1000 - authority["wall_seconds"]) > max(
+        1.0, authority["wall_seconds"] * 0.1
+    ):
+        disagreements.append("wall_time")
+    return {
+        "schema": SCHEMA,
+        "phase": phase,
+        "outcome": outcome,
+        "exit_code": exit_code,
+        "signal": signal,
+        "authority": authority,
+        "limits": {
+            "wall_seconds": limits.wall_seconds,
+            "cpu_seconds": limits.cpu_seconds,
+            "memory_bytes": limits.memory_bytes,
+            "cores": list(limits.cores),
+        },
+        "graphforge": dict(graphforge),
+        "disagreements": disagreements,
+    }

--- a/benchmarks/harness/graphforge_bench/benchexec_authority.py
+++ b/benchmarks/harness/graphforge_bench/benchexec_authority.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any, Mapping
-
+from typing import Any
 
 SCHEMA = "graphforge-benchexec-phase/1"
 
@@ -77,7 +77,7 @@ def _integer(values: Mapping[str, Any], key: str) -> int:
 
 def _outcome(result: Mapping[str, Any]) -> tuple[Outcome, int | None, int | None]:
     termination = result.get("termination_reason")
-    if termination == "cputime" or termination == "walltime":
+    if termination in {"cputime", "walltime"}:
         return Outcome.TIMEOUT, None, None
     if termination == "memory":
         return Outcome.OOM, None, None

--- a/benchmarks/harness/graphforge_bench/local_admission.py
+++ b/benchmarks/harness/graphforge_bench/local_admission.py
@@ -17,7 +17,16 @@ import subprocess
 import sys
 
 SCHEMA = "graphforge-local-admission-evidence/1"
-REQUIRED_METRICS = ("walltime", "cputime", "memory", "blkio-read", "blkio-write")
+REQUIRED_METRICS = (
+    "walltime",
+    "cputime",
+    "memory",
+    "blkio-read",
+    "blkio-write",
+    "pressure-cpu-some",
+    "pressure-io-some",
+    "pressure-memory-some",
+)
 
 
 @dataclass(frozen=True)

--- a/benchmarks/harness/graphforge_bench/tools/__init__.py
+++ b/benchmarks/harness/graphforge_bench/tools/__init__.py
@@ -1,0 +1,1 @@
+"""BenchExec tool-info modules owned by the external benchmark workspace."""

--- a/benchmarks/harness/graphforge_bench/tools/graphforge_certify.py
+++ b/benchmarks/harness/graphforge_bench/tools/graphforge_certify.py
@@ -1,0 +1,30 @@
+"""BenchExec tool-info module for the public GraphForge certification runner."""
+
+from benchexec.tools.template import BaseTool2
+
+
+class Tool(BaseTool2):
+    def executable(self, tool_locator):
+        return tool_locator.find_executable("graphforge-benchmark-certify")
+
+    def name(self):
+        return "GraphForge public certification"
+
+    def project_url(self):
+        return "https://github.com/CurateLabs/graphforge"
+
+    def cmdline(self, executable, options, task, rlimits):
+        if options:
+            raise ValueError("certification definition does not accept opaque options")
+        return [executable, "run", *task.input_files_or_identifier, "evidence.json"]
+
+    def determine_result(self, run):
+        if run.was_timeout:
+            return "TIMEOUT"
+        if run.was_terminated:
+            return "KILLED"
+        return (
+            "DONE"
+            if run.exit_code is not None and run.exit_code.value == 0
+            else "ERROR"
+        )

--- a/benchmarks/harness/graphforge_bench/tools/graphforge_certify.py
+++ b/benchmarks/harness/graphforge_bench/tools/graphforge_certify.py
@@ -23,8 +23,4 @@ class Tool(BaseTool2):
             return "TIMEOUT"
         if run.was_terminated:
             return "KILLED"
-        return (
-            "DONE"
-            if run.exit_code is not None and run.exit_code.value == 0
-            else "ERROR"
-        )
+        return "DONE" if run.exit_code is not None and run.exit_code.value == 0 else "ERROR"

--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -5,7 +5,7 @@ description = "Dependency-isolated external benchmark orchestration for GraphFor
 license = "Apache-2.0"
 requires-python = ">=3.11"
 dependencies = [
-  "benchexec>=3.0,<4",
+  "benchexec>=3.3,<4",
   "jsonschema>=4.0,<5",
   "reframe-hpc>=4.0,<5",
 ]

--- a/benchmarks/schemas/benchexec-phase-evidence.json
+++ b/benchmarks/schemas/benchexec-phase-evidence.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema": "graphforge-benchexec-phase-evidence-schema/1",
+  "$id": "https://graphforge.sh/schemas/benchexec-phase-evidence.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "phase", "outcome", "exit_code", "signal", "authority", "limits", "graphforge", "disagreements"],
+  "properties": {
+    "schema": {"const": "graphforge-benchexec-phase/1"},
+    "phase": {"type": "string", "pattern": "^[a-z_]+$"},
+    "outcome": {"enum": ["passed", "timeout", "oom", "exit", "signal", "harness", "correctness"]},
+    "exit_code": {"type": ["integer", "null"]},
+    "signal": {"type": ["integer", "null"], "minimum": 1},
+    "authority": {
+      "type": "object", "additionalProperties": false,
+      "required": ["wall_seconds", "cpu_seconds", "peak_rss_bytes", "read_bytes", "write_bytes"],
+      "properties": {
+        "wall_seconds": {"type": "number", "minimum": 0},
+        "cpu_seconds": {"type": "number", "minimum": 0},
+        "peak_rss_bytes": {"type": "integer", "minimum": 0},
+        "read_bytes": {"type": "integer", "minimum": 0},
+        "write_bytes": {"type": "integer", "minimum": 0}
+      }
+    },
+    "limits": {
+      "type": "object", "additionalProperties": false,
+      "required": ["wall_seconds", "cpu_seconds", "memory_bytes", "cores"],
+      "properties": {
+        "wall_seconds": {"type": "number", "exclusiveMinimum": 0},
+        "cpu_seconds": {"type": "number", "exclusiveMinimum": 0},
+        "memory_bytes": {"type": "integer", "exclusiveMinimum": 0},
+        "cores": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "integer", "minimum": 0}}
+      }
+    },
+    "graphforge": {
+      "type": "object",
+      "required": ["phase", "status", "duration_ms"],
+      "properties": {
+        "phase": {"type": "string"},
+        "status": {"enum": ["passed", "failed"]},
+        "duration_ms": {"type": "integer", "minimum": 0}
+      }
+    },
+    "disagreements": {"type": "array", "items": {"enum": ["status", "wall_time"]}, "uniqueItems": true}
+  }
+}

--- a/benchmarks/schemas/benchexec-run-evidence.json
+++ b/benchmarks/schemas/benchexec-run-evidence.json
@@ -43,5 +43,40 @@
       }
     },
     "disagreements": {"type": "array", "items": {"enum": ["status", "wall_time"]}, "uniqueItems": true}
-  }
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"outcome": {"const": "passed"}}, "required": ["outcome"]},
+      "then": {"properties": {"exit_code": {"const": 0}, "signal": {"type": "null"}}}
+    },
+    {
+      "if": {"properties": {"outcome": {"const": "correctness"}}, "required": ["outcome"]},
+      "then": {"properties": {"exit_code": {"const": 0}, "signal": {"type": "null"}}}
+    },
+    {
+      "if": {"properties": {"outcome": {"const": "exit"}}, "required": ["outcome"]},
+      "then": {
+        "properties": {
+          "exit_code": {"type": "integer", "not": {"const": 0}},
+          "signal": {"type": "null"}
+        }
+      }
+    },
+    {
+      "if": {"properties": {"outcome": {"const": "signal"}}, "required": ["outcome"]},
+      "then": {
+        "properties": {
+          "exit_code": {"type": "null"},
+          "signal": {"type": "integer", "minimum": 1}
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {"outcome": {"enum": ["timeout", "oom", "harness"]}},
+        "required": ["outcome"]
+      },
+      "then": {"properties": {"exit_code": {"type": "null"}, "signal": {"type": "null"}}}
+    }
+  ]
 }

--- a/benchmarks/schemas/benchexec-run-evidence.json
+++ b/benchmarks/schemas/benchexec-run-evidence.json
@@ -1,25 +1,27 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "schema": "graphforge-benchexec-phase-evidence-schema/1",
+  "schema": "graphforge-benchexec-run-evidence-schema/1",
   "$id": "https://graphforge.sh/schemas/benchexec-phase-evidence.json",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema", "phase", "outcome", "exit_code", "signal", "authority", "limits", "graphforge", "disagreements"],
+  "required": ["schema", "outcome", "exit_code", "signal", "authority", "limits", "graphforge", "disagreements"],
   "properties": {
-    "schema": {"const": "graphforge-benchexec-phase/1"},
-    "phase": {"type": "string", "pattern": "^[a-z_]+$"},
+    "schema": {"const": "graphforge-benchexec-run/1"},
     "outcome": {"enum": ["passed", "timeout", "oom", "exit", "signal", "harness", "correctness"]},
     "exit_code": {"type": ["integer", "null"]},
     "signal": {"type": ["integer", "null"], "minimum": 1},
     "authority": {
       "type": "object", "additionalProperties": false,
-      "required": ["wall_seconds", "cpu_seconds", "peak_rss_bytes", "read_bytes", "write_bytes"],
+      "required": ["wall_seconds", "cpu_seconds", "peak_rss_bytes", "read_bytes", "write_bytes", "pressure_cpu_seconds", "pressure_io_seconds", "pressure_memory_seconds"],
       "properties": {
         "wall_seconds": {"type": "number", "minimum": 0},
         "cpu_seconds": {"type": "number", "minimum": 0},
         "peak_rss_bytes": {"type": "integer", "minimum": 0},
         "read_bytes": {"type": "integer", "minimum": 0},
-        "write_bytes": {"type": "integer", "minimum": 0}
+        "write_bytes": {"type": "integer", "minimum": 0},
+        "pressure_cpu_seconds": {"type": "number", "minimum": 0},
+        "pressure_io_seconds": {"type": "number", "minimum": 0},
+        "pressure_memory_seconds": {"type": "number", "minimum": 0}
       }
     },
     "limits": {
@@ -34,11 +36,10 @@
     },
     "graphforge": {
       "type": "object",
-      "required": ["phase", "status", "duration_ms"],
+      "required": ["status", "phases"],
       "properties": {
-        "phase": {"type": "string"},
         "status": {"enum": ["passed", "failed"]},
-        "duration_ms": {"type": "integer", "minimum": 0}
+        "phases": {"type": "array", "minItems": 1, "items": {"type": "object"}}
       }
     },
     "disagreements": {"type": "array", "items": {"enum": ["status", "wall_time"]}, "uniqueItems": true}

--- a/benchmarks/schemas/local-admission-evidence.json
+++ b/benchmarks/schemas/local-admission-evidence.json
@@ -32,7 +32,22 @@
       "required": ["operating_system", "cgroups_version", "mount_namespace", "pid_namespace", "user_namespace"],
       "additionalProperties": false
     },
-    "measurements": {"type": "object"}
+    "measurements": {
+      "type": "object",
+      "required": ["walltime", "cputime", "memory", "blkio-read", "blkio-write", "pressure-cpu-some", "pressure-io-some", "pressure-memory-some", "terminationreason", "descendant_stopped"],
+      "properties": {
+        "walltime": {"type": "number", "minimum": 0},
+        "cputime": {"type": "number", "minimum": 0},
+        "memory": {"type": "number", "minimum": 0},
+        "blkio-read": {"type": "number", "minimum": 0},
+        "blkio-write": {"type": "number", "minimum": 0},
+        "pressure-cpu-some": {"type": "number", "minimum": 0},
+        "pressure-io-some": {"type": "number", "minimum": 0},
+        "pressure-memory-some": {"type": "number", "minimum": 0},
+        "terminationreason": {"type": "string"},
+        "descendant_stopped": {"type": "boolean"}
+      }
+    }
   },
   "required": ["schema", "result", "cause", "facts"],
   "additionalProperties": false

--- a/benchmarks/schemas/local-admission-evidence.json
+++ b/benchmarks/schemas/local-admission-evidence.json
@@ -50,5 +50,11 @@
     }
   },
   "required": ["schema", "result", "cause", "facts"],
-  "additionalProperties": false
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {"properties": {"result": {"const": "passed"}}, "required": ["result"]},
+      "then": {"required": ["measurements"]}
+    }
+  ]
 }

--- a/benchmarks/tests/test_benchexec_authority.py
+++ b/benchmarks/tests/test_benchexec_authority.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import unittest
 import json
 from pathlib import Path
-
-from jsonschema import Draft202012Validator
+import unittest
 
 from graphforge_bench.benchexec_authority import (
     EvidenceError,
@@ -14,7 +12,7 @@ from graphforge_bench.benchexec_authority import (
     normalize_phase,
 )
 from graphforge_bench.tools.graphforge_certify import Tool
-
+from jsonschema import Draft202012Validator
 
 LIMITS = Limits(10.0, 8.0, 1024, (0, 1))
 

--- a/benchmarks/tests/test_benchexec_authority.py
+++ b/benchmarks/tests/test_benchexec_authority.py
@@ -10,6 +10,7 @@ from graphforge_bench.benchexec_authority import (
     Outcome,
     adapt_run_result,
     normalize_run,
+    require_local_admission,
 )
 from graphforge_bench.tools.graphforge_certify import Tool
 from jsonschema import Draft202012Validator
@@ -35,6 +36,30 @@ def result(**changes):
 
 
 class BenchExecAuthorityTests(unittest.TestCase):
+    def test_consumes_native_child_tree_admission_interface(self):
+        measurements = result() | {
+            "descendant_stopped": True,
+            "walltime": 1.0,
+        }
+        admitted = require_local_admission(
+            {
+                "schema": "graphforge-local-admission-evidence/1",
+                "result": "passed",
+                "cause": None,
+                "measurements": measurements,
+            }
+        )
+        self.assertIs(admitted, measurements)
+        with self.assertRaisesRegex(EvidenceError, "child-tree"):
+            require_local_admission(
+                {
+                    "schema": "graphforge-local-admission-evidence/1",
+                    "result": "passed",
+                    "cause": None,
+                    "measurements": {"descendant_stopped": False},
+                }
+            )
+
     def test_adapts_native_benchexec_process_tree_keys(self):
         class Exit:
             value = 0
@@ -90,7 +115,10 @@ class BenchExecAuthorityTests(unittest.TestCase):
         self.assertEqual(evidence["authority"]["cpu_seconds"], 3.0)
         self.assertEqual(evidence["limits"]["cores"], [0, 1])
         self.assertEqual(evidence["disagreements"], [])
-        schema = json.loads(Path("benchmarks/schemas/benchexec-run-evidence.json").read_text())
+        schema_path = (
+            Path(__file__).resolve().parents[1] / "schemas/benchexec-run-evidence.json"
+        )
+        schema = json.loads(schema_path.read_text())
         Draft202012Validator(schema).validate(evidence)
 
     def test_typed_termination_outcomes_remain_distinct(self):

--- a/benchmarks/tests/test_benchexec_authority.py
+++ b/benchmarks/tests/test_benchexec_authority.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import json
+import math
 from pathlib import Path
 import unittest
+import xml.etree.ElementTree as ET
 
 from graphforge_bench.benchexec_authority import (
     EvidenceError,
@@ -14,8 +16,21 @@ from graphforge_bench.benchexec_authority import (
 )
 from graphforge_bench.tools.graphforge_certify import Tool
 from jsonschema import Draft202012Validator
+import tomllib
 
 LIMITS = Limits(10.0, 8.0, 1024, (0, 1))
+ADMISSION_MEASUREMENTS = {
+    "walltime": 1.0,
+    "cputime": 0.1,
+    "memory": 1024,
+    "blkio-read": 10,
+    "blkio-write": 20,
+    "pressure-cpu-some": 0.0,
+    "pressure-io-some": 0.0,
+    "pressure-memory-some": 0.0,
+    "terminationreason": "walltime",
+    "descendant_stopped": True,
+}
 
 
 def result(**changes):
@@ -37,10 +52,7 @@ def result(**changes):
 
 class BenchExecAuthorityTests(unittest.TestCase):
     def test_consumes_native_child_tree_admission_interface(self):
-        measurements = result() | {
-            "descendant_stopped": True,
-            "walltime": 1.0,
-        }
+        measurements = dict(ADMISSION_MEASUREMENTS)
         admitted = require_local_admission(
             {
                 "schema": "graphforge-local-admission-evidence/1",
@@ -56,9 +68,40 @@ class BenchExecAuthorityTests(unittest.TestCase):
                     "schema": "graphforge-local-admission-evidence/1",
                     "result": "passed",
                     "cause": None,
-                    "measurements": {"descendant_stopped": False},
+                    "measurements": ADMISSION_MEASUREMENTS | {"descendant_stopped": False},
                 }
             )
+
+    def test_passed_admission_requires_complete_finite_measurements(self):
+        for key in ADMISSION_MEASUREMENTS:
+            malformed = dict(ADMISSION_MEASUREMENTS)
+            del malformed[key]
+            with self.subTest(missing=key), self.assertRaises(EvidenceError):
+                require_local_admission(
+                    {
+                        "schema": "graphforge-local-admission-evidence/1",
+                        "result": "passed",
+                        "cause": None,
+                        "measurements": malformed,
+                    }
+                )
+        for invalid in (math.nan, math.inf):
+            with self.subTest(invalid=invalid), self.assertRaisesRegex(EvidenceError, "walltime"):
+                require_local_admission(
+                    {
+                        "schema": "graphforge-local-admission-evidence/1",
+                        "result": "passed",
+                        "cause": None,
+                        "measurements": ADMISSION_MEASUREMENTS | {"walltime": invalid},
+                    }
+                )
+
+    def test_definition_and_dependency_match_benchexec_api(self):
+        benchmark_root = Path(__file__).resolve().parents[1]
+        definition = ET.parse(benchmark_root / "definitions/graphforge-certification-v1.xml")
+        self.assertEqual(int(definition.getroot().attrib["cpuCores"]), 16)
+        project = tomllib.loads((benchmark_root / "pyproject.toml").read_text())
+        self.assertIn("benchexec>=3.3,<4", project["project"]["dependencies"])
 
     def test_adapts_native_benchexec_process_tree_keys(self):
         class Exit:
@@ -139,6 +182,11 @@ class BenchExecAuthorityTests(unittest.TestCase):
                     limits=LIMITS,
                 )
                 self.assertEqual(evidence["outcome"], expected)
+                schema_path = (
+                    Path(__file__).resolve().parents[1] / "schemas/benchexec-run-evidence.json"
+                )
+                schema = json.loads(schema_path.read_text())
+                Draft202012Validator(schema).validate(evidence)
 
     def test_missing_authoritative_process_tree_field_fails_closed(self):
         malformed = result()
@@ -162,6 +210,71 @@ class BenchExecAuthorityTests(unittest.TestCase):
                 },
                 limits=Limits(0, 8, 1024, (0,)),
             )
+
+        for invalid in (math.nan, math.inf):
+            with (
+                self.subTest(invalid_limit=invalid),
+                self.assertRaisesRegex(EvidenceError, "limits"),
+            ):
+                normalize_run(
+                    benchexec=result(),
+                    graphforge={
+                        "status": "passed",
+                        "phases": [{"phase": "export", "duration_ms": 2000}],
+                    },
+                    limits=Limits(invalid, 8, 1024, (0,)),
+                )
+            with (
+                self.subTest(invalid_measurement=invalid),
+                self.assertRaisesRegex(EvidenceError, "wall_seconds"),
+            ):
+                normalize_run(
+                    benchexec=result(wall_seconds=invalid),
+                    graphforge={
+                        "status": "passed",
+                        "phases": [{"phase": "export", "duration_ms": 2000}],
+                    },
+                    limits=LIMITS,
+                )
+
+    def test_schema_rejects_contradictory_outcome_process_status(self):
+        schema_path = Path(__file__).resolve().parents[1] / "schemas/benchexec-run-evidence.json"
+        validator = Draft202012Validator(json.loads(schema_path.read_text()))
+        base = normalize_run(
+            benchexec=result(),
+            graphforge={"status": "passed", "phases": [{"phase": "ingest", "duration_ms": 2000}]},
+            limits=LIMITS,
+        )
+        contradictions = [
+            base | {"outcome": "passed", "exit_code": 7},
+            base | {"outcome": "correctness", "exit_code": 7},
+            base | {"outcome": "exit", "exit_code": 0},
+            base | {"outcome": "signal", "exit_code": 0, "signal": 9},
+            base | {"outcome": "timeout", "exit_code": 7},
+            base | {"outcome": "oom", "signal": 9},
+            base | {"outcome": "harness", "exit_code": 1},
+        ]
+        for evidence in contradictions:
+            with self.subTest(evidence=evidence):
+                self.assertTrue(list(validator.iter_errors(evidence)))
+
+    def test_passed_local_admission_schema_requires_measurements(self):
+        schema_path = Path(__file__).resolve().parents[1] / "schemas/local-admission-evidence.json"
+        validator = Draft202012Validator(json.loads(schema_path.read_text()))
+        evidence = {
+            "schema": "graphforge-local-admission-evidence/1",
+            "result": "passed",
+            "cause": None,
+            "facts": {
+                "operating_system": "linux",
+                "cgroups_version": 2,
+                "mount_namespace": True,
+                "pid_namespace": True,
+                "user_namespace": True,
+            },
+        }
+        self.assertTrue(list(validator.iter_errors(evidence)))
+        validator.validate(evidence | {"measurements": ADMISSION_MEASUREMENTS})
 
     def test_reports_status_and_wall_time_disagreement(self):
         evidence = normalize_run(

--- a/benchmarks/tests/test_benchexec_authority.py
+++ b/benchmarks/tests/test_benchexec_authority.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import unittest
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+from graphforge_bench.benchexec_authority import (
+    EvidenceError,
+    Limits,
+    Outcome,
+    adapt_run_result,
+    normalize_phase,
+)
+from graphforge_bench.tools.graphforge_certify import Tool
+
+
+LIMITS = Limits(10.0, 8.0, 1024, (0, 1))
+
+
+def result(**changes):
+    value = {
+        "wall_seconds": 2.0,
+        "cpu_seconds": 3.0,
+        "peak_rss_bytes": 400,
+        "read_bytes": 500,
+        "write_bytes": 600,
+        "exit_code": 0,
+        "correctness": True,
+    }
+    value.update(changes)
+    return value
+
+
+class BenchExecAuthorityTests(unittest.TestCase):
+    def test_adapts_native_benchexec_process_tree_keys(self):
+        class Exit:
+            value = 0
+            signal = None
+
+        adapted = adapt_run_result(
+            {
+                "walltime": 1.0,
+                "cputime": 1.5,
+                "memory": 99,
+                "blkio-read": 10,
+                "blkio-write": 20,
+                "exitcode": Exit(),
+            },
+            correctness=True,
+        )
+        self.assertEqual(
+            adapted,
+            result(
+                wall_seconds=1.0,
+                cpu_seconds=1.5,
+                peak_rss_bytes=99,
+                read_bytes=10,
+                write_bytes=20,
+            ) | {"termination_reason": None, "signal": None},
+        )
+
+    def test_tool_info_invokes_only_versioned_public_runner_shape(self):
+        class Task:
+            input_files_or_identifier = ("profile.json",)
+
+        self.assertEqual(
+            Tool().cmdline("graphforge-benchmark-certify", [], Task(), None),
+            [
+                "graphforge-benchmark-certify",
+                "run",
+                "profile.json",
+                "evidence.json",
+            ],
+        )
+
+    def test_preserves_tree_authority_and_graphforge_telemetry(self):
+        evidence = normalize_phase(
+            phase="ingest",
+            benchexec=result(),
+            graphforge={"phase": "ingest", "status": "passed", "duration_ms": 2000},
+            limits=LIMITS,
+        )
+        self.assertEqual(evidence["outcome"], Outcome.PASSED)
+        self.assertEqual(evidence["authority"]["cpu_seconds"], 3.0)
+        self.assertEqual(evidence["limits"]["cores"], [0, 1])
+        self.assertEqual(evidence["disagreements"], [])
+        schema = json.loads(
+            Path("benchmarks/schemas/benchexec-phase-evidence.json").read_text()
+        )
+        Draft202012Validator(schema).validate(evidence)
+
+    def test_typed_termination_outcomes_remain_distinct(self):
+        cases = [
+            ({"termination_reason": "walltime"}, Outcome.TIMEOUT),
+            ({"termination_reason": "memory"}, Outcome.OOM),
+            ({"exit_code": 7, "correctness": True}, Outcome.EXIT),
+            ({"signal": 9, "exit_code": None, "correctness": True}, Outcome.SIGNAL),
+            ({"termination_reason": "failed"}, Outcome.HARNESS),
+            ({"correctness": False}, Outcome.CORRECTNESS),
+        ]
+        for changes, expected in cases:
+            with self.subTest(expected=expected):
+                evidence = normalize_phase(
+                    phase="query",
+                    benchexec=result(**changes),
+                    graphforge={"phase": "query", "status": "failed", "duration_ms": 2000},
+                    limits=LIMITS,
+                )
+                self.assertEqual(evidence["outcome"], expected)
+
+    def test_missing_authoritative_process_tree_field_fails_closed(self):
+        malformed = result()
+        del malformed["read_bytes"]
+        with self.assertRaisesRegex(EvidenceError, "read_bytes"):
+            normalize_phase(
+                phase="export",
+                benchexec=malformed,
+                graphforge={"phase": "export", "status": "passed", "duration_ms": 2000},
+                limits=LIMITS,
+            )
+
+        with self.assertRaisesRegex(EvidenceError, "limits"):
+            normalize_phase(
+                phase="export",
+                benchexec=result(),
+                graphforge={"phase": "export", "status": "passed", "duration_ms": 2000},
+                limits=Limits(0, 8, 1024, (0,)),
+            )
+
+    def test_reports_status_and_wall_time_disagreement(self):
+        evidence = normalize_phase(
+            phase="verify",
+            benchexec=result(),
+            graphforge={"phase": "verify", "status": "failed", "duration_ms": 9000},
+            limits=LIMITS,
+        )
+        self.assertEqual(evidence["disagreements"], ["status", "wall_time"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/tests/test_benchexec_authority.py
+++ b/benchmarks/tests/test_benchexec_authority.py
@@ -9,7 +9,7 @@ from graphforge_bench.benchexec_authority import (
     Limits,
     Outcome,
     adapt_run_result,
-    normalize_phase,
+    normalize_run,
 )
 from graphforge_bench.tools.graphforge_certify import Tool
 from jsonschema import Draft202012Validator
@@ -24,6 +24,9 @@ def result(**changes):
         "peak_rss_bytes": 400,
         "read_bytes": 500,
         "write_bytes": 600,
+        "pressure_cpu_seconds": 0.1,
+        "pressure_io_seconds": 0.2,
+        "pressure_memory_seconds": 0.3,
         "exit_code": 0,
         "correctness": True,
     }
@@ -44,6 +47,9 @@ class BenchExecAuthorityTests(unittest.TestCase):
                 "memory": 99,
                 "blkio-read": 10,
                 "blkio-write": 20,
+                "pressure-cpu-some": 0.1,
+                "pressure-io-some": 0.2,
+                "pressure-memory-some": 0.3,
                 "exitcode": Exit(),
             },
             correctness=True,
@@ -56,7 +62,8 @@ class BenchExecAuthorityTests(unittest.TestCase):
                 peak_rss_bytes=99,
                 read_bytes=10,
                 write_bytes=20,
-            ) | {"termination_reason": None, "signal": None},
+            )
+            | {"termination_reason": None, "signal": None},
         )
 
     def test_tool_info_invokes_only_versioned_public_runner_shape(self):
@@ -74,19 +81,16 @@ class BenchExecAuthorityTests(unittest.TestCase):
         )
 
     def test_preserves_tree_authority_and_graphforge_telemetry(self):
-        evidence = normalize_phase(
-            phase="ingest",
+        evidence = normalize_run(
             benchexec=result(),
-            graphforge={"phase": "ingest", "status": "passed", "duration_ms": 2000},
+            graphforge={"status": "passed", "phases": [{"phase": "ingest", "duration_ms": 2000}]},
             limits=LIMITS,
         )
         self.assertEqual(evidence["outcome"], Outcome.PASSED)
         self.assertEqual(evidence["authority"]["cpu_seconds"], 3.0)
         self.assertEqual(evidence["limits"]["cores"], [0, 1])
         self.assertEqual(evidence["disagreements"], [])
-        schema = json.loads(
-            Path("benchmarks/schemas/benchexec-phase-evidence.json").read_text()
-        )
+        schema = json.loads(Path("benchmarks/schemas/benchexec-run-evidence.json").read_text())
         Draft202012Validator(schema).validate(evidence)
 
     def test_typed_termination_outcomes_remain_distinct(self):
@@ -100,10 +104,12 @@ class BenchExecAuthorityTests(unittest.TestCase):
         ]
         for changes, expected in cases:
             with self.subTest(expected=expected):
-                evidence = normalize_phase(
-                    phase="query",
+                evidence = normalize_run(
                     benchexec=result(**changes),
-                    graphforge={"phase": "query", "status": "failed", "duration_ms": 2000},
+                    graphforge={
+                        "status": "failed",
+                        "phases": [{"phase": "query", "duration_ms": 2000}],
+                    },
                     limits=LIMITS,
                 )
                 self.assertEqual(evidence["outcome"], expected)
@@ -112,26 +118,29 @@ class BenchExecAuthorityTests(unittest.TestCase):
         malformed = result()
         del malformed["read_bytes"]
         with self.assertRaisesRegex(EvidenceError, "read_bytes"):
-            normalize_phase(
-                phase="export",
+            normalize_run(
                 benchexec=malformed,
-                graphforge={"phase": "export", "status": "passed", "duration_ms": 2000},
+                graphforge={
+                    "status": "passed",
+                    "phases": [{"phase": "export", "duration_ms": 2000}],
+                },
                 limits=LIMITS,
             )
 
         with self.assertRaisesRegex(EvidenceError, "limits"):
-            normalize_phase(
-                phase="export",
+            normalize_run(
                 benchexec=result(),
-                graphforge={"phase": "export", "status": "passed", "duration_ms": 2000},
+                graphforge={
+                    "status": "passed",
+                    "phases": [{"phase": "export", "duration_ms": 2000}],
+                },
                 limits=Limits(0, 8, 1024, (0,)),
             )
 
     def test_reports_status_and_wall_time_disagreement(self):
-        evidence = normalize_phase(
-            phase="verify",
+        evidence = normalize_run(
             benchexec=result(),
-            graphforge={"phase": "verify", "status": "failed", "duration_ms": 9000},
+            graphforge={"status": "failed", "phases": [{"phase": "verify", "duration_ms": 9000}]},
             limits=LIMITS,
         )
         self.assertEqual(evidence["disagreements"], ["status", "wall_time"])

--- a/benchmarks/tests/test_benchexec_authority.py
+++ b/benchmarks/tests/test_benchexec_authority.py
@@ -115,9 +115,7 @@ class BenchExecAuthorityTests(unittest.TestCase):
         self.assertEqual(evidence["authority"]["cpu_seconds"], 3.0)
         self.assertEqual(evidence["limits"]["cores"], [0, 1])
         self.assertEqual(evidence["disagreements"], [])
-        schema_path = (
-            Path(__file__).resolve().parents[1] / "schemas/benchexec-run-evidence.json"
-        )
+        schema_path = Path(__file__).resolve().parents[1] / "schemas/benchexec-run-evidence.json"
         schema = json.loads(schema_path.read_text())
         Draft202012Validator(schema).validate(evidence)
 

--- a/benchmarks/tests/test_local_admission.py
+++ b/benchmarks/tests/test_local_admission.py
@@ -45,6 +45,9 @@ class LocalAdmissionTests(unittest.TestCase):
                 "memory": 1048576,
                 "blkio-read": 4096,
                 "blkio-write": 65536,
+                "pressure-cpu-some": 0.0,
+                "pressure-io-some": 0.0,
+                "pressure-memory-some": 0.0,
                 "terminationreason": "walltime",
                 "descendant_stopped": True,
             }
@@ -112,6 +115,9 @@ class LocalAdmissionTests(unittest.TestCase):
                         "memory": 1048576,
                         "blkio-read": 4096,
                         "blkio-write": invalid_metric,
+                        "pressure-cpu-some": 0.0,
+                        "pressure-io-some": 0.0,
+                        "pressure-memory-some": 0.0,
                         "terminationreason": "walltime",
                         "descendant_stopped": True,
                     }
@@ -137,6 +143,9 @@ class LocalAdmissionTests(unittest.TestCase):
                         "memory": 1,
                         "blkio-read": 0,
                         "blkio-write": 1,
+                        "pressure-cpu-some": 0.0,
+                        "pressure-io-some": 0.0,
+                        "pressure-memory-some": 0.0,
                         "terminationreason": "walltime",
                         "descendant_stopped": False,
                     }

--- a/benchmarks/uv.lock
+++ b/benchmarks/uv.lock
@@ -230,7 +230,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "benchexec", specifier = ">=3.0,<4" },
+    { name = "benchexec", specifier = ">=3.3,<4" },
     { name = "jsonschema", specifier = ">=4.0,<5" },
     { name = "reframe-hpc", specifier = ">=4.0,<5" },
 ]


### PR DESCRIPTION
## Summary
- add a versioned BenchExec definition and public certification tool-info adapter
- normalize authoritative run-level process-tree resources while preserving GraphForge phase telemetry and surfacing disagreements
- consume native cgroups-v2 child-tree admission and fail closed on missing I/O, pressure, limits, termination, or correctness evidence

## Validation
- `make -C benchmarks smoke`
- `uvx ruff@0.16.1 check benchmarks/harness/graphforge_bench/benchexec_authority.py benchmarks/harness/graphforge_bench/local_admission.py benchmarks/tests/test_benchexec_authority.py benchmarks/tests/test_local_admission.py`

Relates to #957; #954 remains the native admitted-Linux evidence gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the GraphForge public certification v1 benchmark with defined execution, time, memory, and CPU limits.
  * Added standardized result handling for passes, timeouts, resource exhaustion, termination, harness failures, and correctness failures.
* **Bug Fixes**
  * Improved validation of benchmark evidence and resource measurements, failing safely when required data is missing or invalid.
  * Added CPU, I/O, and memory-pressure monitoring to local admission checks.
* **Documentation**
  * Added schemas describing benchmark run and admission evidence for consistent reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->