### PR TITLE
fix(api): route staged imports through construction sessions

### DIFF
--- a/crates/graphforge-api/src/bulk_construction.rs
+++ b/crates/graphforge-api/src/bulk_construction.rs
@@ -18,10 +18,10 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
 
 use arrow::array::{
-    Array, ArrayRef, BooleanArray, FixedSizeBinaryArray, Float32Array, Float64Array, Int8Array,
-    Int16Array, Int32Array, Int64Array, LargeListArray, LargeStringArray, ListArray, StringArray,
-    StructArray, Time64NanosecondArray, TimestampMicrosecondArray, UInt8Array, UInt16Array,
-    UInt32Array, UInt64Array,
+    Array, ArrayRef, BooleanArray, FixedSizeBinaryArray, FixedSizeBinaryBuilder, Float32Array,
+    Float64Array, Int8Array, Int16Array, Int32Array, Int64Array, LargeListArray, LargeStringArray,
+    ListArray, StringArray, StructArray, Time64NanosecondArray, TimestampMicrosecondArray,
+    UInt8Array, UInt16Array, UInt32Array, UInt64Array,
 };
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
@@ -331,6 +331,19 @@ fn canonical_import_chunk(
     })
 }
 
+fn canonical_import_uuid_array(
+    kind: BulkInputKind,
+    values: impl ExactSizeIterator<Item = Uuid>,
+) -> Result<ArrayRef, BulkValidationError> {
+    let mut builder = FixedSizeBinaryBuilder::with_capacity(values.len(), 16);
+    for value in values {
+        builder.append_value(value.as_bytes()).map_err(|error| {
+            contract_error(kind, BulkValidationReason::ProjectState, &error.to_string())
+        })?;
+    }
+    Ok(Arc::new(builder.finish()))
+}
+
 /// Canonical receipt schema used by the later publication slices.
 ///
 /// Receipts retain input order and identify the created object, its node label
@@ -375,25 +388,16 @@ impl GraphForge {
     ) -> Result<RecordBatch, BulkValidationError> {
         let normalized =
             self.normalize_import_nodes(operation_uuid, std::slice::from_ref(batch))?;
-        let identities = FixedSizeBinaryArray::try_from_iter(
-            normalized
-                .rows()
-                .iter()
-                .map(|row| row.node_uuid.as_bytes().as_slice()),
-        )
-        .map_err(|error| {
-            contract_error(
-                BulkInputKind::Node,
-                BulkValidationReason::ProjectState,
-                &error.to_string(),
-            )
-        })?;
+        let identities = canonical_import_uuid_array(
+            BulkInputKind::Node,
+            normalized.rows().iter().map(|row| row.node_uuid),
+        )?;
         let labels =
             StringArray::from_iter_values(normalized.rows().iter().map(|row| row.label.as_str()));
         canonical_import_chunk(
             BulkInputKind::Node,
             batch,
-            vec![Arc::new(identities), Arc::new(labels)],
+            vec![identities, Arc::new(labels)],
         )
     }
 
@@ -832,41 +836,24 @@ impl GraphForge {
             true,
             None,
         )?;
