### PR TITLE
test: expose ordinary storage attribution evidence

### DIFF
--- a/crates/graphforge-api/src/import_session.rs
+++ b/crates/graphforge-api/src/import_session.rs
@@ -1212,6 +1212,37 @@ mod tests {
     }
 
     #[test]
+    fn legacy_manifest_without_publication_work_backfills_from_application_io() {
+        let (_directory, _project, graph) = fixture();
+        let mut session = graph
+            .begin_import_session(OperationId(Uuid::now_v7()), ImportSessionLimits::default())
+            .unwrap();
+        session
+            .append_arrow(BulkInputKind::Node, &[nodes(&[Uuid::now_v7()])])
+            .unwrap();
+        session.validate(&graph).unwrap();
+
+        let root = session.root.clone();
+        let mut legacy = serde_json::to_value(&session.manifest).unwrap();
+        let construction = legacy["progress"]["construction"].as_object_mut().unwrap();
+        let application_io: graphforge_storage::ConstructionPhaseAttribution =
+            serde_json::from_value(construction["application_io"].clone()).unwrap();
+        assert!(construction.remove("publication_work").is_some());
+        fs::write(root.join(MANIFEST), serde_json::to_vec(&legacy).unwrap()).unwrap();
+
+        let restored = read_manifest(&root).unwrap();
+        let evidence = restored.progress.construction.unwrap();
+        assert_eq!(
+            evidence.publication_work.contract,
+            "graphforge-publication-work/1"
+        );
+        evidence
+            .publication_work
+            .validate_against(&application_io)
+            .unwrap();
+    }
+
+    #[test]
     fn zero_row_node_and_edge_sources_are_canonical_and_publishable() {
         let (_directory, project, graph) = fixture();
         let empty_nodes = RecordBatch::new_empty(bulk_node_input_schema(Vec::new()).unwrap());

--- a/crates/graphforge-api/src/import_session.rs
+++ b/crates/graphforge-api/src/import_session.rs
@@ -138,6 +138,9 @@ pub struct ImportConstructionEvidence {
     pub publication_committed: bool,
     /// Exact application-I/O attribution across the closed construction phases.
     pub application_io: graphforge_storage::ConstructionPhaseAttribution,
+    /// Versioned named publication work, derived from the phase counters above.
+    #[serde(default)]
+    pub publication_work: PublicationWorkComponents,
     /// Exact accepted input rows.
     pub input_rows: u64,
     /// Exact non-replay input batches.
@@ -156,6 +159,97 @@ pub struct ImportConstructionEvidence {
     pub peak_batch_bytes: u64,
     /// Exact transient allocation high-water retained across resume.
     pub transient_peak_allocated_bytes: u64,
+}
+
+/// Closed semantic publication-work contract for ordinary construction evidence.
+///
+/// `semantic_total_operations` is exactly the sum of read calls, write calls,
+/// and fsync calls across these five named phase rows. Bytes and call components
+/// remain intact so downstream controllers never need to infer work from time or
+/// filesystem scans.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct PublicationWorkComponents {
+    /// Versioned semantic contract.
+    pub contract: String,
+    /// Canonical encoding, write, and post-write authentication.
+    pub encode_write_postwrite_authentication: graphforge_storage::PhaseIoTotals,
+    /// Publication control preauthentication.
+    pub publication_preauthentication: graphforge_storage::PhaseIoTotals,
+    /// Content-addressed installation reads and writes.
+    pub cas_install_read_write: graphforge_storage::PhaseIoTotals,
+    /// Workspace hydration and verification.
+    pub hydration_verification: graphforge_storage::PhaseIoTotals,
+    /// File and directory durability barriers.
+    pub fsync_synchronization: graphforge_storage::PhaseIoTotals,
+    /// Checked sum of read calls, write calls, and fsync calls in the named rows.
+    pub semantic_total_operations: u64,
+}
+
+impl PublicationWorkComponents {
+    fn checked_operation_total(
+        phases: [&graphforge_storage::PhaseIoTotals; 5],
+    ) -> Result<u64, GfError> {
+        let mut total = 0_u64;
+        for phase in phases {
+            total = total
+                .checked_add(phase.read_calls)
+                .and_then(|value| value.checked_add(phase.write_calls))
+                .and_then(|value| value.checked_add(phase.fsync_calls))
+                .ok_or_else(|| validation("publication work operation total overflowed"))?;
+        }
+        Ok(total)
+    }
+
+    fn from_application_io(
+        application_io: &graphforge_storage::ConstructionPhaseAttribution,
+    ) -> Result<Self, GfError> {
+        use graphforge_storage::StorageIoPhase;
+        application_io.validate_for_qualification()?;
+        let phase = |name| {
+            application_io
+                .phases
+                .get(&name)
+                .cloned()
+                .ok_or_else(|| validation("publication work phase is absent"))
+        };
+        let encode_write_postwrite_authentication =
+            phase(StorageIoPhase::EncodeWritePostwriteAuthentication)?;
+        let publication_preauthentication = phase(StorageIoPhase::PublicationPreauthentication)?;
+        let cas_install_read_write = phase(StorageIoPhase::CasInstallReadWrite)?;
+        let hydration_verification = phase(StorageIoPhase::HydrationVerification)?;
+        let fsync_synchronization = phase(StorageIoPhase::FsyncSynchronization)?;
+        let semantic_total_operations = Self::checked_operation_total([
+            &encode_write_postwrite_authentication,
+            &publication_preauthentication,
+            &cas_install_read_write,
+            &hydration_verification,
+            &fsync_synchronization,
+        ])?;
+        Ok(Self {
+            contract: "graphforge-publication-work/1".to_owned(),
+            encode_write_postwrite_authentication,
+            publication_preauthentication,
+            cas_install_read_write,
+            hydration_verification,
+            fsync_synchronization,
+            semantic_total_operations,
+        })
+    }
+
+    /// Verify the version, arithmetic, and exact phase projection.
+    fn validate_against(
+        &self,
+        application_io: &graphforge_storage::ConstructionPhaseAttribution,
+    ) -> Result<(), GfError> {
+        let expected = Self::from_application_io(application_io)?;
+        if self != &expected {
+            return Err(validation(
+                "publication work components do not reconcile with construction phases",
+            ));
+        }
+        Ok(())
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -632,12 +726,14 @@ impl GraphImportSession {
         let application_io =
             graphforge_storage::ConstructionPhaseAttribution::from_construction(&progress.evidence);
         application_io.validate_for_qualification()?;
+        let publication_work = PublicationWorkComponents::from_application_io(&application_io)?;
         self.manifest.progress.construction = Some(ImportConstructionEvidence {
             configured_batch_rows: u64::try_from(self.manifest.limits.batch_rows)
                 .unwrap_or(u64::MAX),
             accepted_chunks: progress.accepted_chunks,
             publication_committed: progress.publication_committed,
             application_io,
+            publication_work,
             input_rows: progress.evidence.input_rows,
             input_batches: progress.evidence.input_batches,
             immutable_artifacts: progress.evidence.immutable_artifacts,
@@ -774,10 +870,22 @@ fn write_manifest(root: &Path, manifest: &SessionManifest) -> Result<(), GfError
 }
 
 fn read_manifest(root: &Path) -> Result<SessionManifest, GfError> {
-    serde_json::from_reader(BufReader::new(
+    let mut manifest: SessionManifest = serde_json::from_reader(BufReader::new(
         File::open(root.join(MANIFEST)).map_err(storage)?,
     ))
-    .map_err(storage)
+    .map_err(storage)?;
+    if let Some(construction) = manifest.progress.construction.as_mut()
+        && construction.publication_work.contract.is_empty()
+    {
+        construction.publication_work =
+            PublicationWorkComponents::from_application_io(&construction.application_io)?;
+    }
+    if let Some(construction) = manifest.progress.construction.as_ref() {
+        construction
+            .publication_work
+            .validate_against(&construction.application_io)?;
+    }
+    Ok(manifest)
 }
 
 fn reject_unsafe_path(path: &Path) -> Result<(), GfError> {
@@ -1247,6 +1355,27 @@ mod tests {
             assert_eq!(receipt.input_rows, (4 * multiplier) as u64);
             assert_eq!(receipt.input_batches, multiplier as u64);
             assert_eq!(receipt.peak_batch_rows, 4);
+            assert_eq!(
+                receipt.publication_work.contract,
+                "graphforge-publication-work/1"
+            );
+            let named = &receipt.publication_work;
+            let expected_total = [
+                &named.encode_write_postwrite_authentication,
+                &named.publication_preauthentication,
+                &named.cas_install_read_write,
+                &named.hydration_verification,
+                &named.fsync_synchronization,
+            ]
+            .iter()
+            .map(|phase| phase.read_calls + phase.write_calls + phase.fsync_calls)
+            .sum::<u64>();
+            assert_eq!(named.semantic_total_operations, expected_total);
+            assert_eq!(
+                named.publication_preauthentication,
+                receipt.application_io.phases
+                    [&graphforge_storage::StorageIoPhase::PublicationPreauthentication]
+            );
 
             drop(graph);
             let reopened = GraphForge::new(project.to_str()).unwrap();

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -205,7 +205,7 @@ pub use graphforge_core::{
 };
 pub use import_session::{
     GraphImportSession, ImportConstructionEvidence, ImportPhase, ImportProgress,
-    ImportSessionLimits, ImportSourceKind,
+    ImportSessionLimits, ImportSourceKind, PublicationWorkComponents,
 };
 // The Arrow-backed result of [`GraphForge::execute`].
 pub use generation_diff::{
@@ -562,6 +562,13 @@ impl GraphForge {
         let snapshot = graphforge_storage::capture_storage_attribution(&generation)?;
         snapshot.validate_for_qualification()?;
         Ok(snapshot)
+    }
+
+    /// Capture closed, identity-free storage evidence for ordinary consumers.
+    pub fn storage_attribution_receipt(
+        &self,
+    ) -> Result<graphforge_storage::StorageAttributionReceipt, GfError> {
+        graphforge_storage::StorageAttributionReceipt::from_snapshot(&self.storage_attribution()?)
     }
 
     pub(crate) fn stage_project_generation(
@@ -20506,5 +20513,17 @@ mod tests {
             missing.to_string(),
             "execution error: missing query parameter `$absent` for LIMIT"
         );
+    }
+
+    #[test]
+    fn public_storage_attribution_receipt_is_identity_free_and_reconciled() {
+        let project = tempfile::tempdir().unwrap();
+        let graph = GraphForge::new(project.path().to_str()).unwrap();
+        let receipt = graph.storage_attribution_receipt().unwrap();
+        receipt.validate_reconciliation().unwrap();
+        let encoded = serde_json::to_string(&receipt).unwrap();
+        assert!(!encoded.contains("generation_uuid"));
+        assert!(!encoded.contains("sha256"));
+        assert!(!encoded.contains(project.path().to_string_lossy().as_ref()));
     }
 }

--- a/crates/graphforge-bindings-node/tests/non-cypher-parity-policy.json
+++ b/crates/graphforge-bindings-node/tests/non-cypher-parity-policy.json
@@ -1,8 +1,8 @@
 {
   "contractVersion": 1,
   "rustManifest": "../../../tests/contracts/non-cypher-rust-surface.json",
-  "releaseSurfaceCount": 259,
-  "releaseSurfaceDigest": "5b0c6f3b4995545f6527b8be3b3fea7cb7aca0d070ad280ae6ec80e24ac9e938",
+  "releaseSurfaceCount": 260,
+  "releaseSurfaceDigest": "18db4cad7c6a094db21b9026b6cc286c38b4d2031579c34d7d485ef53a1afbe0",
   "requiredEquivalent": [
     "GraphForge.adopt_ontology",
     "GraphForge.clear_ontology",

--- a/crates/graphforge-bindings-py/tests/non_cypher_release.py
+++ b/crates/graphforge-bindings-py/tests/non_cypher_release.py
@@ -23,8 +23,8 @@ ROOT = Path(__file__).resolve().parents[3]
 RUST_MANIFEST = ROOT / "tests/contracts/non-cypher-rust-surface.json"
 RUST_GATE = ROOT / "scripts/ci/non-cypher-surface-gate.py"
 PYO3_SOURCE = ROOT / "crates/graphforge-bindings-py/src/lib.rs"
-EXPECTED_RUST_DIGEST = "499f902e4713931d7b3591fbaf978e6694c3029fde08c5c5476547563e5776e5"
-EXPECTED_RELEASE_DIGEST = "5b0c6f3b4995545f6527b8be3b3fea7cb7aca0d070ad280ae6ec80e24ac9e938"
+EXPECTED_RUST_DIGEST = "59da11b3fe6b32a8c12a77ff9c327546643e90c63dbf5314d33143f81fcaf27a"
+EXPECTED_RELEASE_DIGEST = "18db4cad7c6a094db21b9026b6cc286c38b4d2031579c34d7d485ef53a1afbe0"
 
 PYTHON_ONLY_METHODS = frozenset(
     {
@@ -257,7 +257,7 @@ def _classification_report() -> dict[str, object]:
         for group in manifest["method_evidence_groups"].values()
         for method_id in group["ids"]
     }
-    assert len(release_methods) == 259
+    assert len(release_methods) == 260
     assert _digest(release_methods) == EXPECTED_RELEASE_DIGEST
     assert set(EVIDENCE) == set(manifest["method_evidence_groups"])
 

--- a/crates/graphforge-cli/src/lib.rs
+++ b/crates/graphforge-cli/src/lib.rs
@@ -312,6 +312,58 @@ enum Command {
     },
     /// Emit safe recovery-on-open evidence for the project.
     Recovery,
+    /// Emit authenticated, identity-free retained storage attribution.
+    StorageAttribution,
+}
+
+#[derive(serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct StorageAttributionCommandReceipt {
+    contract: &'static str,
+    storage: graphforge_storage::StorageAttributionReceipt,
+    reopen_agrees: bool,
+}
+
+fn run_storage_attribution(
+    graph: GraphForge,
+    path: &Path,
+    json: bool,
+    output: &mut dyn Write,
+) -> Result<(), graphforge_api::GfError> {
+    let storage = graph.storage_attribution_receipt()?;
+    storage.validate_reconciliation()?;
+    drop(graph);
+    let path_text = path.to_str().ok_or_else(|| {
+        graphforge_api::GfError::Validation("--project must be valid UTF-8".into())
+    })?;
+    let reopened = GraphForge::new(Some(path_text))?;
+    let reopened_storage = reopened.storage_attribution_receipt()?;
+    reopened_storage.validate_reconciliation()?;
+    if reopened_storage != storage {
+        return Err(graphforge_api::GfError::Validation(
+            "storage attribution changed across reopen".into(),
+        ));
+    }
+    if json {
+        serde_json::to_writer(
+            &mut *output,
+            &StorageAttributionCommandReceipt {
+                contract: "graphforge-storage-attribution-command/1",
+                storage,
+                reopen_agrees: true,
+            },
+        )
+        .map_err(|error| graphforge_api::GfError::Execution(error.to_string()))?;
+        writeln!(output).map_err(|error| graphforge_api::GfError::Execution(error.to_string()))?;
+    } else {
+        writeln!(
+            output,
+            "retained_logical_eof_bytes={} allocated_physical_bytes={} reopen_agrees=true",
+            storage.retained_logical_eof_bytes, storage.allocated_physical_bytes
+        )
+        .map_err(|error| graphforge_api::GfError::Execution(error.to_string()))?;
+    }
+    Ok(())
 }
 
 #[derive(Args)]
@@ -1267,6 +1319,11 @@ fn run(cli: Cli, output: &mut dyn Write) -> Result<i32, CliRuntimeError> {
         }
         Command::Recovery => {
             return maintenance_cli::run_recovery(&graph, cli.json, output)
+                .map(|()| 0)
+                .map_err(Into::into);
+        }
+        Command::StorageAttribution => {
+            return run_storage_attribution(graph, &path, cli.json, output)
                 .map(|()| 0)
                 .map_err(Into::into);
         }
@@ -2591,6 +2648,60 @@ mod tests {
             "{}",
             String::from_utf8_lossy(&delete.stderr)
         );
+    }
+
+    #[test]
+    fn storage_attribution_json_is_closed_sanitized_and_reopen_stable() {
+        let project = tempdir().unwrap();
+        let path = project.path().join("state");
+        fs::create_dir(&path).unwrap();
+        let result = execute([
+            "graphforge".to_owned(),
+            "--json".to_owned(),
+            "--project".to_owned(),
+            path.to_string_lossy().into_owned(),
+            "storage-attribution".to_owned(),
+        ]);
+        assert_eq!(
+            result.exit_code,
+            0,
+            "{}",
+            String::from_utf8_lossy(&result.stderr)
+        );
+        let json: serde_json::Value = serde_json::from_slice(&result.stdout).unwrap();
+        assert_eq!(json["contract"], "graphforge-storage-attribution-command/1");
+        assert_eq!(
+            json["storage"]["contract"],
+            "graphforge-storage-attribution/1"
+        );
+        assert_eq!(json["reopen_agrees"], true);
+        assert_eq!(
+            json["storage"]["categories"].as_object().unwrap().len(),
+            graphforge_storage::ArtifactCategory::ALL.len()
+        );
+        fn assert_sanitized(value: &serde_json::Value) {
+            match value {
+                serde_json::Value::Object(object) => {
+                    for (key, value) in object {
+                        assert!(!key.contains("uuid") && !key.contains("path"));
+                        assert_sanitized(value);
+                    }
+                }
+                serde_json::Value::Array(values) => {
+                    values.iter().for_each(assert_sanitized);
+                }
+                serde_json::Value::String(value) => {
+                    assert!(Uuid::parse_str(value).is_err());
+                    assert!(!Path::new(value).is_absolute());
+                }
+                _ => {}
+            }
+        }
+        assert_sanitized(&json);
+        let encoded = String::from_utf8(result.stdout).unwrap();
+        assert!(!encoded.contains("generation_uuid"));
+        assert!(!encoded.contains("sha256"));
+        assert!(!encoded.contains(path.to_string_lossy().as_ref()));
     }
 
     #[test]

--- a/crates/graphforge-cli/src/lib.rs
+++ b/crates/graphforge-cli/src/lib.rs
@@ -2683,7 +2683,22 @@ mod tests {
             match value {
                 serde_json::Value::Object(object) => {
                     for (key, value) in object {
-                        assert!(!key.contains("uuid") && !key.contains("path"));
+                        assert!(
+                            !matches!(
+                                key.as_str(),
+                                "uuid"
+                                    | "path"
+                                    | "generation_uuid"
+                                    | "generation_manifest_sha256"
+                                    | "physical_identity_allocated_bytes"
+                                    | "provider_id"
+                                    | "resource_id"
+                                    | "credential"
+                                    | "credentials"
+                                    | "secret"
+                            ),
+                            "sensitive evidence key: {key}"
+                        );
                         assert_sanitized(value);
                     }
                 }

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -23,8 +23,8 @@ pub mod storage_attribution;
 pub use storage_attribution::{
     ArtifactCategory, ArtifactStorageTotals, ConstructionPhaseAttribution, PhaseIoTotals,
     ProjectStorageIdentityUnion, StorageAllocationLifecycle, StorageAllocationTransition,
-    StorageAttributionSnapshot, StorageIoPhase, capture_project_storage_identity_union,
-    capture_storage_attribution, classify_graph_artifact,
+    StorageAttributionReceipt, StorageAttributionSnapshot, StorageIoPhase,
+    capture_project_storage_identity_union, capture_storage_attribution, classify_graph_artifact,
 };
 
 pub mod generation;

--- a/crates/graphforge-storage/src/storage_attribution.rs
+++ b/crates/graphforge-storage/src/storage_attribution.rs
@@ -334,6 +334,74 @@ pub struct StorageAttributionSnapshot {
     pub physical_identity_allocated_bytes: BTreeMap<String, u64>,
 }
 
+/// Identity-free, closed storage evidence suitable for ordinary CLI output.
+///
+/// This receipt deliberately omits generation identities, native file identities,
+/// paths, and graph content. Every category is present, including truthful zeros.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StorageAttributionReceipt {
+    /// Versioned semantic contract for consumers of this receipt.
+    pub contract: String,
+    /// Every authenticated artifact category exactly once.
+    pub categories: BTreeMap<ArtifactCategory, ArtifactStorageTotals>,
+    /// Reconciled logical references across categories.
+    pub logical_references: u64,
+    /// Reconciled referenced logical bytes across categories.
+    pub logical_bytes: u64,
+    /// Logical EOF bytes of distinct retained physical files.
+    pub retained_logical_eof_bytes: u64,
+    /// Filesystem-allocated bytes of distinct retained physical files.
+    pub allocated_physical_bytes: u64,
+    /// Distinct retained physical files, deduplicated by native identity.
+    pub physical_objects: u64,
+}
+
+impl StorageAttributionReceipt {
+    /// Strip private identities from a validated authenticated snapshot.
+    pub fn from_snapshot(snapshot: &StorageAttributionSnapshot) -> Result<Self, GfError> {
+        snapshot.validate_for_qualification()?;
+        Ok(Self {
+            contract: "graphforge-storage-attribution/1".to_owned(),
+            categories: snapshot.categories.clone(),
+            logical_references: snapshot.logical_references,
+            logical_bytes: snapshot.logical_bytes,
+            retained_logical_eof_bytes: snapshot.physical_logical_bytes,
+            allocated_physical_bytes: snapshot.allocated_bytes,
+            physical_objects: snapshot.physical_objects,
+        })
+    }
+
+    /// Recheck the public arithmetic without relying on stripped identities.
+    pub fn validate_reconciliation(&self) -> Result<(), GfError> {
+        if self.contract != "graphforge-storage-attribution/1"
+            || ArtifactCategory::ALL
+                .iter()
+                .any(|category| !self.categories.contains_key(category))
+            || self.categories.len() != ArtifactCategory::ALL.len()
+        {
+            return Err(validation(
+                "storage attribution receipt contract is incomplete",
+            ));
+        }
+        let mut total = ArtifactStorageTotals::default();
+        for category in ArtifactCategory::ALL {
+            add_totals(&mut total, &self.categories[&category])?;
+        }
+        if total.logical_references != self.logical_references
+            || total.logical_bytes != self.logical_bytes
+            || total.physical_objects != self.physical_objects
+            || total.physical_logical_bytes != self.retained_logical_eof_bytes
+            || total.allocated_bytes != self.allocated_physical_bytes
+        {
+            return Err(validation(
+                "storage attribution receipt totals do not reconcile",
+            ));
+        }
+        Ok(())
+    }
+}
+
 /// Exact native-identity union for the retained project container.
 ///
 /// This includes `FORMAT`, `CURRENT`, and every authenticated generation still
@@ -1419,5 +1487,15 @@ mod tests {
         assert_eq!(snapshot.physical_objects, 1);
         assert_eq!(snapshot.physical_logical_bytes, 6);
         assert!(snapshot.allocated_bytes >= 6);
+
+        let receipt = StorageAttributionReceipt::from_snapshot(&snapshot).unwrap();
+        receipt.validate_reconciliation().unwrap();
+        assert_eq!(receipt.retained_logical_eof_bytes, 6);
+        assert_eq!(receipt.allocated_physical_bytes, snapshot.allocated_bytes);
+        let json = serde_json::to_string(&receipt).unwrap();
+        assert!(!json.contains(&snapshot.generation_uuid.to_string()));
+        assert!(!json.contains("generation_uuid"));
+        assert!(!json.contains("sha256"));
+        assert!(!json.contains(project.path().to_string_lossy().as_ref()));
     }
 }

--- a/scripts/ci/test-non-cypher-surface-gate.py
+++ b/scripts/ci/test-non-cypher-surface-gate.py
@@ -29,7 +29,7 @@ class SurfaceGateTests(unittest.TestCase):
 
     def test_checked_in_inventory_is_complete(self) -> None:
         self.assertEqual(GATE.validate(), [])
-        self.assertEqual(len(GATE.public_methods()), 374)
+        self.assertEqual(len(GATE.public_methods()), 375)
         self.assertEqual(len(GATE.algorithm_registry()), 94)
 
     def test_new_or_removed_public_method_fails_frozen_digest(self) -> None:

--- a/tests/contracts/non-cypher-rust-surface.json
+++ b/tests/contracts/non-cypher-rust-surface.json
@@ -1,7 +1,7 @@
 {
   "contract_version": 1,
   "scope": "Rust non-Cypher public release surface",
-  "public_method_digest": "499f902e4713931d7b3591fbaf978e6694c3029fde08c5c5476547563e5776e5",
+  "public_method_digest": "59da11b3fe6b32a8c12a77ff9c327546643e90c63dbf5314d33143f81fcaf27a",
   "method_policy": {
     "receiver_defaults": {
       "GraphForge": "release-tested",
@@ -265,10 +265,15 @@
         "GraphForge.publish_bulk_nodes",
         "GraphForge.relationship_types",
         "GraphForge.storage_attribution",
+        "GraphForge.storage_attribution_receipt",
         "GraphForge.workspace_configuration",
         "GraphForge.workspace_ontology"
       ],
       "test_refs": [
+        {
+          "path": "crates/graphforge-api/src/lib.rs",
+          "symbol": "public_storage_attribution_receipt_is_identity_free_and_reconciled"
+        },
         {
           "path": "crates/graphforge-api/tests/scale_g500_ladder.rs",
           "symbol": "public_storage_attribution_is_generation_bound_and_fully_classified"


### PR DESCRIPTION
## Summary
- expose a bounded, identity-free authenticated storage-attribution receipt through the Rust facade and `gf --json storage-attribution`
- reconcile the full sanitized category receipt across a real reopen and reject mismatch
- preserve named construction I/O components and add a versioned publication-work operation total derived only from storage-owned phase counters

## Validation
- `cargo fmt --all -- --check`
- `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo check -p graphforge-storage -p graphforge-api -p graphforge-cli`
- `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy -p graphforge-storage -p graphforge-api -p graphforge-cli -- -D warnings`
- `python3 scripts/ci/test-non-cypher-surface-gate.py`
- `make pre-push-fast`
- focused storage receipt test passed; broader API test linking was interrupted by local disk exhaustion and is left to hosted Bazel CI

Related implementation for #951. Provider S20/S22 evidence remains required for the remaining outcome.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added storage-attribution reporting through the CLI, with structured JSON and concise text output.
  * Added identity-free attribution receipts containing validated category and aggregate totals.
  * Added persistent import progress evidence covering storage phases and operation totals.
  * Added reconciliation checks to ensure reported storage metrics remain consistent after reopening projects.

* **Tests**
  * Expanded coverage for receipt validation, sanitization, persistence, and output contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->