### PR TITLE
fix(bench): await Fly app readiness before remote build

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -158,7 +158,11 @@ PYTHONPATH=benchmarks/harness uv run --project benchmarks python -m \
 Only after that exact plan is accepted, append `--execute
 --confirm-disposable`. Execution owns exactly one app, one image attachment,
 one volume, and one Machine. It persists the local ownership ledger immediately
-after every create, retrieves only the existing closed sanitized evidence, and
+after every create. Before starting the one remote build, bounded
+deadline/backoff polling requires the new app to be visible and empty through
+the same Fly Machines authority used by deploy. A permanently unready app
+returns typed `readiness_timeout` evidence, tears down, and never retries the
+build. The executor retrieves only the existing closed sanitized evidence and
 always runs child-first teardown. Before deleting the app it independently
 requires empty Machine, volume, and secret inventories; afterwards it requires
 the app absent and leaves a cleared ledger. The logged-in `flyctl` credential

--- a/benchmarks/harness/graphforge_bench/fly_adapter.py
+++ b/benchmarks/harness/graphforge_bench/fly_adapter.py
@@ -48,6 +48,7 @@ VOLUME_ID = re.compile(r"^vol_[a-z0-9]+$")
 FAILURE_TYPES = frozenset(
     {
         "authorization_refused",
+        "readiness_timeout",
         "build_failed",
         "provision_failed",
         "lifecycle_failed",

--- a/benchmarks/harness/graphforge_bench/fly_tiny_qualification.py
+++ b/benchmarks/harness/graphforge_bench/fly_tiny_qualification.py
@@ -8,7 +8,7 @@ and tears every owned provider resource down on every terminal path.
 from __future__ import annotations
 
 import argparse
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from contextlib import suppress
 from dataclasses import dataclass
 import importlib.util
@@ -46,6 +46,10 @@ BUILD_TIMEOUT_SECONDS = 1_800
 CREATE_TIMEOUT_SECONDS = 180
 RETRIEVAL_TIMEOUT_SECONDS = 1_260
 SFTP_TIMEOUT_SECONDS = 120
+APP_READINESS_TIMEOUT_SECONDS = 60
+APP_READINESS_PROBE_TIMEOUT_SECONDS = 5
+APP_READINESS_INITIAL_BACKOFF_SECONDS = 0.25
+APP_READINESS_MAX_BACKOFF_SECONDS = 2.0
 TEARDOWN_POLL_ATTEMPTS = 6
 TEARDOWN_POLL_INTERVAL_SECONDS = 2
 
@@ -333,6 +337,54 @@ def _machine_id_for_name(value: Any, name: str) -> str:
     if not isinstance(machine_id, str) or not MACHINE_ID.fullmatch(machine_id):
         raise QualificationError("provision_failed", "created Machine identity is malformed")
     return machine_id
+
+
+def wait_for_app_readiness(
+    transport: Transport,
+    invocation: TinyQualificationInvocation,
+    *,
+    timeout_seconds: float = APP_READINESS_TIMEOUT_SECONDS,
+    clock: Callable[[], float] | None = None,
+    sleeper: Callable[[float], None] | None = None,
+) -> None:
+    """Wait until the new app is usable through Fly's Machines authority."""
+    clock = clock or time.monotonic
+    sleeper = sleeper or time.sleep
+    deadline = clock() + timeout_seconds
+    backoff = APP_READINESS_INITIAL_BACKOFF_SECONDS
+    command = ("flyctl", "machine", "list", "--app", invocation.app, "--json")
+    while True:
+        remaining = deadline - clock()
+        if remaining <= 0:
+            raise QualificationError(
+                "readiness_timeout", "created app did not become ready for remote build"
+            )
+        try:
+            machines = _list(
+                transport.json(
+                    command,
+                    timeout=max(
+                        1,
+                        min(APP_READINESS_PROBE_TIMEOUT_SECONDS, int(remaining)),
+                    ),
+                ),
+                "Machine",
+            )
+        except (subprocess.SubprocessError, OSError):
+            machines = None
+        if machines is not None:
+            if machines:
+                raise QualificationError(
+                    "provision_failed", "new app is not empty at readiness admission"
+                )
+            return
+        sleep_for = min(backoff, max(0.0, deadline - clock()))
+        if sleep_for <= 0:
+            raise QualificationError(
+                "readiness_timeout", "created app did not become ready for remote build"
+            )
+        sleeper(sleep_for)
+        backoff = min(backoff * 2, APP_READINESS_MAX_BACKOFF_SECONDS)
 
 
 def verify_machine_state(
@@ -740,6 +792,12 @@ def execute(
         )
         ledger.app_owned = True
         _save_ledger(ledger_path, ledger)
+
+        wait_for_app_readiness(
+            transport,
+            invocation,
+            timeout_seconds=APP_READINESS_TIMEOUT_SECONDS,
+        )
 
         failure_kind = "build_failed"
         build = remote_build_command(

--- a/benchmarks/harness/graphforge_bench/fly_tiny_qualification.py
+++ b/benchmarks/harness/graphforge_bench/fly_tiny_qualification.py
@@ -359,20 +359,25 @@ def wait_for_app_readiness(
             raise QualificationError(
                 "readiness_timeout", "created app did not become ready for remote build"
             )
+        if remaining < 1:
+            raise QualificationError(
+                "readiness_timeout", "created app did not become ready for remote build"
+            )
         try:
             machines = _list(
                 transport.json(
                     command,
-                    timeout=max(
-                        1,
-                        min(APP_READINESS_PROBE_TIMEOUT_SECONDS, int(remaining)),
-                    ),
+                    timeout=min(APP_READINESS_PROBE_TIMEOUT_SECONDS, int(remaining)),
                 ),
                 "Machine",
             )
         except (subprocess.SubprocessError, OSError):
             machines = None
         if machines is not None:
+            if clock() >= deadline:
+                raise QualificationError(
+                    "readiness_timeout", "created app did not become ready for remote build"
+                )
             if machines:
                 raise QualificationError(
                     "provision_failed", "new app is not empty at readiness admission"

--- a/benchmarks/tests/test_fly_tiny_qualification.py
+++ b/benchmarks/tests/test_fly_tiny_qualification.py
@@ -368,6 +368,36 @@ class FlyTinyQualificationTests(unittest.TestCase):
             self.assertNotIn("token", json.dumps(result).lower())
 
     @patch("graphforge_bench.fly_tiny_qualification.check_source")
+    def test_readiness_response_after_deadline_cannot_start_build(
+        self, check_source: object
+    ) -> None:
+        del check_source
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            transport = FakeTransport(readiness_responses=[[]])
+            with (
+                patch("graphforge_bench.fly_tiny_qualification.APP_READINESS_TIMEOUT_SECONDS", 2),
+                patch(
+                    "graphforge_bench.fly_tiny_qualification.time.monotonic",
+                    side_effect=(0.0, 0.0, 3.0),
+                ),
+            ):
+                result = execute(
+                    invocation(),
+                    transport=transport,
+                    root=root,
+                    ledger_path=root / "ledger.json",
+                    evidence_out=root / "evidence.json",
+                    dry_run=False,
+                )
+            self.assertEqual(result["failure"], "readiness_timeout")
+            self.assertFalse(
+                any(command[:2] == ("flyctl", "deploy") for command in transport.commands)
+            )
+            self.assertEqual(ResourceLedger.load(root / "ledger.json"), ResourceLedger())
+            self.assertFalse((root / "evidence.json").exists())
+
+    @patch("graphforge_bench.fly_tiny_qualification.check_source")
     def test_readiness_malformed_inventory_is_typed_provider_failure(
         self, check_source: object
     ) -> None:

--- a/benchmarks/tests/test_fly_tiny_qualification.py
+++ b/benchmarks/tests/test_fly_tiny_qualification.py
@@ -69,6 +69,7 @@ class FakeTransport:
         auto_destroy: bool = True,
         restart_state: object = "valid",
         mount_state: object = "valid",
+        readiness_responses: list[object] | None = None,
     ):
         self.commands: list[tuple[str, ...]] = []
         self.machine_lists = 0
@@ -81,6 +82,7 @@ class FakeTransport:
         self.mount_state = (
             {"volume": "vol_fixture123", "path": "/work"} if mount_state == "valid" else mount_state
         )
+        self.readiness_responses = list(readiness_responses or [])
         self.app_created = False
 
     def run(
@@ -149,6 +151,13 @@ class FakeTransport:
         if argv[1:3] == ("volumes", "create"):
             return {"id": "vol_fixture123"}
         if argv[1:3] == ("machine", "list"):
+            if self.app_created and not self.machine_created and self.readiness_responses:
+                response = self.readiness_responses.pop(0)
+                if isinstance(response, BaseException):
+                    raise response
+                if isinstance(response, list) and response:
+                    self.machine_created = True
+                return response
             if not self.machine_created:
                 return []
             self.machine_lists += 1
@@ -289,6 +298,122 @@ class FlyTinyQualificationTests(unittest.TestCase):
                 ("flyctl", "apps", "destroy", "gf-q958-test", "--yes"),
                 transport.commands,
             )
+
+    @patch("graphforge_bench.fly_tiny_qualification.check_source")
+    def test_readiness_delayed_convergence_precedes_single_build(
+        self, check_source: object
+    ) -> None:
+        del check_source
+        unavailable = subprocess.CalledProcessError(1, ("flyctl", "machine", "list"))
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            transport = FakeTransport(readiness_responses=[unavailable, unavailable, []])
+            with patch("graphforge_bench.fly_tiny_qualification.time.sleep") as sleep:
+                result = execute(
+                    invocation(),
+                    transport=transport,
+                    root=root,
+                    ledger_path=root / "ledger.json",
+                    evidence_out=root / "evidence.json",
+                    dry_run=False,
+                )
+            self.assertEqual(result["status"], "passed")
+            deploy_index = next(
+                index
+                for index, command in enumerate(transport.commands)
+                if command[:2] == ("flyctl", "deploy")
+            )
+            readiness = (
+                "flyctl",
+                "machine",
+                "list",
+                "--app",
+                "gf-q958-test",
+                "--json",
+            )
+            self.assertEqual(transport.commands[:deploy_index].count(readiness), 3)
+            self.assertEqual(sleep.call_count, 2)
+
+    @patch("graphforge_bench.fly_tiny_qualification.check_source")
+    def test_readiness_permanent_absence_times_out_and_cleans_owned_app(
+        self, check_source: object
+    ) -> None:
+        del check_source
+        unavailable = subprocess.CalledProcessError(1, ("flyctl", "machine", "list"))
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            transport = FakeTransport(readiness_responses=[unavailable])
+            with (
+                patch("graphforge_bench.fly_tiny_qualification.APP_READINESS_TIMEOUT_SECONDS", 1),
+                patch(
+                    "graphforge_bench.fly_tiny_qualification.time.monotonic",
+                    side_effect=(0.0, 0.0, 2.0),
+                ),
+                patch("graphforge_bench.fly_tiny_qualification.time.sleep"),
+            ):
+                result = execute(
+                    invocation(),
+                    transport=transport,
+                    root=root,
+                    ledger_path=root / "ledger.json",
+                    evidence_out=root / "evidence.json",
+                    dry_run=False,
+                )
+            self.assertEqual(result["failure"], "readiness_timeout")
+            self.assertFalse(
+                any(command[:2] == ("flyctl", "deploy") for command in transport.commands)
+            )
+            self.assertEqual(ResourceLedger.load(root / "ledger.json"), ResourceLedger())
+            self.assertFalse((root / "evidence.json").exists())
+            self.assertNotIn("token", json.dumps(result).lower())
+
+    @patch("graphforge_bench.fly_tiny_qualification.check_source")
+    def test_readiness_malformed_inventory_is_typed_provider_failure(
+        self, check_source: object
+    ) -> None:
+        del check_source
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            transport = FakeTransport(readiness_responses=[{}])
+            result = execute(
+                invocation(),
+                transport=transport,
+                root=root,
+                ledger_path=root / "ledger.json",
+                evidence_out=root / "evidence.json",
+                dry_run=False,
+            )
+            self.assertEqual(result["failure"], "provision_failed")
+            self.assertEqual(ResourceLedger.load(root / "ledger.json"), ResourceLedger())
+            self.assertFalse((root / "evidence.json").exists())
+
+    @patch("graphforge_bench.fly_tiny_qualification.check_source")
+    def test_readiness_rejects_and_adopts_unexpected_child_for_cleanup(
+        self, check_source: object
+    ) -> None:
+        del check_source
+        adopted = [{"id": "abcdef01234567", "name": "unexpected-machine"}]
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            transport = FakeTransport(readiness_responses=[adopted])
+            result = execute(
+                invocation(),
+                transport=transport,
+                root=root,
+                ledger_path=root / "ledger.json",
+                evidence_out=root / "evidence.json",
+                dry_run=False,
+            )
+            self.assertEqual(result["failure"], "provision_failed")
+            self.assertTrue(
+                any(
+                    command[:3] == ("flyctl", "machine", "destroy")
+                    for command in transport.commands
+                )
+            )
+            self.assertEqual(ResourceLedger.load(root / "ledger.json"), ResourceLedger())
+            self.assertFalse((root / "evidence.json").exists())
+            self.assertNotIn("token", json.dumps(result).lower())
 
     @patch("graphforge_bench.fly_tiny_qualification.check_source")
     def test_nonempty_teardown_inventory_fails_closed(self, check_source: object) -> None:


### PR DESCRIPTION
## Summary

- persist ownership immediately after creating the disposable Fly app, then wait for it through the exact Machines inventory authority used by `flyctl deploy`
- bound readiness with a 60-second deadline, five-second probes, and capped exponential backoff; emit typed `readiness_timeout` without retrying the build
- fail closed on malformed inventory or unexpected adopted children and preserve child-first teardown
- add deterministic delayed-convergence, permanent-timeout, malformed-response, adoption/cleanup, and evidence-leakage coverage
- document the readiness boundary

## Root cause evidence

Two authorized tiny issue 958 attempts from merged SHA `a9014b43` failed at `build_failed` about 21 seconds after immediate app creation, before any image, volume, or Machine existed. Fly deploy verifies the app through Machines inventory first. This repair closes that propagation race without changing benchmark scope, hardware, or build retry policy.

## Validation

- `make -C benchmarks fly-adapter-static` — 27 passed
- `make -C benchmarks smoke-python` — smoke passed; 81 passed
- `uv run ruff format --check` on changed Python files — passed
- `uv run ruff check` on changed Python files — passed
- `python3 scripts/ci/test-fly-filesystem-safety-contract.py` — 2 passed
- `git diff --check` — passed

## Issue

Relates to issue 958. It remains open; a merged executor rerun with qualified tiny evidence and independent teardown remains the close gate.

No Fly resources were created by this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790656354&installation_model_id=20486&pr_number=1000&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1000&signature=37ec8e58f895a92e24d8f3b80044bd1bc57b478e57dee1d76f357f4d0d999890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app readiness detection during qualification runs.
  * Added bounded polling to handle delayed startup and transient failures.
  * Added clearer handling for readiness timeouts, malformed machine inventories, and unexpected machines.
  * Ensured timed-out readiness checks trigger cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->