-        let binary = |values: Vec<Uuid>| {
-            FixedSizeBinaryArray::try_from_iter(
-                values.iter().map(|value| value.as_bytes().as_slice()),
-            )
-            .map(Arc::new)
-            .map(|value| value as ArrayRef)
-            .map_err(|error| {
-                contract_error(
-                    BulkInputKind::Edge,
-                    BulkValidationReason::ProjectState,
-                    &error.to_string(),
-                )
-            })
-        };
         canonical_import_chunk(
             BulkInputKind::Edge,
             batch,
             vec![
-                binary(normalized.rows().iter().map(|row| row.edge_uuid).collect())?,
+                canonical_import_uuid_array(
+                    BulkInputKind::Edge,
+                    normalized.rows().iter().map(|row| row.edge_uuid),
+                )?,
                 Arc::new(StringArray::from_iter_values(
                     normalized.rows().iter().map(|row| row.rel_type.as_str()),
                 )),
-                binary(
-                    normalized
-                        .rows()
-                        .iter()
-                        .map(|row| row.source_uuid)
-                        .collect(),
+                canonical_import_uuid_array(
+                    BulkInputKind::Edge,
+                    normalized.rows().iter().map(|row| row.source_uuid),
                 )?,
-                binary(
-                    normalized
-                        .rows()
-                        .iter()
-                        .map(|row| row.target_uuid)
-                        .collect(),
+                canonical_import_uuid_array(
+                    BulkInputKind::Edge,
+                    normalized.rows().iter().map(|row| row.target_uuid),
                 )?,
             ],
         )

--- a/crates/graphforge-api/src/bulk_construction.rs
+++ b/crates/graphforge-api/src/bulk_construction.rs
@@ -302,6 +302,35 @@ pub fn bulk_edge_input_schema(properties: Vec<Field>) -> Result<SchemaRef, BulkV
     input_schema(BulkInputKind::Edge, &EDGE_REQUIRED, properties)
 }
 
+fn canonical_import_chunk(
+    kind: BulkInputKind,
+    source: &RecordBatch,
+    mut required_columns: Vec<ArrayRef>,
+) -> Result<RecordBatch, BulkValidationError> {
+    let required = match kind {
+        BulkInputKind::Node => &NODE_REQUIRED[..],
+        BulkInputKind::Edge => &EDGE_REQUIRED[..],
+    };
+    let property_fields = source.schema().fields()[required.len()..]
+        .iter()
+        .map(|field| field.as_ref().clone())
+        .collect::<Vec<_>>();
+    let mut fields = match kind {
+        BulkInputKind::Node => graphforge_storage::CONSTRUCTION_NODE_SCHEMA
+            .fields()
+            .to_vec(),
+        BulkInputKind::Edge => graphforge_storage::CONSTRUCTION_EDGE_SCHEMA
+            .fields()
+            .to_vec(),
+    };
+    fields.extend(property_fields.into_iter().map(Arc::new));
+    let schema = Arc::new(Schema::new(fields));
+    required_columns.extend(source.columns()[required.len()..].iter().cloned());
+    RecordBatch::try_new(schema, required_columns).map_err(|error| {
+        contract_error(kind, BulkValidationReason::ProjectState, &error.to_string())
+    })
+}
+
 /// Canonical receipt schema used by the later publication slices.
 ///
 /// Receipts retain input order and identify the created object, its node label
@@ -331,28 +360,6 @@ pub fn bulk_receipt_schema() -> SchemaRef {
 }
 
 impl GraphForge {
-    pub(crate) fn import_base_membership(
-        &self,
-        candidates: &[Uuid],
-        kind: graphforge_storage::UuidIndexKind,
-        input_kind: BulkInputKind,
-    ) -> Result<Vec<bool>, BulkValidationError> {
-        let mut index = open_membership_index(self, input_kind)?;
-        let Some(index) = index.as_mut() else {
-            return Ok(vec![false; candidates.len()]);
-        };
-        index
-            .probe(kind, candidates)
-            .map(|(found, _)| found)
-            .map_err(|error| {
-                contract_error(
-                    input_kind,
-                    BulkValidationReason::ProjectState,
-                    &error.to_string(),
-                )
-            })
-    }
-
     pub(crate) fn normalize_import_nodes(
         &self,
         operation_uuid: OperationId,
@@ -361,26 +368,32 @@ impl GraphForge {
         self.normalize_bulk_nodes(operation_uuid, batches, false)
     }
 
-    pub(crate) fn normalize_import_edges(
+    pub(crate) fn normalize_import_node_chunk(
         &self,
         operation_uuid: OperationId,
-        batches: &[RecordBatch],
-        imported_endpoints: &BTreeSet<Uuid>,
-    ) -> Result<ValidatedBulkEdges, BulkValidationError> {
-        let empty_nodes = ValidatedBulkNodes {
-            rows: Vec::new(),
-            operation_uuid,
-            source_generation_uuid: *self
-                .current_generation_uuid
-                .lock()
-                .expect("generation UUID lock poisoned"),
-        };
-        self.normalize_bulk_edges(
-            operation_uuid,
-            batches,
-            &empty_nodes,
-            false,
-            Some(imported_endpoints),
+        batch: &RecordBatch,
+    ) -> Result<RecordBatch, BulkValidationError> {
+        let normalized =
+            self.normalize_import_nodes(operation_uuid, std::slice::from_ref(batch))?;
+        let identities = FixedSizeBinaryArray::try_from_iter(
+            normalized
+                .rows()
+                .iter()
+                .map(|row| row.node_uuid.as_bytes().as_slice()),
+        )
+        .map_err(|error| {
+            contract_error(
+                BulkInputKind::Node,
+                BulkValidationReason::ProjectState,
+                &error.to_string(),
+            )
+        })?;
+        let labels =
+            StringArray::from_iter_values(normalized.rows().iter().map(|row| row.label.as_str()));
+        canonical_import_chunk(
+            BulkInputKind::Node,
+            batch,
+            vec![Arc::new(identities), Arc::new(labels)],
         )
     }
 
@@ -784,6 +797,79 @@ impl GraphForge {
             operation_uuid,
             source_generation_uuid,
         })
+    }
+
+    pub(crate) fn normalize_import_edge_chunk(
+        &self,
+        operation_uuid: OperationId,
+        batch: &RecordBatch,
+    ) -> Result<RecordBatch, BulkValidationError> {
+        // Construction sealing owns the global endpoint proof across all node
+        // chunks. This prevalidation still checks the complete edge schema,
+        // identities, properties, and within-chunk duplicates without retaining
+        // every imported node UUID in memory.
+        let assumed_endpoints = ValidatedBulkNodes {
+            rows: candidate_endpoint_uuids(std::slice::from_ref(batch))?
+                .into_iter()
+                .enumerate()
+                .map(|(ordinal, node_uuid)| BulkNodeRow {
+                    row_ordinal: ordinal as u64,
+                    node_uuid,
+                    label: String::new(),
+                    properties: BTreeMap::new(),
+                })
+                .collect(),
+            operation_uuid,
+            source_generation_uuid: *self
+                .current_generation_uuid
+                .lock()
+                .expect("generation UUID lock poisoned"),
+        };
+        let normalized = self.normalize_bulk_edges(
+            operation_uuid,
+            std::slice::from_ref(batch),
+            &assumed_endpoints,
+            true,
+            None,
+        )?;
+        let binary = |values: Vec<Uuid>| {
+            FixedSizeBinaryArray::try_from_iter(
+                values.iter().map(|value| value.as_bytes().as_slice()),
+            )
+            .map(Arc::new)
+            .map(|value| value as ArrayRef)
+            .map_err(|error| {
+                contract_error(
+                    BulkInputKind::Edge,
+                    BulkValidationReason::ProjectState,
+                    &error.to_string(),
+                )
+            })
+        };
+        canonical_import_chunk(
+            BulkInputKind::Edge,
+            batch,
+            vec![
+                binary(normalized.rows().iter().map(|row| row.edge_uuid).collect())?,
+                Arc::new(StringArray::from_iter_values(
+                    normalized.rows().iter().map(|row| row.rel_type.as_str()),
+                )),
+                binary(
+                    normalized
+                        .rows()
+                        .iter()
+                        .map(|row| row.source_uuid)
+                        .collect(),
+                )?,
+                binary(
+                    normalized
+                        .rows()
+                        .iter()
+                        .map(|row| row.target_uuid)
+                        .collect(),
+                )?,
+            ],
+        )
     }
 
     /// Validate and atomically publish a logical Arrow edge batch.

--- a/crates/graphforge-api/src/import_session.rs
+++ b/crates/graphforge-api/src/import_session.rs
@@ -1,12 +1,10 @@
 //! Durable, bounded staged graph-import sessions (#738).
 
-use std::collections::{BTreeSet, HashMap};
 use std::fs::{self, File};
-use std::io::{BufRead, BufReader, BufWriter, Read, Seek, SeekFrom, Write};
+use std::io::{BufReader, BufWriter, Write};
 use std::path::{Component, Path, PathBuf};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use arrow::array::{Array, FixedSizeBinaryArray};
 use arrow::ipc::reader::FileReader as ArrowFileReader;
 use arrow::ipc::writer::FileWriter as ArrowFileWriter;
 use arrow::record_batch::RecordBatch;
@@ -16,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
-use crate::{BulkInputKind, CancellationToken, GraphForge, OperationId};
+use crate::{BulkInputKind, CancellationToken, GraphConstructionBudgets, GraphForge, OperationId};
 
 const FORMAT_VERSION: u32 = 1;
 const SESSION_DIR: &str = "import-sessions";
@@ -40,7 +38,7 @@ pub struct ImportSessionLimits {
 impl Default for ImportSessionLimits {
     fn default() -> Self {
         Self {
-            batch_rows: 8_192,
+            batch_rows: GraphConstructionBudgets::default().max_batch_rows,
             max_source_bytes: 1 << 40,
             max_files: 100_000,
             max_rejected_rows: 1_000,
@@ -124,6 +122,40 @@ pub struct ImportProgress {
     pub peak_batch_rows: u64,
     /// Configured source-reader concurrency bound.
     pub io_concurrency_limit: u64,
+    /// Durable, content-free evidence from the ordinary graph-construction path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub construction: Option<ImportConstructionEvidence>,
+}
+
+/// Sanitized durable construction evidence for an ordinary staged import.
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub struct ImportConstructionEvidence {
+    /// Configured authoritative construction chunk budget.
+    pub configured_batch_rows: u64,
+    /// Number of durably accepted construction chunks.
+    pub accepted_chunks: u64,
+    /// Whether the sole generation publication was committed.
+    pub publication_committed: bool,
+    /// Exact application-I/O attribution across the closed construction phases.
+    pub application_io: graphforge_storage::ConstructionPhaseAttribution,
+    /// Exact accepted input rows.
+    pub input_rows: u64,
+    /// Exact non-replay input batches.
+    pub input_batches: u64,
+    /// Immutable construction artifacts accepted from authenticated receipts.
+    pub immutable_artifacts: u64,
+    /// Application payload bytes submitted by construction artifact writers.
+    pub write_bytes: u64,
+    /// Application write submissions by construction artifact writers.
+    pub write_operations: u64,
+    /// File and directory durability barriers completed by construction.
+    pub fsync_operations: u64,
+    /// Largest retained Arrow row window.
+    pub peak_batch_rows: u64,
+    /// Largest retained Arrow byte window.
+    pub peak_batch_bytes: u64,
+    /// Exact transient allocation high-water retained across resume.
+    pub transient_peak_allocated_bytes: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -151,6 +183,8 @@ struct SessionManifest {
     progress: ImportProgress,
     sources: Vec<SourceRecord>,
     #[serde(default)]
+    construction_session_uuid: Option<Uuid>,
+    #[serde(default)]
     updated_unix_millis: u64,
 }
 
@@ -177,15 +211,6 @@ impl GraphForge {
             ));
         }
         fs::create_dir_all(root.join("sources")).map_err(storage)?;
-        copy_tree(&self.dir, &root.join("graph"))?;
-        if !graphforge_storage::uuid_membership_index_is_fresh(&root.join("graph"))? {
-            graphforge_storage::rebuild_uuid_membership_indexes(
-                &root.join("graph"),
-                graphforge_storage::UuidIndexBuildLimits::default(),
-            )?;
-        }
-        File::create(root.join("nodes.uuidx")).map_err(storage)?;
-        File::create(root.join("edges.uuidx")).map_err(storage)?;
         let manifest = SessionManifest {
             format_version: FORMAT_VERSION,
             session_uuid,
@@ -201,6 +226,7 @@ impl GraphForge {
                 ..ImportProgress::default()
             },
             sources: Vec::new(),
+            construction_session_uuid: None,
             updated_unix_millis: unix_millis()?,
         };
         write_manifest(&root, &manifest)?;
@@ -229,6 +255,19 @@ impl GraphForge {
             manifest,
             observed: Instant::now(),
         })
+    }
+
+    /// Reopen the durable, content-free status of any import session, including terminal ones.
+    pub fn import_session_status(
+        &self,
+        session_uuid: Uuid,
+    ) -> Result<(ImportPhase, ImportProgress), GfError> {
+        let root = import_root(self, session_uuid)?;
+        let manifest = read_manifest(&root)?;
+        if manifest.format_version != FORMAT_VERSION || manifest.session_uuid != session_uuid {
+            return Err(validation("incompatible or mismatched import manifest"));
+        }
+        Ok((manifest.phase, manifest.progress))
     }
 
     /// Abort and remove durable staging for non-terminal sessions older than `max_age`.
@@ -261,7 +300,7 @@ impl GraphForge {
             manifest.phase = ImportPhase::Aborted;
             manifest.updated_unix_millis = now;
             write_manifest(&root, &manifest)?;
-            for path in [root.join("sources"), root.join("graph")] {
+            for path in [root.join("sources")] {
                 if path.exists() {
                     fs::remove_dir_all(path).map_err(storage)?;
                 }
@@ -269,99 +308,6 @@ impl GraphForge {
             cleaned = cleaned.saturating_add(1);
         }
         Ok(cleaned)
-    }
-
-    fn publish_import_tree(
-        &self,
-        staged_graph: &Path,
-        operation_uuid: Uuid,
-        expected_parent: Uuid,
-        cancellation: Option<&CancellationToken>,
-    ) -> Result<Uuid, GfError> {
-        use graphforge_storage::{
-            ProjectCapability, ProjectGenerationRequest, ProjectStageOutcome,
-        };
-
-        let _visibility = self.graph_visibility.acquire(cancellation)?;
-        cancellation.map_or(Ok(()), CancellationToken::checkpoint)?;
-        let container = self.resolved_generation.container_root();
-        let parent = graphforge_storage::resolve_project_generation(container)?;
-        parent.validate_complete_participant_inventory()?;
-        if parent.generation_uuid() != expected_parent {
-            return Err(validation(
-                "project generation changed before import commit",
-            ));
-        }
-        if !graphforge_storage::uuid_membership_index_is_fresh(staged_graph)? {
-            graphforge_storage::rebuild_uuid_membership_indexes(
-                staged_graph,
-                graphforge_storage::UuidIndexBuildLimits::default(),
-            )?;
-        }
-        let graph_files = graphforge_storage::capture_graph_files(staged_graph)?.1;
-        let recorded_at = (self.clock.lock().expect("clock lock poisoned"))()?;
-        let receipt = graphforge_exec::MutationReceipt::default();
-        let participants = super::graph_publication_participants(
-            &parent,
-            graph_files,
-            self.semantic_storage_bindings
-                .lock()
-                .expect("semantic storage binding lock poisoned")
-                .as_ref(),
-            parent.capability("provenance")?.is_some(),
-            &receipt,
-            operation_uuid,
-            None,
-            recorded_at,
-        )?;
-        let generation_uuid = super::mutation_generation_uuid(operation_uuid, &participants);
-        let request = ProjectGenerationRequest {
-            transaction_uuid: operation_uuid,
-            generation_uuid,
-            capabilities: parent
-                .capabilities()
-                .into_iter()
-                .map(|capability| ProjectCapability {
-                    capability_id: capability.capability_id,
-                    capability_version: capability.capability_version,
-                })
-                .collect(),
-            participants,
-        };
-        cancellation.map_or(Ok(()), CancellationToken::checkpoint)?;
-        let publication = match graphforge_storage::stage_project_generation_with_graph_tree_mode(
-            container,
-            &request,
-            Some(staged_graph),
-            self.lifecycle_mode,
-        )? {
-            ProjectStageOutcome::AlreadyPublished(receipt) => receipt,
-            ProjectStageOutcome::Staged(staged) => staged
-                .validate(
-                    |_| Ok(()),
-                    |actual_parent, _| {
-                        if actual_parent.generation_uuid() != expected_parent {
-                            return Err(validation(
-                                "project generation changed before import publication",
-                            ));
-                        }
-                        Ok(())
-                    },
-                )?
-                .publish()?,
-        };
-        *self
-            .current_generation_uuid
-            .lock()
-            .expect("generation UUID lock poisoned") = publication.generation_uuid;
-        let resolved = graphforge_storage::resolve_project_generation(container)?;
-        super::rematerialize_graph_workspace(&resolved, &self.dir)?;
-        *self
-            .runtime_catalog
-            .lock()
-            .expect("runtime catalog poisoned") = super::load_runtime_catalog(&self.dir)?;
-        self.adjacency_provider.invalidate();
-        Ok(publication.generation_uuid)
     }
 }
 
@@ -487,6 +433,9 @@ impl GraphImportSession {
     ) -> Result<ImportProgress, GfError> {
         self.ensure_open()?;
         self.ensure_base(graph)?;
+        let mut construction = self.open_construction(graph)?;
+        let session_root = self.root.clone();
+        let batch_rows = self.manifest.limits.batch_rows;
         for input_kind in [BulkInputKind::Node, BulkInputKind::Edge] {
             for source_index in 0..self.manifest.sources.len() {
                 let source = self.manifest.sources[source_index].clone();
@@ -494,74 +443,80 @@ impl GraphImportSession {
                     continue;
                 }
                 let mut batch_index = 0_u64;
-                for_each_source_batch(
-                    &self.root,
-                    &source,
-                    self.manifest.limits.batch_rows,
-                    |batch| {
-                        if batch_index < source.batches_staged {
-                            batch_index += 1;
-                            return Ok(());
-                        }
-                        if cancellation.is_some_and(CancellationToken::is_cancelled) {
-                            return Err(cancelled());
-                        }
-                        let operation = import_batch_operation(
-                            self.manifest.operation_uuid,
-                            source.sequence,
-                            batch_index,
-                        );
-                        let recovering = source.inflight_batch == Some(batch_index);
-                        if !recovering {
-                            self.manifest.sources[source_index].inflight_batch = Some(batch_index);
-                            write_manifest(&self.root, &self.manifest)?;
-                        }
-                        let staged = match input_kind {
-                            BulkInputKind::Node => {
-                                stage_node_batch(graph, &self.root, operation, &batch, recovering)
-                            }
-                            BulkInputKind::Edge => {
-                                stage_edge_batch(graph, &self.root, operation, &batch, recovering)
-                            }
-                        };
-                        if let Err(error) = staged {
-                            self.manifest.sources[source_index].inflight_batch = None;
-                            let remaining = self
-                                .manifest
-                                .limits
-                                .max_rejected_rows
-                                .saturating_sub(self.manifest.progress.rows_rejected);
-                            self.manifest.progress.rows_rejected = self
-                                .manifest
-                                .progress
-                                .rows_rejected
-                                .saturating_add((batch.num_rows() as u64).min(remaining));
-                            write_manifest(&self.root, &self.manifest)?;
-                            return Err(error);
-                        }
+                for_each_source_batch(&session_root, &source, batch_rows, |batch| {
+                    if batch_index < source.batches_staged {
                         batch_index += 1;
-                        self.manifest.sources[source_index].batches_staged = batch_index;
-                        self.manifest.sources[source_index].inflight_batch = None;
-                        self.manifest.progress.rows_accepted = self
-                            .manifest
-                            .progress
-                            .rows_accepted
-                            .saturating_add(batch.num_rows() as u64);
-                        self.manifest.progress.peak_batch_rows = self
-                            .manifest
-                            .progress
-                            .peak_batch_rows
-                            .max(batch.num_rows() as u64);
+                        return Ok(());
+                    }
+                    if cancellation.is_some_and(CancellationToken::is_cancelled) {
+                        return Err(cancelled());
+                    }
+                    let operation = import_batch_operation(
+                        self.manifest.operation_uuid,
+                        source.sequence,
+                        batch_index,
+                    );
+                    let batch = match input_kind {
+                        BulkInputKind::Node => graph.normalize_import_node_chunk(operation, &batch),
+                        BulkInputKind::Edge => graph.normalize_import_edge_chunk(operation, &batch),
+                    }
+                    .map_err(|error| validation(error.to_string()))?;
+                    let recovering = source.inflight_batch == Some(batch_index);
+                    if !recovering {
+                        self.manifest.sources[source_index].inflight_batch = Some(batch_index);
                         write_manifest(&self.root, &self.manifest)?;
-                        Ok(())
-                    },
-                )?;
+                    }
+                    let chunk_id = format!("import-{:020}-{:020}", source.sequence, batch_index);
+                    let staged = match (input_kind, cancellation) {
+                        (BulkInputKind::Node, Some(token)) => {
+                            construction.append_nodes_with_cancellation(&chunk_id, &batch, token)
+                        }
+                        (BulkInputKind::Node, None) => construction.append_nodes(&chunk_id, &batch),
+                        (BulkInputKind::Edge, Some(token)) => {
+                            construction.append_edges_with_cancellation(&chunk_id, &batch, token)
+                        }
+                        (BulkInputKind::Edge, None) => construction.append_edges(&chunk_id, &batch),
+                    };
+                    if let Err(error) = staged {
+                        self.manifest.sources[source_index].inflight_batch = None;
+                        let remaining = self
+                            .manifest
+                            .limits
+                            .max_rejected_rows
+                            .saturating_sub(self.manifest.progress.rows_rejected);
+                        self.manifest.progress.rows_rejected = self
+                            .manifest
+                            .progress
+                            .rows_rejected
+                            .saturating_add((batch.num_rows() as u64).min(remaining));
+                        write_manifest(&self.root, &self.manifest)?;
+                        return Err(error);
+                    }
+                    batch_index += 1;
+                    self.manifest.sources[source_index].batches_staged = batch_index;
+                    self.manifest.sources[source_index].inflight_batch = None;
+                    self.manifest.progress.rows_accepted = self
+                        .manifest
+                        .progress
+                        .rows_accepted
+                        .saturating_add(batch.num_rows() as u64);
+                    self.manifest.progress.peak_batch_rows = self
+                        .manifest
+                        .progress
+                        .peak_batch_rows
+                        .max(batch.num_rows() as u64);
+                    self.update_construction_progress(&construction.progress())?;
+                    write_manifest(&self.root, &self.manifest)?;
+                    Ok(())
+                })?;
                 self.manifest.sources[source_index].staged = true;
                 self.manifest.progress.files_pending =
                     self.manifest.progress.files_pending.saturating_sub(1);
                 write_manifest(&self.root, &self.manifest)?;
             }
         }
+        construction.validate_and_seal(cancellation)?;
+        self.update_construction_progress(&construction.progress())?;
         self.manifest.phase = ImportPhase::Validated;
         self.checkpoint()
     }
@@ -574,7 +529,7 @@ impl GraphImportSession {
         self.manifest.phase = ImportPhase::Aborted;
         self.checkpoint()?;
         let progress = self.manifest.progress.clone();
-        let cleanup = [self.root.join("sources"), self.root.join("graph")]
+        let cleanup = [self.root.join("sources")]
             .into_iter()
             .try_for_each(|path| {
                 if path.exists() {
@@ -599,29 +554,20 @@ impl GraphImportSession {
         graph: &GraphForge,
         cancellation: Option<&CancellationToken>,
     ) -> Result<Uuid, GfError> {
-        if let Some(published) = graphforge_storage::published_project_transaction(
-            graph.resolved_generation.container_root(),
-            self.manifest.operation_uuid,
-        )? {
-            self.manifest.phase = ImportPhase::Committed;
-            self.checkpoint()?;
-            return Ok(published.generation_uuid);
-        }
-        self.ensure_base(graph)?;
         if self.manifest.phase != ImportPhase::Validated
             || self.manifest.progress.files_pending != 0
         {
             return Err(validation("import must be fully validated before commit"));
         }
-        let generation = graph.publish_import_tree(
-            &self.root.join("graph"),
-            self.manifest.operation_uuid,
-            self.manifest.base_generation_uuid,
-            cancellation,
-        )?;
+        let mut construction = self.open_construction(graph)?;
+        let publication = match cancellation {
+            Some(token) => construction.seal_and_publish_with_cancellation(token)?,
+            None => construction.seal_and_publish()?,
+        };
+        self.update_construction_progress(&construction.progress())?;
         self.manifest.phase = ImportPhase::Committed;
         self.checkpoint()?;
-        Ok(generation)
+        Ok(publication.generation_uuid)
     }
 
     fn ensure_open(&self) -> Result<(), GfError> {
@@ -643,6 +589,57 @@ impl GraphImportSession {
         if current != self.manifest.base_generation_uuid {
             return Err(validation("project generation changed since import began"));
         }
+        Ok(())
+    }
+
+    fn construction_budgets(&self) -> GraphConstructionBudgets {
+        let mut budgets = GraphConstructionBudgets::default();
+        budgets.max_batch_rows = self.manifest.limits.batch_rows;
+        budgets.max_run_records = budgets
+            .max_run_records
+            .max(self.manifest.limits.batch_rows.saturating_mul(4));
+        budgets
+    }
+
+    fn open_construction<'a>(
+        &mut self,
+        graph: &'a GraphForge,
+    ) -> Result<crate::GraphConstructionSession<'a>, GfError> {
+        let budgets = self.construction_budgets();
+        if let Some(session_uuid) = self.manifest.construction_session_uuid {
+            return graph.resume_graph_construction(session_uuid, budgets);
+        }
+        let session = graph.begin_graph_construction(budgets)?;
+        self.manifest.construction_session_uuid = Some(session.session_uuid());
+        write_manifest(&self.root, &self.manifest)?;
+        Ok(session)
+    }
+
+    fn update_construction_progress(
+        &mut self,
+        progress: &crate::GraphConstructionProgress,
+    ) -> Result<(), GfError> {
+        let application_io =
+            graphforge_storage::ConstructionPhaseAttribution::from_construction(&progress.evidence);
+        application_io.validate_for_qualification()?;
+        self.manifest.progress.construction = Some(ImportConstructionEvidence {
+            configured_batch_rows: u64::try_from(self.manifest.limits.batch_rows)
+                .unwrap_or(u64::MAX),
+            accepted_chunks: progress.accepted_chunks,
+            publication_committed: progress.publication_committed,
+            application_io,
+            input_rows: progress.evidence.input_rows,
+            input_batches: progress.evidence.input_batches,
+            immutable_artifacts: progress.evidence.immutable_artifacts,
+            write_bytes: progress.evidence.write_bytes,
+            write_operations: progress.evidence.write_operations,
+            fsync_operations: progress.evidence.fsync_operations,
+            peak_batch_rows: progress.evidence.peak_batch_rows,
+            peak_batch_bytes: progress.evidence.peak_batch_bytes,
+            transient_peak_allocated_bytes: progress
+                .evidence
+                .storage_transient_peak_total_allocated_bytes,
+        });
         Ok(())
     }
 
@@ -690,286 +687,6 @@ fn unix_millis() -> Result<u64, GfError> {
             .as_millis(),
     )
     .unwrap_or(u64::MAX))
-}
-
-fn stage_node_batch(
-    graph: &GraphForge,
-    root: &Path,
-    operation: OperationId,
-    batch: &RecordBatch,
-    allow_replay: bool,
-) -> Result<(), GfError> {
-    let graph_dir = root.join("graph");
-    let normalized = graph
-        .normalize_import_nodes(operation, std::slice::from_ref(batch))
-        .map_err(|error| validation(error.to_string()))?;
-    let candidates = normalized
-        .rows()
-        .iter()
-        .map(|row| row.node_uuid)
-        .collect::<Vec<_>>();
-    let base_nodes = graph
-        .import_base_membership(
-            &candidates,
-            graphforge_storage::UuidIndexKind::Node,
-            BulkInputKind::Node,
-        )
-        .map_err(|error| validation(error.to_string()))?;
-    let base_edges = graph
-        .import_base_membership(
-            &candidates,
-            graphforge_storage::UuidIndexKind::Edge,
-            BulkInputKind::Node,
-        )
-        .map_err(|error| validation(error.to_string()))?;
-    let session_nodes = probe_session_index(&root.join("nodes.uuidx"), &candidates)?;
-    let session_edges = probe_session_index(&root.join("edges.uuidx"), &candidates)?;
-    if allow_replay
-        && session_nodes.iter().all(|found| *found)
-        && base_nodes.iter().all(|found| !*found)
-        && base_edges.iter().all(|found| !*found)
-        && session_edges.iter().all(|found| !*found)
-    {
-        return Ok(());
-    }
-    if base_nodes
-        .iter()
-        .chain(&base_edges)
-        .chain(&session_nodes)
-        .chain(&session_edges)
-        .any(|found| *found)
-    {
-        return Err(validation(
-            "import node UUID conflicts with staged graph identity",
-        ));
-    }
-    let mut catalog = super::load_runtime_catalog(&graph_dir)?;
-    let mut writer = graphforge_storage::GraphWriter::open(&graph_dir, graph.ontology_mode)?;
-    for row in normalized.rows() {
-        let type_id = graph
-            .ontology
-            .as_ref()
-            .and_then(|ontology| ontology.entity_type_id(&row.label))
-            .unwrap_or_else(|| {
-                graphforge_ir::runtime_entity_type_id(catalog.intern_label(&row.label))
-            });
-        writer.create_node(row.node_uuid, type_id)?;
-        let properties = row
-            .properties
-            .iter()
-            .map(|(name, value)| {
-                catalog.intern_property(name, Some(&row.label));
-                Ok((name.clone(), crate::construction::prop_literal(value)?))
-            })
-            .collect::<Result<HashMap<_, _>, GfError>>()?;
-        if !properties.is_empty() {
-            writer.set_properties(&row.node_uuid, Some(&row.label), properties)?;
-        }
-    }
-    writer.flush()?;
-    super::persist_runtime_catalog(&graph_dir, &catalog)?;
-    merge_session_index(&root.join("nodes.uuidx"), &candidates)?;
-    Ok(())
-}
-
-fn stage_edge_batch(
-    graph: &GraphForge,
-    root: &Path,
-    operation: OperationId,
-    batch: &RecordBatch,
-    allow_replay: bool,
-) -> Result<(), GfError> {
-    let graph_dir = root.join("graph");
-    let endpoints = batch_endpoint_uuids(batch)?;
-    let imported_found = probe_session_index(&root.join("nodes.uuidx"), &endpoints)?;
-    let imported_endpoints = endpoints
-        .iter()
-        .zip(imported_found)
-        .filter_map(|(candidate, found)| found.then_some(*candidate))
-        .collect::<BTreeSet<_>>();
-    let normalized = graph
-        .normalize_import_edges(operation, std::slice::from_ref(batch), &imported_endpoints)
-        .map_err(|error| validation(error.to_string()))?;
-    let candidates = normalized
-        .rows()
-        .iter()
-        .map(|row| row.edge_uuid)
-        .collect::<Vec<_>>();
-    let base_edges = graph
-        .import_base_membership(
-            &candidates,
-            graphforge_storage::UuidIndexKind::Edge,
-            BulkInputKind::Edge,
-        )
-        .map_err(|error| validation(error.to_string()))?;
-    let base_nodes = graph
-        .import_base_membership(
-            &candidates,
-            graphforge_storage::UuidIndexKind::Node,
-            BulkInputKind::Edge,
-        )
-        .map_err(|error| validation(error.to_string()))?;
-    let session_edges = probe_session_index(&root.join("edges.uuidx"), &candidates)?;
-    let session_nodes = probe_session_index(&root.join("nodes.uuidx"), &candidates)?;
-    if allow_replay
-        && session_edges.iter().all(|found| *found)
-        && base_edges.iter().all(|found| !*found)
-        && base_nodes.iter().all(|found| !*found)
-        && session_nodes.iter().all(|found| !*found)
-    {
-        return Ok(());
-    }
-    if base_edges
-        .iter()
-        .chain(&base_nodes)
-        .chain(&session_edges)
-        .chain(&session_nodes)
-        .any(|found| *found)
-    {
-        return Err(validation(
-            "import edge UUID conflicts with staged graph identity",
-        ));
-    }
-    let mut catalog = super::load_runtime_catalog(&graph_dir)?;
-    let mut writer = graphforge_storage::GraphWriter::open(&graph_dir, graph.ontology_mode)?;
-    let endpoints = normalized
-        .rows()
-        .iter()
-        .flat_map(|row| [row.source_uuid, row.target_uuid])
-        .collect::<BTreeSet<_>>();
-    crate::bulk_construction::register_existing_endpoints(&mut writer, &graph_dir, &endpoints)?;
-    for row in normalized.rows() {
-        catalog.intern_relation_type(&row.rel_type);
-        writer.create_edge(
-            row.edge_uuid,
-            &row.rel_type,
-            &row.source_uuid,
-            &row.target_uuid,
-        )?;
-        let properties = row
-            .properties
-            .iter()
-            .map(|(name, value)| {
-                catalog.intern_property(name, Some(&row.rel_type));
-                Ok((name.clone(), crate::construction::prop_literal(value)?))
-            })
-            .collect::<Result<HashMap<_, _>, GfError>>()?;
-        if !properties.is_empty() {
-            writer.set_edge_properties(&row.edge_uuid, Some(&row.rel_type), properties)?;
-        }
-    }
-    writer.flush()?;
-    super::persist_runtime_catalog(&graph_dir, &catalog)?;
-    merge_session_index(&root.join("edges.uuidx"), &candidates)?;
-    Ok(())
-}
-
-fn batch_endpoint_uuids(batch: &RecordBatch) -> Result<Vec<Uuid>, GfError> {
-    let mut endpoints = Vec::with_capacity(batch.num_rows().saturating_mul(2));
-    for name in ["source_uuid", "target_uuid"] {
-        let column = batch
-            .column_by_name(name)
-            .ok_or_else(|| validation(format!("missing {name}")))?;
-        let values = column
-            .as_any()
-            .downcast_ref::<FixedSizeBinaryArray>()
-            .ok_or_else(|| validation(format!("{name} must be fixed-size binary")))?;
-        for row in 0..values.len() {
-            endpoints.push(Uuid::from_slice(values.value(row)).map_err(storage)?);
-        }
-    }
-    endpoints.sort_unstable();
-    endpoints.dedup();
-    Ok(endpoints)
-}
-
-fn probe_session_index(path: &Path, candidates: &[Uuid]) -> Result<Vec<bool>, GfError> {
-    let mut file = File::open(path).map_err(storage)?;
-    let bytes = file.metadata().map_err(storage)?.len();
-    if bytes % 16 != 0 {
-        return Err(validation("corrupt import membership index"));
-    }
-    let count = bytes / 16;
-    candidates
-        .iter()
-        .map(|candidate| {
-            let mut low = 0_u64;
-            let mut high = count;
-            let needle = candidate.as_bytes();
-            let mut slot = [0_u8; 16];
-            while low < high {
-                let mid = low + (high - low) / 2;
-                file.seek(SeekFrom::Start(mid * 16)).map_err(storage)?;
-                file.read_exact(&mut slot).map_err(storage)?;
-                match slot.cmp(needle) {
-                    std::cmp::Ordering::Less => low = mid + 1,
-                    std::cmp::Ordering::Greater => high = mid,
-                    std::cmp::Ordering::Equal => return Ok(true),
-                }
-            }
-            Ok(false)
-        })
-        .collect()
-}
-
-fn merge_session_index(path: &Path, candidates: &[Uuid]) -> Result<(), GfError> {
-    let mut additions = candidates.to_vec();
-    additions.sort_unstable();
-    additions.dedup();
-    let old_file = File::open(path).map_err(storage)?;
-    if old_file.metadata().map_err(storage)?.len() % 16 != 0 {
-        return Err(validation("corrupt import membership index"));
-    }
-    let temp = path.with_extension("uuidx.tmp");
-    let mut output = BufWriter::new(File::create(&temp).map_err(storage)?);
-    let mut old = BufReader::new(old_file);
-    let mut old_value = read_index_uuid(&mut old)?;
-    let mut new_values = additions.iter().peekable();
-    while old_value.is_some() || new_values.peek().is_some() {
-        match (old_value, new_values.peek()) {
-            (Some(current), Some(new_value)) if current <= *new_value.as_bytes() => {
-                output.write_all(&current).map_err(storage)?;
-                old_value = read_index_uuid(&mut old)?;
-            }
-            (_, Some(new_value)) => {
-                output.write_all(new_value.as_bytes()).map_err(storage)?;
-                new_values.next();
-            }
-            (Some(current), None) => {
-                output.write_all(&current).map_err(storage)?;
-                old_value = read_index_uuid(&mut old)?;
-            }
-            (None, None) => break,
-        }
-    }
-    output.flush().map_err(storage)?;
-    output.get_ref().sync_all().map_err(storage)?;
-    drop(output);
-    fs::rename(temp, path).map_err(storage)
-}
-
-fn read_index_uuid(reader: &mut BufReader<File>) -> Result<Option<[u8; 16]>, GfError> {
-    if reader.fill_buf().map_err(storage)?.is_empty() {
-        return Ok(None);
-    }
-    let mut value = [0_u8; 16];
-    reader.read_exact(&mut value).map_err(storage)?;
-    Ok(Some(value))
-}
-
-fn import_batch_operation(base: Uuid, source: u64, batch: u64) -> OperationId {
-    let mut digest = Sha256::new();
-    digest.update(b"graphforge.import.batch.v1\0");
-    digest.update(base.as_bytes());
-    digest.update(source.to_be_bytes());
-    digest.update(batch.to_be_bytes());
-    let digest = digest.finalize();
-    let mut bytes = [0_u8; 16];
-    bytes[..6].copy_from_slice(&base.as_bytes()[..6]);
-    bytes[6..].copy_from_slice(&digest[..10]);
-    bytes[6] = (bytes[6] & 0x0f) | 0x70;
-    bytes[8] = (bytes[8] & 0x3f) | 0x80;
-    OperationId(Uuid::from_bytes(bytes))
 }
 
 fn for_each_source_batch(
@@ -1063,24 +780,19 @@ fn reject_unsafe_path(path: &Path) -> Result<(), GfError> {
     Ok(())
 }
 
-fn copy_tree(source: &Path, destination: &Path) -> Result<(), GfError> {
-    fs::create_dir_all(destination).map_err(storage)?;
-    for entry in fs::read_dir(source).map_err(storage)? {
-        let entry = entry.map_err(storage)?;
-        let file_type = entry.file_type().map_err(storage)?;
-        if file_type.is_symlink() {
-            return Err(validation("staged graph copy refuses symlink entries"));
-        }
-        let target = destination.join(entry.file_name());
-        if file_type.is_dir() {
-            copy_tree(&entry.path(), &target)?;
-        } else if file_type.is_file() {
-            fs::copy(entry.path(), &target).map_err(storage)?;
-        } else {
-            return Err(validation("staged graph copy refuses special files"));
-        }
-    }
-    Ok(())
+fn import_batch_operation(base: Uuid, source: u64, batch: u64) -> OperationId {
+    let mut digest = Sha256::new();
+    digest.update(b"graphforge.import.batch.v1\0");
+    digest.update(base.as_bytes());
+    digest.update(source.to_be_bytes());
+    digest.update(batch.to_be_bytes());
+    let digest = digest.finalize();
+    let mut bytes = [0_u8; 16];
+    bytes[..6].copy_from_slice(&base.as_bytes()[..6]);
+    bytes[6..].copy_from_slice(&digest[..10]);
+    bytes[6] = (bytes[6] & 0x0f) | 0x70;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    OperationId(Uuid::from_bytes(bytes))
 }
 
 fn sync_file(path: &Path) -> Result<(), GfError> {
@@ -1323,14 +1035,28 @@ mod tests {
             .append_arrow(BulkInputKind::Node, std::slice::from_ref(&batch))
             .unwrap();
         let batch_operation = import_batch_operation(operation.0, 0, 0);
-        stage_node_batch(&graph, &session.root, batch_operation, &batch, false).unwrap();
+        let normalized = graph
+            .normalize_import_node_chunk(batch_operation, &batch)
+            .unwrap();
+        let mut construction = session.open_construction(&graph).unwrap();
+        construction
+            .append_nodes(
+                "import-00000000000000000000-00000000000000000000",
+                &normalized,
+            )
+            .unwrap();
+        drop(construction);
         session.manifest.sources[0].inflight_batch = Some(0);
         write_manifest(&session.root, &session.manifest).unwrap();
         let session_uuid = session.session_uuid();
         drop(session);
 
         let mut resumed = graph.resume_import_session(session_uuid).unwrap();
-        assert_eq!(resumed.validate(&graph).unwrap().rows_accepted, 1);
+        let progress = resumed.validate(&graph).unwrap();
+        assert_eq!(progress.rows_accepted, 1);
+        let construction = progress.construction.unwrap();
+        assert_eq!(construction.accepted_chunks, 1);
+        assert_eq!(construction.input_batches, 1);
         drop(resumed);
 
         let mut manifest = read_manifest(&import_root(&graph, session_uuid).unwrap()).unwrap();
@@ -1343,8 +1069,81 @@ mod tests {
             1
         );
         let root = import_root(&graph, session_uuid).unwrap();
-        assert!(!root.join("graph").exists());
         assert!(!root.join("sources").exists());
         assert_eq!(read_manifest(&root).unwrap().phase, ImportPhase::Aborted);
+    }
+
+    #[test]
+    fn parquet_construction_receipts_scale_linearly_and_survive_reopen() {
+        assert_eq!(ImportSessionLimits::default().batch_rows, 65_536);
+
+        fn run(multiplier: usize) -> ImportConstructionEvidence {
+            let (_directory, project, graph) = fixture();
+            let source_dir = tempfile::tempdir().unwrap();
+            let parquet = source_dir.path().join("nodes.parquet");
+            let ids = (0..(4 * multiplier))
+                .map(|_| Uuid::now_v7())
+                .collect::<Vec<_>>();
+            let batch = nodes(&ids);
+            let mut writer =
+                ArrowWriter::try_new(File::create(&parquet).unwrap(), batch.schema(), None)
+                    .unwrap();
+            writer.write(&batch).unwrap();
+            writer.close().unwrap();
+
+            let limits = ImportSessionLimits {
+                batch_rows: 4,
+                ..ImportSessionLimits::default()
+            };
+            let mut session = graph
+                .begin_import_session(OperationId(Uuid::now_v7()), limits)
+                .unwrap();
+            session
+                .register_parquet(BulkInputKind::Node, &parquet)
+                .unwrap();
+            let session_uuid = session.session_uuid();
+            let validated = session.validate(&graph).unwrap();
+            assert_eq!(
+                validated.construction.as_ref().unwrap().accepted_chunks,
+                multiplier as u64
+            );
+            session.commit(&graph, None).unwrap();
+            let (_, durable) = graph.import_session_status(session_uuid).unwrap();
+            let receipt = durable.construction.unwrap();
+            assert!(receipt.publication_committed);
+            assert_eq!(receipt.input_rows, (4 * multiplier) as u64);
+            assert_eq!(receipt.input_batches, multiplier as u64);
+            assert_eq!(receipt.peak_batch_rows, 4);
+
+            drop(graph);
+            let reopened = GraphForge::new(project.to_str()).unwrap();
+            let (phase, reopened_progress) = reopened.import_session_status(session_uuid).unwrap();
+            assert_eq!(phase, ImportPhase::Committed);
+            assert_eq!(reopened_progress.construction.as_ref(), Some(&receipt));
+            receipt
+        }
+
+        let receipts = [run(1), run(2), run(4)];
+        for (previous, next) in receipts.iter().zip(receipts.iter().skip(1)) {
+            assert_eq!(next.accepted_chunks, previous.accepted_chunks * 2);
+            assert_eq!(next.input_rows, previous.input_rows * 2);
+            assert_eq!(next.input_batches, previous.input_batches * 2);
+            for (smaller, larger) in [
+                (previous.write_bytes, next.write_bytes),
+                (previous.write_operations, next.write_operations),
+                (previous.immutable_artifacts, next.immutable_artifacts),
+                (previous.fsync_operations, next.fsync_operations),
+                (
+                    previous.application_io.totals.write_calls,
+                    next.application_io.totals.write_calls,
+                ),
+            ] {
+                assert!(larger >= smaller, "durable work must be monotonic");
+                assert!(
+                    larger <= smaller.saturating_mul(3),
+                    "doubling rows exceeded the bounded linear work envelope"
+                );
+            }
+        }
     }
 }

--- a/crates/graphforge-api/src/import_session.rs
+++ b/crates/graphforge-api/src/import_session.rs
@@ -289,7 +289,7 @@ impl GraphForge {
                 continue;
             }
             let root = entry.path();
-            let mut manifest = read_manifest(&root)?;
+            let manifest = read_manifest(&root)?;
             if matches!(
                 manifest.phase,
                 ImportPhase::Committed | ImportPhase::Aborted
@@ -297,14 +297,12 @@ impl GraphForge {
             {
                 continue;
             }
-            manifest.phase = ImportPhase::Aborted;
-            manifest.updated_unix_millis = now;
-            write_manifest(&root, &manifest)?;
-            for path in [root.join("sources")] {
-                if path.exists() {
-                    fs::remove_dir_all(path).map_err(storage)?;
-                }
+            GraphImportSession {
+                root,
+                manifest,
+                observed: Instant::now(),
             }
+            .abort(self)?;
             cleaned = cleaned.saturating_add(1);
         }
         Ok(cleaned)
@@ -461,6 +459,13 @@ impl GraphImportSession {
                         BulkInputKind::Edge => graph.normalize_import_edge_chunk(operation, &batch),
                     }
                     .map_err(|error| validation(error.to_string()))?;
+                    if batch.num_rows() == 0 {
+                        batch_index += 1;
+                        self.manifest.sources[source_index].batches_staged = batch_index;
+                        self.manifest.sources[source_index].inflight_batch = None;
+                        write_manifest(&self.root, &self.manifest)?;
+                        return Ok(());
+                    }
                     let recovering = source.inflight_batch == Some(batch_index);
                     if !recovering {
                         self.manifest.sources[source_index].inflight_batch = Some(batch_index);
@@ -522,28 +527,32 @@ impl GraphImportSession {
     }
 
     /// Abort without changing CURRENT; removes staged sources or quarantines on cleanup failure.
-    pub fn abort(mut self) -> Result<ImportProgress, GfError> {
+    pub fn abort(mut self, graph: &GraphForge) -> Result<ImportProgress, GfError> {
         if self.manifest.phase == ImportPhase::Committed {
             return Err(validation("committed import cannot be aborted"));
         }
-        self.manifest.phase = ImportPhase::Aborted;
-        self.checkpoint()?;
-        let progress = self.manifest.progress.clone();
-        let cleanup = [self.root.join("sources")]
-            .into_iter()
-            .try_for_each(|path| {
-                if path.exists() {
-                    fs::remove_dir_all(path)
-                } else {
-                    Ok(())
-                }
-            });
+        let cleanup = (|| {
+            if let Some(session_uuid) = self.manifest.construction_session_uuid {
+                graph
+                    .resume_graph_construction(session_uuid, self.construction_budgets())?
+                    .discard()?;
+                self.manifest.construction_session_uuid = None;
+            }
+            let sources = self.root.join("sources");
+            if sources.exists() {
+                fs::remove_dir_all(sources).map_err(storage)?;
+            }
+            Ok::<(), GfError>(())
+        })();
         match cleanup {
-            Ok(()) => Ok(progress),
+            Ok(()) => {
+                self.manifest.phase = ImportPhase::Aborted;
+                self.checkpoint()
+            }
             Err(error) => {
                 self.manifest.phase = ImportPhase::Quarantined;
                 let _ = write_manifest(&self.root, &self.manifest);
-                Err(storage(error))
+                Err(error)
             }
         }
     }
@@ -559,6 +568,7 @@ impl GraphImportSession {
         {
             return Err(validation("import must be fully validated before commit"));
         }
+        self.ensure_base(graph)?;
         let mut construction = self.open_construction(graph)?;
         let publication = match cancellation {
             Some(token) => construction.seal_and_publish_with_cancellation(token)?,
@@ -825,9 +835,11 @@ fn cancelled() -> GfError {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     use arrow::array::{FixedSizeBinaryArray, StringArray};
+    use arrow::datatypes::DataType;
     use parquet::arrow::ArrowWriter;
 
     use super::*;
@@ -872,6 +884,14 @@ mod tests {
         fs::create_dir(&project).unwrap();
         let graph = GraphForge::new(project.to_str()).unwrap();
         (directory, project, graph)
+    }
+
+    fn construction_root(graph: &GraphForge, session_uuid: Uuid) -> PathBuf {
+        graph
+            .resolved_generation
+            .container_root()
+            .join(".graphforge-construction")
+            .join(session_uuid.simple().to_string())
     }
 
     #[test]
@@ -938,8 +958,16 @@ mod tests {
             .register_parquet(BulkInputKind::Node, &parquet)
             .unwrap();
         session.validate(&graph).unwrap();
-        let progress = session.abort().unwrap();
+        let construction_uuid = session.manifest.construction_session_uuid.unwrap();
+        assert!(construction_root(&graph, construction_uuid).exists());
+        let progress = session.abort(&graph).unwrap();
         assert_eq!(progress.rows_accepted, 1);
+        assert!(!construction_root(&graph, construction_uuid).exists());
+        assert!(
+            graph
+                .resume_graph_construction(construction_uuid, GraphConstructionBudgets::default())
+                .is_err()
+        );
         assert_eq!(*graph.current_generation_uuid.lock().unwrap(), before);
         drop(graph);
         GraphForge::new(project.to_str()).unwrap();
@@ -1057,6 +1085,7 @@ mod tests {
         let construction = progress.construction.unwrap();
         assert_eq!(construction.accepted_chunks, 1);
         assert_eq!(construction.input_batches, 1);
+        let construction_uuid = resumed.manifest.construction_session_uuid.unwrap();
         drop(resumed);
 
         let mut manifest = read_manifest(&import_root(&graph, session_uuid).unwrap()).unwrap();
@@ -1070,7 +1099,111 @@ mod tests {
         );
         let root = import_root(&graph, session_uuid).unwrap();
         assert!(!root.join("sources").exists());
+        assert!(!construction_root(&graph, construction_uuid).exists());
         assert_eq!(read_manifest(&root).unwrap().phase, ImportPhase::Aborted);
+    }
+
+    #[test]
+    fn zero_row_node_and_edge_sources_are_canonical_and_publishable() {
+        let (_directory, project, graph) = fixture();
+        let empty_nodes = RecordBatch::new_empty(bulk_node_input_schema(Vec::new()).unwrap());
+        let empty_edges = RecordBatch::new_empty(bulk_edge_input_schema(Vec::new()).unwrap());
+        let normalized_nodes = graph
+            .normalize_import_node_chunk(OperationId(Uuid::now_v7()), &empty_nodes)
+            .unwrap();
+        let normalized_edges = graph
+            .normalize_import_edge_chunk(OperationId(Uuid::now_v7()), &empty_edges)
+            .unwrap();
+        assert_eq!(normalized_nodes.num_rows(), 0);
+        assert_eq!(normalized_edges.num_rows(), 0);
+        assert_eq!(
+            normalized_nodes.column(0).data_type(),
+            &DataType::FixedSizeBinary(16)
+        );
+        assert_eq!(
+            normalized_edges.column(0).data_type(),
+            &DataType::FixedSizeBinary(16)
+        );
+
+        let retained_node = Uuid::now_v7();
+        let mut session = graph
+            .begin_import_session(OperationId(Uuid::now_v7()), ImportSessionLimits::default())
+            .unwrap();
+        session
+            .append_arrow(BulkInputKind::Node, &[empty_nodes, nodes(&[retained_node])])
+            .unwrap();
+        session
+            .append_arrow(BulkInputKind::Edge, &[empty_edges])
+            .unwrap();
+        let progress = session.validate(&graph).unwrap();
+        assert_eq!(progress.rows_accepted, 1);
+        assert_eq!(progress.files_pending, 0);
+        assert_eq!(progress.construction.as_ref().unwrap().accepted_chunks, 1);
+        let generation = session.commit(&graph, None).unwrap();
+
+        drop(graph);
+        let reopened = GraphForge::new(project.to_str()).unwrap();
+        assert_eq!(
+            *reopened.current_generation_uuid.lock().unwrap(),
+            generation
+        );
+        assert_eq!(reopened.node_count("Person").unwrap(), 1);
+    }
+
+    #[test]
+    fn commit_rechecks_the_import_base_generation() {
+        let (_directory, _project, graph) = fixture();
+        let mut session = graph
+            .begin_import_session(OperationId(Uuid::now_v7()), ImportSessionLimits::default())
+            .unwrap();
+        session
+            .append_arrow(BulkInputKind::Node, &[nodes(&[Uuid::now_v7()])])
+            .unwrap();
+        session.validate(&graph).unwrap();
+        graph.add_node("Other", &HashMap::new()).unwrap();
+        let independent = *graph.current_generation_uuid.lock().unwrap();
+
+        let error = session.commit(&graph, None).unwrap_err();
+        assert!(
+            matches!(error, GfError::Validation(message) if message == "project generation changed since import began")
+        );
+        assert_eq!(*graph.current_generation_uuid.lock().unwrap(), independent);
+    }
+
+    #[test]
+    fn stale_cleanup_quarantines_when_construction_authority_changed() {
+        let (_directory, _project, graph) = fixture();
+        let mut session = graph
+            .begin_import_session(OperationId(Uuid::now_v7()), ImportSessionLimits::default())
+            .unwrap();
+        session
+            .append_arrow(BulkInputKind::Node, &[nodes(&[Uuid::now_v7()])])
+            .unwrap();
+        session.validate(&graph).unwrap();
+        let session_uuid = session.session_uuid();
+        let construction_uuid = session.manifest.construction_session_uuid.unwrap();
+        drop(session);
+
+        graph.add_node("Other", &HashMap::new()).unwrap();
+        let independent = *graph.current_generation_uuid.lock().unwrap();
+        let root = import_root(&graph, session_uuid).unwrap();
+        let mut manifest = read_manifest(&root).unwrap();
+        manifest.updated_unix_millis = 0;
+        write_manifest(&root, &manifest).unwrap();
+
+        let error = graph
+            .cleanup_stale_import_sessions(Duration::from_secs(1))
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            GfError::Validation(_) | GfError::Storage(_)
+        ));
+        assert_eq!(
+            read_manifest(&root).unwrap().phase,
+            ImportPhase::Quarantined
+        );
+        assert!(construction_root(&graph, construction_uuid).exists());
+        assert_eq!(*graph.current_generation_uuid.lock().unwrap(), independent);
     }
 
     #[test]

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -204,7 +204,8 @@ pub use graphforge_core::{
     SpatialType, SpatialValue, TemporalValue,
 };
 pub use import_session::{
-    GraphImportSession, ImportPhase, ImportProgress, ImportSessionLimits, ImportSourceKind,
+    GraphImportSession, ImportConstructionEvidence, ImportPhase, ImportProgress,
+    ImportSessionLimits, ImportSourceKind,
 };
 // The Arrow-backed result of [`GraphForge::execute`].
 pub use generation_diff::{

--- a/crates/graphforge-api/src/resumable_construction.rs
+++ b/crates/graphforge-api/src/resumable_construction.rs
@@ -214,6 +214,27 @@ impl GraphConstructionSession<'_> {
         }
     }
 
+    /// Complete global shape and endpoint validation without publishing CURRENT.
+    pub(crate) fn validate_and_seal(
+        &mut self,
+        cancellation: Option<&crate::CancellationToken>,
+    ) -> Result<(), GfError> {
+        let topology_generation = self.inner.parent_topology_generation().saturating_add(1);
+        if self.inner.state() == GraphConstructionState::Staging {
+            self.inner
+                .seal_and_prepare_canonical_encoding_with_cancellation(
+                    topology_generation,
+                    || cancellation.is_some_and(crate::CancellationToken::is_cancelled),
+                )?;
+        } else {
+            self.inner
+                .prepare_canonical_encoding_with_cancellation(topology_generation, || {
+                    cancellation.is_some_and(crate::CancellationToken::is_cancelled)
+                })?;
+        }
+        Ok(())
+    }
+
     /// Seal, shape, encode, and atomically publish exactly one generation.
     pub fn seal_and_publish(&mut self) -> Result<GraphConstructionPublicationReceipt, GfError> {
         self.seal_and_publish_inner(None)

--- a/crates/graphforge-api/src/resumable_construction.rs
+++ b/crates/graphforge-api/src/resumable_construction.rs
@@ -219,19 +219,7 @@ impl GraphConstructionSession<'_> {
         &mut self,
         cancellation: Option<&crate::CancellationToken>,
     ) -> Result<(), GfError> {
-        let topology_generation = self.inner.parent_topology_generation().saturating_add(1);
-        if self.inner.state() == GraphConstructionState::Staging {
-            self.inner
-                .seal_and_prepare_canonical_encoding_with_cancellation(
-                    topology_generation,
-                    || cancellation.is_some_and(crate::CancellationToken::is_cancelled),
-                )?;
-        } else {
-            self.inner
-                .prepare_canonical_encoding_with_cancellation(topology_generation, || {
-                    cancellation.is_some_and(crate::CancellationToken::is_cancelled)
-                })?;
-        }
+        self.prepare_encoding(cancellation)?;
         Ok(())
     }
 
@@ -256,19 +244,7 @@ impl GraphConstructionSession<'_> {
             token.checkpoint()?;
         }
         let _visibility = self.graph.graph_visibility.lock()?;
-        let topology_generation = self.inner.parent_topology_generation().saturating_add(1);
-        let encoding = if self.inner.state() == GraphConstructionState::Staging {
-            self.inner
-                .seal_and_prepare_canonical_encoding_with_cancellation(
-                    topology_generation,
-                    || cancellation.is_some_and(crate::CancellationToken::is_cancelled),
-                )?
-        } else {
-            self.inner
-                .prepare_canonical_encoding_with_cancellation(topology_generation, || {
-                    cancellation.is_some_and(crate::CancellationToken::is_cancelled)
-                })?
-        };
+        let encoding = self.prepare_encoding(cancellation)?;
         if let Some(token) = cancellation {
             token.checkpoint()?;
         }
@@ -344,9 +320,32 @@ impl GraphConstructionSession<'_> {
         })
     }
 
+    fn prepare_encoding(
+        &mut self,
+        cancellation: Option<&crate::CancellationToken>,
+    ) -> Result<graphforge_storage::GraphConstructionEncoding, GfError> {
+        let topology_generation = self.inner.parent_topology_generation().saturating_add(1);
+        if self.inner.state() == GraphConstructionState::Staging {
+            self.inner
+                .seal_and_prepare_canonical_encoding_with_cancellation(topology_generation, || {
+                    cancellation.is_some_and(crate::CancellationToken::is_cancelled)
+                })
+        } else {
+            self.inner
+                .prepare_canonical_encoding_with_cancellation(topology_generation, || {
+                    cancellation.is_some_and(crate::CancellationToken::is_cancelled)
+                })
+        }
+    }
+
     /// Abort an unsealed session without changing project authority.
     pub fn abort(&mut self) -> Result<(), GfError> {
         self.inner.abort()
+    }
+
+    /// Reclaim every authenticated private artifact of an unpublished session.
+    pub(crate) fn discard(self) -> Result<(), GfError> {
+        self.inner.discard()
     }
 }
 

--- a/crates/graphforge-bindings-node/src/import_session.rs
+++ b/crates/graphforge-bindings-node/src/import_session.rs
@@ -296,7 +296,11 @@ impl GraphImportSession {
                 "import session handle is closed".into(),
             ))
         })?;
-        let progress = session.abort().map_err(|error| to_napi_err(&error))?;
+        let graph = self
+            .engine
+            .read()
+            .map_err(|_| to_napi_err(&GfError::Execution("GraphForge lock poisoned".into())))?;
+        let progress = session.abort(&graph).map_err(|error| to_napi_err(&error))?;
         Ok(progress_output(progress))
     }
 }

--- a/crates/graphforge-bindings-node/tests/non-cypher-parity-policy.json
+++ b/crates/graphforge-bindings-node/tests/non-cypher-parity-policy.json
@@ -1,8 +1,8 @@
 {
   "contractVersion": 1,
   "rustManifest": "../../../tests/contracts/non-cypher-rust-surface.json",
-  "releaseSurfaceCount": 258,
-  "releaseSurfaceDigest": "6963ebeb6999197aff6de3dbb996c72cbc41561dd2d7400ae81e6d296f8165a7",
+  "releaseSurfaceCount": 259,
+  "releaseSurfaceDigest": "5b0c6f3b4995545f6527b8be3b3fea7cb7aca0d070ad280ae6ec80e24ac9e938",
   "requiredEquivalent": [
     "GraphForge.adopt_ontology",
     "GraphForge.clear_ontology",
@@ -205,6 +205,12 @@
       "GraphImportSession.validate"
     ],
     "languageSpecific": {
+      "GraphForge.import_session_status": {
+        "nodeMembers": [
+          "GraphImportSession.status"
+        ],
+        "reason": "Node reads live session status from its owned handle; terminal receipt reopening is a Rust and CLI lifecycle operation."
+      },
       "GraphForge.execute_stream": {
         "nodeMembers": [
           "GraphForge.plan",

--- a/crates/graphforge-bindings-py/src/import_session.rs
+++ b/crates/graphforge-bindings-py/src/import_session.rs
@@ -59,6 +59,17 @@ impl GraphForge {
         })
         .map_err(|error| to_pyerr(py, &error))
     }
+
+    /// Abort and reclaim a staged import while releasing the GIL on `&self`.
+    pub(crate) fn run_import_abort(
+        &self,
+        py: Python<'_>,
+        session: GraphImportSession,
+    ) -> PyResult<ImportProgress> {
+        self.ensure_open()?;
+        py.detach(|| session.abort(&self.inner))
+            .map_err(|error| to_pyerr(py, &error))
+    }
 }
 
 fn phase_name(phase: ImportPhase) -> &'static str {
@@ -237,9 +248,11 @@ impl PyGraphImportSession {
     /// Abort without changing CURRENT.
     fn abort(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let session = self.take_inner(py)?;
-        let progress = py
-            .detach(|| session.abort())
-            .map_err(|error| to_pyerr(py, &error))?;
+        let progress = self
+            .parent
+            .bind(py)
+            .borrow()
+            .run_import_abort(py, session)?;
         progress_dict(py, &progress)
     }
 }

--- a/crates/graphforge-bindings-py/tests/non_cypher_release.py
+++ b/crates/graphforge-bindings-py/tests/non_cypher_release.py
@@ -23,8 +23,8 @@ ROOT = Path(__file__).resolve().parents[3]
 RUST_MANIFEST = ROOT / "tests/contracts/non-cypher-rust-surface.json"
 RUST_GATE = ROOT / "scripts/ci/non-cypher-surface-gate.py"
 PYO3_SOURCE = ROOT / "crates/graphforge-bindings-py/src/lib.rs"
-EXPECTED_RUST_DIGEST = "8e3a0711619a5e50231bf510a76328ea44b7706dfd28c524b760c6564b805bc3"
-EXPECTED_RELEASE_DIGEST = "6963ebeb6999197aff6de3dbb996c72cbc41561dd2d7400ae81e6d296f8165a7"
+EXPECTED_RUST_DIGEST = "499f902e4713931d7b3591fbaf978e6694c3029fde08c5c5476547563e5776e5"
+EXPECTED_RELEASE_DIGEST = "5b0c6f3b4995545f6527b8be3b3fea7cb7aca0d070ad280ae6ec80e24ac9e938"
 
 PYTHON_ONLY_METHODS = frozenset(
     {
@@ -257,7 +257,7 @@ def _classification_report() -> dict[str, object]:
         for group in manifest["method_evidence_groups"].values()
         for method_id in group["ids"]
     }
-    assert len(release_methods) == 258
+    assert len(release_methods) == 259
     assert _digest(release_methods) == EXPECTED_RELEASE_DIGEST
     assert set(EVIDENCE) == set(manifest["method_evidence_groups"])
 

--- a/crates/graphforge-cli/src/portable_cli.rs
+++ b/crates/graphforge-cli/src/portable_cli.rs
@@ -676,7 +676,7 @@ pub(crate) fn run_import_session(
         ImportSessionCommand::Abort(args) => {
             let session = graph.resume_import_session(canonical_uuid(&args.session_uuid)?)?;
             let session_uuid = session.session_uuid();
-            let progress = session.abort()?;
+            let progress = session.abort(graph)?;
             write_progress(session_uuid, "aborted", &progress, json, output)
         }
         ImportSessionCommand::Cleanup(args) => {

--- a/crates/graphforge-cli/src/portable_cli.rs
+++ b/crates/graphforge-cli/src/portable_cli.rs
@@ -539,6 +539,8 @@ pub(crate) enum ImportSessionCommand {
     Begin(ImportSessionBeginArgs),
     /// Resume an existing session by UUID.
     Resume(ImportSessionResumeArgs),
+    /// Read durable progress, including a terminal construction receipt.
+    Status(ImportSessionIdArgs),
     /// Register a Parquet source path into the session.
     RegisterParquet(ImportSessionRegisterArgs),
     /// Checkpoint session progress.
@@ -611,6 +613,17 @@ pub(crate) fn run_import_session(
             let session = graph.resume_import_session(canonical_uuid(&args.session_uuid)?)?;
             write_session_receipt(session.session_uuid(), "resumed", json, output)
         }
+        ImportSessionCommand::Status(args) => {
+            let session_uuid = canonical_uuid(&args.session_uuid)?;
+            let (phase, progress) = graph.import_session_status(session_uuid)?;
+            write_progress(
+                session_uuid,
+                &format!("{phase:?}").to_ascii_lowercase(),
+                &progress,
+                json,
+                output,
+            )
+        }
         ImportSessionCommand::RegisterParquet(args) => {
             let mut session = graph.resume_import_session(canonical_uuid(&args.session_uuid)?)?;
             let kind = match args.kind {
@@ -639,6 +652,7 @@ pub(crate) fn run_import_session(
         ImportSessionCommand::Commit(args) => {
             let mut session = graph.resume_import_session(canonical_uuid(&args.session_uuid)?)?;
             let generation = session.commit(graph, None)?;
+            let (_, progress) = session.status();
             if json {
                 write_json(
                     &serde_json::json!({
@@ -646,6 +660,7 @@ pub(crate) fn run_import_session(
                         "outcome": "committed",
                         "session_uuid": session.session_uuid(),
                         "generation_uuid": generation,
+                        "construction": progress.construction,
                     }),
                     output,
                 )
@@ -720,6 +735,7 @@ fn write_progress(
                 "rows_accepted": progress.rows_accepted,
                 "rows_rejected": progress.rows_rejected,
                 "bytes_accepted": progress.bytes_accepted,
+                "construction": progress.construction,
             }),
             output,
         )

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -2705,6 +2705,51 @@ impl GraphConstructionSession {
         replace_checkpoint_control(&self.root, &self.checkpoint)
     }
 
+    /// Authentically reclaim an unpublished session and every file it owns.
+    ///
+    /// Published or publishing sessions belong to generation recovery and can
+    /// never be discarded through the private staging lifecycle.
+    pub fn discard(mut self) -> Result<(), GfError> {
+        self.revalidate_authority()?;
+        self.recover_intent()?;
+        if matches!(
+            self.checkpoint.publication_state,
+            Some(
+                ConstructionPublicationState::Publishing | ConstructionPublicationState::Published
+            )
+        ) {
+            return Err(storage(
+                "published construction belongs to generation recovery",
+            ));
+        }
+        self.checkpoint.state = GraphConstructionState::Aborted;
+        replace_checkpoint_control(&self.root, &self.checkpoint)?;
+
+        let private = self
+            .project
+            .open_child_directory(OsStr::new(PRIVATE_ROOT))
+            .map_err(storage)?;
+        let operation_name = self.checkpoint.operation_uuid.simple().to_string();
+        let session_identity = self.root.identity();
+        let mut remaining = self
+            .checkpoint
+            .budgets
+            .max_chunks
+            .saturating_mul(16)
+            .saturating_add(
+                u64::try_from(self.checkpoint.budgets.max_schema_groups).unwrap_or(u64::MAX),
+            )
+            .saturating_add(4_096);
+        crate::file_lock::unlock(&self.session_lock).map_err(storage)?;
+        drop(self);
+        remove_owned_directory_tree(
+            &private,
+            OsStr::new(&operation_name),
+            session_identity,
+            &mut remaining,
+        )
+    }
+
     #[allow(clippy::too_many_lines)]
     fn recover_intent(&mut self) -> Result<(), GfError> {
         let mut file = match self.root.open_child_file(OsStr::new(INTENT)) {
@@ -2971,6 +3016,61 @@ impl GraphConstructionSession {
         }
         Ok(())
     }
+}
+
+fn remove_owned_directory_tree(
+    parent: &StableDirectory,
+    name: &OsStr,
+    expected: FileIdentity,
+    remaining: &mut u64,
+) -> Result<(), GfError> {
+    if *remaining == 0 {
+        return Err(storage(
+            "construction discard exceeded authenticated entry bound",
+        ));
+    }
+    *remaining -= 1;
+    let directory = parent.open_child_directory(name).map_err(storage)?;
+    if directory.identity() != expected {
+        return Err(storage("construction discard directory identity changed"));
+    }
+    let child_limit = usize::try_from(*remaining).unwrap_or(usize::MAX);
+    let names = directory
+        .child_names_bounded(child_limit)
+        .map_err(storage)?;
+    for child_name in names {
+        if *remaining == 0 {
+            return Err(storage(
+                "construction discard exceeded authenticated entry bound",
+            ));
+        }
+        *remaining -= 1;
+        match directory.open_child_file(&child_name) {
+            Ok(file) => {
+                let identity = file_identity(&file).map_err(storage)?;
+                drop(file);
+                directory
+                    .unlink_child_if_identity(&child_name, identity)
+                    .map_err(storage)?;
+            }
+            Err(file_error) => {
+                let child = directory
+                    .open_child_directory(&child_name)
+                    .map_err(|directory_error| {
+                        storage(format!(
+                            "construction discard child is neither an authenticated file nor directory: file={file_error}; directory={directory_error}"
+                        ))
+                    })?;
+                let identity = child.identity();
+                drop(child);
+                remove_owned_directory_tree(&directory, &child_name, identity, remaining)?;
+            }
+        }
+    }
+    drop(directory);
+    parent
+        .remove_child_directory_if_identity(name, expected)
+        .map_err(storage)
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -10262,6 +10362,33 @@ mod tests {
         session
     }
 
+    fn construction_session_root(root: &TempDir, operation: Uuid) -> PathBuf {
+        root.path()
+            .join(PRIVATE_ROOT)
+            .join(operation.simple().to_string())
+    }
+
+    #[test]
+    fn discard_reclaims_open_and_sealed_session_trees() {
+        for (index, seal) in [false, true].into_iter().enumerate() {
+            let root = TempDir::new().unwrap();
+            let operation = Uuid::from_u128(9_350 + index as u128);
+            let mut session = open(&root, operation.as_u128());
+            session
+                .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 2))
+                .unwrap();
+            if seal {
+                session.seal().unwrap();
+            }
+            let private_root = construction_session_root(&root, operation);
+            assert!(private_root.exists());
+
+            session.discard().unwrap();
+
+            assert!(!private_root.exists());
+        }
+    }
+
     fn publish_empty_generation(
         root: &TempDir,
         target: Uuid,
@@ -10329,6 +10456,14 @@ mod tests {
                 .to_string()
                 .contains("result changed")
         );
+        let private_root = construction_session_root(&root, operation);
+        let error = session.discard().unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("published construction belongs to generation recovery")
+        );
+        assert!(private_root.exists());
     }
 
     #[test]

--- a/scripts/ci/test-non-cypher-surface-gate.py
+++ b/scripts/ci/test-non-cypher-surface-gate.py
@@ -29,7 +29,7 @@ class SurfaceGateTests(unittest.TestCase):
 
     def test_checked_in_inventory_is_complete(self) -> None:
         self.assertEqual(GATE.validate(), [])
-        self.assertEqual(len(GATE.public_methods()), 373)
+        self.assertEqual(len(GATE.public_methods()), 374)
         self.assertEqual(len(GATE.algorithm_registry()), 94)
 
     def test_new_or_removed_public_method_fails_frozen_digest(self) -> None:

--- a/tests/contracts/non-cypher-rust-surface.json
+++ b/tests/contracts/non-cypher-rust-surface.json
@@ -1,7 +1,7 @@
 {
   "contract_version": 1,
   "scope": "Rust non-Cypher public release surface",
-  "public_method_digest": "8e3a0711619a5e50231bf510a76328ea44b7706dfd28c524b760c6564b805bc3",
+  "public_method_digest": "499f902e4713931d7b3591fbaf978e6694c3029fde08c5c5476547563e5776e5",
   "method_policy": {
     "receiver_defaults": {
       "GraphForge": "release-tested",
@@ -880,6 +880,7 @@
       "ids": [
         "GraphForge.begin_import_session",
         "GraphForge.cleanup_stale_import_sessions",
+        "GraphForge.import_session_status",
         "GraphForge.resume_import_session",
         "GraphImportSession.abort",
         "GraphImportSession.append_arrow",
@@ -898,6 +899,10 @@
         {
           "path": "crates/graphforge-api/src/import_session.rs",
           "symbol": "parquet_abort_and_missing_endpoint_preserve_prior_generation"
+        },
+        {
+          "path": "crates/graphforge-api/src/import_session.rs",
+          "symbol": "parquet_construction_receipts_scale_linearly_and_survive_reopen"
         },
         {
           "path": "crates/graphforge-api/src/import_session.rs",


### PR DESCRIPTION
Closes #991

## Summary
- route ordinary staged Arrow/Parquet import batches through one resumable `GraphConstructionSession` with the authoritative 65,536-row default budget
- validate and privately seal all chunks before the import becomes commit-ready, then publish exactly one generation at commit
- persist sanitized construction phase, I/O, artifact, fsync, bounded-memory, and publication evidence and expose it through Rust plus ordinary `gf import-session ... --json` status/commit output
- remove the copied graph tree, scalar row writer, and per-row UUID-index staging path
- add deterministic replay and 1x/2x/4x Parquet scaling/reopen coverage

## Validation
- `cargo check -p graphforge-api -p graphforge-cli --tests`
- `CARGO_PROFILE_TEST_DEBUG=0 cargo test -p graphforge-api --lib import_session::tests -- --nocapture`
- `cargo clippy -p graphforge-api -p graphforge-cli -- -D warnings`
- `python3 scripts/ci/test-non-cypher-surface-gate.py`
- `make pre-push-fast`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790589077&installation_model_id=20486&pr_number=993&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F993&signature=a9157678093de598438497143700b07d02b9b9dd928a47ba0ecc1758601e0238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added durable, resumable import sessions with progress tracking across validation and commit stages.
  - Added import-session status reporting through the API and CLI.
  - Import receipts now include construction progress and evidence.
- **Bug Fixes**
  - Improved validation for imported nodes and edges, including identifiers, schemas, properties, and endpoint consistency.
  - Added safer cancellation, reopening, cleanup, and abort handling for in-progress imports.
- **Reliability**
  - Improved import scaling with bounded batch processing and durable per-batch progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->