### PR TITLE
build(bench): add disposable Fly adapter planner

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install smoke smoke-python smoke-rust local-admission progressive-qualification-list progressive-qualification-plan progressive-qualification-run progressive-qualification-project-s20 progressive-qualification-binaries
+.PHONY: install smoke smoke-python smoke-rust fly-adapter-static local-admission progressive-qualification-list progressive-qualification-plan progressive-qualification-run progressive-qualification-project-s20 progressive-qualification-binaries
 
 install:
 	uv sync --locked
@@ -14,6 +14,9 @@ smoke-rust: install
 	CARGO_TARGET_DIR=$(CURDIR)/target cargo clippy --workspace --locked -- -D warnings
 	CARGO_TARGET_DIR=$(CURDIR)/target cargo test --locked --manifest-path Cargo.toml
 	PYTHONPATH=harness uv run --locked python -m graphforge_bench.check_rust_graph
+
+fly-adapter-static: install
+	PYTHONPATH=harness uv run --locked python -m unittest tests.test_fly_adapter
 
 local-admission: install
 	PYTHONPATH=$(CURDIR)/harness uv run --locked reframe -C reframe/settings.py -c reframe/checks -n '^LocalBenchExecAdmission$$' -l | grep -F LocalBenchExecAdmission

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -98,6 +98,30 @@ Generated datasets, credentials, execution outputs, and local environments are
 ignored. Fly execution is forbidden until the complete benchmark stack is
 merged and has passed local and hosted qualification.
 
+## Disposable Fly adapter
+
+`graphforge_bench.fly_adapter` is an offline command planner, not another
+benchmark controller. It requires merged #955/#956/#957 attestations, a full
+commit, an immutable `registry.fly.io/...@sha256:...` image, a fixed region,
+an explicitly measured Machine class, and an explicit maximum authorized
+scale. It accepts the controller's lifecycle argv and checked-in profile
+identity unchanged. It cannot select a rung, alter a threshold, or retrieve
+anything except allowlisted sanitized JSON evidence.
+
+The planned provider lifecycle is one remotely built image, one private app,
+one encrypted volume, and one Machine with no services. The Machine remains
+alive only so evidence can be retrieved from its attached volume; restart and
+Fly Proxy autostop are disabled. Teardown uses a persisted ownership ledger and
+is safe to repeat. Static tests launch nothing:
+
+```bash
+make -C benchmarks fly-adapter-static
+```
+
+The adapter remains disabled until #956 is complete. The tiny provider
+qualification and independent post-teardown inventory are separate live
+acceptance evidence and are not claimed by these fixtures.
+
 ## Smoke
 
 From the repository root:

