### PR TITLE
fix(bench): provide explicit Fly build-only config

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -140,6 +140,13 @@ service, uses restart/autostop disabled and Fly's `--rm` auto-destroy
 semantics, and is bounded by the smoke's 930-second timeout, 30-second kill
 grace, and 300-second evidence acknowledgement window.
 
+The remote build uses the checked-in
+`containers/fly-filesystem-qualification/fly.build.toml` explicitly. That
+build-only config contains no app identity, service, or public port: the unique
+disposable app is supplied only by the executor's `--app` argument, while the
+Dockerfile and build context are passed as absolute paths so invocation does
+not depend on the caller's working directory.
+
 Dry-run performs source and read-only live-capacity admission but creates
 nothing. Supply unique disposable names and an existing output directory:
 

--- a/benchmarks/harness/graphforge_bench/fly_adapter.py
+++ b/benchmarks/harness/graphforge_bench/fly_adapter.py
@@ -221,9 +221,15 @@ def verify_checked_in_profile(root: Path, lifecycle: LifecycleInvocation) -> Non
     _refuse(lifecycle.profile_sha256 != f"sha256:{actual}", "checked-in profile digest mismatch")
 
 
-def remote_build_command(*, app: str, source: Path, dockerfile: Path, commit: str) -> Command:
+def remote_build_command(
+    *, app: str, source: Path, config: Path, dockerfile: Path, commit: str
+) -> Command:
     _refuse(not SAFE_NAME.fullmatch(app), "app name is invalid")
     _refuse(not COMMIT.fullmatch(commit), "build commit is invalid")
