### PR TITLE
test(bench): implement progressive Graph500 qualification

### DIFF
--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -3,6 +3,506 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "arrow"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-csv",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a41203398f0eaa6f7ec8e62c0da742a21abf282c148fc157f6c35c90e29981a"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae33dad492b7df00a217563a7b0ef2874df68a0deea1b1a3acf628152f7f7a69"
+dependencies = [
+ "ahash",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9552f96391c005e6ab449fa941420935e7e062489b12b8b1b08879b2163f5b5"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8a327c9649f30d8406995f27642b68df354713cca3baaaf100f076f18d5f34"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af0dd6d90d1955e9f9a014c1e563ee8aeffc21909085d25623e1da44d96eca26"
+dependencies = [
+ "arrow-array",
+ "arrow-cast",
+ "arrow-schema",
+ "chrono",
+ "csv",
+ "csv-core",
+ "regex",
+]
+
+[[package]]
+name = "arrow-data"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b24852db04738907e06c04ea61e42fe7fda962a34513022dc0d0e754fb7976b"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a908a11fcfb3fb2f6730f4ac15e367bc644e419155e96238f68cf3adde572b"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-json"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a96aed3931c076adee39ec2a40d8219fc7f09e79bcdaca1df16272993e1e14"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "chrono",
+ "half",
+ "indexmap",
+ "itoa",
+ "lexical-core",
+ "memchr",
+ "num-traits",
+ "ryu",
+ "serde_core",
+ "serde_json",
+ "simdutf8",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63a083ec750f5c043f02946b4baf05fcdbb55f4560a3277055caca5cc99f3eb0"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514ba0ef0d4c5896202dae736251ce415abb43a950bed570fb7981b8716c0e4c"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21ca356ad6425cecb6eb7b28e4f659f1ee7880fbb1a16127de7dd62901efee9e"
+
+[[package]]
+name = "arrow-select"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c58da39eb3d8350ad4a549e5c2bc49284dac554016c69829310350f1731b0aad"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6789b388467525e3271326b6b4915666ecfdf5142aef09779445c954b67543c"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "brotli"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cc"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags",
+ "rustc_version",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
+dependencies = [
+ "zlib-rs",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+]
+
+[[package]]
 name = "graphforge-benchmark-certify"
 version = "0.0.0"
 dependencies = [
@@ -11,8 +511,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "graphforge-benchmark-graph500-generator"
+version = "0.0.0"
+dependencies = [
+ "arrow",
+ "parquet",
+]
+
+[[package]]
 name = "graphforge-benchmark-smoke"
 version = "0.0.0"
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "itoa"
@@ -21,10 +587,219 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "log"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
+
+[[package]]
+name = "lz4_flex"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "parquet"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
+ "base64",
+ "brotli",
+ "bytes",
+ "chrono",
+ "flate2",
+ "half",
+ "hashbrown",
+ "lz4_flex",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "paste",
+ "seq-macro",
+ "simdutf8",
+ "snap",
+ "thrift",
+ "twox-hash",
+ "zstd",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "proc-macro2"
@@ -43,6 +818,80 @@ checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -71,7 +920,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -88,6 +937,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "snap"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199905e6153d6405f9728fe44daace35f8f837bbf830bb6e85fbd5828709a886"
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "syn"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,13 +983,224 @@ dependencies = [
 ]
 
 [[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5283634e518fe9e82c7b20520bb4bc209009fd16c82077c802f8111ecbb0117a"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
+
+[[package]]
 name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["runners/certify", "runners/smoke"]
+members = ["runners/certify", "runners/graph500-generator", "runners/smoke"]
 resolver = "2"
 
 [workspace.package]
@@ -11,3 +11,5 @@ rust-version = "1.85"
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+arrow = "=58.3.0"
+parquet = { version = "=58.3.0", features = ["arrow"] }

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install smoke smoke-python smoke-rust local-admission
+.PHONY: install smoke smoke-python smoke-rust local-admission progressive-qualification-list
 
 install:
 	uv sync --locked
@@ -18,3 +18,6 @@ smoke-rust: install
 local-admission: install
 	PYTHONPATH=$(CURDIR)/harness uv run --locked reframe -C reframe/settings.py -c reframe/checks -n '^LocalBenchExecAdmission$$' -l | grep -F LocalBenchExecAdmission
 	PYTHONPATH=$(CURDIR)/harness uv run --locked reframe -C reframe/settings.py -c reframe/checks -n '^LocalBenchExecAdmission$$' -r
+
+progressive-qualification-list: install
+	PYTHONPATH=$(CURDIR)/harness uv run --locked reframe -C reframe/settings.py -c reframe/checks -n '^Graph500ProgressiveQualificationProfile' -l

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -29,10 +29,12 @@ belongs to issue #959, after parity is proven.
 ## Public-interface certification runner
 
 `runners/certify` owns the admission through reopen-proof lifecycle. A profile
-declares a typed benchmark-owned generator action for `generate` and one
-ordinary `gf` public command action for every product phase, in order. Runtime
-validation binds each product phase to its real command family and rejects
-global help/version no-ops. The runner does not link product crates, call
+declares a typed benchmark-owned generator action for `generate` and ordinary
+`gf` public command actions for every product phase, in order. Ingest, recount,
+query, and imported reopen proof use ordered multi-command actions; the runner
+executes each child directly, stops on the first failure, and aggregates phase
+duration and peak RSS. Runtime validation binds each product phase to its real
+command family and rejects global help/version no-ops. The runner does not link product crates, call
 storage internals, provision a host, or enforce CPU, memory, disk, or time
 limits. BenchExec or another outer orchestrator owns deadlines and may terminate
 the runner; the certification binary does not silently convert a policy timeout
@@ -44,9 +46,10 @@ cargo run --locked --manifest-path benchmarks/Cargo.toml \
   run PROFILE.json benchmarks/outputs/evidence.json
 ```
 
-Tiny in-process fixtures exercise every phase and first-failure behavior without
-opening a project. Graph500 profiles supply the real generate, ingest, recount,
-query, portable export/verify/import, and reopen commands in #956; a placeholder
+Tiny fixtures exercise every phase and first-failure behavior, including one
+executable scale-1 fixture that opens a real project and completes the ordinary
+source/export/verify/clean-import/reopen lifecycle. Graph500 profiles supply the
+real generate, ingest, recount, query, portable export/verify/import, and reopen commands in #956; a placeholder
 profile that merely labels no-op commands as lifecycle work is intentionally not
 shipped.
 
@@ -120,3 +123,39 @@ Unsupported hosts return sanitized typed disqualification evidence. In
 particular, macOS and Docker Desktop do not prove native Linux admission and
 must not be used as substitutes. This probe creates no Fly resources and does
 not authorize a Graph500 scale run.
+
+## Progressive Graph500 qualification
+
+`profiles/graph500/` contains distinct declarative S18 and S19 local profiles
+and S20, S22, and S26 provider profiles. They pin the reference generator,
+edge factor 16, seed, the same ten-phase public certification lifecycle, and a
+closed sanitized evidence contract. Provider profiles describe environment
+classes only; they contain no app, machine, volume, account, region, or secret
+identifier.
+
+The Python qualification policy consumes completed, correct ordinary-lifecycle
+evidence and stops at the first failed rung. S20 requires S18 and S19. S22 has
+its own S19/S20 gate. S26 is separately refused without adjacent S24/S25 disk
+and bounded-RSS observations from the canonical ladder. Projections preserve
+wall time, peak RSS, retained and transient storage, logical and physical I/O,
+reader calls, and publication work as independent dimensions.
+
+The provider ceiling is four hours, 4 GiB RSS, and 500 GiB storage. Admission
+reserves 20% time and RSS headroom and 15% storage headroom (425 GiB usable),
+which covers runtime variance and filesystem/package transients without
+turning the M5 ceiling into a sizing target. Adjacent RSS growth above 10% is
+an architectural refusal signal: GraphForge is expected to plateau in memory
+while storage and I/O grow. These are engineering qualification claims only,
+never official Graph500 submission claims.
+
+The ReFrame cases are manual execution entry points and are deliberately
+excluded from normal CI and `smoke`; list them with:
+
+```bash
+make -C benchmarks progressive-qualification-list
+```
+
+Actual Linux resource execution remains under the versioned 4 GiB/four-hour
+BenchExec definition and public certification runner. Provider cases are not
+valid on the local ReFrame system. Provider provisioning is a later, separate
+operation; listing these profiles launches nothing.

--- a/benchmarks/definitions/graphforge-progressive-qualification-v1.xml
+++ b/benchmarks/definitions/graphforge-progressive-qualification-v1.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<benchmark tool="graphforge_bench.tools.graphforge_certify" timelimit="14400 s"
+           hardtimelimit="14430 s" memlimit="4 GB" cpuCores="16">
+  <rundefinition name="graphforge-progressive-qualification-v1">
+    <tasks name="profile"><include>profile.json</include></tasks>
+  </rundefinition>
+</benchmark>

--- a/benchmarks/fixtures/progressive/tiny-executable.json
+++ b/benchmarks/fixtures/progressive/tiny-executable.json
@@ -1,0 +1,224 @@
+{
+  "schema": "graphforge-public-certification-profile/1",
+  "id": "graph500-tiny-executable",
+  "executable": "gf",
+  "phases": [
+    {
+      "phase": "admission",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "--info"
+        ]
+      }
+    },
+    {
+      "phase": "generate",
+      "action": {
+        "interface": "benchmark_generator",
+        "identity": "sha256:3b4bdf5ae4f41523f911dc1998db2328dadd2fa9e5f95e49478f148e81a14ce2",
+        "executable": "graphforge-benchmark-graph500-generator",
+        "args": [
+          "--scale",
+          "1",
+          "--edge-factor",
+          "16",
+          "--seed",
+          "13907095936298285200",
+          "--nodes",
+          "workspace/tiny/nodes.parquet",
+          "--edges",
+          "workspace/tiny/edges.parquet"
+        ]
+      }
+    },
+    {
+      "phase": "ingest",
+      "action": {
+        "interface": "graph_forge_cli_workflow",
+        "commands": [
+          [
+            "--project",
+            "workspace/tiny/source",
+            "import-session",
+            "begin",
+            "--operation-uuid",
+            "00000000-0000-4000-8000-000000000018"
+          ],
+          [
+            "--project",
+            "workspace/tiny/source",
+            "import-session",
+            "register-parquet",
+            "--session-uuid",
+            "00000000-0000-4000-8000-000000000018",
+            "--path",
+            "workspace/tiny/nodes.parquet",
+            "--kind",
+            "nodes"
+          ],
+          [
+            "--project",
+            "workspace/tiny/source",
+            "import-session",
+            "register-parquet",
+            "--session-uuid",
+            "00000000-0000-4000-8000-000000000018",
+            "--path",
+            "workspace/tiny/edges.parquet",
+            "--kind",
+            "edges"
+          ],
+          [
+            "--project",
+            "workspace/tiny/source",
+            "import-session",
+            "validate",
+            "--session-uuid",
+            "00000000-0000-4000-8000-000000000018"
+          ],
+          [
+            "--project",
+            "workspace/tiny/source",
+            "import-session",
+            "commit",
+            "--session-uuid",
+            "00000000-0000-4000-8000-000000000018"
+          ]
+        ]
+      }
+    },
+    {
+      "phase": "reopen",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "--project",
+          "workspace/tiny/source",
+          "recovery"
+        ]
+      }
+    },
+    {
+      "phase": "recount",
+      "action": {
+        "interface": "graph_forge_cli_workflow",
+        "commands": [
+          [
+            "--project",
+            "workspace/tiny/source",
+            "query",
+            "--cypher",
+            "MATCH (n) RETURN count(n)",
+            "--output",
+            "workspace/tiny/node-count.arrow"
+          ],
+          [
+            "--project",
+            "workspace/tiny/source",
+            "query",
+            "--cypher",
+            "MATCH ()-[r]->() RETURN count(r)",
+            "--output",
+            "workspace/tiny/edge-count.arrow"
+          ]
+        ]
+      }
+    },
+    {
+      "phase": "query",
+      "action": {
+        "interface": "graph_forge_cli_workflow",
+        "commands": [
+          [
+            "--project",
+            "workspace/tiny/source",
+            "query",
+            "--cypher",
+            "MATCH (a)-[r]->(b) RETURN a, r, b LIMIT 1024",
+            "--output",
+            "workspace/tiny/one-hop.arrow"
+          ],
+          [
+            "--project",
+            "workspace/tiny/source",
+            "query",
+            "--cypher",
+            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN a, r1, b, r2, c LIMIT 1024",
+            "--output",
+            "workspace/tiny/two-hop.arrow"
+          ]
+        ]
+      }
+    },
+    {
+      "phase": "export",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "--project",
+          "workspace/tiny/source",
+          "portable",
+          "export",
+          "--current",
+          "--output",
+          "workspace/tiny/portable"
+        ]
+      }
+    },
+    {
+      "phase": "verify",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "portable",
+          "verify",
+          "--input",
+          "workspace/tiny/portable"
+        ]
+      }
+    },
+    {
+      "phase": "clean_import",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "--project",
+          "workspace/tiny/imported",
+          "portable",
+          "import",
+          "--input",
+          "workspace/tiny/portable",
+          "--idempotency-key",
+          "00000000-0000-4000-8000-000000000018"
+        ]
+      }
+    },
+    {
+      "phase": "reopen_proof",
+      "action": {
+        "interface": "graph_forge_cli_workflow",
+        "commands": [
+          [
+            "--project",
+            "workspace/tiny/imported",
+            "query",
+            "--cypher",
+            "MATCH (n) RETURN count(n)",
+            "--output",
+            "workspace/tiny/imported-node-count.arrow"
+          ],
+          [
+            "--project",
+            "workspace/tiny/imported",
+            "query",
+            "--cypher",
+            "MATCH ()-[r]->() RETURN count(r)",
+            "--output",
+            "workspace/tiny/imported-edge-count.arrow"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/benchmarks/harness/graphforge_bench/progressive_qualification.py
+++ b/benchmarks/harness/graphforge_bench/progressive_qualification.py
@@ -1,0 +1,290 @@
+"""Declarative progressive Graph500 qualification and projection policy."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+WALL_LIMIT_SECONDS = 4 * 60 * 60
+RSS_LIMIT_BYTES = 4 * 1024**3
+VOLUME_LIMIT_BYTES = 500 * 1024**3
+TIME_HEADROOM = 0.20
+RSS_HEADROOM = 0.20
+STORAGE_HEADROOM = 0.15
+MAX_RSS_GROWTH_FRACTION = 0.10
+PHASES = (
+    "admission",
+    "generate",
+    "ingest",
+    "reopen",
+    "recount",
+    "query",
+    "export",
+    "verify",
+    "clean_import",
+    "reopen_proof",
+)
+METRICS = (
+    "wall_seconds",
+    "peak_rss_bytes",
+    "retained_storage_bytes",
+    "transient_peak_storage_bytes",
+    "logical_read_bytes",
+    "logical_write_bytes",
+    "physical_read_bytes",
+    "physical_write_bytes",
+    "reader_calls",
+    "publication_work_units",
+)
+
+
+class QualificationError(ValueError):
+    """Qualification input is missing, malformed, or contradictory."""
+
+
+class Decision(StrEnum):
+    ADMITTED = "admitted"
+    REFUSED = "refused"
+
+
+@dataclass(frozen=True)
+class Profile:
+    id: str
+    scale: int
+    execution: str
+    projection_sources: tuple[int, int] | None
+
+
+def profile_root() -> Path:
+    return Path(__file__).resolve().parents[2] / "profiles" / "graph500"
+
+
+def load_profiles(root: Path | None = None) -> tuple[Profile, ...]:
+    import json
+
+    from jsonschema import Draft202012Validator
+
+    values = []
+    profiles_root = root or profile_root()
+    schema = json.loads(
+        (profiles_root.parents[1] / "schemas/progressive-qualification-profile.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    validator = Draft202012Validator(schema)
+    expected = {
+        18: ("graph500-s18-local", "local", None),
+        19: ("graph500-s19-local", "local", None),
+        20: ("graph500-s20-provider", "provider", [18, 19]),
+        22: ("graph500-s22-provider", "provider", [19, 20]),
+        26: ("graph500-s26-provider", "provider", [24, 25]),
+    }
+    for path in sorted(profiles_root.glob("*.json")):
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        error = next(validator.iter_errors(raw), None)
+        if error is not None:
+            raise QualificationError(f"invalid progressive profile: {error.message}")
+        gate = raw["gate"]
+        sources = gate.get("projection_source_scales")
+        if expected.get(raw["scale"]) != (raw["id"], raw["execution"], sources):
+            raise QualificationError("profile identity, environment, or gate contradicts scale")
+        values.append(
+            Profile(
+                id=raw["id"],
+                scale=raw["scale"],
+                execution=raw["execution"],
+                projection_sources=tuple(sources) if sources is not None else None,
+            )
+        )
+    if [value.scale for value in values] != [18, 19, 20, 22, 26]:
+        raise QualificationError("progressive profiles must be S18,S19,S20,S22,S26")
+    return tuple(values)
+
+
+def select_next(
+    profiles: Sequence[Profile],
+    completed: Sequence[Mapping[str, Any]],
+    provider_capacity: Mapping[str, Any] | None = None,
+) -> Profile | None:
+    """Return only the first unexecuted rung; a failure authorizes nothing larger."""
+    by_scale = {int(item.get("scale", -1)): item for item in completed}
+    for profile in profiles:
+        evidence = by_scale.get(profile.scale)
+        if evidence is None:
+            if any(item.get("status") != "passed" for item in completed):
+                return None
+            if profile.execution == "provider":
+                try:
+                    evidence = project(profile, completed, provider_capacity)
+                except QualificationError:
+                    return None
+                if evidence["decision"] != Decision.ADMITTED:
+                    return None
+            return profile
+        if evidence.get("status") != "passed":
+            return None
+    return None
+
+
+def _integer(metrics: Mapping[str, Any], name: str) -> int:
+    value = metrics.get(name)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise QualificationError(f"missing or invalid metric: {name}")
+    return value
+
+
+def _validate_rung(item: Mapping[str, Any]) -> None:
+    if item.get("status") != "passed" or item.get("correctness") is not True:
+        raise QualificationError("projection sources must be completed and correct")
+    if tuple(item.get("phases", ())) != PHASES:
+        raise QualificationError("projection source did not run the ordinary lifecycle")
+    scale = item.get("scale")
+    if not isinstance(scale, int) or item.get("live_edges") != 16 * (1 << scale):
+        raise QualificationError("projection source edge cardinality contradicts its scale")
+    source = item.get("source")
+    if source not in {"progressive_profile", "canonical_ladder"}:
+        raise QualificationError("projection source provenance is missing")
+    if not isinstance(item.get("profile_id"), str):
+        raise QualificationError("projection source profile identity is missing")
+    metrics = item.get("metrics")
+    if not isinstance(metrics, Mapping):
+        raise QualificationError("projection source metrics are missing")
+    for name in METRICS:
+        _integer(metrics, name)
+
+
+def _ceil_ratio(numerator: int, denominator: int) -> int:
+    if denominator <= 0:
+        raise QualificationError("projection denominator must be positive")
+    return (numerator + denominator - 1) // denominator
+
+
+def _project(low: Mapping[str, Any], high: Mapping[str, Any], target_edges: int, name: str) -> int:
+    low_edges = int(low["live_edges"])
+    high_edges = int(high["live_edges"])
+    if not 0 < low_edges < high_edges < target_edges:
+        raise QualificationError("projection sources and target must increase by live edge count")
+    low_value = _integer(low["metrics"], name)
+    high_value = _integer(high["metrics"], name)
+    delta = max(0, high_value - low_value)
+    adjacent_delta = high_value + _ceil_ratio(
+        delta * (target_edges - high_edges), high_edges - low_edges
+    )
+    latest_ratio = _ceil_ratio(high_value * target_edges, high_edges)
+    return max(high_value, adjacent_delta, latest_ratio)
+
+
+def project(
+    profile: Profile,
+    completed: Sequence[Mapping[str, Any]],
+    provider_capacity: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Project one provider rung from its two declared completed source scales."""
+    if profile.execution != "provider" or profile.projection_sources is None:
+        raise QualificationError("only provider profiles have projection gates")
+    by_scale = {int(item.get("scale", -1)): item for item in completed}
+    try:
+        low, high = (by_scale[scale] for scale in profile.projection_sources)
+    except KeyError as error:
+        raise QualificationError("both declared projection source rungs must complete") from error
+    _validate_rung(low)
+    _validate_rung(high)
+    if profile.scale == 20 and profile.projection_sources != (18, 19):
+        raise QualificationError("S20 requires adjacent S18 and S19 evidence")
+    if profile.scale == 26 and profile.projection_sources != (24, 25):
+        raise QualificationError("S26 requires adjacent S24 and S25 evidence")
+    if profile.scale == 26 and any(
+        item.get("source") != "canonical_ladder" for item in (low, high)
+    ):
+        raise QualificationError("S26 requires canonical S24 and S25 ladder evidence")
+
+    target_edges = (1 << profile.scale) * 16
+    projected = {name: _project(low, high, target_edges, name) for name in METRICS}
+    # RSS is expected to plateau; a per-edge ratio would encode the architectural
+    # failure we are trying to detect as a capacity requirement.
+    projected["peak_rss_bytes"] = max(
+        _integer(high["metrics"], "peak_rss_bytes"),
+        _integer(high["metrics"], "peak_rss_bytes")
+        + max(
+            0,
+            _integer(high["metrics"], "peak_rss_bytes")
+            - _integer(low["metrics"], "peak_rss_bytes"),
+        ),
+    )
+    storage_peak = max(
+        projected["retained_storage_bytes"], projected["transient_peak_storage_bytes"]
+    )
+    rss_low = _integer(low["metrics"], "peak_rss_bytes")
+    rss_high = _integer(high["metrics"], "peak_rss_bytes")
+    rss_growth_fraction = (rss_high - rss_low) / max(1, rss_low)
+    capacity = provider_capacity or {}
+    usable_seconds = int(WALL_LIMIT_SECONDS * (1 - TIME_HEADROOM))
+    required_rates = {
+        "physical_read_bytes_per_second": _ceil_ratio(
+            projected["physical_read_bytes"], usable_seconds
+        ),
+        "physical_write_bytes_per_second": _ceil_ratio(
+            projected["physical_write_bytes"], usable_seconds
+        ),
+        "reader_calls_per_second": _ceil_ratio(projected["reader_calls"], usable_seconds),
+        "publication_work_per_second": _ceil_ratio(
+            projected["publication_work_units"], usable_seconds
+        ),
+    }
+    measured_capacity = all(
+        isinstance(capacity.get(name), int) and not isinstance(capacity.get(name), bool)
+        for name in required_rates
+    )
+    work_headroom = measured_capacity and all(
+        required * 5 <= capacity[name] * 4 for name, required in required_rates.items()
+    )
+    rss_growth = rss_high - rss_low
+    checks = {
+        "time_headroom": projected["wall_seconds"] <= WALL_LIMIT_SECONDS * 80 // 100,
+        "rss_headroom": projected["peak_rss_bytes"] <= RSS_LIMIT_BYTES * 80 // 100,
+        "retained_storage_headroom": projected["retained_storage_bytes"]
+        <= VOLUME_LIMIT_BYTES * 85 // 100,
+        "transient_storage_headroom": projected["transient_peak_storage_bytes"]
+        <= VOLUME_LIMIT_BYTES * 85 // 100,
+        "storage_headroom": storage_peak <= VOLUME_LIMIT_BYTES * 85 // 100,
+        "rss_bounded_or_plateaued": rss_growth <= rss_low * 10 // 100,
+        "io_reader_publication_capacity_measured": measured_capacity,
+        "io_reader_publication_headroom": work_headroom,
+        "correctness": True,
+    }
+    return {
+        "schema": "graphforge-progressive-qualification-evidence/1",
+        "target": f"S{profile.scale}",
+        "source_scales": list(profile.projection_sources),
+        "decision": Decision.ADMITTED if all(checks.values()) else Decision.REFUSED,
+        "limits": {
+            "wall_seconds": WALL_LIMIT_SECONDS,
+            "rss_bytes": RSS_LIMIT_BYTES,
+            "volume_bytes": VOLUME_LIMIT_BYTES,
+        },
+        "headroom": {
+            "time_fraction": TIME_HEADROOM,
+            "rss_fraction": RSS_HEADROOM,
+            "storage_fraction": STORAGE_HEADROOM,
+        },
+        "projected": projected | {"storage_peak_bytes": storage_peak},
+        "required_rates": required_rates,
+        "provider_capacity": dict(capacity) if measured_capacity else None,
+        "slopes_observed": {
+            name: _integer(high["metrics"], name) - _integer(low["metrics"], name)
+            for name in (
+                "logical_read_bytes",
+                "logical_write_bytes",
+                "physical_read_bytes",
+                "physical_write_bytes",
+                "reader_calls",
+                "publication_work_units",
+            )
+        },
+        "rss_growth_fraction": rss_growth_fraction,
+        "checks": checks,
+        "claim": "engineering_evidence_only",
+    }

--- a/benchmarks/harness/graphforge_bench/progressive_qualification.py
+++ b/benchmarks/harness/graphforge_bench/progressive_qualification.py
@@ -272,7 +272,9 @@ def project(
         },
         "projected": projected | {"storage_peak_bytes": storage_peak},
         "required_rates": required_rates,
-        "provider_capacity": dict(capacity) if measured_capacity else None,
+        "provider_capacity": (
+            {name: capacity[name] for name in required_rates} if measured_capacity else None
+        ),
         "slopes_observed": {
             name: _integer(high["metrics"], name) - _integer(low["metrics"], name)
             for name in (

--- a/benchmarks/harness/graphforge_bench/smoke.py
+++ b/benchmarks/harness/graphforge_bench/smoke.py
@@ -20,7 +20,7 @@ def discover_fixtures(root: Path | None = None) -> dict[str, tuple[Path, ...]]:
     discovered: dict[str, tuple[Path, ...]] = {}
     for directory in FIXTURE_DIRECTORIES:
         fixture_root = base / directory
-        fixtures = tuple(sorted(fixture_root.glob("*.json")))
+        fixtures = tuple(sorted(fixture_root.rglob("*.json")))
         if not fixtures:
             raise RuntimeError(f"no fixtures found in {directory}")
         for fixture in fixtures:

--- a/benchmarks/profiles/graph500/s18-local.json
+++ b/benchmarks/profiles/graph500/s18-local.json
@@ -1,0 +1,262 @@
+{
+  "schema": "graphforge-progressive-qualification-profile/1",
+  "id": "graph500-s18-local",
+  "scale": 18,
+  "execution": "local",
+  "executable": "gf",
+  "phases": [
+    {
+      "phase": "admission",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "--info"
+        ]
+      }
+    },
+    {
+      "phase": "generate",
+      "action": {
+        "interface": "benchmark_generator",
+        "identity": "sha256:3b4bdf5ae4f41523f911dc1998db2328dadd2fa9e5f95e49478f148e81a14ce2",
+        "executable": "graphforge-benchmark-graph500-generator",
+        "args": [
+          "--scale",
+          "18",
+          "--edge-factor",
+          "16",
+          "--seed",
+          "13907095936298285200",
+          "--nodes",
+          "workspace/s18/nodes.parquet",
+          "--edges",
+          "workspace/s18/edges.parquet"
+        ]
+      }
+    },
+    {
+      "phase": "ingest",
+      "action": {
+        "interface": "graph_forge_cli_workflow",
+        "commands": [
+          [
+            "--project",
+            "workspace/s18/source",
+            "import-session",
+            "begin",
+            "--operation-uuid",
+            "00000000-0000-4000-8000-000000000018"
+          ],
+          [
+            "--project",
+            "workspace/s18/source",
+            "import-session",
+            "register-parquet",
+            "--session-uuid",
+            "00000000-0000-4000-8000-000000000018",
+            "--path",
+            "workspace/s18/nodes.parquet",
+            "--kind",
+            "nodes"
+          ],
+          [
+            "--project",
+            "workspace/s18/source",
+            "import-session",
+            "register-parquet",
+            "--session-uuid",
+            "00000000-0000-4000-8000-000000000018",
+            "--path",
+            "workspace/s18/edges.parquet",
+            "--kind",
+            "edges"
+          ],
+          [
+            "--project",
+            "workspace/s18/source",
+            "import-session",
+            "validate",
+            "--session-uuid",
+            "00000000-0000-4000-8000-000000000018"
+          ],
+          [
+            "--project",
+            "workspace/s18/source",
+            "import-session",
+            "commit",
+            "--session-uuid",
+            "00000000-0000-4000-8000-000000000018"
+          ]
+        ]
+      }
+    },
+    {
+      "phase": "reopen",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "--project",
+          "workspace/s18/source",
+          "recovery"
+        ]
+      }
+    },
+    {
+      "phase": "recount",
+      "action": {
+        "interface": "graph_forge_cli_workflow",
+        "commands": [
+          [
+            "--project",
+            "workspace/s18/source",
+            "query",
+            "--cypher",
+            "MATCH (n) RETURN count(n)",
+            "--output",
+            "workspace/s18/node-count.arrow"
+          ],
+          [
+            "--project",
+            "workspace/s18/source",
+            "query",
+            "--cypher",
+            "MATCH ()-[r]->() RETURN count(r)",
+            "--output",
+            "workspace/s18/edge-count.arrow"
+          ]
+        ]
+      }
+    },
+    {
+      "phase": "query",
+      "action": {
+        "interface": "graph_forge_cli_workflow",
+        "commands": [
+          [
+            "--project",
+            "workspace/s18/source",
+            "query",
+            "--cypher",
+            "MATCH (a)-[r]->(b) RETURN a, r, b LIMIT 1024",
+            "--output",
+            "workspace/s18/one-hop.arrow"
+          ],
+          [
+            "--project",
+            "workspace/s18/source",
+            "query",
+            "--cypher",
+            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN a, r1, b, r2, c LIMIT 1024",
+            "--output",
+            "workspace/s18/two-hop.arrow"
+          ]
+        ]
+      }
+    },
+    {
+      "phase": "export",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "--project",
+          "workspace/s18/source",
+          "portable",
+          "export",
+          "--current",
+          "--output",
+          "workspace/s18/portable"
+        ]
+      }
+    },
+    {
+      "phase": "verify",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "portable",
+          "verify",
+          "--input",
+          "workspace/s18/portable"
+        ]
+      }
+    },
+    {
+      "phase": "clean_import",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "--project",
+          "workspace/s18/imported",
+          "portable",
+          "import",
+          "--input",
+          "workspace/s18/portable",
+          "--idempotency-key",
+          "00000000-0000-4000-8000-000000000018"
+        ]
+      }
+    },
+    {
+      "phase": "reopen_proof",
+      "action": {
+        "interface": "graph_forge_cli_workflow",
+        "commands": [
+          [
+            "--project",
+            "workspace/s18/imported",
+            "query",
+            "--cypher",
+            "MATCH (n) RETURN count(n)",
+            "--output",
+            "workspace/s18/imported-node-count.arrow"
+          ],
+          [
+            "--project",
+            "workspace/s18/imported",
+            "query",
+            "--cypher",
+            "MATCH ()-[r]->() RETURN count(r)",
+            "--output",
+            "workspace/s18/imported-edge-count.arrow"
+          ]
+        ]
+      }
+    }
+  ],
+  "generator": {
+    "identity": "sha256:3b4bdf5ae4f41523f911dc1998db2328dadd2fa9e5f95e49478f148e81a14ce2",
+    "edge_factor": 16,
+    "seed": 13907095936298285200
+  },
+  "lifecycle": {
+    "mechanics": "public-certification-v1",
+    "phases": [
+      "admission",
+      "generate",
+      "ingest",
+      "reopen",
+      "recount",
+      "query",
+      "export",
+      "verify",
+      "clean_import",
+      "reopen_proof"
+    ],
+    "evidence_schema": "graphforge-public-certification/1"
+  },
+  "gate": {
+    "requires_previous_pass": true,
+    "projection_source_scales": null,
+    "limits": {
+      "wall_seconds": 14400,
+      "rss_bytes": 4294967296,
+      "volume_bytes": 536870912000
+    },
+    "headroom": {
+      "time_fraction": 0.2,
+      "rss_fraction": 0.2,
+      "storage_fraction": 0.15,
+      "max_adjacent_rss_growth_fraction": 0.1
+    }
+  }
+}

--- a/benchmarks/profiles/graph500/s19-local.json
+++ b/benchmarks/profiles/graph500/s19-local.json
@@ -1,0 +1,262 @@
+{
+  "schema": "graphforge-progressive-qualification-profile/1",
+  "id": "graph500-s19-local",
+  "scale": 19,
+  "execution": "local",
+  "executable": "gf",
+  "phases": [
+    {
+      "phase": "admission",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "--info"
+        ]
+      }
+    },
+    {
+      "phase": "generate",
+      "action": {
+        "interface": "benchmark_generator",
+        "identity": "sha256:3b4bdf5ae4f41523f911dc1998db2328dadd2fa9e5f95e49478f148e81a14ce2",
+        "executable": "graphforge-benchmark-graph500-generator",
+        "args": [
+          "--scale",
+          "19",
+          "--edge-factor",
+          "16",
+          "--seed",
+          "13907095936298285200",
+          "--nodes",
+          "workspace/s19/nodes.parquet",
+          "--edges",
+          "workspace/s19/edges.parquet"
+        ]
+      }
+    },
+    {
+      "phase": "ingest",
+      "action": {
+        "interface": "graph_forge_cli_workflow",
+        "commands": [
+          [
+            "--project",
+            "workspace/s19/source",
+            "import-session",
+            "begin",
+            "--operation-uuid",
+            "00000000-0000-4000-8000-000000000019"
+          ],
+          [
+            "--project",
+            "workspace/s19/source",
+            "import-session",
+            "register-parquet",
+            "--session-uuid",
+            "00000000-0000-4000-8000-000000000019",
+            "--path",
+            "workspace/s19/nodes.parquet",
+            "--kind",
+            "nodes"
+          ],
+          [
+            "--project",
+            "workspace/s19/source",
+            "import-session",
+            "register-parquet",
+            "--session-uuid",
+            "00000000-0000-4000-8000-000000000019",
+            "--path",
+            "workspace/s19/edges.parquet",
+            "--kind",
+            "edges"
+          ],
+          [
+            "--project",
+            "workspace/s19/source",
+            "import-session",
+            "validate",
+            "--session-uuid",
+            "00000000-0000-4000-8000-000000000019"
+          ],
+          [
+            "--project",
+            "workspace/s19/source",
+            "import-session",
+            "commit",
+            "--session-uuid",
+            "00000000-0000-4000-8000-000000000019"
+          ]
+        ]
+      }
+    },
+    {
+      "phase": "reopen",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "--project",
+          "workspace/s19/source",
+          "recovery"
+        ]
+      }
+    },
+    {
+      "phase": "recount",
+      "action": {
+        "interface": "graph_forge_cli_workflow",
+        "commands": [
+          [
+            "--project",
+            "workspace/s19/source",
+            "query",
+            "--cypher",
+            "MATCH (n) RETURN count(n)",
+            "--output",
+            "workspace/s19/node-count.arrow"
+          ],
+          [
+            "--project",
+            "workspace/s19/source",
+            "query",
+            "--cypher",
+            "MATCH ()-[r]->() RETURN count(r)",
+            "--output",
+            "workspace/s19/edge-count.arrow"
+          ]
+        ]
+      }
+    },
+    {
+      "phase": "query",
+      "action": {
+        "interface": "graph_forge_cli_workflow",
+        "commands": [
+          [
+            "--project",
+            "workspace/s19/source",
+            "query",
+            "--cypher",
+            "MATCH (a)-[r]->(b) RETURN a, r, b LIMIT 1024",
+            "--output",
+            "workspace/s19/one-hop.arrow"
+          ],
+          [
+            "--project",
+            "workspace/s19/source",
+            "query",
+            "--cypher",
+            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN a, r1, b, r2, c LIMIT 1024",
+            "--output",
+            "workspace/s19/two-hop.arrow"
+          ]
+        ]
+      }
+    },
+    {
+      "phase": "export",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "--project",
+          "workspace/s19/source",
+          "portable",
+          "export",
+          "--current",
+          "--output",
+          "workspace/s19/portable"
+        ]
+      }
+    },
+    {
+      "phase": "verify",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "portable",
+          "verify",
+          "--input",
+          "workspace/s19/portable"
+        ]
+      }
+    },
+    {
+      "phase": "clean_import",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "--project",
+          "workspace/s19/imported",
+          "portable",
+          "import",
+          "--input",
+          "workspace/s19/portable",
+          "--idempotency-key",
+          "00000000-0000-4000-8000-000000000019"
+        ]
+      }
+    },
+    {
+      "phase": "reopen_proof",
+      "action": {
+        "interface": "graph_forge_cli_workflow",
+        "commands": [
+          [
+            "--project",
+            "workspace/s19/imported",
+            "query",
+            "--cypher",
+            "MATCH (n) RETURN count(n)",
+            "--output",
+            "workspace/s19/imported-node-count.arrow"
+          ],
+          [
+            "--project",
+            "workspace/s19/imported",
+            "query",
+            "--cypher",
+            "MATCH ()-[r]->() RETURN count(r)",
+            "--output",
+            "workspace/s19/imported-edge-count.arrow"
+          ]
+        ]
+      }
+    }
+  ],
+  "generator": {
+    "identity": "sha256:3b4bdf5ae4f41523f911dc1998db2328dadd2fa9e5f95e49478f148e81a14ce2",
+    "edge_factor": 16,
+    "seed": 13907095936298285200
+  },
+  "lifecycle": {
+    "mechanics": "public-certification-v1",
+    "phases": [
+      "admission",
+      "generate",
+      "ingest",
+      "reopen",
+      "recount",
+      "query",
+      "export",
+      "verify",
+      "clean_import",
+      "reopen_proof"
+    ],
+    "evidence_schema": "graphforge-public-certification/1"
+  },
+  "gate": {
+    "requires_previous_pass": true,
+    "projection_source_scales": null,
+    "limits": {
+      "wall_seconds": 14400,
+      "rss_bytes": 4294967296,
+      "volume_bytes": 536870912000
+    },
+    "headroom": {
+      "time_fraction": 0.2,
+      "rss_fraction": 0.2,
+      "storage_fraction": 0.15,
+      "max_adjacent_rss_growth_fraction": 0.1
+    }
+  }
+}

--- a/benchmarks/profiles/graph500/s20-provider.json
+++ b/benchmarks/profiles/graph500/s20-provider.json
@@ -1,0 +1,265 @@
+{
+  "schema": "graphforge-progressive-qualification-profile/1",
+  "id": "graph500-s20-provider",
+  "scale": 20,
+  "execution": "provider",
+  "executable": "gf",
+  "phases": [
+    {
+      "phase": "admission",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "--info"
+        ]
+      }
+    },
+    {
+      "phase": "generate",
+      "action": {
+        "interface": "benchmark_generator",
+        "identity": "sha256:3b4bdf5ae4f41523f911dc1998db2328dadd2fa9e5f95e49478f148e81a14ce2",
+        "executable": "graphforge-benchmark-graph500-generator",
+        "args": [
+          "--scale",
+          "20",
+          "--edge-factor",
+          "16",
+          "--seed",
+          "13907095936298285200",
+          "--nodes",
+          "workspace/s20/nodes.parquet",
+          "--edges",
+          "workspace/s20/edges.parquet"
+        ]
+      }
+    },
+    {
+      "phase": "ingest",
+      "action": {
+        "interface": "graph_forge_cli_workflow",
+        "commands": [
+          [
+            "--project",
+            "workspace/s20/source",
+            "import-session",
+            "begin",
+            "--operation-uuid",
+            "00000000-0000-4000-8000-000000000020"
+          ],
+          [
+            "--project",
+            "workspace/s20/source",
+            "import-session",
+            "register-parquet",
+            "--session-uuid",
+            "00000000-0000-4000-8000-000000000020",
+            "--path",
+            "workspace/s20/nodes.parquet",
+            "--kind",
+            "nodes"
+          ],
+          [
+            "--project",
+            "workspace/s20/source",
+            "import-session",
+            "register-parquet",
+            "--session-uuid",
+            "00000000-0000-4000-8000-000000000020",
+            "--path",
+            "workspace/s20/edges.parquet",
+            "--kind",
+            "edges"
+          ],
+          [
+            "--project",
+            "workspace/s20/source",
+            "import-session",
+            "validate",
+            "--session-uuid",
+            "00000000-0000-4000-8000-000000000020"
+          ],
+          [
+            "--project",
+            "workspace/s20/source",
+            "import-session",
+            "commit",
+            "--session-uuid",
+            "00000000-0000-4000-8000-000000000020"
+          ]
+        ]
+      }
+    },
+    {
+      "phase": "reopen",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "--project",
+          "workspace/s20/source",
+          "recovery"
+        ]
+      }
+    },
+    {
+      "phase": "recount",
+      "action": {
+        "interface": "graph_forge_cli_workflow",
+        "commands": [
+          [
+            "--project",
+            "workspace/s20/source",
+            "query",
+            "--cypher",
+            "MATCH (n) RETURN count(n)",
+            "--output",
+            "workspace/s20/node-count.arrow"
+          ],
+          [
+            "--project",
+            "workspace/s20/source",
+            "query",
+            "--cypher",
+            "MATCH ()-[r]->() RETURN count(r)",
+            "--output",
+            "workspace/s20/edge-count.arrow"
+          ]
+        ]
+      }
+    },
+    {
+      "phase": "query",
+      "action": {
+        "interface": "graph_forge_cli_workflow",
+        "commands": [
+          [
+            "--project",
+            "workspace/s20/source",
+            "query",
+            "--cypher",
+            "MATCH (a)-[r]->(b) RETURN a, r, b LIMIT 1024",
+            "--output",
+            "workspace/s20/one-hop.arrow"
+          ],
+          [
+            "--project",
+            "workspace/s20/source",
+            "query",
+            "--cypher",
+            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN a, r1, b, r2, c LIMIT 1024",
+            "--output",
+            "workspace/s20/two-hop.arrow"
+          ]
+        ]
+      }
+    },
+    {
+      "phase": "export",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "--project",
+          "workspace/s20/source",
+          "portable",
+          "export",
+          "--current",
+          "--output",
+          "workspace/s20/portable"
+        ]
+      }
+    },
+    {
+      "phase": "verify",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "portable",
+          "verify",
+          "--input",
+          "workspace/s20/portable"
+        ]
+      }
+    },
+    {
+      "phase": "clean_import",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "--project",
+          "workspace/s20/imported",
+          "portable",
+          "import",
+          "--input",
+          "workspace/s20/portable",
+          "--idempotency-key",
+          "00000000-0000-4000-8000-000000000020"
+        ]
+      }
+    },
+    {
+      "phase": "reopen_proof",
+      "action": {
+        "interface": "graph_forge_cli_workflow",
+        "commands": [
+          [
+            "--project",
+            "workspace/s20/imported",
+            "query",
+            "--cypher",
+            "MATCH (n) RETURN count(n)",
+            "--output",
+            "workspace/s20/imported-node-count.arrow"
+          ],
+          [
+            "--project",
+            "workspace/s20/imported",
+            "query",
+            "--cypher",
+            "MATCH ()-[r]->() RETURN count(r)",
+            "--output",
+            "workspace/s20/imported-edge-count.arrow"
+          ]
+        ]
+      }
+    }
+  ],
+  "generator": {
+    "identity": "sha256:3b4bdf5ae4f41523f911dc1998db2328dadd2fa9e5f95e49478f148e81a14ce2",
+    "edge_factor": 16,
+    "seed": 13907095936298285200
+  },
+  "lifecycle": {
+    "mechanics": "public-certification-v1",
+    "phases": [
+      "admission",
+      "generate",
+      "ingest",
+      "reopen",
+      "recount",
+      "query",
+      "export",
+      "verify",
+      "clean_import",
+      "reopen_proof"
+    ],
+    "evidence_schema": "graphforge-public-certification/1"
+  },
+  "gate": {
+    "requires_previous_pass": true,
+    "projection_source_scales": [
+      18,
+      19
+    ],
+    "limits": {
+      "wall_seconds": 14400,
+      "rss_bytes": 4294967296,
+      "volume_bytes": 536870912000
+    },
+    "headroom": {
+      "time_fraction": 0.2,
+      "rss_fraction": 0.2,
+      "storage_fraction": 0.15,
+      "max_adjacent_rss_growth_fraction": 0.1
+    }
+  }
+}

--- a/benchmarks/profiles/graph500/s22-provider.json
+++ b/benchmarks/profiles/graph500/s22-provider.json
@@ -1,0 +1,265 @@
+{
+  "schema": "graphforge-progressive-qualification-profile/1",
+  "id": "graph500-s22-provider",
+  "scale": 22,
+  "execution": "provider",
+  "executable": "gf",
+  "phases": [
+    {
+      "phase": "admission",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "--info"
+        ]
+      }
+    },
+    {
+      "phase": "generate",
+      "action": {
+        "interface": "benchmark_generator",
+        "identity": "sha256:3b4bdf5ae4f41523f911dc1998db2328dadd2fa9e5f95e49478f148e81a14ce2",
+        "executable": "graphforge-benchmark-graph500-generator",
+        "args": [
+          "--scale",
+          "22",
+          "--edge-factor",
+          "16",
+          "--seed",
+          "13907095936298285200",
+          "--nodes",
+          "workspace/s22/nodes.parquet",
+          "--edges",
+          "workspace/s22/edges.parquet"
+        ]
+      }
+    },
+    {
+      "phase": "ingest",
+      "action": {
+        "interface": "graph_forge_cli_workflow",
+        "commands": [
+          [
+            "--project",
+            "workspace/s22/source",
+            "import-session",
+            "begin",
+            "--operation-uuid",
+            "00000000-0000-4000-8000-000000000022"
+          ],
+          [
+            "--project",
+            "workspace/s22/source",
+            "import-session",
+            "register-parquet",
+            "--session-uuid",
+            "00000000-0000-4000-8000-000000000022",
+            "--path",
+            "workspace/s22/nodes.parquet",
+            "--kind",
+            "nodes"
+          ],
+          [
+            "--project",
+            "workspace/s22/source",
+            "import-session",
+            "register-parquet",
+            "--session-uuid",
+            "00000000-0000-4000-8000-000000000022",
+            "--path",
+            "workspace/s22/edges.parquet",
+            "--kind",
+            "edges"
+          ],
+          [
+            "--project",
+            "workspace/s22/source",
+            "import-session",
+            "validate",
+            "--session-uuid",
+            "00000000-0000-4000-8000-000000000022"
+          ],
+          [
+            "--project",
+            "workspace/s22/source",
+            "import-session",
+            "commit",
+            "--session-uuid",
+            "00000000-0000-4000-8000-000000000022"
+          ]
+        ]
+      }
+    },
+    {
+      "phase": "reopen",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "--project",
+          "workspace/s22/source",
+          "recovery"
+        ]
+      }
+    },
+    {
+      "phase": "recount",
+      "action": {
+        "interface": "graph_forge_cli_workflow",
+        "commands": [
+          [
+            "--project",
+            "workspace/s22/source",
+            "query",
+            "--cypher",
+            "MATCH (n) RETURN count(n)",
+            "--output",
+            "workspace/s22/node-count.arrow"
+          ],
+          [
+            "--project",
+            "workspace/s22/source",
+            "query",
+            "--cypher",
+            "MATCH ()-[r]->() RETURN count(r)",
+            "--output",
+            "workspace/s22/edge-count.arrow"
+          ]
+        ]
+      }
+    },
+    {
+      "phase": "query",
+      "action": {
+        "interface": "graph_forge_cli_workflow",
+        "commands": [
+          [
+            "--project",
+            "workspace/s22/source",
+            "query",
+            "--cypher",
+            "MATCH (a)-[r]->(b) RETURN a, r, b LIMIT 1024",
+            "--output",
+            "workspace/s22/one-hop.arrow"
+          ],
+          [
+            "--project",
+            "workspace/s22/source",
+            "query",
+            "--cypher",
+            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN a, r1, b, r2, c LIMIT 1024",
+            "--output",
+            "workspace/s22/two-hop.arrow"
+          ]
+        ]
+      }
+    },
+    {
+      "phase": "export",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "--project",
+          "workspace/s22/source",
+          "portable",
+          "export",
+          "--current",
+          "--output",
+          "workspace/s22/portable"
+        ]
+      }
+    },
+    {
+      "phase": "verify",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "portable",
+          "verify",
+          "--input",
+          "workspace/s22/portable"
+        ]
+      }
+    },
+    {
+      "phase": "clean_import",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "--project",
+          "workspace/s22/imported",
+          "portable",
+          "import",
+          "--input",
+          "workspace/s22/portable",
+          "--idempotency-key",
+          "00000000-0000-4000-8000-000000000022"
+        ]
+      }
+    },
+    {
+      "phase": "reopen_proof",
+      "action": {
+        "interface": "graph_forge_cli_workflow",
+        "commands": [
+          [
+            "--project",
+            "workspace/s22/imported",
+            "query",
+            "--cypher",
+            "MATCH (n) RETURN count(n)",
+            "--output",
+            "workspace/s22/imported-node-count.arrow"
+          ],
+          [
+            "--project",
+            "workspace/s22/imported",
+            "query",
+            "--cypher",
+            "MATCH ()-[r]->() RETURN count(r)",
+            "--output",
+            "workspace/s22/imported-edge-count.arrow"
+          ]
+        ]
+      }
+    }
+  ],
+  "generator": {
+    "identity": "sha256:3b4bdf5ae4f41523f911dc1998db2328dadd2fa9e5f95e49478f148e81a14ce2",
+    "edge_factor": 16,
+    "seed": 13907095936298285200
+  },
+  "lifecycle": {
+    "mechanics": "public-certification-v1",
+    "phases": [
+      "admission",
+      "generate",
+      "ingest",
+      "reopen",
+      "recount",
+      "query",
+      "export",
+      "verify",
+      "clean_import",
+      "reopen_proof"
+    ],
+    "evidence_schema": "graphforge-public-certification/1"
+  },
+  "gate": {
+    "requires_previous_pass": true,
+    "projection_source_scales": [
+      19,
+      20
+    ],
+    "limits": {
+      "wall_seconds": 14400,
+      "rss_bytes": 4294967296,
+      "volume_bytes": 536870912000
+    },
+    "headroom": {
+      "time_fraction": 0.2,
+      "rss_fraction": 0.2,
+      "storage_fraction": 0.15,
+      "max_adjacent_rss_growth_fraction": 0.1
+    }
+  }
+}

--- a/benchmarks/profiles/graph500/s26-provider.json
+++ b/benchmarks/profiles/graph500/s26-provider.json
@@ -1,0 +1,265 @@
+{
+  "schema": "graphforge-progressive-qualification-profile/1",
+  "id": "graph500-s26-provider",
+  "scale": 26,
+  "execution": "provider",
+  "executable": "gf",
+  "phases": [
+    {
+      "phase": "admission",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "--info"
+        ]
+      }
+    },
+    {
+      "phase": "generate",
+      "action": {
+        "interface": "benchmark_generator",
+        "identity": "sha256:3b4bdf5ae4f41523f911dc1998db2328dadd2fa9e5f95e49478f148e81a14ce2",
+        "executable": "graphforge-benchmark-graph500-generator",
+        "args": [
+          "--scale",
+          "26",
+          "--edge-factor",
+          "16",
+          "--seed",
+          "13907095936298285200",
+          "--nodes",
+          "workspace/s26/nodes.parquet",
+          "--edges",
+          "workspace/s26/edges.parquet"
+        ]
+      }
+    },
+    {
+      "phase": "ingest",
+      "action": {
+        "interface": "graph_forge_cli_workflow",
+        "commands": [
+          [
+            "--project",
+            "workspace/s26/source",
+            "import-session",
+            "begin",
+            "--operation-uuid",
+            "00000000-0000-4000-8000-000000000026"
+          ],
+          [
+            "--project",
+            "workspace/s26/source",
+            "import-session",
+            "register-parquet",
+            "--session-uuid",
+            "00000000-0000-4000-8000-000000000026",
+            "--path",
+            "workspace/s26/nodes.parquet",
+            "--kind",
+            "nodes"
+          ],
+          [
+            "--project",
+            "workspace/s26/source",
+            "import-session",
+            "register-parquet",
+            "--session-uuid",
+            "00000000-0000-4000-8000-000000000026",
+            "--path",
+            "workspace/s26/edges.parquet",
+            "--kind",
+            "edges"
+          ],
+          [
+            "--project",
+            "workspace/s26/source",
+            "import-session",
+            "validate",
+            "--session-uuid",
+            "00000000-0000-4000-8000-000000000026"
+          ],
+          [
+            "--project",
+            "workspace/s26/source",
+            "import-session",
+            "commit",
+            "--session-uuid",
+            "00000000-0000-4000-8000-000000000026"
+          ]
+        ]
+      }
+    },
+    {
+      "phase": "reopen",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "--project",
+          "workspace/s26/source",
+          "recovery"
+        ]
+      }
+    },
+    {
+      "phase": "recount",
+      "action": {
+        "interface": "graph_forge_cli_workflow",
+        "commands": [
+          [
+            "--project",
+            "workspace/s26/source",
+            "query",
+            "--cypher",
+            "MATCH (n) RETURN count(n)",
+            "--output",
+            "workspace/s26/node-count.arrow"
+          ],
+          [
+            "--project",
+            "workspace/s26/source",
+            "query",
+            "--cypher",
+            "MATCH ()-[r]->() RETURN count(r)",
+            "--output",
+            "workspace/s26/edge-count.arrow"
+          ]
+        ]
+      }
+    },
+    {
+      "phase": "query",
+      "action": {
+        "interface": "graph_forge_cli_workflow",
+        "commands": [
+          [
+            "--project",
+            "workspace/s26/source",
+            "query",
+            "--cypher",
+            "MATCH (a)-[r]->(b) RETURN a, r, b LIMIT 1024",
+            "--output",
+            "workspace/s26/one-hop.arrow"
+          ],
+          [
+            "--project",
+            "workspace/s26/source",
+            "query",
+            "--cypher",
+            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN a, r1, b, r2, c LIMIT 1024",
+            "--output",
+            "workspace/s26/two-hop.arrow"
+          ]
+        ]
+      }
+    },
+    {
+      "phase": "export",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "--project",
+          "workspace/s26/source",
+          "portable",
+          "export",
+          "--current",
+          "--output",
+          "workspace/s26/portable"
+        ]
+      }
+    },
+    {
+      "phase": "verify",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "portable",
+          "verify",
+          "--input",
+          "workspace/s26/portable"
+        ]
+      }
+    },
+    {
+      "phase": "clean_import",
+      "action": {
+        "interface": "graph_forge_cli",
+        "args": [
+          "--project",
+          "workspace/s26/imported",
+          "portable",
+          "import",
+          "--input",
+          "workspace/s26/portable",
+          "--idempotency-key",
+          "00000000-0000-4000-8000-000000000026"
+        ]
+      }
+    },
+    {
+      "phase": "reopen_proof",
+      "action": {
+        "interface": "graph_forge_cli_workflow",
+        "commands": [
+          [
+            "--project",
+            "workspace/s26/imported",
+            "query",
+            "--cypher",
+            "MATCH (n) RETURN count(n)",
+            "--output",
+            "workspace/s26/imported-node-count.arrow"
+          ],
+          [
+            "--project",
+            "workspace/s26/imported",
+            "query",
+            "--cypher",
+            "MATCH ()-[r]->() RETURN count(r)",
+            "--output",
+            "workspace/s26/imported-edge-count.arrow"
+          ]
+        ]
+      }
+    }
+  ],
+  "generator": {
+    "identity": "sha256:3b4bdf5ae4f41523f911dc1998db2328dadd2fa9e5f95e49478f148e81a14ce2",
+    "edge_factor": 16,
+    "seed": 13907095936298285200
+  },
+  "lifecycle": {
+    "mechanics": "public-certification-v1",
+    "phases": [
+      "admission",
+      "generate",
+      "ingest",
+      "reopen",
+      "recount",
+      "query",
+      "export",
+      "verify",
+      "clean_import",
+      "reopen_proof"
+    ],
+    "evidence_schema": "graphforge-public-certification/1"
+  },
+  "gate": {
+    "requires_previous_pass": true,
+    "projection_source_scales": [
+      24,
+      25
+    ],
+    "limits": {
+      "wall_seconds": 14400,
+      "rss_bytes": 4294967296,
+      "volume_bytes": 536870912000
+    },
+    "headroom": {
+      "time_fraction": 0.2,
+      "rss_fraction": 0.2,
+      "storage_fraction": 0.15,
+      "max_adjacent_rss_growth_fraction": 0.1
+    }
+  }
+}

--- a/benchmarks/reframe/checks/progressive_qualification.py
+++ b/benchmarks/reframe/checks/progressive_qualification.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+import reframe as rfm
+from reframe.core.builtins import parameter, run_after, sanity_function
+import reframe.utility.sanity as sn
+
+
+@rfm.simple_test
+class Graph500ProgressiveQualificationProfile(rfm.RunOnlyRegressionTest):
+    """Manual-only execution of an ordinary GraphForge qualification profile."""
+
+    profile_id = parameter(
+        [
+            "graph500-s18-local",
+            "graph500-s19-local",
+            "graph500-s20-provider",
+            "graph500-s22-provider",
+            "graph500-s26-provider",
+        ]
+    )
+    valid_prog_environs = ["builtin"]  # noqa: RUF012
+    tags = {"manual", "graph500-progressive"}  # noqa: RUF012
+    executable = "cargo"
+
+    @run_after("init")
+    def configure_profile(self):
+        root = Path(__file__).resolve().parents[2]
+        execution = "local" if self.profile_id.endswith("-local") else "provider"
+        self.valid_systems = (  # unavailable provider profiles cannot pass on local
+            ["graphforge-local:local"]
+            if execution == "local"
+            else ["graphforge-provider:provider"]
+        )
+        self.executable_opts = [
+            "run",
+            "--locked",
+            "--manifest-path",
+            str(root / "Cargo.toml"),
+            "-p",
+            "graphforge-benchmark-certify",
+            "--",
+            "run",
+            str(root / "profiles/graph500" / f"{self.profile_id.removeprefix('graph500-')}.json"),
+            "evidence.json",
+        ]
+
+    @sanity_function
+    def validate_completed_lifecycle(self):
+        return sn.all(
+            [
+                sn.assert_eq(self.exitcode, 0),
+                sn.assert_found(r'"phase":"reopen_proof"', self.stdout),
+                sn.assert_found(r'"status":"passed"', self.stdout),
+            ]
+        )

--- a/benchmarks/reframe/checks/progressive_qualification.py
+++ b/benchmarks/reframe/checks/progressive_qualification.py
@@ -27,9 +27,7 @@ class Graph500ProgressiveQualificationProfile(rfm.RunOnlyRegressionTest):
         root = Path(__file__).resolve().parents[2]
         execution = "local" if self.profile_id.endswith("-local") else "provider"
         self.valid_systems = (  # unavailable provider profiles cannot pass on local
-            ["graphforge-local:local"]
-            if execution == "local"
-            else ["graphforge-provider:provider"]
+            ["graphforge-local:local"] if execution == "local" else ["graphforge-provider:provider"]
         )
         self.executable_opts = [
             "run",

--- a/benchmarks/runners/certify/src/lib.rs
+++ b/benchmarks/runners/certify/src/lib.rs
@@ -55,15 +55,40 @@ pub struct Profile {
     pub id: String,
     pub executable: String,
     pub phases: Vec<PhaseCommand>,
+    #[serde(default)]
+    pub scale: Option<u8>,
+    #[serde(default)]
+    pub execution: Option<String>,
+    #[serde(default)]
+    pub generator: Option<serde_json::Value>,
+    #[serde(default)]
+    pub lifecycle: Option<serde_json::Value>,
+    #[serde(default)]
+    pub gate: Option<serde_json::Value>,
 }
 
 impl Profile {
     pub fn validate(&self) -> Result<(), RunnerError> {
-        if self.schema != "graphforge-public-certification-profile/1" {
+        if !matches!(
+            self.schema.as_str(),
+            "graphforge-public-certification-profile/1"
+                | "graphforge-progressive-qualification-profile/1"
+        ) {
             return Err(RunnerError::Profile("unsupported profile schema"));
         }
         if !is_safe_token(&self.id) {
             return Err(RunnerError::Profile("profile id must be a safe token"));
+        }
+        if self.schema == "graphforge-progressive-qualification-profile/1"
+            && (self.scale.is_none()
+                || !matches!(self.execution.as_deref(), Some("local" | "provider"))
+                || self.generator.is_none()
+                || self.lifecycle.is_none()
+                || self.gate.is_none())
+        {
+            return Err(RunnerError::Profile(
+                "progressive profile requires its qualification contract",
+            ));
         }
         if !is_graphforge_executable(&self.executable) {
             return Err(RunnerError::Profile(
@@ -112,6 +137,9 @@ pub enum PhaseAction {
     GraphForgeCli {
         args: Vec<String>,
     },
+    GraphForgeCliWorkflow {
+        commands: Vec<Vec<String>>,
+    },
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -119,6 +147,7 @@ pub struct Execution {
     pub exit_code: Option<i32>,
     pub duration_ms: u64,
     pub peak_rss_bytes: Option<u64>,
+    pub failure: Option<FailureKind>,
 }
 
 pub trait PhaseExecutor {
@@ -130,35 +159,73 @@ pub struct PublicProcessExecutor;
 
 impl PhaseExecutor for PublicProcessExecutor {
     fn execute(&mut self, profile: &Profile, command: &PhaseCommand) -> Result<Execution, String> {
+        if let PhaseAction::GraphForgeCliWorkflow { commands } = &command.action {
+            let started = Instant::now();
+            let mut peak_rss_bytes = None;
+            for args in commands {
+                let execution = match execute_process(&profile.executable, args) {
+                    Ok(execution) => execution,
+                    Err(_) => {
+                        return Ok(Execution {
+                            exit_code: None,
+                            duration_ms: millis(started.elapsed()),
+                            peak_rss_bytes,
+                            failure: Some(FailureKind::CommandUnavailable),
+                        });
+                    }
+                };
+                peak_rss_bytes = max_optional(peak_rss_bytes, execution.peak_rss_bytes);
+                if execution.exit_code != Some(0) {
+                    return Ok(Execution {
+                        exit_code: execution.exit_code,
+                        duration_ms: millis(started.elapsed()),
+                        peak_rss_bytes,
+                        failure: execution.failure,
+                    });
+                }
+            }
+            return Ok(Execution {
+                exit_code: Some(0),
+                duration_ms: millis(started.elapsed()),
+                peak_rss_bytes,
+                failure: None,
+            });
+        }
         let (executable, args) = match &command.action {
             PhaseAction::BenchmarkGenerator {
                 executable, args, ..
             } => (executable.as_str(), args.as_slice()),
             PhaseAction::GraphForgeCli { args } => (profile.executable.as_str(), args.as_slice()),
+            PhaseAction::GraphForgeCliWorkflow { .. } => unreachable!("handled above"),
         };
-        let started = Instant::now();
-        let mut child = Command::new(executable)
-            .args(args)
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-            .map_err(|_| "public command could not start".to_owned())?;
-        let mut peak_rss_bytes = None;
-        loop {
-            peak_rss_bytes = max_optional(peak_rss_bytes, resident_bytes(child.id()));
-            if let Some(status) = child
-                .try_wait()
-                .map_err(|_| "public command wait failed".to_owned())?
-            {
-                return Ok(Execution {
-                    exit_code: status.code(),
-                    duration_ms: millis(started.elapsed()),
-                    peak_rss_bytes,
-                });
-            }
-            thread::sleep(Duration::from_millis(10));
+        execute_process(executable, args)
+    }
+}
+
+fn execute_process(executable: &str, args: &[String]) -> Result<Execution, String> {
+    let started = Instant::now();
+    let mut child = Command::new(executable)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|_| "public command could not start".to_owned())?;
+    let mut peak_rss_bytes = None;
+    loop {
+        peak_rss_bytes = max_optional(peak_rss_bytes, resident_bytes(child.id()));
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|_| "public command wait failed".to_owned())?
+        {
+            return Ok(Execution {
+                exit_code: status.code(),
+                duration_ms: millis(started.elapsed()),
+                peak_rss_bytes,
+                failure: None,
+            });
         }
+        thread::sleep(Duration::from_millis(10));
     }
 }
 
@@ -223,7 +290,7 @@ pub fn certify_with_events(
     for command in &profile.phases {
         let outcome = match executor.execute(profile, command) {
             Ok(execution) => {
-                let passed = execution.exit_code == Some(0);
+                let passed = execution.exit_code == Some(0) && execution.failure.is_none();
                 PhaseOutcome {
                     phase: command.phase,
                     status: if passed {
@@ -234,7 +301,11 @@ pub fn certify_with_events(
                     duration_ms: execution.duration_ms,
                     peak_rss_bytes: execution.peak_rss_bytes,
                     exit_code: execution.exit_code,
-                    failure: (!passed).then_some(FailureKind::CommandFailed),
+                    failure: if passed {
+                        None
+                    } else {
+                        execution.failure.or(Some(FailureKind::CommandFailed))
+                    },
                 }
             }
             Err(_) => PhaseOutcome {
@@ -416,10 +487,17 @@ fn action_matches_phase(command: &PhaseCommand) -> bool {
     } = &command.action
     {
         return command.phase == Phase::Generate
-            && is_safe_token(identity)
+            && is_sha256_identity(identity)
             && !executable.is_empty()
             && !executable.contains('\0')
             && args.iter().all(|argument| !argument.contains('\0'));
+    }
+    if let PhaseAction::GraphForgeCliWorkflow { commands } = &command.action {
+        return match command.phase {
+            Phase::Ingest => ingest_workflow_is_valid(commands),
+            Phase::Recount | Phase::Query | Phase::ReopenProof => query_workflow_is_valid(commands),
+            _ => false,
+        };
     }
     let PhaseAction::GraphForgeCli { args } = &command.action else {
         return false;
@@ -444,6 +522,42 @@ fn action_matches_phase(command: &PhaseCommand) -> bool {
         Phase::Verify => contains_command(&args, &["portable", "verify"]),
         Phase::CleanImport => contains_command(&args, &["portable", "import"]),
     }
+}
+
+fn is_sha256_identity(value: &str) -> bool {
+    value.strip_prefix("sha256:").is_some_and(|digest| {
+        digest.len() == 64 && digest.bytes().all(|byte| byte.is_ascii_hexdigit())
+    })
+}
+
+fn query_workflow_is_valid(commands: &[Vec<String>]) -> bool {
+    commands.len() == 2
+        && commands.iter().all(|args| {
+            args.iter().all(|argument| !argument.contains('\0'))
+                && contains_command(
+                    &args.iter().map(String::as_str).collect::<Vec<_>>(),
+                    &["query"],
+                )
+        })
+}
+
+fn ingest_workflow_is_valid(commands: &[Vec<String>]) -> bool {
+    const OPERATIONS: [&str; 5] = [
+        "begin",
+        "register-parquet",
+        "register-parquet",
+        "validate",
+        "commit",
+    ];
+    commands.len() == OPERATIONS.len()
+        && commands.iter().zip(OPERATIONS).all(|(args, operation)| {
+            !args.is_empty()
+                && args.iter().all(|argument| !argument.contains('\0'))
+                && contains_command(
+                    &args.iter().map(String::as_str).collect::<Vec<_>>(),
+                    &["import-session", operation],
+                )
+        })
 }
 
 fn contains_command(arguments: &[&str], command: &[&str]) -> bool {
@@ -485,6 +599,8 @@ fn resident_bytes(_pid: u32) -> Option<u64> {
 mod tests {
     use super::*;
     use std::collections::VecDeque;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
 
     struct FakeExecutor {
         executions: VecDeque<Result<Execution, String>>,
@@ -513,9 +629,13 @@ mod tests {
                     phase,
                     action: if phase == Phase::Generate {
                         PhaseAction::BenchmarkGenerator {
-                            identity: "tiny-generator-v1".to_owned(),
+                            identity: format!("sha256:{}", "0".repeat(64)),
                             executable: "tiny-generator".to_owned(),
                             args: vec!["--scale".to_owned(), "tiny".to_owned()],
+                        }
+                    } else if phase == Phase::Ingest {
+                        PhaseAction::GraphForgeCliWorkflow {
+                            commands: ingest_commands(),
                         }
                     } else {
                         PhaseAction::GraphForgeCli {
@@ -524,7 +644,35 @@ mod tests {
                     },
                 })
                 .collect(),
+            scale: None,
+            execution: None,
+            generator: None,
+            lifecycle: None,
+            gate: None,
         }
+    }
+
+    fn ingest_commands() -> Vec<Vec<String>> {
+        [
+            "begin",
+            "register-parquet",
+            "register-parquet",
+            "validate",
+            "commit",
+        ]
+        .into_iter()
+        .map(|operation| {
+            [
+                "--project",
+                "generated/tiny-source",
+                "import-session",
+                operation,
+            ]
+            .into_iter()
+            .map(str::to_owned)
+            .collect()
+        })
+        .collect()
     }
 
     fn tiny_args(phase: Phase) -> Vec<String> {
@@ -594,6 +742,7 @@ mod tests {
             exit_code: Some(0),
             duration_ms: index + 1,
             peak_rss_bytes: Some((index + 1) * 1_024),
+            failure: None,
         })
     }
 
@@ -626,6 +775,7 @@ mod tests {
             exit_code: Some(7),
             duration_ms: 4,
             peak_rss_bytes: Some(4_096),
+            failure: None,
         }));
         executions.extend((4..10).map(passed_execution));
         let mut executor = FakeExecutor {
@@ -682,5 +832,70 @@ mod tests {
                 "phase action must select the matching benchmark or public gf operation"
             ))
         );
+    }
+
+    #[test]
+    fn ingest_workflow_requires_the_complete_ordered_transaction() {
+        let mut profile = tiny_profile();
+        let PhaseAction::GraphForgeCliWorkflow { commands } = &mut profile.phases[2].action else {
+            panic!("ingest fixture must be a workflow");
+        };
+        commands.swap(3, 4);
+        assert!(profile.validate().is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn public_executor_runs_ingest_transaction_in_order() {
+        let root = std::env::temp_dir().join(format!("gf-certify-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        let executable = root.join("gf");
+        let state = root.join("state");
+        fs::write(
+            &executable,
+            format!(
+                "#!/bin/sh\nstate='{}'\nn=0\n[ ! -f \"$state\" ] || n=$(cat \"$state\")\ncase \"$*\" in\n  *'import-session begin') expected=0;;\n  *'import-session register-parquet') if [ \"$n\" = 1 ]; then expected=1; else expected=2; fi;;\n  *'import-session validate') expected=3;;\n  *'import-session commit') expected=4;;\n  *) exit 41;;\nesac\n[ \"$n\" = \"$expected\" ] || exit 42\necho $((n + 1)) > \"$state\"\n",
+                state.display()
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
+        let mut profile = tiny_profile();
+        profile.executable = executable.to_string_lossy().into_owned();
+        let mut executor = PublicProcessExecutor;
+        let result = executor.execute(&profile, &profile.phases[2]).unwrap();
+        assert_eq!(result.exit_code, Some(0));
+        assert_eq!(fs::read_to_string(state).unwrap().trim(), "5");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn public_executor_stops_ingest_at_first_child_failure() {
+        let root = std::env::temp_dir().join(format!("gf-certify-fail-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        let executable = root.join("gf");
+        let calls = root.join("calls");
+        fs::write(
+            &executable,
+            format!(
+                "#!/bin/sh\necho \"$*\" >> '{}'\ncase \"$*\" in *'import-session validate'*) exit 23;; esac\n",
+                calls.display()
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
+        let mut profile = tiny_profile();
+        profile.executable = executable.to_string_lossy().into_owned();
+        let result = PublicProcessExecutor
+            .execute(&profile, &profile.phases[2])
+            .unwrap();
+        assert_eq!(result.exit_code, Some(23));
+        let calls = fs::read_to_string(calls).unwrap();
+        assert_eq!(calls.lines().count(), 4);
+        assert!(!calls.contains("import-session commit"));
+        fs::remove_dir_all(root).unwrap();
     }
 }

--- a/benchmarks/runners/certify/src/lib.rs
+++ b/benchmarks/runners/certify/src/lib.rs
@@ -80,11 +80,7 @@ impl Profile {
             return Err(RunnerError::Profile("profile id must be a safe token"));
         }
         if self.schema == "graphforge-progressive-qualification-profile/1"
-            && (self.scale.is_none()
-                || !matches!(self.execution.as_deref(), Some("local" | "provider"))
-                || self.generator.is_none()
-                || self.lifecycle.is_none()
-                || self.gate.is_none())
+            && !self.progressive_contract_is_valid()
         {
             return Err(RunnerError::Profile(
                 "progressive profile requires its qualification contract",
@@ -117,6 +113,102 @@ impl Profile {
         }
         Ok(())
     }
+
+    fn progressive_contract_is_valid(&self) -> bool {
+        let (Some(scale), Some(execution), Some(generator), Some(lifecycle), Some(gate)) = (
+            self.scale,
+            self.execution.as_deref(),
+            self.generator.clone(),
+            self.lifecycle.clone(),
+            self.gate.clone(),
+        ) else {
+            return false;
+        };
+        let Ok(generator) = serde_json::from_value::<ProgressiveGenerator>(generator) else {
+            return false;
+        };
+        let Ok(lifecycle) = serde_json::from_value::<ProgressiveLifecycle>(lifecycle) else {
+            return false;
+        };
+        let Ok(gate) = serde_json::from_value::<ProgressiveGate>(gate) else {
+            return false;
+        };
+        let expected = match scale {
+            18 | 19 => ("local", None),
+            20 => ("provider", Some([18, 19])),
+            22 => ("provider", Some([19, 20])),
+            26 => ("provider", Some([24, 25])),
+            _ => return false,
+        };
+        execution == expected.0
+            && generator.identity == generator_identity(&self.phases)
+            && generator.edge_factor == 16
+            && generator.seed == 13_907_095_936_298_285_200
+            && lifecycle.mechanics == "public-certification-v1"
+            && lifecycle.phases == Phase::ALL
+            && lifecycle.evidence_schema == EVIDENCE_SCHEMA
+            && gate.requires_previous_pass
+            && gate.projection_source_scales == expected.1
+            && gate.limits.wall_seconds == 14_400
+            && gate.limits.rss_bytes == 4_294_967_296
+            && gate.limits.volume_bytes == 536_870_912_000
+            && gate.headroom.time_fraction == 0.2
+            && gate.headroom.rss_fraction == 0.2
+            && gate.headroom.storage_fraction == 0.15
+            && gate.headroom.max_adjacent_rss_growth_fraction == 0.1
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ProgressiveGenerator {
+    identity: String,
+    edge_factor: u8,
+    seed: u64,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ProgressiveLifecycle {
+    mechanics: String,
+    phases: Vec<Phase>,
+    evidence_schema: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ProgressiveGate {
+    requires_previous_pass: bool,
+    projection_source_scales: Option<[u8; 2]>,
+    limits: ProgressiveLimits,
+    headroom: ProgressiveHeadroom,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ProgressiveLimits {
+    wall_seconds: u64,
+    rss_bytes: u64,
+    volume_bytes: u64,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ProgressiveHeadroom {
+    time_fraction: f64,
+    rss_fraction: f64,
+    storage_fraction: f64,
+    max_adjacent_rss_growth_fraction: f64,
+}
+
+fn generator_identity(phases: &[PhaseCommand]) -> String {
+    phases
+        .iter()
+        .find_map(|command| match &command.action {
+            PhaseAction::BenchmarkGenerator { identity, .. } => Some(identity.clone()),
+            _ => None,
+        })
+        .unwrap_or_default()
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
@@ -526,7 +618,10 @@ fn action_matches_phase(command: &PhaseCommand) -> bool {
 
 fn is_sha256_identity(value: &str) -> bool {
     value.strip_prefix("sha256:").is_some_and(|digest| {
-        digest.len() == 64 && digest.bytes().all(|byte| byte.is_ascii_hexdigit())
+        digest.len() == 64
+            && digest
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
     })
 }
 
@@ -650,6 +745,41 @@ mod tests {
             lifecycle: None,
             gate: None,
         }
+    }
+
+    fn progressive_profile() -> Profile {
+        let mut profile = tiny_profile();
+        let identity = generator_identity(&profile.phases);
+        profile.schema = "graphforge-progressive-qualification-profile/1".to_owned();
+        profile.id = "graph500-s20-provider".to_owned();
+        profile.scale = Some(20);
+        profile.execution = Some("provider".to_owned());
+        profile.generator = Some(serde_json::json!({
+            "identity": identity,
+            "edge_factor": 16,
+            "seed": 13_907_095_936_298_285_200_u64
+        }));
+        profile.lifecycle = Some(serde_json::json!({
+            "mechanics": "public-certification-v1",
+            "phases": Phase::ALL,
+            "evidence_schema": EVIDENCE_SCHEMA
+        }));
+        profile.gate = Some(serde_json::json!({
+            "requires_previous_pass": true,
+            "projection_source_scales": [18, 19],
+            "limits": {
+                "wall_seconds": 14_400,
+                "rss_bytes": 4_294_967_296_u64,
+                "volume_bytes": 536_870_912_000_u64
+            },
+            "headroom": {
+                "time_fraction": 0.2,
+                "rss_fraction": 0.2,
+                "storage_fraction": 0.15,
+                "max_adjacent_rss_growth_fraction": 0.1
+            }
+        }));
+        profile
     }
 
     fn ingest_commands() -> Vec<Vec<String>> {
@@ -842,6 +972,33 @@ mod tests {
         };
         commands.swap(3, 4);
         assert!(profile.validate().is_err());
+    }
+
+    #[test]
+    fn progressive_profile_contract_is_typed_and_scale_specific() {
+        let profile = progressive_profile();
+        assert_eq!(profile.validate(), Ok(()));
+        for malformed in [
+            serde_json::json!([]),
+            serde_json::json!({}),
+            serde_json::json!({"identity": 42, "edge_factor": 16, "seed": 1}),
+        ] {
+            let mut profile = progressive_profile();
+            profile.generator = Some(malformed);
+            assert!(profile.validate().is_err());
+        }
+        let mut profile = progressive_profile();
+        profile.scale = Some(0);
+        assert!(profile.validate().is_err());
+        let mut profile = progressive_profile();
+        profile.gate.as_mut().unwrap()["projection_source_scales"] = serde_json::json!([24, 25]);
+        assert!(profile.validate().is_err());
+    }
+
+    #[test]
+    fn generator_digest_must_be_lowercase_hex() {
+        assert!(is_sha256_identity(&format!("sha256:{}", "a".repeat(64))));
+        assert!(!is_sha256_identity(&format!("sha256:{}", "A".repeat(64))));
     }
 
     #[cfg(unix)]

--- a/benchmarks/runners/certify/src/main.rs
+++ b/benchmarks/runners/certify/src/main.rs
@@ -16,6 +16,10 @@ fn main() {
 fn run() -> Result<(), &'static str> {
     let arguments: Vec<String> = env::args().skip(1).collect();
     match arguments.as_slice() {
+        [command, profile] if command == "validate" => {
+            let profile = read_profile(Path::new(profile)).map_err(|_| "invalid profile")?;
+            profile.validate().map_err(|_| "invalid profile")
+        }
         [command, profile, evidence] if command == "run" => {
             let profile = read_profile(Path::new(profile)).map_err(|_| "invalid profile")?;
             let mut executor = PublicProcessExecutor;
@@ -39,6 +43,8 @@ fn run() -> Result<(), &'static str> {
             let evidence = normalize_evidence(&input).map_err(|_| "legacy evidence invalid")?;
             write_evidence(Path::new(output), &evidence).map_err(|_| "evidence write failed")
         }
-        _ => Err("usage: graphforge-benchmark-certify <run PROFILE OUTPUT|normalize INPUT OUTPUT>"),
+        _ => Err(
+            "usage: graphforge-benchmark-certify <validate PROFILE|run PROFILE OUTPUT|normalize INPUT OUTPUT>",
+        ),
     }
 }

--- a/benchmarks/runners/graph500-generator/Cargo.toml
+++ b/benchmarks/runners/graph500-generator/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "graphforge-benchmark-graph500-generator"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+rust-version.workspace = true
+
+[[bin]]
+name = "graphforge-benchmark-graph500-generator"
+path = "src/main.rs"
+
+[dependencies]
+arrow.workspace = true
+parquet.workspace = true

--- a/benchmarks/runners/graph500-generator/src/main.rs
+++ b/benchmarks/runners/graph500-generator/src/main.rs
@@ -1,0 +1,216 @@
+#![forbid(unsafe_code)]
+
+use std::env;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use arrow::array::{FixedSizeBinaryArray, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use parquet::arrow::ArrowWriter;
+
+const BATCH_ROWS: u64 = 65_536;
+const A: u64 = 57;
+const B: u64 = 19;
+const C: u64 = 19;
+const D: u64 = 5;
+
+#[derive(Debug)]
+struct Config {
+    scale: u32,
+    edge_factor: u64,
+    seed: u64,
+    nodes: PathBuf,
+    edges: PathBuf,
+}
+
+fn main() -> Result<(), String> {
+    let config = parse_args()?;
+    if !(1..=26).contains(&config.scale) || config.edge_factor != 16 {
+        return Err("scale must be 1..26 and edge factor must be 16".to_owned());
+    }
+    let node_count = 1_u64 << config.scale;
+    write_nodes(&config.nodes, node_count)?;
+    write_edges(
+        &config.edges,
+        config.scale,
+        node_count.saturating_mul(config.edge_factor),
+        config.seed,
+    )?;
+    Ok(())
+}
+
+fn parse_args() -> Result<Config, String> {
+    let mut values = env::args().skip(1);
+    let mut scale = None;
+    let mut edge_factor = None;
+    let mut seed = None;
+    let mut nodes = None;
+    let mut edges = None;
+    while let Some(flag) = values.next() {
+        let value = values
+            .next()
+            .ok_or_else(|| format!("missing value for {flag}"))?;
+        match flag.as_str() {
+            "--scale" => scale = Some(value.parse().map_err(|_| "invalid scale")?),
+            "--edge-factor" => {
+                edge_factor = Some(value.parse().map_err(|_| "invalid edge factor")?)
+            }
+            "--seed" => seed = Some(value.parse().map_err(|_| "invalid seed")?),
+            "--nodes" => nodes = Some(PathBuf::from(value)),
+            "--edges" => edges = Some(PathBuf::from(value)),
+            _ => return Err(format!("unknown argument: {flag}")),
+        }
+    }
+    Ok(Config {
+        scale: scale.ok_or("missing --scale")?,
+        edge_factor: edge_factor.ok_or("missing --edge-factor")?,
+        seed: seed.ok_or("missing --seed")?,
+        nodes: nodes.ok_or("missing --nodes")?,
+        edges: edges.ok_or("missing --edges")?,
+    })
+}
+
+fn node_uuid(index: u64) -> [u8; 16] {
+    entity_uuid(0x10, index)
+}
+
+fn edge_uuid(index: u64) -> [u8; 16] {
+    entity_uuid(0x20, index)
+}
+
+fn entity_uuid(namespace: u8, index: u64) -> [u8; 16] {
+    let mut value = [0_u8; 16];
+    value[0] = namespace;
+    value[6] = 0x70;
+    value[8] = 0x80;
+    value[8..].copy_from_slice(&(index | (1_u64 << 63)).to_be_bytes());
+    value
+}
+
+fn binary(values: impl Iterator<Item = [u8; 16]>) -> Result<FixedSizeBinaryArray, String> {
+    FixedSizeBinaryArray::try_from_iter(values.map(|value| value.to_vec()))
+        .map_err(|error| error.to_string())
+}
+
+fn writer(path: &Path, schema: Arc<Schema>) -> Result<ArrowWriter<File>, String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    }
+    ArrowWriter::try_new(
+        File::create(path).map_err(|error| error.to_string())?,
+        schema,
+        None,
+    )
+    .map_err(|error| error.to_string())
+}
+
+fn write_nodes(path: &Path, count: u64) -> Result<(), String> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("node_uuid", DataType::FixedSizeBinary(16), true),
+        Field::new("label", DataType::Utf8, false),
+    ]));
+    let mut output = writer(path, Arc::clone(&schema))?;
+    for start in (0..count).step_by(BATCH_ROWS as usize) {
+        let end = count.min(start + BATCH_ROWS);
+        let rows = usize::try_from(end - start).map_err(|_| "node batch overflow")?;
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(binary((start..end).map(node_uuid))?),
+                Arc::new(StringArray::from(vec!["Node"; rows])),
+            ],
+        )
+        .map_err(|error| error.to_string())?;
+        output.write(&batch).map_err(|error| error.to_string())?;
+    }
+    output.close().map_err(|error| error.to_string())?;
+    Ok(())
+}
+
+fn write_edges(path: &Path, scale: u32, count: u64, seed: u64) -> Result<(), String> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("edge_uuid", DataType::FixedSizeBinary(16), true),
+        Field::new("rel_type", DataType::Utf8, false),
+        Field::new("source_uuid", DataType::FixedSizeBinary(16), false),
+        Field::new("target_uuid", DataType::FixedSizeBinary(16), false),
+    ]));
+    let mut output = writer(path, Arc::clone(&schema))?;
+    let mut random = SplitMix64(seed);
+    for start in (0..count).step_by(BATCH_ROWS as usize) {
+        let end = count.min(start + BATCH_ROWS);
+        let rows = usize::try_from(end - start).map_err(|_| "edge batch overflow")?;
+        let mut sources = Vec::with_capacity(rows);
+        let mut targets = Vec::with_capacity(rows);
+        for _ in start..end {
+            let (source, target) = rmat_edge(scale, &mut random);
+            sources.push(node_uuid(source));
+            targets.push(node_uuid(target));
+        }
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(binary((start..end).map(edge_uuid))?),
+                Arc::new(StringArray::from(vec!["EDGE"; rows])),
+                Arc::new(binary(sources.into_iter())?),
+                Arc::new(binary(targets.into_iter())?),
+            ],
+        )
+        .map_err(|error| error.to_string())?;
+        output.write(&batch).map_err(|error| error.to_string())?;
+    }
+    output.close().map_err(|error| error.to_string())?;
+    Ok(())
+}
+
+fn rmat_edge(scale: u32, random: &mut SplitMix64) -> (u64, u64) {
+    let mut source = 0_u64;
+    let mut target = 0_u64;
+    for bit in (0..scale).rev() {
+        let choice = random.next() % (A + B + C + D);
+        if choice >= A {
+            if choice < A + B {
+                target |= 1_u64 << bit;
+            } else if choice < A + B + C {
+                source |= 1_u64 << bit;
+            } else {
+                source |= 1_u64 << bit;
+                target |= 1_u64 << bit;
+            }
+        }
+    }
+    (source, target)
+}
+
+struct SplitMix64(u64);
+
+impl SplitMix64 {
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut value = self.0;
+        value = (value ^ (value >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        value = (value ^ (value >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        value ^ (value >> 31)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generator_is_deterministic_and_namespaced() {
+        let mut left = SplitMix64(7);
+        let mut right = SplitMix64(7);
+        let first: Vec<_> = (0..8).map(|_| rmat_edge(6, &mut left)).collect();
+        let second: Vec<_> = (0..8).map(|_| rmat_edge(6, &mut right)).collect();
+        assert_eq!(first, second);
+        assert_ne!(node_uuid(1), edge_uuid(1));
+        assert!(
+            first
+                .iter()
+                .all(|(source, target)| *source < 64 && *target < 64)
+        );
+    }
+}

--- a/benchmarks/schemas/certification-profile.json
+++ b/benchmarks/schemas/certification-profile.json
@@ -35,7 +35,8 @@
         "action": {
           "oneOf": [
             { "$ref": "#/$defs/benchmarkGenerator" },
-            { "$ref": "#/$defs/graphForgeCli" }
+            { "$ref": "#/$defs/graphForgeCli" },
+            { "$ref": "#/$defs/graphForgeCliWorkflow" }
           ]
         }
       },
@@ -46,7 +47,7 @@
       "type": "object",
       "properties": {
         "interface": { "const": "benchmark_generator" },
-        "identity": { "type": "string", "pattern": "^[A-Za-z0-9_.-]{1,80}$" },
+        "identity": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
         "executable": { "type": "string", "minLength": 1 },
         "args": { "type": "array", "items": { "type": "string" } }
       },
@@ -62,6 +63,18 @@
       "required": ["interface", "args"],
       "additionalProperties": false
     },
+    "graphForgeCliWorkflow": {
+      "type": "object",
+      "properties": {
+        "interface": { "const": "graph_forge_cli_workflow" },
+        "commands": {
+          "type": "array", "minItems": 2, "maxItems": 5,
+          "items": { "type": "array", "minItems": 1, "items": { "type": "string" } }
+        }
+      },
+      "required": ["interface", "commands"],
+      "additionalProperties": false
+    },
     "graphForgeCommand": {
       "allOf": [
         { "$ref": "#/$defs/command" },
@@ -74,15 +87,33 @@
         { "properties": { "action": { "$ref": "#/$defs/benchmarkGenerator" } } }
       ]
     },
+    "workflowCommand": {
+      "allOf": [
+        { "$ref": "#/$defs/command" },
+        { "properties": { "action": { "$ref": "#/$defs/graphForgeCliWorkflow" } } }
+      ]
+    },
     "admission": { "allOf": [{ "$ref": "#/$defs/graphForgeCommand" }, { "properties": { "phase": { "const": "admission" } } }] },
     "generate": { "allOf": [{ "$ref": "#/$defs/generatorCommand" }, { "properties": { "phase": { "const": "generate" } } }] },
-    "ingest": { "allOf": [{ "$ref": "#/$defs/graphForgeCommand" }, { "properties": { "phase": { "const": "ingest" } } }] },
+    "ingest": { "oneOf": [
+      { "allOf": [{ "$ref": "#/$defs/graphForgeCommand" }, { "properties": { "phase": { "const": "ingest" } } }] },
+      { "allOf": [{ "$ref": "#/$defs/workflowCommand" }, { "properties": { "phase": { "const": "ingest" } } }] }
+    ] },
     "reopen": { "allOf": [{ "$ref": "#/$defs/graphForgeCommand" }, { "properties": { "phase": { "const": "reopen" } } }] },
-    "recount": { "allOf": [{ "$ref": "#/$defs/graphForgeCommand" }, { "properties": { "phase": { "const": "recount" } } }] },
-    "query": { "allOf": [{ "$ref": "#/$defs/graphForgeCommand" }, { "properties": { "phase": { "const": "query" } } }] },
+    "recount": { "oneOf": [
+      { "allOf": [{ "$ref": "#/$defs/graphForgeCommand" }, { "properties": { "phase": { "const": "recount" } } }] },
+      { "allOf": [{ "$ref": "#/$defs/workflowCommand" }, { "properties": { "phase": { "const": "recount" } } }] }
+    ] },
+    "query": { "oneOf": [
+      { "allOf": [{ "$ref": "#/$defs/graphForgeCommand" }, { "properties": { "phase": { "const": "query" } } }] },
+      { "allOf": [{ "$ref": "#/$defs/workflowCommand" }, { "properties": { "phase": { "const": "query" } } }] }
+    ] },
     "export": { "allOf": [{ "$ref": "#/$defs/graphForgeCommand" }, { "properties": { "phase": { "const": "export" } } }] },
     "verify": { "allOf": [{ "$ref": "#/$defs/graphForgeCommand" }, { "properties": { "phase": { "const": "verify" } } }] },
     "cleanImport": { "allOf": [{ "$ref": "#/$defs/graphForgeCommand" }, { "properties": { "phase": { "const": "clean_import" } } }] },
-    "reopenProof": { "allOf": [{ "$ref": "#/$defs/graphForgeCommand" }, { "properties": { "phase": { "const": "reopen_proof" } } }] }
+    "reopenProof": { "oneOf": [
+      { "allOf": [{ "$ref": "#/$defs/graphForgeCommand" }, { "properties": { "phase": { "const": "reopen_proof" } } }] },
+      { "allOf": [{ "$ref": "#/$defs/workflowCommand" }, { "properties": { "phase": { "const": "reopen_proof" } } }] }
+    ] }
   }
 }

--- a/benchmarks/schemas/progressive-qualification-evidence.json
+++ b/benchmarks/schemas/progressive-qualification-evidence.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema": "graphforge-progressive-qualification-evidence-schema/1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "target", "source_scales", "decision", "limits", "headroom", "projected", "required_rates", "provider_capacity", "slopes_observed", "rss_growth_fraction", "checks", "claim"],
+  "properties": {
+    "schema": {"const": "graphforge-progressive-qualification-evidence/1"},
+    "target": {"enum": ["S20", "S22", "S26"]},
+    "source_scales": {"type": "array", "minItems": 2, "maxItems": 2, "uniqueItems": true, "items": {"type": "integer", "minimum": 1}},
+    "decision": {"enum": ["admitted", "refused"]},
+    "limits": {"$ref": "#/$defs/limits"},
+    "headroom": {"$ref": "#/$defs/headroom"},
+    "projected": {"$ref": "#/$defs/projected"},
+    "required_rates": {"$ref": "#/$defs/rates"},
+    "provider_capacity": {"oneOf": [{"$ref": "#/$defs/rates"}, {"type": "null"}]},
+    "slopes_observed": {"$ref": "#/$defs/slopes"},
+    "rss_growth_fraction": {"type": "number"},
+    "checks": {
+      "type": "object", "additionalProperties": false,
+      "required": ["time_headroom", "rss_headroom", "retained_storage_headroom", "transient_storage_headroom", "storage_headroom", "rss_bounded_or_plateaued", "io_reader_publication_capacity_measured", "io_reader_publication_headroom", "correctness"],
+      "properties": {
+        "time_headroom": {"type": "boolean"}, "rss_headroom": {"type": "boolean"},
+        "retained_storage_headroom": {"type": "boolean"}, "transient_storage_headroom": {"type": "boolean"},
+        "storage_headroom": {"type": "boolean"}, "rss_bounded_or_plateaued": {"type": "boolean"},
+        "io_reader_publication_capacity_measured": {"type": "boolean"},
+        "io_reader_publication_headroom": {"type": "boolean"},
+        "correctness": {"const": true}
+      }
+    },
+    "claim": {"const": "engineering_evidence_only"}
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"decision": {"const": "admitted"}}, "required": ["decision"]},
+      "then": {
+        "properties": {
+          "checks": {
+            "properties": {
+              "time_headroom": {"const": true}, "rss_headroom": {"const": true},
+              "retained_storage_headroom": {"const": true}, "transient_storage_headroom": {"const": true},
+              "storage_headroom": {"const": true}, "rss_bounded_or_plateaued": {"const": true},
+              "io_reader_publication_capacity_measured": {"const": true},
+              "io_reader_publication_headroom": {"const": true}, "correctness": {"const": true}
+            }
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "nonnegative": {"type": "integer", "minimum": 0},
+    "limits": {
+      "type": "object", "additionalProperties": false, "required": ["wall_seconds", "rss_bytes", "volume_bytes"],
+      "properties": {"wall_seconds": {"const": 14400}, "rss_bytes": {"const": 4294967296}, "volume_bytes": {"const": 536870912000}}
+    },
+    "headroom": {
+      "type": "object", "additionalProperties": false, "required": ["time_fraction", "rss_fraction", "storage_fraction"],
+      "properties": {"time_fraction": {"const": 0.2}, "rss_fraction": {"const": 0.2}, "storage_fraction": {"const": 0.15}}
+    },
+    "projected": {
+      "type": "object", "additionalProperties": false,
+      "required": ["wall_seconds", "peak_rss_bytes", "retained_storage_bytes", "transient_peak_storage_bytes", "logical_read_bytes", "logical_write_bytes", "physical_read_bytes", "physical_write_bytes", "reader_calls", "publication_work_units", "storage_peak_bytes"],
+      "properties": {
+        "wall_seconds": {"$ref": "#/$defs/nonnegative"}, "peak_rss_bytes": {"$ref": "#/$defs/nonnegative"},
+        "retained_storage_bytes": {"$ref": "#/$defs/nonnegative"}, "transient_peak_storage_bytes": {"$ref": "#/$defs/nonnegative"},
+        "logical_read_bytes": {"$ref": "#/$defs/nonnegative"}, "logical_write_bytes": {"$ref": "#/$defs/nonnegative"},
+        "physical_read_bytes": {"$ref": "#/$defs/nonnegative"}, "physical_write_bytes": {"$ref": "#/$defs/nonnegative"},
+        "reader_calls": {"$ref": "#/$defs/nonnegative"}, "publication_work_units": {"$ref": "#/$defs/nonnegative"},
+        "storage_peak_bytes": {"$ref": "#/$defs/nonnegative"}
+      }
+    },
+    "rates": {
+      "type": "object", "additionalProperties": false,
+      "required": ["physical_read_bytes_per_second", "physical_write_bytes_per_second", "reader_calls_per_second", "publication_work_per_second"],
+      "properties": {
+        "physical_read_bytes_per_second": {"$ref": "#/$defs/nonnegative"},
+        "physical_write_bytes_per_second": {"$ref": "#/$defs/nonnegative"},
+        "reader_calls_per_second": {"$ref": "#/$defs/nonnegative"},
+        "publication_work_per_second": {"$ref": "#/$defs/nonnegative"}
+      }
+    },
+    "slopes": {
+      "type": "object", "additionalProperties": false,
+      "required": ["logical_read_bytes", "logical_write_bytes", "physical_read_bytes", "physical_write_bytes", "reader_calls", "publication_work_units"],
+      "properties": {
+        "logical_read_bytes": {"type": "integer"}, "logical_write_bytes": {"type": "integer"},
+        "physical_read_bytes": {"type": "integer"}, "physical_write_bytes": {"type": "integer"},
+        "reader_calls": {"type": "integer"}, "publication_work_units": {"type": "integer"}
+      }
+    }
+  }
+}

--- a/benchmarks/schemas/progressive-qualification-evidence.json
+++ b/benchmarks/schemas/progressive-qualification-evidence.json
@@ -35,6 +35,7 @@
       "if": {"properties": {"decision": {"const": "admitted"}}, "required": ["decision"]},
       "then": {
         "properties": {
+          "provider_capacity": {"$ref": "#/$defs/rates"},
           "checks": {
             "properties": {
               "time_headroom": {"const": true}, "rss_headroom": {"const": true},
@@ -46,6 +47,18 @@
           }
         }
       }
+    },
+    {
+      "if": {"properties": {"target": {"const": "S20"}}, "required": ["target"]},
+      "then": {"properties": {"source_scales": {"const": [18, 19]}}}
+    },
+    {
+      "if": {"properties": {"target": {"const": "S22"}}, "required": ["target"]},
+      "then": {"properties": {"source_scales": {"const": [19, 20]}}}
+    },
+    {
+      "if": {"properties": {"target": {"const": "S26"}}, "required": ["target"]},
+      "then": {"properties": {"source_scales": {"const": [24, 25]}}}
     }
   ],
   "$defs": {

--- a/benchmarks/schemas/progressive-qualification-profile.json
+++ b/benchmarks/schemas/progressive-qualification-profile.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema": "graphforge-progressive-qualification-profile-schema/1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "id", "scale", "execution", "executable", "phases", "generator", "lifecycle", "gate"],
+  "properties": {
+    "schema": {"const": "graphforge-progressive-qualification-profile/1"},
+    "id": {"enum": ["graph500-s18-local", "graph500-s19-local", "graph500-s20-provider", "graph500-s22-provider", "graph500-s26-provider"]},
+    "scale": {"enum": [18, 19, 20, 22, 26]},
+    "execution": {"enum": ["local", "provider"]},
+    "executable": {"const": "gf"},
+    "phases": {
+      "type": "array", "minItems": 10, "maxItems": 10,
+      "prefixItems": [
+        {"$ref": "#/$defs/admission"}, {"$ref": "#/$defs/generate"},
+        {"$ref": "#/$defs/ingest"}, {"$ref": "#/$defs/reopen"},
+        {"$ref": "#/$defs/recount"}, {"$ref": "#/$defs/query"},
+        {"$ref": "#/$defs/export"}, {"$ref": "#/$defs/verify"},
+        {"$ref": "#/$defs/clean_import"}, {"$ref": "#/$defs/reopen_proof"}
+      ],
+      "items": false
+    },
+    "generator": {
+      "type": "object", "additionalProperties": false,
+      "required": ["identity", "edge_factor", "seed"],
+      "properties": {
+        "identity": {"pattern": "^sha256:[0-9a-f]{64}$"},
+        "edge_factor": {"const": 16},
+        "seed": {"const": 13907095936298285200}
+      }
+    },
+    "lifecycle": {
+      "type": "object", "additionalProperties": false,
+      "required": ["mechanics", "phases", "evidence_schema"],
+      "properties": {
+        "mechanics": {"const": "public-certification-v1"},
+        "evidence_schema": {"const": "graphforge-public-certification/1"},
+        "phases": {
+          "const": ["admission", "generate", "ingest", "reopen", "recount", "query", "export", "verify", "clean_import", "reopen_proof"]
+        }
+      }
+    },
+    "gate": {
+      "type": "object", "additionalProperties": false,
+      "required": ["requires_previous_pass", "projection_source_scales", "limits", "headroom"],
+      "properties": {
+        "requires_previous_pass": {"const": true},
+        "projection_source_scales": {
+          "oneOf": [
+            {"type": "null"},
+            {"type": "array", "minItems": 2, "maxItems": 2, "uniqueItems": true, "items": {"type": "integer", "minimum": 1}}
+          ]
+        },
+        "limits": {
+          "type": "object", "additionalProperties": false,
+          "required": ["wall_seconds", "rss_bytes", "volume_bytes"],
+          "properties": {
+            "wall_seconds": {"const": 14400},
+            "rss_bytes": {"const": 4294967296},
+            "volume_bytes": {"const": 536870912000}
+          }
+        },
+        "headroom": {
+          "type": "object", "additionalProperties": false,
+          "required": ["time_fraction", "rss_fraction", "storage_fraction", "max_adjacent_rss_growth_fraction"],
+          "properties": {
+            "time_fraction": {"const": 0.2},
+            "rss_fraction": {"const": 0.2},
+            "storage_fraction": {"const": 0.15},
+            "max_adjacent_rss_growth_fraction": {"const": 0.1}
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "command": {
+      "type": "object", "additionalProperties": false,
+      "required": ["phase", "action"],
+      "properties": {
+        "phase": {"type": "string"},
+        "action": {
+          "type": "object", "required": ["interface"],
+          "properties": {"interface": {"type": "string"}},
+          "additionalProperties": true
+        }
+      }
+    },
+    "admission": {"allOf": [{"$ref": "#/$defs/command"}, {"properties": {"phase": {"const": "admission"}}}]},
+    "generate": {"allOf": [{"$ref": "#/$defs/command"}, {"properties": {"phase": {"const": "generate"}, "action": {"properties": {"interface": {"const": "benchmark_generator"}, "executable": {"const": "graphforge-benchmark-graph500-generator"}}, "required": ["executable"]}}}]},
+    "ingest": {"allOf": [{"$ref": "#/$defs/command"}, {"properties": {"phase": {"const": "ingest"}, "action": {"properties": {"interface": {"const": "graph_forge_cli_workflow"}}}}}]},
+    "reopen": {"allOf": [{"$ref": "#/$defs/command"}, {"properties": {"phase": {"const": "reopen"}}}]},
+    "recount": {"allOf": [{"$ref": "#/$defs/command"}, {"properties": {"phase": {"const": "recount"}}}]},
+    "query": {"allOf": [{"$ref": "#/$defs/command"}, {"properties": {"phase": {"const": "query"}}}]},
+    "export": {"allOf": [{"$ref": "#/$defs/command"}, {"properties": {"phase": {"const": "export"}}}]},
+    "verify": {"allOf": [{"$ref": "#/$defs/command"}, {"properties": {"phase": {"const": "verify"}}}]},
+    "clean_import": {"allOf": [{"$ref": "#/$defs/command"}, {"properties": {"phase": {"const": "clean_import"}}}]},
+    "reopen_proof": {"allOf": [{"$ref": "#/$defs/command"}, {"properties": {"phase": {"const": "reopen_proof"}}}]}
+  }
+}

--- a/benchmarks/schemas/progressive-qualification-profile.json
+++ b/benchmarks/schemas/progressive-qualification-profile.json
@@ -25,7 +25,7 @@
       "type": "object", "additionalProperties": false,
       "required": ["identity", "edge_factor", "seed"],
       "properties": {
-        "identity": {"pattern": "^sha256:[0-9a-f]{64}$"},
+        "identity": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
         "edge_factor": {"const": 16},
         "seed": {"const": 13907095936298285200}
       }

--- a/benchmarks/schemas/progressive-qualification-rung-evidence.json
+++ b/benchmarks/schemas/progressive-qualification-rung-evidence.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema": "graphforge-progressive-qualification-rung-evidence-schema/1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["profile_id", "source", "scale", "live_edges", "status", "correctness", "phases", "metrics", "failure"],
+  "properties": {
+    "profile_id": {"type": "string", "pattern": "^[A-Za-z0-9_.-]{1,80}$"},
+    "source": {"enum": ["progressive_profile", "canonical_ladder"]},
+    "scale": {"type": "integer", "minimum": 1, "maximum": 26},
+    "live_edges": {"type": "integer", "minimum": 1},
+    "status": {"enum": ["passed", "failed"]},
+    "correctness": {"type": "boolean"},
+    "phases": {
+      "type": "array", "minItems": 1, "maxItems": 10,
+      "items": {"enum": ["admission", "generate", "ingest", "reopen", "recount", "query", "export", "verify", "clean_import", "reopen_proof"]}
+    },
+    "metrics": {
+      "type": "object", "additionalProperties": false,
+      "properties": {
+        "wall_seconds": {"$ref": "#/$defs/nonnegative"}, "peak_rss_bytes": {"$ref": "#/$defs/nonnegative"},
+        "retained_storage_bytes": {"$ref": "#/$defs/nonnegative"}, "transient_peak_storage_bytes": {"$ref": "#/$defs/nonnegative"},
+        "logical_read_bytes": {"$ref": "#/$defs/nonnegative"}, "logical_write_bytes": {"$ref": "#/$defs/nonnegative"},
+        "physical_read_bytes": {"$ref": "#/$defs/nonnegative"}, "physical_write_bytes": {"$ref": "#/$defs/nonnegative"},
+        "reader_calls": {"$ref": "#/$defs/nonnegative"}, "publication_work_units": {"$ref": "#/$defs/nonnegative"}
+      }
+    },
+    "failure": {"type": ["string", "null"], "enum": [null, "admission", "generate", "ingest", "reopen", "recount", "query", "export", "verify", "clean_import", "reopen_proof", "timeout", "oom", "storage", "correctness", "harness"]}
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"status": {"const": "passed"}}, "required": ["status"]},
+      "then": {
+        "properties": {
+          "correctness": {"const": true},
+          "phases": {"const": ["admission", "generate", "ingest", "reopen", "recount", "query", "export", "verify", "clean_import", "reopen_proof"]},
+          "failure": {"type": "null"},
+          "metrics": {"required": ["wall_seconds", "peak_rss_bytes", "retained_storage_bytes", "transient_peak_storage_bytes", "logical_read_bytes", "logical_write_bytes", "physical_read_bytes", "physical_write_bytes", "reader_calls", "publication_work_units"]}
+        }
+      },
+      "else": {"properties": {"failure": {"type": "string"}}}
+    }
+  ],
+  "$defs": {"nonnegative": {"type": "integer", "minimum": 0}}
+}

--- a/benchmarks/tests/test_progressive_qualification.py
+++ b/benchmarks/tests/test_progressive_qualification.py
@@ -75,9 +75,12 @@ class ProgressiveQualificationTests(unittest.TestCase):
             raw_profiles.append(raw)
             self.assertEqual(tuple(raw["lifecycle"]["phases"]), PHASES)
             self.assertEqual(raw["generator"]["edge_factor"], 16)
-            digest = "sha256:" + hashlib.sha256(
-                (ROOT / "runners/graph500-generator/src/main.rs").read_bytes()
-            ).hexdigest()
+            digest = (
+                "sha256:"
+                + hashlib.sha256(
+                    (ROOT / "runners/graph500-generator/src/main.rs").read_bytes()
+                ).hexdigest()
+            )
             self.assertEqual(raw["generator"]["identity"], digest)
             self.assertEqual(raw["phases"][1]["action"]["identity"], digest)
             ingest = raw["phases"][2]["action"]
@@ -105,9 +108,7 @@ class ProgressiveQualificationTests(unittest.TestCase):
         self.assertIsNone(select_next(self.profiles, [rung(18), failed]))
 
     def test_tiny_executable_fixture_is_a_real_certification_profile(self) -> None:
-        fixture = json.loads(
-            (ROOT / "fixtures/progressive/tiny-executable.json").read_text()
-        )
+        fixture = json.loads((ROOT / "fixtures/progressive/tiny-executable.json").read_text())
         self.certification_schema.validate(fixture)
         self.assertEqual([phase["phase"] for phase in fixture["phases"]], list(PHASES))
 

--- a/benchmarks/tests/test_progressive_qualification.py
+++ b/benchmarks/tests/test_progressive_qualification.py
@@ -154,6 +154,17 @@ class ProgressiveQualificationTests(unittest.TestCase):
         contradictory = copy.deepcopy(evidence)
         contradictory["checks"]["rss_headroom"] = False
         self.assertFalse(self.evidence_schema.is_valid(contradictory))
+        wrong_sources = copy.deepcopy(evidence)
+        wrong_sources["source_scales"] = [24, 25]
+        self.assertFalse(self.evidence_schema.is_valid(wrong_sources))
+        missing_capacity = copy.deepcopy(evidence)
+        missing_capacity["provider_capacity"] = None
+        self.assertFalse(self.evidence_schema.is_valid(missing_capacity))
+
+    def test_profile_schema_rejects_non_string_generator_identity(self) -> None:
+        profile = json.loads((ROOT / "profiles/graph500/s18-local.json").read_text())
+        profile["generator"]["identity"] = 42
+        self.assertFalse(self.profile_schema.is_valid(profile))
 
     def test_each_capacity_dimension_refuses_independently(self) -> None:
         cases = {
@@ -207,6 +218,12 @@ class ProgressiveQualificationTests(unittest.TestCase):
         evidence = project(self.profiles[2], [rung(18), rung(19)], constrained)
         self.assertFalse(evidence["checks"]["io_reader_publication_headroom"])
         self.assertEqual(evidence["decision"], "refused")
+
+    def test_provider_capacity_evidence_is_a_closed_rate_allowlist(self) -> None:
+        capacity = CAPACITY | {"provider_id": "must-not-escape", "secret": "must-not-escape"}
+        evidence = project(self.profiles[2], [rung(18), rung(19)], capacity)
+        self.assertEqual(evidence["provider_capacity"], CAPACITY)
+        self.assertNotIn("must-not-escape", json.dumps(evidence))
 
     def test_projection_uses_worse_latest_ratio_not_only_small_delta(self) -> None:
         low, high = rung(18), rung(19)

--- a/benchmarks/tests/test_progressive_qualification.py
+++ b/benchmarks/tests/test_progressive_qualification.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+import unittest
+
+from graphforge_bench.progressive_qualification import (
+    PHASES,
+    QualificationError,
+    load_profiles,
+    project,
+    select_next,
+)
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+CAPACITY = {
+    "physical_read_bytes_per_second": 10**9,
+    "physical_write_bytes_per_second": 10**9,
+    "reader_calls_per_second": 10**6,
+    "publication_work_per_second": 10**6,
+}
+
+
+def rung(scale: int, *, rss: int = 1_000_000_000, wall: int = 100) -> dict:
+    multiplier = 1 << max(0, scale - 18)
+    return {
+        "profile_id": f"graph500-s{scale}-evidence",
+        "source": "canonical_ladder" if scale in {24, 25} else "progressive_profile",
+        "scale": scale,
+        "live_edges": (1 << scale) * 16,
+        "status": "passed",
+        "correctness": True,
+        "phases": list(PHASES),
+        "metrics": {
+            "wall_seconds": wall,
+            "peak_rss_bytes": rss,
+            "retained_storage_bytes": 1_000_000 * multiplier,
+            "transient_peak_storage_bytes": 1_500_000 * multiplier,
+            "logical_read_bytes": 2_000_000 * multiplier,
+            "logical_write_bytes": 3_000_000 * multiplier,
+            "physical_read_bytes": 1_000_000 * multiplier,
+            "physical_write_bytes": 1_500_000 * multiplier,
+            "reader_calls": 1_000 * multiplier,
+            "publication_work_units": 2_000 * multiplier,
+        },
+        "failure": None,
+    }
+
+
+class ProgressiveQualificationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.profiles = load_profiles()
+        cls.profile_schema = Draft202012Validator(
+            json.loads((ROOT / "schemas/progressive-qualification-profile.json").read_text())
+        )
+        cls.evidence_schema = Draft202012Validator(
+            json.loads((ROOT / "schemas/progressive-qualification-evidence.json").read_text())
+        )
+        cls.rung_schema = Draft202012Validator(
+            json.loads((ROOT / "schemas/progressive-qualification-rung-evidence.json").read_text())
+        )
+        cls.certification_schema = Draft202012Validator(
+            json.loads((ROOT / "schemas/certification-profile.json").read_text())
+        )
+
+    def test_distinct_profiles_pin_one_ordinary_lifecycle_without_provider_ids(self) -> None:
+        raw_profiles = []
+        for path in sorted((ROOT / "profiles/graph500").glob("*.json")):
+            raw = json.loads(path.read_text())
+            self.profile_schema.validate(raw)
+            raw_profiles.append(raw)
+            self.assertEqual(tuple(raw["lifecycle"]["phases"]), PHASES)
+            self.assertEqual(raw["generator"]["edge_factor"], 16)
+            digest = "sha256:" + hashlib.sha256(
+                (ROOT / "runners/graph500-generator/src/main.rs").read_bytes()
+            ).hexdigest()
+            self.assertEqual(raw["generator"]["identity"], digest)
+            self.assertEqual(raw["phases"][1]["action"]["identity"], digest)
+            ingest = raw["phases"][2]["action"]
+            self.assertEqual(ingest["interface"], "graph_forge_cli_workflow")
+            self.assertEqual(
+                [command[command.index("import-session") + 1] for command in ingest["commands"]],
+                ["begin", "register-parquet", "register-parquet", "validate", "commit"],
+            )
+            encoded = json.dumps(raw).lower()
+            for forbidden in ("provider_id", "machine_id", "volume_id", "token", "secret"):
+                self.assertNotIn(forbidden, encoded)
+        self.assertEqual([item.scale for item in self.profiles], [18, 19, 20, 22, 26])
+        self.assertEqual(
+            [item.execution for item in self.profiles],
+            ["local", "local", "provider", "provider", "provider"],
+        )
+
+    def test_selection_is_progressive_and_stops_after_first_typed_failure(self) -> None:
+        self.assertEqual(select_next(self.profiles, []).scale, 18)
+        self.assertEqual(select_next(self.profiles, [rung(18)]).scale, 19)
+        self.assertEqual(select_next(self.profiles, [rung(18), rung(19)], CAPACITY).scale, 20)
+        failed = rung(19) | {"status": "failed", "correctness": False, "failure": "correctness"}
+        failed["phases"] = list(PHASES[:6])
+        self.rung_schema.validate(failed)
+        self.assertIsNone(select_next(self.profiles, [rung(18), failed]))
+
+    def test_tiny_executable_fixture_is_a_real_certification_profile(self) -> None:
+        fixture = json.loads(
+            (ROOT / "fixtures/progressive/tiny-executable.json").read_text()
+        )
+        self.certification_schema.validate(fixture)
+        self.assertEqual([phase["phase"] for phase in fixture["phases"]], list(PHASES))
+
+    def test_failed_rung_may_preserve_partial_observations(self) -> None:
+        failed = rung(18) | {
+            "status": "failed",
+            "correctness": False,
+            "phases": list(PHASES[:3]),
+            "metrics": {"wall_seconds": 5, "peak_rss_bytes": 42},
+            "failure": "ingest",
+        }
+        self.rung_schema.validate(failed)
+
+    def test_provider_selection_refuses_failed_projection(self) -> None:
+        high = rung(19, wall=12_000)
+        low = rung(18, wall=12_000)
+        self.assertIsNone(select_next(self.profiles, [low, high], CAPACITY))
+        self.assertIsNone(select_next(self.profiles, [rung(18), rung(19)]))
+
+    def test_s20_requires_two_adjacent_completed_rungs(self) -> None:
+        with self.assertRaisesRegex(QualificationError, "both declared"):
+            project(self.profiles[2], [rung(18)])
+        failed = rung(19) | {"status": "failed", "correctness": False, "failure": "correctness"}
+        with self.assertRaisesRegex(QualificationError, "completed and correct"):
+            project(self.profiles[2], [rung(18), failed])
+
+    def test_plateaued_s20_projection_is_schema_valid_and_sanitized(self) -> None:
+        evidence = project(
+            self.profiles[2],
+            [rung(18, rss=1_000_000_000, wall=100), rung(19, rss=1_050_000_000, wall=110)],
+            CAPACITY,
+        )
+        self.evidence_schema.validate(evidence)
+        self.rung_schema.validate(rung(18))
+        self.rung_schema.validate(rung(19))
+        self.assertEqual(evidence["decision"], "admitted")
+        self.assertEqual(evidence["source_scales"], [18, 19])
+        self.assertTrue(all(evidence["checks"].values()))
+        self.assertEqual(evidence["claim"], "engineering_evidence_only")
+        encoded = json.dumps(evidence).lower()
+        for forbidden in ("provider_id", "machine_id", "volume_id", "path", "token", "secret"):
+            self.assertNotIn(forbidden, encoded)
+        contradictory = copy.deepcopy(evidence)
+        contradictory["checks"]["rss_headroom"] = False
+        self.assertFalse(self.evidence_schema.is_valid(contradictory))
+
+    def test_each_capacity_dimension_refuses_independently(self) -> None:
+        cases = {
+            "time_headroom": ("wall_seconds", 12_000),
+            "rss_headroom": ("peak_rss_bytes", 3_600_000_000),
+            "retained_storage_headroom": ("retained_storage_bytes", 450 * 1024**3),
+            "transient_storage_headroom": ("transient_peak_storage_bytes", 450 * 1024**3),
+        }
+        for check, (metric, high_value) in cases.items():
+            low, high = rung(18), rung(19)
+            if metric in {"wall_seconds", "peak_rss_bytes"}:
+                low["metrics"][metric] = high_value
+            else:
+                low["metrics"][metric] = high_value // 2
+            high["metrics"][metric] = high_value
+            with self.subTest(check=check):
+                evidence = project(self.profiles[2], [low, high], CAPACITY)
+                self.assertEqual(evidence["decision"], "refused")
+                self.assertFalse(evidence["checks"][check])
+
+    def test_material_adjacent_rss_growth_is_architectural_refusal(self) -> None:
+        evidence = project(
+            self.profiles[2],
+            [rung(18, rss=1_000_000_000), rung(19, rss=1_300_000_000)],
+            CAPACITY,
+        )
+        self.assertFalse(evidence["checks"]["rss_bounded_or_plateaued"])
+        self.assertEqual(evidence["decision"], "refused")
+
+    def test_io_reader_and_publication_slopes_are_independently_preserved(self) -> None:
+        evidence = project(self.profiles[2], [rung(18), rung(19)], CAPACITY)
+        self.assertEqual(
+            set(evidence["slopes_observed"]),
+            {
+                "logical_read_bytes",
+                "logical_write_bytes",
+                "physical_read_bytes",
+                "physical_write_bytes",
+                "reader_calls",
+                "publication_work_units",
+            },
+        )
+        self.assertTrue(all(value > 0 for value in evidence["slopes_observed"].values()))
+
+    def test_provider_work_capacity_is_required_and_keeps_headroom(self) -> None:
+        missing = project(self.profiles[2], [rung(18), rung(19)])
+        self.assertEqual(missing["decision"], "refused")
+        self.assertFalse(missing["checks"]["io_reader_publication_capacity_measured"])
+        constrained = dict(CAPACITY)
+        constrained["reader_calls_per_second"] = 0
+        evidence = project(self.profiles[2], [rung(18), rung(19)], constrained)
+        self.assertFalse(evidence["checks"]["io_reader_publication_headroom"])
+        self.assertEqual(evidence["decision"], "refused")
+
+    def test_projection_uses_worse_latest_ratio_not_only_small_delta(self) -> None:
+        low, high = rung(18), rung(19)
+        low["metrics"]["retained_storage_bytes"] = 100_000_000_000
+        high["metrics"]["retained_storage_bytes"] = 101_000_000_000
+        evidence = project(self.profiles[2], [low, high], CAPACITY)
+        self.assertEqual(evidence["projected"]["retained_storage_bytes"], 202_000_000_000)
+
+    def test_s22_and_s26_keep_separate_declared_gates(self) -> None:
+        self.assertEqual(self.profiles[3].projection_sources, (19, 20))
+        self.assertEqual(self.profiles[4].projection_sources, (24, 25))
+        s26 = project(self.profiles[4], [rung(24), rung(25)], CAPACITY)
+        self.assertEqual(s26["source_scales"], [24, 25])
+        malformed = copy.copy(self.profiles[4])
+        object.__setattr__(malformed, "projection_sources", (20, 22))
+        with self.assertRaisesRegex(QualificationError, "adjacent S24 and S25"):
+            project(malformed, [rung(20), rung(22)], CAPACITY)
+        wrong_source = rung(25)
+        wrong_source["source"] = "progressive_profile"
+        with self.assertRaisesRegex(QualificationError, "canonical S24 and S25"):
+            project(self.profiles[4], [rung(24), wrong_source], CAPACITY)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements #956

## Summary
- add distinct executable S18/S19 local and S20/S22/S26 provider qualification profiles with a pinned streaming Graph500 Parquet generator
- extend the public certification runner with phase-validated ordered `gf` workflows, first-child failure semantics, and aggregated phase telemetry
- add conservative adjacent-rung projection and closed sanitized evidence contracts for time, bounded RSS, retained/transient storage, logical/physical I/O, reader calls, and publication work
- add manual-only ReFrame/BenchExec entry points with a four-hour, 4 GiB envelope; provider profiles are invalid on the local ReFrame system and no Fly/provider run is launched

## Validation
- `make -C benchmarks smoke` (36 Python tests; Rust fmt/clippy/tests; isolated dependency graph)
- all five profiles parsed and semantically validated by `graphforge-benchmark-certify validate`
- scale-1 executable fixture completed admission → generated Parquet → five-command import session → reopen/count/one-hop/two-hop → export/verify → clean import → imported reopen/count using the real `gf` binary
- `git diff --check`

This PR does not claim S18/S19 or provider completion; #956 remains the real-evidence close gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790583884&installation_model_id=20486&pr_number=990&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F990&signature=4fb48773d0e2050113b9adf970c5ca72638508838db86960508a7adbb812a0f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added progressive Graph500 qualification profiles for local and provider-scale execution.
  - Added deterministic Graph500 data generation with Parquet output.
  - Added profile validation and progressive qualification evidence reporting.
  - Added workflow support for ingestion, queries, recovery, and proof phases.
  - Added a command to validate certification profiles.
- **Bug Fixes**
  - Improved benchmark fixture discovery to include nested directories.
- **Tests**
  - Added automated coverage for qualification profiles, workflows, validation, failures, and resource gates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->