--- a/benchmarks/harness/graphforge_bench/fly_adapter.py
+++ b/benchmarks/harness/graphforge_bench/fly_adapter.py
@@ -1,0 +1,397 @@
+"""Static, fail-closed command planner for the disposable Fly adapter.
+
+This module never calls Fly.  It turns a closed lifecycle invocation from the
+qualification controller into argv vectors and owns only provider resource
+lifecycle.  Benchmark policy remains in the checked-in controller/profile.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass, field
+import hashlib
+import json
+from pathlib import Path, PurePosixPath
+import re
+from typing import Any
+
+
+class AdapterError(ValueError):
+    """A sanitized refusal; messages never contain provider identifiers."""
+
+
+OCI_DIGEST = re.compile(r"^registry\.fly\.io/[a-z0-9-]+@sha256:[0-9a-f]{64}$")
+SAFE_NAME = re.compile(r"^[a-z0-9][a-z0-9-]{0,62}$")
+SAFE_REGION = re.compile(r"^[a-z]{3}$")
+SAFE_MACHINE = re.compile(r"^(shared|performance)-cpu-[0-9]+x$|^[a-z0-9_-]+$")
+COMMIT = re.compile(r"^[0-9a-f]{40}$")
+FAILURE_TYPES = frozenset(
+    {
+        "authorization_refused",
+        "build_failed",
+        "provision_failed",
+        "lifecycle_failed",
+        "retrieval_failed",
+        "teardown_failed",
+        "inventory_not_empty",
+    }
+)
+
+
+@dataclass(frozen=True)
+class LifecycleInvocation:
+    commit: str
+    rung: int
+    profile: str
+    profile_sha256: str
+    argv: tuple[str, ...]
+    evidence_files: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class FlyAttempt:
+    organization: str
+    app: str
+    region: str
+    volume_name: str
+    volume_gib: int
+    machine_class: str
+    image: str
+    maximum_authorized_scale: int
+    prerequisites: Mapping[int, str]
+    lifecycle: LifecycleInvocation
+
+
+@dataclass(frozen=True)
+class Command:
+    operation: str
+    argv: tuple[str, ...]
+
+
+@dataclass
+class ResourceLedger:
+    """Local ownership ledger. IDs are never copied into evidence/diagnostics."""
+
+    schema: str = "graphforge-fly-resource-ledger/1"
+    app_owned: bool = False
+    volume_id: str | None = None
+    machine_id: str | None = None
+    image_digest: str | None = None
+    secret_names: list[str] = field(default_factory=list)
+    token_material_present: bool = False
+
+    def save(self, path: Path) -> None:
+        path.write_text(json.dumps(asdict(self), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    @classmethod
+    def load(cls, path: Path) -> ResourceLedger:
+        value = json.loads(path.read_text(encoding="utf-8"))
+        if value.pop("schema", None) != "graphforge-fly-resource-ledger/1":
+            raise AdapterError("resource ledger schema is invalid")
+        return cls(**value)
+
+
+def _refuse(condition: bool, message: str) -> None:
+    if condition:
+        raise AdapterError(message)
+
+
+def validate_attempt(attempt: FlyAttempt) -> None:
+    lifecycle = attempt.lifecycle
+    _refuse(set(attempt.prerequisites) != {955, 956, 957}, "prerequisite ledger is incomplete")
+    _refuse(
+        any(state != "merged" for state in attempt.prerequisites.values()),
+        "prerequisite is not merged",
+    )
+    _refuse(not SAFE_NAME.fullmatch(attempt.app), "app name is invalid")
+    _refuse(not SAFE_NAME.fullmatch(attempt.organization), "organization name is invalid")
+    _refuse(not SAFE_NAME.fullmatch(attempt.volume_name), "volume name is invalid")
+    _refuse(not SAFE_REGION.fullmatch(attempt.region), "region is invalid")
+    _refuse(not SAFE_MACHINE.fullmatch(attempt.machine_class), "measured machine class is invalid")
+    _refuse(not OCI_DIGEST.fullmatch(attempt.image), "image must be an immutable Fly OCI digest")
+    _refuse(attempt.volume_gib < 1 or attempt.volume_gib > 500, "volume size is outside Fly bounds")
+    _refuse(not COMMIT.fullmatch(lifecycle.commit), "lifecycle commit is invalid")
+    _refuse(
+        lifecycle.rung > attempt.maximum_authorized_scale,
+        "requested rung lacks explicit authorization",
+    )
+    _refuse(lifecycle.rung not in (18, 19, 20, 22, 24, 25, 26), "requested rung is not canonical")
+    expected = f"benchmarks/profiles/graph500/s{lifecycle.rung}-"
+    _refuse(
+        not lifecycle.profile.startswith(expected),
+        "lifecycle profile does not match requested rung",
+    )
+    _refuse(
+        not re.fullmatch(r"sha256:[0-9a-f]{64}", lifecycle.profile_sha256),
+        "profile digest is invalid",
+    )
+    _refuse(
+        not lifecycle.argv or any(not value or "\x00" in value for value in lifecycle.argv),
+        "lifecycle argv is invalid",
+    )
+    expected_evidence = {
+        f"s{lifecycle.rung}-plan.json",
+        f"s{lifecycle.rung}-benchexec.json",
+        f"s{lifecycle.rung}-graphforge.json",
+        f"s{lifecycle.rung}-rung.json",
+        f"s{lifecycle.rung}-result.json",
+    }
+    _refuse(
+        set(lifecycle.evidence_files) != expected_evidence,
+        "lifecycle evidence set is not canonical",
+    )
+    _refuse(
+        any(PurePosixPath(name).name != name for name in lifecycle.evidence_files),
+        "lifecycle requested a non-sanitized artifact",
+    )
+
+
+def verify_checked_in_profile(root: Path, lifecycle: LifecycleInvocation) -> None:
+    profile = (root / lifecycle.profile).resolve()
+    profiles = (root / "benchmarks" / "profiles" / "graph500").resolve()
+    _refuse(
+        profiles not in profile.parents or not profile.is_file(),
+        "checked-in profile is unavailable",
+    )
+    actual = hashlib.sha256(profile.read_bytes()).hexdigest()
+    _refuse(lifecycle.profile_sha256 != f"sha256:{actual}", "checked-in profile digest mismatch")
+
+
+def remote_build_command(*, app: str, source: Path, dockerfile: Path, commit: str) -> Command:
+    _refuse(not SAFE_NAME.fullmatch(app), "app name is invalid")
+    _refuse(not COMMIT.fullmatch(commit), "build commit is invalid")
+    return Command(
+        "remote_build",
+        (
+            "flyctl",
+            "deploy",
+            str(source),
+            "--app",
+            app,
+            "--dockerfile",
+            str(dockerfile),
+            "--remote-only",
+            "--build-only",
+            "--push",
+            "--no-public-ips",
+            "--image-label",
+            commit,
+            "--build-arg",
+            f"GRAPHFORGE_COMMIT={commit}",
+            "--yes",
+        ),
+    )
+
+
+def provisioning_commands(attempt: FlyAttempt) -> tuple[Command, ...]:
+    validate_attempt(attempt)
+    lifecycle = attempt.lifecycle
+    return (
+        Command(
+            "create_app",
+            (
+                "flyctl",
+                "apps",
+                "create",
+                attempt.app,
+                "--org",
+                attempt.organization,
+                "--json",
+                "--yes",
+            ),
+        ),
+        Command(
+            "create_volume",
+            (
+                "flyctl",
+                "volumes",
+                "create",
+                attempt.volume_name,
+                "--app",
+                attempt.app,
+                "--region",
+                attempt.region,
+                "--size",
+                str(attempt.volume_gib),
+                "--count",
+                "1",
+                "--json",
+                "--yes",
+            ),
+        ),
+        Command(
+            "create_machine",
+            (
+                "flyctl",
+                "machine",
+                "run",
+                attempt.image,
+                "infinity",
+                "--app",
+                attempt.app,
+                "--region",
+                attempt.region,
+                "--vm-size",
+                attempt.machine_class,
+                "--volume",
+                "{volume_id}:/work",
+                "--entrypoint",
+                "/bin/sleep",
+                "--restart",
+                "no",
+                "--autostop",
+                "off",
+                "--autostart=false",
+                "--rootfs-persist",
+                "never",
+                "--skip-dns-registration",
+                "--detach",
+            ),
+        ),
+        Command(
+            "execute_lifecycle",
+            (
+                "flyctl",
+                "machine",
+                "exec",
+                "--app",
+                attempt.app,
+                "--timeout",
+                "14400",
+                "--json",
+                "{machine_id}",
+                "--",
+                *lifecycle.argv,
+            ),
+        ),
+    )
+
+
+def retrieval_commands(attempt: FlyAttempt, destination: Path) -> tuple[Command, ...]:
+    validate_attempt(attempt)
+    return tuple(
+        Command(
+            "retrieve_evidence",
+            (
+                "flyctl",
+                "ssh",
+                "sftp",
+                "get",
+                f"/work/evidence/{name}",
+                str(destination / name),
+                "--app",
+                attempt.app,
+                "--machine",
+                "{machine_id}",
+                "--quiet",
+            ),
+        )
+        for name in attempt.lifecycle.evidence_files
+    )
+
+
+def cleanup_commands(app: str, ledger: ResourceLedger) -> tuple[Command, ...]:
+    """Return repeatable best-effort deletion commands for resources we own."""
+    _refuse(not SAFE_NAME.fullmatch(app), "app name is invalid")
+    commands: list[Command] = []
+    if ledger.machine_id:
+        commands.append(
+            Command(
+                "destroy_machine",
+                ("flyctl", "machine", "destroy", "--app", app, "--force", ledger.machine_id),
+            )
+        )
+    if ledger.volume_id:
+        commands.append(
+            Command(
+                "destroy_volume",
+                ("flyctl", "volumes", "destroy", "--app", app, "--yes", ledger.volume_id),
+            )
+        )
+    for name in sorted(set(ledger.secret_names)):
+        _refuse(not SAFE_NAME.fullmatch(name), "secret ledger is invalid")
+        commands.append(
+            Command("unset_secret", ("flyctl", "secrets", "unset", name, "--app", app, "--yes"))
+        )
+    if ledger.app_owned:
+        commands.append(Command("destroy_app", ("flyctl", "apps", "destroy", app, "--yes")))
+    return tuple(commands)
+
+
+def inventory_commands(app: str) -> tuple[Command, ...]:
+    _refuse(not SAFE_NAME.fullmatch(app), "app name is invalid")
+    return (
+        Command("inventory_machines", ("flyctl", "machine", "list", "--app", app, "--json")),
+        Command("inventory_volumes", ("flyctl", "volumes", "list", "--app", app, "--json")),
+        Command("inventory_secrets", ("flyctl", "secrets", "list", "--app", app, "--json")),
+    )
+
+
+def verify_empty_inventory(*, machines: Any, volumes: Any, secrets: Any, app_exists: bool) -> None:
+    for value in (machines, volumes, secrets):
+        _refuse(not isinstance(value, list), "provider inventory is malformed")
+        _refuse(bool(value), "provider inventory is not empty")
+    _refuse(app_exists, "provider inventory is not empty")
+
+
+def sanitized_failure(failure: str) -> dict[str, Any]:
+    _refuse(failure not in FAILURE_TYPES, "failure type is invalid")
+    return {
+        "schema": "graphforge-fly-adapter-result/1",
+        "status": "failed",
+        "failure": failure,
+    }
+
+
+def pin_remote_image(app: str, digest: str) -> str:
+    """Close remote builder output to the sole immutable runtime identity."""
+    image = f"registry.fly.io/{app}@{digest}"
+    _refuse(not OCI_DIGEST.fullmatch(image), "remote build did not return an immutable digest")
+    return image
+
+
+def accepted_rung_reclamation(
+    *,
+    accepted_rung: int,
+    current_rung: int,
+    running: bool,
+    evidence_accepted: bool,
+    lifecycle_argv: Sequence[str],
+) -> Command:
+    _refuse(
+        running or accepted_rung >= current_rung or not evidence_accepted,
+        "rung artifacts are not reclaimable",
+    )
+    _refuse(
+        not lifecycle_argv or any(not value or "\x00" in value for value in lifecycle_argv),
+        "reclamation argv is invalid",
+    )
+    return Command(
+        "reclaim_accepted_rung",
+        (
+            "flyctl",
+            "machine",
+            "exec",
+            "--app",
+            "{app}",
+            "--timeout",
+            "600",
+            "--json",
+            "{machine_id}",
+            "--",
+            *lifecycle_argv,
+        ),
+    )
+
+
+def verify_download(path: Path, expected_sha256: str) -> None:
+    _refuse(
+        not re.fullmatch(
+            r"s(?:18|19|20|22|24|25|26)-(?:plan|benchexec|graphforge|rung|result)\.json", path.name
+        ),
+        "download is not an allowed evidence document",
+    )
+    value = json.loads(path.read_text(encoding="utf-8"))
+    _refuse(not isinstance(value, dict) or "schema" not in value, "download is not typed evidence")
+    actual = hashlib.sha256(path.read_bytes()).hexdigest()
+    _refuse(expected_sha256 != f"sha256:{actual}", "download digest mismatch")

--- a/benchmarks/harness/graphforge_bench/fly_adapter.py
+++ b/benchmarks/harness/graphforge_bench/fly_adapter.py
@@ -8,11 +8,12 @@ lifecycle.  Benchmark policy remains in the checked-in controller/profile.
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, fields
 import hashlib
 import json
 from pathlib import Path, PurePosixPath
 import re
+import shlex
 from typing import Any
 
 
@@ -23,8 +24,27 @@ class AdapterError(ValueError):
 OCI_DIGEST = re.compile(r"^registry\.fly\.io/[a-z0-9-]+@sha256:[0-9a-f]{64}$")
 SAFE_NAME = re.compile(r"^[a-z0-9][a-z0-9-]{0,62}$")
 SAFE_REGION = re.compile(r"^[a-z]{3}$")
-SAFE_MACHINE = re.compile(r"^(shared|performance)-cpu-[0-9]+x$|^[a-z0-9_-]+$")
 COMMIT = re.compile(r"^[0-9a-f]{40}$")
+MACHINE_CLASSES = frozenset(
+    {
+        "shared-cpu-1x",
+        "shared-cpu-2x",
+        "shared-cpu-4x",
+        "shared-cpu-6x",
+        "shared-cpu-8x",
+        "performance-1x",
+        "performance-2x",
+        "performance-4x",
+        "performance-6x",
+        "performance-8x",
+        "performance-10x",
+        "performance-12x",
+        "performance-14x",
+        "performance-16x",
+    }
+)
+MACHINE_ID = re.compile(r"^[0-9a-f]{14}$")
+VOLUME_ID = re.compile(r"^vol_[a-z0-9]+$")
 FAILURE_TYPES = frozenset(
     {
         "authorization_refused",
@@ -85,15 +105,53 @@ class ResourceLedger:
 
     @classmethod
     def load(cls, path: Path) -> ResourceLedger:
-        value = json.loads(path.read_text(encoding="utf-8"))
+        try:
+            value = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise AdapterError("resource ledger is malformed") from error
+        _refuse(not isinstance(value, dict), "resource ledger is malformed")
         if value.pop("schema", None) != "graphforge-fly-resource-ledger/1":
             raise AdapterError("resource ledger schema is invalid")
-        return cls(**value)
+        expected = {item.name for item in fields(cls)} - {"schema"}
+        _refuse(set(value) != expected, "resource ledger fields are invalid")
+        try:
+            ledger = cls(**value)
+        except TypeError as error:
+            raise AdapterError("resource ledger is malformed") from error
+        validate_ledger(ledger)
+        return ledger
 
 
 def _refuse(condition: bool, message: str) -> None:
     if condition:
         raise AdapterError(message)
+
+
+def validate_ledger(ledger: ResourceLedger) -> None:
+    _refuse(type(ledger.app_owned) is not bool, "resource ledger ownership is invalid")
+    _refuse(
+        type(ledger.token_material_present) is not bool, "resource ledger token state is invalid"
+    )
+    _refuse(
+        ledger.machine_id is not None and not MACHINE_ID.fullmatch(ledger.machine_id),
+        "resource ledger machine identifier is invalid",
+    )
+    _refuse(
+        ledger.volume_id is not None and not VOLUME_ID.fullmatch(ledger.volume_id),
+        "resource ledger volume identifier is invalid",
+    )
+    _refuse(
+        ledger.image_digest is not None and not OCI_DIGEST.fullmatch(ledger.image_digest),
+        "resource ledger image identity is invalid",
+    )
+    _refuse(
+        not isinstance(ledger.secret_names, list)
+        or any(
+            not isinstance(name, str) or not SAFE_NAME.fullmatch(name)
+            for name in ledger.secret_names
+        ),
+        "resource ledger secrets are invalid",
+    )
 
 
 def validate_attempt(attempt: FlyAttempt) -> None:
@@ -107,8 +165,12 @@ def validate_attempt(attempt: FlyAttempt) -> None:
     _refuse(not SAFE_NAME.fullmatch(attempt.organization), "organization name is invalid")
     _refuse(not SAFE_NAME.fullmatch(attempt.volume_name), "volume name is invalid")
     _refuse(not SAFE_REGION.fullmatch(attempt.region), "region is invalid")
-    _refuse(not SAFE_MACHINE.fullmatch(attempt.machine_class), "measured machine class is invalid")
+    _refuse(attempt.machine_class not in MACHINE_CLASSES, "measured machine class is invalid")
     _refuse(not OCI_DIGEST.fullmatch(attempt.image), "image must be an immutable Fly OCI digest")
+    _refuse(
+        not attempt.image.startswith(f"registry.fly.io/{attempt.app}@"),
+        "image does not belong to the requested app",
+    )
     _refuse(attempt.volume_gib < 1 or attempt.volume_gib > 500, "volume size is outside Fly bounds")
     _refuse(not COMMIT.fullmatch(lifecycle.commit), "lifecycle commit is invalid")
     _refuse(
@@ -260,8 +322,7 @@ def provisioning_commands(attempt: FlyAttempt) -> tuple[Command, ...]:
                 "14400",
                 "--json",
                 "{machine_id}",
-                "--",
-                *lifecycle.argv,
+                shlex.join(lifecycle.argv),
             ),
         ),
     )
@@ -293,6 +354,7 @@ def retrieval_commands(attempt: FlyAttempt, destination: Path) -> tuple[Command,
 def cleanup_commands(app: str, ledger: ResourceLedger) -> tuple[Command, ...]:
     """Return repeatable best-effort deletion commands for resources we own."""
     _refuse(not SAFE_NAME.fullmatch(app), "app name is invalid")
+    validate_ledger(ledger)
     commands: list[Command] = []
     if ledger.machine_id:
         commands.append(
@@ -309,7 +371,6 @@ def cleanup_commands(app: str, ledger: ResourceLedger) -> tuple[Command, ...]:
             )
         )
     for name in sorted(set(ledger.secret_names)):
-        _refuse(not SAFE_NAME.fullmatch(name), "secret ledger is invalid")
         commands.append(
             Command("unset_secret", ("flyctl", "secrets", "unset", name, "--app", app, "--yes"))
         )
@@ -378,8 +439,7 @@ def accepted_rung_reclamation(
             "600",
             "--json",
             "{machine_id}",
-            "--",
-            *lifecycle_argv,
+            shlex.join(lifecycle_argv),
         ),
     )
 
@@ -391,7 +451,14 @@ def verify_download(path: Path, expected_sha256: str) -> None:
         ),
         "download is not an allowed evidence document",
     )
-    value = json.loads(path.read_text(encoding="utf-8"))
-    _refuse(not isinstance(value, dict) or "schema" not in value, "download is not typed evidence")
-    actual = hashlib.sha256(path.read_bytes()).hexdigest()
+    try:
+        payload = path.read_bytes()
+    except OSError as error:
+        raise AdapterError("download is unavailable") from error
+    actual = hashlib.sha256(payload).hexdigest()
     _refuse(expected_sha256 != f"sha256:{actual}", "download digest mismatch")
+    try:
+        value = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise AdapterError("download is not typed evidence") from error
+    _refuse(not isinstance(value, dict) or "schema" not in value, "download is not typed evidence")

--- a/benchmarks/tests/test_fly_adapter.py
+++ b/benchmarks/tests/test_fly_adapter.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from graphforge_bench.fly_adapter import (
+    AdapterError,
+    FlyAttempt,
+    LifecycleInvocation,
+    ResourceLedger,
+    accepted_rung_reclamation,
+    cleanup_commands,
+    inventory_commands,
+    pin_remote_image,
+    provisioning_commands,
+    remote_build_command,
+    retrieval_commands,
+    sanitized_failure,
+    validate_attempt,
+    verify_checked_in_profile,
+    verify_download,
+    verify_empty_inventory,
+)
+
+
+def attempt(**changes: object) -> FlyAttempt:
+    lifecycle = LifecycleInvocation(
+        commit="a" * 40,
+        rung=18,
+        profile="benchmarks/profiles/graph500/s18-local.json",
+        profile_sha256="sha256:" + "b" * 64,
+        argv=(
+            "python3",
+            "-m",
+            "graphforge_bench.progressive_run",
+            "--rung",
+            "S18",
+            "--output-dir",
+            "/work/evidence",
+        ),
+        evidence_files=(
+            "s18-plan.json",
+            "s18-benchexec.json",
+            "s18-graphforge.json",
+            "s18-rung.json",
+            "s18-result.json",
+        ),
+    )
+    values = {
+        "organization": "fixture-org",
+        "app": "gf-fixture",
+        "region": "den",
+        "volume_name": "gf-data",
+        "volume_gib": 500,
+        "machine_class": "performance-cpu-4x",
+        "image": "registry.fly.io/gf-fixture@sha256:" + "c" * 64,
+        "maximum_authorized_scale": 18,
+        "prerequisites": {955: "merged", 956: "merged", 957: "merged"},
+        "lifecycle": lifecycle,
+    }
+    values.update(changes)
+    return FlyAttempt(**values)  # type: ignore[arg-type]
+
+
+class FlyAdapterTests(unittest.TestCase):
+    def test_remote_build_is_remote_only_pushed_and_commit_pinned(self) -> None:
+        command = remote_build_command(
+            app="gf-fixture", source=Path(), dockerfile=Path("Dockerfile"), commit="a" * 40
+        )
+        self.assertIn("--remote-only", command.argv)
+        self.assertIn("--build-only", command.argv)
+        self.assertIn("--push", command.argv)
+        self.assertNotIn("--local-only", command.argv)
+        self.assertIn("GRAPHFORGE_COMMIT=" + "a" * 40, command.argv)
+        self.assertEqual(pin_remote_image("gf-fixture", "sha256:" + "c" * 64), attempt().image)
+        with self.assertRaisesRegex(AdapterError, "immutable"):
+            pin_remote_image("gf-fixture", "latest")
+
+    def test_provisioning_is_private_fixed_and_thin(self) -> None:
+        commands = provisioning_commands(attempt())
+        machine = next(c for c in commands if c.operation == "create_machine").argv
+        execute = next(c for c in commands if c.operation == "execute_lifecycle").argv
+        self.assertIn("den", machine)
+        self.assertIn("performance-cpu-4x", machine)
+        self.assertIn("--restart", machine)
+        self.assertIn("no", machine)
+        self.assertIn("--autostop", machine)
+        self.assertNotIn("--port", machine)
+        separator = execute.index("--")
+        self.assertEqual(execute[separator + 1 :], attempt().lifecycle.argv)
+        self.assertNotIn("threshold", " ".join(execute))
+
+    def test_refuses_unmerged_prerequisite_and_unauthorized_scale(self) -> None:
+        with self.assertRaisesRegex(AdapterError, "prerequisite"):
+            validate_attempt(attempt(prerequisites={955: "merged", 956: "open", 957: "merged"}))
+        changed = attempt().lifecycle.__class__(
+            **{
+                **attempt().lifecycle.__dict__,
+                "rung": 19,
+                "profile": "benchmarks/profiles/graph500/s19-local.json",
+            }
+        )
+        with self.assertRaisesRegex(AdapterError, "authorization"):
+            validate_attempt(attempt(lifecycle=changed))
+
+    def test_refuses_mutable_image_and_non_evidence_retrieval(self) -> None:
+        with self.assertRaisesRegex(AdapterError, "immutable"):
+            validate_attempt(attempt(image="registry.fly.io/gf-fixture:latest"))
+        changed = attempt().lifecycle.__class__(
+            **{**attempt().lifecycle.__dict__, "evidence_files": ("dataset.parquet",)}
+        )
+        with self.assertRaisesRegex(AdapterError, "canonical"):
+            retrieval_commands(attempt(lifecycle=changed), Path("out"))
+
+    def test_retrieval_is_only_allowlisted_files(self) -> None:
+        commands = retrieval_commands(attempt(), Path("out"))
+        self.assertEqual(len(commands), 5)
+        self.assertTrue(all("/work/evidence/" in c.argv[4] for c in commands))
+        self.assertTrue(all("--machine" in c.argv for c in commands))
+
+    def test_cleanup_is_owned_ordered_and_idempotent(self) -> None:
+        ledger = ResourceLedger(
+            app_owned=True,
+            volume_id="vol_fixture",
+            machine_id="machine_fixture",
+            secret_names=["temporary-token"],
+        )
+        first = cleanup_commands("gf-fixture", ledger)
+        self.assertEqual(
+            [c.operation for c in first],
+            ["destroy_machine", "destroy_volume", "unset_secret", "destroy_app"],
+        )
+        self.assertEqual(cleanup_commands("gf-fixture", ResourceLedger()), ())
+        self.assertEqual(first, cleanup_commands("gf-fixture", ledger))
+
+    def test_inventory_must_independently_be_empty(self) -> None:
+        self.assertEqual(len(inventory_commands("gf-fixture")), 3)
+        verify_empty_inventory(machines=[], volumes=[], secrets=[], app_exists=False)
+        with self.assertRaisesRegex(AdapterError, "not empty"):
+            verify_empty_inventory(
+                machines=[{"id": "never-exposed"}], volumes=[], secrets=[], app_exists=False
+            )
+
+    def test_failure_is_closed_typed_and_identifier_free(self) -> None:
+        value = sanitized_failure("lifecycle_failed")
+        self.assertEqual(
+            value,
+            {
+                "schema": "graphforge-fly-adapter-result/1",
+                "status": "failed",
+                "failure": "lifecycle_failed",
+            },
+        )
+        self.assertNotIn("id", json.dumps(value))
+        with self.assertRaisesRegex(AdapterError, "failure type"):
+            sanitized_failure("provider said machine-123 failed")
+
+    def test_profile_digest_is_verified_from_repository(self) -> None:
+        root = Path(__file__).resolve().parents[2]
+        profile = root / attempt().lifecycle.profile
+        digest = "sha256:" + hashlib.sha256(profile.read_bytes()).hexdigest()
+        lifecycle = attempt().lifecycle.__class__(
+            **{**attempt().lifecycle.__dict__, "profile_sha256": digest}
+        )
+        verify_checked_in_profile(root, lifecycle)
+        with self.assertRaisesRegex(AdapterError, "digest"):
+            verify_checked_in_profile(root, attempt().lifecycle)
+
+    def test_reclamation_refuses_current_running_and_unaccepted_rungs(self) -> None:
+        for args in (
+            {
+                "accepted_rung": 18,
+                "current_rung": 19,
+                "running": True,
+                "evidence_accepted": True,
+                "lifecycle_argv": ("reclaim", "S18"),
+            },
+            {
+                "accepted_rung": 19,
+                "current_rung": 19,
+                "running": False,
+                "evidence_accepted": True,
+                "lifecycle_argv": ("reclaim", "S19"),
+            },
+            {
+                "accepted_rung": 18,
+                "current_rung": 19,
+                "running": False,
+                "evidence_accepted": False,
+                "lifecycle_argv": ("reclaim", "S18"),
+            },
+        ):
+            with self.assertRaisesRegex(AdapterError, "not reclaimable"):
+                accepted_rung_reclamation(**args)
+        command = accepted_rung_reclamation(
+            accepted_rung=18,
+            current_rung=19,
+            running=False,
+            evidence_accepted=True,
+            lifecycle_argv=("controller-reclaim", "S18"),
+        )
+        self.assertEqual(command.operation, "reclaim_accepted_rung")
+        self.assertEqual(command.argv[-2:], ("controller-reclaim", "S18"))
+
+    def test_download_requires_typed_json_and_digest(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "s18-result.json"
+            path.write_text(
+                json.dumps({"schema": "fixture/1", "status": "passed"}), encoding="utf-8"
+            )
+            digest = "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+            verify_download(path, digest)
+            with self.assertRaisesRegex(AdapterError, "digest"):
+                verify_download(path, "sha256:" + "0" * 64)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/tests/test_fly_adapter.py
+++ b/benchmarks/tests/test_fly_adapter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 from pathlib import Path
+import shlex
 import tempfile
 import unittest
 
@@ -55,7 +56,7 @@ def attempt(**changes: object) -> FlyAttempt:
         "region": "den",
         "volume_name": "gf-data",
         "volume_gib": 500,
-        "machine_class": "performance-cpu-4x",
+        "machine_class": "performance-4x",
         "image": "registry.fly.io/gf-fixture@sha256:" + "c" * 64,
         "maximum_authorized_scale": 18,
         "prerequisites": {955: "merged", 956: "merged", 957: "merged"},
@@ -84,14 +85,19 @@ class FlyAdapterTests(unittest.TestCase):
         machine = next(c for c in commands if c.operation == "create_machine").argv
         execute = next(c for c in commands if c.operation == "execute_lifecycle").argv
         self.assertIn("den", machine)
-        self.assertIn("performance-cpu-4x", machine)
+        self.assertIn("performance-4x", machine)
         self.assertIn("--restart", machine)
         self.assertIn("no", machine)
         self.assertIn("--autostop", machine)
         self.assertNotIn("--port", machine)
-        separator = execute.index("--")
-        self.assertEqual(execute[separator + 1 :], attempt().lifecycle.argv)
+        self.assertEqual(shlex.split(execute[-1]), list(attempt().lifecycle.argv))
         self.assertNotIn("threshold", " ".join(execute))
+
+    def test_refuses_unknown_machine_class_and_cross_app_image(self) -> None:
+        with self.assertRaisesRegex(AdapterError, "machine class"):
+            validate_attempt(attempt(machine_class="gpu-a100-80gb"))
+        with self.assertRaisesRegex(AdapterError, "requested app"):
+            validate_attempt(attempt(image="registry.fly.io/another-app@sha256:" + "c" * 64))
 
     def test_refuses_unmerged_prerequisite_and_unauthorized_scale(self) -> None:
         with self.assertRaisesRegex(AdapterError, "prerequisite"):
@@ -124,8 +130,8 @@ class FlyAdapterTests(unittest.TestCase):
     def test_cleanup_is_owned_ordered_and_idempotent(self) -> None:
         ledger = ResourceLedger(
             app_owned=True,
-            volume_id="vol_fixture",
-            machine_id="machine_fixture",
+            volume_id="vol_fixture123",
+            machine_id="abcdef01234567",
             secret_names=["temporary-token"],
         )
         first = cleanup_commands("gf-fixture", ledger)
@@ -135,6 +141,30 @@ class FlyAdapterTests(unittest.TestCase):
         )
         self.assertEqual(cleanup_commands("gf-fixture", ResourceLedger()), ())
         self.assertEqual(first, cleanup_commands("gf-fixture", ledger))
+
+    def test_ledger_load_closes_shape_types_and_identifiers(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "ledger.json"
+            ledger = ResourceLedger(
+                app_owned=True,
+                volume_id="vol_fixture123",
+                machine_id="abcdef01234567",
+                image_digest=attempt().image,
+                secret_names=["temporary-token"],
+                token_material_present=True,
+            )
+            ledger.save(path)
+            self.assertEqual(ResourceLedger.load(path), ledger)
+            value = json.loads(path.read_text(encoding="utf-8"))
+            value["machine_id"] = "--force"
+            path.write_text(json.dumps(value), encoding="utf-8")
+            with self.assertRaisesRegex(AdapterError, "machine identifier"):
+                ResourceLedger.load(path)
+            value["machine_id"] = "abcdef01234567"
+            value["unexpected"] = True
+            path.write_text(json.dumps(value), encoding="utf-8")
+            with self.assertRaisesRegex(AdapterError, "fields"):
+                ResourceLedger.load(path)
 
     def test_inventory_must_independently_be_empty(self) -> None:
         self.assertEqual(len(inventory_commands("gf-fixture")), 3)
@@ -203,7 +233,7 @@ class FlyAdapterTests(unittest.TestCase):
             lifecycle_argv=("controller-reclaim", "S18"),
         )
         self.assertEqual(command.operation, "reclaim_accepted_rung")
-        self.assertEqual(command.argv[-2:], ("controller-reclaim", "S18"))
+        self.assertEqual(shlex.split(command.argv[-1]), ["controller-reclaim", "S18"])
 
     def test_download_requires_typed_json_and_digest(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
Refs #958

## Summary
- add a static, fail-closed Fly command planner that keeps provider provisioning separate from benchmark policy
- require merged prerequisite attestations, an immutable image digest, fixed region, explicit measured Machine class, and explicit maximum-scale authorization
- allow only canonical checked-in profile identities and sanitized evidence downloads
- add an ownership ledger, ordered idempotent teardown plan, independent empty-inventory verifier, and accepted-rung reclamation guards
- document the disabled boundary and add a no-cost Make target

## Validation
- `make -C benchmarks smoke`
- `uv run ruff format --check benchmarks/harness/graphforge_bench/fly_adapter.py benchmarks/tests/test_fly_adapter.py`
- `uv run ruff check benchmarks/harness/graphforge_bench/fly_adapter.py benchmarks/tests/test_fly_adapter.py`

## Live provider boundary
No Fly resource was created or mutated. #958 remains open until the tiny Fly qualification and independently verified teardown inventory pass; #956 is still a launch prerequisite.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790618784&installation_model_id=20486&pr_number=997&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F997&signature=84df1a0fd2d36eebd4a845337da71d17a93751fd046657cde757e7d67b84ab12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Fly-based benchmark lifecycle support, including provisioning, evidence retrieval, cleanup, inventory checks, and resource reclamation.
  * Added validation for immutable images, approved profiles, downloaded evidence, authorization constraints, and failure sanitization.
* **Tests**
  * Added comprehensive coverage for adapter workflows, validation rules, cleanup behavior, inventory verification, and download integrity.
* **Chores**
  * Added a benchmark command for installing dependencies and running Fly adapter tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->