+    _refuse(
+        not all(path.is_absolute() for path in (source, config, dockerfile)),
+        "build paths must be absolute",
+    )
     return Command(
         "remote_build",
         (
@@ -232,6 +238,8 @@ def remote_build_command(*, app: str, source: Path, dockerfile: Path, commit: st
             str(source),
             "--app",
             app,
+            "--config",
+            str(config),
             "--dockerfile",
             str(dockerfile),
             "--remote-only",

--- a/benchmarks/harness/graphforge_bench/fly_tiny_qualification.py
+++ b/benchmarks/harness/graphforge_bench/fly_tiny_qualification.py
@@ -33,6 +33,7 @@ from graphforge_bench.fly_adapter import (
 
 ROOT = Path(__file__).resolve().parents[3]
 DOCKERFILE = ROOT / "containers" / "fly-filesystem-qualification" / "Dockerfile"
+FLY_BUILD_CONFIG = ROOT / "containers" / "fly-filesystem-qualification" / "fly.build.toml"
 VALIDATOR = ROOT / "scripts" / "ci" / "validate-fly-filesystem-qualification.py"
 COMMIT = re.compile(r"^[0-9a-f]{40}$")
 SAFE_NAME = re.compile(r"^[a-z][a-z0-9-]{2,62}$")
@@ -808,6 +809,7 @@ def execute(
         build = remote_build_command(
             app=invocation.app,
             source=root,
+            config=FLY_BUILD_CONFIG,
             dockerfile=DOCKERFILE,
             commit=invocation.commit,
         )

--- a/benchmarks/tests/test_fly_adapter.py
+++ b/benchmarks/tests/test_fly_adapter.py
@@ -69,16 +69,31 @@ def attempt(**changes: object) -> FlyAttempt:
 class FlyAdapterTests(unittest.TestCase):
     def test_remote_build_is_remote_only_pushed_and_commit_pinned(self) -> None:
         command = remote_build_command(
-            app="gf-fixture", source=Path(), dockerfile=Path("Dockerfile"), commit="a" * 40
+            app="gf-fixture",
+            source=Path("/repo"),
+            config=Path("/repo/fly.build.toml"),
+            dockerfile=Path("/repo/Dockerfile"),
+            commit="a" * 40,
         )
         self.assertIn("--remote-only", command.argv)
         self.assertIn("--build-only", command.argv)
         self.assertIn("--push", command.argv)
+        self.assertEqual(command.argv[command.argv.index("--app") + 1], "gf-fixture")
+        self.assertEqual(command.argv[command.argv.index("--config") + 1], "/repo/fly.build.toml")
+        self.assertEqual(command.argv[command.argv.index("--dockerfile") + 1], "/repo/Dockerfile")
         self.assertNotIn("--local-only", command.argv)
         self.assertIn("GRAPHFORGE_COMMIT=" + "a" * 40, command.argv)
         self.assertEqual(pin_remote_image("gf-fixture", "sha256:" + "c" * 64), attempt().image)
         with self.assertRaisesRegex(AdapterError, "immutable"):
             pin_remote_image("gf-fixture", "latest")
+        with self.assertRaisesRegex(AdapterError, "absolute"):
+            remote_build_command(
+                app="gf-fixture",
+                source=Path(),
+                config=Path("fly.build.toml"),
+                dockerfile=Path("Dockerfile"),
+                commit="a" * 40,
+            )
 
     def test_provisioning_is_private_fixed_and_thin(self) -> None:
         commands = provisioning_commands(attempt())

--- a/benchmarks/tests/test_fly_tiny_qualification.py
+++ b/benchmarks/tests/test_fly_tiny_qualification.py
@@ -17,6 +17,7 @@ from graphforge_bench.fly_tiny_qualification import (
     validate_invocation,
     verify_live_capacity,
 )
+import tomllib
 
 DIGEST = "sha256:" + "b" * 64
 IMAGE = "registry.fly.io/gf-q958-test@" + DIGEST
@@ -248,6 +249,22 @@ class FlyTinyQualificationTests(unittest.TestCase):
         self.assertNotIn("--port", command)
         self.assertNotIn("S18", " ".join(command))
 
+    def test_build_config_is_identity_free_private_and_workdir_independent(self) -> None:
+        config_path = (
+            Path(__file__).resolve().parents[2]
+            / "containers"
+            / "fly-filesystem-qualification"
+            / "fly.build.toml"
+        )
+        config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+        self.assertEqual(
+            config,
+            {"build": {"dockerfile": "containers/fly-filesystem-qualification/Dockerfile"}},
+        )
+        self.assertNotIn("app", config)
+        self.assertNotIn("services", config)
+        self.assertNotIn("http_service", config)
+
     @patch("graphforge_bench.fly_tiny_qualification.check_source")
     def test_success_persists_ledger_retrieves_only_evidence_and_tears_down(
         self, check_source: object
@@ -294,6 +311,22 @@ class FlyTinyQualificationTests(unittest.TestCase):
                 dry_run=False,
             )
             self.assertEqual(result["failure"], "build_failed")
+            deploy = next(
+                command for command in transport.commands if command[:2] == ("flyctl", "deploy")
+            )
+            self.assertEqual(deploy[deploy.index("--app") + 1], "gf-q958-test")
+            self.assertTrue(Path(deploy[deploy.index("--config") + 1]).is_absolute())
+            self.assertTrue(Path(deploy[deploy.index("--dockerfile") + 1]).is_absolute())
+            self.assertIn("--build-only", deploy)
+            self.assertIn("--push", deploy)
+            self.assertIn("--no-public-ips", deploy)
+            self.assertIn("GRAPHFORGE_COMMIT=" + "a" * 40, deploy)
+            self.assertFalse(
+                any(
+                    command[1:3] in {("volumes", "create"), ("machine", "run")}
+                    for command in transport.commands
+                )
+            )
             self.assertIn(
                 ("flyctl", "apps", "destroy", "gf-q958-test", "--yes"),
                 transport.commands,

--- a/containers/fly-filesystem-qualification/fly.build.toml
+++ b/containers/fly-filesystem-qualification/fly.build.toml
@@ -1,0 +1,5 @@
+# Build-only Fly Launch configuration. The disposable app name is supplied
+# exclusively through `flyctl deploy --app` at runtime.
+
+[build]
+dockerfile = "containers/fly-filesystem-qualification/Dockerfile"


### PR DESCRIPTION
## Summary

- add a checked-in minimal Fly build-only config for the filesystem qualification Dockerfile
- keep the config identity-free and service-free; supply the unique disposable app only via runtime `--app`
- pass absolute build-context, config, and Dockerfile paths so execution is independent of the caller working directory
- preserve remote-only, build-only, push, no-public-IPs, commit build argument, and immutable same-app digest behavior
- prove a build failure occurs before volume or Machine creation and still tears down

## Root cause evidence

After PR #1000, app readiness converged in the authorized post-fix attempt, but `flyctl deploy --build-only` still returned typed `build_failed` before image resolution. The repository had no `fly.toml` and the executor supplied no explicit `--config`, while Fly deploy consumes app configuration from that path.

## Validation

- `make -C benchmarks fly-adapter-static` — 29 passed
- `make -C benchmarks smoke-python` — smoke passed; 83 passed
- changed-file Ruff format and lint — passed
- `python3 scripts/ci/test-fly-filesystem-safety-contract.py` — 2 passed
- checked-in TOML parses to only the expected build table
- `git diff --check` — passed

## Issue

Relates to issue 958. It remains open; a merged-executor tiny rerun with qualified evidence and independent teardown remains the completion gate.

No Fly resources were created by this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790658381&installation_model_id=20486&pr_number=1001&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1001&signature=92c46f0fcdde5f94e5d8f342d5e6b25ebe50b13ec038c4faf9c18e95efe7c681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Fly deployment support for explicitly supplied build configuration, source, and Dockerfile paths.
  * Added a dedicated Fly build configuration for qualification deployments.
  * Qualification deployments now use disposable app names supplied at deployment time.

* **Bug Fixes**
  * Invalid relative build paths are now rejected.
  * Qualification builds enforce private, build-only deployments without creating volumes or machines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->